### PR TITLE
LibCore+Userland: Add more detectable formats to file utility

### DIFF
--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -93,6 +93,9 @@ String guess_mime_type_based_on_filename(const StringView& path)
     __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif", 0, 6, 'G', 'I', 'F', '8', '7', 'a')                                                        \
     __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif", 0, 6, 'G', 'I', 'F', '8', '9', 'a')                                                        \
     __ENUMERATE_MIME_TYPE_HEADER(gzip, "application/gzip", 0, 2, 0x1F, 0x8B)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(iso9660_0, "extra/iso-9660", 0x8001, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(iso9660_1, "extra/iso-9660", 0x8801, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(iso9660_2, "extra/iso-9660", 0x9001, 5, 0x43, 0x44, 0x30, 0x30, 0x31)                                           \
     __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg", 0, 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                               \
     __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg", 0, 4, 0xFF, 0xD8, 0xFF, 0xEE)                                                           \
     __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg", 0, 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01)             \
@@ -104,6 +107,7 @@ String guess_mime_type_based_on_filename(const StringView& path)
     __ENUMERATE_MIME_TYPE_HEADER(sevenzip, "application/x-7z-compressed", 0, 6, 0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C)                              \
     __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript", 0, 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')                          \
     __ENUMERATE_MIME_TYPE_HEADER(sqlite, "extra/sqlite", 0, 16, 'S', 'Q', 'L', 'i', 't', 'e', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', '3', 0x00) \
+    __ENUMERATE_MIME_TYPE_HEADER(tar, "application/tar", 0x101, 5, 0x75, 0x73, 0x74, 0x61, 0x72)                                                 \
     __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 0, 4, 'I', 'I', '*', 0x00)                                                                  \
     __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff", 0, 4, 'M', 'M', 0x00, '*')
 

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -85,22 +85,26 @@ String guess_mime_type_based_on_filename(const StringView& path)
     return "text/plain";
 }
 
-#define ENUMERATE_HEADER_CONTENTS                                                                                                 \
-    __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp", 2, 'B', 'M')                                                                   \
-    __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2", 3, 'B', 'Z', 'h')                                                  \
-    __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf", 4, 0x7F, 'E', 'L', 'F')                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif", 6, 'G', 'I', 'F', '8', '7', 'a')                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif", 6, 'G', 'I', 'F', '8', '9', 'a')                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(gzip, "extra/gzip", 2, 0x1F, 0x8B)                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg", 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                   \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg", 4, 0xFF, 0xD8, 0xFF, 0xEE)                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg", 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01) \
-    __ENUMERATE_MIME_TYPE_HEADER(pbm, "image/x-portable-bitmap", 3, 0x50, 0x31, 0x0A)                                             \
-    __ENUMERATE_MIME_TYPE_HEADER(pgm, "image/x-portable-graymap", 3, 0x50, 0x32, 0x0A)                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(png, "image/png", 8, 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A)                                \
-    __ENUMERATE_MIME_TYPE_HEADER(ppm, "image/x-portable-pixmap", 3, 0x50, 0x33, 0x0A)                                             \
-    __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript", 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')              \
-    __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 4, 'I', 'I', '*', 0x00)                                                      \
+#define ENUMERATE_HEADER_CONTENTS                                                                                                             \
+    __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp", 2, 'B', 'M')                                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2", 3, 'B', 'Z', 'h')                                                              \
+    __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf", 4, 0x7F, 'E', 'L', 'F')                                                                    \
+    __ENUMERATE_MIME_TYPE_HEADER(flac, "extra/flac", 4, 0x66, 0x4C, 0x61, 0x43)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif", 6, 'G', 'I', 'F', '8', '7', 'a')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif", 6, 'G', 'I', 'F', '8', '9', 'a')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(gzip, "application/gzip", 2, 0x1F, 0x8B)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg", 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg", 4, 0xFF, 0xD8, 0xFF, 0xEE)                                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg", 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01)             \
+    __ENUMERATE_MIME_TYPE_HEADER(midi, "audio/midi", 4, 0x4D, 0x54, 0x68, 0x64)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(pbm, "image/x-portable-bitmap", 3, 0x50, 0x31, 0x0A)                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(pgm, "image/x-portable-graymap", 3, 0x50, 0x32, 0x0A)                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(png, "image/png", 8, 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A)                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(ppm, "image/x-portable-pixmap", 3, 0x50, 0x33, 0x0A)                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(sevenzip, "application/x-7z-compressed", 6, 0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C)                              \
+    __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript", 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')                          \
+    __ENUMERATE_MIME_TYPE_HEADER(sqlite, "extra/sqlite", 16, 'S', 'Q', 'L', 'i', 't', 'e', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', '3', 0x00) \
+    __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 4, 'I', 'I', '*', 0x00)                                                                  \
     __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff", 4, 'M', 'M', 0x00, '*')
 
 #define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_size, ...) \

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -85,38 +85,38 @@ String guess_mime_type_based_on_filename(const StringView& path)
     return "text/plain";
 }
 
