### PR TITLE
HexEditor: Construct user interface from GML and add toolbar

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -1,8 +1,11 @@
+compile_gml(HexEditorWindow.gml HexEditorWindowGML.h hex_editor_window_gml)
+
 set(SOURCES
     HexEditor.cpp
     HexEditorWidget.cpp
     FindDialog.cpp
     main.cpp
+    HexEditorWindowGML.h
 )
 
 serenity_app(HexEditor ICON app-hex-editor)

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -18,6 +18,8 @@
 #include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 
+namespace HexEditor {
+
 struct Option {
     String title;
     OptionId opt;
@@ -26,7 +28,7 @@ struct Option {
 };
 
 static const Vector<Option> options = {
-    { "ACII String", OPTION_ASCII_STRING, true, true },
+    { "ASCII String", OPTION_ASCII_STRING, true, true },
     { "Hex value", OPTION_HEX_VALUE, true, false },
 };
 
@@ -143,4 +145,6 @@ FindDialog::FindDialog()
 
 FindDialog::~FindDialog()
 {
+}
+
 }

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -10,6 +10,8 @@
 #include <AK/Vector.h>
 #include <LibGUI/Dialog.h>
 
+namespace HexEditor {
+
 enum OptionId {
     OPTION_INVALID = -1,
     OPTION_ASCII_STRING,
@@ -36,3 +38,5 @@ private:
     String m_text_value;
     OptionId m_selected_option { OPTION_INVALID };
 };
+
+}

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <unistd.h>
 
-HexEditor::HexEditor()
+namespace HexEditor {
+
+Editor::Editor()
 {
     set_should_hide_unnecessary_scrollbars(true);
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
@@ -32,18 +34,18 @@ HexEditor::HexEditor()
     vertical_scrollbar().set_step(line_height());
 }
 
-HexEditor::~HexEditor()
+Editor::~Editor()
 {
 }
 
-void HexEditor::set_readonly(bool readonly)
+void Editor::set_readonly(bool readonly)
 {
     if (m_readonly == readonly)
         return;
     m_readonly = readonly;
 }
 
-void HexEditor::set_buffer(const ByteBuffer& buffer)
+void Editor::set_buffer(const ByteBuffer& buffer)
 {
     m_buffer = buffer;
     set_content_length(buffer.size());
@@ -54,7 +56,7 @@ void HexEditor::set_buffer(const ByteBuffer& buffer)
     update_status();
 }
 
-void HexEditor::fill_selection(u8 fill_byte)
+void Editor::fill_selection(u8 fill_byte)
 {
     if (!has_selection())
         return;
@@ -68,7 +70,7 @@ void HexEditor::fill_selection(u8 fill_byte)
     did_change();
 }
 
-void HexEditor::set_position(int position)
+void Editor::set_position(int position)
 {
     if (position > static_cast<int>(m_buffer.size()))
         return;
@@ -79,7 +81,7 @@ void HexEditor::set_position(int position)
     update_status();
 }
 
-bool HexEditor::write_to_file(const String& path)
+bool Editor::write_to_file(const String& path)
 {
     if (m_buffer.is_empty())
         return true;
@@ -112,7 +114,7 @@ bool HexEditor::write_to_file(const String& path)
     return true;
 }
 
-bool HexEditor::copy_selected_hex_to_clipboard()
+bool Editor::copy_selected_hex_to_clipboard()
 {
     if (!has_selection())
         return false;
@@ -125,7 +127,7 @@ bool HexEditor::copy_selected_hex_to_clipboard()
     return true;
 }
 
-bool HexEditor::copy_selected_text_to_clipboard()
+bool Editor::copy_selected_text_to_clipboard()
 {
     if (!has_selection())
         return false;
@@ -138,7 +140,7 @@ bool HexEditor::copy_selected_text_to_clipboard()
     return true;
 }
 
-bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
+bool Editor::copy_selected_hex_to_clipboard_as_c_code()
 {
     if (!has_selection())
         return false;
@@ -161,14 +163,14 @@ bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
     return true;
 }
 
-void HexEditor::set_bytes_per_row(int bytes_per_row)
+void Editor::set_bytes_per_row(int bytes_per_row)
 {
     m_bytes_per_row = bytes_per_row;
     set_content_size({ offset_margin_width() + (m_bytes_per_row * (character_width() * 3)) + 10 + (m_bytes_per_row * character_width()) + 20, total_rows() * line_height() + 10 });
     update();
 }
 
-void HexEditor::set_content_length(int length)
+void Editor::set_content_length(int length)
 {
     if (length == m_content_length)
         return;
@@ -176,7 +178,7 @@ void HexEditor::set_content_length(int length)
     set_content_size({ offset_margin_width() + (m_bytes_per_row * (character_width() * 3)) + 10 + (m_bytes_per_row * character_width()) + 20, total_rows() * line_height() + 10 });
 }
 
-void HexEditor::mousedown_event(GUI::MouseEvent& event)
+void Editor::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() != GUI::MouseButton::Left) {
         return;
@@ -236,7 +238,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
     }
 }
 
