### PR TITLE
Shell: Update shebang handling logic

### DIFF
--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
     if (format) {
         auto file = Core::File::open(format, Core::IODevice::ReadOnly);
         if (file.is_error()) {
-            fprintf(stderr, "Error: %s", file.error().characters());
+            warnln("Error: {}", file.error());
             return 1;
         }
 


### PR DESCRIPTION
This bit of code was kept unmodified since it was first implemented,
and I'm not entirely convinced that it ever actually worked :P
This commit updates the code to use "modern" classes and constructs,
and fixes an issue where the shebang would still contain the '#!'
when it was passed to execvp().
Fixes #6774.