### PR TITLE
Userland: Rename {loop0,e1k0} to {loop,ep0s7}

### DIFF
--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -126,7 +126,7 @@ private:
             auto ifname = if_object.get("name").to_string();
 
             if (!include_loopback)
-                if (ifname == "loop0")
+                if (ifname == "loop")
                     return;
             if (ip_address != "null")
                 connected_adapters++;

--- a/Userland/Utilities/test-bindtodevice.cpp
+++ b/Userland/Utilities/test-bindtodevice.cpp
@@ -107,7 +107,8 @@ void test_send(int fd)
     // bind to an interface that cannot deliver
     char buf[IFNAMSIZ];
     socklen_t buflen = IFNAMSIZ;
-    memcpy(buf, "e1k0", 5);
+    // FIXME: Look up the proper device name instead of hard-coding it
+    memcpy(buf, "ep0s7", 6);
 
     if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, buf, buflen) < 0) {
         perror("setsockopt(SO_BINDTODEVICE) :: send");

--- a/Userland/Utilities/test-bindtodevice.cpp
+++ b/Userland/Utilities/test-bindtodevice.cpp
@@ -60,7 +60,7 @@ void test_valid(int fd)
     // bind to an interface that exists
     char buf[IFNAMSIZ];
     socklen_t buflen = IFNAMSIZ;
-    memcpy(buf, "loop0", 6);
+    memcpy(buf, "loop", 5);
 
     if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, buf, buflen) < 0) {
         perror("setsockopt(SO_BINDTODEVICE) :: valid");
@@ -75,7 +75,7 @@ void test_no_route(int fd)
     // bind to an interface that cannot deliver
     char buf[IFNAMSIZ];
     socklen_t buflen = IFNAMSIZ;
-    memcpy(buf, "loop0", 6);
+    memcpy(buf, "loop", 5);
 
     if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, buf, buflen) < 0) {
         perror("setsockopt(SO_BINDTODEVICE) :: no_route");


### PR DESCRIPTION
Now that the kernel picks a different name for the loopback adapter we should update userland to account for this.