### PR TITLE
Kernel: Remove a bunch of allocations

### DIFF
--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -320,8 +320,7 @@ namespace Detail {
 template<typename T, typename Container>
 inline IntrusiveListNode<T, Container>::~IntrusiveListNode()
 {
-    if (m_storage)
-        remove();
+    VERIFY(!is_in_list());
 }
 
 template<typename T, typename Container>

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -574,23 +574,17 @@ struct MemoryManagerData;
 struct ProcessorMessageEntry;
 
 struct ProcessorMessage {
+    using CallbackFunction = Function<void()>;
+
     enum Type {
         FlushTlb,
         Callback,
-        CallbackWithData
     };
     Type type;
     volatile u32 refs; // atomic
     union {
         ProcessorMessage* next; // only valid while in the pool
-        struct {
-            void (*handler)();
-        } callback;
-        struct {
-            void* data;
-            void (*handler)(void*);
-            void (*free)(void*);
-        } callback_with_data;
+        alignas(CallbackFunction) u8 callback_storage[sizeof(CallbackFunction)];
         struct {
             const PageDirectory* page_directory;
             u8* ptr;
@@ -601,6 +595,17 @@ struct ProcessorMessage {
     volatile bool async;
 
     ProcessorMessageEntry* per_proc_entries;
+
+    CallbackFunction& callback_value()
+    {
+        return *bit_cast<CallbackFunction*>(&callback_storage);
+    }
+
+    void invoke_callback()
+    {
+        VERIFY(type == Type::Callback);
+        callback_value()();
+    }
 };
 
 struct ProcessorMessageEntry {
@@ -935,39 +940,8 @@ public:
     static void smp_enable();
     bool smp_process_pending_messages();
 
-    template<typename Callback>
-    static void smp_broadcast(Callback callback, bool async)
-    {
-        auto* data = new Callback(move(callback));
-        smp_broadcast(
-            [](void* data) {
-                (*reinterpret_cast<Callback*>(data))();
-            },
-            data,
-            [](void* data) {
-                delete reinterpret_cast<Callback*>(data);
-            },
-            async);
-    }
-    static void smp_broadcast(void (*callback)(), bool async);
-    static void smp_broadcast(void (*callback)(void*), void* data, void (*free_data)(void*), bool async);
-    template<typename Callback>
-    static void smp_unicast(u32 cpu, Callback callback, bool async)
-    {
-        auto* data = new Callback(move(callback));
-        smp_unicast(
-            cpu,
-            [](void* data) {
-                (*reinterpret_cast<Callback*>(data))();
-            },
-            data,
-            [](void* data) {
-                delete reinterpret_cast<Callback*>(data);
-            },
-            async);
-    }
-    static void smp_unicast(u32 cpu, void (*callback)(), bool async);
-    static void smp_unicast(u32 cpu, void (*callback)(void*), void* data, void (*free_data)(void*), bool async);
+    static void smp_broadcast(Function<void()>, bool async);
+    static void smp_unicast(u32 cpu, Function<void()>, bool async);
     static void smp_broadcast_flush_tlb(const PageDirectory*, VirtualAddress, size_t);
     static u32 smp_wake_n_idle_processors(u32 wake_count);
 

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -13,10 +13,10 @@ KResultOr<unsigned> Process::sys$alarm(unsigned seconds)
 {
     REQUIRE_PROMISE(stdio);
     unsigned previous_alarm_remaining = 0;
-    if (auto alarm_timer = move(m_alarm_timer)) {
-        if (TimerQueue::the().cancel_timer(*alarm_timer)) {
+    if (m_alarm_timer) {
+        if (TimerQueue::the().cancel_timer(*m_alarm_timer)) {
             // The timer hasn't fired. Round up the remaining time (if any)
-            Time remaining = alarm_timer->remaining() + Time::from_nanoseconds(999'999'999);
+            Time remaining = m_alarm_timer->remaining() + Time::from_nanoseconds(999'999'999);
             previous_alarm_remaining = remaining.to_truncated_seconds();
         }
         // We had an existing alarm, must return a non-zero value here!
@@ -27,9 +27,16 @@ KResultOr<unsigned> Process::sys$alarm(unsigned seconds)
     if (seconds > 0) {
         auto deadline = TimeManagement::the().current_time(CLOCK_REALTIME_COARSE);
         deadline = deadline + Time::from_seconds(seconds);
-        m_alarm_timer = TimerQueue::the().add_timer_without_id(CLOCK_REALTIME_COARSE, deadline, [this]() {
+        if (!m_alarm_timer) {
+            m_alarm_timer = adopt_ref_if_nonnull(new Timer());
+            if (!m_alarm_timer)
+                return ENOMEM;
+        }
+        auto timer_was_added = TimerQueue::the().add_timer_without_id(*m_alarm_timer, CLOCK_REALTIME_COARSE, deadline, [this]() {
             [[maybe_unused]] auto rc = send_signal(SIGALRM, nullptr);
         });
+        if (!timer_was_added)
+            return ENOMEM;
     }
     return previous_alarm_remaining;
 }

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -24,12 +24,14 @@ class Timer : public RefCounted<Timer>
     friend class InlineLinkedListNode<Timer>;
 
 public:
-    Timer(clockid_t clock_id, Time expires, Function<void()>&& callback)
-        : m_clock_id(clock_id)
-        , m_expires(expires)
-        , m_callback(move(callback))
+    void setup(clockid_t clock_id, Time expires, Function<void()>&& callback)
     {
+        VERIFY(!is_queued());
+        m_clock_id = clock_id;
+        m_expires = expires;
+        m_callback = move(callback);
     }
+
     ~Timer()
     {
         VERIFY(!is_queued());
@@ -72,7 +74,7 @@ public:
     static TimerQueue& the();
 
     TimerId add_timer(NonnullRefPtr<Timer>&&);
-    RefPtr<Timer> add_timer_without_id(clockid_t, const Time&, Function<void()>&&);
+    bool add_timer_without_id(NonnullRefPtr<Timer>, clockid_t, const Time&, Function<void()>&&);
     TimerId add_timer(clockid_t, const Time& timeout, Function<void()>&& callback);
     bool cancel_timer(TimerId id);
     bool cancel_timer(Timer&);


### PR DESCRIPTION
**AK: Don't unlink intrusive list elements in the destructor**

Removing the element from the intrusive linked list might not be safe if doing so requires a lock. Instead this is something the caller should have done so let's verify instead that we're not on any lists.

**Kernel: Remove an allocation when blocking a thread**

When blocking a thread with a timeout we would previously allocate a `Timer` object. This removes the allocation for that `Timer` object.

**Kernel: Use the Function class for deferred_call_queue()**

This avoids allocations for `deferred_call_queue()`.

**Kernel: Use the Function class for smp_broadcast()/smp_unicast()**

This avoids allocations for `smp_broadcast()` and `smp_unicast()` by using the `Function` class.



Allocations before:

![Screenshot from 2021-05-19 23-09-44](https://user-images.githubusercontent.com/388571/118900360-0b4b5100-b911-11eb-809c-788808bee842.png)

And afterwards:

![Screenshot from 2021-05-20 02-10-13](https://user-images.githubusercontent.com/388571/118900372-11413200-b911-11eb-8f19-837ff07f10cb.png)
