### PR TITLE
LibJS: Default-initialize the current_node pointer member in CallFrame

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -39,7 +39,7 @@ struct ScopeFrame {
 };
 
 struct CallFrame {
-    const ASTNode* current_node;
+    const ASTNode* current_node { nullptr };
     FlyString function_name;
     Value callee;
     Value this_value;


### PR DESCRIPTION
Some parts of the code depend on this being nullptr without actually
initializing it, leading to odd random crashes.
e.g. `VM::call_internal`.