### PR TITLE
Toolchain: Use set -o pipefail to the toolchain build script

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 # This file will need to be run in bash, for now.
 
 
@@ -137,18 +137,24 @@ popd
 # === DOWNLOAD AND PATCH ===
 
 pushd "$DIR/Tarballs"
-    md5="$($MD5SUM $BINUTILS_PKG | cut -f1 -d' ')"
-    echo "bu md5='$md5'"
-    if [ ! -e $BINUTILS_PKG ] || [ "$md5" != ${BINUTILS_MD5SUM} ] ; then
+    md5=""
+    if [ -e "$BINUTILS_PKG" ]; then
+        md5="$($MD5SUM $BINUTILS_PKG | cut -f1 -d' ')"
+        echo "bu md5='$md5'"
+    fi
+    if [ "$md5" != ${BINUTILS_MD5SUM} ] ; then
         rm -f $BINUTILS_PKG
         curl -LO "$BINUTILS_BASE_URL/$BINUTILS_PKG"
     else
         echo "Skipped downloading binutils"
     fi
 
-    md5="$($MD5SUM ${GCC_PKG} | cut -f1 -d' ')"
-    echo "gc md5='$md5'"
-    if [ ! -e $GCC_PKG ] || [ "$md5" != ${GCC_MD5SUM} ] ; then
+    md5=""
+    if [ -e "$GCC_PKG" ]; then
+        md5="$($MD5SUM ${GCC_PKG} | cut -f1 -d' ')"
+        echo "gc md5='$md5'"
+    fi
+    if [ "$md5" != ${GCC_MD5SUM} ] ; then
         rm -f $GCC_PKG
         curl -LO "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
     else


### PR DESCRIPTION
Previously the `buildstep` function would obscure error codes because the return value of the function was the exit code for the sed command which caused us to continue execution even though one of the build steps had failed.

With `set -o pipefail` the return value of the buildstep function is the real command's exit code.

I've tested this with Bash 3.2 and this is apparently supported. So this hopefully doesn't break macOS builds.