### PR TITLE
AK: Add FixedString

### DIFF
--- a/AK/FixedString.h
+++ b/AK/FixedString.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace AK {
+
+template<auto TSize>
+struct FixedString {
+public:
+    static constexpr auto Size = TSize;
+
+    constexpr FixedString() = default;
+    constexpr FixedString(const char* str)
+    {
+        for (auto i = 0u; i < Size + 1; ++i) {
+            m_data[i] = str[i];
+        }
+    }
+
+    constexpr operator StringView() const { return { m_data, Size }; }
+
+    template<auto TOtherSize>
+    constexpr auto operator+(const FixedString<TOtherSize>& other) -> FixedString<TSize + TOtherSize>
+    {
+        constexpr auto new_size = TSize + TOtherSize;
+        FixedString<new_size> result {};
+        for (auto i = 0u; i < TSize; ++i) {
+            result.m_data[i] = m_data[i];
+        }
+        for (auto i = 0u; i < TOtherSize; ++i) {
+            result.m_data[i + TSize] = other.m_data[i + TSize];
+        }
+        return result;
+    }
+
+    char m_data[Size + 1] {};
+};
+
+template<auto TSize>
+FixedString(char const (&)[TSize]) -> FixedString<TSize - 1>;
+
+template<FixedString TStr>
+constexpr auto operator""_fs() { return TStr; }
+
+}

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -112,6 +112,10 @@ constexpr T exchange(T& slot, U&& value)
 template<typename T>
 using RawPtr = typename Detail::_RawPtr<T>::Type;
 
+constexpr inline bool is_constant_evaluated()
+{
+    return __builtin_is_constant_evaluated();
+}
 }
 
 using AK::array_size;
@@ -120,6 +124,7 @@ using AK::clamp;
 using AK::declval;
 using AK::exchange;
 using AK::forward;
+using AK::is_constant_evaluated;
 using AK::max;
 using AK::min;
 using AK::RawPtr;

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -20,6 +20,7 @@ set(AK_TEST_SOURCES
     TestEndian.cpp
     TestEnumBits.cpp
     TestFind.cpp
+    TestFixedString.cpp
     TestFormat.cpp
     TestGenericLexer.cpp
     TestHashFunctions.cpp

--- a/Tests/AK/TestFixedString.cpp
+++ b/Tests/AK/TestFixedString.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/FixedString.h>
+#include <AK/StringView.h>
+
+using namespace AK;
+
+static_assert(sizeof("") == sizeof(""_fs));
+static_assert(sizeof("SerenityOS") == sizeof("SerenityOS"_fs));
+static_assert(AK::StringView { "SerenityOS" } == AK::StringView { "SerenityOS"_fs });
+
+static_assert(sizeof("SerenityOS") == sizeof("Serenity"_fs + "OS"_fs));
+static_assert(sizeof("OS") == sizeof(""_fs + "OS"_fs));
+static_assert(sizeof("Serenity") == sizeof("Serenity"_fs + ""_fs));


### PR DESCRIPTION
Problem:
- There is no compile-time string capability.

Solution:
- Create a FixedString class which supports conversion to StringView
  and concatenation.