### PR TITLE
LibWeb: Implement :nth-child pseudo-class

### DIFF
--- a/Base/res/html/misc/nth-child.html
+++ b/Base/res/html/misc/nth-child.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>:nth-child test</title>
+    <style>
+        /** We have weird spacing inside parentheses to test parser. */
+        .odd > div:nth-child(odd ),
+        ._2n-plus-1 > div:nth-child(2n+1),
+        .even > div:nth-child( even),
+        ._2n > div:nth-child( 2n ),
+        ._3n > div:nth-child(3n),
+        ._2 > div:nth-child(2 ),
+        ._3n-plus-1 > div:nth-child( 3n + 1 ),
+        ._3n-minus-1 > div:nth-child( 3n -1),
+        ._minus-n-plus-3 > div:nth-child(-n+ 3),
+        .n > div:nth-child(n), /** "n" is special case inside parser. */
+        .plus-n > div:nth-child(+n), /** "+n" is special case inside parser. */
+        .minus-n > div:nth-child(-n), /** "-n" is special case inside parser. */
+        ._0n-plus-1 > div:nth-child(-0n+1),
+        .n-plus-2__minus-n-plus-4 > div:nth-child(+n + 2 ):nth-child( -n+4) {
+            background-color: lightblue;
+        }
+    </style>
+</head>
+<body>
+<h4>:nth-child(odd)</h4>
+<div class="odd">
+    <div>1 +</div>
+    <div>2</div>
+    <div>3 +</div>
+    <div>4</div>
+</div>
+
+<h4>:nth-child(2n+1) - same as odd</h4>
+<div class="_2n-plus-1">
+    <div>1 +</div>
+    <div>2</div>
+    <div>3 +</div>
+    <div>4</div>
+</div>
+
+<h4>:nth-child(even)</h4>
+<div class="even">
+    <div>1</div>
+    <div>2 +</div>
+    <div>3</div>
+    <div>4 +</div>
+</div>
+
+<h4>:nth-child(2n) - same as even</h4>
+<div class="_2n">
+    <div>1</div>
+    <div>2 +</div>
+    <div>3</div>
+    <div>4 +</div>
+</div>
+
+<h4>:nth-child(2)</h4>
+<div class="_2">
+    <div>1</div>
+    <div>2 +</div>
+    <div>3</div>
+</div>
+
+<h4>:nth-child(3n)</h4>
+<div class="_3n">
+    <div>1</div>
+    <div>2</div>
+    <div>3 +</div>
+    <div>4</div>
+    <div>5</div>
+    <div>6 +</div>
+</div>
+
+<h4>:nth-child(3n+1)</h4>
+<div class="_3n-plus-1">
+    <div>1 +</div>
+    <div>2</div>
+    <div>3</div>
+    <div>4 +</div>
+    <div>5</div>
+    <div>6</div>
+</div>
+
+<h4>:nth-child(3n-1)</h4>
+<div class="_3n-minus-1">
+    <div>1</div>
+    <div>2 +</div>
+    <div>3</div>
+    <div>4</div>
+    <div>5 +</div>
+    <div>6</div>
+</div>
+
+<h4>:nth-child(-n+3)</h4>
+<div class="_minus-n-plus-3">
+    <div>1 +</div>
+    <div>2 +</div>
+    <div>3 +</div>
+    <div>4</div>
+</div>
+
+<h4>:nth-child(n)</h4>
+<div class="n">
+    <div>1 +</div>
+    <div>2 +</div>
+    <div>3 +</div>
+</div>
+
+<h4>:nth-child(-n) - same as n</h4>
+<div class="n">
+    <div>1 +</div>
+    <div>2 +</div>
+    <div>3 +</div>
+</div>
+
+<h4>:nth-child(+n) - same as n</h4>
+<div class="n">
+    <div>1 +</div>
+    <div>2 +</div>
+    <div>3 +</div>
+</div>
+
+<h4>:nth-child(0n+1)</h4>
+<div class="_0n-plus-1">
+    <div>1 +</div>
+    <div>2</div>
+    <div>3</div>
+</div>
+
+<h4>:nth-child(n+2):nth-child(-n+4)</h4>
+<div class="n-plus-2__minus-n-plus-4">
+    <div>1</div>
+    <div>2 +</div>
+    <div>3 +</div>
+    <div>4 +</div>
+    <div>5</div>
+</div>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -91,6 +91,7 @@ span#loadtime {
         <li><a href="first-child.html">:first-child</a></li>
         <li><a href="last-child.html">:last-child</a></li>
         <li><a href="only-child.html">:only-child</a></li>
