### PR TITLE
Libcore: IODevice - fixed line buffering

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -150,6 +150,19 @@ public:
         return false;
     }
 
+    bool contains_in_range(const T& value, const size_t start, const size_t end) const
+    {
+        VERIFY(start <= end);
+        VERIFY(end < size());
+        for (size_t i = start; i <= end; ++i) {
+            if (Traits<T>::equals(at(i), value))
+                return true;
+        }
+        return false;
+    }
+
+    // NOTE: Vector::is_null() exists for the benefit of String::copy().
+    bool is_null() const { return false; }
     bool is_empty() const { return size() == 0; }
     ALWAYS_INLINE size_t size() const { return m_size; }
     size_t capacity() const { return m_capacity; }

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -161,8 +161,6 @@ public:
         return false;
     }
 
-    // NOTE: Vector::is_null() exists for the benefit of String::copy().
-    bool is_null() const { return false; }
     bool is_empty() const { return size() == 0; }
     ALWAYS_INLINE size_t size() const { return m_size; }
     size_t capacity() const { return m_capacity; }

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -399,3 +399,43 @@ TEST_CASE(should_find_index)
     EXPECT_EQ(4u, v.find_first_index(0).value());
     EXPECT(!v.find_first_index(42).has_value());
 }
+
+TEST_CASE(should_contain_start)
+{
+    // Tests whether value is found if at the start of the range.
+    Vector<int> v { 1, 2, 3, 4, 5 };
+
+    EXPECT(v.contains_in_range(1, 0, 4));
+}
+
+TEST_CASE(should_contain_end)
+{
+    // Tests whether value is found if at the end of the range.
+    Vector<int> v { 1, 2, 3, 4, 5 };
+
+    EXPECT(v.contains_in_range(5, 0, 4));
+}
+
+TEST_CASE(should_contain_range)
+{
+    // Tests whether value is found within a range.
+    Vector<int> v { 1, 2, 3, 4, 5 };
+
+    EXPECT(v.contains_in_range(3, 0, 4));
+}
+
+TEST_CASE(should_not_contain_not_present)
+{
+    // Tests whether a value that is not present is not found, as expected.
+    Vector<int> v { 1, 2, 3, 4, 5 };
+
+    EXPECT(!v.contains_in_range(6, 0, 4));
+}
+
+TEST_CASE(should_not_contain_present_not_in_range)
+{
+    // Tests whether a value that is present, but not in range, is not found.
+    Vector<int> v { 1, 2, 3, 4, 5 };
+
+    EXPECT(!v.contains_in_range(2, 2, 4));
+}

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -177,7 +177,7 @@ int main(int argc, char** argv)
         ScopeGuard free_line = [line] { free(line); };
         while ((nread = getline(&line, &line_len, stdin)) != -1) {
             VERIFY(nread > 0);
-            StringView line_view(line, nread - 1);
+            StringView line_view(line, nread);
             bool is_binary = line_view.contains(0);
 
             if (is_binary && binary_mode == BinaryFileMode::Skip)


### PR DESCRIPTION
Fixes #5907.

Two issues are fixed with this request.

1. When grep reads from stdin, it discarded the last character of a line. b3f6313 

- lines with \n, this worked fine.
- lines without \n, it discarded the last character of that line, which caused grep to fail to match.

2. When grep searches recursevely, it uses IODevice to buffer the data in. f2bd874

- IODevice::can_read_line only buffers 1024 bytes at a time 
    - If a line is bigger than 1024 (with or without a \n) can_read_line would return false.
- IODevice::can_read_line At eof it only returns true if data has a \n
    - if a line at the end of a file does  not have a \n, can_read_line would return false, which I don't think was the intended behaviour.

  Changed IODevice::can_read_line to buffer data 1024 bytes at time until it either finds a \n in the buffered data, or,
  EOF is reached.

before and after:

![bad png](https://user-images.githubusercontent.com/82210061/116593379-edde2500-a918-11eb-8185-ffc96705a91f.png)
![good png](https://user-images.githubusercontent.com/82210061/116593382-ee76bb80-a918-11eb-9c60-b3e542d746c6.png)



I've never written anything in C++ before, and it's my first time contributing, so I might be missing something.
Thanks!
