### PR TITLE
LibCards: Fix alignment for the card labels

### DIFF
--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -96,7 +96,8 @@ Card::Card(Type type, uint8_t value)
     paint_rect.set_height(paint_rect.height() / 2);
     paint_rect.shrink(10, 6);
 
-    painter.draw_text(paint_rect, label, font, Gfx::TextAlignment::TopLeft, color());
+    auto text_rect = Gfx::IntRect { 4, 6, font.width("10"), font.glyph_height() };
+    painter.draw_text(text_rect, label, font, Gfx::TextAlignment::Center, color());
 
     NonnullRefPtr<Gfx::CharacterBitmap> symbol = s_diamond;
     switch (m_type) {
@@ -117,7 +118,7 @@ Card::Card(Type type, uint8_t value)
     }
 
     painter.draw_bitmap(
-        { paint_rect.x() + (font.width(label) - symbol->size().width()) / 2, font.glyph_height() + paint_rect.y() + 3 },
+        { text_rect.x() + (text_rect.width() - symbol->size().width()) / 2, text_rect.bottom() + 5 },
         symbol, color());
 
     for (int y = height / 2; y < height; ++y) {


### PR DESCRIPTION
Previously the code didn't take into account that the label for the "10" card is larger than for the other cards. This patch also centers the text in the bounding box.

Before:

![card-alignment1](https://user-images.githubusercontent.com/388571/119222480-d4ce2b80-baf4-11eb-8281-f668529dec98.png)

After:

![card-alignment2](https://user-images.githubusercontent.com/388571/119222482-d861b280-baf4-11eb-9d3d-c1113301e9ae.png)