### PR TITLE
TextEditor: Do not prompt to save upon exit if file is unmodified

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -641,6 +641,8 @@ bool MainWidget::request_close()
 {
     if (!editor().document().is_modified())
         return true;
+    if (!window()->is_modified())
+        return true;
     auto result = GUI::MessageBox::show(window(), "The document has been modified. Would you like to save?", "Unsaved changes", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
 
     if (result == GUI::MessageBox::ExecYes) {


### PR DESCRIPTION
For some reason `TextEditor` tracks two modified states (`editor` and `window`). The `request_close` function was not checking the `window` state when checking if the file was unmodified upon exit. Fixes #6926.
