### PR TITLE
LibHTTP: Relax the assertion on extra reads after transfer is finished

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -125,12 +125,9 @@ void Job::on_socket_connected()
             return;
 
         if (m_state == State::Finished) {
-            // This is probably just a EOF notification, which means we should receive nothing
-            // and then get eof() == true.
-            [[maybe_unused]] auto payload = receive(64);
-            // These assertions are only correct if "Connection: close".
-            VERIFY(payload.is_empty());
-            VERIFY(eof());
+            // We have everything we want, at this point, we can either get an EOF, or a bunch of extra newlines
+            // (unless "Connection: close" isn't specified)
+            // So just ignore everything after this.
             return;
         }
 


### PR DESCRIPTION
This was added in #4831, but it didn't account for extra newlines after
the response (seems like some servers like to do this).

I'm not sure if this is _too_ relaxed, though.
we definitely don't need to read until EOF, and technically the job shouldn't be reading extra stuff anyway...
cc @Lubrsi.