### PR TITLE
 Kernel: Handle OOM in  Process creation, replace more usages of adopt_ref<T> with adopt_ref_if_nonull<T>() 

### DIFF
--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -230,6 +230,8 @@ KResultOr<size_t> SB16::write(FileDescription&, u64, const UserOrKernelBuffer& d
         if (!page)
             return ENOMEM;
         auto vmobject = AnonymousVMObject::create_with_physical_page(*page);
+        if (!vmobject)
+            return ENOMEM;
         m_dma_region = MM.allocate_kernel_region_with_vmobject(*vmobject, PAGE_SIZE, "SB16 DMA buffer", Region::Access::Write);
         if (!m_dma_region)
             return ENOMEM;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -499,7 +499,9 @@ private:
     bool add_thread(Thread&);
     bool remove_thread(Thread&);
 
-    Process(RefPtr<Thread>& first_thread, const String& name, uid_t, gid_t, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd = nullptr, RefPtr<Custody> executable = nullptr, TTY* = nullptr, Process* fork_parent = nullptr);
+    Process(const String& name, uid_t uid, gid_t gid, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd, RefPtr<Custody> executable, TTY* tty);
+    static RefPtr<Process> create(RefPtr<Thread>& first_thread, const String& name, uid_t, gid_t, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd = nullptr, RefPtr<Custody> executable = nullptr, TTY* = nullptr, Process* fork_parent = nullptr);
+    KResult attach_resources(RefPtr<Thread>& first_thread, Process* fork_parent);
     static ProcessID allocate_pid();
 
     void kill_threads_except_self();

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -433,7 +433,9 @@ Optional<AsyncDeviceRequest::RequestResult> AHCIPort::prepare_and_set_scatter_li
         allocated_dma_regions.append(m_dma_buffers.at(index));
     }
 
