### PR TITLE
Kernel+LibC: Add statvfs and fstatvfs syscalls and LibC functions.

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -22,6 +22,7 @@ struct timespec;
 struct sockaddr;
 struct siginfo;
 struct stat;
+struct statvfs;
 typedef u32 socklen_t;
 }
 
@@ -177,7 +178,9 @@ namespace Kernel {
     S(anon_create)                \
     S(msyscall)                   \
     S(readv)                      \
-    S(emuctl)
+    S(emuctl)                     \
+    S(statvfs)                    \
+    S(fstatvfs)
 
 namespace Syscall {
 
@@ -456,6 +459,11 @@ struct SC_inode_watcher_add_watch_params {
     int fd;
     StringArgument user_path;
     u32 event_mask;
+};
+
+struct SC_statvfs_params {
+    StringArgument path;
+    struct statvfs* buf;
 };
 
 void initialize();

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -196,6 +196,7 @@ set(KERNEL_SOURCES
     Syscalls/sigaction.cpp
     Syscalls/socket.cpp
     Syscalls/stat.cpp
+    Syscalls/statvfs.cpp
     Syscalls/sync.cpp
     Syscalls/sysconf.cpp
     Syscalls/thread.cpp

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -114,6 +114,7 @@ bool Ext2FS::initialize()
     }
 
     set_block_size(EXT2_BLOCK_SIZE(&super_block));
+    set_fragment_size(EXT2_FRAG_SIZE(&super_block));
 
     VERIFY(block_size() <= (int)max_block_size);
 

--- a/Kernel/FileSystem/FileSystem.cpp
+++ b/Kernel/FileSystem/FileSystem.cpp
@@ -81,4 +81,12 @@ void FS::set_block_size(size_t block_size)
     m_block_size = block_size;
 }
 
+void FS::set_fragment_size(size_t fragment_size)
+{
+    VERIFY(fragment_size > 0);
+    if (fragment_size == m_fragment_size)
+        return;
+    m_fragment_size = fragment_size;
+}
+
 }

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -61,6 +61,7 @@ public:
     virtual void flush_writes() { }
 
     size_t block_size() const { return m_block_size; }
+    size_t fragment_size() const { return m_fragment_size; }
 
     virtual bool is_file_backed() const { return false; }
 
@@ -71,12 +72,14 @@ protected:
     FS();
 
     void set_block_size(size_t);
+    void set_fragment_size(size_t);
 
     mutable Lock m_lock { "FS" };
 
 private:
     unsigned m_fsid { 0 };
     size_t m_block_size { 0 };
+    size_t m_fragment_size { 0 };
     bool m_readonly { false };
 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -410,6 +410,8 @@ public:
     KResultOr<int> sys$prctl(int option, FlatPtr arg1, FlatPtr arg2);
     KResultOr<int> sys$set_coredump_metadata(Userspace<const Syscall::SC_set_coredump_metadata_params*>);
     KResultOr<int> sys$anon_create(size_t, int options);
+    KResultOr<int> sys$statvfs(Userspace<const Syscall::SC_statvfs_params*> user_params);
+    KResultOr<int> sys$fstatvfs(int fd, statvfs* buf);
 
     template<bool sockname, typename Params>
     int get_sock_or_peer_name(const Params&);
@@ -528,6 +530,8 @@ private:
 
     KResult do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags, const Elf32_Ehdr& main_program_header);
     KResultOr<ssize_t> do_write(FileDescription&, const UserOrKernelBuffer&, size_t);
