### PR TITLE
LibGUI: Remove line-is-empty check in TextDocument return-early

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -343,7 +343,7 @@ String TextDocument::text() const
 String TextDocument::text_in_range(const TextRange& a_range) const
 {
     auto range = a_range.normalized();
-    if (is_empty() || line_count() < range.end().line() - range.start().line() || line(range.start().line()).is_empty())
+    if (is_empty() || line_count() < range.end().line() - range.start().line())
         return String("");
 
     StringBuilder builder;


### PR DESCRIPTION
`LibGUI::TextDocument::text_in_range` had an inccorect return-early condition which triggered when the first line of the selection was empty.

This fixes #6895 where TextEditor's status bar showed that 0
characters are selected when the selection started on an empty line.