### PR TITLE
Kernel: Fix regression, removing a ProcessGroup that not in the list

### DIFF
--- a/Kernel/ProcessGroup.cpp
+++ b/Kernel/ProcessGroup.cpp
@@ -14,7 +14,9 @@ InlineLinkedList<ProcessGroup>* g_process_groups;
 ProcessGroup::~ProcessGroup()
 {
     ScopedSpinLock lock(g_process_groups_lock);
-    g_process_groups->remove(this);
+    if (m_next || m_prev) {
+        g_process_groups->remove(this);
+    }
 }
 
 RefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)


### PR DESCRIPTION
I introduced this bug in e95eb7a51, where it's possible that the
ProcessGroup is created, but we never add it to the list. Make sure we
check that we are in the list before removal. This only broke booting in
self-test mode oddly enough.

Reported-By: Andrew Kaster <andrewdkaster@gmail.com>