### PR TITLE
LibGUI/AbstractView: Expose `activates_on_selection`

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -23,6 +23,8 @@ AbstractView::AbstractView()
     : m_sort_order(SortOrder::Ascending)
     , m_selection(*this)
 {
+    REGISTER_BOOL_PROPERTY("activates_on_selection", activates_on_selection, set_activates_on_selection);
+
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
 }
 


### PR DESCRIPTION
Allow setting this property in GML, for example.