### PR TITLE
LibWeb: Fix "adopt" => "adopt_ref" change in adoptNode exception mess…

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -828,10 +828,10 @@ void Document::adopt_node(Node& node)
 ExceptionOr<NonnullRefPtr<Node>> Document::adopt_node_binding(NonnullRefPtr<Node> node)
 {
     if (is<Document>(*node))
-        return DOM ::NotSupportedError::create("Cannot adopt_ref a document into a document");
+        return DOM::NotSupportedError::create("Cannot adopt a document into a document");
 
     if (is<ShadowRoot>(*node))
-        return DOM::HierarchyRequestError::create("Cannot adopt_ref a shadow root into a document");
+        return DOM::HierarchyRequestError::create("Cannot adopt a shadow root into a document");
 
     if (is<DocumentFragment>(*node) && downcast<DocumentFragment>(*node).host())
         return node;


### PR DESCRIPTION
…ages

This was accidentally changed in b91c49364df1683c7fe1191eb02b8d9c331874f6