### PR TITLE
Kernel: Allow remapping Caps Lock to Control

### DIFF
--- a/Kernel/Devices/HID/HIDManagement.cpp
+++ b/Kernel/Devices/HID/HIDManagement.cpp
@@ -12,6 +12,7 @@
 
 namespace Kernel {
 
+Atomic<bool> g_caps_lock_remapped_to_ctrl;
 static AK::Singleton<HIDManagement> s_the;
 
 // clang-format off

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Atomic.h>
 #include <AK/CircularQueue.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefPtr.h>
@@ -19,6 +20,8 @@
 #include <LibKeyboard/CharacterMap.h>
 
 namespace Kernel {
+
+extern Atomic<bool> g_caps_lock_remapped_to_ctrl;
 
 class HIDDevice;
 class I8042Controller;

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -234,8 +234,14 @@ void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
         }
     }
 
-    if (key == Key_CapsLock && pressed)
+    if (!g_caps_lock_remapped_to_ctrl && key == Key_CapsLock && pressed)
         m_caps_lock_on = !m_caps_lock_on;
+
+    if (g_caps_lock_remapped_to_ctrl && key == Key_CapsLock)
+        m_caps_lock_to_ctrl_pressed = pressed;
+
+    if (g_caps_lock_remapped_to_ctrl)
+        update_modifier(Mod_Ctrl, m_caps_lock_to_ctrl_pressed);
 
     Event event;
     event.key = key;

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -53,6 +53,7 @@ protected:
     virtual const char* class_name() const override { return "KeyboardDevice"; }
 
     u8 m_modifiers { 0 };
+    bool m_caps_lock_to_ctrl_pressed { false };
     bool m_caps_lock_on { false };
     bool m_num_lock_on { false };
     bool m_has_e0_prefix { false };

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Spencer Dixon <spencercdixon@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -970,6 +971,7 @@ bool ProcFS::initialize()
 {
     static Lockable<bool>* kmalloc_stack_helper;
     static Lockable<bool>* ubsan_deadly_helper;
+    static Lockable<bool>* caps_lock_to_ctrl_helper;
 
     if (kmalloc_stack_helper == nullptr) {
         kmalloc_stack_helper = new Lockable<bool>();
@@ -981,6 +983,10 @@ bool ProcFS::initialize()
         ubsan_deadly_helper->resource() = UBSanitizer::g_ubsan_is_deadly;
         ProcFS::add_sys_bool("ubsan_is_deadly", *ubsan_deadly_helper, [] {
             UBSanitizer::g_ubsan_is_deadly = ubsan_deadly_helper->resource();
+        });
+        caps_lock_to_ctrl_helper = new Lockable<bool>();
+        ProcFS::add_sys_bool("caps_lock_to_ctrl", *caps_lock_to_ctrl_helper, [] {
+            Kernel::g_caps_lock_remapped_to_ctrl.exchange(caps_lock_to_ctrl_helper->resource());
         });
     }
     return true;


### PR DESCRIPTION
This PR introduces a new global kernel variable that allows folks to remap their caps lock key to control. A quick way to change the setting is to use `sysctl` as follows:

```
su
sysctl caps_lock_to_ctrl=1
```