### PR TITLE
Kernel: Place ext2 dir entries so they don't span multiple blocks

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -58,7 +58,7 @@ private:
     virtual KResult truncate(u64) override;
     virtual KResultOr<int> get_block_address(int) override;
 
-    KResult write_directory(const Vector<Ext2FSDirectoryEntry>&);
+    KResult write_directory(Vector<Ext2FSDirectoryEntry>&);
     bool populate_lookup_cache() const;
     KResult resize(u64);
     KResult write_indirect_block(BlockBasedFS::BlockIndex, Span<BlockBasedFS::BlockIndex>);


### PR DESCRIPTION
Ext2 dir entries spanning multiple blocks are not allowed.
If they do occur they are flagged as corrupt by e2fsck for example.