### PR TITLE
CatDog: Remove global menu and add context menu

### DIFF
--- a/Userland/Demos/CatDog/CatDog.cpp
+++ b/Userland/Demos/CatDog/CatDog.cpp
@@ -137,3 +137,9 @@ void CatDog::track_cursor_globally()
     set_global_cursor_tracking(true);
     GUI::WindowServerConnection::the().set_global_cursor_tracking(window_id, true);
 }
+
+void CatDog::context_menu_event(GUI::ContextMenuEvent& event)
+{
+    if (on_context_menu_request)
+        on_context_menu_request(event);
+}

--- a/Userland/Demos/CatDog/CatDog.h
+++ b/Userland/Demos/CatDog/CatDog.h
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/ElapsedTimer.h>
+#include <LibGUI/Menu.h>
 #include <LibGUI/Widget.h>
 #include <math.h>
 #include <unistd.h>
@@ -19,11 +20,13 @@ public:
     virtual void paint_event(GUI::PaintEvent& event) override;
     virtual void mousemove_event(GUI::MouseEvent& event) override;
     virtual void mousedown_event(GUI::MouseEvent& event) override;
+    virtual void context_menu_event(GUI::ContextMenuEvent& event) override;
 
     void track_cursor_globally();
     void start_the_timer() { m_timer.start(); }
 
     Function<void()> on_click;
+    Function<void(GUI::ContextMenuEvent&)> on_context_menu_request;
 
     bool roaming() const { return m_roaming; }
     void set_roaming(bool roaming)
@@ -40,6 +43,7 @@ public:
 private:
     Gfx::IntPoint m_temp_pos;
     Core::ElapsedTimer m_timer;
+
     int m_curr_frame = 1;
     int m_moveX, m_moveY = 0;
     bool m_up, m_down, m_left, m_right, m_sleeping = false;

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -53,15 +53,10 @@ int main(int argc, char** argv)
     catdog_widget.set_layout<GUI::VerticalBoxLayout>();
     catdog_widget.layout()->set_spacing(0);
 
-    auto menubar = GUI::Menubar::construct();
-
-    auto& file_menu = menubar->add_menu("&File");
-    file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
-
-    auto& help_menu = menubar->add_menu("&Help");
-    help_menu.add_action(GUI::CommonActions::make_about_action("CatDog Demo", app_icon, window));
-
-    window->set_menubar(move(menubar));
+    auto context_menu = GUI::Menu::construct();
+    context_menu->add_action(GUI::CommonActions::make_about_action("CatDog Demo", app_icon, window));
+    context_menu->add_separator();
+    context_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
 
     window->show();
     catdog_widget.track_cursor_globally();
@@ -104,6 +99,10 @@ int main(int argc, char** argv)
             advice_timer->stop();
         else
             advice_timer->start();
+    };
+
+    catdog_widget.on_context_menu_request = [&](GUI::ContextMenuEvent event) {
+        context_menu->popup(event.screen_position());
     };
 
     return app->exec();


### PR DESCRIPTION
There was no way to close catdog since it relied on global menus, this
adds a context menu for opening the about dialog and quitting.

This is my first try at menus and events, please let me now if it looks like a total mess :^)

Fixes #7252