### PR TITLE
Kernel: Fix holding `s_mm_lock` during context switch. 

### DIFF
--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -342,6 +342,10 @@ bool Scheduler::donate_to(RefPtr<Thread>& beneficiary, const char* reason)
 
 bool Scheduler::context_switch(Thread* thread)
 {
+    if (s_mm_lock.own_lock()) {
+        PANIC("In context switch while holding s_mm_lock");
+    }
+
     thread->did_schedule();
 
     auto from_thread = Thread::current();

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -539,8 +539,14 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region, Scoped
 
     // Reading the page may block, so release the MM lock temporarily
     mm_lock.unlock();
-    auto buffer = UserOrKernelBuffer::for_kernel_buffer(page_buffer);
-    auto result = inode.read_bytes(page_index_in_vmobject * PAGE_SIZE, PAGE_SIZE, buffer, nullptr);
+
+    KResultOr<ssize_t> result(KSuccess);
+    {
+        ScopedLockRelease release_paging_lock(vmobject().m_paging_lock);
+        auto buffer = UserOrKernelBuffer::for_kernel_buffer(page_buffer);
+        result = inode.read_bytes(page_index_in_vmobject * PAGE_SIZE, PAGE_SIZE, buffer, nullptr);
+    }
+
     mm_lock.lock();
 
     if (result.is_error()) {


### PR DESCRIPTION
This PR cherry-picks's two commits out of @tomuta's SMP PR (#5184), the commits fix an issue he had previously found where 
the inode page fault handler can accidentally block / context switch while holding the `s_mm_lock`, and given the fact that this lock
is recursive, the other thread can mess with MM state (like page protection) when it shouldn't be able to.

This appears to fix #7359, I've been running that repro for an hour+ in a loop with these changes and it hasn't reproduced yet.

To make sure this can't happen again, I've introduced validation in `Scheduler::context_switch(..)` to make sure we never hold the `s_mm_lock`
during context switch. 

CC: @tomuta 