### PR TITLE
Ports: SDL2-GNUBoy shouldn't try to link against host libs

### DIFF
--- a/Ports/SDL2-GNUBoy/patches/fix-make.patch
+++ b/Ports/SDL2-GNUBoy/patches/fix-make.patch
@@ -22,7 +22,7 @@ index 427d696..653a5d3 100644
 -	make -f makefile.windows
 -	rm -f sys/*/*.o src/*.o
 +CFLAGS =  -std=c99 -Wall -O3 -I./include
-+LDFLAGS = $(CFLAGS)  -s `sdl2-config --cflags --libs`
++LDFLAGS = $(CFLAGS)  -s -lSDL2
 +ASFLAGS = $(CFLAGS)
  
 -.PHONY: osx
@@ -33,11 +33,11 @@ index 427d696..653a5d3 100644
 +
 +SYS_DEFS = -DIS_LITTLE_ENDIAN  -DIS_LINUX -DSOUND
 +SYS_OBJS = sys/nix/nix.o
-+SYS_INCS = -I/usr/local/include  -I./sys/nix
++SYS_INCS = -I./sys/nix
 +
 +SDL_OBJS = sys/sdl2/sdl-video.o sys/sdl2/sdl-audio.o sys/sdl2/sdl-input.o
-+SDL_LIBS = -L/usr/lib -lSDL2 -lpthread
-+SDL_CFLAGS = -I/usr/include/SDL2 -D_GNU_SOURCE=1 -D_REENTRANT `sdl2-config --cflags --libs`
++SDL_LIBS = -lSDL2 -lpthread
++SDL_CFLAGS = -D_GNU_SOURCE=1 -D_REENTRANT `sdl2-config --cflags --libs`
 +
 +
 +all: $(TARGETS)


### PR DESCRIPTION
Without this patch I'm unable to build this port because it tries to link against my host's `libgcc_s.so`.