### PR TITLE
Time: Remove static from function local constexpr variable

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Checked.h>
 #include <AK/Time.h>
 
@@ -21,7 +22,7 @@ int day_of_year(int year, unsigned month, int day)
 {
     VERIFY(month >= 1 && month <= 12);
 
-    static const int seek_table[] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
+    constexpr Array seek_table = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
     int day_of_year = seek_table[month - 1] + day - 1;
 
     if (is_leap_year(year) && month >= 3)
@@ -43,7 +44,7 @@ int days_in_month(int year, unsigned month)
 unsigned day_of_week(int year, unsigned month, int day)
 {
     VERIFY(month >= 1 && month <= 12);
-    static const int seek_table[] = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
+    constexpr Array seek_table = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
     if (month < 3)
         --year;
 


### PR DESCRIPTION
Problem:
- Function local `constexpr` variables do not need to be
  `static`. This consumes memory which is unnecessary and can prevent
  some optimizations.
- C-style arrays are not as safe as AK::Arrays and require the user to
  specify the length of the array manually.

Solution:
- Remove `static` keyword.
- Change from C-style array for AK::Array.