### PR TITLE
LibWeb: Make painting order more spec-compliant

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -42,8 +42,6 @@ void Box::paint(PaintContext& context, PaintPhase phase)
         Painting::paint_border(context, Painting::BorderEdge::Bottom, bordered_rect, computed_values());
     }
 
-    Layout::NodeWithStyleAndBoxModelMetrics::paint(context, phase);
-
     if (phase == PaintPhase::Overlay && dom_node() && document().inspected_node() == dom_node()) {
         auto content_rect = absolute_rect();
 
@@ -177,23 +175,6 @@ StackingContext* Box::enclosing_stacking_context()
     }
     // We should always reach the Layout::InitialContainingBlockBox stacking context.
     VERIFY_NOT_REACHED();
-}
-
-bool Box::establishes_stacking_context() const
-{
-    if (!has_style())
-        return false;
-    if (dom_node() == document().root())
-        return true;
-    auto position = computed_values().position();
-    auto z_index = computed_values().z_index();
-    if (position == CSS::Position::Absolute || position == CSS::Position::Relative) {
-        if (z_index.has_value())
-            return true;
-    }
-    if (position == CSS::Position::Fixed || position == CSS::Position::Sticky)
-        return true;
-    return false;
 }
 
 LineBox& Box::ensure_last_line_box()

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -104,7 +104,6 @@ public:
 
     void set_containing_line_box_fragment(LineBoxFragment&);
 
-    bool establishes_stacking_context() const;
     StackingContext* stacking_context() { return m_stacking_context; }
     const StackingContext* stacking_context() const { return m_stacking_context; }
     void set_stacking_context(NonnullOwnPtr<StackingContext> context) { m_stacking_context = move(context); }

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
@@ -56,18 +56,7 @@ void InitialContainingBlockBox::paint_document_background(PaintContext& context)
 void InitialContainingBlockBox::paint_all_phases(PaintContext& context)
 {
     paint_document_background(context);
-
-    paint(context, PaintPhase::Background);
-    paint(context, PaintPhase::Border);
-    paint(context, PaintPhase::Foreground);
-    if (context.has_focus())
-        paint(context, PaintPhase::FocusOutline);
-    paint(context, PaintPhase::Overlay);
-}
-
-void InitialContainingBlockBox::paint(PaintContext& context, PaintPhase phase)
-{
-    stacking_context()->paint(context, phase);
+    stacking_context()->paint(context);
 }
 
 HitTestResult InitialContainingBlockBox::hit_test(const Gfx::IntPoint& position, HitTestType type) const

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.h
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.h
@@ -19,7 +19,6 @@ public:
     const DOM::Document& dom_node() const { return static_cast<const DOM::Document&>(*Node::dom_node()); }
 
     void paint_all_phases(PaintContext&);
-    virtual void paint(PaintContext&, PaintPhase) override;
 
     void paint_document_background(PaintContext&);
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -67,6 +67,18 @@ const BlockBox* Node::containing_block() const
     return nearest_block_ancestor();
 }
 
+bool Node::establishes_stacking_context() const
+{
+    if (!has_style())
+        return false;
+    if (dom_node() == document().root())
+        return true;
+    auto position = computed_values().position();
+    if (position == CSS::Position::Absolute || position == CSS::Position::Relative || position == CSS::Position::Fixed || position == CSS::Position::Sticky)
+        return true;
+    return false;
+}
+
 void Node::paint(PaintContext& context, PaintPhase phase)
 {
     if (!is_visible())

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -112,6 +112,8 @@ public:
     const BlockBox* containing_block() const;
     BlockBox* containing_block() { return const_cast<BlockBox*>(const_cast<const Node*>(this)->containing_block()); }
 
+    bool establishes_stacking_context() const;
+
     bool can_contain_boxes_with_position_absolute() const;
 
     const Gfx::Font& font() const;

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -18,7 +18,15 @@ public:
     StackingContext* parent() { return m_parent; }
     const StackingContext* parent() const { return m_parent; }
 
-    void paint(PaintContext&, PaintPhase);
+    enum class StackingContextPaintPhase {
+        BackgroundAndBorders,
+        Floats,
+        Foreground,
+        FocusAndOverlay,
+    };
+
+    void paint_descendants(PaintContext&, Node&, StackingContextPaintPhase);
+    void paint(PaintContext&);
     HitTestResult hit_test(const Gfx::IntPoint&, HitTestType) const;
 
     void dump(int indent = 0) const;


### PR DESCRIPTION
Now our painting order inside stacking contexts is closer to the
algorithm specified by CSS 2.1 (see section 9.9 and Appendix E)
I tested this on ACID2 and W3 CSS test suites and it works fine