### PR TITLE
AK: Add inline storage support for the Function class

### DIFF
--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
+#include <AK/OwnPtr.h>
 #include <AK/Types.h>
 
 namespace AK {

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -31,9 +31,7 @@ WorkQueue::WorkQueue(const char* name)
                 have_more = !m_items.is_empty();
             }
             if (item) {
-                item->function(item->data);
-                if (item->free_data)
-                    item->free_data(item->data);
+                item->function();
                 delete item;
 
                 if (have_more)

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/HashMap.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 
 TEST_CASE(construct)

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -7,6 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Demangle.h>
+#include <AK/OwnPtr.h>
 #include <AK/StringBuilder.h>
 #include <LibC/sys/arch/i386/regs.h>
 #include <LibCore/ArgsParser.h>

--- a/Userland/DevTools/StateMachineGenerator/main.cpp
+++ b/Userland/DevTools/StateMachineGenerator/main.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/GenericLexer.h>
 #include <AK/HashTable.h>
-#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/SourceGenerator.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -11,6 +11,7 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtrVector.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/TypeCasts.h>
 #include <AK/Weakable.h>

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -9,6 +9,7 @@
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
+#include <AK/OwnPtr.h>
 #include <AK/Vector.h>
 #include <LibDebug/Dwarf/DIE.h>
 #include <LibDebug/Dwarf/DwarfInfo.h>

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Object.h>

--- a/Userland/Libraries/LibGfx/FontDatabase.h
+++ b/Userland/Libraries/LibGfx/FontDatabase.h
@@ -8,6 +8,7 @@
 
 #include <AK/Function.h>
 #include <AK/HashMap.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Typeface.h>

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -11,7 +11,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
-#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
 #include <AK/Result.h>
 #include <AK/String.h>

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -10,6 +10,7 @@
 #include <AK/GenericLexer.h>
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
+#include <AK/OwnPtr.h>
 #include <AK/SourceGenerator.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -2037,7 +2037,7 @@ bool Parser::parse_heredoc_entries()
             // until we find a line that contains the key
             auto end_condition = move(m_end_condition);
             found_key = false;
-            set_end_condition([this, end = record.end, &found_key] {
+            set_end_condition(make<Function<bool()>>([this, end = record.end, &found_key] {
                 if (found_key)
                     return true;
                 auto offset = current_position();
@@ -2060,7 +2060,7 @@ bool Parser::parse_heredoc_entries()
                 }
                 restore_to(offset.offset, offset.line);
                 return false;
-            });
+            }));
 
             auto expr = parse_doublequoted_string_inner();
             set_end_condition(move(end_condition));

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -94,10 +94,10 @@ private:
     template<typename A, typename... Args>
     NonnullRefPtr<A> create(Args... args);
 
-    void set_end_condition(Function<bool()> condition) { m_end_condition = move(condition); }
+    void set_end_condition(OwnPtr<Function<bool()>> condition) { m_end_condition = move(condition); }
     bool at_end() const
     {
-        if (m_end_condition && m_end_condition())
+        if (m_end_condition && (*m_end_condition)())
             return true;
         return m_input.length() <= m_offset;
     }
@@ -159,7 +159,7 @@ private:
     Vector<size_t> m_rule_start_offsets;
     Vector<AST::Position::Line> m_rule_start_lines;
 
-    Function<bool()> m_end_condition;
+    OwnPtr<Function<bool()>> m_end_condition;
     Vector<HeredocInitiationRecord> m_heredoc_initiations;
     Vector<char> m_extra_chars_not_allowed_in_barewords;
     bool m_is_in_brace_expansion_spec { false };

--- a/Userland/Utilities/disasm.cpp
+++ b/Userland/Utilities/disasm.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/MappedFile.h>
+#include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>


### PR DESCRIPTION
**Everywhere: Add missing includes for <AK/OwnPtr.h>**

Previously `<AK/Function.h>` also included `<AK/OwnPtr.h>`. That's about to change though. This patch fixes a few build problems that will occur when that change happens.

**Shell: Avoid moving AK::Function instances while inside them**

**AK: Add inline storage support for the Function class**

This allows us to allocate most `Function` objects on the stack or as part of other objects and gets rid of quite a few allocations.

**Kernel: Use plain Function objects for the WorkQueue**

The `WorkQueue` class previously had its own inline storage functionality for function pointers. With the recent changes to the `Function` class this is no longer necessary.