### PR TITLE
Meta: Make generate_state_machine() generate a proper target

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -293,7 +293,6 @@ generate_state_machine(../Userland/Libraries/LibVT/StateMachine.txt ../Userland/
 set(VT_SOURCES
     ../Userland/Libraries/LibVT/Terminal.cpp
     ../Userland/Libraries/LibVT/Line.cpp
-    ../Userland/Libraries/LibVT/EscapeSequenceStateMachine.h
     ../Userland/Libraries/LibVT/EscapeSequenceParser.cpp
 )
 
@@ -376,6 +375,8 @@ else()
 endif()
 
 add_executable(Kernel ${SOURCES})
+add_dependencies(Kernel generate_EscapeSequenceStateMachine.h)
+
 if (ENABLE_KERNEL_LTO)
     include(CheckIPOSupported)
     check_ipo_supported()

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -169,13 +169,21 @@ function(embed_resource target section file)
 endfunction()
 
 function(generate_state_machine source header)
-    set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
-    add_custom_command(
-        OUTPUT ${header}
-	COMMAND ${write_if_different} ${header} ${CMAKE_BINARY_DIR}/Userland/DevTools/StateMachineGenerator/StateMachineGenerator ${source} > ${header}
-        VERBATIM
-        DEPENDS StateMachineGenerator
-        MAIN_DEPENDENCY ${source}
-    )
-    get_filename_component(output_name ${header} NAME)
+    get_filename_component(header_name ${header} NAME)
+    set(target_name "generate_${header_name}")
+    # Note: This function is called twice with the same header, once in the kernel
+    #       and once in Userland/LibVT, this check makes sure that only one target
+    #       is generated for that header.
+    if(NOT TARGET ${target_name})
+        set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
+        set(output ${CMAKE_CURRENT_SOURCE_DIR}/${header})
+        add_custom_command(
+            OUTPUT ${output}
+            COMMAND ${write_if_different} ${output} ${CMAKE_BINARY_DIR}/Userland/DevTools/StateMachineGenerator/StateMachineGenerator ${source}
+            VERBATIM
+            DEPENDS StateMachineGenerator
+            MAIN_DEPENDENCY ${source}
+        )
+        add_custom_target(${target_name} DEPENDS ${output})
+    endif()
 endfunction()

--- a/Userland/Libraries/LibVT/CMakeLists.txt
+++ b/Userland/Libraries/LibVT/CMakeLists.txt
@@ -1,6 +1,3 @@
-# FIXME: this assumes that EscapeSequenceStateMachine.h has been
-# already generated when the kernel was built. This will probably
-# mess builds up later on.
 set(SOURCES
     Line.cpp
     Terminal.cpp
@@ -8,5 +5,10 @@ set(SOURCES
     EscapeSequenceParser.cpp
 )
 
+set(GENERATED_SOURCES
+    EscapeSequenceStateMachine.h
+)
+
+generate_state_machine(StateMachine.txt EscapeSequenceStateMachine.h)
 serenity_lib(LibVT vt)
 target_link_libraries(LibVT LibC LibCore LibGUI LibGfx LibDesktop)


### PR DESCRIPTION
And use GENERATED_SOURCES (or add_dependencies) to make LibVT depend on
that target.
Fixes a FIXME.

Less dependency on ninja's target resolution algorithm, at least.
cc @BertalanD.