### PR TITLE
LibJS: Use u64 instead of u32 in NumberPrototype::to_string

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -80,7 +80,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
     if (negative)
         number *= -1;
 
-    u32 int_part = floor(number);
+    u64 int_part = floor(number);
     double decimal_part = number - int_part;
 
     Vector<char> backwards_characters;
@@ -111,7 +111,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
 
         for (u8 i = 0; i < precision; ++i) {
             decimal_part *= radix;
-            u32 integral = floor(decimal_part);
+            u64 integral = floor(decimal_part);
             characters.append(digits[integral]);
             decimal_part -= integral;
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toString.js
@@ -16,6 +16,7 @@ describe("correct behavior", () => {
             // Numbers above 2 ** 31 - 1 (Issue #3931)
             [2147483648, "2147483648"], // 2 ** 31
             [4294967295, "4294967295"], // 2 ** 32 - 1
+            [18014398509481984, "18014398509481984"], // 2 ** 54
         ].forEach(testCase => {
             expect(testCase[0].toString()).toBe(testCase[1]);
         });


### PR DESCRIPTION
Update to #7033
Partial fix for #7034 (just ups the range to about 2 ** 54 before losing precision)