### PR TITLE
Kernel: Fix `write`s to `ProcFS`

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1562,6 +1562,11 @@ KResultOr<NonnullRefPtr<Custody>> ProcFSInode::resolve_as_link(Custody& base, Re
     return *res;
 }
 
+KResult ProcFSInode::set_mtime(time_t)
+{
+    return KSuccess;
+}
+
 ProcFSProxyInode::ProcFSProxyInode(ProcFS& fs, FileDescription& fd)
     : Inode(fs, 0)
     , m_fd(fd)

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -90,6 +90,7 @@ private:
     virtual KResult chmod(mode_t) override;
     virtual KResult chown(uid_t, gid_t) override;
     virtual KResultOr<NonnullRefPtr<Custody>> resolve_as_link(Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0) const override;
+    virtual KResult set_mtime(time_t) override;
 
     KResult refresh_data(FileDescription&) const;
 


### PR DESCRIPTION
When using `sysctl` you can enable/disable values by writing to the
ProcFS. Some drift must of occured where writing was failing due to a
missing `set_mtime` call. Whenever one `write`'s a file the modified time
(mtime) will be updated so we need to implement this interface in ProcFS.