### PR TITLE
Meta: Fix Fuzzers CMakeLists.txt and ReadMe.md to use CXX_COMPILER_ID

### DIFF
--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -6,11 +6,11 @@ function(add_simple_fuzzer name)
           PUBLIC Lagom)
   else()
     target_compile_options(${name}
-      PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
+      PRIVATE $<$<CXX_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
       )
     target_link_libraries(${name}
       PUBLIC Lagom
-      PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer>
+      PRIVATE $<$<CXX_COMPILER_ID:Clang>:-fsanitize=fuzzer>
       )
   endif()
 endfunction()
@@ -53,10 +53,10 @@ set(CMAKE_SHARED_LINKER_FLAGS "${ORIGINAL_CMAKE_SHARED_LINKER_FLAGS} -fsanitize=
 set(CMAKE_MODULE_LINKER_FLAGS "${ORIGINAL_CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
 add_executable(FuzzilliJs FuzzilliJs.cpp)
 target_compile_options(FuzzilliJs
-    PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize-coverage=trace-pc-guard>
+    PRIVATE $<$<CXX_COMPILER_ID:Clang>:-g -O1 -fsanitize-coverage=trace-pc-guard>
     )
 target_link_libraries(FuzzilliJs
     PUBLIC Lagom
-    PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize-coverage=trace-pc-guard>
+    PRIVATE $<$<CXX_COMPILER_ID:Clang>:-fsanitize-coverage=trace-pc-guard>
     )
 endif()

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -18,7 +18,7 @@ Lagom can be used to fuzz parts of SerenityOS's code base. This requires buildli
 
     # From the root of the SerenityOS checkout:
     mkdir BuildLagom && cd BuildLagom
-    cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_FUZZER_SANITIZER=ON -DENABLE_ADDRESS_SANITIZER=ON -DENABLE_UNDEFINED_SANITIZER=ON -DCMAKE_CXX_COMPILER=clang++ ..
+    cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_FUZZER_SANITIZER=ON -DENABLE_ADDRESS_SANITIZER=ON -DENABLE_UNDEFINED_SANITIZER=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
     ninja Meta/Lagom/all
     # Or as a handy rebuild-rerun line:
     ninja FuzzJs && Meta/Lagom/Fuzzers/FuzzJs


### PR DESCRIPTION
Previously the directions omitted that you have to specify
`-CMAKE_CXX_COMPILER` when building the Fuzzers. This
would cause all kinds of weird problems at compilation and
link time. You can't specify one or the other, they must
both be pointing at clang in order for things to work as
experted. Fix this by updating the documentation to specify
that the user should specify both the C and CXX compiler explicitly
to be safe, as well as forcing the cmake clang argument handling
to modify the CXX compiler variable instead of the C version.