### PR TITLE
LibLine+Shell: Add dirty history flag and use it

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -214,6 +214,7 @@ void Editor::add_to_history(const String& line)
     struct timeval tv;
     gettimeofday(&tv, nullptr);
     m_history.append({ line, tv.tv_sec });
+    m_history_dirty = true;
 }
 
 bool Editor::load_history(const String& path)
@@ -301,6 +302,7 @@ bool Editor::save_history(const String& path)
     for (const auto& entry : final_history)
         file->write(String::formatted("{}::{}\n\n", entry.timestamp, entry.entry));
 
+    m_history_dirty = false;
     return true;
 }
 

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -142,6 +142,7 @@ public:
     bool load_history(const String& path);
     bool save_history(const String& path);
     const auto& history() const { return m_history; }
+    bool is_history_dirty() const { return m_history_dirty; }
 
     void register_key_input_callback(const KeyBinding&);
     void register_key_input_callback(Vector<Key> keys, Function<bool(Editor&)> callback) { m_callback_machine.register_key_input_callback(move(keys), move(callback)); }
@@ -442,6 +443,7 @@ private:
     Vector<HistoryEntry> m_history;
     size_t m_history_cursor { 0 };
     size_t m_history_capacity { 1024 };
+    bool m_history_dirty { false };
 
     enum class InputState {
         Free,

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2084,7 +2084,7 @@ void Shell::timer_event(Core::TimerEvent& event)
     if (!m_history_autosave_time.has_value())
         return;
 
-    if (m_editor)
+    if (m_editor && m_editor->is_history_dirty())
         m_editor->save_history(get_history_path());
 }
 


### PR DESCRIPTION
This patch adds a new flag called `history_dirty` to `Line::Editor` that is
set when history is added to but written.  Applications can leverage this
flag to write history only when it changes.  This patch adds an example
usage of this functionality to Shell, which will now only save the
history when it is dirty.