### PR TITLE
LibJS: Poison unused heap blocks until they are re-allocated 

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -45,6 +45,20 @@
 #endif
 #define NO_SANITIZE_ADDRESS [[gnu::no_sanitize_address]]
 
+// GCC doesn't have __has_feature but clang does
+#ifndef __has_feature
+#    define __has_feature(...) 0
+#endif
+
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#    define HAS_ADDRESS_SANITIZER
+#    define ASAN_POISON_MEMORY_REGION(addr, size) __asan_poison_memory_region(addr, size)
+#    define ASAN_UNPOISON_MEMORY_REGION(addr, size) __asan_unpoison_memory_region(addr, size)
+#else
+#    define ASAN_POISON_MEMORY_REGION(addr, size)
+#    define ASAN_UNPOISON_MEMORY_REGION(addr, size)
+#endif
+
 #ifndef __serenity__
 #    include <unistd.h>
 #    undef PAGE_SIZE


### PR DESCRIPTION
This is the coarsest grained ASAN instrumentation possible for the LibJS
heap. Future instrumentation could add red-zones to heap block
allocations, and poison the entire heap block and only un-poison used
cells at the CellAllocator level.

https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning