### PR TITLE
Kernel: Allow Ext2FSInode::write_bytes calls with a byte count of zero

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -971,6 +971,9 @@ KResultOr<ssize_t> Ext2FSInode::write_bytes(off_t offset, ssize_t count, const U
     VERIFY(offset >= 0);
     VERIFY(count >= 0);
 
+    if (count == 0)
+        return 0;
+
     Locker inode_locker(m_lock);
 
     if (auto result = prepare_to_write_data(); result.is_error())


### PR DESCRIPTION
write_bytes is called with a count of 0 bytes if a directory is being
deleted, because in that case even the . and .. pseudo directories are
getting removed. In this case write_bytes is now a no-op.

Before write_bytes would fail because it would check to see if there
were any blocks available to write in (even though it wasn't going to
write in them anyway).

This behavior was uncovered because of a recent change where
directories are correctly reduced in size. Which in this case results in
all the blocks being removed from the inode, whereas previously there
would be some stale blocks around to pass the check.

Fixes: https://github.com/SerenityOS/serenity/issues/6919