### PR TITLE
LibWeb: Support more multi-part CSS border attributes

### DIFF
--- a/Base/res/html/misc/borders.html
+++ b/Base/res/html/misc/borders.html
@@ -121,6 +121,24 @@ div + div {
     border-right-width: 10px;
     border-right-style: inset;
 }
+#two-part-border-attributes {
+    height: 50px;
+    border-color: red lime;
+    border-width: 8px 6px;
+    border-style: solid dashed;
+}
+#three-part-border-attributes {
+    height: 50px;
+    border-color: red lime blue;
+    border-width: 8px 6px 4px;
+    border-style: solid dashed dotted;
+}
+#four-part-border-attributes {
+    height: 50px;
+    border-color: red lime blue orange;
+    border-width: 8px 6px 4px 2px;
+    border-style: solid dashed dotted dotted;
+}
 </style>
 </head>
 <body>
@@ -146,5 +164,8 @@ div + div {
 <div id="dashed-5px">dashed (5px)</div>
 <div id="dashed-20px">dashed (20px)</div>
 <div id="mixed">mixed</div>
+<div id="two-part-border-attributes">two-part border attributes</div>
+<div id="three-part-border-attributes">three-part border attributes</div>
+<div id="four-part-border-attributes">four-part border attributes</div>
 </body>
 </html>

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -441,6 +441,25 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
                 style.set_property(CSS::PropertyID::BorderBottomColor, *bottom);
                 style.set_property(CSS::PropertyID::BorderLeftColor, *left);
             }
+        } else if (value.is_string() && parts.size() == 3) {
+            auto top = parse_css_value(context, parts[0]);
+            auto horizontal = parse_css_value(context, parts[1]);
+            auto bottom = parse_css_value(context, parts[2]);
+            if (top && horizontal && bottom) {
+                style.set_property(CSS::PropertyID::BorderTopColor, *top);
+                style.set_property(CSS::PropertyID::BorderRightColor, *horizontal);
+                style.set_property(CSS::PropertyID::BorderBottomColor, *bottom);
+                style.set_property(CSS::PropertyID::BorderLeftColor, *horizontal);
+            }
+        } else if (value.is_string() && parts.size() == 2) {
+            auto vertical = parse_css_value(context, parts[0]);
+            auto horizontal = parse_css_value(context, parts[1]);
+            if (vertical && horizontal) {
+                style.set_property(CSS::PropertyID::BorderTopColor, *vertical);
+                style.set_property(CSS::PropertyID::BorderRightColor, *horizontal);
+                style.set_property(CSS::PropertyID::BorderBottomColor, *vertical);
+                style.set_property(CSS::PropertyID::BorderLeftColor, *horizontal);
+            }
         } else {
             style.set_property(CSS::PropertyID::BorderTopColor, value);
             style.set_property(CSS::PropertyID::BorderRightColor, value);

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -389,7 +389,28 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BorderWidth) {
         auto parts = split_on_whitespace(value.to_string());
-        if (value.is_string() && parts.size() == 2) {
+        if (value.is_string() && parts.size() == 4) {
+            auto top_border_width = parse_css_value(context, parts[0]);
+            auto right_border_width = parse_css_value(context, parts[1]);
+            auto bottom_border_width = parse_css_value(context, parts[2]);
+            auto left_border_width = parse_css_value(context, parts[3]);
+            if (top_border_width && right_border_width && bottom_border_width && left_border_width) {
+                style.set_property(CSS::PropertyID::BorderTopWidth, *top_border_width);
+                style.set_property(CSS::PropertyID::BorderRightWidth, *right_border_width);
+                style.set_property(CSS::PropertyID::BorderBottomWidth, *bottom_border_width);
+                style.set_property(CSS::PropertyID::BorderLeftWidth, *left_border_width);
+            }
+        } else if (value.is_string() && parts.size() == 3) {
+            auto top_border_width = parse_css_value(context, parts[0]);
+            auto horizontal_border_width = parse_css_value(context, parts[1]);
+            auto bottom_border_width = parse_css_value(context, parts[2]);
+            if (top_border_width && horizontal_border_width && bottom_border_width) {
+                style.set_property(CSS::PropertyID::BorderTopWidth, *top_border_width);
+                style.set_property(CSS::PropertyID::BorderRightWidth, *horizontal_border_width);
+                style.set_property(CSS::PropertyID::BorderBottomWidth, *bottom_border_width);
+                style.set_property(CSS::PropertyID::BorderLeftWidth, *horizontal_border_width);
+            }
+        } else if (value.is_string() && parts.size() == 2) {
             auto vertical_border_width = parse_css_value(context, parts[0]);
             auto horizontal_border_width = parse_css_value(context, parts[1]);
             if (vertical_border_width && horizontal_border_width) {


### PR DESCRIPTION
On Acid1, one of the floating boxes have a 4-part `border-width` attribute. This change more generally adds support for multi-part `border-color` and `border-width` attributes (`border-style` already has this support).