### PR TITLE
AK: Make Checked<T> check for division overflow as well

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -183,6 +183,13 @@ public:
 
     constexpr void div(T other)
     {
+        if constexpr (IsSigned<T>) {
+            // Ensure that the resulting value won't be out of range, this can only happen when dividing by -1.
+            if (other == -1 && m_value == NumericLimits<T>::min()) {
+                m_overflow = true;
+                return;
+            }
+        }
         m_value /= other;
     }
 

--- a/Tests/AK/TestChecked.cpp
+++ b/Tests/AK/TestChecked.cpp
@@ -96,6 +96,9 @@ TEST_CASE(detects_signed_overflow)
     EXPECT((Checked<i64>(0x4000000000000000) - Checked<i64>(-0x4000000000000000)).has_overflow());
     EXPECT(!(Checked<i64>(-0x4000000000000000) - Checked<i64>(0x4000000000000000)).has_overflow());
     EXPECT((Checked<i64>(-0x4000000000000000) - Checked<i64>(0x4000000000000001)).has_overflow());
+
+    EXPECT((Checked<i32>(0x80000000) / Checked<i32>(-1)).has_overflow());
+    EXPECT((Checked<i64>(0x8000000000000000) / Checked<i64>(-1)).has_overflow());
 }
 
 TEST_CASE(detects_unsigned_overflow)


### PR DESCRIPTION
Signed integer overflow can occur with division when the RHS is -1,
as the negative values' range is one larger than the positives.