### PR TITLE
UE: Don't look up binaries in PATH when the user specified a full path

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -19,25 +19,20 @@ bool g_report_to_debug = false;
 
 int main(int argc, char** argv, char** env)
 {
-    Vector<const char*> command;
+    Vector<String> arguments;
 
     Core::ArgsParser parser;
     parser.add_option(g_report_to_debug, "Write reports to the debug log", "report-to-debug", 0);
-    parser.add_positional_argument(command, "Command to emulate", "command");
+    parser.add_positional_argument(arguments, "Command to emulate", "command");
     parser.parse(argc, argv);
 
-    auto executable_path = Core::find_executable_in_path(command[0]);
+    auto executable_path = Core::find_executable_in_path(arguments[0]);
     if (executable_path.is_empty()) {
-        executable_path = Core::File::real_path_for(command[0]);
+        executable_path = Core::File::real_path_for(arguments[0]);
         if (executable_path.is_empty()) {
             reportln("Cannot find executable for '{}'.", executable_path);
             return 1;
         }
-    }
-
-    Vector<String> arguments;
-    for (auto arg : command) {
-        arguments.append(arg);
     }
 
     Vector<String> environment;

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -26,13 +26,14 @@ int main(int argc, char** argv, char** env)
     parser.add_positional_argument(arguments, "Command to emulate", "command");
     parser.parse(argc, argv);
 
-    auto executable_path = Core::find_executable_in_path(arguments[0]);
-    if (executable_path.is_empty()) {
+    String executable_path;
+    if (arguments[0].contains("/"sv))
         executable_path = Core::File::real_path_for(arguments[0]);
-        if (executable_path.is_empty()) {
-            reportln("Cannot find executable for '{}'.", executable_path);
-            return 1;
-        }
+    else
+        executable_path = Core::find_executable_in_path(arguments[0]);
+    if (executable_path.is_empty()) {
+        reportln("Cannot find executable for '{}'.", arguments[0]);
+        return 1;
     }
 
     Vector<String> environment;


### PR DESCRIPTION
**UE: Use Vector<String> for the command-line arguments**

`Core::ArgsParser` gained support for String a while ago. So let's use that.

**UE: Don't look up binaries in PATH when the user specified a full path**

When the user specifies a path such as `./test` we'd incorrectly look for the binary in the `PATH` environment variable and end up executing an incorrect binary (e.g. `/bin/test`). We should only look up binaries in `PATH` if the user-specified path does not contain a slash.