### PR TITLE
LibWeb: Propagate body background properties to root HTML element

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -17,4 +17,12 @@ HTMLHtmlElement::~HTMLHtmlElement()
 {
 }
 
+bool HTMLHtmlElement::should_use_body_background_properties() const
+{
+    auto background_color = layout_node()->computed_values().background_color();
+    const auto* background_image = layout_node()->background_image();
+
+    return (background_color == Color::Transparent) && !background_image;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.h
@@ -16,6 +16,8 @@ public:
 
     HTMLHtmlElement(DOM::Document&, QualifiedName);
     virtual ~HTMLHtmlElement() override;
+
+    bool should_use_body_background_properties() const;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
@@ -42,20 +42,9 @@ void InitialContainingBlockBox::build_stacking_context_tree()
     });
 }
 
-void InitialContainingBlockBox::paint_document_background(PaintContext& context)
-{
-    context.painter().fill_rect(Gfx::IntRect { {}, context.viewport_rect().size() }, document().background_color(context.palette()));
-    context.painter().translate(-context.viewport_rect().location());
-
-    if (auto background_bitmap = document().background_image()) {
-        Gfx::IntRect background_rect = { 0, 0, context.viewport_rect().x() + context.viewport_rect().width(), context.viewport_rect().y() + context.viewport_rect().height() };
-        paint_background_image(context, *background_bitmap, document().background_repeat_x(), document().background_repeat_y(), move(background_rect));
-    }
-}
-
 void InitialContainingBlockBox::paint_all_phases(PaintContext& context)
 {
-    paint_document_background(context);
+    context.painter().translate(-context.viewport_rect().location());
     stacking_context()->paint(context);
 }
 

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.h
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.h
@@ -20,8 +20,6 @@ public:
 
     void paint_all_phases(PaintContext&);
 
-    void paint_document_background(PaintContext&);
-
     virtual HitTestResult hit_test(const Gfx::IntPoint&, HitTestType) const override;
 
     const LayoutRange& selection() const { return m_selection; }


### PR DESCRIPTION
The Acid1 test has a bit of an unusual background - the `html` and `body`
tags have different background colors. Our painting order of the DOM was
such that the `body` background was painted first, then all other elements
were painted in-phase according to Appendix E of CSS 2.1. So the `html`
element's background color was painted over the `body` background.

This removes the special handling of the `body` background from
`InitialContainingBlockBox` and now all boxes are painted in-phase. Doing
this also exposed that we weren't handling Section 2.11.2 of the spec;
when the `html` background is unset, the `body`'s background should be
propagated to the `html` element.

Acid1 before:
![before](https://user-images.githubusercontent.com/5600524/118134932-72787b00-b3d0-11eb-9e58-4b2c51939e91.png)

Acid1 after:
![after](https://user-images.githubusercontent.com/5600524/118134960-7a381f80-b3d0-11eb-94f8-eaf516968ab3.png)
