### PR TITLE
Solitaire: Prevent player dragging entire stack to foundation

### DIFF
--- a/Userland/Games/Solitaire/CardStack.cpp
+++ b/Userland/Games/Solitaire/CardStack.cpp
@@ -131,7 +131,7 @@ void CardStack::add_all_grabbed_cards(const Gfx::IntPoint& click_location, Nonnu
     }
 }
 
-bool CardStack::is_allowed_to_push(const Card& card) const
+bool CardStack::is_allowed_to_push(const Card& card, size_t stack_size) const
 {
     if (m_type == Stock || m_type == Waste || m_type == Play)
         return false;
@@ -148,6 +148,9 @@ bool CardStack::is_allowed_to_push(const Card& card) const
             return false;
 
         if (m_type == Foundation) {
+            // Prevent player from dragging and entire stack of cards to the foundation stack
+            if (stack_size > 1)
+                return false;
             return top_card.type() == card.type() && m_stack.size() == card.value();
         } else if (m_type == Normal) {
             return top_card.color() != card.color() && top_card.value() == card.value() + 1;

--- a/Userland/Games/Solitaire/CardStack.h
+++ b/Userland/Games/Solitaire/CardStack.h
@@ -42,7 +42,7 @@ public:
     void move_to_stack(CardStack&);
     void rebound_cards();
 
-    bool is_allowed_to_push(const Card&) const;
+    bool is_allowed_to_push(const Card&, size_t stack_size = 1) const;
     void add_all_grabbed_cards(const Gfx::IntPoint& click_location, NonnullRefPtrVector<Card>& grabbed);
     void draw(GUI::Painter&, const Gfx::Color& background_color);
     void clear();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -243,7 +243,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
 
         for (auto& focused_card : m_focused_cards) {
             if (stack.bounding_box().intersects(focused_card.rect())) {
-                if (stack.is_allowed_to_push(m_focused_cards.at(0))) {
+                if (stack.is_allowed_to_push(m_focused_cards.at(0), m_focused_cards.size())) {
                     for (auto& to_intersect : m_focused_cards) {
                         mark_intersecting_stacks_dirty(to_intersect);
                         stack.push(to_intersect);


### PR DESCRIPTION
Currently, it is possible for the player to drag an entire stack
of cards to the foundation stack, provided the top card of the stack
(i.e the "root" card) can be dropped onto the foundation stack.
This causes an invalid state where, e.g, red cards end up in a
black foundation stack, or vice versa.