### PR TITLE
Ports: Add missing dependency for vim

### DIFF
--- a/Ports/gettext/package.sh
+++ b/Ports/gettext/package.sh
@@ -7,6 +7,6 @@ auth_type=sha256
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.so -Wl,-soname,libintl.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.a -Wl,--no-whole-archive -liconv
+    ${CC} -shared -pthread -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.so -Wl,-soname,libintl.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.a -Wl,--no-whole-archive -liconv
     rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.la
 }

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -6,7 +6,7 @@ useconfigure="true"
 files="https://github.com/vim/vim/archive/refs/tags/v${version}.tar.gz vim-v${version}.tar.gz 47613400943bbf3e110c38e8c4923b9e51c1d63d9774313820e1d9b4c4bb9e11"
 auth_type=sha256
 configopts="--with-tlib=tinfo --with-features=normal"
-depends="ncurses"
+depends="ncurses gettext"
 
 export vim_cv_getcwd_broken=no
 export vim_cv_memmove_handles_overlap=yes


### PR DESCRIPTION
The vim port links against the (recently-added) gettext port when it's available so we should add it as a dependency in the `package.sh` script.

Also, apparently `libintl` uses `pthread_cond_broadcast()` so let's make sure that we link it against libpthread so we don't call libc's pthread stubs.