### PR TITLE
Kernel: Prevent execution of /usr/lib/Loader.so dynamic loader

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -781,9 +781,12 @@ KResultOr<RefPtr<FileDescription>> Process::find_elf_interpreter_for_executable(
     if (main_program_header.e_type == ET_DYN) {
         // If it's ET_DYN with no PT_INTERP, then it's a dynamic executable responsible
         // for its own relocation (i.e. it's /usr/lib/Loader.so)
-        if (path != "/usr/lib/Loader.so")
-            dbgln("exec({}): WARNING - Dynamic ELF executable without a PT_INTERP header, and isn't /usr/lib/Loader.so", path);
-        return nullptr;
+        if (path != "/usr/lib/Loader.so") {
+            dmesgln("exec({}): WARNING - Dynamic ELF executable without a PT_INTERP header, and isn't /usr/lib/Loader.so", path);
+        } else {
+            dbgln("exec(={}): WARNING - Hold on, you cannot execute the loader!", path);
+        }
+        return ENOEXEC;
     }
 
     // No interpreter, but, path refers to a valid elf image


### PR DESCRIPTION
This little PR intends to fix system hang when try to execute `/usr/lib/Loader.so` and other `.so` files from ports.
Fixes #5583.
I made it here again after I fixes my mess in my forks of `SerenityOS`.
I'm sorry for the annoyance I made in the old PRs.