### PR TITLE
Browser: Support Border radius

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -36,6 +36,7 @@ public:
     void fill_rect_with_checkerboard(const IntRect&, const IntSize&, Color color_dark, Color color_light);
     void fill_rect_with_gradient(Orientation, const IntRect&, Color gradient_start, Color gradient_end);
     void fill_rect_with_gradient(const IntRect&, Color gradient_start, Color gradient_end);
+    void fill_rect_with_rounded_corners(const IntRect&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
     void fill_ellipse(const IntRect&, Color);
     void draw_rect(const IntRect&, Color, bool rough = false);
     void draw_focus_rect(const IntRect&, Color);
@@ -70,6 +71,14 @@ public:
     void draw_glyph(const IntPoint&, u32, const Font&, Color);
     void draw_emoji(const IntPoint&, const Gfx::Bitmap&, const Font&);
     void draw_glyph_or_emoji(const IntPoint&, u32 code_point, const Font&, Color);
+
+    enum class CornerOrientation {
+        TopLeft,
+        TopRight,
+        BottomRight,
+        BottomLeft
+    };
+    void fill_rounded_corner(const IntRect&, int radius, Color, CornerOrientation);
 
     static void for_each_line_segment_on_bezier_curve(const FloatPoint& control_point, const FloatPoint& p1, const FloatPoint& p2, Function<void(const FloatPoint&, const FloatPoint&)>&);
     static void for_each_line_segment_on_bezier_curve(const FloatPoint& control_point, const FloatPoint& p1, const FloatPoint& p2, Function<void(const FloatPoint&, const FloatPoint&)>&&);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -71,6 +71,7 @@ public:
     void draw_glyph(const IntPoint&, u32, const Font&, Color);
     void draw_emoji(const IntPoint&, const Gfx::Bitmap&, const Font&);
     void draw_glyph_or_emoji(const IntPoint&, u32 code_point, const Font&, Color);
+    void draw_circle_arc_intersecting(const IntRect&, const IntPoint&, int radius, Color, int thickness);
 
     enum class CornerOrientation {
         TopLeft,

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -67,6 +67,11 @@ public:
     const BorderData& border_right() const { return m_noninherited.border_right; }
     const BorderData& border_bottom() const { return m_noninherited.border_bottom; }
 
+    const CSS::Length& border_bottom_left_radius() const { return m_noninherited.border_bottom_left_radius; }
+    const CSS::Length& border_bottom_right_radius() const { return m_noninherited.border_bottom_right_radius; }
+    const CSS::Length& border_top_left_radius() const { return m_noninherited.border_top_left_radius; }
+    const CSS::Length& border_top_right_radius() const { return m_noninherited.border_top_right_radius; }
+
     CSS::Overflow overflow_x() const { return m_noninherited.overflow_x; }
     CSS::Overflow overflow_y() const { return m_noninherited.overflow_y; }
 
@@ -114,6 +119,10 @@ protected:
         BorderData border_top;
         BorderData border_right;
         BorderData border_bottom;
+        Length border_bottom_left_radius;
+        Length border_bottom_right_radius;
+        Length border_top_left_radius;
+        Length border_top_right_radius;
         Color background_color { InitialValues::background_color() };
         CSS::Repeat background_repeat_x { InitialValues::background_repeat() };
         CSS::Repeat background_repeat_y { InitialValues::background_repeat() };
@@ -154,6 +163,10 @@ public:
     void set_overflow_y(CSS::Overflow value) { m_noninherited.overflow_y = value; }
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = value; }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
+    void set_border_bottom_left_radius(CSS::Length value) { m_noninherited.border_bottom_left_radius = value; }
+    void set_border_bottom_right_radius(CSS::Length value) { m_noninherited.border_bottom_right_radius = value; }
+    void set_border_top_left_radius(CSS::Length value) { m_noninherited.border_top_left_radius = value; }
+    void set_border_top_right_radius(CSS::Length value) { m_noninherited.border_top_right_radius = value; }
     BorderData& border_left() { return m_noninherited.border_left; }
     BorderData& border_top() { return m_noninherited.border_top; }
     BorderData& border_right() { return m_noninherited.border_right; }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1,6 +1,5 @@
 {
-  "background": {
-  },
+  "background": {},
   "background-attachment": {
     "inherited": false,
     "initial": "scroll"
@@ -72,6 +71,14 @@
     "initial": "currentColor",
     "inherited": false
   },
+  "border-bottom-left-radius": {
+    "initial": 0,
+    "inherited": false
+  },
+  "border-bottom-right-radius": {
+    "initial": 0,
+    "inherited": false
+  },
   "border-bottom-style": {
     "initial": "none",
     "inherited": false
@@ -104,6 +111,14 @@
     "initial": "medium",
     "inherited": false
   },
+  "border-radius": {
+    "longhands": [
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-left-radius",
+      "border-bottom-right-radius"
+    ]
+  },
   "border-right-color": {
     "initial": "currentColor",
     "inherited": false
@@ -130,6 +145,14 @@
   },
   "border-top-color": {
     "initial": "currentColor",
+    "inherited": false
+  },
+  "border-top-left-radius": {
+    "initial": 0,
+    "inherited": false
+  },
+  "border-top-right-radius": {
+    "initial": 0,
     "inherited": false
   },
   "border-top-style": {

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -264,6 +264,60 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::BorderRadius) {
+        // FIXME: Allow for two values per corner to support elliptical radii.
+        // FIXME: Add support the '/' to specify elliptical radii.
+        if (value.is_length()) {
+            style.set_property(CSS::PropertyID::BorderTopLeftRadius, value);
+            style.set_property(CSS::PropertyID::BorderTopRightRadius, value);
+            style.set_property(CSS::PropertyID::BorderBottomRightRadius, value);
+            style.set_property(CSS::PropertyID::BorderBottomLeftRadius, value);
+            return;
+        }
+        if (value.is_string()) {
+            auto parts = split_on_whitespace(value.to_string());
+            if (value.is_string() && parts.size() == 2) {
+                auto diagonal1 = parse_css_value(context, parts[0]);
+                auto diagonal2 = parse_css_value(context, parts[1]);
+                if (diagonal1 && diagonal2) {
+                    style.set_property(CSS::PropertyID::BorderTopLeftRadius, *diagonal1);
+                    style.set_property(CSS::PropertyID::BorderBottomRightRadius, *diagonal1);
+                    style.set_property(CSS::PropertyID::BorderTopRightRadius, *diagonal2);
+                    style.set_property(CSS::PropertyID::BorderBottomLeftRadius, *diagonal2);
+                }
+                return;
+            }
+            if (value.is_string() && parts.size() == 3) {
+                auto top_left = parse_css_value(context, parts[0]);
+                auto diagonal = parse_css_value(context, parts[1]);
+                auto bottom_right = parse_css_value(context, parts[2]);
+                if (top_left && diagonal && bottom_right) {
+                    style.set_property(CSS::PropertyID::BorderTopLeftRadius, *top_left);
+                    style.set_property(CSS::PropertyID::BorderBottomRightRadius, *bottom_right);
+                    style.set_property(CSS::PropertyID::BorderTopRightRadius, *diagonal);
+                    style.set_property(CSS::PropertyID::BorderBottomLeftRadius, *diagonal);
+                }
+                return;
+            }
+            if (value.is_string() && parts.size() == 4) {
+                auto top_left = parse_css_value(context, parts[0]);
+                auto top_right = parse_css_value(context, parts[1]);
+                auto bottom_right = parse_css_value(context, parts[2]);
+                auto bottom_left = parse_css_value(context, parts[3]);
+                if (top_left && top_right && bottom_right && bottom_left) {
+                    style.set_property(CSS::PropertyID::BorderTopLeftRadius, *top_left);
+                    style.set_property(CSS::PropertyID::BorderBottomRightRadius, *bottom_right);
+                    style.set_property(CSS::PropertyID::BorderTopRightRadius, *top_right);
+                    style.set_property(CSS::PropertyID::BorderBottomLeftRadius, *bottom_left);
+                }
+                return;
+            }
+            dbgln("Unsure what to do with CSS border-radius value '{}'", value.to_string());
+            return;
+        }
+        return;
+    }
+
     if (property_id == CSS::PropertyID::BorderTop
         || property_id == CSS::PropertyID::BorderRight
         || property_id == CSS::PropertyID::BorderBottom

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -179,11 +179,11 @@ void Box::paint_background(PaintContext& context)
     if (is_body() && document().html_element()->should_use_body_background_properties())
         return;
 
+    Gfx::IntRect background_rect;
     Color background_color = computed_values().background_color();
     const Gfx::Bitmap* background_image = this->background_image() ? this->background_image()->bitmap() : nullptr;
     CSS::Repeat background_repeat_x = computed_values().background_repeat_x();
     CSS::Repeat background_repeat_y = computed_values().background_repeat_y();
-    auto background_rect = enclosing_int_rect(padded_rect);
 
     if (is_root_element()) {
         // CSS 2.1 Appendix E.2: If the element is a root element, paint the background over the entire canvas.
@@ -200,6 +200,11 @@ void Box::paint_background(PaintContext& context)
     } else {
         background_rect = enclosing_int_rect(padded_rect);
     }
+
+    // HACK: If the Box has a border, use the bordered_rect to paint the background.
+    //       This way if we have a border-radius there will be no gap between the filling and actual border.
+    if (computed_values().border_top().width || computed_values().border_right().width || computed_values().border_bottom().width || computed_values().border_left().width)
+        background_rect = enclosing_int_rect(bordered_rect());
 
     // FIXME: some values should be relative to the height() if specified, but which? For now, all relative values are relative to the width.
     auto border_radius_data = normalized_border_radius_data();

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -60,11 +60,7 @@ void Box::paint(PaintContext& context, PaintPhase phase)
     }
 
     if (phase == PaintPhase::Border) {
-        auto bordered_rect = this->bordered_rect();
-        Painting::paint_border(context, Painting::BorderEdge::Left, bordered_rect, computed_values());
-        Painting::paint_border(context, Painting::BorderEdge::Right, bordered_rect, computed_values());
-        Painting::paint_border(context, Painting::BorderEdge::Top, bordered_rect, computed_values());
-        Painting::paint_border(context, Painting::BorderEdge::Bottom, bordered_rect, computed_values());
+        paint_border(context);
     }
 
     if (phase == PaintPhase::Overlay && dom_node() && document().inspected_node() == dom_node()) {
@@ -85,6 +81,15 @@ void Box::paint(PaintContext& context, PaintPhase phase)
     if (phase == PaintPhase::FocusOutline && dom_node() && dom_node()->is_element() && downcast<DOM::Element>(*dom_node()).is_focused()) {
         context.painter().draw_rect(enclosing_int_rect(absolute_rect()), context.palette().focus_outline());
     }
+}
+
+void Box::paint_border(PaintContext& context)
+{
+    auto bordered_rect = this->bordered_rect();
+    Painting::paint_border(context, Painting::BorderEdge::Left, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Right, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Top, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Bottom, bordered_rect, computed_values());
 }
 
 void Box::paint_background_image(

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -111,6 +111,7 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) override;
     virtual void paint_border(PaintContext& context);
+    virtual void paint_background(PaintContext& context);
 
     Vector<LineBox>& line_boxes() { return m_line_boxes; }
     const Vector<LineBox>& line_boxes() const { return m_line_boxes; }

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -121,6 +121,16 @@ public:
 
     virtual float width_of_logical_containing_block() const;
 
+    struct BorderRadiusData {
+        // FIXME: Use floats here
+        int top_left { 0 };
+        int top_right { 0 };
+        int bottom_right { 0 };
+        int bottom_left { 0 };
+    };
+
+    BorderRadiusData normalized_border_radius_data();
+
 protected:
     Box(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
         : NodeWithStyleAndBoxModelMetrics(document, node, move(style))

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -110,6 +110,7 @@ public:
     StackingContext* enclosing_stacking_context();
 
     virtual void paint(PaintContext&, PaintPhase) override;
+    virtual void paint_border(PaintContext& context);
 
     Vector<LineBox>& line_boxes() { return m_line_boxes; }
     const Vector<LineBox>& line_boxes() const { return m_line_boxes; }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -226,6 +226,22 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         m_background_image = static_ptr_cast<CSS::ImageStyleValue>(bgimage.value());
     }
 
+    auto border_bottom_left_radius = specified_style.property(CSS::PropertyID::BorderBottomLeftRadius);
+    if (border_bottom_left_radius.has_value())
+        computed_values.set_border_bottom_left_radius(border_bottom_left_radius.value()->to_length());
+
+    auto border_bottom_right_radius = specified_style.property(CSS::PropertyID::BorderBottomRightRadius);
+    if (border_bottom_right_radius.has_value())
+        computed_values.set_border_bottom_right_radius(border_bottom_right_radius.value()->to_length());
+
+    auto border_top_left_radius = specified_style.property(CSS::PropertyID::BorderTopLeftRadius);
+    if (border_top_left_radius.has_value())
+        computed_values.set_border_top_left_radius(border_top_left_radius.value()->to_length());
+
+    auto border_top_right_radius = specified_style.property(CSS::PropertyID::BorderTopRightRadius);
+    if (border_top_right_radius.has_value())
+        computed_values.set_border_top_right_radius(border_top_right_radius.value()->to_length());
+
     auto background_repeat_x = specified_style.background_repeat_x();
     if (background_repeat_x.has_value())
         computed_values.set_background_repeat_x(background_repeat_x.value());

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -99,10 +99,15 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
     float p1_step = 0;
     float p2_step = 0;
 
+    bool has_top_left_radius = !style.border_top_left_radius().is_undefined();
+    bool has_top_right_radius = !style.border_top_right_radius().is_undefined();
+    bool has_bottom_left_radius = !style.border_bottom_left_radius().is_undefined();
+    bool has_bottom_right_radius = !style.border_bottom_right_radius().is_undefined();
+
     switch (edge) {
     case BorderEdge::Top:
-        p1_step = style.border_left().width / (float)int_width;
-        p2_step = style.border_right().width / (float)int_width;
+        p1_step = has_top_left_radius ? 0 : style.border_left().width / (float)int_width;
+        p2_step = has_top_right_radius ? 0 : style.border_right().width / (float)int_width;
         for (int i = 0; i < int_width; ++i) {
             draw_line(p1, p2);
             p1.translate_by(p1_step, 1);
@@ -110,8 +115,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         }
         break;
     case BorderEdge::Right:
-        p1_step = style.border_top().width / (float)int_width;
-        p2_step = style.border_bottom().width / (float)int_width;
+        p1_step = has_top_right_radius ? 0 : style.border_top().width / (float)int_width;
+        p2_step = has_bottom_right_radius ? 0 : style.border_bottom().width / (float)int_width;
         for (int i = int_width - 1; i >= 0; --i) {
             draw_line(p1, p2);
             p1.translate_by(-1, p1_step);
@@ -119,8 +124,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         }
         break;
     case BorderEdge::Bottom:
-        p1_step = style.border_left().width / (float)int_width;
-        p2_step = style.border_right().width / (float)int_width;
+        p1_step = has_bottom_left_radius ? 0 : style.border_left().width / (float)int_width;
+        p2_step = has_bottom_right_radius ? 0 : style.border_right().width / (float)int_width;
         for (int i = int_width - 1; i >= 0; --i) {
             draw_line(p1, p2);
             p1.translate_by(p1_step, -1);
@@ -128,8 +133,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         }
         break;
     case BorderEdge::Left:
-        p1_step = style.border_top().width / (float)int_width;
-        p2_step = style.border_bottom().width / (float)int_width;
+        p1_step = has_top_left_radius ? 0 : style.border_top().width / (float)int_width;
+        p2_step = has_bottom_left_radius ? 0 : style.border_bottom().width / (float)int_width;
         for (int i = 0; i < int_width; ++i) {
             draw_line(p1, p2);
             p1.translate_by(1, p1_step);


### PR DESCRIPTION
This PR adds the rendering of `border-radius` to Boxes.
To achieve that the Painter got extended to draw circle(-segments) since the existing ellipse-algorithm is way too overkill and somewhat clunky to use as well as filled rounded rects.
The code to paint the border and to paint the background got moved into their own methods to make the code a bit more readable.

#### Things this PR does not implement:
- different border-styles other than solid for the corners
- Blending between different width borders
- Support for elliptical corners (does anybody use this at all?)
- Caring about background-images

#### TODO-List
- [x] Parse border-radius CSS and expand the shorthand
- [x] Render borders curved
- [x] border-width
- [x] fill space between slanted borders if needed
- [x] clipping
- [x] Cut backgrounds curved
- [x] Truncate overlapping
- [x] Both filled and border leaves white marks.