### PR TITLE
Tests/CI: Resolve ASAN/UBSAN errors and run with Sanitizers in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -216,7 +216,7 @@ jobs:
       run: |
         mkdir -p Build
         cd Build
-        cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_PCI_IDS_DOWNLOAD=OFF -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 ..
+        cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_UNDEFINED_SANITIZER=ON -DENABLE_ADDRESS_SANITIZER=ON -DENABLE_PCI_IDS_DOWNLOAD=OFF -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 ..
       if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
 
     # === ACTUALLY BUILD AND TEST ===
@@ -227,8 +227,11 @@ jobs:
 
     - name: Run CMake tests
       working-directory: ${{ github.workspace }}/Meta/Lagom/Build
-      run: CTEST_OUTPUT_ON_FAILURE=1 ninja test || ${{ matrix.allow-test-failure }}
+      run: ninja test || ${{ matrix.allow-test-failure }}
       timeout-minutes: 4
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+        UBSAN_OPTIONS: "halt_on_error=1"
       if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
 
   lint_commits:

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -52,7 +52,7 @@ public:
             return 0;
 
         static const u8 bitmask_first_byte[8] = { 0xFF, 0xFE, 0xFC, 0xF8, 0xF0, 0xE0, 0xC0, 0x80 };
-        static const u8 bitmask_last_byte[8] = { 0x0, 0x1, 0x3, 0x7, 0xF, 0x1F, 0x3F, 0x7F };
+        static const u8 bitmask_last_byte[8] = { 0x00, 0x1, 0x3, 0x7, 0xF, 0x1F, 0x3F, 0x7F };
 
         size_t count;
         const u8* first = &m_data[start / 8];
