### PR TITLE
LibDebug: add DW_LNS_set_basic_block support

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -242,6 +242,10 @@ void LineProgram::handle_standard_opcode(u8 opcode)
         m_address += delta;
         break;
     }
+    case StandardOpcodes::SetBasicBlock: {
+        m_basic_block = true;
+        break;
+    }
     default:
         dbgln("Unhandled LineProgram opcode {}", opcode);
         VERIFY_NOT_REACHED();
@@ -262,6 +266,8 @@ void LineProgram::handle_special_opcode(u8 opcode)
     }
 
     append_to_line_info();
+
+    m_basic_block = false;
 }
 
 void LineProgram::run_program()

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -171,6 +171,7 @@ private:
     size_t m_line { 0 };
     size_t m_file_index { 0 };
     bool m_is_statement { false };
+    bool m_basic_block { false };
 
     Vector<LineInfo> m_lines;
 };


### PR DESCRIPTION
This adds support for the basic_block register to the Dwarf line number state machine.

I found it to be a blocker for running certain ports with the Debugger.