### PR TITLE
Tests: Sanitize Lagom Tests

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -40,6 +40,11 @@
 #endif
 #define FLATTEN [[gnu::flatten]]
 
+#ifdef NO_SANITIZE_ADDRESS
+#    undef NO_SANITIZE_ADDRESS
+#endif
+#define NO_SANITIZE_ADDRESS [[gnu::no_sanitize_address]]
+
 #ifndef __serenity__
 #    include <unistd.h>
 #    define PAGE_SIZE sysconf(_SC_PAGESIZE)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -7,40 +7,42 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a -fPIC -g -Wno-deprecated-copy")
 endif()
 
+if (ENABLE_ADDRESS_SANITIZER)
+    add_definitions(-fsanitize=address -fno-omit-frame-pointer)
+    set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=address")
+endif()
+
+if (ENABLE_MEMORY_SANITIZER)
+    add_definitions(-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer)
+    set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=memory -fsanitize-memory-track-origins")
+endif()
+
+if (ENABLE_UNDEFINED_SANITIZER)
+    add_definitions(-fsanitize=undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
+    set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined -fno-sanitize=vptr")
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
     # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216")
-
-    if (ENABLE_ADDRESS_SANITIZER)
-        add_definitions(-fsanitize=address -fno-omit-frame-pointer)
-        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=address")
-    endif()
-
-    if (ENABLE_MEMORY_SANITIZER)
-        add_definitions(-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer)
-        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=memory -fsanitize-memory-track-origins")
-    endif()
-
-    if (ENABLE_UNDEFINED_SANITIZER)
-        add_definitions(-fsanitize=undefined -fno-omit-frame-pointer)
-        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined")
-    endif()
 
     if (ENABLE_FUZZER_SANITIZER)
         add_definitions(-fsanitize=fuzzer -fno-omit-frame-pointer)
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")
     endif()
 
-    set(ORIGINAL_CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
-    set(ORIGINAL_CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
-    set(ORIGINAL_CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
-
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKER_FLAGS}")
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-expansion-to-defined -Wno-literal-suffix")
 endif()
+
+# These are here to support Fuzzili builds further down the directory stack
+set(ORIGINAL_CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+set(ORIGINAL_CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+set(ORIGINAL_CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKER_FLAGS}")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 
 file(GLOB AK_SOURCES CONFIGURE_DEPENDS "../../AK/*.cpp")
 file(GLOB AK_TEST_SOURCES CONFIGURE_DEPENDS "../../Tests/AK/*.cpp")

--- a/Tests/AK/TestNeverDestroyed.cpp
+++ b/Tests/AK/TestNeverDestroyed.cpp
@@ -44,14 +44,20 @@ TEST_CASE(should_construct_by_move)
     EXPECT_EQ(1, n->num_moves);
 }
 
-TEST_CASE(should_not_destroy)
+NO_SANITIZE_ADDRESS static void should_not_destroy()
 {
     Counter* c = nullptr;
     {
         AK::NeverDestroyed<Counter> n {};
+        // note: explicit stack-use-after-scope
         c = &n.get();
     }
     EXPECT_EQ(0, c->num_destroys);
+}
+
+TEST_CASE(should_not_destroy)
+{
+    should_not_destroy();
 }
 
 TEST_CASE(should_provide_dereference_operator)

--- a/Tests/AK/TestRefPtr.cpp
+++ b/Tests/AK/TestRefPtr.cpp
@@ -129,22 +129,22 @@ TEST_CASE(assign_copy_self)
 
 TEST_CASE(self_observers)
 {
-    RefPtr<SelfAwareObject> object = adopt_ref(*new SelfAwareObject);
-    EXPECT_EQ(object->ref_count(), 1u);
-    EXPECT_EQ(object->m_has_one_ref_left, false);
-    EXPECT_EQ(SelfAwareObject::num_destroyed, 0u);
+    {
+        RefPtr<SelfAwareObject> object = adopt_ref(*new SelfAwareObject);
+        EXPECT_EQ(object->ref_count(), 1u);
+        EXPECT_EQ(object->m_has_one_ref_left, false);
+        EXPECT_EQ(SelfAwareObject::num_destroyed, 0u);
 
-    object->ref();
-    EXPECT_EQ(object->ref_count(), 2u);
-    EXPECT_EQ(object->m_has_one_ref_left, false);
-    EXPECT_EQ(SelfAwareObject::num_destroyed, 0u);
+        object->ref();
+        EXPECT_EQ(object->ref_count(), 2u);
+        EXPECT_EQ(object->m_has_one_ref_left, false);
+        EXPECT_EQ(SelfAwareObject::num_destroyed, 0u);
 
-    object->unref();
-    EXPECT_EQ(object->ref_count(), 1u);
-    EXPECT_EQ(object->m_has_one_ref_left, true);
-    EXPECT_EQ(SelfAwareObject::num_destroyed, 0u);
-
-    object->unref();
+        object->unref();
+        EXPECT_EQ(object->ref_count(), 1u);
+        EXPECT_EQ(object->m_has_one_ref_left, true);
+        EXPECT_EQ(SelfAwareObject::num_destroyed, 0u);
+    }
     EXPECT_EQ(SelfAwareObject::num_destroyed, 1u);
 }
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -79,9 +79,9 @@ public:
         s_the = this;
     }
 
-    virtual ~TestRunner() = default;
+    virtual ~TestRunner() { s_the = nullptr; };
 
-    void run();
+    Test::Counts run();
 
     const Test::Counts& counts() const { return m_counts; }
 
@@ -197,7 +197,7 @@ Vector<String> TestRunner::get_test_paths() const
     return paths;
 }
 
-void TestRunner::run()
+Test::Counts TestRunner::run()
 {
     size_t progress_counter = 0;
     auto test_paths = get_test_paths();
@@ -212,6 +212,8 @@ void TestRunner::run()
         warn("\033]9;-1;\033\\");
 
     print_test_results();
+
+    return m_counts;
 }
 
 static Result<NonnullRefPtr<JS::Program>, ParserError> parse_file(const String& file_path)
@@ -739,12 +741,13 @@ int main(int argc, char** argv)
 
     vm = JS::VM::create();
 
+    Test::Counts result_counts;
     if (test262_parser_tests)
-        Test262ParserTestRunner(test_root, print_times, print_progress).run();
+        result_counts = Test262ParserTestRunner(test_root, print_times, print_progress).run();
     else
-        TestRunner(test_root, print_times, print_progress).run();
+        result_counts = TestRunner(test_root, print_times, print_progress).run();
 
     vm = nullptr;
 
-    return TestRunner::the()->counts().tests_failed > 0 ? 1 : 0;
+    return result_counts.tests_failed > 0 ? 1 : 0;
 }

--- a/Tests/LibRegex/RegexLibC.cpp
+++ b/Tests/LibRegex/RegexLibC.cpp
@@ -327,6 +327,7 @@ TEST_CASE(parser_error_special_characters_used_at_wrong_place)
         pattern = b.build();
         EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), error_code_to_check);
         EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), error_code_to_check);
