### PR TITLE
Kernel: Resize Ext2FSInode when writing directory contents

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1112,6 +1112,9 @@ KResult Ext2FSInode::write_directory(const Vector<Ext2FSDirectoryEntry>& entries
 
     stream.fill_to_end(0);
 
+    if (auto result = resize(stream.size()); result.is_error())
+        return result;
+
     auto buffer = UserOrKernelBuffer::for_kernel_buffer(stream.data());
     auto result = write_bytes(0, stream.size(), buffer, nullptr);
     if (result.is_error())


### PR DESCRIPTION
Ext2 directory contents are stored in a linked list of ext2_dir_entry
structs. There is no sentinel value to determine where the list ends.
Instead the list fills the entirity of the allocated space for the
inode.

Previously the inode was not correctly resized when it became smaller.
This resulted in stale data being interpreted as part of the linked list
of directory entries.

An alternative solution to this issue could be to overwrite the now stale
blocks with entries where the inode is set to 0.

Probably fixes: https://github.com/SerenityOS/serenity/issues/6367

The issue could also be triggered by adding files, because entries could
end up being packed more tightly together. For example running:
`touch js-tests/aaa` from the home directory corrupted the js-tests directory.