### PR TITLE
Tests: Fix install of test-js and test-web

### DIFF
--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(test-js test-js.cpp)
 target_link_libraries(test-js LibJS LibLine LibCore)
-install(TARGETS ${CMD_NAME} RUNTIME DESTINATION bin)
+install(TARGETS test-js RUNTIME DESTINATION bin)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(test-web test-web.cpp)
 target_link_libraries(test-web LibCore LibWeb)
-install(TARGETS ${CMD_NAME} RUNTIME DESTINATION bin)
+install(TARGETS test-web RUNTIME DESTINATION bin)


### PR DESCRIPTION
When these were moved, there was a copy paste bug in the install
directives of both of these binaries.

Reference: #6912