### PR TITLE
Profiler: Various improvements

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -619,7 +619,7 @@ public:
             return false;
 
         for (size_t i = size(); i < new_size; ++i)
-            new (slot(i)) T;
+            new (slot(i)) T {};
         m_size = new_size;
         return true;
     }

--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -53,6 +53,7 @@ struct [[gnu::packed]] PerformanceEvent {
     u32 pid { 0 };
     u32 tid { 0 };
     u64 timestamp;
+    u32 lost_samples;
     union {
         MallocPerformanceEvent malloc;
         FreePerformanceEvent free;
@@ -77,7 +78,7 @@ public:
 
     KResult append(int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3, Thread* current_thread = Thread::current());
     KResult append_with_eip_and_ebp(ProcessID pid, ThreadID tid, u32 eip, u32 ebp,
-        int type, FlatPtr arg1, FlatPtr arg2, const StringView& arg3);
+        int type, u32 lost_samples, FlatPtr arg1, FlatPtr arg2, const StringView& arg3);
 
     void clear()
     {

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -10,7 +10,6 @@
 #include <AK/Time.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Panic.h>
-#include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/RTC.h>
 #include <Kernel/Scheduler.h>
@@ -500,8 +499,6 @@ void Scheduler::timer_tick(const RegisterState& regs)
     if (!Processor::is_bootstrap_processor())
         return; // TODO: This prevents scheduling on other CPUs!
 #endif
-
-    PerformanceManager::add_cpu_sample_event(*current_thread, regs);
 
     if (current_thread->tick())
         return;

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
+#include <Kernel/Time/TimeManagement.h>
 
 namespace Kernel {
 
@@ -34,6 +35,7 @@ KResultOr<int> Process::sys$profiling_enable(pid_t pid)
             PerformanceManager::add_process_created_event(process);
             return IterationDecision::Continue;
         });
+        TimeManagement::the().enable_profile_timer();
         return 0;
     }
 
@@ -48,6 +50,7 @@ KResultOr<int> Process::sys$profiling_enable(pid_t pid)
     if (!process->create_perf_events_buffer_if_needed())
         return ENOMEM;
     process->set_profiling(true);
+    TimeManagement::the().enable_profile_timer();
     return 0;
 }
 
@@ -60,6 +63,7 @@ KResultOr<int> Process::sys$profiling_disable(pid_t pid)
             return EPERM;
         ScopedCritical critical;
         g_profiling_all_threads = false;
+        TimeManagement::the().disable_profile_timer();
         return 0;
     }
 
@@ -71,6 +75,7 @@ KResultOr<int> Process::sys$profiling_disable(pid_t pid)
         return EPERM;
     if (!process->is_profiling())
         return EINVAL;
+    TimeManagement::the().disable_profile_timer();
     process->set_profiling(false);
     return 0;
 }

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -16,6 +16,7 @@
 namespace Kernel {
 
 #define OPTIMAL_TICKS_PER_SECOND_RATE 250
+#define OPTIMAL_PROFILE_TICKS_PER_SECOND_RATE 1000
 
 class HardwareTimerBase;
 
@@ -55,6 +56,9 @@ public:
 
     static bool is_hpet_periodic_mode_allowed();
 
+    void enable_profile_timer();
+    void disable_profile_timer();
+
     u64 uptime_ms() const;
     static Time now();
 
@@ -90,6 +94,9 @@ private:
 
     RefPtr<HardwareTimerBase> m_system_timer;
     RefPtr<HardwareTimerBase> m_time_keeper_timer;
+
+    Atomic<u32> m_profile_enable_count { 0 };
+    RefPtr<HardwareTimerBase> m_profile_timer;
 };
 
 }

--- a/Userland/DevTools/Profiler/Histogram.h
+++ b/Userland/DevTools/Profiler/Histogram.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+
+template<typename Timestamp = u64, typename Value = u16, size_t inline_capacity = 4096>
+class Histogram {
+public:
+    Histogram(Timestamp start, Timestamp end, size_t bucket_count)
+        : m_start(start)
+        , m_end(end)
+    {
+        m_buckets.resize(bucket_count);
+    }
+
+    void insert(Timestamp const& timestamp, Value value = 1)
+    {
+        VERIFY(timestamp >= m_start && timestamp <= m_end);
+        auto bucket = (timestamp - m_start) * (m_buckets.size() - 1) / (m_end - m_start);
+        m_buckets[bucket] += value;
+    }
+
+    Value at(size_t index) const
+    {
+        return m_buckets[index];
+    }
+
+    size_t size() const
+    {
+        return m_buckets.size();
+    }
+
+private:
+    Timestamp m_start { 0 };
+    Timestamp m_end { 0 };
+    Vector<Value, inline_capacity> m_buckets;
+};

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -99,6 +99,12 @@ void Profile::rebuild_tree()
         if (!process_filter_contains(event.pid, event.timestamp))
             continue;
 
