### PR TITLE
Meta: Remove link to man6 in man.serenityos.org

### DIFF
--- a/Meta/Websites/man.serenityos.org/index.html
+++ b/Meta/Websites/man.serenityos.org/index.html
@@ -11,7 +11,6 @@
 <a href="3/"><p>Man 3</p></a>
 <a href="4/"><p>Man 4</p></a>
 <a href="5/"><p>Man 5</p></a>
-<a href="6/"><p>Man 6</p></a>
 <a href="7/"><p>Man 7</p></a>
 <a href="8/"><p>Man 8</p></a>
 </body>


### PR DESCRIPTION
We dont currently have any man6 entries