### PR TITLE
Kernel: Set InterruptEnable on HPET Comparators when frequency is set

### DIFF
--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -99,6 +99,7 @@ bool HPETComparator::try_to_set_frequency(size_t frequency)
     } else {
         HPET::the().update_non_periodic_comparator_value(*this);
     }
+    HPET::the().enable(*this);
     enable_irq(); // Enable if we haven't already
     return true;
 }

--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -83,7 +83,7 @@ bool HPETComparator::try_to_set_frequency(size_t frequency)
 {
     InterruptDisabler disabler;
     if (!is_capable_of_frequency(frequency)) {
-        dbgln("HPETComparator: not cable of frequency: {}", frequency);
+        dbgln("HPETComparator: not capable of frequency: {}", frequency);
         return false;
     }
 


### PR DESCRIPTION
This fixes non-periodic comparators not receiving interrupts, as we were never setting the InterruptEnable bit in their capabilities register (unlike periodic comparators's bit, which was set as a side effect of calling set_periodic on them to set their periodic bit).

This should help getting profiling work on bare-metal SerenityOS installations, which were not guaranteed to have 2 periodic comparators available. (Fixes #7159)