### PR TITLE
LibGL: Implement glReadBuffer() and glReadPixels()

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -115,6 +115,29 @@ extern "C" {
 #define GL_COMPILE 0x1300
 #define GL_COMPILE_AND_EXECUTE 0x1301
 
+// Type enums
+#define GL_BYTE 0x1400
+#define GL_UNSIGNED_BYTE 0x1401
+#define GL_SHORT 0x1402
+#define GL_UNSIGNED_SHORT 0x1403
+#define GL_INT 0x1404
+#define GL_UNSIGNED_INT 0x1405
+#define GL_FLOAT 0x1406
+
+// Format enums
+#define GL_COLOR_INDEX 0x1900
+#define GL_LUMINANCE 0x1909
+#define GL_LUMINANCE_ALPHA 0x190A
+#define GL_BITMAP 0x1A00
+#define GL_STENCIL_INDEX 0x1901
+#define GL_DEPTH_COMPONENT 0x1902
+#define GL_RED 0x1903
+#define GL_GREEN 0x1904
+#define GL_BLUE 0x1905
+#define GL_ALPHA 0x1906
+#define GL_RGB 0x1907
+#define GL_RGBA 0x1908
+
 // Lighting related defines
 #define GL_FLAT 0x1D00
 #define GL_SMOOTH 0x1D01
@@ -211,6 +234,7 @@ GLAPI void glShadeModel(GLenum mode);
 GLAPI void glAlphaFunc(GLenum func, GLclampf ref);
 GLAPI void glHint(GLenum target, GLenum mode);
 GLAPI void glReadBuffer(GLenum mode);
+GLAPI void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -73,9 +73,15 @@ extern "C" {
 #define GL_ONE_MINUS_DST_COLOR 0x0307
 #define GL_SRC_ALPHA_SATURATE 0x0308
 
-// Culled face side
+// Sides
+#define GL_FRONT_LEFT 0x0400
+#define GL_FRONT_RIGHT 0x0401
+#define GL_BACK_LEFT 0x0402
+#define GL_BACK_RIGHT 0x0403
 #define GL_FRONT 0x0404
 #define GL_BACK 0x0405
+#define GL_LEFT 0x0406
+#define GL_RIGHT 0x0407
 #define GL_FRONT_AND_BACK 0x0408
 
 // Error codes
@@ -204,6 +210,7 @@ GLAPI void glBlendFunc(GLenum sfactor, GLenum dfactor);
 GLAPI void glShadeModel(GLenum mode);
 GLAPI void glAlphaFunc(GLenum func, GLclampf ref);
 GLAPI void glHint(GLenum target, GLenum mode);
+GLAPI void glReadBuffer(GLenum mode);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -54,6 +54,7 @@ public:
     virtual void gl_alpha_func(GLenum func, GLclampf ref) = 0;
     virtual void gl_hint(GLenum target, GLenum mode) = 0;
     virtual void gl_read_buffer(GLenum mode) = 0;
+    virtual void gl_read_pixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -53,6 +53,7 @@ public:
     virtual void gl_shade_model(GLenum mode) = 0;
     virtual void gl_alpha_func(GLenum func, GLclampf ref) = 0;
     virtual void gl_hint(GLenum target, GLenum mode) = 0;
+    virtual void gl_read_buffer(GLenum mode) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -74,3 +74,8 @@ void glHint(GLenum target, GLenum mode)
 {
     g_gl_context->gl_hint(target, mode);
 }
+
+void glReadBuffer(GLenum mode)
+{
+    g_gl_context->gl_read_buffer(mode);
+}

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -79,3 +79,8 @@ void glReadBuffer(GLenum mode)
 {
     g_gl_context->gl_read_buffer(mode);
 }
+
+void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels)
+{
+    g_gl_context->gl_read_pixels(x, y, width, height, format, type, pixels);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1050,6 +1050,75 @@ void SoftwareGLContext::gl_read_buffer(GLenum mode)
     m_current_read_buffer = mode;
 }
 
+void SoftwareGLContext::gl_read_pixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels)
+{
+    if (m_in_draw_state) {
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    // Check for negative width/height omitted because GLsizei is unsigned in our implementation
+
+    if (format != GL_COLOR_INDEX
+        && format != GL_STENCIL_INDEX
+        && format != GL_DEPTH_COMPONENT
+        && format != GL_RED
+        && format != GL_GREEN
+        && format != GL_BLUE
+        && format != GL_ALPHA
+        && format != GL_RGB
+        && format != GL_RGBA
+        && format != GL_LUMINANCE
+        && format != GL_LUMINANCE_ALPHA) {
+        m_error = GL_INVALID_ENUM;
+        return;
+    }
+
+    if (type != GL_UNSIGNED_BYTE
+        && type != GL_BYTE
+        && type != GL_BITMAP
+        && type != GL_UNSIGNED_SHORT
+        && type != GL_SHORT
+        && type != GL_BLUE
+        && type != GL_UNSIGNED_INT
+        && type != GL_INT
+        && type != GL_FLOAT) {
+        m_error = GL_INVALID_ENUM;
+        return;
+    }
+
+    if (format == GL_COLOR_INDEX) {
+        // FIXME: We only support RGBA buffers for now.
+        // Once we add support for indexed color modes do the correct check here
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    if (format == GL_STENCIL_INDEX) {
+        // FIXME: We do not have stencil buffers yet
+        // Once we add support for stencil buffers do the correct check here
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    if (format == GL_DEPTH_COMPONENT) {
+        // FIXME: This check needs to be a bit more sophisticated. Currently the buffers
+        // are hardcoded. Once we add proper structures for them we need to correct this check
+        if (m_current_read_buffer == GL_FRONT
+            || m_current_read_buffer == GL_FRONT_LEFT
+            || m_current_read_buffer == GL_FRONT_RIGHT) {
+            // Error because only back buffer has a depth buffer
+            m_error = GL_INVALID_OPERATION;
+            return;
+        }
+    }
+
+    if (format == GL_DEPTH_COMPONENT) {
+        // Read from depth buffer
+        return;
+    }
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1009,6 +1009,47 @@ void SoftwareGLContext::gl_hint(GLenum target, GLenum mode)
     // According to the spec implementors are free to ignore glHint. So we do.
 }
 
+void SoftwareGLContext::gl_read_buffer(GLenum mode)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_read_buffer, mode);
+
+    if (m_in_draw_state) {
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    // FIXME: Also allow aux buffers GL_AUX0 through GL_AUX3 here
+    // plus any aux buffer between 0 and GL_AUX_BUFFERS
+    if (mode != GL_FRONT_LEFT
+        && mode != GL_FRONT_RIGHT
+        && mode != GL_BACK_LEFT
+        && mode != GL_BACK_RIGHT
+        && mode != GL_FRONT
+        && mode != GL_BACK
+        && mode != GL_LEFT
+        && mode != GL_RIGHT) {
+        m_error = GL_INVALID_ENUM;
+        return;
+    }
+
+    // FIXME: We do not currently have aux buffers, so make it an invalid
+    // operation to select anything but front or back buffers. Also we do
+    // not allow selecting the stereoscopic RIGHT buffers since we do not
+    // have them configured.
+    if (mode != GL_FRONT_LEFT
+        && mode != GL_FRONT
+        && mode != GL_BACK_LEFT
+        && mode != GL_BACK
+        && mode != GL_FRONT
+        && mode != GL_BACK
+        && mode != GL_LEFT) {
+        m_error = GL_INVALID_OPERATION;
+        return;
+    }
+
+    m_current_read_buffer = mode;
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -59,6 +59,7 @@ public:
     virtual void gl_shade_model(GLenum mode) override;
     virtual void gl_alpha_func(GLenum func, GLclampf ref) override;
     virtual void gl_hint(GLenum target, GLenum mode) override;
+    virtual void gl_read_buffer(GLenum mode) override;
 
     virtual void present() override;
 
@@ -117,6 +118,8 @@ private:
     GLenum m_alpha_test_func = GL_ALWAYS;
     GLclampf m_alpha_test_ref_value = 0;
 
+    GLenum m_current_read_buffer = GL_BACK;
+
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 
     Clipper m_clipper;
@@ -172,7 +175,8 @@ private:
             decltype(&SoftwareGLContext::gl_blend_func),
             decltype(&SoftwareGLContext::gl_shade_model),
             decltype(&SoftwareGLContext::gl_alpha_func),
-            decltype(&SoftwareGLContext::gl_hint)>;
+            decltype(&SoftwareGLContext::gl_hint),
+            decltype(&SoftwareGLContext::gl_read_buffer)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -60,6 +60,7 @@ public:
     virtual void gl_alpha_func(GLenum func, GLclampf ref) override;
     virtual void gl_hint(GLenum target, GLenum mode) override;
     virtual void gl_read_buffer(GLenum mode) override;
+    virtual void gl_read_pixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels) override;
 
     virtual void present() override;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -470,4 +470,22 @@ void SoftwareRasterizer::set_options(const RasterizerOptions& options)
     // FIXME: Recreate or reinitialize render threads here when multithreading is being implemented
 }
 
+Gfx::RGBA32 SoftwareRasterizer::get_backbuffer_pixel(int x, int y)
+{
+    // FIXME: Reading individual pixels is very slow, rewrite this to transfer whole blocks
+    if (x < 0 || y < 0 || x >= m_render_target->width() || y >= m_render_target->height())
+        return 0;
+
+    return m_render_target->scanline(y)[x];
+}
+
+float SoftwareRasterizer::get_depthbuffer_value(int x, int y)
+{
+    // FIXME: Reading individual pixels is very slow, rewrite this to transfer whole blocks
+    if (x < 0 || y < 0 || x >= m_render_target->width() || y >= m_render_target->height())
+        return 1.0f;
+
+    return m_depth_buffer->scanline(y)[x];
+}
+
 }

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -38,6 +38,8 @@ public:
     void wait_for_all_threads() const;
     void set_options(const RasterizerOptions&);
     RasterizerOptions options() const { return m_options; }
+    Gfx::RGBA32 get_backbuffer_pixel(int x, int y);
+    float get_depthbuffer_value(int x, int y);
 
 private:
     RefPtr<Gfx::Bitmap> m_render_target;


### PR DESCRIPTION
Some more for #7062 

This implements `glReadBuffer()` and `glReadPixels()`.

We do not currently support every single format and feature that these functions allow but the most important should be covered,