### PR TITLE
PDF part 3: Lots of misc LibPDF changes + PDFViewer functionality

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -234,6 +234,7 @@ bool String::ends_with(char ch) const
         return false;
     return characters()[length() - 1] == ch;
 }
+
 String String::repeated(char ch, size_t count)
 {
     if (!count)
@@ -241,6 +242,17 @@ String String::repeated(char ch, size_t count)
     char* buffer;
     auto impl = StringImpl::create_uninitialized(count, buffer);
     memset(buffer, ch, count);
+    return *impl;
+}
+
+String String::repeated(const StringView& string, size_t count)
+{
+    if (!count || string.is_empty())
+        return empty();
+    char* buffer;
+    auto impl = StringImpl::create_uninitialized(count * string.length(), buffer);
+    for (size_t i = 0; i < count; i++)
+        __builtin_memcpy(buffer + i * string.length(), string.characters_without_null_termination(), string.length());
     return *impl;
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -92,6 +92,7 @@ public:
     String(const FlyString&);
 
     [[nodiscard]] static String repeated(char, size_t count);
+    [[nodiscard]] static String repeated(const StringView&, size_t count);
 
     [[nodiscard]] static String bijective_base_from(size_t value, unsigned base = 26, StringView map = {});
 

--- a/Userland/Applications/PDFViewer/CMakeLists.txt
+++ b/Userland/Applications/PDFViewer/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SOURCES
+    OutlineModel.cpp
     PDFViewer.cpp
     PDFViewerWidget.cpp
+    SidebarWidget.cpp
     main.cpp
     )
 

--- a/Userland/Applications/PDFViewer/CMakeLists.txt
+++ b/Userland/Applications/PDFViewer/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    NumericInput.cpp
     OutlineModel.cpp
     PDFViewer.cpp
     PDFViewerWidget.cpp

--- a/Userland/Applications/PDFViewer/NumericInput.cpp
+++ b/Userland/Applications/PDFViewer/NumericInput.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "NumericInput.h"
+#include "ctype.h"
+
+NumericInput::NumericInput()
+{
+    set_text("0");
+
+    on_change = [&] {
+        auto number_opt = text().to_int();
+        if (number_opt.has_value()) {
+            set_current_number(number_opt.value(), false);
+            return;
+        }
+
+        StringBuilder builder;
+        bool first = true;
+        for (auto& ch : text()) {
+            if (isdigit(ch) || (first && ((ch == '-' && m_min_number < 0) || ch == '+')))
+                builder.append(ch);
+            first = false;
+        }
+
+        auto new_number_opt = builder.to_string().to_int();
+        if (!new_number_opt.has_value()) {
+            m_needs_text_reset = true;
+            set_text(builder.to_string());
+            return;
+        } else {
+            m_needs_text_reset = false;
+        }
+
+        set_text(builder.to_string());
+        set_current_number(new_number_opt.value(), false);
+    };
+
+    on_up_pressed = [&] {
+        if (m_current_number < m_max_number)
+            set_current_number(m_current_number + 1);
+    };
+
+    on_down_pressed = [&] {
+        if (m_current_number > m_min_number)
+            set_current_number(m_current_number - 1);
+    };
+
+    on_focusout = [&] { on_focus_lost(); };
+    on_return_pressed = [&] { on_focus_lost(); };
+    on_escape_pressed = [&] { on_focus_lost(); };
+}
+
+void NumericInput::set_min_number(i32 number)
+{
+    m_min_number = number;
+    if (m_current_number < number)
+        set_current_number(number);
+}
+
+void NumericInput::set_max_number(i32 number)
+{
+    m_max_number = number;
+    if (m_current_number > number)
+        set_current_number(number);
+}
+
+void NumericInput::on_focus_lost()
+{
+    if (m_needs_text_reset) {
+        set_text(String::number(m_current_number));
+        m_needs_text_reset = false;
+    }
+    if (on_number_changed)
+        on_number_changed(m_current_number);
+}
+
+void NumericInput::set_current_number(i32 number, bool call_change_handler)
+{
+    if (number == m_current_number)
+        return;
+
+    m_current_number = clamp(number, m_min_number, m_max_number);
+    set_text(String::number(m_current_number));
+    if (on_number_changed && call_change_handler)
+        on_number_changed(m_current_number);
+}

--- a/Userland/Applications/PDFViewer/NumericInput.h
+++ b/Userland/Applications/PDFViewer/NumericInput.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NumericLimits.h>
+#include <LibGUI/TextBox.h>
+
+class NumericInput final : public GUI::TextBox {
+    C_OBJECT(NumericInput)
+public:
+    NumericInput();
+    virtual ~NumericInput() override = default;
+
+    Function<void(i32)> on_number_changed;
+
+    void set_min_number(i32 number);
+    void set_max_number(i32 number);
+    void set_current_number(i32 number, bool call_change_handler = true);
+
+private:
+    void on_focus_lost();
+
+    bool m_needs_text_reset { false };
+    i32 m_current_number { 0 };
+    i32 m_min_number { NumericLimits<i32>::min() };
+    i32 m_max_number { NumericLimits<i32>::max() };
+};

--- a/Userland/Applications/PDFViewer/OutlineModel.cpp
+++ b/Userland/Applications/PDFViewer/OutlineModel.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "OutlineModel.h"
+#include <LibGfx/FontDatabase.h>
+
+NonnullRefPtr<OutlineModel> OutlineModel::create(const NonnullRefPtr<PDF::OutlineDict>& outline)
+{
+    return adopt_ref(*new OutlineModel(outline));
+}
+
+OutlineModel::OutlineModel(const NonnullRefPtr<PDF::OutlineDict>& outline)
+    : m_outline(outline)
+{
+    m_closed_item_icon.set_bitmap_for_size(16, Gfx::Bitmap::load_from_file("/res/icons/16x16/book.png"));
+    m_open_item_icon.set_bitmap_for_size(16, Gfx::Bitmap::load_from_file("/res/icons/16x16/book-open.png"));
+}
+
+void OutlineModel::set_index_open_state(const GUI::ModelIndex& index, bool is_open)
+{
+    VERIFY(index.is_valid());
+    auto* outline_item = static_cast<PDF::OutlineItem*>(index.internal_data());
+
+    if (is_open) {
+        m_open_outline_items.set(outline_item);
+    } else {
+        m_open_outline_items.remove(outline_item);
+    }
+}
+
+int OutlineModel::row_count(const GUI::ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return m_outline->children.size();
+    auto outline_item = static_cast<PDF::OutlineItem*>(index.internal_data());
+    return static_cast<int>(outline_item->children.size());
+}
+
+int OutlineModel::column_count(const GUI::ModelIndex&) const
+{
+    return 1;
+}
+
+GUI::Variant OutlineModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+{
+    VERIFY(index.is_valid());
+    auto outline_item = static_cast<PDF::OutlineItem*>(index.internal_data());
+
+    switch (role) {
+    case GUI::ModelRole::Display:
+        return outline_item->title;
+    case GUI::ModelRole::Icon:
+        if (m_open_outline_items.contains(outline_item))
+            return m_open_item_icon;
+        return m_closed_item_icon;
+    default:
+        return {};
+    }
+}
+
+void OutlineModel::update()
+{
+    did_update();
+}
+
+GUI::ModelIndex OutlineModel::parent_index(const GUI::ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return {};
+
+    auto* outline_item = static_cast<PDF::OutlineItem*>(index.internal_data());
+    auto& parent = outline_item->parent;
+
+    if (!parent)
+        return {};
+
+    if (parent->parent) {
+        auto& grandparent = parent->parent;
+        for (size_t i = 0; i < grandparent->children.size(); i++) {
+            auto* sibling = &grandparent->children[i];
+            if (sibling == index.internal_data())
+                return create_index(static_cast<int>(i), 0, sibling);
+        }
+    } else {
+        for (size_t i = 0; i < m_outline->children.size(); i++) {
+            auto* sibling = &m_outline->children[i];
+            if (sibling == index.internal_data())
+                return create_index(static_cast<int>(i), 0, sibling);
+        }
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+GUI::ModelIndex OutlineModel::index(int row, int column, const GUI::ModelIndex& parent) const
+{
+    if (!parent.is_valid())
+        return create_index(row, column, &m_outline->children[row]);
+
+    auto parent_outline_item = static_cast<PDF::OutlineItem*>(parent.internal_data());
+    return create_index(row, column, &parent_outline_item->children[row]);
+}

--- a/Userland/Applications/PDFViewer/OutlineModel.h
+++ b/Userland/Applications/PDFViewer/OutlineModel.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Model.h>
+#include <LibGUI/TreeView.h>
+#include <LibPDF/Document.h>
+
+class OutlineModel final : public GUI::Model {
+public:
+    static NonnullRefPtr<OutlineModel> create(const NonnullRefPtr<PDF::OutlineDict>& outline);
+
+    void set_index_open_state(const GUI::ModelIndex& index, bool is_open);
+
+    virtual int row_count(const GUI::ModelIndex&) const override;
+    virtual int column_count(const GUI::ModelIndex&) const override;
+    virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
+    virtual void update() override;
+    virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
+    virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
+
+private:
+    OutlineModel(const NonnullRefPtr<PDF::OutlineDict>& outline);
+
+    GUI::Icon m_closed_item_icon;
+    GUI::Icon m_open_item_icon;
+    NonnullRefPtr<PDF::OutlineDict> m_outline;
+    HashTable<PDF::OutlineItem*> m_open_outline_items;
+};

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -41,6 +41,10 @@ class PDFViewer : public GUI::AbstractScrollableWidget {
 public:
     virtual ~PDFViewer() override = default;
 
+    ALWAYS_INLINE u32 current_page() const { return m_current_page_index; }
+    ALWAYS_INLINE void set_current_page(u32 current_page) { m_current_page_index = current_page; }
+
+    ALWAYS_INLINE const RefPtr<PDF::Document>& document() const { return m_document; }
     void set_document(RefPtr<PDF::Document>);
 
 protected:

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -9,14 +9,19 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FilePicker.h>
+#include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Splitter.h>
+#include <LibGUI/Toolbar.h>
+#include <LibGUI/ToolbarContainer.h>
 
 PDFViewerWidget::PDFViewerWidget()
 {
     set_fill_with_background_color(true);
     set_layout<GUI::VerticalBoxLayout>();
+
+    create_toolbar();
 
     auto& splitter = add<GUI::HorizontalSplitter>();
 
@@ -37,21 +42,53 @@ void PDFViewerWidget::initialize_menubar(GUI::Menubar& menubar)
     file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();
     }));
+}
 
