### PR TITLE
Kernel: Donate time slices for socket interactions

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -113,6 +113,7 @@ namespace Kernel {
     S(create_thread)          \
     S(gettid)                 \
     S(donate)                 \
+    S(donate_peer)            \
     S(rename)                 \
     S(ftruncate)              \
     S(exit_thread)            \

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -54,4 +54,30 @@ void File::detach(FileDescription&)
     m_attach_count--;
 }
 
+void File::remember_thread_access()
+{
+    auto current_thread = Thread::current();
+    auto first_thread = m_accessing_threads[0].strong_ref();
+    auto second_thread = m_accessing_threads[1].strong_ref();
+    // FIXME: This is terrible.
+    if (!first_thread) {
+        m_accessing_threads[0] = current_thread;
+        return;
+    }
+    if (!second_thread && first_thread != current_thread) {
+        m_accessing_threads[1] = current_thread;
+        return;
+    }
+}
+
+RefPtr<Thread> File::likely_peer_thread() const
+{
+    auto current_thread = Thread::current();
+    auto first_thread = m_accessing_threads[0].strong_ref();
+    if (first_thread == current_thread)
+        return m_accessing_threads[1].strong_ref();
+    else
+        return first_thread;
+}
+
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -114,6 +114,9 @@ public:
 
     size_t attach_count() const { return m_attach_count; }
 
+    void remember_thread_access();
+    RefPtr<Thread> likely_peer_thread() const;
+
 protected:
     File();
 
@@ -141,6 +144,7 @@ private:
 
     FileBlockCondition m_block_condition;
     size_t m_attach_count { 0 };
+    WeakPtr<Thread> m_accessing_threads[2];
 };
 
 }

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -819,6 +819,8 @@ static bool procfs$all(InodeIdentifier, KBufferBuilder& builder)
             thread_object.add("inode_faults", thread.inode_faults());
             thread_object.add("zero_faults", thread.zero_faults());
             thread_object.add("cow_faults", thread.cow_faults());
+            thread_object.add("time_slices_donated", thread.time_slices_donated());
+            thread_object.add("time_slices_received", thread.time_slices_received());
             thread_object.add("file_read_bytes", thread.file_read_bytes());
             thread_object.add("file_write_bytes", thread.file_write_bytes());
             thread_object.add("unix_socket_read_bytes", thread.unix_socket_read_bytes());

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -286,6 +286,7 @@ KResultOr<size_t> LocalSocket::sendto(FileDescription& description, const UserOr
     auto* socket_buffer = send_buffer_for(description);
     if (!socket_buffer)
         return EINVAL;
+    remember_thread_access();
     ssize_t nwritten = socket_buffer->write(data, data_size);
     if (nwritten > 0)
         Thread::current()->did_unix_socket_write(nwritten);
@@ -331,6 +332,7 @@ KResultOr<size_t> LocalSocket::recvfrom(FileDescription& description, UserOrKern
     if (!has_attached_peer(description) && socket_buffer->is_empty())
         return 0;
     VERIFY(!socket_buffer->is_empty());
+    remember_thread_access();
     auto nread = socket_buffer->read(buffer, buffer_size);
     if (nread > 0)
         Thread::current()->did_unix_socket_read(nread);

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -55,6 +55,7 @@ RefPtr<Socket> Socket::accept()
     if (m_pending.is_empty())
         return nullptr;
     dbgln_if(SOCKET_DEBUG, "Socket({}) de-queueing connection", this);
+    remember_thread_access();
     auto client = m_pending.take_first();
     VERIFY(!client->is_connected());
     auto& process = *Process::current();

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -257,6 +257,7 @@ public:
     KResultOr<int> sys$dump_backtrace();
     KResultOr<pid_t> sys$gettid();
     KResultOr<int> sys$donate(pid_t tid);
+    KResultOr<int> sys$donate_peer(int fd);
     KResultOr<pid_t> sys$setsid();
     KResultOr<pid_t> sys$getsid(pid_t);
     KResultOr<int> sys$setpgid(pid_t pid, pid_t pgid);

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -306,6 +306,9 @@ bool Scheduler::donate_to_and_switch(Thread* beneficiary, [[maybe_unused]] const
     dbgln_if(SCHEDULER_DEBUG, "Scheduler[{}]: Donating {} ticks to {}, reason={}", proc.get_id(), ticks_to_donate, *beneficiary, reason);
     beneficiary->set_ticks_left(ticks_to_donate);
 
+    current_thread->did_donate_time_slices(ticks_to_donate);
+    beneficiary->did_receive_time_slices(ticks_to_donate);
+
     return Scheduler::context_switch(beneficiary);
 }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -988,6 +988,10 @@ public:
     void did_zero_fault() { ++m_zero_faults; }
     unsigned cow_faults() const { return m_cow_faults; }
     void did_cow_fault() { ++m_cow_faults; }
+    unsigned time_slices_donated() const { return m_time_slices_donated; }
+    void did_donate_time_slices(unsigned slices) { m_time_slices_donated += slices; }
+    unsigned time_slices_received() const { return m_time_slices_received; }
+    void did_receive_time_slices(unsigned slices) { m_time_slices_received += slices; }
 
     unsigned file_read_bytes() const { return m_file_read_bytes; }
     unsigned file_write_bytes() const { return m_file_write_bytes; }
@@ -1237,6 +1241,8 @@ private:
     unsigned m_inode_faults { 0 };
     unsigned m_zero_faults { 0 };
     unsigned m_cow_faults { 0 };
+    unsigned m_time_slices_donated { 0 };
+    unsigned m_time_slices_received { 0 };
 
     unsigned m_file_read_bytes { 0 };
     unsigned m_file_write_bytes { 0 };

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -244,6 +244,11 @@ const FileDescription& Thread::FileDescriptionBlocker::blocked_description() con
     return m_blocked_description;
 }
 
+RefPtr<Thread> Thread::FileDescriptionBlocker::pick_donate_target() const
+{
+    return m_blocked_description->file().likely_peer_thread();
+}
+
 Thread::AcceptBlocker::AcceptBlocker(FileDescription& description, BlockFlags& unblocked_flags)
     : FileDescriptionBlocker(description, BlockFlags::Accept | BlockFlags::Exception, unblocked_flags)
 {
@@ -434,6 +439,13 @@ void Thread::SelectBlocker::was_unblocked(bool did_timeout)
         // If we were blocked and didn't time out, we should have at least one unblocked fd!
         VERIFY(count > 0);
     }
+}
+
+RefPtr<Thread> Thread::SelectBlocker::pick_donate_target() const
+{
+    if (m_fds.is_empty())
+        return nullptr;
+    return m_fds[0].description->file().likely_peer_thread();
 }
 
 Thread::WaitBlockCondition::ProcessBlockInfo::ProcessBlockInfo(NonnullRefPtr<Process>&& process, WaitBlocker::UnblockFlags flags, u8 signal)

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -351,6 +351,8 @@ Thread::SelectBlocker::SelectBlocker(FDVector& fds)
             continue;
         if (!fd_entry.description->block_condition().add_blocker(*this, &fd_entry))
             m_should_block = false;
