### PR TITLE
LibGUI/AbstractView: Remove `on_selection`

### DIFF
--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -41,13 +41,15 @@ InspectorWidget::InspectorWidget()
     auto& top_tab_widget = splitter.add<GUI::TabWidget>();
 
     m_dom_tree_view = top_tab_widget.add_tab<GUI::TreeView>("DOM");
-    m_dom_tree_view->on_selection = [this](auto& index) {
+    m_dom_tree_view->on_selection_change = [this] {
+        const auto& index = m_dom_tree_view->selection().first();
         auto* node = static_cast<Web::DOM::Node*>(index.internal_data());
         set_inspected_node(node);
     };
 
     m_layout_tree_view = top_tab_widget.add_tab<GUI::TreeView>("Layout");
-    m_layout_tree_view->on_selection = [this](auto& index) {
+    m_layout_tree_view->on_selection_change = [this] {
+        const auto& index = m_layout_tree_view->selection().first();
         auto* node = static_cast<Web::Layout::Node*>(index.internal_data());
         set_inspected_node(node->dom_node());
     };

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1049,7 +1049,8 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
         }
     };
 
-    tree_view.on_selection = [&](const GUI::ModelIndex& index) {
+    tree_view.on_selection_change = [&] {
+        const auto& index = tree_view.selection().first();
         if (directories_model->m_previously_selected_index.is_valid())
             directories_model->update_node_on_selection(directories_model->m_previously_selected_index, false);
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -179,24 +179,25 @@ int main(int argc, char* argv[])
                 GUI::MessageBox::Type::Error);
         }
     };
