### PR TITLE
LibGfx: Fix Matrices

### DIFF
--- a/Userland/Demos/Cube/Cube.cpp
+++ b/Userland/Demos/Cube/Cube.cpp
@@ -128,13 +128,13 @@ void Cube::timer_event(Core::TimerEvent&)
     static float angle = 0;
     angle += 0.02f;
 
-    auto matrix = FloatMatrix4x4::translate(FloatVector3(0, 0, 1.5f))
-        * FloatMatrix4x4::rotate(FloatVector3(1, 0, 0), angle * 1.17356641f)
-        * FloatMatrix4x4::rotate(FloatVector3(0, 1, 0), angle * 0.90533273f)
-        * FloatMatrix4x4::rotate(FloatVector3(0, 0, 1), angle);
+    auto matrix = Gfx::translation_matrix(FloatVector3(0, 0, 1.5f))
+        * Gfx::rotation_matrix(FloatVector3(1, 0, 0), angle * 1.17356641f)
+        * Gfx::rotation_matrix(FloatVector3(0, 1, 0), angle * 0.90533273f)
+        * Gfx::rotation_matrix(FloatVector3(0, 0, 1), angle);
 
     for (int i = 0; i < 8; i++) {
-        transformed_vertices[i] = matrix.transform_point(vertices[i]);
+        transformed_vertices[i] = transform_point(matrix, vertices[i]);
     }
 
     GUI::Painter painter(*m_bitmap);

--- a/Userland/Demos/GLTeapot/main.cpp
+++ b/Userland/Demos/GLTeapot/main.cpp
@@ -87,6 +87,10 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
         * FloatMatrix4x4::rotate(FloatVector3(0, 1, 0), 0.0f)
         * FloatMatrix4x4::rotate(FloatVector3(0, 0, 1), angle);
 
+    // We need to transpose here because OpenGL expects matrices in column major order
+    // but our matrix class stores elements in row major order.
+    matrix = matrix.transpose();
+
     glMatrixMode(GL_MODELVIEW);
     glLoadMatrixf((float*)matrix.elements());
 

--- a/Userland/Demos/GLTeapot/main.cpp
+++ b/Userland/Demos/GLTeapot/main.cpp
@@ -82,10 +82,10 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
     glCallList(m_init_list);
 
     angle -= 0.01f;
-    auto matrix = FloatMatrix4x4::translate(FloatVector3(0, 0, -8.5))
-        * FloatMatrix4x4::rotate(FloatVector3(1, 0, 0), angle)
-        * FloatMatrix4x4::rotate(FloatVector3(0, 1, 0), 0.0f)
-        * FloatMatrix4x4::rotate(FloatVector3(0, 0, 1), angle);
+    auto matrix = Gfx::translation_matrix(FloatVector3(0, 0, -8.5))
+        * Gfx::rotation_matrix(FloatVector3(1, 0, 0), angle)
+        * Gfx::rotation_matrix(FloatVector3(0, 1, 0), 0.0f)
+        * Gfx::rotation_matrix(FloatVector3(0, 0, 1), angle);
 
     // We need to transpose here because OpenGL expects matrices in column major order
     // but our matrix class stores elements in row major order.

--- a/Userland/Libraries/LibGL/GLMat.cpp
+++ b/Userland/Libraries/LibGL/GLMat.cpp
@@ -37,11 +37,14 @@ void glPopMatrix()
 
 void glLoadMatrixf(const GLfloat* matrix)
 {
+    // Transpose the matrix here because glLoadMatrix expects elements
+    // in column major order but out Matrix class stores elements in
+    // row major order.
     FloatMatrix4x4 mat(
-        matrix[0], matrix[1], matrix[2], matrix[3],
-        matrix[4], matrix[5], matrix[6], matrix[7],
-        matrix[8], matrix[9], matrix[10], matrix[11],
-        matrix[12], matrix[13], matrix[14], matrix[15]);
+        matrix[0], matrix[4], matrix[8], matrix[12],
+        matrix[1], matrix[5], matrix[9], matrix[13],
+        matrix[2], matrix[6], matrix[10], matrix[14],
+        matrix[3], matrix[7], matrix[11], matrix[15]);
 
     g_gl_context->gl_load_matrix(mat);
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -576,7 +576,7 @@ void SoftwareGLContext::gl_rotate(GLdouble angle, GLdouble x, GLdouble y, GLdoub
 
     FloatVector3 axis = { (float)x, (float)y, (float)z };
     axis.normalize();
-    auto rotation_mat = FloatMatrix4x4::rotate(axis, angle);
+    auto rotation_mat = Gfx::rotation_matrix(axis, static_cast<float>(angle));
 
     if (m_current_matrix_mode == GL_MODELVIEW)
         m_model_view_matrix = m_model_view_matrix * rotation_mat;
@@ -596,9 +596,9 @@ void SoftwareGLContext::gl_scale(GLdouble x, GLdouble y, GLdouble z)
     }
 
     if (m_current_matrix_mode == GL_MODELVIEW) {
-        m_model_view_matrix = m_model_view_matrix * FloatMatrix4x4::scale({ static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) });
+        m_model_view_matrix = m_model_view_matrix * Gfx::scale_matrix(FloatVector3 { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) });
     } else if (m_current_matrix_mode == GL_PROJECTION) {
-        m_projection_matrix = m_projection_matrix * FloatMatrix4x4::scale({ static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) });
+        m_projection_matrix = m_projection_matrix * Gfx::scale_matrix(FloatVector3 { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z) });
     }
 
     m_error = GL_NO_ERROR;
