### PR TITLE
CppLanguageServer+LibCpp: Cache declarations from headers in every document

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -46,12 +46,6 @@ OwnPtr<ParserAutoComplete::DocumentData> ParserAutoComplete::create_document_dat
         return {};
     auto content = document->text();
     auto document_data = create_document_data(document->text(), file);
-    auto root = document_data->parser().parse();
-    for (auto& path : document_data->preprocessor().included_paths()) {
-        get_or_create_document_data(document_path_from_include_path(path));
-    }
-    if constexpr (CPP_LANGUAGE_SERVER_DEBUG)
-        root->dump(0);
 
     update_declared_symbols(*document_data);
 
@@ -494,6 +488,12 @@ OwnPtr<ParserAutoComplete::DocumentData> ParserAutoComplete::create_document_dat
     }
 
     document_data->m_parser = make<Parser>(document_data->preprocessor().processed_text(), filename, move(all_definitions));
+
+    auto root = document_data->parser().parse();
+
+    if constexpr (CPP_LANGUAGE_SERVER_DEBUG)
+        root->dump(0);
+
     return document_data;
 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -146,7 +146,7 @@ Vector<GUI::AutocompleteProvider::Entry> ParserAutoComplete::autocomplete_name(c
         }
     }
 
-    for (auto& preprocessor_name : document.parser().definitions().keys()) {
+    for (auto& preprocessor_name : document.parser().preprocessor_definitions().keys()) {
         if (preprocessor_name.starts_with(partial_text)) {
             suggestions.append({ preprocessor_name.to_string(), partial_text.length(), GUI::AutocompleteProvider::CompletionKind::PreprocessorDefinition });
         }
@@ -489,7 +489,7 @@ OwnPtr<ParserAutoComplete::DocumentData> ParserAutoComplete::create_document_dat
         auto included_document = get_or_create_document_data(document_path_from_include_path(include));
         if (!included_document)
             continue;
-        for (auto item : included_document->parser().definitions())
+        for (auto item : included_document->parser().preprocessor_definitions())
             all_definitions.set(move(item.key), move(item.value));
     }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
@@ -59,6 +59,9 @@ private:
         String m_text;
         OwnPtr<Preprocessor> m_preprocessor;
         OwnPtr<Parser> m_parser;
+
+        // FIXME: This HashTable must be re-computed if a declaration from a header file is modified
+        HashTable<NonnullRefPtr<Declaration>> m_declarations_from_headers;
     };
 
     Vector<GUI::AutocompleteProvider::Entry> autocomplete_property(const DocumentData&, const MemberExpression&, const String partial_text) const;
@@ -85,7 +88,7 @@ private:
 
     OwnPtr<DocumentData> create_document_data_for(const String& file);
     String document_path_from_include_path(const StringView& include_path) const;
-    void update_declared_symbols(const DocumentData&);
+    void update_declared_symbols(DocumentData&);
     GUI::AutocompleteProvider::DeclarationType type_of_declaration(const Declaration&);
     String scope_of_declaration(const Declaration&);
     Optional<GUI::AutocompleteProvider::ProjectLocation> find_preprocessor_definition(const DocumentData&, const GUI::TextPosition&);

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -19,7 +19,7 @@ RefPtr<const GUI::TextDocument> FileDB::get(const String& filename) const
     if (!document_optional.has_value())
         return nullptr;
 
-    return adopt_ref(*document_optional.value());
+    return *document_optional.value();
 }
 
 RefPtr<GUI::TextDocument> FileDB::get(const String& filename)

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -757,6 +757,13 @@ Vector<Token> Lexer::lex()
                 commit_token(Token::Type::Identifier);
             continue;
         }
+
+        if (ch == '\\' && peek(1) == '\n') {
+            consume();
+            consume();
+            continue;
+        }
+
         dbgln("Unimplemented token character: {}", ch);
         emit_single_char_token(Token::Type::Unknown);
     }

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -14,7 +14,7 @@
 namespace Cpp {
 
 Parser::Parser(const StringView& program, const String& filename, Preprocessor::Definitions&& definitions)
-    : m_definitions(move(definitions))
+    : m_preprocessor_definitions(move(definitions))
     , m_filename(filename)
 {
     initialize_program_tokens(program);
@@ -38,7 +38,7 @@ void Parser::initialize_program_tokens(const StringView& program)
         if (token.type() == Token::Type::Whitespace)
             continue;
         if (token.type() == Token::Type::Identifier) {
-            if (auto defined_value = m_definitions.find(text_of_token(token)); defined_value != m_definitions.end()) {
+            if (auto defined_value = m_preprocessor_definitions.find(text_of_token(token)); defined_value != m_preprocessor_definitions.end()) {
                 add_tokens_for_preprocessor(token, defined_value->value);
                 m_replaced_preprocessor_tokens.append({ token, defined_value->value });
                 continue;

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -34,7 +34,7 @@ public:
     StringView text_of_token(const Cpp::Token& token) const;
     void print_tokens() const;
     const Vector<String>& errors() const { return m_state.errors; }
-    const Preprocessor::Definitions& definitions() const { return m_definitions; }
+    const Preprocessor::Definitions& preprocessor_definitions() const { return m_preprocessor_definitions; }
 
     struct TokenAndPreprocessorDefinition {
         Token token;
@@ -169,7 +169,7 @@ private:
     Vector<StringView> parse_type_qualifiers();
     Vector<StringView> parse_function_qualifiers();
 
-    Preprocessor::Definitions m_definitions;
+    Preprocessor::Definitions m_preprocessor_definitions;
     String m_filename;
     Vector<Token> m_tokens;
     State m_state;


### PR DESCRIPTION
This makes the autocomplete feature actually usable in programs with a large #include tree, such as:
```c++
#include <LibGUI/Widget.h>
int main()
{
}
```
Previously, requesting the language server to autocomplete in this program would make the language server spin on 100% CPU for a while until it ran out of memory and crashed.
Now it returns in an instant (Provided that the c++ language server has already finished parsing everything).