### PR TITLE
Kernel: VFS::rename - Fixed kernel crash while using mv command

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -498,6 +498,10 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
             return new_custody_or_error.error();
     }
 
+    if (!old_parent_custody || !new_parent_custody) {
+        return EPERM;
+    }
+
     auto& old_parent_inode = old_parent_custody->inode();
     auto& new_parent_inode = new_parent_custody->inode();
 

--- a/Userland/Utilities/mv.cpp
+++ b/Userland/Utilities/mv.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     for (auto& old_path : paths) {
         String combined_new_path;
         const char* new_path = original_new_path;
-        if (rc == 0 && S_ISDIR(st.st_mode)) {
+        if (S_ISDIR(st.st_mode)) {
             auto old_basename = LexicalPath(old_path).basename();
             combined_new_path = String::formatted("{}/{}", original_new_path, old_basename);
             new_path = combined_new_path.characters();
@@ -67,7 +67,12 @@ int main(int argc, char** argv)
         rc = rename(old_path, new_path);
         if (rc < 0) {
             if (errno == EXDEV) {
-                auto result = Core::File::copy_file_or_directory(new_path, old_path, Core::File::RecursionMode::Allowed, Core::File::LinkMode::Disallowed, Core::File::AddDuplicateFileMarker::No);
+                auto result = Core::File::copy_file_or_directory(
+                    new_path, old_path,
+                    Core::File::RecursionMode::Allowed,
+                    Core::File::LinkMode::Disallowed,
+                    Core::File::AddDuplicateFileMarker::No);
+
                 if (result.is_error()) {
                     warnln("mv: could not move '{}': {}", old_path, result.error().error_code);
                     return 1;
@@ -75,6 +80,8 @@ int main(int argc, char** argv)
                 rc = unlink(old_path);
                 if (rc < 0)
                     fprintf(stderr, "mv: unlink '%s': %s\n", old_path, strerror(errno));
+            } else {
+                warnln("mv: cannot move '{}' : {}", old_path, strerror(errno));
             }
         }
 


### PR DESCRIPTION
Hi!

I've found a kernel crash while using the mv command:
![mv_crash](https://user-images.githubusercontent.com/82210061/117343163-eaf4ae80-ae9b-11eb-9e81-137bb9ba02f5.png)

I've fixed the mv command itself to stop passing bad paths to the kernel and to print proper error messages (if mv failed, it did not print any information).

I've also fixed the VFS::rename from using null pointers so that it doesn't crash even if given improper inputs.

Final result:
![mv_fixed](https://user-images.githubusercontent.com/82210061/117343912-b6cdbd80-ae9c-11eb-92f1-17c3d1df8912.png)



Thanks!
