### PR TITLE
LibGL: Implement glShadeModel()

### DIFF
--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     GLBlend.cpp
     GLColor.cpp
     GLContext.cpp
+    GLLights.cpp
     GLLists.cpp
     GLMat.cpp
     GLUtils.cpp

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -79,6 +79,10 @@ extern "C" {
 #define GL_COMPILE 0x1300
 #define GL_COMPILE_AND_EXECUTE 0x1301
 
+// Lighting related defines
+#define GL_FLAT 0x1D00
+#define GL_SMOOTH 0x1D01
+
 // More blend factors
 #define GL_CONSTANT_COLOR 0x8001
 #define GL_ONE_MINUS_CONSTANT_COLOR 0x8002
@@ -147,6 +151,7 @@ GLAPI void glNewList(GLuint list, GLenum mode);
 GLAPI void glFlush();
 GLAPI void glFinish();
 GLAPI void glBlendFunc(GLenum sfactor, GLenum dfactor);
+GLAPI void glShadeModel(GLenum mode);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -50,6 +50,7 @@ public:
     virtual void gl_flush() = 0;
     virtual void gl_finish() = 0;
     virtual void gl_blend_func(GLenum src_factor, GLenum dst_factor) = 0;
+    virtual void gl_shade_model(GLenum mode) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLLights.cpp
+++ b/Userland/Libraries/LibGL/GLLights.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GL/gl.h"
+#include "GLContext.h"
+
+extern GL::GLContext* g_gl_context;
+
+void glShadeModel(GLenum mode)
+{
+    g_gl_context->gl_shade_model(mode);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -925,6 +925,23 @@ void SoftwareGLContext::gl_blend_func(GLenum src_factor, GLenum dst_factor)
     m_rasterizer.set_options(options);
 }
 
+void SoftwareGLContext::gl_shade_model(GLenum mode)
+{
+    if (m_in_draw_state) {
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    if (mode != GL_FLAT && mode != GL_SMOOTH) {
+        m_error = GL_INVALID_ENUM;
+        return;
+    }
+
+    auto options = m_rasterizer.options();
+    options.shade_smooth = (mode == GL_SMOOTH);
+    m_rasterizer.set_options(options);
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -871,6 +871,8 @@ void SoftwareGLContext::gl_finish()
 
 void SoftwareGLContext::gl_blend_func(GLenum src_factor, GLenum dst_factor)
 {
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_blend_func, src_factor, dst_factor);
+
     if (m_in_draw_state) {
         m_error = GL_INVALID_OPERATION;
         return;
@@ -927,6 +929,8 @@ void SoftwareGLContext::gl_blend_func(GLenum src_factor, GLenum dst_factor)
 
 void SoftwareGLContext::gl_shade_model(GLenum mode)
 {
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_shade_model, mode);
+
     if (m_in_draw_state) {
         m_error = GL_INVALID_OPERATION;
         return;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -162,7 +162,9 @@ private:
             decltype(&SoftwareGLContext::gl_disable),
             decltype(&SoftwareGLContext::gl_front_face),
             decltype(&SoftwareGLContext::gl_cull_face),
-            decltype(&SoftwareGLContext::gl_call_list)>;
+            decltype(&SoftwareGLContext::gl_call_list),
+            decltype(&SoftwareGLContext::gl_blend_func),
+            decltype(&SoftwareGLContext::gl_shade_model)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -56,6 +56,7 @@ public:
     virtual void gl_flush() override;
     virtual void gl_finish() override;
     virtual void gl_blend_func(GLenum src_factor, GLenum dst_factor) override;
+    virtual void gl_shade_model(GLenum mode) override;
 
     virtual void present() override;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -295,11 +295,16 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                     barycentric = barycentric * FloatVector3(triangle.vertices[0].w, triangle.vertices[1].w, triangle.vertices[2].w) * interpolated_w;
 
                     // FIXME: make this more generic. We want to interpolate more than just color and uv
-                    auto rgba = interpolate(
-                        FloatVector4(triangle.vertices[0].r, triangle.vertices[0].g, triangle.vertices[0].b, triangle.vertices[0].a),
-                        FloatVector4(triangle.vertices[1].r, triangle.vertices[1].g, triangle.vertices[1].b, triangle.vertices[1].a),
-                        FloatVector4(triangle.vertices[2].r, triangle.vertices[2].g, triangle.vertices[2].b, triangle.vertices[2].a),
-                        barycentric);
+                    FloatVector4 vertex_color;
+                    if (options.shade_smooth) {
+                        vertex_color = interpolate(
+                            FloatVector4(triangle.vertices[0].r, triangle.vertices[0].g, triangle.vertices[0].b, triangle.vertices[0].a),
+                            FloatVector4(triangle.vertices[1].r, triangle.vertices[1].g, triangle.vertices[1].b, triangle.vertices[1].a),
+                            FloatVector4(triangle.vertices[2].r, triangle.vertices[2].g, triangle.vertices[2].b, triangle.vertices[2].a),
+                            barycentric);
+                    } else {
+                        vertex_color = { triangle.vertices[0].r, triangle.vertices[0].g, triangle.vertices[0].b, triangle.vertices[0].a };
+                    }
 
                     auto uv = interpolate(
                         FloatVector2(triangle.vertices[0].u, triangle.vertices[0].v),
@@ -307,7 +312,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                         FloatVector2(triangle.vertices[2].u, triangle.vertices[2].v),
                         barycentric);
 
-                    *pixel = pixel_shader(uv, rgba);
+                    *pixel = pixel_shader(uv, vertex_color);
                 }
             }
 


### PR DESCRIPTION
This turns off interpolation of vertex colors when GL_FLAT is selected.

#7062