### PR TITLE
LibWeb: Add initial implementation of createDocument and createDocumentType

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -19,8 +19,40 @@ DOMImplementation::DOMImplementation(Document& document)
 {
 }
 
-const NonnullRefPtr<Document> DOMImplementation::create_html_document(const String& title) const
+// https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
+NonnullRefPtr<Document> DOMImplementation::create_document(const String& namespace_, const String& qualified_name) const
 {
+    // FIXME: This should specifically be an XML document.
+    auto xml_document = Document::create();
+
+    xml_document->set_ready_for_post_load_tasks(true);
+
+    RefPtr<Element> element;
+
+    if (!qualified_name.is_empty())
+        element = xml_document->create_element_ns(namespace_, qualified_name /* FIXME: and an empty dictionary */);
+
+    // FIXME: If doctype is non-null, append doctype to document.
+
+    if (element)
+        xml_document->append_child(element.release_nonnull());
+
+    xml_document->set_origin(m_document.origin());
+
+    if (namespace_ == Namespace::HTML)
+        m_document.set_content_type("application/xhtml+xml");
+    else if (namespace_ == Namespace::SVG)
+        m_document.set_content_type("image/svg+xml");
+    else
+        m_document.set_content_type("application/xml");
+
+    return xml_document;
+}
+
+// https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
+NonnullRefPtr<Document> DOMImplementation::create_html_document(const String& title) const
+{
+    // FIXME: This should specifically be a HTML document.
     auto html_document = Document::create();
 
     html_document->set_content_type("text/html");
@@ -50,6 +82,17 @@ const NonnullRefPtr<Document> DOMImplementation::create_html_document(const Stri
     html_document->set_origin(m_document.origin());
 
     return html_document;
+}
+
+// https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype
+NonnullRefPtr<DocumentType> DOMImplementation::create_document_type(const String& qualified_name, const String& public_id, const String& system_id) const
+{
+    // FIXME: Validate qualified_name.
+    auto document_type = DocumentType::create(m_document);
+    document_type->set_name(qualified_name);
+    document_type->set_public_id(public_id);
+    document_type->set_system_id(system_id);
+    return document_type;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
@@ -25,7 +25,10 @@ public:
         return adopt_ref(*new DOMImplementation(document));
     }
 
-    const NonnullRefPtr<Document> create_html_document(const String& title) const;
+    // FIXME: Add optional DocumentType once supported by IDL
+    NonnullRefPtr<Document> create_document(const String&, const String&) const;
+    NonnullRefPtr<Document> create_html_document(const String& title) const;
+    NonnullRefPtr<DocumentType> create_document_type(const String&, const String&, const String&) const;
 
     // https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature
     bool has_feature() const { return true; }

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.idl
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.idl
@@ -1,6 +1,10 @@
 interface DOMImplementation {
 
-    Document createHTMLDocument(optional DOMString title);
+    // FIXME: This is missing "optional DocumentType? doctype = null" at the end.
+    // FIXME: This should return XMLDocument instead of Document.
+    [NewObject] Document createDocument(DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName);
+    [NewObject] Document createHTMLDocument(optional DOMString title);
+    [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
 
     boolean hasFeature();
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.h
@@ -15,6 +15,11 @@ class DocumentType final : public Node {
 public:
     using WrapperType = Bindings::DocumentTypeWrapper;
 
+    static NonnullRefPtr<DocumentType> create(Document& document)
+    {
+        return adopt_ref(*new DocumentType(document));
+    }
+
     explicit DocumentType(Document&);
     virtual ~DocumentType() override;
 


### PR DESCRIPTION
LibWeb: Add support for extended attributes on IDL parameters

Also adds support for [LegacyNullToEmptyString] for parameters.

-----

LibWeb: Add initial implementation of createDocument and createDocumentType

Both required for the acid3 test.
createDocument is used extensively in Web Platform Tests.