+        <li><a href="nth-child.html">:nth-child</a></li>
         <li><a href="empty.html">:empty</a></li>
         <li><a href="root.html">:root</a></li>
         <li><a href="form.html">form</a></li>

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -369,9 +369,14 @@ public:
         return original_index != index;
     }
 
-    bool is_valid_selector_char(char ch) const
+    static bool is_valid_selector_char(char ch)
     {
-        return isalnum(ch) || ch == '-' || ch == '_' || ch == '(' || ch == ')' || ch == '@';
+        return isalnum(ch) || ch == '-' || ch == '+' || ch == '_' || ch == '(' || ch == ')' || ch == '@';
+    }
+
+    static bool is_valid_selector_args_char(char ch)
+    {
+        return is_valid_selector_char(ch) || ch == ' ' || ch == '\t';
     }
 
     bool is_combinator(char ch) const
@@ -513,8 +518,19 @@ public:
                     return {};
                 buffer.append(')');
             } else {
-                while (is_valid_selector_char(peek()))
-                    buffer.append(consume_one());
+                int nesting_level = 0;
+                while (true) {
+                    const auto ch = peek();
+                    if (ch == '(')
+                        ++nesting_level;
+                    else if (ch == ')' && nesting_level > 0)
+                        --nesting_level;
+
+                    if (nesting_level > 0 ? is_valid_selector_args_char(ch) : is_valid_selector_char(ch))
+                        buffer.append(consume_one());
+                    else
+                        break;
+                };
             }
 
             auto pseudo_name = String::copy(buffer);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -104,15 +104,9 @@ Vector<CSS::Selector::ComplexSelector> Parser::parse_selectors(Vector<String> pa
         if (currentToken == "*") {
             type = CSS::Selector::SimpleSelector::Type::Universal;
             index++;
-            return CSS::Selector::SimpleSelector {
-                type,
-                CSS::Selector::SimpleSelector::PseudoClass::None,
-                CSS::Selector::SimpleSelector::PseudoElement::None,
-                String(),
-                CSS::Selector::SimpleSelector::AttributeMatchType::None,
-                String(),
-                String()
-            };
+            CSS::Selector::SimpleSelector result;
+            result.type = type;
+            return result;
         }
 
         if (currentToken == ".") {
@@ -132,15 +126,9 @@ Vector<CSS::Selector::ComplexSelector> Parser::parse_selectors(Vector<String> pa
             value = value.to_lowercase();
         }
 
-        CSS::Selector::SimpleSelector simple_selector {
-            type,
-            CSS::Selector::SimpleSelector::PseudoClass::None,
-            CSS::Selector::SimpleSelector::PseudoElement::None,
-            value,
-            CSS::Selector::SimpleSelector::AttributeMatchType::None,
-            String(),
-            String()
-        };
+        CSS::Selector::SimpleSelector simple_selector;
+        simple_selector.type = type;
+        simple_selector.value = value;
 
         if (index >= parts.size()) {
             return simple_selector;

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "Selector.h"
+#include <AK/StringUtils.h>
 #include <LibWeb/CSS/Selector.h>
+#include <ctype.h>
 
 namespace Web::CSS {
 
@@ -42,6 +45,75 @@ u32 Selector::specificity() const
     }
 
     return ids * 0x10000 + classes * 0x100 + tag_names;
+}
+
+Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPattern::parse(const StringView& args)
+{
+    CSS::Selector::SimpleSelector::NthChildPattern pattern;
+    if (args.equals_ignoring_case("odd")) {
+        pattern.step_size = 2;
+        pattern.offset = 1;
+    } else if (args.equals_ignoring_case("even")) {
+        pattern.step_size = 2;
+    } else {
+        const auto consume_int = [](GenericLexer& lexer) -> Optional<int> {
+            return AK::StringUtils::convert_to_int(lexer.consume_while([](char c) -> bool {
+                return isdigit(c) || c == '+' || c == '-';
+            }));
+        };
+
+        // Try to match any of following patterns:
+        // 1. An+B
+        // 2. An
+        // 3. B
+        // ...where "A" is "step_size", "B" is "offset" and rest are literals.
+        // "A" can be omitted, in that case "A" = 1.
+        // "A" may have "+" or "-" sign, "B" always must be predated by sign for pattern (1).
+
+        int step_size_or_offset = 0;
+        GenericLexer lexer { args };
+
+        // "When a=1, or a=-1, the 1 may be omitted from the rule."
+        if (lexer.consume_specific("n") || lexer.consume_specific("+n")) {
+            step_size_or_offset = +1;
+            lexer.retreat();
+        } else if (lexer.consume_specific("-n")) {
+            step_size_or_offset = -1;
+            lexer.retreat();
+        } else {
+            const auto value = consume_int(lexer);
+            if (!value.has_value())
+                return {};
+            step_size_or_offset = value.value();
+        }
+
+        if (lexer.consume_specific("n")) {
+            lexer.ignore_while(isspace);
+            if (lexer.next_is('+') || lexer.next_is('-')) {
+                const auto sign = lexer.next_is('+') ? 1 : -1;
+                lexer.ignore();
+                lexer.ignore_while(isspace);
+
+                // "An+B" pattern
+                const auto offset = consume_int(lexer);
+                if (!offset.has_value())
+                    return {};
+                pattern.step_size = step_size_or_offset;
+                pattern.offset = sign * offset.value();
+            } else {
+                // "An" pattern
+                pattern.step_size = step_size_or_offset;
+            }
+        } else {
+            // "B" pattern
+            pattern.offset = step_size_or_offset;
+        }
+
+        if (lexer.remaining().length() > 0)
+            return {};
+    }
+
+    return pattern;
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -36,6 +36,7 @@ public:
             Root,
             FirstOfType,
             LastOfType,
+            NthChild,
         };
         PseudoClass pseudo_class { PseudoClass::None };
 
@@ -59,6 +60,17 @@ public:
         AttributeMatchType attribute_match_type { AttributeMatchType::None };
         FlyString attribute_name;
         String attribute_value;
+
+        struct NthChildPattern {
+            int step_size = 0;
+            int offset = 0;
+
+            static NthChildPattern parse(const StringView& args);
+        };
+
+        // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
+        // Only used when "pseudo_class" == PseudoClass::NthChild.
+        NthChildPattern nth_child_pattern;
     };
 
     struct ComplexSelector {

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -351,6 +351,9 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
             case CSS::Selector::SimpleSelector::PseudoClass::LastOfType:
                 pseudo_class_description = "LastOfType";
                 break;
+            case CSS::Selector::SimpleSelector::PseudoClass::NthChild:
+                pseudo_class_description = "NthChild";
+                break;
             case CSS::Selector::SimpleSelector::PseudoClass::Focus:
                 pseudo_class_description = "Focus";
                 break;


### PR DESCRIPTION
First commit allows parser to read white space inside parenthesis followed by pseudo-class name: `div:nth-child(2n + 3)`.
Second commit is actual implementation, third is test document, so you can look at stuff in the browser.

<details>
<summary>Screenshot</summary>

![Screenshot from 2021-05-08 23-35-51](https://user-images.githubusercontent.com/3995549/117552780-25a24680-b056-11eb-840d-9ff4455e2995.png)
</details>