### PR TITLE
Kernel: Remove shadowing member variable from FileDescriptionBlocker

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -559,7 +559,6 @@ public:
         const BlockFlags m_flags;
         BlockFlags& m_unblocked_flags;
         bool m_did_unblock { false };
-        bool m_should_block { true };
     };
 
     class AcceptBlocker final : public FileDescriptionBlocker {


### PR DESCRIPTION
FileDescriptionBlocker::m_should_block was shadowing the parent's
FileBlocker::m_should_block variable, which would cause should_block()
to return the wrong value.

Found by @gunnarbeutner