### PR TITLE
Meta: Bump BIOS/MBR boot partition size of grub disk image to 1MiB

### DIFF
--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -62,7 +62,7 @@ trap cleanup EXIT
 
 printf "creating partition table... "
 if [ "$1" = "mbr" ]; then
-    parted -s "${dev}" mklabel msdos mkpart primary ext2 32k 100% -a minimal set 1 boot on || die "couldn't partition disk"
+    parted -s "${dev}" mklabel msdos mkpart primary ext2 1MiB 100% -a minimal set 1 boot on || die "couldn't partition disk"
     partition_number="p1"
     partition_scheme="mbr"
 elif [ "$1" = "gpt" ]; then
@@ -74,7 +74,7 @@ elif [ "$1" = "ebr" ]; then
     partition_number="p5"
     partition_scheme="ebr"
 else
-    parted -s "${dev}" mklabel msdos mkpart primary ext2 32k 100% -a minimal set 1 boot on || die "couldn't partition disk"
+    parted -s "${dev}" mklabel msdos mkpart primary ext2 1MiB 100% -a minimal set 1 boot on || die "couldn't partition disk"
     partition_number="p1"
     partition_scheme="mbr"
 fi


### PR DESCRIPTION
As of ~April 2021 the Meta/build-image-grub.sh script no longer works
for me (on Fedora 34) and fails with the following error:

    /usr/sbin/grub2-install: warning: ../grub-core/partmap/msdos.c:403:
    your core.img is unusually large. It won't fit in the embedding
    area.

    /usr/sbin/grub2-install: warning: Embedding is not possible. GRUB
    can only be installed in this setup by using blocklists. However,
    blocklists are UNRELIABLE and their use is discouraged..

    /usr/sbin/grub2-install: error: will not proceed with blocklists.

Changing the size of the boot partition from 32 kiB to 1 MiB (2048
sectors) fixes the issue. This is also described in the following Ubuntu
grub2 bug (as well as 40 duplicates!) from 2012, which suggests the same
fix: https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1059827

The Arch Linux wiki also uses 1 MiB in their BIOS/MBR examples for
parted: https://wiki.archlinux.org/title/Parted

I'm not sure why this suddenly stopped working, however I was able to
boot with an image created with this change applied.