### PR TITLE
Kernel: Replace usages of adopt_ref<T>() and make<T>() with adopt_{}_if_nonnull<T>()

### DIFF
--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -22,11 +22,11 @@ class Custody : public RefCounted<Custody> {
 public:
     static KResultOr<NonnullRefPtr<Custody>> create(Custody* parent, const StringView& name, Inode& inode, int mount_flags)
     {
-        auto custody = new Custody(parent, name, inode, mount_flags);
+        auto custody = adopt_ref_if_nonnull(new Custody(parent, name, inode, mount_flags));
         if (!custody)
             return ENOMEM;
 
-        return adopt_ref(*custody);
+        return custody.release_nonnull();
     }
 
     ~Custody();

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1495,7 +1495,10 @@ KResultOr<Ext2FS::CachedBitmap*> Ext2FS::get_bitmap_block(BlockIndex bitmap_bloc
         dbgln("Ext2FS: Failed to load bitmap block {}", bitmap_block_index);
         return result;
     }
-    if (!m_cached_bitmaps.try_append(make<CachedBitmap>(bitmap_block_index, move(block))))
+    auto new_bitmap = adopt_own_if_nonnull(new CachedBitmap(bitmap_block_index, move(block)));
+    if (!new_bitmap)
+        return ENOMEM;
+    if (!m_cached_bitmaps.try_append(move(new_bitmap)))
         return ENOMEM;
     return m_cached_bitmaps.last();
 }

--- a/Kernel/FileSystem/InodeWatcher.h
+++ b/Kernel/FileSystem/InodeWatcher.h
@@ -25,9 +25,12 @@ struct WatchDescription {
     Inode& inode;
     unsigned event_mask;
 
-    static NonnullOwnPtr<WatchDescription> create(int wd, Inode& inode, unsigned event_mask)
+    static KResultOr<NonnullOwnPtr<WatchDescription>> create(int wd, Inode& inode, unsigned event_mask)
     {
-        return adopt_own(*new WatchDescription(wd, inode, event_mask));
+        auto description = adopt_own_if_nonnull(new WatchDescription(wd, inode, event_mask));
+        if (description)
+            return description.release_nonnull();
+        return ENOMEM;
     }
 
 private:
@@ -41,7 +44,7 @@ private:
 
 class InodeWatcher final : public File {
 public:
-    static NonnullRefPtr<InodeWatcher> create();
+    static KResultOr<NonnullRefPtr<InodeWatcher>> create();
     virtual ~InodeWatcher() override;
 
     virtual bool can_read(const FileDescription&, size_t) const override;

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -32,7 +32,7 @@ public:
         auto region = MM.allocate_kernel_region(page_round_up(size), name, access, strategy);
         if (!region)
             return nullptr;
-        return adopt_ref(*new KBufferImpl(region.release_nonnull(), size, strategy));
+        return adopt_ref_if_nonnull(new KBufferImpl(region.release_nonnull(), size, strategy));
     }
 
     static RefPtr<KBufferImpl> try_create_with_bytes(ReadonlyBytes bytes, Region::Access access, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
@@ -41,7 +41,8 @@ public:
         if (!region)
             return nullptr;
         memcpy(region->vaddr().as_ptr(), bytes.data(), bytes.size());
-        return adopt_ref(*new KBufferImpl(region.release_nonnull(), bytes.size(), strategy));
+
+        return adopt_ref_if_nonnull(new KBufferImpl(region.release_nonnull(), bytes.size(), strategy));
     }
 
     static RefPtr<KBufferImpl> create_with_size(size_t size, Region::Access access, const char* name, AllocationStrategy strategy = AllocationStrategy::Reserve)

--- a/Kernel/KBufferBuilder.cpp
+++ b/Kernel/KBufferBuilder.cpp
@@ -38,7 +38,8 @@ OwnPtr<KBuffer> KBufferBuilder::build()
 {
     if (!flush())
         return {};
-    return make<KBuffer>(move(m_buffer));
+
+    return adopt_own_if_nonnull(new KBuffer(move(m_buffer)));
 }
 
 KBufferBuilder::KBufferBuilder(bool can_expand)

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -42,8 +42,12 @@ KResultOr<NonnullRefPtr<Socket>> IPv4Socket::create(int type, int protocol)
             return tcp_socket.error();
         return tcp_socket.release_value();
     }
