### PR TITLE
Ports: Fix building OpenTTD

### DIFF
--- a/Ports/libicu/patches/std.patch
+++ b/Ports/libicu/patches/std.patch
@@ -1,0 +1,48 @@
+diff -Naur source/i18n/decimfmt.cpp source.serenity/i18n/decimfmt.cpp
+--- source/i18n/decimfmt.cpp	2021-05-11 18:48:28.172956656 +0200
++++ source.serenity/i18n/decimfmt.cpp	2021-05-11 18:47:42.222070235 +0200
+@@ -9,7 +9,7 @@
+ // Helpful in toString methods and elsewhere.
+ #define UNISTR_FROM_STRING_EXPLICIT
+ 
+-#include <cmath>
++#include <math.h>
+ #include <cstdlib>
+ #include <stdlib.h>
+ #include "unicode/errorcode.h"
+diff -Naur source/i18n/number_decimalquantity.cpp source.serenity/i18n/number_decimalquantity.cpp
+--- source/i18n/number_decimalquantity.cpp	2021-05-11 18:48:28.172956656 +0200
++++ source.serenity/i18n/number_decimalquantity.cpp	2021-05-11 18:48:02.715798916 +0200
+@@ -6,7 +6,7 @@
+ #if !UCONFIG_NO_FORMATTING
+ 
+ #include <cstdlib>
+-#include <cmath>
++#include <math.h>
+ #include <limits>
+ #include <stdlib.h>
+ 
+diff -Naur source/i18n/number_utils.cpp source.serenity/i18n/number_utils.cpp
+--- source/i18n/number_utils.cpp	2021-05-11 18:48:28.172956656 +0200
++++ source.serenity/i18n/number_utils.cpp	2021-05-11 18:47:22.298352531 +0200
+@@ -10,7 +10,7 @@
+ #define UNISTR_FROM_STRING_EXPLICIT
+ 
+ #include <stdlib.h>
+-#include <cmath>
++#include <math.h>
+ #include "number_decnum.h"
+ #include "number_types.h"
+ #include "number_utils.h"
+diff -Naur source/i18n/reldatefmt.cpp source.serenity/i18n/reldatefmt.cpp
+--- source/i18n/reldatefmt.cpp	2021-05-11 18:48:28.172956656 +0200
++++ source.serenity/i18n/reldatefmt.cpp	2021-05-11 18:46:45.380973593 +0200
+@@ -14,7 +14,7 @@
+ 
+ #if !UCONFIG_NO_FORMATTING && !UCONFIG_NO_BREAK_ITERATION
+ 
+-#include <cmath>
++#include <math.h>
+ #include <functional>
+ #include "unicode/dtfmtsym.h"
+ #include "unicode/ucasemap.h"

--- a/Ports/openttd/package.sh
+++ b/Ports/openttd/package.sh
@@ -2,7 +2,7 @@
 port=openttd
 version=1.11.0
 auth_type=sha256
-depends="SDL2 libpng zlib xz"
+depends="freetype SDL2 libicu libpng zlib xz openttd-opengfx openttd-opensfx"
 files="https://cdn.openttd.org/openttd-releases/${version}/openttd-${version}-source.tar.xz openttd-${version}.tar.xz 5e65184e07368ba1afa62dbb3e35abaee6c4da6730ff4bc9eb4447d53363c7a8"
 useconfigure=true
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"


### PR DESCRIPTION
This makes libicu include `<math.h>` instead of `<cmath>`.

If you're on the new toolchain with `std` support already you'd be unable to build libicu because `<cmath>` `#undef`s some of the defines from `<math.h>` (e.g. `isfinite`).

I've also added some missing dependencies for OpenTTD without which the port would not build or would not run (OpenGFX, OpenSFX).