### PR TITLE
WindowServer: Ignore mouse clicks we're not handling

### DIFF
--- a/Userland/Services/WindowServer/Button.cpp
+++ b/Userland/Services/WindowServer/Button.cpp
@@ -40,6 +40,25 @@ void Button::paint(Gfx::Painter& painter)
 
 void Button::on_mouse_event(const MouseEvent& event)
 {
+    auto interesting_button = false;
+
+    switch (event.button()) {
+    case MouseButton::Left:
+        interesting_button = !!on_click;
+        break;
+    case MouseButton::Middle:
+        interesting_button = !!on_middle_click;
+        break;
+    case MouseButton::Right:
+        interesting_button = !!on_right_click;
+        break;
+    default:
+        break;
+    }
+
+    if (!interesting_button)
+        return;
+
     auto& wm = WindowManager::the();
 
     if (event.type() == Event::MouseDown && (event.button() == MouseButton::Left || event.button() == MouseButton::Right || event.button() == MouseButton::Middle)) {


### PR DESCRIPTION
This ignores unhandled mouse clicks for the window buttons. Right now right-clicking on the window buttons animates them as if some action were to occur when the mouse button is released.

There is one corner case that's not currently handled: middle-clicking the maximize button while the window is already vertically maximized. I don't know how to reliably detect that.