### PR TITLE
LibM: Fix linking with LibM when compiling Userland without -O2

### DIFF
--- a/Userland/Libraries/LibM/CMakeLists.txt
+++ b/Userland/Libraries/LibM/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(SOURCES
     math.cpp
+    ../LibC/ssp.cpp
 )
 
+set_source_files_properties (../LibC/ssp.cpp PROPERTIES COMPILE_FLAGS
+    "-fno-stack-protector")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib")
 serenity_libc(LibM m)


### PR DESCRIPTION
While playing with conditionally disabling -O2 optimization when
building the Userland subdirectory, I discovered that we can no longer
link without -O2. This happens as LibM.so doesn't link to
anything else, resulting in no stack protector implementation. It
appears that optimization somehow avoids this problem?

To fix this inject LibC/ssp.cpp as we do with in dynamic loader.

Fixes #5862