### PR TITLE
Userland: Remove extra slashes from `find` output

### DIFF
--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -465,8 +465,8 @@ static void walk_tree(const char* root_path, Command& command)
 
 int main(int argc, char* argv[])
 {
-    auto root_path = parse_options(argc, argv);
+    LexicalPath root_path(parse_options(argc, argv));
     auto command = parse_all_commands(argv);
-    walk_tree(root_path, *command);
+    walk_tree(root_path.string().characters(), *command);
     return g_there_was_an_error ? 1 : 0;
 }


### PR DESCRIPTION
I noticed while testing `file` that the output of `find` contains extra
forward slashes if the root path has a trailing slash. This patch fixes
that issue by passing the root path through `LexicalPath` before
proceeding.

Before:
<img width="384" alt="Edit View Help" src="https://user-images.githubusercontent.com/20117975/117502922-e6f28a80-af88-11eb-91f2-1e355da08e7b.png">

And after:
<img width="384" alt="Edit View Help" src="https://user-images.githubusercontent.com/20117975/117502938-ece86b80-af88-11eb-916a-41e19ca70c30.png">
