### PR TITLE
AK: Use calculate_base64_encoded_length in encode_base64

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -96,7 +96,7 @@ ByteBuffer decode_base64(const StringView& input)
 String encode_base64(ReadonlyBytes input)
 {
     constexpr auto alphabet = make_alphabet();
-    StringBuilder output(calculate_base64_decoded_length(input));
+    StringBuilder output(calculate_base64_encoded_length(input));
 
     auto get = [&](const size_t offset, bool* need_padding = nullptr) -> u8 {
         if (offset >= input.size()) {


### PR DESCRIPTION
We were accidentally calling calculate_base64_decoded_length instead, which resulted in extra allocations during the StringBuilder::append calls that can be avoided.