### PR TITLE
Userland: Treat inet_pton returning 0 as an error

### DIFF
--- a/Userland/Libraries/LibC/arpa/inet.cpp
+++ b/Userland/Libraries/LibC/arpa/inet.cpp
@@ -62,7 +62,7 @@ in_addr_t inet_addr(const char* str)
 {
     in_addr_t tmp {};
     int rc = inet_pton(AF_INET, str, &tmp);
-    if (rc < 0)
+    if (rc <= 0)
         return INADDR_NONE;
     return tmp;
 }

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
         sa.sin_port = htons(port);
         sa.sin_addr.s_addr = htonl(INADDR_ANY);
         if (target) {
-            if (inet_pton(AF_INET, target, &sa.sin_addr) < 0) {
+            if (inet_pton(AF_INET, target, &sa.sin_addr) <= 0) {
                 perror("inet_pton");
                 return 1;
             }


### PR DESCRIPTION
The POSIX man-page states that inet_pton returns 0 if the input is not a valid IPv4 dotted-decimal string or a valid IPv6 address string. This is also how it is implemented in SerenityOS.

This means that we should treat a return value of 0 as an error to avoid using an invalid address (or 0.0.0.0).