### PR TITLE
LibC: Use \010 for erasing instead of \0177

### DIFF
--- a/Userland/Libraries/LibC/sys/ttydefaults.h
+++ b/Userland/Libraries/LibC/sys/ttydefaults.h
@@ -17,7 +17,7 @@
 #define CTRL(c) (c & 0x1F)
 #define CINTR CTRL('c')
 #define CQUIT 034
-#define CERASE 0177
+#define CERASE 010
 #define CKILL CTRL('u')
 #define CEOF CTRL('d')
 #define CTIME 0


### PR DESCRIPTION
We ignore \0177 in the terminal -- as the ANSI standard dictates.

Fixes #7415