### PR TITLE
Ports: Add libiconv dependency to gettext

### DIFF
--- a/Ports/gettext/package.sh
+++ b/Ports/gettext/package.sh
@@ -4,6 +4,7 @@ version=0.21
 useconfigure=true
 files="https://ftp.gnu.org/pub/gnu/gettext/gettext-${version}.tar.gz gettext-${version}.tar.gz c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12"
 auth_type=sha256
+depends="libiconv"
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install


### PR DESCRIPTION
libiconv is explicitly linked later and required by gettext as well.

Add it to the dependencies to make builds in a clean environment work.