### PR TITLE
LibSQL: Start of storage layer

### DIFF
--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -136,7 +136,7 @@ public:
     u32 duplicate_acks() const { return m_duplicate_acks; }
 
     KResult send_ack(bool allow_duplicate = false);
-    KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0);
+    KResult send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0, RoutingDecision* = nullptr);
     void receive_tcp_packet(const TCPPacket&, u16 size);
 
     bool should_delay_next_ack() const;

--- a/Tests/LibSQL/TestSqlStorage.cpp
+++ b/Tests/LibSQL/TestSqlStorage.cpp
@@ -1,0 +1,520 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <unistd.h>
+
+#include <LibTest/TestCase.h>
+#include <LibSQL/BTree.h>
+#include <LibSQL/Database.h>
+#include <LibSQL/Heap.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Tuple.h>
+#include <LibSQL/Value.h>
+
+TEST_CASE(text_value)
+{
+    SQL::Value v(SQL::Text);
+    v = "Test";
+    VERIFY((String) v == "Test");
+}
+
+TEST_CASE(text_value_to_int)
+{
+    SQL::Value v(SQL::Text);
+    v = "42";
+    EXPECT_EQ((int) v, 42);
+}
+
+TEST_CASE(text_value_to_int_crash)
+{
+    SQL::Value v(SQL::Text);
+    v = "Test";
+    EXPECT_CRASH("Can't convert 'Test' to integer", [&]() { (void) (int) v; return Test::Crash::Failure::DidNotCrash; });
+}
+
+TEST_CASE(serialize_text_value)
+{
+    SQL::Value v(SQL::Text);
+    v = "Test";
+    VERIFY((String) v == "Test");
+
+    ByteBuffer buffer;
+    v.serialize(buffer);
+
+    size_t offset = 0;
+    SQL::Value v2(SQL::Text, buffer, offset);
+    VERIFY((String) v2 == "Test");
+}
+
+TEST_CASE(integer_value)
+{
+    SQL::Value v(SQL::Integer);
+    v = 42;
+    VERIFY((int) v == 42);
+}
+
+TEST_CASE(serialize_int_value)
+{
+    SQL::Value v(SQL::Text);
+    v = 42;
+    VERIFY((int) v == 42);
+
+    ByteBuffer buffer;
+    v.serialize(buffer);
+
+    size_t offset = 0;
+    SQL::Value v2(SQL::Text, buffer, offset);
+    VERIFY(v2 == v);
+}
+
+TEST_CASE(float_value)
+{
+    SQL::Value v(SQL::Float);
+    v = 3.14;
+    VERIFY((double) v - 3.14 < 0.001);
+}
+
+TEST_CASE(assign_text_value_to_int)
+{
+    SQL::Value text(SQL::Text);
+    text = "42";
+    SQL::Value integer(SQL::Integer);
+    integer = text;
+    EXPECT_EQ((int) integer, 42);
+}
+
+TEST_CASE(assign_int_to_text_value)
+{
+    SQL::Value text(SQL::Text);
+    text = 42;
+    EXPECT_EQ((String) text, "42");
+}
+
+TEST_CASE(copy_value)
+{
+    SQL::Value text(SQL::Text);
+    text = 42;
+    SQL::Value copy(text);
+    EXPECT_EQ((String) copy, "42");
+}
+
+TEST_CASE(compare_text_to_int)
+{
+    SQL::Value text(SQL::Text);
+    text = 42;
+    SQL::Value integer(SQL::Integer);
+    integer = 42;
+    EXPECT(text == integer);
+    EXPECT(integer == text);
+}
+
+TEST_CASE(order_text_values)
+{
+    SQL::Value v1(SQL::Text);
+    v1 = "Test_A";
+    SQL::Value v2(SQL::Text);
+    v2 = "Test_B";
+    EXPECT(v1 <= v2);
+    EXPECT(v1 < v2);
+    EXPECT(v2 >= v1);
+    EXPECT(v2 > v1);
+}
+
+TEST_CASE(order_int_values)
+{
+    SQL::Value v1(SQL::Integer);
+    v1 = 12;
+    SQL::Value v2(SQL::Integer);
+    v2 = 42;
+    EXPECT(v1 <= v2);
+    EXPECT(v1 < v2);
+    EXPECT(v2 >= v1);
+    EXPECT(v2 > v1);
+}
+
+TEST_CASE(key)
+{
+    auto index_def = SQL::IndexDef::construct("test", false, 0);
+    index_def->append_column("col1", SQL::Text, SQL::Ascending);
+    index_def->append_column("col2", SQL::Integer, SQL::Descending);
+    SQL::Key key(*index_def);
+
+    key["col1"] = "Test";
+    key["col2"] = 42;
+    VERIFY(key[0] == "Test");
+    VERIFY(key[1] == 42);
+}
+
+TEST_CASE(serialize_key)
+{
+    auto index_def = SQL::IndexDef::construct("test", false, 0);
+    index_def->append_column("col1", SQL::Text, SQL::Ascending);
+    index_def->append_column("col2", SQL::Integer, SQL::Descending);
+    SQL::Key key(*index_def);
+
+    key["col1"] = "Test";
+    key["col2"] = 42;
+
+    auto buffer = ByteBuffer();
+    key.serialize(buffer);
+    EXPECT_EQ((String) key[0], "Test");
+    EXPECT_EQ((int) key[1], 42);
+
+    size_t offset = 0;
+    SQL::Key key2(*index_def, buffer, offset);
+    VERIFY(key2[0] == "Test");
+    VERIFY(key2[1] == 42);
+}
+
+TEST_CASE(copy_key)
+{
+    auto index_def = SQL::IndexDef::construct("test", false, 0);
+    index_def->append_column("col1", SQL::Text, SQL::Ascending);
+    index_def->append_column("col2", SQL::Integer, SQL::Descending);
+    SQL::Key key(*index_def);
+
+    key["col1"] = "Test";
+    key["col2"] = 42;
+
+    SQL::Key copy;
+    copy = key;
+    VERIFY(key == copy);
+
+    SQL::Key copy_2(copy);
+    VERIFY(key == copy_2);
+}
+
+TEST_CASE(compare_keys)
+{
+    auto index_def = SQL::IndexDef::construct("test", false, 0);
+    index_def->append_column("col1", SQL::Text, SQL::Ascending);
+    index_def->append_column("col2", SQL::Integer, SQL::Ascending);
+
+    SQL::Key key1(*index_def);
+    key1["col1"] = "Test";
+    key1["col2"] = 12;
+
+    SQL::Key key2(*index_def);
+    key2["col1"] = "Test";
+    key2["col2"] = 42;
+
+    SQL::Key key3(*index_def);
+    key3["col1"] = "Text";
+    key3["col2"] = 12;
+
+    EXPECT(key1 <= key2);
+    EXPECT(key1 < key2);
+    EXPECT(key2 >= key1);
+    EXPECT(key2 > key1);
+
+    EXPECT(key1 <= key3);
+    EXPECT(key1 < key3);
+    EXPECT(key3 >= key1);
+    EXPECT(key3 > key1);
+}
+
+TEST_CASE(compare_tuples)
+{
+    auto table = SQL::TableDef::construct("Test");
+    table->append_column("TextColumn", SQL::Text);
+    table->append_column("IntColumn", SQL::Integer);
+
+    SQL::Tuple tuple1(*table);
+    tuple1["TextColumn"] = "Test";
+    tuple1["IntColumn"] = 12;
+
+    SQL::Tuple tuple2(*table);
+    tuple2["TextColumn"] = "Test";
+    tuple2["IntColumn"] = 42;
+
+    SQL::Tuple tuple3(tuple1);
+
+    EXPECT(tuple1 != tuple2);
+    EXPECT(tuple2 != tuple1);
+    EXPECT(tuple1 == tuple3);
+    EXPECT(tuple3 == tuple1);
+}
+
+
+TEST_CASE(create_heap) {
+    unlink("test.db");
+    auto heap = SQL::Heap::construct("test.db");
+    EXPECT_EQ(heap->version(), 0x00000001u);
+}
+
+constexpr static int keys[] = { 39, 87, 77, 42, 98, 40, 53, 8, 37, 12, 90, 72, 73, 11, 88, 22, 10, 82, 25, 61, 97, 18, 60, 68, 21, 3, 58, 29, 13, 17, 89, 81, 16, 64, 5, 41, 36, 91, 38, 24, 32, 50, 34, 94, 49, 47, 1, 6, 44, 76, };
+constexpr static u32 pointers[] = { 92, 4, 50, 47, 68, 73, 24, 28, 50, 93, 60, 36, 92, 72, 53, 26, 91, 84, 25, 43, 88, 12, 62, 35, 96, 27, 96, 27, 99, 30, 21, 89, 54, 60, 37, 68, 35, 55, 80, 2, 33, 26, 93, 70, 45, 44, 3, 66, 75, 4, };
+
+NonnullRefPtr<SQL::BTree> setup_btree(SQL::Heap& heap);
+void insert_and_get_to_and_from_btree(int num_keys);
+void insert_into_and_scan_btree(int num_keys);
+
+
+NonnullRefPtr<SQL::BTree> setup_btree(SQL::Heap& heap)
+{
+    auto index_def = SQL::IndexDef::construct("test", true, 0);
+    index_def->append_column("key_value", SQL::SQLType::Integer, SQL::SortOrder::Ascending);
+
+    auto root_pointer = heap.user_value(0);
+    if (!root_pointer) {
+        root_pointer = heap.new_record_pointer();
+        heap.set_user_value(0, root_pointer);
+    }
+    auto btree = SQL::BTree::construct(heap, index_def, root_pointer);
+    btree->on_new_root = [&]() {
+        heap.set_user_value(0, btree->root());
+    };
+    return btree;
+}
+
+void insert_and_get_to_and_from_btree(int num_keys)
+{
+    unlink("test.db");
+    {
+        auto heap = SQL::Heap::construct("test.db");
+        auto btree = setup_btree(heap);
+
+        for (auto ix = 0; ix < num_keys; ix++) {
+            SQL::Key k(btree->index_def());
+            k[0] = keys[ix];
+            k.pointer(pointers[ix]);
+            btree->insert(k);
+        }
+#ifdef LIST_TREE
+        btree->list_tree();
+#endif
+    }
+
+    {
+        auto heap = SQL::Heap::construct("test.db");
+        auto btree = setup_btree(heap);
+
+        for (auto ix = 0; ix < num_keys; ix++) {
+            SQL::Key k(btree->index_def());
+            k[0] = keys[ix];
+            auto pointer_opt = btree->get(k);
+            EXPECT(pointer_opt.has_value());
+            EXPECT_EQ(pointer_opt.value(), pointers[ix]);
+        }
+    }
+}
+
+void insert_into_and_scan_btree(int num_keys)
+{
+    unlink("test.db");
+    {
+        auto heap = SQL::Heap::construct("test.db");
+        auto btree = setup_btree(heap);
+
+        for (auto ix = 0; ix < num_keys; ix++) {
+            SQL::Key k(btree->index_def());
+            k[0] = keys[ix];
+            k.pointer(pointers[ix]);
+            btree->insert(k);
+        }
+#ifdef LIST_TREE
+        btree->list_tree();
+#endif
+    }
+
+    {
+        auto heap = SQL::Heap::construct("test.db");
+        auto btree = setup_btree(heap);
+
+        int count = 0;
+        SQL::Key prev;
+        for (auto iter = btree->begin(); !iter.is_end(); iter++, count++) {
+            auto key = (*iter);
+            dbgln((String) key);
+            if (prev.length()) {
+                EXPECT(prev < key);
+            }
+            auto key_value = (int) key[0];
+            for (auto ix = 0; ix < num_keys; ix++) {
+                if (keys[ix] == key_value) {
+                    EXPECT_EQ(key.pointer(), pointers[ix]);
+                    break;
+                }
+            }
+            prev = key;
+        }
+        EXPECT_EQ(count, num_keys);
+    }
+}
+
+TEST_CASE(btree_one_key)
+{
+    insert_and_get_to_and_from_btree(1);
+}
+
+TEST_CASE(btree_four_keys)
+{
+    insert_and_get_to_and_from_btree(4);
+}
+
+TEST_CASE(btree_five_keys)
+{
+    insert_and_get_to_and_from_btree(5);
+}
+
+TEST_CASE(btree_10_keys)
+{
+    insert_and_get_to_and_from_btree(10);
+}
+
+TEST_CASE(btree_13_keys)
+{
+    insert_and_get_to_and_from_btree(13);
+}
+
+TEST_CASE(btree_20_keys)
+{
+    insert_and_get_to_and_from_btree(20);
+}
+
+TEST_CASE(btree_25_keys)
+{
+    insert_and_get_to_and_from_btree(25);
+}
+
+TEST_CASE(btree_30_keys)
+{
+    insert_and_get_to_and_from_btree(30);
+}
+
+TEST_CASE(btree_35_keys)
+{
+    insert_and_get_to_and_from_btree(35);
+}
+
+TEST_CASE(btree_40_keys)
+{
+    insert_and_get_to_and_from_btree(40);
+}
+
+TEST_CASE(btree_45_keys)
+{
+    insert_and_get_to_and_from_btree(45);
+}
+
+TEST_CASE(btree_50_keys)
+{
+    insert_and_get_to_and_from_btree(50);
+}
+
+TEST_CASE(btree_scan_one_key)
+{
+    insert_into_and_scan_btree(1);
+}
+
+TEST_CASE(btree_scan_four_keys)
+{
+    insert_into_and_scan_btree(4);
+}
+
+TEST_CASE(btree_scan_five_keys)
+{
+    insert_into_and_scan_btree(5);
+}
+
+TEST_CASE(btree_scan_10_keys)
+{
+    insert_into_and_scan_btree(10);
+}
+
+TEST_CASE(btree_scan_15_keys)
+{
+    insert_into_and_scan_btree(15);
+}
+
+TEST_CASE(btree_scan_30_keys)
+{
+    insert_into_and_scan_btree(15);
+}
+
+TEST_CASE(btree_scan_50_keys)
+{
+    insert_into_and_scan_btree(50);
+}
+
+TEST_CASE(create_database) {
+    unlink("test.db");
+    auto db = SQL::Database::construct("test.db");
+    db->commit();
+}
+
+TEST_CASE(add_table_to_btree) {
+    unlink("test.db");
+    auto db = SQL::Database::construct("test.db");
+    auto table = SQL::TableDef::construct("Test");
+
+    table->append_column("TextColumn", SQL::Text);
+    table->append_column("IntColumn", SQL::Integer);
+    db->add_table(table);
+    db->commit();
+}
+
+TEST_CASE(get_table_from_btree) {
+    auto db = SQL::Database::construct("test.db");
+    auto table = db->get_table("Test");
+    EXPECT(table);
+    EXPECT_EQ(table->name(), "Test");
+    EXPECT_EQ(table->num_columns(), 2u);
+    db->commit();
+}
+
+TEST_CASE(insert_into_table) {
+    auto db = SQL::Database::construct("test.db");
+    auto table = db->get_table("Test");
+    EXPECT(table);
+
+    SQL::Tuple tuple(*table);
+    tuple["TextColumn"] = "Test123";
+    tuple["IntColumn"] = 42;
+    EXPECT(db->insert(tuple));
+    db->commit();
+}
+
+TEST_CASE(select_from_table) {
+    auto db = SQL::Database::construct("test.db");
+    auto table = db->get_table("Test");
+    EXPECT(table);
+
+    int count = 0;
+    for (auto &tuple : db->select_all(*table)) {
+        EXPECT_EQ(tuple["TextColumn"], "Test123");
+        EXPECT_EQ(tuple["IntColumn"], "42");
+        count++;
+    }
+    EXPECT_EQ(count, 1);
+}
+
+TEST_CASE(insert_more_into_table) {
+    auto db = SQL::Database::construct("test.db");
+    auto table = db->get_table("Test");
+    EXPECT(table);
+
+    for (int count = 0; count < 10; count++) {
+        SQL::Tuple tuple(*table);
+        StringBuilder builder;
+        builder.appendff("Test{}", count);
+
+        tuple["TextColumn"] = builder.build();
+        tuple["IntColumn"] = count;
+        EXPECT(db->insert(tuple));
+    }
+    db->commit();
+}
+
+TEST_CASE(select_more_from_table) {
+    auto db = SQL::Database::construct("test.db");
+    auto table = db->get_table("Test");
+    EXPECT(table);
+
+    auto results = db->select_all(*table);
+    EXPECT_EQ(results.size(), 11u);
+}

