### PR TITLE
LibChess: Fixed PGN export bug

### DIFF
--- a/Userland/Libraries/LibChess/Chess.cpp
+++ b/Userland/Libraries/LibChess/Chess.cpp
@@ -199,7 +199,7 @@ String Move::to_algebraic() const
     }
 
     if (is_capture) {
-        if (piece.type == Type::Pawn)
+        if (piece.type == Type::Pawn && !is_ambiguous)
             builder.append(from.to_algebraic().substring(0, 1));
         builder.append("x");
     }


### PR DESCRIPTION
In cases with ambiguous captures involving pawns (where multiple pieces could
have made the capture), we were exporting invalid syntax for the move:

`1. e4 e5 2. Bb5 c6 3. Bxc6 ddxc6`

Move 3 should be `Bxc6 dxc6`, but we were duplicating the d on the pawn
move.