@@ -614,9 +614,9 @@ void SoftwareGLContext::gl_translate(GLdouble x, GLdouble y, GLdouble z)
     }
 
     if (m_current_matrix_mode == GL_MODELVIEW) {
-        m_model_view_matrix = m_model_view_matrix * FloatMatrix4x4::translate({ (float)x, (float)y, (float)z });
+        m_model_view_matrix = m_model_view_matrix * Gfx::translation_matrix(FloatVector3 { (float)x, (float)y, (float)z });
     } else if (m_current_matrix_mode == GL_PROJECTION) {
-        m_projection_matrix = m_projection_matrix * FloatMatrix4x4::translate({ (float)x, (float)y, (float)z });
+        m_projection_matrix = m_projection_matrix * Gfx::translation_matrix(FloatVector3 { (float)x, (float)y, (float)z });
     }
 
     m_error = GL_NO_ERROR;

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -49,23 +49,23 @@ public:
                 auto& element = product.m_elements[i][j];
 
                 if constexpr (N == 4) {
-                    element = m_elements[0][j] * other.m_elements[i][0]
-                        + m_elements[1][j] * other.m_elements[i][1]
-                        + m_elements[2][j] * other.m_elements[i][2]
-                        + m_elements[3][j] * other.m_elements[i][3];
+                    element = m_elements[i][0] * other.m_elements[0][j]
+                        + m_elements[i][1] * other.m_elements[1][j]
+                        + m_elements[i][2] * other.m_elements[2][j]
+                        + m_elements[i][3] * other.m_elements[3][j];
                 } else if constexpr (N == 3) {
-                    element = m_elements[0][j] * other.m_elements[i][0]
-                        + m_elements[1][j] * other.m_elements[i][1]
-                        + m_elements[2][j] * other.m_elements[i][2];
+                    element = m_elements[i][0] * other.m_elements[0][j]
+                        + m_elements[i][1] * other.m_elements[1][j]
+                        + m_elements[i][2] * other.m_elements[2][j];
                 } else if constexpr (N == 2) {
-                    element = m_elements[0][j] * other.m_elements[i][0]
-                        + m_elements[1][j] * other.m_elements[i][1];
+                    element = m_elements[i][0] * other.m_elements[0][j]
+                        + m_elements[i][1] * other.m_elements[1][j];
                 } else if constexpr (N == 1) {
-                    element = m_elements[0][j] * other.m_elements[i][0];
+                    element = m_elements[i][0] * other.m_elements[0][j];
                 } else {
                     T value {};
                     for (size_t k = 0; k < N; ++k)
-                        value += m_elements[k][j] * other.m_elements[i][k];
+                        value += m_elements[i][k] * other.m_elements[k][j];
 
                     element = value;
                 }

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -44,8 +44,8 @@ public:
     constexpr Matrix operator*(const Matrix& other) const
     {
         Matrix product;
-        for (int i = 0; i < N; ++i) {
-            for (int j = 0; j < N; ++j) {
+        for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < N; ++j) {
                 auto& element = product.m_elements[i][j];
 
                 if constexpr (N == 4) {
@@ -73,6 +73,31 @@ public:
         }
 
         return product;
+    }
+
+    constexpr static Matrix identity()
+    {
+        Matrix result;
+        for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < N; ++j) {
+                if (i == j)
+                    result.m_elements[i][j] = 1;
+                else
+                    result.m_elements[i][j] = 0;
+            }
+        }
+        return result;
+    }
+
+    constexpr Matrix transpose() const
+    {
+        Matrix result;
+        for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < N; ++j) {
+                result.m_elements[i][j] = m_elements[j][i];
+            }
+        }
+        return result;
     }
 
 private:

