### PR TITLE
LibGUI: Move widget registration to LibCore

### DIFF
--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -11,9 +11,9 @@
 #include <LibGfx/Font.h>
 #include <WindowServer/WindowManager.h>
 
-namespace SpaceAnalyzer {
-
 REGISTER_WIDGET(SpaceAnalyzer, TreeMapWidget)
+
+namespace SpaceAnalyzer {
 
 TreeMapWidget::TreeMapWidget()
     : m_viewpoint(0)

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -799,7 +799,11 @@ void HackStudioWidget::create_form_editor(GUI::Widget& parent)
 
     form_widgets_toolbar.add_action(cursor_tool_action);
 
-    GUI::WidgetClassRegistration::for_each([&, this](const GUI::WidgetClassRegistration& reg) {
+    auto& widget_class = *Core::ObjectClassRegistration::find("GUI::Widget");
+
+    Core::ObjectClassRegistration::for_each([&, this](const Core::ObjectClassRegistration& reg) {
+        if (!reg.is_derived_from(widget_class))
+            return;
         constexpr size_t gui_namespace_prefix_length = sizeof("GUI::") - 1;
         auto icon_path = String::formatted("/res/icons/hackstudio/G{}.png",
             reg.class_name().substring(gui_namespace_prefix_length, reg.class_name().length() - gui_namespace_prefix_length));
@@ -808,7 +812,7 @@ void HackStudioWidget::create_form_editor(GUI::Widget& parent)
 
         auto action = GUI::Action::create_checkable(reg.class_name(), Gfx::Bitmap::load_from_file(icon_path), [&reg, this](auto&) {
             m_form_editor_widget->set_tool(make<WidgetTool>(*m_form_editor_widget, reg));
-            auto widget = reg.construct();
+            auto widget = static_ptr_cast<Widget>(reg.construct());
             m_form_editor_widget->form_widget().add_child(widget);
             widget->set_relative_rect(30, 30, 30, 30);
             m_form_editor_widget->model().update();

--- a/Userland/DevTools/HackStudio/Tool.h
+++ b/Userland/DevTools/HackStudio/Tool.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
+#include <LibCore/Forward.h>
 #include <LibGUI/Forward.h>
 
 namespace HackStudio {

--- a/Userland/DevTools/HackStudio/WidgetTool.h
+++ b/Userland/DevTools/HackStudio/WidgetTool.h
@@ -12,7 +12,7 @@ namespace HackStudio {
 
 class WidgetTool final : public Tool {
 public:
-    explicit WidgetTool(FormEditorWidget& editor, const GUI::WidgetClassRegistration& meta_class)
+    explicit WidgetTool(FormEditorWidget& editor, const Core::ObjectClassRegistration& meta_class)
         : Tool(editor)
         , m_meta_class(meta_class)
     {
@@ -26,7 +26,7 @@ private:
     virtual void on_mousemove(GUI::MouseEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
 
-    const GUI::WidgetClassRegistration& m_meta_class;
+    const Core::ObjectClassRegistration& m_meta_class;
 };
 
 }

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
 
     editor.on_change = [&] {
         preview.remove_all_children();
-        preview.load_from_gml(editor.text(), [](const String& class_name) -> RefPtr<GUI::Widget> {
+        preview.load_from_gml(editor.text(), [](const String& class_name) -> RefPtr<Core::Object> {
             return UnregisteredWidget::construct(class_name);
         });
     };

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -27,6 +27,7 @@ class NetworkJob;
 class NetworkResponse;
 class Notifier;
 class Object;
+class ObjectClassRegistration;
 class ProcessStatisticsReader;
 class Socket;
 class SocketAddress;

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -10,8 +10,8 @@
 #include <LibGfx/Orientation.h>
 #include <stdio.h>
 
-REGISTER_WIDGET(GUI, HorizontalBoxLayout)
-REGISTER_WIDGET(GUI, VerticalBoxLayout)
+REGISTER_CORE_OBJECT(GUI, HorizontalBoxLayout)
+REGISTER_CORE_OBJECT(GUI, VerticalBoxLayout)
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -78,7 +78,6 @@ class VerticalBoxLayout;
 class VerticalSlider;
 class WMEvent;
 class Widget;
-class WidgetClassRegistration;
 class Window;
 class WindowServerConnection;
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -19,9 +19,18 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/StandardCursor.h>
 
-#define REGISTER_WIDGET(namespace_, class_name)                                                                                                 \
-    namespace {                                                                                                                                 \
-    GUI::WidgetClassRegistration registration_##class_name(#namespace_ "::" #class_name, []() { return namespace_::class_name::construct(); }); \
+namespace Core {
+namespace Registration {
+extern Core::ObjectClassRegistration registration_Widget;
+}
+}
+
+#define REGISTER_WIDGET(namespace_, class_name)                                                                                                   \
+    namespace Core {                                                                                                                              \
+    namespace Registration {                                                                                                                      \
+    Core::ObjectClassRegistration registration_##class_name(                                                                                      \
+        #namespace_ "::" #class_name, []() { return static_ptr_cast<Core::Object>(namespace_::class_name::construct()); }, &registration_Widget); \
+    }                                                                                                                                             \
     }
 
 namespace GUI {
@@ -33,25 +42,6 @@ enum class HorizontalDirection {
 enum class VerticalDirection {
     Up,
     Down
-};
-
-class WidgetClassRegistration {
-    AK_MAKE_NONCOPYABLE(WidgetClassRegistration);
-    AK_MAKE_NONMOVABLE(WidgetClassRegistration);
-
-public:
-    WidgetClassRegistration(const String& class_name, Function<NonnullRefPtr<Widget>()> factory);
-    ~WidgetClassRegistration();
-
-    String class_name() const { return m_class_name; }
-    NonnullRefPtr<Widget> construct() const { return m_factory(); }
-
-    static void for_each(Function<void(const WidgetClassRegistration&)>);
-    static const WidgetClassRegistration* find(const String& class_name);
-
-private:
-    String m_class_name;
-    Function<NonnullRefPtr<Widget>()> m_factory;
 };
 
 enum class FocusPolicy {
@@ -281,7 +271,7 @@ public:
     void set_override_cursor(Gfx::StandardCursor);
 
     bool load_from_gml(const StringView&);
-    bool load_from_gml(const StringView&, RefPtr<Widget> (*unregistered_child_handler)(const String&));
+    bool load_from_gml(const StringView&, RefPtr<Core::Object> (*unregistered_child_handler)(const String&));
 
     void set_shrink_to_fit(bool);
     bool is_shrink_to_fit() const { return m_shrink_to_fit; }
@@ -341,7 +331,7 @@ private:
     void focus_previous_widget(FocusSource, bool siblings_only);
     void focus_next_widget(FocusSource, bool siblings_only);
 
-    bool load_from_json(const JsonObject&, RefPtr<Widget> (*unregistered_child_handler)(const String&));
+    virtual bool load_from_json(const JsonObject&, RefPtr<Core::Object> (*unregistered_child_handler)(const String&)) override;
 
     // HACK: These are used as property getters for the fixed_* size property aliases.
     int dummy_fixed_width() { return 0; }


### PR DESCRIPTION
This also moves `Widget::load_from_json` into Core::Object as a virtual function in order to allow loading non-widget objects in GML (e.g. `BoxLayout`).