+        regfree(&regex);
 
         // After vertical line
         b.clear();
@@ -335,6 +336,7 @@ TEST_CASE(parser_error_special_characters_used_at_wrong_place)
         pattern = b.build();
         EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), error_code_to_check);
         EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), error_code_to_check);
+        regfree(&regex);
 
         // After circumflex
         b.clear();
@@ -343,6 +345,7 @@ TEST_CASE(parser_error_special_characters_used_at_wrong_place)
         pattern = b.build();
         EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), error_code_to_check);
         EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), error_code_to_check);
+        regfree(&regex);
 
         // After dollar
         b.clear();
@@ -351,6 +354,7 @@ TEST_CASE(parser_error_special_characters_used_at_wrong_place)
         pattern = b.build();
         EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), error_code_to_check);
         EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), error_code_to_check);
+        regfree(&regex);
 
         // After left parens
         b.clear();
@@ -360,9 +364,8 @@ TEST_CASE(parser_error_special_characters_used_at_wrong_place)
         pattern = b.build();
         EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), error_code_to_check);
         EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), error_code_to_check);
+        regfree(&regex);
     }
-
-    regfree(&regex);
 }
 
 TEST_CASE(parser_error_vertical_line_used_at_wrong_place)
@@ -376,22 +379,24 @@ TEST_CASE(parser_error_vertical_line_used_at_wrong_place)
     pattern = "|asdf";
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_EMPTY_EXPR);
     EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), REG_EMPTY_EXPR);
