### PR TITLE
FontEditor: Add missing `unix` pledge

### DIFF
--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio recvfd sendfd thread rpath cpath wpath", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd thread rpath unix cpath wpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
Without this change, FontEditor would crash due to LibDesktop opening an
IPC connection.

Fixes #7137