### PR TITLE
LibJS: Add inline capacity to BlockAllocator's blocks Vector

### DIFF
--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.h
@@ -22,7 +22,7 @@ public:
 private:
     static constexpr size_t max_cached_blocks = 64;
 
-    Vector<void*> m_blocks;
+    Vector<void*, max_cached_blocks> m_blocks;
 };
 
 }


### PR DESCRIPTION
There's no need to dynamically allocate a constant sized vector :^)