### PR TITLE
AK: Make LexicalPath handle relative paths correctly

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -55,7 +55,7 @@ void LexicalPath::canonicalize()
         }
     }
     if (canonical_parts.is_empty()) {
-        m_string = m_basename = m_dirname = "/";
+        m_string = m_basename = m_dirname = m_is_absolute ? "/" : ".";
         return;
     }
 

--- a/Tests/AK/TestLexicalPath.cpp
+++ b/Tests/AK/TestLexicalPath.cpp
@@ -24,12 +24,16 @@ TEST_CASE(basic)
     EXPECT_EQ(path.parts().size(), 3u);
     EXPECT_EQ(path.parts(), Vector<String>({ "abc", "def", "ghi.txt" }));
     EXPECT_EQ(path.string(), "/abc/def/ghi.txt");
+    EXPECT_EQ(LexicalPath(".").string(), ".");
+    EXPECT_EQ(LexicalPath("..").string(), "..");
 }
 
 TEST_CASE(dotdot_coalescing)
 {
     EXPECT_EQ(LexicalPath("/home/user/../../not/home").string(), "/not/home");
     EXPECT_EQ(LexicalPath("/../../../../").string(), "/");
+    EXPECT_EQ(LexicalPath("./../../../../").string(), "../../../..");
+    EXPECT_EQ(LexicalPath("../../../../../").string(), "../../../../..");
 }
 
 TEST_CASE(has_extension)


### PR DESCRIPTION
Previously LexicalPath would consider "." and ".." as equivalent to "/". This is not true though.