### PR TITLE
Meta: Improve man.serenityos.org titles and link names

### DIFF
--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -22,7 +22,8 @@ jobs:
         run: |
           for d in $MAN_DIR*/; do
             dir_name=$(basename "$d")
-            mkdir -p output/${dir_name/man}
+            section="${dir_name/man}"
+            mkdir -p "output/${section}"
           done
       - name: Convert markdown to html
         run: |
@@ -33,18 +34,26 @@ jobs:
             return el
           end
           EOF
-          find $MAN_DIR -iname '*.md' -type f -exec sh -c 'relative_path=$(realpath --relative-to=$MAN_DIR $0) && stripped_path=${relative_path#man} && pandoc -f gfm -t html5 -s --lua-filter=link-fixup.lua -o output/${stripped_path%.md}.html ${0}' {} \;
+          find $MAN_DIR -iname '*.md' -type f -exec sh -c '\
+            relative_path="$(realpath --relative-to=$MAN_DIR $0)" \
+            && stripped_path="${relative_path#man}" \
+            && section="${stripped_path%%/*}" \
+            && filename="${stripped_path#*/}" \
+            && name="${filename%.md}" \
+            && pandoc -f gfm -t html5 -s --lua-filter=link-fixup.lua --metadata title="${name}(${section}) - SerenityOS man pages" -o "output/${section}/${name}.html" "${0}" \
+          ' {} \;
       - name: Generate man page listings
         run: |
           for d in output/*/; do
-            dir_name=$(basename "$d")
-            echo "<!DOCTYPE html><html><head><title>$dir_name</title></head><body>" > "$d/index.html"
+            section=$(basename "$d")
+            echo "<!DOCTYPE html><html><head><title>Section ${section} - SerenityOS man pages</title></head><body>" > "${d}/index.html"
             for f in $d/*; do
-              file_name=$(basename "$f")
-              if [[ "$file_name" == "index.html" ]]; then
+              filename=$(basename "$f")
+              name="${filename%.html}"
+              if [[ "$filename" == "index.html" ]]; then
                  continue
               fi
-              echo "<a href=\"$file_name\"><p>${file_name%.html}</p></a>" >> "$d/index.html"
+              echo "<a href=\"${filename}\"><p>${name}(${section})</p></a>" >> "${d}/index.html"
             done
             echo "</body></html>" >> "$d/index.html"
           done

--- a/Meta/Websites/man.serenityos.org/index.html
+++ b/Meta/Websites/man.serenityos.org/index.html
@@ -6,12 +6,12 @@
 <body>
 <img src="banner.png" alt="SerenityOS">
 <h1>SerenityOS man pages</h1>
-<a href="1/"><p>Man 1</p></a>
-<a href="2/"><p>Man 2</p></a>
-<a href="3/"><p>Man 3</p></a>
-<a href="4/"><p>Man 4</p></a>
-<a href="5/"><p>Man 5</p></a>
-<a href="7/"><p>Man 7</p></a>
-<a href="8/"><p>Man 8</p></a>
+<a href="1/"><p>Section 1</p></a>
+<a href="2/"><p>Section 2</p></a>
+<a href="3/"><p>Section 3</p></a>
+<a href="4/"><p>Section 4</p></a>
+<a href="5/"><p>Section 5</p></a>
+<a href="7/"><p>Section 7</p></a>
+<a href="8/"><p>Section 8</p></a>
 </body>
 </html>


### PR DESCRIPTION
Index page:
- Change links from "Man 1" to "Section 1"

Section index pages:
- Change title from "1" to "Section 1 - SerenityOS man pages"
- Change links from "foo" to "foo(1)"

Man pages:
- Change title from "foo" to "foo(1) - SerenityOS man pages"

Also fixes these warnings:

![image](https://user-images.githubusercontent.com/19366641/117484849-89961380-af5f-11eb-9c5f-1cea280bee44.png)
