### PR TITLE
LibGUI/Splitter: Support setting minimum resizee size

### DIFF
--- a/Userland/Applications/FileManager/FileManagerWindow.gml
+++ b/Userland/Applications/FileManager/FileManagerWindow.gml
@@ -39,6 +39,7 @@
 
     @GUI::HorizontalSplitter {
         name: "splitter"
+        first_resizee_minimum_size: 80
 
         @GUI::TreeView {
             name: "tree_view"

--- a/Userland/Libraries/LibGUI/Splitter.cpp
+++ b/Userland/Libraries/LibGUI/Splitter.cpp
@@ -18,6 +18,9 @@ namespace GUI {
 Splitter::Splitter(Orientation orientation)
     : m_orientation(orientation)
 {
+    REGISTER_INT_PROPERTY("first_resizee_minimum_size", first_resizee_minimum_size, set_first_resizee_minimum_size);
+    REGISTER_INT_PROPERTY("second_resizee_minimum_size", second_resizee_minimum_size, set_second_resizee_minimum_size);
+
     set_background_role(ColorRole::Button);
     set_layout<BoxLayout>(orientation);
     set_fill_with_background_color(true);
@@ -149,20 +152,19 @@ void Splitter::mousemove_event(MouseEvent& event)
         m_resizing = false;
         return;
     }
-    int minimum_size = 0;
     auto new_first_resizee_size = m_first_resizee_start_size;
     auto new_second_resizee_size = m_second_resizee_start_size;
 
     new_first_resizee_size.set_primary_size_for_orientation(m_orientation, new_first_resizee_size.primary_size_for_orientation(m_orientation) + delta.primary_offset_for_orientation(m_orientation));
     new_second_resizee_size.set_primary_size_for_orientation(m_orientation, new_second_resizee_size.primary_size_for_orientation(m_orientation) - delta.primary_offset_for_orientation(m_orientation));
 
-    if (new_first_resizee_size.primary_size_for_orientation(m_orientation) < minimum_size) {
-        int correction = minimum_size - new_first_resizee_size.primary_size_for_orientation(m_orientation);
+    if (new_first_resizee_size.primary_size_for_orientation(m_orientation) < m_first_resizee_minimum_size) {
+        int correction = m_first_resizee_minimum_size - new_first_resizee_size.primary_size_for_orientation(m_orientation);
         new_first_resizee_size.set_primary_size_for_orientation(m_orientation, new_first_resizee_size.primary_size_for_orientation(m_orientation) + correction);
         new_second_resizee_size.set_primary_size_for_orientation(m_orientation, new_second_resizee_size.primary_size_for_orientation(m_orientation) - correction);
     }
-    if (new_second_resizee_size.primary_size_for_orientation(m_orientation) < minimum_size) {
-        int correction = minimum_size - new_second_resizee_size.primary_size_for_orientation(m_orientation);
+    if (new_second_resizee_size.primary_size_for_orientation(m_orientation) < m_second_resizee_minimum_size) {
+        int correction = m_second_resizee_minimum_size - new_second_resizee_size.primary_size_for_orientation(m_orientation);
         new_second_resizee_size.set_primary_size_for_orientation(m_orientation, new_second_resizee_size.primary_size_for_orientation(m_orientation) + correction);
         new_first_resizee_size.set_primary_size_for_orientation(m_orientation, new_first_resizee_size.primary_size_for_orientation(m_orientation) - correction);
     }

--- a/Userland/Libraries/LibGUI/Splitter.h
+++ b/Userland/Libraries/LibGUI/Splitter.h
@@ -16,6 +16,11 @@ class Splitter : public Widget {
 public:
     virtual ~Splitter() override;
 
+    int first_resizee_minimum_size() { return m_first_resizee_minimum_size; }
+    void set_first_resizee_minimum_size(int minimum_size) { m_first_resizee_minimum_size = minimum_size; }
+    int second_resizee_minimum_size() { return m_second_resizee_minimum_size; }
+    void set_second_resizee_minimum_size(int minimum_size) { m_second_resizee_minimum_size = minimum_size; }
+
 protected:
     explicit Splitter(Gfx::Orientation);
 
@@ -41,6 +46,8 @@ private:
     WeakPtr<Widget> m_second_resizee;
     Gfx::IntSize m_first_resizee_start_size;
     Gfx::IntSize m_second_resizee_start_size;
+    int m_first_resizee_minimum_size { 0 };
+    int m_second_resizee_minimum_size { 0 };
     Gfx::IntRect m_grabbable_rect;
 };
 


### PR DESCRIPTION
The travel range of the Splitter widget was unconstrained. This PR allows setting two minimum sizes for both sides of the Splitter and as an example, sets the minimum width for the FileManager's folder pane.