### PR TITLE
LibJS: Make number parts unsigned in NumberPrototype::to_string

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -80,7 +80,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
     if (negative)
         number *= -1;
 
-    int int_part = floor(number);
+    u32 int_part = floor(number);
     double decimal_part = number - int_part;
 
     Vector<char> backwards_characters;
@@ -107,11 +107,11 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
     if (decimal_part != 0.0) {
         characters.append('.');
 
-        int precision = max_precision_for_radix[radix];
+        u8 precision = max_precision_for_radix[radix];
 
-        for (int i = 0; i < precision; ++i) {
+        for (u8 i = 0; i < precision; ++i) {
             decimal_part *= radix;
-            int integral = floor(decimal_part);
+            u32 integral = floor(decimal_part);
             characters.append(digits[integral]);
             decimal_part -= integral;
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toString.js
@@ -13,6 +13,9 @@ describe("correct behavior", () => {
             [12, "12"],
             [93465, "93465"],
             [358000, "358000"],
+            // Numbers above 2 ** 31 - 1 (Issue #3931)
+            [2147483648, "2147483648"], // 2 ** 31
+            [4294967295, "4294967295"], // 2 ** 32 - 1
         ].forEach(testCase => {
             expect(testCase[0].toString()).toBe(testCase[1]);
         });


### PR DESCRIPTION
Fixes #3931