### PR TITLE
LibWeb: Don't try to load anything if src is empty in <img>

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -60,7 +60,7 @@ void HTMLImageElement::parse_attribute(const FlyString& name, const String& valu
 {
     HTMLElement::parse_attribute(name, value);
 
-    if (name == HTML::AttributeNames::src)
+    if (name == HTML::AttributeNames::src && !value.is_empty())
         m_image_loader.load(document().complete_url(value));
 }
 


### PR DESCRIPTION
I noticed when loading GitHub we waited for the RequestServer to time-out loading the content of `<img>`s where the `src` was empty, eg `<src class="something" src="" />`.
I think it is a good thing to stop the HTMLImageElement from making the Request in the first place and not wait for the RequestServer to handle that (there certainly should be a catch for empty request Strings though) since there really isn't anything to load under any circumstance and we can just keep the round-trip out of here.