### PR TITLE
Kernel: Rename method and fix virtio init process

### DIFF
--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -48,9 +48,6 @@ VirtIODevice::VirtIODevice(PCI::Address address, String class_name)
     PCI::enable_interrupt_line(pci_address());
     enable_irq();
 
-    reset_device();
-    set_status_bit(DEVICE_STATUS_ACKNOWLEDGE);
-
     auto capabilities = PCI::get_physical_id(address).capabilities();
     for (auto& capability : capabilities) {
         if (capability.id() == PCI_CAPABILITY_VENDOR_SPECIFIC) {
@@ -89,6 +86,9 @@ VirtIODevice::VirtIODevice(PCI::Address address, String class_name)
         m_notify_cfg = get_config(ConfigurationType::Notify, 0);
         m_isr_cfg = get_config(ConfigurationType::ISR, 0);
     }
+
+    reset_device();
+    set_status_bit(DEVICE_STATUS_ACKNOWLEDGE);
 
     set_status_bit(DEVICE_STATUS_DRIVER);
 }

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -161,9 +161,9 @@ u8 VirtIODevice::read_status_bits()
     return config_read8(*m_common_cfg, COMMON_CFG_DEVICE_STATUS);
 }
 
-void VirtIODevice::clear_status_bit(u8 status_bit)
+void VirtIODevice::mask_status_bits(u8 status_mask)
 {
-    m_status &= status_bit;
+    m_status &= status_mask;
     if (!m_common_cfg)
         out<u8>(REG_DEVICE_STATUS, m_status);
     else
@@ -241,7 +241,7 @@ void VirtIODevice::reset_device()
 {
     dbgln_if(VIRTIO_DEBUG, "{}: Reset device", m_class_name);
     if (!m_common_cfg) {
-        clear_status_bit(0);
+        mask_status_bits(0);
         while (read_status_bits() != 0) {
             // TODO: delay a bit?
         }

--- a/Kernel/VirtIO/VirtIO.h
+++ b/Kernel/VirtIO/VirtIO.h
@@ -157,7 +157,7 @@ protected:
     auto mapping_for_bar(u8) -> MappedMMIO&;
 
     u8 read_status_bits();
-    void clear_status_bit(u8);
+    void mask_status_bits(u8 status_mask);
     void set_status_bit(u8);
     u64 get_device_features();
     bool setup_queues(u16 requested_queue_count = 0);


### PR DESCRIPTION
The method has been renamed since its name was a bit misleading. It's not really clearing the status bits, it's masking the current status bits with its argument. People calling the method may assume that the argument they should pass is just the bit they want to clear, when really they should be constructing a mask.

The initial reset_device()/set_status_bit() calls need to be moved down after the initial PCI configuration space querying, since these methods depend on us having figured out where certain components are in the configuration space.