### PR TITLE
Kernel: Fix lock state corruption in AHCIPORT::start_request

### DIFF
--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -454,7 +454,7 @@ void AHCIPort::start_request(AsyncBlockDeviceRequest& request)
     auto result = prepare_and_set_scatter_list(request);
     if (result.has_value()) {
         dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request failure.", representative_port_index());
-        m_lock.unlock();
+        locker.unlock();
         complete_current_request(result.value());
         return;
     }
@@ -462,7 +462,7 @@ void AHCIPort::start_request(AsyncBlockDeviceRequest& request)
     auto success = access_device(request.request_type(), request.block_index(), request.block_count());
     if (!success) {
         dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request failure.", representative_port_index());
-        m_lock.unlock();
+        locker.unlock();
         complete_current_request(AsyncDeviceRequest::Failure);
         return;
     }


### PR DESCRIPTION
This code was unlocking the lock directly, but the Locker is still
attached, causing the lock to be unlocked an extra time, hence
corrupting the internal lock state.

This is extra confusing though, as complete_current_request() runs
without a lock which also looks like a bug. But that's a task for
another day.

It looks like this came from 0b1fa97b3