-    m_current_scatter_list = ScatterGatherList::create(request, allocated_dma_regions, m_connected_device->block_size());
+    m_current_scatter_list = ScatterGatherList::create(request, move(allocated_dma_regions), m_connected_device->block_size());
+    if (!m_current_scatter_list)
+        return AsyncDeviceRequest::Failure;
     if (request.request_type() == AsyncBlockDeviceRequest::Write) {
         if (!request.read_from_buffer(request.buffer(), m_current_scatter_list->dma_region().as_ptr(), m_connected_device->block_size() * request.block_count())) {
             return AsyncDeviceRequest::MemoryFault;

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -17,8 +17,8 @@ KResultOr<pid_t> Process::sys$fork(RegisterState& regs)
 {
     REQUIRE_PROMISE(proc);
     RefPtr<Thread> child_first_thread;
-    auto child = adopt_ref(*new Process(child_first_thread, m_name, uid(), gid(), pid(), m_is_kernel_process, m_cwd, m_executable, m_tty, this));
-    if (!child_first_thread)
+    auto child = Process::create(child_first_thread, m_name, uid(), gid(), pid(), m_is_kernel_process, m_cwd, m_executable, m_tty, this);
+    if (!child || !child_first_thread)
         return ENOMEM;
     child->m_root_directory = m_root_directory;
     child->m_root_directory_relative_to_global_root = m_root_directory_relative_to_global_root;

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -40,9 +40,11 @@ KResultOr<NonnullRefPtr<FileDescription>> PTYMultiplexer::open(int options)
     if (m_freelist.is_empty())
         return EBUSY;
     auto master_index = m_freelist.take_last();
-    auto master = adopt_ref(*new MasterPTY(master_index));
+    auto master = adopt_ref_if_nonnull(new MasterPTY(master_index));
+    if (!master)
+        return ENOMEM;
     dbgln_if(PTMX_DEBUG, "PTYMultiplexer::open: Vending master {}", master->index());
-    auto description = FileDescription::create(move(master));
+    auto description = FileDescription::create(*master);
     if (!description.is_error()) {
         description.value()->set_rw_mode(options);
         description.value()->set_file_flags(options);

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -47,7 +47,7 @@ RefPtr<VMObject> AnonymousVMObject::clone()
     // or reset all pages to be copied again if we were previously cloned
     ensure_or_reset_cow_map();
 
-    return adopt_ref(*new AnonymousVMObject(*this));
+    return adopt_ref_if_nonnull(new AnonymousVMObject(*this));
 }
 
 RefPtr<AnonymousVMObject> AnonymousVMObject::create_with_size(size_t size, AllocationStrategy commit)
@@ -57,7 +57,7 @@ RefPtr<AnonymousVMObject> AnonymousVMObject::create_with_size(size_t size, Alloc
         if (!MM.commit_user_physical_pages(ceil_div(size, static_cast<size_t>(PAGE_SIZE))))
             return {};
     }
-    return adopt_ref(*new AnonymousVMObject(size, commit));
+    return adopt_ref_if_nonnull(new AnonymousVMObject(size, commit));
 }
 
 NonnullRefPtr<AnonymousVMObject> AnonymousVMObject::create_with_physical_pages(NonnullRefPtrVector<PhysicalPage> physical_pages)
@@ -76,7 +76,7 @@ RefPtr<AnonymousVMObject> AnonymousVMObject::create_for_physical_range(PhysicalA
         dbgln("Shenanigans! create_for_physical_range({}, {}) would wrap around", paddr, size);
         return nullptr;
     }
-    return adopt_ref(*new AnonymousVMObject(paddr, size));
+    return adopt_ref_if_nonnull(new AnonymousVMObject(paddr, size));
 }
 
 AnonymousVMObject::AnonymousVMObject(size_t size, AllocationStrategy strategy)

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -60,14 +60,14 @@ RefPtr<AnonymousVMObject> AnonymousVMObject::create_with_size(size_t size, Alloc
     return adopt_ref_if_nonnull(new AnonymousVMObject(size, commit));
 }
 
-NonnullRefPtr<AnonymousVMObject> AnonymousVMObject::create_with_physical_pages(NonnullRefPtrVector<PhysicalPage> physical_pages)
+RefPtr<AnonymousVMObject> AnonymousVMObject::create_with_physical_pages(NonnullRefPtrVector<PhysicalPage> physical_pages)
 {
-    return adopt_ref(*new AnonymousVMObject(physical_pages));
+    return adopt_ref_if_nonnull(new AnonymousVMObject(physical_pages));
 }
 
-NonnullRefPtr<AnonymousVMObject> AnonymousVMObject::create_with_physical_page(PhysicalPage& page)
+RefPtr<AnonymousVMObject> AnonymousVMObject::create_with_physical_page(PhysicalPage& page)
 {
-    return adopt_ref(*new AnonymousVMObject(page));
+    return adopt_ref_if_nonnull(new AnonymousVMObject(page));
 }
 
 RefPtr<AnonymousVMObject> AnonymousVMObject::create_for_physical_range(PhysicalAddress paddr, size_t size)

--- a/Kernel/VM/AnonymousVMObject.h
+++ b/Kernel/VM/AnonymousVMObject.h
@@ -22,8 +22,8 @@ public:
 
     static RefPtr<AnonymousVMObject> create_with_size(size_t, AllocationStrategy);
     static RefPtr<AnonymousVMObject> create_for_physical_range(PhysicalAddress paddr, size_t size);
-    static NonnullRefPtr<AnonymousVMObject> create_with_physical_page(PhysicalPage& page);
-    static NonnullRefPtr<AnonymousVMObject> create_with_physical_pages(NonnullRefPtrVector<PhysicalPage>);
+    static RefPtr<AnonymousVMObject> create_with_physical_page(PhysicalPage& page);
+    static RefPtr<AnonymousVMObject> create_with_physical_pages(NonnullRefPtrVector<PhysicalPage>);
     virtual RefPtr<VMObject> clone() override;
 
     RefPtr<PhysicalPage> allocate_committed_page(size_t);

--- a/Kernel/VM/ScatterGatherList.cpp
+++ b/Kernel/VM/ScatterGatherList.cpp
@@ -8,13 +8,16 @@
 
 namespace Kernel {
 
-NonnullRefPtr<ScatterGatherList> ScatterGatherList::create(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
+RefPtr<ScatterGatherList> ScatterGatherList::create(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
 {
-    return adopt_ref(*new ScatterGatherList(request, allocated_pages, device_block_size));
+    auto vm_object = AnonymousVMObject::create_with_physical_pages(allocated_pages);
+    if (!vm_object)
+        return {};
+    return adopt_ref_if_nonnull(new ScatterGatherList(vm_object.release_nonnull(), request, device_block_size));
 }
 
-ScatterGatherList::ScatterGatherList(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
-    : m_vm_object(AnonymousVMObject::create_with_physical_pages(allocated_pages))
+ScatterGatherList::ScatterGatherList(NonnullRefPtr<AnonymousVMObject> vm_object, AsyncBlockDeviceRequest& request, size_t device_block_size)
+    : m_vm_object(move(vm_object))
 {
     m_dma_region = MM.allocate_kernel_region_with_vmobject(m_vm_object, page_round_up((request.block_count() * device_block_size)), "AHCI Scattered DMA", Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes);
 }

--- a/Kernel/VM/ScatterGatherList.h
+++ b/Kernel/VM/ScatterGatherList.h
@@ -18,13 +18,13 @@ namespace Kernel {
 
 class ScatterGatherList : public RefCounted<ScatterGatherList> {
 public:
-    static NonnullRefPtr<ScatterGatherList> create(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
+    static RefPtr<ScatterGatherList> create(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
     const VMObject& vmobject() const { return m_vm_object; }
     VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
     size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
 
 private:
-    ScatterGatherList(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
+    ScatterGatherList(NonnullRefPtr<AnonymousVMObject>, AsyncBlockDeviceRequest&, size_t device_block_size);
     NonnullRefPtr<AnonymousVMObject> m_vm_object;
     OwnPtr<Region> m_dma_region;
 };


### PR DESCRIPTION
The 7th patch set of changes working away at #6369.

This round is focusing on replacing more smart pointer factories (adopt_ref, etc) with versions which support OOM propagation.