### PR TITLE
LibJS: Expose TypedArray.prototype.{BYTES_PER_ELEMENT,buffer,byteLength,byteOffset}

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -57,6 +57,7 @@ namespace JS {
     P(atan2)                                 \
     P(atanh)                                 \
     P(bind)                                  \
+    P(buffer)                                \
     P(byteLength)                            \
     P(call)                                  \
     P(callee)                                \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -59,6 +59,7 @@ namespace JS {
     P(bind)                                  \
     P(buffer)                                \
     P(byteLength)                            \
+    P(byteOffset)                            \
     P(call)                                  \
     P(callee)                                \
     P(cbrt)                                  \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -194,6 +194,8 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
     PrototypeName::PrototypeName(GlobalObject& global_object)                                                                          \
         : Object(*global_object.typed_array_prototype())                                                                               \
     {                                                                                                                                  \
+        auto& vm = this->vm();                                                                                                         \
+        define_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                                      \
     }                                                                                                                                  \
     PrototypeName::~PrototypeName() { }                                                                                                \
                                                                                                                                        \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -24,6 +24,11 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     // FIXME: This should be an accessor property
     define_native_property(vm.names.length, length_getter, nullptr, Attribute::Configurable);
     define_native_property(vm.names.buffer, buffer_getter, nullptr, Attribute::Configurable);
+<<<<<<< HEAD
+=======
+    define_native_property(vm.names.byteLength, byte_length_getter, nullptr, Attribute::Configurable);
+    define_native_property(vm.names.BYTES_PER_ELEMENT, bytes_per_element_getter, nullptr, 0); // FIXME: This should just be a normal property and not a getter.
+>>>>>>> 6be44bc62... LibJS: Expose TypedArray.prototype.byteLength
     define_native_function(vm.names.at, at, 1, attr);
 }
 
@@ -83,6 +88,18 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::buffer_getter)
     auto* array_buffer = typed_array->viewed_array_buffer();
     VERIFY(array_buffer);
     return Value(array_buffer);
+}
+
+// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_length_getter)
+{
+    auto typed_array = typed_array_from(vm, global_object);
+    if (!typed_array)
+        return {};
+    auto* array_buffer = typed_array->viewed_array_buffer();
+    VERIFY(array_buffer);
+    // FIXME: If array_buffer is detached, return 0.
+    return Value(typed_array->byte_length());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -23,6 +23,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
 
     // FIXME: This should be an accessor property
     define_native_property(vm.names.length, length_getter, nullptr, Attribute::Configurable);
+    define_native_property(vm.names.buffer, buffer_getter, nullptr, Attribute::Configurable);
     define_native_function(vm.names.at, at, 1, attr);
 }
 
@@ -71,6 +72,17 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::at)
     if (index.has_overflow() || index.value() >= length)
         return js_undefined();
     return typed_array->get(index.value());
+}
+
+// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::buffer_getter)
+{
+    auto typed_array = typed_array_from(vm, global_object);
+    if (!typed_array)
+        return {};
+    auto* array_buffer = typed_array->viewed_array_buffer();
+    VERIFY(array_buffer);
+    return Value(array_buffer);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -24,11 +24,8 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     // FIXME: This should be an accessor property
     define_native_property(vm.names.length, length_getter, nullptr, Attribute::Configurable);
     define_native_property(vm.names.buffer, buffer_getter, nullptr, Attribute::Configurable);
-<<<<<<< HEAD
-=======
     define_native_property(vm.names.byteLength, byte_length_getter, nullptr, Attribute::Configurable);
-    define_native_property(vm.names.BYTES_PER_ELEMENT, bytes_per_element_getter, nullptr, 0); // FIXME: This should just be a normal property and not a getter.
->>>>>>> 6be44bc62... LibJS: Expose TypedArray.prototype.byteLength
+    define_native_property(vm.names.byteOffset, byte_offset_getter, nullptr, Attribute::Configurable);
     define_native_function(vm.names.at, at, 1, attr);
 }
 
@@ -100,6 +97,18 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_length_getter)
     VERIFY(array_buffer);
     // FIXME: If array_buffer is detached, return 0.
     return Value(typed_array->byte_length());
