### PR TITLE
Kernel: Move some of the `InlineLInkedList` usages to `IntrusiveList`

### DIFF
--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -855,18 +855,18 @@ void MemoryManager::register_region(Region& region)
 {
     ScopedSpinLock lock(s_mm_lock);
     if (region.is_kernel())
-        m_kernel_regions.append(&region);
+        m_kernel_regions.append(region);
     else
-        m_user_regions.append(&region);
+        m_user_regions.append(region);
 }
 
 void MemoryManager::unregister_region(Region& region)
 {
     ScopedSpinLock lock(s_mm_lock);
     if (region.is_kernel())
-        m_kernel_regions.remove(&region);
+        m_kernel_regions.remove(region);
     else
-        m_user_regions.remove(&region);
+        m_user_regions.remove(region);
 }
 
 void MemoryManager::dump_kernel_regions()

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -842,13 +842,13 @@ bool MemoryManager::validate_user_stack(const Process& process, VirtualAddress v
 void MemoryManager::register_vmobject(VMObject& vmobject)
 {
     ScopedSpinLock lock(s_mm_lock);
-    m_vmobjects.append(&vmobject);
+    m_vmobjects.append(vmobject);
 }
 
 void MemoryManager::unregister_vmobject(VMObject& vmobject)
 {
     ScopedSpinLock lock(s_mm_lock);
-    m_vmobjects.remove(&vmobject);
+    m_vmobjects.remove(vmobject);
 }
 
 void MemoryManager::register_region(Region& region)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -233,8 +233,8 @@ private:
     NonnullRefPtrVector<PhysicalRegion> m_user_physical_regions;
     NonnullRefPtrVector<PhysicalRegion> m_super_physical_regions;
 
-    InlineLinkedList<Region> m_user_regions;
-    InlineLinkedList<Region> m_kernel_regions;
+    Region::List m_user_regions;
+    Region::List m_kernel_regions;
     Vector<UsedMemoryRange> m_used_memory_ranges;
     Vector<PhysicalMemoryRange> m_physical_memory_ranges;
     Vector<ContiguousReservedMemoryRange> m_reserved_memory_ranges;

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -239,7 +239,7 @@ private:
     Vector<PhysicalMemoryRange> m_physical_memory_ranges;
     Vector<ContiguousReservedMemoryRange> m_reserved_memory_ranges;
 
-    InlineLinkedList<VMObject> m_vmobjects;
+    VMObject::List m_vmobjects;
 };
 
 template<typename Callback>

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/EnumBits.h>
-#include <AK/InlineLinkedList.h>
+#include <AK/IntrusiveList.h>
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
@@ -29,8 +29,7 @@ enum class ShouldFlushTLB {
 };
 
 class Region final
-    : public InlineLinkedListNode<Region>
-    , public Weakable<Region>
+    : public Weakable<Region>
     , public PurgeablePageRanges {
     friend class MemoryManager;
 
@@ -211,10 +210,6 @@ public:
 
     void remap();
 
-    // For InlineLinkedListNode
-    Region* m_next { nullptr };
-    Region* m_prev { nullptr };
-
     bool remap_vmobject_page_range(size_t page_index, size_t page_count);
 
     bool is_volatile(VirtualAddress vaddr, size_t size) const;
@@ -267,6 +262,10 @@ private:
     bool m_mmap : 1 { false };
     bool m_syscall_region : 1 { false };
     WeakPtr<Process> m_owner;
+    IntrusiveListNode<Region> m_list_node;
+
+public:
+    using List = IntrusiveList<Region, RawPtr<Region>, &Region::m_list_node>;
 };
 
 AK_ENUM_BITWISE_OPERATORS(Region::Access)


### PR DESCRIPTION
There's no reason to have `IntrusiveList` and `InlineLinkedList`, they do the same thing with minor differences in semantics.
This series starts the work to converge on `IntrusiveList`, so `InlineLinkedList` can eventually be deleted. 