### PR TITLE
LexicalPath: Reset dirname if it's empty

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -68,6 +68,10 @@ void LexicalPath::canonicalize()
     }
     m_dirname = dirname_builder.to_string();
 
+    if (m_dirname.is_empty()) {
+        m_dirname = m_is_absolute ? "/" : ".";
+    }
+
     m_basename = canonical_parts.last();
 
     Optional<size_t> last_dot = StringView(m_basename).find_last_of('.');

--- a/Tests/AK/TestLexicalPath.cpp
+++ b/Tests/AK/TestLexicalPath.cpp
@@ -78,3 +78,11 @@ TEST_CASE(relative_path)
     EXPECT_EQ(LexicalPath::relative_path("/tmp/foo.txt", "tmp"), String {});
     EXPECT_EQ(LexicalPath::relative_path("tmp/foo.txt", "/tmp"), String {});
 }
+
+TEST_CASE(dirname)
+{
+    EXPECT_EQ(LexicalPath(".").dirname(), ".");
+    EXPECT_EQ(LexicalPath("/").dirname(), "/");
+    EXPECT_EQ(LexicalPath("abc.txt").dirname(), ".");
+    EXPECT_EQ(LexicalPath("/abc.txt").dirname(), "/");
+}


### PR DESCRIPTION
dirname ends up empty if the canonical path only contains one element.

Reset it to the default for relative/absolute paths if that is the case.

This also fixes the output of (as an example) `dirname ./autogen.sh`.

While we're at it, add a test case that checks for such special cases.