### PR TITLE
Kernel: Various network fixes

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -528,6 +528,11 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
             return;
         }
     case TCPSocket::State::Established:
+        if (tcp_packet.has_rst()) {
+            socket->set_state(TCPSocket::State::Closed);
+            return;
+        }
+
         if (tcp_packet.has_fin()) {
             if (payload_size != 0)
                 socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), KBuffer::copy(&ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size()), packet_timestamp);

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -29,12 +29,20 @@ static void handle_icmp(const EthernetFrameHeader&, const IPv4Packet&, const Tim
 static void handle_udp(const IPv4Packet&, const Time& packet_timestamp);
 static void handle_tcp(const IPv4Packet&, const Time& packet_timestamp);
 
+static Thread* network_task = nullptr;
+
 [[noreturn]] static void NetworkTask_main(void*);
 
 void NetworkTask::spawn()
 {
     RefPtr<Thread> thread;
     Process::create_kernel_process(thread, "NetworkTask", NetworkTask_main, nullptr);
+    network_task = thread;
+}
+
+bool NetworkTask::is_current()
+{
+    return Thread::current() == network_task;
 }
 
 void NetworkTask_main(void*)

--- a/Kernel/Net/NetworkTask.h
+++ b/Kernel/Net/NetworkTask.h
@@ -10,5 +10,6 @@ namespace Kernel {
 class NetworkTask {
 public:
     static void spawn();
+    static bool is_current();
 };
 }

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -197,7 +197,8 @@ KResult TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload,
     }
 
     auto routing_decision = route_to(peer_address(), local_address(), bound_interface());
-    VERIFY(!routing_decision.is_zero());
+    if (routing_decision.is_zero())
+        return EHOSTUNREACH;
 
     auto packet_buffer = UserOrKernelBuffer::for_kernel_buffer(buffer.data());
     auto result = routing_decision.adapter->send_ipv4(
@@ -214,7 +215,8 @@ KResult TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload,
 void TCPSocket::send_outgoing_packets()
 {
     auto routing_decision = route_to(peer_address(), local_address(), bound_interface());
-    VERIFY(!routing_decision.is_zero());
+    if (routing_decision.is_zero())
+        return;
 
     auto now = kgettimeofday();
 

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -40,6 +40,9 @@ void TCPSocket::set_state(State new_state)
     if (new_state == State::Closed) {
         Locker locker(closing_sockets().lock());
         closing_sockets().resource().remove(tuple());
+
+        if (m_originator)
+            release_to_originator();
     }
 
     if (previous_role != m_role || was_disconnected != protocol_is_disconnected())
@@ -114,6 +117,7 @@ void TCPSocket::release_to_originator()
 {
     VERIFY(!!m_originator);
     m_originator.strong_ref()->release_for_accept(this);
+    m_originator.clear();
 }
 
 void TCPSocket::release_for_accept(RefPtr<TCPSocket> socket)

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -471,8 +471,10 @@ KResult TCPSocket::close()
         set_state(State::LastAck);
     }
 
-    Locker locker(closing_sockets().lock());
-    closing_sockets().resource().set(tuple(), *this);
+    if (state() != State::Closed && state() != State::Listen) {
+        Locker locker(closing_sockets().lock());
+        closing_sockets().resource().set(tuple(), *this);
+    }
     return result;
 }
 


### PR DESCRIPTION
This fixes a number of issues with the network stack:

* Avoid deadlock when trying to send packets from the NetworkTask - see #6758 for details

* Don't put closed/listener sockets into the `closing_sockets` list. Because once they're in the list they become immortal (as seen with `SystemMonitor`: Try starting `nc -l 0 7000` and then hit Ctrl-C. Observe how the listener socket doesn't get destroyed.

* Remove socket from the listener's accept list when it is closed.

Without this patch we end up with sockets in the listener's accept queue with state 'closed' when doing stealth SYN scans:

Client -> Server: SYN for port 22
Server -> Client: SYN/ACK
Client -> Server: RST (i.e. don't complete the TCP handshake, socket stays in the list and shows up as `Closed` in `SystemMonitor`)

* Record MAC addresses for incoming IPv4 packets.

This way we don't have to do ARP just to send packets back to an address which just sent us a packet.

* Tear down connections when we receive an RST packet.

Start `nc -l 0 7000` and connect to it from another host. Hit Ctrl-C on that other host and observe how `nc` in SerenityOS doesn't realize that the connection was closed.