### PR TITLE
Kernel: Store whether a thread is the idle thread in Thread directly

### DIFF
--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -779,11 +779,6 @@ public:
         return *m_mm_data;
     }
 
-    ALWAYS_INLINE Thread* idle_thread() const
-    {
-        return m_idle_thread;
-    }
-
     ALWAYS_INLINE void set_idle_thread(Thread& idle_thread)
     {
         m_idle_thread = &idle_thread;
@@ -804,6 +799,12 @@ public:
     {
         // See comment in Processor::current_thread
         write_fs_u32(__builtin_offsetof(Processor, m_current_thread), FlatPtr(&current_thread));
+    }
+
+    ALWAYS_INLINE static Thread* idle_thread()
+    {
+        // See comment in Processor::current_thread
+        return (Thread*)read_fs_u32(__builtin_offsetof(Processor, m_idle_thread));
     }
 
     ALWAYS_INLINE u32 get_id() const

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1112,6 +1112,8 @@ public:
         return m_handling_page_fault;
     }
     void set_handling_page_fault(bool b) { m_handling_page_fault = b; }
+    void set_idle_thread() { m_is_idle_thread = true; }
+    bool is_idle_thread() const { return m_is_idle_thread; }
 
 private:
     Thread(NonnullRefPtr<Process>, NonnullOwnPtr<Region> kernel_stack_region);
@@ -1248,6 +1250,7 @@ private:
     bool m_should_die { false };
     bool m_initialized { false };
     bool m_in_block { false };
+    bool m_is_idle_thread { false };
     Atomic<bool> m_have_any_unmasked_pending_signals { false };
 
     void yield_without_holding_big_lock();


### PR DESCRIPTION
This solves a problem where checking whether a thread is an idle
thread may require iterating all processors if it is not the idle
thread of the current processor.

**Note:** This is @tomuta's work that I cherry-picked out of #5184.
It's a small, self contained fix, that bringing to master will help move that large PR forward.
Sending this out after the discord discussion on helping move the smp branch into master. 