-void HexEditor::mousemove_event(GUI::MouseEvent& event)
+void Editor::mousemove_event(GUI::MouseEvent& event)
 {
     auto absolute_x = horizontal_scrollbar().value() + event.x();
     auto absolute_y = vertical_scrollbar().value() + event.y();
@@ -289,7 +291,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
     }
 }
 
-void HexEditor::mouseup_event(GUI::MouseEvent& event)
+void Editor::mouseup_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Left) {
         if (m_in_drag_select) {
@@ -306,7 +308,7 @@ void HexEditor::mouseup_event(GUI::MouseEvent& event)
     }
 }
 
-void HexEditor::scroll_position_into_view(int position)
+void Editor::scroll_position_into_view(int position)
 {
     int y = position / bytes_per_row();
     int x = position % bytes_per_row();
@@ -319,7 +321,7 @@ void HexEditor::scroll_position_into_view(int position)
     scroll_into_view(rect, true, true);
 }
 
-void HexEditor::keydown_event(GUI::KeyEvent& event)
+void Editor::keydown_event(GUI::KeyEvent& event)
 {
     dbgln_if(HEX_DEBUG, "HexEditor::keydown_event key={}", static_cast<u8>(event.key()));
 
@@ -387,7 +389,7 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
     }
 }
 
-void HexEditor::hex_mode_keydown_event(GUI::KeyEvent& event)
+void Editor::hex_mode_keydown_event(GUI::KeyEvent& event)
 {
     if ((event.key() >= KeyCode::Key_0 && event.key() <= KeyCode::Key_9) || (event.key() >= KeyCode::Key_A && event.key() <= KeyCode::Key_F)) {
         if (m_buffer.is_empty())
@@ -417,7 +419,7 @@ void HexEditor::hex_mode_keydown_event(GUI::KeyEvent& event)
     }
 }
 
-void HexEditor::text_mode_keydown_event(GUI::KeyEvent& event)
+void Editor::text_mode_keydown_event(GUI::KeyEvent& event)
 {
     if (m_buffer.is_empty())
         return;
@@ -438,19 +440,19 @@ void HexEditor::text_mode_keydown_event(GUI::KeyEvent& event)
     did_change();
 }
 
-void HexEditor::update_status()
+void Editor::update_status()
 {
     if (on_status_change)
         on_status_change(m_position, m_edit_mode, m_selection_start, m_selection_end);
 }
 
-void HexEditor::did_change()
+void Editor::did_change()
 {
     if (on_change)
         on_change();
 }
 
-void HexEditor::paint_event(GUI::PaintEvent& event)
+void Editor::paint_event(GUI::PaintEvent& event)
 {
     GUI::Frame::paint_event(event);
 
@@ -558,20 +560,20 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     }
 }
 
-void HexEditor::select_all()
+void Editor::select_all()
 {
     highlight(0, m_buffer.size());
     set_position(0);
 }
 
-void HexEditor::highlight(int start, int end)
+void Editor::highlight(int start, int end)
 {
     m_selection_start = start;
     m_selection_end = end;
     set_position(start);
 }
 
-int HexEditor::find_and_highlight(ByteBuffer& needle, int start)
+int Editor::find_and_highlight(ByteBuffer& needle, int start)
 {
     if (m_buffer.is_empty())
         return -1;
@@ -587,4 +589,6 @@ int HexEditor::find_and_highlight(ByteBuffer& needle, int start)
     highlight(relative_offset, end_of_match);
 
     return end_of_match;
+}
+
 }

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -16,15 +16,17 @@
 #include <LibGfx/Font.h>
 #include <LibGfx/TextAlignment.h>
 
