### PR TITLE
Hearts: Make the AI pick better cards

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -210,7 +210,10 @@ size_t Game::pick_card(Player& player)
             auto prefer_card = [this, &player](Card& card) {
                 return !other_player_has_lower_value_card(player, card) && other_player_has_higher_value_card(player, card);
             };
-            return player.pick_lead_card(move(valid_card), move(prefer_card));
+            auto lower_value_card_in_play = [this, &player](Card& card) {
+                return other_player_has_lower_value_card(player, card);
+            };
+            return player.pick_lead_card(move(valid_card), move(prefer_card), move(lower_value_card_in_play));
         }
     }
     auto* high_card = &m_trick[0];

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -41,6 +41,7 @@ Game::Game()
     };
     m_players[0].name_alignment = Gfx::TextAlignment::BottomRight;
     m_players[0].name = "Gunnar";
+    m_players[0].is_human = true;
     m_players[0].taken_cards_target = { width / 2 - Card::width / 2, height };
 
     m_players[1].first_card_position = { outer_border_size, (height - player_deck_height) / 2 };
@@ -252,7 +253,7 @@ void Game::let_player_play_card()
     else
         on_status_change(String::formatted("Waiting for {} to play a card...", player));
 
-    if (is_human(player)) {
+    if (player.is_human) {
         m_human_can_play = true;
         update();
         return;
@@ -351,13 +352,19 @@ void Game::advance_game()
 
 void Game::keydown_event(GUI::KeyEvent& event)
 {
-    if (event.shift() && event.key() == KeyCode::Key_F11)
+    if (event.shift() && event.key() == KeyCode::Key_F10) {
+        m_players[0].is_human = !m_players[0].is_human;
+        advance_game();
+    } else if (event.key() == KeyCode::Key_F10) {
+        if (m_human_can_play)
+            play_card(m_players[0], pick_card(m_players[0]));
+    } else if (event.shift() && event.key() == KeyCode::Key_F11)
         dump_state();
 }
 
 void Game::play_card(Player& player, size_t card_index)
 {
-    if (is_human(player))
+    if (player.is_human)
         m_human_can_play = false;
     VERIFY(player.hand[card_index]);
     VERIFY(m_trick.size() < 4);

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -40,7 +40,6 @@ private:
     void continue_game_after_delay(int interval_ms = 750);
     void advance_game();
     size_t pick_card(Player& player);
-    bool is_human(Player& player) const { return &player == &m_players[0]; }
     size_t player_index(Player& player);
     Player& current_player();
     bool game_ended() const { return m_trick_number == 13; }

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -6,6 +6,7 @@
 
 #include "Player.h"
 #include "Helpers.h"
+#include <AK/Debug.h>
 #include <AK/QuickSort.h>
 
 namespace Hearts {
@@ -23,19 +24,28 @@ size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Ca
             sorted_hand.empend(card, i);
     }
     quick_sort(sorted_hand, [](auto& cwi1, auto& cwi2) {
-        if (hearts_card_points(*cwi1.card) >= hearts_card_points(*cwi2.card))
+        if (hearts_card_points(*cwi2.card) < hearts_card_points(*cwi1.card))
             return true;
-        if (hearts_card_value(*cwi1.card) >= hearts_card_value(*cwi2.card))
+        if (hearts_card_points(*cwi1.card) == hearts_card_points(*cwi2.card) && hearts_card_value(*cwi2.card) < hearts_card_value(*cwi1.card))
             return true;
         return false;
     });
+
+    if constexpr (HEARTS_DEBUG) {
+        dbgln("Sorted hand:");
+        for (auto& cwi : sorted_hand)
+            dbgln("{}", *cwi.card);
+        dbgln("----");
+    }
 
     size_t last_index = -1;
     for (auto& cwi : sorted_hand) {
         if (!valid_play(*cwi.card))
             continue;
-        if (prefer_card(*cwi.card))
+        if (prefer_card(*cwi.card)) {
+            dbgln_if(HEARTS_DEBUG, "Preferring card {}", *cwi.card);
             return cwi.index;
+        }
         last_index = cwi.index;
     }
     return last_index;

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -21,7 +21,7 @@ public:
     {
     }
 
-    size_t pick_lead_card(Function<bool(Card&)>, Function<bool(Card&)>);
+    size_t pick_lead_card(Function<bool(Card&)>, Function<bool(Card&)>, Function<bool(Card&)>);
     Optional<size_t> pick_low_points_high_value_card(Optional<Card::Type> type = {});
     Optional<size_t> pick_lower_value_card(Card& other_card);
     Optional<size_t> pick_slightly_higher_value_card(Card& other_card);

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -38,6 +38,7 @@ public:
     Gfx::TextAlignment name_alignment;
     Gfx::IntPoint taken_cards_target;
     String name;
+    bool is_human { false };
 };
 
 }


### PR DESCRIPTION
**Hearts: Fix sorting function for lead cards**

The `pick_lead_card()` function sometimes picks the incorrect card because the `sorted_hand` vector wasn't being sorted properly.

**Hearts: Let the AI prefer lead cards for which other cards are in play**

When picking a lead card the AI should avoid playing cards where it knows that no other player has a lower value card of the same type.

**Hearts: Add key combinations to letting the AI play for you**

A single card can be played with F10 while Shift-F10 toggles the AI for the current as well as all future tricks.