### PR TITLE
Meta: Added Discord badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Graphical Unix-like operating system for x86 computers.
 
 [![Build status](https://github.com/SerenityOS/serenity/workflows/Build,%20lint,%20and%20test/badge.svg)](https://github.com/SerenityOS/serenity/actions?query=workflow%3A"Build%2C%20lint%2C%20and%20test")
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:serenity)
+[![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/29gCcKsXkF)  
 
 ## About
 


### PR DESCRIPTION
I made a small update to the readme by adding a new shield. I will show the number of members that are online. If you click on it you will get an invite too.

To activate it, you only need to enable the [widget](https://vimeo.com/364220040) option in the discord server settings. 

The location is maybe not the best but I could move it to the "Get in touch" section if required.