### PR TITLE
Kernel+LibC+LibCore: Optimize SpaceAnalyzer startup time

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -422,6 +422,7 @@ struct SC_waitid_params {
 };
 
 struct SC_stat_params {
+    int dirfd;
     StringArgument path;
     struct stat* statbuf;
     int follow_symlinks;

--- a/Kernel/Syscalls/stat.cpp
+++ b/Kernel/Syscalls/stat.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/NonnullRefPtrVector.h>
+#include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
@@ -33,7 +34,20 @@ KResultOr<int> Process::sys$stat(Userspace<const Syscall::SC_stat_params*> user_
     auto path = get_syscall_path_argument(params.path);
     if (path.is_error())
         return path.error();
-    auto metadata_or_error = VFS::the().lookup_metadata(path.value(), current_directory(), params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR);
+    RefPtr<Custody> base;
+    if (params.dirfd == AT_FDCWD) {
+        base = current_directory();
+    } else {
+        auto base_description = file_description(params.dirfd);
+        if (!base_description)
+            return EBADF;
+        if (!base_description->is_directory())
+            return ENOTDIR;
+        if (!base_description->custody())
+            return EINVAL;
+        base = base_description->custody();
+    }
+    auto metadata_or_error = VFS::the().lookup_metadata(path.value(), *base, params.follow_symlinks ? 0 : O_NOFOLLOW_NOERROR);
     if (metadata_or_error.is_error())
         return metadata_or_error.error();
     stat statbuf;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -680,6 +680,7 @@ struct rtentry {
 #define RTF_GATEWAY 0x2 /* the route is a gateway and not an end host */
 
 #define AT_FDCWD -100
+#define AT_SYMLINK_NOFOLLOW 0x100
 
 #define PURGE_ALL_VOLATILE 0x1
 #define PURGE_ALL_CLEAN_INODE 0x2

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -22,6 +22,7 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Statusbar.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -170,7 +171,7 @@ static void populate_filesize_tree(TreeNode& root, Vector<MountInfo>& mounts, Ha
                 int name_len = name.length();
                 builder.append(name);
                 struct stat st;
-                int stat_result = lstat(builder.to_string().characters(), &st);
+                int stat_result = fstatat(dir_iterator.fd(), name.characters(), &st, AT_SYMLINK_NOFOLLOW);
                 if (stat_result < 0) {
                     int error_sum = error_accumulator.get(errno).value_or(0);
                     error_accumulator.set(errno, error_sum + 1);

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -40,6 +40,7 @@ __BEGIN_DECLS
 int creat(const char* path, mode_t);
 int open(const char* path, int options, ...);
 #define AT_FDCWD -100
+#define AT_SYMLINK_NOFOLLOW 0x100
 int openat(int dirfd, const char* path, int options, ...);
 
 int fcntl(int fd, int cmd, ...);

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -50,30 +51,35 @@ int mkfifo(const char* pathname, mode_t mode)
     return mknod(pathname, mode | S_IFIFO, 0);
 }
 
-static int do_stat(const char* path, struct stat* statbuf, bool follow_symlinks)
+static int do_stat(int dirfd, const char* path, struct stat* statbuf, bool follow_symlinks)
 {
     if (!path) {
         errno = EFAULT;
         return -1;
     }
-    Syscall::SC_stat_params params { { path, strlen(path) }, statbuf, follow_symlinks };
+    Syscall::SC_stat_params params { dirfd, { path, strlen(path) }, statbuf, follow_symlinks };
     int rc = syscall(SC_stat, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
 int lstat(const char* path, struct stat* statbuf)
 {
-    return do_stat(path, statbuf, false);
+    return do_stat(AT_FDCWD, path, statbuf, false);
 }
 
 int stat(const char* path, struct stat* statbuf)
 {
-    return do_stat(path, statbuf, true);
+    return do_stat(AT_FDCWD, path, statbuf, true);
 }
 
 int fstat(int fd, struct stat* statbuf)
 {
     int rc = syscall(SC_fstat, fd, statbuf);
     __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int fstatat(int fd, const char* path, struct stat* statbuf, int flags)
+{
+    return do_stat(fd, path, statbuf, !(flags & AT_SYMLINK_NOFOLLOW));
 }
 }

--- a/Userland/Libraries/LibC/sys/stat.h
+++ b/Userland/Libraries/LibC/sys/stat.h
@@ -77,6 +77,7 @@ int mkfifo(const char* pathname, mode_t);
 int fstat(int fd, struct stat* statbuf);
 int lstat(const char* path, struct stat* statbuf);
 int stat(const char* path, struct stat* statbuf);
+int fstatat(int fd, const char* path, struct stat* statbuf, int flags);
 
 inline dev_t makedev(unsigned int major, unsigned int minor) { return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u); }
 inline unsigned int major(dev_t dev) { return (dev & 0xfff00u) >> 8u; }

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -99,4 +99,11 @@ String find_executable_in_path(String filename)
     return {};
 }
 
+int DirIterator::fd() const
+{
+    if (!m_dir)
+        return -1;
+    return dirfd(m_dir);
+}
+
 }

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -29,6 +29,7 @@ public:
     bool has_next();
     String next_path();
     String next_full_path();
+    int fd() const;
 
 private:
     DIR* m_dir = nullptr;


### PR DESCRIPTION
By implementing fstatat and using it in SpaceAnalyzer, its startup time went from:

- cold cache: ~1331ms
- hot cache: ~636ms

to

- cold cache: ~812ms
- hot cache ~324ms.