+}
+
+// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_offset_getter)
+{
+    auto typed_array = typed_array_from(vm, global_object);
+    if (!typed_array)
+        return {};
+    auto* array_buffer = typed_array->viewed_array_buffer();
+    VERIFY(array_buffer);
+    // FIXME: If array_buffer is detached, return 0.
+    return Value(typed_array->byte_offset());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_GETTER(length_getter);
+    JS_DECLARE_NATIVE_GETTER(buffer_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(at);
 };

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -22,6 +22,7 @@ private:
     JS_DECLARE_NATIVE_GETTER(length_getter);
     JS_DECLARE_NATIVE_GETTER(buffer_getter);
     JS_DECLARE_NATIVE_GETTER(byte_length_getter);
+    JS_DECLARE_NATIVE_GETTER(byte_offset_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(at);
 };

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -21,6 +21,7 @@ public:
 private:
     JS_DECLARE_NATIVE_GETTER(length_getter);
     JS_DECLARE_NATIVE_GETTER(buffer_getter);
+    JS_DECLARE_NATIVE_GETTER(byte_length_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(at);
 };

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.BYTES_PER_ELEMENT.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.BYTES_PER_ELEMENT.js
@@ -1,0 +1,18 @@
+// Update when more typed arrays get added
+const TYPED_ARRAYS = [
+    { array: Uint8Array, expected: 1 },
+    { array: Uint16Array, expected: 2 },
+    { array: Uint32Array, expected: 4 },
+    { array: Int8Array, expected: 1 },
+    { array: Int16Array, expected: 2 },
+    { array: Int32Array, expected: 4 },
+    { array: Float32Array, expected: 4 },
+    { array: Float64Array, expected: 8 },
+];
+
+test("basic functionality", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T.array();
+        expect(typedArray.BYTES_PER_ELEMENT).toBe(T.expected);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.buffer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.buffer.js
@@ -1,0 +1,31 @@
+// Update when more typed arrays get added
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+test("basic functionality", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T([1, 2, 3]);
+        expect(Object.hasOwn(typedArray, "byteOffset")).toBeFalse();
+
+        const buffer = typedArray.buffer;
+        expect(buffer).toBeInstanceOf(ArrayBuffer);
+        expect(buffer.byteLength).toBe(typedArray.byteLength);
+        expect(buffer.byteLength).toBe(typedArray.length * typedArray.BYTES_PER_ELEMENT);
+
+        const arrayFromBuffer = new T(buffer);
+        expect(arrayFromBuffer.length).toBe(typedArray.length);
+        expect(arrayFromBuffer.byteLength).toBe(typedArray.byteLength);
+        expect(arrayFromBuffer.byteOffset).toBe(typedArray.byteOffset);
+        expect(arrayFromBuffer[0]).toBe(typedArray[0]);
+        expect(arrayFromBuffer[1]).toBe(typedArray[1]);
+        expect(arrayFromBuffer[2]).toBe(typedArray[2]);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
@@ -1,0 +1,19 @@
+// Update when more typed arrays get added
+const TYPED_ARRAYS = [
+    { array: Uint8Array, expected: 3 },
+    { array: Uint16Array, expected: 6 },
+    { array: Uint32Array, expected: 12 },
+    { array: Int8Array, expected: 3 },
+    { array: Int16Array, expected: 6 },
+    { array: Int32Array, expected: 12 },
+    { array: Float32Array, expected: 12 },
+    { array: Float64Array, expected: 24 },
+];
+
+test("basic functionality", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T.array([1, 2, 3]);
+        expect(Object.hasOwn(typedArray, "byteOffset")).toBeFalse();
+        expect(typedArray.byteLength).toBe(T.expected);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteOffset.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteOffset.js
@@ -1,0 +1,28 @@
+// Update when more typed arrays get added
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+test("basic functionality", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T([1, 2, 3]);
+        expect(Object.hasOwn(typedArray, "byteOffset")).toBeFalse();
+        expect(typedArray.byteOffset).toBe(0);
+        expect(typedArray.length).toBe(3);
+
+        const buffer = typedArray.buffer;
+
+        const arrayFromOffset = new T(buffer, T.BYTES_PER_ELEMENT);
+        expect(arrayFromOffset.byteOffset).toBe(T.BYTES_PER_ELEMENT);
+        expect(arrayFromOffset.length).toBe(2);
+        expect(arrayFromOffset[0]).toBe(2);
+        expect(arrayFromOffset[1]).toBe(3);
+    });
+});


### PR DESCRIPTION
We already stored this information, but was not exposing them to JS code.