### PR TITLE
Kernel: Accepted socket file descriptors should not inherit flags

### DIFF
--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -125,10 +125,7 @@ KResultOr<int> Process::sys$accept(int accepting_socket_fd, Userspace<sockaddr*>
 
     accepted_socket_description_result.value()->set_readable(true);
     accepted_socket_description_result.value()->set_writable(true);
-    // NOTE: The accepted socket inherits fd flags from the accepting socket.
-    //       I'm not sure if this matches other systems but it makes sense to me.
-    accepted_socket_description_result.value()->set_blocking(accepting_socket_description->is_blocking());
-    m_fds[accepted_socket_fd].set(accepted_socket_description_result.release_value(), m_fds[accepting_socket_fd].flags());
+    m_fds[accepted_socket_fd].set(accepted_socket_description_result.release_value(), 0);
 
     // NOTE: Moving this state to Completed is what causes connect() to unblock on the client side.
     accepted_socket->set_setup_state(Socket::SetupState::Completed);


### PR DESCRIPTION
For example Linux accepts an additional argument for flags in `accept4()` that let the user specify what flags they want. However, by default `accept()` should not inherit those flags from the listener socket.