### PR TITLE
Kernel: Improve TCP performance

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -369,7 +369,7 @@ KResultOr<size_t> IPv4Socket::recvfrom(FileDescription& description, UserOrKerne
     return nreceived;
 }
 
-bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port, KBuffer&& packet, const Time& packet_timestamp)
+bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port, ReadonlyBytes packet, const Time& packet_timestamp)
 {
     Locker locker(lock());
 
@@ -398,7 +398,7 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
             dbgln("IPv4Socket({}): did_receive refusing packet since queue is full.", this);
             return false;
         }
-        m_receive_queue.append({ source_address, source_port, packet_timestamp, move(packet) });
+        m_receive_queue.append({ source_address, source_port, packet_timestamp, KBuffer::copy(packet.data(), packet.size()) });
         set_can_read(true);
     }
     m_bytes_received += packet_size;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -139,6 +139,8 @@ KResult IPv4Socket::connect(FileDescription& description, Userspace<const sockad
         return EFAULT;
 
     m_peer_address = IPv4Address((const u8*)&safe_address.sin_addr.s_addr);
+    if (m_peer_address == IPv4Address { 0, 0, 0, 0 })
+        m_peer_address = IPv4Address { 127, 0, 0, 1 };
     m_peer_port = ntohs(safe_address.sin_port);
 
     return protocol_connect(description, should_block);

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -43,7 +43,7 @@ public:
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
 
-    bool did_receive(const IPv4Address& peer_address, u16 peer_port, KBuffer&&, const Time&);
+    bool did_receive(const IPv4Address& peer_address, u16 peer_port, ReadonlyBytes, const Time&);
 
     const IPv4Address& local_address() const { return m_local_address; }
     u16 local_port() const { return m_local_port; }

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -110,7 +110,7 @@ private:
 
     SinglyLinkedListWithCount<ReceivedPacket> m_receive_queue;
 
-    DoubleBuffer m_receive_buffer;
+    DoubleBuffer m_receive_buffer { 256 * KiB };
 
     u16 m_local_port { 0 };
     u16 m_peer_port { 0 };

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -40,6 +40,8 @@ RefPtr<NetworkAdapter> NetworkAdapter::from_ipv4_address(const IPv4Address& addr
         if (adapter->ipv4_address() == address || adapter->ipv4_broadcast() == address)
             return adapter;
     }
+    if (address[0] == 0 && address[1] == 0 && address[2] == 0 && address[3] == 0)
+        return LoopbackAdapter::the();
     if (address[0] == 127)
         return LoopbackAdapter::the();
     return nullptr;

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -28,8 +28,11 @@ static void handle_ipv4(const EthernetFrameHeader&, size_t frame_size, const Tim
 static void handle_icmp(const EthernetFrameHeader&, const IPv4Packet&, const Time& packet_timestamp);
 static void handle_udp(const IPv4Packet&, const Time& packet_timestamp);
 static void handle_tcp(const IPv4Packet&, const Time& packet_timestamp);
+static void send_delayed_tcp_ack(RefPtr<TCPSocket> socket);
+static void flush_delayed_tcp_acks(bool all);
 
 static Thread* network_task = nullptr;
+static HashTable<RefPtr<TCPSocket>>* delayed_ack_sockets;
 
 [[noreturn]] static void NetworkTask_main(void*);
 
@@ -47,6 +50,8 @@ bool NetworkTask::is_current()
 
 void NetworkTask_main(void*)
 {
+    delayed_ack_sockets = new HashTable<RefPtr<TCPSocket>>;
+
     WaitQueue packet_wait_queue;
     int pending_packets = 0;
     NetworkAdapter::for_each([&](auto& adapter) {
@@ -86,9 +91,13 @@ void NetworkTask_main(void*)
     for (;;) {
         size_t packet_size = dequeue_packet(buffer, buffer_size, packet_timestamp);
         if (!packet_size) {
+            // We might sleep for a while so we must flush all delayed TCP ACKs
+            // including those which haven't expired yet.
+            flush_delayed_tcp_acks(true);
             packet_wait_queue.wait_forever("NetworkTask");
             continue;
         }
+        flush_delayed_tcp_acks(false);
         if (packet_size < sizeof(EthernetFrameHeader)) {
             dbgln("NetworkTask: Packet is too small to be an Ethernet packet! ({})", packet_size);
             continue;
@@ -279,6 +288,38 @@ void handle_udp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
         socket->did_receive(ipv4_packet.source(), udp_packet.source_port(), { &ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size() }, packet_timestamp);
 }
 
+void send_delayed_tcp_ack(RefPtr<TCPSocket> socket)
+{
+    VERIFY(socket->lock().is_locked());
+    if (!socket->should_delay_next_ack()) {
+        [[maybe_unused]] auto result = socket->send_ack();
+        return;
+    }
+
+    delayed_ack_sockets->set(move(socket));
+}
+
+void flush_delayed_tcp_acks(bool all)
+{
+    Vector<RefPtr<TCPSocket>, 32> remaining_sockets;
+    for (auto& socket : *delayed_ack_sockets) {
+        Locker locker(socket->lock());
+        if (!all && socket->should_delay_next_ack()) {
+            remaining_sockets.append(socket);
+            continue;
+        }
+        [[maybe_unused]] auto result = socket->send_ack();
+    }
+
+    if (remaining_sockets.size() != delayed_ack_sockets->size()) {
+        delayed_ack_sockets->clear();
+        if (remaining_sockets.size() > 0)
+            dbgln("flush_delayed_tcp_acks: {} sockets remaining", remaining_sockets.size());
+        for (auto&& socket : remaining_sockets)
+            delayed_ack_sockets->set(move(socket));
+    }
+}
+
 void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
 {
     if (ipv4_packet.payload_size() < sizeof(TCPPacket)) {
@@ -393,26 +434,26 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
         switch (tcp_packet.flags()) {
         case TCPFlags::SYN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+            send_delayed_tcp_ack(socket);
             socket->set_state(TCPSocket::State::SynReceived);
             return;
         case TCPFlags::ACK | TCPFlags::SYN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+            send_delayed_tcp_ack(socket);
             socket->set_state(TCPSocket::State::Established);
             socket->set_setup_state(Socket::SetupState::Completed);
             socket->set_connected(true);
             return;
         case TCPFlags::ACK | TCPFlags::FIN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+            send_delayed_tcp_ack(socket);
             socket->set_state(TCPSocket::State::Closed);
             socket->set_error(TCPSocket::Error::FINDuringConnect);
             socket->set_setup_state(Socket::SetupState::Completed);
             return;
         case TCPFlags::ACK | TCPFlags::RST:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
-            unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+            send_delayed_tcp_ack(socket);
             socket->set_state(TCPSocket::State::Closed);
             socket->set_error(TCPSocket::Error::RSTDuringConnect);
             socket->set_setup_state(Socket::SetupState::Completed);
@@ -536,7 +577,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
             if (socket->duplicate_acks() < TCPSocket::maximum_duplicate_acks) {
                 dbgln_if(TCP_DEBUG, "Sending ACK with same ack number to trigger fast retransmission");
                 socket->set_duplicate_acks(socket->duplicate_acks() + 1);
-                unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+                [[maybe_unused]] auto result = socket->send_ack(true);
             }
             return;
         }
@@ -548,7 +589,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
                 socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), { &ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size() }, packet_timestamp);
 
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+            send_delayed_tcp_ack(socket);
             socket->set_state(TCPSocket::State::CloseWait);
             socket->set_connected(false);
             return;
@@ -559,7 +600,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
                 socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
                 dbgln_if(TCP_DEBUG, "Got packet with ack_no={}, seq_no={}, payload_size={}, acking it with new ack_no={}, seq_no={}",
                     tcp_packet.ack_number(), tcp_packet.sequence_number(), payload_size, socket->ack_number(), socket->sequence_number());
-                unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
+                send_delayed_tcp_ack(socket);
             }
         }
     }

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -221,7 +221,7 @@ void handle_icmp(const EthernetFrameHeader& eth, const IPv4Packet& ipv4_packet, 
             }
         }
         for (auto& socket : icmp_sockets)
-            socket.did_receive(ipv4_packet.source(), 0, KBuffer::copy(&ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size()), packet_timestamp);
+            socket.did_receive(ipv4_packet.source(), 0, { &ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size() }, packet_timestamp);
     }
 
     auto adapter = NetworkAdapter::from_ipv4_address(ipv4_packet.destination());
@@ -276,7 +276,7 @@ void handle_udp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
     auto& destination = ipv4_packet.destination();
 
     if (destination == IPv4Address(255, 255, 255, 255) || NetworkAdapter::from_ipv4_address(destination) || socket->multicast_memberships().contains_slow(destination))
-        socket->did_receive(ipv4_packet.source(), udp_packet.source_port(), KBuffer::copy(&ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size()), packet_timestamp);
+        socket->did_receive(ipv4_packet.source(), udp_packet.source_port(), { &ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size() }, packet_timestamp);
 }
 
 void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
