### PR TITLE
LibCore: Fix building the library on macOS

### DIFF
--- a/Userland/Libraries/LibC/shadow.h
+++ b/Userland/Libraries/LibC/shadow.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
-#include <bits/FILE.h>
+#ifndef AK_OS_MACOS
+#    include <bits/FILE.h>
+#endif
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
@@ -24,6 +26,7 @@ struct spwd {
     unsigned long int sp_flag;
 };
 
+#ifndef AK_OS_MACOS
 struct spwd* getspent();
 void setspent();
 void endspent();
@@ -35,5 +38,6 @@ int getspnam_r(const char* name, struct spwd* spbuf, char* buf, size_t buflen, s
 
 int fgetspent_r(FILE* fp, struct spwd* spbuf, char* buf, size_t buflen, struct spwd** spbufp);
 int sgetspent_r(const char* s, struct spwd* spbuf, char* buf, size_t buflen, struct spwd** spbufp);
+#endif
 
 __END_DECLS

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -11,7 +11,11 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <pwd.h>
-#include <shadow.h>
+#ifndef AK_OS_MACOS
+#    include <shadow.h>
+#else
+#    include <LibC/shadow.h>
+#endif
 #include <sys/types.h>
 
 namespace Core {
@@ -52,7 +56,9 @@ private:
     Account(const passwd& pwd, const spwd& spwd, Vector<gid_t> extra_gids);
 
     String generate_passwd_file() const;
+#ifndef AK_OS_MACOS
     String generate_shadow_file() const;
+#endif
 
     String m_username;
 


### PR DESCRIPTION
Turns out macOS doesn't have `<shadow.h>` at all.