### PR TITLE
ImageViewer: Fix crash with empty image and stop animation timer when needed

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -31,6 +31,8 @@ ViewWidget::~ViewWidget()
 
 void ViewWidget::clear()
 {
+    m_timer->stop();
+    m_decoded_image.clear();
     m_bitmap = nullptr;
     if (on_image_change)
         on_image_change(m_bitmap);
@@ -265,6 +267,8 @@ void ViewWidget::load_from_file(const String& path)
         m_timer->set_interval(first_frame.duration);
         m_timer->on_timeout = [this] { animate(); };
         m_timer->start();
+    } else {
+        m_timer->stop();
     }
 
     m_path = path;

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -32,6 +32,8 @@ ViewWidget::~ViewWidget()
 void ViewWidget::clear()
 {
     m_bitmap = nullptr;
+    if (on_image_change)
+        on_image_change(m_bitmap);
     m_path = {};
 
     reset_view();
@@ -255,6 +257,8 @@ void ViewWidget::load_from_file(const String& path)
 
     m_decoded_image = decoded_image_or_error.release_value();
     m_bitmap = m_decoded_image->frames[0].bitmap;
+    if (on_image_change)
+        on_image_change(m_bitmap);
 
     if (m_decoded_image->is_animated && m_decoded_image->frames.size() > 1) {
         const auto& first_frame = m_decoded_image->frames[0];

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -42,6 +42,7 @@ public:
     Function<void(int, Gfx::IntRect)> on_scale_change;
     Function<void()> on_doubleclick;
     Function<void(const GUI::DropEvent&)> on_drop;
+    Function<void(const Gfx::Bitmap*)> on_image_change;
 
 private:
     ViewWidget();

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
             widget.navigate(ViewWidget::Directions::Last);
         });
 
-    auto full_sceen_action = GUI::CommonActions::make_fullscreen_action(
+    auto full_screen_action = GUI::CommonActions::make_fullscreen_action(
         [&](auto&) {
             widget.on_doubleclick();
         });
@@ -237,6 +237,26 @@ int main(int argc, char** argv)
         if (widget.bitmap())
             GUI::Clipboard::the().set_bitmap(*widget.bitmap());
     });
+
+    widget.on_image_change = [&](const Gfx::Bitmap* bitmap) {
+        bool should_enable_image_actions = (bitmap != nullptr);
+        delete_action->set_enabled(should_enable_image_actions);
+        rotate_left_action->set_enabled(should_enable_image_actions);
+        rotate_right_action->set_enabled(should_enable_image_actions);
+        vertical_flip_action->set_enabled(should_enable_image_actions);
+        horizontal_flip_action->set_enabled(should_enable_image_actions);
+        desktop_wallpaper_action->set_enabled(should_enable_image_actions);
+        go_first_action->set_enabled(should_enable_image_actions);
+        go_back_action->set_enabled(should_enable_image_actions);
+        go_forward_action->set_enabled(should_enable_image_actions);
+        go_last_action->set_enabled(should_enable_image_actions);
+        zoom_in_action->set_enabled(should_enable_image_actions);
+        reset_zoom_action->set_enabled(should_enable_image_actions);
+        zoom_out_action->set_enabled(should_enable_image_actions);
+        if (!should_enable_image_actions) {
+            window->set_title("Image Viewer");
+        }
+    };
 
     main_toolbar.add_action(open_action);
     main_toolbar.add_action(delete_action);
@@ -273,7 +293,7 @@ int main(int argc, char** argv)
     navigate_menu.add_action(go_last_action);
 
     auto& view_menu = menubar->add_menu("&View");
-    view_menu.add_action(full_sceen_action);
+    view_menu.add_action(full_screen_action);
     view_menu.add_separator();
     view_menu.add_action(zoom_in_action);
     view_menu.add_action(reset_zoom_action);
@@ -291,6 +311,8 @@ int main(int argc, char** argv)
 
     if (path != nullptr) {
         widget.load_from_file(path);
+    } else {
+        widget.clear();
     }
 
     window->show();


### PR DESCRIPTION
Previously some actions like Rotate/Flip/Set as Desktop Wallpaper would
make the application crash if no image was loaded.

Also fixed a small typo.