### PR TITLE
LibGfx/Vector*: Implement Formatters

### DIFF
--- a/Userland/Libraries/LibGfx/Vector2.h
+++ b/Userland/Libraries/LibGfx/Vector2.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <math.h>
 
 namespace Gfx {
@@ -107,6 +108,11 @@ public:
         return sqrt(m_x * m_x + m_y * m_y);
     }
 
+    constexpr String to_string() const
+    {
+        return String::formatted("[{},{}]", x(), y());
+    }
+
 private:
     T m_x;
     T m_y;
@@ -114,6 +120,18 @@ private:
 
 typedef Vector2<float> FloatVector2;
 typedef Vector2<double> DoubleVector2;
+
+}
+
+namespace AK {
+
+template<typename T>
+struct Formatter<Gfx::Vector2<T>> : Formatter<StringView> {
+    void format(FormatBuilder& builder, const Gfx::Vector2<T>& value)
+    {
+        Formatter<StringView>::format(builder, value.to_string());
+    }
+};
 
 }
 

--- a/Userland/Libraries/LibGfx/Vector3.h
+++ b/Userland/Libraries/LibGfx/Vector3.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <math.h>
 
 namespace Gfx {
@@ -123,6 +124,11 @@ public:
         return sqrt(m_x * m_x + m_y * m_y + m_z * m_z);
     }
 
+    constexpr String to_string() const
+    {
+        return String::formatted("[{},{},{}]", x(), y(), z());
+    }
+
 private:
     T m_x;
     T m_y;
@@ -131,6 +137,18 @@ private:
 
 typedef Vector3<float> FloatVector3;
 typedef Vector3<double> DoubleVector3;
+
+}
+
+namespace AK {
+
+template<typename T>
+struct Formatter<Gfx::Vector3<T>> : Formatter<StringView> {
+    void format(FormatBuilder& builder, const Gfx::Vector3<T>& value)
+    {
+        Formatter<StringView>::format(builder, value.to_string());
+    }
+};
 
 }
 

--- a/Userland/Libraries/LibGfx/Vector4.h
+++ b/Userland/Libraries/LibGfx/Vector4.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <math.h>
 
 namespace Gfx {
@@ -123,6 +124,11 @@ public:
         return sqrt(m_x * m_x + m_y * m_y + m_z * m_z + m_w * m_w);
     }
 
+    constexpr String to_string() const
+    {
+        return String::formatted("[{},{},{},{}]", x(), y(), z(), w());
+    }
+
 private:
     T m_x;
     T m_y;
@@ -132,6 +138,18 @@ private:
 
 typedef Vector4<float> FloatVector4;
 typedef Vector4<double> DoubleVector4;
+
+}
+
+namespace AK {
+
+template<typename T>
+struct Formatter<Gfx::Vector4<T>> : Formatter<StringView> {
+    void format(FormatBuilder& builder, const Gfx::Vector4<T>& value)
+    {
+        Formatter<StringView>::format(builder, value.to_string());
+    }
+};
 
 }
 


### PR DESCRIPTION
Add convenient formatters for `Vector2`, `Vector3` and `Vector4`.