### PR TITLE
LibWeb+Browser+TextEditor: Basic HTML syntax highlighting

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -25,6 +25,7 @@
 #include <LibGUI/ToolbarContainer.h>
 #include <LibGUI/Window.h>
 #include <LibJS/Interpreter.h>
+#include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>
 #include <LibWeb/InProcessWebView.h>
 #include <LibWeb/Layout/BlockBox.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
@@ -69,6 +70,7 @@ void Tab::view_source(const URL& url, const String& source)
     auto& editor = window->set_main_widget<GUI::TextEditor>();
     editor.set_text(source);
     editor.set_mode(GUI::TextEditor::ReadOnly);
+    editor.set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
     editor.set_ruler_visible(true);
     window->resize(640, 480);
     window->set_title(url.to_string());

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -39,6 +39,7 @@
 #include <LibJS/SyntaxHighlighter.h>
 #include <LibMarkdown/Document.h>
 #include <LibSQL/SyntaxHighlighter.h>
+#include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>
 #include <LibWeb/OutOfProcessWebView.h>
 #include <Shell/SyntaxHighlighter.h>
 
@@ -547,6 +548,13 @@ void MainWidget::initialize_menubar(GUI::Menubar& menubar)
     syntax_actions.add_action(*m_js_highlight);
     syntax_menu.add_action(*m_js_highlight);
 
+    m_html_highlight = GUI::Action::create_checkable("&HTML File", [&](auto&) {
+        m_editor->set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
+        m_editor->update();
+    });
+    syntax_actions.add_action(*m_html_highlight);
+    syntax_menu.add_action(*m_html_highlight);
+
     m_gml_highlight = GUI::Action::create_checkable("&GML", [&](auto&) {
         m_editor->set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());
         m_editor->update();
@@ -598,6 +606,8 @@ void MainWidget::set_path(const LexicalPath& lexical_path)
         m_ini_highlight->activate();
     } else if (m_extension == "sql") {
         m_sql_highlight->activate();
+    } else if (m_extension == "html") {
+        m_html_highlight->activate();
     } else {
         m_plain_text_highlight->activate();
     }

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -111,6 +111,7 @@ private:
     RefPtr<GUI::Action> m_plain_text_highlight;
     RefPtr<GUI::Action> m_cpp_highlight;
     RefPtr<GUI::Action> m_js_highlight;
+    RefPtr<GUI::Action> m_html_highlight;
     RefPtr<GUI::Action> m_gml_highlight;
     RefPtr<GUI::Action> m_ini_highlight;
     RefPtr<GUI::Action> m_shell_highlight;

