### PR TITLE
Demo: Improve the lighting model in the OpenGL teapot demo

### DIFF
--- a/Userland/Demos/GLTeapot/Common.h
+++ b/Userland/Demos/GLTeapot/Common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,7 +18,7 @@ struct Vertex {
 
 // A triangle defines a single "face" of a mesh
 struct Triangle {
-    Vertex a;
-    Vertex b;
-    Vertex c;
+    GLuint a;
+    GLuint b;
+    GLuint c;
 };

--- a/Userland/Demos/GLTeapot/Mesh.cpp
+++ b/Userland/Demos/GLTeapot/Mesh.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,6 +21,12 @@ const Color colors[] {
     Color::Yellow,
 };
 
+Mesh::Mesh(Vector<Vertex> vertices, Vector<Triangle> triangles)
+    : m_vertex_list(move(vertices))
+    , m_triangle_list(move(triangles))
+{
+}
+
 void Mesh::draw()
 {
     u32 color_index = 0;
@@ -31,9 +38,23 @@ void Mesh::draw()
         glBegin(GL_TRIANGLES);
         glColor4ub(cur_color.red(), cur_color.green(), cur_color.blue(), 255);
 
-        glVertex3f(triangle.a.x, triangle.a.y, triangle.a.z); // Vertex 1
-        glVertex3f(triangle.b.x, triangle.b.y, triangle.b.z); // Vertex 2
-        glVertex3f(triangle.c.x, triangle.c.y, triangle.c.z); // Vertex 3
+        // Vertex 1
+        glVertex3f(
+            m_vertex_list.at(triangle.a).x,
+            m_vertex_list.at(triangle.a).y,
+            m_vertex_list.at(triangle.a).z);
+
+        // Vertex 2
+        glVertex3f(
+            m_vertex_list.at(triangle.b).x,
+            m_vertex_list.at(triangle.b).y,
+            m_vertex_list.at(triangle.b).z);
+
+        // Vertex 3
+        glVertex3f(
+            m_vertex_list.at(triangle.c).x,
+            m_vertex_list.at(triangle.c).y,
+            m_vertex_list.at(triangle.c).z);
 
         glEnd();
 

--- a/Userland/Demos/GLTeapot/Mesh.cpp
+++ b/Userland/Demos/GLTeapot/Mesh.cpp
@@ -7,7 +7,8 @@
 
 #include <LibGL/GL/gl.h>
 #include <LibGfx/Color.h>
-#include <stdlib.h>
+#include <LibGfx/Vector3.h>
+#include <LibGfx/Vector4.h>
 
 #include "Mesh.h"
 
@@ -15,10 +16,10 @@ const Color colors[] {
     Color::Red,
     Color::Green,
     Color::Blue,
-    Color::Blue,
     Color::Magenta,
-    Color::White,
     Color::Yellow,
+    Color::Cyan,
+    Color::White
 };
 
 Mesh::Mesh(Vector<Vertex> vertices, Vector<Triangle> triangles)
@@ -29,35 +30,62 @@ Mesh::Mesh(Vector<Vertex> vertices, Vector<Triangle> triangles)
 
 void Mesh::draw()
 {
-    u32 color_index = 0;
-    Color cur_color;
+    // Light direction
+    const FloatVector3 light_direction(1.f, 1.f, 1.f);
 
-    for (const auto& triangle : m_triangle_list) {
-        cur_color = colors[color_index];
+    // Mesh color
+    const FloatVector4 mesh_ambient_color(0.2f, 0.2f, 0.2f, 1.f);
+    const FloatVector4 mesh_diffuse_color(0.6f, 0.6f, 0.6f, 1.f);
 
-        glBegin(GL_TRIANGLES);
-        glColor4ub(cur_color.red(), cur_color.green(), cur_color.blue(), 255);
+    for (u32 i = 0; i < m_triangle_list.size(); i++) {
+        const auto& triangle = m_triangle_list[i];
 
-        // Vertex 1
-        glVertex3f(
+        const FloatVector3 vertex_a(
             m_vertex_list.at(triangle.a).x,
             m_vertex_list.at(triangle.a).y,
             m_vertex_list.at(triangle.a).z);
 
-        // Vertex 2
-        glVertex3f(
+        const FloatVector3 vertex_b(
             m_vertex_list.at(triangle.b).x,
             m_vertex_list.at(triangle.b).y,
             m_vertex_list.at(triangle.b).z);
 
-        // Vertex 3
-        glVertex3f(
+        const FloatVector3 vertex_c(
             m_vertex_list.at(triangle.c).x,
             m_vertex_list.at(triangle.c).y,
             m_vertex_list.at(triangle.c).z);
 
-        glEnd();
+        // Compute the triangle normal
+        const FloatVector3 vec_ab = vertex_b - vertex_a;
+        const FloatVector3 vec_ac = vertex_c - vertex_a;
+        const FloatVector3 normal = vec_ab.cross(vec_ac).normalized();
 
-        color_index = ((color_index + 1) % 7);
+        // Compute lighting with a Lambertian color model
+        const auto light_intensity = max(light_direction.dot(normal), 0.f);
+        const FloatVector4 color = mesh_ambient_color
+            + mesh_diffuse_color * light_intensity;
+
+        glBegin(GL_TRIANGLES);
+        glColor4f(color.x(), color.y(), color.z(), color.w());
+
+        // Vertex 1
+        glVertex3f(
+            m_vertex_list.at(m_triangle_list[i].a).x,
+            m_vertex_list.at(m_triangle_list[i].a).y,
+            m_vertex_list.at(m_triangle_list[i].a).z);
+
+        // Vertex 2
+        glVertex3f(
+            m_vertex_list.at(m_triangle_list[i].b).x,
+            m_vertex_list.at(m_triangle_list[i].b).y,
+            m_vertex_list.at(m_triangle_list[i].b).z);
+
+        // Vertex 3
+        glVertex3f(
+            m_vertex_list.at(m_triangle_list[i].c).x,
+            m_vertex_list.at(m_triangle_list[i].c).y,
+            m_vertex_list.at(m_triangle_list[i].c).z);
+
+        glEnd();
     }
 }

--- a/Userland/Demos/GLTeapot/Mesh.h
+++ b/Userland/Demos/GLTeapot/Mesh.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,19 +12,19 @@
 
 #include "Common.h"
 
-// NOTE: We don't support indexed
 class Mesh : public RefCounted<Mesh> {
 public:
     Mesh() = delete;
-    Mesh(const Vector<Triangle>& triangles)
-        : m_triangle_list(triangles)
-    {
-    }
 
-    void draw();
+    Mesh(Vector<Vertex> vertices, Vector<Triangle> triangles);
+
+    size_t vertex_count() const { return m_vertex_list.size(); }
 
     size_t triangle_count() const { return m_triangle_list.size(); }
 
+    void draw();
+
 private:
+    Vector<Vertex> m_vertex_list;
     Vector<Triangle> m_triangle_list;
 };

--- a/Userland/Demos/GLTeapot/WavefrontOBJLoader.cpp
+++ b/Userland/Demos/GLTeapot/WavefrontOBJLoader.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -47,13 +48,13 @@ RefPtr<Mesh> WavefrontOBJLoader::load(const String& fname)
             // Create a new triangle
             triangles.append(
                 {
-                    vertices.at(face_line.at(1).to_uint().value() - 1),
-                    vertices.at(face_line.at(2).to_uint().value() - 1),
-                    vertices.at(face_line.at(3).to_uint().value() - 1),
+                    face_line.at(1).to_uint().value() - 1,
+                    face_line.at(2).to_uint().value() - 1,
+                    face_line.at(3).to_uint().value() - 1,
                 });
         }
     }
 
     dbgln("Wavefront: Done.");
-    return adopt_ref(*new Mesh(triangles));
+    return adopt_ref(*new Mesh(vertices, triangles));
 }


### PR DESCRIPTION
The OpenGL demo features a Utah teapot, but currently there were one major and two minor issues:
- The depth management is not implemented and occluded parts are still visible 
- The OBJ mesh loader does not feature indices and triangles are stored as vertices, which consumes a lot of memory
- No lighting model is implemented and the teapot has random colors associated to triangles instead

For my first contribution (before I start modifying the software renderer), I wanted to make a straightforward modification to make sure I'm familiar with the process. I worked with people on the Discord OpenGL channel to make sure my contribution is in line with what they have in mind. So, I implemented a basic Lambertian lighting model for the teapot, until lighting is actually implemented in the software renderer. I also modified the OBJ mesh loader to use indexed triangles. Here is the result:

![teapot](https://user-images.githubusercontent.com/3775757/117553489-ccf78d00-b006-11eb-9b8f-aca427792ea1.png)