+
+    KResultOr<int> do_statvfs(String path, statvfs* buf);
 
     KResultOr<RefPtr<FileDescription>> find_elf_interpreter_for_executable(const String& path, const Elf32_Ehdr& elf_header, int nread, size_t file_size);
 

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Justin Mietzner <sw1tchbl4d3@sw1tchbl4d3.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/Custody.h>
+#include <Kernel/FileSystem/FileDescription.h>
+#include <Kernel/FileSystem/VirtualFileSystem.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+KResultOr<int> Process::do_statvfs(String path, statvfs* buf)
+{
+    auto custody_or_error = VFS::the().resolve_path(path, current_directory(), nullptr, 0);
+    if (custody_or_error.is_error())
+        return custody_or_error.error();
+
+    auto& custody = custody_or_error.value();
+    auto& inode = custody->inode();
+    auto& fs = inode.fs();
+
+    statvfs kernelbuf = {};
+
+    kernelbuf.f_bsize = static_cast<u64>(fs.block_size());
+    kernelbuf.f_frsize = fs.fragment_size();
+    kernelbuf.f_blocks = fs.total_block_count();
+    kernelbuf.f_bfree = fs.free_block_count();
+
+    // FIXME: Implement "available blocks" into Filesystem
+    kernelbuf.f_bavail = fs.free_block_count();
+
+    kernelbuf.f_files = fs.total_inode_count();
+    kernelbuf.f_ffree = fs.free_inode_count();
+    kernelbuf.f_favail = fs.free_inode_count(); // FIXME: same as f_bavail
+
+    kernelbuf.f_fsid = 0; // FIXME: Implement "Filesystem ID" into Filesystem
+
+    kernelbuf.f_namemax = 255;
+
+    Custody* current_custody = custody;
+
+    while (current_custody) {
+        VFS::the().for_each_mount([&kernelbuf, &current_custody](auto& mount) {
+            if (current_custody) {
+                if (&current_custody->inode() == &mount.guest()) {
+                    int mountflags = mount.flags();
+                    int flags = 0;
+                    if (mountflags & MS_RDONLY)
+                        flags = flags | ST_RDONLY;
+                    if (mountflags & MS_NOSUID)
+                        flags = flags | ST_NOSUID;
+
+                    kernelbuf.f_flag = flags;
+                    current_custody = nullptr;
+                }
+            }
+        });
+
+        if (current_custody) {
+            current_custody = current_custody->parent();
+        }
+    }
+
+    if (!copy_to_user(buf, &kernelbuf))
+        return EFAULT;
+
+    return 0;
+}
+
+KResultOr<int> Process::sys$statvfs(Userspace<const Syscall::SC_statvfs_params*> user_params)
+{
+    REQUIRE_PROMISE(rpath);
+
+    Syscall::SC_statvfs_params params;
+    if (!copy_from_user(&params, user_params))
+        return EFAULT;
+    auto path = get_syscall_path_argument(params.path);
+    if (path.is_error())
+        return path.error();
+
+    return do_statvfs(path.value(), params.buf);
+}
+
+KResultOr<int> Process::sys$fstatvfs(int fd, statvfs* buf)
+{
+    REQUIRE_PROMISE(stdio);
+
+    auto description = file_description(fd);
+    if (!description)
+        return EBADF;
+
+    return do_statvfs(description->absolute_path(), buf);
+}
+
+}

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -718,3 +718,25 @@ enum {
     DT_WHT = 14
 #define DT_WHT DT_WHT
 };
+
+typedef uint64_t fsblkcnt_t;
+typedef uint64_t fsfilcnt_t;
+
+#define ST_RDONLY 0x1
+#define ST_NOSUID 0x2
+
+struct statvfs {
+    unsigned long f_bsize;
+    unsigned long f_frsize;
+    fsblkcnt_t f_blocks;
+    fsblkcnt_t f_bfree;
+    fsblkcnt_t f_bavail;
+
+    fsfilcnt_t f_files;
+    fsfilcnt_t f_ffree;
+    fsfilcnt_t f_favail;
+
+    unsigned long f_fsid;
+    unsigned long f_flag;
+    unsigned long f_namemax;
+};

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -46,6 +46,7 @@ set(LIBC_SOURCES
     sys/socket.cpp
     sys/uio.cpp
     sys/wait.cpp
+    sys/statvfs.cpp
     termcap.cpp
     termios.cpp
     time.cpp

--- a/Userland/Libraries/LibC/sys/statvfs.cpp
+++ b/Userland/Libraries/LibC/sys/statvfs.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Justin Mietzner <sw1tchbl4d3@sw1tchbl4d3.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <sys/statvfs.h>
+#include <syscall.h>
+
+extern "C" {
+
+int statvfs(const char* path, struct statvfs* buf)
+{
+    Syscall::SC_statvfs_params params { { path, strlen(path) }, buf };
+    int rc = syscall(SC_statvfs, &params);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int fstatvfs(int fd, struct statvfs* buf)
+{
+    int rc = syscall(SC_fstatvfs, fd, buf);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+}

--- a/Userland/Libraries/LibC/sys/statvfs.h
+++ b/Userland/Libraries/LibC/sys/statvfs.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Justin Mietzner <sw1tchbl4d3@sw1tchbl4d3.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+__BEGIN_DECLS
+
+#define ST_RDONLY 0x1
+#define ST_NOSUID 0x2
+
+struct statvfs {
+    unsigned long f_bsize;
+    unsigned long f_frsize;
+    fsblkcnt_t f_blocks;
+    fsblkcnt_t f_bfree;
+    fsblkcnt_t f_bavail;
+
+    fsfilcnt_t f_files;
+    fsfilcnt_t f_ffree;
+    fsfilcnt_t f_favail;
+
+    unsigned long f_fsid;
+    unsigned long f_flag;
+    unsigned long f_namemax;
+};
+
+int statvfs(const char* path, struct statvfs* buf);
+int fstatvfs(int fd, struct statvfs* buf);
+
+__END_DECLS


### PR DESCRIPTION
This PR will add the statvfs and fstatvfs functions mentioned in #6410 and #6068.
In this PR I am extremely open to feedback, as this is my first time editing such low-level code.

This PR has 3 commits:
1) Exposes fragment_size for the EXT2FileSystem,
2) Adds the syscalls and 
3) Adds the LibC functions.

Things I'm not quite happy with:
1) The FIXME's in `Kernel/Syscalls/statvfs.cpp`
2) The "longest_match" thing in the same file.

As testing on my linux machine suggests, if you do statvfs("/path/to/test/file"), and `/` is a mount point, but also `/path/to` is another mount point, the second one is the one which's info gets returned. 
So the `longest_match` is currently just an ugly hack abusing that the longest mountpoint path with is contained in the given path is the right one.