### PR TITLE
Shell: only write history when it's changed

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1676,8 +1676,10 @@ bool Shell::read_single_line()
 
     run_command(line);
 
-    if (!has_history_event(line))
+    if (!has_history_event(line)) {
         m_editor->add_to_history(line);
+        m_history_dirty = true;
+    }
 
     return true;
 }
@@ -2084,8 +2086,10 @@ void Shell::timer_event(Core::TimerEvent& event)
     if (!m_history_autosave_time.has_value())
         return;
 
-    if (m_editor)
+    if (m_editor && m_history_dirty) {
         m_editor->save_history(get_history_path());
+        m_history_dirty = false;
+    }
 }
 
 void FileDescriptionCollector::collect()

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -351,6 +351,7 @@ private:
     mutable bool m_last_continuation_state { false }; // false == not needed.
 
     Optional<size_t> m_history_autosave_time;
+    bool m_history_dirty { false };
 };
 
 [[maybe_unused]] static constexpr bool is_word_character(char c)


### PR DESCRIPTION
This patch reduces the frequency of history writes in the shell by only
writing when a new item has been added to the history.