### PR TITLE
Ports: Build shared libraries for the GnuPG libraries

### DIFF
--- a/Ports/libassuan/package.sh
+++ b/Ports/libassuan/package.sh
@@ -2,15 +2,20 @@
 port=libassuan
 version=2.5.5
 useconfigure=true
-#configopts="--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+depends="libgpg-error"
 files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2 8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4"
 auth_type=sha256
 
 pre_configure() {
-    export gcry_cv_gcc_has_f_visibility=no
     export ac_cv_lib_pthread_pthread_create=no
 }
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts
+}
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libassuan.so -Wl,-soname,libassuan.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libassuan.a -Wl,--no-whole-archive -lgpg-error
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libassuan.la
 }

--- a/Ports/libgcrypt/package.sh
+++ b/Ports/libgcrypt/package.sh
@@ -8,10 +8,15 @@ files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgc
 auth_type=sha256
 
 pre_configure() {
-    export gcry_cv_gcc_has_f_visibility=no
     export ac_cv_lib_pthread_pthread_create=no
 }
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts
+}
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgcrypt.so -Wl,-soname,libgcrypt.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgcrypt.a -Wl,--no-whole-archive -lgpg-error
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgcrypt.la
 }

--- a/Ports/libgpg-error/package.sh
+++ b/Ports/libgpg-error/package.sh
@@ -2,14 +2,17 @@
 port=libgpg-error
 version=1.42
 useconfigure=true
+depends="gettext"
 configopts="--disable-tests --disable-threads"
 files="https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${version}.tar.bz2 libgpg-error-${version}.tar.bz2 fc07e70f6c615f8c4f590a8e37a9b8dd2e2ca1e9408f8e60459c67452b925e23"
 auth_type=sha256
 
-pre_configure() {
-    export gcry_cv_gcc_has_f_visibility=no
-}
-
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts
+}
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgpg-error.so -Wl,-soname,libgpg-error.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgpg-error.a -Wl,--no-whole-archive -lintl
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgpg-error.la
 }

--- a/Ports/libksba/package.sh
+++ b/Ports/libksba/package.sh
@@ -2,6 +2,7 @@
 port=libksba
 version=1.5.1
 useconfigure=true
+depends=libgpg-error
 files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2 b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921"
 auth_type=sha256
 
@@ -11,4 +12,10 @@ pre_configure() {
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts
+}
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libksba.so -Wl,-soname,libksba.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libksba.a -Wl,--no-whole-archive -lgpg-error
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libksba.la
 }

--- a/Ports/npth/package.sh
+++ b/Ports/npth/package.sh
@@ -8,3 +8,9 @@ auth_type=sha256
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts
 }
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -pthread -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libnpth.so -Wl,-soname,libnpth.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libnpth.a -Wl,--no-whole-archive
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libnpth.la
+}

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -2,7 +2,7 @@
 port=ntbtls
 version=0.2.0
 useconfigure=true
-#configopts="--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+depends="libgpg-error libksba libgcrypt"
 files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 649fe74a311d13e43b16b26ebaa91665ddb632925b73902592eac3ed30519e17"
 auth_type=sha256
 
@@ -12,4 +12,10 @@ pre_configure() {
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts
+}
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libntbtls.so -Wl,-soname,libntbtls.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libntbtls.a -Wl,--no-whole-archive -lgpg-error -lksba -lgcrypt
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libntbtls.la
 }


### PR DESCRIPTION
This builds all the GnuPG libraries as shared libraries so that `-lintl` is linked when building the final GnuPG executable.