### PR TITLE
LibCrypto: Prevent a signed overflow during BigInt Modular Power

### DIFF
--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp
@@ -58,9 +58,9 @@ ALWAYS_INLINE static u32 inverse_wrapped(u32 value)
 {
     VERIFY(value & 1);
 
-    i64 b = static_cast<i64>(value);
-    i64 k0 = (2 - b);
-    i64 t = (b - 1);
+    u64 b = static_cast<u64>(value);
+    u64 k0 = (2 - b);
+    u64 t = (b - 1);
     size_t i = 1;
     while (i < 32) {
         t = t * t;


### PR DESCRIPTION
Found in #7093 

The algorithm isn't explicit about what type this needs to be, so I'm not sure if that's exactly correct. But this passes all of the tests, so that's probably fine :^)
Source : [Jean-Guillaume Dumas, On Newton-Raphson iteration for multiplicative inverses modulo prime powers (Arxiv page)](https://arxiv.org/abs/1209.6626), Algorithm 3