### PR TITLE
CI: Enable more verbose and strict sanitizer options

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -242,7 +242,9 @@ jobs:
       timeout-minutes: 4
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
-        UBSAN_OPTIONS: "halt_on_error=1"
+        # FIXME: enable detect_stack_use_after_return=1 #7420
+        ASAN_OPTIONS: "strict_string_checks=1:check_initialization_order=1:strict_init_order=1"
+        UBSAN_OPTIONS: "print_stacktrace=1:print_summary=1:halt_on_error=1"
       if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
 
   notify_irc:


### PR DESCRIPTION
Options shamelessly stolen from this article on systemd's website:

https://systemd.io/TESTING_WITH_SANITIZERS/

We make ASAN more strict and tell UBSAN to print more verbose output on
failure. One of the more interesting ASAN options,
detect_stack_use_after_return, sadly causes both UBSAN and ASAN failures
in test-js.

I opened #7420 to track the issues with `detect_stack_use_on_return=1`