### PR TITLE
CppLanguageServer: Autocomplete #include paths

### DIFF
--- a/Meta/check-newlines-at-eof.py
+++ b/Meta/check-newlines-at-eof.py
@@ -21,7 +21,9 @@ def run():
             "*.json",
             "CMake*.txt",
             "**/CMake*.txt",
-            ":!:Kernel/FileSystem/ext2_fs.h"
+            ":!:Kernel/FileSystem/ext2_fs.h",
+            ':!:Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/*',
+            ':!:Userland/Libraries/LibCpp/Tests/*'
         ],
         check=True,
         capture_output=True

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -536,7 +536,7 @@ GUI::AutocompleteProvider::DeclarationType CppComprehensionEngine::type_of_decla
 OwnPtr<CppComprehensionEngine::DocumentData> CppComprehensionEngine::create_document_data(String&& text, const String& filename)
 {
     auto document_data = make<DocumentData>();
-    document_data->m_filename = move(filename);
+    document_data->m_filename = filename;
     document_data->m_text = move(text);
     document_data->m_preprocessor = make<Preprocessor>(document_data->m_filename, document_data->text());
     document_data->preprocessor().set_ignore_unsupported_keywords(true);

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -76,17 +76,17 @@ Vector<GUI::AutocompleteProvider::Entry> CppComprehensionEngine::get_suggestions
     if (!node->parent())
         return {};
 
-    auto results = autocomplete_property(document, *node, containing_token);
+    auto results = try_autocomplete_property(document, *node, containing_token);
     if (results.has_value())
         return results.value();
 
-    results = autocomplete_name(document, *node, containing_token);
+    results = try_autocomplete_name(document, *node, containing_token);
     if (results.has_value())
         return results.value();
     return {};
 }
 
-Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::autocomplete_name(const DocumentData& document, const ASTNode& node, Optional<Token> containing_token) const
+Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_autocomplete_name(const DocumentData& document, const ASTNode& node, Optional<Token> containing_token) const
 {
     auto partial_text = String::empty();
     if (containing_token.has_value() && containing_token.value().type() != Token::Type::ColonColon) {
@@ -95,7 +95,7 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::autoc
     return autocomplete_name(document, node, partial_text);
 }
 
-Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::autocomplete_property(const DocumentData& document, const ASTNode& node, Optional<Token> containing_token) const
+Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_autocomplete_property(const DocumentData& document, const ASTNode& node, Optional<Token> containing_token) const
 {
     if (!containing_token.has_value())
         return {};

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -542,19 +542,19 @@ OwnPtr<CppComprehensionEngine::DocumentData> CppComprehensionEngine::create_docu
     document_data->preprocessor().set_ignore_unsupported_keywords(true);
     document_data->preprocessor().process();
 
-    Preprocessor::Definitions all_definitions;
+    Preprocessor::Definitions preprocessor_definitions;
     for (auto item : document_data->preprocessor().definitions())
-        all_definitions.set(move(item.key), move(item.value));
+        preprocessor_definitions.set(move(item.key), move(item.value));
 
     for (auto include : document_data->preprocessor().included_paths()) {
         auto included_document = get_or_create_document_data(document_path_from_include_path(include));
         if (!included_document)
             continue;
         for (auto item : included_document->parser().preprocessor_definitions())
-            all_definitions.set(move(item.key), move(item.value));
+            preprocessor_definitions.set(move(item.key), move(item.value));
     }
 
-    document_data->m_parser = make<Parser>(document_data->preprocessor().processed_text(), filename, move(all_definitions));
+    document_data->m_parser = make<Parser>(document_data->preprocessor().processed_text(), filename, move(preprocessor_definitions));
 
     auto root = document_data->parser().parse();
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
@@ -103,6 +103,7 @@ private:
     OwnPtr<DocumentData> create_document_data(String&& text, const String& filename);
     Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_property(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
     Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_name(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
+    Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_include(const DocumentData&, Token include_path_token);
 
     HashMap<String, OwnPtr<DocumentData>> m_documents;
 };

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
@@ -101,8 +101,8 @@ private:
     Optional<GUI::AutocompleteProvider::ProjectLocation> find_preprocessor_definition(const DocumentData&, const GUI::TextPosition&);
 
     OwnPtr<DocumentData> create_document_data(String&& text, const String& filename);
-    Optional<Vector<GUI::AutocompleteProvider::Entry>> autocomplete_property(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
-    Optional<Vector<GUI::AutocompleteProvider::Entry>> autocomplete_name(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
+    Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_property(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
+    Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_name(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
 
     HashMap<String, OwnPtr<DocumentData>> m_documents;
 };

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests.cpp
@@ -41,6 +41,7 @@ static void test_complete_local_args();
 static void test_complete_local_vars();
 static void test_complete_type();
 static void test_find_variable_definition();
+static void test_complete_includes();
 
 int run_tests()
 {
@@ -48,6 +49,7 @@ int run_tests()
     test_complete_local_vars();
     test_complete_type();
     test_find_variable_definition();
+    test_complete_includes();
     return s_some_test_failed ? 1 : 0;
 }
 
@@ -119,4 +121,29 @@ void test_find_variable_definition()
     if (position.value().file == "find_variable_declaration.cpp" && position.value().line == 0 && position.value().column >= 19)
         PASS;
     FAIL("wrong declaration location");
+}
+void test_complete_includes()
+{
+    I_TEST(Complete Type)
+    FileDB filedb;
+    filedb.set_project_root(TESTS_ROOT_DIR);
+    add_file(filedb, "complete_includes.cpp");
+    add_file(filedb, "sample_header.h");
+    CppComprehensionEngine autocomplete(filedb);
+
+    auto suggestions = autocomplete.get_suggestions("complete_includes.cpp", { 0, 23 });
+    if (suggestions.size() != 1)
+        FAIL(project include - bad size);
+
+    if (suggestions[0].completion != "sample_header.h")
+        FAIL("project include - wrong results");
+
+    suggestions = autocomplete.get_suggestions("complete_includes.cpp", { 1, 19 });
+    if (suggestions.size() != 1)
+        FAIL(global include - bad size);
+
+    if (suggestions[0].completion != "cdefs.h")
+        FAIL("global include - wrong results");
+
+    PASS;
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/complete_includes.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/complete_includes.cpp
@@ -1,0 +1,5 @@
+#include "sample_heade
+#include <sys/cdef
+
+void foo() {}
+

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/sample_header.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/sample_header.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int bar();

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.h
@@ -23,6 +23,7 @@ public:
     bool add(const String& filename, const String& content);
 
     void set_project_root(const String& root_path) { m_project_root = root_path; }
+    const String& project_root() const { return m_project_root; }
 
     void on_file_edit_insert_text(const String& filename, const String& inserted_text, size_t start_line, size_t start_column);
     void on_file_edit_remove_text(const String& filename, size_t start_line, size_t start_column, size_t end_line, size_t end_column);

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -21,12 +21,7 @@ Parser::Parser(const StringView& program, const String& filename, Preprocessor::
     if constexpr (CPP_DEBUG) {
         dbgln("Tokens:");
         for (auto& token : m_tokens) {
-            StringView text;
-            if (token.start().line != token.end().line || token.start().column > token.end().column)
-                text = {};
-            else
-                text = text_of_token(token);
-            dbgln("{}  {}:{}-{}:{} ({})", token.to_string(), token.start().line, token.start().column, token.end().line, token.end().column, text);
+            dbgln("{}", token.to_string());
         }
     }
 }
@@ -930,7 +925,7 @@ Optional<size_t> Parser::index_of_token_at(Position pos) const
 void Parser::print_tokens() const
 {
     for (auto& token : m_tokens) {
-        dbgln("{}", token.to_string());
+        outln("{}", token.to_string());
     }
 }
 

--- a/Userland/Libraries/LibCpp/Preprocessor.cpp
+++ b/Userland/Libraries/LibCpp/Preprocessor.cpp
@@ -22,11 +22,20 @@ const String& Preprocessor::process()
 {
     for (; m_line_index < m_lines.size(); ++m_line_index) {
         auto& line = m_lines[m_line_index];
+
+        bool include_in_processed_text = false;
         if (line.starts_with("#")) {
-            handle_preprocessor_line(line);
+            auto keyword = handle_preprocessor_line(line);
+            if (m_options.keep_include_statements && keyword == "include")
+                include_in_processed_text = true;
         } else if (m_state == State::Normal) {
+            include_in_processed_text = true;
+        }
+
+        if (include_in_processed_text) {
             m_builder.append(line);
         }
+
         m_builder.append("\n");
     }
 

--- a/Userland/Libraries/LibCpp/Preprocessor.h
+++ b/Userland/Libraries/LibCpp/Preprocessor.h
@@ -35,7 +35,9 @@ public:
     void set_ignore_unsupported_keywords(bool ignore) { m_options.ignore_unsupported_keywords = ignore; }
 
 private:
-    void handle_preprocessor_line(const StringView&);
+    using PreprocessorKeyword = StringView;
+    PreprocessorKeyword handle_preprocessor_line(const StringView&);
+    void handle_preprocessor_keyword(const StringView& keyword, GenericLexer& line_lexer);
 
     Definitions m_definitions;
     const String m_filename;

--- a/Userland/Libraries/LibCpp/Preprocessor.h
+++ b/Userland/Libraries/LibCpp/Preprocessor.h
@@ -33,6 +33,7 @@ public:
     const Definitions& definitions() const { return m_definitions; }
 
     void set_ignore_unsupported_keywords(bool ignore) { m_options.ignore_unsupported_keywords = ignore; }
+    void set_keep_include_statements(bool keep) { m_options.keep_include_statements = keep; }
 
 private:
     using PreprocessorKeyword = StringView;
@@ -61,6 +62,7 @@ private:
 
     struct Options {
         bool ignore_unsupported_keywords { false };
+        bool keep_include_statements { false };
     } m_options;
 };
 }

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
@@ -63,7 +63,7 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
 
     Vector<GUI::TextDocumentSpan> spans;
     for (auto& token : tokens) {
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ {}:{} - {}:{}", token.to_string(), token.start().line, token.start().column, token.end().line, token.end().column);
+        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ {}:{} - {}:{}", token.type_as_string(), token.start().line, token.start().column, token.end().line, token.end().column);
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.start().line, token.start().column });
         span.range.set_end({ token.end().line, token.end().column });

--- a/Userland/Libraries/LibCpp/Token.cpp
+++ b/Userland/Libraries/LibCpp/Token.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Token.h"
+#include <AK/String.h>
 
 namespace Cpp {
 
@@ -24,4 +25,15 @@ bool Position::operator<=(const Position& other) const
 {
     return !(*this > other);
 }
+
+String Token::to_string() const
+{
+    return String::formatted("{}  {}:{}-{}:{} ({})", type_to_string(m_type), start().line, start().column, end().line, end().column, text());
+}
+
+String Token::type_as_string() const
+{
+    return type_to_string(m_type);
+}
+
 }

--- a/Userland/Libraries/LibCpp/Token.h
+++ b/Userland/Libraries/LibCpp/Token.h
@@ -116,10 +116,9 @@ struct Token {
         VERIFY_NOT_REACHED();
     }
 
-    const char* to_string() const
-    {
-        return type_to_string(m_type);
-    }
+    String to_string() const;
+    String type_as_string() const;
+
     const Position& start() const { return m_start; }
     const Position& end() const { return m_end; }
 

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -84,7 +84,7 @@ AutocompleteBox::AutocompleteBox(TextEditor& editor)
 {
     m_popup_window = GUI::Window::construct(m_editor->window());
     m_popup_window->set_window_type(GUI::WindowType::Tooltip);
-    m_popup_window->set_rect(0, 0, 200, 100);
+    m_popup_window->set_rect(0, 0, 300, 100);
 
     m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>();
     m_suggestion_view->set_column_headers_visible(false);

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -176,7 +176,17 @@ void AutocompleteBox::apply_suggestion()
     size_t partial_length = suggestion_index.data((GUI::ModelRole)AutocompleteSuggestionModel::InternalRole::PartialInputLength).to_i64();
 
     VERIFY(suggestion.length() >= partial_length);
-    auto completion = suggestion.substring_view(partial_length, suggestion.length() - partial_length);
+    auto completion_view = suggestion.substring_view(partial_length, suggestion.length() - partial_length);
+    auto completion_kind = (GUI::AutocompleteProvider::CompletionKind)suggestion_index.data((GUI::ModelRole)AutocompleteSuggestionModel::InternalRole::Kind).as_uint();
+
+    String completion;
+    if (completion_view.ends_with(".h") && completion_kind == GUI::AutocompleteProvider::CompletionKind::SystemInclude)
+        completion = String::formatted("{}{}", completion_view, ">");
+    else if (completion_view.ends_with(".h") && completion_kind == GUI::AutocompleteProvider::CompletionKind::ProjectInclude)
+        completion = String::formatted("{}{}", completion_view, "\"");
+    else
+        completion = completion_view;
+
     m_editor->insert_at_cursor_or_replace_selection(completion);
 }
 

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -23,6 +23,8 @@ public:
     enum class CompletionKind {
         Identifier,
         PreprocessorDefinition,
+        SystemInclude,
+        ProjectInclude,
     };
 
     enum class Language {


### PR DESCRIPTION
This was a classic autocomplete feature we didn't support before.

Screenshot:

![hs-autocomplete-includes](https://user-images.githubusercontent.com/9247514/119222115-7193c780-bafb-11eb-8736-5ca9e674b977.png)
