### PR TITLE
Mandelbrot: Various improvements

### DIFF
--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -29,12 +29,14 @@ public:
     void reset()
     {
         set_view();
+        correct_aspect();
         calculate();
     }
 
     void resize(Gfx::IntSize const& size)
     {
         m_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, size);
+        correct_aspect();
         calculate();
     }
 
@@ -45,6 +47,7 @@ public:
             rect.right() * (m_x_end - m_x_start) / m_bitmap->width() + m_x_start,
             rect.top() * (m_y_end - m_y_start) / m_bitmap->height() + m_y_start,
             rect.bottom() * (m_y_end - m_y_start) / m_bitmap->height() + m_y_start);
+        correct_aspect();
         calculate();
     }
 
@@ -98,8 +101,7 @@ public:
 
     void calculate(int max_iterations = 100)
     {
-        if (!m_bitmap)
-            return;
+        VERIFY(m_bitmap);
 
         for (int py = 0; py < m_bitmap->height(); py++)
             for (int px = 0; px < m_bitmap->width(); px++)
@@ -118,12 +120,20 @@ private:
     double m_y_end { 0 };
     RefPtr<Gfx::Bitmap> m_bitmap;
 
-    void set_view(double x_start = -2.5, double x_end = 1.0, double y_start = -1.0, double y_end = 1.0)
+    void set_view(double x_start = -2.5, double x_end = 1.0, double y_start = -1.75, double y_end = 1.75)
     {
         m_x_start = x_start;
         m_x_end = x_end;
         m_y_start = y_start;
         m_y_end = y_end;
+    }
+
+    void correct_aspect()
+    {
+        auto y_mid = m_y_start + (m_y_end - m_y_start) / 2;
+        auto aspect_corrected_y_length = (m_x_end - m_x_start) * m_bitmap->height() / m_bitmap->width();
+        m_y_start = y_mid - aspect_corrected_y_length / 2;
+        m_y_end = y_mid + aspect_corrected_y_length / 2;
     }
 };
 

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -152,7 +152,15 @@ void Mandelbrot::mousedown_event(GUI::MouseEvent& event)
 void Mandelbrot::mousemove_event(GUI::MouseEvent& event)
 {
     if (m_dragging) {
-        m_selection_end = event.position();
+        // Maintain aspect ratio
+        int selection_width = event.position().x() - m_selection_start.x();
+        int selection_height = event.position().y() - m_selection_start.y();
+        int aspect_corrected_selection_width = selection_height * width() / height();
+        int aspect_corrected_selection_height = selection_width * height() / width();
+        if (selection_width * aspect_corrected_selection_height > aspect_corrected_selection_width * selection_height)
+            m_selection_end = { event.position().x(), m_selection_start.y() + abs(aspect_corrected_selection_height) * ((selection_height < 0) ? -1 : 1) };
+        else
+            m_selection_end = { m_selection_start.x() + abs(aspect_corrected_selection_width) * ((selection_width < 0) ? -1 : 1), event.position().y() };
         update();
     }
 

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -221,7 +221,9 @@ void Mandelbrot::resize_event(GUI::ResizeEvent& event)
 
 void Mandelbrot::export_image(String const& export_path)
 {
+    m_set.resize(Gfx::IntSize { 1920, 1080 });
     auto png = Gfx::PNGWriter::encode(m_set.bitmap());
+    m_set.resize(size());
     auto file = fopen(export_path.characters(), "wb");
     if (!file) {
         GUI::MessageBox::show(window(), String::formatted("Could not open '{}' for writing.", export_path), "Mandelbrot", GUI::MessageBox::Type::Error);


### PR DESCRIPTION
**Mandelbrot: Maintain aspect ratio when selecting a region**

This makes sure the aspect ratio of the widget and the selection match. Otherwise you'd end up with distorted images when zooming in.

**Mandelbrot: Implement color smoothing with gradients**

This removes the color banding that happens for some of the "outer" areas which all have the same iteration count.

![Screenshot from 2021-05-17 17-07-01](https://user-images.githubusercontent.com/388571/118511567-522f2000-b732-11eb-96d7-dd2463512375.png)

**Mandelbrot: Add support for exporting the current image**

Unfortunately this means `unveil()` won't work - at least until we get something like `FilePickerServer`.

**Mandelbrot: Keep the aspect ratio when (re-)sizing the window**

Previously the initial aspect ratio was incorrect and there was nothing to ensure that the aspect ratio is kept when resizing the
window.

**Mandelbrot: Export images in a fixed resolution**
    
This makes the exported image independent from the current window size and just always exports it at 1920x1080.