### PR TITLE
Kernel: Hardening syscalls using AK::Vector against OOM

### DIFF
--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -24,7 +24,8 @@ KResultOr<ssize_t> Process::sys$readv(int fd, Userspace<const struct iovec*> iov
 
     u64 total_length = 0;
     Vector<iovec, 32> vecs;
-    vecs.resize(iov_count);
+    if (!vecs.try_resize(iov_count))
+        return ENOMEM;
     if (!copy_n_from_user(vecs.data(), iov, iov_count))
         return EFAULT;
     for (auto& vec : vecs) {

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -78,8 +78,10 @@ KResultOr<int> Process::sys$select(Userspace<const Syscall::SC_select_params*> u
             dbgln("sys$select: Bad fd number {}", fd);
             return EBADF;
         }
-        fds_info.append({ description.release_nonnull(), block_flags });
-        fds.append(fd);
+        if (!fds_info.try_append({ description.release_nonnull(), block_flags }))
+            return ENOMEM;
+        if (!fds.try_append(fd))
+            return ENOMEM;
     }
 
     if constexpr (IO_DEBUG || POLL_SELECT_DEBUG)

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -178,7 +178,8 @@ KResultOr<ssize_t> Process::sys$sendmsg(int sockfd, Userspace<const struct msghd
     if (msg.msg_iovlen != 1)
         return ENOTSUP; // FIXME: Support this :)
     Vector<iovec, 1> iovs;
-    iovs.resize(msg.msg_iovlen);
+    if (!iovs.try_resize(msg.msg_iovlen))
+        return ENOMEM;
     if (!copy_n_from_user(iovs.data(), msg.msg_iov, msg.msg_iovlen))
         return EFAULT;
 
@@ -213,7 +214,8 @@ KResultOr<ssize_t> Process::sys$recvmsg(int sockfd, Userspace<struct msghdr*> us
     if (msg.msg_iovlen != 1)
         return ENOTSUP; // FIXME: Support this :)
     Vector<iovec, 1> iovs;
-    iovs.resize(msg.msg_iovlen);
+    if (!iovs.try_resize(msg.msg_iovlen))
+        return ENOMEM;
     if (!copy_n_from_user(iovs.data(), msg.msg_iov, msg.msg_iovlen))
         return EFAULT;
 

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -23,7 +23,8 @@ KResultOr<ssize_t> Process::sys$writev(int fd, Userspace<const struct iovec*> io
 
     u64 total_length = 0;
     Vector<iovec, 32> vecs;
-    vecs.resize(iov_count);
+    if (!vecs.try_resize(iov_count))
+        return ENOMEM;
     if (!copy_n_from_user(vecs.data(), iov, iov_count))
         return EFAULT;
     for (auto& vec : vecs) {


### PR DESCRIPTION
Now that we have fail-able `AK::Vector` API's in the tree, we can start making more progress towards: #6369
This series of commits focuses on the syscalll surface area, there's some more details in the individual commit messages.