@@ -533,7 +533,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
 
         if (tcp_packet.has_fin()) {
             if (payload_size != 0)
-                socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), KBuffer::copy(&ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size()), packet_timestamp);
+                socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), { &ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size() }, packet_timestamp);
 
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
@@ -548,7 +548,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
             tcp_packet.ack_number(), tcp_packet.sequence_number(), payload_size, socket->ack_number(), socket->sequence_number());
 
         if (payload_size) {
-            if (socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), KBuffer::copy(&ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size()), packet_timestamp))
+            if (socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), { &ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size() }, packet_timestamp))
                 unused_rc = socket->send_tcp_packet(TCPFlags::ACK);
         }
     }

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -141,6 +141,8 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
         return { adapter, mac };
     };
 
+    if (target[0] == 0 && target[1] == 0 && target[2] == 0 && target[3] == 0)
+        return if_matches(LoopbackAdapter::the(), LoopbackAdapter::the().mac_address());
     if (target[0] == 127)
         return if_matches(LoopbackAdapter::the(), LoopbackAdapter::the().mac_address());
 

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -21,6 +21,23 @@ struct TCPFlags {
     };
 };
 
+class [[gnu::packed]] TCPOptionMSS {
+public:
+    TCPOptionMSS(u16 value)
+        : m_value(value)
+    {
+    }
+
+    u16 value() const { return m_value; }
+
+private:
+    u8 m_option_kind { 0x02 };
+    u8 m_option_length { sizeof(TCPOptionMSS) };
+    NetworkOrdered<u16> m_value;
+};
+
+static_assert(sizeof(TCPOptionMSS) == 4);
+
 class [[gnu::packed]] TCPPacket {
 public:
     TCPPacket() = default;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -174,7 +174,7 @@ KResult TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload,
     VERIFY(local_port());
     tcp_packet.set_source_port(local_port());
     tcp_packet.set_destination_port(peer_port());
-    tcp_packet.set_window_size(1024);
+    tcp_packet.set_window_size(NumericLimits<u16>::max());
     tcp_packet.set_sequence_number(m_sequence_number);
     tcp_packet.set_data_offset(sizeof(TCPPacket) / sizeof(u32));
     tcp_packet.set_flags(flags);

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -129,7 +129,7 @@ public:
     u32 bytes_out() const { return m_bytes_out; }
 
     KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0);
