### PR TITLE
Userland: Remove an unused function declaration from tac.

### DIFF
--- a/Userland/Utilities/tac.cpp
+++ b/Userland/Utilities/tac.cpp
@@ -9,8 +9,6 @@
 #include <LibCore/File.h>
 #include <unistd.h>
 
-void print_lines(const Vector<String>& vec);
-
 int main(int argc, char** argv)
 {
     if (pledge("stdio rpath", nullptr) < 0) {


### PR DESCRIPTION
The function declaration seems to have come from an earlier commit. The function is no longer here though, so there's no reason to keep this around.