### PR TITLE
Utilities: Allow for white spaces in lsof name parsing

### DIFF
--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -38,7 +38,7 @@ static bool parse_name(StringView name, OpenFile& file)
         return true;
     } else {
         file.type = component1;
-        auto component2 = lexer.consume_while([](char c) { return isprint(c) && !isspace(c) && c != '('; });
+        auto component2 = lexer.consume_while([](char c) { return isprint(c) && c != '('; });
         lexer.ignore_while(isspace);
         file.name = component2;
 


### PR DESCRIPTION
Previously lsof would crash by incorrectly parsing valid file names
that contain spaces.

For example, established TCP socket file descriptors would cause an
lsof crash:

	socket:127.0.0.1:33985 / 127.0.0.1:8080 (connected)

This commit fixes the issue by not parsing for white spaces to set the
file name.