### PR TITLE
HackStudio: Attempt to fix #include autocomplete crash

### DIFF
--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -92,6 +92,10 @@ AutocompleteBox::AutocompleteBox(TextEditor& editor)
 
 void AutocompleteBox::update_suggestions(Vector<AutocompleteProvider::Entry>&& suggestions)
 {
+    // FIXME: There's a potential race here if, after the user selected an autocomplete suggestion,
+    // the LanguageServer sends an update and this function is executed before AutocompleteBox::apply_suggestion()
+    // is executed.
+
     bool has_suggestions = !suggestions.is_empty();
     if (m_suggestion_view->model()) {
         auto& model = *static_cast<AutocompleteSuggestionModel*>(m_suggestion_view->model());

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -168,7 +168,7 @@ void AutocompleteBox::apply_suggestion()
         return;
 
     auto selected_index = m_suggestion_view->selection().first();
-    if (!selected_index.is_valid())
+    if (!selected_index.is_valid() || !m_suggestion_view->model()->is_valid(selected_index))
         return;
 
     auto suggestion_index = m_suggestion_view->model()->index(selected_index.row(), AutocompleteSuggestionModel::Column::Name);


### PR DESCRIPTION
This is a best-effort attempt to fix #7404. I can't verify it does fix it as I wasn't able to reproduce it.

Anyways I _think_ we can close #7404 (until proven otherwise) after merging this. @awesomekling your opinion?