### PR TITLE
AK: Support NonnullRefPtr in HashMap

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -95,7 +95,23 @@ public:
 
     void ensure_capacity(size_t capacity) { m_table.ensure_capacity(capacity); }
 
-    Optional<typename Traits<V>::PeekType> get(const K& key) const
+    Optional<typename Traits<V>::PeekType> get(const K& key) const requires(!IsPointer<typename Traits<V>::PeekType>)
+    {
+        auto it = find(key);
+        if (it == end())
+            return {};
+        return (*it).value;
+    }
+
+    Optional<typename Traits<V>::ConstPeekType> get(const K& key) const requires(IsPointer<typename Traits<V>::PeekType>)
+    {
+        auto it = find(key);
+        if (it == end())
+            return {};
+        return (*it).value;
+    }
+
+    Optional<typename Traits<V>::PeekType> get(const K& key) requires(!IsConst<typename Traits<V>::PeekType>)
     {
         auto it = find(key);
         if (it == end())

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -158,7 +158,8 @@ make(Args&&... args)
 
 template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public GenericTraits<NonnullOwnPtr<T>> {
-    using PeekType = const T*;
+    using PeekType = T*;
+    using ConstPeekType = const T*;
     static unsigned hash(const NonnullOwnPtr<T>& p) { return int_hash((u32)p.ptr()); }
     static bool equals(const NonnullOwnPtr<T>& a, const NonnullOwnPtr<T>& b) { return a.ptr() == b.ptr(); }
 };

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -9,6 +9,7 @@
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/Format.h>
+#include <AK/Traits.h>
 #include <AK/Types.h>
 #ifdef KERNEL
 #    include <Kernel/Arch/x86/CPU.h>
@@ -334,6 +335,14 @@ inline void swap(NonnullRefPtr<T>& a, NonnullRefPtr<U>& b)
 }
 
 }
+
+template<typename T>
+struct Traits<NonnullRefPtr<T>> : public GenericTraits<NonnullRefPtr<T>> {
+    using PeekType = T*;
+    using ConstPeekType = const T*;
+    static unsigned hash(const NonnullRefPtr<T>& p) { return ptr_hash(p.ptr()); }
+    static bool equals(const NonnullRefPtr<T>& a, const NonnullRefPtr<T>& b) { return a.ptr() == b.ptr(); }
+};
 
 using AK::adopt_ref;
 using AK::NonnullRefPtr;

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -56,6 +56,21 @@ public:
         }
     }
 
