### PR TITLE
LibWeb: Support `X-Content-Type-Options` to opt out of MIME type sniffing

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -82,7 +82,12 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
         dbgln_if(RESOURCE_DEBUG, "This is a data URL with mime-type _{}_", url().data_mime_type());
         m_mime_type = url().data_mime_type();
     } else {
-        m_mime_type = Core::guess_mime_type_based_on_filename(url().path());
+        auto content_type_options = headers.get("X-Content-Type-Options");
+        if (content_type_options.value_or("").equals_ignoring_case("nosniff")) {
+            m_mime_type = "text/plain";
+        } else {
+            m_mime_type = Core::guess_mime_type_based_on_filename(url().path());
+        }
     }
 
     m_encoding = {};


### PR DESCRIPTION
Before

![Before](https://user-images.githubusercontent.com/434827/118822156-40e53f80-b8fb-11eb-9087-b6fff8683f0e.png)

After

![After](https://user-images.githubusercontent.com/434827/118822145-3e82e580-b8fb-11eb-9954-375b943dab3b.png)

Test file:

```php
<?php
header("Content-Type: ");
header("X-Content-Type-Options: nosniff");
?>

<html>
<p>hello</p>
<script>alert(window.location.href)</script>
</html>
```

Raw HTTP response:

```
$ curl -isk http://10.1.1.115/test/
HTTP/1.1 200 OK
Date: Wed, 19 May 2021 13:32:44 GMT
Server: Apache/2.4.46 (Debian)
X-Content-Type-Options: nosniff
Content-Length: 75


<html>
<p>hello</p>
<script>alert(window.location.href)</script>
</html>
```

