### PR TITLE
LibWebSocket: Fixed occasional infinite loop with TLS sockets

### DIFF
--- a/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.cpp
@@ -26,14 +26,12 @@ void TLSv12WebSocketConnectionImpl::connect(ConnectionInfo const& connection)
     VERIFY(on_ready_to_read);
     m_socket = TLS::TLSv12::construct(this);
 
-    m_notifier = Core::Notifier::construct(m_socket->fd(), Core::Notifier::Read);
-    m_notifier->on_ready_to_read = [this] {
-        on_ready_to_read();
-    };
-
     m_socket->set_root_certificates(DefaultRootCACertificates::the().certificates());
     m_socket->on_tls_error = [this](TLS::AlertDescription) {
         on_connection_error();
+    };
+    m_socket->on_tls_ready_to_read = [this] {
+        on_ready_to_read();
     };
     m_socket->on_tls_ready_to_write = [this] {
         on_connected();

--- a/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.h
+++ b/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.h
@@ -38,7 +38,6 @@ public:
     virtual void discard_connection() override;
 
 private:
-    RefPtr<Core::Notifier> m_notifier;
     RefPtr<TLS::TLSv12> m_socket;
 };
 


### PR DESCRIPTION
This was caused by a double notifier on the TLS socket, which caused the TLS code to freak out about not being able to read properly.

In addition, the existing loop inside of drain_read() has been replaced by code that actually works, and which includes new warnings when the drain method is called before initialization is done or after the websocket gets closed.