### PR TITLE
LibCompress: Add missing #include

### DIFF
--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
 


### PR DESCRIPTION
This previously worked because `<AK/ByteBuffer.h>` included `<AK/Optional.h>` - and now it doesn't anymore.