### PR TITLE
LibGfx: Circle fastpath for ellipses

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1965,6 +1965,13 @@ void Painter::draw_elliptical_arc(const IntPoint& p1, const IntPoint& p2, const 
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
 
+    // Circle fastpath
+    if (radii.x() == radii.y()) {
+        auto direction = theta_delta > 0 ? RotationDirection::Clockwise : RotationDirection::CounterClockwise;
+        draw_circle_arc(p1, p2, center, radii.x(), color, thickness, direction);
+        return;
+    }
+
     for_each_line_segment_on_elliptical_arc(FloatPoint(p1), FloatPoint(p2), FloatPoint(center), radii, x_axis_rotation, theta_1, theta_delta, [&](const FloatPoint& fp1, const FloatPoint& fp2) {
         draw_line(IntPoint(fp1.x(), fp1.y()), IntPoint(fp2.x(), fp2.y()), color, thickness, style);
     });

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -73,6 +73,12 @@ public:
     void draw_glyph_or_emoji(const IntPoint&, u32 code_point, const Font&, Color);
     void draw_circle_arc_intersecting(const IntRect&, const IntPoint&, int radius, Color, int thickness);
 
+    enum RotationDirection {
+        CounterClockwise,
+        Clockwise
+    };
+    void draw_circle_arc(const IntPoint&, const IntPoint&, const IntPoint& center, int radius, Color, int thickness, RotationDirection direction = RotationDirection::CounterClockwise);
+
     enum class CornerOrientation {
         TopLeft,
         TopRight,


### PR DESCRIPTION
This PR adds the ability to draw plain old circle arcs. Those are easier to understand and calculate than real ellipses.
This also adds a fastpath into the ellipse-drawing to draw circles with the new code.

This fixes #6984 