### PR TITLE
CMake: Make missing medium icon a FATAL_ERROR

### DIFF
--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -109,7 +109,7 @@ function(serenity_app target_name)
         list(APPEND allowed_missing_medium_icons "edit-copy")
 
         if (NOT ${SERENITY_APP_ICON} IN_LIST allowed_missing_medium_icons)
-            message(WARNING "Missing medium app icon: ${medium_icon}")
+            message(FATAL_ERROR "Missing medium app icon: ${medium_icon}")
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
Now that all of the medium icons pass this check, we can make it
FATAL_ERROR to stop any new violations from being checked in.

The last one was fixed in PR #7088