### PR TITLE
Kernel: Stop allocating the PS2KeyboardDevice in the eternal heap

### DIFF
--- a/Kernel/Devices/HID/PS2KeyboardDevice.h
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.h
@@ -21,7 +21,6 @@ namespace Kernel {
 class PS2KeyboardDevice final : public IRQHandler
     , public KeyboardDevice
     , public I8042Device {
-    AK_MAKE_ETERNAL
 public:
     static RefPtr<PS2KeyboardDevice> try_to_initialize(const I8042Controller&);
     virtual ~PS2KeyboardDevice() override;


### PR DESCRIPTION
The PS2KeyboardDevice can be free'd in try_to_initialize if the initialization failed, resulting in an assertion.