### PR TITLE
Demos: Added Alt+F4 funtionality to demos that lacked it

### DIFF
--- a/Userland/Demos/Fire/Fire.cpp
+++ b/Userland/Demos/Fire/Fire.cpp
@@ -23,9 +23,12 @@
 */
 
 #include <LibCore/ElapsedTimer.h>
+#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Label.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Menubar.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -217,6 +220,11 @@ int main(int argc, char** argv)
     window->set_title("Fire");
     window->set_resizable(false);
     window->resize(640, 400);
+
+    auto menubar = GUI::Menubar::construct();
+    auto& app_menu = menubar->add_menu("File");
+    app_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
+    window->set_menubar(move(menubar));
 
     auto& fire = window->set_main_widget<Fire>();
 

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Menubar.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -200,6 +203,11 @@ int main(int argc, char** argv)
     window->set_title("LibGfx Demo");
     window->set_resizable(false);
     window->resize(WIDTH, HEIGHT);
+
+    auto menubar = GUI::Menubar::construct();
+    auto& app_menu = menubar->add_menu("File");
+    app_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
+    window->set_menubar(move(menubar));
 
     auto app_icon = GUI::Icon::default_icon("app-libgfx-demo");
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Menubar.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -122,6 +125,11 @@ int main(int argc, char** argv)
     window->set_title("LibGfx Scale Demo");
     window->set_resizable(false);
     window->resize(WIDTH * 2, HEIGHT * 3);
+
+    auto menubar = GUI::Menubar::construct();
+    auto& app_menu = menubar->add_menu("File");
+    app_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
+    window->set_menubar(move(menubar));
 
     auto app_icon = GUI::Icon::default_icon("app-libgfx-demo");
     window->set_icon(app_icon.bitmap_for_size(16));


### PR DESCRIPTION
Fixes #5940

The Fire, LibGfxDemo and LibGfxScaleDemo demos did not have Alt+F4 functionality as they lacked menubars - I just added basic menubars with Quit entries to allow this shortcut with the demos that didn't have it.