### PR TITLE
AK: StringBuilder should prefer to use its inline capacity first

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -22,7 +22,9 @@ inline void StringBuilder::will_append(size_t size)
     needed_capacity += size;
     VERIFY(!needed_capacity.has_overflow());
     Checked<size_t> expanded_capacity = needed_capacity;
-    expanded_capacity *= 2;
+    // Prefer to completely use the inline buffer first
+    if (needed_capacity > inline_capacity)
+        expanded_capacity *= 2;
     VERIFY(!expanded_capacity.has_overflow());
     m_buffer.grow(expanded_capacity.value());
 }


### PR DESCRIPTION
Previously `StringBuilder` would start allocating an external buffer once the caller has used up more than half of the inline buffer's
capacity. Instead we should prefer to use the inline buffer until it is full and only then start to allocate an external buffer.