### PR TITLE
Kernel/Graphics: More console fixes

### DIFF
--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -16,6 +16,7 @@
 #include <Kernel/Devices/HID/PS2KeyboardDevice.h>
 #include <Kernel/IO.h>
 #include <Kernel/TTY/ConsoleManagement.h>
+#include <Kernel/WorkQueue.h>
 
 namespace Kernel {
 
@@ -70,7 +71,9 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         if (m_modifiers & Mod_Alt) {
             switch (ch) {
             case 0x02 ... 0x07: // 1 to 6
-                ConsoleManagement::the().switch_to(ch - 0x02);
+                g_io_work->queue([this, ch]() {
+                    ConsoleManagement::the().switch_to(ch - 0x02);
+                });
                 break;
             default:
                 key_state_changed(ch, pressed);

--- a/Kernel/Graphics/BochsGraphicsAdapter.cpp
+++ b/Kernel/Graphics/BochsGraphicsAdapter.cpp
@@ -143,7 +143,7 @@ void BochsGraphicsAdapter::enable_consoles()
     auto registers = map_typed_writable<volatile BochsDisplayMMIORegisters>(m_mmio_registers);
     registers->bochs_regs.y_offset = 0;
     if (m_framebuffer_device)
-        m_framebuffer_device->dectivate_writes();
+        m_framebuffer_device->deactivate_writes();
     m_framebuffer_console->enable();
 }
 void BochsGraphicsAdapter::disable_consoles()

--- a/Kernel/Graphics/BochsGraphicsAdapter.cpp
+++ b/Kernel/Graphics/BochsGraphicsAdapter.cpp
@@ -53,11 +53,11 @@ UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::Address pci_add
     : PCI::DeviceController(pci_address)
     , m_mmio_registers(PCI::get_BAR2(pci_address) & 0xfffffff0)
 {
-    set_safe_resolution();
     // We assume safe resolutio is 1024x768x32
     m_framebuffer_console = Graphics::FramebufferConsole::initialize(PhysicalAddress(PCI::get_BAR0(pci_address) & 0xfffffff0), 1024, 768, 1024 * sizeof(u32));
     // FIXME: This is a very wrong way to do this...
     GraphicsManagement::the().m_console = m_framebuffer_console;
+    set_safe_resolution();
 }
 
 UNMAP_AFTER_INIT void BochsGraphicsAdapter::initialize_framebuffer_devices()
@@ -76,6 +76,7 @@ GraphicsDevice::Type BochsGraphicsAdapter::type() const
 
 void BochsGraphicsAdapter::set_safe_resolution()
 {
+    VERIFY(m_framebuffer_console);
     set_resolution(1024, 768);
 }
 
@@ -105,6 +106,7 @@ bool BochsGraphicsAdapter::try_to_set_resolution(size_t width, size_t height)
 
 bool BochsGraphicsAdapter::set_resolution(size_t width, size_t height)
 {
+    VERIFY(m_framebuffer_console);
     if (Checked<size_t>::multiplication_would_overflow(width, height, sizeof(u32)))
         return false;
 
@@ -112,6 +114,7 @@ bool BochsGraphicsAdapter::set_resolution(size_t width, size_t height)
         return false;
 
     dbgln("BochsGraphicsAdapter: resolution set to {}x{}", width, height);
+    m_framebuffer_console->set_resolution(width, height, width * sizeof(u32));
     return true;
 }
 

--- a/Kernel/Graphics/Console/Console.h
+++ b/Kernel/Graphics/Console/Console.h
@@ -74,8 +74,8 @@ protected:
     Atomic<bool> m_enabled;
     Color m_default_foreground_color { Color::White };
     Color m_default_background_color { Color::Black };
-    const size_t m_width;
-    const size_t m_height;
+    size_t m_width;
+    size_t m_height;
     mutable size_t m_x { 0 };
     mutable size_t m_y { 0 };
 };

--- a/Kernel/Graphics/Console/FramebufferConsole.h
+++ b/Kernel/Graphics/Console/FramebufferConsole.h
@@ -16,6 +16,8 @@ class FramebufferConsole final : public Console {
 public:
     static NonnullRefPtr<FramebufferConsole> initialize(PhysicalAddress, size_t width, size_t height, size_t pitch);
 
+    void set_resolution(size_t width, size_t height, size_t pitch);
+
     virtual size_t bytes_per_base_glyph() const override;
     virtual size_t chars_per_line() const override;
 

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -60,7 +60,7 @@ KResultOr<Region*> FramebufferDevice::mmap(Process& process, FileDescription&, c
     return result;
 }
 
-void FramebufferDevice::dectivate_writes()
+void FramebufferDevice::deactivate_writes()
 {
     ScopedSpinLock lock(m_activation_lock);
     if (!m_userspace_framebuffer_region)

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -59,6 +59,8 @@ private:
     OwnPtr<Region> m_real_framebuffer_region;
     OwnPtr<Region> m_swapped_framebuffer_region;
 
+    bool m_graphical_writes_enabled { true };
+
     RefPtr<AnonymousVMObject> m_userspace_real_framebuffer_vmobject;
     Region* m_userspace_framebuffer_region { nullptr };
 };

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -27,7 +27,7 @@ public:
     virtual mode_t required_mode() const override { return 0660; }
     virtual String device_name() const override;
 
-    virtual void dectivate_writes();
+    virtual void deactivate_writes();
     virtual void activate_writes();
     virtual size_t framebuffer_size_in_bytes() const { return m_framebuffer_pitch * m_framebuffer_height; }
 

--- a/Kernel/Graphics/VGACompatibleAdapter.cpp
+++ b/Kernel/Graphics/VGACompatibleAdapter.cpp
@@ -59,7 +59,7 @@ void VGACompatibleAdapter::enable_consoles()
 {
     VERIFY(m_framebuffer_console);
     if (m_framebuffer_device)
-        m_framebuffer_device->dectivate_writes();
+        m_framebuffer_device->deactivate_writes();
     m_framebuffer_console->enable();
 }
 void VGACompatibleAdapter::disable_consoles()

--- a/Kernel/TTY/ConsoleManagement.cpp
+++ b/Kernel/TTY/ConsoleManagement.cpp
@@ -15,6 +15,13 @@ namespace Kernel {
 
 static AK::Singleton<ConsoleManagement> s_the;
 
+void ConsoleManagement::resolution_was_changed()
+{
+    for (auto& console : m_consoles) {
+        console.refresh_after_resolution_change();
+    }
+}
+
 bool ConsoleManagement::is_initialized()
 {
     if (!s_the.is_initialized())

--- a/Kernel/TTY/ConsoleManagement.h
+++ b/Kernel/TTY/ConsoleManagement.h
@@ -26,6 +26,8 @@ public:
     void switch_to(unsigned);
     void initialize();
 
+    void resolution_was_changed();
+
     void switch_to_debug() { switch_to(1); }
 
     NonnullRefPtr<VirtualConsole> first_tty() const { return m_consoles[0]; }

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -286,6 +286,8 @@ void VirtualConsole::emit_char(char ch)
 
 void VirtualConsole::flush_dirty_lines()
 {
+    if (!m_active)
+        return;
     VERIFY(GraphicsManagement::is_initialized());
     VERIFY(GraphicsManagement::the().console());
     for (u16 visual_row = 0; visual_row < rows(); ++visual_row) {

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -60,6 +60,7 @@ class VirtualConsole final : public TTY
 public:
     struct Line {
         bool dirty;
+        size_t length;
     };
 
     struct Cell {
@@ -79,6 +80,8 @@ public:
     virtual ~VirtualConsole() override;
 
     size_t index() const { return m_index; }
+
+    void refresh_after_resolution_change();
 
     bool is_graphical() { return m_graphical; }
     void set_graphical(bool graphical);


### PR DESCRIPTION
Instead of processing the input after receiving an IRQ, we shift the
responsibility to the io work queue to handle this for us, so if a page fault
occurs, the kernel can handle that.

Might fix #7241 (?)

cc @gunnarbeutner @bgianfo 