### PR TITLE
Kernel: Make perf_event() work for global profiles

### DIFF
--- a/Kernel/Syscalls/perf_event.cpp
+++ b/Kernel/Syscalls/perf_event.cpp
@@ -11,9 +11,13 @@ namespace Kernel {
 
 KResultOr<int> Process::sys$perf_event(int type, FlatPtr arg1, FlatPtr arg2)
 {
-    if (!create_perf_events_buffer_if_needed())
-        return ENOMEM;
-    return perf_events()->append(type, arg1, arg2, nullptr);
+    auto events_buffer = current_perf_events_buffer();
+    if (!events_buffer) {
+        if (!create_perf_events_buffer_if_needed())
+            return ENOMEM;
+        events_buffer = perf_events();
+    }
+    return events_buffer->append(type, arg1, arg2, nullptr);
 }
 
 }


### PR DESCRIPTION
Previously calls to `perf_event()` would end up in a process-specific perfcore file even though global profiling was enabled. This changes the behavior for `perf_event()` so that these events are stored into the global profile instead.