-#define ENUMERATE_HEADER_CONTENTS                                                                                                             \
-    __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp", 2, 'B', 'M')                                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2", 3, 'B', 'Z', 'h')                                                              \
-    __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf", 4, 0x7F, 'E', 'L', 'F')                                                                    \
-    __ENUMERATE_MIME_TYPE_HEADER(flac, "extra/flac", 4, 0x66, 0x4C, 0x61, 0x43)                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif", 6, 'G', 'I', 'F', '8', '7', 'a')                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif", 6, 'G', 'I', 'F', '8', '9', 'a')                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(gzip, "application/gzip", 2, 0x1F, 0x8B)                                                                     \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg", 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg", 4, 0xFF, 0xD8, 0xFF, 0xEE)                                                           \
-    __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg", 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01)             \
-    __ENUMERATE_MIME_TYPE_HEADER(midi, "audio/midi", 4, 0x4D, 0x54, 0x68, 0x64)                                                               \
-    __ENUMERATE_MIME_TYPE_HEADER(pbm, "image/x-portable-bitmap", 3, 0x50, 0x31, 0x0A)                                                         \
-    __ENUMERATE_MIME_TYPE_HEADER(pgm, "image/x-portable-graymap", 3, 0x50, 0x32, 0x0A)                                                        \
-    __ENUMERATE_MIME_TYPE_HEADER(png, "image/png", 8, 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A)                                            \
-    __ENUMERATE_MIME_TYPE_HEADER(ppm, "image/x-portable-pixmap", 3, 0x50, 0x33, 0x0A)                                                         \
-    __ENUMERATE_MIME_TYPE_HEADER(sevenzip, "application/x-7z-compressed", 6, 0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C)                              \
-    __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript", 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')                          \
-    __ENUMERATE_MIME_TYPE_HEADER(sqlite, "extra/sqlite", 16, 'S', 'Q', 'L', 'i', 't', 'e', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', '3', 0x00) \
-    __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 4, 'I', 'I', '*', 0x00)                                                                  \
-    __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff", 4, 'M', 'M', 0x00, '*')
+#define ENUMERATE_HEADER_CONTENTS                                                                                                                \
+    __ENUMERATE_MIME_TYPE_HEADER(bmp, "image/bmp", 0, 2, 'B', 'M')                                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(bzip2, "application/x-bzip2", 0, 3, 'B', 'Z', 'h')                                                              \
+    __ENUMERATE_MIME_TYPE_HEADER(elf, "extra/elf", 0, 4, 0x7F, 'E', 'L', 'F')                                                                    \
+    __ENUMERATE_MIME_TYPE_HEADER(flac, "extra/flac", 0, 4, 0x66, 0x4C, 0x61, 0x43)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(gif_87, "image/gif", 0, 6, 'G', 'I', 'F', '8', '7', 'a')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(gif_89, "image/gif", 0, 6, 'G', 'I', 'F', '8', '9', 'a')                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(gzip, "application/gzip", 0, 2, 0x1F, 0x8B)                                                                     \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg, "image/jpeg", 0, 4, 0xFF, 0xD8, 0xFF, 0xDB)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg_huh, "image/jpeg", 0, 4, 0xFF, 0xD8, 0xFF, 0xEE)                                                           \
+    __ENUMERATE_MIME_TYPE_HEADER(jpeg_jfif, "image/jpeg", 0, 12, 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01)             \
+    __ENUMERATE_MIME_TYPE_HEADER(midi, "audio/midi", 0, 4, 0x4D, 0x54, 0x68, 0x64)                                                               \
+    __ENUMERATE_MIME_TYPE_HEADER(pbm, "image/x-portable-bitmap", 0, 3, 0x50, 0x31, 0x0A)                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(pgm, "image/x-portable-graymap", 0, 3, 0x50, 0x32, 0x0A)                                                        \
+    __ENUMERATE_MIME_TYPE_HEADER(png, "image/png", 0, 8, 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A)                                            \
+    __ENUMERATE_MIME_TYPE_HEADER(ppm, "image/x-portable-pixmap", 0, 3, 0x50, 0x33, 0x0A)                                                         \
+    __ENUMERATE_MIME_TYPE_HEADER(sevenzip, "application/x-7z-compressed", 0, 6, 0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C)                              \
+    __ENUMERATE_MIME_TYPE_HEADER(shell, "text/x-shellscript", 0, 10, '#', '!', '/', 'b', 'i', 'n', '/', 's', 'h', '\n')                          \
+    __ENUMERATE_MIME_TYPE_HEADER(sqlite, "extra/sqlite", 0, 16, 'S', 'Q', 'L', 'i', 't', 'e', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', '3', 0x00) \
+    __ENUMERATE_MIME_TYPE_HEADER(tiff, "image/tiff", 0, 4, 'I', 'I', '*', 0x00)                                                                  \
+    __ENUMERATE_MIME_TYPE_HEADER(tiff_bigendian, "image/tiff", 0, 4, 'M', 'M', 0x00, '*')
 
-#define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_size, ...) \
-    static const u8 var_name##_arr[pattern_size] = { __VA_ARGS__ };          \
+#define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_offset, pattern_size, ...) \
+    static const u8 var_name##_arr[pattern_size] = { __VA_ARGS__ };                          \
     static constexpr ReadonlyBytes var_name = ReadonlyBytes { var_name##_arr, pattern_size };
 ENUMERATE_HEADER_CONTENTS
 #undef __ENUMERATE_MIME_TYPE_HEADER
 
 Optional<String> guess_mime_type_based_on_sniffed_bytes(const ReadonlyBytes& bytes)
 {
-#define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_size, ...) \
-    if (bytes.starts_with(var_name))                                         \
+#define __ENUMERATE_MIME_TYPE_HEADER(var_name, mime_type, pattern_offset, pattern_size, ...)                       \
+    if (static_cast<ssize_t>(bytes.size()) >= pattern_offset && bytes.slice(pattern_offset).starts_with(var_name)) \
         return mime_type;
     ENUMERATE_HEADER_CONTENTS;
 #undef __ENUMERATE_MIME_TYPE_HEADER

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -56,9 +56,11 @@ static Optional<String> gzip_details(String description, const String& path)
     __ENUMERATE_MIME_TYPE_DESCRIPTION("application/gzip", "gzip compressed data", gzip_details)         \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("application/javascript", "JavaScript source", description_only)  \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("application/json", "JSON data", description_only)                \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/tar", "tape archive", description_only)              \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("application/x-7z-compressed", "7-Zip archive", description_only) \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/midi", "MIDI sound", description_only)                     \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/flac", "FLAC audio", description_only)                     \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/iso-9660", "ISO 9660 CD/DVD image", description_only)      \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/sqlite", "sqlite database", description_only)              \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("image/bmp", "BMP image data", image_details)                     \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("image/gif", "GIF image data", image_details)                     \
@@ -105,7 +107,8 @@ int main(int argc, char** argv)
             all_ok = false;
             continue;
         }
