### PR TITLE
LibC: Add missing initialization for the FILE mutex

### DIFF
--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -29,6 +29,7 @@ public:
         : m_fd(fd)
         , m_mode(mode)
     {
+        __pthread_mutex_init(&m_mutex, nullptr);
     }
     ~FILE();
 


### PR DESCRIPTION
Oops. I'm surprised it worked as well as it did.