### PR TITLE
Kernel: Don't try to send TCP packets larger than the MSS

### DIFF
--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -136,7 +136,7 @@ public:
     u32 duplicate_acks() const { return m_duplicate_acks; }
 
     KResult send_ack(bool allow_duplicate = false);
-    KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0);
+    KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0, RoutingDecision* = nullptr);
     void receive_tcp_packet(const TCPPacket&, u16 size);
 
     bool should_delay_next_ack() const;

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -158,12 +158,15 @@ ByteBuffer Socket::receive(int max_size)
 
 bool Socket::send(ReadonlyBytes data)
 {
-    ssize_t nsent = ::send(fd(), data.data(), data.size(), 0);
-    if (nsent < 0) {
-        set_error(errno);
-        return false;
+    auto remaining_bytes = data.size();
+    while (remaining_bytes > 0) {
+        ssize_t nsent = ::send(fd(), data.data() + (data.size() - remaining_bytes), remaining_bytes, 0);
+        if (nsent < 0) {
+            set_error(errno);
+            return false;
+        }
+        remaining_bytes -= nsent;
     }
-    VERIFY(static_cast<size_t>(nsent) == data.size());
     return true;
 }
 


### PR DESCRIPTION
**LibCore: Handle partial writes in Socket::send()**

Right now `Socket::send()` assumes that it can send everything in one go. However, `send()` is allowed to do partial writes and while that can't happen at the moment there's nothing that says this can't happen in the future (like in the next commit).

**Kernel: Don't try to send TCP packets larger than the MSS**

Previously `TCPSocket::send_tcp_packet()` would try to send TCP packets which matched whatever size the userspace program specified. We'd try to break those packets up into smaller fragments, however a much better approach is to limit TCP packets to the maximum segment size and avoid fragmentation altogether.