### PR TITLE
UserspaceEmulator: Make sure TLS allocation behavior matches the kernel

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -160,7 +160,7 @@ private:
     pid_t virt$setsid();
     int virt$watch_file(FlatPtr, size_t);
     int virt$readlink(FlatPtr);
-    u32 virt$allocate_tls(size_t);
+    u32 virt$allocate_tls(FlatPtr, size_t);
     int virt$ptsname(int fd, FlatPtr buffer, size_t buffer_size);
     int virt$beep();
     int virt$ftruncate(int fd, FlatPtr length_addr);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -169,6 +169,7 @@ private:
     int virt$recvfd(int, int);
     int virt$sendfd(int, int);
     int virt$msyscall(FlatPtr);
+    int virt$futex(FlatPtr);
 
     bool find_malloc_symbols(const MmapRegion& libc_text);
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -242,6 +242,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$chown(arg1);
     case SC_msyscall:
         return virt$msyscall(arg1);
+    case SC_futex:
+        return virt$futex(arg1);
     default:
         reportln("\n=={}==  \033[31;1mUnimplemented syscall: {}\033[0m, {:p}", getpid(), Syscall::to_string((Syscall::Function)function), function);
         dump_backtrace();
@@ -1463,4 +1465,12 @@ int Emulator::virt$msyscall(FlatPtr)
     return 0;
 }
 
+int Emulator::virt$futex(FlatPtr params_addr)
+{
+    Syscall::SC_futex_params params;
+    mmu().copy_from_vm(&params, params_addr, sizeof(params));
+
+    // FIXME: Implement this.
+    return 0;
+}
 }

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1432,9 +1432,10 @@ int Emulator::virt$readlink(FlatPtr params_addr)
 
 u32 Emulator::virt$allocate_tls(FlatPtr initial_data, size_t size)
 {
-    // TODO: Why is this needed? without this, the loader overflows the bounds of the TLS region.
-    constexpr size_t TLS_SIZE_HACK = 8;
-    auto tcb_region = make<SimpleRegion>(0x20000000, size + TLS_SIZE_HACK);
+    // TODO: This matches what Thread::make_thread_specific_region does. The kernel
+    // ends up allocating one more page. Figure out if this is intentional.
+    auto region_size = align_up_to(size, PAGE_SIZE) + PAGE_SIZE;
+    auto tcb_region = make<SimpleRegion>(0x20000000, region_size);
 
     size_t offset = 0;
     while (size - offset > 0) {


### PR DESCRIPTION
With these fixes applies the `UserspaceEmulator` becomes usable again. Previously even `UserspaceEmulator ls` didn't work.

* Adds missing `sys$futex` system call. Static initializers are thread safe now and will call `pthread_mutex_lock` during initialization.
* Adds support for the `initial_data` argument for `sys$allocate_tls`.
* Makes sure the allocation behavior for `sys$allocate_tls` matches what the kernel does (even though it seems somewhat unusual and something might be wrong with either the kernel or the loader).