### PR TITLE
Calculator: Various fixes and improvments

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -7,13 +7,11 @@
  */
 
 #include "CalculatorWidget.h"
-#include <AK/Assertions.h>
 #include <Applications/Calculator/CalculatorGML.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/TextBox.h>
 #include <LibGfx/Font.h>
-#include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 
 CalculatorWidget::CalculatorWidget()

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
  * Copyright (c) 2021, Glenford Williams <gw_dev@outlook.com>
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -154,37 +155,32 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
 
     if (event.key() == KeyCode::Key_Return) {
         m_keypad.set_value(m_calculator.finish_operation(m_keypad.value()));
-
-    } else if (event.key() >= KeyCode::Key_0 && event.key() <= KeyCode::Key_9) {
-        m_keypad.type_digit(atoi(event.text().characters()));
-
-    } else if (event.key() == KeyCode::Key_Period) {
+    } else if (event.code_point() >= '0' && event.code_point() <= '9') {
+        m_keypad.type_digit(event.code_point() - '0');
+    } else if (event.code_point() == '.') {
         m_keypad.type_decimal_point();
-
     } else if (event.key() == KeyCode::Key_Escape) {
         m_keypad.set_value(0.0);
         m_calculator.clear_operation();
-
     } else if (event.key() == KeyCode::Key_Backspace) {
         m_keypad.type_backspace();
-
     } else {
         Calculator::Operation operation;
 
-        switch (event.key()) {
-        case KeyCode::Key_Plus:
+        switch (event.code_point()) {
+        case '+':
             operation = Calculator::Operation::Add;
             break;
-        case KeyCode::Key_Minus:
+        case '-':
             operation = Calculator::Operation::Subtract;
             break;
-        case KeyCode::Key_Asterisk:
+        case '*':
             operation = Calculator::Operation::Multiply;
             break;
-        case KeyCode::Key_Slash:
+        case '/':
             operation = Calculator::Operation::Divide;
             break;
-        case KeyCode::Key_Percent:
+        case '%':
             operation = Calculator::Operation::Percent;
             break;
         default:

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -144,10 +145,14 @@ String Keypad::to_string() const
         builder.append("-");
     builder.appendff("{}", m_int_value);
 
+    // NOTE: This is so the decimal point appears on screen as soon as you type it.
+    if (m_frac_length > 0 || m_state == State::TypingDecimal)
+        builder.append('.');
+
     if (m_frac_length > 0) {
         // FIXME: This disables the compiletime format string check since we can't parse '}}' here correctly.
         //        remove the 'StringView { }' when that's fixed.
-        builder.appendff(StringView { ".{:0{}}" }, m_frac_value, m_frac_length);
+        builder.appendff(StringView { "{:0{}}" }, m_frac_value, m_frac_length);
     }
 
     return builder.to_string();

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -57,6 +57,7 @@ void Keypad::type_decimal_point()
         m_int_value = 0;
         m_frac_value = 0;
         m_frac_length = 0;
+        m_state = State::TypingDecimal;
         break;
     case State::TypingInteger:
         VERIFY(m_frac_value.value() == 0);

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -7,7 +7,6 @@
 
 #include "Keypad.h"
 #include <AK/StringBuilder.h>
-#include <math.h>
 
 Keypad::Keypad()
 {

--- a/Userland/Applications/Calculator/Keypad.h
+++ b/Userland/Applications/Calculator/Keypad.h
@@ -30,9 +30,9 @@ public:
 private:
     // Internal representation of the current decimal value.
     bool m_negative { false };
-    long m_int_value { 0 };
-    long m_frac_value { 0 };
-    int m_frac_length { 0 };
+    Checked<u64> m_int_value { 0 };
+    Checked<u64> m_frac_value { 0 };
+    u8 m_frac_length { 0 };
     // E.g. for -35.004200,
     // m_negative = true
     // m_int_value = 35


### PR DESCRIPTION
This improves the calculator app in various ways:
* Handle keydown events correctly with all keyboard layouts by using `codepoint()` instead of comparing the `KeyCode`.
* Show the decimal point immediately when it is typed, not only after the next digit is entered.
* Use `Checked<u64>` to ensure entered values do not overflow.
* Fix behavior when entering number starting with decimal (so typing ".15" results in 0.15, not 15).
* Remove some unused headers.

This fixes #1263.