### PR TITLE
CMake: Fix building with AppleClang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_compile_options(-Wno-literal-suffix)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-fconcepts)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
     add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals)
 endif()
 


### PR DESCRIPTION
On macOS CMAKE_CXX_COMPILER_ID is equal to "AppleClang"

This change aims to detect "Clang" and "AppleClang" so CMake can add the necessary flags.

We still need this fix #6745 to successfully boot though.