### PR TITLE
Kernel: Shift to usage of KStrings

### DIFF
--- a/Kernel/ConsoleDevice.h
+++ b/Kernel/ConsoleDevice.h
@@ -35,7 +35,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "console"; }
+    virtual StringView device_name() const override { return "console"; }
 
 private:
     CircularQueue<char, 16384> m_logbuffer;

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -38,7 +38,7 @@ public:
     uid_t gid() const { return m_gid; }
 
     virtual mode_t required_mode() const = 0;
-    virtual String device_name() const = 0;
+    virtual StringView device_name() const = 0;
 
     virtual bool is_device() const override { return true; }
     virtual bool is_disk_device() const { return false; }
@@ -66,6 +66,8 @@ protected:
     void set_gid(gid_t gid) { m_gid = gid; }
 
     static HashMap<u32, Device*>& all_devices();
+
+    OwnPtr<KString> m_determined_name;
 
 private:
     unsigned m_major { 0 };

--- a/Kernel/Devices/FullDevice.h
+++ b/Kernel/Devices/FullDevice.h
@@ -18,7 +18,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "full"; }
+    virtual StringView device_name() const override { return "full"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -268,6 +268,9 @@ void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
 UNMAP_AFTER_INIT KeyboardDevice::KeyboardDevice()
     : HIDDevice(85, HIDManagement::the().generate_minor_device_number_for_keyboard())
 {
+    auto name = String::formatted("keyboard{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
 }
 
 // FIXME: UNMAP_AFTER_INIT is fine for now, but for hot-pluggable devices
@@ -307,6 +310,12 @@ KResultOr<size_t> KeyboardDevice::read(FileDescription&, u64, UserOrKernelBuffer
         lock.lock();
     }
     return nread;
+}
+
+StringView KeyboardDevice::device_name() const
+{
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 KResultOr<size_t> KeyboardDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t)

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -35,7 +35,7 @@ public:
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }
 
-    virtual String device_name() const override { return String::formatted("keyboard{}", minor()); }
+    virtual StringView device_name() const override;
 
     void update_modifier(u8 modifier, bool state)
     {

--- a/Kernel/Devices/HID/MouseDevice.cpp
+++ b/Kernel/Devices/HID/MouseDevice.cpp
@@ -12,6 +12,9 @@ namespace Kernel {
 MouseDevice::MouseDevice()
     : HIDDevice(10, HIDManagement::the().generate_minor_device_number_for_mouse())
 {
+    auto name = String::formatted("mouse{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
 }
 
 MouseDevice::~MouseDevice()
@@ -47,6 +50,12 @@ KResultOr<size_t> MouseDevice::read(FileDescription&, u64, UserOrKernelBuffer& b
         lock.lock();
     }
     return nread;
+}
+
+StringView MouseDevice::device_name() const
+{
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 KResultOr<size_t> MouseDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t)

--- a/Kernel/Devices/HID/MouseDevice.h
+++ b/Kernel/Devices/HID/MouseDevice.h
@@ -34,7 +34,7 @@ public:
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }
 
-    virtual String device_name() const override { return String::formatted("mouse{}", minor()); }
+    virtual StringView device_name() const override;
 
 protected:
     MouseDevice();

--- a/Kernel/Devices/MemoryDevice.h
+++ b/Kernel/Devices/MemoryDevice.h
@@ -23,7 +23,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }
-    virtual String device_name() const override { return "mem"; };
+    virtual StringView device_name() const override { return "mem"; };
 
 private:
     virtual const char* class_name() const override { return "MemoryDevice"; }

--- a/Kernel/Devices/NullDevice.h
+++ b/Kernel/Devices/NullDevice.h
@@ -21,7 +21,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "null"; }
+    virtual StringView device_name() const override { return "null"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/RandomDevice.h
+++ b/Kernel/Devices/RandomDevice.h
@@ -18,7 +18,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "random"; }
+    virtual StringView device_name() const override { return "random"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/SB16.h
+++ b/Kernel/Devices/SB16.h
@@ -36,7 +36,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0220; }
-    virtual String device_name() const override { return "audio"; }
+    virtual StringView device_name() const override { return "audio"; }
 
 private:
     // ^IRQHandler

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -14,6 +14,9 @@ UNMAP_AFTER_INIT SerialDevice::SerialDevice(IOAddress base_addr, unsigned minor)
     : CharacterDevice(4, minor)
     , m_base_addr(base_addr)
 {
+    auto name = String::formatted("ttyS{}", minor - 64);
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
     initialize();
 }
 
