### PR TITLE
2048: Change settings window to behave less surprisingly

### DIFF
--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -11,9 +11,13 @@
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/SpinBox.h>
+#include <math.h>
 
-GameSizeDialog::GameSizeDialog(GUI::Window* parent)
+GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t target, bool evil_ai)
     : GUI::Dialog(parent)
+    , m_board_size(board_size)
+    , m_target_tile_power(log2(target))
+    , m_evil_ai(evil_ai)
 {
     set_rect({ 0, 0, 200, 150 });
     set_title("New Game");

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -65,7 +65,7 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     evil_ai_checkbox.set_checked(m_evil_ai);
     evil_ai_checkbox.on_checked = [this](auto checked) { m_evil_ai = checked; };
 
-    auto& temp_checkbox = main_widget.add<GUI::CheckBox>("Temporary");
+    auto& temp_checkbox = main_widget.add<GUI::CheckBox>("Temporarily apply changes");
     temp_checkbox.set_checked(m_temporary);
     temp_checkbox.on_checked = [this](auto checked) { m_temporary = checked; };
 

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -19,7 +19,7 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     , m_target_tile_power(log2(target))
     , m_evil_ai(evil_ai)
 {
-    set_rect({ 0, 0, 200, 150 });
+    set_rect({ 0, 0, 250, 150 });
     set_title("New Game");
     set_icon(parent->icon());
     set_resizable(false);

--- a/Userland/Games/2048/GameSizeDialog.h
+++ b/Userland/Games/2048/GameSizeDialog.h
@@ -12,16 +12,16 @@
 class GameSizeDialog : public GUI::Dialog {
     C_OBJECT(GameSizeDialog)
 public:
-    GameSizeDialog(GUI::Window* parent);
-
     size_t board_size() const { return m_board_size; }
     u32 target_tile() const { return 1u << m_target_tile_power; }
     bool evil_ai() const { return m_evil_ai; }
     bool temporary() const { return m_temporary; }
 
 private:
-    size_t m_board_size { 4 };
-    size_t m_target_tile_power { 11 };
-    bool m_evil_ai { false };
+    GameSizeDialog(GUI::Window* parent, size_t board_size, size_t target_tile, bool evil_ai);
+
+    size_t m_board_size;
+    size_t m_target_tile_power;
+    bool m_evil_ai;
     bool m_temporary { true };
 };

--- a/Userland/Games/2048/GameSizeDialog.h
+++ b/Userland/Games/2048/GameSizeDialog.h
@@ -23,5 +23,5 @@ private:
     size_t m_board_size;
     size_t m_target_tile_power;
     bool m_evil_ai;
-    bool m_temporary { true };
+    bool m_temporary { false };
 };

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -18,6 +18,7 @@
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/Window.h>
+#include <LibGfx/Painter.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
@@ -86,6 +87,17 @@ int main(int argc, char** argv)
     auto& board_view = main_widget.add<BoardView>(&game.board());
     board_view.set_focus(true);
     auto& statusbar = main_widget.add<GUI::Statusbar>();
+
+    app->on_action_enter = [&](GUI::Action& action) {
+        auto text = action.status_tip();
+        if (text.is_empty())
+            text = Gfx::parse_ampersand_string(action.text());
+        statusbar.set_override_text(move(text));
+    };
+
+    app->on_action_leave = [&](GUI::Action&) {
+        statusbar.set_override_text({});
+    };
 
     auto update = [&]() {
         board_view.set_board(&game.board());

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -39,8 +39,13 @@ int main(int argc, char** argv)
     auto config = Core::ConfigFile::get_for_app("2048");
 
     size_t board_size = config->read_num_entry("", "board_size", 4);
-    u32 target_tile = config->read_num_entry("", "target_tile", 0);
+    u32 target_tile = config->read_num_entry("", "target_tile", 2048);
     bool evil_ai = config->read_bool_entry("", "evil_ai", false);
+
+    if ((target_tile & (target_tile - 1)) != 0) {
+        // If the target tile is not a power of 2, reset to its default value.
+        target_tile = 2048;
+    }
 
     config->write_num_entry("", "board_size", board_size);
     config->write_num_entry("", "target_tile", target_tile);
@@ -94,7 +99,7 @@ int main(int argc, char** argv)
     Vector<Game> redo_stack;
 
     auto change_settings = [&] {
-        auto size_dialog = GameSizeDialog::construct(window);
+        auto size_dialog = GameSizeDialog::construct(window, board_size, target_tile, evil_ai);
         if (size_dialog->exec() || size_dialog->result() != GUI::Dialog::ExecOK)
             return;
 


### PR DESCRIPTION
* When the settings window is opened, show the current values rather than the default values
* Persist settings changes by default
* Clarify some settings text