### PR TITLE
Userland: Tweak the visual display of the `bt` utility

### DIFF
--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -37,10 +37,14 @@ int main(int argc, char** argv)
 
     while (iterator.has_next()) {
         pid_t tid = iterator.next_path().to_int().value();
-        outln("tid: {}", tid);
+        outln("thread: {}", tid);
+        outln("frames:");
         auto symbols = Symbolication::symbolicate_thread(pid, tid);
+        auto frame_number = symbols.size() - 1;
         for (auto& symbol : symbols) {
-            out("{:p}  ", symbol.address);
+            // Make kernel stack frames stand out.
+            int color = symbol.address < 0xc0000000 ? 35 : 31;
+            out("{:3}: \033[{};1m{:p}\033[0m | ", frame_number, color, symbol.address);
             if (!symbol.name.is_empty())
                 out("{} ", symbol.name);
             if (!symbol.filename.is_empty()) {
@@ -64,6 +68,7 @@ int main(int argc, char** argv)
                 out(")");
             }
             outln("");
+            frame_number--;
         }
         outln("");
     }


### PR DESCRIPTION
This patch adds a few minor visual features to the `bt` utility:
- Number each frame of the back trace.
- Color the address based on if it's in kernel or user space.
- Add a "frames:" heading to visually seperate the thread id.
- Rename "tid: <tid>" -> "thread: <tid>" as it's more visually
  appealing since it aligns vertically with "frames:"
- Add a visual " | " seperate between the address and symbol name.

Before: 
![image](https://user-images.githubusercontent.com/1212/119244245-f3b4d800-bb5d-11eb-906b-af603d00e561.png)

After:
![image](https://user-images.githubusercontent.com/1212/119244187-75583600-bb5d-11eb-91ae-4a979a30e0f2.png)
