### PR TITLE
Meta: Remove existing test directories before copying new ones in

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -104,6 +104,7 @@ mkdir -p mnt/home/anon
 mkdir -p mnt/home/anon/Desktop
 mkdir -p mnt/home/anon/Downloads
 mkdir -p mnt/home/nona
+rm -fr mnt/home/anon/js-tests mnt/home/anon/web-tests
 cp "$SERENITY_SOURCE_DIR"/README.md mnt/home/anon/
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibJS/Tests mnt/home/anon/js-tests
 cp -r "$SERENITY_SOURCE_DIR"/Userland/Libraries/LibWeb/Tests mnt/home/anon/web-tests


### PR DESCRIPTION
("Unrelated" fix from #6673)
Previously, we would end up with `js-tests/Tests` and `web-tests/Tests`
because the previous directories were already there.