### PR TITLE
Add 'binutils-devel' to Fedora build requirements

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -46,7 +46,7 @@ sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2
 #### Fedora
 
 ```console
-sudo dnf install curl cmake mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja-build patch @"C Development Tools and Libraries" @Virtualization
+sudo dnf install binutils-devel curl cmake mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja-build patch @"C Development Tools and Libraries" @Virtualization
 ```
 
 #### openSUSE


### PR DESCRIPTION
Without this package, the `Toolchain/BuildIt.sh` script fails, complaining of a missing `libopcodes.so`.
What worries me, is that a `libopcodes.so` gets built as part of the gcc-toolchain, so in theory this shouldn't be necessary and may be masking an issue in the `./BuildIt.sh` shell script.