### PR TITLE
LookupServer: Send mDNS announcements 

### DIFF
--- a/Userland/Services/LookupServer/ClientConnection.cpp
+++ b/Userland/Services/LookupServer/ClientConnection.cpp
@@ -30,7 +30,7 @@ void ClientConnection::die()
 
 Messages::LookupServer::LookupNameResponse ClientConnection::lookup_name(String const& name)
 {
-    auto answers = LookupServer::the().lookup(name, T_A);
+    auto answers = LookupServer::the().lookup(name, DNSRecordType::A);
     if (answers.is_empty())
         return { 1, Vector<String>() };
     Vector<String> addresses;
@@ -50,7 +50,7 @@ Messages::LookupServer::LookupAddressResponse ClientConnection::lookup_address(S
         ip_address[2],
         ip_address[1],
         ip_address[0]);
-    auto answers = LookupServer::the().lookup(name, T_PTR);
+    auto answers = LookupServer::the().lookup(name, DNSRecordType::PTR);
     if (answers.is_empty())
         return { 1, String() };
     return { 0, answers[0].record_data() };

--- a/Userland/Services/LookupServer/DNSAnswer.cpp
+++ b/Userland/Services/LookupServer/DNSAnswer.cpp
@@ -18,15 +18,12 @@ DNSAnswer::DNSAnswer(const DNSName& name, DNSRecordType type, DNSRecordClass cla
     , m_record_data(record_data)
     , m_mdns_cache_flush(mdns_cache_flush)
 {
-    auto now = time(nullptr);
-    m_expiration_time = now + m_ttl;
-    if (m_expiration_time < now)
-        m_expiration_time = 0;
+    time(&m_received_time);
 }
 
 bool DNSAnswer::has_expired() const
 {
-    return time(nullptr) >= m_expiration_time;
+    return time(nullptr) >= m_received_time + m_ttl;
 }
 
 }

--- a/Userland/Services/LookupServer/DNSAnswer.cpp
+++ b/Userland/Services/LookupServer/DNSAnswer.cpp
@@ -9,12 +9,13 @@
 
 namespace LookupServer {
 
-DNSAnswer::DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data)
+DNSAnswer::DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data, bool mdns_cache_flush)
     : m_name(name)
     , m_type(type)
     , m_class_code(class_code)
     , m_ttl(ttl)
     , m_record_data(record_data)
+    , m_mdns_cache_flush(mdns_cache_flush)
 {
     auto now = time(nullptr);
     m_expiration_time = now + m_ttl;

--- a/Userland/Services/LookupServer/DNSAnswer.cpp
+++ b/Userland/Services/LookupServer/DNSAnswer.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "DNSAnswer.h"
+#include <AK/Stream.h>
 #include <time.h>
 
 namespace LookupServer {
 
-DNSAnswer::DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data, bool mdns_cache_flush)
+DNSAnswer::DNSAnswer(const DNSName& name, DNSRecordType type, DNSRecordClass class_code, u32 ttl, const String& record_data, bool mdns_cache_flush)
     : m_name(name)
     , m_type(type)
     , m_class_code(class_code)
@@ -28,4 +29,43 @@ bool DNSAnswer::has_expired() const
     return time(nullptr) >= m_expiration_time;
 }
 
+}
+
+void AK::Formatter<LookupServer::DNSRecordType>::format(AK::FormatBuilder& builder, LookupServer::DNSRecordType value)
+{
+    switch (value) {
+    case LookupServer::DNSRecordType::A:
+        builder.put_string("A");
+        return;
+    case LookupServer::DNSRecordType::NS:
+        builder.put_string("NS");
+        return;
+    case LookupServer::DNSRecordType::CNAME:
+        builder.put_string("CNAME");
+        return;
+    case LookupServer::DNSRecordType::SOA:
+        builder.put_string("SOA");
+        return;
+    case LookupServer::DNSRecordType::PTR:
+        builder.put_string("PTR");
+        return;
+    case LookupServer::DNSRecordType::MX:
+        builder.put_string("MX");
+        return;
+    }
+
+    builder.put_string("DNS record type ");
+    builder.put_u64((u16)value);
+}
+
+void AK::Formatter<LookupServer::DNSRecordClass>::format(AK::FormatBuilder& builder, LookupServer::DNSRecordClass value)
+{
+    switch (value) {
+    case LookupServer::DNSRecordClass::IN:
+        builder.put_string("IN");
+        return;
+    }
+
+    builder.put_string("DNS record class ");
+    builder.put_u64((u16)value);
 }

