### PR TITLE
LibWeb: Add a maximum redirects limit to FrameLoader

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -237,9 +237,16 @@ void FrameLoader::resource_did_load()
     // FIXME: Also check HTTP status code before redirecting
     auto location = resource()->response_headers().get("Location");
     if (location.has_value()) {
+        if (m_redirects_count > maximum_redirects_allowed) {
+            m_redirects_count = 0;
+            load_error_page(url, "Too many redirects");
+            return;
+        }
+        m_redirects_count++;
         load(url.complete_url(location.value()), FrameLoader::Type::Navigation);
         return;
     }
+    m_redirects_count = 0;
 
     dbgln("I believe this content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding());
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -12,6 +12,8 @@
 
 namespace Web {
 
+constexpr size_t maximum_redirects_allowed = 20;
+
 class FrameLoader final
     : public ResourceClient {
 public:
@@ -41,6 +43,7 @@ private:
     bool parse_document(DOM::Document&, const ByteBuffer& data);
 
     Frame& m_frame;
+    size_t m_redirects_count { 0 };
 };
 
 }


### PR DESCRIPTION
This prevents the browser from crashing when trying to load an infinite redirects loop.
The chosen limit is arbitrary but common. (Both Firefox and Chrome have the same limit)