### PR TITLE
Toolchain+LibM: Make various C99/C11 functions available in the std namespace

### DIFF
--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -6297,3 +6297,23 @@ diff -Naur gcc-11.1.0-RC-20210420/libstdc++-v3/crossconfig.m4 gcc-11.1.0-RC-2021
    arm*-*-symbianelf*)
      # This is a freestanding configuration; there is nothing to do here.
      ;;
+diff -Naur gcc-11.1.0/libstdc++-v3/configure gcc-11.1.0.serenity/libstdc++-v3/configure
+--- gcc-11.1.0/libstdc++-v3/configure	2021-05-08 23:33:02.665399548 +0200
++++ gcc-11.1.0.serenity/libstdc++-v3/configure	2021-05-09 08:49:22.325309643 +0200
+@@ -4219,15 +4219,7 @@
+ }
+ _ACEOF
+ # FIXME: Cleanup?
+-if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
+-  (eval $ac_link) 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
+-  gcc_no_link=no
+-else
+-  gcc_no_link=yes
+-fi
++gcc_no_link=yes
+ if test x$gcc_no_link = xyes; then
+   # Setting cross_compile will disable run tests; it will
+   # also disable AC_CHECK_FILE but that's generally

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -6297,3 +6297,23 @@ diff -Naur gcc-11.1.0-RC-20210420/libstdc++-v3/crossconfig.m4 gcc-11.1.0-RC-2021
    arm*-*-symbianelf*)
      # This is a freestanding configuration; there is nothing to do here.
      ;;
+diff -Naur gcc-11.1.0/libstdc++-v3/configure gcc-11.1.0.serenity/libstdc++-v3/configure
+--- gcc-11.1.0/libstdc++-v3/configure	2021-05-08 23:33:02.665399548 +0200
++++ gcc-11.1.0.serenity/libstdc++-v3/configure	2021-05-09 08:49:22.325309643 +0200
+@@ -4219,15 +4219,7 @@
+ }
+ _ACEOF
+ # FIXME: Cleanup?
+-if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
+-  (eval $ac_link) 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
+-  gcc_no_link=no
+-else
+-  gcc_no_link=yes
+-fi
++gcc_no_link=yes
+ if test x$gcc_no_link = xyes; then
+   # Setting cross_compile will disable run tests; it will
+   # also disable AC_CHECK_FILE but that's generally

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1257,6 +1257,11 @@ int vfscanf(FILE* stream, const char* fmt, va_list ap)
     return vsscanf(buffer, fmt, ap);
 }
 
+int vscanf(const char* fmt, va_list ap)
+{
+    return vfscanf(stdin, fmt, ap);
+}
+
 void flockfile([[maybe_unused]] FILE* filehandle)
 {
     dbgln("FIXME: Implement flockfile()");

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -89,6 +89,7 @@ void perror(const char*);
 int scanf(const char* fmt, ...) __attribute__((format(scanf, 1, 2)));
 int sscanf(const char* str, const char* fmt, ...) __attribute__((format(scanf, 2, 3)));
 int fscanf(FILE*, const char* fmt, ...) __attribute__((format(scanf, 2, 3)));
+int vscanf(const char*, va_list) __attribute__((format(scanf, 1, 0)));
 int vfscanf(FILE*, const char*, va_list) __attribute__((format(scanf, 2, 0)));
 int vsscanf(const char*, const char*, va_list) __attribute__((format(scanf, 2, 0)));
 int setvbuf(FILE*, char* buf, int mode, size_t);

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -1180,3 +1180,8 @@ int unlockpt([[maybe_unused]] int fd)
     return 0;
 }
 }
+
+void _Exit(int status)
+{
+    _exit(status);
+}

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -61,6 +61,7 @@ int mbtowc(wchar_t*, const char*, size_t);
 int wctomb(char*, wchar_t);
 size_t wcstombs(char*, const wchar_t*, size_t);
 char* realpath(const char* pathname, char* buffer);
+__attribute__((noreturn)) void _Exit(int status);
 
 #define RAND_MAX 32767
 int rand();

--- a/Userland/Libraries/LibM/math.h
+++ b/Userland/Libraries/LibM/math.h
@@ -236,6 +236,11 @@ long lroundl(long double) NOEXCEPT;
 long long llroundf(float) NOEXCEPT;
 long long llround(double) NOEXCEPT;
 long long llroundd(long double) NOEXCEPT;
+long long llroundl(long double x) NOEXCEPT;
+double nearbyint(double x) NOEXCEPT;
+float nearbyintf(float x) NOEXCEPT;
+long double nearbyintl(long double x) NOEXCEPT;
+
 float rintf(float) NOEXCEPT;
 double rint(double) NOEXCEPT;
 long double rintl(long double) NOEXCEPT;
@@ -261,6 +266,7 @@ double scalbn(double, int) NOEXCEPT;
 long double scalbnl(long double, int) NOEXCEPT;
 float scalbnlf(float, long) NOEXCEPT;
 double scalbln(double, long) NOEXCEPT;
+float scalblnf(float, long) NOEXCEPT;
 long double scalblnl(long double, long) NOEXCEPT;
 int ilogbl(long double) NOEXCEPT;
 int ilogb(double) NOEXCEPT;
@@ -277,5 +283,20 @@ long double nexttowardl(long double, long double) NOEXCEPT;
 float copysignf(float x, float y) NOEXCEPT;
 double copysign(double x, double y) NOEXCEPT;
 long double copysignl(long double x, long double y) NOEXCEPT;
+
+/* positive difference */
+double fdim(double x, double y) NOEXCEPT;
+float fdimf(float x, float y) NOEXCEPT;
+long double fdiml(long double x, long double y) NOEXCEPT;
+
+/* floating-point multiply and add */
+double fma(double x, double y, double z) NOEXCEPT;
+float fmaf(float x, float y, float z) NOEXCEPT;
+long double fmal(long double x, long double y, long double z) NOEXCEPT;
+
+/* remainder and part of quotient */
+double remquo(double x, double y, int* quo) NOEXCEPT;
+float remquof(float x, float y, int* quo) NOEXCEPT;
+long double remquol(long double x, long double y, int* quo) NOEXCEPT;
 
 __END_DECLS

--- a/Userland/Libraries/LibM/math.h
+++ b/Userland/Libraries/LibM/math.h
@@ -74,7 +74,7 @@ __BEGIN_DECLS
 #define isless(x, y) __builtin_isless((x), (y))
 #define islessequal(x, y) __builtin_islessequal((x), (y))
 #define islessgreater(x, y) __builtin_islessgreater((x), (y))
-#define isunordered(x, y) __builtin_isunoredered((x), (y))
+#define isunordered(x, y) __builtin_isunordered((x), (y))
 
 #define DOUBLE_MAX ((double)0b0111111111101111111111111111111111111111111111111111111111111111)
 #define DOUBLE_MIN ((double)0b0000000000010000000000000000000000000000000000000000000000000000)


### PR DESCRIPTION
We were missing various bits of C99/C11 functionality for those functions to show up in the `std` namespace. See #6969 for a list of patches this makes obsolete.

Even though this is a toolchain patch this does not necessarily require rebuilding the toolchain right away. This is only required once we start using any of these new members in the std namespace, e.g. for ports.