### PR TITLE
Kernel: Add Processor::is_bootstrap_processor() function, and use it.

### DIFF
--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -823,6 +823,11 @@ public:
         return read_fs_ptr(__builtin_offsetof(Processor, m_cpu));
     }
 
+    ALWAYS_INLINE static bool is_bootstrap_processor()
+    {
+        return Processor::id() == 0;
+    }
+
     ALWAYS_INLINE u32 raise_irq()
     {
         return m_in_irq++;

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -485,7 +485,7 @@ UNMAP_AFTER_INIT APICTimer* APIC::initialize_timers(HardwareTimerBase& calibrati
         return nullptr;
 
     // We should only initialize and calibrate the APIC timer once on the BSP!
-    VERIFY(Processor::id() == 0);
+    VERIFY(Processor::is_bootstrap_processor());
     VERIFY(!m_apic_timer);
 
     m_apic_timer = APICTimer::initialize(IRQ_APIC_TIMER, calibration_timer);

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -475,7 +475,7 @@ UNMAP_AFTER_INIT Thread* Scheduler::create_ap_idle_thread(u32 cpu)
 {
     VERIFY(cpu != 0);
     // This function is called on the bsp, but creates an idle thread for another AP
-    VERIFY(Processor::id() == 0);
+    VERIFY(Processor::is_bootstrap_processor());
 
     VERIFY(s_colonel_process);
     Thread* idle_thread = s_colonel_process->create_kernel_thread(idle_loop, nullptr, THREAD_PRIORITY_MIN, String::formatted("idle thread #{}", cpu), 1 << cpu, false);
@@ -497,8 +497,7 @@ void Scheduler::timer_tick(const RegisterState& regs)
     VERIFY(current_thread->current_trap()->regs == &regs);
 
 #if !SCHEDULE_ON_ALL_PROCESSORS
-    bool is_bsp = Processor::id() == 0;
-    if (!is_bsp)
+    if (!Processor::is_bootstrap_processor())
         return; // TODO: This prevents scheduling on other CPUs!
 #endif
 

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -153,7 +153,7 @@ UNMAP_AFTER_INIT void TimeManagement::initialize(u32 cpu)
 
 void TimeManagement::set_system_timer(HardwareTimerBase& timer)
 {
-    VERIFY(Processor::id() == 0); // This should only be called on the BSP!
+    VERIFY(Processor::is_bootstrap_processor()); // This should only be called on the BSP!
     auto original_callback = m_system_timer->set_callback(nullptr);
     m_system_timer->disable();
     timer.set_callback(move(original_callback));
@@ -269,7 +269,7 @@ UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_non_legacy_hardware_timers()
         // Update the time. We don't really care too much about the
         // frequency of the interrupt because we'll query the main
         // counter to get an accurate time.
-        if (Processor::id() == 0) {
+        if (Processor::is_bootstrap_processor()) {
             // TODO: Have the other CPUs call system_timer_tick directly
             increment_time_since_boot_hpet();
         }


### PR DESCRIPTION
The variety of checks for `Processor::id() == 0` could use some assistance
int he readability department. This change adds a new function to
represent this check, and replaces the comparison everywhere it's used.