### PR TITLE
Kernel: Ignore interfaces without an IP address when routing packages

### DIFF
--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -220,11 +220,13 @@ void NetworkAdapter::set_ipv4_gateway(const IPv4Address& gateway)
 
 void NetworkAdapter::set_interface_name(const StringView& basename)
 {
-    // FIXME: Find a unique name for this interface, starting with $basename.
-    StringBuilder builder;
-    builder.append(basename);
-    builder.append('0');
-    m_name = builder.to_string();
+    for (int i = 0; i < NumericLimits<int>::max(); i++) {
+        auto name = String::formatted("{}{}", basename, i);
+        if (!lookup_by_name(name)) {
+            m_name = name;
+            break;
+        }
+    }
 }
 
 }

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -152,7 +152,7 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
     RefPtr<NetworkAdapter> local_adapter = nullptr;
     RefPtr<NetworkAdapter> gateway_adapter = nullptr;
 
-    NetworkAdapter::for_each([source_addr, &target_addr, &local_adapter, &gateway_adapter, &matches](auto& adapter) {
+    NetworkAdapter::for_each([source_addr, &target_addr, &local_adapter, &gateway_adapter, &matches, &through](auto& adapter) {
         auto adapter_addr = adapter.ipv4_address().to_u32();
         auto adapter_mask = adapter.ipv4_netmask().to_u32();
 
@@ -160,6 +160,9 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
             local_adapter = LoopbackAdapter::the();
             return;
         }
+
+        if (!adapter.link_up() || (adapter_addr == 0 && !through))
+            return;
 
         if (source_addr != 0 && source_addr != adapter_addr)
             return;


### PR DESCRIPTION
**Kernel: Make sure network adapters have unique names**

Previously we'd just slap 0 onto the adapter's basename. This ensures we actually end up with unique names.

**Kernel: Ignore interfaces without an IP address when routing packages**

Let's not route packages through interfaces which don't have an address yet unless we're explicitly asked to (e.g. by `DHCPClient`).
