### PR TITLE
Kernel: static vs non-static constexpr variables

### DIFF
--- a/Kernel/Devices/HID/HIDManagement.cpp
+++ b/Kernel/Devices/HID/HIDManagement.cpp
@@ -16,7 +16,7 @@ Atomic<bool> g_caps_lock_remapped_to_ctrl;
 static AK::Singleton<HIDManagement> s_the;
 
 // clang-format off
-static const Keyboard::CharacterMapData DEFAULT_CHARACTER_MAP =
+static constexpr Keyboard::CharacterMapData DEFAULT_CHARACTER_MAP =
 {
     .map = {
         0,    '\033',    '1',    '2',    '3',    '4',    '5',    '6',    '7',    '8',    '9',    '0',    '-',    '=',    0x08,
@@ -73,10 +73,6 @@ static const Keyboard::CharacterMapData DEFAULT_CHARACTER_MAP =
     },
 };
 // clang-format on
-
-KeyboardClient::~KeyboardClient()
-{
-}
 
 size_t HIDManagement::generate_minor_device_number_for_mouse()
 {

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -60,7 +60,7 @@ private:
 
 class KeyboardClient {
 public:
-    virtual ~KeyboardClient();
+    virtual ~KeyboardClient() = default;
     virtual void on_key_pressed(KeyEvent) = 0;
 };
 

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -18,9 +18,7 @@
 
 namespace Kernel {
 
-#define IRQ_KEYBOARD 1
-
-static const KeyCode unshifted_key_map[0x80] = {
+static constexpr KeyCode unshifted_key_map[0x80] = {
     Key_Invalid,
     Key_Escape,
     Key_1,
@@ -36,7 +34,7 @@ static const KeyCode unshifted_key_map[0x80] = {
     Key_Minus,
     Key_Equal,
     Key_Backspace,
-    Key_Tab, //15
+    Key_Tab, // 15
     Key_Q,
     Key_W,
     Key_E,
@@ -117,7 +115,7 @@ static const KeyCode unshifted_key_map[0x80] = {
     Key_Menu,
 };
 
-static const KeyCode shifted_key_map[0x100] = {
+static constexpr KeyCode shifted_key_map[0x100] = {
     Key_Invalid,
     Key_Escape,
     Key_ExclamationPoint,
@@ -214,8 +212,6 @@ static const KeyCode shifted_key_map[0x100] = {
     Key_Menu,
 };
 
-static const KeyCode numpad_key_map[13] = { Key_7, Key_8, Key_9, Key_Invalid, Key_4, Key_5, Key_6, Key_Invalid, Key_1, Key_2, Key_3, Key_0, Key_Comma };
-
 void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
 {
     KeyCode key = (m_modifiers & Mod_Shift) ? shifted_key_map[scan_code] : unshifted_key_map[scan_code];
@@ -226,6 +222,7 @@ void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
     if (m_num_lock_on && !m_has_e0_prefix) {
         if (scan_code >= 0x47 && scan_code <= 0x53) {
             u8 index = scan_code - 0x47;
+            constexpr KeyCode numpad_key_map[13] = { Key_7, Key_8, Key_9, Key_Invalid, Key_4, Key_5, Key_6, Key_Invalid, Key_1, Key_2, Key_3, Key_0, Key_Comma };
             KeyCode newKey = numpad_key_map[index];
 
             if (newKey != Key_Invalid) {

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -20,9 +20,8 @@
 
 namespace Kernel {
 
-static const size_t max_link_count = 65535;
-static const size_t max_block_size = 4096;
-static const ssize_t max_inline_symlink_length = 60;
+static constexpr size_t max_block_size = 4096;
+static constexpr ssize_t max_inline_symlink_length = 60;
 
 struct Ext2FSDirectoryEntry {
     String name;
@@ -1667,6 +1666,7 @@ KResult Ext2FSInode::increment_link_count()
     Locker locker(m_lock);
     if (fs().is_readonly())
         return EROFS;
+    constexpr size_t max_link_count = 65535;
     if (m_raw_inode.i_links_count == max_link_count)
         return EMLINK;
     ++m_raw_inode.i_links_count;

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -18,7 +18,7 @@
 
 namespace Kernel {
 
-static const u32 mepoch = 476763780;
+static constexpr u32 mepoch = 476763780;
 
 class Inode;
 class FileDescription;

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -84,8 +84,8 @@ private:
     bool m_use_mmio { false };
     EntropySource m_entropy_source;
 
-    static const size_t number_of_rx_descriptors = 32;
-    static const size_t number_of_tx_descriptors = 8;
+    static constexpr size_t number_of_rx_descriptors = 32;
+    static constexpr size_t number_of_tx_descriptors = 8;
 
     WaitQueue m_wait_queue;
 };

--- a/Kernel/Net/NE2000NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000NetworkAdapter.cpp
@@ -137,7 +137,7 @@ struct [[gnu::packed]] received_packet_header {
 
 UNMAP_AFTER_INIT void NE2000NetworkAdapter::detect()
 {
-    static const auto ne2k_ids = Array<PCI::ID, 11> {
+    constexpr auto ne2k_ids = Array {
         PCI::ID { 0x10EC, 0x8029 }, // RealTek RTL-8029(AS)
 
         // List of clones, taken from Linux's ne2k-pci.c

--- a/Kernel/Net/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8139NetworkAdapter.cpp
@@ -107,7 +107,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT void RTL8139NetworkAdapter::detect()
 {
-    static const PCI::ID rtl8139_id = { 0x10EC, 0x8139 };
+    constexpr PCI::ID rtl8139_id = { 0x10EC, 0x8139 };
     PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {
         if (address.is_null())
             return;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -404,9 +404,9 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
 
 KResultOr<u16> TCPSocket::protocol_allocate_local_port()
 {
-    static const u16 first_ephemeral_port = 32768;
-    static const u16 last_ephemeral_port = 60999;
-    static const u16 ephemeral_port_range_size = last_ephemeral_port - first_ephemeral_port;
+    constexpr u16 first_ephemeral_port = 32768;
+    constexpr u16 last_ephemeral_port = 60999;
+    constexpr u16 ephemeral_port_range_size = last_ephemeral_port - first_ephemeral_port;
     u16 first_scan_port = first_ephemeral_port + get_good_random<u16>() % ephemeral_port_range_size;
 
     Locker locker(sockets_by_tuple().lock());

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -103,9 +103,9 @@ KResult UDPSocket::protocol_connect(FileDescription&, ShouldBlock)
 
 KResultOr<u16> UDPSocket::protocol_allocate_local_port()
 {
-    static const u16 first_ephemeral_port = 32768;
-    static const u16 last_ephemeral_port = 60999;
-    static const u16 ephemeral_port_range_size = last_ephemeral_port - first_ephemeral_port;
+    constexpr u16 first_ephemeral_port = 32768;
+    constexpr u16 last_ephemeral_port = 60999;
+    constexpr u16 ephemeral_port_range_size = last_ephemeral_port - first_ephemeral_port;
     u16 first_scan_port = first_ephemeral_port + get_good_random<u16>() % ephemeral_port_range_size;
 
     Locker locker(sockets_by_port().lock());

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -572,7 +572,7 @@ private:
 
     OwnPtr<ThreadTracer> m_tracer;
 
-    static const int m_max_open_file_descriptors { FD_SETSIZE };
+    static constexpr int m_max_open_file_descriptors { FD_SETSIZE };
 
     class FileDescriptionAndFlags {
     public:

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -14,7 +14,6 @@
 
 namespace Kernel {
 
-static const unsigned s_max_pty_pairs = 8;
 static AK::Singleton<PTYMultiplexer> s_the;
 
 PTYMultiplexer& PTYMultiplexer::the()
@@ -25,8 +24,9 @@ PTYMultiplexer& PTYMultiplexer::the()
 UNMAP_AFTER_INIT PTYMultiplexer::PTYMultiplexer()
     : CharacterDevice(5, 2)
 {
-    m_freelist.ensure_capacity(s_max_pty_pairs);
-    for (int i = s_max_pty_pairs; i > 0; --i)
+    constexpr unsigned max_pty_pairs = 8;
+    m_freelist.ensure_capacity(max_pty_pairs);
+    for (int i = max_pty_pairs; i > 0; --i)
         m_freelist.unchecked_append(i - 1);
 }
 

--- a/Kernel/UBSanitizer.cpp
+++ b/Kernel/UBSanitizer.cpp
@@ -127,7 +127,7 @@ void __ubsan_handle_out_of_bounds(const OutOfBoundsData& data, ValueHandle)
 void __ubsan_handle_type_mismatch_v1(const TypeMismatchData&, ValueHandle) __attribute__((used));
 void __ubsan_handle_type_mismatch_v1(const TypeMismatchData& data, ValueHandle ptr)
 {
-    static const char* kinds[] = {
+    constexpr StringView kinds[] = {
         "load of",
         "store to",
         "reference binding to",
@@ -143,7 +143,7 @@ void __ubsan_handle_type_mismatch_v1(const TypeMismatchData& data, ValueHandle p
     };
 
     FlatPtr alignment = (FlatPtr)1 << data.log_alignment;
-    auto* kind = kinds[data.type_check_kind];
+    auto kind = kinds[data.type_check_kind];
 
     if (!ptr) {
         dbgln("KUBSAN: {} null pointer of type {}", kind, data.type.name());

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -54,7 +54,7 @@ enum class UsedMemoryRangeType {
     BootModule,
 };
 
-constexpr static const char* UserMemoryRangeTypeNames[] {
+static constexpr StringView UserMemoryRangeTypeNames[] {
     "Low memory",
     "Kernel",
     "Boot module",

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -13,9 +13,6 @@
 
 namespace Kernel {
 
-static const FlatPtr userspace_range_base = 0x00800000;
-static const FlatPtr userspace_range_ceiling = 0xbe000000;
-
 static AK::Singleton<HashMap<u32, PageDirectory*>> s_cr3_map;
 
 static HashMap<u32, PageDirectory*>& cr3_map()
@@ -53,6 +50,9 @@ UNMAP_AFTER_INIT PageDirectory::PageDirectory()
 
 PageDirectory::PageDirectory(const RangeAllocator* parent_range_allocator)
 {
+    constexpr FlatPtr userspace_range_base = 0x00800000;
+    constexpr FlatPtr userspace_range_ceiling = 0xbe000000;
+
     ScopedSpinLock lock(s_mm_lock);
     if (parent_range_allocator) {
         m_range_allocator.initialize_from_parent(*parent_range_allocator);


### PR DESCRIPTION
Problem:
- `static` variables consume memory and sometimes are less
  optimizable.
- `static const` variables can be `constexpr`, usually.
- `static` function-local variables require an initialization check
  every time the function is run.

Solution:
- If a global `static` variable is only used in a single function then
  move it into the function and make it non-`static` and `constexpr`.
- Make all global `static` variables `constexpr` instead of `const`.
- Change function-local `static const[expr]` variables to be just
  `constexpr`.