### PR TITLE
Meta: Add Discord badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Graphical Unix-like operating system for x86 computers.
 
 [![Build status](https://github.com/SerenityOS/serenity/workflows/Build,%20lint,%20and%20test/badge.svg)](https://github.com/SerenityOS/serenity/actions?query=workflow%3A"Build%2C%20lint%2C%20and%20test")
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:serenity)
+[![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/29gCcKsXkF)  
 
 ## About
 


### PR DESCRIPTION
This will add a shield/badge to the top of the README.md file. It will
show the amount of only users in the discord server. If clicked it will
redirect you to the invite page.

Important: this will only work if the widget option is enabled.