### PR TITLE
Kernel + Profiler: Add PerformancManager to Kernel, fix loop complexity when loading profiles. 

### DIFF
--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -20,12 +20,11 @@ PerformanceEventBuffer::PerformanceEventBuffer(NonnullOwnPtr<KBuffer> buffer)
 {
 }
 
-NEVER_INLINE KResult PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3)
+NEVER_INLINE KResult PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3, Thread* current_thread)
 {
     FlatPtr ebp;
     asm volatile("movl %%ebp, %%eax"
                  : "=a"(ebp));
-    auto current_thread = Thread::current();
     return append_with_eip_and_ebp(current_thread->pid(), current_thread->tid(), 0, ebp, type, arg1, arg2, arg3);
 }
 

--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -75,7 +75,7 @@ class PerformanceEventBuffer {
 public:
     static OwnPtr<PerformanceEventBuffer> try_create_with_size(size_t buffer_size);
 
-    KResult append(int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3);
+    KResult append(int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3, Thread* current_thread = Thread::current());
     KResult append_with_eip_and_ebp(ProcessID pid, ThreadID tid, u32 eip, u32 ebp,
         int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3);
 

--- a/Kernel/PerformanceManager.h
+++ b/Kernel/PerformanceManager.h
@@ -29,6 +29,15 @@ public:
         }
     }
 
+    inline static void add_process_exit_event(Process& process)
+    {
+        if (g_profiling_all_threads) {
+            VERIFY(g_global_perf_events);
+            [[maybe_unused]] auto rc = g_global_perf_events->append_with_eip_and_ebp(
+                process.pid(), 0, 0, 0, PERF_EVENT_PROCESS_EXIT, 0, 0, nullptr);
+        }
+    }
+
     inline static void add_thread_created_event(Thread& thread)
     {
         if (auto* event_buffer = thread.process().current_perf_events_buffer()) {

--- a/Kernel/PerformanceManager.h
+++ b/Kernel/PerformanceManager.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/PerformanceEventBuffer.h>
+#include <Kernel/Process.h>
+#include <Kernel/Thread.h>
+
+namespace Kernel {
+
+class PerformanceManager {
+
+public:
+    inline static void add_thread_created_event(Thread& thread)
+    {
+        if (auto* event_buffer = thread.process().current_perf_events_buffer()) {
+            [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_CREATE, thread.tid().value(), 0, nullptr, &thread);
+        }
+    }
+
+    inline static void add_thread_exit_event(Thread& thread)
+    {
+        if (auto* event_buffer = thread.process().current_perf_events_buffer()) {
+            [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_EXIT, thread.tid().value(), 0, nullptr, &thread);
+        }
+    }
+
+    inline static void add_mmap_perf_event(Process& current_process, Region const& region)
+    {
+        if (auto* event_buffer = current_process.current_perf_events_buffer()) {
+            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_MMAP, region.vaddr().get(), region.size(), region.name());
+        }
+    }
+
+    inline static void add_unmap_perf_event(Process& current_process, Range const& region)
+    {
+        if (auto* event_buffer = current_process.current_perf_events_buffer()) {
+            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_MUNMAP, region.base().get(), region.size(), nullptr);
+        }
+    }
+};
+
+}