-    auto& view_menu = menubar.add_menu("&View");
+void PDFViewerWidget::create_toolbar()
+{
+    auto& toolbar_container = add<GUI::ToolbarContainer>();
+    auto& toolbar = toolbar_container.add<GUI::Toolbar>();
 
-    auto open_sidebar_action = GUI::Action::create(
+    auto open_outline_action = GUI::Action::create(
         "Open &Sidebar", { Mod_Ctrl, Key_O }, Gfx::Bitmap::load_from_file("/res/icons/16x16/sidebar.png"), [&](auto& action) {
             m_sidebar_open = !m_sidebar_open;
             m_sidebar->set_fixed_width(m_sidebar_open ? 0 : 200);
             action.set_text(m_sidebar_open ? "Open &Sidebar" : "Close &Sidebar");
         },
         nullptr);
-    open_sidebar_action->set_enabled(false);
+    open_outline_action->set_enabled(false);
+    m_toggle_sidebar_action = open_outline_action;
 
-    view_menu.add_action(open_sidebar_action);
+    toolbar.add_action(*open_outline_action);
+    toolbar.add_separator();
 
-    m_open_outline_action = open_sidebar_action;
+    m_go_to_prev_page_action = GUI::Action::create("Go to &Previous Page", Gfx::Bitmap::load_from_file("/res/icons/16x16/go-up.png"), [&](auto&) {
+        if (m_viewer->current_page() > 0)
+            m_page_text_box->set_current_number(m_viewer->current_page());
+    });
+    m_go_to_prev_page_action->set_enabled(false);
+
+    m_go_to_next_page_action = GUI::Action::create("Go to &Next Page", Gfx::Bitmap::load_from_file("/res/icons/16x16/go-down.png"), [&](auto&) {
+        if (m_viewer->current_page() < m_viewer->document()->get_page_count() - 1)
+            m_page_text_box->set_current_number(m_viewer->current_page() + 2);
+    });
+    m_go_to_next_page_action->set_enabled(false);
+
+    toolbar.add_action(*m_go_to_prev_page_action);
+    toolbar.add_action(*m_go_to_next_page_action);
+
+    m_page_text_box = toolbar.add<NumericInput>();
+    m_page_text_box->set_enabled(false);
+    m_page_text_box->set_fixed_width(30);
+    m_page_text_box->set_min_number(1);
+
+    m_page_text_box->on_number_changed = [&](i32 number) {
+        VERIFY(number >= 1 && static_cast<u32>(number) <= m_viewer->document()->get_page_count());
+        m_viewer->set_current_page(static_cast<u32>(number) - 1);
+        m_viewer->update();
+    };
+
+    m_total_page_label = toolbar.add<GUI::Label>();
 }
 
 void PDFViewerWidget::open_file(const String& path)
@@ -62,17 +99,24 @@ void PDFViewerWidget::open_file(const String& path)
     m_buffer = file_result.value()->read_all();
     auto document = adopt_ref(*new PDF::Document(m_buffer));
     m_viewer->set_document(document);
+    m_total_page_label->set_text(String::formatted("of {}", document->get_page_count()));
+    m_total_page_label->set_fixed_width(30);
+
+    m_page_text_box->set_text(String::number(m_viewer->current_page() + 1));
+    m_page_text_box->set_enabled(true);
+    m_page_text_box->set_max_number(document->get_page_count());
+    m_go_to_prev_page_action->set_enabled(true);
+    m_go_to_next_page_action->set_enabled(true);
+    m_toggle_sidebar_action->set_enabled(true);
 
     if (document->outline()) {
         auto outline = document->outline();
         m_sidebar->set_outline(outline.release_nonnull());
         m_sidebar->set_fixed_width(200);
         m_sidebar_open = true;
-        m_open_outline_action->set_enabled(true);
     } else {
         m_sidebar->set_outline({});
         m_sidebar->set_fixed_width(0);
         m_sidebar_open = false;
-        m_open_outline_action->set_enabled(false);
     }
 }

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -6,23 +6,24 @@
 
 #include "PDFViewerWidget.h"
 #include <LibCore/File.h>
-#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
+#include <LibGUI/Splitter.h>
 
 PDFViewerWidget::PDFViewerWidget()
 {
     set_fill_with_background_color(true);
     set_layout<GUI::VerticalBoxLayout>();
 
-    m_viewer = add<PDFViewer>();
-}
+    auto& splitter = add<GUI::HorizontalSplitter>();
 
-PDFViewerWidget::~PDFViewerWidget()
-{
+    m_sidebar = splitter.add<SidebarWidget>();
+    m_sidebar->set_fixed_width(0);
+
+    m_viewer = splitter.add<PDFViewer>();
 }
 
 void PDFViewerWidget::initialize_menubar(GUI::Menubar& menubar)
@@ -36,6 +37,21 @@ void PDFViewerWidget::initialize_menubar(GUI::Menubar& menubar)
     file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();
     }));