@@ -76,9 +79,10 @@ void SerialDevice::put_char(char ch)
     m_last_put_char_was_carriage_return = (ch == '\r');
 }
 
-String SerialDevice::device_name() const
+StringView SerialDevice::device_name() const
 {
-    return String::formatted("ttyS{}", minor() - 64);
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 UNMAP_AFTER_INIT void SerialDevice::initialize()

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -108,7 +108,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0620; }
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
 private:
     friend class PCISerialDevice;

--- a/Kernel/Devices/ZeroDevice.h
+++ b/Kernel/Devices/ZeroDevice.h
@@ -18,7 +18,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "zero"; }
+    virtual StringView device_name() const override { return "zero"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Graphics/Console/Console.h
+++ b/Kernel/Graphics/Console/Console.h
@@ -56,9 +56,7 @@ public:
 
     virtual void clear(size_t x, size_t y, size_t length) const = 0;
     virtual void write(size_t x, size_t y, char ch, Color background, Color foreground) const = 0;
-    virtual void write(size_t x, size_t y, String, Color background, Color foreground) const = 0;
     virtual void write(size_t x, size_t y, char ch) const = 0;
-    virtual void write(size_t x, size_t y, String) const = 0;
     virtual void write(char ch) const = 0;
 
     virtual ~Console() { }

--- a/Kernel/Graphics/Console/FramebufferConsole.cpp
+++ b/Kernel/Graphics/Console/FramebufferConsole.cpp
@@ -339,17 +339,9 @@ void FramebufferConsole::write(size_t x, size_t y, char ch, Color background, Co
     }
 }
 
-void FramebufferConsole::write(size_t, size_t, String, Color, Color) const
-{
-    TODO();
-}
 void FramebufferConsole::write(size_t x, size_t y, char ch) const
 {
     write(x, y, ch, m_default_background_color, m_default_foreground_color);
-}
-void FramebufferConsole::write(size_t, size_t, String) const
-{
-    TODO();
 }
 
 void FramebufferConsole::write(char ch) const

--- a/Kernel/Graphics/Console/FramebufferConsole.h
+++ b/Kernel/Graphics/Console/FramebufferConsole.h
@@ -33,9 +33,7 @@ public:
 
     virtual void clear(size_t x, size_t y, size_t length) const override;
     virtual void write(size_t x, size_t y, char ch, Color background, Color foreground) const override;
-    virtual void write(size_t x, size_t y, String cstring, Color background, Color foreground) const override;
     virtual void write(size_t x, size_t y, char ch) const override;
-    virtual void write(size_t x, size_t y, String) const override;
     virtual void write(char ch) const override;
 
     virtual void enable() override;

--- a/Kernel/Graphics/Console/TextModeConsole.cpp
+++ b/Kernel/Graphics/Console/TextModeConsole.cpp
@@ -132,44 +132,13 @@ void TextModeConsole::write(size_t x, size_t y, char ch) const
             m_y = 0;
     }
 }
