### PR TITLE
Browser: Don't add multiple page reloads to history

### DIFF
--- a/Userland/Applications/Browser/History.cpp
+++ b/Userland/Applications/Browser/History.cpp
@@ -20,6 +20,8 @@ void History::dump() const
 
 void History::push(const URL& url)
 {
+    if (!m_items.is_empty() && m_items[m_current] == url)
+        return;
     m_items.shrink(m_current + 1);
     m_items.append(url);
     m_current++;


### PR DESCRIPTION
When reloading a page multiple times, it was also added multiple
times to the history. This commit prohibits an url to be added
twice in a row.

Fixes #7264