### PR TITLE
Toolchain: Enable native host optimizations when building toolchain

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -31,8 +31,8 @@ SYSTEM_NAME="$(uname -s)"
 # We *most definitely* don't need debug symbols in the linker/compiler.
 # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 120 MiB.
 # Hence, this might actually cause marginal speedups, although the point is to not waste space as blatantly.
-export CFLAGS="-g0 -O2"
-export CXXFLAGS="-g0 -O2"
+export CFLAGS="-g0 -O2 -march=native"
+export CXXFLAGS="-g0 -O2 -march=native"
 
 if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     MAKE=gmake


### PR DESCRIPTION
-march=native specializes the binaries for the CPU features available on
the CPU the binary is being compiled on. This matches the needs of the
Toolchain, as it's always built and used on that machine only.

This should be safe for the github actions VMs as well, as they all run
on a standard VM SKU in "the cloud".

I saw small but notable improvements in end-2-end build times in my
local testing. Each compilation unit is on average around a second
faster on my Intel(R) Core(TM) i7-8705G CPU @ 3.10GHz.