### PR TITLE
LibGL: Add Depth Buffer

### DIFF
--- a/Userland/Demos/GLTeapot/main.cpp
+++ b/Userland/Demos/GLTeapot/main.cpp
@@ -36,6 +36,7 @@ private:
         GL::make_context_current(m_context);
         glFrontFace(GL_CW);
         glEnable(GL_CULL_FACE);
+        glEnable(GL_DEPTH_TEST);
 
         // Set projection matrix
         glMatrixMode(GL_PROJECTION);
@@ -74,7 +75,8 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
     angle -= 0.01f;
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
+    glClearDepth(1.0);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     auto matrix = FloatMatrix4x4::translate(FloatVector3(0, 0, -8.5))
         * FloatMatrix4x4::rotate(FloatVector3(1, 0, 0), angle)

--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     GLVert.cpp
     SoftwareGLContext.cpp
     SoftwareRasterizer.cpp
+    DepthBuffer.cpp
 )
 
 serenity_lib(LibGL gl)

--- a/Userland/Libraries/LibGL/DepthBuffer.cpp
+++ b/Userland/Libraries/LibGL/DepthBuffer.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "DepthBuffer.h"
+
+namespace GL {
+
+DepthBuffer::DepthBuffer(Gfx::IntSize const& size)
+    : m_size(size)
+    , m_data(new float[size.width() * size.height()])
+{
+}
+
+DepthBuffer::~DepthBuffer()
+{
+    delete[] m_data;
+}
+
+float* DepthBuffer::scanline(int y)
+{
+    VERIFY(y >= 0 && y < m_size.height());
+    return &m_data[y * m_size.width()];
+}
+
+void DepthBuffer::clear(float depth)
+{
+    int num_entries = m_size.width() * m_size.height();
+    for (int i = 0; i < num_entries; ++i) {
+        m_data[i] = depth;
+    }
+}
+
+}

--- a/Userland/Libraries/LibGL/DepthBuffer.h
+++ b/Userland/Libraries/LibGL/DepthBuffer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Size.h>
+
+namespace GL {
+
+class DepthBuffer final {
+public:
+    DepthBuffer(Gfx::IntSize const&);
+    ~DepthBuffer();
+
+    float* scanline(int y);
+
+    void clear(float depth);
+
+private:
+    Gfx::IntSize m_size;
+    float* m_data { nullptr };
+};
+
+}

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -31,9 +31,11 @@ extern "C" {
 
 // Buffer bits
 #define GL_COLOR_BUFFER_BIT 0x0200
+#define GL_DEPTH_BUFFER_BIT 0x0400
 
 // Enable capabilities
 #define GL_CULL_FACE 0x0B44
+#define GL_DEPTH_TEST 0x0B71
 
 // Utility
 #define GL_VENDOR 0x1F00
@@ -85,6 +87,7 @@ typedef unsigned int GLbitfield;
 GLAPI void glBegin(GLenum mode);
 GLAPI void glClear(GLbitfield mask);
 GLAPI void glClearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
+GLAPI void glClearDepth(GLdouble depth);
 GLAPI void glColor3f(GLfloat r, GLfloat g, GLfloat b);
 GLAPI void glColor4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
 GLAPI void glColor4fv(const GLfloat* v);

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -21,6 +21,7 @@ public:
     virtual void gl_begin(GLenum mode) = 0;
     virtual void gl_clear(GLbitfield mask) = 0;
     virtual void gl_clear_color(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) = 0;
+    virtual void gl_clear_depth(GLdouble depth) = 0;
     virtual void gl_color(GLdouble r, GLdouble g, GLdouble b, GLdouble a) = 0;
     virtual void gl_end() = 0;
     virtual void gl_frustum(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble near_val, GLdouble far_val) = 0;

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -40,6 +40,11 @@ void glClearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
     g_gl_context->gl_clear_color(red, green, blue, alpha);
 }
 
+void glClearDepth(GLdouble depth)
+{
+    g_gl_context->gl_clear_depth(depth);
+}
+
 GLubyte* glGetString(GLenum name)
 {
     return g_gl_context->gl_get_string(name);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -25,6 +25,7 @@ public:
     virtual void gl_begin(GLenum mode) override;
     virtual void gl_clear(GLbitfield mask) override;
     virtual void gl_clear_color(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) override;
+    virtual void gl_clear_depth(GLdouble depth) override;
     virtual void gl_color(GLdouble r, GLdouble g, GLdouble b, GLdouble a) override;
     virtual void gl_end() override;
     virtual void gl_frustum(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble near_val, GLdouble far_val) override;
@@ -60,6 +61,7 @@ private:
     Vector<FloatMatrix4x4> m_model_view_matrix_stack;
 
     FloatVector4 m_clear_color = { 0.0f, 0.0f, 0.0f, 0.0f };
+    double m_clear_depth = { 1.0 };
     FloatVector4 m_current_vertex_color = { 1.0f, 1.0f, 1.0f, 1.0f };
 
     Vector<GLVertex, 96> vertex_list;
@@ -68,6 +70,8 @@ private:
 
     GLenum m_error = GL_NO_ERROR;
     bool m_in_draw_state = false;
+
+    bool m_depth_test_enabled = false;
 
     bool m_cull_faces = false;
     GLenum m_front_face = GL_CCW;

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include "DepthBuffer.h"
 #include "GLStruct.h"
+#include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Vector4.h>
 
@@ -32,6 +34,7 @@ public:
 
 private:
     RefPtr<Gfx::Bitmap> m_render_target;
+    OwnPtr<DepthBuffer> m_depth_buffer;
     RasterizerOptions m_options;
 };
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -14,6 +14,7 @@ namespace GL {
 
 struct RasterizerOptions {
     bool shade_smooth { false };
+    bool enable_depth_test { false };
 };
 
 class SoftwareRasterizer final {


### PR DESCRIPTION
Adds a simple depth buffer implementation.
Currently only GL_LESS is used for comparison.

![grafik](https://user-images.githubusercontent.com/2094371/117553904-74e77780-b054-11eb-8de1-cc0e96b2e7b2.png)
