### PR TITLE
Revert "Revert "Kernel: Fix PCI layout of i440fx QEMU machine""

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -59,7 +59,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -device virtio-rng-pci
 -soundhw pcspk
 -device sb16
--device pci-bridge,chassis_nr=1,id=bridge1 -device e1000,bus=bridge1
+-device pci-bridge,chassis_nr=1,id=bridge1 -device megasas,bus=bridge1
 -device i82801b11-bridge,bus=bridge1,id=bridge2 -device sdhci-pci,bus=bridge2
 -device i82801b11-bridge,id=bridge3 -device sdhci-pci,bus=bridge3
 -device ich9-ahci,bus=bridge3


### PR DESCRIPTION
This reverts commit 72c097530f192611a60053b15706468888b0ae68.

With that patch applied audio doesn't work anymore.

Fixes #7445.