### PR TITLE
LibLine: Bracketed paste support / Shell+LibLine: Allow some programs to modify the default termios

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -40,3 +40,5 @@ if [ "$(id -u)" = "0" ] {
 export PROMPT="\\X\\u@\\h:\\w\\a\\e[$prompt_color;1m\\h\\e[0m:\\e[34;1m\\w\\e[0m \\p "
 
 export HISTORY_AUTOSAVE_TIME_MS=10000
+
+PROGRAMS_ALLOWED_TO_MODIFY_DEFAULT_TERMIOS=(stty)

--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -40,6 +40,15 @@ If `t` is not a non-negative integer, zero will be assumed.
 Note that multiple shell instances will not interfere with each other if they are to save to the same history file, instead, the entries will all be merged together chronologically.
 The default value for this option is set in `/etc/shellrc`.
 
+3. Terminal settings
+
+`PROGRAMS_ALLOWED_TO_MODIFY_DEFAULT_TERMIOS` (local)
+
+The list value stored in this variable is used as an allow-list to filter programs that may modify the current terminal settings (i.e. default termios configuration) of the current shell session.
+By default, this list includes `stty`, making it possible for the user to modify the terminal settings from within the shell.
+Note that the shell will revert any termios changes if the running program is not in this list, or if it failed to run successfully (exited with an exit code other than zero).
+Also note that the line editor will re-evaluate the keybindings and sync them when such a change occurs.
+
 ## Visual
 
 1. Prompting

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -148,6 +148,8 @@ public:
 
     void initialize();
 
+    void refetch_default_termios();
+
     void add_to_history(const String& line);
     bool load_history(const String& path);
     bool save_history(const String& path);

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -108,9 +108,9 @@ public:
 
     static bool has_history_event(StringView);
 
-    RefPtr<AST::Value> get_argument(size_t);
-    RefPtr<AST::Value> lookup_local_variable(const String&);
-    String local_variable_or(const String&, const String&);
+    RefPtr<AST::Value> get_argument(size_t) const;
+    RefPtr<AST::Value> lookup_local_variable(const String&) const;
+    String local_variable_or(const String&, const String&) const;
     void set_local_variable(const String&, RefPtr<AST::Value>, bool only_in_current_frame = false);
     void unset_local_variable(const String&, bool only_in_current_frame = false);
 
@@ -278,6 +278,8 @@ private:
 
     void timer_event(Core::TimerEvent&) override;
 
+    bool is_allowed_to_modify_termios(const AST::Command&) const;
+
     // FIXME: Port to Core::Property
     void save_to(JsonObject&);
     void bring_cursor_to_beginning_of_a_line() const;
@@ -288,6 +290,10 @@ private:
     void stop_all_jobs();
     const Job* m_current_job { nullptr };
     LocalFrame* find_frame_containing_local_variable(const String& name);
+    const LocalFrame* find_frame_containing_local_variable(const String& name) const
+    {
+        return const_cast<Shell*>(this)->find_frame_containing_local_variable(name);
+    }
 
     void run_tail(RefPtr<Job>);
     void run_tail(const AST::Command&, const AST::NodeWithAction&, int head_exit_code);


### PR DESCRIPTION
- LibLine: Add bracketed paste mode support 

Fixes #7276.

-  LibLine+Shell: Allow some programs to modify the current termios 

cc @BertalanD - you requested this.