### PR TITLE
Meta: Add a check for periods on the end of titles to commit linter

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -265,6 +265,14 @@ jobs:
         pattern: '^\S.*?: .+'
         error: 'Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)'
 
+    - name: Check title
+      if: ${{ success() || failure() }}
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        pattern: '^.+[^.\n](\n.*)*$'
+        error: 'Commit title ends in a period'
+
   notify_irc:
     needs: [build_and_test_serenity, build_and_test_lagom, lint_commits]
     runs-on: ubuntu-20.04

--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -28,6 +28,10 @@ while read -r line; do
     error "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)"
   fi
 
+  if [[ $line_number -eq 1 ]] && [[ "$line" =~ \.$ ]]; then
+    error "Commit title ends in a period"
+  fi
+
   if [[ $line_length -gt 72 ]]; then
     error "Commit message lines are too long (maximum allowed is 72 characters)"
   fi


### PR DESCRIPTION
inspired by https://github.com/SerenityOS/serenity/commit/84b4b06c4b9f69dd786a80ee3c9a4562aa2b0f45