### PR TITLE
LibWeb: Remove StringBuilders from the HTMLToken class

### DIFF
--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -46,6 +46,13 @@ public:
             m_index_into_first = 0;
         }
         --m_size;
+        if (m_size == 0 && !m_segments.is_empty()) {
+            // This is not necessary for correctness but avoids faulting in
+            // all the pages for the underlying Vector in the case where
+            // the caller repeatedly enqueues and then dequeues a single item.
+            m_index_into_first = 0;
+            m_segments.last()->data.clear_with_capacity();
+        }
         return value;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -1572,8 +1572,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::image) {
         // Parse error. Change the token's tag name to HTML::TagNames::img and reprocess it. (Don't ask.)
         log_parse_error();
-        token.m_tag.tag_name.clear();
-        token.m_tag.tag_name.append(HTML::TagNames::img);
+        token.m_tag.tag_name = "img";
         process_using_the_rules_for(m_insertion_mode, token);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -317,7 +317,7 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }
@@ -347,7 +347,7 @@ void HTMLDocumentParser::handle_before_html(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }
@@ -520,7 +520,7 @@ AnythingElse:
 
 void HTMLDocumentParser::insert_comment(HTMLToken& token)
 {
-    auto data = token.m_comment_or_character.data.to_string();
+    auto data = token.m_comment_or_character.data;
     auto adjusted_insertion_location = find_appropriate_place_for_inserting_node();
     adjusted_insertion_location.parent->insert_before(adopt_ref(*new DOM::Comment(document(), data)), adjusted_insertion_location.insert_before_sibling);
 }
