### PR TITLE
LibWeb: Add support for more pseudo classes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -573,6 +573,12 @@ public:
                 simple_selector.pseudo_element = CSS::Selector::SimpleSelector::PseudoElement::Before;
             } else if (pseudo_name.equals_ignoring_case("after")) {
                 simple_selector.pseudo_element = CSS::Selector::SimpleSelector::PseudoElement::After;
+            } else if (pseudo_name.equals_ignoring_case("disabled")) {
+                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Disabled;
+            } else if (pseudo_name.equals_ignoring_case("enabled")) {
+                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Enabled;
+            } else if (pseudo_name.equals_ignoring_case("checked")) {
+                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Checked;
             } else {
                 dbgln("Unknown pseudo class: '{}'", pseudo_name);
                 return {};

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -38,6 +38,9 @@ public:
             LastOfType,
             NthChild,
             NthLastChild,
+            Disabled,
+            Enabled,
+            Checked,
         };
         PseudoClass pseudo_class { PseudoClass::None };
 

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -82,6 +82,24 @@ static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::E
                 return false;
         }
         break;
+    case CSS::Selector::SimpleSelector::PseudoClass::Disabled:
+        if (!element.tag_name().equals_ignoring_case(HTML::TagNames::input))
+            return false;
+        if (!element.has_attribute("disabled"))
+            return false;
+        break;
+    case CSS::Selector::SimpleSelector::PseudoClass::Enabled:
+        if (!element.tag_name().equals_ignoring_case(HTML::TagNames::input))
+            return false;
+        if (element.has_attribute("disabled"))
+            return false;
+        break;
+    case CSS::Selector::SimpleSelector::PseudoClass::Checked:
+        if (!element.tag_name().equals_ignoring_case(HTML::TagNames::input))
+            return false;
+        if (!element.has_attribute("checked"))
+            return false;
+        break;
     case CSS::Selector::SimpleSelector::PseudoClass::NthChild:
     case CSS::Selector::SimpleSelector::PseudoClass::NthLastChild:
         const auto step_size = component.nth_child_pattern.step_size;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -375,6 +375,15 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
             case CSS::Selector::SimpleSelector::PseudoClass::OnlyChild:
                 pseudo_class_description = "OnlyChild";
                 break;
+            case CSS::Selector::SimpleSelector::PseudoClass::Disabled:
+                pseudo_class_description = "Disabled";
+                break;
+            case CSS::Selector::SimpleSelector::PseudoClass::Enabled:
+                pseudo_class_description = "Enabled";
+                break;
+            case CSS::Selector::SimpleSelector::PseudoClass::Checked:
+                pseudo_class_description = "Checked";
+                break;
             }
 
             builder.appendff("{}:{}", type_description, simple_selector.value);


### PR DESCRIPTION
:disabled, :enabled and :checked are now parsed and matched.
Since the :not pseudo class (PR #7422 ) works on my branch, the Browser started screaming about other unimplemented pseudo classes when visiting GitHub.
There are probably more things to consider than I just did, but this works as expected.

Note: `:checked` doesn't do anything since we don't care about a `checked` attribute at all for checkboxes.