### PR TITLE
Kernel: Fix return value for {enable,disable}_profile_timer()

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -492,8 +492,10 @@ void Process::finalize()
     if (is_dumpable()) {
         if (m_should_dump_core)
             dump_core();
-        if (m_perf_event_buffer)
+        if (m_perf_event_buffer) {
             dump_perfcore();
+            TimeManagement::the().disable_profile_timer();
+        }
     }
 
     m_threads_for_coredump.clear();

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -402,20 +402,20 @@ void TimeManagement::system_timer_tick(const RegisterState& regs)
 
 bool TimeManagement::enable_profile_timer()
 {
-    if (m_profile_timer && m_profile_enable_count.fetch_add(1) == 0) {
-        m_profile_timer->try_to_set_frequency(m_profile_timer->calculate_nearest_possible_frequency(OPTIMAL_PROFILE_TICKS_PER_SECOND_RATE));
-        return true;
-    }
-    return false;
+    if (!m_profile_timer)
+        return false;
+    if (m_profile_enable_count.fetch_add(1) == 0)
+        return m_profile_timer->try_to_set_frequency(m_profile_timer->calculate_nearest_possible_frequency(OPTIMAL_PROFILE_TICKS_PER_SECOND_RATE));
+    return true;
 }
 
 bool TimeManagement::disable_profile_timer()
 {
-    if (m_profile_timer && m_profile_enable_count.fetch_sub(1) == 1) {
-        m_profile_timer->try_to_set_frequency(m_profile_timer->calculate_nearest_possible_frequency(1));
-        return true;
-    }
-    return false;
+    if (!m_profile_timer)
+        return false;
+    if (m_profile_enable_count.fetch_sub(1) == 1)
+        return m_profile_timer->try_to_set_frequency(m_profile_timer->calculate_nearest_possible_frequency(1));
+    return true;
 }
 
 }


### PR DESCRIPTION
**Kernel: Fix return value for {enable,disable}_profile_timer()**

These functions should return success when being called when profiling has been requested from multiple callers because enabling/disabling the timer is a no-op in that case and thus didn't fail.

**Kernel: Disable profile timer when the process exits**

When profiling a single process we didn't disable the profile timer. `enable_profile_timer()`/`disable_profiler_timer()` support nested calls so no special care has to be taken here to only disable the timer when nobody else is using it.