### PR TITLE
Meta+Toolchain: Enable linting of shell scripts under Toolchain

### DIFF
--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -9,7 +9,6 @@ if [ "$#" -eq "0" ]; then
     mapfile -t files < <(
         git ls-files -- \
             '*.sh' \
-            ':!:Toolchain' \
             ':!:Ports' \
             ':!:Userland/Shell/Tests' \
             ':!:Base/home/anon/tests'

--- a/Toolchain/BuildFuseExt2.sh
+++ b/Toolchain/BuildFuseExt2.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -e
+# This file will need to be run in bash.
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export PATH="/usr/local/opt/m4/bin:$PATH"
 

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -258,8 +258,8 @@ pushd "$DIR/Build/$ARCH"
         perl -pi -e 's/-no-pie/-nopie/g' "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/configure"
     fi
 
-    if [ ! -f $DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity-userland.h ]; then
-        cp $DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity.h $DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity-kernel.h
+    if [ ! -f "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity-userland.h" ]; then
+        cp "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity.h" "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity-kernel.h"
     fi
 
     for STAGE in Userland Kernel; do
@@ -277,9 +277,9 @@ pushd "$DIR/Build/$ARCH"
                 REALTARGET="$PREFIX/Kernel"
             fi
 
-            cp $DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity-kernel.h $DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity.h
+            cp "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity-kernel.h" "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity.h"
             if [ "$STAGE" = "Userland" ]; then
-                sed -i='' 's@-fno-exceptions @@' $DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity.h
+                sed -i='' 's@-fno-exceptions @@' "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/config/serenity.h"
             fi
 
             buildstep "gcc/configure/${STAGE,,}" "$DIR/Tarballs/gcc-$GCC_VERSION/configure" --prefix="$PREFIX" \
@@ -302,16 +302,16 @@ pushd "$DIR/Build/$ARCH"
                 fi
                 buildstep "libgcc/build" "$MAKE" -j "$MAKEJOBS" all-target-libgcc || exit 1
                 echo "XXX install gcc and libgcc"
-                buildstep "gcc+libgcc/install" "$MAKE" DESTDIR=$TEMPTARGET install-gcc install-target-libgcc || exit 1
+                buildstep "gcc+libgcc/install" "$MAKE" DESTDIR="$TEMPTARGET" install-gcc install-target-libgcc || exit 1
             fi
 
             echo "XXX build libstdc++"
             buildstep "libstdc++/build/${STAGE,,}" "$MAKE" -j "$MAKEJOBS" all-target-libstdc++-v3 || exit 1
             echo "XXX install libstdc++"
-            buildstep "libstdc++/install/${STAGE,,}" "$MAKE" DESTDIR=$TEMPTARGET install-target-libstdc++-v3 || exit 1
+            buildstep "libstdc++/install/${STAGE,,}" "$MAKE" DESTDIR="$TEMPTARGET" install-target-libstdc++-v3 || exit 1
 
             mkdir -p "$REALTARGET"
-            cp -a $TEMPTARGET/$PREFIX/* "$REALTARGET/"
+            cp -a "$TEMPTARGET"/"$PREFIX"/* "$REALTARGET/"
             rm -rf "$TEMPTARGET"
         popd
 

--- a/Toolchain/BuildPython.sh
+++ b/Toolchain/BuildPython.sh
@@ -10,6 +10,7 @@ PREFIX_DIR="$DIR/Local/$ARCH"
 BUILD_DIR="$DIR/Build/$ARCH"
 TARBALLS_DIR="$DIR/Tarballs"
 
+# shellcheck source=/dev/null
 source "$DIR/../Ports/python3/version.sh"
 
 mkdir -p "${TARBALLS_DIR}"


### PR DESCRIPTION
 -  __Toolchain: Make BuildPython.sh shellcheck compliant.__

    Shell checks unable to source non-literal includes,
    so inform shellcheck to just ignore this include.


 -  __Toolchain: Make BuildFuseExt2.sh shellcheck compliant.__

    BuildFuseExt2.sh was saying it should be run under /bin/sh but it is
    using bash extensions like pushd/popd, ${BASH_SOURCE[0]}, etc. So just
    run it under bash to avoid any potential issues.

 -  __Toolchain: Fix expansion bugs and make BuildIt.sh shellcheck compliant.__

    BuildIt.sh had a bunch of SC2086 errors, where we were not quoting
    variables in variable expansions. The logic being:

        Quoting variables prevents word splitting and glob expansion,
        and prevents the script from breaking when input contains spaces,
        line feeds, glob characters and such.

        Reference: https://github.com/koalaman/shellcheck/wiki/SC2086

    As bcoles noticed in #6772, shell check actually found a real bug here,
    where the users path did have a space in it.

    Closes: #6772

 - __Meta: Enable linting of shell scripts under Toolchain__

    Now that everything under Toolchain is shellcheck clean,
    remove it from the exception list.