### PR TITLE
LibGUI: Debounce TextDocument undo stack

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -129,7 +129,7 @@ protected:
     explicit TextDocument(Client* client);
 
 private:
-    void update_undo_timer();
+    void update_undo();
 
     NonnullOwnPtrVector<TextDocumentLine> m_lines;
     Vector<TextDocumentSpan> m_spans;


### PR DESCRIPTION
Replace the repeating 2-sec timer with a debounced single-shot timer on user input.