### PR TITLE
Kernel: Don't use the profile timer if we don't have a timer to assign

### DIFF
--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -56,8 +56,8 @@ public:
 
     static bool is_hpet_periodic_mode_allowed();
 
-    void enable_profile_timer();
-    void disable_profile_timer();
+    bool enable_profile_timer();
+    bool disable_profile_timer();
 
     u64 uptime_ms() const;
     static Time now();


### PR DESCRIPTION
I open this as @IdanHo requested this fix to be in a separate PR.