### PR TITLE
LibHTTP: Make sure we're not sending an empty path in requests

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -37,7 +37,10 @@ ByteBuffer HttpRequest::to_raw_request() const
     StringBuilder builder;
     builder.append(method_name());
     builder.append(' ');
-    builder.append(m_url.path());
+    if (!m_url.path().is_empty())
+        builder.append(m_url.path());
+    else
+        builder.append('/');
     if (!m_url.query().is_empty()) {
         builder.append('?');
         builder.append(m_url.query());


### PR DESCRIPTION
When the path component of the request URL was empty we'd end up sending requests like `GET  HTTP/1.1` (note the missing `/`). This ensures that we always send a path.