### PR TITLE
Kernel: Remove ScatterGatherList from VirtIO code

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -236,6 +236,7 @@ set(KERNEL_SOURCES
     VM/Range.cpp
     VM/RangeAllocator.cpp
     VM/Region.cpp
+    VM/RingBuffer.cpp
     VM/ScatterGatherList.cpp
     VM/SharedInodeVMObject.cpp
     VM/Space.cpp

--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -20,6 +20,7 @@
 #include <Kernel/Storage/StorageDevice.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/PhysicalPage.h>
+#include <Kernel/VM/ScatterGatherList.h>
 #include <Kernel/WaitQueue.h>
 
 namespace Kernel {
@@ -31,20 +32,6 @@ class SATADiskDevice;
 class AHCIPort : public RefCounted<AHCIPort> {
     friend class AHCIPortHandler;
     friend class SATADiskDevice;
-
-private:
-    class ScatterList : public RefCounted<ScatterList> {
-    public:
-        static NonnullRefPtr<ScatterList> create(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
-        const VMObject& vmobject() const { return m_vm_object; }
-        VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
-        size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
-
-    private:
-        ScatterList(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
-        NonnullRefPtr<AnonymousVMObject> m_vm_object;
-        OwnPtr<Region> m_dma_region;
-    };
 
 public:
     UNMAP_AFTER_INIT static NonnullRefPtr<AHCIPort> create(const AHCIPortHandler&, volatile AHCI::PortRegisters&, u32 port_index);
@@ -132,7 +119,7 @@ private:
     AHCI::PortInterruptStatusBitField m_interrupt_status;
     AHCI::PortInterruptEnableBitField m_interrupt_enable;
 
-    RefPtr<AHCIPort::ScatterList> m_current_scatter_list;
+    RefPtr<ScatterGatherList> m_current_scatter_list;
     bool m_disabled_by_firmware { false };
 };
 }

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -104,7 +104,6 @@ class MemoryManager {
     friend class PhysicalRegion;
     friend class AnonymousVMObject;
     friend class Region;
-    friend class ScatterGatherRefList;
     friend class VMObject;
 
 public:

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -104,7 +104,7 @@ class MemoryManager {
     friend class PhysicalRegion;
     friend class AnonymousVMObject;
     friend class Region;
-    friend class ScatterGatherList;
+    friend class ScatterGatherRefList;
     friend class VMObject;
 
 public:

--- a/Kernel/VM/RingBuffer.cpp
+++ b/Kernel/VM/RingBuffer.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Sahan Fernando <sahan.h.fernando@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/UserOrKernelBuffer.h>
+#include <Kernel/VM/MemoryManager.h>
+#include <Kernel/VM/RingBuffer.h>
+
+namespace Kernel {
+
+RingBuffer::RingBuffer(String region_name, size_t capacity)
+    : m_region(MM.allocate_contiguous_kernel_region(page_round_up(capacity), move(region_name), Region::Access::Read | Region::Access::Write))
+    , m_capacity_in_bytes(capacity)
+{
+}
+
+bool RingBuffer::copy_data_in(const UserOrKernelBuffer& buffer, size_t offset, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied)
+{
+    size_t start_of_free_area = (m_start_of_used + m_num_used_bytes) % m_capacity_in_bytes;
+    bytes_copied = min(m_capacity_in_bytes - m_num_used_bytes, min(m_capacity_in_bytes - start_of_free_area, length));
+    if (bytes_copied == 0)
+        return false;
+    if (buffer.read(m_region->vaddr().offset(start_of_free_area).as_ptr(), offset, bytes_copied)) {
+        m_num_used_bytes += bytes_copied;
+        start_of_copied_data = m_region->physical_page(start_of_free_area / PAGE_SIZE)->paddr().offset(start_of_free_area % PAGE_SIZE);
+        return true;
+    }
+    return false;
+}
+
+void RingBuffer::reclaim_space(PhysicalAddress chunk_start, size_t chunk_size)
+{
+    VERIFY(start_of_used() == chunk_start);
+    VERIFY(m_num_used_bytes >= chunk_size);
+    m_num_used_bytes -= chunk_size;
+    m_start_of_used += chunk_size;
+}
+
+PhysicalAddress RingBuffer::start_of_used() const
+{
+    size_t start = m_start_of_used % m_capacity_in_bytes;
+    return m_region->physical_page(start / PAGE_SIZE)->paddr().offset(start % PAGE_SIZE);
+}
+
+}

--- a/Kernel/VM/RingBuffer.h
+++ b/Kernel/VM/RingBuffer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Sahan Fernando <sahan.h.fernando@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel {
+
+class RingBuffer {
+public:
+    RingBuffer(String region_name, size_t capacity);
+
+    bool has_space() const { return m_num_used_bytes < m_capacity_in_bytes; }
+    bool copy_data_in(const UserOrKernelBuffer& buffer, size_t offset, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied);
+    void reclaim_space(PhysicalAddress chunk_start, size_t chunk_size);
+    PhysicalAddress start_of_used() const;
+
+    SpinLock<u8>& lock() { return m_lock; }
+
+private:
+    OwnPtr<Region> m_region;
+    SpinLock<u8> m_lock;
+    size_t m_start_of_used {};
+    size_t m_num_used_bytes {};
+    size_t m_capacity_in_bytes {};
+};
+
+}

--- a/Kernel/VM/ScatterGatherList.cpp
+++ b/Kernel/VM/ScatterGatherList.cpp
@@ -19,40 +19,4 @@ ScatterGatherList::ScatterGatherList(AsyncBlockDeviceRequest& request, NonnullRe
     m_dma_region = MM.allocate_kernel_region_with_vmobject(m_vm_object, page_round_up((request.block_count() * device_block_size)), "AHCI Scattered DMA", Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes);
 }
 
-ScatterGatherRefList ScatterGatherRefList::create_from_buffer(const u8* buffer, size_t size)
-{
-    VERIFY(buffer && size);
-    ScatterGatherRefList new_list;
-    auto* region = MM.find_region_from_vaddr(VirtualAddress(buffer));
-    VERIFY(region);
-    while (size > 0) {
-        size_t offset_in_page = (VirtualAddress(buffer) - region->vaddr()).get() % PAGE_SIZE;
-        size_t size_in_page = min(PAGE_SIZE - offset_in_page, size);
-        VERIFY(offset_in_page + size_in_page - 1 <= PAGE_SIZE);
-        new_list.add_entry(region->physical_page(region->page_index_from_address(VirtualAddress(buffer)))->paddr().get(), offset_in_page, size_in_page);
-        size -= size_in_page;
-        buffer += size_in_page;
-    }
-    return new_list;
-}
-
-ScatterGatherRefList ScatterGatherRefList::create_from_physical(PhysicalAddress paddr, size_t size)
-{
-    VERIFY(!paddr.is_null() && size);
-    ScatterGatherRefList new_list;
-    new_list.add_entry(paddr.page_base().get(), paddr.offset_in_page(), size);
-    return new_list;
-}
-
-void ScatterGatherRefList::add_entry(FlatPtr addr, size_t offset, size_t size)
-{
-    m_entries.append({ addr, offset, size });
-}
-
-void ScatterGatherRefList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
-{
-    for (auto& entry : m_entries)
-        callback(entry.page_base + entry.offset, entry.length);
-}
-
 }

--- a/Kernel/VM/ScatterGatherList.cpp
+++ b/Kernel/VM/ScatterGatherList.cpp
@@ -8,10 +8,21 @@
 
 namespace Kernel {
 
-ScatterGatherList ScatterGatherList::create_from_buffer(const u8* buffer, size_t size)
+NonnullRefPtr<ScatterGatherList> ScatterGatherList::create(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
+{
+    return adopt_ref(*new ScatterGatherList(request, allocated_pages, device_block_size));
+}
+
+ScatterGatherList::ScatterGatherList(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
+    : m_vm_object(AnonymousVMObject::create_with_physical_pages(allocated_pages))
+{
+    m_dma_region = MM.allocate_kernel_region_with_vmobject(m_vm_object, page_round_up((request.block_count() * device_block_size)), "AHCI Scattered DMA", Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes);
+}
+
+ScatterGatherRefList ScatterGatherRefList::create_from_buffer(const u8* buffer, size_t size)
 {
     VERIFY(buffer && size);
-    ScatterGatherList new_list;
+    ScatterGatherRefList new_list;
     auto* region = MM.find_region_from_vaddr(VirtualAddress(buffer));
     VERIFY(region);
     while (size > 0) {
@@ -25,20 +36,20 @@ ScatterGatherList ScatterGatherList::create_from_buffer(const u8* buffer, size_t
     return new_list;
 }
 
-ScatterGatherList ScatterGatherList::create_from_physical(PhysicalAddress paddr, size_t size)
+ScatterGatherRefList ScatterGatherRefList::create_from_physical(PhysicalAddress paddr, size_t size)
 {
     VERIFY(!paddr.is_null() && size);
-    ScatterGatherList new_list;
+    ScatterGatherRefList new_list;
     new_list.add_entry(paddr.page_base().get(), paddr.offset_in_page(), size);
     return new_list;
 }
 
-void ScatterGatherList::add_entry(FlatPtr addr, size_t offset, size_t size)
+void ScatterGatherRefList::add_entry(FlatPtr addr, size_t offset, size_t size)
 {
     m_entries.append({ addr, offset, size });
 }
 
-void ScatterGatherList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
+void ScatterGatherRefList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
 {
     for (auto& entry : m_entries)
         callback(entry.page_base + entry.offset, entry.length);

--- a/Kernel/VM/ScatterGatherList.h
+++ b/Kernel/VM/ScatterGatherList.h
@@ -7,21 +7,40 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/MemoryManager.h>
 
 namespace Kernel {
 
-class ScatterGatherList {
-    struct ScatterGatherEntry {
+/// A Scatter-Gather List type that owns its buffers
+
+class ScatterGatherList : public RefCounted<ScatterGatherList> {
+public:
+    static NonnullRefPtr<ScatterGatherList> create(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
+    const VMObject& vmobject() const { return m_vm_object; }
+    VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
+    size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
+
+private:
+    ScatterGatherList(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
+    NonnullRefPtr<AnonymousVMObject> m_vm_object;
+    OwnPtr<Region> m_dma_region;
+};
+
+/// A Scatter-Gather List type that doesn't own its buffers
+
+class ScatterGatherRefList {
+    struct ScatterGatherRef {
         FlatPtr page_base;
         size_t offset;
         size_t length;
     };
 
 public:
-    static ScatterGatherList create_from_buffer(const u8* buffer, size_t);
-    static ScatterGatherList create_from_physical(PhysicalAddress, size_t);
+    static ScatterGatherRefList create_from_buffer(const u8* buffer, size_t);
+    static ScatterGatherRefList create_from_physical(PhysicalAddress, size_t);
 
     void add_entry(FlatPtr, size_t offset, size_t size);
     [[nodiscard]] size_t length() const { return m_entries.size(); }
@@ -29,7 +48,7 @@ public:
     void for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const;
 
 private:
-    Vector<ScatterGatherEntry> m_entries;
+    Vector<ScatterGatherRef> m_entries;
 };
 
 }

--- a/Kernel/VM/ScatterGatherList.h
+++ b/Kernel/VM/ScatterGatherList.h
@@ -29,26 +29,4 @@ private:
     OwnPtr<Region> m_dma_region;
 };
 
-/// A Scatter-Gather List type that doesn't own its buffers
-
-class ScatterGatherRefList {
-    struct ScatterGatherRef {
-        FlatPtr page_base;
-        size_t offset;
-        size_t length;
-    };
-
-public:
-    static ScatterGatherRefList create_from_buffer(const u8* buffer, size_t);
-    static ScatterGatherRefList create_from_physical(PhysicalAddress, size_t);
-
-    void add_entry(FlatPtr, size_t offset, size_t size);
-    [[nodiscard]] size_t length() const { return m_entries.size(); }
-
-    void for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const;
-
-private:
-    Vector<ScatterGatherRef> m_entries;
-};
-
 }

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -335,7 +335,7 @@ void VirtIODevice::finish_init()
     dbgln_if(VIRTIO_DEBUG, "{}: Finished initialization", m_class_name);
 }
 
-void VirtIODevice::supply_buffer_and_notify(u16 queue_index, const ScatterGatherList& scatter_list, BufferType buffer_type, void* token)
+void VirtIODevice::supply_buffer_and_notify(u16 queue_index, const ScatterGatherRefList& scatter_list, BufferType buffer_type, void* token)
 {
     VERIFY(queue_index < m_queue_count);
     if (get_queue(queue_index).supply_buffer({}, scatter_list, buffer_type, token))

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -335,13 +335,6 @@ void VirtIODevice::finish_init()
     dbgln_if(VIRTIO_DEBUG, "{}: Finished initialization", m_class_name);
 }
 
-void VirtIODevice::supply_buffer_and_notify(u16 queue_index, const ScatterGatherRefList& scatter_list, BufferType buffer_type, void* token)
-{
-    VERIFY(queue_index < m_queue_count);
-    if (get_queue(queue_index).supply_buffer({}, scatter_list, buffer_type, token))
-        notify_queue(queue_index);
-}
-
 u8 VirtIODevice::isr_status()
 {
     if (!m_isr_cfg)
@@ -353,12 +346,14 @@ void VirtIODevice::handle_irq(const RegisterState&)
 {
     u8 isr_type = isr_status();
     if (isr_type & DEVICE_CONFIG_INTERRUPT) {
+        dbgln_if(VIRTIO_DEBUG, "{}: VirtIO Device config interrupt!", m_class_name);
         if (!handle_device_config_change()) {
             set_status_bit(DEVICE_STATUS_FAILED);
             dbgln("{}: Failed to handle device config change!", m_class_name);
         }
     }
     if (isr_type & QUEUE_INTERRUPT) {
+        dbgln_if(VIRTIO_DEBUG, "{}: VirtIO Queue interrupt!", m_class_name);
         for (size_t i = 0; i < m_queues.size(); i++) {
             if (get_queue(i).new_data_available())
                 return handle_queue_update(i);
@@ -367,6 +362,16 @@ void VirtIODevice::handle_irq(const RegisterState&)
     }
     if (isr_type & ~(QUEUE_INTERRUPT | DEVICE_CONFIG_INTERRUPT))
         dbgln("{}: Handling interrupt with unknown type: {}", m_class_name, isr_type);
+}
+
+void VirtIODevice::supply_chain_and_notify(u16 queue_index, VirtIOQueueChain& chain)
+{
+    auto& queue = get_queue(queue_index);
+    VERIFY(&chain.queue() == &queue);
+    VERIFY(queue.lock().is_locked());
+    chain.submit_to_queue();
+    if (queue.should_notify())
+        notify_queue(queue_index);
 }
 
 }

--- a/Kernel/VirtIO/VirtIO.h
+++ b/Kernel/VirtIO/VirtIO.h
@@ -12,7 +12,6 @@
 #include <Kernel/PCI/Access.h>
 #include <Kernel/PCI/Device.h>
 #include <Kernel/VM/MemoryManager.h>
-#include <Kernel/VM/ScatterGatherList.h>
 #include <Kernel/VirtIO/VirtIOQueue.h>
 
 namespace Kernel {
@@ -196,7 +195,7 @@ protected:
         return is_feature_set(m_accepted_features, feature);
     }
 
-    void supply_buffer_and_notify(u16 queue_index, const ScatterGatherRefList&, BufferType, void* token);
+    void supply_chain_and_notify(u16 queue_index, VirtIOQueueChain& chain);
 
     virtual bool handle_device_config_change() = 0;
     virtual void handle_queue_update(u16 queue_index) = 0;

--- a/Kernel/VirtIO/VirtIO.h
+++ b/Kernel/VirtIO/VirtIO.h
@@ -196,7 +196,7 @@ protected:
         return is_feature_set(m_accepted_features, feature);
     }
 
-    void supply_buffer_and_notify(u16 queue_index, const ScatterGatherList&, BufferType, void* token);
+    void supply_buffer_and_notify(u16 queue_index, const ScatterGatherRefList&, BufferType, void* token);
 
     virtual bool handle_device_config_change() = 0;
     virtual void handle_queue_update(u16 queue_index) = 0;

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -43,7 +43,7 @@ VirtIOConsole::VirtIOConsole(PCI::Address address)
             finish_init();
             m_receive_region = MM.allocate_contiguous_kernel_region(PAGE_SIZE, "VirtIOConsole Receive", Region::Access::Read | Region::Access::Write);
             if (m_receive_region) {
-                supply_buffer_and_notify(RECEIVEQ, ScatterGatherList::create_from_physical(m_receive_region->physical_page(0)->paddr(), m_receive_region->size()), BufferType::DeviceWritable, m_receive_region->vaddr().as_ptr());
+                supply_buffer_and_notify(RECEIVEQ, ScatterGatherRefList::create_from_physical(m_receive_region->physical_page(0)->paddr(), m_receive_region->size()), BufferType::DeviceWritable, m_receive_region->vaddr().as_ptr());
             }
             m_transmit_region = MM.allocate_contiguous_kernel_region(PAGE_SIZE, "VirtIOConsole Transmit", Region::Access::Read | Region::Access::Write);
         }
@@ -98,7 +98,7 @@ KResultOr<size_t> VirtIOConsole::write(FileDescription&, u64, const UserOrKernel
     if (!size)
         return 0;
 
-    auto scatter_list = ScatterGatherList::create_from_buffer(static_cast<const u8*>(data.user_or_kernel_ptr()), size);
+    auto scatter_list = ScatterGatherRefList::create_from_buffer(static_cast<const u8*>(data.user_or_kernel_ptr()), size);
     supply_buffer_and_notify(TRANSMITQ, scatter_list, BufferType::DeviceReadable, const_cast<void*>(data.user_or_kernel_ptr()));
 
     return size;

--- a/Kernel/VirtIO/VirtIOConsole.h
+++ b/Kernel/VirtIO/VirtIOConsole.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/VM/RingBuffer.h>
 #include <Kernel/VirtIO/VirtIO.h>
 
 namespace Kernel {
@@ -25,6 +26,7 @@ public:
     virtual ~VirtIOConsole() override;
 
 private:
+    constexpr static size_t RINGBUFFER_SIZE = 2 * PAGE_SIZE;
     virtual const char* class_name() const override { return m_class_name.characters(); }
 
     virtual bool can_read(const FileDescription&, size_t) const override;
@@ -38,8 +40,8 @@ private:
     virtual String device_name() const override { return String::formatted("hvc{}", minor()); }
     virtual void handle_queue_update(u16 queue_index) override;
 
-    OwnPtr<Region> m_receive_region;
-    OwnPtr<Region> m_transmit_region;
+    OwnPtr<RingBuffer> m_receive_buffer;
+    OwnPtr<RingBuffer> m_transmit_buffer;
 
     static unsigned next_device_id;
 };

--- a/Kernel/VirtIO/VirtIOQueue.cpp
+++ b/Kernel/VirtIO/VirtIOQueue.cpp
@@ -48,7 +48,7 @@ void VirtIOQueue::disable_interrupts()
     m_driver->flags = 1;
 }
 
-bool VirtIOQueue::supply_buffer(Badge<VirtIODevice>, const ScatterGatherList& scatter_list, BufferType buffer_type, void* token)
+bool VirtIOQueue::supply_buffer(Badge<VirtIODevice>, const ScatterGatherRefList& scatter_list, BufferType buffer_type, void* token)
 {
     VERIFY(scatter_list.length() && scatter_list.length() <= m_free_buffers);
     m_free_buffers -= scatter_list.length();

--- a/Kernel/VirtIO/VirtIOQueue.cpp
+++ b/Kernel/VirtIO/VirtIOQueue.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/StdLib.h>
+#include <AK/Atomic.h>
 #include <Kernel/VirtIO/VirtIOQueue.h>
 
 namespace Kernel {
@@ -25,10 +25,9 @@ VirtIOQueue::VirtIOQueue(u16 queue_size, u16 notify_offset)
     m_descriptors = reinterpret_cast<VirtIOQueueDescriptor*>(ptr);
     m_driver = reinterpret_cast<VirtIOQueueDriver*>(ptr + size_of_descriptors);
     m_device = reinterpret_cast<VirtIOQueueDevice*>(ptr + size_of_descriptors + size_of_driver);
-    m_tokens.resize(queue_size);
 
-    for (auto i = 0; i < queue_size; i++) {
-        m_descriptors[i].next = (i + 1) % queue_size; // link all of the descriptors in a circle
+    for (auto i = 0; i + 1 < queue_size; i++) {
+        m_descriptors[i].next = i + 1; // link all of the descriptors in a line
     }
 
     enable_interrupts();
@@ -40,94 +39,157 @@ VirtIOQueue::~VirtIOQueue()
 
 void VirtIOQueue::enable_interrupts()
 {
+    ScopedSpinLock lock(m_lock);
     m_driver->flags = 0;
 }
 
 void VirtIOQueue::disable_interrupts()
 {
+    ScopedSpinLock lock(m_lock);
     m_driver->flags = 1;
-}
-
-bool VirtIOQueue::supply_buffer(Badge<VirtIODevice>, const ScatterGatherRefList& scatter_list, BufferType buffer_type, void* token)
-{
-    VERIFY(scatter_list.length() && scatter_list.length() <= m_free_buffers);
-    m_free_buffers -= scatter_list.length();
-
-    auto descriptor_index = m_free_head;
-    auto last_index = descriptor_index;
-    scatter_list.for_each_entry([&](auto paddr, auto size) {
-        m_descriptors[descriptor_index].flags = static_cast<u16>(buffer_type) | VIRTQ_DESC_F_NEXT;
-        m_descriptors[descriptor_index].address = static_cast<u64>(paddr);
-        m_descriptors[descriptor_index].length = static_cast<u32>(size);
-        last_index = descriptor_index;
-        descriptor_index = m_descriptors[descriptor_index].next; // ensure we place the buffer in chain order
-    });
-    m_descriptors[last_index].flags &= ~(VIRTQ_DESC_F_NEXT); // last descriptor in chain doesn't have a next descriptor
-
-    m_driver->rings[m_driver_index_shadow % m_queue_size] = m_free_head; // m_driver_index_shadow is used to prevent accesses to index before the rings are updated
-    m_tokens[m_free_head] = token;
-    m_free_head = descriptor_index;
-
-    full_memory_barrier();
-
-    m_driver_index_shadow++;
-    m_driver->index++;
-
-    full_memory_barrier();
-
-    auto device_flags = m_device->flags;
-    return !(device_flags & 1); // if bit 1 is enabled the device disabled interrupts
 }
 
 bool VirtIOQueue::new_data_available() const
 {
-    return m_device->index != m_used_tail;
+    const auto index = AK::atomic_load(&m_device->index, AK::MemoryOrder::memory_order_relaxed);
+    const auto used_tail = AK::atomic_load(&m_used_tail, AK::MemoryOrder::memory_order_relaxed);
+    return index != used_tail;
 }
 
-void* VirtIOQueue::get_buffer(size_t* size)
+VirtIOQueueChain VirtIOQueue::pop_used_buffer_chain(size_t& used)
 {
+    VERIFY(m_lock.is_locked());
     if (!new_data_available()) {
-        *size = 0;
-        return nullptr;
+        used = 0;
+        return VirtIOQueueChain(*this);
     }
 
     full_memory_barrier();
 
-    auto descriptor_index = m_device->rings[m_used_tail % m_queue_size].index;
-    *size = m_device->rings[m_used_tail % m_queue_size].length;
+    // Determine used length
+    used = m_device->rings[m_used_tail % m_queue_size].length;
 
+    // Determine start, end and number of nodes in chain
+    auto descriptor_index = m_device->rings[m_used_tail % m_queue_size].index;
+    size_t length_of_chain = 1;
+    auto last_index = descriptor_index;
+    while (m_descriptors[last_index].flags & VIRTQ_DESC_F_NEXT) {
+        ++length_of_chain;
+        last_index = m_descriptors[last_index].next;
+    }
+
+    // We are now done with this buffer chain
     m_used_tail++;
 
-    auto token = m_tokens[descriptor_index];
-    pop_buffer(descriptor_index);
-    return token;
+    return VirtIOQueueChain(*this, descriptor_index, last_index, length_of_chain);
 }
 
 void VirtIOQueue::discard_used_buffers()
 {
-    size_t size;
-    while (!get_buffer(&size)) {
+    VERIFY(m_lock.is_locked());
+    size_t used;
+    for (auto buffer = pop_used_buffer_chain(used); !buffer.is_empty(); buffer = pop_used_buffer_chain(used)) {
+        buffer.release_buffer_slots_to_queue();
     }
 }
 
-void VirtIOQueue::pop_buffer(u16 descriptor_index)
+void VirtIOQueue::reclaim_buffer_chain(u16 chain_start_index, u16 chain_end_index, size_t length_of_chain)
 {
-    m_tokens[descriptor_index] = nullptr;
-
-    auto i = descriptor_index;
-    while (m_descriptors[i].flags & VIRTQ_DESC_F_NEXT) {
-        m_free_buffers++;
-        i = m_descriptors[i].next;
-    }
-    m_free_buffers++; // the last descriptor in the chain doesn't have the NEXT flag
-
-    m_descriptors[i].next = m_free_head; // empend the popped descriptors to the free chain
-    m_free_head = descriptor_index;
+    VERIFY(m_lock.is_locked());
+    m_descriptors[chain_end_index].next = m_free_head;
+    m_free_head = chain_start_index;
+    m_free_buffers += length_of_chain;
 }
 
-bool VirtIOQueue::can_write() const
+bool VirtIOQueue::has_free_slots() const
 {
-    return m_free_buffers > 0;
+    const auto free_buffers = AK::atomic_load(&m_free_buffers, AK::MemoryOrder::memory_order_relaxed);
+    return free_buffers > 0;
+}
+
+Optional<u16> VirtIOQueue::take_free_slot()
+{
+    VERIFY(m_lock.is_locked());
+    if (has_free_slots()) {
+        auto descriptor_index = m_free_head;
+        m_free_head = m_descriptors[descriptor_index].next;
+        --m_free_buffers;
+        return descriptor_index;
+    } else {
+        return {};
+    }
+}
+
+bool VirtIOQueue::should_notify() const
+{
+    VERIFY(m_lock.is_locked());
+    auto device_flags = m_device->flags;
+    return !(device_flags & VIRTQ_USED_F_NO_NOTIFY);
+}
+
+bool VirtIOQueueChain::add_buffer_to_chain(PhysicalAddress buffer_start, size_t buffer_length, BufferType buffer_type)
+{
+    VERIFY(m_queue.lock().is_locked());
+
+    // Ensure that no readable pages will be inserted after a writable one, as required by the VirtIO spec
+    VERIFY(buffer_type == BufferType::DeviceWritable || !m_chain_has_writable_pages);
+    m_chain_has_writable_pages |= (buffer_type == BufferType::DeviceWritable);
+
+    // Take a free slot from the queue
+    auto descriptor_index = m_queue.take_free_slot();
+    if (!descriptor_index.has_value())
+        return false;
+
+    if (!m_start_of_chain_index.has_value()) {
+        // Set start of chain if it hasn't been set
+        m_start_of_chain_index = descriptor_index.value();
+    } else {
+        // Link from previous element in VirtIOQueueChain
+        m_queue.m_descriptors[m_end_of_chain_index.value()].flags |= VIRTQ_DESC_F_NEXT;
+        m_queue.m_descriptors[m_end_of_chain_index.value()].next = descriptor_index.value();
+    }
+
+    // Update end of chain
+    m_end_of_chain_index = descriptor_index.value();
+    ++m_chain_length;
+
+    // Populate buffer info
+    VERIFY(buffer_length <= NumericLimits<size_t>::max());
+    m_queue.m_descriptors[descriptor_index.value()].address = static_cast<u64>(buffer_start.get());
+    m_queue.m_descriptors[descriptor_index.value()].flags = static_cast<u16>(buffer_type);
+    m_queue.m_descriptors[descriptor_index.value()].length = static_cast<u32>(buffer_length);
+
+    return true;
+}
+
+void VirtIOQueueChain::submit_to_queue()
+{
+    VERIFY(m_queue.lock().is_locked());
+    VERIFY(m_start_of_chain_index.has_value());
+
+    auto next_index = m_queue.m_driver_index_shadow % m_queue.m_queue_size;
+    m_queue.m_driver->rings[next_index] = m_start_of_chain_index.value();
+    m_queue.m_driver_index_shadow++;
+    full_memory_barrier();
+    m_queue.m_driver->index = m_queue.m_driver_index_shadow;
+
+    // Reset internal chain state
+    m_start_of_chain_index = m_end_of_chain_index = {};
+    m_chain_has_writable_pages = false;
+    m_chain_length = 0;
+}
+
+void VirtIOQueueChain::release_buffer_slots_to_queue()
+{
+    VERIFY(m_queue.lock().is_locked());
+    if (m_start_of_chain_index.has_value()) {
+        // Add the currently stored chain back to the queue's free pool
+        m_queue.reclaim_buffer_chain(m_start_of_chain_index.value(), m_end_of_chain_index.value(), m_chain_length);
+        // Reset internal chain state
+        m_start_of_chain_index = m_end_of_chain_index = {};
+        m_chain_has_writable_pages = false;
+        m_chain_length = 0;
+    }
 }
 
 }

--- a/Kernel/VirtIO/VirtIOQueue.h
+++ b/Kernel/VirtIO/VirtIOQueue.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Badge.h>
 #include <Kernel/SpinLock.h>
 #include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/ScatterGatherList.h>
@@ -16,12 +15,16 @@ namespace Kernel {
 #define VIRTQ_DESC_F_NEXT 1
 #define VIRTQ_DESC_F_INDIRECT 4
 
+#define VIRTQ_AVAIL_F_NO_INTERRUPT 1
+#define VIRTQ_USED_F_NO_NOTIFY 1
+
 enum class BufferType {
     DeviceReadable = 0,
     DeviceWritable = 2
 };
 
 class VirtIODevice;
+class VirtIOQueueChain;
 
 class VirtIOQueue {
 public:
@@ -38,14 +41,18 @@ public:
     PhysicalAddress driver_area() const { return to_physical(m_driver.ptr()); }
     PhysicalAddress device_area() const { return to_physical(m_device.ptr()); }
 
-    bool supply_buffer(Badge<VirtIODevice>, const ScatterGatherRefList&, BufferType, void* token);
     bool new_data_available() const;
-    bool can_write() const;
-    void* get_buffer(size_t*);
+    bool has_free_slots() const;
+    Optional<u16> take_free_slot();
+    VirtIOQueueChain pop_used_buffer_chain(size_t& used);
     void discard_used_buffers();
 
+    SpinLock<u8>& lock() { return m_lock; }
+
+    bool should_notify() const;
+
 private:
-    void pop_buffer(u16 descriptor_index);
+    void reclaim_buffer_chain(u16 chain_start_index, u16 chain_end_index, size_t length_of_chain);
 
     PhysicalAddress to_physical(const void* ptr) const
     {
@@ -86,9 +93,94 @@ private:
     OwnPtr<VirtIOQueueDescriptor> m_descriptors { nullptr };
     OwnPtr<VirtIOQueueDriver> m_driver { nullptr };
     OwnPtr<VirtIOQueueDevice> m_device { nullptr };
-    Vector<void*> m_tokens;
     OwnPtr<Region> m_queue_region;
     SpinLock<u8> m_lock;
+
+    friend class VirtIOQueueChain;
+};
+
+class VirtIOQueueChain {
+public:
+    VirtIOQueueChain(VirtIOQueue& queue)
+        : m_queue(queue)
+    {
+    }
+
+    VirtIOQueueChain(VirtIOQueue& queue, u16 start_index, u16 end_index, size_t chain_length)
+        : m_queue(queue)
+        , m_start_of_chain_index(start_index)
+        , m_end_of_chain_index(end_index)
+        , m_chain_length(chain_length)
+    {
+    }
+
+    VirtIOQueueChain(VirtIOQueueChain&& other)
+        : m_queue(other.m_queue)
+        , m_start_of_chain_index(other.m_start_of_chain_index)
+        , m_end_of_chain_index(other.m_end_of_chain_index)
+        , m_chain_length(other.m_chain_length)
+        , m_chain_has_writable_pages(other.m_chain_has_writable_pages)
+    {
+        other.m_start_of_chain_index = {};
+        other.m_end_of_chain_index = {};
+        other.m_chain_length = 0;
+        other.m_chain_has_writable_pages = false;
+    }
+
+    VirtIOQueueChain& operator=(VirtIOQueueChain&& other)
+    {
+        VERIFY(&m_queue == &other.m_queue);
+        ensure_chain_is_empty();
+        m_start_of_chain_index = other.m_start_of_chain_index;
+        m_end_of_chain_index = other.m_end_of_chain_index;
+        m_chain_length = other.m_chain_length;
+        m_chain_has_writable_pages = other.m_chain_has_writable_pages;
+        other.m_start_of_chain_index = {};
+        other.m_end_of_chain_index = {};
+        other.m_chain_length = 0;
+        other.m_chain_has_writable_pages = false;
+        return *this;
+    }
+
+    ~VirtIOQueueChain()
+    {
+        ensure_chain_is_empty();
+    }
+
+    [[nodiscard]] VirtIOQueue& queue() const { return m_queue; }
+    [[nodiscard]] bool is_empty() const { return m_chain_length == 0; }
+    [[nodiscard]] size_t length() const { return m_chain_length; }
+    bool add_buffer_to_chain(PhysicalAddress buffer_start, size_t buffer_length, BufferType buffer_type);
+    void submit_to_queue();
+    void release_buffer_slots_to_queue();
+
+    void for_each(Function<void(PhysicalAddress, size_t)> callback)
+    {
+        VERIFY(m_queue.lock().is_locked());
+        if (!m_start_of_chain_index.has_value())
+            return;
+        auto index = m_start_of_chain_index.value();
+        for (size_t i = 0; i < m_chain_length; ++i) {
+            auto addr = m_queue.m_descriptors[index].address;
+            auto length = m_queue.m_descriptors[index].length;
+            callback(PhysicalAddress(addr), length);
+            index = m_queue.m_descriptors[index].next;
+        }
+    }
+
+private:
+    void ensure_chain_is_empty() const
+    {
+        VERIFY(!m_start_of_chain_index.has_value());
+        VERIFY(!m_end_of_chain_index.has_value());
+        VERIFY(m_chain_length == 0);
+    }
+
+    VirtIOQueue& m_queue;
+    Optional<u16> m_start_of_chain_index {};
+    Optional<u16> m_end_of_chain_index {};
+    size_t m_chain_length {};
+    bool m_chain_has_writable_pages { false };
 };
 
 }

--- a/Kernel/VirtIO/VirtIOQueue.h
+++ b/Kernel/VirtIO/VirtIOQueue.h
@@ -38,7 +38,7 @@ public:
     PhysicalAddress driver_area() const { return to_physical(m_driver.ptr()); }
     PhysicalAddress device_area() const { return to_physical(m_device.ptr()); }
 
-    bool supply_buffer(Badge<VirtIODevice>, const ScatterGatherList&, BufferType, void* token);
+    bool supply_buffer(Badge<VirtIODevice>, const ScatterGatherRefList&, BufferType, void* token);
     bool new_data_available() const;
     bool can_write() const;
     void* get_buffer(size_t*);

--- a/Kernel/VirtIO/VirtIORNG.cpp
+++ b/Kernel/VirtIO/VirtIORNG.cpp
@@ -23,7 +23,7 @@ VirtIORNG::VirtIORNG(PCI::Address address)
         m_entropy_buffer = MM.allocate_contiguous_kernel_region(PAGE_SIZE, "VirtIORNG", Region::Access::Read | Region::Access::Write);
         if (m_entropy_buffer) {
             memset(m_entropy_buffer->vaddr().as_ptr(), 0, m_entropy_buffer->size());
-            supply_buffer_and_notify(REQUESTQ, ScatterGatherList::create_from_physical(m_entropy_buffer->physical_page(0)->paddr(), m_entropy_buffer->size()), BufferType::DeviceWritable, m_entropy_buffer->vaddr().as_ptr());
+            supply_buffer_and_notify(REQUESTQ, ScatterGatherRefList::create_from_physical(m_entropy_buffer->physical_page(0)->paddr(), m_entropy_buffer->size()), BufferType::DeviceWritable, m_entropy_buffer->vaddr().as_ptr());
         }
     }
 }

--- a/Kernel/VirtIO/VirtIORNG.h
+++ b/Kernel/VirtIO/VirtIORNG.h
@@ -33,6 +33,7 @@ public:
 private:
     virtual bool handle_device_config_change() override;
     virtual void handle_queue_update(u16 queue_index) override;
+    void request_entropy_from_host();
 
     OwnPtr<Region> m_entropy_buffer;
     EntropySource m_entropy_source;


### PR DESCRIPTION
Supersedes #6600. This PR is still a WIP, but basically, we remove the ScatterGatherList class from the VirtIO code, and replace it with VirtioQueueChain, a builder class for queue chains. This allows us to avoid allocating a temporary vector when supplying buffers to the virtqueues, which would improve the performance the read/write path of all VirtIO devices. This draft so far reflects the rough idea of the API, I do plan on cleaning up the implementation to make the code a bit cleaner

I've kept the changes from the last PR moving AHCIPort's ScatterList to the VM::ScatterGatherList directory, since it is more of a VM concept and we should Ideally have only one scatter gather list in the repo.

Also included in this PR are some changes to the VirtIOConsole, making it store the the data to write into an internal ring buffer instead of storing references to userspace pages that may not exist by the time that the write goes through.

@IdanHo @supercomputer7 Thoughts on the VirtIOQueueChain API?