### PR TITLE
Documentation: CLionConfiguration: Suggest excluding the Ports directory

### DIFF
--- a/Documentation/CLionConfiguration.md
+++ b/Documentation/CLionConfiguration.md
@@ -13,8 +13,10 @@ and set the following fields: (Assuming you use `Ninja` as the build system and 
 
 Source files are copied to the `Build` directory during the build, if you do not exclude them from CLion indexing they will show up
 in search results. This is often confusing, unintuitive, and can result in you losing changes you have made to files. To exclude
-these files navigate to the `Project` tool window, right-click the `Build` folder and select `Mark Directory as | Excluded`. If you
-want exclude Toolchain files as well, follow the same procedure with the following paths:
+these files navigate to the `Project` tool window, right-click the `Build` folder and select `Mark Directory as | Excluded`.
+
+If you want to exclude source files included with the Toolchain and Ports packages, follow the same procedure with the following paths:
+- `Ports`
 - `Toolchain/Local`
 - `Toolchain/Tarballs`
 - `Toolchain/Build`


### PR DESCRIPTION
Friends don't let friends index their `Ports` directory with CLion.
