### PR TITLE
Shell: Make sure all tests put their temp dirs in /tmp

### DIFF
--- a/Userland/Shell/Tests/builtin-redir.sh
+++ b/Userland/Shell/Tests/builtin-redir.sh
@@ -2,9 +2,9 @@
 
 source $(dirname "$0")/test-commons.inc
 
-rm -rf shell-test
-mkdir -p shell-test
-cd shell-test
+rm -rf /tmp/shell-test 2> /dev/null
+mkdir -p /tmp/shell-test
+pushd /tmp/shell-test
 
     time sleep 1 2>timeerr >timeout
     cat timeout
@@ -15,7 +15,7 @@ cd shell-test
     time ls 2> /dev/null | head > timeout
     if not test -n "$(cat timeout)" { fail "'time' stdout not piped correctly" }
 
-cd ..
-rm -rf shell-test # TODO: Remove this file at the end once we have `trap'
+popd
+rm -rf /tmp/shell-test # TODO (#7339): Remove this file at the end once we have `trap'
 
 echo PASS

--- a/Userland/Shell/Tests/control-structure-as-command.sh
+++ b/Userland/Shell/Tests/control-structure-as-command.sh
@@ -4,9 +4,9 @@ source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 
-rm -rf shell-test 2> /dev/null
-mkdir shell-test
-cd shell-test
+rm -rf /tmp/shell-test 2> /dev/null
+mkdir -p /tmp/shell-test
+pushd /tmp/shell-test
 
     touch a b c
 
@@ -38,7 +38,7 @@ cd shell-test
     if not test "$(cat listing)" = "TRUE!" { fail if cannot be correctly redirected from }
     rm listing
 
-cd ..
-rm -rf shell-test
+popd
+rm -rf /tmp/shell-test
 
 echo PASS

--- a/Userland/Shell/Tests/subshell.sh
+++ b/Userland/Shell/Tests/subshell.sh
@@ -4,9 +4,9 @@ source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 
-rm -rf shell-test
-mkdir shell-test
-cd shell-test
+rm -rf /tmp/shell-test 2> /dev/null
+mkdir -p /tmp/shell-test
+pushd /tmp/shell-test
 
     # Simple sequence (grouping)
     { echo test > testfile }
@@ -33,7 +33,7 @@ cd shell-test
         fail exits with $exitcode when it should exit with 0
     }
 
-cd ..
-rm -rf shell-test
+popd
+rm -rf /tmp/shell-test
 
 echo PASS

--- a/Userland/Shell/Tests/valid.sh
+++ b/Userland/Shell/Tests/valid.sh
@@ -65,6 +65,7 @@ word_count=(() | wc -w)
 if not test "$(echo well hello friends $word_count)" -eq 3  { fail variable containing pipeline }
 
 # Globs
+rm -fr /tmp/sh-test 2> /dev/null
 mkdir -p /tmp/sh-test
 pushd /tmp/sh-test
     touch (a b c)(d e f)


### PR DESCRIPTION
Follow-on to #7337. Been seeing other CI test failures that point to
these temp directories, so let's just move all of them to /tmp. I'm sure
someone will write ext2fs stress tests later :^)

Example:

/usr/Tests/Shell/control-structure-as-command.sh
  Core::Socket: Failed to connect() to /tmp/portal/inspectables: ...
  + rm -rf shell-test 2>/dev/null
  + mkdir shell-test
  Error: The action has timed out.