### PR TITLE
HackStudio: Pledge "fattr"

### DIFF
--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -40,7 +40,7 @@ static void update_path_environment_variable();
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix thread ptrace", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix fattr thread ptrace", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
HackStudio's pledges recently tightened due to changes in
Core::EventLoop. But apparently, HackStudio still needs
fattr to able to create a new project and set its permissions.


Before adding fattr to pledges, debug output looked like this when I tried to create new project.

```
...
HackStudio(46:46): execvpe() leaving :(
HackStudio(46:46): perror(): posix_spawn exec: No such file or directory
HackStudio(45:45): Couldn't watch '/dev': Could not watch file '/dev' : Not supported
HackStudio(45:45): Couldn't watch '/proc': Could not watch file '/proc' : Not supported
HackStudio(45:45): Load config file from /home/anon/.config/Terminal.ini
HackStudio(45:45): Creating project at path '/home/anon/Source/omerr' with name 'omerr'
[#0 HackStudio(45:45)]: Has not pledged fattr
[#0 HackStudio(45:45)]: 0x00000000  (?)

[#0 HackStudio(45:45)]: 0xc0395cc9  Kernel::Process::crash(int, unsigned int, bool) +0x333
[#0 HackStudio(45:45)]: 0xc03cc299  Kernel::Process::sys$fchmod(int, unsigned short) +0x235
[#0 HackStudio(45:45)]: 0xc03c1d7e  syscall_handler +0x1e7d
[#0 HackStudio(45:45)]: 0xc03bfec9  syscall_asm_entry +0x31
[#0 HackStudio(45:45)]: Process regions:
[#0 HackStudio(45:45)]: BEGIN       END         SIZE        ACCESS  NAME
[#0 HackStudio(45:45)]: 00801000 -- 00900fff 00100000 RW  T  Stack (Main thread)
...
```