### PR TITLE
Profiler: Migrate mouse events to TimelineView so we can hover between tracks

### DIFF
--- a/Userland/DevTools/Profiler/TimelineContainer.cpp
+++ b/Userland/DevTools/Profiler/TimelineContainer.cpp
@@ -18,6 +18,8 @@ TimelineContainer::TimelineContainer(GUI::Widget& header_container, TimelineView
     add_child(timeline_view);
     header_container.move_to_back();
     timeline_view.move_to_back();
+    update_widget_sizes();
+    update_widget_positions();
 }
 
 TimelineContainer::~TimelineContainer()

--- a/Userland/DevTools/Profiler/TimelineTrack.h
+++ b/Userland/DevTools/Profiler/TimelineTrack.h
@@ -21,17 +21,13 @@ public:
     virtual ~TimelineTrack() override;
 
 private:
+    virtual void event(Core::Event&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
-    virtual void mousedown_event(GUI::MouseEvent&) override;
-    virtual void mousemove_event(GUI::MouseEvent&) override;
-    virtual void mouseup_event(GUI::MouseEvent&) override;
 
-    explicit TimelineTrack(TimelineView&, Profile&, Process const&);
+    explicit TimelineTrack(TimelineView const&, Profile const&, Process const&);
 
-    u64 timestamp_at_x(int x) const;
-
-    TimelineView& m_view;
-    Profile& m_profile;
+    TimelineView const& m_view;
+    Profile const& m_profile;
     Process const& m_process;
 };
 

--- a/Userland/DevTools/Profiler/TimelineView.cpp
+++ b/Userland/DevTools/Profiler/TimelineView.cpp
@@ -5,11 +5,13 @@
  */
 
 #include "TimelineView.h"
+#include "Profile.h"
 #include <LibGUI/BoxLayout.h>
 
 namespace Profiler {
 
-TimelineView::TimelineView()
+TimelineView::TimelineView(Profile& profile)
+    : m_profile(profile)
 {
     set_layout<GUI::VerticalBoxLayout>();
     set_shrink_to_fit(true);
@@ -17,6 +19,47 @@ TimelineView::TimelineView()
 
 TimelineView::~TimelineView()
 {
+}
+
+u64 TimelineView::timestamp_at_x(int x) const
+{
+    float column_width = (float)width() / (float)m_profile.length_in_ms();
+    float ms_into_profile = (float)x / column_width;
+    return m_profile.first_timestamp() + (u64)ms_into_profile;
+}
+
+void TimelineView::mousedown_event(GUI::MouseEvent& event)
+{
+    if (event.button() != GUI::MouseButton::Left)
+        return;
+
+    set_selecting(true);
+    set_select_start_time(timestamp_at_x(event.x()));
+    set_select_end_time(select_start_time());
+    m_profile.set_timestamp_filter_range(select_start_time(), select_end_time());
+    update();
+}
+
+void TimelineView::mousemove_event(GUI::MouseEvent& event)
+{
+    set_hover_time(timestamp_at_x(event.x()));
+
+    if (is_selecting()) {
+        set_select_end_time(hover_time());
+        m_profile.set_timestamp_filter_range(select_start_time(), select_end_time());
+    }
+
+    update();
+}
+
+void TimelineView::mouseup_event(GUI::MouseEvent& event)
+{
+    if (event.button() != GUI::MouseButton::Left)
+        return;
+
+    set_selecting(false);
+    if (select_start_time() == select_end_time())
+        m_profile.clear_timestamp_filter_range();
 }
 
 }

--- a/Userland/DevTools/Profiler/TimelineView.h
+++ b/Userland/DevTools/Profiler/TimelineView.h
@@ -10,6 +10,7 @@
 
 namespace Profiler {
 
+class Profile;
 class TimelineTrack;
 
 class TimelineView final : public GUI::Widget {
@@ -25,14 +26,14 @@ public:
     u64 select_end_time() const { return m_select_end_time; }
     u64 hover_time() const { return m_hover_time; }
 
-    void set_selecting(Badge<TimelineTrack>, bool value)
+    void set_selecting(bool value)
     {
         if (m_selecting == value)
             return;
         m_selecting = value;
     }
 
-    void set_select_start_time(Badge<TimelineTrack>, u64 value)
+    void set_select_start_time(u64 value)
     {
         if (m_select_start_time == value)
             return;
@@ -41,7 +42,7 @@ public:
         if (on_selection_change)
             on_selection_change();
     }
-    void set_select_end_time(Badge<TimelineTrack>, u64 value)
+    void set_select_end_time(u64 value)
     {
         if (m_select_end_time == value)
             return;
@@ -50,7 +51,7 @@ public:
         if (on_selection_change)
             on_selection_change();
     }
-    void set_hover_time(Badge<TimelineTrack>, u64 value)
+    void set_hover_time(u64 value)
     {
         if (m_hover_time == value)
             return;
@@ -61,8 +62,15 @@ public:
     }
 
 private:
-    TimelineView();
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void mouseup_event(GUI::MouseEvent&) override;
 
+    explicit TimelineView(Profile&);
+
+    u64 timestamp_at_x(int x) const;
+
+    Profile& m_profile;
     bool m_selecting { false };
     u64 m_select_start_time { 0 };
     u64 m_select_end_time { 0 };

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
     timeline_header_container->set_fill_with_background_color(true);
     timeline_header_container->set_shrink_to_fit(true);
 
-    auto timeline_view = TimelineView::construct();
+    auto timeline_view = TimelineView::construct(*profile);
     for (auto& process : profile->processes()) {
         bool matching_event_found = false;
         for (auto& event : profile->events()) {


### PR DESCRIPTION
This change allows for continuous mouse events when hovering the layout spaces between tracks.

This also fixes a bug where the timeline would start at `Time: 2000ms` before scrolling.