### PR TITLE
tar: -x: Ignore "extended headers"

### DIFF
--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -102,8 +102,17 @@ int main(int argc, char** argv)
                     }
                     break;
                 }
+                case Archive::TarFileType::GlobalExtendedHeader: {
+                    dbgln("ignoring global extended header: {}", header.filename());
+                    break;
+                }
+                case Archive::TarFileType::ExtendedHeader: {
+                    dbgln("ignoring extended header: {}", header.filename());
+                    break;
+                }
                 default:
                     // FIXME: Implement other file types
+                    warnln("file type '{}' of {} is not yet supported", (char)header.type_flag(), header.filename());
                     VERIFY_NOT_REACHED();
                 }
             }


### PR DESCRIPTION
Looking around on the internet, it seems like this is normally a bit of metadata that the extract operation can safely ignore.

I ran into this while trying to untar an archive created by `git archive`, which contains a GlobalExtendedHeader entry called `pax_global_header` saying which commit the archive was made from. After this change, I could successfully untar it.

I erred on the safe side and added a `warnln`, but maybe it doesn't even need that. I found other tar implementations that ignore these file types silently ([example](https://github.com/alexcrichton/tar-rs/pull/49/files)). Does `if (verbose) warnln` make sense?