### PR TITLE
LibVT+Kernel: Add support for setting cursor styles

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -387,6 +387,11 @@ void VirtualConsole::emit(const u8* data, size_t size)
         TTY::emit(data[i], true);
 }
 
+void VirtualConsole::set_cursor_style(VT::CursorStyle)
+{
+    // Do nothing
+}
+
 String VirtualConsole::device_name() const
 {
     return String::formatted("tty{}", minor());

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -106,6 +106,7 @@ private:
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
     virtual void terminal_history_changed() override;
     virtual void emit(const u8*, size_t) override;
+    virtual void set_cursor_style(VT::CursorStyle) override;
 
     // ^CharacterDevice
     virtual const char* class_name() const override { return "VirtualConsole"; }

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -26,6 +26,16 @@ class VirtualConsole;
 
 namespace VT {
 
+enum CursorStyle {
+    None,
+    BlinkingBlock,
+    SteadyBlock,
+    BlinkingUnderline,
+    SteadyUnderline,
+    BlinkingBar,
+    SteadyBar
+};
+
 class TerminalClient {
 public:
     virtual ~TerminalClient() { }
@@ -36,6 +46,7 @@ public:
     virtual void terminal_did_resize(u16 columns, u16 rows) = 0;
     virtual void terminal_history_changed() = 0;
     virtual void emit(const u8*, size_t) = 0;
+    virtual void set_cursor_style(CursorStyle) = 0;
 };
 
 class Terminal : public EscapeSequenceExecutor {
@@ -238,6 +249,9 @@ protected:
     // DSR - Device Status Reports
     void DSR(Parameters);
 
+    // DECSCUSR - Set Cursor Style
+    void DECSCUSR(Parameters);
+
 #ifndef KERNEL
     // ICH - Insert Character
     void ICH(Parameters);
@@ -318,6 +332,9 @@ protected:
     u16 m_saved_cursor_column { 0 };
     bool m_swallow_current { false };
     bool m_stomp { false };
+
+    CursorStyle m_cursor_style { BlinkingBlock };
+    CursorStyle m_saved_cursor_style { BlinkingBlock };
 
     Attribute m_current_attribute;
     Attribute m_saved_attribute;

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -114,6 +114,7 @@ private:
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
     virtual void terminal_history_changed() override;
     virtual void emit(const u8*, size_t) override;
+    virtual void set_cursor_style(CursorStyle) override;
 
     void set_logical_focus(bool);
 
@@ -172,6 +173,8 @@ private:
     u8 m_opacity { 255 };
     bool m_cursor_blink_state { true };
     bool m_automatic_size_policy { false };
+
+    VT::CursorStyle m_cursor_style { BlinkingBlock };
 
     enum class AutoScrollDirection {
         None,


### PR DESCRIPTION
This commit introduces support for 3 new escape sequences:
1. Stop blinking cursor mode
2. `DECTCEM` mode (enable/disable cursor)
3. `DECSCUSR` (set cursor style)

`TerminalWidget` now supports the following cursor types: block, underline and vertical bar. Each of these can blink or be steady.`VirtualConsole` ignores these (just as we were doing before).