### PR TITLE
CppLanguageServer: Don't suggest inaccessible delcarations

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
@@ -76,8 +76,9 @@ private:
         RefPtr<Type> type;
     };
     Vector<PropertyInfo> properties_of_type(const DocumentData& document, const String& type) const;
-    NonnullRefPtrVector<Declaration> get_global_declarations_including_headers(const DocumentData& document) const;
-    NonnullRefPtrVector<Declaration> get_global_declarations(const ASTNode& node) const;
+    NonnullRefPtrVector<Declaration> get_global_declarations_including_headers(const DocumentData&) const;
+    NonnullRefPtrVector<Declaration> get_global_declarations(const DocumentData&) const;
+    NonnullRefPtrVector<Declaration> get_declarations_recursive(const ASTNode&) const;
 
     const DocumentData* get_document_data(const String& file) const;
     const DocumentData* get_or_create_document_data(const String& file);


### PR DESCRIPTION
Previously, declarations that are not available in the global namespace, such as member functions of a class, would also appear in
the autocomplete suggestions list.