### PR TITLE
Kernel+Userland: Fix 64-bit portability issues

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -87,7 +87,10 @@ ByteBuffer decode_base64(const StringView& input)
             output.append(out2);
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     return ByteBuffer::copy(output.data(), output.size());
+#pragma GCC diagnostic pop
 }
 
 String encode_base64(ReadonlyBytes input)

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -854,7 +854,7 @@ KResultOr<ssize_t> Ext2FSInode::read_bytes(off_t offset, ssize_t count, UserOrKe
     for (auto bi = first_block_logical_index; remaining_count && bi <= last_block_logical_index; bi = bi.value() + 1) {
         auto block_index = m_block_list[bi.value()];
         size_t offset_into_block = (bi == first_block_logical_index) ? offset_into_first_block : 0;
-        size_t num_bytes_to_copy = min((off_t)block_size - offset_into_block, remaining_count);
+        size_t num_bytes_to_copy = min((size_t)block_size - offset_into_block, (size_t)remaining_count);
         auto buffer_offset = buffer.offset(nread);
         if (block_index.value() == 0) {
             // This is a hole, act as if it's filled with zeroes.
@@ -1005,7 +1005,7 @@ KResultOr<ssize_t> Ext2FSInode::write_bytes(off_t offset, ssize_t count, const U
 
     for (auto bi = first_block_logical_index; remaining_count && bi <= last_block_logical_index; bi = bi.value() + 1) {
         size_t offset_into_block = (bi == first_block_logical_index) ? offset_into_first_block : 0;
-        size_t num_bytes_to_copy = min((off_t)block_size - offset_into_block, remaining_count);
+        size_t num_bytes_to_copy = min((size_t)block_size - offset_into_block, (size_t)remaining_count);
         dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_bytes(): Writing block {} (offset_into_block: {})", identifier(), m_block_list[bi.value()], offset_into_block);
         if (auto result = fs().write_block(m_block_list[bi.value()], data.offset(nwritten), num_bytes_to_copy, offset_into_block, allow_cache); result.is_error()) {
             dbgln("Ext2FSInode[{}]::write_bytes(): Failed to write block {} (index {})", identifier(), m_block_list[bi.value()], bi);

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -129,7 +129,7 @@ diff -Naur gcc-11.1.0-RC-20210420/gcc/config/serenity.h gcc-11.1.0-RC-20210420.s
 +#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} %{!fbuilding-libgcc:-lgcc_s -dynamic-linker /usr/lib/Loader.so}}"
 +
 +#undef CC1_SPEC
-+#define CC1_SPEC "-fno-exceptions -ftls-model=initial-exec"
++#define CC1_SPEC "-fno-exceptions -ftls-model=initial-exec %{!fno-pic:%{!fno-PIC:%{!fpic:%{!fPIC: -fPIC}}}} -fno-semantic-interposition"
 +
 +#undef CC1PLUS_SPEC
 +#define CC1PLUS_SPEC "-fno-exceptions -ftls-model=initial-exec"

--- a/Userland/DynamicLoader/math.cpp
+++ b/Userland/DynamicLoader/math.cpp
@@ -163,7 +163,7 @@ int64_t __moddi3(int64_t a, int64_t b)
     b = (b ^ s) - s;                   // negate if s == -1
     s = a >> bits_in_dword_m1;         // s = a < 0 ? -1 : 0
     a = (a ^ s) - s;                   // negate if s == -1
-    uint64_t r;
+    uint64_t r = 0;
     __udivmoddi4(a, b, &r);
     return ((int64_t)r ^ s) - s; // negate if s == -1
 }

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -360,13 +360,13 @@ void ChessWidget::set_piece_set(const StringView& set)
 
 Chess::Square ChessWidget::mouse_to_square(GUI::MouseEvent& event) const
 {
-    size_t tile_width = width() / 8;
-    size_t tile_height = height() / 8;
+    unsigned tile_width = width() / 8;
+    unsigned tile_height = height() / 8;
 
     if (side() == Chess::Color::White) {
-        return { 7 - (event.y() / tile_height), event.x() / tile_width };
+        return { (unsigned)(7 - (event.y() / tile_height)), (unsigned)(event.x() / tile_width) };
     } else {
-        return { event.y() / tile_height, 7 - (event.x() / tile_width) };
+        return { (unsigned)(event.y() / tile_height), (unsigned)(7 - (event.x() / tile_width)) };
     }
 }
 

--- a/Userland/Libraries/LibC/elf.h
+++ b/Userland/Libraries/LibC/elf.h
@@ -791,3 +791,9 @@ struct elf_args {
 #define R_386_RELATIVE 8   /* Base address + Addned */
 #define R_386_TLS_TPOFF 14 /* Negative offset into the static TLS storage */
 #define R_386_TLS_TPOFF32 37
+
+#define R_X86_64_NONE 0
+#define R_X86_64_64 1
+#define R_X86_64_GLOB_DAT 6
+#define R_X86_64_JUMP_SLOT 7
+#define R_X86_64_RELATIVE 8

--- a/Userland/Libraries/LibC/inttypes.h
+++ b/Userland/Libraries/LibC/inttypes.h
@@ -18,23 +18,40 @@ __BEGIN_DECLS
 #define PRIi8 "d"
 #define PRIi16 "d"
 #define PRIi32 "d"
-#define PRIi64 "lld"
+#ifndef __LP64__
+#    define PRIi64 "lld"
+#else
+#    define PRIi64 "ld"
+#endif
 #define PRIu8 "u"
 #define PRIo8 "o"
 #define PRIo16 "o"
 #define PRIo32 "o"
-#define PRIo64 "llo"
+#ifndef __LP64__
+#    define PRIo64 "llo"
+#else
+#    define PRIo64 "lo"
+#endif
 #define PRIu16 "u"
 #define PRIu32 "u"
-#define PRIu64 "llu"
+#ifndef __LP64__
+#    define PRIu64 "llu"
+#else
+#    define PRIu64 "lu"
+#endif
 #define PRIx8 "b"
 #define PRIX8 "hhX"
 #define PRIx16 "w"
 #define PRIX16 "hX"
 #define PRIx32 "x"
 #define PRIX32 "X"
-#define PRIx64 "llx"
-#define PRIX64 "llX"
+#ifndef __LP64__
+#    define PRIx64 "llx"
+#    define PRIX64 "llX"
+#else
+#    define PRIx64 "lx"
+#    define PRIX64 "lX"
+#endif
 
 #define __PRI64_PREFIX "ll"
 #define __PRIPTR_PREFIX

--- a/Userland/Libraries/LibC/link.h
+++ b/Userland/Libraries/LibC/link.h
@@ -11,17 +11,22 @@
 #else
 #    include <elf.h>
 #endif
+#include <limits.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
 
-#define ElfW(type) Elf32_##type
+#ifdef __LP64__
+#    define ElfW(type) Elf64_##type
+#else
+#    define ElfW(type) Elf32_##type
+#endif
 
 struct dl_phdr_info {
-    Elf32_Addr dlpi_addr;
+    ElfW(Addr) dlpi_addr;
     const char* dlpi_name;
-    const Elf32_Phdr* dlpi_phdr;
-    Elf32_Half dlpi_phnum;
+    const ElfW(Phdr) * dlpi_phdr;
+    ElfW(Half) dlpi_phnum;
 };
 
 int dl_iterate_phdr(int (*callback)(struct dl_phdr_info* info, size_t size, void* data), void* data);

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -259,7 +259,7 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
         Optional<BreakPoint> current_breakpoint;
 
         if (state == State::FreeRun || state == State::Syscall) {
-            current_breakpoint = m_breakpoints.get((void*)((u32)regs.eip - 1));
+            current_breakpoint = m_breakpoints.get((void*)((uintptr_t)regs.eip - 1));
             if (current_breakpoint.has_value())
                 state = State::FreeRun;
         } else {

--- a/Userland/Libraries/LibELF/Arch/x86_64/plt_trampoline.S
+++ b/Userland/Libraries/LibELF/Arch/x86_64/plt_trampoline.S
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+    .align 4
+    .globl _plt_trampoline
+    .hidden _plt_trampoline
+    .type _plt_trampoline,@function
+_plt_trampoline:
+    int3

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -16,15 +16,15 @@
 
 namespace ELF {
 
-static const char* name_for_dtag(Elf32_Sword d_tag);
+static const char* name_for_dtag(ElfW(Sword) d_tag);
 
 DynamicObject::DynamicObject(const String& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address)
     : m_filename(filename)
     , m_base_address(base_address)
     , m_dynamic_address(dynamic_section_address)
 {
-    auto* header = (Elf32_Ehdr*)base_address.as_ptr();
-    auto* pheader = (Elf32_Phdr*)(base_address.as_ptr() + header->e_phoff);
+    auto* header = (ElfW(Ehdr)*)base_address.as_ptr();
+    auto* pheader = (ElfW(Phdr)*)(base_address.as_ptr() + header->e_phoff);
     m_elf_base_address = VirtualAddress(pheader->p_vaddr - pheader->p_offset);
     if (header->e_type == ET_DYN)
         m_is_elf_dynamic = true;
@@ -178,7 +178,7 @@ void DynamicObject::parse()
         // TODO: FIXME, this shouldn't be hardcoded
         // The reason we need this here is that for some reason, when there only PLT relocations, the compiler
         // doesn't insert a 'PLTRELSZ' entry to the dynamic section
-        m_size_of_relocation_entry = sizeof(Elf32_Rel);
+        m_size_of_relocation_entry = sizeof(ElfW(Rel));
     }
 
     auto hash_section_address = hash_section().address().as_ptr();
@@ -191,21 +191,21 @@ DynamicObject::Relocation DynamicObject::RelocationSection::relocation(unsigned 
 {
     VERIFY(index < entry_count());
     unsigned offset_in_section = index * entry_size();
-    auto relocation_address = (Elf32_Rel*)address().offset(offset_in_section).as_ptr();
+    auto relocation_address = (ElfW(Rel)*)address().offset(offset_in_section).as_ptr();
     return Relocation(m_dynamic, *relocation_address, offset_in_section);
 }
 
 DynamicObject::Relocation DynamicObject::RelocationSection::relocation_at_offset(unsigned offset) const
 {
     VERIFY(offset <= (m_section_size_bytes - m_entry_size));
-    auto relocation_address = (Elf32_Rel*)address().offset(offset).as_ptr();
+    auto relocation_address = (ElfW(Rel)*)address().offset(offset).as_ptr();
     return Relocation(m_dynamic, *relocation_address, offset);
 }
 
 DynamicObject::Symbol DynamicObject::symbol(unsigned index) const
 {
     auto symbol_section = Section(*this, m_symbol_table_offset, (m_symbol_count * m_size_of_symbol_table_entry), m_size_of_symbol_table_entry, "DT_SYMTAB");
-    auto symbol_entry = (Elf32_Sym*)symbol_section.address().offset(index * symbol_section.entry_size()).as_ptr();
+    auto symbol_entry = (ElfW(Sym)*)symbol_section.address().offset(index * symbol_section.entry_size()).as_ptr();
     return Symbol(*this, index, *symbol_entry);
 }
 
@@ -239,16 +239,16 @@ DynamicObject::RelocationSection DynamicObject::plt_relocation_section() const
     return RelocationSection(Section(*this, m_plt_relocation_offset_location, m_size_of_plt_relocation_entry_list, m_size_of_relocation_entry, "DT_JMPREL"sv));
 }
 
-Elf32_Half DynamicObject::program_header_count() const
+ElfW(Half) DynamicObject::program_header_count() const
 {
-    auto* header = (const Elf32_Ehdr*)m_base_address.as_ptr();
+    auto* header = (const ElfW(Ehdr)*)m_base_address.as_ptr();
     return header->e_phnum;
 }
 
-const Elf32_Phdr* DynamicObject::program_headers() const
+const ElfW(Phdr) * DynamicObject::program_headers() const
 {
-    auto* header = (const Elf32_Ehdr*)m_base_address.as_ptr();
-    return (const Elf32_Phdr*)(m_base_address.as_ptr() + header->e_phoff);
+    auto* header = (const ElfW(Ehdr)*)m_base_address.as_ptr();
+    return (const ElfW(Phdr)*)(m_base_address.as_ptr() + header->e_phoff);
 }
 
 auto DynamicObject::HashSection::lookup_sysv_symbol(const StringView& name, u32 hash_value) const -> Optional<Symbol>
@@ -319,12 +319,12 @@ auto DynamicObject::HashSection::lookup_gnu_symbol(const StringView& name, u32 h
     return {};
 }
 
-StringView DynamicObject::symbol_string_table_string(Elf32_Word index) const
+StringView DynamicObject::symbol_string_table_string(ElfW(Word) index) const
 {
     return StringView { (const char*)base_address().offset(m_string_table_offset + index).as_ptr() };
 }
 
-const char* DynamicObject::raw_symbol_string_table_string(Elf32_Word index) const
+const char* DynamicObject::raw_symbol_string_table_string(ElfW(Word) index) const
 {
     return (const char*)base_address().offset(m_string_table_offset + index).as_ptr();
 }
@@ -335,7 +335,7 @@ DynamicObject::InitializationFunction DynamicObject::init_section_function() con
     return (InitializationFunction)init_section().address().as_ptr();
 }
 
-static const char* name_for_dtag(Elf32_Sword d_tag)
+static const char* name_for_dtag(ElfW(Sword) d_tag)
 {
     switch (d_tag) {
     case DT_NULL:

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -12,6 +12,7 @@
 #include <AK/String.h>
 #include <Kernel/VirtualAddress.h>
 #include <LibC/elf.h>
+#include <LibC/link.h>
 
 namespace ELF {
 
@@ -31,24 +32,24 @@ public:
 
     class DynamicEntry {
     public:
-        explicit DynamicEntry(const Elf32_Dyn& dyn)
+        explicit DynamicEntry(const ElfW(Dyn) & dyn)
             : m_dyn(dyn)
         {
         }
 
         ~DynamicEntry() { }
 
-        Elf32_Sword tag() const { return m_dyn.d_tag; }
-        Elf32_Addr ptr() const { return m_dyn.d_un.d_ptr; }
-        Elf32_Word val() const { return m_dyn.d_un.d_val; }
+        ElfW(Sword) tag() const { return m_dyn.d_tag; }
+        ElfW(Addr) ptr() const { return m_dyn.d_un.d_ptr; }
+        ElfW(Word) val() const { return m_dyn.d_un.d_val; }
 
     private:
-        const Elf32_Dyn& m_dyn;
+        const ElfW(Dyn) & m_dyn;
     };
 
     class Symbol {
     public:
-        Symbol(const DynamicObject& dynamic, unsigned index, const Elf32_Sym& sym)
+        Symbol(const DynamicObject& dynamic, unsigned index, const ElfW(Sym) & sym)
             : m_dynamic(dynamic)
             , m_sym(sym)
             , m_index(index)
@@ -76,7 +77,7 @@ public:
 
     private:
         const DynamicObject& m_dynamic;
-        const Elf32_Sym& m_sym;
+        const ElfW(Sym) & m_sym;
         const unsigned m_index;
     };
 
@@ -130,7 +131,7 @@ public:
 
     class Relocation {
     public:
-        Relocation(const DynamicObject& dynamic, const Elf32_Rel& rel, unsigned offset_in_section)
+        Relocation(const DynamicObject& dynamic, const ElfW(Rel) & rel, unsigned offset_in_section)
             : m_dynamic(dynamic)
             , m_rel(rel)
             , m_offset_in_section(offset_in_section)
@@ -153,7 +154,7 @@ public:
 
     private:
         const DynamicObject& m_dynamic;
-        const Elf32_Rel& m_rel;
+        const ElfW(Rel) & m_rel;
         const unsigned m_offset_in_section;
     };
 
@@ -247,8 +248,8 @@ public:
     void set_tls_offset(FlatPtr offset) { m_tls_offset = offset; }
     void set_tls_size(FlatPtr size) { m_tls_size = size; }
 
-    Elf32_Half program_header_count() const;
-    const Elf32_Phdr* program_headers() const;
+    ElfW(Half) program_header_count() const;
+    const ElfW(Phdr) * program_headers() const;
 
     template<typename F>
     void for_each_needed_library(F) const;
@@ -283,8 +284,8 @@ public:
 private:
     explicit DynamicObject(const String& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address);
 
-    StringView symbol_string_table_string(Elf32_Word) const;
-    const char* raw_symbol_string_table_string(Elf32_Word) const;
+    StringView symbol_string_table_string(ElfW(Word)) const;
+    const char* raw_symbol_string_table_string(ElfW(Word)) const;
     void parse();
 
     String m_filename;
@@ -312,7 +313,7 @@ private:
     FlatPtr m_symbol_table_offset { 0 };
     size_t m_size_of_symbol_table_entry { 0 };
 
-    Elf32_Sword m_procedure_linkage_table_relocation_type { -1 };
+    ElfW(Sword) m_procedure_linkage_table_relocation_type { -1 };
     FlatPtr m_plt_relocation_offset_location { 0 }; // offset of PLT relocations, at end of relocations
     size_t m_size_of_plt_relocation_entry_list { 0 };
     Optional<FlatPtr> m_procedure_linkage_table_offset;
@@ -326,14 +327,14 @@ private:
     bool m_is_elf_dynamic { false };
 
     // DT_FLAGS
-    Elf32_Word m_dt_flags { 0 };
+    ElfW(Word) m_dt_flags { 0 };
 
     bool m_has_soname { false };
-    Elf32_Word m_soname_index { 0 }; // Index into dynstr table for SONAME
+    ElfW(Word) m_soname_index { 0 }; // Index into dynstr table for SONAME
     bool m_has_rpath { false };
-    Elf32_Word m_rpath_index { 0 }; // Index into dynstr table for RPATH
+    ElfW(Word) m_rpath_index { 0 }; // Index into dynstr table for RPATH
     bool m_has_runpath { false };
-    Elf32_Word m_runpath_index { 0 }; // Index into dynstr table for RUNPATH
+    ElfW(Word) m_runpath_index { 0 }; // Index into dynstr table for RUNPATH
 
     Optional<FlatPtr> m_tls_offset;
     Optional<FlatPtr> m_tls_size;
@@ -364,7 +365,7 @@ inline void DynamicObject::for_each_symbol(F func) const
 template<typename F>
 inline void DynamicObject::for_each_dynamic_entry(F func) const
 {
-    auto* dyns = reinterpret_cast<const Elf32_Dyn*>(m_dynamic_address.as_ptr());
+    auto* dyns = reinterpret_cast<const ElfW(Dyn)*>(m_dynamic_address.as_ptr());
     for (unsigned i = 0;; ++i) {
         auto&& dyn = DynamicEntry(dyns[i]);
         if (dyn.tag() == DT_NULL)
@@ -379,7 +380,7 @@ inline void DynamicObject::for_each_needed_library(F func) const
     for_each_dynamic_entry([func, this](auto entry) {
         if (entry.tag() != DT_NEEDED)
             return IterationDecision::Continue;
-        Elf32_Word offset = entry.val();
+        ElfW(Word) offset = entry.val();
         StringView name { (const char*)(m_base_address.offset(m_string_table_offset).offset(offset)).as_ptr() };
         if (func(StringView(name)) == IterationDecision::Break)
             return IterationDecision::Break;

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -17,6 +17,7 @@
 #include <LibCore/FileStream.h>
 #include <LibCore/MimeData.h>
 #include <LibHTTP/HttpRequest.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -220,7 +221,7 @@ void Client::handle_directory_listing(const String& requested_path, const String
         builder.append(escape_html_entities(name));
         builder.append("</a></td><td>&nbsp;</td>");
 
-        builder.appendf("<td>%10lld</td><td>&nbsp;</td>", st.st_size);
+        builder.appendf("<td>%10" PRIi64 "</td><td>&nbsp;</td>", st.st_size);
         builder.append("<td>");
         builder.append(Core::DateTime::from_timestamp(st.st_mtime).to_string());
         builder.append("</td>");

--- a/Userland/Tests/Kernel/bxvga-mmap-kernel-into-userspace.cpp
+++ b/Userland/Tests/Kernel/bxvga-mmap-kernel-into-userspace.cpp
@@ -53,7 +53,7 @@ int main()
 
     uintptr_t g_processes = *(uintptr_t*)&base[0x1b51c4];
     printf("base = %p\n", base);
-    printf("g_processes = %#08x\n", g_processes);
+    printf("g_processes = %p\n", (void*)g_processes);
 
     auto get_ptr = [&](uintptr_t value) -> void* {
         value -= 0xc0000000;
@@ -80,7 +80,7 @@ int main()
 
     Process* process = (Process*)get_ptr(process_list->head);
 
-    printf("{%p} PID: %d, UID: %d, next: %#08x\n", process, process->pid, process->uid, process->next);
+    printf("{%p} PID: %d, UID: %d, next: %p\n", process, process->pid, process->uid, (void*)process->next);
 
     if (process->pid == getpid()) {
         printf("That's me! Let's become r00t!\n");

--- a/Userland/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
+++ b/Userland/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
@@ -88,7 +88,7 @@ int main()
     strcpy(shstrtab, ".strtab");
 
     auto* code = &buffer[8192];
-    size_t haxcode_size = (u32)haxcode_end - (u32)haxcode;
+    size_t haxcode_size = (uintptr_t)haxcode_end - (uintptr_t)haxcode;
     printf("memcpy(%p, %p, %zu)\n", code, haxcode, haxcode_size);
     memcpy(code, (void*)haxcode, haxcode_size);
 
@@ -100,7 +100,7 @@ int main()
         return 1;
     }
 
-    int nwritten = write(fd, buffer, sizeof(buffer));
+    auto nwritten = write(fd, buffer, sizeof(buffer));
     if (nwritten < 0) {
         perror("write");
         return 1;

--- a/Userland/Tests/Kernel/stress-writeread.cpp
+++ b/Userland/Tests/Kernel/stress-writeread.cpp
@@ -21,18 +21,18 @@ bool verify_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer)
     auto offset = block * buffer.size();
     auto rs = lseek(fd, offset, SEEK_SET);
     if (rs < 0) {
-        fprintf(stderr, "Couldn't seek to block %lld (offset %lld) while verifying: %s\n", block, offset, strerror(errno));
+        fprintf(stderr, "Couldn't seek to block %" PRIi64 " (offset %" PRIi64 ") while verifying: %s\n", block, offset, strerror(errno));
         return false;
     }
     auto rw = read(fd, buffer.data(), buffer.size());
     if (rw != static_cast<int>(buffer.size())) {
-        fprintf(stderr, "Failure to read block %lld: %s\n", block, strerror(errno));
+        fprintf(stderr, "Failure to read block %" PRIi64 ": %s\n", block, strerror(errno));
         return false;
     }
     srand((seed + 1) * (block + 1));
     for (size_t i = 0; i < buffer.size(); i++) {
         if (buffer[i] != rand() % 256) {
-            fprintf(stderr, "Discrepancy detected at block %lld offset %zd\n", block, i);
+            fprintf(stderr, "Discrepancy detected at block %" PRIi64 " offset %zd\n", block, i);
             return false;
         }
     }
@@ -44,7 +44,7 @@ bool write_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer)
     auto offset = block * buffer.size();
     auto rs = lseek(fd, offset, SEEK_SET);
     if (rs < 0) {
-        fprintf(stderr, "Couldn't seek to block %lld (offset %lld) while verifying: %s\n", block, offset, strerror(errno));
+        fprintf(stderr, "Couldn't seek to block %" PRIi64 " (offset %" PRIi64 ") while verifying: %s\n", block, offset, strerror(errno));
         return false;
     }
     srand((seed + 1) * (block + 1));
@@ -52,7 +52,7 @@ bool write_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer)
         buffer[i] = rand();
     auto rw = write(fd, buffer.data(), buffer.size());
     if (rw != static_cast<int>(buffer.size())) {
-        fprintf(stderr, "Failure to write block %lld: %s\n", block, strerror(errno));
+        fprintf(stderr, "Failure to write block %" PRIi64 ": %s\n", block, strerror(errno));
         return false;
     }
     return true;

--- a/Userland/Utilities/crash.cpp
+++ b/Userland/Utilities/crash.cpp
@@ -267,8 +267,14 @@ int main(int argc, char** argv)
                 return Crash::Failure::UnexpectedError;
 
             u8* bad_esp = bad_stack + 2048;
+#ifndef __LP64__
             asm volatile("mov %%eax, %%esp" ::"a"(bad_esp));
             asm volatile("pushl $0");
+#else
+            asm volatile("movq %%rax, %%rsp" ::"a"(bad_esp));
+            asm volatile("pushq $0");
+#endif
+
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -7,6 +7,7 @@
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>

--- a/Userland/Utilities/df.cpp
+++ b/Userland/Utilities/df.cpp
@@ -71,9 +71,9 @@ int main(int argc, char** argv)
             printf("%10s   ", human_readable_size((total_block_count - free_block_count) * block_size).characters());
             printf("%10s   ", human_readable_size(free_block_count * block_size).characters());
         } else {
-            printf("%10" PRIu64 "  ", total_block_count);
-            printf("%10" PRIu64 "   ", total_block_count - free_block_count);
-            printf("%10" PRIu64 "   ", free_block_count);
+            printf("%10" PRIu64 "  ", (uint64_t)total_block_count);
+            printf("%10" PRIu64 "   ", (uint64_t)(total_block_count - free_block_count));
+            printf("%10" PRIu64 "   ", (uint64_t)free_block_count);
         }
 
         printf("%s", mount_point.characters());

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCore/Object.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <math.h>
 #include <stdio.h>
@@ -151,7 +152,7 @@ int print_space_usage(const String& path, const DuOption& du_option, int max_dep
             return 0;
     }
 
-    long long size = path_stat.st_size;
+    off_t size = path_stat.st_size;
     if (du_option.apparent_size) {
         const auto block_size = 512;
         size = path_stat.st_blocks * block_size;
@@ -164,7 +165,7 @@ int print_space_usage(const String& path, const DuOption& du_option, int max_dep
     size = size / block_size + (size % block_size != 0);
 
     if (du_option.time_type == DuOption::TimeType::NotUsed)
-        printf("%lld\t%s\n", size, path.characters());
+        printf("%" PRIi64 "\t%s\n", size, path.characters());
     else {
         auto time = path_stat.st_mtime;
         switch (du_option.time_type) {
@@ -178,7 +179,7 @@ int print_space_usage(const String& path, const DuOption& du_option, int max_dep
         }
 
         const auto formatted_time = Core::DateTime::from_timestamp(time).to_string();
-        printf("%lld\t%s\t%s\n", size, formatted_time.characters(), path.characters());
+        printf("%" PRIi64 "\t%s\t%s\n", size, formatted_time.characters(), path.characters());
     }
 
     return 0;

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -68,7 +68,7 @@ static NonnullOwnPtr<HashMap<void*, X86::Instruction>> instrument_code()
             if (section.name() != ".text")
                 return IterationDecision::Continue;
 
-            X86::SimpleInstructionStream stream((const u8*)((u32)lib.file->data() + section.offset()), section.size());
+            X86::SimpleInstructionStream stream((const u8*)((uintptr_t)lib.file->data() + section.offset()), section.size());
             X86::Disassembler disassembler(stream);
             for (;;) {
                 auto offset = stream.offset();

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
+#include <inttypes.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <string.h>
@@ -313,7 +314,7 @@ static bool print_filesystem_object(const String& path, const String& name, cons
         if (flag_human_readable) {
             printf(" %10s ", human_readable_size(st.st_size).characters());
         } else {
-            printf(" %10lld ", st.st_size);
+            printf(" %10" PRIu64 " ", (uint64_t)st.st_size);
         }
     }
 

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
 #include <grp.h>
+#include <inttypes.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -28,7 +29,7 @@ static int stat(const char* file, bool should_follow_links)
     if (S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode))
         printf("  Device: %u,%u\n", major(st.st_rdev), minor(st.st_rdev));
     else
-        printf("    Size: %lld\n", st.st_size);
+        printf("    Size: %" PRIi64 "\n", st.st_size);
     printf("   Links: %u\n", st.st_nlink);
     printf("  Blocks: %u\n", st.st_blocks);
     printf("     UID: %u", st.st_uid);

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/DateTime.h>
 #include <LibCore/File.h>
 #include <LibCore/ProcessStatisticsReader.h>
+#include <inttypes.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -87,7 +88,7 @@ int main()
         if (stat(tty.characters(), &st) == 0) {
             auto idle_time = now - st.st_mtime;
             if (idle_time >= 0) {
-                builder.appendf("%llds", idle_time);
+                builder.appendf("%" PRIi64 "s", idle_time);
                 idle_string = builder.to_string();
             }
         }


### PR DESCRIPTION
This lets us build most of the userland for x86_64. There are still some build problems (around 100 files fail to compile) but those are now mostly related to 32-bit registers (e.g. in `UserspaceEmulator`, `LibDebug`, etc.).

This PR also adds _some_ support for doing x86_64 ELF relocations. This is untested and there are definitely some relocation types we're missing.

I've added `-fPIC` to the GCC specfile so that all code is built with it, including static libraries. Ordinarily this would force the compiler to not inline certain symbols and call them via the PLT instead. To counteract this I've also added `-fno-semantic-interposition` which disables ELF symbol interposition. Our dynamic loader doesn't support this anyway and we might even consider not implementing this at all.

This does not require a toolchain rebuild unless you're actively working on getting x86_64 up and running.

Adding `-fno-semantic-interposition` to the GCC command line caused a new warning in `AK/Base64.cpp`. I don't see how output.data() could be uninitialized here. Also, commenting out the `ensure_capacity()` call for the Vector also gets rid of this warning.
