### PR TITLE
Utilities: Various changes in passwd

### DIFF
--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -93,6 +93,7 @@ int main(int argc, char** argv)
 
             if (!target_account.authenticate(current_password.value().characters())) {
                 warnln("Incorrect or disabled password.");
+                warnln("Password for user {} unchanged.", target_account.username());
                 return 1;
             }
         }
@@ -111,6 +112,7 @@ int main(int argc, char** argv)
 
         if (new_password.value() != new_password_retype.value()) {
             warnln("Sorry, passwords don't match.");
+            warnln("Password for user {} unchanged.", target_account.username());
             return 1;
         }
 
@@ -124,6 +126,8 @@ int main(int argc, char** argv)
 
     if (!target_account.sync()) {
         perror("Core::Account::Sync");
+    } else {
+        outln("Password for user {} successfully updated.", target_account.username());
     }
 
     return 0;

--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -103,6 +103,17 @@ int main(int argc, char** argv)
             return 1;
         }
 
+        auto new_password_retype = Core::get_password("Retype new password: ");
+        if (new_password_retype.is_error()) {
+            warnln("{}", new_password_retype.error());
+            return 1;
+        }
+
+        if (new_password.value() != new_password_retype.value()) {
+            warnln("Sorry, passwords don't match.");
+            return 1;
+        }
+
         target_account.set_password(new_password.value().characters());
     }
 

--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -84,6 +84,19 @@ int main(int argc, char** argv)
     } else if (unlock) {
         target_account.set_password_enabled(true);
     } else {
+        if (current_uid != 0) {
+            auto current_password = Core::get_password("Current password: ");
+            if (current_password.is_error()) {
+                warnln("{}", current_password.error());
+                return 1;
+            }
+
+            if (!target_account.authenticate(current_password.value().characters())) {
+                warnln("Incorrect or disabled password.");
+                return 1;
+            }
+        }
+
         auto new_password = Core::get_password("New password: ");
         if (new_password.is_error()) {
             warnln("{}", new_password.error());

--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -110,6 +110,12 @@ int main(int argc, char** argv)
             return 1;
         }
 
+        if (new_password.value().is_empty() && new_password_retype.value().is_empty()) {
+            warnln("No password supplied.");
+            warnln("Password for user {} unchanged.", target_account.username());
+            return 1;
+        }
+
         if (new_password.value() != new_password_retype.value()) {
             warnln("Sorry, passwords don't match.");
             warnln("Password for user {} unchanged.", target_account.username());


### PR DESCRIPTION
This adds additional functionalities to the passwd utility:

-  Requires non-root users to authenticate with the current password before being able to change to new password
-  Prompts the user to enter the new password twice to check for mismatches
-  Returns error when attempting to change password with no input
-  Provides more verbose output indicating the status of the changed password