+        else
+            fd_entry.description->file().remember_thread_access();
     }
 }
 

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -102,6 +102,10 @@ String ProcessModel::column_name(int column) const
         return "F:Zero";
     case Column::CowFaults:
         return "F:CoW";
+    case Column::TimeSlicesDonated:
+        return "S:DonatedSlices";
+    case Column::TimeSlicesReceived:
+        return "S:ReceivedSlices";
     case Column::IPv4SocketReadBytes:
         return "IPv4 In";
     case Column::IPv4SocketWriteBytes:
@@ -159,6 +163,8 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
         case Column::InodeFaults:
         case Column::ZeroFaults:
         case Column::CowFaults:
+        case Column::TimeSlicesDonated:
+        case Column::TimeSlicesReceived:
         case Column::FileReadBytes:
         case Column::FileWriteBytes:
         case Column::UnixSocketReadBytes:
@@ -220,6 +226,10 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
             return thread.current_state.zero_faults;
         case Column::CowFaults:
             return thread.current_state.cow_faults;
+        case Column::TimeSlicesDonated:
+            return thread.current_state.time_slices_donated;
+        case Column::TimeSlicesReceived:
+            return thread.current_state.time_slices_received;
         case Column::IPv4SocketReadBytes:
             return thread.current_state.ipv4_socket_read_bytes;
         case Column::IPv4SocketWriteBytes:
@@ -291,6 +301,10 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
             return thread.current_state.zero_faults;
         case Column::CowFaults:
             return thread.current_state.cow_faults;
+        case Column::TimeSlicesDonated:
+            return thread.current_state.time_slices_donated;
+        case Column::TimeSlicesReceived:
+            return thread.current_state.time_slices_received;
         case Column::IPv4SocketReadBytes:
             return thread.current_state.ipv4_socket_read_bytes;
         case Column::IPv4SocketWriteBytes:
@@ -340,6 +354,8 @@ void ProcessModel::update()
                 state.inode_faults = thread.inode_faults;
                 state.zero_faults = thread.zero_faults;
                 state.cow_faults = thread.cow_faults;
