### PR TITLE
Userland: Make rev(1) read from stdin if no file supplied and add manpage clarification.

### DIFF
--- a/Base/usr/share/man/man1/rev.md
+++ b/Base/usr/share/man/man1/rev.md
@@ -11,8 +11,9 @@ $ rev [files...]
 ## Description
 
 `rev` reads the specified files line by line, and prints them to standard
-output with each line being reversed characterwise. If no files are specifed,
-then `rev` will read from standard input.
+output with each line being reversed characterwise with the exception of
+trailing newline characters which will always print at the end of the line. If
+no files are specifed, then `rev` will read from standard input.
 
 ## Examples
 

--- a/Userland/Utilities/rev.cpp
+++ b/Userland/Utilities/rev.cpp
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
+#include <stdio.h>
 #include <unistd.h>
 
 int main(int argc, char** argv)
@@ -25,18 +27,14 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     Vector<RefPtr<Core::File>> files;
-    if (paths.is_empty()) {
-        files.append(Core::File::standard_input());
-    } else {
-        for (auto const& path : paths) {
-            auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
-            if (file_or_error.is_error()) {
-                warnln("Failed to open {}: {}", path, file_or_error.error());
-                continue;
-            }
-
-            files.append(file_or_error.value());
+    for (auto const& path : paths) {
+        auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
+        if (file_or_error.is_error()) {
+            warnln("Failed to open {}: {}", path, file_or_error.error());
+            continue;
         }
+
+        files.append(file_or_error.value());
     }
 
     if (pledge("stdio", nullptr) < 0) {
@@ -44,10 +42,28 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    for (auto& file : files) {
-        while (file->can_read_line()) {
-            auto line = file->read_line();
-            outln("{}", line.reverse());
+    if (files.is_empty()) {
+        char* line = nullptr;
+        size_t length = 0;
+        ssize_t nread = 0;
+
+        ScopeGuard free_line = [line] { free(line); };
+        while ((nread = getline(&line, &length, stdin)) != -1) {
+            VERIFY(nread > 0);
+            if (line[--nread] == '\n')
+                nread--;
+
+            for (; nread >= 0; nread--)
+                putchar(line[nread]);
+
+            putchar('\n');
+        }
+    } else {
+        for (auto& file : files) {
+            while (file->can_read_line()) {
+                auto line = file->read_line();
+                outln("{}", line.reverse());
+            }
         }
     }
 


### PR DESCRIPTION
This should bring the behaviour of rev inline with the BSD versions and other tools such as cat and grep. Also I clarified trailing newlines in the rev manpage.