+        if (!m_show_scheduler && !event.frames.is_empty()) {
+            auto top_frame = event.frames[event.frames.size() - 1];
+            if (top_frame.symbol == "Kernel::Scheduler::yield()")
+                continue;
+        }
+
         m_filtered_event_indices.append(event_index);
 
         if (event.type == "malloc" && !live_allocations.contains(event.ptr))
@@ -448,6 +454,15 @@ void Profile::set_show_percentages(bool show_percentages)
     if (m_show_percentages == show_percentages)
         return;
     m_show_percentages = show_percentages;
+}
+
+void Profile::set_show_scheduler(bool show_scheduler)
+{
+    if (m_show_scheduler == show_scheduler)
+        return;
+    m_show_scheduler = show_scheduler;
+    // FIXME: This only works when kernel symbols are available
+    rebuild_tree();
 }
 
 void Profile::set_disassembly_index(const GUI::ModelIndex& index)

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -228,6 +228,7 @@ Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const St
         Event event;
 
         event.timestamp = perf_event.get("timestamp").to_number<u64>();
+        event.lost_samples = perf_event.get("lost_samples").to_number<u32>();
         event.type = perf_event.get("type").to_string();
         event.pid = perf_event.get("pid").to_i32();
         event.tid = perf_event.get("tid").to_i32();

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -196,6 +196,9 @@ public:
     bool show_percentages() const { return m_show_percentages; }
     void set_show_percentages(bool);
 
+    bool show_scheduler() const { return m_show_scheduler; }
+    void set_show_scheduler(bool);
+
     const Vector<Process>& processes() const { return m_processes; }
 
     template<typename Callback>
@@ -240,6 +243,7 @@ private:
     bool m_inverted { false };
     bool m_show_top_functions { false };
     bool m_show_percentages { false };
+    bool m_show_scheduler { true };
 };
 
 }

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -166,6 +166,7 @@ public:
         String executable;
         int pid { 0 };
         int tid { 0 };
+        u32 lost_samples { 0 };
         bool in_kernel { false };
         Vector<Frame> frames;
     };

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -45,6 +45,8 @@ String SamplesModel::column_name(int column) const
         return "TID";
     case Column::ExecutableName:
         return "Executable";
+    case Column::LostSamples:
+        return "Lost Samples";
     case Column::InnermostStackFrame:
         return "Innermost Frame";
     default:
@@ -79,6 +81,10 @@ GUI::Variant SamplesModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
 
         if (index.column() == Column::Timestamp) {
             return (u32)event.timestamp;
+        }
+
+        if (index.column() == Column::LostSamples) {
+            return event.lost_samples;
         }
 
         if (index.column() == Column::InnermostStackFrame) {

--- a/Userland/DevTools/Profiler/SamplesModel.h
+++ b/Userland/DevTools/Profiler/SamplesModel.h
@@ -25,6 +25,7 @@ public:
         ProcessID,
         ThreadID,
         ExecutableName,
+        LostSamples,
         InnermostStackFrame,
         __Count
     };

--- a/Userland/DevTools/Profiler/TimelineTrack.cpp
+++ b/Userland/DevTools/Profiler/TimelineTrack.cpp
@@ -71,6 +71,12 @@ void TimelineTrack::paint_event(GUI::PaintEvent& event)
         if (!m_process.valid_at(event.timestamp))
             continue;
 
+        if (!m_profile.show_scheduler() && !event.frames.is_empty()) {
+            auto top_frame = event.frames[event.frames.size() - 1];
+            if (top_frame.symbol == "Kernel::Scheduler::yield()")
+                continue;
+        }
+
         auto& histogram = event.in_kernel ? kernel_histogram : usermode_histogram;
         histogram.insert(clamp_timestamp(event.timestamp), 1);
     }

--- a/Userland/DevTools/Profiler/TimelineTrack.cpp
+++ b/Userland/DevTools/Profiler/TimelineTrack.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TimelineTrack.h"
+#include "Histogram.h"
 #include "Profile.h"
 #include "TimelineView.h"
 #include <LibGUI/Painter.h>
@@ -57,7 +58,11 @@ void TimelineTrack::paint_event(GUI::PaintEvent& event)
     };
 
     float column_width = (float)frame_inner_rect().width() / (float)m_profile.length_in_ms();
