### PR TITLE
Userland: Change typedef to using directive

### DIFF
--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -13,7 +13,7 @@
 #include <AK/SinglyLinkedList.h>
 #include <LibAudio/Buffer.h>
 
-typedef AK::SinglyLinkedListIterator<SinglyLinkedList<RollNote>, RollNote> RollIter;
+using RollIter = AK::SinglyLinkedListIterator<SinglyLinkedList<RollNote>, RollNote>;
 
 class Track {
     AK_MAKE_NONCOPYABLE(Track);

--- a/Userland/DevTools/HackStudio/Debugger/BreakpointCallback.h
+++ b/Userland/DevTools/HackStudio/Debugger/BreakpointCallback.h
@@ -17,6 +17,5 @@ enum class BreakpointChange {
     Removed,
 };
 
-typedef Function<void(const String& file, size_t line, BreakpointChange)> BreakpointChangeCallback;
-
+using BreakpointChangeCallback = Function<void(const String& file, size_t line, BreakpointChange)>;
 }

--- a/Userland/DevTools/HackStudio/Git/GitFilesView.h
+++ b/Userland/DevTools/HackStudio/Git/GitFilesView.h
@@ -13,7 +13,7 @@
 namespace HackStudio {
 
 // A "GitFileAction" is either the staging or the unstaging of a file.
-typedef Function<void(const LexicalPath& file)> GitFileActionCallback;
+using GitFileActionCallback = Function<void(const LexicalPath& file)>;
 
 class GitFilesView : public GUI::ListView {
     C_OBJECT(GitFilesView)

--- a/Userland/DevTools/HackStudio/Git/GitWidget.h
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.h
@@ -14,7 +14,7 @@
 
 namespace HackStudio {
 
-typedef Function<void(const String& original_content, const String& diff)> ViewDiffCallback;
+using ViewDiffCallback = Function<void(const String& original_content, const String& diff)>;
 
 class GitWidget final : public GUI::Widget {
     C_OBJECT(GitWidget)

--- a/Userland/DevTools/StateMachineGenerator/main.cpp
+++ b/Userland/DevTools/StateMachineGenerator/main.cpp
@@ -332,7 +332,7 @@ public:
     generator.append(R"~~~(
     }; // end Action
 
-    typedef Function<void(Action, u8)> Handler;
+    using Handler = Function<void(Action, u8)>;
 
     @class_name@(Handler handler)
     : m_handler(move(handler))

--- a/Userland/Utilities/ntpquery.cpp
+++ b/Userland/Utilities/ntpquery.cpp
@@ -25,7 +25,7 @@
 // An NtpTimestamp is a 64-bit integer that's a 32.32 binary-fixed point number.
 // The integral part in the upper 32 bits represents seconds since 1900-01-01.
 // The fractional part in the lower 32 bits stores fractional bits times 2 ** 32.
-typedef uint64_t NtpTimestamp;
+using NtpTimestamp = uint64_t;
 
 struct [[gnu::packed]] NtpPacket {
     uint8_t li_vn_mode;


### PR DESCRIPTION
Problem:
- `typedef`s are read backwards making it confusing.
- `using` statements can be used in template aliases.
- `using` provides similarity to most other C++ syntax.

- C++ core guidelines say to prefer `using` over `typedef`:
  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rt-using

Solution:
- Switch these where appropriate.