--- a/Userland/Services/LookupServer/DNSAnswer.cpp
+++ b/Userland/Services/LookupServer/DNSAnswer.cpp
@@ -52,6 +52,15 @@ void AK::Formatter<LookupServer::DNSRecordType>::format(AK::FormatBuilder& build
     case LookupServer::DNSRecordType::MX:
         builder.put_string("MX");
         return;
+    case LookupServer::DNSRecordType::TXT:
+        builder.put_string("TXT");
+        return;
+    case LookupServer::DNSRecordType::AAAA:
+        builder.put_string("AAAA");
+        return;
+    case LookupServer::DNSRecordType::SRV:
+        builder.put_string("SRV");
+        return;
     }
 
     builder.put_string("DNS record type ");

--- a/Userland/Services/LookupServer/DNSAnswer.h
+++ b/Userland/Services/LookupServer/DNSAnswer.h
@@ -12,15 +12,19 @@
 
 namespace LookupServer {
 
+#define MDNS_CACHE_FLUSH 0x8000
+
 class DNSAnswer {
 public:
-    DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data);
+    DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data, bool mdns_cache_flush);
 
     const DNSName& name() const { return m_name; }
     u16 type() const { return m_type; }
     u16 class_code() const { return m_class_code; }
+    u16 raw_class_code() const { return m_class_code | (m_mdns_cache_flush ? MDNS_CACHE_FLUSH : 0); }
     u32 ttl() const { return m_ttl; }
     const String& record_data() const { return m_record_data; }
+    bool mdns_cache_flush() const { return m_mdns_cache_flush; }
 
     bool has_expired() const;
 
@@ -31,6 +35,7 @@ private:
     u32 m_ttl { 0 };
     time_t m_expiration_time { 0 };
     String m_record_data;
+    bool m_mdns_cache_flush { false };
 };
 
 }

--- a/Userland/Services/LookupServer/DNSAnswer.h
+++ b/Userland/Services/LookupServer/DNSAnswer.h
@@ -20,6 +20,9 @@ enum class DNSRecordType : u16 {
     SOA = 6,
     PTR = 12,
     MX = 15,
+    TXT = 16,
+    AAAA = 28,
+    SRV = 33,
 };
 
 enum class DNSRecordClass : u16 {

--- a/Userland/Services/LookupServer/DNSAnswer.h
+++ b/Userland/Services/LookupServer/DNSAnswer.h
@@ -7,21 +7,35 @@
 #pragma once
 
 #include "DNSName.h"
+#include <AK/Format.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 
 namespace LookupServer {
 
+enum class DNSRecordType : u16 {
+    A = 1,
+    NS = 2,
+    CNAME = 5,
+    SOA = 6,
+    PTR = 12,
+    MX = 15,
+};
+
+enum class DNSRecordClass : u16 {
+    IN = 1
+};
+
 #define MDNS_CACHE_FLUSH 0x8000
 
 class DNSAnswer {
 public:
-    DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data, bool mdns_cache_flush);
+    DNSAnswer(const DNSName& name, DNSRecordType type, DNSRecordClass class_code, u32 ttl, const String& record_data, bool mdns_cache_flush);
 
     const DNSName& name() const { return m_name; }
-    u16 type() const { return m_type; }
-    u16 class_code() const { return m_class_code; }
-    u16 raw_class_code() const { return m_class_code | (m_mdns_cache_flush ? MDNS_CACHE_FLUSH : 0); }
+    DNSRecordType type() const { return m_type; }
+    DNSRecordClass class_code() const { return m_class_code; }
+    u16 raw_class_code() const { return (u16)m_class_code | (m_mdns_cache_flush ? MDNS_CACHE_FLUSH : 0); }
     u32 ttl() const { return m_ttl; }
     const String& record_data() const { return m_record_data; }
     bool mdns_cache_flush() const { return m_mdns_cache_flush; }
@@ -30,8 +44,8 @@ public:
 
 private:
     DNSName m_name;
-    u16 m_type { 0 };
-    u16 m_class_code { 0 };
+    DNSRecordType m_type { 0 };
+    DNSRecordClass m_class_code { 0 };
     u32 m_ttl { 0 };
     time_t m_expiration_time { 0 };
     String m_record_data;
@@ -39,3 +53,24 @@ private:
 };
 
 }
+template<>
+struct AK::Formatter<LookupServer::DNSRecordType> : StandardFormatter {
+    Formatter() = default;
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
+    void format(AK::FormatBuilder&, LookupServer::DNSRecordType);
+};
+
+template<>
+struct AK::Formatter<LookupServer::DNSRecordClass> : StandardFormatter {
+    Formatter() = default;
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
+    void format(AK::FormatBuilder&, LookupServer::DNSRecordClass);
+};

