### PR TITLE
LibVT: Miscellaneous features

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -105,6 +105,10 @@ void Terminal::alter_mode(bool should_set, Parameters params, Intermediates inte
                     m_client.set_cursor_style(None);
                 }
                 break;
+            case 2004:
+                dbgln_if(TERMINAL_DEBUG, "Setting bracketed mode enabled={}", should_set);
+                m_needs_bracketed_paste = should_set;
+                break;
             default:
                 dbgln("Terminal::alter_mode: Unimplemented private mode {} (should_set={})", mode, should_set);
                 break;

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -339,6 +339,9 @@ protected:
     Attribute m_current_attribute;
     Attribute m_saved_attribute;
 
+    String m_current_window_title;
+    Vector<String> m_title_stack;
+
 #ifndef KERNEL
     u32 m_next_href_id { 0 };
 #endif

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -157,6 +157,11 @@ public:
     Attribute attribute_at(const Position&) const;
 #endif
 
+    bool needs_bracketed_paste() const
+    {
+        return m_needs_bracketed_paste;
+    };
+
 protected:
     // ^EscapeSequenceExecutor
     virtual void emit_code_point(u32) override;
@@ -335,6 +340,8 @@ protected:
 
     CursorStyle m_cursor_style { BlinkingBlock };
     CursorStyle m_saved_cursor_style { BlinkingBlock };
+
+    bool m_needs_bracketed_paste { false };
 
     Attribute m_current_attribute;
     Attribute m_saved_attribute;

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -118,6 +118,8 @@ private:
 
     void set_logical_focus(bool);
 
+    void send_non_user_input(const ReadonlyBytes&);
+
     Gfx::IntRect glyph_rect(u16 row, u16 column);
     Gfx::IntRect row_rect(u16 row);
 


### PR DESCRIPTION
## LibVT: Add title stack support
This feature allows applications to reset the window title once they exited. It is used by `vim` if `set title` is enabled.

## LibVT: Implement Bracketed Paste Mode 
This mode allow us to escape any data that was not directly typed by the user. `vim` currently uses this. If we implement it in the shell, we could prevent newlines from being injected into the shell by pasting text or dragging files into it (see #7276).