### PR TITLE
Hearts: Clean up some code and improve the AI

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -180,6 +180,12 @@ size_t Game::pick_card(Player& player)
         } else
             return player.pick_low_points_low_value_card();
     }
+    auto* high_card = &m_trick[0];
+    for (auto& card : m_trick)
+        if (high_card->type() == card.type() && hearts_card_value(card) > hearts_card_value(*high_card))
+            high_card = &card;
+    if (high_card->type() == Card::Type::Spades && hearts_card_value(*high_card) > CardValue::Queen)
+        RETURN_CARD_IF_VALID(player.pick_specific_card(Card::Type::Spades, CardValue::Queen));
     auto card_has_points = [](Card& card) { return hearts_card_points(card) > 0; };
     auto trick_has_points = m_trick.first_matching(card_has_points).has_value();
     bool is_trailing_player = m_trick.size() == 3;
@@ -190,12 +196,6 @@ size_t Game::pick_card(Player& player)
         else
             return player.pick_max_points_card();
     }
-    auto* high_card = &m_trick[0];
-    for (auto& card : m_trick)
-        if (high_card->type() == card.type() && hearts_card_value(card) > hearts_card_value(*high_card))
-            high_card = &card;
-    if (!is_first_trick && high_card->type() == Card::Type::Spades && hearts_card_value(*high_card) > CardValue::Queen)
-        RETURN_CARD_IF_VALID(player.pick_specific_card(Card::Type::Spades, CardValue::Queen));
     RETURN_CARD_IF_VALID(player.pick_lower_value_card(*high_card));
     if (!is_trailing_player)
         RETURN_CARD_IF_VALID(player.pick_slightly_higher_value_card(*high_card));

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -121,6 +121,8 @@ void Game::setup()
 
 void Game::start_animation(NonnullRefPtrVector<Card> cards, Gfx::IntPoint const& end, Function<void()> did_finish_callback, int initial_delay_ms, int steps)
 {
+    stop_animation();
+
     m_animation_end = end;
     m_animation_current_step = 0;
     m_animation_steps = steps;

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -45,6 +45,8 @@ private:
     Player& current_player();
     bool game_ended() const { return m_trick_number == 13; }
     bool is_winner(Player& player);
+    bool other_player_has_lower_value_card(Player& player, Card& card);
+    bool other_player_has_higher_value_card(Player& player, Card& card);
 
     void start_animation(NonnullRefPtrVector<Card> cards, Gfx::IntPoint const& end, Function<void()> did_finish_callback, int initial_delay_ms, int steps = 30);
     void stop_animation();

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -11,7 +11,6 @@
 #include <LibCards/Card.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/Frame.h>
-#include <LibGUI/Painter.h>
 
 using Cards::Card;
 

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -21,7 +21,7 @@ public:
     {
     }
 
-    size_t pick_low_points_low_value_card();
+    size_t pick_lead_card(Function<bool(Card&)>, Function<bool(Card&)>);
     Optional<size_t> pick_low_points_high_value_card(Optional<Card::Type> type = {});
     Optional<size_t> pick_lower_value_card(Card& other_card);
     Optional<size_t> pick_slightly_higher_value_card(Card& other_card);

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -74,9 +74,6 @@ int main(int argc, char** argv)
         statusbar.set_override_text({});
     };
 
-    GUI::ActionGroup draw_settng_actions;
-    draw_settng_actions.set_exclusive(true);
-
     auto menubar = GUI::Menubar::construct();
     auto& game_menu = menubar->add_menu("&Game");
 

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -139,7 +139,7 @@ void Card::draw(GUI::Painter& painter) const
 
 void Card::clear(GUI::Painter& painter, const Color& background_color) const
 {
-    painter.fill_rect({ old_positon(), { width, height } }, background_color);
+    painter.fill_rect({ old_position(), { width, height } }, background_color);
 }
 
 void Card::save_old_position()

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -39,7 +39,7 @@ public:
 
     Gfx::IntRect& rect() { return m_rect; }
     Gfx::IntPoint position() const { return m_rect.location(); }
-    const Gfx::IntPoint& old_positon() const { return m_old_position; }
+    const Gfx::IntPoint& old_position() const { return m_old_position; }
     uint8_t value() const { return m_value; };
     Type type() const { return m_type; }
 


### PR DESCRIPTION
**Hearts: Remove dead code**

**LibCards: Correct a spelling mistake**

**Hearts: Fix crash when starting an animation when there already is one**

This ensures that the preceding animation is stopped first.

**Hearts: Prefer to play Queen of Spades when we're the trailing player**

Previously in a trick like `2S`, `KS`, `5S` we'd rather follow up with `AS` instead of `QS`. We should prefer to play `QS` in this case.

**Hearts: Let the AI pick better lead cards**

Instead of picking the card with the lowest value we should pick the card with the highest value for which we know no lower value card is in play anymore and that someone else still has an even higher value card.