### PR TITLE
FileManager: Added basic Trash support

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -512,6 +512,14 @@ void DirectoryView::do_delete(bool should_confirm)
     FileUtils::delete_paths(paths, should_confirm, window());
 }
 
+void DirectoryView::do_trash()
+{
+    auto paths = selected_file_paths();
+    VERIFY(!paths.is_empty());
+    if (!FileUtils::move_to_trash(paths))
+        dbgln("Could not trash the selected files/directories");
+}
+
 void DirectoryView::handle_selection_change()
 {
     update_statusbar();
@@ -519,6 +527,7 @@ void DirectoryView::handle_selection_change()
     bool can_delete = !current_view().selection().is_empty() && access(path().characters(), W_OK) == 0;
     m_delete_action->set_enabled(can_delete);
     m_force_delete_action->set_enabled(can_delete);
+    m_trash_action->set_enabled(can_delete);
 
     if (on_selection_change)
         on_selection_change(current_view());
@@ -585,6 +594,10 @@ void DirectoryView::setup_actions()
         "Delete Without Confirmation", { Mod_Shift, Key_Delete },
         [this](auto&) { do_delete(false); },
         window());
+
+    m_trash_action = GUI::Action::create("Move to &Trash", Gfx::Bitmap::load_from_file("/res/icons/16x16/delete.png"), [&](auto&) {
+        do_trash();
+    });
 }
 
 void DirectoryView::handle_drop(const GUI::ModelIndex& index, const GUI::DropEvent& event)

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -121,6 +121,7 @@ public:
     GUI::Action& open_terminal_action() { return *m_open_terminal_action; }
     GUI::Action& delete_action() { return *m_delete_action; }
     GUI::Action& force_delete_action() { return *m_force_delete_action; }
+    GUI::Action& trash_action() { return *m_trash_action; }
 
 private:
     explicit DirectoryView(Mode);
@@ -131,6 +132,7 @@ private:
     void handle_selection_change();
     void handle_drop(const GUI::ModelIndex&, const GUI::DropEvent&);
     void do_delete(bool should_confirm);
+    void do_trash();
 
     // ^GUI::ModelClient
     virtual void model_did_update(unsigned) override;
@@ -166,6 +168,7 @@ private:
     RefPtr<GUI::Action> m_open_terminal_action;
     RefPtr<GUI::Action> m_delete_action;
     RefPtr<GUI::Action> m_force_delete_action;
+    RefPtr<GUI::Action> m_trash_action;
 };
 
 }

--- a/Userland/Applications/FileManager/FileUtils.h
+++ b/Userland/Applications/FileManager/FileUtils.h
@@ -20,4 +20,8 @@ enum class FileOperation {
 
 void delete_path(const String&, GUI::Window*);
 void delete_paths(const Vector<String>&, bool should_confirm, GUI::Window*);
+void create_trash_bin();
+[[maybe_unused]] bool move_to_trash(String const&);
+[[maybe_unused]] bool move_to_trash(Vector<String> const&);
+
 }

--- a/Userland/Libraries/LibCore/StandardPaths.cpp
+++ b/Userland/Libraries/LibCore/StandardPaths.cpp
@@ -54,4 +54,12 @@ String StandardPaths::tempfile_directory()
     return "/tmp";
 }
 
+String StandardPaths::trash_directory()
+{
+    StringBuilder builder;
+    builder.append(home_directory());
+    builder.append("/.trash");
+    return LexicalPath::canonicalized_path(builder.to_string());
+}
+
 }

--- a/Userland/Libraries/LibCore/StandardPaths.h
+++ b/Userland/Libraries/LibCore/StandardPaths.h
@@ -17,6 +17,7 @@ public:
     static String downloads_directory();
     static String tempfile_directory();
     static String config_directory();
+    static String trash_directory();
 };
 
 }


### PR DESCRIPTION
Hello friends!

I've added basic Trash support to SerenityOS based on [Free Desktop](https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html).

It adds a new context menu item to move the selected file to Trash bin.

It lacks some features like Restore or Browsing the the Trash bin for the moment but if this addition is welcome I will complete the whole thing and continue improving.