### PR TITLE
LibC: Add definition for the rlim_t type

### DIFF
--- a/Ports/stress-ng/patches/0002-missing-types-and-functionality.patch
+++ b/Ports/stress-ng/patches/0002-missing-types-and-functionality.patch
@@ -49,25 +49,6 @@ diff -ur stress-ng-master/core-job.c stress-ng-master-2/core-job.c
  
  /*
   *  stress_chop()
-diff -ur stress-ng-master/core-limit.c stress-ng-master-2/core-limit.c
---- stress-ng-master/core-limit.c	2020-11-07 10:52:22.000000000 -0800
-+++ stress-ng-master-2/core-limit.c	2020-11-08 22:32:39.497668500 -0800
-@@ -80,6 +80,7 @@
-  */
- void stress_set_max_limits(void)
- {
-+#if 0
- 	size_t i;
- 	struct rlimit rlim;
- 
-@@ -90,6 +91,7 @@
- 		(void)setrlimit(limits[i], &rlim);
- 	}
- 
-+#endif
- #if defined(RLIMIT_NOFILE)
- 	{
- 		uint64_t max_fd = 0;
 diff -ur stress-ng-master/core-net.c stress-ng-master-2/core-net.c
 --- stress-ng-master/core-net.c	2020-11-07 10:52:22.000000000 -0800
 +++ stress-ng-master-2/core-net.c	2020-11-08 22:33:09.007668500 -0800
@@ -119,50 +100,6 @@ diff -ur stress-ng-master/stress-chown.c stress-ng-master-2/stress-chown.c
  		inc_counter(args);
  	} while (keep_stressing());
  
-diff -ur stress-ng-master/stress-cyclic.c stress-ng-master-2/stress-cyclic.c
---- stress-ng-master/stress-cyclic.c	2020-11-07 10:52:22.000000000 -0800
-+++ stress-ng-master-2/stress-cyclic.c	2020-11-08 22:37:33.407668500 -0800
-@@ -587,7 +587,11 @@
- 	const stress_cyclic_method_info_t *cyclic_method = &cyclic_methods[0];
- 	const uint32_t num_instances = args->num_instances;
- 	struct sigaction old_action_xcpu;
-+
-+/* No RLIMIT_CPU support in serenity */
-+#if 0
- 	struct rlimit rlim;
-+#endif
- 	pid_t pid;
- 	NOCLOBBER uint64_t timeout;
- 	uint64_t cyclic_sleep = DEFAULT_DELAY_NS;
-@@ -692,6 +696,8 @@
- 		} while (keep_stressing() && count < num_instances);
- #endif
- 
-+/* No RLIMIT_CPU support in serenity */
-+#if 0
- 		/*
- 		 * We run the stressor as a child so that
- 		 * if we the hard time timits the child is
-@@ -701,6 +707,7 @@
- 		rlim.rlim_cur = timeout;
- 		rlim.rlim_max = timeout;
- 		(void)setrlimit(RLIMIT_CPU, &rlim);
-+#endif
- 
- #if defined(RLIMIT_RTTIME)
- 		rlim.rlim_cur = 1000000 * timeout;
-diff -ur stress-ng-master/stress-dirdeep.c stress-ng-master-2/stress-dirdeep.c
---- stress-ng-master/stress-dirdeep.c	2020-11-07 10:52:22.000000000 -0800
-+++ stress-ng-master-2/stress-dirdeep.c	2020-11-08 22:38:40.877668500 -0800
-@@ -98,7 +98,7 @@
- 	errno = 0;
- 	if (mkdir(path, S_IRUSR | S_IWUSR | S_IXUSR) < 0) {
- 		if ((errno == ENOSPC) || (errno == ENOMEM) ||
--		    (errno == ENAMETOOLONG) || (errno == EDQUOT) ||
-+		    (errno == ENAMETOOLONG) ||
- 		    (errno == EMLINK)) {
- 			return;
- 		}
 diff -ur stress-ng-master/stress-epoll.c stress-ng-master-2/stress-epoll.c
 --- stress-ng-master/stress-epoll.c	2020-11-07 10:52:22.000000000 -0800
 +++ stress-ng-master-2/stress-epoll.c	2020-11-08 22:39:49.607668500 -0800

--- a/Userland/Libraries/LibC/sys/resource.h
+++ b/Userland/Libraries/LibC/sys/resource.h
@@ -46,9 +46,11 @@ int getrusage(int who, struct rusage* usage);
 
 #define RLIM_INFINITY SIZE_MAX
 
+typedef size_t rlim_t;
+
 struct rlimit {
-    size_t rlim_cur;
-    size_t rlim_max;
+    rlim_t rlim_cur;
+    rlim_t rlim_max;
 };
 
 int getrlimit(int, struct rlimit*);


### PR DESCRIPTION
The missing type caused the `binutils` and `dash` ports to fail to build. They detected that we have `getrlimit()` but then failed later on when trying to use `rlim_t`.

This also removes some patches for `stress-ng` that are not necessary anymore.