### PR TITLE
Kernel: More performance improvements for the network stack

### DIFF
--- a/Kernel/KBufferBuilder.h
+++ b/Kernel/KBufferBuilder.h
@@ -33,7 +33,9 @@ public:
     {
         // FIXME: This is really not the way to go about it, but vformat expects a
         //        StringBuilder. Why does this class exist anyways?
-        append(String::formatted(fmtstr.view(), parameters...));
+        StringBuilder builder;
+        vformat(builder, fmtstr.view(), AK::VariadicFormatParams { parameters... });
+        append_bytes(builder.string_view().bytes());
     }
 
     bool flush();

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -21,16 +21,9 @@ namespace Kernel {
 
 static AK::Singleton<Lockable<HashTable<NetworkAdapter*>>> s_table;
 
-static Lockable<HashTable<NetworkAdapter*>>& all_adapters()
+Lockable<HashTable<NetworkAdapter*>>& NetworkAdapter::all_adapters()
 {
     return *s_table;
-}
-
-void NetworkAdapter::for_each(Function<void(NetworkAdapter&)> callback)
-{
-    Locker locker(all_adapters().lock());
-    for (auto& it : all_adapters().resource())
-        callback(*it);
 }
 
 RefPtr<NetworkAdapter> NetworkAdapter::from_ipv4_address(const IPv4Address& address)

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -199,10 +199,8 @@ size_t NetworkAdapter::dequeue_packet(u8* buffer, size_t buffer_size, Time& pack
     size_t packet_size = packet.size();
     VERIFY(packet_size <= buffer_size);
     memcpy(buffer, packet.data(), packet_size);
-    if (m_unused_packet_buffers_count < 100) {
-        m_unused_packet_buffers.append(packet);
-        ++m_unused_packet_buffers_count;
-    }
+    m_unused_packet_buffers.append(packet);
+    ++m_unused_packet_buffers_count;
     return packet_size;
 }
 

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -25,7 +25,14 @@ class NetworkAdapter;
 
 class NetworkAdapter : public RefCounted<NetworkAdapter> {
 public:
-    static void for_each(Function<void(NetworkAdapter&)>);
+    template<typename Callback>
+    static inline void for_each(Callback callback)
+    {
+        Locker locker(all_adapters().lock());
+        for (auto& it : all_adapters().resource())
+            callback(*it);
+    }
+
     static RefPtr<NetworkAdapter> from_ipv4_address(const IPv4Address&);
     static RefPtr<NetworkAdapter> lookup_by_name(const StringView&);
     virtual ~NetworkAdapter();
@@ -70,6 +77,8 @@ protected:
     void did_receive(ReadonlyBytes);
 
 private:
+    static Lockable<HashTable<NetworkAdapter*>>& all_adapters();
+
     MACAddress m_mac_address;
     IPv4Address m_ipv4_address;
     IPv4Address m_ipv4_netmask;

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -31,7 +31,7 @@ SlavePTY::~SlavePTY()
     DevPtsFS::unregister_slave_pty(*this);
 }
 
-String SlavePTY::tty_name() const
+String const& SlavePTY::tty_name() const
 {
     return m_tty_name;
 }

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -26,7 +26,7 @@ public:
 
 private:
     // ^TTY
-    virtual String tty_name() const override;
+    virtual String const& tty_name() const override;
     virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) override;
     virtual void echo(u8) override;
 

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -26,7 +26,7 @@ public:
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override final;
     virtual String absolute_path(const FileDescription&) const override { return tty_name(); }
 
-    virtual String tty_name() const = 0;
+    virtual String const& tty_name() const = 0;
 
     unsigned short rows() const { return m_rows; }
     unsigned short columns() const { return m_columns; }

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -35,7 +35,7 @@ private:
 
     // ^TTY
     virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) override;
-    virtual String tty_name() const override { return m_tty_name; }
+    virtual String const& tty_name() const override { return m_tty_name; }
     virtual void echo(u8) override;
 
     // ^TerminalClient


### PR DESCRIPTION
**Kernel: Avoid allocating and then freeing packet buffers**

We already have another limit for the total number of packet buffers allowed (`max_packet_buffers`). This second (lower) limit caused us to repeatedly allocate and then free buffers.

**Kernel: Avoid unnecessary allocations in NetworkAdapter::for_each**

This avoids allocations for initializing the `Function<T>` for the `NetworkAdapter::for_each` callback argument.

Applying this patch decreases CPU utilization for `NetworkTask` from 40% to 28% when receiving TCP packets at a rate of 100Mbit/s.

**Kernel: Avoid allocations in KBufferBuilder::appendff**

This avoids some of the the shortest-lived allocations in the kernel:

```
StringImpl::create_uninitialized(unsigned long, char*&)
StringImpl::create(char const*, unsigned long, ShouldChomp)
StringBuilder::to_string() const
String::vformatted(StringView, TypeErasedFormatParams)
void Kernel::KBufferBuilder::appendff<unsigned int>(...)
JsonObjectSerializer<Kernel::KBufferBuilder>::add(..., unsigned int)
Kernel::procfs$all(Kernel::InodeIdentifier, ...) const
Kernel::procfs$all(Kernel::InodeIdentifier, Kernel::KBufferBuilder&)
```

**Kernel: Avoid unnecessary allocations for TTY::tty_name()**

Not strictly related to the network stack, but it removes some pressure that's being put on `kmalloc`.