### PR TITLE
HexEditor: Construct Find dialog from GML

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -1,5 +1,6 @@
 compile_gml(HexEditorWindow.gml HexEditorWindowGML.h hex_editor_window_gml)
 compile_gml(GoToOffsetDialog.gml GoToOffsetDialogGML.h go_to_offset_dialog_gml)
+compile_gml(FindDialog.gml FindDialogGML.h find_dialog_gml)
 
 set(SOURCES
     HexEditor.cpp
@@ -7,6 +8,7 @@ set(SOURCES
     FindDialog.cpp
     GoToOffsetDialog.cpp
     main.cpp
+    FindDialogGML.h
     GoToOffsetDialogGML.h
     HexEditorWindowGML.h
 )

--- a/Userland/Applications/HexEditor/FindDialog.gml
+++ b/Userland/Applications/HexEditor/FindDialog.gml
@@ -1,0 +1,46 @@
+@GUI::Widget {
+    name: "main"
+    fixed_width: 280
+    fixed_height: 146
+    fill_with_background_color: true
+
+    layout: @GUI::VerticalBoxLayout {
+        spacing: 2
+        margins: [4, 4, 4, 4]
+    }
+
+    @GUI::Widget {
+        layout: @GUI::HorizontalBoxLayout
+
+        @GUI::Label {
+            text: "Value to find"
+            fixed_width: 80
+            text_alignment: "CenterLeft"
+        }
+
+        @GUI::TextBox {
+            name: "text_editor"
+            fixed_height: 20
+        }
+    }
+
+    @GUI::Widget {
+        layout: @GUI::VerticalBoxLayout
+
+        name: "radio_container"
+    }
+
+    @GUI::Widget {
+        layout: @GUI::HorizontalBoxLayout
+
+        @GUI::Button {
+            name: "ok_button"
+            text: "OK"
+        }
+
+        @GUI::Button {
+            name: "cancel_button"
+            text: "Cancel"
+        }
+    }
+}

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -32,6 +32,8 @@ private:
     virtual ~FindDialog() override;
 
     RefPtr<GUI::TextEditor> m_text_editor;
+    RefPtr<GUI::Button> m_ok_button;
+    RefPtr<GUI::Button> m_cancel_button;
 
     String m_text_value;
     OptionId m_selected_option { OPTION_INVALID };


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/434827/119489744-5943d700-bd9f-11eb-9fa0-a26bcc09fa2a.png)

After

![image](https://user-images.githubusercontent.com/434827/119489718-4fba6f00-bd9f-11eb-87e0-d31277b0c6b4.png)

Both look kind of silly, but I want to move onto improving the find dialog and associated functionality as a separate commit.
