### PR TITLE
Meta: Run 'du' with '--apparent-size', except on macOS

### DIFF
--- a/Meta/build-image-extlinux.sh
+++ b/Meta/build-image-extlinux.sh
@@ -25,7 +25,11 @@ if [ -z $syslinux_dir ]; then
 fi
 
 disk_usage() {
+if [ "$(uname -s)" = "Darwin" ]; then
     du -sm "$1" | cut -f1
+else
+    du -sm --apparent-size "$1" | cut -f1
+fi
 }
 
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 300))

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -24,7 +24,11 @@ fi
 echo "using grub-install at ${grub}"
 
 disk_usage() {
+if [ "$(uname -s)" = "Darwin" ]; then
     du -sm "$1" | cut -f1
+else
+    du -sm --apparent-size "$1" | cut -f1
+fi
 }
 
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 300))

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -20,7 +20,11 @@ fi
 
 disk_usage() {
     # shellcheck disable=SC2003
+if [ "$(uname -s)" = "Darwin" ]; then
     expr "$(du -sk "$1" | cut -f1)" / 1024
+else
+    expr "$(du -sk --apparent-size "$1" | cut -f1)" / 1024
+fi
 }
 
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 100))


### PR DESCRIPTION
1. Added to check to add `--apparent-size` in `du` for all OS except MacOS
2. References #7172