### PR TITLE
HackStudio: Add statusbar with selected text and cursor information

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -32,17 +32,9 @@ EditorWrapper::EditorWrapper()
     m_filename_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
     m_filename_label->set_fixed_height(14);
 
-    m_cursor_label = label_wrapper.add<GUI::Label>("(Cursor)");
-    m_cursor_label->set_text_alignment(Gfx::TextAlignment::CenterRight);
-    m_cursor_label->set_fixed_height(14);
-
     m_editor = add<Editor>();
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
-
-    m_editor->on_cursor_change = [this] {
-        m_cursor_label->set_text(String::formatted("Line: {}, Column: {}", m_editor->cursor().line() + 1, m_editor->cursor().column()));
-    };
 
     m_editor->on_focus = [this] {
         set_current_editor_wrapper(this);

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -47,7 +47,6 @@ private:
 
     String m_filename;
     RefPtr<GUI::Label> m_filename_label;
-    RefPtr<GUI::Label> m_cursor_label;
     RefPtr<Editor> m_editor;
     bool m_document_dirty { false };
 };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -48,6 +48,7 @@
 #include <LibGUI/RegularEditingEngine.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/StackWidget.h>
+#include <LibGUI/Statusbar.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
@@ -132,6 +133,8 @@ HackStudioWidget::HackStudioWidget(const String& path_to_project)
     initialize_debugger();
 
     create_toolbar(toolbar_container);
+
+    m_statusbar = add<GUI::Statusbar>(3);
 
     auto maybe_watcher = Core::FileWatcher::create();
     if (maybe_watcher.is_error()) {
@@ -280,6 +283,8 @@ bool HackStudioWidget::open_file(const String& full_filename)
     current_editor_wrapper().set_filename(filename);
 
     current_editor().set_focus(true);
+
+    current_editor().on_cursor_change = [this] { update_statusbar(); };
     return true;
 }
 
@@ -482,6 +487,8 @@ void HackStudioWidget::add_new_editor(GUI::Widget& parent)
     m_current_editor_wrapper = wrapper;
     m_all_editor_wrappers.append(wrapper);
     wrapper->editor().set_focus(true);
+    
+    wrapper->editor().on_cursor_change = [this] { update_statusbar(); };
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_switch_to_next_editor_action()
@@ -1006,6 +1013,20 @@ void HackStudioWidget::initialize_menubar(GUI::Menubar& menubar)
     create_build_menubar(menubar);
     create_view_menubar(menubar);
     create_help_menubar(menubar);
+}
+
+void HackStudioWidget::update_statusbar()
+{
+    m_statusbar->set_text(0, String::formatted("Ln {}, Col {}", current_editor().cursor().line() + 1, current_editor().cursor().column()));
+
+    StringBuilder builder;
+    if (current_editor().has_selection()) {
+        String selected_text = current_editor().selected_text();
+        auto word_count = current_editor().number_of_selected_words();
+        builder.appendff("Selected: {} {} ({} {})", selected_text.length(), selected_text.length() == 1 ? "character" : "characters", word_count, word_count != 1 ? "words" : "word");
+    }
+
+    m_statusbar->set_text(1, builder.to_string());
 }
 
 void HackStudioWidget::handle_external_file_deletion(const String& filepath)

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -96,6 +96,7 @@ private:
     void on_action_tab_change();
     void reveal_action_tab(GUI::Widget&);
     void initialize_debugger();
+    void update_statusbar();
 
     void handle_external_file_deletion(const String& filepath);
 
@@ -137,6 +138,7 @@ private:
     RefPtr<GitWidget> m_git_widget;
     RefPtr<ClassViewWidget> m_class_view;
     RefPtr<GUI::Menu> m_project_tree_view_context_menu;
+    RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::TabWidget> m_action_tab_widget;
     RefPtr<GUI::TabWidget> m_project_tab;
     RefPtr<TerminalWrapper> m_terminal_wrapper;


### PR DESCRIPTION
This removes the cursor information located at the top right of the editor
and moves it to the statusbar. This statusbar will also show the number of
selected words and characters if the user selects text.