### PR TITLE
Solitaire: Stop timer if new game animation is running

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -96,6 +96,9 @@ void Game::stop_game_over_animation()
 
 void Game::setup(Mode mode)
 {
+    if (m_new_game_animation)
+        stop_timer();
+
     stop_game_over_animation();
     m_mode = mode;
 


### PR DESCRIPTION
Starting a new game before the animation had finished caused a crash
since it never stopped the timer before starting a new one.

Fixes #7222