### PR TITLE
Ports: Make git able to (mostly) clone HTTPS repositories

### DIFF
--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -5,7 +5,7 @@ useconfigure="true"
 files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz 9f61417a44d5b954a5012b6f34e526a3336dcf5dd720e2bb7ada92ad8b3d6680"
 auth_type=sha256
 configopts="--target=${SERENITY_ARCH}-pc-serenity CFLAGS=-DNO_IPV6"
-depends="zlib"
+depends="zlib curl"
 
 build() {
     run make $makeopts

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -555,14 +555,24 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t buffer_size)
     __RETURN_PTHREAD_ERROR(rc);
 }
 
-int pthread_setcancelstate([[maybe_unused]] int state, [[maybe_unused]] int* oldstate)
+int pthread_setcancelstate(int state, int* oldstate)
 {
-    TODO();
+    if (oldstate)
+        *oldstate = PTHREAD_CANCEL_DISABLE;
+    dbgln("FIXME: Implement pthread_setcancelstate({}, ...)", state);
+    if (state != PTHREAD_CANCEL_DISABLE)
+        return EINVAL;
+    return 0;
 }
 
-int pthread_setcanceltype([[maybe_unused]] int type, [[maybe_unused]] int* oldtype)
+int pthread_setcanceltype(int type, int* oldtype)
 {
-    TODO();
+    if (oldtype)
+        *oldtype = PTHREAD_CANCEL_DEFERRED;
+    dbgln("FIXME: Implement pthread_setcanceltype({}, ...)", type);
+    if (type != PTHREAD_CANCEL_DEFERRED)
+        return EINVAL;
+    return 0;
 }
 
 constexpr static pid_t spinlock_unlock_sentinel = 0;

--- a/Userland/Libraries/LibPthread/pthread.h
+++ b/Userland/Libraries/LibPthread/pthread.h
@@ -97,6 +97,9 @@ int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const struct times
 #define PTHREAD_CANCEL_ENABLE 1
 #define PTHREAD_CANCEL_DISABLE 2
 
+#define PTHREAD_CANCEL_DEFERRED 1
+#define PTHREAD_CANCEL_ASYNCHRONOUS 2
+
 int pthread_cancel(pthread_t);
 int pthread_setcancelstate(int state, int* oldstate);
 int pthread_setcanceltype(int type, int* oldtype);


### PR DESCRIPTION
With these two patches applied I can _mostly_ clone Git repositories via HTTPS:

```
courage:~ $ git clone -c http.sslVerify=false https://github.com/SerenityOS/serenity
Cloning into 'serenity'...
remote: Enumerating objects: 178826, done.
remote: Counting objects: 100% (1880/1880), done.
remote: Compressing objects: 100% (907/907), done.
error: RPC failed; curl 56 OpenSSL SSL_read: error:1408F119:SSL routines:SSL3_GET_RECORD:decryption failed or bad record mac, errno 0
error: 1918 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

And another attempt with a smaller repository:

```
courage:~ $ git clone -v -c http.sslVerify=false https://github.com/gunnarbeutner/shop-app
Cloning into 'shop-app'...
POST git-upload-pack (164 bytes)
POST git-upload-pack (252 bytes)
remote: Enumerating objects: 820, done.
remote: Total 820 (delta 0), reused 0 (delta 0), pack-reused 820
Receiving objects: 100% (820/820), 479.24 KiB | 59. 0 KiB/s, done.
Resolving deltas: 100% (559/559), done.
courage:~ $ ls shop-app/
COPYING README.md app composer.json config.example.php doc jabber menus public schema scripts
courage:~ $ 
```

The download is excruciatingly slow, but at least it works - sometimes.