### PR TITLE
TextEditor: Clear the selection before deleting it

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1220,8 +1220,9 @@ String TextEditor::selected_text() const
 void TextEditor::delete_selection()
 {
     auto selection = normalized_selection();
-    execute<RemoveTextCommand>(selected_text(), selection);
+    auto selected = selected_text();
     m_selection.clear();
+    execute<RemoveTextCommand>(selected, selection);
     did_update_selection();
     did_change();
     set_cursor(selection.start());


### PR DESCRIPTION
This patches fixes a crash of the Userland/TextEditor where it would
crash when deleting a range spanning two lines. This was because the
TextEditor would delete the range and modify the cursor position
before clearing the selection. This would trigger a status bar update
with the invalid selection.