### PR TITLE
Kernel: Signal EOF/EOL characters properly in `TTY`

### DIFF
--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -13,6 +13,8 @@
 #include <Kernel/ProcessGroup.h>
 #include <Kernel/UnixTypes.h>
 
+#define TTY_BUFFER_SIZE 1024
+
 namespace Kernel {
 
 class TTY : public CharacterDevice {
@@ -79,7 +81,10 @@ private:
     // ^CharacterDevice
     virtual bool is_tty() const final override { return true; }
 
-    CircularDeque<u8, 1024> m_input_buffer;
+    CircularDeque<u8, TTY_BUFFER_SIZE> m_input_buffer;
+    // FIXME: use something like AK::Bitmap but which takes a size template parameter
+    u8 m_special_character_bitmask[TTY_BUFFER_SIZE / 8];
+
     WeakPtr<Process> m_original_process_parent;
     WeakPtr<ProcessGroup> m_pg;
     termios m_termios;


### PR DESCRIPTION
I introduced a regression in #7184 where `TTY` would report 1 byte read in canonical mode even if we had no more characters left. This was caused by counting the '\0' that denotes EOF into the number of characters that were read.

The fix was simple: exclude the EOF character from the number of bytes.

This still wouldn't be correct by itself, as the EOF and EOL control characters could change between when the data was written to the TTY and when it is read. We fix this by signaling out-of-band whether something is a special character. End-of-file markers have a value of zero and have their special bits set. Any other bytes with a special flag are treated as line endings. This is possible, as POSIX doesn't allow special characters to be 0.

Fixes #7419