### PR TITLE
Kernel: Closing a file descriptor should not always close the file

### DIFF
--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -43,4 +43,15 @@ KResultOr<Region*> File::mmap(Process&, FileDescription&, const Range&, u64, int
     return ENODEV;
 }
 
+KResult File::attach(FileDescription&)
+{
+    m_attach_count++;
+    return KSuccess;
+}
+
+void File::detach(FileDescription&)
+{
+    m_attach_count--;
+}
+
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -82,8 +82,8 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const = 0;
     virtual bool can_write(const FileDescription&, size_t) const = 0;
 
-    virtual KResult attach(FileDescription&) { return KSuccess; }
-    virtual void detach(FileDescription&) { }
+    virtual KResult attach(FileDescription&);
+    virtual void detach(FileDescription&);
     virtual void did_seek(FileDescription&, off_t) { }
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) = 0;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) = 0;
@@ -112,6 +112,8 @@ public:
 
     virtual FileBlockCondition& block_condition() { return m_block_condition; }
 
+    size_t attach_count() const { return m_attach_count; }
+
 protected:
     File();
 
@@ -138,6 +140,7 @@ private:
     }
 
     FileBlockCondition m_block_condition;
+    size_t m_attach_count { 0 };
 };
 
 }

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -288,7 +288,7 @@ MasterPTY* FileDescription::master_pty()
 
 KResult FileDescription::close()
 {
-    if (m_file->ref_count() > 1)
+    if (m_file->attach_count() > 0)
         return KSuccess;
     return m_file->close();
 }


### PR DESCRIPTION
When there is more than one file descriptor for a file closing one of them should not close the underlying file.

Previously this relied on the file's `ref_count()` but at least for sockets this didn't work reliably.

Here's an example program that shows the problem:

```C
#include <stdio.h>
#include <unistd.h>
#include <sys/socket.h>
#include <arpa/inet.h>
#include <netinet/in.h>
#include <netinet/tcp.h>
 
int main() {
    int fd = socket(AF_INET, SOCK_STREAM, PF_INET);
 
    struct sockaddr_in sin;
    sin.sin_family = AF_INET;
    sin.sin_port = htons(80);
    inet_pton(AF_INET, "142.250.185.238", (in_addr_t*)&sin.sin_addr.s_addr);
 
    int rc = connect(fd, (struct sockaddr*)&sin, sizeof(sin));
    if (rc < 0) {
        perror("connect");
        close(fd);
        return 1;
    }
 
    rc = write(fd, "GET /", 4);
    if (rc < 0) {
        perror("write");
        close(fd);
        return 1;
    }
 
    int fd2 = dup(fd);
    close(fd);
 
    rc = write(fd2, " HTTP/1.0\n\n", 11);
    if (rc < 0) {
        perror("write");
        close(fd);
        return 1;
    }
 
    char buf[10];
    buf[9] = '\0';
    if (read(fd2, buf, sizeof(buf) - 1) < 0) {
        perror("read2");
        close(fd);
        return 1;
    }
 
    write(1, buf, 10);
 
    close(fd2);
}
```

This should work, however, by the time we hit the second `write()` call the socket was already incorrectly closed.