### PR TITLE
Kernel: Fixup SerialDevice and Implement PCI-based serial device driver

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -33,6 +33,7 @@ set(KERNEL_SOURCES
     Devices/FullDevice.cpp
     Devices/MemoryDevice.cpp
     Devices/NullDevice.cpp
+    Devices/PCISerialDevice.cpp
     Devices/PCSpeaker.cpp
     Devices/RandomDevice.cpp
     Devices/SB16.cpp

--- a/Kernel/Devices/PCISerialDevice.cpp
+++ b/Kernel/Devices/PCISerialDevice.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Devices/PCISerialDevice.h>
+
+namespace Kernel {
+
+static SerialDevice* s_the = nullptr;
+
+void PCISerialDevice::detect()
+{
+    PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {
+        if (address.is_null())
+            return;
+
+        // HACK: There's currently no way to break out of PCI::enumerate, so we just early return if we already initialized the pci serial device
+        if (is_available())
+            return;
+
+        for (auto& board_definition : board_definitions) {
+            if (board_definition.device_id != id)
+                continue;
+
+            auto bar_base = PCI::get_BAR(address, board_definition.pci_bar) & ~1;
+            // FIXME: We should support more than 1 PCI serial port (per card/multiple devices)
+            s_the = new SerialDevice(IOAddress(bar_base + board_definition.first_offset), 64);
+            if (board_definition.baud_rate != SerialDevice::Baud::Baud38400) // non-default baud
+                s_the->set_baud(board_definition.baud_rate);
+
+            dmesgln("PCISerialDevice: Found {} @ {}", board_definition.name, address);
+            return;
+        }
+    });
+}
+
+SerialDevice& PCISerialDevice::the()
+{
+    VERIFY(s_the);
+    return *s_the;
+}
+
+bool PCISerialDevice::is_available()
+{
+    return s_the;
+}
+
+}

--- a/Kernel/Devices/PCISerialDevice.h
+++ b/Kernel/Devices/PCISerialDevice.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/Devices/SerialDevice.h>
+#include <Kernel/PCI/Device.h>
+#include <Kernel/PCI/IDs.h>
+
+namespace Kernel {
+
+class PCISerialDevice {
+    AK_MAKE_ETERNAL
+public:
+    static void detect();
+    static SerialDevice& the();
+    static bool is_available();
+
+private:
+    struct BoardDefinition {
+        PCI::ID device_id;
+        StringView name;
+        u32 port_count { 0 };
+        u32 pci_bar { 0 };
+        u32 first_offset { 0 };
+        u32 port_size { 0 };
+        SerialDevice::Baud baud_rate { SerialDevice::Baud::Baud38400 };
+    };
+
+    static constexpr BoardDefinition board_definitions[1] = {
+        { { (u16)PCIVendorID::WCH, 0x3253 }, "WCH CH382 2S", 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 }
+    };
+};
+
+}

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -87,8 +87,8 @@ void SerialDevice::set_baud(Baud baud)
     m_baud = baud;
 
     IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) | 0x80); // turn on DLAB
