### PR TITLE
Solitaire: Start timer when first card is moved

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -155,6 +155,11 @@ void Game::mousedown_event(GUI::MouseEvent& event)
     if (m_new_game_animation || m_game_over_animation)
         return;
 
+    if (on_game_start && m_waiting_for_new_game) {
+        on_game_start();
+        m_waiting_for_new_game = false;
+    }
+
     auto click_location = event.position();
     for (auto& to_check : m_stacks) {
         if (to_check.type() == CardStack::Type::Waste)
@@ -440,10 +445,8 @@ void Game::paint_event(GUI::PaintEvent& event)
                 while (!m_new_deck.is_empty())
                     stack(Stock).push(m_new_deck.take_last());
                 m_new_game_animation = false;
+                m_waiting_for_new_game = true;
                 stop_timer();
-
-                if (on_game_start)
-                    on_game_start();
             }
         }
     }

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -173,7 +173,7 @@ private:
 
     Animation m_animation;
     bool m_game_over_animation { false };
-
+    bool m_waiting_for_new_game { true };
     bool m_new_game_animation { false };
     uint8_t m_new_game_animation_pile { 0 };
     uint8_t m_new_game_animation_delay { 0 };

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -146,6 +146,7 @@ int main(int argc, char** argv)
                 statusbar.set_text(1, String::formatted("High Score: {}", score));
             }
         }
+        statusbar.set_text(2, "Timer starts after your first move");
     };
 
     GUI::ActionGroup draw_setting_actions;


### PR DESCRIPTION
Starts the game timer when the first card is clicked or moved instead of
when a new game is started.

Fixes #7489