### PR TITLE
Kernel: Handle both shift keys being pressed and then released

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -58,6 +58,7 @@ protected:
     bool m_caps_lock_on { false };
     bool m_num_lock_on { false };
     bool m_has_e0_prefix { false };
+    bool m_both_shift_keys_pressed { false };
 
     void key_state_changed(u8 raw, bool pressed);
 };

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -54,7 +54,12 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         break;
     case 0x2a:
     case 0x36:
-        update_modifier(Mod_Shift, pressed);
+        if (m_both_shift_keys_pressed)
+            m_both_shift_keys_pressed = false;
+        else if ((m_modifiers & Mod_Shift) != 0 && pressed)
+            m_both_shift_keys_pressed = true;
+        else
+            update_modifier(Mod_Shift, pressed);
         break;
     }
     switch (ch) {


### PR DESCRIPTION
Our current implementation does not work in the special case in which both shift keys are pressed, and then only one of the keys is released, as this would result in writing lower case letters, instead of the expected upper case letters.

This commit fixes that by keeping track of the amount of shift keys that are pressed (instead of if any are at all), and only switching to the unshifted keymap once all of them are released.