### PR TITLE
Browser: Add context menu with history for back/forward button

### DIFF
--- a/Userland/Applications/Browser/History.cpp
+++ b/Userland/Applications/Browser/History.cpp
@@ -34,22 +34,40 @@ URL History::current() const
     return m_items[m_current];
 }
 
-void History::go_back()
+void History::go_back(int steps)
 {
-    VERIFY(can_go_back());
-    m_current--;
+    VERIFY(can_go_back(steps));
+    m_current -= steps;
 }
 
-void History::go_forward()
+void History::go_forward(int steps)
 {
-    VERIFY(can_go_forward());
-    m_current++;
+    VERIFY(can_go_forward(steps));
+    m_current += steps;
 }
 
 void History::clear()
 {
     m_items = {};
     m_current = -1;
+}
+
+const Vector<URL> History::get_back_history()
+{
+    Vector<URL> back_history;
+    for (int i = m_current - 1; i >= 0; i--) {
+        back_history.append(m_items[i]);
+    }
+    return back_history;
+}
+
+const Vector<URL> History::get_forward_history()
+{
+    Vector<URL> forward_history;
+    for (int i = m_current + 1; i < static_cast<int>(m_items.size()); i++) {
+        forward_history.append(m_items[i]);
+    }
+    return forward_history;
 }
 
 }

--- a/Userland/Applications/Browser/History.h
+++ b/Userland/Applications/Browser/History.h
@@ -17,13 +17,14 @@ public:
 
     void push(const URL&);
     URL current() const;
+    const Vector<URL> get_back_history();
+    const Vector<URL> get_forward_history();
 
-    void go_back();
-    void go_forward();
+    void go_back(int steps = 1);
+    void go_forward(int steps = 1);
 
-    bool can_go_back() { return m_current > 0; }
-    bool can_go_forward() { return m_current + 1 < static_cast<int>(m_items.size()); }
-
+    bool can_go_back(int steps = 1) { return (m_current - steps) >= 0; }
+    bool can_go_forward(int steps = 1) { return (m_current + steps) < static_cast<int>(m_items.size()); }
     void clear();
 
 private:

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -46,8 +46,8 @@ public:
 
     void load(const URL&, LoadType = LoadType::Normal);
     void reload();
-    void go_back();
-    void go_forward();
+    void go_back(int steps = 1);
+    void go_forward(int steps = 1);
 
     void did_become_active();
     void context_menu_requested(const Gfx::IntPoint& screen_position);
@@ -104,7 +104,8 @@ private:
 
     RefPtr<GUI::Menu> m_tab_context_menu;
     RefPtr<GUI::Menu> m_page_context_menu;
-
+    RefPtr<GUI::Menu> m_go_back_context_menu;
+    RefPtr<GUI::Menu> m_go_forward_context_menu;
     String m_title;
     RefPtr<const Gfx::Bitmap> m_icon;
 


### PR DESCRIPTION
Right clicking on back or forward button will now show a context menu with possible urls, like a bunch of other browsers do.
Also added optional argument for number of steps in go_back() and go_forward().

For the moment the plain url is shown since AK/URL doesn't store title. I don't feel it's AK/URLs job to store that information so perhaps just wrap it in Browser::History?