### PR TITLE
Lagom/CMake: Add -fconstexpr-steps for AppleClang compiler

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a -fPIC -g -Wno-deprecated-copy")
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
     # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216")
 


### PR DESCRIPTION
When support for bidirectional text rendering was added on #6613 
it became necessary to increase the limit of constexpr steps for clang.

On macOS CMAKE_CXX_COMPILER_ID is equal to "AppleClang"

This change aims to detect "Clang" and "AppleClang" so CMake can add the `-fconstexpr-steps` flag.