### PR TITLE
Browser: Support CSS custom properties

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -9,8 +9,9 @@
 
 namespace Web::CSS {
 
-CSSStyleDeclaration::CSSStyleDeclaration(Vector<StyleProperty>&& properties)
+CSSStyleDeclaration::CSSStyleDeclaration(Vector<StyleProperty>&& properties, HashMap<String, StyleProperty>&& custom_properties)
     : m_properties(move(properties))
+    , m_custom_properties(move(custom_properties))
 {
 }
 
@@ -26,7 +27,7 @@ String CSSStyleDeclaration::item(size_t index) const
 }
 
 ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element& element)
-    : CSSStyleDeclaration({})
+    : CSSStyleDeclaration({}, {})
     , m_element(element.make_weak_ptr<DOM::Element>())
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -16,6 +16,7 @@ namespace Web::CSS {
 struct StyleProperty {
     CSS::PropertyID property_id;
     NonnullRefPtr<StyleValue> value;
+    String custom_name {};
     bool important { false };
 };
 
@@ -25,25 +26,28 @@ class CSSStyleDeclaration
 public:
     using WrapperType = Bindings::CSSStyleDeclarationWrapper;
 
-    static NonnullRefPtr<CSSStyleDeclaration> create(Vector<StyleProperty>&& properties)
+    static NonnullRefPtr<CSSStyleDeclaration> create(Vector<StyleProperty>&& properties, HashMap<String, StyleProperty>&& custom_properties)
     {
-        return adopt_ref(*new CSSStyleDeclaration(move(properties)));
+        return adopt_ref(*new CSSStyleDeclaration(move(properties), move(custom_properties)));
     }
 
     virtual ~CSSStyleDeclaration();
 
     const Vector<StyleProperty>& properties() const { return m_properties; }
+    const Optional<StyleProperty> custom_property(const String& custom_property_name) const { return m_custom_properties.get(custom_property_name); }
+    size_t custom_property_count() const { return m_custom_properties.size(); };
 
     size_t length() const { return m_properties.size(); }
     String item(size_t index) const;
 
 protected:
-    explicit CSSStyleDeclaration(Vector<StyleProperty>&&);
+    explicit CSSStyleDeclaration(Vector<StyleProperty>&&, HashMap<String, StyleProperty>&&);
 
 private:
     friend class Bindings::CSSStyleDeclarationWrapper;
 
     Vector<StyleProperty> m_properties;
+    HashMap<String, StyleProperty> m_custom_properties;
 };
 
 class ElementInlineCSSStyleDeclaration final : public CSSStyleDeclaration {

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -74,7 +74,7 @@ Vector<MatchingRule> StyleResolver::collect_matching_rules(const DOM::Element& e
             size_t selector_index = 0;
             for (auto& selector : rule.selectors()) {
                 if (SelectorEngine::matches(selector, element)) {
-                    matching_rules.append({ rule, style_sheet_index, rule_index, selector_index });
+                    matching_rules.append({ rule, style_sheet_index, rule_index, selector_index, selector.specificity() });
                     break;
                 }
                 ++selector_index;

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.h
@@ -18,6 +18,7 @@ struct MatchingRule {
     size_t style_sheet_index { 0 };
     size_t rule_index { 0 };
     size_t selector_index { 0 };
+    u32 specificity { 0 };
 };
 
 class StyleResolver {

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.h
@@ -8,6 +8,7 @@
 
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/OwnPtr.h>
+#include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/Forward.h>
 
@@ -33,6 +34,12 @@ public:
 
     Vector<MatchingRule> collect_matching_rules(const DOM::Element&) const;
     void sort_matching_rules(Vector<MatchingRule>&) const;
+    struct CustomPropertyResolutionTuple {
+        Optional<StyleProperty> style {};
+        u32 specificity { 0 };
+    };
+    CustomPropertyResolutionTuple resolve_custom_property_with_specificity(const DOM::Element&, const String&) const;
+    Optional<StyleProperty> resolve_custom_property(const DOM::Element&, const String&) const;
 
     static bool is_inherited_property(CSS::PropertyID);
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -195,6 +195,7 @@ public:
         Identifier,
         Image,
         Position,
+        CustomProperty,
     };
 
     Type type() const { return m_type; }
@@ -207,6 +208,7 @@ public:
     bool is_string() const { return type() == Type::String; }
     bool is_length() const { return type() == Type::Length; }
     bool is_position() const { return type() == Type::Position; }
+    bool is_custom_property() const { return type() == Type::CustomProperty; }
 
     virtual String to_string() const = 0;
     virtual Length to_length() const { return Length::make_auto(); }
@@ -231,6 +233,26 @@ protected:
 
 private:
     Type m_type { Type::Invalid };
+};
+
+// FIXME: Allow for fallback
+class CustomStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<CustomStyleValue> create(const String& custom_property_name)
+    {
+        return adopt_ref(*new CustomStyleValue(custom_property_name));
+    }
+    String custom_property_name() const { return m_custom_property_name; }
+    String to_string() const override { return m_custom_property_name; }
+
+private:
+    explicit CustomStyleValue(const String& custom_property_name)
+        : StyleValue(Type::CustomProperty)
+        , m_custom_property_name(custom_property_name)
+    {
+    }
+
+    String m_custom_property_name {};
 };
 
 class StringStyleValue : public StyleValue {

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -53,6 +53,7 @@ namespace Web::CSS {
 
 enum class PropertyID {
     Invalid,
+    Custom,
 )~~~");
 
     json.value().as_object().for_each_member([&](auto& name, auto& value) {


### PR DESCRIPTION
This PR adds support for custom CSS properties. I didn't really know about them before, so here's the [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) and [Spec](https://www.w3.org/TR/css-variables-1/#defining-variables).

There is no error handling at all and the code for the resolution is pretty ugly, but it works.

GitHub has colors (and a lot of greys) when opened in the Browser! :^)

### What is still missing?
- specified fallbacks
- invalid variable fallbacks
- nested `var()`

But I think this is a good starting point.


If anybody wants to test this, [here](https://github.com/SerenityOS/serenity/files/6535104/var.zip) is the file I created to test the implementation (as well as GitHub of course)

----

_GitHub:_
![image](https://user-images.githubusercontent.com/6002167/119410016-72d61780-bce8-11eb-899d-a74676cb3aae.png)
_Test Page:_
![image](https://user-images.githubusercontent.com/6002167/119410039-7b2e5280-bce8-11eb-91f6-210c5799a16c.png)
