### PR TITLE
HackStudio: Use common copy functions in ProjectTemplate.cpp

### DIFF
--- a/Userland/DevTools/HackStudio/ProjectTemplate.cpp
+++ b/Userland/DevTools/HackStudio/ProjectTemplate.cpp
@@ -19,12 +19,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-// FIXME: shameless copy+paste from Userland/cp. We should have system-wide file management functions.
-// Issue #5209
-bool copy_file_or_directory(String, String, bool, bool);
-bool copy_file(String, String, const struct stat&, int);
-bool copy_directory(String, String, bool);
-
 namespace HackStudio {
 
 ProjectTemplate::ProjectTemplate(const String& id, const String& name, const String& description, const GUI::Icon& icon, int priority)
@@ -76,8 +70,10 @@ Result<void, String> ProjectTemplate::create_project(const String& name, const S
     // Verify that the template content directory exists. If it does, copy it's contents.
     // Otherwise, create an empty directory at the project path.
     if (Core::File::is_directory(content_path())) {
-        if (!copy_directory(content_path(), path, false))
-            return String("Failed to copy template contents.");
+        auto result = Core::File::copy_file_or_directory(path, content_path());
+        dbgln("Copying {} -> {}", content_path(), path);
+        if (result.is_error())
+            return String::formatted("Failed to copy template contents. Error code: {}", result.error().error_code);
     } else {
         dbgln("No template content directory found for '{}', creating an empty directory for the project.", m_id);
         int rc;
@@ -122,138 +118,4 @@ Result<void, String> ProjectTemplate::create_project(const String& name, const S
     return {};
 }
 
-}
-
-// FIXME: shameless copy+paste from Userland/cp. We should have system-wide file management functions.
-// Issue #5209
-bool copy_file_or_directory(String src_path, String dst_path, bool recursion_allowed, bool link)
-{
-    int src_fd = open(src_path.characters(), O_RDONLY);
-    if (src_fd < 0) {
-        perror("open src");
-        return false;
-    }
-
-    struct stat src_stat;
-    int rc = fstat(src_fd, &src_stat);
-    if (rc < 0) {
-        perror("stat src");
-        return false;
-    }
-
-    if (S_ISDIR(src_stat.st_mode)) {
-        if (!recursion_allowed) {
-            fprintf(stderr, "cp: -R not specified; omitting directory '%s'\n", src_path.characters());
-            return false;
-        }
-        return copy_directory(src_path, dst_path, link);
-    }
-    if (link) {
-        if (::link(src_path.characters(), dst_path.characters()) < 0) {
-            perror("link");
-            return false;
-        }
-        return true;
-    }
-
-    return copy_file(src_path, dst_path, src_stat, src_fd);
-}
-
-bool copy_file(String src_path, String dst_path, const struct stat& src_stat, int src_fd)
-{
-    // Get umask
-    auto my_umask = umask(0);
-    umask(my_umask);
-
-    // NOTE: We don't copy the set-uid and set-gid bits.
-    mode_t mode = (src_stat.st_mode & ~my_umask) & ~06000;
-
-    int dst_fd = creat(dst_path.characters(), mode);
-    if (dst_fd < 0) {
-        if (errno != EISDIR) {
-            perror("open dst");
-            return false;
-        }
-        StringBuilder builder;
-        builder.append(dst_path);
-        builder.append('/');
-        builder.append(LexicalPath(src_path).basename());
-        dst_path = builder.to_string();
-        dst_fd = creat(dst_path.characters(), 0666);
-        if (dst_fd < 0) {
-            perror("open dst");
-            return false;
-        }
-    }
-
-    if (src_stat.st_size > 0) {
-        if (ftruncate(dst_fd, src_stat.st_size) < 0) {
-            perror("cp: ftruncate");
-            return false;
-        }
-    }
-
-    for (;;) {
-        char buffer[32768];
-        ssize_t nread = read(src_fd, buffer, sizeof(buffer));
-        if (nread < 0) {
-            perror("read src");
-            return false;
-        }
-        if (nread == 0)
-            break;
-        ssize_t remaining_to_write = nread;
-        char* bufptr = buffer;
-        while (remaining_to_write) {
-            ssize_t nwritten = write(dst_fd, bufptr, remaining_to_write);
-            if (nwritten < 0) {
-                perror("write dst");
-                return false;
-            }
-            assert(nwritten > 0);
-            remaining_to_write -= nwritten;
-            bufptr += nwritten;
-        }
-    }
-
-    close(src_fd);
-    close(dst_fd);
-    return true;
-}
-
-bool copy_directory(String src_path, String dst_path, bool link)
-{
-    int rc = mkdir(dst_path.characters(), 0755);
-    if (rc < 0) {
-        perror("cp: mkdir");
-        return false;
-    }
-
-    String src_rp = Core::File::real_path_for(src_path);
-    src_rp = String::formatted("{}/", src_rp);
-    String dst_rp = Core::File::real_path_for(dst_path);
-    dst_rp = String::formatted("{}/", dst_rp);
-
-    if (!dst_rp.is_empty() && dst_rp.starts_with(src_rp)) {
-        fprintf(stderr, "cp: Cannot copy %s into itself (%s)\n",
-            src_path.characters(), dst_path.characters());
-        return false;
-    }
-
-    Core::DirIterator di(src_path, Core::DirIterator::SkipDots);
-    if (di.has_error()) {
-        fprintf(stderr, "cp: DirIterator: %s\n", di.error_string());
-        return false;
-    }
-    while (di.has_next()) {
-        String filename = di.next_path();
-        bool is_copied = copy_file_or_directory(
-            String::formatted("{}/{}", src_path, filename),
-            String::formatted("{}/{}", dst_path, filename),
-            true, link);
-        if (!is_copied) {
-            return false;
-        }
-    }
-    return true;
 }


### PR DESCRIPTION
Yet another FIXME patch. I verified it works by creating a few template projects, seems to work just as it did before.