### PR TITLE
Browser: Add CSS :not() pseudoclass

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -579,6 +579,9 @@ public:
                 simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Enabled;
             } else if (pseudo_name.equals_ignoring_case("checked")) {
                 simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Checked;
+            } else if (pseudo_name.starts_with("not", CaseSensitivity::CaseInsensitive)) {
+                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Not;
+                simple_selector.not_selector = capture_selector_args(pseudo_name);
             } else {
                 dbgln("Unknown pseudo class: '{}'", pseudo_name);
                 return {};

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace Web::CSS {
@@ -41,6 +42,7 @@ public:
             Disabled,
             Enabled,
             Checked,
+            Not,
         };
         PseudoClass pseudo_class { PseudoClass::None };
 
@@ -75,6 +77,7 @@ public:
         // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
         // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
         NthChildPattern nth_child_pattern;
+        String not_selector {};
     };
 
     struct ComplexSelector {

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/Parser/DeprecatedCSSParser.h>
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -100,6 +101,17 @@ static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::E
         if (!element.has_attribute("checked"))
             return false;
         break;
+    case CSS::Selector::SimpleSelector::PseudoClass::Not: {
+        if (component.not_selector.is_empty())
+            return false;
+        auto not_selector = Web::parse_selector(CSS::ParsingContext(element), component.not_selector);
+        if (!not_selector.has_value())
+            return false;
+        auto not_matches = matches(not_selector.value(), element);
+        if (not_matches)
+            return false;
+        break;
+    }
     case CSS::Selector::SimpleSelector::PseudoClass::NthChild:
     case CSS::Selector::SimpleSelector::PseudoClass::NthLastChild:
         const auto step_size = component.nth_child_pattern.step_size;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -384,6 +384,9 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
             case CSS::Selector::SimpleSelector::PseudoClass::Checked:
                 pseudo_class_description = "Checked";
                 break;
+            case CSS::Selector::SimpleSelector::PseudoClass::Not:
+                pseudo_class_description = "Not";
+                break;
             }
 
             builder.appendff("{}:{}", type_description, simple_selector.value);


### PR DESCRIPTION
I just amended the DeprecatedCSSParser for now.
I doubt that this is in any way clean or the best way to go about this, but it works.