### PR TITLE
CMake: Fix building libraries on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,10 @@ foreach(lang ASM C CXX OBJC OBJCXX)
     unset(CMAKE_${lang}_OSX_DEPLOYMENT_TARGET_FLAG)
     unset(CMAKE_${lang}_SYSROOT_FLAG)
     if (CMAKE_SYSTEM_NAME MATCHES Darwin)
-        ## MacOS Workaround. Don't generate install_name flag when cross compiling
+        ## macOS workaround. Use GNU ld flags for SONAMEs.
         set(CMAKE_${lang}_CREATE_SHARED_LIBRARY
-            "<CMAKE_${lang}_COMPILER> <LANGUAGE_COMPILE_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_${lang}_FLAGS> <LINK_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
+            "<CMAKE_${lang}_COMPILER> <LANGUAGE_COMPILE_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_${lang}_FLAGS> <LINK_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
+        set(CMAKE_SHARED_LIBRARY_SONAME_${lang}_FLAG "-Wl,-soname,")
     endif()
 endforeach()
 


### PR DESCRIPTION
When building libraries on macOS they'd be missing the `SONAME` attribute which causes the linker to embed relative paths into
other libraries and executables:

```
Dynamic section at offset 0x52794 contains 28 entries:
 Type     Name/Value
(NEEDED) Shared library: [libgcc_s.so]
(NEEDED) Shared library: [Userland/Libraries/LibCrypt/libcrypt.so]
(NEEDED) Shared library: [Userland/Libraries/LibCrypto/libcrypto.so]
(NEEDED) Shared library: [Userland/Libraries/LibC/libc.so]
(NEEDED) Shared library: [libsystem.so]
(NEEDED) Shared library: [libm.so]
(NEEDED) Shared library: [libc.so]
```

The dynamic linker then fails to load those libraries which makes the system unbootable.