### PR TITLE
Hearts: Allow player to set their name

### DIFF
--- a/Userland/Games/Hearts/CMakeLists.txt
+++ b/Userland/Games/Hearts/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     Game.cpp
     main.cpp
     Player.cpp
+    SettingsDialog.cpp
     HeartsGML.h
 )
 

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -78,8 +78,10 @@ Game::~Game()
 {
 }
 
-void Game::setup()
+void Game::setup(String player_name)
 {
+    m_players[0].name = move(player_name);
+
     NonnullRefPtrVector<Card> deck;
 
     dbgln_if(HEARTS_DEBUG, "=====");

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -24,7 +24,7 @@ public:
 
     virtual ~Game() override;
 
-    void setup();
+    void setup(String player_name);
 
     Function<void(String const&)> on_status_change;
 

--- a/Userland/Games/Hearts/SettingsDialog.cpp
+++ b/Userland/Games/Hearts/SettingsDialog.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "SettingsDialog.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/TextBox.h>
+
+SettingsDialog::SettingsDialog(GUI::Window* parent, String player_name)
+    : GUI::Dialog(parent)
+    , m_player_name(move(player_name))
+{
+    set_rect({ 0, 0, 250, 75 });
+    set_title("Settings");
+    set_icon(parent->icon());
+    set_resizable(false);
+
+    auto& main_widget = set_main_widget<GUI::Widget>();
+    main_widget.set_fill_with_background_color(true);
+
+    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
+    layout.set_margins({ 4, 4, 4, 4 });
+
+    auto& name_box = main_widget.add<GUI::Widget>();
+    auto& input_layout = name_box.set_layout<GUI::HorizontalBoxLayout>();
+    input_layout.set_spacing(4);
+
+    auto& name_label = name_box.add<GUI::Label>("Name:");
+    name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+
+    auto& textbox = name_box.add<GUI::TextBox>();
+    textbox.set_text(m_player_name);
+    textbox.on_change = [&] {
+        m_player_name = textbox.text();
+    };
+
+    auto& button_box = main_widget.add<GUI::Widget>();
+    auto& button_layout = button_box.set_layout<GUI::HorizontalBoxLayout>();
+    button_layout.set_spacing(10);
+
+    button_box.add<GUI::Button>("Cancel").on_click = [this](auto) {
+        done(Dialog::ExecCancel);
+    };
+
+    button_box.add<GUI::Button>("OK").on_click = [this](auto) {
+        done(Dialog::ExecOK);
+    };
+}

--- a/Userland/Games/Hearts/SettingsDialog.h
+++ b/Userland/Games/Hearts/SettingsDialog.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <LibGUI/Dialog.h>
+
+class SettingsDialog : public GUI::Dialog {
+    C_OBJECT(SettingsDialog)
+public:
+    String const& player_name() const { return m_player_name; }
+
+private:
+    SettingsDialog(GUI::Window* parent, String player_name);
+
+    String m_player_name { "Gunnar" };
+};

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Game.h"
+#include "SettingsDialog.h"
 #include <Games/Hearts/HeartsGML.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/Timer.h>
@@ -59,6 +60,8 @@ int main(int argc, char** argv)
     auto& statusbar = *widget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     statusbar.set_text(0, "Score: 0");
 
+    String player_name = config->read_entry("", "player_name", "Gunnar");
+
     game.on_status_change = [&](const AK::StringView& status) {
         statusbar.set_override_text(status);
     };
@@ -74,11 +77,32 @@ int main(int argc, char** argv)
         statusbar.set_override_text({});
     };
 
+    auto change_settings = [&] {
+        auto settings_dialog = SettingsDialog::construct(window, player_name);
+        if (settings_dialog->exec() || settings_dialog->result() != GUI::Dialog::ExecOK)
+            return;
+
+        player_name = settings_dialog->player_name();
+
+        config->write_entry("", "player_name", player_name);
+
+        if (!config->sync()) {
+            GUI::MessageBox::show(window, "Settings could not be saved!", "Error", GUI::MessageBox::Type::Error);
+            return;
+        }
+
+        GUI::MessageBox::show(window, "Settings have been successfully saved and will take effect in the next game.", "Settings Changed Successfully", GUI::MessageBox::Type::Information);
+    };
+
     auto menubar = GUI::Menubar::construct();
     auto& game_menu = menubar->add_menu("&Game");
 
     game_menu.add_action(GUI::Action::create("&New Game", { Mod_None, Key_F2 }, [&](auto&) {
-        game.setup();
+        game.setup(player_name);
+    }));
+    game_menu.add_separator();
+    game_menu.add_action(GUI::Action::create("&Settings...", [&](auto&) {
+        change_settings();
     }));
     game_menu.add_separator();
     game_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
@@ -91,7 +115,7 @@ int main(int argc, char** argv)
     window->set_menubar(move(menubar));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
-    game.setup();
+    game.setup(player_name);
 
     return app->exec();
 }


### PR DESCRIPTION
Added a new settings dialog to hearts with a textbox to allow the
player to set a name, which is persisted in the Hearts config file.

I'm not 100% sure I'm going about this the right way (passing a String into game.setup) since I'm not at all a cpp developer but it does work. :smile: 