### PR TITLE
DHCPClient: Resend DHCP packets when we don't receive an answer

### DIFF
--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -5,16 +5,12 @@
  */
 
 #include "DHCPv4Client.h"
-#include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
-#include <AK/Endian.h>
-#include <AK/Function.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
 #include <AK/Random.h>
 #include <LibCore/File.h>
-#include <LibCore/SocketAddress.h>
 #include <LibCore/Timer.h>
 #include <stdio.h>
 

--- a/Userland/Services/DHCPClient/DHCPv4Client.h
+++ b/Userland/Services/DHCPClient/DHCPv4Client.h
@@ -19,9 +19,9 @@
 #include <sys/socket.h>
 
 struct InterfaceDescriptor {
-    String m_ifname;
-    MACAddress m_mac_address;
-    IPv4Address m_current_ip_address;
+    String ifname;
+    MACAddress mac_address;
+    IPv4Address current_ip_address;
 };
 
 struct DHCPv4Transaction {

--- a/Userland/Services/DHCPClient/DHCPv4Client.h
+++ b/Userland/Services/DHCPClient/DHCPv4Client.h
@@ -21,7 +21,7 @@
 struct InterfaceDescriptor {
     String m_ifname;
     MACAddress m_mac_address;
-    IPv4Address m_current_ip_address { 0, 0, 0, 0 };
+    IPv4Address m_current_ip_address;
 };
 
 struct DHCPv4Transaction {
@@ -40,7 +40,7 @@ class DHCPv4Client final : public Core::Object {
     C_OBJECT(DHCPv4Client)
 
 public:
-    explicit DHCPv4Client(Vector<InterfaceDescriptor> ifnames_for_immediate_discover, Vector<InterfaceDescriptor> ifnames_for_later);
+    explicit DHCPv4Client();
     virtual ~DHCPv4Client() override;
 
     void dhcp_discover(const InterfaceDescriptor& ifname);
@@ -57,13 +57,11 @@ public:
     static Result<Interfaces, String> get_discoverable_interfaces();
 
 private:
-    void try_discover_deferred_ifs();
+    void try_discover_ifs();
 
     HashMap<u32, OwnPtr<DHCPv4Transaction>> m_ongoing_transactions;
-    Vector<InterfaceDescriptor> m_ifnames_for_immediate_discover;
-    Vector<InterfaceDescriptor> m_ifnames_for_later;
     RefPtr<Core::UDPServer> m_server;
-    RefPtr<Core::Timer> m_fail_check_timer;
+    RefPtr<Core::Timer> m_check_timer;
     int m_max_timer_backoff_interval { 600000 }; // 10 minutes
 
     void handle_offer(const DHCPv4Packet&, const ParsedDHCPv4Options&);

--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -34,14 +34,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     unveil(nullptr, nullptr);
 
-    auto ifs_result = DHCPv4Client::get_discoverable_interfaces();
-    if (ifs_result.is_error()) {
-        warnln("Error: {}", ifs_result.error());
-        return 1;
-    }
-
-    auto ifs = ifs_result.release_value();
-    auto client = DHCPv4Client::construct(move(ifs.ready), move(ifs.not_ready));
+    auto client = DHCPv4Client::construct();
 
     if (pledge("stdio inet cpath rpath", nullptr) < 0) {
         perror("pledge");

--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -5,17 +5,11 @@
  */
 
 #include "DHCPv4Client.h"
-#include <AK/Debug.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
-#include <AK/String.h>
-#include <AK/StringUtils.h>
-#include <AK/Types.h>
 #include <LibCore/EventLoop.h>
-#include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)


### PR DESCRIPTION
**DHCPClient: Resend DHCP packets when we don't receive an answer**

Previously we'd only only send one DHCP request for network interfaces which were up when DHCPClient started. If that packet was lost we'd never send another request for those interfaces.

Also, if an interface were to appear after DHCPClient started (not that that is possible at the moment) we wouldn't send requests for
that interface either.

**DHCPClient: Remove unused #includes**

**DHCPClient: Rename struct members for InterfaceDescriptor**

Public members shouldn't have an "m_" prefix.