### PR TITLE
AK+LibTLS+LibCrypto: Make more sanitizer-friendly

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -277,7 +277,8 @@ inline void ByteBufferImpl::grow(size_t size)
         return;
     }
     u8* new_data = static_cast<u8*>(kmalloc(size));
-    __builtin_memcpy(new_data, m_data, m_size);
+    if (m_data)
+        __builtin_memcpy(new_data, m_data, m_size);
     u8* old_data = m_data;
     m_data = new_data;
     m_size = size;

--- a/AK/ByteReader.h
+++ b/AK/ByteReader.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace AK {
+
+struct ByteReader {
+    static void store(u8* address, u16 value)
+    {
+        union {
+            u16 _16;
+            u8 _8[2];
+        } const v { ._16 = value };
+        __builtin_memcpy(address, v._8, 2);
+    }
+
+    static void store(u8* address, u32 value)
+    {
+        union {
+            u32 _32;
+            u8 _8[4];
+        } const v { ._32 = value };
+        __builtin_memcpy(address, v._8, 4);
+    }
+
+    static void load(const u8* address, u16& value)
+    {
+        union {
+            u16 _16;
+            u8 _8[2];
+        } v { ._16 = 0 };
+        __builtin_memcpy(&v._8, address, 2);
+        value = v._16;
+    }
+
+    static void load(const u8* address, u32& value)
+    {
+        union {
+            u32 _32;
+            u8 _8[4];
+        } v { ._32 = 0 };
+        __builtin_memcpy(&v._8, address, 4);
+        value = v._32;
+    }
+
+    static u16 load16(const u8* address)
+    {
+        u16 value;
+        load(address, value);
+        return value;
+    }
+
+    static u32 load32(const u8* address)
+    {
+        u32 value;
+        load(address, value);
+        return value;
+    }
+};
+
+}
+
+using AK::ByteReader;

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteReader.h>
 #include <AK/Debug.h>
 #include <AK/MemoryStream.h>
 #include <AK/Types.h>
@@ -15,14 +16,13 @@ namespace {
 
 static u32 to_u32(const u8* b)
 {
-    return AK::convert_between_host_and_big_endian(*(const u32*)b);
+    return AK::convert_between_host_and_big_endian(ByteReader::load32(b));
 }
 
 static void to_u8s(u8* b, const u32* w)
 {
     for (auto i = 0; i < 4; ++i) {
-        auto& e = *((u32*)(b + i * 4));
-        e = AK::convert_between_host_and_big_endian(w[i]);
+        ByteReader::store(b + i * 4, AK::convert_between_host_and_big_endian(w[i]));
     }
 }
 

--- a/Userland/Libraries/LibCrypto/Cipher/AES.h
+++ b/Userland/Libraries/LibCrypto/Cipher/AES.h
@@ -37,9 +37,9 @@ public:
     virtual void overwrite(ReadonlyBytes) override;
     virtual void overwrite(const u8* data, size_t size) override { overwrite({ data, size }); }
 
-    virtual void apply_initialization_vector(const u8* ivec) override
+    virtual void apply_initialization_vector(ReadonlyBytes ivec) override
     {
-        for (size_t i = 0; i < block_size(); ++i)
+        for (size_t i = 0; i < min(block_size(), ivec.size()); ++i)
             m_data[i] ^= ivec[i];
     }
 

--- a/Userland/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Cipher.h
@@ -44,7 +44,7 @@ public:
     virtual void overwrite(ReadonlyBytes) = 0;
     virtual void overwrite(const u8* data, size_t size) { overwrite({ data, size }); }
 
-    virtual void apply_initialization_vector(const u8* ivec) = 0;
+    virtual void apply_initialization_vector(ReadonlyBytes ivec) = 0;
 
     PaddingMode padding_mode() const { return m_padding_mode; }
     void set_padding_mode(PaddingMode mode) { m_padding_mode = mode; }

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/CTR.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/CTR.h
@@ -168,7 +168,7 @@ protected:
 
             cipher.encrypt_block(m_cipher_block, m_cipher_block);
             if (in) {
-                m_cipher_block.apply_initialization_vector(in->data() + offset);
+                m_cipher_block.apply_initialization_vector(in->slice(offset));
             }
             auto write_size = min(block_size, length);
 

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
@@ -84,7 +84,7 @@ public:
             CTR<T>::encrypt(in, out, iv);
 
         auto auth_tag = m_ghash->process(aad, out);
-        block0.apply_initialization_vector(auth_tag.data);
+        block0.apply_initialization_vector({ auth_tag.data, array_size(auth_tag.data) });
         block0.bytes().copy_to(tag);
     }
 
