### PR TITLE
Hearts: Highlight cards when an invalid play is attempted

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -402,6 +402,11 @@ void Game::advance_game()
     if (m_animation_playing)
         return;
 
+    if (m_inverted_card) {
+        m_inverted_card->set_inverted(false);
+        m_inverted_card.clear();
+    }
+
     if (m_state == State::Play && game_ended()) {
         m_state = State::GameEnded;
         on_status_change("Game ended.");
@@ -638,6 +643,11 @@ void Game::card_clicked_during_play(size_t card_index, Card& card)
 {
     String explanation;
     if (!is_valid_play(m_players[0], card, &explanation)) {
+        if (m_inverted_card)
+            m_inverted_card->set_inverted(false);
+        card.set_inverted(true);
+        m_inverted_card = card;
+        update();
         on_status_change(String::formatted("You can't play this card: {}", explanation));
         continue_game_after_delay();
         return;

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -106,6 +106,8 @@ private:
     int m_animation_current_step { 0 };
     int m_animation_steps { 0 };
     OwnPtr<Function<void()>> m_animation_did_finish;
+
+    RefPtr<Card> m_inverted_card;
 };
 
 }

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -46,11 +46,13 @@ public:
     bool is_old_position_valid() const { return m_old_position_valid; }
     bool is_moving() const { return m_moving; }
     bool is_upside_down() const { return m_upside_down; }
+    bool is_inverted() const { return m_inverted; }
     Gfx::Color color() const { return (m_type == Diamonds || m_type == Hearts) ? Color::Red : Color::Black; }
 
     void set_position(const Gfx::IntPoint p) { m_rect.set_location(p); }
     void set_moving(bool moving) { m_moving = moving; }
     void set_upside_down(bool upside_down) { m_upside_down = upside_down; }
+    void set_inverted(bool inverted) { m_inverted = inverted; }
 
     void save_old_position();
 
@@ -61,14 +63,18 @@ public:
 private:
     Card(Type type, uint8_t value);
 
+    static NonnullRefPtr<Gfx::Bitmap> invert_bitmap(Gfx::Bitmap&);
+
     Gfx::IntRect m_rect;
     NonnullRefPtr<Gfx::Bitmap> m_front;
+    RefPtr<Gfx::Bitmap> m_front_inverted;
     Gfx::IntPoint m_old_position;
     Type m_type;
     uint8_t m_value;
     bool m_old_position_valid { false };
     bool m_moving { false };
     bool m_upside_down { false };
+    bool m_inverted { false };
 };
 
 }


### PR DESCRIPTION
This briefly inverts the selected card when the user attempts to make an invalid play.

![Screenshot from 2021-05-26 09-26-48](https://user-images.githubusercontent.com/388571/119619746-95f5e980-be04-11eb-9306-bc73246fa723.png)