@@ -832,7 +832,7 @@ void HTMLDocumentParser::handle_after_body(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto data = token.m_comment_or_character.data.to_string();
+        auto data = token.m_comment_or_character.data;
         auto& insertion_location = m_stack_of_open_elements.first();
         insertion_location.append_child(adopt_ref(*new DOM::Comment(document(), data)));
         return;
@@ -870,7 +870,7 @@ void HTMLDocumentParser::handle_after_body(HTMLToken& token)
 void HTMLDocumentParser::handle_after_after_body(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }
@@ -2751,7 +2751,7 @@ void HTMLDocumentParser::handle_after_frameset(HTMLToken& token)
 void HTMLDocumentParser::handle_after_after_frameset(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -437,7 +437,7 @@ NonnullRefPtr<DOM::Element> HTMLDocumentParser::create_element_for(const HTMLTok
 {
     auto element = create_element(document(), token.tag_name(), namespace_);
     for (auto& attribute : token.m_tag.attributes) {
-        element->set_attribute(attribute.local_name, attribute.value_builder.to_string());
+        element->set_attribute(attribute.local_name, attribute.value);
     }
     return element;
 }
@@ -1122,7 +1122,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         for (auto& attribute : token.m_tag.attributes) {
             if (current_node().has_attribute(attribute.local_name))
                 continue;
-            current_node().set_attribute(attribute.local_name, attribute.value_builder.to_string());
+            current_node().set_attribute(attribute.local_name, attribute.value);
         }
         return;
     }
@@ -1149,7 +1149,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         for (auto& attribute : token.m_tag.attributes) {
             if (body_element.has_attribute(attribute.local_name))
                 continue;
-            body_element.set_attribute(attribute.local_name, attribute.value_builder.to_string());
+            body_element.set_attribute(attribute.local_name, attribute.value);
         }
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -266,7 +266,7 @@ DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_t
         return DOM::QuirksMode::Yes;
 
     auto const& public_identifier = doctype_token.m_doctype.public_identifier;
-    auto system_identifier = doctype_token.m_doctype.system_identifier.to_string();
+    auto const& system_identifier = doctype_token.m_doctype.system_identifier;
 
     if (public_identifier.equals_ignoring_case("-//W3O//DTD W3 HTML Strict 3.0//EN//"))
         return DOM::QuirksMode::Yes;
@@ -326,7 +326,7 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
         auto doctype = adopt_ref(*new DOM::DocumentType(document()));
         doctype->set_name(token.m_doctype.name.to_string());
         doctype->set_public_id(token.m_doctype.public_identifier);
-        doctype->set_system_id(token.m_doctype.system_identifier.to_string());
+        doctype->set_system_id(token.m_doctype.system_identifier);
         document().append_child(move(doctype));
         document().set_quirks_mode(which_quirks_mode(token));
         m_insertion_mode = InsertionMode::BeforeHTML;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -437,7 +437,7 @@ NonnullRefPtr<DOM::Element> HTMLDocumentParser::create_element_for(const HTMLTok
 {
     auto element = create_element(document(), token.tag_name(), namespace_);
     for (auto& attribute : token.m_tag.attributes) {
-        element->set_attribute(attribute.local_name_builder.to_string(), attribute.value_builder.to_string());
+        element->set_attribute(attribute.local_name, attribute.value_builder.to_string());
     }
     return element;
 }
@@ -1120,9 +1120,9 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         if (m_stack_of_open_elements.contains(HTML::TagNames::template_))
             return;
         for (auto& attribute : token.m_tag.attributes) {
-            if (current_node().has_attribute(attribute.local_name_builder.string_view()))
+            if (current_node().has_attribute(attribute.local_name))
                 continue;
-            current_node().set_attribute(attribute.local_name_builder.to_string(), attribute.value_builder.to_string());
+            current_node().set_attribute(attribute.local_name, attribute.value_builder.to_string());
         }
         return;
     }
@@ -1147,9 +1147,9 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         m_frameset_ok = false;
         auto& body_element = m_stack_of_open_elements.elements().at(1);
         for (auto& attribute : token.m_tag.attributes) {
-            if (body_element.has_attribute(attribute.local_name_builder.string_view()))
+            if (body_element.has_attribute(attribute.local_name))
                 continue;
-            body_element.set_attribute(attribute.local_name_builder.to_string(), attribute.value_builder.to_string());
+            body_element.set_attribute(attribute.local_name, attribute.value_builder.to_string());
         }
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -265,7 +265,7 @@ DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_t
     if (doctype_token.m_doctype.name.to_string() != "html")
         return DOM::QuirksMode::Yes;
 
-    auto public_identifier = doctype_token.m_doctype.public_identifier.to_string();
+    auto const& public_identifier = doctype_token.m_doctype.public_identifier;
     auto system_identifier = doctype_token.m_doctype.system_identifier.to_string();
 
     if (public_identifier.equals_ignoring_case("-//W3O//DTD W3 HTML Strict 3.0//EN//"))
@@ -325,7 +325,7 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
     if (token.is_doctype()) {
         auto doctype = adopt_ref(*new DOM::DocumentType(document()));
         doctype->set_name(token.m_doctype.name.to_string());
-        doctype->set_public_id(token.m_doctype.public_identifier.to_string());
+        doctype->set_public_id(token.m_doctype.public_identifier);
         doctype->set_system_id(token.m_doctype.system_identifier.to_string());
         document().append_child(move(doctype));
         document().set_quirks_mode(which_quirks_mode(token));

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -262,7 +262,7 @@ DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_t
         return DOM::QuirksMode::Yes;
 
     // NOTE: The tokenizer puts the name into lower case for us.
-    if (doctype_token.m_doctype.name.to_string() != "html")
+    if (doctype_token.m_doctype.name != "html")
         return DOM::QuirksMode::Yes;
 
     auto const& public_identifier = doctype_token.m_doctype.public_identifier;
@@ -324,7 +324,7 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
 
     if (token.is_doctype()) {
         auto doctype = adopt_ref(*new DOM::DocumentType(document()));
-        doctype->set_name(token.m_doctype.name.to_string());
+        doctype->set_name(token.m_doctype.name);
         doctype->set_public_id(token.m_doctype.public_identifier);
         doctype->set_system_id(token.m_doctype.system_identifier);
         document().append_child(move(doctype));

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -16,7 +16,7 @@ String HTMLToken::to_string() const
     case HTMLToken::Type::DOCTYPE:
         builder.append("DOCTYPE");
         builder.append(" { name: '");
-        builder.append(m_doctype.name.to_string());
+        builder.append(m_doctype.name);
         builder.append("' }");
         break;
     case HTMLToken::Type::StartTag:

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -40,7 +40,7 @@ String HTMLToken::to_string() const
 
     if (type() == HTMLToken::Type::StartTag || type() == HTMLToken::Type::EndTag) {
         builder.append(" { name: '");
-        builder.append(m_tag.tag_name.to_string());
+        builder.append(m_tag.tag_name);
         builder.append("', { ");
         for (auto& attribute : m_tag.attributes) {
             builder.append(attribute.local_name);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -53,7 +53,7 @@ String HTMLToken::to_string() const
 
     if (type() == HTMLToken::Type::Comment || type() == HTMLToken::Type::Character) {
         builder.append(" { data: '");
-        builder.append(m_comment_or_character.data.to_string());
+        builder.append(m_comment_or_character.data);
         builder.append("' }");
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -43,7 +43,7 @@ String HTMLToken::to_string() const
         builder.append(m_tag.tag_name.to_string());
         builder.append("', { ");
         for (auto& attribute : m_tag.attributes) {
-            builder.append(attribute.local_name_builder.to_string());
+            builder.append(attribute.local_name);
             builder.append("=\"");
             builder.append(attribute.value_builder.to_string());
             builder.append("\" ");

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -45,7 +45,7 @@ String HTMLToken::to_string() const
         for (auto& attribute : m_tag.attributes) {
             builder.append(attribute.local_name);
             builder.append("=\"");
-            builder.append(attribute.value_builder.to_string());
+            builder.append(attribute.value);
             builder.append("\" ");
         }
         builder.append("} }");

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -42,7 +42,7 @@ public:
     {
         HTMLToken token;
         token.m_type = Type::StartTag;
-        token.m_tag.tag_name.append(tag_name);
+        token.m_tag.tag_name = tag_name;
         return token;
     }
 
@@ -81,7 +81,7 @@ public:
     String tag_name() const
     {
         VERIFY(is_start_tag() || is_end_tag());
-        return m_tag.tag_name.to_string();
+        return m_tag.tag_name;
     }
 
     bool is_self_closing() const
@@ -120,10 +120,8 @@ public:
     void adjust_tag_name(const FlyString& old_name, const FlyString& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
-        if (old_name == m_tag.tag_name.string_view()) {
-            m_tag.tag_name.clear();
-            m_tag.tag_name.append(new_name);
-        }
+        if (old_name == m_tag.tag_name)
+            m_tag.tag_name = new_name;
     }
 
     void adjust_attribute_name(const FlyString& old_name, const FlyString& new_name)
@@ -202,7 +200,7 @@ private:
     // Type::StartTag
     // Type::EndTag
     struct {
-        StringBuilder tag_name;
+        String tag_name;
         bool self_closing { false };
         bool self_closing_acknowledged { false };
         Vector<AttributeBuilder> attributes;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -8,7 +8,6 @@
 
 #include <AK/FlyString.h>
 #include <AK/String.h>
-#include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
@@ -34,7 +33,10 @@ public:
     {
         HTMLToken token;
         token.m_type = Type::Character;
-        token.m_comment_or_character.data.append(code_point);
+        StringBuilder builder;
+        // FIXME: This narrows code_point to char, should this be append_code_point() instead?
+        builder.append(code_point);
+        token.m_comment_or_character.data = builder.to_string();
         return token;
     }
 
@@ -56,7 +58,7 @@ public:
     u32 code_point() const
     {
         VERIFY(is_character());
-        Utf8View view(m_comment_or_character.data.string_view());
+        Utf8View view(m_comment_or_character.data);
         VERIFY(view.length() == 1);
         return *view.begin();
     }
@@ -209,7 +211,7 @@ private:
     // Type::Comment
     // Type::Character
     struct {
-        StringBuilder data;
+        String data;
     } m_comment_or_character;
 
     Position m_start_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -142,14 +142,12 @@ public:
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
             if (old_name == attribute.local_name_builder.string_view()) {
-                attribute.prefix_builder.clear();
-                attribute.prefix_builder.append(prefix);
+                attribute.prefix = prefix;
 
                 attribute.local_name_builder.clear();
                 attribute.local_name_builder.append(local_name);
 
-                attribute.namespace_builder.clear();
-                attribute.namespace_builder.append(namespace_);
+                attribute.namespace_ = namespace_;
             }
         }
     }
@@ -180,9 +178,9 @@ private:
     };
 
     struct AttributeBuilder {
-        StringBuilder prefix_builder;
+        String prefix;
         StringBuilder local_name_builder;
-        StringBuilder namespace_builder;
+        String namespace_;
         StringBuilder value_builder;
         Position name_start_position;
         Position value_start_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -194,7 +194,7 @@ private:
     struct {
         // NOTE: "Missing" is a distinct state from the empty string.
 
-        StringBuilder name;
+        String name;
         bool missing_name { true };
         String public_identifier;
         bool missing_public_identifier { true };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -107,7 +107,7 @@ public:
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
             if (attribute_name == attribute.local_name)
-                return attribute.value_builder.string_view();
+                return attribute.value;
         }
         return {};
     }
@@ -177,7 +177,7 @@ private:
         String prefix;
         String local_name;
         String namespace_;
-        StringBuilder value_builder;
+        String value;
         Position name_start_position;
         Position value_start_position;
         Position name_end_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -198,7 +198,7 @@ private:
         bool missing_name { true };
         String public_identifier;
         bool missing_public_identifier { true };
-        StringBuilder system_identifier;
+        String system_identifier;
         bool missing_system_identifier { true };
         bool force_quirks { false };
     } m_doctype;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -106,7 +106,7 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (attribute_name == attribute.local_name_builder.string_view())
+            if (attribute_name == attribute.local_name)
                 return attribute.value_builder.string_view();
         }
         return {};
@@ -130,9 +130,8 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (old_name == attribute.local_name_builder.string_view()) {
-                attribute.local_name_builder.clear();
-                attribute.local_name_builder.append(new_name);
+            if (old_name == attribute.local_name) {
+                attribute.local_name = new_name;
             }
         }
     }
@@ -141,12 +140,9 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (old_name == attribute.local_name_builder.string_view()) {
+            if (old_name == attribute.local_name) {
                 attribute.prefix = prefix;
-
-                attribute.local_name_builder.clear();
-                attribute.local_name_builder.append(local_name);
-
+                attribute.local_name = local_name;
                 attribute.namespace_ = namespace_;
             }
         }
@@ -179,7 +175,7 @@ private:
 
     struct AttributeBuilder {
         String prefix;
-        StringBuilder local_name_builder;
+        String local_name;
         String namespace_;
         StringBuilder value_builder;
         Position name_start_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -196,7 +196,7 @@ private:
 
         StringBuilder name;
         bool missing_name { true };
-        StringBuilder public_identifier;
+        String public_identifier;
         bool missing_public_identifier { true };
         StringBuilder system_identifier;
         bool missing_system_identifier { true };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -57,13 +57,13 @@ namespace Web::HTML {
         goto _StartOfFunction;                   \
     } while (0)
 
-#define SWITCH_TO_AND_EMIT_CURRENT_TOKEN(new_state) \
-    do {                                            \
-        will_switch_to(State::new_state);           \
-        m_state = State::new_state;                 \
-        will_emit(m_current_token);                 \
-        m_queued_tokens.enqueue(m_current_token);   \
-        return m_queued_tokens.dequeue();           \
+#define SWITCH_TO_AND_EMIT_CURRENT_TOKEN(new_state)     \
+    do {                                                \
+        will_switch_to(State::new_state);               \
+        m_state = State::new_state;                     \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
 #define EMIT_CHARACTER_AND_RECONSUME_IN(code_point, new_state)          \
@@ -83,7 +83,7 @@ namespace Web::HTML {
                 create_new_token(HTMLToken::Type::Character);                            \
                 m_current_builder.append_code_point(code_point);                         \
                 m_current_token.m_comment_or_character.data = consume_current_builder(); \
-                m_queued_tokens.enqueue(m_current_token);                                \
+                m_queued_tokens.enqueue(move(m_current_token));                          \
             }                                                                            \
         }                                                                                \
     } while (0)
@@ -122,22 +122,22 @@ namespace Web::HTML {
 
 #define ANYTHING_ELSE if (1)
 
-#define EMIT_EOF                                      \
-    do {                                              \
-        if (m_has_emitted_eof)                        \
-            return {};                                \
-        m_has_emitted_eof = true;                     \
-        create_new_token(HTMLToken::Type::EndOfFile); \
-        will_emit(m_current_token);                   \
-        m_queued_tokens.enqueue(m_current_token);     \
-        return m_queued_tokens.dequeue();             \
+#define EMIT_EOF                                        \
+    do {                                                \
+        if (m_has_emitted_eof)                          \
+            return {};                                  \
+        m_has_emitted_eof = true;                       \
+        create_new_token(HTMLToken::Type::EndOfFile);   \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
-#define EMIT_CURRENT_TOKEN                        \
-    do {                                          \
-        will_emit(m_current_token);               \
-        m_queued_tokens.enqueue(m_current_token); \
-        return m_queued_tokens.dequeue();         \
+#define EMIT_CURRENT_TOKEN                              \
+    do {                                                \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
 #define EMIT_CHARACTER(code_point)                                               \
@@ -145,7 +145,7 @@ namespace Web::HTML {
         create_new_token(HTMLToken::Type::Character);                            \
         m_current_builder.append_code_point(code_point);                         \
         m_current_token.m_comment_or_character.data = consume_current_builder(); \
-        m_queued_tokens.enqueue(m_current_token);                                \
+        m_queued_tokens.enqueue(move(m_current_token));                          \
         return m_queued_tokens.dequeue();                                        \
     } while (0)
 
@@ -418,7 +418,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ON(0)
@@ -450,7 +450,7 @@ _StartOfFunction:
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -494,7 +494,7 @@ _StartOfFunction:
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -534,7 +534,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -559,7 +559,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -605,7 +605,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -647,7 +647,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -685,7 +685,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -723,7 +723,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -759,7 +759,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -794,7 +794,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -829,7 +829,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -864,7 +864,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -901,7 +901,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -937,7 +937,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -963,7 +963,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -987,7 +987,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1368,7 +1368,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1399,7 +1399,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1429,7 +1429,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1455,7 +1455,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1475,7 +1475,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -313,29 +313,32 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO(SelfClosingStartTag);
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     m_current_token.m_end_position = nth_last_position(0);
                     continue;
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_tag.tag_name.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     m_current_token.m_end_position = nth_last_position(0);
                     continue;
                 }
@@ -347,7 +350,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_tag.tag_name.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     m_current_token.m_end_position = nth_last_position(0);
                     continue;
                 }
@@ -1855,6 +1858,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1866,6 +1870,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1877,6 +1882,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1888,13 +1894,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
@@ -1965,6 +1971,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1976,6 +1983,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1987,6 +1995,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1998,13 +2007,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(current_input_character.value());
+                    m_current_builder.append(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
@@ -2175,6 +2184,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(BeforeAttributeName);
 
@@ -2187,6 +2197,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(SelfClosingStartTag);
 
@@ -2199,6 +2210,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
 
@@ -2211,13 +2223,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(current_input_character.value());
+                    m_current_builder.append(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
@@ -2500,6 +2512,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(BeforeAttributeName);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2510,6 +2523,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(SelfClosingStartTag);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2520,6 +2534,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2530,13 +2545,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(current_input_character.value());
+                    m_current_builder.append(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -618,14 +618,14 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier.clear();
+                    m_current_token.m_doctype.system_identifier = {};
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier.clear();
+                    m_current_token.m_doctype.system_identifier = {};
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
@@ -697,13 +697,11 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
@@ -803,17 +801,19 @@ _StartOfFunction:
             {
                 ON('"')
                 {
+                    m_current_token.m_doctype.public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPESystemIdentifier);
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('>')
                 {
                     log_parse_error();
+                    m_current_token.m_doctype.public_identifier = consume_current_builder();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
@@ -826,7 +826,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_doctype.system_identifier.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
             }
@@ -836,17 +836,19 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
+                    m_current_token.m_doctype.system_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPESystemIdentifier);
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('>')
                 {
                     log_parse_error();
+                    m_current_token.m_doctype.system_identifier = consume_current_builder();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
@@ -859,7 +861,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_doctype.system_identifier.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
             }
@@ -878,14 +880,12 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
@@ -917,13 +917,11 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1016,9 +1016,9 @@ _StartOfFunction:
                     log_parse_error();
                     auto new_attribute = HTMLToken::AttributeBuilder();
                     new_attribute.name_start_position = nth_last_position(1);
-                    new_attribute.local_name_builder.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     m_current_token.m_tag.attributes.append(new_attribute);
-                    SWITCH_TO(AttributeName);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(AttributeName);
                 }
                 ANYTHING_ELSE
                 {
@@ -1054,33 +1054,38 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON_EOF
                 {
+                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('=')
                 {
+                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
                     SWITCH_TO(BeforeAttributeValue);
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.attributes.last().local_name_builder.append_code_point(tolower(current_input_character.value()));
+                    m_current_builder.append_code_point(tolower(current_input_character.value()));
                     continue;
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_tag.attributes.last().local_name_builder.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('"')
@@ -1101,7 +1106,7 @@ _StartOfFunction:
                 ANYTHING_ELSE
                 {
                 AnythingElseAttributeName:
-                    m_current_token.m_tag.attributes.last().local_name_builder.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
             }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2658,16 +2658,16 @@ void HTMLTokenizer::switch_to(Badge<HTMLDocumentParser>, State new_state)
 void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
-        m_last_emitted_start_tag = token;
+        m_last_emitted_start_tag_name = token.tag_name();
     token.m_end_position = m_source_positions.last();
 }
 
 bool HTMLTokenizer::current_end_tag_token_is_appropriate() const
 {
     VERIFY(m_current_token.is_end_tag());
-    if (!m_last_emitted_start_tag.is_start_tag())
+    if (!m_last_emitted_start_tag_name.has_value())
         return false;
-    return m_current_token.tag_name() == m_last_emitted_start_tag.tag_name();
+    return m_current_token.tag_name() == m_last_emitted_start_tag_name.value();
 }
 
 bool HTMLTokenizer::consumed_as_part_of_an_attribute() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -464,17 +464,17 @@ _StartOfFunction:
                 ON_ASCII_UPPER_ALPHA
                 {
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.m_doctype.name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     m_current_token.m_doctype.missing_name = false;
-                    SWITCH_TO(DOCTYPEName);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
                 ON(0)
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.m_doctype.name.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     m_current_token.m_doctype.missing_name = false;
-                    SWITCH_TO(DOCTYPEName);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
                 ON('>')
                 {
@@ -494,9 +494,9 @@ _StartOfFunction:
                 ANYTHING_ELSE
                 {
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.m_doctype.name.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     m_current_token.m_doctype.missing_name = false;
-                    SWITCH_TO(DOCTYPEName);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
             }
             END_STATE
@@ -505,21 +505,23 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_doctype.name = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEName);
                 }
                 ON('>')
                 {
+                    m_current_token.m_doctype.name = consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_doctype.name.append(tolower(current_input_character.value()));
+                    m_current_builder.append(tolower(current_input_character.value()));
                     continue;
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.name.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
@@ -531,7 +533,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_doctype.name.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
             }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Queue.h>
+#include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Utf8View.h>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -164,7 +164,7 @@ private:
 
     HTMLToken m_current_token;
 
-    HTMLToken m_last_emitted_start_tag;
+    Optional<String> m_last_emitted_start_tag_name;
 
     bool m_has_emitted_eof { false };
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -127,6 +127,7 @@ private:
     bool consume_next_if_match(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive);
     void create_new_token(HTMLToken::Type);
     bool current_end_tag_token_is_appropriate() const;
+    String consume_current_builder();
 
     static const char* state_name(State state)
     {
@@ -163,6 +164,7 @@ private:
     Utf8CodepointIterator m_prev_utf8_iterator;
 
     HTMLToken m_current_token;
+    StringBuilder m_current_builder;
 
     Optional<String> m_last_emitted_start_tag_name;
 


### PR DESCRIPTION
**AK: Avoid allocations for the Queue class**

Previously the `Queue` class used a `SinglyLinkedList` to manage its queue segments. This changes the Queue class to use the `IntrusiveList` class instead which saves us one allocation per segment.

**AK: Avoid pagefaults when repeatedly enqueing/dequeing items in a Queue**
    
When repeatedly enqueing and dequeing a single item in a `Queue` we end up faulting in all the pages for the underlying `Vector`. This is a performance issue - especially if the element type is large.

**LibWeb: Remove StringBuilders from the HTMLToken class**

This removes the `StringBuilder`s from the `HTMLToken` class and adds one to `HTMLTokenizer` instead. In my tests this has a 10% performance increase when loading the HTML spec bookmark.

I've tested this by making a local copy of the page and then adding the page load time indicator from `welcome.html` to it. Each test is a cold boot + `Browser -s test_page.html` (times are in milliseconds):

```
master: 1787, 1852, 1844
This PR: 1663, 1596, 1632
```

**LibWeb: Use move() when enqueuing tokens**

We're not using the current token anymore once it's enqueued so let's use `move()` when enqueuing the tokens.