### PR TITLE
Kernel: Route packets destined for us through the loopback adapter

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -206,7 +206,8 @@ KResultOr<size_t> IPv4Socket::sendto(FileDescription&, const UserOrKernelBuffer&
     dbgln_if(IPV4_SOCKET_DEBUG, "sendto: destination={}:{}", m_peer_address, m_peer_port);
 
     if (type() == SOCK_RAW) {
-        auto result = routing_decision.adapter->send_ipv4(routing_decision.next_hop, m_peer_address, (IPv4Protocol)protocol(), data, data_length, m_ttl);
+        auto result = routing_decision.adapter->send_ipv4(local_address(), routing_decision.next_hop,
+            m_peer_address, (IPv4Protocol)protocol(), data, data_length, m_ttl);
         if (result.is_error())
             return result;
         return data_length;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -45,8 +45,8 @@ public:
     void set_ipv4_gateway(const IPv4Address&);
 
     void send(const MACAddress&, const ARPPacket&);
-    KResult send_ipv4(const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
-    KResult send_ipv4_fragmented(const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
+    KResult send_ipv4(const IPv4Address& source_ipv4, const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
+    KResult send_ipv4_fragmented(const IPv4Address& source_ipv4, const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
 
     size_t dequeue_packet(u8* buffer, size_t buffer_size, Time& packet_timestamp);
 

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -256,7 +256,8 @@ void handle_icmp(const EthernetFrameHeader& eth, const IPv4Packet& ipv4_packet, 
         response.header.set_checksum(internet_checksum(&response, icmp_packet_size));
         // FIXME: What is the right TTL value here? Is 64 ok? Should we use the same TTL as the echo request?
         auto response_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&response);
-        [[maybe_unused]] auto result = adapter->send_ipv4(eth.source(), ipv4_packet.source(), IPv4Protocol::ICMP, response_buffer, buffer.size(), 64);
+        [[maybe_unused]] auto result = adapter->send_ipv4(adapter->ipv4_address(), eth.source(),
+            ipv4_packet.source(), IPv4Protocol::ICMP, response_buffer, buffer.size(), 64);
     }
 }
 

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -156,6 +156,11 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
         auto adapter_addr = adapter.ipv4_address().to_u32();
         auto adapter_mask = adapter.ipv4_netmask().to_u32();
 
+        if (target_addr == adapter_addr) {
+            local_adapter = LoopbackAdapter::the();
+            return;
+        }
+
         if (source_addr != 0 && source_addr != adapter_addr)
             return;
 
@@ -204,6 +209,9 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
     //        a broadcast to a subnet rather than a full broadcast.
     if (target_addr == 0xffffffff && matches(adapter))
         return { adapter, { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
+
+    if (adapter == LoopbackAdapter::the())
+        return { adapter, adapter->mac_address() };
 
     if ((target_addr & IPv4Address { 240, 0, 0, 0 }.to_u32()) == IPv4Address { 224, 0, 0, 0 }.to_u32())
         return { adapter, multicast_ethernet_address(target) };

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -227,7 +227,7 @@ KResult TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload,
 
     auto packet_buffer = UserOrKernelBuffer::for_kernel_buffer(buffer.data());
     auto result = routing_decision.adapter->send_ipv4(
-        routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
+        local_address(), routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
         packet_buffer, buffer_size, ttl());
     if (result.is_error())
         return result;
@@ -265,8 +265,8 @@ void TCPSocket::send_outgoing_packets(RoutingDecision& routing_decision)
 
         auto packet_buffer = UserOrKernelBuffer::for_kernel_buffer(packet.buffer.data());
         int err = routing_decision.adapter->send_ipv4(
-            routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
-            packet_buffer, packet.buffer.size(), ttl());
+            local_address(), routing_decision.next_hop, peer_address(),
+            IPv4Protocol::TCP, packet_buffer, packet.buffer.size(), ttl());
         if (err < 0) {
             auto& tcp_packet = *(const TCPPacket*)(packet.buffer.data());
             dmesgln("Error ({}) sending TCP packet from {}:{} to {}:{} with ({}{}{}{}) seq_no={}, ack_no={}, tx_counter={}",

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -84,7 +84,8 @@ KResultOr<size_t> UDPSocket::protocol_send(const UserOrKernelBuffer& data, size_
     if (!data.read(udp_packet.payload(), data_length))
         return EFAULT;
 
-    auto result = routing_decision.adapter->send_ipv4(routing_decision.next_hop, peer_address(), IPv4Protocol::UDP, UserOrKernelBuffer::for_kernel_buffer(buffer.data()), buffer_size, ttl());
+    auto result = routing_decision.adapter->send_ipv4(local_address(), routing_decision.next_hop,
+        peer_address(), IPv4Protocol::UDP, UserOrKernelBuffer::for_kernel_buffer(buffer.data()), buffer_size, ttl());
     if (result.is_error())
         return result;
     return data_length;


### PR DESCRIPTION
**Kernel: Outbound packets should use the source address from the socket**

Previously we'd use the adapter's address as the source address when sending packets. Instead we should use the socket's bound local address.

**Kernel: Route packets destined for us through the loopback adapter**

Without this patch we'd send packets through the physical adapter and they'd incorrectly end up on the network.

![Screenshot from 2021-05-12 13-51-49](https://user-images.githubusercontent.com/388571/117978311-05aea380-b332-11eb-80a1-04488c3e0d4e.png)
