### PR TITLE
AK: Fix Variant construction from lvalue references

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -278,14 +278,14 @@ public:
     }
 
     template<typename T>
-    [[gnu::noinline]] T& get()
+    T& get()
     {
         VERIFY(has<T>());
         return *bit_cast<T*>(&m_data);
     }
 
     template<typename T>
-    [[gnu::noinline]] const T* get_pointer() const
+    const T* get_pointer() const
     {
         if (index_of<T>() == m_index)
             return bit_cast<const T*>(&m_data);
@@ -293,7 +293,7 @@ public:
     }
 
     template<typename T>
-    [[gnu::noinline]] const T& get() const
+    const T& get() const
     {
         VERIFY(has<T>());
         return *bit_cast<const T*>(&m_data);

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -172,3 +172,44 @@ TEST_CASE(return_values_by_reference)
     EXPECT_EQ(ref->ref_count(), 1u);
     EXPECT_EQ(value->ref_count(), 1u);
 }
+
+struct HoldsInt {
+    int i;
+};
+struct HoldsFloat {
+    float f;
+};
+
+TEST_CASE(copy_assign)
+{
+    {
+        Variant<int, String, float> the_value { 42.0f };
+
+        VERIFY(the_value.has<float>());
+        EXPECT_EQ(the_value.get<float>(), 42.0f);
+
+        int twelve = 12;
+        the_value = twelve;
+        VERIFY(the_value.has<int>());
+        EXPECT_EQ(the_value.get<int>(), 12);
+
+        the_value = String("Hello, world!");
+        VERIFY(the_value.has<String>());
+        EXPECT_EQ(the_value.get<String>(), "Hello, world!");
+    }
+    {
+        Variant<HoldsInt, String, HoldsFloat> the_value { HoldsFloat { 42.0f } };
+
+        VERIFY(the_value.has<HoldsFloat>());
+        EXPECT_EQ(the_value.get<HoldsFloat>().f, 42.0f);
+
+        HoldsInt twelve { 12 };
+        the_value = twelve;
+        VERIFY(the_value.has<HoldsInt>());
+        EXPECT_EQ(the_value.get<HoldsInt>().i, 12);
+
+        the_value = String("Hello, world!");
+        VERIFY(the_value.has<String>());
+        EXPECT_EQ(the_value.get<String>(), "Hello, world!");
+    }
+}


### PR DESCRIPTION
Also makes the compiler understand that the underlying buffer is initialised when constructed, should probably fix putting optionals in variants.