### PR TITLE
Utilities: Specify mode argument when creating files with dd

### DIFF
--- a/Userland/Utilities/dd.cpp
+++ b/Userland/Utilities/dd.cpp
@@ -58,7 +58,7 @@ static int handle_io_file_arguments(int& fd, int flags, const char* argument)
         return -1;
     }
 
-    fd = open(value.characters(), flags);
+    fd = open(value.characters(), flags, 0666);
     if (fd == -1) {
         fprintf(stderr, "Unable to open: %s\n", value.characters());
         return -1;


### PR DESCRIPTION
When using `open()` with the `O_CREAT` flag we must specify the mode argument. Otherwise we'll incorrectly set the new file's mode to whatever is left on the stack:

```
courage:~ $ dd if=/dev/zero of=test count=1
1+0 blocks in
1+0 blocks out
512 bytes copied.
courage:~ $ ls -l test
--w-r-x---   1    anon   users        512   2021-05-08 01:29:52  test
courage:~ $
```

This also specifies the mode argument when opening files for reading. This however is harmless because in those cases the argument is ignored.