--- a/Userland/Libraries/LibGfx/Matrix4x4.h
+++ b/Userland/Libraries/LibGfx/Matrix4x4.h
@@ -14,7 +14,7 @@
 namespace Gfx {
 
 template<typename T>
-class Matrix4x4 final : public Matrix<4, T> {
+class Matrix4x4 final {
 public:
     constexpr Matrix4x4() = default;
     constexpr Matrix4x4(T _11, T _12, T _13, T _14,
@@ -38,10 +38,10 @@ public:
         Matrix4x4 product;
         for (int i = 0; i < 4; ++i) {
             for (int j = 0; j < 4; ++j) {
-                product.m_elements[i][j] = m_elements[0][j] * other.m_elements[i][0]
-                    + m_elements[1][j] * other.m_elements[i][1]
-                    + m_elements[2][j] * other.m_elements[i][2]
-                    + m_elements[3][j] * other.m_elements[i][3];
+                product.m_elements[i][j] = m_elements[i][0] * other.m_elements[0][j]
+                    + m_elements[i][1] * other.m_elements[1][j]
+                    + m_elements[i][2] * other.m_elements[2][j]
+                    + m_elements[i][3] * other.m_elements[3][j];
             }
         }
         return product;
@@ -50,18 +50,18 @@ public:
     constexpr Vector4<T> operator*(const Vector4<T>& v) const
     {
         return Vector4<T>(
-            v.x() * m_elements[0][0] + v.y() * m_elements[1][0] + v.z() * m_elements[2][0] + v.w() * m_elements[3][0],
-            v.x() * m_elements[0][1] + v.y() * m_elements[1][1] + v.z() * m_elements[2][1] + v.w() * m_elements[3][1],
-            v.x() * m_elements[0][2] + v.y() * m_elements[1][2] + v.z() * m_elements[2][2] + v.w() * m_elements[3][2],
-            v.x() * m_elements[0][3] + v.y() * m_elements[1][3] + v.z() * m_elements[2][3] + v.w() * m_elements[3][3]);
+            v.x() * m_elements[0][0] + v.y() * m_elements[0][1] + v.z() * m_elements[0][2] + v.w() * m_elements[0][3],
+            v.x() * m_elements[1][0] + v.y() * m_elements[1][1] + v.z() * m_elements[1][2] + v.w() * m_elements[1][3],
+            v.x() * m_elements[2][0] + v.y() * m_elements[2][1] + v.z() * m_elements[2][2] + v.w() * m_elements[2][3],
+            v.x() * m_elements[3][0] + v.y() * m_elements[3][1] + v.z() * m_elements[3][2] + v.w() * m_elements[3][3]);
     }
 
     constexpr Vector3<T> transform_point(const Vector3<T>& p) const
     {
         return Vector3<T>(
-            p.x() * m_elements[0][0] + p.y() * m_elements[1][0] + p.z() * m_elements[2][0] + m_elements[3][0],
-            p.x() * m_elements[0][1] + p.y() * m_elements[1][1] + p.z() * m_elements[2][1] + m_elements[3][1],
-            p.x() * m_elements[0][2] + p.y() * m_elements[1][2] + p.z() * m_elements[2][2] + m_elements[3][2]);
+            p.x() * m_elements[0][0] + p.y() * m_elements[0][1] + p.z() * m_elements[0][2] + m_elements[0][3],
+            p.x() * m_elements[1][0] + p.y() * m_elements[1][1] + p.z() * m_elements[1][2] + m_elements[1][3],
+            p.x() * m_elements[2][0] + p.y() * m_elements[2][1] + p.z() * m_elements[2][2] + m_elements[2][3]);
     }
 
     constexpr static Matrix4x4 identity()
@@ -76,10 +76,10 @@ public:
     constexpr static Matrix4x4 translate(const Vector3<T>& p)
     {
         return Matrix4x4(
-            1, 0, 0, 0,
-            0, 1, 0, 0,
-            0, 0, 1, 0,
-            p.x(), p.y(), p.z(), 1);
+            1, 0, 0, p.x(),
+            0, 1, 0, p.y(),
+            0, 0, 1, p.z(),
+            0, 0, 0, 1);
     }
 
     constexpr static Matrix4x4 scale(const Vector3<T>& s)
@@ -105,6 +105,17 @@ public:
             t * x * y + z * s, t * y * y + c, t * y * z - x * s, 0,
             t * x * z - y * s, t * y * z + x * s, t * z * z + c, 0,
             0, 0, 0, 1);
