### PR TITLE
Browser: Show title in back/forward context menu

### DIFF
--- a/Userland/Applications/Browser/History.cpp
+++ b/Userland/Applications/Browser/History.cpp
@@ -13,21 +13,24 @@ void History::dump() const
     dbgln("Dump {} items(s)", m_items.size());
     int i = 0;
     for (auto& item : m_items) {
-        dbgln("[{}] {} {}", i, item, m_current == i ? '*' : ' ');
+        dbgln("[{}] {} '{}' {}", i, item.url, item.title, m_current == i ? '*' : ' ');
         ++i;
     }
 }
 
-void History::push(const URL& url)
+void History::push(const URL& url, String title)
 {
-    if (!m_items.is_empty() && m_items[m_current] == url)
+    if (!m_items.is_empty() && m_items[m_current].url == url)
         return;
     m_items.shrink(m_current + 1);
-    m_items.append(url);
+    m_items.append(URLTitlePair {
+        .url = url,
+        .title = title,
+    });
     m_current++;
 }
 
-URL History::current() const
+History::URLTitlePair History::current() const
 {
     if (m_current == -1)
         return {};
@@ -52,22 +55,28 @@ void History::clear()
     m_current = -1;
 }
 
-const Vector<URL> History::get_back_history()
+void History::update_title(const URL& url, const String& title)
 {
-    Vector<URL> back_history;
-    for (int i = m_current - 1; i >= 0; i--) {
-        back_history.append(m_items[i]);
-    }
-    return back_history;
+    if (m_items[m_current].url == url)
+        m_items[m_current].title = title;
 }
 
-const Vector<URL> History::get_forward_history()
+const Vector<StringView> History::get_back_title_history()
 {
-    Vector<URL> forward_history;
-    for (int i = m_current + 1; i < static_cast<int>(m_items.size()); i++) {
-        forward_history.append(m_items[i]);
+    Vector<StringView> back_title_history;
+    for (int i = m_current - 1; i >= 0; i--) {
+        back_title_history.append(m_items[i].title);
     }
-    return forward_history;
+    return back_title_history;
+}
+
+const Vector<StringView> History::get_forward_title_history()
+{
+    Vector<StringView> forward_title_history;
+    for (int i = m_current + 1; i < static_cast<int>(m_items.size()); i++) {
+        forward_title_history.append(m_items[i].title);
+    }
+    return forward_title_history;
 }
 
 }

--- a/Userland/Applications/Browser/History.h
+++ b/Userland/Applications/Browser/History.h
@@ -13,12 +13,18 @@ namespace Browser {
 
 class History {
 public:
+    struct URLTitlePair {
+        URL url;
+        String title;
+    };
     void dump() const;
 
-    void push(const URL&);
-    URL current() const;
-    const Vector<URL> get_back_history();
-    const Vector<URL> get_forward_history();
+    void push(const URL& url, String title);
+    void update_title(const URL& url, const String& title);
+    URLTitlePair current() const;
+
+    const Vector<StringView> get_back_title_history();
+    const Vector<StringView> get_forward_title_history();
 
     void go_back(int steps = 1);
     void go_forward(int steps = 1);
@@ -28,7 +34,7 @@ public:
     void clear();
 
 private:
-    Vector<URL> m_items;
+    Vector<URLTitlePair> m_items;
     int m_current { -1 };
 };
 

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -98,9 +98,9 @@ Tab::Tab(BrowserWindow& window, Type type)
             return;
         int i = 0;
         m_go_back_context_menu = GUI::Menu::construct();
-        for (auto& url : m_history.get_back_history()) {
+        for (auto& title : m_history.get_back_title_history()) {
             i++;
-            m_go_back_context_menu->add_action(GUI::Action::create(url.to_string(),
+            m_go_back_context_menu->add_action(GUI::Action::create(title,
                 Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-html.png"),
                 [this, i](auto&) { go_back(i); }));
         }
@@ -113,9 +113,9 @@ Tab::Tab(BrowserWindow& window, Type type)
             return;
         int i = 0;
         m_go_forward_context_menu = GUI::Menu::construct();
-        for (auto& url : m_history.get_forward_history()) {
+        for (auto& title : m_history.get_forward_title_history()) {
             i++;
-            m_go_forward_context_menu->add_action(GUI::Action::create(url.to_string(),
+            m_go_forward_context_menu->add_action(GUI::Action::create(title,
                 Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-html.png"),
                 [this, i](auto&) { go_forward(i); }));
         }
@@ -161,7 +161,7 @@ Tab::Tab(BrowserWindow& window, Type type)
 
         // don't add to history if back or forward is pressed
         if (!m_is_history_navigation)
-            m_history.push(url);
+            m_history.push(url, title());
         m_is_history_navigation = false;
 
         update_actions();
@@ -232,8 +232,10 @@ Tab::Tab(BrowserWindow& window, Type type)
     hooks().on_title_change = [this](auto& title) {
         if (title.is_null()) {
             m_title = url().to_string();
+            m_history.update_title(url(), url().to_string());
         } else {
             m_title = title;
+            m_history.update_title(url(), title);
         }
         if (on_title_change)
             on_title_change(m_title);
@@ -347,14 +349,14 @@ void Tab::go_back(int steps)
 {
     m_history.go_back(steps);
     update_actions();
-    load(m_history.current(), LoadType::HistoryNavigation);
+    load(m_history.current().url, LoadType::HistoryNavigation);
 }
 
 void Tab::go_forward(int steps)
 {
     m_history.go_forward(steps);
     update_actions();
-    load(m_history.current(), LoadType::HistoryNavigation);
+    load(m_history.current().url, LoadType::HistoryNavigation);
 }
 
 void Tab::update_actions()


### PR DESCRIPTION
Keeps track of the page title in History and shows it instead of the url when using the back/forward context menu.