### PR TITLE
CI: Update comment-on-pr to a version that supports pull_request_target

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Comment on PR
         if: ${{ failure() }}
-        uses: unsplash/comment-on-pr@85a56be792d927ac4bfa2f4326607d38e80e6e60
+        uses: IdanHo/comment-on-pr@5f51df338210754f519f721f8320d8f72525a4d0
         env:
           GITHUB_TOKEN: ${{ secrets.BUGGIEBOT }}
         with:


### PR DESCRIPTION
The previous version unfortunately didnt work for that workflow type if the author of the PR did not already have write access to the repo.