-    IO::out8(m_base_addr + 0, ((u8)(baud)) >> 2);               // lower half of divisor
-    IO::out8(m_base_addr + 1, ((u8)(baud)) & 0xff);             // upper half of divisor
+    IO::out8(m_base_addr + 0, ((u8)(baud)) & 0xff);             // lower half of divisor
+    IO::out8(m_base_addr + 1, ((u8)(baud)) >> 2);               // upper half of divisor
     IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) & 0x7f); // turn off DLAB
 }
 

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -105,7 +105,7 @@ void SerialDevice::set_line_control(ParitySelect parity_select, StopBits stop_bi
     m_stop_bits = stop_bits;
     m_word_length = word_length;
 
-    IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) & (0xc0 | parity_select | stop_bits | word_length));
+    IO::out8(m_base_addr + 3, (IO::in8(m_base_addr + 3) & ~0x3f) | parity_select | stop_bits | word_length);
 }
 
 void SerialDevice::set_break_enable(bool break_enable)

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -18,7 +18,7 @@ namespace Kernel {
 class SerialDevice final : public CharacterDevice {
     AK_MAKE_ETERNAL
 public:
-    SerialDevice(int base_addr, unsigned minor);
+    SerialDevice(u32 base_addr, unsigned minor);
     virtual ~SerialDevice() override;
 
     // ^CharacterDevice
@@ -112,25 +112,23 @@ private:
     virtual const char* class_name() const override { return "SerialDevice"; }
 
     void initialize();
-    void set_interrupts(char interrupt_enable);
+    void set_interrupts(bool interrupt_enable);
     void set_baud(Baud);
-    void set_fifo_control(char fifo_control);
+    void set_fifo_control(u8 fifo_control);
     void set_line_control(ParitySelect, StopBits, WordLength);
     void set_break_enable(bool break_enable);
-    void set_modem_control(char modem_control);
-    char get_line_status() const;
-    bool rx_ready();
-    bool tx_ready();
+    void set_modem_control(u8 modem_control);
+    u8 get_line_status() const;
 
-    int m_base_addr;
-    char m_interrupt_enable;
-    char m_fifo_control;
-    Baud m_baud;
-    ParitySelect m_parity_select;
-    StopBits m_stop_bits;
-    WordLength m_word_length;
-    bool m_break_enable;
-    char m_modem_control;
+    u32 m_base_addr { 0 };
+    bool m_interrupt_enable { false };
+    u8 m_fifo_control { 0 };
+    Baud m_baud { Baud38400 };
+    ParitySelect m_parity_select { None };
+    StopBits m_stop_bits { One };
+    WordLength m_word_length { EightBits };
+    bool m_break_enable { false };
+    u8 m_modem_control { 0 };
 };
 
 }

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/IO.h>
 
 namespace Kernel {
 
@@ -18,7 +19,7 @@ namespace Kernel {
 class SerialDevice final : public CharacterDevice {
     AK_MAKE_ETERNAL
 public:
-    SerialDevice(u32 base_addr, unsigned minor);
+    SerialDevice(IOAddress base_addr, unsigned minor);
     virtual ~SerialDevice() override;
 
     // ^CharacterDevice
@@ -122,7 +123,7 @@ private:
     void set_modem_control(u8 modem_control);
     u8 get_line_status() const;
 
-    u32 m_base_addr { 0 };
+    IOAddress m_base_addr;
     bool m_interrupt_enable { false };
     u8 m_fifo_control { 0 };
     Baud m_baud { Baud38400 };

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -111,6 +111,8 @@ public:
     virtual String device_name() const override;
 
 private:
+    friend class PCISerialDevice;
+
     // ^CharacterDevice
     virtual const char* class_name() const override { return "SerialDevice"; }
 

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -27,6 +27,8 @@ public:
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
 
+    void put_char(char);
+
     enum InterruptEnable {
         LowPowerMode = 0x01 << 5,
         SleepMode = 0x01 << 4,
@@ -129,6 +131,7 @@ private:
     WordLength m_word_length { EightBits };
     bool m_break_enable { false };
     u8 m_modem_control { 0 };
+    bool m_last_put_char_was_carriage_return { false };
 };
 
 }

--- a/Kernel/PCI/IDs.h
+++ b/Kernel/PCI/IDs.h
@@ -11,6 +11,7 @@ namespace Kernel {
 enum class PCIVendorID {
     VirtIO = 0x1af4,
     Intel = 0x8086,
+    WCH = 0x1c00,
 };
 
 enum class PCIDeviceID {

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -157,10 +157,10 @@ extern "C" UNMAP_AFTER_INIT [[noreturn]] void init()
 
     NullDevice::initialize();
     if (!get_serial_debug())
-        new SerialDevice(SERIAL_COM1_ADDR, 64);
-    new SerialDevice(SERIAL_COM2_ADDR, 65);
-    new SerialDevice(SERIAL_COM3_ADDR, 66);
-    new SerialDevice(SERIAL_COM4_ADDR, 67);
+        new SerialDevice(IOAddress(SERIAL_COM1_ADDR), 64);
+    new SerialDevice(IOAddress(SERIAL_COM2_ADDR), 65);
+    new SerialDevice(IOAddress(SERIAL_COM3_ADDR), 66);
+    new SerialDevice(IOAddress(SERIAL_COM4_ADDR), 67);
 
     VMWareBackdoor::the(); // don't wait until first mouse packet
     HIDManagement::initialize();

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -144,6 +144,9 @@ extern "C" UNMAP_AFTER_INIT [[noreturn]] void init()
     InterruptManagement::initialize();
     ACPI::initialize();
 
+    // Initialize the PCI Bus as early as possible, for early boot (PCI based) serial logging
+    PCI::initialize();
+
     VFS::initialize();
 
     dmesgln("Starting SerenityOS...");
@@ -162,7 +165,6 @@ extern "C" UNMAP_AFTER_INIT [[noreturn]] void init()
     VMWareBackdoor::the(); // don't wait until first mouse packet
     HIDManagement::initialize();
 
-    PCI::initialize();
     GraphicsManagement::the().initialize();
     ConsoleManagement::the().initialize();
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -16,6 +16,7 @@
 #include <Kernel/Devices/HID/HIDManagement.h>
 #include <Kernel/Devices/MemoryDevice.h>
 #include <Kernel/Devices/NullDevice.h>
+#include <Kernel/Devices/PCISerialDevice.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/SerialDevice.h>
@@ -146,6 +147,7 @@ extern "C" UNMAP_AFTER_INIT [[noreturn]] void init()
 
     // Initialize the PCI Bus as early as possible, for early boot (PCI based) serial logging
     PCI::initialize();
+    PCISerialDevice::detect();
 
     VFS::initialize();
 

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -7,6 +7,7 @@
 #include <AK/PrintfImplementation.h>
 #include <AK/Types.h>
 #include <Kernel/ConsoleDevice.h>
+#include <Kernel/Devices/PCISerialDevice.h>
 #include <Kernel/Graphics/Console/Console.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 #include <Kernel/IO.h>
@@ -34,6 +35,9 @@ int get_serial_debug()
 
 static void serial_putch(char ch)
 {
+    if (PCISerialDevice::is_available())
+        return PCISerialDevice::the().put_char(ch);
+
     static bool serial_ready = false;
     static bool was_cr = false;
 


### PR DESCRIPTION
This PR fixes a couple of bugs in the SerialDevice implementation as well as adds a generic pci serial driver that simply finds a device in a device definitions list and then sets up a SerialDevice instance based on the definition.

The driver currently only supports the "WCH CH382 2S" pci serial board, as that is the only device available for me to test with, but most other pci serial devices should be as easily addable as adding a board_definitions entry.