### PR TITLE
RequestServer: Only attempt to flush() on a timer

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -42,6 +42,7 @@ protected:
     virtual bool is_established() const = 0;
     virtual bool should_fail_on_empty_payload() const { return true; }
     virtual void read_while_data_available(Function<IterationDecision()> read) { read(); };
+    virtual void timer_event(Core::TimerEvent&) override;
 
     enum class State {
         InStatus,


### PR DESCRIPTION
...instead of doing so immediately.
This makes RequestServer not spin as much when its client isn't fast
enough to empty the download pipe.
It also has the nice benefit of allowing multiple downloads to happen
at the same time without one blocking the other too much.