### PR TITLE
LibLine: Make line management less broken when at the last line

### DIFF
--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -256,6 +256,8 @@ private:
     void handle_interrupt_event();
     void handle_read_event();
 
+    void ensure_free_lines_from_origin(size_t count);
+
     Vector<size_t, 2> vt_dsr();
     void remove_at_index(size_t);
 

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -223,6 +223,8 @@ void Editor::enter_search()
             m_pre_search_buffer.append(code_point);
         m_pre_search_cursor = m_cursor;
 
+        ensure_free_lines_from_origin(1 + num_lines());
+
         // Disable our own notifier so as to avoid interfering with the search editor.
         m_notifier->set_enabled(false);
 
@@ -310,9 +312,6 @@ void Editor::enter_search()
             return false;
         });
 
-        fprintf(stderr, "\n");
-        fflush(stderr);
-
         auto search_prompt = "\x1b[32msearch:\x1b[0m ";
 
         // While the search editor is active, we do not want editing events.
@@ -348,6 +347,10 @@ void Editor::enter_search()
         VT::clear_lines(0, metrics.lines_with_addition(search_metrics, m_num_columns) + search_end_row - m_origin_row - 1);
 
         reposition_cursor();
+
+        m_refresh_needed = true;
+        m_cached_prompt_valid = false;
+        m_chars_touched_in_the_middle = 1;
 
         if (!m_reset_buffer_on_search_end || search_metrics.total_length == 0) {
             // If the entry was empty, or we purposely quit without a newline,


### PR DESCRIPTION
Previously, all sorts of weird stuff would happen when the editor was at
the last line of the terminal (or when the printed line would be at the
last line), this commit makes the editor scroll the terminal up before
trying to write to a row that doesn't actually exist (yet).
This fixes ^R search making a mess when initiated at the last line
(especially with multiline prompts).