### PR TITLE
AK+Kernel: noexcept operator new/new[], add adopt_{ref/own}_if_nonnull and use them in OOM hardening. 

### DIFF
--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -192,6 +192,14 @@ inline void swap(OwnPtr<T>& a, OwnPtr<U>& b)
 }
 
 template<typename T>
+inline OwnPtr<T> adopt_own_if_nonnull(T* object)
+{
+    if (object)
+        return OwnPtr<T>(object);
+    return {};
+}
+
+template<typename T>
 struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
     using PeekType = T*;
     using ConstPeekType = const T*;
@@ -201,4 +209,5 @@ struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
 
 }
 
+using AK::adopt_own_if_nonnull;
 using AK::OwnPtr;

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -475,7 +475,16 @@ inline void swap(RefPtr<T, PtrTraitsT>& a, RefPtr<U, PtrTraitsU>& b)
     a.swap(b);
 }
 
+template<typename T>
+inline RefPtr<T> adopt_ref_if_nonnull(T* object)
+{
+    if (object)
+        return RefPtr<T>(RefPtr<T>::Adopt, *object);
+    return {};
 }
 
+}
+
+using AK::adopt_ref_if_nonnull;
 using AK::RefPtr;
 using AK::static_ptr_cast;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -7,7 +7,6 @@
 #include <AK/MemoryStream.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/BlockDevice.h>
-#include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FIFO.h>
 #include <Kernel/FileSystem/FileDescription.h>

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -25,25 +25,34 @@ namespace Kernel {
 
 KResultOr<NonnullRefPtr<FileDescription>> FileDescription::create(Custody& custody)
 {
-    auto description = adopt_ref(*new FileDescription(InodeFile::create(custody.inode())));
+    auto inode_file = InodeFile::create(custody.inode());
+    if (inode_file.is_error())
+        return inode_file.error();
+
+    auto description = adopt_ref_if_nonnull(new FileDescription(*inode_file.release_value()));
+    if (!description)
+        return ENOMEM;
+
     description->m_custody = custody;
     auto result = description->attach();
     if (result.is_error()) {
         dbgln_if(FILEDESCRIPTION_DEBUG, "Failed to create file description for custody: {}", result);
         return result;
     }
-    return description;
+    return description.release_nonnull();
 }
 
 KResultOr<NonnullRefPtr<FileDescription>> FileDescription::create(File& file)
 {
-    auto description = adopt_ref(*new FileDescription(file));
+    auto description = adopt_ref_if_nonnull(new FileDescription(file));
+    if (!description)
+        return ENOMEM;
     auto result = description->attach();
     if (result.is_error()) {
         dbgln_if(FILEDESCRIPTION_DEBUG, "Failed to create file description for file: {}", result);
         return result;
     }
-    return description;
+    return description.release_nonnull();
 }
 
 FileDescription::FileDescription(File& file)

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -56,7 +56,7 @@ public:
     bool can_read() const;
     bool can_write() const;
 
-    ssize_t get_dir_entries(UserOrKernelBuffer& buffer, ssize_t);
+    KResultOr<ssize_t> get_dir_entries(UserOrKernelBuffer& buffer, ssize_t);
 
     KResultOr<NonnullOwnPtr<KBuffer>> read_entire_file();
 

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -14,9 +14,12 @@ class Inode;
 
 class InodeFile final : public File {
 public:
-    static NonnullRefPtr<InodeFile> create(NonnullRefPtr<Inode>&& inode)
+    static KResultOr<NonnullRefPtr<InodeFile>> create(NonnullRefPtr<Inode>&& inode)
     {
-        return adopt_ref(*new InodeFile(move(inode)));
+        auto file = adopt_ref_if_nonnull(new InodeFile(move(inode)));
+        if (!file)
+            return ENOMEM;
+        return file.release_nonnull();
     }
 
     virtual ~InodeFile() override;

--- a/Kernel/Heap/SlabAllocator.h
+++ b/Kernel/Heap/SlabAllocator.h
@@ -19,11 +19,11 @@ void slab_dealloc(void*, size_t slab_size);
 void slab_alloc_init();
 void slab_alloc_stats(Function<void(size_t slab_size, size_t allocated, size_t free)>);
 
-#define MAKE_SLAB_ALLOCATED(type)                                        \
-public:                                                                  \
-    void* operator new(size_t) { return slab_alloc(sizeof(type)); }      \
-    void operator delete(void* ptr) { slab_dealloc(ptr, sizeof(type)); } \
-                                                                         \
+#define MAKE_SLAB_ALLOCATED(type)                                                          \
+public:                                                                                    \
+    [[nodiscard]] void* operator new(size_t) noexcept { return slab_alloc(sizeof(type)); } \
+    void operator delete(void* ptr) noexcept { slab_dealloc(ptr, sizeof(type)); }          \
+                                                                                           \
 private:
 
 }

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -264,14 +264,34 @@ void* krealloc(void* ptr, size_t new_size)
     return g_kmalloc_global->m_heap.reallocate(ptr, new_size);
 }
 
-void* operator new(size_t size)
+void* operator new(size_t size) noexcept
 {
     return kmalloc(size);
 }
 
-void* operator new[](size_t size)
+void* operator new[](size_t size) noexcept
 {
     return kmalloc(size);
+}
+
+void operator delete(void* ptr) noexcept
+{
+    return kfree(ptr);
+}
+
+void operator delete(void* ptr, size_t) noexcept
+{
+    return kfree(ptr);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+    return kfree(ptr);
+}
+
+void operator delete[](void* ptr, size_t) noexcept
+{
+    return kfree(ptr);
 }
 
 void get_kmalloc_stats(kmalloc_stats& stats)

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -12,11 +12,11 @@
 #define KMALLOC_SCRUB_BYTE 0xbb
 #define KFREE_SCRUB_BYTE 0xaa
 
