### PR TITLE
Base: Make desktop shortcuts owned by anon

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -121,11 +121,12 @@ chown -R 100:100 mnt/home/anon
 chown -R 200:200 mnt/home/nona
 echo "done"
 
-printf "adding some desktop icons..."
+printf "adding some desktop icons... "
 ln -sf /bin/Browser mnt/home/anon/Desktop/
 ln -sf /bin/TextEditor mnt/home/anon/Desktop/Text\ Editor
 ln -sf /bin/Help mnt/home/anon/Desktop/
 ln -sf /home/anon mnt/home/anon/Desktop/Home
+chown -R 100:100 mnt/home/anon/Desktop
 echo "done"
 
 printf "installing shortcuts... "


### PR DESCRIPTION
This fixes #7492. The permissions cannot be changed as symbolic links always have `rwxrwxrwx` permissions.