-void TextModeConsole::write(size_t x, size_t y, String cstring) const
-{
-    ScopedSpinLock lock(m_vga_lock);
-    auto* buf = (u16*)(m_current_vga_window + (x * 2) + (y * width() * 2));
-    u16 color_mask = (m_default_foreground_color << 8) | (m_default_background_color << 12);
-    for (size_t index = 0; index < cstring.length(); index++) {
-        buf[index] = color_mask | cstring[index];
-    }
-    m_x = x + cstring.length();
-    if (m_x >= max_column()) {
-        m_x = 0;
-        m_y = y + 1;
-        if (m_y >= max_row())
-            m_y = 0;
-    }
-}
+
 void TextModeConsole::write(size_t x, size_t y, char ch, Color background, Color foreground) const
 {
     ScopedSpinLock lock(m_vga_lock);
     auto* buf = (u16*)(m_current_vga_window + (x * 2) + (y * width() * 2));
     *buf = foreground << 8 | background << 12 | ch;
     m_x = x + 1;
-    if (m_x >= max_column()) {
-        m_x = 0;
-        m_y = y + 1;
-        if (m_y >= max_row())
-            m_y = 0;
-    }
-}
-void TextModeConsole::write(size_t x, size_t y, String cstring, Color background, Color foreground) const
-{
-    ScopedSpinLock lock(m_vga_lock);
-    auto* buf = (u16*)(m_current_vga_window + (x * 2) + (y * width() * 2));
-    u16 color_mask = foreground << 8 | background << 12;
-    for (size_t index = 0; index < cstring.length(); index++) {
-        buf[index] = color_mask | cstring[index];
-    }
-    m_x = x + cstring.length();
     if (m_x >= max_column()) {
         m_x = 0;
         m_y = y + 1;

--- a/Kernel/Graphics/Console/TextModeConsole.h
+++ b/Kernel/Graphics/Console/TextModeConsole.h
@@ -26,9 +26,7 @@ public:
     virtual void show_cursor() override;
     virtual void clear(size_t x, size_t y, size_t length) const override;
     virtual void write(size_t x, size_t y, char ch) const override;
-    virtual void write(size_t x, size_t y, String cstring) const override;
     virtual void write(size_t x, size_t y, char ch, Color background, Color foreground) const override;
-    virtual void write(size_t x, size_t y, String, Color background, Color foreground) const override;
     virtual void write(char ch) const override;
 
     virtual void enable() override { }

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -94,11 +94,6 @@ void FramebufferDevice::activate_writes()
     m_graphical_writes_enabled = true;
 }
 
-String FramebufferDevice::device_name() const
-{
-    return String::formatted("fb{}", minor());
-}
-
 UNMAP_AFTER_INIT void FramebufferDevice::initialize()
 {
     m_real_framebuffer_vmobject = AnonymousVMObject::create_for_physical_range(m_framebuffer_address, page_round_up(framebuffer_size_in_bytes()));
@@ -120,6 +115,10 @@ UNMAP_AFTER_INIT FramebufferDevice::FramebufferDevice(const GraphicsDevice& adap
     , m_output_port_index(output_port_index)
     , m_graphics_adapter(adapter)
 {
+    auto name = String::formatted("fb{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
+
     VERIFY(!m_framebuffer_address.is_null());
     VERIFY(m_framebuffer_pitch);
     VERIFY(m_framebuffer_width);
@@ -218,6 +217,12 @@ int FramebufferDevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     default:
         return -EINVAL;
     };
+}
+
+StringView FramebufferDevice::device_name() const
+{
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 }

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -27,7 +27,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
     virtual void deactivate_writes();
     virtual void activate_writes();

--- a/Kernel/Storage/PATADiskDevice.cpp
+++ b/Kernel/Storage/PATADiskDevice.cpp
@@ -41,11 +41,6 @@ void PATADiskDevice::start_request(AsyncBlockDeviceRequest& request)
     m_channel->start_request(request, is_slave(), m_capabilities);
 }
 
-String PATADiskDevice::device_name() const
-{
-    return String::formatted("hd{:c}", 'a' + minor());
-}
-
 bool PATADiskDevice::is_slave() const
 {
     return m_drive_type == DriveType::Slave;

--- a/Kernel/Storage/PATADiskDevice.h
+++ b/Kernel/Storage/PATADiskDevice.h
@@ -42,7 +42,6 @@ public:
 
     // ^BlockDevice
     virtual void start_request(AsyncBlockDeviceRequest&) override;
-    virtual String device_name() const override;
 
 private:
     PATADiskDevice(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u64);

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -20,6 +20,11 @@ DiskPartition::DiskPartition(BlockDevice& device, unsigned minor_number, DiskPar
     , m_device(device)
     , m_metadata(metadata)
 {
+    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
+    size_t partition_index = minor() % 16;
+    auto name = String::formatted("{}{}", m_device->device_name(), partition_index + 1);
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
 }
 
 DiskPartition::~DiskPartition()
@@ -65,11 +70,10 @@ bool DiskPartition::can_write(const FileDescription& fd, size_t offset) const
     return m_device->can_write(fd, offset + adjust);
 }
 
-String DiskPartition::device_name() const
+StringView DiskPartition::device_name() const
 {
-    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
-    size_t partition_index = minor() % 16;
-    return String::formatted("{}{}", m_device->device_name(), partition_index + 1);
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 const char* DiskPartition::class_name() const

--- a/Kernel/Storage/Partition/DiskPartition.h
+++ b/Kernel/Storage/Partition/DiskPartition.h
@@ -27,7 +27,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0600; }
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
     const DiskPartitionMetadata& metadata() const;
 

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -21,6 +21,11 @@ RamdiskDevice::RamdiskDevice(const RamdiskController& controller, NonnullOwnPtr<
     : StorageDevice(controller, major, minor, 512, region->size() / 512)
     , m_region(move(region))
 {
+    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
+    size_t drive_index = minor / 16;
+    auto name = String::formatted("ramdisk{}", drive_index);
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
     dmesgln("Ramdisk: Device #{} @ {}, Capacity={}", minor, m_region->vaddr(), max_addressable_block() * 512);
 }
 
@@ -57,11 +62,10 @@ void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)
     }
 }
 
-String RamdiskDevice::device_name() const
+StringView RamdiskDevice::device_name() const
 {
-    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
-    size_t drive_index = minor() / 16;
-    return String::formatted("ramdisk{}", drive_index);
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 }

--- a/Kernel/Storage/RamdiskDevice.h
+++ b/Kernel/Storage/RamdiskDevice.h
@@ -26,7 +26,7 @@ public:
 
     // ^DiskDevice
     virtual const char* class_name() const override;
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
     bool is_slave() const;
 

--- a/Kernel/Storage/SATADiskDevice.cpp
+++ b/Kernel/Storage/SATADiskDevice.cpp
@@ -38,9 +38,4 @@ void SATADiskDevice::start_request(AsyncBlockDeviceRequest& request)
     m_port->start_request(request);
 }
 