+    regfree(&regex);
 
     // Last in ere
     pattern = "asdf|";
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_EMPTY_EXPR);
     EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), REG_EMPTY_EXPR);
+    regfree(&regex);
 
     // After left parens
     pattern = "(|asdf)";
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_EMPTY_EXPR);
     EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), REG_EMPTY_EXPR);
+    regfree(&regex);
 
     // Proceed right parens
     pattern = "(asdf)|";
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_EMPTY_EXPR);
     EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), REG_EMPTY_EXPR);
-
     regfree(&regex);
 }
 
@@ -969,6 +974,7 @@ TEST_CASE(simple_bracket_chars)
     EXPECT_EQ(regexec(&regex, "c", 0, NULL, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "d", 0, NULL, 0), REG_NOMATCH);
     EXPECT_EQ(regexec(&regex, "e", 0, NULL, 0), REG_NOMATCH);
+    regfree(&regex);
 }
 
 TEST_CASE(simple_bracket_chars_inverse)
@@ -982,6 +988,7 @@ TEST_CASE(simple_bracket_chars_inverse)
     EXPECT_EQ(regexec(&regex, "c", 0, NULL, 0), REG_NOMATCH);
     EXPECT_EQ(regexec(&regex, "d", 0, NULL, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "e", 0, NULL, 0), REG_NOERR);
+    regfree(&regex);
 }
 
 TEST_CASE(simple_bracket_chars_range)
@@ -995,6 +1002,7 @@ TEST_CASE(simple_bracket_chars_range)
     EXPECT_EQ(regexec(&regex, "c", 0, NULL, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "d", 0, NULL, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "e", 0, NULL, 0), REG_NOMATCH);
+    regfree(&regex);
 }
 
 TEST_CASE(simple_bracket_chars_range_inverse)
@@ -1010,6 +1018,7 @@ TEST_CASE(simple_bracket_chars_range_inverse)
     EXPECT_EQ(regexec(&regex, "e", 0, NULL, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "k", 0, NULL, 0), REG_NOMATCH);
     EXPECT_EQ(regexec(&regex, "z", 0, NULL, 0), REG_NOMATCH);
+    regfree(&regex);
 }
 
 TEST_CASE(bracket_character_class_uuid)
@@ -1035,6 +1044,7 @@ TEST_CASE(simple_bracket_character_class_inverse)
     EXPECT_EQ(regexec(&regex, "3", 0, NULL, 0), REG_NOMATCH);
     EXPECT_EQ(regexec(&regex, "d", 0, NULL, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "e", 0, NULL, 0), REG_NOERR);
+    regfree(&regex);
 }
 
 TEST_CASE(email_address)
@@ -1115,4 +1125,5 @@ TEST_CASE(simple_notbol_noteol)
     EXPECT_EQ(regexec(&regex2, "hello friends", 0, NULL, REG_NOTEOL), REG_NOMATCH);
 
     regfree(&regex);
+    regfree(&regex2);
 }

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -30,7 +30,7 @@ Heap::Heap(VM& vm)
     m_allocators.append(make<Allocator>(256));
     m_allocators.append(make<Allocator>(512));
     m_allocators.append(make<Allocator>(1024));
-    m_allocators.append(make<Allocator>(3172));
+    m_allocators.append(make<Allocator>(3072));
 }
 
 Heap::~Heap()


### PR DESCRIPTION
- ~~Run with  ASAN and UBSAN in CI for lagom~~ Not doing this because there's ASAN aborts I don't know how to fix :)
- Enable using sanitizers for gcc builds of lagom
- Fix a few bugs in Tests/
- Fix a few bugs in actual code :)

Fixes #4592

Tested using the following:
```
cmake ../Meta/Lagom -GNinja -DBUILD_LAGOM=ON -DENABLE_ADDRESS_SANITIZER=ON -DENABLE_UNDEFINED_SANITIZER=ON
```

For extra fun, try running `ninja test` with UBSAN_OPTIONS=halt_on_error=1 :)