### PR TITLE
LibC+Kernel: Add sys/ttydefaults.h

### DIFF
--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -11,6 +11,9 @@
 #include <LibC/errno_numbers.h>
 #include <LibC/signal_numbers.h>
 #include <LibC/sys/ioctl_numbers.h>
+#define TTYDEFCHARS
+#include <LibC/sys/ttydefaults.h>
+#undef TTYDEFCHARS
 
 namespace Kernel {
 
@@ -27,9 +30,13 @@ TTY::~TTY()
 void TTY::set_default_termios()
 {
     memset(&m_termios, 0, sizeof(m_termios));
-    m_termios.c_lflag |= ISIG | ECHO | ICANON;
-    static const char default_cc[32] = "\003\034\010\025\004\0\1\0\021\023\032\0\022\017\027\026\0\024";
-    memcpy(m_termios.c_cc, default_cc, sizeof(default_cc));
+    m_termios.c_iflag = TTYDEF_IFLAG;
+    m_termios.c_oflag = TTYDEF_OFLAG;
+    m_termios.c_cflag = TTYDEF_CFLAG;
+    m_termios.c_lflag = TTYDEF_LFLAG;
+    m_termios.c_ispeed = TTYDEF_SPEED;
+    m_termios.c_ospeed = TTYDEF_SPEED;
+    memcpy(m_termios.c_cc, ttydefchars, sizeof(ttydefchars));
 }
 
 KResultOr<size_t> TTY::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)

--- a/Userland/Libraries/LibC/sys/ttydefaults.h
+++ b/Userland/Libraries/LibC/sys/ttydefaults.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define TTYDEF_IFLAG (ICRNL | IXON | IXANY)
+#define TTYDEF_OFLAG (OPOST | ONLCR)
+#define TTYDEF_LFLAG_NOECHO (ISIG | ICANON)
+#define TTYDEF_LFLAG_ECHO (TTYDEF_LFLAG_NOECHO | ECHO | ECHOE | ECHOK | ECHONL)
+#define TTYDEF_LFLAG TTYDEF_LFLAG_ECHO
+#define TTYDEF_CFLAG (0)
+#define TTYDEF_SPEED (B9600)
+
+#define CTRL(c) (c & 0x1F)
+#define CINTR CTRL('c')
+#define CQUIT 034
+#define CERASE 0177
+#define CKILL CTRL('u')
+#define CEOF CTRL('d')
+#define CTIME 0
+#define CMIN 1
+#define CSWTC 0
+#define CSTART CTRL('q')
+#define CSTOP CTRL('s')
+#define CSUSP CTRL('z')
+#define CEOL 0
+#define CREPRINT CTRL('r')
+#define CDISCARD CTRL('o')
+#define CWERASE CTRL('w')
+#define CLNEXT CTRL('v')
+#define CEOL2 CEOL
+
+#define CEOT CEOF
+#define CBRK CEOL
+#define CRPRNT CREPRINT
+#define CFLUSH CDISCARD
+
+#ifdef TTYDEFCHARS
+#    ifdef KERNEL
+#        include <Kernel/UnixTypes.h>
+#    else
+#        include <termios.h>
+#    endif
+#    include <sys/cdefs.h>
+
+__BEGIN_DECLS
+static const cc_t ttydefchars[NCCS] = {
+    [VINTR] = CINTR,
+    [VQUIT] = CQUIT,
+    [VERASE] = CERASE,
+    [VKILL] = CKILL,
+    [VEOF] = CEOF,
+    [VTIME] = CTIME,
+    [VMIN] = CMIN,
+    [VSWTC] = CSWTC,
+    [VSTART] = CSTART,
+    [VSTOP] = CSTOP,
+    [VSUSP] = CSUSP,
+    [VEOL] = CEOL,
+    [VREPRINT] = CREPRINT,
+    [VDISCARD] = CDISCARD,
+    [VWERASE] = CWERASE,
+    [VLNEXT] = CLNEXT,
+    [VEOL2] = CEOL2
+};
+__END_DECLS
+#endif


### PR DESCRIPTION
This non-POSIX header is used in Linux/BSD systems for storing the default termios settings. This lets us setup new TTYs' `m_termios.c_cc` in a nicer way than using a magic string.