### PR TITLE
LibGUI: Fix undo stack reporting wrong modified state

### DIFF
--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -92,16 +92,12 @@ void UndoStack::finalize_current_combo()
 
 void UndoStack::set_current_unmodified()
 {
-    // Skip empty container
-    if (can_undo() && m_stack[m_stack_index].commands.is_empty())
-        m_clean_index = m_stack_index + 1;
-    else
-        m_clean_index = m_stack_index;
+    m_clean_index = non_empty_stack_index();
 }
 
 bool UndoStack::is_current_modified() const
 {
-    return !m_clean_index.has_value() || m_stack_index != m_clean_index.value();
+    return !m_clean_index.has_value() || non_empty_stack_index() != m_clean_index.value();
 }
 
 void UndoStack::clear()
@@ -109,6 +105,14 @@ void UndoStack::clear()
     m_stack.clear();
     m_stack_index = 0;
     m_clean_index.clear();
+}
+
+size_t UndoStack::non_empty_stack_index() const
+{
+    if (can_undo() && m_stack[m_stack_index].commands.is_empty())
+        return m_stack_index + 1;
+    else
+        return m_stack_index;
 }
 
 }

--- a/Userland/Libraries/LibGUI/UndoStack.h
+++ b/Userland/Libraries/LibGUI/UndoStack.h
@@ -32,6 +32,8 @@ public:
     void clear();
 
 private:
+    size_t non_empty_stack_index() const;
+
     struct Combo {
         NonnullOwnPtrVector<Command> commands;
     };


### PR DESCRIPTION
Fixes: #6926 

Since the `redo` action never goes back to `index: 0`,
we have to mark the clean index as being the current
non-empty index for the undo/redo navigation to work properly.

The problem is that if we never `undo`, the stack index stays at zero,
which is the empty container waiting for commands. In that situation,
if we save the document, it registers the clean index as being 1
(the non-empty index) but because the stack index has never left zero,
the document was being reported as modified, being out of sync with
the window modified state.