--- a/Kernel/PerformanceManager.h
+++ b/Kernel/PerformanceManager.h
@@ -13,8 +13,22 @@
 namespace Kernel {
 
 class PerformanceManager {
-
 public:
+    inline static void add_process_created_event(Process& process)
+    {
+        if (g_profiling_all_threads) {
+            VERIFY(g_global_perf_events);
+            g_global_perf_events->add_process(process, ProcessEventType::Create);
+        }
+    }
+
+    inline static void add_process_exec_event(Process& process)
+    {
+        if (auto* event_buffer = process.current_perf_events_buffer()) {
+            event_buffer->add_process(process, ProcessEventType::Exec);
+        }
+    }
+
     inline static void add_thread_created_event(Thread& thread)
     {
         if (auto* event_buffer = thread.process().current_perf_events_buffer()) {

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -21,6 +21,7 @@
 #include <Kernel/KSyms.h>
 #include <Kernel/Module.h>
 #include <Kernel/PerformanceEventBuffer.h>
+#include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/RTC.h>
 #include <Kernel/StdLib.h>
@@ -245,11 +246,7 @@ Process::~Process()
     VERIFY(thread_count() == 0); // all threads should have been finalized
     VERIFY(!m_alarm_timer);
 
-    if (g_profiling_all_threads) {
-        VERIFY(g_global_perf_events);
-        [[maybe_unused]] auto rc = g_global_perf_events->append_with_eip_and_ebp(
-            pid(), 0, 0, 0, PERF_EVENT_PROCESS_EXIT, 0, 0, nullptr);
-    }
+    PerformanceManager::add_process_exit_event(*this);
 
     {
         ScopedSpinLock processes_lock(g_processes_lock);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -492,6 +492,7 @@ private:
     friend class MemoryManager;
     friend class Scheduler;
     friend class Region;
+    friend class PerformanceManager;
 
     bool add_thread(Thread&);
     bool remove_thread(Thread&);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -11,7 +11,7 @@
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
-#include <Kernel/PerformanceEventBuffer.h>
+#include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/Random.h>
 #include <Kernel/Time/TimeManagement.h>
@@ -636,9 +636,7 @@ KResult Process::do_exec(NonnullRefPtr<FileDescription> main_program_description
     tss.cr3 = space().page_directory().cr3();
     tss.ss2 = pid().value();
 
-    if (auto* event_buffer = current_perf_events_buffer()) {
-        event_buffer->add_process(*this, ProcessEventType::Exec);
-    }
+    PerformanceManager::add_process_exec_event(*this);
 
     {
         ScopedSpinLock lock(g_scheduler_lock);

--- a/Kernel/Syscalls/exit.cpp
+++ b/Kernel/Syscalls/exit.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <Kernel/KSyms.h>
-#include <Kernel/PerformanceEventBuffer.h>
+#include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 
 namespace Kernel {
@@ -18,12 +18,11 @@ void Process::sys$exit(int status)
         m_termination_signal = 0;
     }
 
-    if (auto* event_buffer = current_perf_events_buffer()) {
-        [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_EXIT, Thread::current()->tid().value(), 0, nullptr);
-    }
+    auto* current_thread = Thread::current();
+    PerformanceManager::add_thread_exit_event(*current_thread);
 
     die();
-    Thread::current()->die_if_needed();
+    current_thread->die_if_needed();
     VERIFY_NOT_REACHED();
 }
 

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -7,7 +7,7 @@
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
-#include <Kernel/PerformanceEventBuffer.h>
+#include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/Region.h>
 
@@ -85,10 +85,7 @@ KResultOr<pid_t> Process::sys$fork(RegisterState& regs)
         g_processes->prepend(child);
     }
 
-    if (g_profiling_all_threads) {
-        VERIFY(g_global_perf_events);
-        g_global_perf_events->add_process(*child, ProcessEventType::Create);
-    }
+    PerformanceManager::add_process_created_event(*child);
 
     ScopedSpinLock lock(g_scheduler_lock);
     child_first_thread->set_affinity(Thread::current()->affinity());

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -7,7 +7,7 @@
 #include <Kernel/CoreDump.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
-#include <Kernel/PerformanceEventBuffer.h>
+#include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 
 namespace Kernel {
@@ -27,12 +27,13 @@ KResultOr<int> Process::sys$profiling_enable(pid_t pid)
             g_global_perf_events->clear();
         else
             g_global_perf_events = PerformanceEventBuffer::try_create_with_size(32 * MiB).leak_ptr();
+
         ScopedSpinLock lock(g_processes_lock);
+        g_profiling_all_threads = true;
         Process::for_each([](auto& process) {
-            g_global_perf_events->add_process(process, ProcessEventType::Create);
+            PerformanceManager::add_process_created_event(process);
             return IterationDecision::Continue;
         });
-        g_profiling_all_threads = true;
         return 0;
     }
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -99,12 +99,14 @@ int main(int argc, char** argv)
 
     auto timeline_view = TimelineView::construct();
     for (auto& process : profile->processes()) {
-        size_t event_count = 0;
+        bool matching_event_found = false;
         for (auto& event : profile->events()) {
-            if (event.pid == process.pid && process.valid_at(event.timestamp))
-                ++event_count;
+            if (event.pid == process.pid && process.valid_at(event.timestamp)) {
+                matching_event_found = true;
+                break;
+            }
         }
-        if (!event_count)
+        if (!matching_event_found)
             continue;
         timeline_header_container->add<TimelineHeader>(process);
         timeline_view->add<TimelineTrack>(*timeline_view, *profile, process);


### PR DESCRIPTION
Doing some re-organizing in preparation for capturing more event types. 

 -  __Kernel: Add PerformanceManager static class, move perf event APIs there__

    The current method of emitting performance events requires a bit of
    boiler plate at every invocation, as well as having to ignore the
    return code which isn't used outside of the perf event syscall. This
    change attempts to clean that up by exposing high level API's that
    can be used around the code base.


  -  __Kernel: Move process creation perf events to PerformanceManager__



 -   __Kernel: Move process exit perf events to PerformanceManager__



 -   __Kernel: Move cpu sample perf event to PerformanceManager__

 -  __Profiler: Don't iterate all events when filtering timeline view__

    There is no need to iterate through all events in a profile when
    loading the timeline view, as soon as we see one event we can
    move on to the next process.