### PR TITLE
Profiler: Use a more reasonable default event mask

### DIFF
--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -280,7 +280,10 @@ bool generate_profile(pid_t& pid)
         process_name = "(unknown)";
     }
 
-    if (profiling_enable(pid, PERF_EVENT_MASK_ALL) < 0) {
+    static constexpr u64 event_mask = PERF_EVENT_SAMPLE | PERF_EVENT_MMAP | PERF_EVENT_MUNMAP | PERF_EVENT_PROCESS_CREATE
+        | PERF_EVENT_PROCESS_EXEC | PERF_EVENT_PROCESS_EXIT | PERF_EVENT_THREAD_CREATE | PERF_EVENT_THREAD_EXIT;
+
+    if (profiling_enable(pid, event_mask) < 0) {
         int saved_errno = errno;
         GUI::MessageBox::show(nullptr, String::formatted("Unable to profile process {}({}): {}", process_name, pid, strerror(saved_errno)), "Profiler", GUI::MessageBox::Type::Error);
         return false;


### PR DESCRIPTION
Previously `Profiler` (e.g. when started via the context menu in `SystemMonitor`) would request logging _all_ event types. While this
might be useful at a later point in time the lack of event type filtering in the profile viewer makes this less useful because showing different event types in the same timeline shows an inaccurate picture of what was really going on.

Some event types (like `kmalloc`) happen more frequently than others (e.g. CPU samples) and while they don't carry the same weight they would still dominate the samples graph.

This changes the `Profiler` app to just do CPU sampling for now.