### PR TITLE
FontSettingsWidget: Fix font name bug on startup and reduce code duplication

### DIFF
--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Thomas Keppler <winfr34k@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,41 +14,45 @@
 
 namespace DisplaySettings {
 
+static void update_label_with_font(GUI::Label&, Gfx::Font const&);
+
 FontSettingsWidget::FontSettingsWidget()
 {
     load_from_gml(font_settings_gml);
 
     auto& default_font = Gfx::FontDatabase::default_font();
     m_default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");
-    m_default_font_label->set_font(default_font);
-    m_default_font_label->set_text(default_font.qualified_name());
+    update_label_with_font(*m_default_font_label, default_font);
 
     auto& default_font_button = *find_descendant_of_type_named<GUI::Button>("default_font_button");
     default_font_button.on_click = [this] {
         auto font_picker = GUI::FontPicker::construct(window(), &m_default_font_label->font(), false);
         if (font_picker->exec() == GUI::Dialog::ExecOK) {
-            m_default_font_label->set_font(font_picker->font());
-            m_default_font_label->set_text(font_picker->font()->qualified_name());
+            update_label_with_font(*m_default_font_label, *font_picker->font());
         }
     };
 
     auto& default_fixed_width_font = Gfx::FontDatabase::default_fixed_width_font();
     m_fixed_width_font_label = *find_descendant_of_type_named<GUI::Label>("fixed_width_font_label");
-    m_fixed_width_font_label->set_font(default_fixed_width_font);
-    m_fixed_width_font_label->set_text(default_fixed_width_font.qualified_name());
+    update_label_with_font(*m_fixed_width_font_label, default_fixed_width_font);
 
     auto& fixed_width_font_button = *find_descendant_of_type_named<GUI::Button>("fixed_width_font_button");
     fixed_width_font_button.on_click = [this] {
         auto font_picker = GUI::FontPicker::construct(window(), &m_fixed_width_font_label->font(), true);
         if (font_picker->exec() == GUI::Dialog::ExecOK) {
-            m_fixed_width_font_label->set_font(font_picker->font());
-            m_fixed_width_font_label->set_text(font_picker->font()->qualified_name());
+            update_label_with_font(*m_fixed_width_font_label, *font_picker->font());
         }
     };
 }
 
 FontSettingsWidget::~FontSettingsWidget()
 {
+}
+
+static void update_label_with_font(GUI::Label& label, Gfx::Font const& font)
+{
+    label.set_text(font.qualified_name());
+    label.set_font(font);
 }
 
 void FontSettingsWidget::apply_settings()

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -8,7 +8,6 @@
 #include <Applications/DisplaySettings/FontSettingsGML.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/FontPicker.h>
-#include <LibGUI/Label.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/FontDatabase.h>
 
@@ -18,32 +17,31 @@ FontSettingsWidget::FontSettingsWidget()
 {
     load_from_gml(font_settings_gml);
 
-    auto& default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");
-    auto& default_font_button = *find_descendant_of_type_named<GUI::Button>("default_font_button");
-    auto& fixed_width_font_label = *find_descendant_of_type_named<GUI::Label>("fixed_width_font_label");
-    auto& fixed_width_font_button = *find_descendant_of_type_named<GUI::Button>("fixed_width_font_button");
-
     auto& default_font = Gfx::FontDatabase::default_font();
-    default_font_label.set_font(default_font);
-    default_font_label.set_text(default_font.qualified_name());
+    m_default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");
+    m_default_font_label->set_font(default_font);
+    m_default_font_label->set_text(default_font.qualified_name());
 
-    auto& default_fixed_width_font = Gfx::FontDatabase::default_fixed_width_font();
-    fixed_width_font_label.set_font(default_fixed_width_font);
-    fixed_width_font_label.set_text(default_fixed_width_font.qualified_name());
-
-    default_font_button.on_click = [this, &default_font_label] {
-        auto font_picker = GUI::FontPicker::construct(window(), &default_font_label.font(), false);
+    auto& default_font_button = *find_descendant_of_type_named<GUI::Button>("default_font_button");
+    default_font_button.on_click = [this] {
+        auto font_picker = GUI::FontPicker::construct(window(), &m_default_font_label->font(), false);
         if (font_picker->exec() == GUI::Dialog::ExecOK) {
-            default_font_label.set_font(font_picker->font());
-            default_font_label.set_text(font_picker->font()->qualified_name());
+            m_default_font_label->set_font(font_picker->font());
+            m_default_font_label->set_text(font_picker->font()->qualified_name());
         }
     };
 
-    fixed_width_font_button.on_click = [this, &fixed_width_font_label] {
-        auto font_picker = GUI::FontPicker::construct(window(), &fixed_width_font_label.font(), true);
+    auto& default_fixed_width_font = Gfx::FontDatabase::default_fixed_width_font();
+    m_fixed_width_font_label = *find_descendant_of_type_named<GUI::Label>("fixed_width_font_label");
+    m_fixed_width_font_label->set_font(default_fixed_width_font);
+    m_fixed_width_font_label->set_text(default_fixed_width_font.qualified_name());
+
+    auto& fixed_width_font_button = *find_descendant_of_type_named<GUI::Button>("fixed_width_font_button");
+    fixed_width_font_button.on_click = [this] {
+        auto font_picker = GUI::FontPicker::construct(window(), &m_fixed_width_font_label->font(), true);
         if (font_picker->exec() == GUI::Dialog::ExecOK) {
-            fixed_width_font_label.set_font(font_picker->font());
-            fixed_width_font_label.set_text(font_picker->font()->qualified_name());
+            m_fixed_width_font_label->set_font(font_picker->font());
+            m_fixed_width_font_label->set_text(font_picker->font()->qualified_name());
         }
     };
 }
@@ -54,9 +52,7 @@ FontSettingsWidget::~FontSettingsWidget()
 
 void FontSettingsWidget::apply_settings()
 {
-    auto& default_font_label = *find_descendant_of_type_named<GUI::Label>("default_font_label");
-    auto& fixed_width_font_label = *find_descendant_of_type_named<GUI::Label>("fixed_width_font_label");
-    GUI::WindowServerConnection::the().set_system_fonts(default_font_label.text(), fixed_width_font_label.text());
+    GUI::WindowServerConnection::the().set_system_fonts(m_default_font_label->text(), m_fixed_width_font_label->text());
 }
 
 }

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -23,8 +23,13 @@ FontSettingsWidget::FontSettingsWidget()
     auto& fixed_width_font_label = *find_descendant_of_type_named<GUI::Label>("fixed_width_font_label");
     auto& fixed_width_font_button = *find_descendant_of_type_named<GUI::Button>("fixed_width_font_button");
 
-    default_font_label.set_font(Gfx::FontDatabase::default_font());
-    fixed_width_font_label.set_font(Gfx::FontDatabase::default_fixed_width_font());
+    auto& default_font = Gfx::FontDatabase::default_font();
+    default_font_label.set_font(default_font);
+    default_font_label.set_text(default_font.qualified_name());
+
+    auto& default_fixed_width_font = Gfx::FontDatabase::default_fixed_width_font();
+    fixed_width_font_label.set_font(default_fixed_width_font);
+    fixed_width_font_label.set_text(default_fixed_width_font.qualified_name());
 
     default_font_button.on_click = [this, &default_font_label] {
         auto font_picker = GUI::FontPicker::construct(window(), &default_font_label.font(), false);

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGUI/Label.h>
 #include <LibGUI/Widget.h>
 
 namespace DisplaySettings {
@@ -20,6 +21,9 @@ public:
 
 private:
     FontSettingsWidget();
+
+    RefPtr<GUI::Label> m_default_font_label;
+    RefPtr<GUI::Label> m_fixed_width_font_label;
 };
 
 }


### PR DESCRIPTION
This pull request contains commits to fix a bug that when you have changed the fonts and freshly start the DisplaySettings, you don't see the name of that font because it wasn't set.
It also tries to minimize on the code duplication as introduced in the first PoC Andreas made for the video.

Ideally, I would like to drive this further and pull another Widget out and maybe also continue on dealing with all that blank space, but I thought this is too much for one pull request. I hope I haven't done too much :^)

I committed in a way that if I did too much, one could easily just apply the first commit as a patch and not use the others.

Keep in mind that my C++ is far from fluid, so I appreciate any comments to improve the code and hope that it is a first good PR :-D