### PR TITLE
LibCore: Allow TCPServer to be blocking

### DIFF
--- a/Userland/Libraries/LibCore/TCPServer.cpp
+++ b/Userland/Libraries/LibCore/TCPServer.cpp
@@ -64,6 +64,17 @@ bool TCPServer::listen(const IPv4Address& address, u16 port)
     return true;
 }
 
+void TCPServer::set_blocking(bool blocking)
+{
+    int flags = fcntl(m_fd, F_GETFL, 0);
+    VERIFY(flags >= 0);
+    if (blocking)
+        flags = fcntl(m_fd, F_SETFL, flags & ~O_NONBLOCK);
+    else
+        flags = fcntl(m_fd, F_SETFL, flags | O_NONBLOCK);
+    VERIFY(flags == 0);
+}
+
 RefPtr<TCPSocket> TCPServer::accept()
 {
     VERIFY(m_listening);

--- a/Userland/Libraries/LibCore/TCPServer.h
+++ b/Userland/Libraries/LibCore/TCPServer.h
@@ -19,6 +19,7 @@ public:
 
     bool is_listening() const { return m_listening; }
     bool listen(const IPv4Address& address, u16 port);
+    void set_blocking(bool blocking);
 
     RefPtr<TCPSocket> accept();
 


### PR DESCRIPTION
If the FD for TCPServer is set blocking, the accept() call will wait for an avaliable socket.