### PR TITLE
Ports: Update build options for curl

### DIFF
--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -2,7 +2,7 @@
 port=curl
 version=7.65.3
 useconfigure=true
-configopts="--disable-threaded-resolver --disable-ipv6 --disable-ntlm-wb"
+configopts="--disable-ntlm-wb --with-ssl"
 files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2
 https://curl.se/download/curl-${version}.tar.bz2.asc curl-${version}.tar.bz2.asc"
 


### PR DESCRIPTION
This enables SSL support (verified to work), IPv6 (won't work for lack of IPv6 support in the kernel) and threads.