### PR TITLE
Kernel: Truncate UDP packets on read

### DIFF
--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -64,10 +64,10 @@ KResultOr<size_t> UDPSocket::protocol_receive(ReadonlyBytes raw_ipv4_packet, Use
     auto& ipv4_packet = *(const IPv4Packet*)(raw_ipv4_packet.data());
     auto& udp_packet = *static_cast<const UDPPacket*>(ipv4_packet.payload());
     VERIFY(udp_packet.length() >= sizeof(UDPPacket)); // FIXME: This should be rejected earlier.
-    VERIFY(buffer_size >= (udp_packet.length() - sizeof(UDPPacket)));
-    if (!buffer.write(udp_packet.payload(), udp_packet.length() - sizeof(UDPPacket)))
+    size_t read_size = min(buffer_size, udp_packet.length() - sizeof(UDPPacket));
+    if (!buffer.write(udp_packet.payload(), read_size))
         return EFAULT;
-    return udp_packet.length() - sizeof(UDPPacket);
+    return read_size;
 }
 
 KResultOr<size_t> UDPSocket::protocol_send(const UserOrKernelBuffer& data, size_t data_length)

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -287,7 +287,11 @@ void DHCPv4Client::process_incoming(const DHCPv4Packet& packet)
 
     dbgln_if(DHCPV4CLIENT_DEBUG, "Here are the options: {}", options.to_string());
 
-    auto value = options.get<DHCPMessageType>(DHCPOption::DHCPMessageType).value();
+    auto value_or_error = options.get<DHCPMessageType>(DHCPOption::DHCPMessageType);
+    if (!value_or_error.has_value())
+        return;
+
+    auto value = value_or_error.value();
     switch (value) {
     case DHCPMessageType::DHCPOffer:
         handle_offer(packet, options);


### PR DESCRIPTION
When reading UDP packets from userspace with `recvmsg()`/`recv()` we would hit a `VERIFY()` if the supplied buffer is smaller than the received UDP packet. Instead we should just return truncated data to the caller.

This can be reproduced with:

```
    $ dd if=/dev/zero bs=1024 count=1 | nc -u 127.0.0.1 68
```

Plus there's a bonus fix for the DHCP client. It'd crash when being sent all-zero UDP packets (like above).