### PR TITLE
DevTools: Remove redundant default destructor and forward declarations

### DIFF
--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -16,10 +16,6 @@ Project::Project(const String& root_path)
     m_model = GUI::FileSystemModel::create(root_path, GUI::FileSystemModel::Mode::FilesAndDirectories);
 }
 
-Project::~Project()
-{
-}
-
 OwnPtr<Project> Project::open_with_root_path(const String& root_path)
 {
     if (!Core::File::is_directory(root_path))

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -19,8 +19,6 @@ class Project {
     AK_MAKE_NONMOVABLE(Project);
 
 public:
-    ~Project();
-
     static OwnPtr<Project> open_with_root_path(const String& root_path);
 
     GUI::FileSystemModel& model() { return *m_model; }

--- a/Userland/DevTools/Inspector/InspectorServerClient.h
+++ b/Userland/DevTools/Inspector/InspectorServerClient.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <InspectorServer/InspectorClientEndpoint.h>
+#include <InspectorServer/InspectorServerEndpoint.h>
+#include <LibIPC/ServerConnection.h>
+
+namespace Inspector {
+
+class InspectorServerClient final
+    : public IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>
+    , public InspectorClientEndpoint {
+    C_OBJECT(InspectorServerClient);
+
+public:
+    virtual void handshake() override
+    {
+        greet();
+    }
+
+    virtual ~InspectorServerClient() override = default;
+
+private:
+    InspectorServerClient()
+        : IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>(*this, "/tmp/portal/inspector")
+    {
+        handshake();
+    }
+
+    virtual void dummy() override { }
+};
+
+}

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -8,36 +8,10 @@
 #include "RemoteObject.h"
 #include "RemoteObjectGraphModel.h"
 #include "RemoteObjectPropertyModel.h"
-#include <InspectorServer/InspectorClientEndpoint.h>
-#include <InspectorServer/InspectorServerEndpoint.h>
-#include <LibIPC/ServerConnection.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 namespace Inspector {
-
-class InspectorServerClient final
-    : public IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>
-    , public InspectorClientEndpoint {
-    C_OBJECT(InspectorServerClient);
-
-public:
-    virtual void handshake() override
-    {
-        greet();
-    }
-
-    virtual ~InspectorServerClient() override { }
-
-private:
-    InspectorServerClient()
-        : IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>(*this, "/tmp/portal/inspector")
-    {
-        handshake();
-    }
-
-    virtual void dummy() override { }
-};
 
 RemoteProcess* s_the;
 
@@ -52,10 +26,6 @@ RemoteProcess::RemoteProcess(pid_t pid)
 {
     s_the = this;
     m_client = InspectorServerClient::construct();
-}
-
-RemoteProcess::~RemoteProcess()
-{
 }
 
 void RemoteProcess::handle_identify_response(const JsonObject& response)

--- a/Userland/DevTools/Inspector/RemoteProcess.h
+++ b/Userland/DevTools/Inspector/RemoteProcess.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
+#include "InspectorServerClient.h"
 #include <AK/NonnullOwnPtrVector.h>
 #include <LibCore/LocalSocket.h>
 
 namespace Inspector {
 
-class InspectorServerClient;
 class RemoteObjectGraphModel;
 class RemoteObject;
 
@@ -20,7 +20,6 @@ public:
     static RemoteProcess& the();
 
     explicit RemoteProcess(pid_t);
-    ~RemoteProcess();
     void update();
 
     pid_t pid() const { return m_pid; }

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -47,10 +47,6 @@ Profile::Profile(Vector<Process> processes, Vector<Event> events)
     rebuild_tree();
 }
 
-Profile::~Profile()
-{
-}
-
 GUI::Model& Profile::model()
 {
     return *m_model;

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -6,7 +6,11 @@
 
 #pragma once
 
+#include "DisassemblyModel.h"
 #include "Process.h"
+#include "Profile.h"
+#include "ProfileModel.h"
+#include "SamplesModel.h"
 #include <AK/Bitmap.h>
 #include <AK/FlyString.h>
 #include <AK/JsonArray.h>
@@ -21,11 +25,6 @@
 #include <LibGUI/ModelIndex.h>
 
 namespace Profiler {
-
-class DisassemblyModel;
-class Profile;
-class ProfileModel;
-class SamplesModel;
 
 class ProfileNode : public RefCounted<ProfileNode> {
 public:
@@ -130,7 +129,6 @@ struct ProcessFilter {
 class Profile {
 public:
     static Result<NonnullOwnPtr<Profile>, String> load_from_perfcore_file(const StringView& path);
-    ~Profile();
 
     GUI::Model& model();
     GUI::Model& samples_model();

--- a/Userland/DevTools/UserspaceEmulator/RangeAllocator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/RangeAllocator.cpp
@@ -26,10 +26,6 @@ void RangeAllocator::initialize_with_range(VirtualAddress base, size_t size)
     m_available_ranges.append({ base, size });
 }
 
-RangeAllocator::~RangeAllocator()
-{
-}
-
 void RangeAllocator::dump() const
 {
     dbgln("RangeAllocator({})", this);

--- a/Userland/DevTools/UserspaceEmulator/RangeAllocator.h
+++ b/Userland/DevTools/UserspaceEmulator/RangeAllocator.h
@@ -14,7 +14,6 @@ namespace UserspaceEmulator {
 class RangeAllocator {
 public:
     RangeAllocator();
-    ~RangeAllocator();
 
     void initialize_with_range(VirtualAddress, size_t);
 


### PR DESCRIPTION
Problem:
- Default destructors (and constructors) are in `.cpp` files. This
  prevents the compiler's optimizer from inlining them when it thinks
  inlining is appropriate (unless LTO is used).
- Forward declarations can prevent some optimizations, such as
  inlining of constructors and destructors.

Solution:
- Remove them or set them to `= default` and let the compiler handle
  the generation of them.
- Remove unneeded forward declarations.