### PR TITLE
LibC: Remove static from function local constexpr variable

### DIFF
--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -165,7 +165,7 @@ inline int generate_unique_filename(char* pattern, Callback callback)
 
     size_t start = length - 6;
 
-    static constexpr char random_characters[] = "abcdefghijklmnopqrstuvwxyz0123456789";
+    constexpr char random_characters[] = "abcdefghijklmnopqrstuvwxyz0123456789";
 
     for (int attempt = 0; attempt < 100; ++attempt) {
         for (int i = 0; i < 6; ++i)

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -21,7 +21,7 @@ static char* generate_random_filename(const char* pattern)
     char* new_filename = strdup(pattern);
     int pattern_length = strlen(pattern);
 
-    static constexpr char random_characters[] = "abcdefghijklmnopqrstuvwxyz0123456789";
+    constexpr char random_characters[] = "abcdefghijklmnopqrstuvwxyz0123456789";
     for (auto i = pattern_length - 1; i >= 0; --i) {
         if (pattern[i] != 'X')
             break;


### PR DESCRIPTION
Problem:
- Function local `constexpr` variables do not need to be
  `static`. This consumes memory which is unnecessary and can prevent
  some optimizations.

Solution:
- Remove `static` keyword.