### PR TITLE
Userland: Allow the Analog Clock window border to be hidden

### DIFF
--- a/Userland/Applications/AnalogClock/AnalogClock.cpp
+++ b/Userland/Applications/AnalogClock/AnalogClock.cpp
@@ -110,7 +110,7 @@ void AnalogClock::draw_seconds_hand(GUI::Painter& painter, double angle)
 void AnalogClock::paint_event(GUI::PaintEvent& event)
 {
     GUI::Painter painter(*this);
-    painter.clear_rect(event.rect(), palette().window());
+    painter.clear_rect(event.rect(), m_show_window_frame ? palette().window() : Gfx::Color::Transparent);
 
     draw_face(painter);
 
@@ -131,4 +131,21 @@ void AnalogClock::paint_event(GUI::PaintEvent& event)
 void AnalogClock::update_title_date()
 {
     window()->set_title(Core::DateTime::now().to_string("Clock %d-%m-%Y"));
+}
+
+void AnalogClock::context_menu_event(GUI::ContextMenuEvent& event)
+{
+    if (on_context_menu_request)
+        on_context_menu_request(event);
+}
+
+void AnalogClock::set_show_window_frame(bool show)
+{
+    if (show == m_show_window_frame)
+        return;
+    m_show_window_frame = show;
+    auto& w = *window();
+    w.set_frameless(!m_show_window_frame);
+    w.set_has_alpha_channel(!m_show_window_frame);
+    w.set_alpha_hit_threshold(m_show_window_frame ? 0 : 1);
 }

--- a/Userland/Applications/AnalogClock/AnalogClock.h
+++ b/Userland/Applications/AnalogClock/AnalogClock.h
@@ -13,6 +13,10 @@ class AnalogClock : public GUI::Widget {
     C_OBJECT(AnalogClock)
 public:
     ~AnalogClock() override = default;
+    void set_show_window_frame(bool);
+    bool show_window_frame() const { return m_show_window_frame; }
+
+    Function<void(GUI::ContextMenuEvent&)> on_context_menu_request;
 
 private:
     AnalogClock()
@@ -32,7 +36,10 @@ private:
     double m_hand_tail_length { 22 };
     double m_hand_wing_span { 5 };
 
+    bool m_show_window_frame { true };
+
 protected:
+    void context_menu_event(GUI::ContextMenuEvent& event) override;
     void paint_event(GUI::PaintEvent&) override;
     void draw_face(GUI::Painter&);
     void draw_mirrored_graduations(GUI::Painter&, Gfx::IntRect&, int x, int y, int rect_center_offset);

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -13,14 +13,9 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd accept rpath unix cpath wpath fattr", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
-
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio recvfd sendfd accept rpath cpath wpath", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -8,6 +8,8 @@
 #include <LibCore/DateTime.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
 #include <unistd.h>
 
@@ -32,12 +34,22 @@ int main(int argc, char** argv)
 
     auto app_icon = GUI::Icon::default_icon("app-analog-clock");
     auto window = GUI::Window::construct();
-
-    window->set_main_widget<AnalogClock>();
     window->set_title(Core::DateTime::now().to_string("Clock %d-%m-%Y"));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(170, 170);
     window->set_resizable(false);
+    auto& clock = window->set_main_widget<AnalogClock>();
+
+    auto show_window_frame_action = GUI::Action::create_checkable(
+        "Show Window &Frame", { Mod_Alt, KeyCode::Key_F }, [&](auto& action) {
+            clock.set_show_window_frame(action.is_checked());
+        });
+    show_window_frame_action->set_checked(clock.show_window_frame());
+    auto menu = GUI::Menu::construct();
+    menu->add_action(move(show_window_frame_action));
+    clock.on_context_menu_request = [&](auto& event) {
+        menu->popup(event.screen_position());
+    };
 
     window->show();
     return app->exec();

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -896,6 +896,9 @@ void Window::set_frameless(bool frameless)
     if (!is_visible())
         return;
     WindowServerConnection::the().set_frameless(m_window_id, frameless);
+
+    if (!frameless)
+        apply_icon();
 }
 
 bool Window::is_maximized() const


### PR DESCRIPTION
A few minor improvements to the new Analog Clock app.
 
-  __Userland: Reduce pledges requested by AnalogClock__

    After startup AnalogClock only needs the normal GUI event loop pledges.


-   __Userland: Allow the Analog Clock window border to be hidden__

    Introduce the ability to hide the window border for the new Analog Clock
    app, with the feature enabled it looks like the clock is floating and
    kind of integrated into the desktop.

    The Cube Demo has the same feature, and was used as inspiration when
    implementing it for the Analog Clock.


cc: @ReasonablePanic 

Example:
![unknown](https://user-images.githubusercontent.com/1212/117603470-b0f90600-b142-11eb-9da2-cf6f7b4b0d42.png)