### PR TITLE
Base + Userland: Enhance bt command to dump all threads in a process, add a man page

### DIFF
--- a/Base/usr/share/man/man1/bt.md
+++ b/Base/usr/share/man/man1/bt.md
@@ -1,0 +1,44 @@
+## Name
+
+bt - view the backtrace of the specified process
+
+## Synopsis
+
+```**sh
+$ bt <pid>
+```
+
+## Description
+
+This program is used to inspect the current executable state of a process.
+It will read the stack of each thread in the process, and symbolize the
+addresses for each frame in the stack producing a backtrace.
+
+**NOTE**:
+
+* Kernel addresses will not be available unless you are super user.
+
+* If Kernel addresses are available, they will not be symbolized unless the
+  `SymbolServer` service has access to the `/boot/Kernel` file.
+
+## Examples
+
+View all stacks of pid number 10:
+
+```sh
+$ bt 10
+```
+
+Use [`watch`(1)](watch.md) to emit a backtrace of pid 124, every second:
+
+```sh
+$ watch -n 1 -- bt 124
+```
+
+## See also
+
+* [`Inspector`(1)](Inspector.md)
+
+* [`Profiler`(1)](Profiler.md)
+
+* [`watch`(1)](watch.md)

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv)
 
             // See if we can find the sources in /usr/src
             // FIXME: I'm sure this can be improved!
-            auto full_path = LexicalPath::canonicalized_path(String::formatted("/usr/src/serenity/dummy/{}", symbol.filename));
+            auto full_path = LexicalPath::canonicalized_path(String::formatted("/usr/src/serenity/dummy/dummy/{}", symbol.filename));
             if (access(full_path.characters(), F_OK) == 0) {
                 linked = true;
                 out("\033]8;;file://{}{}?line_number={}\033\\", hostname, full_path, symbol.line_number);


### PR DESCRIPTION
-    __bt: Fix generation of click-able links for source files.__

     When the default build location was moved from /Build to the new
     architecture specific directory, /Build/i686, this code broke.
     All file names are now path relative one additional level up.

     So continue the hack, and introduce another dummy directory to
     make the relative paths resolve correctly.

-   __bt: Enumerate all threads when symbolizing stacks in the bt utility__

    Enumerate tid's from /proc/{pid}/stacks/ and use it to print the
    backtrace for all active threads in the specified process.

-    __Base: Add a man page for the 'bt' command.__