### PR TITLE
Profiler: Fix scrolling behavior

### DIFF
--- a/Userland/DevTools/Profiler/TimelineContainer.cpp
+++ b/Userland/DevTools/Profiler/TimelineContainer.cpp
@@ -55,6 +55,7 @@ void TimelineContainer::update_widget_sizes()
 void TimelineContainer::resize_event(GUI::ResizeEvent& event)
 {
     AbstractScrollableWidget::resize_event(event);
+    update_widget_positions();
     update_widget_sizes();
 }
 

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -50,6 +50,7 @@ void ScrollableContainerWidget::update_widget_size()
 void ScrollableContainerWidget::resize_event(GUI::ResizeEvent& event)
 {
     AbstractScrollableWidget::resize_event(event);
+    update_widget_position();
     update_widget_size();
 }
 


### PR DESCRIPTION
When resizing the timeline view the timelines should scroll to the bottom when the resize operation reveals space that is beyond the
view.

This also fixes the same issue in the `ScrollableContainerWidget` widget in `LibGUI`.

![Screenshot from 2021-05-08 03-04-53](https://user-images.githubusercontent.com/388571/117520773-3b5a3200-afaa-11eb-9b1c-cbfc0006a83d.png)