-String SATADiskDevice::device_name() const
-{
-    return String::formatted("hd{:c}", 'a' + minor());
-}
-
 }

--- a/Kernel/Storage/SATADiskDevice.h
+++ b/Kernel/Storage/SATADiskDevice.h
@@ -30,7 +30,6 @@ public:
     // ^StorageDevice
     // ^BlockDevice
     virtual void start_request(AsyncBlockDeviceRequest&) override;
-    virtual String device_name() const override;
 
 private:
     SATADiskDevice(const AHCIController&, const AHCIPort&, size_t sector_size, u64 max_addressable_block);

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -18,6 +18,9 @@ StorageDevice::StorageDevice(const StorageController& controller, size_t sector_
     , m_storage_controller(controller)
     , m_max_addressable_block(max_addressable_block)
 {
+    auto name = String::formatted("hd{:c}", 'a' + minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
 }
 
 StorageDevice::StorageDevice(const StorageController& controller, int major, int minor, size_t sector_size, u64 max_addressable_block)
@@ -25,6 +28,15 @@ StorageDevice::StorageDevice(const StorageController& controller, int major, int
     , m_storage_controller(controller)
     , m_max_addressable_block(max_addressable_block)
 {
+    auto name = String::formatted("hd{:c}", 'a' + minor);
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
+}
+
+StringView StorageDevice::device_name() const
+{
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 const char* StorageDevice::class_name() const

--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -30,6 +30,7 @@ public:
     virtual bool can_write(const FileDescription&, size_t) const override;
 
     // ^Device
+    virtual StringView device_name() const override;
     virtual mode_t required_mode() const override { return 0600; }
 
 protected:

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -20,6 +20,11 @@ MasterPTY::MasterPTY(unsigned index)
     , m_slave(adopt_ref(*new SlavePTY(*this, index)))
     , m_index(index)
 {
+
+    auto name = String::formatted("{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
+
     m_pts_name = String::formatted("/dev/pts/{}", m_index);
     auto process = Process::current();
     set_uid(process->uid());
@@ -120,9 +125,10 @@ String MasterPTY::absolute_path(const FileDescription&) const
     return String::formatted("ptm:{}", m_pts_name);
 }
 
-String MasterPTY::device_name() const
+StringView MasterPTY::device_name() const
 {
-    return String::formatted("{}", minor());
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 }

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -30,7 +30,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0640; }
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
 private:
     // ^CharacterDevice

--- a/Kernel/TTY/PTYMultiplexer.h
+++ b/Kernel/TTY/PTYMultiplexer.h
@@ -37,7 +37,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "ptmx"; }
+    virtual StringView device_name() const override { return "ptmx"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -17,6 +17,10 @@ SlavePTY::SlavePTY(MasterPTY& master, unsigned index)
     , m_master(master)
     , m_index(index)
 {
+    auto name = String::formatted("{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
+
     m_tty_name = String::formatted("/dev/pts/{}", m_index);
     auto process = Process::current();
     set_uid(process->uid());
@@ -86,9 +90,10 @@ KResult SlavePTY::close()
     return KSuccess;
 }
 
-String SlavePTY::device_name() const
+StringView SlavePTY::device_name() const
 {
-    return String::formatted("{}", minor());
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 FileBlockCondition& SlavePTY::block_condition()

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -38,7 +38,7 @@ private:
     virtual KResult close() override;
 
     // ^Device
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
     friend class MasterPTY;
     SlavePTY(MasterPTY&, unsigned index);

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -122,6 +122,10 @@ UNMAP_AFTER_INIT NonnullRefPtr<VirtualConsole> VirtualConsole::create_with_prese
 
 UNMAP_AFTER_INIT void VirtualConsole::initialize()
 {
+    auto name = String::formatted("tty{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
+
     m_tty_name = String::formatted("/dev/tty{}", m_index);
     VERIFY(GraphicsManagement::the().console());
     set_size(GraphicsManagement::the().console()->max_column(), GraphicsManagement::the().console()->max_row());
@@ -391,9 +395,10 @@ void VirtualConsole::set_cursor_style(VT::CursorStyle)
     // Do nothing
 }
 
-String VirtualConsole::device_name() const
+StringView VirtualConsole::device_name() const
 {
-    return String::formatted("tty{}", minor());
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 void VirtualConsole::echo(u8 ch)

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -112,7 +112,7 @@ private:
     virtual const char* class_name() const override { return "VirtualConsole"; }
 
     // ^Device
-    virtual String device_name() const override;
+    virtual StringView device_name() const override;
 
     void set_active(bool);
     void flush_dirty_lines();

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -14,6 +14,10 @@ VirtIOConsole::VirtIOConsole(PCI::Address address)
     : CharacterDevice(229, next_device_id++)
     , VirtIODevice(address, "VirtIOConsole")
 {
+    auto name = String::formatted("hvc{}", minor());
+    m_determined_name = KString::try_create(name.substring_view(0));
+    VERIFY(m_determined_name);
+
     if (auto cfg = get_config(ConfigurationType::Device)) {
         bool success = negotiate_features([&](u64 supported_features) {
             u64 negotiated = 0;
@@ -44,6 +48,12 @@ VirtIOConsole::VirtIOConsole(PCI::Address address)
             m_transmit_buffer = make<RingBuffer>("VirtIOConsole Transmit", RINGBUFFER_SIZE);
         }
     }
+}
+
+StringView VirtIOConsole::device_name() const
+{
+    VERIFY(m_determined_name);
+    return m_determined_name->view();
 }
 
 VirtIOConsole::~VirtIOConsole()

--- a/Kernel/VirtIO/VirtIOConsole.h
+++ b/Kernel/VirtIO/VirtIOConsole.h
@@ -37,7 +37,7 @@ private:
     virtual mode_t required_mode() const override { return 0666; }
 
     virtual bool handle_device_config_change() override;
-    virtual String device_name() const override { return String::formatted("hvc{}", minor()); }
+    virtual StringView device_name() const override;
     virtual void handle_queue_update(u16 queue_index) override;
 
     OwnPtr<RingBuffer> m_receive_buffer;

--- a/Kernel/VirtIO/VirtIORNG.h
+++ b/Kernel/VirtIO/VirtIORNG.h
@@ -25,7 +25,7 @@ public:
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return 0; }
 
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return "hwrng"; }
+    virtual StringView device_name() const override { return "hwrng"; }
 
     VirtIORNG(PCI::Address);
     virtual ~VirtIORNG() override;


### PR DESCRIPTION
KStrings are really what we needed for a very long time, so let's try to use them now :)

I shifted the `Device` derived classes to use `StringView` and `KString`, with little help of `String::formatted` only when creating the object.