-    void send_outgoing_packets();
+    void send_outgoing_packets(RoutingDecision&);
     void receive_tcp_packet(const TCPPacket&, u16 size);
 
     static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& sockets_by_tuple();

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -133,9 +133,12 @@ public:
     void set_duplicate_acks(u32 acks) { m_duplicate_acks = acks; }
     u32 duplicate_acks() const { return m_duplicate_acks; }
 
+    KResult send_ack(bool allow_duplicate = false);
     KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0);
     void send_outgoing_packets(RoutingDecision&);
     void receive_tcp_packet(const TCPPacket&, u16 size);
+
+    bool should_delay_next_ack() const;
 
     static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& sockets_by_tuple();
     static RefPtr<TCPSocket> from_tuple(const IPv4SocketTuple& tuple);
@@ -194,6 +197,9 @@ private:
     SinglyLinkedList<OutgoingPacket> m_not_acked;
 
     u32 m_duplicate_acks { 0 };
+
+    u32 m_last_ack_number_sent { 0 };
+    Time m_last_ack_sent_time;
 };
 
 }

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -128,6 +128,11 @@ public:
     u32 packets_out() const { return m_packets_out; }
     u32 bytes_out() const { return m_bytes_out; }
 
+    // FIXME: Make this configurable?
+    static constexpr u32 maximum_duplicate_acks = 5;
+    void set_duplicate_acks(u32 acks) { m_duplicate_acks = acks; }
+    u32 duplicate_acks() const { return m_duplicate_acks; }
+
     KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0);
     void send_outgoing_packets(RoutingDecision&);
     void receive_tcp_packet(const TCPPacket&, u16 size);
@@ -187,6 +192,8 @@ private:
 
     Lock m_not_acked_lock { "TCPSocket unacked packets" };
     SinglyLinkedList<OutgoingPacket> m_not_acked;
+
+    u32 m_duplicate_acks { 0 };
 };
 
 }


### PR DESCRIPTION
**Kernel: Increase IPv4 buffer size to 256kB**

This increases the buffer size for connection-oriented sockets to 256kB. In combination with the other patches in this series
I was able to receive TCP packets at a rate of about 120Mbps.

**Kernel: Increase the default TCP window size**

This increases the default TCP window size to a more reasonable value of 64k. This allows TCP peers to send us more packets before waiting for corresponding ACKs.

**Kernel: Avoid allocating KBuffers for TCP packets**

This avoids allocating a KBuffer for each incoming TCP packet.

**Kernel: Set MSS option for outbound TCP SYN packets**

When the MSS option header is missing the default maximum segment size is 536 which results in lots of very small TCP packets that `NetworkTask` has to handle.

This adds the MSS option header to outbound TCP SYN packets and sets it to an appropriate value depending on the interface's MTU.

Note that we do not currently do path MTU discovery so this could cause problems when hops don't fragment packets properly.

**Kernel: Don't process TCP packets out of order**

Previously we'd process TCP packets in whatever order we received them in. In the case where packets arrived out of order we'd end up passing garbage to the userspace process.

This was most evident for TLS connections:

```
courage:~ $ git clone -c http.sslVerify=false https://github.com/SerenityOS/serenity
Cloning into 'serenity'...
remote: Enumerating objects: 178826, done.
remote: Counting objects: 100% (1880/1880), done.
remote: Compressing objects: 100% (907/907), done.
error: RPC failed; curl 56 OpenSSL SSL_read: error:1408F119:SSL routines:SSL3_GET_RECORD:decryption failed or bad record mac, errno 0
error: 1918 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

**Kernel: Trigger TCP fast retransmission when we encounter lost packets**
    
When we receive a TCP packet with a sequence number that is not what we expected we have lost one or more packets. We can signal this to the sender by sending a TCP ACK with the previous ack number so that they can resend the missing TCP fragments.

**Kernel: Coalesce TCP ACKs**

Previously we'd send a TCP ACK for each TCP packet we received. This changes NetworkTask so that we send fewer TCP ACKs.

**Kernel: Treat 0.0.0.0 as a loopback address**

This matches what other operating systems like Linux do:

```
$ ip route get 0.0.0.0
local 0.0.0.0 dev lo src 127.0.0.1 uid 1000
    cache <local>
```

```
$ ssh 0.0.0.0
gunnar@0.0.0.0's password:
```

```
$ ss -na | grep :22 | grep ESTAB
tcp   ESTAB      0      0   127.0.0.1:43118   127.0.0.1:22
tcp   ESTAB      0      0   127.0.0.1:22      127.0.0.1:43118
```