-    search_list_view.on_selection = [&](auto index) {
+    search_list_view.on_selection_change = [&] {
+        const auto& index = search_list_view.selection().first();
         if (!index.is_valid())
             return;
 
-        if (auto model = search_list_view.model()) {
-            auto& search_model = *static_cast<GUI::FilteringProxyModel*>(model);
-            index = search_model.map(index);
-        } else {
+        auto view_model = search_list_view.model();
+        if (!view_model) {
             page_view.load_empty_document();
             return;
         }
-        String path = model->page_path(index);
+        auto& search_model = *static_cast<GUI::FilteringProxyModel*>(view_model);
+        const auto& mapped_index = search_model.map(index);
+        String path = model->page_path(mapped_index);
         if (path.is_null()) {
             page_view.load_empty_document();
             return;
         }
         tree_view.selection().clear();
-        tree_view.selection().add(index);
+        tree_view.selection().add(mapped_index);
         history.push(path);
         update_actions();
         open_page(path);

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -141,7 +141,8 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
         auto& type_list = left_side.add<GUI::ListView>();
         type_list.set_model(*GUI::ItemListModel<String>::create(g_types));
         type_list.set_should_hide_unnecessary_scrollbars(true);
-        type_list.on_selection = [&](auto& index) {
+        type_list.on_selection_change = [&] {
+            const auto& index = type_list.selection().first();
             if (!index.is_valid()) {
                 m_type = nullptr;
                 return;

--- a/Userland/DevTools/HackStudio/ClassViewWidget.cpp
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.cpp
@@ -19,7 +19,8 @@ ClassViewWidget::ClassViewWidget()
     set_layout<GUI::VerticalBoxLayout>();
     m_class_tree = add<GUI::TreeView>();
 
-    m_class_tree->on_selection = [this](auto& index) {
+    m_class_tree->on_selection_change = [this] {
+        const auto& index = m_class_tree->selection().first();
         if (!index.is_valid())
             return;
 

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
@@ -65,7 +65,8 @@ DebugInfoWidget::DebugInfoWidget()
     variables_tab_widget.add_widget("Variables", build_variables_tab());
     variables_tab_widget.add_widget("Registers", build_registers_tab());
 
-    m_backtrace_view->on_selection = [this](auto& index) {
+    m_backtrace_view->on_selection_change = [this] {
+        const auto& index = m_backtrace_view->selection().first();
         auto& model = static_cast<BacktraceModel&>(*m_backtrace_view->model());
 
         // Note: The reconstruction of the register set here is obviously incomplete.

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -44,7 +44,8 @@ GitWidget::GitWidget(const LexicalPath& repo_root)
     m_unstaged_files = unstaged.add<GitFilesView>(
         [this](const auto& file) { stage_file(file); },
         Gfx::Bitmap::load_from_file("/res/icons/16x16/plus.png").release_nonnull());
-    m_unstaged_files->on_selection = [this](const GUI::ModelIndex& index) {
+    m_unstaged_files->on_selection_change = [this] {
+        const auto& index = m_unstaged_files->selection().first();
         const auto& selected = index.data().as_string();
         show_diff(LexicalPath(selected));
     };

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -143,7 +143,8 @@ int main(int argc, char** argv)
     auto& disassembly_view = bottom_splitter.add<GUI::TableView>();
     disassembly_view.set_visible(false);
 
-    tree_view.on_selection = [&](auto& index) {
+    tree_view.on_selection_change = [&] {
+        const auto& index = tree_view.selection().first();
         profile->set_disassembly_index(index);
         disassembly_view.set_model(profile->disassembly_model());
     };
@@ -161,7 +162,8 @@ int main(int argc, char** argv)
     samples_table_view.set_model(profile->samples_model());
 
     auto& individual_sample_view = samples_splitter.add<GUI::TableView>();
-    samples_table_view.on_selection = [&](const GUI::ModelIndex& index) {
+    samples_table_view.on_selection_change = [&] {
+        const auto& index = samples_table_view.selection().first();
         auto model = IndividualSampleModel::create(*profile, index.data(GUI::ModelRole::Custom).to_integer<size_t>());
         individual_sample_view.set_model(move(model));
     };

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -110,8 +110,8 @@ void AbstractView::did_update_selection()
 {
     if (!model() || selection().first() != m_edit_index)
         stop_editing();
-    if (model() && on_selection && selection().first().is_valid())
-        on_selection(selection().first());
+    if (model() && on_selection_change)
+        on_selection_change();
 }
 
 void AbstractView::did_scroll()
@@ -194,8 +194,6 @@ void AbstractView::activate_selected()
 void AbstractView::notify_selection_changed(Badge<ModelSelection>)
 {
     did_update_selection();
-    if (on_selection_change)
-        on_selection_change();
     if (!m_suppress_update_on_selection_change)
         update();
 }

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -98,7 +98,6 @@ public:
 
     Function<void()> on_selection_change;
     Function<void(const ModelIndex&)> on_activation;
-    Function<void(const ModelIndex&)> on_selection;
     Function<void(const ModelIndex&, const ContextMenuEvent&)> on_context_menu_request;
     Function<void(const ModelIndex&, const DropEvent&)> on_drop;
 

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -101,8 +101,9 @@ ComboBox::ComboBox()
     m_list_view->set_hover_highlighting(true);
     m_list_view->set_frame_thickness(1);
     m_list_view->set_frame_shadow(Gfx::FrameShadow::Plain);
-    m_list_view->on_selection = [this](auto& index) {
+    m_list_view->on_selection_change = [this] {
         VERIFY(model());
+        const auto& index = m_list_view->selection().first();
         m_list_view->set_activates_on_selection(true);
         if (m_updating_model)
             selection_updated(index);

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -56,7 +56,8 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
     });
     quick_sort(m_families);
 
-    m_family_list_view->on_selection = [this](auto& index) {
+    m_family_list_view->on_selection_change = [this] {
+        const auto& index = m_family_list_view->selection().first();
         m_family = index.data().to_string();
         m_weights.clear();
         Gfx::FontDatabase::the().for_each_typeface([&](auto& typeface) {
@@ -76,7 +77,8 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
         update_font();
     };
 
-    m_weight_list_view->on_selection = [this](auto& index) {
+    m_weight_list_view->on_selection_change = [this] {
+        const auto& index = m_weight_list_view->selection().first();
         bool font_is_fixed_size = false;
         m_weight = index.data(ModelRole::Custom).to_i32();
         m_sizes.clear();
@@ -130,7 +132,8 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
         update_font();
     };
 
-    m_size_list_view->on_selection = [this](auto& index) {
+    m_size_list_view->on_selection_change = [this] {
+        const auto& index = m_size_list_view->selection().first();
         m_size = index.data().to_i32();
         m_size_spin_box->set_value(m_size.value());
         update_font();


### PR DESCRIPTION
> GMTA: Why do we have both AbstractView::on_selection and ::on_selection_change? (...)
> awesomekling: it’s just leftover cruft from before multi select was a thing :)

Since the introduction of multi-select, we have had both `on_selection` and `on_selection_change`, the latter of which was only invoked when a change in selection came in through the model.

This removes `AbstractView::on_selection` and replaces its usage everywhere with the more explicit `on_selection_change`.