+                state.time_slices_donated = thread.time_slices_donated;
+                state.time_slices_received = thread.time_slices_received;
                 state.unix_socket_read_bytes = thread.unix_socket_read_bytes;
                 state.unix_socket_write_bytes = thread.unix_socket_write_bytes;
                 state.ipv4_socket_read_bytes = thread.ipv4_socket_read_bytes;

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -42,6 +42,8 @@ public:
         InodeFaults,
         ZeroFaults,
         CowFaults,
+        TimeSlicesDonated,
+        TimeSlicesReceived,
         FileReadBytes,
         FileWriteBytes,
         UnixSocketReadBytes,
@@ -108,6 +110,8 @@ private:
         unsigned inode_faults;
         unsigned zero_faults;
         unsigned cow_faults;
+        unsigned time_slices_donated;
+        unsigned time_slices_received;
         unsigned unix_socket_read_bytes;
         unsigned unix_socket_write_bytes;
         unsigned ipv4_socket_read_bytes;

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -87,7 +87,7 @@ ProcessStateWidget::ProcessStateWidget(pid_t pid)
     layout()->set_margins({ 4, 4, 4, 4 });
     m_table_view = add<GUI::TableView>();
     m_table_view->column_header().set_visible(false);
-    m_table_view->column_header().set_section_size(0, 90);
+    m_table_view->column_header().set_section_size(0, 120);
     m_table_view->set_model(adopt_ref(*new ProcessStateModel(ProcessModel::the(), pid)));
 }
 

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -681,6 +681,12 @@ int donate(int tid)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+int donate_peer(int fd)
+{
+    int rc = syscall(SC_donate_peer, fd);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 void sysbeep()
 {
     syscall(SC_beep);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -42,6 +42,7 @@ int fsync(int fd);
 void sysbeep();
 int gettid();
 int donate(int tid);
+int donate_peer(int fd);
 int getpagesize();
 pid_t fork();
 pid_t vfork();

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -82,6 +82,8 @@ Optional<HashMap<pid_t, Core::ProcessStatistics>> ProcessStatisticsReader::get_a
             thread.inode_faults = thread_object.get("inode_faults").to_u32();
             thread.zero_faults = thread_object.get("zero_faults").to_u32();
             thread.cow_faults = thread_object.get("cow_faults").to_u32();
+            thread.time_slices_donated = thread_object.get("time_slices_donated").to_u32();
+            thread.time_slices_received = thread_object.get("time_slices_received").to_u32();
             thread.unix_socket_read_bytes = thread_object.get("unix_socket_read_bytes").to_u32();
             thread.unix_socket_write_bytes = thread_object.get("unix_socket_write_bytes").to_u32();
             thread.ipv4_socket_read_bytes = thread_object.get("ipv4_socket_read_bytes").to_u32();

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -22,6 +22,8 @@ struct ThreadStatistics {
     unsigned inode_faults;
     unsigned zero_faults;
     unsigned cow_faults;
+    unsigned time_slices_donated;
+    unsigned time_slices_received;
     unsigned unix_socket_read_bytes;
     unsigned unix_socket_write_bytes;
     unsigned ipv4_socket_read_bytes;

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -101,6 +101,10 @@ public:
             total_nwritten += nwritten;
         }
 
+#ifdef __serenity__
+        (void)donate_peer(m_socket->fd());
+#endif
+
         m_responsiveness_timer->start();
     }
 


### PR DESCRIPTION
This PR implements support for intelligently scheduling threads for IPC interactions:

1. It adds support to the kernel that lets it remember which user threads access a file via read()/write()/select()/poll().
2. Fixes a scheduler hang with non-runnable threads:

When a thread that is non-runnable tried to donate their remaining time slice to another thread that was also non-runnable we'd remove the thread from the ready queue but didn't add it back.

This would cause the thread to never get scheduled again. Previously this could not happen because non-runnable threads had no way of donating their time slice to anyone else.

3. Donates time slices to peer when waiting on a socket:

This causes the user-mode thread to donate their remaining time slice to the peer of a socket when it does a blocking `read()`/`write()` or waits for data with `select()`/`poll()`.

4. Adds the `donate_peer` system call:

This system call donates the calling thread's remaining time slice to the peer of the specified file descriptor (only sockets are
supported for now).

`LibIPC` has been updated to use this after writing a complete IPC message to a socket.

5. Adds statistics for time slices donated/received. These show up in `SystemMonitor`. Note, that `SystemMonitor` does not currently support threads so you might have to look at `/proc/all` instead for some processes.

This might be biased and quite subjective but Super Mario's keyboard input seems significantly more response than it was before. I'd suggest trying this in comparison with the `master` branch.

![Screenshot from 2021-05-05 05-10-50](https://user-images.githubusercontent.com/388571/117093140-681b0900-ad60-11eb-84b8-befecb871139.png)
