### PR TITLE
IRQHandler/PCIDevice: add flag to not initialize interrupts

### DIFF
--- a/Kernel/Interrupts/IRQHandler.cpp
+++ b/Kernel/Interrupts/IRQHandler.cpp
@@ -11,11 +11,12 @@
 
 namespace Kernel {
 
-IRQHandler::IRQHandler(u8 irq)
+IRQHandler::IRQHandler(u8 irq, bool setup_irq)
     : GenericInterruptHandler(irq)
     , m_responsible_irq_controller(InterruptManagement::the().get_responsible_irq_controller(irq))
 {
-    disable_irq();
+    if (setup_irq)
+        disable_irq();
 }
 
 IRQHandler::~IRQHandler()

--- a/Kernel/Interrupts/IRQHandler.h
+++ b/Kernel/Interrupts/IRQHandler.h
@@ -37,7 +37,7 @@ public:
 
 protected:
     void change_irq_number(u8 irq);
-    explicit IRQHandler(u8 irq);
+    explicit IRQHandler(u8 irq, bool setup_irq = true);
 
 private:
     bool m_shared_with_others { false };

--- a/Kernel/PCI/Device.cpp
+++ b/Kernel/PCI/Device.cpp
@@ -9,8 +9,8 @@
 namespace Kernel {
 namespace PCI {
 
-Device::Device(Address address)
-    : IRQHandler(get_interrupt_line(address))
+Device::Device(Address address, bool setup_irq)
+    : IRQHandler(get_interrupt_line(address), setup_irq)
     , m_pci_address(address)
 {
     // FIXME: Register PCI device somewhere...

--- a/Kernel/PCI/Device.h
+++ b/Kernel/PCI/Device.h
@@ -16,7 +16,7 @@ public:
     Address pci_address() const { return m_pci_address; };
 
 protected:
-    Device(Address pci_address);
+    Device(Address pci_address, bool setup_irq = true);
     Device(Address pci_address, u8 interrupt_vector);
     ~Device();
 


### PR DESCRIPTION
This is mainly for PCI Devices which do not have
interrupts, or only sometimes have interrupts.