### PR TITLE
LibVT: Fix 8-bit control codes clobbering UTF-8

### DIFF
--- a/Userland/Libraries/LibVT/StateMachine.txt
+++ b/Userland/Libraries/LibVT/StateMachine.txt
@@ -10,23 +10,7 @@
 @anywhere {
     0x18         => (Ground, Execute)
     0x1a         => (Ground, Execute)
-    [0x80..0x8f] => (Ground, Execute)
-    [0x91..0x97] => (Ground, Execute)
-    0x99         => (Ground, Execute)
-    0x9a         => (Ground, Execute)
-    0x9c         => (Ground, _)
-
     0x1b         => (Escape, _)
-
-    0x90         => (DcsEntry, _)
-
-    0x98         => (SosPmApcString, _)
-    0x9e         => (SosPmApcString, _)
-    0x9f         => (SosPmApcString, _)
-
-    0x9d         => (OscString, _)
-
-    0x9b         => (CsiEntry, _)
 }
 
 Ground {


### PR DESCRIPTION
Bytes in the 0x80..0x9F range were treated as C1 control codes, which prevented them from being parsed as UTF-8 bytes.

VT100 and most modern implementations does not support 8-bit control codes anyways, so we're not missing out on anything.

This caused some characters (like U+DF, encoded as 0xC3 0x9F) from being recognized as printable characters.