-    float frame_height = (float)frame_inner_rect().height() / (float)m_profile.deepest_stack_depth();
+    size_t columns = frame_inner_rect().width() / column_width;
+
+    Histogram kernel_histogram { start_of_trace, end_of_trace, columns };
+    Histogram usermode_histogram { start_of_trace, end_of_trace, columns };
+    auto bucket_count = kernel_histogram.size();
 
     for (auto& event : m_profile.events()) {
         if (event.pid != m_process.pid)
@@ -66,16 +71,37 @@ void TimelineTrack::paint_event(GUI::PaintEvent& event)
         if (!m_process.valid_at(event.timestamp))
             continue;
 
-        u64 t = clamp_timestamp(event.timestamp) - start_of_trace;
+        auto& histogram = event.in_kernel ? kernel_histogram : usermode_histogram;
+        histogram.insert(clamp_timestamp(event.timestamp), 1);
+    }
+
+    decltype(kernel_histogram.at(0)) max_value = 0;
+    for (size_t bucket = 0; bucket < bucket_count; bucket++) {
+        auto value = kernel_histogram.at(bucket) + usermode_histogram.at(bucket);
+        if (value > max_value)
+            max_value = value;
+    }
+
+    float frame_height = (float)frame_inner_rect().height() / (float)max_value;
+
+    for (size_t bucket = 0; bucket < bucket_count; bucket++) {
+        auto kernel_value = kernel_histogram.at(bucket);
+        auto usermode_value = usermode_histogram.at(bucket);
+        if (kernel_value + usermode_value == 0)
+            continue;
+
+        auto t = bucket;
+
         int x = (int)((float)t * column_width);
         int cw = max(1, (int)column_width);
 
-        int column_height = frame_inner_rect().height() - (int)((float)event.frames.size() * frame_height);
+        int kernel_column_height = frame_inner_rect().height() - (int)((float)kernel_value * frame_height);
+        int usermode_column_height = frame_inner_rect().height() - (int)((float)(kernel_value + usermode_value) * frame_height);
 
-        bool in_kernel = event.in_kernel;
-        Color color = in_kernel ? Color::from_rgb(0xc25e5a) : Color::from_rgb(0x5a65c2);
-        for (int i = 1; i <= cw; ++i)
-            painter.draw_line({ x + i, frame_thickness() + column_height }, { x + i, height() - frame_thickness() * 2 }, color);
+        constexpr auto kernel_color = Color::from_rgb(0xc25e5a);
+        constexpr auto usermode_color = Color::from_rgb(0x5a65c2);
+        painter.fill_rect({ x, frame_thickness() + usermode_column_height, cw, height() - frame_thickness() * 2 }, usermode_color);
+        painter.fill_rect({ x, frame_thickness() + kernel_column_height, cw, height() - frame_thickness() * 2 }, kernel_color);
     }
 
     u64 normalized_start_time = clamp_timestamp(min(m_view.select_start_time(), m_view.select_end_time()));

--- a/Userland/DevTools/Profiler/TimelineTrack.cpp
+++ b/Userland/DevTools/Profiler/TimelineTrack.cpp
@@ -78,7 +78,7 @@ void TimelineTrack::paint_event(GUI::PaintEvent& event)
         }
 
         auto& histogram = event.in_kernel ? kernel_histogram : usermode_histogram;
-        histogram.insert(clamp_timestamp(event.timestamp), 1);
+        histogram.insert(clamp_timestamp(event.timestamp), 1 + event.lost_samples);
     }
 
     decltype(kernel_histogram.at(0)) max_value = 0;

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -209,6 +209,15 @@ int main(int argc, char** argv)
     percent_action->set_checked(false);
     view_menu.add_action(percent_action);
 
+    auto scheduler_action = GUI::Action::create_checkable("Show &Context Switches", { Mod_Ctrl, Key_C }, [&](auto& action) {
+        profile->set_show_scheduler(action.is_checked());
+        tree_view.update();
+        disassembly_view.update();
+        timeline_container.update();
+    });
+    scheduler_action->set_checked(true);
+    view_menu.add_action(scheduler_action);
+
     auto& help_menu = menubar->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
         Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Profiler.md"), "/bin/Help");


### PR DESCRIPTION

![Screenshot from 2021-05-13 23-48-55](https://user-images.githubusercontent.com/388571/118192436-6c24e600-b446-11eb-821b-d22750f97bf0.png)


**AK: Vector::resize() should initialize new slots for primitive types**

We call placement new for the newly added slots. However, we should also specify an initializer so primitive data types like u64 are initialized appropriately.

**Profiler: Add histogram for sample counts**

Previously `Profiler` would use the stack depth to draw the timeline graphs. This is not an accurate representation of whether a thread is "busy" or not. Instead this updates the timelines to use the sample count.

**Profiler: Let the user ignore context switches**

Now that the profiling timer is independent from the scheduler the user will get quite a few CPU samples from "within" the scheduler. These events are less useful when just profiling a user-mode process rather than the whole system. This patch adds an option to `Profiler` to hide these events.

Note: This currently doesn't work when the user is running `Profiler` as non-root because this uses the symbol name for `Kernel::Scheduler::yield()` to determine whether a sample belongs to the scheduler.

**Kernel: Use a separate timer for profiling the system**

This updates the profiling subsystem to use a separate timer to trigger CPU sampling. This timer has a higher resolution (1000Hz) and is independent from the scheduler. At a later time the resolution could even be made configurable with an argument for `sys$profiling_enable()` - but not today.

**Kernel+Profiler: Track lost time between profiler timer ticks**

We can lose profiling timer events for a few reasons, for example disabled interrupts or system slowness. This accounts for lost
time between CPU samples by adding a field `lost_samples` to each profiling event which tracks how many samples were lost immediately preceding the event.