-    if (type == SOCK_DGRAM)
-        return UDPSocket::create(protocol);
+    if (type == SOCK_DGRAM) {
+        auto udp_socket = UDPSocket::create(protocol);
+        if (udp_socket.is_error())
+            return udp_socket.error();
+        return udp_socket.release_value();
+    }
     if (type == SOCK_RAW) {
         auto raw_socket = adopt_ref_if_nonnull(new IPv4Socket(type, protocol));
         if (raw_socket)

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -36,8 +36,12 @@ Lockable<HashTable<IPv4Socket*>>& IPv4Socket::all_sockets()
 
 KResultOr<NonnullRefPtr<Socket>> IPv4Socket::create(int type, int protocol)
 {
-    if (type == SOCK_STREAM)
-        return TCPSocket::create(protocol);
+    if (type == SOCK_STREAM) {
+        auto tcp_socket = TCPSocket::create(protocol);
+        if (tcp_socket.is_error())
+            return tcp_socket.error();
+        return tcp_socket.release_value();
+    }
     if (type == SOCK_DGRAM)
         return UDPSocket::create(protocol);
     if (type == SOCK_RAW)

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -44,8 +44,12 @@ KResultOr<NonnullRefPtr<Socket>> IPv4Socket::create(int type, int protocol)
     }
     if (type == SOCK_DGRAM)
         return UDPSocket::create(protocol);
-    if (type == SOCK_RAW)
-        return adopt_ref(*new IPv4Socket(type, protocol));
+    if (type == SOCK_RAW) {
+        auto raw_socket = adopt_ref_if_nonnull(new IPv4Socket(type, protocol));
+        if (raw_socket)
+            return raw_socket.release_nonnull();
+        return ENOMEM;
+    }
     return EINVAL;
 }
 

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -33,12 +33,17 @@ void LocalSocket::for_each(Function<void(const LocalSocket&)> callback)
 
 KResultOr<NonnullRefPtr<Socket>> LocalSocket::create(int type)
 {
-    return adopt_ref(*new LocalSocket(type));
+    auto socket = adopt_ref_if_nonnull(new LocalSocket(type));
+    if (socket)
+        return socket.release_nonnull();
+    return ENOMEM;
 }
 
 KResultOr<SocketPair> LocalSocket::create_connected_pair(int type)
 {
-    auto socket = adopt_ref(*new LocalSocket(type));
+    auto socket = adopt_ref_if_nonnull(new LocalSocket(type));
+    if (!socket)
+        return ENOMEM;
 
     auto description1_result = FileDescription::create(*socket);
     if (description1_result.is_error())

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -10,6 +10,7 @@
 #include <AK/HashMap.h>
 #include <AK/SinglyLinkedList.h>
 #include <AK/WeakPtr.h>
+#include <Kernel/KResult.h>
 #include <Kernel/Net/IPv4Socket.h>
 
 namespace Kernel {
@@ -17,7 +18,7 @@ namespace Kernel {
 class TCPSocket final : public IPv4Socket {
 public:
     static void for_each(Function<void(const TCPSocket&)>);
-    static NonnullRefPtr<TCPSocket> create(int protocol);
+    static KResultOr<NonnullRefPtr<TCPSocket>> create(int protocol);
     virtual ~TCPSocket() override;
 
     enum class Direction {

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -54,9 +54,12 @@ UDPSocket::~UDPSocket()
     sockets_by_port().resource().remove(local_port());
 }
 
-NonnullRefPtr<UDPSocket> UDPSocket::create(int protocol)
+KResultOr<NonnullRefPtr<UDPSocket>> UDPSocket::create(int protocol)
 {
-    return adopt_ref(*new UDPSocket(protocol));
+    auto socket = adopt_ref_if_nonnull(new UDPSocket(protocol));
+    if (socket)
+        return socket.release_nonnull();
+    return ENOMEM;
 }
 
 KResultOr<size_t> UDPSocket::protocol_receive(ReadonlyBytes raw_ipv4_packet, UserOrKernelBuffer& buffer, size_t buffer_size, [[maybe_unused]] int flags)

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <Kernel/KResult.h>
 #include <Kernel/Net/IPv4Socket.h>
 
 namespace Kernel {
 
 class UDPSocket final : public IPv4Socket {
 public:
-    static NonnullRefPtr<UDPSocket> create(int protocol);
+    static KResultOr<NonnullRefPtr<UDPSocket>> create(int protocol);
     virtual ~UDPSocket() override;
 
     static SocketHandle<UDPSocket> from_port(u16);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -660,9 +660,13 @@ void Process::set_tty(TTY* tty)
     m_tty = tty;
 }
 
-void Process::start_tracing_from(ProcessID tracer)
+KResult Process::start_tracing_from(ProcessID tracer)
 {
-    m_tracer = ThreadTracer::create(tracer);
+    auto thread_tracer = ThreadTracer::create(tracer);
+    if (!thread_tracer)
+        return ENOMEM;
+    m_tracer = move(thread_tracer);
+    return KSuccess;
 }
 
 void Process::stop_tracing()

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -241,7 +241,7 @@ public:
 
     ThreadTracer* tracer() { return m_tracer.ptr(); }
     bool is_traced() const { return !!m_tracer; }
-    void start_tracing_from(ProcessID tracer);
+    KResult start_tracing_from(ProcessID tracer);
     void stop_tracing();
     void tracer_trap(Thread&, const RegisterState&);
 

--- a/Kernel/Syscalls/inode_watcher.cpp
+++ b/Kernel/Syscalls/inode_watcher.cpp
@@ -21,7 +21,11 @@ KResultOr<int> Process::sys$create_inode_watcher(u32 flags)
     if (fd < 0)
         return fd;
 
-    auto description_or_error = FileDescription::create(*InodeWatcher::create());
+    auto watcher_or_error = InodeWatcher::create();
+    if (watcher_or_error.is_error())
+        return watcher_or_error.error();
+
+    auto description_or_error = FileDescription::create(*watcher_or_error.value());
     if (description_or_error.is_error())
         return description_or_error.error();
 

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -51,7 +51,9 @@ static KResultOr<u32> handle_ptrace(const Kernel::Syscall::SC_ptrace_params& par
         if (peer_process.tracer()) {
             return EBUSY;
         }
-        peer_process.start_tracing_from(caller.pid());
+        auto result = peer_process.start_tracing_from(caller.pid());
+        if (result.is_error())
+            return result.error();
         ScopedSpinLock lock(peer->get_lock());
         if (peer->state() != Thread::State::Stopped) {
             peer->send_signal(SIGSTOP, &caller);

--- a/Kernel/ThreadTracer.h
+++ b/Kernel/ThreadTracer.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
+#include <AK/OwnPtr.h>
 #include <Kernel/UnixTypes.h>
 #include <LibC/sys/arch/i386/regs.h>
 
@@ -15,7 +15,7 @@ namespace Kernel {
 
 class ThreadTracer {
 public:
-    static NonnullOwnPtr<ThreadTracer> create(ProcessID tracer) { return make<ThreadTracer>(tracer); }
+    static OwnPtr<ThreadTracer> create(ProcessID tracer) { return adopt_own_if_nonnull(new ThreadTracer(tracer)); }
 
     ProcessID tracer_pid() const { return m_tracer_pid; }
     bool has_pending_signal(u32 signal) const { return m_pending_signals & (1 << (signal - 1)); }


### PR DESCRIPTION
The 6th patch set of changes working away at #6369.

This round is focusing on replacing smart pointer factory (make<T>, etc) with versions which support OOM propagation. 