--- a/Userland/Libraries/LibSQL/BTree.cpp
+++ b/Userland/Libraries/LibSQL/BTree.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+
+#include <LibSQL/BTree.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Meta.h>
+
+namespace SQL {
+
+BTree::BTree(Heap& heap, IndexDef& index, u32 pointer)
+    : m_heap(heap)
+    , m_index(index)
+    , m_root(nullptr)
+    , m_pointer(pointer)
+{
+}
+
+BTreeIterator BTree::begin()
+{
+    if (!m_root)
+        initialize_root();
+    VERIFY(m_root);
+    return BTreeIterator(m_root, -1);
+}
+
+BTreeIterator BTree::end()
+{
+    return BTreeIterator(nullptr, -1);
+}
+
+void BTree::initialize_root()
+{
+    if (m_pointer) {
+        if (m_pointer < m_heap.size()) {
+            auto buffer = read_block(m_pointer);
+            size_t offset = 0;
+            m_root = make<TreeNode>(*this, nullptr, m_pointer, buffer, offset);
+        } else {
+            m_root = make<TreeNode>(*this, nullptr, m_pointer);
+        }
+    } else {
+        m_pointer = new_record_pointer();
+        m_root = make<TreeNode>(*this, nullptr, m_pointer);
+    }
+    if (on_new_root)
+        on_new_root();
+}
+
+TreeNode* BTree::new_root()
+{
+    m_pointer = new_record_pointer();
+    m_root = make<TreeNode>(*this, nullptr, m_root.leak_ptr(), m_pointer);
+    add_to_write_ahead_log(*m_root);
+    if (on_new_root)
+        on_new_root();
+    return m_root;
+}
+
+bool BTree::insert(Key const& key)
+{
+    if (!m_root)
+        initialize_root();
+    VERIFY(m_root);
+    return m_root->insert(key);
+}
+
+Optional<u32> BTree::get(Key& key)
+{
+    if (!m_root)
+        initialize_root();
+    VERIFY(m_root);
+    return m_root->get(key);
+}
+
+BTreeIterator BTree::find(Key const& key)
+{
+    if (!m_root)
+        initialize_root();
+    VERIFY(m_root);
+    for (auto node = m_root->node_for(key); node; node = node->up()) {
+        for (auto ix = 0u; ix < node->size(); ix++) {
+            auto match = (*node)[ix].match(key);
+            if (match == 0)
+                return BTreeIterator(node, (int)ix);
+            else if (match > 0)
+                return end();
+        }
+    }
+    return end();
+}
+
+BTreeIterator BTree::find(Key&& key)
+{
+    if (!m_root)
+        initialize_root();
+    return find(key);
+}
+
+ByteBuffer BTree::read_block(u32 block)
+{
+    auto ret = m_heap.read_block(block);
+    if (ret.is_error()) {
+        warnln("Error reading block {}: {}", block, ret.error());
+        VERIFY_NOT_REACHED();
+    }
+    return ret.value();
+}
+
+void BTree::add_to_write_ahead_log(TreeNode& node)
+{
+    ByteBuffer buffer;
+    node.serialize(buffer);
+    m_heap.add_to_wal(node.pointer(), buffer);
+}
+
+void BTree::list_tree()
+{
+    if (!m_root)
+        initialize_root();
+    m_root->list_node(0);
+}
+
+}

--- a/Userland/Libraries/LibSQL/BTree.h
+++ b/Userland/Libraries/LibSQL/BTree.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/NonnullRefPtrVector.h>
+#include <AK/Optional.h>
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibCore/File.h>
+#include <LibCore/Object.h>
+#include <LibSQL/Heap.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/StorageForward.h>
+
+namespace SQL {
+
+#ifndef BTREE_DEBUG
+    #define BTREE_DEBUG 0
+#endif
+
+#ifndef SERIALIZE_DEBUG
+    #define SERIALIZE_DEBUG 0
+#endif
+
+/**
+ * The BTree class models a B-Tree index. It contains a collection of
+ * Key objects organized in TreeNode objects. Keys can be inserted,
+ * located, deleted, and the set can be traversed in sort order. All keys in
+ * a tree have the same underlying structure. A BTree's TreeNodes and
+ * the keys it includes are lazily loaded from the Heap when needed.
+ *
+ * The classes implementing the B-Tree functionality are BTree, TreeNode,
+ * BTreeIterator, and DownPointer (a smart pointer-like helper class).
+ */
+class DownPointer {
+public:
+    explicit DownPointer(TreeNode*, u32 = 0);
+    DownPointer(TreeNode*, TreeNode*);
+    DownPointer(DownPointer const&);
+    DownPointer(TreeNode*, DownPointer&);
+    ~DownPointer() = default;
+    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    TreeNode* node();
+
+private:
+    void inflate();
+
+    TreeNode* m_owner;
+    u32 m_pointer { 0 };
+    OwnPtr<TreeNode> m_node { nullptr };
+    friend TreeNode;
+};
+
+class TreeNode {
+public:
+    TreeNode(BTree&, TreeNode*, u32 = 0);
+    TreeNode(BTree&, TreeNode*, TreeNode*, u32 = 0);
+    TreeNode(BTree&, TreeNode*, u32 pointer, ByteBuffer&, size_t&);
+    ~TreeNode() = default;
+
+    [[nodiscard]] NonnullRefPtr<BTree> tree() const { return m_tree; }
+    [[nodiscard]] TreeNode* up() const { return m_up; }
+    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    [[nodiscard]] size_t size() const { return m_entries.size(); }
+    [[nodiscard]] Vector<Key> entries() const { return m_entries; }
+    [[nodiscard]] u32 down_pointer(size_t) const;
+    [[nodiscard]] TreeNode* down_node(size_t);
+    [[nodiscard]] bool is_leaf() const { return m_is_leaf; }
+
+    // FIXME The number of entries per node is hardcoded to 4.
+    // This needs to be dynamic based on the size of the key.
+    [[nodiscard]] static size_t max_entries() { return 4; } // FIXME
+    Key const& operator[](size_t) const;
+    bool insert(Key const&);
+    bool insert(Key const&& entry) { return insert(entry); }
+    TreeNode* node_for(Key const&);
+    Optional<u32> get(Key&);
+    void serialize(ByteBuffer&) const;
+
+private:
+    TreeNode(BTree&, TreeNode*, DownPointer&, u32 = 0);
+    void dump_if(int, String&& = "");
+    bool insert_in_leaf(Key const&);
+    void just_insert(Key const&, TreeNode* = nullptr);
+    void split();
+    void list_node(int);
+
+    NonnullRefPtr<BTree> m_tree;
+    TreeNode* m_up;
+    u32 m_pointer;
+    Vector<Key> m_entries;
+    bool m_is_leaf { true };
+    Vector<DownPointer> m_down;
+
+    friend BTree;
+    friend BTreeIterator;
+};
+
+class BTree : public Core::Object {
+    C_OBJECT(BTree);
+
+public:
+    BTree(Heap& heap, IndexDef& index, u32 pointer);
+    ~BTree() override = default;
+
+    NonnullRefPtr<IndexDef> index_def() const { return m_index; }
+    u32 root() const { return (m_root) ? m_root->pointer() : 0; }
+    bool insert(Key const&);
+    Optional<u32> get(Key&);
+    BTreeIterator find(Key const& key);
+    BTreeIterator find(Key&& key);
+    [[nodiscard]] bool duplicates_allowed() const { return m_index->unique(); }
+    BTreeIterator begin();
+    static BTreeIterator end();
+    void list_tree();
+
+    Function<void(void)> on_new_root;
+
+private:
+    void initialize_root();
+    TreeNode* new_root();
+    u32 new_record_pointer() { return m_heap.new_record_pointer(); }
+    ByteBuffer read_block(u32);
+    void add_to_write_ahead_log(TreeNode&);
+
+    Heap& m_heap;
+    NonnullRefPtr<IndexDef> m_index;
+    OwnPtr<TreeNode> m_root { nullptr };
+    u32 m_pointer { 0 };
+
+    friend BTreeIterator;
+    friend DownPointer;
+    friend TreeNode;
+};
+
+class BTreeIterator {
+public:
+    [[nodiscard]] bool is_end() const { return m_where == End; }
+    [[nodiscard]] size_t index() const { return m_index; }
+    bool update(Key const&);
+
+    bool operator==(BTreeIterator const& other) const { return cmp(other) == 0; }
+    bool operator!=(BTreeIterator const& other) const { return cmp(other) != 0; }
+    bool operator<(BTreeIterator const& other) const { return cmp(other) < 0; }
+    bool operator>(BTreeIterator const& other) const { return cmp(other) > 0; }
+    bool operator<=(BTreeIterator const& other) const { return cmp(other) <= 0; }
+    bool operator>=(BTreeIterator const& other) const { return cmp(other) >= 0; }
+    bool operator==(Key const& other) const { return cmp(other) == 0; }
+    bool operator!=(Key const& other) const { return cmp(other) != 0; }
+    bool operator<(Key const& other) const { return cmp(other) < 0; }
+    bool operator>(Key const& other) const { return cmp(other) > 0; }
+    bool operator<=(Key const& other) const { return cmp(other) <= 0; }
+    bool operator>=(Key const& other) const { return cmp(other) >= 0; }
+
+    BTreeIterator operator++()
+    {
+        *this = next();
+        return *this;
+    }
+
+    BTreeIterator operator++(int)
+    {
+        *this = next();
+        return *this;
+    }
+
+    BTreeIterator operator--()
+    {
+        *this = previous();
+        return *this;
+    }
+
+    BTreeIterator const operator--(int)
+    {
+        *this = previous();
+        return *this;
+    }
+
+    Key const& operator*() const
+    {
+        VERIFY(!is_end());
+        return (*m_current)[m_index];
+    }
+
+    Key const& operator->() const
+    {
+        VERIFY(!is_end());
+        return (*m_current)[m_index];
+    }
+
+    BTreeIterator& operator=(BTreeIterator const&);
+    BTreeIterator(BTreeIterator const&) = default;
+
+private:
+    BTreeIterator(TreeNode*, int index);
+    static BTreeIterator end() { return BTreeIterator(nullptr, -1); }
+
+    [[nodiscard]] int cmp(BTreeIterator const&) const;
+    [[nodiscard]] int cmp(Key const&) const;
+    [[nodiscard]] BTreeIterator next() const;
+    [[nodiscard]] BTreeIterator previous() const;
+    [[nodiscard]] Key key() const;
+    enum Where { Valid, End };
+
+    Where m_where { Valid };
+    TreeNode* m_current { nullptr };
+    int m_index { -1 };
+
+    friend BTree;
+};
+
+}

