### PR TITLE
Kernel/Net: Make interfaces to have persistent names

### DIFF
--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -176,7 +176,7 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address address, 
     , m_rx_descriptors_region(MM.allocate_contiguous_kernel_region(page_round_up(sizeof(e1000_rx_desc) * number_of_rx_descriptors + 16), "E1000 RX", Region::Access::Read | Region::Access::Write))
     , m_tx_descriptors_region(MM.allocate_contiguous_kernel_region(page_round_up(sizeof(e1000_tx_desc) * number_of_tx_descriptors + 16), "E1000 TX", Region::Access::Read | Region::Access::Write))
 {
-    set_interface_name("e1k");
+    set_interface_name(address);
 
     dmesgln("E1000: Found @ {}", pci_address());
 

--- a/Kernel/Net/LoopbackAdapter.cpp
+++ b/Kernel/Net/LoopbackAdapter.cpp
@@ -18,7 +18,7 @@ LoopbackAdapter& LoopbackAdapter::the()
 
 LoopbackAdapter::LoopbackAdapter()
 {
-    set_interface_name("loop");
+    set_loopback_name();
     set_mtu(65536);
     set_mac_address({ 19, 85, 2, 9, 0x55, 0xaa });
 }

--- a/Kernel/Net/NE2000NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000NetworkAdapter.cpp
@@ -166,7 +166,7 @@ UNMAP_AFTER_INIT NE2000NetworkAdapter::NE2000NetworkAdapter(PCI::Address address
     : PCI::Device(address, irq)
     , m_io_base(PCI::get_BAR0(pci_address()) & ~3)
 {
-    set_interface_name("ne2k");
+    set_interface_name(address);
 
     dmesgln("NE2000: Found @ {}", pci_address());
 

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -218,15 +218,18 @@ void NetworkAdapter::set_ipv4_gateway(const IPv4Address& gateway)
     m_ipv4_gateway = gateway;
 }
 
-void NetworkAdapter::set_interface_name(const StringView& basename)
+void NetworkAdapter::set_interface_name(const PCI::Address& pci_address)
 {
-    for (int i = 0; i < NumericLimits<int>::max(); i++) {
-        auto name = String::formatted("{}{}", basename, i);
-        if (!lookup_by_name(name)) {
-            m_name = name;
-            break;
-        }
-    }
+    // Note: This stands for e - "Ethernet", p - "Port" as for PCI bus, "s" for slot as for PCI slot
+    auto name = String::formatted("ep{}s{}", pci_address.bus(), pci_address.device());
+    VERIFY(!lookup_by_name(name));
+    m_name = move(name);
 }
 
+void NetworkAdapter::set_loopback_name()
+{
+    auto name = String("loop");
+    VERIFY(!lookup_by_name(name));
+    m_name = move(name);
+}
 }

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -17,6 +17,7 @@
 #include <Kernel/Net/ARP.h>
 #include <Kernel/Net/ICMP.h>
 #include <Kernel/Net/IPv4.h>
+#include <Kernel/PCI/Definitions.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -73,10 +74,12 @@ public:
 
 protected:
     NetworkAdapter();
-    void set_interface_name(const StringView& basename);
+    void set_interface_name(const PCI::Address&);
     void set_mac_address(const MACAddress& mac_address) { m_mac_address = mac_address; }
     virtual void send_raw(ReadonlyBytes) = 0;
     void did_receive(ReadonlyBytes);
+
+    void set_loopback_name();
 
 private:
     static Lockable<HashTable<NetworkAdapter*>>& all_adapters();

--- a/Kernel/Net/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8139NetworkAdapter.cpp
@@ -125,7 +125,7 @@ UNMAP_AFTER_INIT RTL8139NetworkAdapter::RTL8139NetworkAdapter(PCI::Address addre
     , m_packet_buffer(MM.allocate_contiguous_kernel_region(page_round_up(PACKET_SIZE_MAX), "RTL8139 Packet buffer", Region::Access::Read | Region::Access::Write))
 {
     m_tx_buffers.ensure_capacity(RTL8139_TX_BUFFER_COUNT);
-    set_interface_name("rtl8139");
+    set_interface_name(address);
 
     dmesgln("RTL8139: Found @ {}", pci_address());
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -59,7 +59,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -device virtio-rng-pci
 -soundhw pcspk
 -device sb16
--device pci-bridge,chassis_nr=1,id=bridge1 -device megasas,bus=bridge1
+-device pci-bridge,chassis_nr=1,id=bridge1 -device e1000,bus=bridge1
 -device i82801b11-bridge,bus=bridge1,id=bridge2 -device sdhci-pci,bus=bridge2
 -device i82801b11-bridge,id=bridge3 -device sdhci-pci,bus=bridge3
 -device ich9-ahci,bus=bridge3


### PR DESCRIPTION
There's no good reason to distinguish between network interfaces based
on their model. It's probably a good idea to try keep the names more
persistent so scripts written for a specific network interface will be
useable after hotplug event (or after rebooting with new hardware
setup).