### PR TITLE
Kernel: Ignore duplicate SYN packets

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -504,6 +504,9 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
             }
 
             return;
+        case TCPFlags::SYN:
+            dbgln("handle_tcp: ignoring SYN for partially established connection");
+            return;
         default:
             dbgln("handle_tcp: unexpected flags in SynReceived state ({:x})", tcp_packet.flags());
             unused_rc = socket->send_tcp_packet(TCPFlags::RST);


### PR DESCRIPTION
When receiving a SYN packet for a connection that's in the "SYN received" state we should ignore the duplicate SYN packet instead of closing the connection. This can happen when we didn't accept the connection in time and our peer has sent us another SYN packet because it thought that the initial SYN packet was lost.