### PR TITLE
Meta: Remove obsolete Kernel/.gitignore

### DIFF
--- a/Kernel/.gitignore
+++ b/Kernel/.gitignore
@@ -1,3 +1,0 @@
-kernel.map
-*.pcap
-eth_null*


### PR DESCRIPTION
The Kernel/.gitignore file is a remnant of the prior build system,
where the kernel.map was written directly to to the Kernel folder.
The run.sh was also under Kernel so pcap files and others would get
dropped there when running the system under qemu.

None of these situations are possible now, so lets get rid of it.