### PR TITLE
Meta: Add GDB pretty printers for AK::SinglyLinkedList / AK::InlineLinkedList 

### DIFF
--- a/Meta/serenity_gdb.py
+++ b/Meta/serenity_gdb.py
@@ -159,6 +159,24 @@ class AKHashMapPrettyPrinter:
         return elements
 
 
+class AKSinglyLinkedList:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return self.val.type.name
+
+    def children(self):
+        elements = []
+
+        node = self.val["m_head"]
+        while node != 0:
+            elements.append(node["value"])
+            node = node["next"]
+
+        return [(f"[{i}]", elements[i]) for i in range(len(elements))]
+
+
 class AKInlineLinkedList:
     def __init__(self, val):
         self.val = val
@@ -218,6 +236,8 @@ class SerenityPrettyPrinterLocator(gdb.printing.PrettyPrinter):
             return AKOwnPtr(val)
         elif klass == 'AK::NonnullRefPtr':
             return AKRefPtr(val)
+        elif klass == 'AK::SinglyLinkedList':
+            return AKSinglyLinkedList(val)
         elif klass == 'AK::String':
             return AKString(val)
         elif klass == 'AK::StringView':

--- a/Meta/serenity_gdb.py
+++ b/Meta/serenity_gdb.py
@@ -159,6 +159,25 @@ class AKHashMapPrettyPrinter:
         return elements
 
 
+class AKInlineLinkedList:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return self.val.type.name
+
+    def children(self):
+        node_type_ptr = self.val.type.template_argument(0).pointer()
+
+        elements = []
+        node = self.val["m_head"]
+        while node != 0:
+            elements.append(node.cast(node_type_ptr))
+            node = node["m_next"]
+
+        return [(f"[{i}]", elements[i].dereference()) for i in range(len(elements))]
+
+
 class VirtualAddress:
     def __init__(self, val):
         self.val = val
@@ -187,6 +206,8 @@ class SerenityPrettyPrinterLocator(gdb.printing.PrettyPrinter):
             return AKAtomic(val)
         elif klass == 'AK::DistinctNumeric':
             return AKDistinctNumeric(val)
+        elif klass == 'AK::InlineLinkedList':
+            return AKInlineLinkedList(val)
         elif klass == 'AK::HashMap':
             return AKHashMapPrettyPrinter(val)
         elif klass == 'AK::RefCounted':


### PR DESCRIPTION

 -  __Meta: Add GDB pretty printer for AK::InlineLinkedList__

    This allows a developer to easily dump a InlineLinkedList in the
    debugger without having to manually running the list.
    I needed this for a recent bug investigation in the Kernel.

-  __Meta: Add GDB pretty printer for AK::SinglyLinkedList__