### PR TITLE
Ports: Update the packages.db directory in README

### DIFF
--- a/Ports/README.md
+++ b/Ports/README.md
@@ -26,7 +26,7 @@ configuration/compilation options, and some other things (see
   script in this directory. This is sometimes required when LibC changes, for
   example. Pass `clean` as first argument to remove old build files beforehand.
 
-Installed ports are being tracked in `Build/packages.db` (a simple text file).
+Installed ports are being tracked in `Build/i686/Root/usr/Ports/packages.db` (a simple text file).
 You can delete this file at any time, in fact it must be edited or removed
 when clearing the build directory as port dependencies may not be installed
 again otherwise.


### PR DESCRIPTION
"packages.db" used to be under "Build" directory but it has
been moved to "Build/i686/Root/usr/Ports/". With this small PR,
README should be up to date.

You can see the packages.db update here. #6227