### PR TITLE
Shell: Make escaping more intelligent

### DIFF
--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -477,7 +477,8 @@ string :: '"' dquoted_string_inner '"'
 dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
                       | variable dquoted_string_inner?    {compose}
                       | . dquoted_string_inner?
-                      | '\' 'x' digit digit dquoted_string_inner?
+                      | '\' 'x' xdigit*2 dquoted_string_inner?
+                      | '\' 'u' xdigit*8 dquoted_string_inner?
                       | '\' [abefrn] dquoted_string_inner?
 
 variable :: variable_ref slice?

--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -479,7 +479,7 @@ dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
                       | . dquoted_string_inner?
                       | '\' 'x' xdigit*2 dquoted_string_inner?
                       | '\' 'u' xdigit*8 dquoted_string_inner?
-                      | '\' [abefrn] dquoted_string_inner?
+                      | '\' [abefrnt] dquoted_string_inner?
 
 variable :: variable_ref slice?
 

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1345,6 +1345,9 @@ RefPtr<AST::Node> Parser::parse_doublequoted_string_inner()
             case 'n':
                 builder.append('\n');
                 break;
+            case 't':
+                builder.append('\t');
+                break;
             }
             continue;
         }

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1315,6 +1315,18 @@ RefPtr<AST::Node> Parser::parse_doublequoted_string_inner()
                 builder.append(to_byte(first_nibble, second_nibble));
                 break;
             }
+            case 'u': {
+                if (m_input.length() <= m_offset + 8)
+                    break;
+                size_t counter = 8;
+                auto chars = consume_while([&](auto) { return counter-- > 0; });
+                if (auto number = AK::StringUtils::convert_to_uint_from_hex(chars); number.has_value())
+                    builder.append(Utf32View { &number.value(), 1 });
+                else
+                    builder.append(chars);
+
+                break;
+            }
             case 'a':
                 builder.append('\a');
                 break;

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -265,7 +265,8 @@ string :: '"' dquoted_string_inner '"'
 dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
                       | variable dquoted_string_inner?    {compose}
                       | . dquoted_string_inner?
-                      | '\' 'x' digit digit dquoted_string_inner?
+                      | '\' 'x' xdigit*2 dquoted_string_inner?
+                      | '\' 'u' xdigit*8 dquoted_string_inner?
                       | '\' [abefrn] dquoted_string_inner?
 
 variable :: variable_ref slice?

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -267,7 +267,7 @@ dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
                       | . dquoted_string_inner?
                       | '\' 'x' xdigit*2 dquoted_string_inner?
                       | '\' 'u' xdigit*8 dquoted_string_inner?
-                      | '\' [abefrn] dquoted_string_inner?
+                      | '\' [abefrnt] dquoted_string_inner?
 
 variable :: variable_ref slice?
 


### PR DESCRIPTION
Instead of the previous only-escape-with-backslashes, extend the escaping to one of:
- No escape
- Escape with backslash
- Escape with "\xhh" if control character that isn't easily represented as \X
- Escape with "\uhhhhhhhh" if unicode character that is too big to represent as "\xhh".

Fixes #6986.