### PR TITLE
LibGUI+TextEditor: Add the calculation of selected words

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -765,20 +765,8 @@ void MainWidget::update_statusbar()
     builder.appendff("Line: {}, Column: {}", m_editor->cursor().line() + 1, m_editor->cursor().column());
 
     if (m_editor->has_selection()) {
-        int word_count = 0;
-        bool in_word = false;
         String selected_text = m_editor->selected_text();
-        for (char c : selected_text) {
-            if (in_word && isspace(c)) {
-                in_word = false;
-                word_count++;
-                continue;
-            }
-            if (!in_word && !isspace(c))
-                in_word = true;
-        }
-        if (in_word)
-            word_count++;
+        auto word_count = m_editor->number_of_selected_words();
         builder.appendff("        Selected: {} {} ({} {})", selected_text.length(), selected_text.length() == 1 ? "character" : "characters", word_count, word_count != 1 ? "words" : "word");
     }
     m_statusbar->set_text(builder.to_string());

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1217,6 +1217,29 @@ String TextEditor::selected_text() const
     return document().text_in_range(m_selection);
 }
 
+size_t TextEditor::number_of_selected_words() const
+{
+    if (!has_selection())
+        return 0;
+
+    size_t word_count = 0;
+    bool in_word = false;
+    auto selected_text = this->selected_text();
+    for (char c : selected_text) {
+        if (in_word && isspace(c)) {
+            in_word = false;
+            word_count++;
+            continue;
+        }
+        if (!in_word && !isspace(c))
+            in_word = true;
+    }
+    if (in_word)
+        word_count++;
+
+    return word_count;
+}
+
 void TextEditor::delete_selection()
 {
     auto selection = normalized_selection();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -115,6 +115,7 @@ public:
     bool write_to_file(const String& path);
     bool has_selection() const { return m_selection.is_valid(); }
     String selected_text() const;
+    size_t number_of_selected_words() const;
     void set_selection(const TextRange&);
     void clear_selection();
     bool can_undo() const { return document().can_undo(); }


### PR DESCRIPTION
This moves the calculation of selected words that was originally
in the TextEditor application to TextEditor in LibGUI.
This allows all applications with text editors to get
this number without having to calculating it themselves.