### PR TITLE
add groups program

### DIFF
--- a/Base/usr/share/man/man1/groups.md
+++ b/Base/usr/share/man/man1/groups.md
@@ -1,0 +1,31 @@
+## Name
+
+groups - list group memberships
+
+## Synopsis
+
+```**sh
+$ groups [username...]
+```
+
+## Description
+
+`groups` lists group memberships.
+
+If no username is provided group memberships are listed for current user.
+
+## Arguments
+
+* username: username to list group memberships for
+
+## Examples
+
+```sh
+# List group memberships for current user
+$ groups
+# List group memberships for one user
+$ groups nona
+# List group memberships for multiple users
+$ groups nona anon root
+```
+

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -43,6 +43,7 @@ static Vector<gid_t> get_extra_gids(const passwd& pwd)
 {
     StringView username { pwd.pw_name };
     Vector<gid_t> extra_gids;
+    setgrent();
     for (auto* group = getgrent(); group; group = getgrent()) {
         if (group->gr_gid == pwd.pw_gid)
             continue;

--- a/Userland/Utilities/groups.cpp
+++ b/Userland/Utilities/groups.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <LibCore/Account.h>
+#include <LibCore/ArgsParser.h>
+#include <grp.h>
+#include <unistd.h>
+
+static void print_account_gids(const Core::Account& account)
+{
+    auto* gr = getgrgid(account.gid());
+    if (!gr) {
+        outln();
+        return;
+    }
+
+    out("{}", gr->gr_name);
+    for (auto& gid : account.extra_gids()) {
+        gr = getgrgid(gid);
+        out(" {}", gr->gr_name);
+    }
+    outln();
+}
+
+int main(int argc, char** argv)
+{
+    if (unveil("/etc/passwd", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/etc/shadow", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/etc/group", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil(nullptr, nullptr) < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (pledge("stdio rpath", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    Vector<const char*> usernames;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("Print group memberships for each username or, if no username is specified, for the current process.");
+    args_parser.add_positional_argument(usernames, "Usernames to list group memberships for", "usernames", Core::ArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
+    if (usernames.is_empty()) {
+        auto result = Core::Account::from_uid(geteuid());
+        if (result.is_error()) {
+            warnln("{}", result.error());
+            return 1;
+        }
+        print_account_gids(result.value());
+    }
+
+    for (auto username : usernames) {
+        auto result = Core::Account::from_name(username);
+        if (result.is_error()) {
+            warnln("{} '{}'", result.error(), username);
+            continue;
+        }
+        out("{} : ", username);
+        print_account_gids(result.value());
+    }
+    return 0;
+}


### PR DESCRIPTION
add groups program listing group memberships for current user or users passed via command line ; modeled on groups from shadow-utils

I promoted get_gids function in LibCore/Account.cpp to be a static member function of Core::Account ; I don't know if it is the best move but it seemed to be the most "chirurgical" way to access the data I needed seeing as Core::Account::from_name/from_uid used /etc/shadows and thus needs superuser privilege. 