### PR TITLE
Shell: Heredocs

### DIFF
--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -44,6 +44,17 @@ Any sequence of _Double Quoted String Part_ tokens:
 * Evaluate expressions
 * Escaped sequences
 
+##### Heredocs
+Heredocs are made in two parts, the _initiator_ and the _contents_, the _initiator_ may be used in place of a string (i.e. wherever a string is allowed to be used), with the constraint that the _contents_ must follow the _sequence_ that the _initiator_ is used in.
+
+There are four different _initiators_:
+- `<<-token`: The _contents_ may contain interpolations, and are terminated with a line containing only whitespace and then _token_
+- `<<-'token'`: The _contents_ may _not_ contain interpolations, but otherwise is the same as `<<-token`
+- `<<~token`: Similar to `<<-token`, but the starting whitespace of the lines in the _contents_ is stripped, note that this happens after any and all expansions/interpolations are done.
+- `<<~'token'`: Dedents (i.e. strips the initial whitespace) like `<<~token`, and disallows interpolations like `<<-'token'`.
+
+Note that heredocs _must_ be listed in the same order as they are used after a sequence that has been terminated with a newline.
+
 ##### Variable Reference
 Any sequence of _Identifier_ characters, or a _Special Variable_ following a `$`.
 Variables may be followed by a _Slice_ (see [Slice](#Slice))
@@ -387,7 +398,9 @@ and_logical_sequence :: pipe_sequence '&' '&' and_logical_sequence
                       | pipe_sequence
 
 terminator :: ';'
-            | '\n'
+            | '\n' [?!heredoc_stack.is_empty] heredoc_entries
+
+heredoc_entries :: { .*? (heredoc_entry) '\n' } [each heredoc_entries]
 
 variable_decls :: identifier '=' expression (' '+ variable_decls)? ' '*
                 | identifier '=' '(' pipe_sequence ')' (' '+ variable_decls)? ' '*
@@ -407,7 +420,7 @@ control_structure[c] :: for_expr
 continuation_control :: 'break'
                       | 'continue'
 
-for_expr :: 'for' ws+ (('enum' ' '+ identifier)? identifier ' '+ 'in' ws*)? expression ws+ '{' [c] toplevel '}'
+for_expr :: 'for' ws+ (('index' ' '+ identifier ' '+)? identifier ' '+ 'in' ws*)? expression ws+ '{' [c] toplevel '}'
 
 loop_expr :: 'loop' ws* '{' [c] toplevel '}'
 
@@ -451,6 +464,12 @@ string_composite :: string string_composite?
                   | bareword string_composite?
                   | glob string_composite?
                   | brace_expansion string_composite?
+                  | heredoc_initiator string_composite?    {append to heredoc_entries}
+
+heredoc_initiator :: '<' '<' '-' bareword         {*bareword, interpolate, no deindent}
+                   | '<' '<' '-' "'" [^']* "'"    {*string, no interpolate, no deindent}
+                   | '<' '<' '~' bareword         {*bareword, interpolate, deindent}
+                   | '<' '<' '~' "'" [^']* "'"    {*bareword, no interpolate, deindent}
 
 string :: '"' dquoted_string_inner '"'
         | "'" [^']* "'"
@@ -476,7 +495,7 @@ comment :: '#' [^\n]*
 
 immediate_expression :: '$' '{' immediate_function expression* '}'
 
-immediate_function :: identifier    { predetermined list of names, see Shell.h:ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS }
+immediate_function :: identifier       { predetermined list of names, see Shell.h:ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS }
 
 history_designator :: '!' event_selector (':' word_selector_composite)?
 

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -402,9 +402,6 @@ void And::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMetad
 
 HitTestResult And::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_left->hit_test_position(offset);
     if (result.matching_node) {
         if (!result.closest_command_node)
@@ -508,9 +505,6 @@ void ListConcatenate::highlight_in_editor(Line::Editor& editor, Shell& shell, Hi
 
 HitTestResult ListConcatenate::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     bool first = true;
     for (auto& element : m_list) {
         auto result = element->hit_test_position(offset);
@@ -570,9 +564,6 @@ void Background::highlight_in_editor(Line::Editor& editor, Shell& shell, Highlig
 
 HitTestResult Background::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     return m_command->hit_test_position(offset);
 }
 
@@ -665,9 +656,6 @@ RefPtr<Value> BraceExpansion::run(RefPtr<Shell> shell)
 
 HitTestResult BraceExpansion::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     for (auto& entry : m_entries) {
         auto result = entry.hit_test_position(offset);
         if (result.matching_node) {
@@ -730,9 +718,6 @@ void CastToCommand::highlight_in_editor(Line::Editor& editor, Shell& shell, High
 
 HitTestResult CastToCommand::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_inner->hit_test_position(offset);
     if (!result.closest_node_with_semantic_meaning)
         result.closest_node_with_semantic_meaning = this;
@@ -812,9 +797,6 @@ void CastToList::highlight_in_editor(Line::Editor& editor, Shell& shell, Highlig
 
 HitTestResult CastToList::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (!m_inner)
         return {};
 
@@ -966,9 +948,6 @@ void DoubleQuotedString::highlight_in_editor(Line::Editor& editor, Shell& shell,
 
 HitTestResult DoubleQuotedString::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     return m_inner->hit_test_position(offset);
 }
 
@@ -1014,9 +993,6 @@ void DynamicEvaluate::highlight_in_editor(Line::Editor& editor, Shell& shell, Hi
 
 HitTestResult DynamicEvaluate::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     return m_inner->hit_test_position(offset);
 }
 
@@ -1102,9 +1078,6 @@ void FunctionDeclaration::highlight_in_editor(Line::Editor& editor, Shell& shell
 
 HitTestResult FunctionDeclaration::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (!m_block)
         return {};
 
@@ -1275,9 +1248,6 @@ void ForLoop::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightM
 
 HitTestResult ForLoop::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (m_iterated_expression) {
         if (auto result = m_iterated_expression->hit_test_position(offset); result.matching_node)
             return result;
@@ -1676,9 +1646,6 @@ void Execute::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightM
 
 HitTestResult Execute::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_command->hit_test_position(offset);
     if (!result.closest_node_with_semantic_meaning)
         result.closest_node_with_semantic_meaning = this;
@@ -1770,9 +1737,6 @@ void IfCond::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMe
 
 HitTestResult IfCond::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (auto result = m_condition->hit_test_position(offset); result.matching_node)
         return result;
 
@@ -1883,9 +1847,6 @@ Vector<Line::CompletionSuggestion> ImmediateExpression::complete_for_editor(Shel
 
 HitTestResult ImmediateExpression::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (m_function.position.contains(offset))
         return { this, this, this };
 
@@ -1943,9 +1904,6 @@ void Join::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMeta
 
 HitTestResult Join::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_left->hit_test_position(offset);
     if (result.matching_node)
         return result;
@@ -2105,9 +2063,6 @@ void MatchExpr::highlight_in_editor(Line::Editor& editor, Shell& shell, Highligh
 
 HitTestResult MatchExpr::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_matched_expr->hit_test_position(offset);
     if (result.matching_node)
         return result;
@@ -2170,9 +2125,6 @@ void Or::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMetada
 
 HitTestResult Or::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_left->hit_test_position(offset);
     if (result.matching_node) {
         if (!result.closest_command_node)
@@ -2268,9 +2220,6 @@ void Pipe::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMeta
 
 HitTestResult Pipe::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_left->hit_test_position(offset);
     if (result.matching_node) {
         if (!result.closest_command_node)
@@ -2327,9 +2276,6 @@ void PathRedirectionNode::highlight_in_editor(Line::Editor& editor, Shell& shell
 
 HitTestResult PathRedirectionNode::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_path->hit_test_position(offset);
     if (!result.closest_node_with_semantic_meaning)
         result.closest_node_with_semantic_meaning = this;
@@ -2442,9 +2388,6 @@ void Range::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMet
 
 HitTestResult Range::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_start->hit_test_position(offset);
     if (result.matching_node) {
         if (!result.closest_command_node)
@@ -2565,9 +2508,6 @@ void Sequence::highlight_in_editor(Line::Editor& editor, Shell& shell, Highlight
 
 HitTestResult Sequence::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     for (auto& entry : m_entries) {
         auto result = entry.hit_test_position(offset);
         if (result.matching_node) {
@@ -2621,9 +2561,6 @@ void Subshell::highlight_in_editor(Line::Editor& editor, Shell& shell, Highlight
 
 HitTestResult Subshell::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (m_block)
         return m_block->hit_test_position(offset);
 
@@ -2713,9 +2650,6 @@ void SimpleVariable::highlight_in_editor(Line::Editor& editor, Shell& shell, Hig
 
 HitTestResult SimpleVariable::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (m_slice && m_slice->position().contains(offset))
         return m_slice->hit_test_position(offset);
 
@@ -2783,9 +2717,6 @@ Vector<Line::CompletionSuggestion> SpecialVariable::complete_for_editor(Shell&, 
 
 HitTestResult SpecialVariable::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     if (m_slice && m_slice->position().contains(offset))
         return m_slice->hit_test_position(offset);
 
@@ -2902,9 +2833,6 @@ Vector<Line::CompletionSuggestion> Juxtaposition::complete_for_editor(Shell& she
 
 HitTestResult Juxtaposition::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_left->hit_test_position(offset);
     if (!result.closest_node_with_semantic_meaning)
         result.closest_node_with_semantic_meaning = this;
@@ -2991,9 +2919,6 @@ void StringPartCompose::highlight_in_editor(Line::Editor& editor, Shell& shell, 
 
 HitTestResult StringPartCompose::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     auto result = m_left->hit_test_position(offset);
     if (result.matching_node)
         return result;
@@ -3219,9 +3144,6 @@ void VariableDeclarations::highlight_in_editor(Line::Editor& editor, Shell& shel
 
 HitTestResult VariableDeclarations::hit_test_position(size_t offset) const
 {
-    if (!position().contains(offset))
-        return {};
-
     for (auto decl : m_variables) {
         auto result = decl.value->hit_test_position(offset);
         if (result.matching_node)

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -248,6 +248,25 @@ static Vector<String> resolve_slices(RefPtr<Shell> shell, Vector<String>&& value
     return move(values);
 }
 
+void Node::clear_syntax_error()
+{
+    m_syntax_error_node->clear_syntax_error();
+}
+
+void Node::set_is_syntax_error(const SyntaxError& error_node)
+{
+    if (!m_syntax_error_node) {
+        m_syntax_error_node = error_node;
+    } else {
+        m_syntax_error_node->set_is_syntax_error(error_node);
+    }
+}
+
+bool Node::is_syntax_error() const
+{
+    return m_syntax_error_node && m_syntax_error_node->is_syntax_error();
+}
+
 void Node::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(NonnullRefPtr<Value>)> callback)
 {
     auto value = run(shell)->resolve_without_cast(shell);
@@ -1884,7 +1903,7 @@ ImmediateExpression::ImmediateExpression(Position position, NameWithPosition fun
     , m_function(move(function))
     , m_closing_brace_position(move(closing_brace_position))
 {
-    if (m_is_syntax_error)
+    if (is_syntax_error())
         return;
 
     for (auto& argument : m_arguments) {
@@ -3021,7 +3040,6 @@ SyntaxError::SyntaxError(Position position, String error, bool is_continuable)
     , m_syntax_error_text(move(error))
     , m_is_continuable(is_continuable)
 {
-    m_is_syntax_error = true;
 }
 
 const SyntaxError& SyntaxError::syntax_error_node() const

--- a/Userland/Shell/Formatter.cpp
+++ b/Userland/Shell/Formatter.cpp
@@ -7,6 +7,7 @@
 #include "Formatter.h"
 #include "AST.h"
 #include "Parser.h"
+#include <AK/Hex.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/TemporaryChange.h>
 
@@ -36,12 +37,14 @@ String Formatter::format()
 
     node->visit(*this);
 
-    auto string = m_builder.string_view();
+    VERIFY(m_builders.size() == 1);
+
+    auto string = current_builder().string_view();
 
     if (!string.ends_with(" "))
-        m_builder.append(m_trivia);
+        current_builder().append(m_trivia);
 
-    return m_builder.to_string();
+    return current_builder().to_string();
 }
 
 void Formatter::with_added_indent(int indent, Function<void()> callback)
@@ -61,6 +64,13 @@ void Formatter::in_new_block(Function<void()> callback)
 
     insert_separator();
     current_builder().append('}');
+}
+
+String Formatter::in_new_builder(Function<void()> callback, StringBuilder new_builder)
+{
+    m_builders.append(move(new_builder));
+    callback();
+    return m_builders.take_last().to_string();
 }
 
 void Formatter::test_and_update_output_cursor(const AST::Node* node)
@@ -96,9 +106,17 @@ void Formatter::will_visit(const AST::Node* node)
     }
 }
 
-void Formatter::insert_separator()
+void Formatter::insert_separator(bool escaped)
 {
+    if (escaped)
+        current_builder().append('\\');
     current_builder().append('\n');
+    if (!escaped && !m_heredocs_to_append_after_sequence.is_empty()) {
+        for (auto& entry : m_heredocs_to_append_after_sequence) {
+            current_builder().append(entry);
+        }
+        m_heredocs_to_append_after_sequence.clear();
+    }
     insert_indent();
 }
 
@@ -127,8 +145,8 @@ void Formatter::visit(const AST::And* node)
     with_added_indent(should_indent ? 1 : 0, [&] {
         node->left()->visit(*this);
 
-        current_builder().append(" \\");
-        insert_separator();
+        current_builder().append(' ');
+        insert_separator(true);
         current_builder().append("&& ");
 
         node->right()->visit(*this);
@@ -269,14 +287,17 @@ void Formatter::visit(const AST::DoubleQuotedString* node)
 {
     will_visit(node);
     test_and_update_output_cursor(node);
-    current_builder().append("\"");
+    auto not_in_heredoc = m_parent_node->kind() != AST::Node::Kind::Heredoc;
+    if (not_in_heredoc)
+        current_builder().append("\"");
 
     TemporaryChange quotes { m_options.in_double_quotes, true };
     TemporaryChange<const AST::Node*> parent { m_parent_node, node };
 
     NodeVisitor::visit(node);
 
-    current_builder().append("\"");
+    if (not_in_heredoc)
+        current_builder().append("\"");
     visited(node);
 }
 
@@ -352,6 +373,39 @@ void Formatter::visit(const AST::Glob* node)
     will_visit(node);
     test_and_update_output_cursor(node);
     current_builder().append(node->text());
+    visited(node);
+}
+
+void Formatter::visit(const AST::Heredoc* node)
+{
+    will_visit(node);
+    test_and_update_output_cursor(node);
+
+    current_builder().append("<<");
+    if (node->deindent())
+        current_builder().append('~');
+    else
+        current_builder().append('-');
+
+    if (node->allow_interpolation())
+        current_builder().appendff("{}", node->end());
+    else
+        current_builder().appendff("'{}'", node->end());
+
+    auto content = in_new_builder([&] {
+        if (!node->contents())
+            return;
+
+        TemporaryChange<const AST::Node*> parent { m_parent_node, node };
+        TemporaryChange heredoc { m_options.in_heredoc, true };
+
+        auto& contents = *node->contents();
+        contents.visit(*this);
+        current_builder().appendff("\n{}\n", node->end());
+    });
+
+    m_heredocs_to_append_after_sequence.append(move(content));
+
     visited(node);
 }
 
@@ -567,8 +621,8 @@ void Formatter::visit(const AST::Or* node)
     with_added_indent(should_indent ? 1 : 0, [&] {
         node->left()->visit(*this);
 
-        current_builder().append(" \\");
-        insert_separator();
+        current_builder().append(" ");
+        insert_separator(true);
         current_builder().append("|| ");
 
         node->right()->visit(*this);
@@ -584,10 +638,10 @@ void Formatter::visit(const AST::Pipe* node)
     TemporaryChange<const AST::Node*> parent { m_parent_node, node };
 
     node->left()->visit(*this);
-    current_builder().append(" \\");
+    current_builder().append(" ");
 
     with_added_indent(should_indent ? 1 : 0, [&] {
-        insert_separator();
+        insert_separator(true);
         current_builder().append("| ");
 
         node->right()->visit(*this);
@@ -720,10 +774,10 @@ void Formatter::visit(const AST::StringLiteral* node)
 {
     will_visit(node);
     test_and_update_output_cursor(node);
-    if (!m_options.in_double_quotes)
+    if (!m_options.in_double_quotes && !m_options.in_heredoc)
         current_builder().append("'");
 
-    if (m_options.in_double_quotes) {
+    if (m_options.in_double_quotes && !m_options.in_heredoc) {
         for (auto ch : node->text()) {
             switch (ch) {
             case '"':
@@ -761,7 +815,7 @@ void Formatter::visit(const AST::StringLiteral* node)
         current_builder().append(node->text());
     }
 
-    if (!m_options.in_double_quotes)
+    if (!m_options.in_double_quotes && !m_options.in_heredoc)
         current_builder().append("'");
     visited(node);
 }

--- a/Userland/Shell/Forward.h
+++ b/Userland/Shell/Forward.h
@@ -34,6 +34,7 @@ class Fd2FdRedirection;
 class FunctionDeclaration;
 class ForLoop;
 class Glob;
+class Heredoc;
 class HistoryEvent;
 class Execute;
 class IfCond;

--- a/Userland/Shell/NodeVisitor.cpp
+++ b/Userland/Shell/NodeVisitor.cpp
@@ -101,6 +101,12 @@ void NodeVisitor::visit(const AST::Glob*)
 {
 }
 
+void NodeVisitor::visit(const AST::Heredoc* node)
+{
+    if (node->contents())
+        node->contents()->visit(*this);
+}
+
 void NodeVisitor::visit(const AST::HistoryEvent*)
 {
 }

--- a/Userland/Shell/NodeVisitor.h
+++ b/Userland/Shell/NodeVisitor.h
@@ -30,6 +30,7 @@ public:
     virtual void visit(const AST::FunctionDeclaration*);
     virtual void visit(const AST::ForLoop*);
     virtual void visit(const AST::Glob*);
+    virtual void visit(const AST::Heredoc*);
     virtual void visit(const AST::HistoryEvent*);
     virtual void visit(const AST::Execute*);
     virtual void visit(const AST::IfCond*);

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -7,6 +7,7 @@
 #include "Parser.h"
 #include "Shell.h"
 #include <AK/AllOf.h>
+#include <AK/ScopeGuard.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/TemporaryChange.h>
 #include <ctype.h>
@@ -187,9 +188,47 @@ RefPtr<AST::Node> Parser::parse_toplevel()
 
 Parser::SequenceParseResult Parser::parse_sequence()
 {
-    consume_while(is_any_of(" \t\n;")); // ignore whitespaces or terminators without effect.
-
     NonnullRefPtrVector<AST::Node> left;
+    auto read_terminators = [&](bool consider_tabs_and_spaces) {
+        if (m_heredoc_initiations.is_empty()) {
+        discard_terminators:;
+            consume_while(is_any_of(consider_tabs_and_spaces ? " \t\n;" : "\n;"));
+        } else {
+            for (;;) {
+                if (consider_tabs_and_spaces && (peek() == '\t' || peek() == ' ')) {
+                    consume();
+                    continue;
+                }
+                if (peek() == ';') {
+                    consume();
+                    continue;
+                }
+                if (peek() == '\n') {
+                    auto rule_start = push_start();
+                    consume();
+                    if (!parse_heredoc_entries()) {
+                        StringBuilder error_builder;
+                        error_builder.append("Expected to find heredoc entries for ");
+                        bool first = true;
+                        for (auto& entry : m_heredoc_initiations) {
+                            if (first)
+                                error_builder.appendff("{} (at {}:{})", entry.end, entry.node->position().start_line.line_column, entry.node->position().start_line.line_number);
+                            else
+                                error_builder.appendff(", {} (at {}:{})", entry.end, entry.node->position().start_line.line_column, entry.node->position().start_line.line_number);
+                            first = false;
+                        }
+                        left.append(create<AST::SyntaxError>(error_builder.build(), true));
+                        // Just read the rest of the newlines
+                        goto discard_terminators;
+                    }
+                    continue;
+                }
+                break;
+            }
+        }
+    };
+
+    read_terminators(true);
 
     auto rule_start = push_start();
     {
@@ -203,8 +242,10 @@ Parser::SequenceParseResult Parser::parse_sequence()
     switch (peek()) {
     case '}':
         return { move(left), {}, ShouldReadMoreSequences::No };
-    case ';':
-    case '\n': {
+    case '\n':
+        read_terminators(false);
+        [[fallthrough]];
+    case ';': {
         if (left.is_empty())
             break;
 
@@ -235,8 +276,10 @@ Parser::SequenceParseResult Parser::parse_sequence()
 
     pos_before_seps = save_offset();
     switch (peek()) {
-    case ';':
-    case '\n': {
+    case '\n':
+        read_terminators(false);
+        [[fallthrough]];
+    case ';': {
         consume_while(is_any_of("\n;"));
         auto pos_after_seps = save_offset();
         separator_positions.empend(pos_before_seps.offset, pos_after_seps.offset, pos_before_seps.line, pos_after_seps.line);
@@ -960,6 +1003,11 @@ RefPtr<AST::Node> Parser::parse_match_pattern()
 RefPtr<AST::Node> Parser::parse_redirection()
 {
     auto rule_start = push_start();
+
+    // heredoc entry
+    if (next_is("<<-") || next_is("<<~"))
+        return nullptr;
+
     auto pipe_fd = 0;
     auto number = consume_while(is_digit);
     if (number.is_empty()) {
@@ -1091,8 +1139,11 @@ RefPtr<AST::Node> Parser::parse_expression()
         return move(expr);
     };
 
-    if (strchr("&|)} ;<>\n", starting_char) != nullptr)
-        return nullptr;
+    // Heredocs are expressions, so allow them
+    if (!(next_is("<<-") || next_is("<<~"))) {
+        if (strchr("&|)} ;<>\n", starting_char) != nullptr)
+            return nullptr;
+    }
 
     if (m_extra_chars_not_allowed_in_barewords.contains_slow(starting_char))
         return nullptr;
@@ -1186,6 +1237,13 @@ RefPtr<AST::Node> Parser::parse_string_composite()
             return create<AST::Juxtaposition>(inline_command.release_nonnull(), next_part.release_nonnull()); // Concatenate Execute StringComposite
 
         return inline_command;
+    }
+
+    if (auto heredoc = parse_heredoc_initiation_record()) {
+        if (auto next_part = parse_string_composite())
+            return create<AST::Juxtaposition>(heredoc.release_nonnull(), next_part.release_nonnull()); // Concatenate Heredoc StringComposite
+
+        return heredoc;
     }
 
     return nullptr;
@@ -1850,6 +1908,163 @@ RefPtr<AST::Node> Parser::parse_brace_expansion_spec()
         return nullptr;
 
     return create<AST::BraceExpansion>(move(subexpressions));
+}
+
+RefPtr<AST::Node> Parser::parse_heredoc_initiation_record()
+{
+    if (!next_is("<<"))
+        return nullptr;
+
+    auto rule_start = push_start();
+
+    // '<' '<'
+    consume();
+    consume();
+
+    HeredocInitiationRecord record;
+    record.end = "<error>";
+
+    RefPtr<AST::SyntaxError> syntax_error_node;
+
+    // '-' | '~'
+    switch (peek()) {
+    case '-':
+        record.deindent = false;
+        consume();
+        break;
+    case '~':
+        record.deindent = true;
+        consume();
+        break;
+    default:
+        restore_to(*rule_start);
+        return nullptr;
+    }
+
+    // StringLiteral | bareword
+    if (auto bareword = parse_bareword()) {
+        if (bareword->is_syntax_error())
+            syntax_error_node = bareword->syntax_error_node();
+        else
+            record.end = static_cast<AST::BarewordLiteral*>(bareword.ptr())->text();
+
+        record.interpolate = true;
+    } else if (peek() == '\'') {
+        consume();
+        auto text = consume_while(is_not('\''));
+        bool is_error = false;
+        if (!expect('\''))
+            is_error = true;
+        if (is_error)
+            syntax_error_node = create<AST::SyntaxError>("Expected a terminating single quote", true);
+
+        record.end = text;
+        record.interpolate = false;
+    } else {
+        syntax_error_node = create<AST::SyntaxError>("Expected a bareword or a single-quoted string literal for heredoc end key", true);
+    }
+
+    auto node = create<AST::Heredoc>(record.end, record.interpolate, record.deindent);
+    if (syntax_error_node)
+        node->set_is_syntax_error(*syntax_error_node);
+    else
+        node->set_is_syntax_error(*create<AST::SyntaxError>(String::formatted("Expected heredoc contents for heredoc with end key '{}'", node->end()), true));
+
+    record.node = node;
+    m_heredoc_initiations.append(move(record));
+
+    return node;
+}
+
+bool Parser::parse_heredoc_entries()
+{
+    // Try to parse heredoc entries, as reverse recorded in the initiation records
+    for (auto& record : m_heredoc_initiations) {
+        auto rule_start = push_start();
+        bool found_key = false;
+        if (!record.interpolate) {
+            // Since no interpolation is allowed, just read lines until we hit the key
+            Optional<Offset> last_line_offset;
+            for (;;) {
+                if (at_end())
+                    break;
+                if (peek() == '\n')
+                    consume();
+                last_line_offset = current_position();
+                auto line = consume_while(is_not('\n'));
+                if (peek() == '\n')
+                    consume();
+                if (line.trim_whitespace() == record.end) {
+                    found_key = true;
+                    break;
+                }
+            }
+
+            if (!last_line_offset.has_value())
+                last_line_offset = current_position();
+            // Now just wrap it in a StringLiteral and set it as the node's contents
+            auto node = create<AST::StringLiteral>(m_input.substring_view(rule_start->offset, last_line_offset->offset - rule_start->offset));
+            if (!found_key)
+                node->set_is_syntax_error(*create<AST::SyntaxError>(String::formatted("Expected to find the heredoc key '{}', but found Eof", record.end), true));
+            record.node->set_contents(move(node));
+        } else {
+            // Interpolation is allowed, so we're going to read doublequoted string innards
+            // until we find a line that contains the key
+            auto end_condition = move(m_end_condition);
+            found_key = false;
+            set_end_condition([this, end = record.end, &found_key] {
+                if (found_key)
+                    return true;
+                auto offset = current_position();
+                auto cond = move(m_end_condition);
+                ScopeGuard guard {
+                    [&] {
+                        m_end_condition = move(cond);
+                    }
+                };
+                if (peek() == '\n') {
+                    consume();
+                    auto line = consume_while(is_not('\n'));
+                    if (peek() == '\n')
+                        consume();
+                    if (line.trim_whitespace() == end) {
+                        restore_to(offset.offset, offset.line);
+                        found_key = true;
+                        return true;
+                    }
+                }
+                restore_to(offset.offset, offset.line);
+                return false;
+            });
+
+            auto expr = parse_doublequoted_string_inner();
+            set_end_condition(move(end_condition));
+
+            if (found_key) {
+                auto offset = current_position();
+                if (peek() == '\n')
+                    consume();
+                auto line = consume_while(is_not('\n'));
+                if (peek() == '\n')
+                    consume();
+                if (line.trim_whitespace() != record.end)
+                    restore_to(offset.offset, offset.line);
+            }
+
+            if (!expr && found_key) {
+                expr = create<AST::StringLiteral>("");
+            } else if (!expr) {
+                expr = create<AST::SyntaxError>(String::formatted("Expected to find a valid string inside a heredoc (with end key '{}')", record.end), true);
+            } else if (!found_key) {
+                expr->set_is_syntax_error(*create<AST::SyntaxError>(String::formatted("Expected to find the heredoc key '{}'", record.end), true));
+            }
+
+            record.node->set_contents(create<AST::DoubleQuotedString>(move(expr)));
+        }
+    }
+
+    m_heredoc_initiations.clear();
+    return true;
 }
 
 StringView Parser::consume_while(Function<bool(char)> condition)

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1867,9 +1867,9 @@ StringView Parser::consume_while(Function<bool(char)> condition)
 
 bool Parser::next_is(const StringView& next)
 {
-    auto start = push_start();
+    auto start = current_position();
     auto res = expect(next);
-    restore_to(*start);
+    restore_to(start.offset, start.line);
     return res;
 }
 

--- a/Userland/Shell/Tests/heredocs.sh
+++ b/Userland/Shell/Tests/heredocs.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+source $(dirname "$0")/test-commons.inc
+
+# Simple usage, single doc
+echo <<-test > sh.doc.test
+this is a test
+test
+if test "$(cat sh.doc.test)" != "this is a test" {
+    fail "Could not use normal interpolated heredoc"
+}
+
+echo <<-'test' > sh.doc.test
+this is a test
+test
+if test "$(cat sh.doc.test)" != "this is a test" {
+    fail "Could not use normal non-interpolated heredoc"
+}
+
+echo <<~test > sh.doc.test
+    this is a test
+test
+if test "$(cat sh.doc.test)" != "this is a test" {
+    fail "Could not use normal dedented heredoc"
+}
+
+echo <<~'test' > sh.doc.test
+    this is a test
+test
+if test "$(cat sh.doc.test)" != "this is a test" {
+    fail "Could not use normal non-interpolated dedented heredoc"
+}
+
+var=test
+echo <<-test > sh.doc.test
+this is a $var
+test
+if test "$(cat sh.doc.test)" != "this is a test" {
+    fail "Could not use interpolated heredoc with interpolation"
+}
+
+echo <<~test > sh.doc.test
+    this is a $var
+test
+if test "$(cat sh.doc.test)" != "this is a test" {
+    fail "Could not use dedented interpolated heredoc with interpolation"
+}
+
+# Multiple heredocs
+echo <<-test <<-test2 > sh.doc.test
+contents for test
+test
+contents for test2
+test2
+if test "$(cat sh.doc.test)" != "contents for test contents for test2" {
+    fail "Could not use two heredocs"
+}
+
+# Why would you do this you crazy person?
+if test "$(echo <<~text)" != "test" {
+                test
+                text
+    fail "Could not use heredocs in a weird place"
+}
+
+# Now let's try something _really_ weird!
+if test "$(echo <<~test1)" != "$(echo <<~test2)" { fail "The parser forgot about heredocs after a block, oops" }
+test
+test1
+test
+test2
+
+rm -f sh.doc.test
+pass


### PR DESCRIPTION
We too, now support these terrible but useful constructs!
Closes #4283.

TL;DR:
![shot-2021-04-29_07-39-49](https://user-images.githubusercontent.com/14001776/116498173-5fd55080-a8be-11eb-9d06-4929be6eb72c.jpg)

Notes:
- No spaces before the key and after `<<-`, much easier to see for humans.
- "dedent" deletes _all_ starting whitespace in lines, might want to make that smarter, but I don't think it's particularly useful.
- This is not a redirection! bash people, beware!