### PR TITLE
LibWeb: Add selector support to the "new" CSSParser

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -68,6 +68,7 @@ private:
     Token peek_token();
     Token current_token();
     void reconsume_current_input_token();
+    bool is_combinator(String);
 
     Vector<QualifiedStyleRule> consume_a_list_of_rules(bool top_level);
     AtStyleRule consume_an_at_rule();

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -161,7 +161,7 @@ String StyleFunctionRule::to_string() const
     builder.append(m_name);
     builder.append("(");
     append_raw(builder, ", ", m_values);
-    builder.append(");");
+    builder.append(")");
 
     return builder.to_string();
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -53,6 +53,7 @@ public:
             HasAttribute,
             ExactValueMatch,
             Contains,
+            StartsWith,
         };
 
         AttributeMatchType attribute_match_type { AttributeMatchType::None };
@@ -67,6 +68,7 @@ public:
             Descendant,
             AdjacentSibling,
             GeneralSibling,
+            Column,
         };
         Relation relation { Relation::None };
 

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -151,6 +151,8 @@ static bool matches(const CSS::Selector& selector, int component_list_index, con
                 return true;
         }
         return false;
+    case CSS::Selector::ComplexSelector::Relation::Column:
+        TODO();
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -285,6 +285,9 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
         case CSS::Selector::ComplexSelector::Relation::GeneralSibling:
             relation_description = "GeneralSibling";
             break;
+        case CSS::Selector::ComplexSelector::Relation::Column:
+            relation_description = "Column";
+            break;
         }
 
         if (*relation_description)
@@ -322,6 +325,9 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
                 break;
             case CSS::Selector::SimpleSelector::AttributeMatchType::Contains:
                 attribute_match_type_description = "Contains";
+                break;
+            case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWith:
+                attribute_match_type_description = "StartsWith";
                 break;
             }
 


### PR DESCRIPTION
Adds a "naive" implementation of selector parsing.
This is stolen from the old parser, but it seems to parse fine :^)