### PR TITLE
Tests: static vs non-static constexpr variables

### DIFF
--- a/Tests/AK/TestTrie.cpp
+++ b/Tests/AK/TestTrie.cpp
@@ -6,15 +6,15 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/StringView.h>
 #include <AK/Trie.h>
 
 TEST_CASE(normal_behaviour)
 {
     Trie<char, String> dictionary('/', "");
-    constexpr static const char* data[] { "test", "example", "foo", "foobar" };
-    constexpr static const size_t total_chars = 18; // root (1), 'test' (4), 'example' (7), 'foo' (3), 'foobar' (3, "foo" already stored).
-    for (auto& entry : data) {
-        StringView view { entry };
+    constexpr StringView data[] { "test", "example", "foo", "foobar" };
+    constexpr size_t total_chars = 18; // root (1), 'test' (4), 'example' (7), 'foo' (3), 'foobar' (3, "foo" already stored).
+    for (auto& view : data) {
         auto it = view.begin();
         dictionary.insert(it, view.end(), view, [](auto& parent, auto& it) -> Optional<String> { return String::formatted("{}{}", parent.metadata_value(), *it); });
     }
@@ -24,8 +24,7 @@ TEST_CASE(normal_behaviour)
         ++i;
     EXPECT_EQ(i, total_chars);
 
-    for (auto& entry : data) {
-        StringView view { entry };
+    for (auto& view : data) {
         auto it = view.begin();
         auto& node = dictionary.traverse_until_last_accessible_node(it, view.end());
         EXPECT(it.is_end());
@@ -33,9 +32,8 @@ TEST_CASE(normal_behaviour)
         EXPECT_EQ(view, node.metadata_value());
     }
 
-    constexpr static const char* test_data_with_prefix_in_dict[] { "testx", "exampley", "fooa", "foobarb", "fox", "text" };
-    for (auto& entry : test_data_with_prefix_in_dict) {
-        StringView view { entry };
+    constexpr StringView test_data_with_prefix_in_dict[] { "testx", "exampley", "fooa", "foobarb", "fox", "text" };
+    for (auto& view : test_data_with_prefix_in_dict) {
         auto it = view.begin();
         auto& node = dictionary.traverse_until_last_accessible_node(it, view.end());
         EXPECT(!it.is_end());

--- a/Tests/Kernel/fuzz-syscalls.cpp
+++ b/Tests/Kernel/fuzz-syscalls.cpp
@@ -87,7 +87,7 @@ static void randomize_from(size_t* buffer, size_t len, const Vector<size_t>& val
 
 // The largest SC_*_params struct is SC_mmap_params with 36 bytes.
 static_assert(sizeof(size_t) == 4, "Cannot handle size_t != 4 bytes");
-static const size_t fake_params_count = 36 / sizeof(size_t);
+static constexpr size_t fake_params_count = 36 / sizeof(size_t);
 
 static void do_weird_call(size_t attempt, int syscall_fn, size_t arg1, size_t arg2, size_t arg3, size_t* fake_params)
 {

--- a/Tests/LibC/accuracy-strtod.cpp
+++ b/Tests/LibC/accuracy-strtod.cpp
@@ -14,11 +14,11 @@
 
 typedef char assert_size_t_is_int[sizeof(size_t) == 4 ? 1 : -1];
 
-static const char* TEXT_ERROR = "\x1b[01;35m";
-static const char* TEXT_WRONG = "\x1b[01;31m";
-static const char* TEXT_OFBY1 = "\x1b[01;97m";
-static const char* TEXT_RESET = "\x1b[0m";
-static const long long LENIENCY = 8;
+static constexpr char TEXT_ERROR[] = "\x1b[01;35m";
+static constexpr char TEXT_WRONG[] = "\x1b[01;31m";
+static constexpr char TEXT_OFBY1[] = "\x1b[01;97m";
+static constexpr char TEXT_RESET[] = "\x1b[0m";
+static constexpr long long LENIENCY = 8;
 
 struct Testcase {
     const char* test_name;

--- a/Tests/LibC/overlong_realpath.cpp
+++ b/Tests/LibC/overlong_realpath.cpp
@@ -14,14 +14,14 @@
 #include <unistd.h>
 
 // FIXME
-static const char* TEXT_FAIL = "\x1b[01;31m";
-static const char* TEXT_PASS = "\x1b[01;32m";
-static const char* TEXT_RESET = "\x1b[0m";
+static constexpr char TEXT_FAIL[] = "\x1b[01;31m";
+static constexpr char TEXT_PASS[] = "\x1b[01;32m";
+static constexpr char TEXT_RESET[] = "\x1b[0m";
 
-static const char* TMPDIR_PATTERN = "/tmp/overlong_realpath_XXXXXX";
-static const char* PATH_LOREM_250 = "This-is-an-annoyingly-long-name-that-should-take-up-exactly-two-hundred-and-fifty-characters-and-is-surprisingly-difficult-to-fill-with-reasonably-meaningful-text-which-is-necessary-because-that-makes-it-easier-for-my-eyes-to-spot-any-corruption-fast";
+static constexpr char TMPDIR_PATTERN[] = "/tmp/overlong_realpath_XXXXXX";
+static constexpr char PATH_LOREM_250[] = "This-is-an-annoyingly-long-name-that-should-take-up-exactly-two-hundred-and-fifty-characters-and-is-surprisingly-difficult-to-fill-with-reasonably-meaningful-text-which-is-necessary-because-that-makes-it-easier-for-my-eyes-to-spot-any-corruption-fast";
 
-static const size_t ITERATION_DEPTH = 17;
+static constexpr size_t ITERATION_DEPTH = 17;
 
 static bool check_result(const char* what, const String& expected, const char* actual)
 {

--- a/Tests/LibC/snprintf-correctness.cpp
+++ b/Tests/LibC/snprintf-correctness.cpp
@@ -42,10 +42,10 @@ static String show(const ByteBuffer& buf)
     return builder.build();
 }
 
-static const size_t SANDBOX_CANARY_SIZE = 8;
-
 static bool test_single(const Testcase& testcase)
 {
+    constexpr size_t SANDBOX_CANARY_SIZE = 8;
+
     // Preconditions:
     if (testcase.dest_n != testcase.dest_expected_n) {
         warnln("dest length {} != expected dest length {}? Check testcase! (Probably miscounted.)", testcase.dest_n, testcase.dest_expected_n);

--- a/Tests/LibC/strlcpy-correctness.cpp
+++ b/Tests/LibC/strlcpy-correctness.cpp
@@ -40,10 +40,10 @@ static String show(const ByteBuffer& buf)
     return builder.build();
 }
 
-static const size_t SANDBOX_CANARY_SIZE = 8;
-
 static bool test_single(const Testcase& testcase)
 {
+    constexpr size_t SANDBOX_CANARY_SIZE = 8;
+
     // Preconditions:
     if (testcase.dest_n != testcase.dest_expected_n) {
         warnln("dest length {} != expected dest length {}? Check testcase! (Probably miscounted.)", testcase.dest_n, testcase.dest_expected_n);


### PR DESCRIPTION
Problem:
- `static` variables consume memory and sometimes are less
  optimizable.
- `static const` variables can be `constexpr`, usually.
- `static` function-local variables require an initialization check
  every time the function is run.

Solution:
- If a global `static` variable is only used in a single function then
  move it into the function and make it non-`static` and `constexpr`.
- Make all global `static` variables `constexpr` instead of `const`.
- Change function-local `static const[expr]` variables to be just
  `constexpr`.