+    ALWAYS_INLINE Optional(Optional& other)
+        : m_has_value(other.m_has_value)
+    {
+        if (m_has_value) {
+            new (&m_storage) T(other.value());
+        }
+    }
+
+    template<typename U>
+    ALWAYS_INLINE Optional(U& value)
+        : m_has_value(true)
+    {
+        new (&m_storage) T(value);
+    }
+
     ALWAYS_INLINE Optional& operator=(const Optional& other)
     {
         if (this != &other) {

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -193,7 +193,8 @@ inline void swap(OwnPtr<T>& a, OwnPtr<U>& b)
 
 template<typename T>
 struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
-    using PeekType = const T*;
+    using PeekType = T*;
+    using ConstPeekType = const T*;
     static unsigned hash(const OwnPtr<T>& p) { return ptr_hash(p.ptr()); }
     static bool equals(const OwnPtr<T>& a, const OwnPtr<T>& b) { return a.ptr() == b.ptr(); }
 };

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -451,7 +451,8 @@ struct Formatter<RefPtr<T>> : Formatter<const T*> {
 
 template<typename T>
 struct Traits<RefPtr<T>> : public GenericTraits<RefPtr<T>> {
-    using PeekType = const T*;
+    using PeekType = T*;
+    using ConstPeekType = const T*;
     static unsigned hash(const RefPtr<T>& p) { return ptr_hash(p.ptr()); }
     static bool equals(const RefPtr<T>& a, const RefPtr<T>& b) { return a.ptr() == b.ptr(); }
 };

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -14,6 +14,7 @@ namespace AK {
 template<typename T>
 struct GenericTraits {
     using PeekType = T;
+    using ConstPeekType = T;
     static constexpr bool is_trivial() { return false; }
     static constexpr bool equals(const T& a, const T& b) { return a == b; }
 };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -223,7 +223,6 @@ bool HackStudioWidget::open_file(const String& full_filename)
         // Update the scrollbar values of the previous_open_project_file and save them to m_open_files.
         previous_open_project_file->vertical_scroll_value(current_editor().vertical_scrollbar().value());
         previous_open_project_file->horizontal_scroll_value(current_editor().horizontal_scrollbar().value());
-        m_open_files.set(active_file(), previous_open_project_file);
     }
 
     RefPtr<ProjectFile> new_project_file = nullptr;

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -7,6 +7,7 @@
 #include "ParserAutoComplete.h"
 #include <AK/Assertions.h>
 #include <AK/HashTable.h>
+#include <AK/OwnPtr.h>
 #include <LibCpp/AST.h>
 #include <LibCpp/Lexer.h>
 #include <LibCpp/Parser.h>

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -7,6 +7,7 @@
 #include "FileDB.h"
 
 #include <AK/LexicalPath.h>
+#include <AK/NonnullRefPtr.h>
 #include <LibCore/File.h>
 
 namespace LanguageServers {
@@ -18,7 +19,7 @@ RefPtr<const GUI::TextDocument> FileDB::get(const String& filename) const
     if (!document_optional.has_value())
         return nullptr;
 
-    return document_optional.value();
+    return adopt_ref(*document_optional.value());
 }
 
 RefPtr<GUI::TextDocument> FileDB::get(const String& filename)

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -311,7 +311,7 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> load_main_library(co
         loader.load_stage_4();
     }
 
-    return main_library_loader;
+    return NonnullRefPtr<DynamicLoader>(*main_library_loader);
 }
 
 static Result<void, DlErrorMessage> __dlclose(void* handle)
@@ -377,7 +377,8 @@ static Result<void*, DlErrorMessage> __dlopen(const char* filename, int flags)
     auto existing_elf_object = s_global_objects.get(library_name);
     if (existing_elf_object.has_value()) {
         // It's up to the caller to release the ref with dlclose().
-        return &existing_elf_object->leak_ref();
+        existing_elf_object.value()->ref();
+        return *existing_elf_object;
     }
 
     VERIFY(!library_name.is_empty());
@@ -406,7 +407,8 @@ static Result<void*, DlErrorMessage> __dlopen(const char* filename, int flags)
         return DlErrorMessage { "Could not load ELF object." };
 
     // It's up to the caller to release the ref with dlclose().
-    return &object->leak_ref();
+    object.value()->ref();
+    return *object;
 }
 
 static Result<void*, DlErrorMessage> __dlsym(void* handle, const char* symbol_name)

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -144,7 +144,7 @@ NonnullRefPtr<GUI::Menu> build_system_menu()
                 dbgln("App {} has icon with size {}", app.name, icon->size());
         }
 
-        auto parent_menu = app_category_menus.get(app.category).value_or(*system_menu);
+        auto parent_menu = app_category_menus.get(app.category).value_or(system_menu.ptr());
         parent_menu->add_action(GUI::Action::create(app.name, icon, [app_identifier](auto&) {
             dbgln("Activated app with ID {}", app_identifier);
             const auto& bin = g_apps[app_identifier].executable;

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -46,14 +46,14 @@ public:
         auto menu = m_menus.get(menu_id);
         if (!menu.has_value())
             return nullptr;
-        return const_cast<Menu*>(menu.value().ptr());
+        return menu.value();
     }
     const Menu* find_menu_by_id(int menu_id) const
     {
         auto menu = m_menus.get(menu_id);
         if (!menu.has_value())
             return nullptr;
-        return menu.value().ptr();
+        return menu.value();
     }
 
     template<typename Callback>


### PR DESCRIPTION
The initial motivation for this was to fix the changes requested for #6916.

I also added a non-const variant to `HashMap::get()`, which means we don't have to add lots of const_casts
after implementing `GenericTraits` for `NonnullRefPtr`.

cc @alimpfard @awesomekling 