@@ -103,7 +103,7 @@ public:
         CTR<T>::increment(iv);
 
         auto auth_tag = m_ghash->process(aad, in);
-        block0.apply_initialization_vector(auth_tag.data);
+        block0.apply_initialization_vector({ auth_tag.data, array_size(auth_tag.data) });
 
         auto test_consistency = [&] {
             if (block0.block_size() != tag.size() || __builtin_memcmp(block0.bytes().data(), tag.data(), tag.size()) != 0)

--- a/Userland/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Userland/Libraries/LibTLS/ClientHandshake.cpp
@@ -259,8 +259,7 @@ void TLSv12::build_random(PacketBuilder& builder)
 
     m_context.premaster_key = ByteBuffer::copy(random_bytes, bytes);
 
-    // const auto& certificate_option = verify_chain_and_get_matching_certificate(m_context.extensions.SNI); // if the SNI is empty, we'll make a special case and match *a* leaf certificate.
-    Optional<size_t> certificate_option = 0;
+    const auto& certificate_option = verify_chain_and_get_matching_certificate(m_context.extensions.SNI); // if the SNI is empty, we'll make a special case and match *a* leaf certificate.
     if (!certificate_option.has_value()) {
         dbgln("certificate verification failed :(");
         alert(AlertLevel::Critical, AlertDescription::BadCertificate);

--- a/Userland/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Userland/Libraries/LibTLS/ClientHandshake.cpp
@@ -53,7 +53,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
         dbgln("not enough data for version");
         return (i8)Error::NeedMoreData;
     }
-    auto version = (Version)AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res));
+    auto version = static_cast<Version>(AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res))));
 
     res += 2;
     if (!supports_version(version))
@@ -84,7 +84,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
         dbgln("not enough data for cipher suite listing");
         return (i8)Error::NeedMoreData;
     }
-    auto cipher = (CipherSuite)AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res));
+    auto cipher = static_cast<CipherSuite>(AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res))));
     res += 2;
     if (!supports_cipher(cipher)) {
         m_context.cipher = CipherSuite::Invalid;
@@ -113,14 +113,14 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
 
     // Presence of extensions is determined by availability of bytes after compression_method
     if (buffer.size() - res >= 2) {
-        auto extensions_bytes_total = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res += 2));
+        auto extensions_bytes_total = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res += 2)));
         dbgln_if(TLS_DEBUG, "Extensions bytes total: {}", extensions_bytes_total);
     }
 
     while (buffer.size() - res >= 4) {
-        auto extension_type = (HandshakeExtension)AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res));
+        auto extension_type = (HandshakeExtension)AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res)));
         res += 2;
-        u16 extension_length = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res));
+        u16 extension_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res)));
         res += 2;
 
         dbgln_if(TLS_DEBUG, "Extension {} with length {}", (u16)extension_type, extension_length);
@@ -134,14 +134,14 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
                 // ServerNameList total size
                 if (buffer.size() - res < 2)
                     return (i8)Error::NeedMoreData;
-                auto sni_name_list_bytes = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res += 2));
+                auto sni_name_list_bytes = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res += 2)));
                 dbgln_if(TLS_DEBUG, "SNI: expecting ServerNameList of {} bytes", sni_name_list_bytes);
 
                 // Exactly one ServerName should be present
                 if (buffer.size() - res < 3)
                     return (i8)Error::NeedMoreData;
                 auto sni_name_type = (NameType)(*(const u8*)buffer.offset_pointer(res++));
