### PR TITLE
LibGfx: remove constexpr, add noexcept on Color interpolate method

### DIFF
--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -149,7 +149,7 @@ public:
 #endif
     }
 
-    constexpr Color interpolate(const Color& other, float weight) const
+    Color interpolate(const Color& other, float weight) const noexcept
     {
         u8 r = red() + roundf(static_cast<float>(other.red() - red()) * weight);
         u8 g = green() + roundf(static_cast<float>(other.green() - green()) * weight);


### PR DESCRIPTION
This removes `constexpr` from the interpolate method in Color.h and adds
`noexcept`. The roundf call cannot be constexpr on clang. This is the
only incompatibility preventing serenity from building under clang. I
tested this on OSX Big Sur 11.3 and 11.3.1, and everything works with
this change.
