### PR TITLE
Kernel: Avoid un-necessary time under lock in TCPSocket::create

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -88,9 +88,11 @@ RefPtr<TCPSocket> TCPSocket::create_client(const IPv4Address& new_local_address,
 {
     auto tuple = IPv4SocketTuple(new_local_address, new_local_port, new_peer_address, new_peer_port);
 
-    Locker locker(sockets_by_tuple().lock());
-    if (sockets_by_tuple().resource().contains(tuple))
-        return {};
+    {
+        Locker locker(sockets_by_tuple().lock(), Lock::Mode::Shared);
+        if (sockets_by_tuple().resource().contains(tuple))
+            return {};
+    }
 
     auto client = TCPSocket::create(protocol());
 
@@ -102,10 +104,11 @@ RefPtr<TCPSocket> TCPSocket::create_client(const IPv4Address& new_local_address,
     client->set_direction(Direction::Incoming);
     client->set_originator(*this);
 
+    Locker locker(sockets_by_tuple().lock());
     m_pending_release_for_accept.set(tuple, client);
     sockets_by_tuple().resource().set(tuple, client);
 
-    return from_tuple(tuple);
+    return client;
 }
 
 void TCPSocket::release_to_originator()

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -84,12 +84,6 @@ RefPtr<TCPSocket> TCPSocket::from_tuple(const IPv4SocketTuple& tuple)
 
     return {};
 }
-
-RefPtr<TCPSocket> TCPSocket::from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port)
-{
-    return from_tuple(IPv4SocketTuple(local_address, local_port, peer_address, peer_port));
-}
-
 RefPtr<TCPSocket> TCPSocket::create_client(const IPv4Address& new_local_address, u16 new_local_port, const IPv4Address& new_peer_address, u16 new_peer_port)
 {
     auto tuple = IPv4SocketTuple(new_local_address, new_local_port, new_peer_address, new_peer_port);

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -142,7 +142,6 @@ public:
 
     static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& sockets_by_tuple();
     static RefPtr<TCPSocket> from_tuple(const IPv4SocketTuple& tuple);
-    static RefPtr<TCPSocket> from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
 
     static Lockable<HashMap<IPv4SocketTuple, RefPtr<TCPSocket>>>& closing_sockets();
 


### PR DESCRIPTION
Some minor things I noticed reading the code while working on OOM hardening. 

 -  __Kernel: Avoid unnecessary time under lock in TCPSocket::create__

    Avoid holding the sockets_by_tuple lock while allocating the TCPSocket.
    While checking if the list contains the item we can also hold the lock
    in shared mode, as we are only reading the hash table.

    In addition the call to from_tuple appears to be superfluous, as we
    created the socket, so we should be able to just return it directly.
    This avoids the recursive lock acquisition, as well as the unnecessary
    hash table look ups.

 -  __Kernel: Remove dead TCPSocket::from_endpoints method__

CC: @gunnarbeutner 