### PR TITLE
Kernel: Try to retransmit lost TCP packets

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -435,12 +435,12 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
         switch (tcp_packet.flags()) {
         case TCPFlags::SYN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            send_delayed_tcp_ack(socket);
+            unused_rc = socket->send_ack(true);
             socket->set_state(TCPSocket::State::SynReceived);
             return;
         case TCPFlags::ACK | TCPFlags::SYN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            send_delayed_tcp_ack(socket);
+            unused_rc = socket->send_ack(true);
             socket->set_state(TCPSocket::State::Established);
             socket->set_setup_state(Socket::SetupState::Completed);
             socket->set_connected(true);

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -176,7 +176,6 @@ private:
     virtual KResult protocol_bind() override;
     virtual KResult protocol_listen() override;
 
-    void do_retransmit_packets();
     void enqueue_for_retransmit();
     void dequeue_for_retransmit();
 


### PR DESCRIPTION
**Kernel: Don't use delayed ACKs when establishing the connection**

When establishing the connection we should send ACKs right away so as to not delay the connection process. This didn't previously matter because we'd flush all delayed ACKs when `NetworkTask` waits for incoming packets.

**Kernel: Wake up NetworkTask every 500 milliseconds**

This wakes up `NetworkTask` every 500 milliseconds so that it can send pending delayed TCP ACKs and isn't forced to send all of them early when it goes to sleep like it did before.

**Kernel: Try to retransmit lost TCP packets**

Previously we didn't retransmit lost TCP packets which would cause connections to hang if packets were lost. Also we now time out TCP connections after a number of retransmission attempts.

**Kernel: Merge do_retransmit_packets() into retransmit_packets()**