### PR TITLE
Kernel: Implement TCP window scaling

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -576,11 +576,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
 
         if (tcp_packet.sequence_number() != socket->ack_number()) {
             dbgln_if(TCP_DEBUG, "Discarding out of order packet: seq {} vs. ack {}", tcp_packet.sequence_number(), socket->ack_number());
-            if (socket->duplicate_acks() < TCPSocket::maximum_duplicate_acks) {
-                dbgln_if(TCP_DEBUG, "Sending ACK with same ack number to trigger fast retransmission");
-                socket->set_duplicate_acks(socket->duplicate_acks() + 1);
-                [[maybe_unused]] auto result = socket->send_ack(true);
-            }
+            socket->handle_lost_packet();
             return;
         }
 

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -38,6 +38,35 @@ private:
 
 static_assert(sizeof(TCPOptionMSS) == 4);
 
+class [[gnu::packed]] TCPOptionWindowScale {
+public:
+    TCPOptionWindowScale(u16 shift)
+        : m_shift(shift)
+    {
+    }
+
+    u16 shift() const { return m_shift; }
+
+private:
+    u8 m_option_kind { 0x03 };
+    u8 m_option_length { sizeof(TCPOptionWindowScale) };
+    u8 m_shift;
+};
+
+static_assert(sizeof(TCPOptionWindowScale) == 3);
+
+class [[gnu::packed]] TCPOptionEnd {
+public:
+    TCPOptionEnd()
+    {
+    }
+
+private:
+    u8 m_option_kind { 0x00 };
+};
+
+static_assert(sizeof(TCPOptionEnd) == 1);
+
 class [[gnu::packed]] TCPPacket {
 public:
     TCPPacket() = default;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -564,4 +564,13 @@ void TCPSocket::retransmit_packets()
     }
 }
 
+void TCPSocket::handle_lost_packet()
+{
+    if (duplicate_acks() < TCPSocket::maximum_duplicate_acks) {
+        dbgln_if(TCP_DEBUG, "Sending ACK with same ack number to trigger fast retransmission");
+        set_duplicate_acks(duplicate_acks() + 1);
+        [[maybe_unused]] auto result = send_ack(true);
+    }
+}
+
 }

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -182,8 +182,8 @@ KResult TCPSocket::send_ack(bool allow_duplicate)
 
 KResult TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload, size_t payload_size)
 {
-    const bool has_mss_option = flags == TCPFlags::SYN;
-    const size_t options_size = has_mss_option ? sizeof(TCPOptionMSS) : 0;
+    const bool has_options = flags & TCPFlags::SYN;
+    const size_t options_size = has_options ? sizeof(TCPOptionMSS) : 0;
     const size_t header_size = sizeof(TCPPacket) + options_size;
     const size_t buffer_size = header_size + payload_size;
     auto buffer = NetworkByteBuffer::create_zeroed(buffer_size);
@@ -215,7 +215,7 @@ KResult TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload,
     if (routing_decision.is_zero())
         return EHOSTUNREACH;
 
-    if (has_mss_option) {
+    if (has_options) {
         u16 mss = routing_decision.adapter->mtu() - sizeof(IPv4Packet) - sizeof(TCPPacket);
         TCPOptionMSS mss_option { mss };
         VERIFY(buffer.size() >= sizeof(TCPPacket) + sizeof(mss_option));

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -154,6 +154,7 @@ public:
 
     static Lockable<HashTable<TCPSocket*>>& sockets_for_retransmit();
     void retransmit_packets();
+    void handle_lost_packet();
 
     virtual KResult close() override;
 

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -211,6 +211,18 @@ private:
     static constexpr u32 maximum_retransmits = 5;
     Time m_last_retransmit_time;
     u32 m_retransmit_attempts { 0 };
+
+    // This lets us change our window size in increments of 2 ** 13, i.e. 8192 bytes.
+    static constexpr u8 window_scale_shift = 13;
+    u16 m_window_size { 8 };
+
+    // FIXME: Make this configurable
+    static constexpr Time window_increase_interval = Time::from_seconds(5);
+    static constexpr u8 window_increase_step = 2;
+    static constexpr Time window_decrease_interval = Time::from_seconds(1);
+    static constexpr u8 window_decrease_step = 1;
+    Time m_last_window_increase;
+    Time m_last_window_decrease;
 };
 
 }


### PR DESCRIPTION
**Kernel: Also set TCP MSS option for SYN|ACK packets**

This sets the MSS option when we accept client connections. Previously we'd only set this option when we initiate the connection.

**Kernel: Move code for handling lost packets into its own function**

**WIP: TCP Window Scale**

This adds support for sending the TCP window scale option. The window size calculation is all wrong atm.