--- a/Userland/Libraries/LibSQL/BTreeIterator.cpp
+++ b/Userland/Libraries/LibSQL/BTreeIterator.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/StringBuilder.h>
+
+#include <LibSQL/BTree.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Value.h>
+
+namespace SQL {
+
+BTreeIterator::BTreeIterator(TreeNode *node, int index)
+    : m_current(node)
+    , m_index(index)
+{
+    if (!node) {
+        m_where = End;
+    } else {
+        if (index < 0) {
+            while (!node->is_leaf() && (node->size() != 0)) {
+                node = node->down_node(0);
+            }
+            if (node->size() == 0) {
+                m_where = End;
+                m_current = nullptr;
+                m_index = -1;
+            } else {
+                m_where = Valid;
+                m_current = node;
+                m_index = 0;
+            }
+        } else {
+            VERIFY(m_index < (int) m_current->size());
+        }
+    }
+}
+
+int BTreeIterator::cmp(BTreeIterator const& other) const
+{
+    if (is_end()) {
+        return (other.is_end()) ? 0 : 1;
+    }
+    if (other.is_end()) {
+        return -1;
+    }
+    VERIFY(static_cast<void *>(other.m_current->tree()) == static_cast<void *>(m_current->tree()));
+    VERIFY((m_current->size() > 0) && (other.m_current->size() > 0));
+    if (&m_current != &other.m_current) {
+        return (*m_current)[m_current->size() - 1].compare((*(other.m_current))[0]);
+    }
+    return (*m_current)[m_index].compare((*(other.m_current))[other.m_index]);
+}
+
+int BTreeIterator::cmp(Key const& other) const
+{
+    if (is_end())
+        return 1;
+    if (other.is_null())
+        return -1;
+    return key().compare(other);
+}
+
+BTreeIterator BTreeIterator::next() const
+{
+    if (is_end())
+        return end();
+
+    auto ix = m_index;
+    auto node = m_current;
+    if (ix < (int)(node->size() - 1)) {
+        if (node->is_leaf()) {
+            // We're in the middle of a leaf node. Next entry is
+            // is the next entry of the node:
+            return BTreeIterator(node, ix + 1);
+        } else {
+            /*
+             * We're in the middle of a non-leaf node. The iterator's
+             * next value is all the way down to the right, first entry.
+             *
+             *                  |
+             *                  +--+--+--+--+
+             *                  |  |##|  |  |
+             *                  +--+--+--+--+
+             *                 /   |  |  |   \
+             *                        |
+             *               +--+--+--+--+
+             *               |  |  |  |  |
+             *               +--+--+--+--+
+             *              /
+             * +--+--+--+--+
+             * |++|  |  |  |
+             * +--+--+--+--+
+             */
+            ix++;
+            while (!node->is_leaf()) {
+                node = node->down_node(ix);
+                ix = 0;
+            }
+        }
+        VERIFY(node->is_leaf() && (ix < (int)node->size()));
+        return BTreeIterator(node, ix);
+    }
+
+    if (node->is_leaf()) {
+        // We currently at the last entry of a leaf node. We need to check
+        // one or more levels up until we end up in the "middle" of a node.
+        // If one level up we're still at the end of the node, we need
+        // to keep going up until we hit the root node. If we're at the
+        // end of the root node, we reached the end of the btree.
+        for (auto up = node->up(); up; up = node->up()) {
+            for (size_t i = 0; i < up->size(); i++) {
+                // One level up, try to find the entry with the current
+                // node's pointer as the left pointer:
+                if (up->down_pointer(i) == node->pointer())
+                    // Found it. This is the iterator's next value:
+                    return BTreeIterator(up, (int)i);
+            }
+            // We didn't find the m_current's pointer as a left node. So
+            // it must be the right node all the way at the end and we need
+            // to go one more level up:
+            node = up;
+        }
+        // We reached the root node and we're still at the end of the node.
+        // That means we're at the end of the btree.
+        return end();
+    }
+
+    // If we're at the end of a non-leaf node, we need to follow the
+    // right pointer down until we find a leaf:
+    TreeNode *down;
+    for (down = node->down_node(node->size()); !down->is_leaf(); down = down->down_node(0));
+    return BTreeIterator(down, 0);
+}
+
+// FIXME Reverse iterating doesn't quite work; we don't recognize the
+// end (which is really the beginning) of the tree.
+BTreeIterator BTreeIterator::previous() const
+{
+    if (is_end()) {
+        return end();
+    }
+
+    auto node = m_current;
+    auto ix = m_index;
+    if (ix > 0) {
+        if (node->is_leaf()) {
+            // We're in the middle of a leaf node. Previous entry is
+            // is the previous entry of the node:
+            return BTreeIterator(node, ix - 1);
+        } else {
+            /*
+             * We're in the middle of a non-leaf node. The iterator's
+             * previous value is all the way down to the left, last entry.
+             *
+             *                  |
+             *                  +--+--+--+--+
+             *                  |  |  |##|  |
+             *                  +--+--+--+--+
+             *                 /   |  |  |   \
+             *                        |
+             *               +--+--+--+--+
+             *               |  |  |  |  |
+             *               +--+--+--+--+
+             *                            \
+             *                 +--+--+--+--+
+             *                 |  |  |  |++|
+             *                 +--+--+--+--+
+             */
+            while (!node->is_leaf()) {
+                node = node->down_node(ix);
+                ix = (int) node->size();
+            }
+        }
+        VERIFY(node->is_leaf() && (ix <= (int) node->size()));
+        return BTreeIterator(node, ix);
+    }
+
+    if (node->is_leaf()) {
+        // We currently at the first entry of a leaf node. We need to check one
+        // or more levels up until we end up in the "middle" of a node.
+        // If one level up we're still at the start of the node, we need
+        // to keep going up until we hit the root node. If we're at the
+        // start of the root node, we reached the start of the btree.
+        auto stash_current = node;
+        for (auto up = node->up(); up; up = node->up()) {
+            for (size_t i = up->size(); i > 0; i--) {
+                // One level up, try to find the entry with the current
+                // node's pointer as the right pointer:
+                if (up->down_pointer(i) == node->pointer()) {
+                    // Found it. This is the iterator's next value:
+                    node = up;
+                    ix = (int)i - 1;
+                    return BTreeIterator(node, ix);
+                }
+            }
+            // We didn't find the m_current's pointer as a right node. So
+            // it must be the left node all the way at the start and we need
+            // to go one more level up:
+            node = up;
+        }
+        // We reached the root node and we're still at the start of the node.
+        // That means we're at the start of the btree.
+        return BTreeIterator(stash_current, 0);
+    }
+
+    // If we're at the start of a non-leaf node, we need to follow the
+    // left pointer down until we find a leaf:
+    TreeNode *down;
+    for (down = node->down_node(0); !down->is_leaf(); down = down->down_node(down->size()));
+    return BTreeIterator(down, down->size()-1);
+}
+
+Key BTreeIterator::key() const
+{
+    if (is_end())
+        return {};
+    return (*m_current)[m_index];
+}
+
+bool BTreeIterator::update(Key const &new_value)
+{
+    if (is_end())
+        return false;
+    if ((cmp(new_value) == 0) && (key().pointer() == new_value.pointer()))
+        return true;
+    auto previous_iter = previous();
+    auto next_iter = next();
+    if (!m_current->tree()->duplicates_allowed() &&
+        ((previous_iter == new_value) || (next_iter == new_value))) {
+        return false;
+    }
+    if ((previous_iter > new_value) || (next_iter < new_value))
+        return false;
+
+    // We are friend of BTree and TreeNode. Don't know how I feel about that.
+    m_current->m_entries[m_index] = new_value;
+    m_current->tree()->add_to_write_ahead_log(*m_current);
+    return true;
+}
+
+BTreeIterator& BTreeIterator::operator=(BTreeIterator const& other)
+{
+    if (&other != this) {
+        m_current = other.m_current;
+        m_index = other.m_index;
+        m_where = other.m_where;
+    }
+    return *this;
+}
+
+}

--- a/Userland/Libraries/LibSQL/CMakeLists.txt
+++ b/Userland/Libraries/LibSQL/CMakeLists.txt
@@ -1,8 +1,17 @@
 set(SOURCES
+    BTree.cpp
+    BTreeIterator.cpp
+    Database.cpp
+    Heap.cpp
+    Key.cpp
     Lexer.cpp
+    Meta.cpp
     Parser.cpp
     SyntaxHighlighter.cpp
     Token.cpp
+    TreeNode.cpp
+    Tuple.cpp
+    Value.cpp
 )
 
 serenity_lib(LibSQL sql)

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+
+#include <LibSQL/BTree.h>
+#include <LibSQL/Database.h>
+#include <LibSQL/Heap.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Tuple.h>
+
+namespace SQL {
+
+Database::Database(String name)
+{
+    m_heap = Heap::construct(move(name));
+    m_tables = BTree::construct(*m_heap, TableDef::index_def(), m_heap->tables_root());
+    m_tables->on_new_root = [&]() {
+        m_heap->set_tables_root(m_tables->root());
+    };
+    m_table_columns = BTree::construct(*m_heap, ColumnDef::index_def(), m_heap->table_columns_root());
+    m_table_columns->on_new_root = [&]() {
+        m_heap->set_table_columns_root(m_table_columns->root());
+    };
+}
+
+void Database::add_table(TableDef& table)
+{
+    m_tables->insert(table.key());
+    for (auto &column : table.columns()) {
+        m_table_columns->insert(column.key());
+    }
+}
+
+Optional<Key> Database::get_table_key(String table_name)
+{
+    auto n = move(table_name);
+    auto key = TableDef::make_table_key(n);
+    auto table_iterator = m_tables->find(key);
+    if (table_iterator.is_end() || (String) ((*table_iterator)[0]) != n) {
+        warnln("Table {} not found", n);
+        return {};
+    }
+    return *table_iterator;
+}
+
+RefPtr<TableDef> Database::get_table(String name)
+{
+    auto n = move(name);
+    auto optional_iter = get_table_key(n);
+    if (!optional_iter.has_value()) {
+        return nullptr;
+    }
+    auto ret = TableDef::construct(optional_iter.value());
+    auto key = ColumnDef::get_column_key(n);
+
+    for (auto column_iterator = m_table_columns->find(key);
+         !column_iterator.is_end() && (((String) (*column_iterator)["table_name"]) == n);
+         column_iterator++) {
+        ret->append_column(
+            (String)(*column_iterator)["column_name"],
+            (SQLType)((int)(*column_iterator)["column_type"]));
+    }
+    return ret;
+}
+
+Vector<Tuple> Database::select_all(TableDef const& table)
+{
+    Vector<Tuple> ret;
+    auto optional_iter = get_table_key(table.name());
+    if (!optional_iter.has_value()) {
+        return ret;
+    }
+    for (auto pointer = optional_iter.value().pointer(); pointer; ) {
+        auto buffer_or_error = m_heap->read_block(pointer);
+        if (buffer_or_error.is_error())
+            VERIFY_NOT_REACHED();
+        ret.empend(table, pointer, buffer_or_error.value());
+        pointer = ret.last().next_pointer();
+    }
+    return ret;
+}
+
+Vector<Tuple> Database::match(TableDef const& table, Key const& key)
+{
+    Vector<Tuple> ret;
+    auto optional_iter = get_table_key(table.name());
+    if (!optional_iter.has_value())
+        return ret;
+
+    // TODO Match key against indexes defined on table. If found,
+    // use the index instead of scanning the table.
+    for (auto pointer = optional_iter.value().pointer(); pointer; ) {
+        auto buffer_or_error = m_heap->read_block(pointer);
+        if (buffer_or_error.is_error())
+            VERIFY_NOT_REACHED();
+        Tuple tuple(table, pointer, buffer_or_error.value());
+        if (tuple.match(key))
+            ret.append(tuple);
+        pointer = ret.last().next_pointer();
+    }
+    return ret;
+}
+
+bool Database::insert(Tuple& tuple)
+{
+    tuple.pointer(m_heap->new_record_pointer());
+    tuple.next_pointer(tuple.table()->pointer());
+    update(tuple);
+
+    // TODO update indexes defined on table.
+
+    auto table_key = tuple.table()->key();
+    auto table_iter = m_tables->find(table_key);
+    table_key.pointer(tuple.pointer());
+    table_iter.update(table_key);
+    tuple.table()->set_pointer(tuple.pointer());
+    return true;
+}
+
+bool Database::update(Tuple& tuple)
+{
+    ByteBuffer buffer;
+    tuple.serialize(buffer);
+    m_heap->add_to_wal(tuple.pointer(), buffer);
+
+    // TODO update indexes defined on table.
+    return true;
+}
+
+}

