### PR TITLE
Kernel: Let the user read/write more than one page from/to dev files

### DIFF
--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -28,10 +28,9 @@ bool FullDevice::can_read(const FileDescription&, size_t) const
 
 KResultOr<size_t> FullDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
-    ssize_t count = min(static_cast<size_t>(PAGE_SIZE), size);
-    if (!buffer.memset(0, count))
+    if (!buffer.memset(0, size))
         return EFAULT;
-    return count;
+    return size;
 }
 
 KResultOr<size_t> FullDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t size)

--- a/Kernel/Devices/NullDevice.cpp
+++ b/Kernel/Devices/NullDevice.cpp
@@ -43,7 +43,7 @@ KResultOr<size_t> NullDevice::read(FileDescription&, u64, UserOrKernelBuffer&, s
 
 KResultOr<size_t> NullDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t buffer_size)
 {
-    return min(static_cast<size_t>(PAGE_SIZE), buffer_size);
+    return buffer_size;
 }
 
 }

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -34,7 +34,7 @@ KResultOr<size_t> RandomDevice::read(FileDescription&, u64, UserOrKernelBuffer& 
 KResultOr<size_t> RandomDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t size)
 {
     // FIXME: Use input for entropy? I guess that could be a neat feature?
-    return min(static_cast<size_t>(PAGE_SIZE), size);
+    return size;
 }
 
 }

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -26,15 +26,14 @@ bool ZeroDevice::can_read(const FileDescription&, size_t) const
 
 KResultOr<size_t> ZeroDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
-    ssize_t count = min(static_cast<size_t>(PAGE_SIZE), size);
-    if (!buffer.memset(0, count))
+    if (!buffer.memset(0, size))
         return EFAULT;
-    return count;
+    return size;
 }
 
 KResultOr<size_t> ZeroDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t size)
 {
-    return min(static_cast<size_t>(PAGE_SIZE), size);
+    return size;
 }
 
 }


### PR DESCRIPTION
Previously reads and writes to `/dev/zero`, `/dev/full`, `/dev/null` and `/dev/random` were limited to 4096 bytes.

This removes that restriction so that users can enjoy more zero bytes in their buffers.