### PR TITLE
Revert "Kernel: Avoid allocating under spinlock in ProcessGroup::find_or_create"

### DIFF
--- a/Kernel/ProcessGroup.cpp
+++ b/Kernel/ProcessGroup.cpp
@@ -30,31 +30,18 @@ RefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)
 
 RefPtr<ProcessGroup> ProcessGroup::find_or_create(ProcessGroupID pgid)
 {
-    // Avoid allocating under spinlock, this compromises by wasting the
-    // allocation when we race with another process to see if they have
-    // already created a process group.
-    auto process_group = adopt_ref_if_nonnull(new ProcessGroup(pgid));
     ScopedSpinLock lock(g_process_groups_lock);
 
-    if (auto existing = from_pgid_nolock(pgid))
+    if (auto existing = from_pgid(pgid))
         return existing.release_nonnull();
 
-    if (!process_group)
-        return {};
-
-    g_process_groups->prepend(process_group);
-    return process_group;
+    return create(pgid);
 }
 
 RefPtr<ProcessGroup> ProcessGroup::from_pgid(ProcessGroupID pgid)
 {
     ScopedSpinLock lock(g_process_groups_lock);
-    return from_pgid_nolock(pgid);
-}
 
-RefPtr<ProcessGroup> ProcessGroup::from_pgid_nolock(ProcessGroupID pgid)
-{
-    VERIFY(g_process_groups_lock.own_lock());
     for (auto& group : *g_process_groups) {
         if (group.pgid() == pgid)
             return &group;

--- a/Kernel/ProcessGroup.cpp
+++ b/Kernel/ProcessGroup.cpp
@@ -14,9 +14,7 @@ InlineLinkedList<ProcessGroup>* g_process_groups;
 ProcessGroup::~ProcessGroup()
 {
     ScopedSpinLock lock(g_process_groups_lock);
-    if (m_next || m_prev) {
-        g_process_groups->remove(this);
-    }
+    g_process_groups->remove(this);
 }
 
 RefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)

--- a/Kernel/ProcessGroup.h
+++ b/Kernel/ProcessGroup.h
@@ -40,8 +40,6 @@ private:
     {
     }
 
-    static RefPtr<ProcessGroup> from_pgid_nolock(ProcessGroupID);
-
     ProcessGroup* m_prev { nullptr };
     ProcessGroup* m_next { nullptr };
 


### PR DESCRIPTION
This reverts commit e95eb7a and bbe315d. 

This is causing some sort of list corruption, as evident by #7313
I haven't been able to figure it out yet, so lets revert this change
until I can figure out what's going on.