### PR TITLE
Meta: Cleanup stale rules form .gitignore + update .gitattributes 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,11 @@
 * text=auto eol=lf
 
 # Denote all files that are truly binary and should not be modified.
-*.png binary
+*.bmp binary
+*.dds binary
+*.gif binary
 *.jpg binary
+*.pbm binary
+*.pgm binary
+*.png binary
+*.ppm binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,3 @@
-*
-!*.*
-!*/
-!Makefile
-!LICENSE
-!Base/**
-!Meta/ShellCompletions/**
-
-*.o
-*.ao
-*.a
-*.so
-*.d
-
 *.swo
 *.swp
 *.config
@@ -25,8 +11,6 @@
 *.autosave
 Meta/Lagom/build
 Build
-build
-CMakeFiles
 Toolchain/Tarballs
 Toolchain/Build
 Toolchain/Local
@@ -37,7 +21,6 @@ compile_commands.json
 .cache
 .clang_complete
 .clangd
-*Endpoint.h
 .idea/
 cmake-build-debug/
 sync-local.sh


### PR DESCRIPTION
 -  Meta: Mark the other image file formats as binary in .gitattributes

    We had rules for .png and .jpg files, but we have not maintained the
    list as support for other file formats has been added. To test these
    changes test files have been committed for each of these formats.

    This change updates the list with all of the binary image file types I
    was able to find in the tree at the time of writing.

  - Meta: Cleanup stale rules from .gitignore

    The wild card rules at the top of the .gitignore came from a time when
    the build wrote back to the git repository and placed files right next
    to the source. (Original commit that introduced them 37c27e2e, they were
    later consolidated into the root .gitignore in 802d4dc) We have since
    moved to cmake, and these rules have become obsolete, and they just
    cause issues where we need to go and add negations for these rules in
    order for things to work.

    A previous change attempted to remove the top wild card rules (PR #4565)
    but it was later reverted, as they forgot to remove the top ignore
    everything rule '*', so all files were ignored. This change just removes
    all of these rules that no longer make sense, restoring a bit of sanity.

    *.o,*.d,*.a rules were also from when the build wrote to the repository,
    they are now defunct. The same goes for the *Endpoint.h and CMakeFiles
    rules.

    The lowercase build directory can be removed as we've standardized on
    the uppercase 'Build' directory as the root of the build output dir.