### PR TITLE
CatDog: Don't show context menu when clicking outside of widget

### DIFF
--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -101,8 +101,9 @@ int main(int argc, char** argv)
             advice_timer->start();
     };
 
-    catdog_widget.on_context_menu_request = [&](GUI::ContextMenuEvent event) {
-        context_menu->popup(event.screen_position());
+    catdog_widget.on_context_menu_request = [&](GUI::ContextMenuEvent& event) {
+        if (catdog_widget.rect().contains(event.position()))
+            context_menu->popup(event.screen_position());
     };
 
     return app->exec();


### PR DESCRIPTION
The context menu for CatDog was shown when right clicking anywhere on
the screen because of global cursor tracking being enabled.
Also fix event not being passed by reference.

Fixes #7285