### PR TITLE
AK/PrintfImplementation: Change static constexpr array to function local

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -19,9 +19,6 @@ extern "C" size_t strlen(const char*);
 
 namespace PrintfImplementation {
 
-static constexpr const char* printf_hex_digits_lower = "0123456789abcdef";
-static constexpr const char* printf_hex_digits_upper = "0123456789ABCDEF";
-
 template<typename PutChFunc, typename T>
 ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zero_pad, u8 field_width)
 {
@@ -64,6 +61,9 @@ ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper
     } else {
         u8 shift_count = digits * 4;
         while (shift_count) {
+            constexpr const char* printf_hex_digits_lower = "0123456789abcdef";
+            constexpr const char* printf_hex_digits_upper = "0123456789ABCDEF";
+
             shift_count -= 4;
             putch(bufptr,
                 upper_case


### PR DESCRIPTION
…cal constexpr

Problem:
- Static variables take memory and can be subject to less optimization.
- This static variable is only used in 1 place.

Solution:
- Move the variable into the function and make it non-static.