-#define MAKE_ALIGNED_ALLOCATED(type, alignment)                                     \
-public:                                                                             \
-    void* operator new(size_t) { return kmalloc_aligned<alignment>(sizeof(type)); } \
-    void operator delete(void* ptr) { kfree_aligned(ptr); }                         \
-                                                                                    \
+#define MAKE_ALIGNED_ALLOCATED(type, alignment)                                                            \
+public:                                                                                                    \
+    [[nodiscard]] void* operator new(size_t) noexcept { return kmalloc_aligned<alignment>(sizeof(type)); } \
+    void operator delete(void* ptr) noexcept { kfree_aligned(ptr); }                                       \
+                                                                                                           \
 private:
 
 void kmalloc_init();

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -40,6 +40,13 @@ extern bool g_dump_kmalloc_stacks;
 inline void* operator new(size_t, void* p) { return p; }
 inline void* operator new[](size_t, void* p) { return p; }
 
+[[nodiscard]] void* operator new(size_t size) noexcept;
+void operator delete(void* ptr) noexcept;
+void operator delete(void* ptr, size_t) noexcept;
+[[nodiscard]] void* operator new[](size_t size) noexcept;
+void operator delete[](void* ptrs) noexcept;
+void operator delete[](void* ptr, size_t) noexcept;
+
 [[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] void* kmalloc(size_t);
 
 template<size_t ALIGNMENT>

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -41,7 +41,12 @@ KResultOr<NonnullRefPtr<Thread>> Thread::try_create(NonnullRefPtr<Process> proce
     if (!kernel_stack_region)
         return ENOMEM;
     kernel_stack_region->set_stack(true);
-    return adopt_ref(*new Thread(move(process), kernel_stack_region.release_nonnull()));
+
+    auto thread = adopt_ref_if_nonnull(new Thread(move(process), kernel_stack_region.release_nonnull()));
+    if (!thread)
+        return ENOMEM;
+
+    return thread.release_nonnull();
 }
 
 Thread::Thread(NonnullRefPtr<Process> process, NonnullOwnPtr<Region> kernel_stack_region)

--- a/Tests/AK/TestRefPtr.cpp
+++ b/Tests/AK/TestRefPtr.cpp
@@ -147,3 +147,14 @@ TEST_CASE(self_observers)
     object->unref();
     EXPECT_EQ(SelfAwareObject::num_destroyed, 1u);
 }
+
+TEST_CASE(adopt_ref_if_nonnull)
+{
+    RefPtr<SelfAwareObject> object = adopt_ref_if_nonnull(new SelfAwareObject);
+    EXPECT_EQ(object.is_null(), false);
+    EXPECT_EQ(object->ref_count(), 1u);
+
+    SelfAwareObject* null_object = nullptr;
+    RefPtr<SelfAwareObject> failed_allocation = adopt_ref_if_nonnull(null_object);
+    EXPECT_EQ(failed_allocation.is_null(), true);
+}


### PR DESCRIPTION
Another series of changes working away at #6369:
 
-  __Kernel: Declare operator new/delete as noexcept for the Kernel__

    For Kernel OOM hardening to work correctly, we need to be able to
    call a "nothrow" version of operator new. Unfortunately the default
    "throwing" version of operator new assumes that the allocation will
    never return on failure and will always throw an exception. This isn't
    true in the Kernel, as we don't have exceptions. So if we call the
    normal/throwing new and kmalloc returns NULL, the generated code will
    happily go and dereference that NULL pointer by invoking the constructor
    before we have a chance to handle the failure.

    To fix this we declare operator new as noexcept in the Kernel headers,
    which will allow the caller to actually handle allocation failure.

    The delete implementations need to match the prototype of the new which
    allocated them, so we need define delete as noexcept as well. GCC then
    errors out declaring that you should implement sized delete as well, so
    this change provides those stubs in order to compile cleanly.

    Finally the new operator definitions have been standardized as being
    declared with [[nodiscard]] to avoid potential memory leaks. So lets
    declares the kernel versions that way as well.

  - __Kernel: Declare operator new/delete noexcept for MAKE_ALIGNED_ALLOCATED__

  - __Kernel: Declare operator new/delete noexcept for MAKE_SLAB_ALLOCATED__

 - __AK: Introduce adopt_ref_if_nonnull(..) to aid in Kernel OOM hardening__

    Unfortunately adopt_ref requires a reference, which obviously does not
    work well with when attempting to harden against allocation failure.
    The adopt_ref_if_nonnull() variant will allow you to avoid using bare
    pointers, while still allowing you to handle allocation failure.


-  __AK: Introduce adopt_own_if_nonnull(..) to aid in Kernel OOM hardening__

    Unfortunately adopt_own requires a reference, which obviously does not
    work well with when attempting to harden against allocation failure.
    The adopt_own_if_nonnull() variant will allow you to avoid using bare
    pointers, while still allowing you to handle allocation failure.

  -  __Kernel: Make Thread::try_create API OOM safe__

  - __Kernel: Make InodeFile::create() API OOM safe__

 -  __Kernel: Make FileDescription::create() APIs OOM safe__

  - __Kernel: Remove unused header from FileDescription.cpp__

  -  __Kernel: Move FileDescription::get_dir_entries to KResultOr<ssize_t>__

     This normalizes the error handling with the rest of the subsystem.