+    }
+
+    constexpr Matrix4x4 transpose() const
+    {
+        Matrix4x4 result;
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                result.m_elements[i][j] = m_elements[j][i];
+            }
+        }
+        return result;
     }
 
 private:

--- a/Userland/Libraries/LibGfx/Matrix4x4.h
+++ b/Userland/Libraries/LibGfx/Matrix4x4.h
@@ -14,117 +14,78 @@
 namespace Gfx {
 
 template<typename T>
-class Matrix4x4 final {
-public:
-    constexpr Matrix4x4() = default;
-    constexpr Matrix4x4(T _11, T _12, T _13, T _14,
-        T _21, T _22, T _23, T _24,
-        T _31, T _32, T _33, T _34,
-        T _41, T _42, T _43, T _44)
-        : m_elements {
-            _11, _12, _13, _14,
-            _21, _22, _23, _24,
-            _31, _32, _33, _34,
-            _41, _42, _43, _44
-        }
-    {
-    }
+using Matrix4x4 = Matrix<4, T>;
 
-    constexpr auto elements() const { return m_elements; }
-    constexpr auto elements() { return m_elements; }
+template<typename T>
+constexpr static Vector4<T> operator*(const Matrix4x4<T>& m, const Vector4<T>& v)
+{
+    auto const& elements = m.elements();
+    return Vector4<T>(
+        v.x() * elements[0][0] + v.y() * elements[0][1] + v.z() * elements[0][2] + v.w() * elements[0][3],
+        v.x() * elements[1][0] + v.y() * elements[1][1] + v.z() * elements[1][2] + v.w() * elements[1][3],
+        v.x() * elements[2][0] + v.y() * elements[2][1] + v.z() * elements[2][2] + v.w() * elements[2][3],
+        v.x() * elements[3][0] + v.y() * elements[3][1] + v.z() * elements[3][2] + v.w() * elements[3][3]);
+}
 
-    constexpr Matrix4x4 operator*(const Matrix4x4& other) const
-    {
-        Matrix4x4 product;
-        for (int i = 0; i < 4; ++i) {
-            for (int j = 0; j < 4; ++j) {
-                product.m_elements[i][j] = m_elements[i][0] * other.m_elements[0][j]
-                    + m_elements[i][1] * other.m_elements[1][j]
-                    + m_elements[i][2] * other.m_elements[2][j]
-                    + m_elements[i][3] * other.m_elements[3][j];
-            }
-        }
-        return product;
-    }
+template<typename T>
+constexpr static Vector3<T> transform_point(const Matrix4x4<T>& m, const Vector3<T>& p)
+{
+    auto const& elements = m.elements();
+    return Vector3<T>(
+        p.x() * elements[0][0] + p.y() * elements[0][1] + p.z() * elements[0][2] + elements[0][3],
+        p.x() * elements[1][0] + p.y() * elements[1][1] + p.z() * elements[1][2] + elements[1][3],
+        p.x() * elements[2][0] + p.y() * elements[2][1] + p.z() * elements[2][2] + elements[2][3]);
+}
 
-    constexpr Vector4<T> operator*(const Vector4<T>& v) const
-    {
-        return Vector4<T>(
-            v.x() * m_elements[0][0] + v.y() * m_elements[0][1] + v.z() * m_elements[0][2] + v.w() * m_elements[0][3],
-            v.x() * m_elements[1][0] + v.y() * m_elements[1][1] + v.z() * m_elements[1][2] + v.w() * m_elements[1][3],
-            v.x() * m_elements[2][0] + v.y() * m_elements[2][1] + v.z() * m_elements[2][2] + v.w() * m_elements[2][3],
-            v.x() * m_elements[3][0] + v.y() * m_elements[3][1] + v.z() * m_elements[3][2] + v.w() * m_elements[3][3]);
-    }
+template<typename T>
+constexpr static Vector3<T> transform_direction(const Matrix4x4<T>& m, const Vector3<T>& d)
+{
+    auto const& elements = m.elements();
+    return Vector3<T>(
+        d.x() * elements[0][0] + d.y() * elements[0][1] + d.z() * elements[0][2],
+        d.x() * elements[1][0] + d.y() * elements[1][1] + d.z() * elements[1][2],
+        d.x() * elements[2][0] + d.y() * elements[2][1] + d.z() * elements[2][2]);
+}
 
-    constexpr Vector3<T> transform_point(const Vector3<T>& p) const
-    {
-        return Vector3<T>(
-            p.x() * m_elements[0][0] + p.y() * m_elements[0][1] + p.z() * m_elements[0][2] + m_elements[0][3],
-            p.x() * m_elements[1][0] + p.y() * m_elements[1][1] + p.z() * m_elements[1][2] + m_elements[1][3],
-            p.x() * m_elements[2][0] + p.y() * m_elements[2][1] + p.z() * m_elements[2][2] + m_elements[2][3]);
-    }
+template<typename T>
+constexpr static Matrix4x4<T> translation_matrix(const Vector3<T>& p)
+{
+    return Matrix4x4<T>(
+        1, 0, 0, p.x(),
+        0, 1, 0, p.y(),
+        0, 0, 1, p.z(),
+        0, 0, 0, 1);
+}
 
-    constexpr static Matrix4x4 identity()
-    {
-        return Matrix4x4(
-            1, 0, 0, 0,
-            0, 1, 0, 0,
-            0, 0, 1, 0,
-            0, 0, 0, 1);
-    }
+template<typename T>
+constexpr static Matrix4x4<T> scale_matrix(const Vector3<T>& s)
+{
+    return Matrix4x4<T>(
+        s.x(), 0, 0, 0,
+        0, s.y(), 0, 0,
+        0, 0, s.z(), 0,
+        0, 0, 0, 1);
+}
 
-    constexpr static Matrix4x4 translate(const Vector3<T>& p)
-    {
-        return Matrix4x4(
-            1, 0, 0, p.x(),
-            0, 1, 0, p.y(),
-            0, 0, 1, p.z(),
-            0, 0, 0, 1);
-    }
+template<typename T>
+constexpr static Matrix4x4<T> rotation_matrix(const Vector3<T>& axis, T angle)
+{
+    T c = cos(angle);
+    T s = sin(angle);
+    T t = 1 - c;
+    T x = axis.x();
+    T y = axis.y();
+    T z = axis.z();
 
-    constexpr static Matrix4x4 scale(const Vector3<T>& s)
-    {
-        return Matrix4x4(
-            s.x(), 0, 0, 0,
-            0, s.y(), 0, 0,
-            0, 0, s.z(), 0,
-            0, 0, 0, 1);
-    }
-
-    constexpr static Matrix4x4 rotate(const Vector3<T>& axis, T angle)
-    {
-        T c = cos(angle);
-        T s = sin(angle);
-        T t = 1 - c;
-        T x = axis.x();
-        T y = axis.y();
-        T z = axis.z();
-
-        return Matrix4x4(
-            t * x * x + c, t * x * y - z * s, t * x * z + y * s, 0,
-            t * x * y + z * s, t * y * y + c, t * y * z - x * s, 0,
-            t * x * z - y * s, t * y * z + x * s, t * z * z + c, 0,
-            0, 0, 0, 1);
-    }
-
-    constexpr Matrix4x4 transpose() const
-    {
-        Matrix4x4 result;
-        for (int i = 0; i < 4; ++i) {
-            for (int j = 0; j < 4; ++j) {
-                result.m_elements[i][j] = m_elements[j][i];
-            }
-        }
-        return result;
-    }
-
-private:
-    T m_elements[4][4];
-};
+    return Matrix4x4<T>(
+        t * x * x + c, t * x * y - z * s, t * x * z + y * s, 0,
+        t * x * y + z * s, t * y * y + c, t * y * z - x * s, 0,
+        t * x * z - y * s, t * y * z + x * s, t * z * z + c, 0,
+        0, 0, 0, 1);
+}
 
 typedef Matrix4x4<float> FloatMatrix4x4;
 typedef Matrix4x4<double> DoubleMatrix4x4;
-
 }
 
 using Gfx::DoubleMatrix4x4;


### PR DESCRIPTION
This PR does two things:

_1) Fix memory layout interpretation of the matrix members._
There were different expectations as to how exactly the members are laid out in memory. rows x columns, vs columns x rows.
The matrix is now definitely row major, e.g accessing element i,j in a 4x4 matrix points to memory location m[i * 4 + j].
Matrix multiplication has been fixed so that rows from the left operand are multiplied with columns from the right operand.

_2) Make `Matrix4x4` a partially specialized alias for `Matrix<4, T>`._
Before this `Matrix4x4` was defined as a derived class of `Matrix`. There were some issues as it had various code duplications and assigning results from operators defined in the parent class to instances of `Matrix4x4` was not possible due to type mismatch.
Some static functions that were special to `Matrix4x4` had to be pulled out and are now free standing functions in the `Gfx` namespace.

