### PR TITLE
HexEditor: find_and_highlight: Limit search to remaining buffer size

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -563,7 +563,7 @@ int HexEditor::find_and_highlight(ByteBuffer& needle, int start)
     if (m_buffer.is_empty())
         return -1;
 
-    auto raw_offset = memmem(m_buffer.data() + start, m_buffer.size(), needle.data(), needle.size());
+    auto raw_offset = memmem(m_buffer.data() + start, m_buffer.size() - start, needle.data(), needle.size());
     if (raw_offset == NULL)
         return -1;
 


### PR DESCRIPTION
Otherwise `HexEditor` crashes once we reach end of file.