-class HexEditor : public GUI::AbstractScrollableWidget {
-    C_OBJECT(HexEditor)
+namespace HexEditor {
+
+class Editor : public GUI::AbstractScrollableWidget {
+    C_OBJECT(Editor)
 public:
     enum EditMode {
         Hex,
         Text
     };
 
-    virtual ~HexEditor() override;
+    virtual ~Editor() override;
 
     bool is_readonly() const { return m_readonly; }
     void set_readonly(bool);
@@ -49,7 +51,7 @@ public:
     Function<void()> on_change;
 
 protected:
-    HexEditor();
+    Editor();
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
@@ -85,3 +87,5 @@ private:
     void update_status();
     void did_change();
 };
+
+}

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -8,6 +8,7 @@
 #include "FindDialog.h"
 #include <AK/Optional.h>
 #include <AK/StringBuilder.h>
+#include <Applications/HexEditor/HexEditorWindowGML.h>
 #include <LibCore/File.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
@@ -21,20 +22,25 @@
 #include <LibGUI/TextBox.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Toolbar.h>
+#include <LibGUI/ToolbarContainer.h>
 #include <stdio.h>
 #include <string.h>
 
+REGISTER_WIDGET(HexEditor, Editor);
+
+namespace HexEditor {
+
 HexEditorWidget::HexEditorWidget()
 {
-    set_fill_with_background_color(true);
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_spacing(2);
+    load_from_gml(hex_editor_window_gml);
+    m_toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
+    m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
+    m_editor = *find_descendant_of_type_named<Editor>("editor");
+    m_statusbar = *find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
-    m_editor = add<HexEditor>();
-
-    m_editor->on_status_change = [this](int position, HexEditor::EditMode edit_mode, int selection_start, int selection_end) {
+    m_editor->on_status_change = [this](int position, Editor::EditMode edit_mode, int selection_start, int selection_end) {
         m_statusbar->set_text(0, String::formatted("Offset: {:#08X}", position));
-        m_statusbar->set_text(1, String::formatted("Edit Mode: {}", edit_mode == HexEditor::EditMode::Hex ? "Hex" : "Text"));
+        m_statusbar->set_text(1, String::formatted("Edit Mode: {}", edit_mode == Editor::EditMode::Hex ? "Hex" : "Text"));
         m_statusbar->set_text(2, String::formatted("Selection Start: {}", selection_start));
         m_statusbar->set_text(3, String::formatted("Selection End: {}", selection_end));
         m_statusbar->set_text(4, String::formatted("Selected Bytes: {}", abs(selection_end - selection_start)));
@@ -46,8 +52,6 @@ HexEditorWidget::HexEditorWidget()
         if (!was_dirty)
             update_title();
     };
-
-    m_statusbar = add<GUI::Statusbar>(5);
 
     m_new_action = GUI::Action::create("New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::load_from_file("/res/icons/16x16/new.png"), [this](const GUI::Action&) {
         if (m_document_dirty) {
@@ -107,6 +111,38 @@ HexEditorWidget::HexEditorWidget()
         set_path(LexicalPath(save_path.value()));
         dbgln("Wrote document to {}", save_path.value());
     });
+
+    m_find_action = GUI::Action::create("&Find", { Mod_Ctrl, Key_F }, Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"), [&](const GUI::Action&) {
+        auto old_buffer = m_search_buffer;
+        if (FindDialog::show(window(), m_search_text, m_search_buffer) == GUI::InputBox::ExecOK) {
+
+            bool same_buffers = false;
+            if (old_buffer.size() == m_search_buffer.size()) {
+                if (memcmp(old_buffer.data(), m_search_buffer.data(), old_buffer.size()) == 0)
+                    same_buffers = true;
+            }
+
+            auto result = m_editor->find_and_highlight(m_search_buffer, same_buffers ? last_found_index() : 0);
+
+            if (result == -1) {
+                GUI::MessageBox::show(window(), String::formatted("Pattern \"{}\" not found in this file", m_search_text), "Not found", GUI::MessageBox::Type::Warning);
+                return;
+            }
+            m_editor->update();
+            m_last_found_index = result;
+        }
+    });
+
+    m_layout_toolbar_action = GUI::Action::create_checkable("&Toolbar", [&](auto& action) {
+        action.is_checked() ? m_toolbar_container->set_visible(true) : m_toolbar_container->set_visible(false);
+    });
+
+    m_toolbar->add_action(*m_new_action);
+    m_toolbar->add_action(*m_open_action);
+    m_toolbar->add_action(*m_save_action);
+    m_toolbar->add_separator();
+    m_toolbar->add_action(*m_find_action);
+    m_toolbar->add_separator();
 
     m_editor->set_focus(true);
 }
@@ -172,27 +208,7 @@ void HexEditorWidget::initialize_menubar(GUI::Menubar& menubar)
         m_editor->copy_selected_hex_to_clipboard_as_c_code();
     }));
     edit_menu.add_separator();
