### PR TITLE
Kernel: More OOM handling, and start fixing allocation under spinlock. 

### DIFF
--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -623,6 +623,11 @@ struct DeferredCallEntry {
     bool was_allocated;
 };
 
+class Processor;
+// Note: We only support processors at most at the moment,
+// so allocate 8 slots of inline capacity in the container.
+using ProcessorContainer = Array<Processor*, 8>;
+
 class Processor {
     friend class ProcessorInfo;
 
@@ -665,7 +670,7 @@ class Processor {
     void gdt_init();
     void write_raw_gdt_entry(u16 selector, u32 low, u32 high);
     void write_gdt_entry(u16 selector, Descriptor& descriptor);
-    static Vector<Processor*>& processors();
+    static ProcessorContainer& processors();
 
     static void smp_return_to_pool(ProcessorMessage& msg);
     static ProcessorMessage& smp_get_from_pool();
@@ -751,8 +756,10 @@ public:
     {
         auto& procs = processors();
         size_t count = procs.size();
-        for (size_t i = 0; i < count; i++)
-            callback(*procs[i]);
+        for (size_t i = 0; i < count; i++) {
+            if (procs[i] != nullptr)
+                callback(*procs[i]);
+        }
         return IterationDecision::Continue;
     }
 

--- a/Kernel/ProcessGroup.cpp
+++ b/Kernel/ProcessGroup.cpp
@@ -17,10 +17,10 @@ ProcessGroup::~ProcessGroup()
     g_process_groups->remove(this);
 }
 
-NonnullRefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)
+RefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)
 {
-    auto process_group = adopt_ref(*new ProcessGroup(pgid));
-    {
+    auto process_group = adopt_ref_if_nonnull(new ProcessGroup(pgid));
+    if (process_group) {
         ScopedSpinLock lock(g_process_groups_lock);
         g_process_groups->prepend(process_group);
     }
@@ -28,7 +28,7 @@ NonnullRefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)
     return process_group;
 }
 
-NonnullRefPtr<ProcessGroup> ProcessGroup::find_or_create(ProcessGroupID pgid)
+RefPtr<ProcessGroup> ProcessGroup::find_or_create(ProcessGroupID pgid)
 {
     ScopedSpinLock lock(g_process_groups_lock);
 

--- a/Kernel/ProcessGroup.cpp
+++ b/Kernel/ProcessGroup.cpp
@@ -30,18 +30,31 @@ RefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)
 
 RefPtr<ProcessGroup> ProcessGroup::find_or_create(ProcessGroupID pgid)
 {
+    // Avoid allocating under spinlock, this compromises by wasting the
+    // allocation when we race with another process to see if they have
+    // already created a process group.
+    auto process_group = adopt_ref_if_nonnull(new ProcessGroup(pgid));
     ScopedSpinLock lock(g_process_groups_lock);
 
-    if (auto existing = from_pgid(pgid))
+    if (auto existing = from_pgid_nolock(pgid))
         return existing.release_nonnull();
 
-    return create(pgid);
+    if (!process_group)
+        return {};
+
+    g_process_groups->prepend(process_group);
+    return process_group;
 }
 
 RefPtr<ProcessGroup> ProcessGroup::from_pgid(ProcessGroupID pgid)
 {
     ScopedSpinLock lock(g_process_groups_lock);
+    return from_pgid_nolock(pgid);
+}
 
+RefPtr<ProcessGroup> ProcessGroup::from_pgid_nolock(ProcessGroupID pgid)
+{
+    VERIFY(g_process_groups_lock.own_lock());
     for (auto& group : *g_process_groups) {
         if (group.pgid() == pgid)
             return &group;

--- a/Kernel/ProcessGroup.h
+++ b/Kernel/ProcessGroup.h
@@ -28,8 +28,8 @@ class ProcessGroup
 public:
     ~ProcessGroup();
 
-    static NonnullRefPtr<ProcessGroup> create(ProcessGroupID);
-    static NonnullRefPtr<ProcessGroup> find_or_create(ProcessGroupID);
+    static RefPtr<ProcessGroup> create(ProcessGroupID);
+    static RefPtr<ProcessGroup> find_or_create(ProcessGroupID);
     static RefPtr<ProcessGroup> from_pgid(ProcessGroupID);
 
     const ProcessGroupID& pgid() const { return m_pgid; }

--- a/Kernel/ProcessGroup.h
+++ b/Kernel/ProcessGroup.h
@@ -40,6 +40,8 @@ private:
     {
     }
 
+    static RefPtr<ProcessGroup> from_pgid_nolock(ProcessGroupID);
+
     ProcessGroup* m_prev { nullptr };
     ProcessGroup* m_next { nullptr };
 

--- a/Kernel/Syscalls/setpgid.cpp
+++ b/Kernel/Syscalls/setpgid.cpp
@@ -116,6 +116,9 @@ KResultOr<int> Process::sys$setpgid(pid_t specified_pid, pid_t specified_pgid)
     }
     // FIXME: There are more EPERM conditions to check for here..
     process->m_pg = ProcessGroup::find_or_create(new_pgid);
+    if (!process->m_pg) {
+        return ENOMEM;
+    }
     return 0;
 }
 


### PR DESCRIPTION
This series makes some minor progress on OOM handling (#6369).
It also starts working on fixing allocations performed while holding spinlocks, found with `KMALLOC_VERIFY_NO_SPINLOCK_HELD` introduced in  9c384756088658e02ee6fba10030efcce1dc876b.