### PR TITLE
LibGui: Bump up common locations width 90->95

### DIFF
--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -20,7 +20,7 @@
 
         @GUI::Frame {
             name: "common_locations_frame"
-            fixed_width: 90
+            fixed_width: 95
             fill_with_background_color: true
 
             layout: @GUI::VerticalBoxLayout {


### PR DESCRIPTION
Bold Documents directory shows up properly now.