+
+    auto& view_menu = menubar.add_menu("&View");
+
+    auto open_sidebar_action = GUI::Action::create(
+        "Open &Sidebar", { Mod_Ctrl, Key_O }, Gfx::Bitmap::load_from_file("/res/icons/16x16/sidebar.png"), [&](auto& action) {
+            m_sidebar_open = !m_sidebar_open;
+            m_sidebar->set_fixed_width(m_sidebar_open ? 0 : 200);
+            action.set_text(m_sidebar_open ? "Open &Sidebar" : "Close &Sidebar");
+        },
+        nullptr);
+    open_sidebar_action->set_enabled(false);
+
+    view_menu.add_action(open_sidebar_action);
+
+    m_open_outline_action = open_sidebar_action;
 }
 
 void PDFViewerWidget::open_file(const String& path)
@@ -44,5 +60,19 @@ void PDFViewerWidget::open_file(const String& path)
     auto file_result = Core::File::open(path, Core::OpenMode::ReadOnly);
     VERIFY(!file_result.is_error());
     m_buffer = file_result.value()->read_all();
-    m_viewer->set_document(adopt_ref(*new PDF::Document(m_buffer)));
+    auto document = adopt_ref(*new PDF::Document(m_buffer));
+    m_viewer->set_document(document);
+
+    if (document->outline()) {
+        auto outline = document->outline();
+        m_sidebar->set_outline(outline.release_nonnull());
+        m_sidebar->set_fixed_width(200);
+        m_sidebar_open = true;
+        m_open_outline_action->set_enabled(true);
+    } else {
+        m_sidebar->set_outline({});
+        m_sidebar->set_fixed_width(0);
+        m_sidebar_open = false;
+        m_open_outline_action->set_enabled(false);
+    }
 }

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include "NumericInput.h"
 #include "PDFViewer.h"
 #include "SidebarWidget.h"
 #include <LibGUI/Action.h>
+#include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 
 class PDFViewer;
@@ -19,16 +21,20 @@ class PDFViewerWidget final : public GUI::Widget {
 public:
     ~PDFViewerWidget() override = default;
 
-    void open_file(const String& path);
     void initialize_menubar(GUI::Menubar&);
+    void create_toolbar();
+    void open_file(const String& path);
 
 private:
     PDFViewerWidget();
 
-    RefPtr<GUI::Action> m_open_outline_action;
     RefPtr<PDFViewer> m_viewer;
     RefPtr<SidebarWidget> m_sidebar;
+    RefPtr<NumericInput> m_page_text_box;
+    RefPtr<GUI::Label> m_total_page_label;
+    RefPtr<GUI::Action> m_go_to_prev_page_action;
+    RefPtr<GUI::Action> m_go_to_next_page_action;
+    RefPtr<GUI::Action> m_toggle_sidebar_action;
     bool m_sidebar_open { false };
     ByteBuffer m_buffer;
-    RefPtr<GUI::Action> m_open_action;
 };

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -7,21 +7,28 @@
 #pragma once
 
 #include "PDFViewer.h"
+#include "SidebarWidget.h"
+#include <LibGUI/Action.h>
 #include <LibGUI/Widget.h>
 
 class PDFViewer;
 
 class PDFViewerWidget final : public GUI::Widget {
     C_OBJECT(PDFViewerWidget)
+
 public:
-    ~PDFViewerWidget() override;
+    ~PDFViewerWidget() override = default;
+
     void open_file(const String& path);
     void initialize_menubar(GUI::Menubar&);
 
 private:
     PDFViewerWidget();
 
+    RefPtr<GUI::Action> m_open_outline_action;
     RefPtr<PDFViewer> m_viewer;
+    RefPtr<SidebarWidget> m_sidebar;
+    bool m_sidebar_open { false };
     ByteBuffer m_buffer;
     RefPtr<GUI::Action> m_open_action;
 };

--- a/Userland/Applications/PDFViewer/SidebarWidget.cpp
+++ b/Userland/Applications/PDFViewer/SidebarWidget.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "SidebarWidget.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/TabWidget.h>
+
+SidebarWidget::SidebarWidget()
+{
+    set_fill_with_background_color(true);
+    set_layout<GUI::VerticalBoxLayout>();
+    set_enabled(false);
+
+    auto& tab_bar = add<GUI::TabWidget>();
+
+    auto& outline_container = tab_bar.add_tab<GUI::Widget>("Outline");
+    outline_container.set_layout<GUI::VerticalBoxLayout>();
+    outline_container.layout()->set_margins({ 4, 4, 4, 4 });
+
+    m_outline_tree_view = outline_container.add<GUI::TreeView>();
+    m_outline_tree_view->set_activates_on_selection(true);
+
+    auto& thumbnails_container = tab_bar.add_tab<GUI::Widget>("Thumbnails");
+    thumbnails_container.set_layout<GUI::VerticalBoxLayout>();
+    thumbnails_container.layout()->set_margins({ 4, 4, 4, 4 });
+
+    // FIXME: Add thumbnail previews
+}

--- a/Userland/Applications/PDFViewer/SidebarWidget.h
+++ b/Userland/Applications/PDFViewer/SidebarWidget.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "OutlineModel.h"
+#include <LibGUI/TreeView.h>
+#include <LibGUI/Widget.h>
+
+class SidebarWidget final : public GUI::Widget {
+    C_OBJECT(SidebarWidget)
+
+public:
+    ~SidebarWidget() override = default;
+
+    void set_outline(RefPtr<PDF::OutlineDict> outline)
+    {
+        if (outline) {
+            m_model = OutlineModel::create(outline.release_nonnull());
+            m_outline_tree_view->set_model(m_model);
+        } else {
+            m_model = RefPtr<OutlineModel> {};
+            m_outline_tree_view->set_model({});
+        }
+    }
+
+private:
+    SidebarWidget();
+
+    RefPtr<OutlineModel> m_model;
+    RefPtr<GUI::TreeView> m_outline_tree_view;
+};

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -71,6 +71,15 @@ public:
     static constexpr Color from_rgb(unsigned rgb) { return Color(rgb | 0xff000000); }
     static constexpr Color from_rgba(unsigned rgba) { return Color(rgba); }
 
+    static constexpr Color from_cmyk(float c, float m, float y, float k)
+    {
+        auto r = static_cast<u8>(255.0f * (1.0f - c) * (1.0f - k));
+        auto g = static_cast<u8>(255.0f * (1.0f - m) * (1.0f - k));
+        auto b = static_cast<u8>(255.0f * (1.0f - y) * (1.0f - k));
+
+        return Color(r, g, b);
+    }
+
     constexpr u8 red() const { return (m_value >> 16) & 0xff; }
     constexpr u8 green() const { return (m_value >> 8) & 0xff; }
     constexpr u8 blue() const { return m_value & 0xff; }

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -176,6 +176,12 @@ public:
         return m_split_lines.value();
     }
 
