### PR TITLE
AK: Make vout() log to debug instead of VERIFY()'ing

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -20,6 +20,7 @@
 #    include <Kernel/Thread.h>
 #else
 #    include <stdio.h>
+#    include <string.h>
 #endif
 
 namespace AK {
@@ -608,7 +609,10 @@ void vout(FILE* file, StringView fmtstr, TypeErasedFormatParams params, bool new
 
     const auto string = builder.string_view();
     const auto retval = ::fwrite(string.characters_without_null_termination(), 1, string.length(), file);
-    VERIFY(static_cast<size_t>(retval) == string.length());
+    if (static_cast<size_t>(retval) != string.length()) {
+        auto error = ferror(file);
+        dbgln("vout() failed ({} written out of {}), error was {} ({})", retval, string.length(), error, strerror(error));
+    }
 }
 #endif
 


### PR DESCRIPTION
In case the write was to stderr/stdout, and it just so happened to fail
because of an issue like "the pty is gone", VERIFY() would end up
calling vout() back to write to stderr, which would then fail forever
until the stack is exhausted.
"Fixes" the issue where the Shell would crash in horrible ways when the
terminal is closed.

now it will just cry a little:
```
Shell(26:26): vout() failed (0 written out of 34), error was 5 (I/O error)
Shell(26:26): Job entry 'TextEditor' deleted in 2577 ms
Shell(26:26): Terminal DSR issue; received no response
```