### PR TITLE
Kernel: Make sure we read all packets

### DIFF
--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -426,7 +426,7 @@ void E1000NetworkAdapter::receive()
 {
     auto* rx_descriptors = (e1000_tx_desc*)m_rx_descriptors_region->vaddr().as_ptr();
     u32 rx_current;
-    for (u32 i = 0; i < number_of_rx_descriptors; i++) {
+    for (;;) {
         rx_current = in32(REG_RXDESCTAIL) % number_of_rx_descriptors;
         rx_current = (rx_current + 1) % number_of_rx_descriptors;
         if (!(rx_descriptors[rx_current].status & 1))


### PR DESCRIPTION
The previous patch (#6669) already helped with this, however my idea of only reading a few packets didn't work and we'd still sometimes end up not receiving any more packets from the E1000 interface.

With this patch applied my NIC seems to receive packets just fine, at least for now.