### PR TITLE
LibC: Make malloc(0) return a non-null pointer

### DIFF
--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -162,8 +162,11 @@ static void* malloc_impl(size_t size, CallerWillInitializeMemory caller_will_ini
     if (s_log_malloc)
         dbgln("LibC: malloc({})", size);
 
-    if (!size)
-        return nullptr;
+    if (!size) {
+        // Legally we could just return a null pointer here, but this is more
+        // compatible with existing software.
+        size = 1;
+    }
 
     g_malloc_stats.number_of_malloc_calls++;
 


### PR DESCRIPTION
Legally we could just return a null pointer, however returning a pointer other than the null pointer is more compatible with
improperly written software that assumes that a null pointer means allocation failure.

I ran into this problem while helping @Cleverking2003 port his puzzle collection thing.