-                auto sni_name_length = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res += 2));
+                auto sni_name_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res += 2)));
 
                 if (sni_name_type != NameType::HostName)
                     return (i8)Error::NotUnderstood;
@@ -158,7 +158,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
             }
         } else if (extension_type == HandshakeExtension::ApplicationLayerProtocolNegotiation && m_context.alpn.size()) {
             if (buffer.size() - res > 2) {
-                auto alpn_length = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res));
+                auto alpn_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res)));
                 if (alpn_length && alpn_length <= extension_length - 2) {
                     const u8* alpn = buffer.offset_pointer(res + 2);
                     size_t alpn_position = 0;

--- a/Userland/Libraries/LibTLS/TLSPacketBuilder.h
+++ b/Userland/Libraries/LibTLS/TLSPacketBuilder.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/ByteReader.h>
 #include <AK/Endian.h>
 #include <AK/Types.h>
 
@@ -38,7 +39,7 @@ public:
         m_packet_data = ByteBuffer::create_uninitialized(size_hint + 16);
         m_current_length = 5;
         m_packet_data[0] = (u8)type;
-        *(u16*)m_packet_data.offset_pointer(1) = AK::convert_between_host_and_network_endian((u16)version);
+        ByteReader::store(m_packet_data.offset_pointer(1), AK::convert_between_host_and_network_endian((u16)version));
     }
 
     inline void append(u16 value)

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -601,7 +601,7 @@ void TLSv12::consume(ReadonlyBytes record)
     dbgln_if(TLS_DEBUG, "message buffer length {}", buffer_length);
 
     while (buffer_length >= 5) {
-        auto length = AK::convert_between_host_and_network_endian(*(u16*)m_context.message_buffer.offset_pointer(index + size_offset)) + header_size;
+        auto length = AK::convert_between_host_and_network_endian(ByteReader::load16(m_context.message_buffer.offset_pointer(index + size_offset))) + header_size;
         if (length > buffer_length) {
             dbgln_if(TLS_DEBUG, "Need more data: {} > {}", length, buffer_length);
             break;


### PR DESCRIPTION
- Fixes #7072.
- Adds `AK::ByteReader` which should answer the question "How do I do unaligned reads/writes"
    No more excuse to `*(const u16*)value` or whatever.
- Uses that to get rid of unaligned reads and writes in LibCrypto and LibTLS.
- One less `memcpy` being passed a `nullptr`
- Fixes a silly error where LibTLS assumes that the first certificate is fine and just goes with it without verifying it.

cc @Dexesttp:
There are a bunch of overflows in the montgomery modpow route:
```
Testing (RSA RAW | Encryption)... 
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:67:12: runtime error: signed integer overflow: -901883205 * 813393317264838437 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:66:11: runtime error: signed integer overflow: 813393317264838436 * 813393317264838436 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:67:12: runtime error: signed integer overflow: -7008714270157843961 * 6155376598497312017 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:66:11: runtime error: signed integer overflow: 6155376598497312016 * 6155376598497312016 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:67:12: runtime error: signed integer overflow: 5601826140463930743 * -4322787710529920767 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:66:11: runtime error: signed integer overflow: -4322787710529920768 * -4322787710529920768 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:67:12: runtime error: signed integer overflow: 9018452991970210935 * -4334820189003513855 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:66:11: runtime error: signed integer overflow: -4334820189003513856 * -4334820189003513856 cannot be represented in type 'long int'
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:67:12: runtime error: signed integer overflow: 5812531251426915447 * -2504535201418313727 cannot be represented in type 'long int'

... snip ...

Testing (RSA EMSA_PSS | Construction)...
/home/Test/Workspace/serenity/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp:66:11: runtime error: signed integer overflow: 3063273556 * 3063273556 cannot be represented in type 'long int'

```