### PR TITLE
Meta: man pages website fixes

### DIFF
--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "Base/usr/share/man/**"
+      - "Meta/Websites/man.serenityos.org/**"
 
 env:
   MAN_DIR: ${{ github.workspace }}/Base/usr/share/man/

--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -21,11 +21,19 @@ jobs:
       - name: Prepare output directories
         run: |
           for d in $MAN_DIR*/; do
-            mkdir -p output/$(basename "$d")
+            dir_name=$(basename "$d")
+            mkdir -p output/${dir_name/man}
           done
       - name: Convert markdown to html
         run: |
-          find $MAN_DIR -iname '*.md' -type f -exec sh -c 'relative=$(realpath --relative-to=$MAN_DIR $0) && pandoc -f gfm -t html5 -s -o output/${relative%.md}.html ${0}' {} \;
+          cat << EOF > link-fixup.lua
+          function Link(el)
+            el.target = string.gsub(el.target, "%.md", ".html") -- fixup .md to .html links
+            el.target = string.gsub(el.target, "man", "", 1) -- fixup man1/???.html to 1/???.html links
+            return el
+          end
+          EOF
+          find $MAN_DIR -iname '*.md' -type f -exec sh -c 'relative_path=$(realpath --relative-to=$MAN_DIR $0) && stripped_path=${relative_path#man} && pandoc -f gfm -t html5 -s --lua-filter=link-fixup.lua -o output/${stripped_path%.md}.html ${0}' {} \;
       - name: Generate man page listings
         run: |
           for d in output/*/; do

--- a/Meta/Websites/man.serenityos.org/index.html
+++ b/Meta/Websites/man.serenityos.org/index.html
@@ -6,13 +6,13 @@
 <body>
 <img src="banner.png" alt="SerenityOS">
 <h1>SerenityOS man pages</h1>
-<a href="man1/"><p>Man 1</p></a>
-<a href="man2/"><p>Man 2</p></a>
-<a href="man3/"><p>Man 3</p></a>
-<a href="man4/"><p>Man 4</p></a>
-<a href="man5/"><p>Man 5</p></a>
-<a href="man6/"><p>Man 6</p></a>
-<a href="man7/"><p>Man 7</p></a>
-<a href="man8/"><p>Man 8</p></a>
+<a href="1/"><p>Man 1</p></a>
+<a href="2/"><p>Man 2</p></a>
+<a href="3/"><p>Man 3</p></a>
+<a href="4/"><p>Man 4</p></a>
+<a href="5/"><p>Man 5</p></a>
+<a href="6/"><p>Man 6</p></a>
+<a href="7/"><p>Man 7</p></a>
+<a href="8/"><p>Man 8</p></a>
 </body>
 </html>

--- a/Meta/Websites/man.serenityos.org/index.html
+++ b/Meta/Websites/man.serenityos.org/index.html
@@ -7,12 +7,12 @@
 <img src="banner.png" alt="SerenityOS">
 <h1>SerenityOS man pages</h1>
 <a href="man1/"><p>Man 1</p></a>
-<a href="man1/"><p>Man 2</p></a>
-<a href="man1/"><p>Man 3</p></a>
-<a href="man1/"><p>Man 4</p></a>
-<a href="man1/"><p>Man 5</p></a>
-<a href="man1/"><p>Man 6</p></a>
-<a href="man1/"><p>Man 7</p></a>
-<a href="man1/"><p>Man 8</p></a>
+<a href="man2/"><p>Man 2</p></a>
+<a href="man3/"><p>Man 3</p></a>
+<a href="man4/"><p>Man 4</p></a>
+<a href="man5/"><p>Man 5</p></a>
+<a href="man6/"><p>Man 6</p></a>
+<a href="man7/"><p>Man 7</p></a>
+<a href="man8/"><p>Man 8</p></a>
 </body>
 </html>


### PR DESCRIPTION
A couple of fixes and changes:

- Track Meta/Websites/man.serenityos.org/ changes for deploys as well
- Fixup hrefs in the main index.html (Found by @alimpfard)
- Fixup cross-manpage hrefs inside man pages (Found by @bgianfo)
- Change /man[1-8]/ directories to /[1-8]/ (Requested by @awesomekling)