### PR TITLE
LibGUI: Remember modified state on undo/redo actions

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -299,7 +299,7 @@ MainWidget::MainWidget()
             return;
         }
 
-        editor().document().set_modified(false);
+        editor().document().set_unmodified();
         // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
         window()->set_modified(false);
 
@@ -312,7 +312,7 @@ MainWidget::MainWidget()
             if (!m_editor->write_to_file(m_path)) {
                 GUI::MessageBox::show(window(), "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
             } else {
-                editor().document().set_modified(false);
+                editor().document().set_unmodified();
                 // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
                 window()->set_modified(false);
 

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -26,7 +26,7 @@ TextDocument::TextDocument(Client* client)
     if (client)
         m_clients.set(client);
     append_line(make<TextDocumentLine>(*this));
-    set_modified(false);
+    set_unmodified();
 
     m_undo_timer = Core::Timer::create_single_shot(
         2000, [this] {
@@ -94,7 +94,7 @@ bool TextDocument::set_text(const StringView& text)
     clear_text_guard.disarm();
 
     // FIXME: Should the modified state be cleared on some of the earlier returns as well?
-    set_modified(false);
+    set_unmodified();
     return true;
 }
 
@@ -309,8 +309,6 @@ void TextDocument::update_views(Badge<TextDocumentLine>)
 
 void TextDocument::notify_did_change()
 {
-    set_modified(true);
-
     if (m_undo_timer)
         m_undo_timer->restart();
 
@@ -887,9 +885,9 @@ const TextDocumentSpan* TextDocument::span_at(const TextPosition& position) cons
     return nullptr;
 }
 
-void TextDocument::set_modified(bool modified)
+void TextDocument::set_unmodified()
 {
-    m_modified = modified;
+    m_undo_stack.set_current_unmodified();
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -41,6 +41,7 @@ TextDocument::~TextDocument()
 bool TextDocument::set_text(const StringView& text)
 {
     m_client_notifications_enabled = false;
+    m_undo_stack.clear();
     m_spans.clear();
     remove_all_lines();
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -122,8 +122,8 @@ public:
     virtual bool is_code_document() const { return false; }
 
     bool is_empty() const;
-    bool is_modified() const { return m_modified; }
-    void set_modified(bool);
+    bool is_modified() const { return m_undo_stack.is_current_modified(); }
+    void set_unmodified();
 
 protected:
     explicit TextDocument(Client* client);
@@ -136,7 +136,6 @@ private:
 
     HashTable<Client*> m_clients;
     bool m_client_notifications_enabled { true };
-    bool m_modified { false };
 
     UndoStack m_undo_stack;
     RefPtr<Core::Timer> m_undo_timer;

--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -80,4 +80,10 @@ void UndoStack::finalize_current_combo()
     m_stack.prepend(move(undo_commands_container));
 }
 
+void UndoStack::clear()
+{
+    m_stack.clear();
+    m_stack_index = 0;
+}
+
 }

--- a/Userland/Libraries/LibGUI/UndoStack.h
+++ b/Userland/Libraries/LibGUI/UndoStack.h
@@ -26,6 +26,8 @@ public:
 
     void finalize_current_combo();
 
+    void clear();
+
 private:
     struct UndoCommandsContainer {
         NonnullOwnPtrVector<Command> m_undo_vector;

--- a/Userland/Libraries/LibGUI/UndoStack.h
+++ b/Userland/Libraries/LibGUI/UndoStack.h
@@ -19,12 +19,15 @@ public:
     void push(NonnullOwnPtr<Command>&&);
 
     bool can_undo() const { return m_stack_index < m_stack.size() && !m_stack.is_empty(); }
-    bool can_redo() const { return m_stack_index > 0 && !m_stack.is_empty(); }
+    bool can_redo() const { return m_stack_index > 0 && !m_stack.is_empty() && m_stack[m_stack_index - 1].m_undo_vector.size() > 0; }
 
     void undo();
     void redo();
 
     void finalize_current_combo();
+
+    void set_current_unmodified();
+    bool is_current_modified() const;
 
     void clear();
 
@@ -35,6 +38,7 @@ private:
 
     NonnullOwnPtrVector<UndoCommandsContainer> m_stack;
     size_t m_stack_index { 0 };
+    Optional<size_t> m_clean_index;
 };
 
 }


### PR DESCRIPTION
This change allows any application that uses the undo stack to keep track of the modified state for each undo/redo action.