### PR TITLE
Kernel: Make kprintf use VirtIOConsole as backend if available

### DIFF
--- a/Kernel/VM/RingBuffer.cpp
+++ b/Kernel/VM/RingBuffer.cpp
@@ -16,13 +16,13 @@ RingBuffer::RingBuffer(String region_name, size_t capacity)
 {
 }
 
-bool RingBuffer::copy_data_in(const UserOrKernelBuffer& buffer, size_t offset, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied)
+bool RingBuffer::copy_data_in(const UserOrKernelBuffer& buffer, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied)
 {
     size_t start_of_free_area = (m_start_of_used + m_num_used_bytes) % m_capacity_in_bytes;
     bytes_copied = min(m_capacity_in_bytes - m_num_used_bytes, min(m_capacity_in_bytes - start_of_free_area, length));
     if (bytes_copied == 0)
         return false;
-    if (buffer.read(m_region->vaddr().offset(start_of_free_area).as_ptr(), offset, bytes_copied)) {
+    if (buffer.read(m_region->vaddr().offset(start_of_free_area).as_ptr(), bytes_copied)) {
         m_num_used_bytes += bytes_copied;
         start_of_copied_data = m_region->physical_page(start_of_free_area / PAGE_SIZE)->paddr().offset(start_of_free_area % PAGE_SIZE);
         return true;

--- a/Kernel/VM/RingBuffer.h
+++ b/Kernel/VM/RingBuffer.h
@@ -16,7 +16,7 @@ public:
     RingBuffer(String region_name, size_t capacity);
 
     bool has_space() const { return m_num_used_bytes < m_capacity_in_bytes; }
-    bool copy_data_in(const UserOrKernelBuffer& buffer, size_t offset, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied);
+    bool copy_data_in(const UserOrKernelBuffer& buffer, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied);
     void reclaim_space(PhysicalAddress chunk_start, size_t chunk_size);
     PhysicalAddress start_of_used() const;
 

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -108,13 +108,13 @@ KResultOr<size_t> VirtIOConsole::write(FileDescription& desc, u64, const UserOrK
     if (!size)
         return 0;
 
-    if (!can_write(desc, size))
-        return EAGAIN;
-
     ScopedSpinLock ringbuffer_lock(m_transmit_buffer->lock());
     auto& queue = get_queue(TRANSMITQ);
     ScopedSpinLock queue_lock(queue.lock());
     VirtIOQueueChain chain(queue);
+
+    if (!can_write(desc, size))
+        return EAGAIN;
 
     size_t total_bytes_copied = 0;
     do {

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -51,6 +51,7 @@ VirtIOConsole::VirtIOConsole(PCI::Address address)
 
 VirtIOConsole::~VirtIOConsole()
 {
+    VERIFY_NOT_REACHED();
 }
 
 bool VirtIOConsole::handle_device_config_change()

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -121,7 +121,7 @@ KResultOr<size_t> VirtIOConsole::write(FileDescription& desc, u64, const UserOrK
         PhysicalAddress start_of_chunk;
         size_t length_of_chunk;
 
-        if (!m_transmit_buffer->copy_data_in(data, total_bytes_copied, size - total_bytes_copied, start_of_chunk, length_of_chunk)) {
+        if (!m_transmit_buffer->copy_data_in(data.offset(total_bytes_copied), size - total_bytes_copied, start_of_chunk, length_of_chunk)) {
             chain.release_buffer_slots_to_queue();
             return EINVAL;
         }

--- a/Kernel/VirtIO/VirtIOConsole.h
+++ b/Kernel/VirtIO/VirtIOConsole.h
@@ -25,6 +25,9 @@ public:
     VirtIOConsole(PCI::Address);
     virtual ~VirtIOConsole() override;
 
+    static VirtIOConsole* main_console();
+    size_t write_from_kernel(const char* data, size_t size);
+
 private:
     constexpr static size_t RINGBUFFER_SIZE = 2 * PAGE_SIZE;
     virtual const char* class_name() const override { return m_class_name.characters(); }
@@ -44,6 +47,7 @@ private:
     OwnPtr<RingBuffer> m_transmit_buffer;
 
     static unsigned next_device_id;
+    static Atomic<VirtIOConsole*> g_main_console;
 };
 
 }


### PR DESCRIPTION
This is very much a draft, I'm not entirely sure what the best way to hook this up would be however the code below is enough to play around with it. Things that we need to consider:

- [x] Handling the case where the VirtIOConsole is destroyed after it is registered as the main kernel printf backend (actually, there is nothing in the VirtIO spec about how graceful shutdown of VirtIO devices should be done. Should we just assume that it cannot happen (i.e. `VERIFY_NOT_REACHED()` in the `VirtIODevice` destructor?)). 
- [x] We need a better interface for referencing the main VirtIOConsole.
- [ ] Maybe we should make our method of choosing a main kernel printf backend more resilient in general.
- [ ] Maybe we should make it so that `/dev/console` redirects to whatever the main kernel console is at the time?
- [x] If we enable VIRTIO_DEBUG, then we get a kernel panic since attempting to `dbgln()` will then write to the VirtIOConsole which will then `dbgln_if(VIRTIO_DEBUG)` and so on. 
- [ ] What do we do if we fill up the VirtIOQueue when kprintf-ing? We can't block until there is space, since dbgln() can be called inside spinlock critical sections and interrupt handlers. Falling back to port 0xe9 knocking doesn't work, since bytes sent to the VirtIOConsole and the e9 port aren't synchronised by QEMU (they aren't required to be by any spec either). Should we just drop the bytes?

The benefit of having this enabled is that kernel debug prints are significantly faster. I was able to get serenity to boot and run reasonably smoothly with `THREAD_DEBUG` defined, which is not really possible with the normal console.