### PR TITLE
LibC: Lazily initialize malloc chunks

### DIFF
--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -244,8 +244,13 @@ static void* malloc_impl(size_t size, CallerWillInitializeMemory caller_will_ini
 
     --block->m_free_chunks;
     void* ptr = block->m_freelist;
+    if (ptr) {
+        block->m_freelist = block->m_freelist->next;
+    } else {
+        ptr = block->m_slot + block->m_next_lazy_freelist_index * block->m_size;
+        block->m_next_lazy_freelist_index++;
+    }
     VERIFY(ptr);
-    block->m_freelist = block->m_freelist->next;
     if (block->is_full()) {
         g_malloc_stats.number_of_blocks_full++;
         dbgln_if(MALLOC_DEBUG, "Block {:p} is now full in size class {}", block, good_size);

--- a/Userland/Libraries/LibC/mallocdefs.h
+++ b/Userland/Libraries/LibC/mallocdefs.h
@@ -57,18 +57,11 @@ struct ChunkedBlock
         m_magic = MAGIC_PAGE_HEADER;
         m_size = bytes_per_chunk;
         m_free_chunks = chunk_capacity();
-        m_freelist = (FreelistEntry*)chunk(0);
-        for (size_t i = 0; i < chunk_capacity(); ++i) {
-            auto* entry = (FreelistEntry*)chunk(i);
-            if (i != chunk_capacity() - 1)
-                entry->next = (FreelistEntry*)chunk(i + 1);
-            else
-                entry->next = nullptr;
-        }
     }
 
     ChunkedBlock* m_prev { nullptr };
     ChunkedBlock* m_next { nullptr };
+    size_t m_next_lazy_freelist_index { 0 };
     FreelistEntry* m_freelist { nullptr };
     size_t m_free_chunks { 0 };
     [[gnu::aligned(8)]] unsigned char m_slot[0];


### PR DESCRIPTION
By default `malloc` manages memory internally in larger blocks. When one of those blocks is added we initialize a free list by touching each of the new block's pages, thereby committing all that memory upfront.

This changes `malloc` to build the free list on demand which as a bonus also distributes the latency hit for new blocks more evenly
because the page faults for the zero pages now don't happen all at once.

Before:

![zinit-memory-master](https://user-images.githubusercontent.com/388571/117263663-c9230980-ae52-11eb-8c55-d4ccbece6db8.png)

![taskbar-master](https://user-images.githubusercontent.com/388571/117263926-09828780-ae53-11eb-96c2-a6d1a27be763.png)

After:

![zinit-memory-feature](https://user-images.githubusercontent.com/388571/117263677-cd4f2700-ae52-11eb-846e-bf35f207b33a.png)

![taskbar-lazy-init](https://user-images.githubusercontent.com/388571/117263946-0d160e80-ae53-11eb-9536-861e9ec8d2c0.png)


I also repeatedly built SQLite as a benchmark but this patch hasn't had the desirable effect of making those builds faster. But it hasn't slowed them down either.