--- a/Userland/Services/LookupServer/DNSAnswer.h
+++ b/Userland/Services/LookupServer/DNSAnswer.h
@@ -40,6 +40,7 @@ public:
     DNSRecordClass class_code() const { return m_class_code; }
     u16 raw_class_code() const { return (u16)m_class_code | (m_mdns_cache_flush ? MDNS_CACHE_FLUSH : 0); }
     u32 ttl() const { return m_ttl; }
+    time_t received_time() const { return m_received_time; }
     const String& record_data() const { return m_record_data; }
     bool mdns_cache_flush() const { return m_mdns_cache_flush; }
 
@@ -50,7 +51,7 @@ private:
     DNSRecordType m_type { 0 };
     DNSRecordClass m_class_code { 0 };
     u32 m_ttl { 0 };
-    time_t m_expiration_time { 0 };
+    time_t m_received_time { 0 };
     String m_record_data;
     bool m_mdns_cache_flush { false };
 };

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -152,7 +152,15 @@ Optional<DNSPacket> DNSPacket::from_raw_packet(const u8* raw_data, size_t raw_si
             data = DNSName::parse(raw_data, dummy_offset, raw_size).as_string();
             break;
         }
+        case DNSRecordType::CNAME:
+            // Fall through
         case DNSRecordType::A:
+            // Fall through
+        case DNSRecordType::TXT:
+            // Fall through
+        case DNSRecordType::AAAA:
+            // Fall through
+        case DNSRecordType::SRV:
             data = { record.data(), record.data_length() };
             break;
         default:

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -40,13 +40,14 @@ ByteBuffer DNSPacket::to_byte_buffer() const
         header.set_is_query();
     else
         header.set_is_response();
+    header.set_authoritative_answer(m_authoritative_answer);
     // FIXME: What should this be?
     header.set_opcode(0);
     header.set_response_code(m_code);
     header.set_truncated(false); // hopefully...
-    header.set_recursion_desired(true);
+    header.set_recursion_desired(m_recursion_desired);
     // FIXME: what should the be for requests?
-    header.set_recursion_available(true);
+    header.set_recursion_available(m_recursion_available);
     header.set_question_count(m_questions.size());
     header.set_answer_count(m_answers.size());
 

--- a/Userland/Services/LookupServer/DNSPacket.h
+++ b/Userland/Services/LookupServer/DNSPacket.h
@@ -29,8 +29,14 @@ public:
 
     bool is_query() const { return !m_query_or_response; }
     bool is_response() const { return m_query_or_response; }
+    bool is_authoritative_answer() const { return m_authoritative_answer; }
+    bool recursion_desired() const { return m_recursion_desired; }
+    bool recursion_available() const { return m_recursion_available; }
     void set_is_query() { m_query_or_response = false; }
     void set_is_response() { m_query_or_response = true; }
+    void set_authoritative_answer(bool authoritative_answer) { m_authoritative_answer = authoritative_answer; }
+    void set_recursion_desired(bool recursion_desired) { m_recursion_desired = recursion_desired; }
+    void set_recursion_available(bool recursion_available) { m_recursion_available = recursion_available; }
 
     u16 id() const { return m_id; }
     void set_id(u16 id) { m_id = id; }
@@ -72,7 +78,10 @@ public:
 private:
     u16 m_id { 0 };
     u8 m_code { 0 };
+    bool m_authoritative_answer { false };
     bool m_query_or_response { false };
+    bool m_recursion_desired { true };
+    bool m_recursion_available { true };
     Vector<DNSQuestion> m_questions;
     Vector<DNSAnswer> m_answers;
 };

