### PR TITLE
Kernel: Don't crash in page_fault_handler if current_thread is null

### DIFF
--- a/Kernel/UBSanitizer.cpp
+++ b/Kernel/UBSanitizer.cpp
@@ -5,8 +5,8 @@
  */
 
 #include <AK/Format.h>
+#include <Kernel/Arch/x86/CPU.h>
 #include <Kernel/KSyms.h>
-#include <Kernel/Panic.h>
 #include <Kernel/UBSanitizer.h>
 
 using namespace Kernel;
@@ -24,8 +24,10 @@ static void print_location(const SourceLocation& location)
         dbgln("KUBSAN: at {}, line {}, column: {}", location.filename(), location.line(), location.column());
     }
     dump_backtrace();
-    if (g_ubsan_is_deadly)
-        PANIC("UB is configured to be deadly.");
+    if (g_ubsan_is_deadly) {
+        dbgln("UB is configured to be deadly, halting the system.");
+        Processor::halt();
+    }
 }
 
 void __ubsan_handle_load_invalid_value(const InvalidValueData&, ValueHandle) __attribute__((used));


### PR DESCRIPTION

 -  __Kernel: Don't crash in page_fault_handler if current_thread is null__

    If we are attempting to emit debugging information about an unhandleable
    page fault, don't crash trying to kill threads or dump processes if the
    current_thread isn't set in TLS. Attempt to keep proceeding in order to
    dump as much useful information as possible.

    Related: #6948

 -  __Kernel: Halt CPU on deadly UBSAN instead of calling PANIC__

    The separate backtrace that the PANIC emits isn't useful and just adds
    more data to visually filter from the output when debugging an issue.
    Instead of calling PANIC, just emit the message with dbgln() and
    manually halt the system.