### PR TITLE
Kernel: Expose minor device numbers for keyboard and mouse

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -35,9 +35,7 @@ public:
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }
 
-    //FIXME: It should be something like String::formatted("keyboard{}", minor())
-    // instead of a fixed string like this
-    virtual String device_name() const override { return "keyboard"; }
+    virtual String device_name() const override { return String::formatted("keyboard{}", minor()); }
 
     void update_modifier(u8 modifier, bool state)
     {

--- a/Kernel/Devices/HID/MouseDevice.h
+++ b/Kernel/Devices/HID/MouseDevice.h
@@ -34,9 +34,7 @@ public:
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }
 
-    //FIXME: It should be something like String::formatted("mouse{}", minor())
-    // instead of a fixed string like this
-    virtual String device_name() const override { return "mouse"; }
+    virtual String device_name() const override { return String::formatted("mouse{}", minor()); }
 
 protected:
     MouseDevice();

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -101,9 +101,9 @@ static void prepare_devfs()
     VERIFY(phys_group);
     chown_wrapper("/dev/fb0", 0, phys_group->gr_gid);
 
-    chown_wrapper("/dev/keyboard", 0, phys_group->gr_gid);
+    chown_wrapper("/dev/keyboard0", 0, phys_group->gr_gid);
 
-    chown_wrapper("/dev/mouse", 0, phys_group->gr_gid);
+    chown_wrapper("/dev/mouse0", 0, phys_group->gr_gid);
 
     auto tty_group = getgrnam("tty");
     VERIFY(tty_group);

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -30,8 +30,8 @@ EventLoop::EventLoop()
     : m_window_server(Core::LocalServer::construct())
     , m_wm_server(Core::LocalServer::construct())
 {
-    m_keyboard_fd = open("/dev/keyboard", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-    m_mouse_fd = open("/dev/mouse", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    m_keyboard_fd = open("/dev/keyboard0", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    m_mouse_fd = open("/dev/mouse0", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
 
     bool ok = m_window_server->take_over_from_system_server("/tmp/portal/window");
     VERIFY(ok);
@@ -64,14 +64,14 @@ EventLoop::EventLoop()
         m_keyboard_notifier = Core::Notifier::construct(m_keyboard_fd, Core::Notifier::Read);
         m_keyboard_notifier->on_ready_to_read = [this] { drain_keyboard(); };
     } else {
-        dbgln("Couldn't open /dev/keyboard");
+        dbgln("Couldn't open /dev/keyboard0");
     }
 
     if (m_mouse_fd >= 0) {
         m_mouse_notifier = Core::Notifier::construct(m_mouse_fd, Core::Notifier::Read);
         m_mouse_notifier->on_ready_to_read = [this] { drain_mouse(); };
     } else {
-        dbgln("Couldn't open /dev/mouse");
+        dbgln("Couldn't open /dev/mouse0");
     }
 }
 


### PR DESCRIPTION
A fix for two FIXMEs, and paving the way for multi-keyboard/mouse
support, I guess.