--- a/Userland/Services/LookupServer/DNSPacket.h
+++ b/Userland/Services/LookupServer/DNSPacket.h
@@ -13,15 +13,6 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 
-#define T_A 1
-#define T_NS 2
-#define T_CNAME 5
-#define T_SOA 6
-#define T_PTR 12
-#define T_MX 15
-
-#define C_IN 1
-
 namespace LookupServer {
 
 enum class ShouldRandomizeCase {

--- a/Userland/Services/LookupServer/DNSQuestion.h
+++ b/Userland/Services/LookupServer/DNSQuestion.h
@@ -15,7 +15,7 @@ namespace LookupServer {
 
 class DNSQuestion {
 public:
-    DNSQuestion(const DNSName& name, u16 record_type, u16 class_code, bool mdns_wants_unicast_response)
+    DNSQuestion(const DNSName& name, DNSRecordType record_type, DNSRecordClass class_code, bool mdns_wants_unicast_response)
         : m_name(name)
         , m_record_type(record_type)
         , m_class_code(class_code)
@@ -23,16 +23,16 @@ public:
     {
     }
 
-    u16 record_type() const { return m_record_type; }
-    u16 class_code() const { return m_class_code; }
+    DNSRecordType record_type() const { return m_record_type; }
+    DNSRecordClass class_code() const { return m_class_code; }
     u16 raw_class_code() const { return (u16)m_class_code | (m_mdns_wants_unicast_response ? MDNS_WANTS_UNICAST_RESPONSE : 0); }
     const DNSName& name() const { return m_name; }
     bool mdns_wants_unicast_response() const { return m_mdns_wants_unicast_response; }
 
 private:
     DNSName m_name;
-    u16 m_record_type { 0 };
-    u16 m_class_code { 0 };
+    DNSRecordType m_record_type { 0 };
+    DNSRecordClass m_class_code { 0 };
     bool m_mdns_wants_unicast_response { false };
 };
 

--- a/Userland/Services/LookupServer/DNSQuestion.h
+++ b/Userland/Services/LookupServer/DNSQuestion.h
@@ -11,23 +11,29 @@
 
 namespace LookupServer {
 
+#define MDNS_WANTS_UNICAST_RESPONSE 0x8000
+
 class DNSQuestion {
 public:
-    DNSQuestion(const DNSName& name, u16 record_type, u16 class_code)
+    DNSQuestion(const DNSName& name, u16 record_type, u16 class_code, bool mdns_wants_unicast_response)
         : m_name(name)
         , m_record_type(record_type)
         , m_class_code(class_code)
+        , m_mdns_wants_unicast_response(mdns_wants_unicast_response)
     {
     }
 
     u16 record_type() const { return m_record_type; }
     u16 class_code() const { return m_class_code; }
+    u16 raw_class_code() const { return (u16)m_class_code | (m_mdns_wants_unicast_response ? MDNS_WANTS_UNICAST_RESPONSE : 0); }
     const DNSName& name() const { return m_name; }
+    bool mdns_wants_unicast_response() const { return m_mdns_wants_unicast_response; }
 
 private:
     DNSName m_name;
     u16 m_record_type { 0 };
     u16 m_class_code { 0 };
+    bool m_mdns_wants_unicast_response { false };
 };
 
 }

--- a/Userland/Services/LookupServer/DNSServer.cpp
+++ b/Userland/Services/LookupServer/DNSServer.cpp
@@ -43,7 +43,7 @@ void DNSServer::handle_client()
     response.set_id(request.id());
 
     for (auto& question : request.questions()) {
-        if (question.class_code() != C_IN)
+        if (question.class_code() != DNSRecordClass::IN)
             continue;
         response.add_question(question);
         auto answers = lookup_server.lookup(question.name(), question.record_type());

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -75,7 +75,7 @@ void LookupServer::load_etc_hosts()
             m_etc_hosts.set(name, {});
             it = m_etc_hosts.find(name);
         }
-        it->value.empend(name, record_type, (u16)C_IN, static_ttl, data);
+        it->value.empend(name, record_type, (u16)C_IN, static_ttl, data, false);
     };
 
     auto file = Core::File::construct("/etc/hosts");
@@ -123,7 +123,8 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, unsigned short recor
             answer.type(),
             answer.class_code(),
             answer.ttl(),
-            answer.record_data()
+            answer.record_data(),
+            answer.mdns_cache_flush(),
         };
         answers.append(answer_with_original_case);
     };
@@ -197,7 +198,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, const String& namese
     DNSName name_in_question = name;
     if (should_randomize_case == ShouldRandomizeCase::Yes)
         name_in_question.randomize_case();
