### PR TITLE
Kernel: Remove unused header includes + mark some classes as final.

### DIFF
--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -12,7 +12,7 @@ namespace Kernel {
 
 class BlockDevice;
 
-class AsyncBlockDeviceRequest : public AsyncDeviceRequest {
+class AsyncBlockDeviceRequest final : public AsyncDeviceRequest {
 public:
     enum RequestType {
         Read,

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -4,16 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Assertions.h>
 #include <AK/OwnPtr.h>
 #include <AK/Singleton.h>
-#include <AK/String.h>
 #include <Kernel/API/MousePacket.h>
 #include <Kernel/Arch/x86/CPU.h>
 #include <Kernel/CommandLine.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/VMWareBackdoor.h>
-#include <Kernel/IO.h>
 
 namespace Kernel {
 

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -7,7 +7,6 @@
 #include <AK/Assertions.h>
 #include <AK/Memory.h>
 #include <AK/Singleton.h>
-#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <Kernel/ACPI/Parser.h>
 #include <Kernel/Arch/x86/CPU.h>

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -5,14 +5,12 @@
  */
 
 #include <AK/Optional.h>
-#include <AK/StringView.h>
 #include <Kernel/ACPI/MultiProcessorParser.h>
 #include <Kernel/Arch/x86/CPU.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Interrupts/APIC.h>
 #include <Kernel/Interrupts/IOAPIC.h>
 #include <Kernel/Interrupts/InterruptManagement.h>
-#include <Kernel/VM/MemoryManager.h>
 
 #define IOAPIC_REDIRECTION_ENTRY_OFFSET 0x10
 namespace Kernel {

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringView.h>
 #include <Kernel/ACPI/MultiProcessorParser.h>
 #include <Kernel/API/Syscall.h>
 #include <Kernel/Arch/x86/CPU.h>
@@ -16,7 +15,6 @@
 #include <Kernel/Interrupts/PIC.h>
 #include <Kernel/Interrupts/SpuriousInterruptHandler.h>
 #include <Kernel/Interrupts/UnhandledInterruptHandler.h>
-#include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/TypedMapping.h>
 
 #define PCAT_COMPAT_FLAG 0x1

--- a/Kernel/VM/AnonymousVMObject.h
+++ b/Kernel/VM/AnonymousVMObject.h
@@ -14,7 +14,7 @@
 
 namespace Kernel {
 
-class AnonymousVMObject : public VMObject {
+class AnonymousVMObject final : public VMObject {
     friend class PurgeablePageRanges;
 
 public:


### PR DESCRIPTION
-    Kernel: Remove unused header includes from various files.

     Found while browsing code with CLion.

-  Kernel: Mark AsyncBlockDeviceRequest + AnonymousVMObject as final

    Mark final to aid in de-virtualization since they are not currently
    derived from.