### PR TITLE
IntrusiveList: Remove redundant constructor

### DIFF
--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -46,7 +46,7 @@ private:
 template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
 class IntrusiveList {
 public:
-    IntrusiveList();
+    IntrusiveList() = default;
     ~IntrusiveList();
 
     void clear();
@@ -163,11 +163,6 @@ inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, 
     m_value = IntrusiveList<T, Container, member>::next(m_value);
     (old->*member).remove();
     return *this;
-}
-
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
-inline IntrusiveList<T, Container, member>::IntrusiveList()
-{
 }
 
 template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>


### PR DESCRIPTION
Problem:
- The constructor is defined to be the default constructor.

Solution:
- Let the compiler generate the constructor by setting it to the
  default.