### PR TITLE
LibCore+Everywhere: Move OpenMode and SeekMode out of IODevice

### DIFF
--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -217,7 +217,7 @@ void TestRunner::run()
 static Result<NonnullRefPtr<JS::Program>, ParserError> parse_file(const String& file_path)
 {
     auto file = Core::File::construct(file_path);
-    auto result = file->open(Core::IODevice::ReadOnly);
+    auto result = file->open(Core::OpenMode::ReadOnly);
     if (!result) {
         warnln("Failed to open the following file: \"{}\"", file_path);
         cleanup_and_exit();

--- a/Tests/LibWeb/test-web.cpp
+++ b/Tests/LibWeb/test-web.cpp
@@ -222,7 +222,7 @@ void TestRunner::run()
 static Result<NonnullRefPtr<JS::Program>, ParserError> parse_file(const String& file_path)
 {
     auto file = Core::File::construct(file_path);
-    auto result = file->open(Core::IODevice::ReadOnly);
+    auto result = file->open(Core::OpenMode::ReadOnly);
     if (!result) {
         printf("Failed to open the following file: \"%s\"\n", file_path.characters());
         cleanup_and_exit();

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -108,7 +108,7 @@ private:
         StringBuilder adapter_info;
 
         auto file = Core::File::construct("/proc/net/adapters");
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             fprintf(stderr, "Error: %s\n", file->error_string());
             return adapter_info.to_string();
         }

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -144,7 +144,7 @@ private:
     {
         if (m_proc_mem) {
             // Seeking to the beginning causes a data refresh!
-            if (!m_proc_mem->seek(0, Core::File::SeekMode::SetPosition))
+            if (!m_proc_mem->seek(0, Core::SeekMode::SetPosition))
                 return false;
         } else {
             auto proc_memstat = Core::File::construct("/proc/memstat");

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -148,7 +148,7 @@ private:
                 return false;
         } else {
             auto proc_memstat = Core::File::construct("/proc/memstat");
-            if (!proc_memstat->open(Core::IODevice::OpenMode::ReadOnly))
+            if (!proc_memstat->open(Core::OpenMode::ReadOnly))
                 return false;
             m_proc_mem = move(proc_memstat);
         }

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -43,7 +43,7 @@ DownloadWidget::DownloadWidget(const URL& url)
     };
 
     {
-        auto file_or_error = Core::File::open(m_destination_path, Core::IODevice::WriteOnly);
+        auto file_or_error = Core::File::open(m_destination_path, Core::OpenMode::WriteOnly);
         if (file_or_error.is_error()) {
             GUI::MessageBox::show(window(), String::formatted("Cannot open {} for writing", m_destination_path), "Download failed", GUI::MessageBox::Type::Error);
             window()->close();

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
     Browser::g_home_url = m_config->read_entry("Preferences", "Home", "about:blank");
     Browser::g_search_engine = m_config->read_entry("Preferences", "SearchEngine", {});
 
-    auto ad_filter_list_or_error = Core::File::open(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()), Core::IODevice::ReadOnly);
+    auto ad_filter_list_or_error = Core::File::open(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()), Core::OpenMode::ReadOnly);
     if (!ad_filter_list_or_error.is_error()) {
         auto& ad_filter_list = *ad_filter_list_or_error.value();
         while (!ad_filter_list.eof()) {

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -71,7 +71,7 @@ static void run_file_operation([[maybe_unused]] FileOperation operation, const S
     file_operation_windows.set(window);
 
     auto pipe_input_file = Core::File::construct();
-    pipe_input_file->open(pipe_fds[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
+    pipe_input_file->open(pipe_fds[0], Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
 
     window->set_title("Copying Files...");
     window->set_main_widget<FileOperationProgressWidget>(pipe_input_file);

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -242,7 +242,7 @@ void HexEditorWidget::update_title()
 void HexEditorWidget::open_file(const String& path)
 {
     auto file = Core::File::construct(path);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: {}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
         return;
     }

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -189,7 +189,7 @@ void KeyboardMapperWidget::save_to_file(const StringView& filename)
     String file_content = map_json.to_string();
 
     auto file = Core::File::construct(filename);
-    file->open(Core::IODevice::WriteOnly);
+    file->open(Core::OpenMode::WriteOnly);
     if (!file->is_open()) {
         StringBuilder sb;
         sb.append("Failed to open ");

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
     auto app_icon = GUI::Icon::default_icon("app-keyboard-settings");
 
     auto proc_keymap = Core::File::construct("/proc/keymap");
-    if (!proc_keymap->open(Core::IODevice::OpenMode::ReadOnly))
+    if (!proc_keymap->open(Core::OpenMode::ReadOnly))
         VERIFY_NOT_REACHED();
 
     auto json = JsonValue::from_string(proc_keymap->read_all());

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
 
     auto audio_thread = LibThread::Thread::construct([&] {
         auto audio = Core::File::construct("/dev/audio");
-        if (!audio->open(Core::IODevice::WriteOnly)) {
+        if (!audio->open(Core::OpenMode::WriteOnly)) {
             dbgln("Can't open audio device: {}", audio->error_string());
             return 1;
         }

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -171,7 +171,7 @@ String RunWindow::history_file_path()
 void RunWindow::load_history()
 {
     m_path_history.clear();
-    auto file_or_error = Core::File::open(history_file_path(), Core::IODevice::ReadOnly);
+    auto file_or_error = Core::File::open(history_file_path(), Core::OpenMode::ReadOnly);
     if (file_or_error.is_error())
         return;
 
@@ -185,7 +185,7 @@ void RunWindow::load_history()
 
 void RunWindow::save_history()
 {
-    auto file_or_error = Core::File::open(history_file_path(), Core::IODevice::WriteOnly);
+    auto file_or_error = Core::File::open(history_file_path(), Core::OpenMode::WriteOnly);
     if (file_or_error.is_error())
         return;
 

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -74,7 +74,7 @@ static void fill_mounts(Vector<MountInfo>& output)
 {
     // Output info about currently mounted filesystems.
     auto df = Core::File::construct("/proc/df");
-    if (!df->open(Core::IODevice::ReadOnly)) {
+    if (!df->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Failed to open /proc/df: %s\n", df->error_string());
         return;
     }

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -198,7 +198,7 @@ void CSVExportDialogPage::update_preview()
 
     auto file_or_error = Core::File::open(
         m_temp_output_file_path,
-        Core::IODevice::ReadOnly);
+        Core::OpenMode::ReadOnly);
     if (file_or_error.is_error())
         goto fail;
 

--- a/Userland/Applications/Spreadsheet/Readers/Test/TestXSV.cpp
+++ b/Userland/Applications/Spreadsheet/Readers/Test/TestXSV.cpp
@@ -77,7 +77,7 @@ TEST_CASE(should_iterate_rows)
 
 BENCHMARK_CASE(fairly_big_data)
 {
-    auto file_or_error = Core::File::open(__FILE__ ".data", Core::IODevice::OpenMode::ReadOnly);
+    auto file_or_error = Core::File::open(__FILE__ ".data", Core::OpenMode::ReadOnly);
     EXPECT_EQ_FORCE(file_or_error.is_error(), false);
 
     auto data = file_or_error.value()->read_all();

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -46,7 +46,7 @@ Sheet::Sheet(Workbook& workbook)
     global_object().put("thisSheet", &global_object()); // Self-reference is unfortunate, but required.
 
     // Sadly, these have to be evaluated once per sheet.
-    auto file_or_error = Core::File::open("/res/js/Spreadsheet/runtime.js", Core::IODevice::OpenMode::ReadOnly);
+    auto file_or_error = Core::File::open("/res/js/Spreadsheet/runtime.js", Core::OpenMode::ReadOnly);
     if (!file_or_error.is_error()) {
         auto buffer = file_or_error.value()->read_all();
         JS::Parser parser { JS::Lexer(buffer) };

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -52,7 +52,7 @@ bool Workbook::set_filename(const String& filename)
 
 Result<bool, String> Workbook::load(const StringView& filename)
 {
-    auto file_or_error = Core::File::open(filename, Core::IODevice::OpenMode::ReadOnly);
+    auto file_or_error = Core::File::open(filename, Core::OpenMode::ReadOnly);
     if (file_or_error.is_error()) {
         StringBuilder sb;
         sb.append("Failed to open ");
@@ -81,7 +81,7 @@ Result<bool, String> Workbook::save(const StringView& filename)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
     auto file = Core::File::construct(filename);
-    file->open(Core::IODevice::WriteOnly);
+    file->open(Core::OpenMode::WriteOnly);
     if (!file->is_open()) {
         StringBuilder sb;
         sb.append("Failed to open ");

--- a/Userland/Applications/SystemMonitor/DevicesModel.cpp
+++ b/Userland/Applications/SystemMonitor/DevicesModel.cpp
@@ -122,7 +122,7 @@ GUI::Variant DevicesModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
 void DevicesModel::update()
 {
     auto proc_devices = Core::File::construct("/proc/devices");
-    if (!proc_devices->open(Core::IODevice::OpenMode::ReadOnly))
+    if (!proc_devices->open(Core::OpenMode::ReadOnly))
         VERIFY_NOT_REACHED();
 
     auto json = JsonValue::from_string(proc_devices->read_all());

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -77,7 +77,7 @@ static inline size_t bytes_to_kb(size_t bytes)
 void MemoryStatsWidget::refresh()
 {
     auto proc_memstat = Core::File::construct("/proc/memstat");
-    if (!proc_memstat->open(Core::IODevice::OpenMode::ReadOnly))
+    if (!proc_memstat->open(Core::OpenMode::ReadOnly))
         VERIFY_NOT_REACHED();
 
     auto file_contents = proc_memstat->read_all();

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -25,7 +25,7 @@ ProcessModel::ProcessModel()
     s_the = this;
 
     auto file = Core::File::construct("/proc/cpuinfo");
-    if (file->open(Core::IODevice::ReadOnly)) {
+    if (file->open(Core::OpenMode::ReadOnly)) {
         auto json = JsonValue::from_string({ file->read_all() });
         auto cpuinfo_array = json.value().as_array();
         cpuinfo_array.for_each([&](auto& value) {

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -631,7 +631,7 @@ void MainWidget::update_title()
 bool MainWidget::open_file(const String& path)
 {
     auto file = Core::File::construct(path);
-    if (!file->open(Core::IODevice::ReadOnly) && file->error() != ENOENT) {
+    if (!file->open(Core::OpenMode::ReadOnly) && file->error() != ENOENT) {
         GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: {}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
         return false;
     }

--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -86,7 +86,7 @@ WelcomeWidget::~WelcomeWidget()
 void WelcomeWidget::open_and_parse_tips_file()
 {
     auto file = Core::File::construct("/home/anon/Documents/tips.txt");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         m_tip_label->set_text("~/Documents/tips.txt has gone missing!");
         return;
     }
@@ -108,7 +108,7 @@ void WelcomeWidget::open_and_parse_tips_file()
 void WelcomeWidget::open_and_parse_readme_file()
 {
     auto file = Core::File::construct("/home/anon/README.md");
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return;
 
     auto document = Markdown::Document::parse(file->read_all());

--- a/Userland/Demos/GLTeapot/WavefrontOBJLoader.cpp
+++ b/Userland/Demos/GLTeapot/WavefrontOBJLoader.cpp
@@ -11,7 +11,7 @@
 
 RefPtr<Mesh> WavefrontOBJLoader::load(const String& fname)
 {
-    auto obj_file_or_error = Core::File::open(fname, Core::IODevice::OpenMode::ReadOnly);
+    auto obj_file_or_error = Core::File::open(fname, Core::OpenMode::ReadOnly);
     Vector<Vertex> vertices;
     Vector<Triangle> triangles;
 

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -170,7 +170,7 @@ void Editor::show_documentation_tooltip_if_available(const String& hovered_token
 
     dbgln_if(EDITOR_DEBUG, "opening {}", it->value);
     auto file = Core::File::construct(it->value);
-    if (!file->open(Core::File::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("failed to open {}, {}", it->value, file->error_string());
         return;
     }

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -149,7 +149,7 @@ void GitWidget::show_diff(const LexicalPath& file_path)
 {
     if (!m_git_repo->is_tracked(file_path)) {
         auto file = Core::File::construct(file_path.string());
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             perror("open");
             VERIFY_NOT_REACHED();
         }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -340,7 +340,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_file_action()
         filepath = String::formatted("{}{}", filepath, filename);
 
         auto file = Core::File::construct(filepath);
-        if (!file->open((Core::IODevice::OpenMode)(Core::IODevice::WriteOnly | Core::IODevice::MustBeNew))) {
+        if (!file->open((Core::OpenMode)(Core::OpenMode::WriteOnly | Core::OpenMode::MustBeNew))) {
             GUI::MessageBox::show(window(), String::formatted("Failed to create '{}'", filepath), "Error", GUI::MessageBox::Type::Error);
             return;
         }

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -73,7 +73,7 @@ String FileDB::to_absolute_path(const String& filename) const
 
 RefPtr<GUI::TextDocument> FileDB::create_from_filesystem(const String& filename) const
 {
-    auto file = Core::File::open(to_absolute_path(filename), Core::IODevice::ReadOnly);
+    auto file = Core::File::open(to_absolute_path(filename), Core::OpenMode::ReadOnly);
     if (file.is_error()) {
         dbgln("failed to create document for {} from filesystem", filename);
         return nullptr;
@@ -84,7 +84,7 @@ RefPtr<GUI::TextDocument> FileDB::create_from_filesystem(const String& filename)
 RefPtr<GUI::TextDocument> FileDB::create_from_fd(int fd) const
 {
     auto file = Core::File::construct();
-    if (!file->open(fd, Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes)) {
+    if (!file->open(fd, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes)) {
         errno = file->error();
         perror("open");
         dbgln("Failed to open project file");

--- a/Userland/DevTools/HackStudio/ProjectFile.cpp
+++ b/Userland/DevTools/HackStudio/ProjectFile.cpp
@@ -55,7 +55,7 @@ void ProjectFile::create_document_if_needed() const
         return;
 
     m_document = CodeDocument::create(m_name);
-    auto file_or_error = Core::File::open(m_name, Core::File::ReadOnly);
+    auto file_or_error = Core::File::open(m_name, Core::OpenMode::ReadOnly);
     if (file_or_error.is_error()) {
         warnln("Couldn't open '{}': {}", m_name, file_or_error.error());
         // This is okay though, we'll just go with an empty document and create the file when saving.

--- a/Userland/DevTools/IPCCompiler/main.cpp
+++ b/Userland/DevTools/IPCCompiler/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
     }
 
     auto file = Core::File::construct(argv[1]);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         warnln("Error: Cannot open {}: {}", argv[1], file->error_string());
         return 1;
     }

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
         editor.set_cursor(4, 28); // after "...widgets!"
     } else {
         auto file = Core::File::construct(path);
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             GUI::MessageBox::show(window, String::formatted("Opening \"{}\" failed: {}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
             return 1;
         }
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
             return;
 
         auto file = Core::File::construct(open_path.value());
-        if (!file->open(Core::IODevice::ReadOnly) && file->error() != ENOENT) {
+        if (!file->open(Core::OpenMode::ReadOnly) && file->error() != ENOENT) {
             GUI::MessageBox::show(window, String::formatted("Opening \"{}\" failed: {}", open_path.value(), strerror(errno)), "Error", GUI::MessageBox::Type::Error);
             return;
         }

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -192,7 +192,7 @@ void Profile::rebuild_tree()
 Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const StringView& path)
 {
     auto file = Core::File::construct(path);
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return String::formatted("Unable to open {}, error: {}", path, file->error_string());
 
     auto json = JsonValue::from_string(file->read_all());

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -483,7 +483,7 @@ String ChessWidget::get_fen() const
 
 bool ChessWidget::import_pgn(const StringView& import_path)
 {
-    auto file_or_error = Core::File::open(import_path, Core::File::OpenMode::ReadOnly);
+    auto file_or_error = Core::File::open(import_path, Core::OpenMode::ReadOnly);
     if (file_or_error.is_error()) {
         warnln("Couldn't open '{}': {}", import_path, file_or_error.error());
         return false;
@@ -588,7 +588,7 @@ bool ChessWidget::import_pgn(const StringView& import_path)
 
 bool ChessWidget::export_pgn(const StringView& export_path) const
 {
-    auto file_or_error = Core::File::open(export_path, Core::File::WriteOnly);
+    auto file_or_error = Core::File::open(export_path, Core::OpenMode::WriteOnly);
     if (file_or_error.is_error()) {
         warnln("Couldn't open '{}': {}", export_path, file_or_error.error());
         return false;

--- a/Userland/Games/Chess/Engine.cpp
+++ b/Userland/Games/Chess/Engine.cpp
@@ -49,11 +49,11 @@ Engine::Engine(const StringView& command)
     close(rpipefds[1]);
 
     auto infile = Core::File::construct();
-    infile->open(rpipefds[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
+    infile->open(rpipefds[0], Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
     set_in(infile);
 
     auto outfile = Core::File::construct();
-    outfile->open(wpipefds[1], Core::IODevice::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
+    outfile->open(wpipefds[1], Core::OpenMode::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
     set_out(outfile);
 
     send_command(Chess::UCI::UCICommand());

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -20,7 +20,7 @@ static constexpr size_t maximum_wav_size = 1 * GiB; // FIXME: is there a more ap
 WavLoaderPlugin::WavLoaderPlugin(const StringView& path)
     : m_file(Core::File::construct(path))
 {
-    if (!m_file->open(Core::IODevice::ReadOnly)) {
+    if (!m_file->open(Core::OpenMode::ReadOnly)) {
         m_error_string = String::formatted("Can't open file: {}", m_file->error_string());
         return;
     }

--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -32,7 +32,7 @@ WavWriter::~WavWriter()
 void WavWriter::set_file(const StringView& path)
 {
     m_file = Core::File::construct(path);
-    if (!m_file->open(Core::IODevice::ReadWrite)) {
+    if (!m_file->open(Core::OpenMode::ReadWrite)) {
         m_error_string = String::formatted("Can't open file: {}", m_file->error_string());
         return;
     }

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -80,7 +80,7 @@ String command(const String& program, const Vector<String>& arguments, Optional<
 
     auto read_all_from_pipe = [](int pipe[2]) {
         auto result_file = Core::File::construct();
-        if (!result_file->open(pipe[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes)) {
+        if (!result_file->open(pipe[0], Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes)) {
             perror("open");
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -57,7 +57,7 @@ void ConfigFile::reparse()
     m_groups.clear();
 
     auto file = File::construct(m_filename);
-    if (!file->open(IODevice::OpenMode::ReadOnly))
+    if (!file->open(OpenMode::ReadOnly))
         return;
 
     HashMap<String, String>* current_group = nullptr;

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -19,7 +19,7 @@ class File final : public IODevice {
 public:
     virtual ~File() override;
 
-    static Result<NonnullRefPtr<File>, String> open(String filename, IODevice::OpenMode, mode_t = 0644);
+    static Result<NonnullRefPtr<File>, String> open(String filename, OpenMode, mode_t = 0644);
 
     String filename() const { return m_filename; }
     void set_filename(const String filename) { m_filename = move(filename); }
@@ -67,13 +67,13 @@ public:
     };
     static Result<void, RemoveError> remove(const String& path, RecursionMode, bool force);
 
-    virtual bool open(IODevice::OpenMode) override;
+    virtual bool open(OpenMode) override;
 
     enum class ShouldCloseFileDescriptor {
         No = 0,
         Yes
     };
-    bool open(int fd, IODevice::OpenMode, ShouldCloseFileDescriptor);
+    bool open(int fd, OpenMode, ShouldCloseFileDescriptor);
 
     static NonnullRefPtr<File> standard_input();
     static NonnullRefPtr<File> standard_output();
@@ -86,7 +86,7 @@ private:
     }
     explicit File(String filename, Object* parent = nullptr);
 
-    bool open_impl(IODevice::OpenMode, mode_t);
+    bool open_impl(OpenMode, mode_t);
 
     String m_filename;
     ShouldCloseFileDescriptor m_should_close_file_descriptor { ShouldCloseFileDescriptor::Yes };

--- a/Userland/Libraries/LibCore/FileStream.h
+++ b/Userland/Libraries/LibCore/FileStream.h
@@ -63,7 +63,7 @@ public:
         return true;
     }
 
-    bool discard_or_error(size_t count) override { return m_file->seek(count, IODevice::SeekMode::FromCurrentPosition); }
+    bool discard_or_error(size_t count) override { return m_file->seek(count, SeekMode::FromCurrentPosition); }
 
     bool unreliable_eof() const override { return m_file->eof(); }
 

--- a/Userland/Libraries/LibCore/FileStream.h
+++ b/Userland/Libraries/LibCore/FileStream.h
@@ -20,9 +20,9 @@ public:
     {
     }
 
-    static Result<InputFileStream, String> open(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::ReadOnly, mode_t permissions = 0644)
+    static Result<InputFileStream, String> open(StringView filename, OpenMode mode = OpenMode::ReadOnly, mode_t permissions = 0644)
     {
-        VERIFY((mode & 0xf) == IODevice::OpenMode::ReadOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+        VERIFY(has_flag(mode, OpenMode::ReadOnly));
 
         auto file_result = File::open(filename, mode, permissions);
 
@@ -32,9 +32,9 @@ public:
         return InputFileStream { file_result.value() };
     }
 
-    static Result<Buffered<InputFileStream>, String> open_buffered(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::ReadOnly, mode_t permissions = 0644)
+    static Result<Buffered<InputFileStream>, String> open_buffered(StringView filename, OpenMode mode = OpenMode::ReadOnly, mode_t permissions = 0644)
     {
-        VERIFY((mode & 0xf) == IODevice::OpenMode::ReadOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+        VERIFY(has_flag(mode, OpenMode::ReadOnly));
 
         auto file_result = File::open(filename, mode, permissions);
 
@@ -84,9 +84,9 @@ public:
     {
     }
 
-    static Result<OutputFileStream, String> open(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::WriteOnly, mode_t permissions = 0644)
+    static Result<OutputFileStream, String> open(StringView filename, OpenMode mode = OpenMode::WriteOnly, mode_t permissions = 0644)
     {
-        VERIFY((mode & 0xf) == IODevice::OpenMode::WriteOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+        VERIFY(has_flag(mode, OpenMode::WriteOnly));
 
         auto file_result = File::open(filename, mode, permissions);
 
@@ -96,9 +96,9 @@ public:
         return OutputFileStream { file_result.value() };
     }
 
-    static Result<Buffered<OutputFileStream>, String> open_buffered(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::WriteOnly, mode_t permissions = 0644)
+    static Result<Buffered<OutputFileStream>, String> open_buffered(StringView filename, OpenMode mode = OpenMode::WriteOnly, mode_t permissions = 0644)
     {
-        VERIFY((mode & 0xf) == IODevice::OpenMode::WriteOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+        VERIFY(has_flag(mode, OpenMode::WriteOnly));
 
         auto file_result = File::open(filename, mode, permissions);
 

--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -209,7 +209,7 @@ bool IODevice::populate_read_buffer() const
 
 bool IODevice::close()
 {
-    if (fd() < 0 || mode() == NotOpen)
+    if (fd() < 0 || m_mode == OpenMode::NotOpen)
         return false;
     int rc = ::close(fd());
     if (rc < 0) {
@@ -217,7 +217,7 @@ bool IODevice::close()
         return false;
     }
     set_fd(-1);
-    set_mode(IODevice::NotOpen);
+    set_mode(OpenMode::NotOpen);
     return true;
 }
 

--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -44,6 +44,12 @@ enum class OpenMode : unsigned {
     MustBeNew = 16,
 };
 
+enum class SeekMode {
+    SetPosition,
+    FromCurrentPosition,
+    FromEndPosition,
+};
+
 AK_ENUM_BITWISE_OPERATORS(OpenMode)
 
 class IODevice : public Object {
@@ -75,12 +81,6 @@ public:
     bool can_read_line() const;
 
     bool can_read() const;
-
-    enum class SeekMode {
-        SetPosition,
-        FromCurrentPosition,
-        FromEndPosition,
-    };
 
     bool seek(i64, SeekMode = SeekMode::SetPosition, off_t* = nullptr);
 

--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/Forward.h>
 #include <LibCore/Object.h>
 
@@ -33,24 +34,26 @@ private:
     String m_buffer;
 };
 
+enum class OpenMode : unsigned {
+    NotOpen = 0,
+    ReadOnly = 1,
+    WriteOnly = 2,
+    ReadWrite = 3,
+    Append = 4,
+    Truncate = 8,
+    MustBeNew = 16,
+};
+
+AK_ENUM_BITWISE_OPERATORS(OpenMode)
+
 class IODevice : public Object {
     C_OBJECT_ABSTRACT(IODevice)
 public:
-    enum OpenMode {
-        NotOpen = 0,
-        ReadOnly = 1,
-        WriteOnly = 2,
-        ReadWrite = 3,
-        Append = 4,
-        Truncate = 8,
-        MustBeNew = 16,
-    };
-
     virtual ~IODevice() override;
 
     int fd() const { return m_fd; }
-    unsigned mode() const { return m_mode; }
-    bool is_open() const { return m_mode != NotOpen; }
+    OpenMode mode() const { return m_mode; }
+    bool is_open() const { return m_mode != OpenMode::NotOpen; }
     bool eof() const { return m_eof; }
 
     int error() const { return m_error; }
@@ -81,7 +84,7 @@ public:
 
     bool seek(i64, SeekMode = SeekMode::SetPosition, off_t* = nullptr);
 
-    virtual bool open(IODevice::OpenMode) = 0;
+    virtual bool open(OpenMode) = 0;
     virtual bool close();
 
     LineIterator line_begin() & { return LineIterator(*this); }
@@ -102,7 +105,7 @@ private:
     bool can_read_from_fd() const;
 
     int m_fd { -1 };
-    OpenMode m_mode { NotOpen };
+    OpenMode m_mode { OpenMode::NotOpen };
     mutable int m_error { 0 };
     mutable bool m_eof { false };
     mutable Vector<u8> m_buffered_data;

--- a/Userland/Libraries/LibCore/LocalSocket.cpp
+++ b/Userland/Libraries/LibCore/LocalSocket.cpp
@@ -24,7 +24,7 @@ LocalSocket::LocalSocket(int fd, Object* parent)
     // NOTE: This constructor is used by LocalServer::accept(), so the socket is already connected.
     m_connected = true;
     set_fd(fd);
-    set_mode(IODevice::ReadWrite);
+    set_mode(OpenMode::ReadWrite);
     set_error(0);
 }
 
@@ -44,7 +44,7 @@ LocalSocket::LocalSocket(Object* parent)
         set_error(errno);
     } else {
         set_fd(fd);
-        set_mode(IODevice::ReadWrite);
+        set_mode(OpenMode::ReadWrite);
         set_error(0);
     }
 }

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -26,7 +26,7 @@ Optional<HashMap<pid_t, Core::ProcessStatistics>> ProcessStatisticsReader::get_a
         }
     } else {
         proc_all_file = Core::File::construct("/proc/all");
-        if (!proc_all_file->open(Core::IODevice::ReadOnly)) {
+        if (!proc_all_file->open(Core::OpenMode::ReadOnly)) {
             fprintf(stderr, "ProcessStatisticsReader: Failed to open /proc/all: %s\n", proc_all_file->error_string());
             return {};
         }

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -20,7 +20,7 @@ HashMap<uid_t, String> ProcessStatisticsReader::s_usernames;
 Optional<HashMap<pid_t, Core::ProcessStatistics>> ProcessStatisticsReader::get_all(RefPtr<Core::File>& proc_all_file)
 {
     if (proc_all_file) {
-        if (!proc_all_file->seek(0, Core::File::SeekMode::SetPosition)) {
+        if (!proc_all_file->seek(0, Core::SeekMode::SetPosition)) {
             fprintf(stderr, "ProcessStatisticsReader: Failed to refresh /proc/all: %s\n", proc_all_file->error_string());
             return {};
         }

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -58,7 +58,7 @@ protected:
     virtual bool common_connect(const struct sockaddr*, socklen_t);
 
 private:
-    virtual bool open(IODevice::OpenMode) override { VERIFY_NOT_REACHED(); }
+    virtual bool open(OpenMode) override { VERIFY_NOT_REACHED(); }
     void ensure_read_notifier();
 
     Type m_type { Type::Invalid };

--- a/Userland/Libraries/LibCore/TCPSocket.cpp
+++ b/Userland/Libraries/LibCore/TCPSocket.cpp
@@ -20,7 +20,7 @@ TCPSocket::TCPSocket(int fd, Object* parent)
     // NOTE: This constructor is used by TCPServer::accept(), so the socket is already connected.
     m_connected = true;
     set_fd(fd);
-    set_mode(IODevice::ReadWrite);
+    set_mode(OpenMode::ReadWrite);
     set_error(0);
 }
 
@@ -38,7 +38,7 @@ TCPSocket::TCPSocket(Object* parent)
         set_error(errno);
     } else {
         set_fd(fd);
-        set_mode(IODevice::ReadWrite);
+        set_mode(OpenMode::ReadWrite);
         set_error(0);
     }
 }

--- a/Userland/Libraries/LibCore/UDPSocket.cpp
+++ b/Userland/Libraries/LibCore/UDPSocket.cpp
@@ -29,7 +29,7 @@ UDPSocket::UDPSocket(Object* parent)
         set_error(errno);
     } else {
         set_fd(fd);
-        set_mode(IODevice::ReadWrite);
+        set_mode(OpenMode::ReadWrite);
         set_error(0);
     }
 }

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -392,7 +392,7 @@ Optional<DebugSession::InsertBreakpointAtSourcePositionResult> DebugSession::ins
 void DebugSession::update_loaded_libs()
 {
     auto file = Core::File::construct(String::formatted("/proc/{}/vm", m_debuggee_pid));
-    bool rc = file->open(Core::IODevice::ReadOnly);
+    bool rc = file->open(Core::OpenMode::ReadOnly);
     VERIFY(rc);
 
     auto file_contents = file->read_all();

--- a/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
+++ b/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
@@ -41,7 +41,7 @@ static void initialize_if_needed()
 void CommonLocationsProvider::load_from_json(const String& json_path)
 {
     auto file = Core::File::construct(json_path);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("Unable to open {}", file->filename());
         return;
     }

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -13,7 +13,7 @@ namespace GUI {
 void JsonArrayModel::update()
 {
     auto file = Core::File::construct(m_json_path);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("Unable to open {}", file->filename());
         m_array.clear();
         did_update();
@@ -32,7 +32,7 @@ void JsonArrayModel::update()
 bool JsonArrayModel::store()
 {
     auto file = Core::File::construct(m_json_path);
-    if (!file->open(Core::IODevice::WriteOnly)) {
+    if (!file->open(Core::OpenMode::WriteOnly)) {
         dbgln("Unable to open {}", file->filename());
         return false;
     }

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -23,7 +23,7 @@ Optional<CharacterMapData> CharacterMapFile::load_from_file(const String& filena
     }
 
     auto file = Core::File::construct(path);
-    file->open(Core::IODevice::ReadOnly);
+    file->open(Core::OpenMode::ReadOnly);
     if (!file->is_open()) {
         dbgln("Failed to open {}: {}", filename, file->error_string());
         return {};

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -220,7 +220,7 @@ void Editor::add_to_history(const String& line)
 bool Editor::load_history(const String& path)
 {
     auto history_file = Core::File::construct(path);
-    if (!history_file->open(Core::IODevice::ReadOnly))
+    if (!history_file->open(Core::OpenMode::ReadOnly))
         return false;
     auto data = history_file->read_all();
     auto hist = StringView { data.data(), data.size() };
@@ -279,7 +279,7 @@ bool Editor::save_history(const String& path)
 {
     Vector<HistoryEntry> final_history { { "", 0 } };
     {
-        auto file_or_error = Core::File::open(path, Core::IODevice::ReadWrite, 0600);
+        auto file_or_error = Core::File::open(path, Core::OpenMode::ReadWrite, 0600);
         if (file_or_error.is_error())
             return false;
         auto file = file_or_error.release_value();
@@ -294,7 +294,7 @@ bool Editor::save_history(const String& path)
             [](const HistoryEntry& left, const HistoryEntry& right) { return left.timestamp < right.timestamp; });
     }
 
-    auto file_or_error = Core::File::open(path, Core::IODevice::WriteOnly, 0600);
+    auto file_or_error = Core::File::open(path, Core::OpenMode::WriteOnly, 0600);
     if (file_or_error.is_error())
         return false;
     auto file = file_or_error.release_value();

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -569,7 +569,7 @@ void Editor::edit_in_external_editor()
     }
 
     {
-        auto file_or_error = Core::File::open(file_path, Core::IODevice::OpenMode::ReadOnly);
+        auto file_or_error = Core::File::open(file_path, Core::OpenMode::ReadOnly);
         if (file_or_error.is_error())
             return;
 

--- a/Userland/Libraries/LibSymbolClient/Client.cpp
+++ b/Userland/Libraries/LibSymbolClient/Client.cpp
@@ -63,7 +63,7 @@ Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid)
     {
 
         auto stack_path = String::formatted("/proc/{}/stacks/{}", pid, tid);
-        auto file_or_error = Core::File::open(stack_path, Core::IODevice::ReadOnly);
+        auto file_or_error = Core::File::open(stack_path, Core::OpenMode::ReadOnly);
         if (file_or_error.is_error()) {
             warnln("Could not open {}: {}", stack_path, file_or_error.error());
             return {};
@@ -83,7 +83,7 @@ Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid)
 
     {
         auto vm_path = String::formatted("/proc/{}/vm", pid);
-        auto file_or_error = Core::File::open(vm_path, Core::IODevice::ReadOnly);
+        auto file_or_error = Core::File::open(vm_path, Core::OpenMode::ReadOnly);
         if (file_or_error.is_error()) {
             warnln("Could not open {}: {}", vm_path, file_or_error.error());
             return {};

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -867,7 +867,7 @@ TLSv12::TLSv12(Core::Object* parent, Options options)
         set_error(errno);
     } else {
         set_fd(fd);
-        set_mode(IODevice::ReadWrite);
+        set_mode(Core::OpenMode::ReadWrite);
         set_error(0);
     }
 }

--- a/Userland/Libraries/LibTTF/Font.cpp
+++ b/Userland/Libraries/LibTTF/Font.cpp
@@ -207,13 +207,13 @@ GlyphHorizontalMetrics Hmtx::get_glyph_horizontal_metrics(u32 glyph_id) const
 
 RefPtr<Font> Font::load_from_file(String path, unsigned index)
 {
-    auto file_or_error = Core::File::open(move(path), Core::IODevice::ReadOnly);
+    auto file_or_error = Core::File::open(move(path), Core::OpenMode::ReadOnly);
     if (file_or_error.is_error()) {
         dbgln("Could not open file: {}", file_or_error.error());
         return nullptr;
     }
     auto file = file_or_error.value();
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("Could not open file");
         return nullptr;
     }

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
         return 1;
     }
     auto file = Core::File::construct(argv[1]);
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return 1;
 
     auto json = JsonValue::from_string(file->read_all());

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
         return 1;
     }
     auto file = Core::File::construct(argv[1]);
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return 1;
 
     auto json = JsonValue::from_string(file->read_all());

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_cpp.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_cpp.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
         return 1;
     }
     auto file = Core::File::construct(argv[1]);
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return 1;
 
     auto json = JsonValue::from_string(file->read_all());

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_h.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
         return 1;
     }
     auto file = Core::File::construct(argv[1]);
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return 1;
 
     auto json = JsonValue::from_string(file->read_all());

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -394,7 +394,7 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(path, "IDL file", "idl-file");
     args_parser.parse(argc, argv);
 
-    auto file_or_error = Core::File::open(path, Core::IODevice::ReadOnly);
+    auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
     if (file_or_error.is_error()) {
         fprintf(stderr, "Cannot open %s\n", path);
         return 1;

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -133,7 +133,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
     if (url.protocol() == "file") {
         auto f = Core::File::construct();
         f->set_filename(url.path());
-        if (!f->open(Core::IODevice::OpenMode::ReadOnly)) {
+        if (!f->open(Core::OpenMode::ReadOnly)) {
             dbgln("ResourceLoader::load: Error: {}", f->error_string());
             if (error_callback)
                 error_callback(f->error_string(), {});

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -23,7 +23,7 @@ Mixer::Mixer()
           },
           "AudioServer[mixer]"))
 {
-    if (!m_device->open(Core::IODevice::WriteOnly)) {
+    if (!m_device->open(Core::OpenMode::WriteOnly)) {
         dbgln("Can't open audio device: {}", m_device->error_string());
         return;
     }

--- a/Userland/Services/CrashDaemon/main.cpp
+++ b/Userland/Services/CrashDaemon/main.cpp
@@ -46,7 +46,7 @@ static bool compress_coredump(const String& coredump_path)
         return false;
     }
     auto output_path = String::formatted("{}.gz", coredump_path);
-    auto output_file_or_error = Core::File::open(output_path, Core::File::WriteOnly);
+    auto output_file_or_error = Core::File::open(output_path, Core::OpenMode::WriteOnly);
     if (output_file_or_error.is_error()) {
         dbgln("Could not open '{}' for writing: {}", output_path, output_file_or_error.error());
         return false;

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -169,7 +169,7 @@ void DHCPv4Client::try_discover_deferred_ifs()
 Result<DHCPv4Client::Interfaces, String> DHCPv4Client::get_discoverable_interfaces()
 {
     auto file = Core::File::construct("/proc/net/adapters");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("Error: Failed to open /proc/net/adapters: {}", file->error_string());
         return String { file->error_string() };
     }

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -127,12 +127,12 @@ int perform_copy(const String& source, const String& destination)
             continue;
         }
         VERIFY(item.type == WorkItem::Type::CopyFile);
-        auto source_file_or_error = Core::File::open(item.source, Core::File::ReadOnly);
+        auto source_file_or_error = Core::File::open(item.source, Core::OpenMode::ReadOnly);
         if (source_file_or_error.is_error()) {
             report_warning(String::formatted("Failed to open {} for reading: {}", item.source, source_file_or_error.error()));
             return 1;
         }
-        auto destination_file_or_error = Core::File::open(item.destination, (Core::IODevice::OpenMode)(Core::File::WriteOnly | Core::File::Truncate));
+        auto destination_file_or_error = Core::File::open(item.destination, (Core::OpenMode)(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate));
         if (destination_file_or_error.is_error()) {
             report_warning(String::formatted("Failed to open {} for write: {}", item.destination, destination_file_or_error.error()));
             return 1;

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -79,7 +79,7 @@ void LookupServer::load_etc_hosts()
     };
 
     auto file = Core::File::construct("/etc/hosts");
-    if (!file->open(Core::IODevice::ReadOnly))
+    if (!file->open(Core::OpenMode::ReadOnly))
         return;
     while (!file->eof()) {
         auto line = file->read_line(1024);

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -114,7 +114,7 @@ ssize_t MulticastDNS::emit_packet(const DNSPacket& packet, const sockaddr_in* de
 Vector<IPv4Address> MulticastDNS::local_addresses() const
 {
     auto file = Core::File::construct("/proc/net/adapters");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("Failed to open /proc/net/adapters: {}", file->error_string());
         return {};
     }

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -50,7 +50,7 @@ static void sigchld_handler(int)
 static void parse_boot_mode()
 {
     auto f = Core::File::construct("/proc/cmdline");
-    if (!f->open(Core::IODevice::ReadOnly)) {
+    if (!f->open(Core::OpenMode::ReadOnly)) {
         dbgln("Failed to read command line: {}", f->error_string());
         return;
     }

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -103,7 +103,7 @@ void Client::handle_request(ReadonlyBytes raw_request)
     }
 
     auto file = Core::File::construct(real_path);
-    if (!file->open(Core::File::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         send_error_response(404, "Not found!", request);
         return;
     }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -879,7 +879,7 @@ void Shell::execute_process(Vector<const char*>&& argv)
         }
         if (saved_errno == ENOENT) {
             do {
-                auto file_result = Core::File::open(argv[0], Core::IODevice::OpenMode::ReadOnly);
+                auto file_result = Core::File::open(argv[0], Core::OpenMode::ReadOnly);
                 if (file_result.is_error())
                     break;
                 auto& file = file_result.value();
@@ -1012,7 +1012,7 @@ bool Shell::run_file(const String& filename, bool explicitly_invoked)
     TemporaryChange interactive_change { m_is_interactive, false };
     TemporaryChange<Optional<SourcePosition>> source_change { m_source_position, SourcePosition { .source_file = filename, .literal_source_text = {}, .position = {} } };
 
-    auto file_result = Core::File::open(filename, Core::File::ReadOnly);
+    auto file_result = Core::File::open(filename, Core::OpenMode::ReadOnly);
     if (file_result.is_error()) {
         auto error = String::formatted("'{}': {}", escape_token_for_single_quotes(filename), file_result.error());
         if (explicitly_invoked)
@@ -1995,7 +1995,7 @@ void Shell::possibly_print_error() const
         i64 line_to_skip_to = max(source_position.position->start_line.line_number, 2ul) - 2;
 
         if (!source_position.source_file.is_null()) {
-            auto file = Core::File::open(source_position.source_file, Core::IODevice::OpenMode::ReadOnly);
+            auto file = Core::File::open(source_position.source_file, Core::OpenMode::ReadOnly);
             if (file.is_error()) {
                 warnln("Shell: Internal error while trying to display source information: {} (while reading '{}')", file.error(), source_position.source_file);
                 return;

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
     parser.parse(argc, argv);
 
     if (format) {
-        auto file = Core::File::open(format, Core::IODevice::ReadOnly);
+        auto file = Core::File::open(format, Core::OpenMode::ReadOnly);
         if (file.is_error()) {
             warnln("Error: {}", file.error());
             return 1;

--- a/Userland/Utilities/CppParserTest.cpp
+++ b/Userland/Utilities/CppParserTest.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     if (!path)
         path = "Source/little/main.cpp";
     auto file = Core::File::construct(path);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         perror("open");
         exit(1);
     }

--- a/Userland/Utilities/PreprocessorTest.cpp
+++ b/Userland/Utilities/PreprocessorTest.cpp
@@ -10,7 +10,7 @@
 int main(int, char**)
 {
     auto file = Core::File::construct("/home/anon/Source/little/other.h");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         perror("open");
         exit(1);
     }

--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -13,7 +13,7 @@
 int main()
 {
     auto file = Core::File::construct("/proc/net/arp");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Error: %s\n", file->error_string());
         return 1;
     }

--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -32,12 +32,12 @@ int main(int argc, char** argv)
         auto file = Core::File::construct();
         bool success = file->open(
             STDIN_FILENO,
-            Core::IODevice::OpenMode::ReadOnly,
+            Core::OpenMode::ReadOnly,
             Core::File::ShouldCloseFileDescriptor::Yes);
         VERIFY(success);
         buffer = file->read_all();
     } else {
-        auto result = Core::File::open(filepath, Core::IODevice::OpenMode::ReadOnly);
+        auto result = Core::File::open(filepath, Core::OpenMode::ReadOnly);
         VERIFY(!result.is_error());
         auto file = result.value();
         buffer = file->read_all();

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -54,10 +54,10 @@ int main(int argc, char** argv)
 
     for (auto const& path : paths) {
         if (path == "-") {
-            success = file->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
+            success = file->open(STDIN_FILENO, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
         } else {
             file->set_filename(path);
-            success = file->open(Core::IODevice::OpenMode::ReadOnly);
+            success = file->open(Core::OpenMode::ReadOnly);
         }
         if (!success) {
             warnln("{}: {}: {}", argv[0], path, file->error_string());

--- a/Userland/Utilities/cksum.cpp
+++ b/Userland/Utilities/cksum.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     bool fail = false;
     for (auto& path : paths) {
         auto file = Core::File::construct((StringView(path) == "-") ? "/dev/stdin" : path);
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             warnln("{}: {}: {}", argv[0], path, file->error_string());
             fail = true;
             continue;

--- a/Userland/Utilities/copy.cpp
+++ b/Userland/Utilities/copy.cpp
@@ -43,7 +43,7 @@ static Options parse_options(int argc, char* argv[])
         auto c_stdin = Core::File::construct();
         bool success = c_stdin->open(
             STDIN_FILENO,
-            Core::IODevice::OpenMode::ReadOnly,
+            Core::OpenMode::ReadOnly,
             Core::File::ShouldCloseFileDescriptor::No);
         VERIFY(success);
         auto buffer = c_stdin->read_all();

--- a/Userland/Utilities/df.cpp
+++ b/Userland/Utilities/df.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     auto file = Core::File::construct("/proc/df");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Failed to open /proc/df: %s\n", file->error_string());
         return 1;
     }

--- a/Userland/Utilities/dmesg.cpp
+++ b/Userland/Utilities/dmesg.cpp
@@ -26,7 +26,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     unveil(nullptr, nullptr);
 
     auto f = Core::File::construct("/proc/dmesg");
-    if (!f->open(Core::IODevice::ReadOnly)) {
+    if (!f->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "open: failed to open /proc/dmesg: %s\n", f->error_string());
         return 1;
     }

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -104,7 +104,7 @@ int parse_args(int argc, char** argv, Vector<String>& files, DuOption& du_option
         du_option.excluded_patterns.append(pattern);
     if (exclude_from) {
         auto file = Core::File::construct(exclude_from);
-        bool success = file->open(Core::IODevice::ReadOnly);
+        bool success = file->open(Core::OpenMode::ReadOnly);
         VERIFY(success);
         if (const auto buff = file->read_all()) {
             String patterns = String::copy(buff, Chomp);

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
 
     for (auto path : paths) {
         auto file = Core::File::construct(path);
-        if (!file->open(Core::File::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             perror(path);
             all_ok = false;
             continue;

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     auto file = Core::File::construct(path);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         warnln("Couldn't open {} for reading: {}", path, file->error_string());
         return 1;
     }

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -18,7 +18,7 @@ bool format_file(const StringView& path, bool inplace)
     if (read_from_stdin) {
         file = Core::File::standard_input();
     } else {
-        auto open_mode = inplace ? Core::File::ReadWrite : Core::File::ReadOnly;
+        auto open_mode = inplace ? Core::OpenMode::ReadWrite : Core::OpenMode::ReadOnly;
         auto file_or_error = Core::File::open(path, open_mode);
         if (file_or_error.is_error()) {
             warnln("Could not open {}: {}", path, file_or_error.error());

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
 
     auto handle_file = [&matches, binary_mode](StringView filename, bool print_filename) -> bool {
         auto file = Core::File::construct(filename);
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             warnln("Failed to open {}: {}", filename, file->error_string());
             return false;
         }

--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
         return 0;
     }
     auto file = Core::File::construct(argv[1]);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Couldn't open %s for reading: %s\n", argv[1], file->error_string());
         return 1;
     }

--- a/Userland/Utilities/hexdump.cpp
+++ b/Userland/Utilities/hexdump.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     if (!path) {
         file = Core::File::standard_input();
     } else {
-        auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
+        auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
         if (file_or_error.is_error()) {
             warnln("Failed to open {}: {}", path, file_or_error.error());
             return 1;

--- a/Userland/Utilities/ifconfig.cpp
+++ b/Userland/Utilities/ifconfig.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
     if (!value_ipv4 && !value_adapter && !value_gateway && !value_mask) {
 
         auto file = Core::File::construct("/proc/net/adapters");
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             fprintf(stderr, "Error: %s\n", file->error_string());
             return 1;
         }

--- a/Userland/Utilities/jp.cpp
+++ b/Userland/Utilities/jp.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
     if (path == nullptr)
         path = "/dev/stdin";
     auto file = Core::File::construct(path);
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         warnln("Couldn't open {} for reading: {}", path, file->error_string());
         return 1;
     }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -587,7 +587,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReplObject::load_file)
     for (auto& file : vm.call_frame().arguments) {
         String filename = file.as_string().string();
         auto js_file = Core::File::construct(filename);
-        if (!js_file->open(Core::IODevice::ReadOnly)) {
+        if (!js_file->open(Core::OpenMode::ReadOnly)) {
             warnln("Failed to open {}: {}", filename, js_file->error_string());
             continue;
         }
@@ -969,7 +969,7 @@ int main(int argc, char** argv)
         });
 
         auto file = Core::File::construct(script_path);
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             warnln("Failed to open {}: {}", script_path, file->error_string());
             return 1;
         }

--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -26,7 +26,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     unveil(nullptr, nullptr);
 
     auto proc_interrupts = Core::File::construct("/proc/interrupts");
-    if (!proc_interrupts->open(Core::IODevice::ReadOnly)) {
+    if (!proc_interrupts->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Error: %s\n", proc_interrupts->error_string());
         return 1;
     }

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -64,7 +64,7 @@ static bool parse_name(StringView name, OpenFile& file)
 
 static Vector<OpenFile> get_open_files_by_pid(pid_t pid)
 {
-    auto file = Core::File::open(String::formatted("/proc/{}/fds", pid), Core::IODevice::OpenMode::ReadOnly);
+    auto file = Core::File::open(String::formatted("/proc/{}/fds", pid), Core::OpenMode::ReadOnly);
     if (file.is_error()) {
         printf("lsof: PID %d: %s\n", pid, file.error().characters());
         return Vector<OpenFile>();

--- a/Userland/Utilities/lspci.cpp
+++ b/Userland/Utilities/lspci.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
     }
 
     auto proc_pci = Core::File::construct("/proc/pci");
-    if (!proc_pci->open(Core::IODevice::ReadOnly)) {
+    if (!proc_pci->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Error: %s\n", proc_pci->error_string());
         return 1;
     }

--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
     auto file = Core::File::construct();
     file->set_filename(make_path(section));
 
-    if (!file->open(Core::IODevice::OpenMode::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         perror("Failed to open man page file");
         exit(1);
     }

--- a/Userland/Utilities/md.cpp
+++ b/Userland/Utilities/md.cpp
@@ -48,10 +48,10 @@ int main(int argc, char* argv[])
     auto file = Core::File::construct();
     bool success;
     if (filename == nullptr) {
-        success = file->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
+        success = file->open(STDIN_FILENO, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
     } else {
         file->set_filename(filename);
-        success = file->open(Core::IODevice::OpenMode::ReadOnly);
+        success = file->open(Core::OpenMode::ReadOnly);
     }
     if (!success) {
         fprintf(stderr, "Error: %s\n", file->error_string());

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -68,7 +68,7 @@ static bool mount_all()
     dbgln("Mounting all filesystems...");
 
     auto fstab = Core::File::construct("/etc/fstab");
-    if (!fstab->open(Core::IODevice::OpenMode::ReadOnly)) {
+    if (!fstab->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Failed to open /etc/fstab: %s\n", fstab->error_string());
         return false;
     }
@@ -118,7 +118,7 @@ static bool print_mounts()
 {
     // Output info about currently mounted filesystems.
     auto df = Core::File::construct("/proc/df");
-    if (!df->open(Core::IODevice::ReadOnly)) {
+    if (!df->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Failed to open /proc/df: %s\n", df->error_string());
         return false;
     }

--- a/Userland/Utilities/nproc.cpp
+++ b/Userland/Utilities/nproc.cpp
@@ -18,7 +18,7 @@ int main()
     }
 
     auto file = Core::File::construct("/proc/cpuinfo");
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         perror("Core::File::open()");
         return 1;
     }

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     auto file = Core::File::construct(String::formatted("/proc/{}/vm", pid));
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    if (!file->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Error: %s\n", file->error_string());
         return 1;
     }

--- a/Userland/Utilities/rev.cpp
+++ b/Userland/Utilities/rev.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
         files.append(Core::File::standard_input());
     } else {
         for (auto const& path : paths) {
-            auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
+            auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
             if (file_or_error.is_error()) {
                 warnln("Failed to open {}: {}", path, file_or_error.error());
                 continue;

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto file_or_error = Core::File::open(output_path, Core::IODevice::ReadWrite);
+    auto file_or_error = Core::File::open(output_path, Core::OpenMode::ReadWrite);
     if (file_or_error.is_error()) {
         warnln("Could not open '{}' for writing: {}", output_path, file_or_error.error());
         return 1;

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
     parser.parse(argc, argv);
 
     if (output_filename != nullptr) {
-        auto open_result = Core::File::open(output_filename, Core::IODevice::OpenMode::WriteOnly);
+        auto open_result = Core::File::open(output_filename, Core::OpenMode::WriteOnly);
         if (open_result.is_error()) {
             outln(stderr, "Failed to open output file: {}", open_result.error());
             return 1;

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -25,7 +25,7 @@ static String read_var(const String& name)
     builder.append(name);
     auto path = builder.to_string();
     auto f = Core::File::construct(path);
-    if (!f->open(Core::IODevice::ReadOnly)) {
+    if (!f->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "open: %s\n", f->error_string());
         exit(1);
     }
@@ -44,7 +44,7 @@ static void write_var(const String& name, const String& value)
     builder.append(name);
     auto path = builder.to_string();
     auto f = Core::File::construct(path);
-    if (!f->open(Core::IODevice::WriteOnly)) {
+    if (!f->open(Core::OpenMode::WriteOnly)) {
         fprintf(stderr, "open: %s\n", f->error_string());
         exit(1);
     }

--- a/Userland/Utilities/tac.cpp
+++ b/Userland/Utilities/tac.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
             if (path == "-") {
                 file = Core::File::standard_input();
             } else {
-                auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
+                auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
                 if (file_or_error.is_error()) {
                     warnln("Failed to open {}: {}", path, strerror(errno));
                     continue;

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
     args_parser.parse(argc, argv);
 
     auto f = Core::File::construct(file);
-    if (!f->open(Core::IODevice::ReadOnly)) {
+    if (!f->open(Core::OpenMode::ReadOnly)) {
         fprintf(stderr, "Error opening file %s: %s\n", file, strerror(errno));
         exit(1);
     }

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -47,7 +47,7 @@ static off_t find_seek_pos(Core::File& file, int wanted_lines)
     // Rather than reading the whole file, start at the end and work backwards,
     // stopping when we've found the number of lines we want.
     off_t pos = 0;
-    if (!file.seek(0, Core::IODevice::SeekMode::FromEndPosition, &pos)) {
+    if (!file.seek(0, Core::SeekMode::FromEndPosition, &pos)) {
         fprintf(stderr, "Failed to find end of file: %s\n", file.error_string());
         return 1;
     }

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
         auto file = Core::File::standard_input();
 
         if (archive_file) {
-            auto maybe_file = Core::File::open(archive_file, Core::IODevice::OpenMode::ReadOnly);
+            auto maybe_file = Core::File::open(archive_file, Core::OpenMode::ReadOnly);
             if (maybe_file.is_error()) {
                 warnln("Core::File::open: {}", maybe_file.error());
                 return 1;
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
         auto file = Core::File::standard_output();
 
         if (archive_file) {
-            auto maybe_file = Core::File::open(archive_file, Core::IODevice::OpenMode::WriteOnly);
+            auto maybe_file = Core::File::open(archive_file, Core::OpenMode::WriteOnly);
             if (maybe_file.is_error()) {
                 warnln("Core::File::open: {}", maybe_file.error());
                 return 1;
@@ -137,7 +137,7 @@ int main(int argc, char** argv)
 
         auto add_file = [&](String path) {
             auto file = Core::File::construct(path);
-            if (!file->open(Core::IODevice::ReadOnly)) {
+            if (!file->open(Core::OpenMode::ReadOnly)) {
                 warnln("Failed to open {}: {}", path, file->error_string());
                 return;
             }

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -135,7 +135,7 @@ static int run(Function<void(const char*, size_t)> fn)
             puts("File does not exist");
             return 1;
         }
-        auto file = Core::File::open(filename, Core::IODevice::OpenMode::ReadOnly);
+        auto file = Core::File::open(filename, Core::OpenMode::ReadOnly);
         if (file.is_error()) {
             printf("That's a weird file man...\n");
             return 1;

--- a/Userland/Utilities/test-fuzz.cpp
+++ b/Userland/Utilities/test-fuzz.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
 
     auto fn = parse_target_name(type);
 
-    auto file = Core::File::open(filename, Core::IODevice::OpenMode::ReadOnly);
+    auto file = Core::File::open(filename, Core::OpenMode::ReadOnly);
     if (file.is_error()) {
         warnln("Cannot read from file: {}", file.error());
         exit(1);

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -24,7 +24,7 @@ static bool unpack_zip_member(Archive::ZipMember zip_member)
         return true;
     }
     auto new_file = Core::File::construct(zip_member.name);
-    if (!new_file->open(Core::IODevice::WriteOnly)) {
+    if (!new_file->open(Core::OpenMode::WriteOnly)) {
         warnln("Can't write file {}: {}", zip_member.name, new_file->error_string());
         return false;
     }

--- a/Userland/Utilities/utmpupdate.cpp
+++ b/Userland/Utilities/utmpupdate.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
 
     dbgln("Updating utmp from UID={} GID={} EGID={} PID={}", getuid(), getgid(), getegid(), pid);
 
-    auto file_or_error = Core::File::open("/var/run/utmp", Core::IODevice::ReadWrite);
+    auto file_or_error = Core::File::open("/var/run/utmp", Core::OpenMode::ReadWrite);
     if (file_or_error.is_error()) {
         dbgln("Error: {}", file_or_error.error());
         return 1;

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -45,7 +45,7 @@ int main()
 
     unveil(nullptr, nullptr);
 
-    auto file_or_error = Core::File::open("/var/run/utmp", Core::IODevice::ReadOnly);
+    auto file_or_error = Core::File::open("/var/run/utmp", Core::OpenMode::ReadOnly);
     if (file_or_error.is_error()) {
         warnln("Error: {}", file_or_error.error());
         return 1;

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
     parser.add_positional_argument(filename, "File name to parse", "file");
     parser.parse(argc, argv);
 
-    auto result = Core::File::open(filename, Core::IODevice::OpenMode::ReadOnly);
+    auto result = Core::File::open(filename, Core::OpenMode::ReadOnly);
     if (result.is_error()) {
         warnln("Failed to open {}: {}", filename, result.error());
         return 1;

--- a/Userland/Utilities/zip.cpp
+++ b/Userland/Utilities/zip.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
 
     auto add_file = [&](String path) {
         auto file = Core::File::construct(path);
-        if (!file->open(Core::IODevice::ReadOnly)) {
+        if (!file->open(Core::OpenMode::ReadOnly)) {
             warnln("Failed to open {}: {}", path, file->error_string());
             return;
         }


### PR DESCRIPTION
These two were poorly placed, and moving them out will help #6513 recover or be more easily rewritten.