--- a/Userland/Libraries/LibSyntax/Highlighter.h
+++ b/Userland/Libraries/LibSyntax/Highlighter.h
@@ -15,13 +15,14 @@
 namespace Syntax {
 
 enum class Language {
-    PlainText,
     Cpp,
-    JavaScript,
-    INI,
     GML,
-    Shell,
+    HTML,
+    INI,
+    JavaScript,
+    PlainText,
     SQL,
+    Shell,
 };
 
 struct TextStyle {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -153,6 +153,7 @@ set(SOURCES
     HTML/Parser/ListOfActiveFormattingElements.cpp
     HTML/Parser/StackOfOpenElements.cpp
     HTML/SubmitEvent.cpp
+    HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
     HTML/TagNames.cpp
     HTML/WebSocket.cpp
     HighResolutionTime/Performance.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(SOURCES
     Bindings/CSSStyleDeclarationWrapperCustom.cpp
     Bindings/EventListenerWrapper.cpp
-    Bindings/EventWrapperFactory.cpp
     Bindings/EventTargetWrapperFactory.cpp
+    Bindings/EventWrapperFactory.cpp
     Bindings/HTMLCollectionWrapperCustom.cpp
     Bindings/ImageConstructor.cpp
     Bindings/LocationObject.cpp
@@ -12,7 +12,6 @@ set(SOURCES
     Bindings/ScriptExecutionContext.cpp
     Bindings/WindowObject.cpp
     Bindings/Wrappable.cpp
-    Cookie/ParsedCookie.cpp
     CSS/CSSImportRule.cpp
     CSS/CSSRule.cpp
     CSS/CSSStyleDeclaration.cpp
@@ -39,25 +38,26 @@ set(SOURCES
     CSS/StyleValue.cpp
     CSS/ValueID.cpp
     CSS/ValueID.h
+    Cookie/ParsedCookie.cpp
     DOM/CharacterData.cpp
     DOM/CharacterData.idl
     DOM/Comment.cpp
+    DOM/DOMImplementation.cpp
     DOM/Document.cpp
     DOM/DocumentFragment.cpp
     DOM/DocumentType.cpp
-    DOM/DOMImplementation.cpp
     DOM/Element.cpp
     DOM/ElementFactory.cpp
     DOM/Event.cpp
-    DOM/HTMLCollection.cpp
-    DOM/Range.cpp
     DOM/EventDispatcher.cpp
     DOM/EventListener.cpp
     DOM/EventTarget.cpp
+    DOM/HTMLCollection.cpp
     DOM/Node.cpp
     DOM/ParentNode.cpp
     DOM/Position.cpp
     DOM/ProcessingInstruction.cpp
+    DOM/Range.cpp
     DOM/ShadowRoot.cpp
     DOM/Text.cpp
     DOM/Text.idl
@@ -193,8 +193,8 @@ set(SOURCES
     Layout/TextNode.cpp
     Layout/TreeBuilder.cpp
     LayoutTreeModel.cpp
-    Loader/ContentFilter.cpp
     Loader/CSSLoader.cpp
+    Loader/ContentFilter.cpp
     Loader/FrameLoader.cpp
     Loader/ImageLoader.cpp
     Loader/ImageResource.cpp
@@ -204,8 +204,8 @@ set(SOURCES
     Namespace.cpp
     NavigationTiming/PerformanceTiming.cpp
     OutOfProcessWebView.cpp
-    Page/EventHandler.cpp
     Page/EditEventHandler.cpp
+    Page/EventHandler.cpp
     Page/Frame.cpp
     Page/Page.cpp
     Painting/BorderPainting.cpp
@@ -220,9 +220,9 @@ set(SOURCES
     UIEvents/EventNames.cpp
     UIEvents/MouseEvent.cpp
     URLEncoder.cpp
+    WebContentClient.cpp
     XHR/EventNames.cpp
     XHR/XMLHttpRequest.cpp
-    WebContentClient.cpp
 )
 
 set(GENERATED_SOURCES

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -57,6 +57,10 @@ String HTMLToken::to_string() const
         builder.append("' }");
     }
 
+    builder.appendff("@{}:{}-{}:{}",
+        m_start_position.line, m_start_position.column,
+        m_end_position.line, m_end_position.column);
+
     return builder.to_string();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -164,12 +164,30 @@ public:
 
     String to_string() const;
 
+    const auto& start_position() const { return m_start_position; }
+    const auto& end_position() const { return m_end_position; }
+
+    const auto& attributes() const
+    {
+        VERIFY(is_start_tag() || is_end_tag());
+        return m_tag.attributes;
+    }
+
 private:
+    struct Position {
+        size_t line { 0 };
+        size_t column { 0 };
+    };
+
     struct AttributeBuilder {
         StringBuilder prefix_builder;
         StringBuilder local_name_builder;
         StringBuilder namespace_builder;
         StringBuilder value_builder;
+        Position name_start_position;
+        Position value_start_position;
+        Position name_end_position;
+        Position value_end_position;
     };
 
     Type m_type { Type::Invalid };
@@ -201,6 +219,9 @@ private:
     struct {
         StringBuilder data;
     } m_comment_or_character;
+
+    Position m_start_position;
+    Position m_end_position;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -229,6 +229,11 @@ Optional<u32> HTMLTokenizer::peek_code_point(size_t offset) const
 
 Optional<HTMLToken> HTMLTokenizer::next_token()
 {
+    {
+        auto last_position = m_source_positions.last();
+        m_source_positions.clear();
+        m_source_positions.append(move(last_position));
+    }
 _StartOfFunction:
     if (!m_queued_tokens.is_empty())
         return m_queued_tokens.dequeue();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -117,6 +117,7 @@ public:
     String source() const { return m_decoded_input; }
 
 private:
+    void skip(size_t count);
     Optional<u32> next_code_point();
     Optional<u32> peek_code_point(size_t offset) const;
     bool consume_next_if_match(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive);
@@ -140,6 +141,9 @@ private:
     void will_reconsume_in(State);
 
     bool consumed_as_part_of_an_attribute() const;
+
+    void restore_to(const Utf8CodepointIterator& new_iterator);
+    auto& nth_last_position(size_t n = 0) { return m_source_positions.at(m_source_positions.size() - 1 - n); }
 
     State m_state { State::Data };
     State m_return_state { State::Data };
@@ -165,6 +169,8 @@ private:
     u32 m_character_reference_code { 0 };
 
     bool m_blocked { false };
+
+    Vector<HTMLToken::Position> m_source_positions;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -110,6 +110,10 @@ public:
     Optional<HTMLToken> next_token();
 
     void switch_to(Badge<HTMLDocumentParser>, State new_state);
+    void switch_to(State new_state)
+    {
+        m_state = new_state;
+    }
 
     void set_blocked(bool b) { m_blocked = b; }
     bool is_blocked() const { return m_blocked; }

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/Parser/HTMLTokenizer.h>
+#include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>
+
+namespace Web::HTML {
+
+enum class AugmentedTokenKind : u32 {
+    AttributeName,
+    AttributeValue,
+    OpenTag,
+    CloseTag,
+    Comment,
+    Doctype,
+};
+
+bool SyntaxHighlighter::is_identifier(void* token) const
+{
+    if (!token)
+        return false;
+    return false;
+}
+
+bool SyntaxHighlighter::is_navigatable(void*) const
+{
+    return false;
+}
+
+void SyntaxHighlighter::rehighlight(const Palette& palette)
+{
+    (void)palette;
+    auto text = m_client->get_text();
+
+    Vector<GUI::TextDocumentSpan> spans;
+    auto highlight = [&](auto start_line, auto start_column, auto end_line, auto end_column, Gfx::TextAttributes attributes, AugmentedTokenKind kind) {
+        spans.empend(
+            GUI::TextRange {
+                { start_line, start_column },
+                { end_line, end_column },
+            },
+            move(attributes),
+            (void*)kind,
+            false);
+    };
+
+    HTMLTokenizer tokenizer { text, "utf-8" };
+    [[maybe_unused]] enum class State {
+        HTML,
+        Javascript,
+        CSS,
+    } state { State::HTML };
+    for (;;) {
+        auto token = tokenizer.next_token();
+        if (!token.has_value())
+            break;
+
+        if (token->is_start_tag()) {
+            if (token->tag_name() == "script"sv) {
+                tokenizer.switch_to(HTMLTokenizer::State::ScriptData);
+                state = State::Javascript;
+            } else if (token->tag_name() == "style"sv) {
+                tokenizer.switch_to(HTMLTokenizer::State::RAWTEXT);
+                state = State::CSS;
+            }
+        } else if (token->is_end_tag()) {
+            if (token->tag_name().is_one_of("script"sv, "style"sv)) {
+                if (state == State::Javascript) {
+                    // FIXME: Highlight javascript code here instead.
+                } else if (state == State::CSS) {
+                    // FIXME: Highlight CSS code here instead.
+                }
+                state = State::HTML;
+            }
+        }
+
+        size_t token_start_offset = token->is_end_tag() ? 1 : 0;
+
+        if (token->is_comment()) {
+            highlight(
+                token->start_position().line,
+                token->start_position().column,
+                token->start_position().line,
+                token->start_position().column,
+                { palette.syntax_comment(), {} },
+                AugmentedTokenKind::Comment);
+        } else if (token->is_start_tag() || token->is_end_tag()) {
+            // FIXME: This breaks with single-character tag names.
+            highlight(
+                token->start_position().line,
+                token->start_position().column + token_start_offset,
+                token->start_position().line,
+                token->start_position().column + token->tag_name().length() + token_start_offset - 1,
+                { palette.syntax_keyword(), {} },
+                token->is_start_tag() ? AugmentedTokenKind::OpenTag : AugmentedTokenKind::CloseTag);
+
+            for (auto& attribute : token->attributes()) {
+                highlight(
+                    attribute.name_start_position.line,
+                    attribute.name_start_position.column + token_start_offset,
+                    attribute.name_end_position.line,
+                    attribute.name_end_position.column + token_start_offset,
+                    { palette.syntax_identifier(), {} },
+                    AugmentedTokenKind::AttributeName);
+                highlight(
+                    attribute.value_start_position.line,
+                    attribute.value_start_position.column + token_start_offset,
+                    attribute.value_end_position.line,
+                    attribute.value_end_position.column + token_start_offset,
+                    { palette.syntax_string(), {} },
+                    AugmentedTokenKind::AttributeValue);
+            }
+        } else if (token->is_doctype()) {
+            highlight(
+                token->start_position().line,
+                token->start_position().column,
+                token->start_position().line,
+                token->start_position().column,
+                { palette.syntax_preprocessor_statement(), {} },
+                AugmentedTokenKind::Doctype);
+        }
+    }
+
+    m_client->do_set_spans(move(spans));
+    m_has_brace_buddies = false;
+    highlight_matching_token_pair();
+    m_client->do_update();
+}
+
+Vector<Syntax::Highlighter::MatchingTokenPair> SyntaxHighlighter::matching_token_pairs() const
+{
+    static Vector<MatchingTokenPair> pairs;
+    if (pairs.is_empty()) {
+        pairs.append({ (void*)AugmentedTokenKind::OpenTag, (void*)AugmentedTokenKind::CloseTag });
+    }
+    return pairs;
+}
+
+bool SyntaxHighlighter::token_types_equal(void* token0, void* token1) const
+{
+    return token0 == token1;
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibSyntax/Highlighter.h>
+
+namespace Web::HTML {
+
+class SyntaxHighlighter : public Syntax::Highlighter {
+public:
+    SyntaxHighlighter() = default;
+    virtual ~SyntaxHighlighter() override = default;
+
+    virtual bool is_identifier(void*) const override;
+    virtual bool is_navigatable(void*) const override;
+
+    virtual Syntax::Language language() const override { return Syntax::Language::HTML; }
+    virtual void rehighlight(const Palette&) override;
+
+protected:
+    virtual Vector<MatchingTokenPair> matching_token_pairs() const override;
+    virtual bool token_types_equal(void*, void*) const override;
+
+    size_t m_line { 1 };
+    size_t m_column { 0 };
+};
+
+}


### PR DESCRIPTION
Notable issues (and why this isn't marked as fixing #7295):
- Single-character tag names are not highlighted (I couldn't figure out why)
- No JS/CSS highlighting
- a vector of positions is used to track positioning info, which is not cleared until a token is read, the size of this vector is technically unbounded.
- This makes the "switch state" method in the tokeniser public, I'm not sure what to do with that.
 
With that said, enjoy the basic highlighting:
![image_2021-05-20_23-19-13](https://user-images.githubusercontent.com/14001776/119032964-f2e73f00-b9c1-11eb-88c0-e3bc8542cc33.png)