### PR TITLE
FontEditor: Minor improvments to the FontEditor GUI

### DIFF
--- a/AK/UnicodeUtils.cpp
+++ b/AK/UnicodeUtils.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+#include <AK/UnicodeUtils.h>
+
+namespace AK::UnicodeUtils {
+
+Optional<StringView> get_unicode_control_code_point_alias(u32 code_point)
+{
+    static constexpr Array<StringView, 32> ascii_controls_lookup_table = {
+        "NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL",
+        "BS", "HT", "LF", "VT", "FF", "CR", "SO", "SI",
+        "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
+        "CAN", "EM", "SUB", "ESC", "FS", "GS", "RS", "US"
+    };
+
+    static constexpr Array<StringView, 32> c1_controls_lookup_table = {
+        "XXX", "XXX", "BPH", "NBH", "IND", "NEL", "SSA", "ESA",
+        "HTS", "HTJ", "VTS", "PLD", "PLU", "RI", "SS2", "SS3",
+        "DCS", "PU1", "PU2", "STS", "CCH", "MW", "SPA", "EPA",
+        "SOS", "XXX", "SCI", "CSI", "ST", "OSC", "PM", "APC"
+    };
+
+    if (code_point < 0x20)
+        return ascii_controls_lookup_table[code_point];
+    if (code_point >= 0x80 && code_point < 0xa0)
+        return c1_controls_lookup_table[code_point - 0x80];
+    return {};
+}
+
+}

--- a/AK/UnicodeUtils.h
+++ b/AK/UnicodeUtils.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+
+namespace AK::UnicodeUtils {
+
+constexpr bool is_unicode_control_code_point(u32 code_point)
+{
+    return code_point < 0x20 || (code_point >= 0x80 && code_point < 0xa0);
+}
+
+Optional<StringView> get_unicode_control_code_point_alias(u32);
+
+}

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -9,6 +9,7 @@
 #include "GlyphMapWidget.h"
 #include "NewFontDialog.h"
 #include <AK/StringBuilder.h>
+#include <AK/UnicodeUtils.h>
 #include <Applications/FontEditor/FontEditorWindowGML.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
@@ -33,6 +34,7 @@
 #include <LibGUI/Window.h>
 #include <LibGfx/BitmapFont.h>
 #include <LibGfx/Palette.h>
+#include <LibGfx/TextDirection.h>
 #include <stdlib.h>
 
 static constexpr int s_pangram_count = 7;
@@ -130,18 +132,21 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
     auto update_statusbar = [&] {
         auto glyph = m_glyph_map_widget->selected_glyph();
         StringBuilder builder;
-        builder.appendff("{:#02x} (", glyph);
-        if (glyph < 128) {
-            if (glyph == 10)
-                builder.append("LF");
-            else
-                builder.append(glyph);
+        builder.appendff("U+{:04X} (", glyph);
+
+        if (AK::UnicodeUtils::is_unicode_control_code_point(glyph)) {
+            builder.append(AK::UnicodeUtils::get_unicode_control_code_point_alias(glyph).value());
+        } else if (Gfx::get_char_bidi_class(glyph) == Gfx::BidirectionalClass::STRONG_RTL) {
+            // FIXME: This is a necessary hack, as RTL text will mess up the painting of the statusbar text.
+            // For now, replace RTL glyphs with U+FFFD, the replacement character.
+            builder.append_code_point(0xFFFD);
         } else {
-            builder.append(128 | 64 | (glyph / 64));
-            builder.append(128 | (glyph % 64));
+            builder.append_code_point(glyph);
         }
-        builder.append(") ");
-        builder.appendff("[{}x{}]", m_edited_font->raw_glyph_width(glyph), m_edited_font->glyph_height());
+
+        builder.append(")");
+        if (m_edited_font->raw_glyph_width(glyph) > 0)
+            builder.appendff(" [{}x{}]", m_edited_font->raw_glyph_width(glyph), m_edited_font->glyph_height());
         statusbar.set_text(builder.to_string());
     };
 

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -47,6 +47,7 @@
                     @GUI::Button {
                         name: "move_glyph_button"
                         fixed_width: 22
+                        tooltip: "Move Glyph"
                         button_style: "Coolbar"
                     }
                 }


### PR DESCRIPTION
This patch consists of two parts:

### Tooltip
I added a tooltip to the "Move Glyph" button in FontEditor to indicate it's functionality. When I first encountered it, I had no idea what it does, and I couldn't figure it out without checking in the code.

### Statusbar
I updated the statusbar text generation:
* Use the canonical U+0000 instead of a two-byte 0x00 representation of Unicode codepoints.
* For control characters such as NUL, BEL or LF, display their alias (as specified by the Unicode consortium) instead of plain whitespace. For this, I added the `AK/UnicodeUtils.h/.cpp` files, which are similar to `AK/StringUtils`, but intended to keep Unicode-specific logic out of `StringUtils`. I imagine that functions like `get_codepoint_length_in_bytes(u32)U` could be included there, which are surely needed at some point.
* Substitute RTL codepoints with � (U+FFFD replacement character) for now, because the painting breaks for bidirectional text (see issue #7286).
* Only show a glyph's dimensions if it actually exists in the font that is edited.

This fixes #7286.

In my eyes, `UnicodeUtils` will at some point be included by `AK/Utf8View` and/or `AK/Utf32View`, which makes it necessary for it to be in AK, rather than something like LibTextCodec.