### PR TITLE
LibGL: implement different blending modes

### DIFF
--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Clipper.cpp
+    GLBlend.cpp
     GLColor.cpp
     GLContext.cpp
     GLLists.cpp

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -119,13 +119,13 @@ GLAPI void glEnable(GLenum cap);
 GLAPI void glDisable(GLenum cap);
 GLAPI void glCullFace(GLenum mode);
 GLAPI void glFrontFace(GLenum mode);
-GLuint glGenLists(GLsizei range);
-void glCallList(GLuint list);
-void glDeleteLists(GLuint list, GLsizei range);
-void glEndList(void);
-void glNewList(GLuint list, GLenum mode);
-void glFlush();
-void glFinish();
+GLAPI GLuint glGenLists(GLsizei range);
+GLAPI void glCallList(GLuint list);
+GLAPI void glDeleteLists(GLuint list, GLsizei range);
+GLAPI void glEndList(void);
+GLAPI void glNewList(GLuint list, GLenum mode);
+GLAPI void glFlush();
+GLAPI void glFinish();
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -42,6 +42,19 @@ extern "C" {
 #define GL_RENDERER 0x1F01
 #define GL_VERSION 0x1F02
 
+/* Blend factors */
+#define GL_ZERO 0
+#define GL_ONE 1
+#define GL_SRC_COLOR 0x0300
+#define GL_ONE_MINUS_SRC_COLOR 0x0301
+#define GL_SRC_ALPHA 0x0302
+#define GL_ONE_MINUS_SRC_ALPHA 0x0303
+#define GL_DST_ALPHA 0x0304
+#define GL_ONE_MINUS_DST_ALPHA 0x0305
+#define GL_DST_COLOR 0x0306
+#define GL_ONE_MINUS_DST_COLOR 0x0307
+#define GL_SRC_ALPHA_SATURATE 0x0308
+
 // Culled face side
 #define GL_FRONT 0x0404
 #define GL_BACK 0x0405
@@ -64,6 +77,12 @@ extern "C" {
 // Listing enums
 #define GL_COMPILE 0x1300
 #define GL_COMPILE_AND_EXECUTE 0x1301
+
+// More blend factors
+#define GL_CONSTANT_COLOR 0x8001
+#define GL_ONE_MINUS_CONSTANT_COLOR 0x8002
+#define GL_CONSTANT_ALPHA 0x8003
+#define GL_ONE_MINUS_CONSTANT_ALPHA 0x8004
 
 //
 // OpenGL typedefs
@@ -126,6 +145,7 @@ GLAPI void glEndList(void);
 GLAPI void glNewList(GLuint list, GLenum mode);
 GLAPI void glFlush();
 GLAPI void glFinish();
+GLAPI void glBlendFunc(GLenum sfactor, GLenum dfactor);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -36,6 +36,7 @@ extern "C" {
 // Enable capabilities
 #define GL_CULL_FACE 0x0B44
 #define GL_DEPTH_TEST 0x0B71
+#define GL_BLEND 0x0BE2
 
 // Utility
 #define GL_VENDOR 0x1F00

--- a/Userland/Libraries/LibGL/GLBlend.cpp
+++ b/Userland/Libraries/LibGL/GLBlend.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GL/gl.h"
+#include "GLContext.h"
+
+extern GL::GLContext* g_gl_context;
+
+void glBlendFunc(GLenum sfactor, GLenum dfactor)
+{
+    return g_gl_context->gl_blend_func(sfactor, dfactor);
+}

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -49,6 +49,7 @@ public:
     virtual void gl_new_list(GLuint list, GLenum mode) = 0;
     virtual void gl_flush() = 0;
     virtual void gl_finish() = 0;
+    virtual void gl_blend_func(GLenum src_factor, GLenum dst_factor) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -859,6 +859,57 @@ void SoftwareGLContext::gl_finish()
     // No-op since SoftwareGLContext is completely synchronous at the moment
 }
 
+void SoftwareGLContext::gl_blend_func(GLenum src_factor, GLenum dst_factor)
+{
+    if (m_in_draw_state) {
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    // FIXME: The list of allowed enums differs between API versions
+    // This was taken from the 2.0 spec on https://docs.gl/gl2/glBlendFunc
+
+    if (!(src_factor == GL_ZERO
+            || src_factor == GL_ONE
+            || src_factor == GL_SRC_COLOR
+            || src_factor == GL_ONE_MINUS_SRC_COLOR
+            || src_factor == GL_DST_COLOR
+            || src_factor == GL_ONE_MINUS_DST_COLOR
+            || src_factor == GL_SRC_ALPHA
+            || src_factor == GL_ONE_MINUS_SRC_ALPHA
+            || src_factor == GL_DST_ALPHA
+            || src_factor == GL_ONE_MINUS_DST_ALPHA
+            || src_factor == GL_CONSTANT_COLOR
+            || src_factor == GL_ONE_MINUS_CONSTANT_COLOR
+            || src_factor == GL_CONSTANT_ALPHA
+            || src_factor == GL_ONE_MINUS_CONSTANT_ALPHA
+            || src_factor == GL_SRC_ALPHA_SATURATE)) {
+        m_error = GL_INVALID_ENUM;
+        return;
+    }
+
+    if (!(dst_factor == GL_ZERO
+            || dst_factor == GL_ONE
+            || dst_factor == GL_SRC_COLOR
+            || dst_factor == GL_ONE_MINUS_SRC_COLOR
+            || dst_factor == GL_DST_COLOR
+            || dst_factor == GL_ONE_MINUS_DST_COLOR
+            || dst_factor == GL_SRC_ALPHA
+            || dst_factor == GL_ONE_MINUS_SRC_ALPHA
+            || dst_factor == GL_DST_ALPHA
+            || dst_factor == GL_ONE_MINUS_DST_ALPHA
+            || dst_factor == GL_CONSTANT_COLOR
+            || dst_factor == GL_ONE_MINUS_CONSTANT_COLOR
+            || dst_factor == GL_CONSTANT_ALPHA
+            || dst_factor == GL_ONE_MINUS_CONSTANT_ALPHA)) {
+        m_error = GL_INVALID_ENUM;
+        return;
+    }
+
+    m_blend_source_factor = src_factor;
+    m_blend_destination_factor = dst_factor;
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -683,6 +683,11 @@ void SoftwareGLContext::gl_enable(GLenum capability)
         rasterizer_options.enable_depth_test = true;
         update_rasterizer_options = true;
         break;
+    case GL_BLEND:
+        m_blend_enabled = true;
+        rasterizer_options.enable_blending = true;
+        update_rasterizer_options = true;
+        break;
     default:
         m_error = GL_INVALID_ENUM;
         break;
@@ -712,6 +717,11 @@ void SoftwareGLContext::gl_disable(GLenum capability)
         m_depth_test_enabled = false;
         rasterizer_options.enable_depth_test = false;
         update_rasterizer_options = true;
+        break;
+    case GL_BLEND:
+        m_blend_enabled = false;
+        rasterizer_options.enable_blending = false;
+        update_rasterizer_options = false;
         break;
     default:
         m_error = GL_INVALID_ENUM;
@@ -908,6 +918,11 @@ void SoftwareGLContext::gl_blend_func(GLenum src_factor, GLenum dst_factor)
 
     m_blend_source_factor = src_factor;
     m_blend_destination_factor = dst_factor;
+
+    auto options = m_rasterizer.options();
+    options.blend_source_factor = m_blend_source_factor;
+    options.blend_destination_factor = m_blend_destination_factor;
+    m_rasterizer.set_options(options);
 }
 
 void SoftwareGLContext::present()

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -106,6 +106,7 @@ private:
     GLenum m_front_face = GL_CCW;
     GLenum m_culled_sides = GL_BACK;
 
+    bool m_blend_enabled = false;
     GLenum m_blend_source_factor = GL_ONE;
     GLenum m_blend_destination_factor = GL_ZERO;
 

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -55,6 +55,7 @@ public:
     virtual void gl_new_list(GLuint list, GLenum mode) override;
     virtual void gl_flush() override;
     virtual void gl_finish() override;
+    virtual void gl_blend_func(GLenum src_factor, GLenum dst_factor) override;
 
     virtual void present() override;
 
@@ -104,6 +105,9 @@ private:
     bool m_cull_faces = false;
     GLenum m_front_face = GL_CCW;
     GLenum m_culled_sides = GL_BACK;
+
+    GLenum m_blend_source_factor = GL_ONE;
+    GLenum m_blend_destination_factor = GL_ZERO;
 
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DepthBuffer.h"
+#include "GL/gl.h"
 #include "GLStruct.h"
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
@@ -15,8 +16,11 @@
 namespace GL {
 
 struct RasterizerOptions {
-    bool shade_smooth { false };
+    bool shade_smooth { true };
     bool enable_depth_test { false };
+    bool enable_blending { false };
+    GLenum blend_source_factor { GL_ONE };
+    GLenum blend_destination_factor { GL_ONE };
 };
 
 class SoftwareRasterizer final {


### PR DESCRIPTION
This implements almost all blending modes in the SoftwareRasterizer.
We can drop `glBlendFunc()` from #7062

This is GLTeapot with `glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` and vertex color alpha at 0.5

![Bildschirmfoto zu 2021-05-15 23-37-39](https://user-images.githubusercontent.com/2094371/118379057-31eb4e00-b5d8-11eb-9897-536998676a97.png)
