### PR TITLE
LibVT: Fix UTF-8 handling in OSC sequences

### DIFF
--- a/Userland/Libraries/LibVT/StateMachine.txt
+++ b/Userland/Libraries/LibVT/StateMachine.txt
@@ -20,7 +20,7 @@ Ground {
 
     [0x20..0x7f] => (_, Print)
 
-    [0xa0..0xc1] => (Ground, FailUTF8)
+    [0x80..0xc1] => (Ground, FailUTF8)
     [0xc2..0xdf] => (UTF81ByteNeeded, BeginUTF8)
     [0xe0..0xef] => (UTF82BytesNeeded, BeginUTF8)
     [0xf0..0xf4] => (UTF83BytesNeeded, BeginUTF8)
@@ -211,7 +211,6 @@ OscString {
     0x19         => (_, _)
     [0x1c..0x1f] => (_, _)
 
-    [0x20..0x7f] => (_, OscPut)
-    0x9c         => (Ground, _)
+    [0x20..0xff] => (_, OscPut)
     @exit OscEnd
 }


### PR DESCRIPTION
Previously, we would ignore bytes in the `0x80..0xff` range when parsing
OSC strings. This caused terminal titles and hyperlinks containing
non-ASCII characters to fail. Also added is extending the UTF-8 fail
functionality for C1 control codes, since we do not handle those.

Fixes #7377