### PR TITLE
LibGfx+UE: Fixes for building with -flto

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -445,8 +445,8 @@ void Emulator::dispatch_one_pending_signal()
 }
 
 // Make sure the compiler doesn't "optimize away" this function:
-extern void signal_trampoline_dummy();
-void signal_trampoline_dummy()
+static void signal_trampoline_dummy() __attribute__((used));
+NEVER_INLINE void signal_trampoline_dummy()
 {
     // The trampoline preserves the current eax, pushes the signal code and
     // then calls the signal handler. We do this because, when interrupting a

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -185,9 +185,9 @@ RefPtr<Gfx::Bitmap> load_bmp_from_memory(const u8* data, size_t length)
     return bitmap;
 }
 
-class Streamer {
+class InputStreamer {
 public:
-    Streamer(const u8* data, size_t size)
+    InputStreamer(const u8* data, size_t size)
         : m_data_ptr(data)
         , m_size_remaining(size)
     {
@@ -411,7 +411,7 @@ static bool check_for_invalid_bitmask_combinations(BMPLoadingContext& context)
     return true;
 }
 
-static bool set_dib_bitmasks(BMPLoadingContext& context, Streamer& streamer)
+static bool set_dib_bitmasks(BMPLoadingContext& context, InputStreamer& streamer)
 {
     if (!check_for_invalid_bitmask_combinations(context))
         return false;
@@ -456,7 +456,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
         return false;
     }
 
-    Streamer streamer(context.file_bytes, bmp_header_size);
+    InputStreamer streamer(context.file_bytes, bmp_header_size);
 
     u16 header = streamer.read_u16();
     if (header != 0x4d42) {
@@ -490,7 +490,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
     return true;
 }
 
-static bool decode_bmp_core_dib(BMPLoadingContext& context, Streamer& streamer)
+static bool decode_bmp_core_dib(BMPLoadingContext& context, InputStreamer& streamer)
 {
     auto& core = context.dib.core;
 
@@ -551,7 +551,7 @@ ALWAYS_INLINE static bool is_supported_compression_format(BMPLoadingContext& con
         || compression == Compression::RLE4 || (compression == Compression::RLE24 && context.dib_type <= DIBType::OSV2);
 }
 
-static bool decode_bmp_osv2_dib(BMPLoadingContext& context, Streamer& streamer, bool short_variant = false)
+static bool decode_bmp_osv2_dib(BMPLoadingContext& context, InputStreamer& streamer, bool short_variant = false)
 {
     auto& core = context.dib.core;
 
@@ -636,7 +636,7 @@ static bool decode_bmp_osv2_dib(BMPLoadingContext& context, Streamer& streamer, 
     return true;
 }
 
-static bool decode_bmp_info_dib(BMPLoadingContext& context, Streamer& streamer)
+static bool decode_bmp_info_dib(BMPLoadingContext& context, InputStreamer& streamer)
 {
     if (!decode_bmp_core_dib(context, streamer))
         return false;
@@ -676,7 +676,7 @@ static bool decode_bmp_info_dib(BMPLoadingContext& context, Streamer& streamer)
     return true;
 }
 
-static bool decode_bmp_v2_dib(BMPLoadingContext& context, Streamer& streamer)
+static bool decode_bmp_v2_dib(BMPLoadingContext& context, InputStreamer& streamer)
 {
     if (!decode_bmp_info_dib(context, streamer))
         return false;
@@ -694,7 +694,7 @@ static bool decode_bmp_v2_dib(BMPLoadingContext& context, Streamer& streamer)
     return true;
 }
 
-static bool decode_bmp_v3_dib(BMPLoadingContext& context, Streamer& streamer)
+static bool decode_bmp_v3_dib(BMPLoadingContext& context, InputStreamer& streamer)
 {
     if (!decode_bmp_v2_dib(context, streamer))
         return false;
@@ -719,7 +719,7 @@ static bool decode_bmp_v3_dib(BMPLoadingContext& context, Streamer& streamer)
     return true;
 }
 
-static bool decode_bmp_v4_dib(BMPLoadingContext& context, Streamer& streamer)
+static bool decode_bmp_v4_dib(BMPLoadingContext& context, InputStreamer& streamer)
 {
     if (!decode_bmp_v3_dib(context, streamer))
         return false;
@@ -742,7 +742,7 @@ static bool decode_bmp_v4_dib(BMPLoadingContext& context, Streamer& streamer)
     return true;
 }
 
-static bool decode_bmp_v5_dib(BMPLoadingContext& context, Streamer& streamer)
+static bool decode_bmp_v5_dib(BMPLoadingContext& context, InputStreamer& streamer)
 {
     if (!decode_bmp_v4_dib(context, streamer))
         return false;
@@ -775,7 +775,7 @@ static bool decode_bmp_dib(BMPLoadingContext& context)
     if (context.file_size < bmp_header_size + 4)
         return false;
 
-    Streamer streamer(context.file_bytes + bmp_header_size, 4);
+    InputStreamer streamer(context.file_bytes + bmp_header_size, 4);
     u32 dib_size = streamer.read_u32();
 
     if (context.file_size < bmp_header_size + dib_size)
@@ -785,7 +785,7 @@ static bool decode_bmp_dib(BMPLoadingContext& context)
         return false;
     }
 
-    streamer = Streamer(context.file_bytes + bmp_header_size + 4, context.data_offset - bmp_header_size - 4);
+    streamer = InputStreamer(context.file_bytes + bmp_header_size + 4, context.data_offset - bmp_header_size - 4);
 
     dbgln_if(BMP_DEBUG, "BMP dib size: {}", dib_size);
 
@@ -888,7 +888,7 @@ static bool decode_bmp_color_table(BMPLoadingContext& context)
         }
     }
 
-    Streamer streamer(context.file_bytes + bmp_header_size + context.dib_size(), size_of_color_table);
+    InputStreamer streamer(context.file_bytes + bmp_header_size + context.dib_size(), size_of_color_table);
     for (u32 i = 0; !streamer.at_end() && i < max_colors; ++i) {
         if (bytes_per_color == 4) {
             if (!streamer.has_u32())
@@ -922,7 +922,7 @@ static bool uncompress_bmp_rle_data(BMPLoadingContext& context, ByteBuffer& buff
         return false;
     }
 
-    Streamer streamer(context.file_bytes + context.data_offset, context.file_size - context.data_offset);
+    InputStreamer streamer(context.file_bytes + context.data_offset, context.file_size - context.data_offset);
 
     auto compression = context.dib.info.compression;
 
@@ -1201,7 +1201,7 @@ static bool decode_bmp_pixel_data(BMPLoadingContext& context)
         bytes = rle_buffer.bytes();
     }
 
-    Streamer streamer(bytes.data(), bytes.size());
+    InputStreamer streamer(bytes.data(), bytes.size());
 
     auto process_row = [&](u32 row) -> bool {
         u32 space_remaining_before_consuming_row = streamer.remaining();

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -16,9 +16,9 @@ constexpr int bytes_per_pixel = 3;
 #define IMAGE_INFORMATION_SIZE 40
 #define PIXEL_DATA_OFFSET FILE_HEADER_SIZE + IMAGE_INFORMATION_SIZE
 
-class Streamer {
+class OutputStreamer {
 public:
-    Streamer(u8* data)
+    OutputStreamer(u8* data)
         : m_data(data)
     {
     }
@@ -88,7 +88,7 @@ ByteBuffer BMPWriter::dump(const RefPtr<Bitmap> bitmap)
     pixel_data = compress_pixel_data(pixel_data, m_compression);
 
     int file_size = PIXEL_DATA_OFFSET + pixel_data.size();
-    Streamer streamer(buffer.data());
+    OutputStreamer streamer(buffer.data());
     streamer.write_u8('B');
     streamer.write_u8('M');
     streamer.write_u32(file_size);

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -71,7 +71,7 @@ struct [[gnu::packed]] BMP_ARGB {
 };
 static_assert(sizeof(BMP_ARGB) == 4);
 
-struct ImageDescriptor {
+struct ICOImageDescriptor {
     u16 width;
     u16 height;
     size_t offset;
@@ -89,7 +89,7 @@ struct ICOLoadingContext {
     State state { NotDecoded };
     const u8* data { nullptr };
     size_t data_size { 0 };
-    Vector<ImageDescriptor> images;
+    Vector<ICOImageDescriptor> images;
     size_t largest_index;
 };
 
@@ -126,14 +126,14 @@ static Optional<size_t> decode_ico_header(InputMemoryStream& stream)
     return { header.image_count };
 }
 
-static Optional<ImageDescriptor> decode_ico_direntry(InputMemoryStream& stream)
+static Optional<ICOImageDescriptor> decode_ico_direntry(InputMemoryStream& stream)
 {
     ICONDIRENTRY entry;
     stream >> Bytes { &entry, sizeof(entry) };
     if (stream.handle_any_error())
         return {};
 
-    ImageDescriptor desc = { entry.width, entry.height, entry.offset, entry.size, nullptr };
+    ICOImageDescriptor desc = { entry.width, entry.height, entry.offset, entry.size, nullptr };
     if (desc.width == 0)
         desc.width = 256;
     if (desc.height == 0)
@@ -192,7 +192,7 @@ static bool load_ico_directory(ICOLoadingContext& context)
     return true;
 }
 
-static bool load_ico_bmp(ICOLoadingContext& context, ImageDescriptor& desc)
+static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
 {
     BITMAPINFOHEADER info;
     if (desc.size < sizeof(info))
@@ -293,7 +293,7 @@ static bool load_ico_bitmap(ICOLoadingContext& context, Optional<size_t> index)
         return false;
     }
 
-    ImageDescriptor& desc = context.images[real_index];
+    ICOImageDescriptor& desc = context.images[real_index];
 
     PNGImageDecoderPlugin png_decoder(context.data + desc.offset, desc.size);
     if (png_decoder.sniff()) {


### PR DESCRIPTION
**UE: Make sure signal_trampoline_dummy is not optimized away with -flto**

This adds `__attribute__((used))` to the function declaration so the compiler doesn't discard it. It also makes the function `NEVER_INLINE` so that we don't end up with multiple copies of the function. This is necessary because the function uses inline assembly to define some unique labels.

**LibGfx: Make sure we use unique class names**

Previously there were different definitions for classes with the same name. This is a violation of the C++ ODR.