@@ -64,9 +64,12 @@ public:
             count = __builtin_popcount(byte);
         } else {
             count = __builtin_popcount(byte);
-            byte = *last;
-            byte &= bitmask_last_byte[(start + len) % 8];
-            count += __builtin_popcount(byte);
+            // Don't access *last if it's out of bounds
+            if (last < &m_data[size_in_bytes()]) {
+                byte = *last;
+                byte &= bitmask_last_byte[(start + len) % 8];
+                count += __builtin_popcount(byte);
+            }
             if (++first < last) {
                 const u32* ptr32 = (const u32*)(((FlatPtr)first + sizeof(u32) - 1) & ~(sizeof(u32) - 1));
                 if ((const u8*)ptr32 > last)

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -74,7 +74,8 @@ public:
     [[nodiscard]] static ByteBuffer copy(void const* data, size_t size)
     {
         auto buffer = create_uninitialized(size);
-        __builtin_memcpy(buffer.data(), data, size);
+        if (size != 0)
+            __builtin_memcpy(buffer.data(), data, size);
         return buffer;
     }
 

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -267,6 +267,11 @@ For the changes to take effect, SerenityOS needs to be recompiled and the disk i
 
 To add a package from the ports collection to Serenity, for example curl, go into `Ports/curl/` and run `./package.sh`. The sourcecode for the package will be downloaded and the package will be built. After that, rebuild the disk image. The next time you start Serenity, `curl` will be available.
 
+## Tests
+
+For information on running host and target tests, see [Running Tests](RunningTests.md). The documentation there explains the difference between host tests run with Lagom and
+target tests run on SerenityOS. It also contains useful information for debugging CI test failures.
+
 ## Customize disk image
 
 To add, modify or remove files of the disk image's file system, e.g. to change the default keyboard layout, you can create a shell script with the name `sync-local.sh` in the project root, with content like this:

--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -1,10 +1,10 @@
-## Running SerenityOS Tests
+# Running SerenityOS Tests
 
-There are two classes of tests built during a Serenity build: host tests and target tests. Host tests run on the build
-machine, and use [Lagom](../Meta/Lagom/ReadMe.md) to build Serenity userspace libraries for the host platform. Target
-tests run on the Serenity machine, either emulated or bare metal.
+There are two classes of tests built during a SerenityOS build: host tests and target tests. Host tests run on the build
+machine, and use [Lagom](../Meta/Lagom/ReadMe.md) to build SerenityOS userspace libraries for the host platform. Target
+tests run on the SerenityOS machine, either emulated or bare metal.
 
-### Running Host Tests
+## Running Host Tests
 
 There are two ways to build host tests: from a full build, or from a Lagom-only build. The only difference is the CMake
 command used to initialize the build directory.
@@ -12,41 +12,78 @@ command used to initialize the build directory.
 For a full build, pass `-DBUILD_LAGOM=ON` to the CMake command.
 
 ```sh
-mkdir Build
-cd Build
-cmake .. -GNinja -DBUILD_LAGOM=ON
+mkdir -p Build/lagom
+cd Build/lagom
+cmake ../.. -GNinja -DBUILD_LAGOM=ON
 ```
 
-For a Lagom-only build, pass the Lagom directory to CMake.
+For a Lagom-only build, pass the Lagom directory to CMake. The `BUILD_LAGOM` CMake option is still required.
 
 ```sh
 mkdir BuildLagom
 cd BuildLagom
-cmake ../Meta/Lagom -GNinja
+cmake ../Meta/Lagom -GNinja -DBUILD_LAGOM=ON
 ```
 
-In both cases, the tests can be run via ninja after doing a build:
+In both cases, the tests can be run via ninja after doing a build. Note that `test-js` requires the `SERENITY_SOURCE_DIR` environment variable to be set
+to the root of the serenity source tree when running on a non-SerenityOS host.
 
 ```sh
+# /path/to/serenity repository
+export SERENITY_SOURCE_DIR=${PWD}/..
 ninja && ninja test
 ```
 
-### Running Target Tests
+To see the stdout/stderr output of failing tests, the reccommended way is to set the environment variable [`CTEST_OUTPUT_ON_FAILURE`](https://cmake.org/cmake/help/latest/manual/ctest.1.html#options) to 1.
 
-Tests built for the Serenity target get installed either into `/usr/Tests` or `/bin`. `/usr/Tests` is preferred, but
+```sh
+CTEST_OUTPUT_ON_FAILURE=1 ninja test
+
+# or, using ctest directly...
+ctest --output-on-failure
+```
+
+### Running with Sanitizers
+
+CI runs host tests with Address Sanitizer and Undefined Sanitizer instrumentation enabled. These tools catch many
+classes of common C++ errors, including memory leaks, out of bounds access to stack and heap allocations, and
+signed integer overflow. For more info on the sanitizers, check out the Address Sanitizer [wiki page](https://github.com/google/sanitizers/wiki),
+or the Undefined Sanitizer [documentation](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) from clang.
+
+Note that a sanitizer build will take significantly longer than a non-santizer build, and will mess with caches in tools such as `ccache`.
+The sanitizers can be enabled with the `-DENABLE_FOO_SANITIZER` set of flags. Sanitizers are only supported for Lagom tests, as SerenityOS support
+for gcc's `libsanitizer` is not yet implemented.
+
+```sh
+mkdir BuildLagom
+cd BuildLagom
+cmake ../Meta/Lagom -GNinja -DBUILD_LAGOM=ON -DENABLE_ADDRESS_SANITIZER=ON -DENABLE_UNDEFINED_SANITIZER=ON
+ninja
+CTEST_OUTPUT_ON_FAILURE=1 SERENITY_SOURCE_DIR=${PWD}/.. ninja test
+```
+
+To ensure that Undefined Sanitizer errors fail the test, the `halt_on_error` flag should be set to 1 in the environment variable `UBSAN_OPTIONS`.
+
+```sh
+UBSAN_OPTIONS=halt_on_error=1 CTEST_OUTPUT_ON_FAILURE=1 SERENITY_SOURCE_DIR=${PWD}/.. ninja test
+```
+
+## Running Target Tests
+
+Tests built for the SerenityOS target get installed either into `/usr/Tests` or `/bin`. `/usr/Tests` is preferred, but
 some system tests are installed into `/bin` for historical reasons.
 
 The easiest way to run all of the known tests in the system is to use the `run-tests-and-shutdown.sh` script that gets
 installed into `/home/anon/tests`. When running in CI, the environment variable `$DO_SHUTDOWN_AFTER_TESTS` is set, which
 will run `shutdown -n` after running all the tests.
 
-For completeness, a basic on-target test run will need the Serenity image built and run via QEMU.
+For completeness, a basic on-target test run will need the SerenityOS image built and run via QEMU.
 
 ```sh
-mkdir Build
-cd Build
-cmake .. -GNinja
-ninja && ninja install && ninja image && ninja run
+mkdir Build/i686
+cd Build/i686
+cmake ../.. -GNinja
+ninja install && ninja image && ninja run
 ```
 
 In the initial terminal, one can easily run the test runner script:
@@ -77,8 +114,8 @@ BootModes=self-test
 the serial debug output to `./debug.log` so that both stdout of the tests and the dbgln from the kernel/tests can be
 captured.
 
-To run with CI's TestRunner system server entry, Serenity needs booted in self-test mode. Running the following shell
-lines will boot Serenity in self-test mode, run tests, and exit.
+To run with CI's TestRunner system server entry, SerenityOS needs booted in self-test mode. Running the following shell
+lines will boot SerenityOS in self-test mode, run tests, and exit.
 
 ```sh
 export SERENITY_RUN=ci

--- a/Tests/AK/TestBitmap.cpp
+++ b/Tests/AK/TestBitmap.cpp
@@ -248,3 +248,31 @@ TEST_CASE(count_in_range)
     test_with_value(true);
     test_with_value(false);
 }
+
+TEST_CASE(byte_aligned_access)
+{
+    {
+        Bitmap bitmap(16, true);
+        EXPECT_EQ(bitmap.count_in_range(0, 16, true), 16u);
+        EXPECT_EQ(bitmap.count_in_range(8, 8, true), 8u);
+        EXPECT_EQ(bitmap.count_in_range(0, 8, true), 8u);
+        EXPECT_EQ(bitmap.count_in_range(4, 8, true), 8u);
+    }
+    {
+        Bitmap bitmap(16, false);
+        bitmap.set_range(4, 8, true);
+        EXPECT_EQ(bitmap.count_in_range(0, 16, true), 8u);
+        EXPECT_EQ(bitmap.count_in_range(8, 8, true), 4u);
+        EXPECT_EQ(bitmap.count_in_range(0, 8, true), 4u);
+        EXPECT_EQ(bitmap.count_in_range(4, 8, true), 8u);
+    }
+    {
+        Bitmap bitmap(8, false);
+        bitmap.set(2, true);
+        bitmap.set(4, true);
+        EXPECT_EQ(bitmap.count_in_range(0, 2, true), 0u);
+        EXPECT_EQ(bitmap.count_in_range(0, 4, true), 1u);
+        EXPECT_EQ(bitmap.count_in_range(0, 8, true), 2u);
+        EXPECT_EQ(bitmap.count_in_range(4, 4, true), 1u);
+    }
+}

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -106,7 +106,8 @@ bool ArgsParser::parse(int argc, char** argv, bool exit_on_failure)
     // We're done processing options, now let's parse positional arguments.
 
     int values_left = argc - optind;
-    int num_values_for_arg[m_positional_args.size()];
+    Vector<int, 16> num_values_for_arg;
+    num_values_for_arg.resize(m_positional_args.size(), true);
     int total_values_required = 0;
     for (size_t i = 0; i < m_positional_args.size(); i++) {
         auto& arg = m_positional_args[i];


### PR DESCRIPTION
Fixes the last remaining UBSAN and ASAN reported errors in the current suite of Lagom tests.

- Copying a zero size byte buffer would pass nullptr to __builtin_memcpy
- Zero Length VLAs were possible in ArgsParser::parse
- BitmapView::count_in_range would read one-past-the-end of byte-aligned sized bitmaps. Fixes #7073 

And finally, enable USBAN and ASAN in CI runs so that properly sanitized Tests/UUTs become other people's problems too :^)