### PR TITLE
LibWeb: Implement HTML Specifications's "encoding sniffing algorithm"

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -129,6 +129,14 @@ void StringBuilder::append(const Utf32View& utf32_view)
     }
 }
 
+void StringBuilder::append_as_lowercase(char ch)
+{
+    if (ch >= 'A' && ch <= 'Z')
+        append(ch + 0x20);
+    else
+        append(ch);
+}
+
 void StringBuilder::append_escaped_for_json(const StringView& string)
 {
     for (auto ch : string) {

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -28,6 +28,7 @@ public:
     void append(const char*, size_t);
     void appendvf(const char*, va_list);
 
+    void append_as_lowercase(char);
     void append_escaped_for_json(const StringView&);
 
     template<typename... Parameters>

--- a/Userland/Libraries/LibTextCodec/Decoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Decoder.cpp
@@ -64,24 +64,26 @@ CyrillicDecoder& cyrillic_decoder()
 Decoder* decoder_for(const String& a_encoding)
 {
     auto encoding = get_standardized_encoding(a_encoding);
-    if (encoding.equals_ignoring_case("windows-1252"))
-        return &latin1_decoder();
-    if (encoding.equals_ignoring_case("utf-8"))
-        return &utf8_decoder();
-    if (encoding.equals_ignoring_case("utf-16be"))
-        return &utf16be_decoder();
-    if (encoding.equals_ignoring_case("iso-8859-2"))
-        return &latin2_decoder();
-    if (encoding.equals_ignoring_case("windows-1255"))
-        return &hebrew_decoder();
-    if (encoding.equals_ignoring_case("windows-1251"))
-        return &cyrillic_decoder();
+    if (encoding.has_value()) {
+        if (encoding.value().equals_ignoring_case("windows-1252"))
+            return &latin1_decoder();
+        if (encoding.value().equals_ignoring_case("utf-8"))
+            return &utf8_decoder();
+        if (encoding.value().equals_ignoring_case("utf-16be"))
+            return &utf16be_decoder();
+        if (encoding.value().equals_ignoring_case("iso-8859-2"))
+            return &latin2_decoder();
+        if (encoding.value().equals_ignoring_case("windows-1255"))
+            return &hebrew_decoder();
+        if (encoding.value().equals_ignoring_case("windows-1251"))
+            return &cyrillic_decoder();
+    }
     dbgln("TextCodec: No decoder implemented for encoding '{}'", a_encoding);
     return nullptr;
 }
 
 // https://encoding.spec.whatwg.org/#concept-encoding-get
-String get_standardized_encoding(const String& encoding)
+Optional<String> get_standardized_encoding(const String& encoding)
 {
     String trimmed_lowercase_encoding = encoding.trim_whitespace().to_lowercase();
 
@@ -172,7 +174,8 @@ String get_standardized_encoding(const String& encoding)
 
 bool is_standardized_encoding(const String& encoding)
 {
-    return encoding.equals_ignoring_case(get_standardized_encoding(encoding));
+    auto standardized_encoding = get_standardized_encoding(encoding);
+    return standardized_encoding.has_value() && encoding.equals_ignoring_case(standardized_encoding.value());
 }
 
 String UTF8Decoder::to_utf8(const StringView& input)

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -49,7 +49,7 @@ public:
 };
 
 Decoder* decoder_for(const String& encoding);
-String get_standardized_encoding(const String& encoding);
+Optional<String> get_standardized_encoding(const String& encoding);
 bool is_standardized_encoding(const String& encoding);
 
 }

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -147,6 +147,7 @@ set(SOURCES
     HTML/ImageData.cpp
     HTML/Parser/Entities.cpp
     HTML/Parser/HTMLDocumentParser.cpp
+    HTML/Parser/HTMLEncodingDetection.cpp
     HTML/Parser/HTMLToken.cpp
     HTML/Parser/HTMLTokenizer.cpp
     HTML/Parser/ListOfActiveFormattingElements.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -237,13 +237,15 @@ public:
     const String& content_type() const { return m_content_type; }
     void set_content_type(const String& content_type) { m_content_type = content_type; }
 
-    const String& encoding() const { return m_encoding; }
-    void set_encoding(const String& encoding) { m_encoding = encoding; }
+    bool has_encoding() const { return m_encoding.has_value(); }
+    const Optional<String>& encoding() const { return m_encoding; }
+    String encoding_or_default() const { return m_encoding.value_or("UTF-8"); }
+    void set_encoding(const Optional<String>& encoding) { m_encoding = encoding; }
 
     // NOTE: These are intended for the JS bindings
-    const String& character_set() const { return encoding(); }
-    const String& charset() const { return encoding(); }
-    const String& input_encoding() const { return encoding(); }
+    String character_set() const { return encoding_or_default(); }
+    String charset() const { return encoding_or_default(); }
+    String input_encoding() const { return encoding_or_default(); }
 
     bool ready_for_post_load_tasks() const { return m_ready_for_post_load_tasks; }
     void set_ready_for_post_load_tasks(bool ready) { m_ready_for_post_load_tasks = ready; }
@@ -327,7 +329,7 @@ private:
 
     String m_ready_state { "loading" };
     String m_content_type { "application/xml" };
-    String m_encoding { "UTF-8" };
+    Optional<String> m_encoding;
 
     bool m_ready_for_post_load_tasks { false };
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -104,7 +104,9 @@ HTMLDocumentParser::HTMLDocumentParser(DOM::Document& document, const StringView
     , m_document(document)
 {
     m_document->set_should_invalidate_styles_on_attribute_changes(false);
-    m_document->set_encoding(TextCodec::get_standardized_encoding(encoding));
+    auto standardized_encoding = TextCodec::get_standardized_encoding(encoding);
+    VERIFY(standardized_encoding.has_value());
+    m_document->set_encoding(standardized_encoding.value());
 }
 
 HTMLDocumentParser::~HTMLDocumentParser()

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
 #include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
+#include <LibWeb/HTML/Parser/HTMLEncodingDetection.h>
 #include <LibWeb/HTML/Parser/HTMLToken.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/SVG/TagNames.h>
@@ -3039,4 +3040,14 @@ NonnullRefPtrVector<DOM::Node> HTMLDocumentParser::parse_html_fragment(DOM::Elem
     }
     return children;
 }
+
+NonnullOwnPtr<HTMLDocumentParser> HTMLDocumentParser::create_with_uncertain_encoding(DOM::Document& document, const ByteBuffer& input)
+{
+    if (document.has_encoding())
+        return make<HTMLDocumentParser>(document, input, document.encoding().value());
+    auto encoding = run_encoding_sniffing_algorithm(input);
+    dbgln("The encoding sniffing algorithm returned encoding '{}'", encoding);
+    return make<HTMLDocumentParser>(document, input, encoding);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
@@ -46,6 +46,8 @@ public:
     HTMLDocumentParser(DOM::Document&, const StringView& input, const String& encoding);
     ~HTMLDocumentParser();
 
+    static NonnullOwnPtr<HTMLDocumentParser> create_with_uncertain_encoding(DOM::Document&, const ByteBuffer& input);
+
     void run(const URL&);
 
     DOM::Document& document();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringView.h>
+#include <AK/Utf8View.h>
+#include <LibTextCodec/Decoder.h>
+#include <LibWeb/HTML/Parser/HTMLEncodingDetection.h>
+#include <ctype.h>
+
+namespace Web::HTML {
+
+bool prescan_should_abort(const ByteBuffer& input, const size_t& position)
+{
+    return position >= input.size() || position >= 1024;
+}
+
+bool prescan_is_whitespace_or_slash(const u8& byte)
+{
+    return byte == '\t' || byte == '\n' || byte == '\f' || byte == '\r' || byte == ' ' || byte == '/';
+}
+
+bool prescan_skip_whitespace_and_slashes(const ByteBuffer& input, size_t& position)
+{
+    while (!prescan_should_abort(input, position) && (input[position] == '\t' || input[position] == '\n' || input[position] == '\f' || input[position] == '\r' || input[position] == ' ' || input[position] == '/'))
+        ++position;
+    return !prescan_should_abort(input, position);
+}
+
+Optional<Attribute> prescan_get_attribute(const ByteBuffer& input, size_t& position)
+{
+    if (!prescan_skip_whitespace_and_slashes(input, position))
+        return {};
+    if (input[position] == '>')
+        return {};
+
+    StringBuilder attribute_name;
+    while (true) {
+        if (input[position] == '=' && !attribute_name.is_empty()) {
+            ++position;
+            goto value;
+        } else if (input[position] == '\t' || input[position] == '\n' || input[position] == '\f' || input[position] == '\r' || input[position] == ' ')
+            goto spaces;
+        else if (input[position] == '/' || input[position] == '>')
+            return Attribute(attribute_name.to_string(), "");
+        else
+            attribute_name.append_as_lowercase(input[position]);
+        ++position;
+        if (prescan_should_abort(input, position))
+            return {};
+    }
+
+spaces:
+    if (!prescan_skip_whitespace_and_slashes(input, position))
+        return {};
+    if (input[position] != '=')
+        return Attribute(attribute_name.to_string(), "");
+    ++position;
+
+value:
+    if (!prescan_skip_whitespace_and_slashes(input, position))
+        return {};
+
+    StringBuilder attribute_value;
+    if (input[position] == '"' || input[position] == '\'') {
+        u8 quote_character = input[position];
+        ++position;
+        for (; !prescan_should_abort(input, position); ++position) {
+            if (input[position] == quote_character)
+                return Attribute(attribute_name.to_string(), attribute_value.to_string());
+            else
+                attribute_value.append_as_lowercase(input[position]);
+        }
+        return {};
+    } else if (input[position] == '>')
+        return Attribute(attribute_name.to_string(), "");
+    else
+        attribute_value.append_as_lowercase(input[position]);
+
+    ++position;
+    if (prescan_should_abort(input, position))
+        return {};
+
+    for (; !prescan_should_abort(input, position); ++position) {
+        if (input[position] == '\t' || input[position] == '\n' || input[position] == '\f' || input[position] == '\r' || input[position] == ' ' || input[position] == '>')
+            return Attribute(attribute_name.to_string(), attribute_value.to_string());
+        else
+            attribute_value.append_as_lowercase(input[position]);
+    }
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding
+Optional<String> run_prescan_byte_stream_algorithm(const ByteBuffer& input)
+{
+    // https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding
+
+    // Detects '<?x'
+    if (!prescan_should_abort(input, 6)) {
+        if (input[0] == 0x3C && input[1] == 0x00 && input[2] == 0x3F && input[3] == 0x00 && input[4] == 0x78 && input[5] == 0x00)
+            return "utf-16le";
+        if (input[0] == 0x00 && input[1] == 0x3C && input[2] == 0x00 && input[4] == 0x3F && input[5] == 0x00 && input[6] == 0x78)
+            return "utf-16be";
+    }
+
+    for (size_t position = 0; !prescan_should_abort(input, position); ++position) {
+        if (!prescan_should_abort(input, position + 5) && input[position] == '<' && input[position + 1] == '!'
+            && input[position + 2] == '-' && input[position + 3] == '-') {
+            position += 2;
+            for (; !prescan_should_abort(input, position + 3); ++position) {
+                if (input[position] == '-' && input[position + 1] == '-' && input[position + 2] == '>') {
+                    position += 2;
+                    break;
+                }
+            }
+        } else if (!prescan_should_abort(input, position + 6)
+            && input[position] == '<'
+            && (input[position + 1] == 'M' || input[position + 1] == 'm')
+            && (input[position + 2] == 'E' || input[position + 2] == 'e')
+            && (input[position + 3] == 'T' || input[position + 3] == 't')
+            && (input[position + 4] == 'A' || input[position + 4] == 'a')
+            && prescan_is_whitespace_or_slash(input[position + 5])) {
+            position += 6;
+            Vector<String> attribute_list {};
+            bool got_pragma = false;
+            Optional<bool> need_pragma {};
+            Optional<String> charset {};
+
+            while (true) {
+                auto attribute = prescan_get_attribute(input, position);
+                if (!attribute.has_value())
+                    break;
+                if (attribute_list.contains_slow(attribute.value().name()))
+                    continue;
+                auto& attribute_name = attribute.value().name();
+                attribute_list.append(attribute.value().name());
+
+                if (attribute_name == "http-equiv" && attribute.value().value() == "content-type")
+                    got_pragma = true;
+                else if (attribute_name == "charset") {
+                    auto maybe_charset = TextCodec::get_standardized_encoding(attribute.value().value());
+                    if (maybe_charset.has_value()) {
+                        charset = Optional<String> { maybe_charset };
+                        need_pragma = { false };
+                    }
+                }
+
+                // FIXME: For attribute name "content", do this:
+                //        Apply the "algorithm for extracting a character encoding from a meta
+                //        element", giving the attribute's value as the string to parse. If a
+                //        character encoding is returned, and if charset is still set to null,
+                //        let charset be the encoding returned, and set need pragma to true.
+            }
+
+            if (!need_pragma.has_value() || (need_pragma.value() && !got_pragma) || !charset.has_value())
+                continue;
+            if (charset.value() == "UTF-16BE/LE")
+                return "UTF-8";
+            else if (charset.value() == "x-user-defined")
+                return "windows-1252";
+            else
+                return charset.value();
+        } else if (!prescan_should_abort(input, position + 3) && input[position] == '<'
+            && ((input[position + 1] == '/' && isalpha(input[position + 2])) || isalpha(input[position + 1]))) {
+            position += 2;
+            prescan_skip_whitespace_and_slashes(input, position);
+            while (prescan_get_attribute(input, position).has_value()) { };
+        } else if (!prescan_should_abort(input, position + 1) && input[position] == '<' && (input[position + 1] == '!' || input[position + 1] == '/' || input[position + 1] == '?')) {
+            position += 2;
+            while (input[position] != '>') {
+                ++position;
+                if (prescan_should_abort(input, position))
+                    return {};
+            }
+        } else {
+            // Do nothing.
+        }
+    }
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding
+String run_encoding_sniffing_algorithm(const ByteBuffer& input)
+{
+    if (input.size() >= 2) {
+        if (input[0] == 0xFE && input[1] == 0xFF) {
+            return "UTF-16BE";
+        } else if (input[0] == 0xFF && input[1] == 0xFE) {
+            return "UTF-16LE";
+        } else if (input.size() >= 3 && input[0] == 0xEF && input[1] == 0xBB && input[2] == 0xBF) {
+            return "UTF-8";
+        }
+    }
+
+    // FIXME: If the user has explicitly instructed the user agent to override the document's character
+    //        encoding with a specific encoding.
+    // FIXME: The user agent may wait for more bytes of the resource to be available, either in this step or
+    //        at any later step in this algorithm.
+    // FIXME: If the transport layer specifies a character encoding, and it is supported.
+
+    auto optional_encoding = run_prescan_byte_stream_algorithm(input);
+    if (optional_encoding.has_value()) {
+        return optional_encoding.value();
+    }
+
+    // FIXME: If the HTML parser for which this algorithm is being run is associated with a Document whose browsing context
+    //        is non-null and a child browsing context.
+    // FIXME: If the user agent has information on the likely encoding for this page, e.g. based on the encoding of the page
+    //        when it was last visited.
+
+    if (!Utf8View(StringView(input)).validate()) {
+        // FIXME: As soon as Locale is supported, this should sometimes return a different encoding based on the locale.
+        return "windows-1252";
+    }
+
+    // NOTE: This is the authoritative place to actually decide on using the default encoding as per the HTML specification.
+    //       "Otherwise, return an implementation-defined or user-specified default character encoding, [...]."
+    return "UTF-8";
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibWeb/DOM/Attribute.h>
+
+namespace Web::HTML {
+
+bool prescan_should_abort(const ByteBuffer& input, const size_t& position);
+bool prescan_is_whitespace_or_slash(const u8& byte);
+bool prescan_skip_whitespace_and_slashes(const ByteBuffer& input, size_t& position);
+Optional<Attribute> prescan_get_attribute(const ByteBuffer& input, size_t& position);
+Optional<String> run_prescan_byte_stream_algorithm(const ByteBuffer& input);
+String run_encoding_sniffing_algorithm(const ByteBuffer& input);
+
+}

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -113,7 +113,7 @@ bool FrameLoader::parse_document(DOM::Document& document, const ByteBuffer& data
 {
     auto& mime_type = document.content_type();
     if (mime_type == "text/html" || mime_type == "image/svg+xml") {
-        HTML::HTMLDocumentParser parser(document, data, document.encoding());
+        HTML::HTMLDocumentParser parser(document, data, document.encoding_or_default());
         parser.run(document.url());
         return true;
     }
@@ -251,12 +251,12 @@ void FrameLoader::resource_did_load()
     if (resource()->has_encoding()) {
         dbgln("This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
     } else {
-        dbgln("This content has MIME type '{}', encoding unknown (defaulting to 'utf-8')", resource()->mime_type());
+        dbgln("This content has MIME type '{}', encoding unknown", resource()->mime_type());
     }
 
     auto document = DOM::Document::create();
     document->set_url(url);
-    document->set_encoding(resource()->encoding().value_or("utf-8"));
+    document->set_encoding(resource()->encoding());
     document->set_content_type(resource()->mime_type());
 
     frame().set_document(document);

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -113,8 +113,8 @@ bool FrameLoader::parse_document(DOM::Document& document, const ByteBuffer& data
 {
     auto& mime_type = document.content_type();
     if (mime_type == "text/html" || mime_type == "image/svg+xml") {
-        HTML::HTMLDocumentParser parser(document, data, document.encoding_or_default());
-        parser.run(document.url());
+        auto parser = HTML::HTMLDocumentParser::create_with_uncertain_encoding(document, data);
+        parser->run(document.url());
         return true;
     }
     if (mime_type.starts_with("image/"))

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -248,11 +248,15 @@ void FrameLoader::resource_did_load()
     }
     m_redirects_count = 0;
 
-    dbgln("I believe this content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding());
+    if (resource()->has_encoding()) {
+        dbgln("This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
+    } else {
+        dbgln("This content has MIME type '{}', encoding unknown (defaulting to 'utf-8')", resource()->mime_type());
+    }
 
     auto document = DOM::Document::create();
     document->set_url(url);
-    document->set_encoding(resource()->encoding());
+    document->set_encoding(resource()->encoding().value_or("utf-8"));
     document->set_content_type(resource()->mime_type());
 
     frame().set_document(document);

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -85,14 +85,12 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
         m_mime_type = Core::guess_mime_type_based_on_filename(url().path());
     }
 
+    m_encoding = {};
     if (content_type.has_value()) {
         auto encoding = encoding_from_content_type(content_type.value());
         if (encoding.has_value()) {
             dbgln_if(RESOURCE_DEBUG, "Set encoding '{}' from Content-Type", encoding.has_value());
             m_encoding = encoding.value();
-        } else {
-            // FIXME: This doesn't seem nice.
-            m_encoding = "utf-8";
         }
     }
 

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -52,7 +52,8 @@ public:
     void register_client(Badge<ResourceClient>, ResourceClient&);
     void unregister_client(Badge<ResourceClient>, ResourceClient&);
 
-    const String& encoding() const { return m_encoding; }
+    bool has_encoding() const { return m_encoding.has_value(); }
+    const Optional<String>& encoding() const { return m_encoding; }
     const String& mime_type() const { return m_mime_type; }
 
     void for_each_client(Function<void(ResourceClient&)>);
@@ -70,7 +71,8 @@ private:
     bool m_loaded { false };
     bool m_failed { false };
     String m_error;
-    String m_encoding;
+    Optional<String> m_encoding;
+
     String m_mime_type;
     HashMap<String, String, CaseInsensitiveStringTraits> m_response_headers;
     Optional<u32> m_status_code;


### PR DESCRIPTION
This pull request partly implements the [HTML Specification's encoding sniffing algorithm](https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding). This allows LibWeb to now load some non-UTF-8 files even when there is no `Content-Type: text/html; charset=foo` HTTP header available (such as if a local file is loaded).

Now, this should work:
```sh
printf "\xA9" >> test.html # This is a windows-1252 copyright sign, which is invalid UTF-8.
br -s test.html
```

Whereas before, this happened:
```
ASSERTION FAILED: first_byte_makes_sense
../../AK/Utf8View.cpp:169
```

This change required some minor architectural changes, as the information that no encoding was specified in the `Content-Type` header has to be "transmitted" from `FrameLoader` to `Resource` to `Document` to `HTMLDocumentParser`, where this algorithm should reside (at least that's what I think). Most importantly, I modified the `Resource` and `Document` classes to use `Optional<String>` for their `m_encoding`.

With all of this, if no encoding is specified, we do no longer decide on using UTF-8 in `FrameLoader`, rather delaying this decision as long as possible. This allows the HTML encoding sniffing algorithm (as well as possible future algorithms for determining encodings of arbitrary non-HTML plain text documents) to determine whether the encoding is already known or if they need to get to work.

This pull request also includes three minor changes to some more generic APIs:
* `AK::StringBuilder::append_as_lowercase(char ch)` has been added.
* `TextCodec::get_standardized_encoding` now returns `Optional<String>`. If it cannot match the provided encoding to a standarized one, it will now return as an empty `Optional`. Before that, this function returned the empty string to indicate failure.
* `TextCodec::is_valid_utf8(const ByteBuffer& input)` has been added.

This pull request fixes #6910.

**Note**: I am not expecting a merge right away. This is my first large change here. I would especially like some feedback about my choice of putting the algorithm into it's own file, `HTMLEncodingDetection.cpp/h`. I am not sure if this is the right way to structure it.