### PR TITLE
LibC: Make scanf() not increment the assignment count for %n

### DIFF
--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -612,7 +612,6 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
                 auto* ptr = va_arg(ap, int*);
                 *ptr = input_lexer.tell();
             }
-            ++elements_matched;
             break;
         }
         }


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/c/io/fscanf

```
n | returns the number of characters read so far.  No input is consumed. Does not increment the assignment count. If the  specifier has assignment-suppressing operator defined, the behavior is  undefined
```