### PR TITLE
Solitaire: Scoring tweaks

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -80,7 +80,7 @@ void Game::start_game_over_animation()
     start_timer(s_timer_interval_ms);
 
     if (on_game_end)
-        on_game_end();
+        on_game_end(GameOverReason::Victory, m_score);
 }
 
 void Game::stop_game_over_animation()
@@ -103,7 +103,7 @@ void Game::setup(Mode mode)
     m_mode = mode;
 
     if (on_game_end)
-        on_game_end();
+        on_game_end(GameOverReason::NewGame, m_score);
 
     for (auto& stack : m_stacks)
         stack.clear();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -110,6 +110,7 @@ void Game::setup(Mode mode)
 
     m_new_deck.clear();
     m_new_game_animation_pile = 0;
+    m_passes_left_before_punishment = recycle_rules().passes_allowed_before_punishment;
     m_score = 0;
     update_score(0);
 
@@ -182,7 +183,11 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                         stock.push(card);
                     }
 
-                    update_score(-100);
+                    if (m_passes_left_before_punishment == 0)
+                        update_score(recycle_rules().punishment);
+                    else
+                        --m_passes_left_before_punishment;
+
                     update(stock.bounding_box());
                 } else {
                     auto play_bounding_box = play.bounding_box();

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -321,7 +321,6 @@ void Game::doubleclick_event(GUI::MouseEvent& event)
     GUI::Frame::doubleclick_event(event);
 
     if (m_game_over_animation) {
-        start_game_over_animation();
         setup(mode());
         return;
     }

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -21,6 +21,11 @@ enum class Mode : u8 {
     __Count
 };
 
+enum class GameOverReason {
+    Victory,
+    NewGame,
+};
+
 class Game final : public GUI::Frame {
     C_OBJECT(Game)
 public:
@@ -34,7 +39,7 @@ public:
 
     Function<void(uint32_t)> on_score_update;
     Function<void()> on_game_start;
-    Function<void()> on_game_end;
+    Function<void(GameOverReason, uint32_t)> on_game_end;
 
 private:
     Game();

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <LibCards/CardStack.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/Painter.h>
@@ -97,6 +98,11 @@ private:
         bool m_dirty { false };
     };
 
+    struct WasteRecycleRules {
+        uint8_t passes_allowed_before_punishment { 0 };
+        int8_t punishment { 0 };
+    };
+
     enum StackLocation {
         Stock,
         Waste,
@@ -115,6 +121,23 @@ private:
         __Count
     };
     static constexpr Array piles = { Pile1, Pile2, Pile3, Pile4, Pile5, Pile6, Pile7 };
+
+    ALWAYS_INLINE const WasteRecycleRules& recycle_rules()
+    {
+        static constexpr Array<WasteRecycleRules, 2> rules { {
+            { 0, -100 },
+            { 2, -20 },
+        } };
+
+        switch (m_mode) {
+        case Mode::SingleCardDraw:
+            return rules[0];
+        case Mode::ThreeCardDraw:
+            return rules[1];
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
 
     void mark_intersecting_stacks_dirty(Card& intersecting_card);
     void update_score(int to_add);
@@ -156,6 +179,7 @@ private:
     uint8_t m_new_game_animation_delay { 0 };
 
     uint32_t m_score { 0 };
+    uint8_t m_passes_left_before_punishment { 0 };
 };
 
 }

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -115,9 +115,17 @@ int main(int argc, char** argv)
         if (timer->is_active())
             timer->stop();
 
-        if ((reason == Solitaire::GameOverReason::Victory) && (score > high_score)) {
-            update_high_score(score);
-            statusbar.set_text(1, String::formatted("High Score: {}", high_score));
+        if (reason == Solitaire::GameOverReason::Victory) {
+            if (seconds_elapsed >= 30) {
+                uint32_t bonus = (20'000 / seconds_elapsed) * 35;
+                statusbar.set_text(0, String::formatted("Score: {} (Bonus: {})", score, bonus));
+                score += bonus;
+            }
+
+            if (score > high_score) {
+                update_high_score(score);
+                statusbar.set_text(1, String::formatted("High Score: {}", high_score));
+            }
         }
     };
 

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -93,11 +93,6 @@ int main(int argc, char** argv)
 
     game.on_score_update = [&](uint32_t score) {
         statusbar.set_text(0, String::formatted("Score: {}", score));
-
-        if (score > high_score) {
-            update_high_score(score);
-            statusbar.set_text(1, String::formatted("High Score: {}", high_score));
-        }
     };
 
     uint64_t seconds_elapsed = 0;
@@ -116,9 +111,14 @@ int main(int argc, char** argv)
         seconds_elapsed = 0;
         timer->start();
     };
-    game.on_game_end = [&]() {
+    game.on_game_end = [&](Solitaire::GameOverReason reason, uint32_t score) {
         if (timer->is_active())
             timer->stop();
+
+        if ((reason == Solitaire::GameOverReason::Victory) && (score > high_score)) {
+            update_high_score(score);
+            statusbar.set_text(1, String::formatted("High Score: {}", high_score));
+        }
     };
 
     GUI::ActionGroup draw_setting_actions;


### PR DESCRIPTION
Updates to Solitaire scoring based on game mode:
* Track high score of one-card and three-card draw modes separately
* Reduce punishment of recycling the waste stack in three-card draw mode
* Award bonus points based on time elapsed
* Only update the high score after a game has actually been won