### PR TITLE
Bitmap: Don't call Bitmap::create with width/height equal to 0

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -427,7 +427,10 @@ RefPtr<Gfx::Bitmap> Bitmap::scaled(float sx, float sy) const
     if (floorf(sx) == sx && floorf(sy) == sy)
         return scaled(static_cast<int>(sx), static_cast<int>(sy));
 
-    auto new_bitmap = Gfx::Bitmap::create(format(), { width() * sx, height() * sy }, scale());
+    int scaled_width = (int)ceilf(sx * (float)width());
+    int scaled_height = (int)ceilf(sy * (float)height());
+
+    auto new_bitmap = Gfx::Bitmap::create(format(), { scaled_width, scaled_height }, scale());
     if (!new_bitmap)
         return nullptr;
 


### PR DESCRIPTION
With very small bitmaps and small scale factor, such as tile.png, the
type conversion in the call to Bitmap:create would cause width or
height to be 0, causing a mmap failure.

Fixes #7352

I'm a bit unsure if using ceil instead of rounding to nearest int (and checking for cases where it would result in 0) makes the scaling less accurate or if it's a negligible difference.