+    void clear()
+    {
+        m_segments.clear();
+        m_split_lines.clear();
+    }
+
     const Gfx::FloatRect& bounding_box()
     {
         if (!m_bounding_box.has_value()) {

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SOURCES
-    Object.cpp
     Document.cpp
+    Filter.cpp
     Object.cpp
     Parser.cpp
     Renderer.cpp

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    CommonNames.cpp
     Document.cpp
     Filter.cpp
     Object.cpp

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SOURCES
     )
 
 serenity_lib(LibPDF pdf)
-target_link_libraries(LibPDF LibC LibCore LibIPC LibGfx)
+target_link_libraries(LibPDF LibC LibCore LibIPC LibGfx LibTextCodec)

--- a/Userland/Libraries/LibPDF/Command.h
+++ b/Userland/Libraries/LibPDF/Command.h
@@ -23,7 +23,7 @@
     V(SetColorRenderingIntent, set_color_rendering_intent, ri)                           \
     V(SetFlatnessTolerance, set_flatness_tolerance, i)                                   \
     V(SetGraphicsStateFromDict, set_graphics_state_from_dict, gs)                        \
-    V(PathBegin, path_begin, m)                                                          \
+    V(PathMove, path_move, m)                                                            \
     V(PathLine, path_line, l)                                                            \
     V(PathCubicBezierCurve, path_cubic_bezier_curve, c)                                  \
     V(PathCubicBezierCurveNoFirstControl, path_cubic_bezier_curve_no_first_control, v)   \

--- a/Userland/Libraries/LibPDF/Command.h
+++ b/Userland/Libraries/LibPDF/Command.h
@@ -59,18 +59,18 @@
     V(TextShowStringArray, text_show_string_array, TJ)                                   \
     V(Type3FontSetGlyphWidth, type3_font_set_glyph_width, d0)                            \
     V(Type3FontSetGlyphWidthAndBBox, type3_font_set_glyph_width_and_bbox, d1)            \
-    V(ColorSetStrokingSpace, color_set_stroking_space, CS)                               \
-    V(ColorSetPaintingSpace, color_set_painting_space, cs)                               \
-    V(ColorSetStroking, color_set_stroking, SC)                                          \
-    V(ColorSetStrokingExtended, color_set_stroking_extended, SCN)                        \
-    V(ColorSetPainting, color_set_painting, sc)                                          \
-    V(ColorSetPaintingExtended, color_set_painting_extended, scn)                        \
-    V(ColorSetStrokingSpaceToGray, color_set_stroking_space_to_gray, G)                  \
-    V(ColorSetPaintingSpaceToGray, color_set_painting_space_to_gray, g)                  \
-    V(ColorSetStrokingSpaceToRGB, color_set_stroking_space_to_rgb, RG)                   \
-    V(ColorSetPaintingSpaceToRGB, color_set_painting_space_to_rgb, rg)                   \
-    V(ColorSetStrokingSpaceToCMYK, color_set_stroking_space_to_cmyk, K)                  \
-    V(ColorSetPaintingSpaceToCMYK, color_set_painting_space_to_cmyk, k)                  \
+    V(SetStrokingSpace, set_stroking_space, CS)                                          \
+    V(SetPaintingSpace, set_painting_space, cs)                                          \
+    V(SetStrokingColor, set_stroking_color, SC)                                          \
+    V(SetStrokingColorExtended, set_stroking_color_extended, SCN)                        \
+    V(SetPaintingColor, set_painting_color, sc)                                          \
+    V(SetPaintingColorExtended, set_painting_color_extended, scn)                        \
+    V(SetStrokingColorAndSpaceToGray, set_stroking_color_and_space_to_gray, G)           \
+    V(SetPaintingColorAndSpaceToGray, set_painting_color_and_space_to_gray, g)           \
+    V(SetStrokingColorAndSpaceToRGB, set_stroking_color_and_space_to_rgb, RG)            \
+    V(SetPaintingColorAndSpaceToRGB, set_painting_color_and_space_to_rgb, rg)            \
+    V(SetStrokingColorAndSpaceToCMYK, set_stroking_color_and_space_to_cmyk, K)           \
+    V(SetPaintingColorAndSpaceToCMYK, set_painting_color_and_space_to_cmyk, k)           \
     V(Shade, shade, sh)                                                                  \
     V(InlineImageBegin, inline_image_begin, BI)                                          \
     V(InlineImageBeginData, inline_image_begin_data, ID)                                 \

--- a/Userland/Libraries/LibPDF/Command.h
+++ b/Userland/Libraries/LibPDF/Command.h
@@ -11,43 +11,78 @@
 #include <AK/StringBuilder.h>
 #include <LibPDF/Value.h>
 
-#define ENUMERATE_COMMANDS(V)                                          \
-    V(SaveState, save_state, q)                                        \
-    V(RestoreState, restore_state, Q)                                  \
-    V(ConcatenateMatrix, concatenate_matrix, cm)                       \
-    V(SetLineWidth, set_line_width, w)                                 \
-    V(SetLineCap, set_line_cap, J)                                     \
-    V(SetLineJoin, set_line_join, j)                                   \
-    V(SetMiterLimit, set_miter_limit, M)                               \
-    V(SetDashPattern, set_dash_pattern, d)                             \
-    V(PathBegin, path_begin, m)                                        \
-    V(PathEnd, path_end, n)                                            \
-    V(PathLine, path_line, l)                                          \
-    V(PathClose, path_close, h)                                        \
-    V(PathAppendRect, path_append_rect, re)                            \
-    V(PathStroke, path_stroke, S)                                      \
-    V(PathCloseAndStroke, path_close_and_stroke, s)                    \
-    V(PathFillNonZero, path_fill_nonzero, f)                           \
-    V(PathFillNonZeroDeprecated, path_fill_nonzero_deprecated, F)      \
-    V(PathFillEvenOdd, path_fill_evenodd, f*)                          \
-    V(PathFillStrokeNonZero, path_fill_stroke_nonzero, B)              \
-    V(PathFillStrokeEvenOdd, path_fill_stroke_evenodd, B*)             \
-    V(PathCloseFillStrokeNonZero, path_close_fill_stroke_nonzero, b)   \
-    V(PathCloseFillStrokeEvenOdd, path_close_fill_stroke_evenodd, b*)  \
-    V(TextSetCharSpace, text_set_char_space, Tc)                       \
-    V(TextSetWordSpace, text_set_word_space, Tw)                       \
-    V(TextSetHorizontalScale, text_set_horizontal_scale, Tz)           \
-    V(TextSetLeading, text_set_leading, TL)                            \
-    V(TextSetFont, text_set_font, Tf)                                  \
-    V(TextSetRenderingMode, text_set_rendering_mode, Tr)               \
-    V(TextSetRise, text_set_rise, Ts)                                  \
-    V(TextBegin, text_begin, BT)                                       \
-    V(TextEnd, text_end, ET)                                           \
-    V(TextNextLineOffset, text_next_line_offset, Td)                   \
-    V(TextNextLineAndSetLeading, text_next_line_and_set_leading, TD)   \
-    V(TextSetMatrixAndLineMatrix, text_set_matrix_and_line_matrix, Tm) \
-    V(TextNextLine, text_next_line, T*)                                \
-    V(TextShowString, text_show_string, Tj)
+#define ENUMERATE_COMMANDS(V)                                                            \
+    V(SaveState, save_state, q)                                                          \
+    V(RestoreState, restore_state, Q)                                                    \
+    V(ConcatenateMatrix, concatenate_matrix, cm)                                         \
+    V(SetLineWidth, set_line_width, w)                                                   \
+    V(SetLineCap, set_line_cap, J)                                                       \
+    V(SetLineJoin, set_line_join, j)                                                     \
+    V(SetMiterLimit, set_miter_limit, M)                                                 \
+    V(SetDashPattern, set_dash_pattern, d)                                               \
+    V(SetColorRenderingIntent, set_color_rendering_intent, ri)                           \
+    V(SetFlatnessTolerance, set_flatness_tolerance, i)                                   \
+    V(SetGraphicsStateFromDict, set_graphics_state_from_dict, gs)                        \
+    V(PathBegin, path_begin, m)                                                          \
+    V(PathLine, path_line, l)                                                            \
+    V(PathCubicBezierCurve, path_cubic_bezier_curve, c)                                  \
+    V(PathCubicBezierCurveNoFirstControl, path_cubic_bezier_curve_no_first_control, v)   \
+    V(PathCubicBezierCurveNoSecondControl, path_cubic_bezier_curve_no_second_control, y) \
+    V(PathClose, path_close, h)                                                          \
+    V(PathAppendRect, path_append_rect, re)                                              \
+    V(PathStroke, path_stroke, S)                                                        \
+    V(PathCloseAndStroke, path_close_and_stroke, s)                                      \
+    V(PathFillNonZero, path_fill_nonzero, f)                                             \
+    V(PathFillNonZeroDeprecated, path_fill_nonzero_deprecated, F)                        \
+    V(PathFillEvenOdd, path_fill_evenodd, f*)                                            \
+    V(PathFillStrokeNonZero, path_fill_stroke_nonzero, B)                                \
+    V(PathFillStrokeEvenOdd, path_fill_stroke_evenodd, B*)                               \
+    V(PathCloseFillStrokeNonZero, path_close_fill_stroke_nonzero, b)                     \
+    V(PathCloseFillStrokeEvenOdd, path_close_fill_stroke_evenodd, b*)                    \
+    V(PathEnd, path_end, n)                                                              \
+    V(PathIntersectClipNonZero, path_intersect_clip_nonzero, W)                          \
+    V(PathIntersectClipEvenOdd, path_intersect_clip_evenodd, W*)                         \
+    V(TextBegin, text_begin, BT)                                                         \
+    V(TextEnd, text_end, ET)                                                             \
+    V(TextSetCharSpace, text_set_char_space, Tc)                                         \
+    V(TextSetWordSpace, text_set_word_space, Tw)                                         \
+    V(TextSetHorizontalScale, text_set_horizontal_scale, Tz)                             \
+    V(TextSetLeading, text_set_leading, TL)                                              \
+    V(TextSetFont, text_set_font, Tf)                                                    \
+    V(TextSetRenderingMode, text_set_rendering_mode, Tr)                                 \
+    V(TextSetRise, text_set_rise, Ts)                                                    \
+    V(TextNextLineOffset, text_next_line_offset, Td)                                     \
+    V(TextNextLineAndSetLeading, text_next_line_and_set_leading, TD)                     \
+    V(TextSetMatrixAndLineMatrix, text_set_matrix_and_line_matrix, Tm)                   \
+    V(TextNextLine, text_next_line, T*)                                                  \
+    V(TextShowString, text_show_string, Tj)                                              \
+    V(TextShowStringArray, text_show_string_array, TJ)                                   \
+    V(Type3FontSetGlyphWidth, type3_font_set_glyph_width, d0)                            \
+    V(Type3FontSetGlyphWidthAndBBox, type3_font_set_glyph_width_and_bbox, d1)            \
+    V(ColorSetStrokingSpace, color_set_stroking_space, CS)                               \
+    V(ColorSetPaintingSpace, color_set_painting_space, cs)                               \
+    V(ColorSetStroking, color_set_stroking, SC)                                          \
+    V(ColorSetStrokingExtended, color_set_stroking_extended, SCN)                        \
+    V(ColorSetPainting, color_set_painting, sc)                                          \
+    V(ColorSetPaintingExtended, color_set_painting_extended, scn)                        \
+    V(ColorSetStrokingSpaceToGray, color_set_stroking_space_to_gray, G)                  \
+    V(ColorSetPaintingSpaceToGray, color_set_painting_space_to_gray, g)                  \
+    V(ColorSetStrokingSpaceToRGB, color_set_stroking_space_to_rgb, RG)                   \
+    V(ColorSetPaintingSpaceToRGB, color_set_painting_space_to_rgb, rg)                   \
+    V(ColorSetStrokingSpaceToCMYK, color_set_stroking_space_to_cmyk, K)                  \
+    V(ColorSetPaintingSpaceToCMYK, color_set_painting_space_to_cmyk, k)                  \
+    V(Shade, shade, sh)                                                                  \
+    V(InlineImageBegin, inline_image_begin, BI)                                          \
+    V(InlineImageBeginData, inline_image_begin_data, ID)                                 \
+    V(InlineImageEnd, inline_image_end, EI)                                              \
+    V(PaintXObject, paint_xobject, Do)                                                   \
+    V(MarkedContentPoint, marked_content_point, MP)                                      \
+    V(MarkedContentDesignate, marked_content_designate, DP)                              \
+    V(MarkedContentBegin, marked_content_begin, BMC)                                     \
+    V(MarkedContentBeginWithPropertyList, marked_content_begin_with_property_list, BDC)  \
+    V(MarkedContentEnd, marked_content_end, EMC)                                         \
+    V(CompatibilityBegin, compatibility_begin, BX)                                       \
+    V(CompatibilityEnd, compatibility_end, EX)
 
 namespace PDF {
 
@@ -56,6 +91,7 @@ enum class CommandType {
     ENUMERATE_COMMANDS(V)
 #undef V
         TextNextLineShowString,
+    TextNextLineShowStringSetSpacing,
 };
 
 class Command {
@@ -70,6 +106,8 @@ public:
 
         if (symbol_string == "'")
             return CommandType::TextNextLineShowString;
+        if (symbol_string == "''")
+            return CommandType::TextNextLineShowStringSetSpacing;
 
         dbgln("unsupported graphics symbol {}", symbol_string);
         VERIFY_NOT_REACHED();
@@ -85,6 +123,8 @@ public:
 
         if (command_name == CommandType::TextNextLineShowString)
             return "TextNextLineShowString";
+        if (command_name == CommandType::TextNextLineShowStringSetSpacing)
+            return "TextNextLineShowStringSetSpacing";
 
         VERIFY_NOT_REACHED();
     }
@@ -99,6 +139,8 @@ public:
 
         if (command_name == CommandType::TextNextLineShowString)
             return "'";
+        if (command_name == CommandType::TextNextLineShowStringSetSpacing)
+            return "''";
 
         VERIFY_NOT_REACHED();
     }
@@ -126,10 +168,17 @@ struct Formatter<PDF::Command> : Formatter<StringView> {
     void format(FormatBuilder& format_builder, const PDF::Command& command)
     {
         StringBuilder builder;
-        builder.appendff("{} [ ", PDF::Command::command_name(command.command_type()));
-        for (auto& argument : command.arguments())
-            builder.appendff(" {}", argument);
-        builder.append(" ]");
+        builder.appendff("{} ({})",
+            PDF::Command::command_name(command.command_type()),
+            PDF::Command::command_symbol(command.command_type()));
+
+        if (!command.arguments().is_empty()) {
+            builder.append(" [");
+            for (auto& argument : command.arguments())
+                builder.appendff(" {}", argument);
+            builder.append(" ]");
+        }
+
         Formatter<StringView>::format(format_builder, builder.to_string());
     }
 };

--- a/Userland/Libraries/LibPDF/CommonNames.cpp
+++ b/Userland/Libraries/LibPDF/CommonNames.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/CommonNames.h>
+
+namespace PDF {
+
+#define ENUMERATE(name) FlyString CommonNames::name = #name;
+ENUMERATE_COMMON_NAMES(ENUMERATE)
+#undef ENUMERATE
+
+}

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+
+#define ENUMERATE_COMMON_NAMES(V) \
+    V(ASCII85Decode)              \
+    V(ASCIIHexDecode)             \
+    V(BaseFont)                   \
+    V(C)                          \
+    V(CCITTFaxDecode)             \
+    V(Contents)                   \
+    V(Count)                      \
+    V(CropBox)                    \
+    V(Crypt)                      \
+    V(DCTDecode)                  \
+    V(Dest)                       \
+    V(F)                          \
+    V(Filter)                     \
+    V(First)                      \
+    V(Fit)                        \
+    V(FitB)                       \
+    V(FitBH)                      \
+    V(FitBV)                      \
+    V(FitH)                       \
+    V(FitR)                       \
+    V(FitV)                       \
+    V(FlateDecode)                \
+    V(Font)                       \
+    V(JBIG2Decode)                \
+    V(JPXDecode)                  \
+    V(Kids)                       \
+    V(LZWDecode)                  \
+    V(Last)                       \
+    V(Length)                     \
+    V(MediaBox)                   \
+    V(Next)                       \
+    V(Outlines)                   \
+    V(Pages)                      \
+    V(Parent)                     \
+    V(Resources)                  \
+    V(Root)                       \
+    V(Rotate)                     \
+    V(RunLengthDecode)            \
+    V(Title)                      \
+    V(Type)                       \
+    V(UserUnit)                   \
+    V(XYZ)
+
+namespace PDF {
+
+class CommonNames {
+public:
+#define ENUMERATE(name) static FlyString name;
+    ENUMERATE_COMMON_NAMES(ENUMERATE)
+#undef ENUMERATE
+};
+
+}

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Hex.h>
+#include <LibCompress/Deflate.h>
+#include <LibPDF/Filter.h>
+
+namespace PDF {
+
+Optional<ByteBuffer> Filter::decode(const ReadonlyBytes& bytes, const FlyString& encoding_type)
+{
+    if (encoding_type == "ASCIIHexDecode")
+        return decode_ascii_hex(bytes);
+    if (encoding_type == "ASCII85Decode")
+        return decode_ascii85(bytes);
+    if (encoding_type == "LZWDecode")
+        return decode_lzw(bytes);
+    if (encoding_type == "FlateDecode")
+        return decode_flate(bytes);
+    if (encoding_type == "RunLengthDecode")
+        return decode_run_length(bytes);
+    if (encoding_type == "CCITTFaxDecode")
+        return decode_ccitt(bytes);
+    if (encoding_type == "JBIG2Decode")
+        return decode_jbig2(bytes);
+    if (encoding_type == "DCTDecode")
+        return decode_dct(bytes);
+    if (encoding_type == "JPXDecode")
+        return decode_jpx(bytes);
+    if (encoding_type == "Crypt")
+        return decode_crypt(bytes);
+
+    return {};
+}
+
+Optional<ByteBuffer> Filter::decode_ascii_hex(const ReadonlyBytes& bytes)
+{
+    if (bytes.size() % 2 == 0)
+        return decode_hex(bytes);
+
+    // FIXME: Integrate this padding into AK/Hex?
+
+    auto output = ByteBuffer::create_zeroed(bytes.size() / 2 + 1);
+
+    for (size_t i = 0; i < bytes.size() / 2; ++i) {
+        const auto c1 = decode_hex_digit(static_cast<char>(bytes[i * 2]));
+        if (c1 >= 16)
+            return {};
+
+        const auto c2 = decode_hex_digit(static_cast<char>(bytes[i * 2 + 1]));
+        if (c2 >= 16)
+            return {};
+
+        output[i] = (c1 << 4) + c2;
+    }
+
+    // Process last byte with a padded zero
+    output[output.size() - 1] = decode_hex_digit(static_cast<char>(bytes[bytes.size() - 1])) * 16;
+
+    return output;
+};
+
+Optional<ByteBuffer> Filter::decode_ascii85(const ReadonlyBytes& bytes)
+{
+    Vector<u8> buff;
+    buff.ensure_capacity(bytes.size());
+
+    size_t byte_index = 0;
+
+    while (byte_index < bytes.size()) {
+        if (bytes[byte_index] == ' ') {
+            byte_index++;
+            continue;
+        }
+
+        if (bytes[byte_index] == 'z') {
+            byte_index++;
+            for (int i = 0; i < 4; i++)
+                buff.append(0);
+            continue;
+        }
+
+        u32 number = 0;
+
+        if (byte_index + 5 >= bytes.size()) {
+            auto to_write = bytes.size() - byte_index;
+            for (int i = 0; i < 5; i++) {
+                auto byte = byte_index >= bytes.size() ? 'u' : bytes[byte_index++];
+                if (byte == ' ') {
+                    i--;
+                    continue;
+                }
+                number = number * 85 + byte - 33;
+            }
+
+            for (size_t i = 0; i < to_write - 1; i++)
+                buff.append(reinterpret_cast<u8*>(&number)[3 - i]);
+
+            break;
+        } else {
+            for (int i = 0; i < 5; i++) {
+                auto byte = bytes[byte_index++];
+                if (byte == ' ') {
+                    i--;
+                    continue;
+                }
+                number = number * 85 + byte - 33;
+            }
+        }
+
+        for (int i = 0; i < 4; i++)
+            buff.append(reinterpret_cast<u8*>(&number)[3 - i]);
+    }
+
+    return ByteBuffer::copy(buff.span());
+};
+
+Optional<ByteBuffer> Filter::decode_lzw(const ReadonlyBytes&)
+{
+    dbgln("LZW decoding is not supported");
+    VERIFY_NOT_REACHED();
+};
+
+Optional<ByteBuffer> Filter::decode_flate(const ReadonlyBytes& bytes)
+{
+    // FIXME: The spec says Flate decoding is "based on" zlib, does that mean they
+    // aren't exactly the same?
+
+    auto buff = Compress::DeflateDecompressor::decompress_all(bytes.slice(2));
+    VERIFY(buff.has_value());
+    return buff.value();
+};
+
+Optional<ByteBuffer> Filter::decode_run_length(const ReadonlyBytes&)
+{
+    // FIXME: Support RunLength decoding
+    TODO();
+};
+
+Optional<ByteBuffer> Filter::decode_ccitt(const ReadonlyBytes&)
+{
+    // FIXME: Support CCITT decoding
+    TODO();
+};
+
+Optional<ByteBuffer> Filter::decode_jbig2(const ReadonlyBytes&)
+{
+    // FIXME: Support JBIG2 decoding
+    TODO();
+};
+
+Optional<ByteBuffer> Filter::decode_dct(const ReadonlyBytes&)
+{
+    // FIXME: Support dct decoding
+    TODO();
+};
+
+Optional<ByteBuffer> Filter::decode_jpx(const ReadonlyBytes&)
+{
+    // FIXME: Support JPX decoding
+    TODO();
+};
+
+Optional<ByteBuffer> Filter::decode_crypt(const ReadonlyBytes&)
+{
+    // FIXME: Support Crypt decoding
+    TODO();
+};
+
+}

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -6,31 +6,32 @@
 
 #include <AK/Hex.h>
 #include <LibCompress/Deflate.h>
+#include <LibPDF/CommonNames.h>
 #include <LibPDF/Filter.h>
 
 namespace PDF {
 
 Optional<ByteBuffer> Filter::decode(const ReadonlyBytes& bytes, const FlyString& encoding_type)
 {
-    if (encoding_type == "ASCIIHexDecode")
+    if (encoding_type == CommonNames::ASCIIHexDecode)
         return decode_ascii_hex(bytes);
-    if (encoding_type == "ASCII85Decode")
+    if (encoding_type == CommonNames::ASCII85Decode)
         return decode_ascii85(bytes);
-    if (encoding_type == "LZWDecode")
+    if (encoding_type == CommonNames::LZWDecode)
         return decode_lzw(bytes);
-    if (encoding_type == "FlateDecode")
+    if (encoding_type == CommonNames::FlateDecode)
         return decode_flate(bytes);
-    if (encoding_type == "RunLengthDecode")
+    if (encoding_type == CommonNames::RunLengthDecode)
         return decode_run_length(bytes);
-    if (encoding_type == "CCITTFaxDecode")
+    if (encoding_type == CommonNames::CCITTFaxDecode)
         return decode_ccitt(bytes);
-    if (encoding_type == "JBIG2Decode")
+    if (encoding_type == CommonNames::JBIG2Decode)
         return decode_jbig2(bytes);
-    if (encoding_type == "DCTDecode")
+    if (encoding_type == CommonNames::DCTDecode)
         return decode_dct(bytes);
-    if (encoding_type == "JPXDecode")
+    if (encoding_type == CommonNames::JPXDecode)
         return decode_jpx(bytes);
-    if (encoding_type == "Crypt")
+    if (encoding_type == CommonNames::Crypt)
         return decode_crypt(bytes);
 
     return {};

--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/FlyString.h>
+
+namespace PDF {
+
+class Filter {
+public:
+    static Optional<ByteBuffer> decode(const ReadonlyBytes& bytes, const FlyString& encoding_type);
+
+private:
+    static Optional<ByteBuffer> decode_ascii_hex(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_ascii85(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_lzw(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_flate(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_run_length(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_ccitt(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_jbig2(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_dct(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_jpx(const ReadonlyBytes& bytes);
+    static Optional<ByteBuffer> decode_crypt(const ReadonlyBytes& bytes);
+};
+
+}

--- a/Userland/Libraries/LibPDF/Forward.h
+++ b/Userland/Libraries/LibPDF/Forward.h
@@ -11,6 +11,9 @@ namespace PDF {
 class Document;
 class Object;
 
+// Note: This macro doesn't care about PlainTextStreamObject and EncodedStreamObject because
+//       we never need to work directly with either of them.
+
 #define ENUMERATE_DIRECT_OBJECT_TYPES(V) \
     V(StringObject, string)              \
     V(NameObject, name)                  \

--- a/Userland/Libraries/LibPDF/Forward.h
+++ b/Userland/Libraries/LibPDF/Forward.h
@@ -14,17 +14,13 @@ class Object;
 // Note: This macro doesn't care about PlainTextStreamObject and EncodedStreamObject because
 //       we never need to work directly with either of them.
 
-#define ENUMERATE_DIRECT_OBJECT_TYPES(V) \
-    V(StringObject, string)              \
-    V(NameObject, name)                  \
-    V(ArrayObject, array)                \
-    V(DictObject, dict)                  \
-    V(StreamObject, stream)              \
+#define ENUMERATE_OBJECT_TYPES(V) \
+    V(StringObject, string)       \
+    V(NameObject, name)           \
+    V(ArrayObject, array)         \
+    V(DictObject, dict)           \
+    V(StreamObject, stream)       \
     V(IndirectValue, indirect_value)
-
-#define ENUMERATE_OBJECT_TYPES(V)    \
-    ENUMERATE_DIRECT_OBJECT_TYPES(V) \
-    V(IndirectValueRef, indirect_value_ref)
 
 #define FORWARD_DECL(class_name, _) class class_name;
 ENUMERATE_OBJECT_TYPES(FORWARD_DECL)

--- a/Userland/Libraries/LibPDF/Object.cpp
+++ b/Userland/Libraries/LibPDF/Object.cpp
@@ -30,7 +30,7 @@ NonnullRefPtr<Object> DictObject::get_object(Document* document, const FlyString
     {                                                                                                      \
         return document->resolve_to<class_name>(get(key).value());                                         \
     }
-ENUMERATE_DIRECT_OBJECT_TYPES(DEFINE_ACCESSORS)
+ENUMERATE_OBJECT_TYPES(DEFINE_ACCESSORS)
 #undef DEFINE_INDEXER
 
 static void append_indent(StringBuilder& builder, int indent)
@@ -130,11 +130,6 @@ String IndirectValue::to_string(int indent) const
     append_indent(builder, indent);
     builder.append("endobj");
     return builder.to_string();
-}
-
-String IndirectValueRef::to_string(int) const
-{
-    return String::formatted("{} {} R", index(), generation_index());
 }
 
 }

--- a/Userland/Libraries/LibPDF/Object.h
+++ b/Userland/Libraries/LibPDF/Object.h
@@ -67,7 +67,7 @@ public:
 
     ~NameObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE FlyString name() const { return m_name; }
+    [[nodiscard]] ALWAYS_INLINE const FlyString& name() const { return m_name; }
 
     ALWAYS_INLINE bool is_name() const override { return true; }
     ALWAYS_INLINE const char* type_name() const override { return "name"; }
@@ -86,6 +86,7 @@ public:
 
     ~ArrayObject() override = default;
 
+    [[nodiscard]] ALWAYS_INLINE size_t size() const { return m_elements.size(); }
     [[nodiscard]] ALWAYS_INLINE Vector<Value> elements() const { return m_elements; }
 
     ALWAYS_INLINE auto begin() const { return m_elements.begin(); }

--- a/Userland/Libraries/LibPDF/Object.h
+++ b/Userland/Libraries/LibPDF/Object.h
@@ -222,26 +222,6 @@ private:
     Value m_value;
 };
 
-class IndirectValueRef final : public Object {
-public:
-    IndirectValueRef(u32 index, u32 generation_index)
-        : m_index(index)
-    {
-        set_generation_index(generation_index);
-    }
-
-    ~IndirectValueRef() override = default;
-
-    [[nodiscard]] ALWAYS_INLINE u32 index() const { return m_index; }
-
-    ALWAYS_INLINE bool is_indirect_value_ref() const override { return true; }
-    ALWAYS_INLINE const char* type_name() const override { return "indirect_object_ref"; }
-    String to_string(int indent) const override;
-
-private:
-    u32 m_index;
-};
-
 template<IsObject To, IsObject From>
 [[nodiscard]] ALWAYS_INLINE static NonnullRefPtr<To> object_cast(NonnullRefPtr<From> obj
 #ifdef PDF_DEBUG

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -321,7 +321,7 @@ Value Parser::parse_possible_indirect_value_or_ref()
         m_reader.discard();
         consume();
         consume_whitespace();
-        return make_object<IndirectValueRef>(first_number.as_int(), second_number.as_int());
+        return Value(first_number.as_int(), second_number.as_int());
     }
 
     if (m_reader.matches("obj")) {

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/ScopeGuard.h>
 #include <AK/TypeCasts.h>
+#include <LibPDF/CommonNames.h>
 #include <LibPDF/Document.h>
 #include <LibPDF/Filter.h>
 #include <LibPDF/Parser.h>
@@ -616,19 +617,19 @@ RefPtr<DictObject> Parser::conditionally_parse_page_tree_node_at_offset(size_t o
             break;
         auto name = parse_name();
         auto name_string = name->name();
-        if (!name_string.is_one_of("Type", "Parent", "Kids", "Count")) {
+        if (!name_string.is_one_of(CommonNames::Type, CommonNames::Parent, CommonNames::Kids, CommonNames::Count)) {
             // This is a page, not a page tree node
             return {};
         }
         auto value = parse_value();
-        if (name_string == "Type") {
+        if (name_string == CommonNames::Type) {
             if (!value.is_object())
                 return {};
             auto type_object = value.as_object();
             if (!type_object->is_name())
                 return {};
             auto type_name = object_cast<NameObject>(type_object);
-            if (type_name->name() != "Pages")
+            if (type_name->name() != CommonNames::Pages)
                 return {};
         }
         map.set(name->name(), value);
@@ -649,7 +650,7 @@ NonnullRefPtr<StreamObject> Parser::parse_stream(NonnullRefPtr<DictObject> dict)
 
     ReadonlyBytes bytes;
 
-    auto maybe_length = dict->get("Length");
+    auto maybe_length = dict->get(CommonNames::Length);
     if (maybe_length.has_value()) {
         // The PDF writer has kindly provided us with the direct length of the stream
         m_reader.save();
@@ -677,8 +678,8 @@ NonnullRefPtr<StreamObject> Parser::parse_stream(NonnullRefPtr<DictObject> dict)
     m_reader.move_by(9);
     consume_whitespace();
 
-    if (dict->contains("Filter")) {
-        auto filter_type = dict->get_name(m_document, "Filter")->name();
+    if (dict->contains(CommonNames::Filter)) {
+        auto filter_type = dict->get_name(m_document, CommonNames::Filter)->name();
         auto maybe_bytes = Filter::decode(bytes, filter_type);
         // FIXME: Handle error condition
         VERIFY(maybe_bytes.has_value());

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -339,10 +339,9 @@ NonnullRefPtr<IndirectValue> Parser::parse_indirect_value(int index, int generat
     if (matches_eol())
         consume_eol();
     auto value = parse_value();
-    VERIFY(value.is_object());
     VERIFY(m_reader.matches("endobj"));
 
-    return make_object<IndirectValue>(index, generation, value.as_object());
+    return make_object<IndirectValue>(index, generation, value);
 }
 
 NonnullRefPtr<IndirectValue> Parser::parse_indirect_value()

--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -126,23 +126,21 @@ public:
 #ifdef PDF_DEBUG
     void dump_state() const
     {
-        StringBuilder builder;
-        builder.append("Reader State Dump\n\n");
+        dbgln("Reader State (offset={} size={})", offset(), bytes().size());
 
-        size_t from = max(0ul, offset() - 10);
+        size_t from = max(0, static_cast<int>(offset()) - 10);
         size_t to = min(bytes().size() - 1, offset() + 10);
 
         for (auto i = from; i <= to; i++) {
             char value = static_cast<char>(bytes().at(i));
-            builder.appendff("{}: '{}' (value={:3d}) ", i, value, static_cast<u8>(value));
-            if (i == offset())
-                builder.appendff(" <<< current location, forwards={}", m_forwards);
-            builder.append('\n');
+            auto line = String::formatted("  {}: '{}' (value={:3d}) ", i, value, static_cast<u8>(value));
+            if (i == offset()) {
+                dbgln("{} <<< current location, forwards={}", line, m_forwards);
+            } else {
+                dbgln("{}", line);
+            }
         }
-        builder.append('\n');
-
-        auto str = builder.to_string();
-        dbgputstr(str.characters(), str.length());
+        dbgln();
     }
 #endif
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Utf8View.h>
+#include <LibPDF/CommonNames.h>
 #include <LibPDF/Renderer.h>
 #include <ctype.h>
 #include <math.h>
@@ -21,7 +22,7 @@
 
 namespace PDF {
 
-Optional<ColorSpace::Type> ColorSpace::color_space_from_string(const StringView& str)
+Optional<ColorSpace::Type> ColorSpace::color_space_from_string(const FlyString& str)
 {
 #define ENUM(name)    \
     if (str == #name) \
@@ -339,13 +340,13 @@ RENDERER_HANDLER(text_set_leading)
 RENDERER_HANDLER(text_set_font)
 {
     auto target_font_name = m_document->resolve_to<NameObject>(args[0])->name();
-    auto fonts_dictionary = m_page.resources->get_dict(m_document, "Font");
+    auto fonts_dictionary = m_page.resources->get_dict(m_document, CommonNames::Font);
     auto font_dictionary = fonts_dictionary->get_dict(m_document, target_font_name);
 
     // FIXME: We do not yet have the standard 14 fonts, as some of them are not open fonts,
     // so we just use LiberationSerif for everything
 
-    auto font_name = font_dictionary->get_name(m_document, "BaseFont")->name().to_lowercase();
+    auto font_name = font_dictionary->get_name(m_document, CommonNames::BaseFont)->name().to_lowercase();
     auto font_view = font_name.view();
     bool is_bold = font_view.contains("bold");
     bool is_italic = font_view.contains("italic");

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -81,7 +81,7 @@ public:
 #undef ENUM
     };
 
-    static Optional<ColorSpace::Type> color_space_from_string(const StringView&);
+    static Optional<ColorSpace::Type> color_space_from_string(const FlyString&);
     static Color default_color_for_color_space(ColorSpace::Type);
     static Color color_from_parameters(ColorSpace::Type color_space, const Vector<Value>& args);
 };

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -110,7 +110,7 @@ private:
     const Page& m_page;
     Gfx::Painter m_painter;
 
-    Gfx::Path m_path;
+    Gfx::Path m_current_path;
     Vector<GraphicsState> m_graphics_state_stack;
     Gfx::AffineTransform m_text_matrix;
     Gfx::AffineTransform m_text_line_matrix;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -87,6 +87,7 @@ private:
     ENUMERATE_COMMANDS(V)
 #undef V
     void handle_text_next_line_show_string(const Vector<Value>& args);
+    void handle_text_next_line_show_string_set_spacing(const Vector<Value>& args);
 
     // shift is the manual advance given in the TJ command array
     void show_text(const String&, int shift = 0);

--- a/Userland/Libraries/LibPDF/Value.cpp
+++ b/Userland/Libraries/LibPDF/Value.cpp
@@ -30,6 +30,9 @@ Value& Value::operator=(const Value& other)
     case Type::Float:
         m_as_float = other.m_as_float;
         break;
+    case Type::Ref:
+        m_as_ref = other.m_as_ref;
+        break;
     case Type::Object:
         m_as_object = other.m_as_object;
         if (m_as_object)
@@ -50,6 +53,8 @@ String Value::to_string(int indent) const
         return String::number(as_int());
     case Type::Float:
         return String::number(as_float());
+    case Type::Ref:
+        return String::formatted("{} {} R", as_ref_index(), as_ref_generation_index());
     case Type::Object:
         return as_object()->to_string(indent);
     }

--- a/Userland/Libraries/LibPDF/Value.h
+++ b/Userland/Libraries/LibPDF/Value.h
@@ -14,6 +14,14 @@ class Object;
 
 class Value {
 public:
+    // We store refs as u32, with 18 bits for the index and 14 bits for the
+    // generation index. The generation index is stored in the higher bits.
+    // This may need to be rethought later, as the max generation index is
+    // 2^16 and the max for the object index is probably 2^32 (I don't know
+    // exactly)
+    static constexpr auto max_ref_index = (1 << 19) - 1;            // 2 ^ 18 - 1
+    static constexpr auto max_ref_generation_index = (1 << 15) - 1; // 2 ^ 14 - 1
+
     Value()
         : m_type(Type::Null)
     {
@@ -35,6 +43,14 @@ public:
         : m_type(Type::Float)
     {
         m_as_float = f;
+    }
+
+    Value(u32 index, u32 generation_index)
+        : m_type(Type::Ref)
+    {
+        VERIFY(index < max_ref_index);
+        VERIFY(generation_index < max_ref_generation_index);
+        m_as_ref = (generation_index << 14) | index;
     }
 
     template<IsObject T>
@@ -59,7 +75,7 @@ public:
     [[nodiscard]] ALWAYS_INLINE bool is_int() const { return m_type == Type::Int; }
     [[nodiscard]] ALWAYS_INLINE bool is_float() const { return m_type == Type::Float; }
     [[nodiscard]] ALWAYS_INLINE bool is_number() const { return is_int() || is_float(); }
-
+    [[nodiscard]] ALWAYS_INLINE bool is_ref() const { return m_type == Type::Ref; }
     [[nodiscard]] ALWAYS_INLINE bool is_object() const { return m_type == Type::Object; }
 
     [[nodiscard]] ALWAYS_INLINE bool as_bool() const
@@ -94,6 +110,18 @@ public:
         return static_cast<float>(as_int());
     }
 
+    [[nodiscard]] ALWAYS_INLINE u32 as_ref_index() const
+    {
+        VERIFY(is_ref());
+        return m_as_ref & 0x3ffff;
+    }
+
+    [[nodiscard]] ALWAYS_INLINE u32 as_ref_generation_index() const
+    {
+        VERIFY(is_ref());
+        return m_as_ref >> 18;
+    }
+
     [[nodiscard]] ALWAYS_INLINE NonnullRefPtr<Object> as_object() const { return *m_as_object; }
 
     [[nodiscard]] ALWAYS_INLINE explicit operator bool() const { return !is_null(); }
@@ -106,12 +134,14 @@ private:
         Bool,
         Int,
         Float,
+        Ref,
         Object,
     };
 
     union {
         bool m_as_bool;
         int m_as_int;
+        u32 m_as_ref;
         float m_as_float;
         Object* m_as_object;
     };


### PR DESCRIPTION
#### PDF parser improvements

- Remove the `IndirectValueRef` class and just store that information in the `Value`. It is very small and one of the most common objects in a PDF file, so this change will reduce the number of allocations the parser has to do.
- Add stream filters. The parser can now decode stream objects encoded with the following filters: `ASCII`, `ASCII85`, `Flate`
- Parse outlines (the sidebar on the left side of a PDF document, at least in Firefox).

#### PDF renderer improvements

- Complete `Command.h` and stub unimplemented commands with `TODO()`
- Add initial support for color spaces. The renderer support grayscale, RGB, and CMYK.

#### PDF Viewer improvements

- Add a sidebar for viewing outlines and thumbnails (thumbnails are not implemented)
- Added a toolbar which allows the user to toggle the sidebar, as well as navigate through the pages without scrolling.


The PDF Viewer improvements make the application feel a lot more "full", as there is a lot less empty space, as seen in the following screenshot. 

![img](https://i.imgur.com/jkKzOX5.png)