### PR TITLE
GML-Playground: show document modified state in window title

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -302,8 +302,6 @@ MainWidget::MainWidget()
             GUI::MessageBox::show(window(), "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
             return;
         }
-
-        editor().document().set_unmodified();
         // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
         window()->set_modified(false);
 
@@ -316,7 +314,6 @@ MainWidget::MainWidget()
             if (!m_editor->write_to_file(m_path)) {
                 GUI::MessageBox::show(window(), "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
             } else {
-                editor().document().set_unmodified();
                 // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
                 window()->set_modified(false);
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1190,7 +1190,7 @@ bool TextEditor::write_to_file(const String& path)
             return false;
         }
     }
-
+    document().set_unmodified();
     return true;
 }
 


### PR DESCRIPTION
Similar to the text editor the GML Playgroud now also shows the modified state in the window title. Mechanisms like asking the user before opening a document, while having modifications on the current document, have also been implemented. 

Also in the TextEditor now the modified state is set to `false` whenever `write_to_file` succeeds. Since those both actions are conceptually intertwined they should be happening implicilty. 