### PR TITLE
Meta: pre-commit should run lint-ports.py only when Ports change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,12 @@ repos:
       - id: meta-lint-ci
         name: Running Meta/lint-ci.sh to ensure changes will pass linting on CI
         entry: bash Meta/lint-ci.sh
+        args: [ --no-ports ]
+        language: system
+
+      - id: meta-lint-ports
+        name: Running Meta/lint-ports.py to ensure changes will pass linting on CI
+        entry: Meta/lint-ports.py
+        pass_filenames: false
+        files: ^Ports/
         language: system

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -5,6 +5,12 @@ set -e
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
+ports=true
+if [ "$1" == "--no-ports" ]; then
+  ports=false
+  shift
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
@@ -22,7 +28,6 @@ for cmd in \
         Meta/lint-ipc-ids.sh \
         Meta/lint-keymaps.py \
         Meta/lint-shell-scripts.sh \
-        Meta/lint-ports.py \
         Meta/lint-prettier.sh \
         Meta/lint-python.sh; do
     echo "Running ${cmd}... "
@@ -40,6 +45,21 @@ if Meta/lint-clang-format.sh --overwrite-inplace "$@" && git diff --exit-code; t
 else
     echo -e "[${RED}FAIL${NC}]: Meta/lint-clang-format.sh"
     ((FAILURES+=1))
+fi
+
+# lint-ports.py is handled separately as it scans all Ports/ all the time.
+# This is fine when running lint-ci.sh from the PR validation workflow.
+# However when running from the pre-commit workflow it takes an excessive
+# amount of time. This condition allows the pre-commit program to detect
+# when Ports/ files have changed and only invoke lint-ports.py when needed.
+#
+if [ "$ports" = true ]; then
+    if Meta/lint-ports.py; then
+        echo -e "[${GREEN}OK${NC}]: Meta/lint-ports.py"
+    else
+        echo -e "[${RED}FAIL${NC}]: Meta/lint-ports.py"
+        ((FAILURES+=1))
+    fi
 fi
 
 echo "(Not running lint-missing-resources.sh due to high false-positive rate.)"


### PR DESCRIPTION
Most of the existing lint-ing shell scripts have the ability
to only run on the files which have actually changed.
The new port lint-ing script doesn't have this functionality
unfortunately. This forces us to lint ALL the ports on every
single change to any other file in the system if you have
the pre-commit hook setup for your git clone locally.

Instead we can use pre-commit's feature to only run a hook
if certain files have changed to reduce the situations in
which we would run the Meta/lint-ports.py script.

This shaves off a few seconds for me locally when committing.