### PR TITLE
LibWeb: Compute intrinsic height of absolute replaced elements

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -619,8 +619,9 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
 
 void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(ReplacedBox& box)
 {
-    // FIXME: Implement this.
-    return compute_height_for_absolutely_positioned_non_replaced_element(box);
+    // 10.6.5 Absolutely positioned, replaced elements
+    // The used value of 'height' is determined as for inline replaced elements.
+    box.set_height(compute_height_for_replaced_element(box));
 }
 
 }


### PR DESCRIPTION
I noticed that the dinosaurs on the [Dromaeo test page](http://serenityos.org/dromaeo/) went missing recently. The height computation for absolutely positioned, non-replaced elements is now implemented fully enough that it computes a height of 0px for replaced elements, so we shouldn't use that computation for replaced elements anymore. The implementation here is much like that for computing width.