### PR TITLE
HexEditor: Add 'Find All' option to Find Dialog to find all matches

### DIFF
--- a/Userland/Applications/HexEditor/FindDialog.gml
+++ b/Userland/Applications/HexEditor/FindDialog.gml
@@ -34,8 +34,13 @@
         layout: @GUI::HorizontalBoxLayout
 
         @GUI::Button {
-            name: "ok_button"
-            text: "OK"
+            name: "find_button"
+            text: "Find"
+        }
+
+        @GUI::Button {
+            name: "find_all_button"
+            text: "Find All"
         }
 
         @GUI::Button {

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -20,21 +20,24 @@ class FindDialog : public GUI::Dialog {
     C_OBJECT(FindDialog);
 
 public:
-    static int show(GUI::Window* parent_window, String& out_tex, ByteBuffer& out_buffer);
+    static int show(GUI::Window* parent_window, String& out_tex, ByteBuffer& out_buffer, bool& find_all);
 
 private:
     Result<ByteBuffer, String> process_input(String text_value, OptionId opt);
 
     String text_value() const { return m_text_value; }
     OptionId selected_option() const { return m_selected_option; }
+    bool find_all() const { return m_find_all; }
 
     FindDialog();
     virtual ~FindDialog() override;
 
     RefPtr<GUI::TextEditor> m_text_editor;
-    RefPtr<GUI::Button> m_ok_button;
+    RefPtr<GUI::Button> m_find_button;
+    RefPtr<GUI::Button> m_find_all_button;
     RefPtr<GUI::Button> m_cancel_button;
 
+    bool m_find_all { false };
     String m_text_value;
     OptionId m_selected_option { OPTION_INVALID };
 };

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "SearchResultsModel.h"
 #include <AK/ByteBuffer.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
@@ -46,7 +47,9 @@ public:
 
     void set_position(int position);
     void highlight(int start, int end);
+    int find(ByteBuffer& needle, int start = 0);
     int find_and_highlight(ByteBuffer& needle, int start = 0);
+    Vector<Match> find_all(ByteBuffer& needle, int start = 0);
     Function<void(int, EditMode, int, int)> on_status_change; // position, edit mode, selection start, selection end
     Function<void()> on_change;
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -29,6 +29,7 @@ private:
     HexEditorWidget();
     void set_path(const LexicalPath& file);
     void update_title();
+    void set_search_results_visible(bool visible);
 
     RefPtr<Core::ConfigFile> m_config;
 
@@ -50,12 +51,15 @@ private:
     RefPtr<GUI::Action> m_find_action;
     RefPtr<GUI::Action> m_goto_offset_action;
     RefPtr<GUI::Action> m_layout_toolbar_action;
+    RefPtr<GUI::Action> m_layout_search_results_action;
 
     GUI::ActionGroup m_bytes_per_row_actions;
 
     RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::Toolbar> m_toolbar;
     RefPtr<GUI::ToolbarContainer> m_toolbar_container;
+    RefPtr<GUI::TableView> m_search_results;
+    RefPtr<GUI::Widget> m_search_results_container;
 
     bool m_document_dirty { false };
 };

--- a/Userland/Applications/HexEditor/HexEditorWindow.gml
+++ b/Userland/Applications/HexEditor/HexEditorWindow.gml
@@ -14,8 +14,22 @@
         }
     }
 
-    @HexEditor::HexEditor {
-        name: "editor"
+    @GUI::HorizontalSplitter {
+        @HexEditor::HexEditor {
+            name: "editor"
+        }
+
+        @GUI::Widget {
+            name: "search_results_container"
+            visible: false
+
+            layout: @GUI::VerticalBoxLayout {
+            }
+
+            @GUI::TableView {
+                name: "search_results"
+            }
+        }
     }
 
     @GUI::Statusbar {

--- a/Userland/Applications/HexEditor/SearchResultsModel.h
+++ b/Userland/Applications/HexEditor/SearchResultsModel.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Hex.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
+#include <AK/Utf8View.h>
+#include <AK/Vector.h>
+#include <LibGUI/Model.h>
+
+struct Match {
+    int offset;
+    String value;
+};
+
+class SearchResultsModel final : public GUI::Model {
+public:
+    enum Column {
+        Offset,
+        Value
+    };
+
+    explicit SearchResultsModel(const Vector<Match>&& matches)
+        : m_matches(move(matches))
+    {
+    }
+
+    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override
+    {
+        return m_matches.size();
+    }
+
+    virtual int column_count(const GUI::ModelIndex&) const override
+    {
+        return 2;
+    }
+
+    String column_name(int column) const override
+    {
+        switch (column) {
+        case Column::Offset:
+            return "Offset";
+        case Column::Value:
+            return "Value";
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override
+    {
+        if (role == GUI::ModelRole::TextAlignment)
+            return Gfx::TextAlignment::CenterLeft;
+        if (role == GUI::ModelRole::Custom) {
+            auto& match = m_matches.at(index.row());
+            return match.offset;
+        }
+        if (role == GUI::ModelRole::Display) {
+            auto& match = m_matches.at(index.row());
+            switch (index.column()) {
+            case Column::Offset:
+                return String::formatted("{:#08X}", match.offset);
+            case Column::Value: {
+                Utf8View utf8_view(match.value);
+                if (!utf8_view.validate())
+                    return {};
+                return StringView(match.value);
+            }
+            }
+        }
+        return {};
+    }
+
+    virtual void update() override { }
+
+private:
+    Vector<Match> m_matches;
+};


### PR DESCRIPTION
Showing the value in the column looks a little goofy when they're all the same.

It will be more useful once "Find all strings" functionality is added. Also, maybe one day, support for regex searching.

![image](https://user-images.githubusercontent.com/434827/119851272-9f409c80-bf51-11eb-85ab-af9e9e0728d0.png)

![image](https://user-images.githubusercontent.com/434827/119851262-9cde4280-bf51-11eb-816c-12ee31d3379d.png)

