### PR TITLE
LibCrypto: Change static constexpr array to function local constexpr

### DIFF
--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
@@ -6,10 +6,9 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Random.h>
 #include <LibCrypto/PK/Code/Code.h>
-
-static constexpr u8 zeros[] { 0, 0, 0, 0, 0, 0, 0, 0 };
 
 namespace Crypto {
 namespace PK {
@@ -44,7 +43,9 @@ public:
             return;
         }
 
-        m_buffer.overwrite(0, zeros, 8);
+        constexpr Array<u8, 8> zeros {};
+
+        m_buffer.overwrite(0, zeros.data(), 8);
         m_buffer.overwrite(8, message_hash.data, HashFunction::DigestSize);
         m_buffer.overwrite(8 + HashFunction::DigestSize, salt, SaltLength);
 


### PR DESCRIPTION
Problem:
- Static variables take memory and can be subject to less optimization
  (https://serenityos.godbolt.org/z/7EYebr1aa)
- This static variable is only used in 1 place.

Solution:
- Move the variable into the function and make it non-static.