--- a/Userland/Libraries/LibSQL/Database.h
+++ b/Userland/Libraries/LibSQL/Database.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+#include <LibCore/Object.h>
+#include <LibSQL/Heap.h>
+#include <LibSQL/StorageForward.h>
+
+namespace SQL {
+
+/**
+ * A Database object logically connects a Heap with the SQL data we want
+ * to store in it. It has BTree pointers for B-Trees holding the definitions
+ * of tables, columns, indexes, and other SQL objects.
+ */
+class Database : public Core::Object {
+    C_OBJECT(Database);
+public:
+    explicit Database(String);
+
+    void commit() { m_heap->flush(); }
+    void add_table(TableDef &table);
+    Optional<Key> get_table_key(String table_name);
+    RefPtr<TableDef> get_table(String);
+
+    Vector<Tuple> select_all(TableDef const&);
+    Vector<Tuple> match(TableDef const&, Key const&);
+    bool insert(Tuple &);
+    bool update(Tuple &);
+
+private:
+    RefPtr<Heap> m_heap;
+    RefPtr<BTree> m_tables;
+    RefPtr<BTree> m_table_columns;
+};
+
+}

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <AK/Format.h>
+#include <AK/QuickSort.h>
+#include <AK/String.h>
+
+#include <LibCore/IODevice.h>
+#include <LibSQL/Heap.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Serialize.h>
+
+namespace SQL {
+
+Heap::Heap(String file_name)
+{
+    set_name(move(file_name));
+    size_t file_size = 0;
+    struct stat stat_buffer;
+    if (stat(name().characters(), &stat_buffer) != 0) {
+        if (errno != ENOENT) {
+            perror("stat");
+            VERIFY_NOT_REACHED();
+        }
+    } else {
+        file_size = stat_buffer.st_size;
+    }
+    if (file_size > 0)
+        m_next_block = m_end_of_file = file_size / BLOCKSIZE;
+
+    auto file_or_error = Core::File::open(name(), Core::OpenMode::ReadWrite);
+    if (file_or_error.is_error()) {
+        warnln("Couldn't open '{}': {}", name(), file_or_error.error());
+        VERIFY_NOT_REACHED();
+    }
+    m_file = file_or_error.value();
+    if (file_size > 0)
+        read_zero_block();
+    else
+        initialize_zero_block();
+}
+
+Result<ByteBuffer, String> Heap::read_block(u32 block)
+{
+    VERIFY(block < m_next_block);
+    if (!seek_block(block))
+        VERIFY_NOT_REACHED();
+    auto ret = m_file->read(BLOCKSIZE);
+    if (ret.is_empty())
+        return String("Could not read block");
+    return ret;
+}
+
+bool Heap::write_block(u32 block, ByteBuffer &buffer)
+{
+    VERIFY(block < m_next_block);
+    if (!seek_block(block))
+        VERIFY_NOT_REACHED();
+    VERIFY(buffer.size() <= BLOCKSIZE);
+    auto sz = buffer.size();
+    if (sz < BLOCKSIZE) {
+        buffer.grow(BLOCKSIZE);
+        memset(buffer.offset_pointer((int) sz), 0, BLOCKSIZE - sz);
+    }
+    if (m_file->write(buffer.data(), (int) buffer.size())) {
+        if (block == m_end_of_file)
+            m_end_of_file++;
+        return true;
+    }
+    return false;
+}
+
+bool Heap::seek_block(u32 block)
+{
+    if (block == m_end_of_file) {
+        off_t pos;
+        if (!m_file->seek(0, Core::SeekMode::FromEndPosition, &pos)) {
+            warnln("Could not seek block {} from file {}, which is at the end of the file", block, name());
+            warnln("FD: {} Position: {} error: {}", m_file->fd(), pos, m_file->error_string());
+            return false;
+        }
+    } else if (block > m_end_of_file) {
+        warnln("Seeking block {} of file {} which is beyond the end of the file", block, name());
+        return false;
+    } else {
+        if (!m_file->seek(block * BLOCKSIZE)) {
+            warnln("Could not seek block {} of file {}. The current size is {} blocks",
+                block, name(), m_end_of_file);
+            return false;
+        }
+    }
+    return true;
+}
+
+u32 Heap::new_record_pointer() {
+    if (m_free_list) {
+        auto block_or_error = read_block(m_free_list);
+        if (block_or_error.is_error()) {
+            warnln("FREE LIST CORRUPTION");
+            VERIFY_NOT_REACHED();
+        }
+        auto new_pointer = m_free_list;
+        size_t offset = 0;
+        deserialize_from<u32>(block_or_error.value(), offset, m_free_list);
+        update_zero_block();
+        return new_pointer;
+    }
+    return m_next_block++;
+}
+
+void Heap::flush()
+{
+    Vector<u32> blocks;
+    for (auto &wal_entry : m_write_ahead_log) {
+        blocks.append(wal_entry.key);
+    }
+    quick_sort(blocks);
+    for (auto &block : blocks) {
+        auto buffer_or_empty = m_write_ahead_log.get(block);
+        if (buffer_or_empty->is_empty()) {
+            VERIFY_NOT_REACHED();
+        }
+        dbgln_if(SQLHEAP_DEBUG, "Flushing block {} to {}", block, name());
+        write_block(block, buffer_or_empty.value());
+    }
+    m_write_ahead_log.clear();
+}
+
+constexpr static const char *FILE_ID="SerenitySQL ";
+constexpr static int VERSION_OFFSET=12;
+constexpr static int TABLES_ROOT_OFFSET=16;
+constexpr static int TABLE_COLUMNS_ROOT_OFFSET=20;
+constexpr static int FREE_LIST_OFFSET=24;
+constexpr static int USER_VALUES_OFFSET=28;
+
+void Heap::read_zero_block()
+{
+    char file_id[256];
+    auto bytes_or_error = read_block(0);
+    if (bytes_or_error.is_error())
+        VERIFY_NOT_REACHED();
+    auto buffer = bytes_or_error.value();
+    memcpy(file_id, buffer.offset_pointer(0), strlen(FILE_ID));
+    file_id[strlen(FILE_ID)] = 0;
+    if (strncmp(file_id, FILE_ID, strlen(FILE_ID)) != 0) {
+        warnln("Corrupt zero page in {}", name());
+        VERIFY_NOT_REACHED();
+    }
+    dbgln_if(SQLHEAP_DEBUG, "Read zero block from {}", name());
+    memcpy(&m_version, buffer.offset_pointer(VERSION_OFFSET), sizeof(u32));
+    dbgln_if(SQLHEAP_DEBUG, "Version: {}.{}", (m_version & 0xFFFF0000) >> 16, (m_version & 0x0000FFFF));
+    memcpy(&m_tables_root, buffer.offset_pointer(TABLES_ROOT_OFFSET), sizeof(u32));
+    dbgln_if(SQLHEAP_DEBUG, "Tables root node: {}", m_tables_root);
+    memcpy(&m_table_columns_root, buffer.offset_pointer(TABLE_COLUMNS_ROOT_OFFSET), sizeof(u32));
+    dbgln_if(SQLHEAP_DEBUG, "Table columns root node: {}", m_table_columns_root);
+    memcpy(&m_free_list, buffer.offset_pointer(FREE_LIST_OFFSET), sizeof(u32));
+    dbgln_if(SQLHEAP_DEBUG, "Free list: {}", m_free_list);
+    memcpy(m_user_values.data(), buffer.offset_pointer(USER_VALUES_OFFSET), m_user_values.size() * sizeof(u32));
+    for (auto ix = 0u; ix < m_user_values.size(); ix++) {
+        if (m_user_values[ix]) {
+            dbgln_if(SQLHEAP_DEBUG, "User value {}: {}", ix, m_user_values[ix]);
+        }
+    }
+}
+
+void Heap::update_zero_block()
+{
+    dbgln_if(SQLHEAP_DEBUG, "Write zero block to {}", name());
+    dbgln_if(SQLHEAP_DEBUG, "Version: {}.{}", (m_version & 0xFFFF0000) >> 16, (m_version & 0x0000FFFF));
+    dbgln_if(SQLHEAP_DEBUG, "Tables root node: {}", m_tables_root);
+    dbgln_if(SQLHEAP_DEBUG, "Table Columns root node: {}", m_table_columns_root);
+    dbgln_if(SQLHEAP_DEBUG, "Free list: {}", m_free_list);
+    for (auto ix = 0u; ix < m_user_values.size(); ix++) {
+        if (m_user_values[ix]) {
+            dbgln_if(SQLHEAP_DEBUG, "User value {}: {}", ix, m_user_values[ix]);
+        }
+    }
+
+    auto buffer = ByteBuffer::create_zeroed(BLOCKSIZE);
+    buffer.overwrite(0, FILE_ID, strlen(FILE_ID));
+    buffer.overwrite(VERSION_OFFSET, &m_version, sizeof(u32));
+    buffer.overwrite(TABLES_ROOT_OFFSET, &m_tables_root, sizeof(u32));
+    buffer.overwrite(TABLE_COLUMNS_ROOT_OFFSET, &m_table_columns_root, sizeof(u32));
+    buffer.overwrite(FREE_LIST_OFFSET, &m_free_list, sizeof(u32));
+    buffer.overwrite(USER_VALUES_OFFSET, m_user_values.data(), m_user_values.size() * sizeof(u32));
+
+    if (!write_block(0, buffer)) {
+        warnln("Error writing zero block");
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void Heap::initialize_zero_block()
+{
+    m_version = 0x00000001;
+    m_tables_root = 0;
+    m_next_block = 1;
+    m_free_list = 0;
+    for (auto &user : m_user_values) {
+        user = 0u;
+    }
+    update_zero_block();
+}
+
+}

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibCore/File.h>
+#include <LibCore/Object.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Serialize.h>
+
+#ifndef SQLHEAP_DEBUG
+#    define SQLHEAP_DEBUG 0
+#endif
+
+namespace SQL {
+
+constexpr static u32 BLOCKSIZE = 1024;
+
+/**
+ * A Heap is a logical container for database (SQL) data. Conceptually a
+ * Heap can be a database file, or a memory block, or another storage medium.
+ * It contains datastructures, like B-Trees, hash tables, or tuple stores
+ * (basically a list of data tuples).
+ *
+ * A Heap can be thought of the backing storage of a single database. It's
+ * assumed that a single SQL database is backed by a single Heap.
+ *
+ * Currently only B-Trees and tuple stores are implemented.
+ */
+class Heap : public Core::Object {
+    C_OBJECT(Heap);
+
+public:
+    explicit Heap(String);
+    virtual ~Heap() override { flush(); }
+
+    u32 size() const { return m_end_of_file; }
+    Result<ByteBuffer, String> read_block(u32);
+    bool write_block(u32, ByteBuffer&);
+    u32 new_record_pointer();
+    u32 tables_root() const { return m_tables_root; }
+
+    void set_tables_root(u32 root)
+    {
+        m_tables_root = root;
+        update_zero_block();
+    }
+
+    u32 table_columns_root() const { return m_table_columns_root; }
+
+    void set_table_columns_root(u32 root)
+    {
+        m_table_columns_root = root;
+        update_zero_block();
+    }
+    u32 version() const { return m_version; }
+
+    u32 user_value(size_t index) const
+    {
+        VERIFY(index < m_user_values.size());
+        return m_user_values[index];
+    }
+
+    void set_user_value(size_t index, u32 value)
+    {
+        VERIFY(index < m_user_values.size());
+        m_user_values[index] = value;
+        update_zero_block();
+    }
+
+    void add_to_wal(u32 block, ByteBuffer& buffer) { m_write_ahead_log.set(block, buffer); }
+    void flush();
+
+private:
+    bool seek_block(u32);
+    void read_zero_block();
+    void initialize_zero_block();
+    void update_zero_block();
+
+    RefPtr<Core::File> m_file;
+    u32 m_free_list { 0 };
+    u32 m_next_block { 1 };
+    u32 m_end_of_file { 1 };
+    u32 m_tables_root { 0 };
+    u32 m_table_columns_root { 0 };
+    u32 m_version { 0x00000001 };
+    Array<u32, 16> m_user_values;
+    HashMap<u32, ByteBuffer> m_write_ahead_log;
+};
+
+}

--- a/Userland/Libraries/LibSQL/Key.cpp
+++ b/Userland/Libraries/LibSQL/Key.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <cstring>
+
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+
+#include <LibSQL/BTree.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Serialize.h>
+#include <LibSQL/Value.h>
+
+namespace SQL {
+
+Key::Key()
+    : m_part_definitions()
+    , m_key_data()
+{
+}
+
+Key::Key(IndexDef const& index)
+    : m_part_definitions()
+    , m_key_data()
+{
+    for (auto& part : index.key()) {
+        m_part_definitions.append(part);
+        m_key_data.append(Value(part.type()));
+    }
+}
+
+Key::Key(IndexDef const& index, ByteBuffer& buffer, size_t& offset)
+    : m_part_definitions()
+    , m_key_data()
+{
+    for (auto& part : index.key()) {
+        m_part_definitions.append(part);
+    }
+    dbgln_if(SERIALIZE_DEBUG, "deserialize key at offset {}", offset);
+    deserialize_from<u32>(buffer, offset, m_pointer);
+    dbgln_if(SERIALIZE_DEBUG, "pointer: {}", m_pointer);
+    for (auto& part : m_part_definitions) {
+        m_key_data.append(Value(part.type(), buffer, offset));
+        dbgln_if(SERIALIZE_DEBUG, "Deserializing key column {} = {}", part.name(), (String) m_key_data.last());
+    }
+}
+
+void Key::serialize(ByteBuffer& buffer) const
+{
+    VERIFY(m_part_definitions.size() == m_key_data.size());
+    dbgln_if(SERIALIZE_DEBUG, "Serializing key pointer {}", pointer());
+    serialize_to<u32>(buffer, pointer());
+    for (auto ix = 0u; ix < m_part_definitions.size(); ix++) {
+        auto& key_part = m_key_data[ix];
+        if constexpr (SERIALIZE_DEBUG) {
+            auto str_opt = key_part.to_string();
+            auto& key_part_definition = m_part_definitions[ix];
+            dbgln("Serializing key[{}] = {}", key_part_definition.name(), (str_opt.has_value()) ? str_opt.value() : "(null)");
+        }
+        key_part.serialize(buffer);
+    }
+}
+
+Key::Key(Key const& other)
+    : m_part_definitions()
+    , m_key_data()
+{
+    copy_from(other);
+}
+
+Key & Key::operator = (Key const& other)
+{
+    if (this != &other) {
+        copy_from(other);
+    }
+    return *this;
+}
+
+int Key::index_of(String name) const
+{
+    auto n = move(name);
+    for (auto ix = 0u; ix < m_part_definitions.size(); ix++) {
+        auto &part = m_part_definitions[ix];
+        if (part.name() == n) {
+            return (int) ix;
+        }
+    }
+    return -1;
+}
+
+void Key::append(const Value& value)
+{
+    VERIFY(m_part_definitions.size() == 0);
+    m_key_data.append(value);
+}
+
+Key& Key::operator +=(Value const& value)
+{
+    append(value);
+    return *this;
+}
+
+bool Key::is_compatible(Key const& other) const
+{
+    if ((m_part_definitions.size() == 0) && (other.m_part_definitions.size() == 0)) {
+        return true;
+    }
+    if (m_part_definitions.size() != other.m_part_definitions.size()) {
+        return false;
+    }
+    for (auto ix = 0u; ix < m_part_definitions.size(); ix++) {
+        auto& my_part = m_part_definitions[ix];
+        auto& other_part = other.m_part_definitions[ix];
+        if (my_part.type() != other_part.type()) {
+            return false;
+        }
+        if (my_part.sort_order() != other_part.sort_order()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+String Key::to_string() const
+{
+    StringBuilder builder;
+    for (auto &part : m_key_data) {
+        if (!builder.is_empty()) {
+            builder.append('|');
+        }
+        auto str_opt = part.to_string();
+        builder.append((str_opt.has_value()) ? str_opt.value() : "(null)");
+    }
+    if (pointer() != 0) {
+        builder.appendff(":{}", pointer());
+    }
+    return builder.build();
+}
+
+size_t Key::size() const
+{
+    size_t sz = sizeof(u32);
+    for (auto &part : m_key_data) {
+        sz += part.size();
+    }
+    return sz;
+}
+
+void Key::copy_from(const Key& other)
+{
+    m_part_definitions.clear();
+    for (auto &part : other.m_part_definitions) {
+        m_part_definitions.append(part);
+    }
+    m_key_data.clear();
+    for (auto &part : other.m_key_data) {
+        m_key_data.append(part);
+    }
+    m_pointer = other.pointer();
+}
+
+int Key::compare(const Key& other) const
+{
+    auto ret = 0;
+    auto num_values = min(m_key_data.size(), other.m_key_data.size());
+    VERIFY(num_values > 0);
+    for (auto ix = 0u; ix < num_values; ix++) {
+        ret = m_key_data[ix].compare(other.m_key_data[ix]);
+        if (ret != 0) {
+            return ((ix < m_part_definitions.size()) && m_part_definitions[ix].sort_order() == SortOrder::Descending) ? -ret : ret;
+        }
+    }
+    return 0;
+}
+
+int Key::match(const Key& other) const
+{
+    auto ret = 0;
+    for (auto ix = 0u; ix < m_key_data.size(); ix++) {
+        if (other[ix].is_null()) {
+            return 0;
+        }
+        ret = m_key_data[ix].compare(other[ix]);
+        if (ret != 0) {
+            return (m_part_definitions[ix].sort_order() == SortOrder::Descending) ? -ret : ret;
+        }
+    }
+    return 0;
+}
+
+}

--- a/Userland/Libraries/LibSQL/Key.h
+++ b/Userland/Libraries/LibSQL/Key.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Meta.h"
+#include <LibCore/Object.h>
+#include <LibSQL/StorageForward.h>
+#include <LibSQL/Value.h>
+
+namespace SQL {
+
+/**
+ * A Key is an element of a random-access data structure persisted in a Heap.
+ * Key objects stored in such a structure have a definition controlling the
+ * number of parts or columns the key has, the types of the parts, and the
+ * sort order of these parts. Besides having an optional definition, a Key
+ * consists of one Value object per part. In addition, keys have a u32 pointer
+ * member which points to a Heap location.
+ *
+ * Key objects without a definition can be used to locate/find objects in
+ * a searchable data collection.
+ *
+ * FIXME Currently the Key definition is passed as an `IndexDefinition` meta
+ * data object, meaning that names are associated with both the definition
+ * and the parts of the key. These names are not used, meaning that key
+ * definitions should probably be constructed in a different way.
+ */
+class Key {
+public:
+    Key();
+    explicit Key(IndexDef const&);
+    Key(IndexDef const&, ByteBuffer&, size_t&);
+    Key(Key const&);
+    ~Key() = default;
+
+    Key& operator=(Key const&);
+
+    [[nodiscard]] String to_string() const;
+    explicit operator String() const { return to_string(); }
+
+    bool operator<(Key const& other) const { return compare(other) < 0; }
+    bool operator<=(Key const& other) const { return compare(other) <= 0; }
+    bool operator==(Key const& other) const { return compare(other) == 0; }
+    bool operator!=(Key const& other) const { return compare(other) != 0; }
+    bool operator>(Key const& other) const { return compare(other) > 0; }
+    bool operator>=(Key const& other) const { return compare(other) >= 0; }
+
+    [[nodiscard]] bool is_null() const { return m_part_definitions.is_empty(); }
+    [[nodiscard]] bool has(String name) const { return index_of(move(name)) >= 0; }
+
+    Value const& operator[](size_t ix) const
+    {
+        VERIFY(ix < m_key_data.size());
+        return m_key_data[ix];
+    }
+
+    Value& operator[](size_t ix)
+    {
+        VERIFY(ix < m_key_data.size());
+        return m_key_data[ix];
+    }
+
+    Value const& operator[](String name) const { return (*this)[(size_t)index_of(move(name))]; }
+    Value& operator[](String name) { return (*this)[(size_t)index_of(move(name))]; }
+    void append(Value const&);
+    Key& operator+=(Value const&);
+    [[nodiscard]] bool is_compatible(Key const&) const;
+
+    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    void pointer(u32 ptr) { m_pointer = ptr; }
+
+    [[nodiscard]] size_t size() const;
+    [[nodiscard]] size_t length() const { return m_part_definitions.size(); }
+    [[nodiscard]] NonnullRefPtrVector<KeyPartDef> parts() const { return m_part_definitions; }
+    void serialize(ByteBuffer&) const;
+    [[nodiscard]] int compare(Key const&) const;
+    [[nodiscard]] int match(Key const&) const;
+
+private:
+    NonnullRefPtrVector<KeyPartDef> m_part_definitions;
+    Vector<Value> m_key_data;
+    u32 m_pointer { 0 };
+
+    [[nodiscard]] int index_of(String) const;
+    void copy_from(Key const&);
+};
+
+}

--- a/Userland/Libraries/LibSQL/Meta.cpp
+++ b/Userland/Libraries/LibSQL/Meta.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSQL/Key.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Type.h>
+
+namespace SQL {
+
+ColumnDef::ColumnDef(Relation *parent, size_t column_number, String name, SQLType sql_type)
+    : Relation(move(name), parent)
+    , m_index(column_number)
+    , m_type(sql_type)
+{
+}
+
+Key ColumnDef::key() const {
+    auto key = Key(index_def());
+
+    key["table_name"] = parent()->name();
+    key["column_number"] = (int) column_number();
+    key["column_name"] = name();
+    key["column_type"] = (int) type();
+    key["column_hash"] = (int) hash();
+    VERIFY((int) key["column_hash"] == (int) hash());
+    return key;
+}
+
+Key ColumnDef::get_column_key(String table_name)
+{
+    Key key(*index_def());
+    key["table_name"] = move(table_name);
+    return key;
+}
+
+NonnullRefPtr<IndexDef> ColumnDef::s_index_def = IndexDef::construct("$columns", true, 0);
+
+NonnullRefPtr<IndexDef> ColumnDef::index_def()
+{
+  if (!s_index_def->size()) {
+    s_index_def->append_column("table_name", SQLType::Text, SortOrder::Ascending);
+    s_index_def->append_column("column_number", SQLType::Integer, SortOrder::Ascending);
+    s_index_def->append_column("column_name", SQLType::Text, SortOrder::Ascending);
+    s_index_def->append_column("column_type", SQLType::Integer, SortOrder::Ascending);
+    s_index_def->append_column("column_hash", SQLType::Integer, SortOrder::Ascending);
+  }
+  return s_index_def;
+}
+
+
+KeyPartDef::KeyPartDef(IndexDef *index, String name, SQLType sql_type, SortOrder sort_order)
+    : ColumnDef(index, index->size(), move(name), sql_type)
+    , m_sort_order(sort_order)
+{
+}
+
+
+IndexDef::IndexDef(TableDef *table, String name, bool unique, u32 pointer)
+    : Relation(move(name), pointer, table)
+    , m_key()
+    , m_unique(unique)
+{
+}
+
+IndexDef::IndexDef(String name, bool unique, u32 pointer)
+    : IndexDef(nullptr, move(name), unique, pointer)
+{
+}
+
+void IndexDef::append_column(String name, SQLType sql_type, SortOrder sort_order)
+{
+    auto part = KeyPartDef::construct(this, move(name), sql_type, sort_order);
+    m_key.append(part);
+}
+
+
+TableDef::TableDef(String name)
+    : Relation(move(name))
+    , m_columns()
+    , m_indexes()
+{
+}
+
+TableDef::TableDef(Key const& key)
+    : Relation((String) key[0], key.pointer())
+    , m_columns()
+    , m_indexes()
+{
+    set_hash((int) key[1]);
+}
+
+Key TableDef::key() const {
+    auto key = Key(index_def());
+    key["table_hash"] = (int) hash();
+    key["table_name"] = name();
+    VERIFY((int) key["table_hash"] == (int) hash());
+    key.pointer(pointer());
+    return key;
+}
+
+void TableDef::append_column(String name, SQLType sql_type)
+{
+    auto column = ColumnDef::construct(this, num_columns(), move(name), sql_type);
+    m_columns.append(column);
+}
+
+Key TableDef::make_table_key(String name)
+{
+    Key key(*index_def());
+    key["table_name"] = move(name);
+    return key;
+}
+
+NonnullRefPtr<IndexDef> TableDef::s_index_def = IndexDef::construct("$tables", true, 0);
+
+NonnullRefPtr<IndexDef> TableDef::index_def()
+{
+    if (!s_index_def->size()) {
+        s_index_def->append_column("table_name", SQLType::Text, SortOrder::Ascending);
+        s_index_def->append_column("table_hash", SQLType::Integer, SortOrder::Ascending);
+    }
+    return s_index_def;
+}
+
+}

--- a/Userland/Libraries/LibSQL/Meta.h
+++ b/Userland/Libraries/LibSQL/Meta.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullOwnPtrVector.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Result.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibCore/Object.h>
+#include <LibSQL/StorageForward.h>
+#include <LibSQL/Type.h>
+
+namespace SQL {
+
+/**
+ * This file declares objects describing tables, indexes, and columns.
+ * It remains to be seen if this will survive in it's current form.
+ */
+
+enum SortOrder {
+    Ascending,
+    Descending
+};
+
+class Heap;
+class ColumnDef;
+class KeyPartDef;
+class IndexDef;
+class TableDef;
+
+class Relation : public Core::Object {
+    C_OBJECT_ABSTRACT(Relation);
+public:
+    int hash() const { return m_hash; }
+    u32 pointer() const { return m_pointer; }
+    void set_pointer(u32 pointer) { m_pointer = pointer; }
+    ~Relation() override = default;
+
+protected:
+    Relation(String name, u32 pointer, Relation *parent = nullptr)
+        : Core::Object(parent)
+        , m_pointer(pointer)
+    {
+        set_hash(name.hash());
+        set_name(move(name));
+    }
+
+    explicit Relation(String name, Relation *parent = nullptr)
+        : Core::Object(parent)
+        , m_pointer(0)
+    {
+        set_hash(name.hash());
+        set_name(move(name));
+    }
+
+    void set_hash(u32 hash) {
+        m_hash = abs((int) hash);
+    }
+
+private:
+    int m_hash { 0 };  // FIXME Have to use int so comparisons work; no unsigned Values yet.
+    u32 m_pointer { 0 };
+};
+
+class ColumnDef : public Relation {
+    C_OBJECT(ColumnDef);
+public:
+    Key key() const;
+    SQLType type() const { return m_type; }
+    size_t column_number() const { return m_index; }
+    static NonnullRefPtr<IndexDef> index_def();
+    static Key get_column_key(String);
+
+protected:
+    ColumnDef(Relation *, size_t, String, SQLType);
+
+private:
+    size_t m_index;
+    SQLType m_type { SQLType::Text };
+    static NonnullRefPtr<IndexDef> s_index_def;
+};
+
+class KeyPartDef : public ColumnDef {
+    C_OBJECT(KeyPartDef);
+
+public:
+    KeyPartDef(IndexDef *, String, SQLType, SortOrder = Ascending);
+    SortOrder sort_order() const { return m_sort_order; }
+
+private:
+    SortOrder m_sort_order { SortOrder::Ascending };
+};
+
+class IndexDef : public Relation {
+    C_OBJECT(IndexDef);
+public:
+    ~IndexDef() override = default;
+
+    NonnullRefPtrVector<KeyPartDef> key() const { return m_key; }
+    bool unique() const { return m_unique; }
+    size_t size() { return m_key.size(); }
+    void append_column(String, SQLType, SortOrder = SortOrder::Ascending);
+private:
+    IndexDef(TableDef *, String, bool unique= true, u32 pointer = 0);
+    explicit IndexDef(String, bool unique = true, u32 pointer = 0);
+
+    NonnullRefPtrVector<KeyPartDef> m_key;
+    bool m_unique { false };
+
+    friend TableDef;
+};
+
+class TableDef : public Relation {
+    C_OBJECT(TableDef);
+public:
+    Key key() const;
+    void append_column(String, SQLType);
+    size_t num_columns() { return m_columns.size(); }
+    size_t num_indexes() { return m_indexes.size(); }
+    NonnullRefPtrVector<ColumnDef> columns() const { return m_columns; }
+    NonnullRefPtrVector<IndexDef> indexes() const { return m_indexes; }
+
+    static NonnullRefPtr<IndexDef> index_def();
+    static Key make_table_key(String);
+private:
+    explicit TableDef(String);
+    explicit TableDef(Key const&);
+
+    NonnullRefPtrVector<ColumnDef> m_columns;
+    NonnullRefPtrVector<IndexDef> m_indexes;
+    static NonnullRefPtr<IndexDef> s_index_def;
+};
+
+}

--- a/Userland/Libraries/LibSQL/Serialize.h
+++ b/Userland/Libraries/LibSQL/Serialize.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <string.h>
+#include <AK/ByteBuffer.h>
+
+namespace SQL {
+
+template<typename T>
+void deserialize_from(ByteBuffer& buffer, size_t &at_offset, T& t)
+{
+    auto ptr = buffer.offset_pointer((int) at_offset);
+    memcpy(&t, ptr, sizeof(T));
+    at_offset += sizeof(T);
+}
+
+template<typename T>
+void serialize_to(ByteBuffer& buffer, T const& t)
+{
+    buffer.append(&t, sizeof(T));
+}
+
+}

--- a/Userland/Libraries/LibSQL/StorageForward.h
+++ b/Userland/Libraries/LibSQL/StorageForward.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace SQL {
+
+class BTree;
+class BTreeIterator;
+class ColumnDef;
+class Database;
+class Heap;
+class IndexDef;
+class Key;
+class KeyPartDef;
+class TableDef;
+class TreeNode;
+class Tuple;
+class Value;
+
+}

--- a/Userland/Libraries/LibSQL/TreeNode.cpp
+++ b/Userland/Libraries/LibSQL/TreeNode.cpp
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StringBuilder.h>
+
+#include <LibSQL/BTree.h>
+#include <LibSQL/Key.h>
+#include <LibSQL/Serialize.h>
+
+namespace SQL {
+
+DownPointer::DownPointer(TreeNode* owner, u32 pointer)
+    : m_owner(owner)
+    , m_pointer(pointer)
+    , m_node(nullptr)
+{
+}
+
+DownPointer::DownPointer(TreeNode* owner, TreeNode* node)
+    : m_owner(owner)
+    , m_pointer((node) ? node->pointer() : 0)
+    , m_node(node)
+{
+}
+
+DownPointer::DownPointer(TreeNode* owner, DownPointer& down)
+    : m_owner(owner)
+    , m_pointer(down.m_pointer)
+    , m_node(down.m_node.leak_ptr())
+{
+}
+
+DownPointer::DownPointer(DownPointer const& other)
+    : m_owner(other.m_owner)
+    , m_pointer(other.pointer())
+{
+    if (other.m_node)
+        m_node = const_cast<DownPointer&>(other).m_node.release_nonnull<TreeNode>();
+    else
+        m_node = nullptr;
+}
+
+TreeNode * DownPointer::node()
+{
+    if (!m_node)
+        inflate();
+    return m_node;
+}
+
+void DownPointer::inflate()
+{
+    if (m_node || !m_pointer)
+        return;
+    auto buffer = m_owner->tree()->read_block(m_pointer);
+    size_t offset = 0;
+    m_node = make<TreeNode>(m_owner->tree(), m_owner, m_pointer, buffer, offset);
+}
+
+
+TreeNode::TreeNode(BTree& tree, TreeNode* up, u32 pointer)
+    : m_tree(tree)
+    , m_up(up)
+    , m_pointer(pointer)
+    , m_entries()
+    , m_down()
+{
+    m_down.append(DownPointer(this, nullptr));
+    m_is_leaf = true;
+}
+
+TreeNode::TreeNode(BTree& tree, TreeNode* up, DownPointer& left, u32 pointer)
+    : m_tree(tree)
+    , m_up(up)
+    , m_pointer(pointer)
+    , m_entries()
+    , m_down()
+{
+    if (left.m_node != nullptr)
+        left.m_node->m_up = this;
+    m_down.append(DownPointer(this, left));
+    m_is_leaf = left.pointer() == 0;
+    if (!m_pointer)
+        m_pointer = m_tree->new_record_pointer();
+}
+
+TreeNode::TreeNode(BTree& tree, TreeNode* up, TreeNode* left, u32 pointer)
+    : m_tree(tree)
+    , m_up(up)
+    , m_pointer(pointer)
+    , m_entries()
+    , m_down()
+{
+    m_down.append(DownPointer(this, left));
+    m_is_leaf = left->pointer() == 0;
+}
+
+TreeNode::TreeNode(BTree& tree, TreeNode* up, u32 pointer, ByteBuffer& buffer, size_t& at_offset)
+    : m_tree(tree)
+    , m_up(up)
+    , m_pointer(pointer)
+    , m_entries()
+    , m_down()
+{
+    u32 nodes;
+    deserialize_from<u32>(buffer, at_offset, nodes);
+    dbgln_if(SERIALIZE_DEBUG, "Deserializing node. Size {}", nodes);
+    if (nodes > 0) {
+        for (u32 i = 0; i < nodes; i++) {
+            u32 left;
+            deserialize_from<u32>(buffer, at_offset, left);
+            dbgln_if(SERIALIZE_DEBUG, "Down[{}] {}", i, left);
+            if (!m_down.is_empty())
+                VERIFY((left == 0) == m_is_leaf);
+            else
+                m_is_leaf = (left == 0);
+            m_entries.append(Key(m_tree->index_def(), buffer, at_offset));
+            m_down.empend(this, left);
+        }
+        u32 right;
+        deserialize_from<u32>(buffer, at_offset, right);
+        dbgln_if(SERIALIZE_DEBUG, "Right {}", right);
+        VERIFY((right == 0) == m_is_leaf);
+        m_down.empend(this, right);
+    }
+}
+
+bool TreeNode::insert(Key const& key)
+{
+    dbgln_if(BTREE_DEBUG, "[#{}] INSERT({})", m_pointer, key.to_string());
+    if (!is_leaf())
+        return node_for(key)->insert_in_leaf(key);
+    return insert_in_leaf(key);
+}
+
+bool TreeNode::insert_in_leaf(Key const& key)
+{
+    VERIFY(is_leaf());
+    if (!m_tree->duplicates_allowed()) {
+        for (auto& entry : m_entries) {
+            if (key == entry) {
+                dbgln_if(BTREE_DEBUG, "[#{}] duplicate key {}", m_pointer, key.to_string());
+                return false;
+            }
+        }
+    }
+
+    dbgln_if(BTREE_DEBUG, "[#{}] insert_in_leaf({})", m_pointer, key.to_string());
+    just_insert(key, nullptr);
+    return true;
+}
+
+Key const& TreeNode::operator[](size_t ix) const
+{
+    VERIFY(ix < size());
+    return m_entries[ix];
+}
+
+u32 TreeNode::down_pointer(size_t ix) const
+{
+    VERIFY(ix < m_down.size());
+    return m_down[ix].pointer();
+}
+
+TreeNode* TreeNode::down_node(size_t ix)
+{
+    VERIFY(ix < m_down.size());
+    return m_down[ix].node();
+}
+
+TreeNode* TreeNode::node_for(Key const& key)
+{
+    dump_if(BTREE_DEBUG, String::formatted("node_for(Key {})", key.to_string()));
+    if (is_leaf())
+        return this;
+    for (size_t ix = 0; ix < size(); ix++) {
+        if (key < m_entries[ix]) {
+            dbgln_if(BTREE_DEBUG, "[{}] {} < {} v{}",
+                m_pointer, (String) key, (String) m_entries[ix],m_down[ix].pointer());
+            return down_node(ix)->node_for(key);
+        }
+    }
+    dbgln_if(BTREE_DEBUG, "[#{}] {} >= {} v{}",
+        m_pointer, key.to_string(), (String) m_entries[size() - 1],m_down[size()].pointer());
+    return down_node(size())->node_for(key);
+}
+
+Optional<u32> TreeNode::get(Key& key)
+{
+    dump_if(BTREE_DEBUG, String::formatted("get({})", key.to_string()));
+    for (auto ix = 0u; ix < size(); ix++) {
+        if (key < m_entries[ix]) {
+            if (is_leaf()) {
+                dbgln_if(BTREE_DEBUG, "[#{}] {} < {} -> 0",
+                    m_pointer, key.to_string(), (String) m_entries[ix]);
+                return {};
+            } else {
+                dbgln_if(BTREE_DEBUG, "[{}] {} < {} ({} -> {})",
+                    m_pointer, key.to_string(), (String) m_entries[ix],
+                    ix, m_down[ix].pointer());
+                return down_node(ix)->get(key);
+            }
+        }
+        if (key == m_entries[ix]) {
+            dbgln_if(BTREE_DEBUG, "[#{}] {} == {} -> {}",
+                m_pointer, key.to_string(), (String) m_entries[ix],
+                m_entries[ix].pointer());
+            key.pointer(m_entries[ix].pointer());
+            return m_entries[ix].pointer();
+        }
+    }
+    if (m_entries.is_empty()) {
+        dbgln_if(BTREE_DEBUG, "[#{}] {} Empty node??", m_pointer, key.to_string());
+        VERIFY_NOT_REACHED();
+    }
+    if (is_leaf()) {
+        dbgln_if(BTREE_DEBUG, "[#{}] {} > {} -> 0",
+            m_pointer, key.to_string(), (String) m_entries[size() - 1]);
+        return {};
+    }
+    dbgln_if(BTREE_DEBUG, "[#{}] {} > {} ({} -> {})",
+        m_pointer, key.to_string(), (String) m_entries[size() - 1],
+        size(), m_down[size()].pointer());
+    return down_node(size())->get(key);
+}
+
+void TreeNode::serialize(ByteBuffer& buffer) const
+{
+    u32 sz = size();
+    serialize_to<u32>(buffer, sz);
+    if (sz > 0) {
+        for (auto ix = 0u; ix < size(); ix++) {
+            auto& entry = m_entries[ix];
+            dbgln_if(SERIALIZE_DEBUG, "Serializing Left[{}] = {}", ix, m_down[ix].pointer());
+            serialize_to<u32>(buffer, is_leaf() ? 0u : m_down[ix].pointer());
+            entry.serialize(buffer);
+        }
+        dbgln_if(SERIALIZE_DEBUG, "Serializing Right = {}", m_down[size()].pointer());
+        serialize_to<u32>(buffer, is_leaf() ? 0u : m_down[size()].pointer());
+    }
+}
+
+void TreeNode::just_insert(Key const& key, TreeNode *right)
+{
+    dbgln_if(BTREE_DEBUG, "[#{}] just_insert({}, right = {})",
+        m_pointer, (String)key, (right) ? right->m_pointer : 0);
+    dump_if(BTREE_DEBUG, "Before");
+    for (auto ix = 0u; ix < size(); ix++) {
+        if (key < m_entries[ix]) {
+            m_entries.insert(ix, key);
+            VERIFY(is_leaf() == (right == nullptr));
+            m_down.insert(ix + 1, DownPointer(this, right));
+            if (size() > max_entries()) {
+                split();
+            } else {
+                dump_if(BTREE_DEBUG, "To WAL");
+                tree()->add_to_write_ahead_log(*this);
+            }
+            return;
+        }
+    }
+    m_entries.append(key);
+    m_down.empend(this, right);
+
+    if (size() > max_entries()) {
+        split();
+    } else {
+        dump_if(BTREE_DEBUG, "To WAL");
+        tree()->add_to_write_ahead_log(*this);
+    }
+}
+
+void TreeNode::split()
+{
+    dump_if(BTREE_DEBUG, "Splitting node");
+    if (!m_up)
+        // Make new m_up. This is the new root node.
+        m_up = m_tree->new_root();
+
+    // Take the left pointer for the new node:
+    DownPointer left = m_down.take(max_entries()/2 + 1);
+
+    // Create the new right node:
+    auto* new_node = new TreeNode(tree(), m_up, left);
+
+    // Move the rightmost keys from this node to the new right node:
+    while (m_entries.size() > max_entries()/2+1) {
+        auto entry = m_entries.take(max_entries()/2+1);
+        auto down = m_down.take(max_entries()/2+1);
+
+        // Reparent to new right node:
+        if (down.m_node != nullptr) {
+            down.m_node->m_up = new_node;
+        }
+        new_node->m_entries.append(entry);
+        new_node->m_down.append(down);
+    }
+
+    // Move the median key in the node one level up. Its right node will
+    // be the new node:
+    auto median = m_entries.take_last();
+
+    dump_if(BTREE_DEBUG, "Split Left To WAL");
+    tree()->add_to_write_ahead_log(*this);
+    new_node->dump_if(BTREE_DEBUG, "Split Right to WAL");
+    tree()->add_to_write_ahead_log(*new_node);
+
+    m_up->just_insert(median, new_node);
+}
+
+void TreeNode::dump_if(int flag, String &&msg) {
+    if (!flag)
+        return;
+    StringBuilder builder;
+    builder.appendff("[#{}] ", pointer());
+    if (!msg.is_empty())
+        builder.appendff("{}", msg);
+    builder.append(": ");
+    if (m_up)
+        builder.appendff("[^{}] -> ", m_up->pointer());
+    else
+        builder.append("* -> ");
+    for (size_t ix = 0; ix < m_entries.size(); ix++) {
+        if (!is_leaf())
+            builder.appendff("[v{}] ", m_down[ix].pointer());
+        else
+            VERIFY(m_down[ix].pointer() == 0);
+        builder.appendff("'{}' ", (String) m_entries[ix]);
+    }
+    if (!is_leaf()) {
+        builder.appendff("[v{}]", m_down[size()].pointer());
+    } else {
+        VERIFY(m_down[size()].pointer() == 0);
+    }
+    builder.appendff(" (size {}", (int) size());
+    if (is_leaf()) {
+        builder.append(", leaf");
+    }
+    builder.append(")");
+    dbgln(builder.build());
+}
+
+void TreeNode::list_node(int indent)
+{
+    auto do_indent = [&]() {
+        for (int i = 0; i < indent; ++i) {
+            fprintf(stderr," ");
+        }
+    };
+    do_indent();
+    fprintf(stderr,"--> #%d\n", m_pointer);
+    for (auto ix = 0u; ix < size(); ix++) {
+        if (!is_leaf()) {
+            down_node(ix)->list_node(indent + 2);
+        }
+        do_indent();
+        fprintf(stderr, "%s\n", ((String) m_entries[ix]).characters());
+    }
+    if (!is_leaf()) {
+        down_node(size())->list_node(indent + 2);
+    }
+}
+
+}

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSQL/Key.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Serialize.h>
+#include <LibSQL/Tuple.h>
+
+namespace SQL {
+
+Tuple::Tuple()
+    : m_table()
+    , m_values()
+{
+}
+
+Tuple::Tuple(TableDef const& table)
+    : m_table(table)
+    , m_values()
+{
+    for (auto& column : table.columns()) {
+        m_values.append(Value(column.type()));
+    }
+}
+
+Tuple::Tuple(TableDef const& table, u32 pointer, ByteBuffer& buffer)
+    : m_table(table)
+    , m_values()
+    , m_pointer(pointer)
+{
+    size_t offset = 0;
+    for (auto& column : table.columns()) {
+        m_values.append(Value(column.type(), buffer, offset));
+    }
+    deserialize_from<u32>(buffer, offset, m_next_pointer);
+}
+
+void Tuple::serialize(ByteBuffer& buffer) const
+{
+    for (auto &value : m_values) {
+        value.serialize(buffer);
+    }
+    serialize_to<u32>(buffer, m_next_pointer);
+}
+
+Tuple::Tuple(Tuple const& other)
+    : m_table()
+    , m_values()
+{
+    copy_from(other);
+}
+
+Tuple& Tuple::operator = (Tuple const& other)
+{
+    if (this != &other) {
+        copy_from(other);
+    }
+    return *this;
+}
+
+int Tuple::index_of(String name) const
+{
+    auto n = move(name);
+    for (auto ix = 0u; ix < m_table->columns().size(); ix++) {
+        auto & column = m_table->columns()[ix];
+        if (column.name() == n) {
+            return (int) ix;
+        }
+    }
+    return -1;
+}
+
+String Tuple::to_string() const
+{
+    StringBuilder builder;
+    builder.appendff("{} tuple [{}]: ", m_table->name(), m_pointer);
+    for (auto & value : m_values) {
+        if (!builder.is_empty()) {
+            builder.append('|');
+        }
+        builder.append((String)value);
+    }
+    builder.appendff(" -> [{}]", m_next_pointer);
+    return builder.build();
+}
+
+bool Tuple::operator==(const Tuple& other) const
+{
+    if (pointer() != other.pointer())
+        return false;
+    // Two tuples with the same pointer belonging to different
+    // tables shouldn't happen:
+    VERIFY(m_table == other.m_table);
+    for (auto ix = 0u; ix < length(); ix++) {
+        if (m_values[ix] != other[ix])
+            return false;
+    }
+    return true;
+}
+
+size_t Tuple::size() const
+{
+    size_t sz = sizeof(u32);
+    for (auto& value : m_values) {
+        sz += value.size();
+    }
+    return sz;
+}
+
+void Tuple::copy_from(Tuple const& other)
+{
+    m_table = other.m_table;
+    m_values.clear();
+    for (auto &part : other.m_values) {
+        m_values.append(part);
+    }
+    m_pointer = other.pointer();
+    m_next_pointer = other.next_pointer();
+}
+
+bool Tuple::match(Key const& key) const
+{
+    auto key_index = 0u;
+    for (auto& part : key.parts()) {
+        auto my_index = index_of(part.name());
+        if (my_index < 0)
+            return false;
+        auto key_value = key[key_index];
+        if (key_value.is_null())
+            return true;
+        if (m_values[my_index] != key_value)
+            return false;
+        key_index++;
+    }
+    return true;
+}
+
+}

--- a/Userland/Libraries/LibSQL/Tuple.h
+++ b/Userland/Libraries/LibSQL/Tuple.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/NonnullRefPtrVector.h>
+#include <AK/String.h>
+#include <LibSQL/StorageForward.h>
+#include <LibSQL/Value.h>
+
+namespace SQL {
+
+/**
+ * A Tuple is an element of a sequential-access persistence data structure
+ * like a flat table. Like a key it has a definition for all its parts,
+ * but unlike a key this definition is not optional.
+ *
+ * FIXME Tuples should logically belong to a TupleStore object, but right now
+ * they stand by themselves; they contain a row's worth of data and a pointer
+ * to the next Tuple.
+ */
+class Tuple {
+public:
+    Tuple();
+    explicit Tuple(TableDef const&);
+    Tuple(TableDef const&, u32, ByteBuffer&);
+    Tuple(Tuple const&);
+    ~Tuple() = default;
+
+    Tuple& operator=(Tuple const&);
+    String to_string() const;
+    explicit operator String() const { return to_string(); }
+    bool operator==(Tuple const&) const;
+    bool operator!=(Tuple const& other) const { return !(*this == other); }
+
+    [[nodiscard]] bool has(String name) const { return index_of(move(name)) >= 0; }
+
+    Value const& operator[](size_t ix) const
+    {
+        VERIFY(ix < m_values.size());
+        return m_values[ix];
+    }
+
+    Value& operator[](size_t ix)
+    {
+        VERIFY(ix < m_values.size());
+        return m_values[ix];
+    }
+
+    Value const& operator[](String name) const { return (*this)[(size_t)index_of(move(name))]; }
+    Value& operator[](String name) { return (*this)[(size_t)index_of(move(name))]; }
+
+    [[nodiscard]] RefPtr<TableDef> table() const { return m_table; }
+    [[nodiscard]] u32 pointer() const { return m_pointer; }
+    void pointer(u32 ptr) { m_pointer = ptr; }
+    [[nodiscard]] u32 next_pointer() const { return m_next_pointer; }
+    void next_pointer(u32 ptr) { m_next_pointer = ptr; }
+
+    [[nodiscard]] size_t size() const;
+    [[nodiscard]] size_t length() const { return m_values.size(); }
+    void serialize(ByteBuffer&) const;
+    bool match(Key const&) const;
+
+private:
+    [[nodiscard]] int index_of(String) const;
+    void copy_from(Tuple const&);
+
+    RefPtr<TableDef> m_table;
+    Vector<Value> m_values;
+    u32 m_pointer { 0 };
+    u32 m_next_pointer { 0 };
+};
+
+}

--- a/Userland/Libraries/LibSQL/Type.h
+++ b/Userland/Libraries/LibSQL/Type.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/String.h>
+
+namespace SQL {
+
+#define ENUMERATE_SQL_TYPES(S)  \
+    S("text", 0, Text, String)  \
+    S("int", 1, Integer, int)   \
+    S("float", 2, Float, double)
+
+enum SQLType {
+#undef __ENUMERATE_SQL_TYPE
+#define __ENUMERATE_SQL_TYPE(name, cardinal, type, impl) type = (cardinal),
+    ENUMERATE_SQL_TYPES(__ENUMERATE_SQL_TYPE)
+#undef __ENUMERATE_SQL_TYPE
+};
+
+}

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//#include <cmath>
+#include <cstring>
+#include <LibSQL/Value.h>
+
+namespace SQL {
+
+Value::Value(SQLType sql_type)
+{
+    setup(sql_type);
+}
+
+Value::Value(SQLType sql_type, ByteBuffer &buffer, size_t &offset)
+{
+    setup(sql_type);
+    m_deserialize(buffer, offset);
+    m_is_null = false;
+}
+
+Value::Value(Value const &other)
+{
+    setup(other.type());
+    m_is_null = other.is_null();
+    if (!m_is_null)
+        m_assign_value(other);
+}
+
+Value::~Value()
+{
+}
+
+Value& Value::operator=(Value const& other)
+{
+    if (this != &other) {
+        m_is_null = other.is_null();
+        if (!m_is_null) {
+            VERIFY(can_cast(other));
+            m_assign_value(other);
+        }
+    }
+    return (*this);
+}
+
+Value& Value::operator=(String value)
+{
+    m_assign_string(value);
+    m_is_null = false;
+    return (*this);
+}
+
+Value& Value::operator=(int value)
+{
+    m_assign_int(value);
+    m_is_null = false;
+    return (*this);
+}
+
+Value& Value::operator=(double value)
+{
+    m_assign_double(value);
+    m_is_null = false;
+    return (*this);
+}
+
+Value& Value::set_null()
+{
+    m_is_null = true;
+    return (*this);
+}
+
+Optional<String> Value::to_string() const
+{
+    if (!m_is_null)
+        return m_to_string();
+    else
+        return {};
+}
+
+Value::operator String() const
+{
+    auto str = to_string();
+    VERIFY(str.has_value());
+    return str.value();
+}
+
+Optional<int> Value::to_int() const
+{
+    if (!m_is_null) {
+        return m_to_int();
+    } else {
+        return {};
+    }
+}
+
+Value::operator int() const
+{
+    auto i = to_int();
+    VERIFY(i.has_value());
+    return i.value();
+}
+
+Optional<double> Value::to_double() const
+{
+    if (!m_is_null)
+        return m_to_double();
+    else
+        return {};
+}
+
+Value::operator double() const
+{
+    auto dbl = to_double();
+    VERIFY(dbl.has_value());
+    return dbl.value();
+}
+
+bool Value::can_cast(Value const& other) const
+{
+    if (other.is_null())
+        return true;
+    if (type() == other.type())
+        return true;
+    return m_can_cast(other);
+}
+
+bool Value::operator == (String const &other) const
+{
+    return operator String() == other;
+}
+
+bool Value::operator == (int other) const
+{
+    return operator int() == other;
+}
+
+bool Value::operator == (double other) const
+{
+    return operator double() == other;
+}
+
+void Value::setup(SQLType sql_type) {
+    m_type = sql_type;
+    switch (sql_type) {
+    case Text:
+        setup_text();
+        break;
+    case Integer:
+        setup_int();
+        break;
+    case Float:
+        setup_float();
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void Value::setup_text()
+{
+    m_string = "";
+    m_type_name = []() { return "Text"; };
+    m_size = []() { return 64 + sizeof(int); };
+
+    m_deserialize = [&](ByteBuffer& buffer, size_t &at_offset) {
+        int len;
+        memcpy(&len, buffer.offset_pointer((int) at_offset), sizeof(int));
+        at_offset += sizeof(int);
+        m_string = String((const char *) buffer.offset_pointer((int) at_offset));
+        at_offset += 64;
+    };
+
+    m_serialize = [&](ByteBuffer &buffer) {
+        char zeroes[64];
+
+        int len = min((int) m_string.length(), 63);
+        buffer.append(&len, sizeof(int));
+        buffer.append(m_string.characters(), len);
+        memset(zeroes, 0, 64);
+        buffer.append(zeroes, 64 - len);
+    };
+
+    m_assign_value = [&](Value const& other) {
+        auto str = other.to_string();
+        VERIFY(str.has_value());
+        m_string = str.value();
+    };
+
+    m_assign_string = [&](String const& string) {
+        m_string = string;
+    };
+
+    m_assign_int = [&](int i) {
+        m_string = String::number(i);
+    };
+
+    m_assign_double = [&](double d) {
+        m_string = String::number(d);
+    };
+
+    m_to_string = [&]() -> Optional<String> {
+        return m_string;
+    };
+
+    m_to_int = [&]() -> Optional<int> {
+        return m_string.to_int();
+    };
+
+    m_to_double = [&]() -> Optional<double> {
+        char *end_ptr;
+        double ret = strtod(m_string.characters(), &end_ptr);
+        if (end_ptr == m_string.characters()) {
+            return {};
+        }
+        return ret;
+    };
+
+    m_compare = [&](Value const& other) -> int {
+        auto s1 = to_string();
+        auto s2 = other.to_string();
+        VERIFY(s1.has_value());
+        if (!s2.has_value()) {
+            return 1;
+        }
+        return (s1.value() == s2.value()) ? 0 : (s1.value() < s2.value()) ? -1 : 1;
+    };
+
+    m_can_cast = [](Value const&) -> bool {
+        return true;
+    };
+
+}
+
+void Value::setup_int()
+{
+    m_int = 0;
+    m_type_name = []() { return "Integer"; };
+    m_size = []() { return sizeof(int); };
+
+    m_deserialize = [&](ByteBuffer& buffer, size_t& at_offset) {
+        memcpy(&m_int, buffer.offset_pointer((int)at_offset), sizeof(int));
+        at_offset += sizeof(int);
+    };
+
+    m_serialize = [&](ByteBuffer & buffer) {
+        buffer.append(&m_int, sizeof(int));
+    };
+
+    m_assign_value = [&](Value const& other) {
+        auto i = other.to_int();
+        VERIFY(i.has_value());
+        m_int = i.value();
+    };
+
+    m_assign_string = [&](String const &string) {
+        auto i = string.to_int();
+        VERIFY(i.has_value());
+        m_double = i.value();
+    };
+
+    m_assign_int = [&](int i) {
+        m_int = i;
+    };
+
+    m_assign_double = [&](double d) {
+        m_double = (int) d;
+    };
+
+    m_to_string = [&]() -> Optional<String> {
+        StringBuilder builder;
+        builder.appendff("{}", m_int);
+        return builder.build();
+    };
+
+    m_to_int = [&]() -> Optional<int> {
+        return m_int;
+    };
+
+    m_to_double = [&]() -> Optional<double> {
+        return (double) m_double;
+    };
+
+    m_compare = [&](Value const& other) -> int {
+        auto casted = other.to_int();
+        if (!casted.has_value()) {
+            return 1;
+        }
+        return m_int - casted.value();
+    };
+
+    m_can_cast = [](Value const& other) -> bool {
+        auto i = other.to_int();
+        return i.has_value();
+    };
+
+}
+
+void Value::setup_float()
+{
+    m_double = 0.0;
+    m_type_name = []() { return "Float"; };
+    m_size = []() { return sizeof(double); };
+
+    m_deserialize = [&](ByteBuffer& buffer, size_t& at_offset) {
+        memcpy(&m_double, buffer.offset_pointer((int)at_offset), sizeof(double));
+        at_offset += sizeof(double);
+    };
+
+    m_serialize = [&](ByteBuffer& buffer) {
+        buffer.append(&m_double, sizeof(double));
+    };
+
+    m_to_string = [&]() -> Optional<String> {
+        StringBuilder builder;
+        builder.appendff("{}", m_double);
+        return builder.build();
+    };
+
+    m_to_int = [&]() -> Optional<int> {
+        return (int) m_double;
+    };
+
+    m_to_double = [&]() -> Optional<double> {
+        return m_double;
+    };
+
+    m_assign_value = [&](Value const& other) {
+        auto dbl = other.to_double();
+        VERIFY(dbl.has_value());
+        m_double = dbl.value();
+    };
+
+    m_assign_string = [&](String const& string) {
+        char* end_ptr;
+        auto dbl = strtod(string.characters(), &end_ptr);
+        VERIFY(end_ptr != string.characters());
+        m_double = dbl;
+    };
+
+    m_assign_int = [&](int i) {
+        m_double = i;
+    };
+
+    m_assign_double = [&](double d) {
+        m_double = d;
+    };
+
+    m_compare = [&](Value const& other) -> int {
+        auto casted = other.to_double();
+        if (!casted.has_value()) {
+            return 1;
+        }
+        // FIXME probably fails if difference is -0.5<diff<0 because
+        // that will round to 0?
+        return ((m_double - casted.value()) < 1e-6) ? 0 : (int) (m_double - casted.value());
+    };
+
+    m_can_cast = [](Value const& other) -> bool {
+        auto dbl = other.to_double();
+        return dbl.has_value();
+    };
+
+}
+
+}

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Function.h>
+#include <AK/String.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Type.h>
+
+namespace SQL {
+
+/**
+ * A `Value` is an atomic piece of SQL data. A `Value` has a basic type
+ * (Text/String, Integer, Float, etc). Richer types are implemented in higher
+ * level layers, but the resulting data is stored in these `Value` objects.
+ */
+class Value {
+public:
+    explicit Value(SQLType sql_type = Text);
+    Value(SQLType sql_type, ByteBuffer &buffer, size_t &offset);
+    Value(Value const &other);
+    ~Value();
+
+    Value& operator=(Value&& other) noexcept { (*this) = other; return (*this); }
+    Value& operator=(Value const& other);
+    Value& operator=(String);
+    Value& operator=(int);
+    Value& operator=(double);
+    Value& set_null();
+
+    Optional<String> to_string() const;
+    explicit operator String() const;
+    Optional<int> to_int() const;
+    explicit operator int() const;
+    Optional<double> to_double() const;
+    explicit operator double() const;
+
+    [[nodiscard]] SQLType type() const { return m_type; }
+    [[nodiscard]] const char* type_name() const { return m_type_name(); }
+    [[nodiscard]] size_t size() const { return m_size(); }
+    [[nodiscard]] int compare(Value const &other) const { return m_compare(other); }
+    [[nodiscard]] bool is_null() const { return m_is_null; }
+    [[nodiscard]] bool can_cast(Value const&) const;
+
+    bool operator == (Value const&other) const { return m_compare(other) == 0; }
+    bool operator == (String const &other) const;
+    bool operator == (int other) const;
+    bool operator == (double other) const;
+    bool operator != (Value const& other) const { return m_compare(other) != 0; }
+    bool operator < (Value const& other) const { return m_compare(other) < 0; }
+    bool operator <= (Value const& other) const { return m_compare(other) <= 0; }
+    bool operator > (Value const& other) const { return m_compare(other) > 0; }
+    bool operator >= (Value const& other) const { return m_compare(other) >= 0; }
+
+    void serialize(ByteBuffer &buffer) const { VERIFY(!is_null()); m_serialize(buffer); }
+
+private:
+    void setup(SQLType sql_type);
+    void setup_text();
+    void setup_int();
+    void setup_float();
+
+    Function<Optional<String>()> m_to_string;
+    Function<Optional<int>()> m_to_int;
+    Function<Optional<double>()> m_to_double;
+    Function<void(Value const&)> m_assign_value;
+    Function<void(String const &)> m_assign_string;
+    Function<void(int)> m_assign_int;
+    Function<void(double)> m_assign_double;
+    Function<int(Value const&)> m_compare;
+    Function<void(ByteBuffer&)> m_serialize;
+    Function<void(ByteBuffer&, size_t &offset)> m_deserialize;
+    Function<size_t()> m_size;
+    Function<const char *()> m_type_name;
+    Function<bool(Value const&)> m_can_cast;
+
+    SQLType m_type { SQLType::Text };
+    bool m_is_null { true };
+
+    union {
+        String m_string = "";
+        int m_int;
+        double m_double;
+    };
+};
+
+}


### PR DESCRIPTION
Attempt #2. I saved my files, and started over. This is a fresh, single commit, patch. 
Hopefully it's better than yesterday's attempts. I think I addressed all issues raised 
in that previous pull request.

This patch provides a number of classes providing the base for the
persistence of SQL databases. They define a logical storage unit (Heap) and
data structures which can be stored in a Heap.

This layer will live in a Serenity service which will receive SQL
statements, parse them, plan them and execute them by interacting with the
persistent storage layer.
