### PR TITLE
LibWeb: Expose Element.{prefix,localName} and fix Element.tagName

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -30,12 +30,12 @@ public:
     virtual ~Element() override;
 
     const String& qualified_name() const { return m_qualified_name.as_string(); }
-    String html_uppercased_qualified_name() const { return m_html_uppercased_qualified_name; }
+    const String& html_uppercased_qualified_name() const { return m_html_uppercased_qualified_name; }
     virtual FlyString node_name() const final { return html_uppercased_qualified_name(); }
     const FlyString& local_name() const { return m_qualified_name.local_name(); }
 
     // NOTE: This is for the JS bindings
-    const FlyString& tag_name() const { return local_name(); }
+    const String& tag_name() const { return html_uppercased_qualified_name(); }
 
     const FlyString& prefix() const { return m_qualified_name.prefix(); }
     const FlyString& namespace_() const { return m_qualified_name.namespace_(); }

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -1,5 +1,7 @@
 interface Element : Node {
     readonly attribute DOMString? namespaceURI;
+    readonly attribute DOMString? prefix;
+    readonly attribute DOMString localName;
     readonly attribute DOMString tagName;
 
     DOMString? getAttribute(DOMString qualifiedName);


### PR DESCRIPTION
LibWeb: Expose Element.{prefix,localName}

-----

LibWeb: Make Element::tag_name return the HTML uppercased qualified name

I forgot to change tag_name when this was added.
Also makes html_uppercased_qualified_name return a const reference.