### PR TITLE
Toolchain+CI: Disable the march=native gcc flag for CI Toolchain builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,7 +78,7 @@ jobs:
         # However, we want to avoid false cache hits at all costs.
         key: ${{ runner.os }}-toolchain-i686-${{ steps.stamps.outputs.libc_headers }}
     - name: Restore or regenerate Toolchain
-      run: TRY_USE_LOCAL_TOOLCHAIN=y ${{ github.workspace }}/Toolchain/BuildIt.sh
+      run: TRY_USE_LOCAL_TOOLCHAIN=y DISABLE_PROCESSOR_SPECIFIC_INSTRUCTIONS=y ${{ github.workspace }}/Toolchain/BuildIt.sh
     - name: ccache(1) cache
       # Pull the ccache *after* building the toolchain, in case building the Toolchain somehow interferes.
       uses: actions/cache@v2

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -31,8 +31,16 @@ SYSTEM_NAME="$(uname -s)"
 # We *most definitely* don't need debug symbols in the linker/compiler.
 # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 120 MiB.
 # Hence, this might actually cause marginal speedups, although the point is to not waste space as blatantly.
-export CFLAGS="-g0 -O2 -march=native"
-export CXXFLAGS="-g0 -O2 -march=native"
+export CFLAGS="-g0 -O2"
+export CXXFLAGS="-g0 -O2"
+
+if [ "${DISABLE_PROCESSOR_SPECIFIC_INSTRUCTIONS}" = "y" ] ; then
+    export CFLAGS="$CFLAGS -mtune=native"
+    export CXXFLAGS="$CXXFLAGS -mtune=native"
+else
+    export CFLAGS="$CFLAGS -march=native"
+    export CXXFLAGS="$CXXFLAGS -march=native"
+fi
 
 if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     MAKE=gmake


### PR DESCRIPTION
Since some GitHub actions runners support AVX-512, and some dont, the toolchain cache can get "polluted" by an AVX-512 build, resulting in the non AVX-512 supporting runners failing.