-    edit_menu.add_action(GUI::Action::create("&Find", { Mod_Ctrl, Key_F }, Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"), [&](const GUI::Action&) {
-        auto old_buffer = m_search_buffer;
-        if (FindDialog::show(window(), m_search_text, m_search_buffer) == GUI::InputBox::ExecOK) {
-
-            bool same_buffers = false;
-            if (old_buffer.size() == m_search_buffer.size()) {
-                if (memcmp(old_buffer.data(), m_search_buffer.data(), old_buffer.size()) == 0)
-                    same_buffers = true;
-            }
-
-            auto result = m_editor->find_and_highlight(m_search_buffer, same_buffers ? last_found_index() : 0);
-
-            if (result == -1) {
-                GUI::MessageBox::show(window(), String::formatted("Pattern \"{}\" not found in this file", m_search_text), "Not found", GUI::MessageBox::Type::Warning);
-                return;
-            }
-            m_editor->update();
-            m_last_found_index = result;
-        }
-    }));
-
+    edit_menu.add_action(*m_find_action);
     edit_menu.add_action(GUI::Action::create("Find &Next", { Mod_None, Key_F3 }, Gfx::Bitmap::load_from_file("/res/icons/16x16/find-next.png"), [&](const GUI::Action&) {
         if (m_search_text.is_empty() || m_search_buffer.is_empty()) {
             GUI::MessageBox::show(window(), "Nothing to search for", "Not found", GUI::MessageBox::Type::Warning);
@@ -209,6 +225,8 @@ void HexEditorWidget::initialize_menubar(GUI::Menubar& menubar)
     }));
 
     auto& view_menu = menubar.add_menu("&View");
+    view_menu.add_action(*m_layout_toolbar_action);
+    m_layout_toolbar_action->set_checked(true);
     m_bytes_per_row_actions.set_exclusive(true);
     auto& bytes_per_row_menu = view_menu.add_submenu("Bytes per &Row");
     for (int i = 8; i <= 32; i += 8) {
@@ -263,4 +281,6 @@ bool HexEditorWidget::request_close()
         return true;
     auto result = GUI::MessageBox::show(window(), "The file has been modified. Quit without saving?", "Quit without saving?", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
     return result == GUI::MessageBox::ExecOK;
+}
+
 }

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -15,7 +15,9 @@
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 
-class HexEditor;
+namespace HexEditor {
+
+class Editor;
 
 class HexEditorWidget final : public GUI::Widget {
     C_OBJECT(HexEditorWidget)
@@ -30,7 +32,7 @@ private:
     void set_path(const LexicalPath& file);
     void update_title();
 
-    RefPtr<HexEditor> m_editor;
+    RefPtr<Editor> m_editor;
     String m_path;
     String m_name;
     String m_extension;
@@ -44,12 +46,18 @@ private:
     RefPtr<GUI::Action> m_open_action;
     RefPtr<GUI::Action> m_save_action;
     RefPtr<GUI::Action> m_save_as_action;
+    RefPtr<GUI::Action> m_find_action;
     RefPtr<GUI::Action> m_goto_decimal_offset_action;
     RefPtr<GUI::Action> m_goto_hex_offset_action;
+    RefPtr<GUI::Action> m_layout_toolbar_action;
 
     GUI::ActionGroup m_bytes_per_row_actions;
 
     RefPtr<GUI::Statusbar> m_statusbar;
+    RefPtr<GUI::Toolbar> m_toolbar;
+    RefPtr<GUI::ToolbarContainer> m_toolbar_container;
 
     bool m_document_dirty { false };
 };
+
+}

--- a/Userland/Applications/HexEditor/HexEditorWindow.gml
+++ b/Userland/Applications/HexEditor/HexEditorWindow.gml
@@ -1,0 +1,25 @@
+@GUI::Widget {
+    name: "main"
+    fill_with_background_color: true
+
+    layout: @GUI::VerticalBoxLayout {
+        spacing: 2
+    }
+
+    @GUI::ToolbarContainer {
+        name: "toolbar_container"
+
+        @GUI::Toolbar {
+            name: "toolbar"
+        }
+    }
+
+    @HexEditor::Editor {
+        name: "editor"
+    }
+
+    @GUI::Statusbar {
+        name: "statusbar"
+        label_count: 5
+    }
+}

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <unistd.h>
 
+using namespace HexEditor;
+
 int main(int argc, char** argv)
 {
     if (pledge("stdio recvfd sendfd rpath unix cpath wpath thread", nullptr) < 0) {


### PR DESCRIPTION
Moved everything into a `HexEditor` namespace while I was at it. `HexEditor::Editor` sounds kind of silly, but I don't have a better idea.

![HexEditor](https://user-images.githubusercontent.com/434827/119224717-21d8ee80-bb43-11eb-9b00-ee6c7511874a.png)
