### PR TITLE
LibC+UE: Keep more unused chunked blocks around

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1121,6 +1121,9 @@ int Emulator::virt$emuctl(FlatPtr arg1, FlatPtr arg2, FlatPtr arg3)
     case 3:
         tracer->target_did_realloc({}, arg3, arg2);
         return 0;
+    case 4:
+        tracer->target_did_change_chunk_size({}, arg3, arg2);
+        return 0;
     default:
         return -EINVAL;
     }

--- a/Userland/DevTools/UserspaceEmulator/MallocTracer.h
+++ b/Userland/DevTools/UserspaceEmulator/MallocTracer.h
@@ -61,6 +61,7 @@ public:
     void target_did_malloc(Badge<Emulator>, FlatPtr address, size_t);
     void target_did_free(Badge<Emulator>, FlatPtr address);
     void target_did_realloc(Badge<Emulator>, FlatPtr address, size_t);
+    void target_did_change_chunk_size(Badge<Emulator>, FlatPtr, size_t);
 
     void audit_read(const Region&, FlatPtr address, size_t);
     void audit_write(const Region&, FlatPtr address, size_t);
@@ -78,6 +79,8 @@ private:
 
     void dump_memory_graph();
     void populate_memory_graph();
+
+    void update_metadata(MmapRegion& mmap_region, size_t chunk_size);
 
     Emulator& m_emulator;
 


### PR DESCRIPTION
Previously each malloc size class would keep around a limited number of unused blocks which were marked with `MADV_SET_VOLATILE` which could then be reinitialized when additional blocks were needed.

This changes `malloc()` so that it also keeps around a number of blocks without marking them with `MADV_SET_VOLATILE`. I termed these "hot" blocks whereas blocks which were marked as `MADV_SET_VOLATILE` are called "cold" blocks because they're more expensive to reinitialize.

In the worst case this could increase memory usage per process by 1MB when a program requests a bunch of memory and frees all of it.

Also, in order to make more efficient use of these unused blocks they're now shared between size classes.

With these changes @alimpfard's Wasm Mandelbrot demo (which makes heavy use of `LibC`'s allocator) is about 42% faster:

```
master: 996ms
This PR: 579ms
```


https://user-images.githubusercontent.com/388571/119258231-1d571900-bbc9-11eb-898b-2ddafdc5fe18.mp4