### PR TITLE
LibWeb: Implement Node.replaceChild and replacing the current body when setting document.body

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -222,7 +222,9 @@ ExceptionOr<void> Document::set_body(HTML::HTMLElement& new_body)
 
     auto* existing_body = body();
     if (existing_body) {
-        TODO();
+        auto replace_result = existing_body->parent()->replace_child(new_body, *existing_body);
+        if (replace_result.is_exception())
+            return NonnullRefPtr<DOMException>(replace_result.exception());
         return {};
     }
 
@@ -230,7 +232,9 @@ ExceptionOr<void> Document::set_body(HTML::HTMLElement& new_body)
     if (!document_element)
         return DOM::HierarchyRequestError::create("Missing document element");
 
-    document_element->append_child(new_body);
+    auto append_result = document_element->append_child(new_body);
+    if (append_result.is_exception())
+        return NonnullRefPtr<DOMException>(append_result.exception());
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -184,7 +184,7 @@ const Element* Document::document_element() const
     return first_child_of_type<Element>();
 }
 
-const HTML::HTMLHtmlElement* Document::html_element() const
+HTML::HTMLHtmlElement* Document::html_element()
 {
     auto* html = document_element();
     if (is<HTML::HTMLHtmlElement>(html))
@@ -192,7 +192,7 @@ const HTML::HTMLHtmlElement* Document::html_element() const
     return nullptr;
 }
 
-const HTML::HTMLHeadElement* Document::head() const
+HTML::HTMLHeadElement* Document::head()
 {
     auto* html = html_element();
     if (!html)
@@ -200,7 +200,7 @@ const HTML::HTMLHeadElement* Document::head() const
     return html->first_child_of_type<HTML::HTMLHeadElement>();
 }
 
-const HTML::HTMLElement* Document::body() const
+HTML::HTMLElement* Document::body()
 {
     auto* html = html_element();
     if (!html)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -91,9 +91,25 @@ public:
     Element* document_element();
     const Element* document_element() const;
 
-    const HTML::HTMLHtmlElement* html_element() const;
-    const HTML::HTMLHeadElement* head() const;
-    const HTML::HTMLElement* body() const;
+    HTML::HTMLHtmlElement* html_element();
+    HTML::HTMLHeadElement* head();
+    HTML::HTMLElement* body();
+
+    const HTML::HTMLHtmlElement* html_element() const
+    {
+        return const_cast<Document*>(this)->html_element();
+    }
+
+    const HTML::HTMLHeadElement* head() const
+    {
+        return const_cast<Document*>(this)->head();
+    }
+
+    const HTML::HTMLElement* body() const
+    {
+        return const_cast<Document*>(this)->body();
+    }
+
     ExceptionOr<void> set_body(HTML::HTMLElement& new_body);
 
     String title() const;

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -82,6 +82,8 @@ public:
     void remove_all_children(bool suppress_observers = false);
     u16 compare_document_position(RefPtr<Node> other);
 
+    ExceptionOr<NonnullRefPtr<Node>> replace_child(NonnullRefPtr<Node> node, NonnullRefPtr<Node> child);
+
     NonnullRefPtr<Node> clone_node(Document* document = nullptr, bool clone_children = false) const;
     ExceptionOr<NonnullRefPtr<Node>> clone_node_binding(bool deep) const;
 

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -18,6 +18,7 @@ interface Node : EventTarget {
 
     Node appendChild(Node node);
     [ImplementedAs=pre_insert] Node insertBefore(Node node, Node? child);
+    Node replaceChild(Node node, Node child);
     [ImplementedAs=pre_remove] Node removeChild(Node child);
     [ImplementedAs=clone_node_binding] Node cloneNode(optional boolean deep = false);
 


### PR DESCRIPTION
LibWeb: Implement Node.replaceChild

The `if (child->parent())` check seems to be redundant, but I'm keeping
it just to match the spec.

-----

LibWeb: Add non-const variants of Document::{html_element,body,head}()

-----

LibWeb: Implement replacing the current body when setting document.body

Also adds an exception check to the append at the end.