### PR TITLE
Kernel: Harden more Vector usage against OOM

### DIFF
--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -275,6 +275,10 @@ KResultOr<NonnullRefPtr<Inode>> DevFSRootDirectoryInode::create_child(const Stri
         if (name != "pts")
             return EROFS;
         auto new_directory_inode = adopt_ref(*new DevFSPtsDirectoryInode(m_parent_fs));
+        if (!m_subfolders.try_ensure_capacity(m_subfolders.size() + 1))
+            return ENOMEM;
+        if (!m_parent_fs.m_nodes.try_ensure_capacity(m_parent_fs.m_nodes.size() + 1))
+            return ENOMEM;
         m_subfolders.append(new_directory_inode);
         m_parent_fs.m_nodes.append(new_directory_inode);
         return KResult(KSuccess);
@@ -285,6 +289,10 @@ KResultOr<NonnullRefPtr<Inode>> DevFSRootDirectoryInode::create_child(const Stri
                 return EEXIST;
         }
         auto new_link_inode = adopt_ref(*new DevFSLinkInode(m_parent_fs, name));
+        if (!m_links.try_ensure_capacity(m_links.size() + 1))
+            return ENOMEM;
+        if (!m_parent_fs.m_nodes.try_ensure_capacity(m_parent_fs.m_nodes.size() + 1))
+            return ENOMEM;
         m_links.append(new_link_inode);
         m_parent_fs.m_nodes.append(new_link_inode);
         return new_link_inode;

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -466,7 +466,8 @@ KResult LocalSocket::sendfd(const FileDescription& socket_description, FileDescr
     // FIXME: Figure out how we should limit this properly.
     if (queue.size() > 128)
         return EBUSY;
-    queue.append(move(passing_description));
+    if (!queue.try_append(move(passing_description)))
+        return ENOMEM;
     return KSuccess;
 }
 

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -72,7 +72,8 @@ KResult Socket::queue_connection_from(NonnullRefPtr<Socket> peer)
     Locker locker(m_lock);
     if (m_pending.size() >= m_backlog)
         return ECONNREFUSED;
-    m_pending.append(peer);
+    if (!m_pending.try_append(peer))
+        return ENOMEM;
     evaluate_block_conditions();
     return KSuccess;
 }

--- a/Kernel/Syscalls/setuid.cpp
+++ b/Kernel/Syscalls/setuid.cpp
@@ -138,7 +138,8 @@ KResultOr<int> Process::sys$setgroups(ssize_t count, Userspace<const gid_t*> use
     }
 
     Vector<gid_t> new_extra_gids;
-    new_extra_gids.resize(count);
+    if (!new_extra_gids.try_resize(count))
+        return ENOMEM;
     if (!copy_n_from_user(new_extra_gids.data(), user_gids, count))
         return EFAULT;
 
@@ -149,7 +150,8 @@ KResultOr<int> Process::sys$setgroups(ssize_t count, Userspace<const gid_t*> use
     }
 
     ProtectedDataMutationScope scope { *this };
-    m_extra_gids.resize(unique_extra_gids.size());
+    if (!m_extra_gids.try_resize(unique_extra_gids.size()))
+        return ENOMEM;
     size_t i = 0;
     for (auto& extra_gid : unique_extra_gids) {
         if (extra_gid == gid())


### PR DESCRIPTION
Another series of commits working towards: #6369
There's some more details in the individual commit messages.

-   __Kernel: Harden LocalSocket Vector usage against OOM.__

 -   __Kernel: Harden Socket Vector usage against OOM__

  -  __Kernel: Harden sys$setgroups Vector usage against OOM__

  -  __Kernel: Harden DevFS Vector usage against OOM.__

     The dance here is not complicated, but it is something that should
     be taken note of. Since we append to both lists, we don't want to
     orphan the new Inode in the m_links/m_subfolders Vector in the event
     that the append to m_parent_fs.m_nodes fails.

  -  __Kernel: Harden Process Vector usage against OOM.__

 -   __Kernel: Harden Ext2FileSystem Vector usage against OOM.__