### PR TITLE
CI: Fail the build if tests fail

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -152,7 +152,18 @@ jobs:
         echo "::group::ninja run # Qemu output"
         ninja run
         echo "::endgroup::"
-      timeout-minutes: 20
+        echo "::group::Verify Output File"
+        mkdir fsmount
+        sudo mount -t ext2 -o loop,rw _disk_image fsmount
+        echo "Results: "
+        sudo cat fsmount/home/anon/test-results.log
+        if ! sudo grep -q "Failed: 0" fsmount/home/anon/test-results.log
+        then
+          echo "::error :^( Tests failed, failing job"
+          exit 1
+        fi
+        echo "::endgroup::"
+      timeout-minutes: 30
 
     - name: Print Target Logs
       # Extremely useful if Serenity hangs trying to run one of the tests

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,10 +35,14 @@ jobs:
     - name: "Install Ubuntu dependencies"
       # These packages are already part of the ubuntu-20.04 image:
       # cmake gcc-10 g++-10 shellcheck libgmp-dev
-      # These aren't:
+      # Packages below aren't.
+      #
+      # We add the canonical-server/server-backports PPA to get updated QEMU releases without having to manage
+      #    yet another cache in github actions
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+        sudo add-apt-repository ppa:canonical-server/server-backports
         sudo apt-get update
         sudo apt-get install clang-format-11 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm e2fsprogs qemu-utils qemu-system-i386 ccache
     - name: Use GCC 10 instead
@@ -52,7 +56,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 requests
     - name: Check versions
-      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version
+      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version; qemu-system-i386 --version
 
     # === PREPARE FOR BUILDING ===
 

--- a/Base/home/anon/tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/tests/run-tests-and-shutdown.sh
@@ -47,6 +47,8 @@ if test $fail_count -gt 0 {
     echo "==== Failing tests: $failed_tests ===="
 }
 
+echo "Failed: $fail_count" > ./test-results.log
+
 if test $DO_SHUTDOWN_AFTER_TESTS {
     shutdown -n
 }


### PR DESCRIPTION
Two steps:

1) Enable ppa:canonical-server/server-backports to get QEMU 5.2.x in the github actions runners.
   - An alternative to using this "not production ready" PPA would be to build and cache the output of Toolchain/BuildQemu.sh, but it doesn't look like any features of Qemu 6.x.x are strictly required?
   
Using Qemu 5 fixes the mis-emulation of FPU instructions that were causing test-js and test-math to fail 🥳 

2) Crack open the disk image and extract some test results from it after the build
   - Also increasethe timeout on the test run step to 30 minutes, just to be safe from weaker runners