-        auto bytes = file->read(25);
+        // Read accounts for longest possible offset + signature we currently match against.
+        auto bytes = file->read(0x9006);
         auto file_name_guess = Core::guess_mime_type_based_on_filename(path);
         auto mime_type = Core::guess_mime_type_based_on_sniffed_bytes(bytes.bytes()).value_or(file_name_guess);
         auto human_readable_description = get_description_from_mime_type(mime_type, String(path)).value_or(mime_type);

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -52,18 +52,22 @@ static Optional<String> gzip_details(String description, const String& path)
     return String::formatted("{}, {}", description, gzip_details.value());
 }
 
-#define ENUMERATE_MIME_TYPE_DESCRIPTIONS                                                               \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/javascript", "JavaScript source", description_only) \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/json", "JSON data", description_only)               \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/gzip", "gzip compressed data", gzip_details)              \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/bmp", "BMP image data", image_details)                    \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/gif", "GIF image data", image_details)                    \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/jpeg", "JPEG image data", image_details)                  \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/png", "PNG image data", image_details)                    \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-bitmap", "PBM image data", image_details)      \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-graymap", "PGM image data", image_details)     \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-pixmap", "PPM image data", image_details)      \
-    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/markdown", "Markdown document", description_only)          \
+#define ENUMERATE_MIME_TYPE_DESCRIPTIONS                                                                \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/gzip", "gzip compressed data", gzip_details)         \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/javascript", "JavaScript source", description_only)  \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/json", "JSON data", description_only)                \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("application/x-7z-compressed", "7-Zip archive", description_only) \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("audio/midi", "MIDI sound", description_only)                     \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/flac", "FLAC audio", description_only)                     \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("extra/sqlite", "sqlite database", description_only)              \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/bmp", "BMP image data", image_details)                     \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/gif", "GIF image data", image_details)                     \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/jpeg", "JPEG image data", image_details)                   \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/png", "PNG image data", image_details)                     \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-bitmap", "PBM image data", image_details)       \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-graymap", "PGM image data", image_details)      \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("image/x-portable-pixmap", "PPM image data", image_details)       \
+    __ENUMERATE_MIME_TYPE_DESCRIPTION("text/markdown", "Markdown document", description_only)           \
     __ENUMERATE_MIME_TYPE_DESCRIPTION("text/x-shellscript", "POSIX shell script text executable", description_only)
 
 static Optional<String> get_description_from_mime_type(const String& mime, const String& path)


### PR DESCRIPTION
This PR adds 7 new detectable formats, as well as new functionality for detecting binary signatures at an arbitrary offset in a given file.