-    request.add_question({ name_in_question, record_type, C_IN });
+    request.add_question({ name_in_question, record_type, C_IN, false });
 
     auto buffer = request.to_byte_buffer();
 

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -21,7 +21,7 @@ class LookupServer final : public Core::Object {
 
 public:
     static LookupServer& the();
-    Vector<DNSAnswer> lookup(const DNSName& name, unsigned short record_type);
+    Vector<DNSAnswer> lookup(const DNSName& name, DNSRecordType record_type);
 
 private:
     LookupServer();
@@ -29,7 +29,7 @@ private:
     void load_etc_hosts();
     void put_in_cache(const DNSAnswer&);
 
-    Vector<DNSAnswer> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
+    Vector<DNSAnswer> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, DNSRecordType record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
 
     RefPtr<Core::LocalServer> m_local_server;
     RefPtr<DNSServer> m_dns_server;

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -82,6 +82,9 @@ void MulticastDNS::announce()
     DNSPacket response;
     response.set_is_response();
     response.set_code(DNSPacket::Code::NOERROR);
+    response.set_authoritative_answer(true);
+    response.set_recursion_desired(false);
+    response.set_recursion_available(false);
 
     for (auto& address : local_addresses()) {
         auto raw_addr = address.to_in_addr_t();
@@ -142,6 +145,7 @@ Vector<DNSAnswer> MulticastDNS::lookup(const DNSName& name, DNSRecordType record
 {
     DNSPacket request;
     request.set_is_query();
+    request.set_recursion_desired(false);
     request.add_question({ name, record_type, DNSRecordClass::IN, false });
 
     if (emit_packet(request) < 0) {

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -88,9 +88,10 @@ void MulticastDNS::announce()
         DNSAnswer answer {
             m_hostname,
             T_A,
-            C_IN | 0x8000,
+            C_IN,
             120,
-            String { (const char*)&raw_addr, sizeof(raw_addr) }
+            String { (const char*)&raw_addr, sizeof(raw_addr) },
+            true,
         };
         response.add_answer(answer);
     }
@@ -141,7 +142,7 @@ Vector<DNSAnswer> MulticastDNS::lookup(const DNSName& name, unsigned short recor
 {
     DNSPacket request;
     request.set_is_query();
-    request.add_question({ name, record_type, C_IN });
+    request.add_question({ name, record_type, C_IN, false });
 
     if (emit_packet(request) < 0) {
         perror("failed to emit request packet");

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -87,8 +87,8 @@ void MulticastDNS::announce()
         auto raw_addr = address.to_in_addr_t();
         DNSAnswer answer {
             m_hostname,
-            T_A,
-            C_IN,
+            DNSRecordType::A,
+            DNSRecordClass::IN,
             120,
             String { (const char*)&raw_addr, sizeof(raw_addr) },
             true,
@@ -138,11 +138,11 @@ Vector<IPv4Address> MulticastDNS::local_addresses() const
     return addresses;
 }
 
-Vector<DNSAnswer> MulticastDNS::lookup(const DNSName& name, unsigned short record_type)
+Vector<DNSAnswer> MulticastDNS::lookup(const DNSName& name, DNSRecordType record_type)
 {
     DNSPacket request;
     request.set_is_query();
-    request.add_question({ name, record_type, C_IN, false });
+    request.add_question({ name, record_type, DNSRecordClass::IN, false });
 
     if (emit_packet(request) < 0) {
         perror("failed to emit request packet");

--- a/Userland/Services/LookupServer/MulticastDNS.h
+++ b/Userland/Services/LookupServer/MulticastDNS.h
@@ -18,7 +18,7 @@ namespace LookupServer {
 class MulticastDNS : public Core::UDPServer {
     C_OBJECT(MulticastDNS)
 public:
-    Vector<DNSAnswer> lookup(const DNSName&, unsigned short record_type);
+    Vector<DNSAnswer> lookup(const DNSName&, DNSRecordType record_type);
 
 private:
     explicit MulticastDNS(Object* parent = nullptr);


### PR DESCRIPTION
This contains a number of related fixes and changes for `LookupServer`:

**LookupServer: Add DNS record types TXT, AAAA and SRV**

They're not being used elsewhere at the moment but this gets rid of the debug message for incoming mDNS response packets.

 **LookupServer: Turn #defines into enum classes and add formatter**

 **Kernel: Use correct destination MAC address for multicast packets**

Previously we'd incorrectly use the default gateway's MAC address. Instead we must use destination MAC addresses that are derived from the multicast IPv4 address.

With this patch applied I can query mDNS on a real network.

 **LookupServer: Send mDNS announcements**

This also corrects some of the flags in the DNS packets to match what I saw on my local network.

With this patch applies I can query a caching mDNS service for the VM's IP address:

```
gunnar@arch:~ $ ping courage.local
PING courage.local (192.168.3.190) 56(84) bytes of data.
64 bytes from 192.168.3.190: icmp_seq=1 ttl=64 time=1.79 ms
64 bytes from 192.168.3.190: icmp_seq=2 ttl=64 time=1.81 ms
64 bytes from 192.168.3.190: icmp_seq=3 ttl=64 time=1.73 ms
^C
--- courage.local ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 5ms
rtt min/avg/max/mdev = 1.730/1.775/1.808/0.058 ms
gunnar@arch:~ $
```