### PR TITLE
Userland: Add the rev(1) utility to reverse lines and it's manpage.

### DIFF
--- a/Base/usr/share/man/man1/rev.md
+++ b/Base/usr/share/man/man1/rev.md
@@ -1,0 +1,41 @@
+## Name
+
+rev - reverse lines
+
+## Synopsis
+
+```*sh
+$ rev [files...]
+```
+
+## Description
+
+`rev` reads the specified files line by line, and prints them to standard
+output with each line being reversed characterwise. If no files are specifed,
+then `rev` will read from standard input.
+
+## Examples
+
+To print two files 'foo' and 'bar' in reverse:
+```sh
+$ cat foo bar
+foo 1
+foo 2
+bar 1
+bar 2
+$ rev foo bar
+1 oof
+2 oof
+1 rab
+2 rab
+```
+
+To list files with their names in reverse:
+```sh
+$ ls
+foo
+bar
+$ ls | rev
+oof
+rab
+```

--- a/Userland/Utilities/rev.cpp
+++ b/Userland/Utilities/rev.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Thomas Voss <thomasvoss@live.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    if (pledge("stdio rpath", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    Vector<String> paths;
+    Core::ArgsParser args_parser;
+
+    args_parser.set_general_help("Concatente files to stdout with each line in reverse.");
+    args_parser.add_positional_argument(paths, "File path", "path", Core::ArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
+    Vector<RefPtr<Core::File>> files;
+    if (paths.is_empty()) {
+        files.append(Core::File::standard_input());
+    } else {
+        for (auto const& path : paths) {
+            auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
+            if (file_or_error.is_error()) {
+                warnln("Failed to open {}: {}", path, file_or_error.error());
+                continue;
+            }
+
+            files.append(file_or_error.value());
+        }
+    }
+
+    if (pledge("stdio", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    for (auto& file : files) {
+        while (file->can_read_line()) {
+            auto line = file->read_line();
+            outln("{}", line.reverse());
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
My first time writing C++ :)
I made sure to test it, and it worked perfectly on multiple files, piped input, and redirected files.

Also I accidentally made a typo in one of the commit messages, saying I added a manpage for `man` instead of `rev`, whoops.