### PR TITLE
Kernel+LibC: Make get_dir_entries syscall retriable

### DIFF
--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -129,6 +129,7 @@ public:
 
     size_t size() const { return m_offset; }
     size_t remaining() const { return m_bytes.size() - m_offset; }
+    void reset() { m_offset = 0; }
 
 private:
     size_t m_offset { 0 };

--- a/Userland/Libraries/LibC/dirent.cpp
+++ b/Userland/Libraries/LibC/dirent.cpp
@@ -98,15 +98,30 @@ static int allocate_dirp_buffer(DIR* dirp)
     }
     size_t size_to_allocate = max(st.st_size, static_cast<off_t>(4096));
     dirp->buffer = (char*)malloc(size_to_allocate);
-    ssize_t nread = syscall(SC_get_dir_entries, dirp->fd, dirp->buffer, size_to_allocate);
-    if (nread < 0) {
-        // uh-oh, the syscall returned an error
-        free(dirp->buffer);
-        dirp->buffer = nullptr;
-        return -nread;
+    if (!dirp->buffer)
+        return ENOMEM;
+    for (;;) {
+        ssize_t nread = syscall(SC_get_dir_entries, dirp->fd, dirp->buffer, size_to_allocate);
+        if (nread < 0) {
+            if (nread == -EINVAL) {
+                size_to_allocate *= 2;
+                char* new_buffer = (char*)realloc(dirp->buffer, size_to_allocate);
+                if (new_buffer) {
+                    dirp->buffer = new_buffer;
+                    continue;
+                } else {
+                    nread = -ENOMEM;
+                }
+            }
+            // uh-oh, the syscall returned an error
+            free(dirp->buffer);
+            dirp->buffer = nullptr;
+            return -nread;
+        }
+        dirp->buffer_size = nread;
+        dirp->nextptr = dirp->buffer;
+        break;
     }
-    dirp->buffer_size = nread;
-    dirp->nextptr = dirp->buffer;
     return 0;
 }
 


### PR DESCRIPTION
The get_dir_entries syscall failed if the serialized form of all the
directory entries together was too large to fit in its temporary buffer.

Now the kernel uses a fixed size buffer, that is flushed to an output
buffer when it is full. If this flushing operation fails because there
is not enough space available, the syscall will return -EINVAL. That
error code is then used in userspace as a signal to allocate a larger
buffer and retry the syscall.

Fixes: https://github.com/SerenityOS/serenity/issues/7025

I'm not sure if it's okay to write to the userspace buffer with a partial
result only to later return an error.