### PR TITLE
Kernel: Return one kernel frame from procfs$tid_stack for normal users.

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -961,19 +961,6 @@ void ProcFS::add_sys_bool(String&& name, Lockable<bool>& var, Function<void()>&&
     sys_variables().append(move(variable));
 }
 
-void ProcFS::add_sys_string(String&& name, Lockable<String>& var, Function<void()>&& notify_callback)
-{
-    InterruptDisabler disabler;
-
-    SysVariable variable;
-    variable.name = move(name);
-    variable.type = SysVariable::Type::String;
-    variable.notify_callback = move(notify_callback);
-    variable.address = &var;
-
-    sys_variables().append(move(variable));
-}
-
 bool ProcFS::initialize()
 {
     static Lockable<bool>* kmalloc_stack_helper;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -599,9 +599,14 @@ static bool procfs$tid_stack(InodeIdentifier identifier, KBufferBuilder& builder
 
     JsonArraySerializer array { builder };
     bool show_kernel_addresses = Process::current()->is_superuser();
+    bool kernel_address_added = false;
     for (auto address : Processor::capture_stack_trace(*thread, 1024)) {
-        if (!show_kernel_addresses && !is_user_address(VirtualAddress { address }))
+        if (!show_kernel_addresses && !is_user_address(VirtualAddress { address })) {
+            if (kernel_address_added)
+                continue;
             address = 0xdeadc0de;
+            kernel_address_added = true;
+        }
         array.add(JsonValue(address));
     }
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/JsonArraySerializer.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
@@ -26,7 +25,6 @@
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Interrupts/InterruptManagement.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/KSyms.h>
 #include <Kernel/Module.h>
 #include <Kernel/Net/LocalSocket.h>
 #include <Kernel/Net/NetworkAdapter.h>

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -32,7 +32,6 @@ public:
     virtual NonnullRefPtr<Inode> root_inode() const override;
 
     static void add_sys_bool(String&&, Lockable<bool>&, Function<void()>&& notify_callback = nullptr);
-    static void add_sys_string(String&&, Lockable<String>&, Function<void()>&& notify_callback = nullptr);
 
 private:
     ProcFS();


### PR DESCRIPTION
 -   Kernel: Remove unused header includes from ProcFS.cpp

 -   Kernel: Remove unused function ProcFS::add_sys_string

 -  Kernel: Return one kernel frame from procfs$tid_stack for normal users.

    Previously we would return a 0xdeadc0de frame for every kernel frame
    in the real kernel stack when an non super-user issued the request.
    This isn't useful, and just produces visual clutter in tools which
    attempt to symbolize stacks.