### PR TITLE
Kernel: Add support for QEMU's emulated pci serial (-pci-serial option) + Small fix

### DIFF
--- a/Kernel/Devices/PCISerialDevice.cpp
+++ b/Kernel/Devices/PCISerialDevice.cpp
@@ -26,7 +26,7 @@ void PCISerialDevice::detect()
 
             auto bar_base = PCI::get_BAR(address, board_definition.pci_bar) & ~1;
             // FIXME: We should support more than 1 PCI serial port (per card/multiple devices)
-            s_the = new SerialDevice(IOAddress(bar_base + board_definition.first_offset), 64);
+            s_the = new SerialDevice(IOAddress(bar_base + board_definition.first_offset), 68);
             if (board_definition.baud_rate != SerialDevice::Baud::Baud38400) // non-default baud
                 s_the->set_baud(board_definition.baud_rate);
 

--- a/Kernel/Devices/PCISerialDevice.h
+++ b/Kernel/Devices/PCISerialDevice.h
@@ -31,8 +31,11 @@ private:
         SerialDevice::Baud baud_rate { SerialDevice::Baud::Baud38400 };
     };
 
-    static constexpr BoardDefinition board_definitions[1] = {
-        { { (u16)PCIVendorID::WCH, 0x3253 }, "WCH CH382 2S", 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 }
+    static constexpr BoardDefinition board_definitions[4] = {
+        { { (u16)PCIVendorID::WCH, 0x3253 }, "WCH CH382 2S", 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 },
+        { { (u16)PCIVendorID::RedHat, 0x0002 }, "QEMU PCI 16550A", 1, 0, 0, 8, SerialDevice::Baud::Baud115200 },
+        { { (u16)PCIVendorID::RedHat, 0x0003 }, "QEMU PCI Dual-port 16550A", 2, 0, 0, 8, SerialDevice::Baud::Baud115200 },
+        { { (u16)PCIVendorID::RedHat, 0x0004 }, "QEMU PCI Quad-port 16550A", 4, 0, 0, 8, SerialDevice::Baud::Baud115200 }
     };
 };
 

--- a/Kernel/PCI/IDs.h
+++ b/Kernel/PCI/IDs.h
@@ -12,6 +12,7 @@ enum class PCIVendorID {
     VirtIO = 0x1af4,
     Intel = 0x8086,
     WCH = 0x1c00,
+    RedHat = 0x1b36
 };
 
 enum class PCIDeviceID {


### PR DESCRIPTION
I just noticed this qemu option was available :^)