### PR TITLE
WebServer: Fixed jailbreaking of server via .. relative paths

### DIFF
--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -73,7 +73,7 @@ void Client::handle_request(ReadonlyBytes raw_request)
         return;
     }
 
-    auto requested_path = LexicalPath::canonicalized_path(request.resource());
+    auto requested_path = LexicalPath::join("/", request.resource()).string();
     dbgln("Canonical requested path: '{}'", requested_path);
 
     StringBuilder path_builder;


### PR DESCRIPTION
The recent patch to LexicalPath allowed relative paths like ../ to work in requests to WebServer. This wasn't too dangerous because of unveil, but let's still fix this :^)

Before:

![image](https://user-images.githubusercontent.com/5400651/118606239-78e36a00-b7b7-11eb-945d-be2abd65ff76.png)

After:
![image](https://user-images.githubusercontent.com/5400651/118606858-2eaeb880-b7b8-11eb-9919-96553bcc89ad.png)

