### PR TITLE
Kernel: More OOM hardening,  and hide `AK::adopt_own(..)` from usage in Kernel

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -143,11 +143,15 @@ private:
     T* m_ptr = nullptr;
 };
 
+#if !defined(KERNEL)
+
 template<typename T>
 inline NonnullOwnPtr<T> adopt_own(T& object)
 {
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, object);
 }
+
+#endif
 
 template<class T, class... Args>
 inline NonnullOwnPtr<T>
@@ -180,6 +184,8 @@ struct Formatter<NonnullOwnPtr<T>> : Formatter<const T*> {
 
 }
 
+#if !defined(KERNEL)
 using AK::adopt_own;
+#endif
 using AK::make;
 using AK::NonnullOwnPtr;

--- a/Kernel/ACPI/MultiProcessorParser.cpp
+++ b/Kernel/ACPI/MultiProcessorParser.cpp
@@ -21,7 +21,9 @@ UNMAP_AFTER_INIT OwnPtr<MultiProcessorParser> MultiProcessorParser::autodetect()
     auto floating_pointer = find_floating_pointer();
     if (!floating_pointer.has_value())
         return {};
-    return adopt_own(*new MultiProcessorParser(floating_pointer.value()));
+    auto parser = adopt_own_if_nonnull(new MultiProcessorParser(floating_pointer.value()));
+    VERIFY(parser != nullptr);
+    return parser;
 }
 
 UNMAP_AFTER_INIT MultiProcessorParser::MultiProcessorParser(PhysicalAddress floating_pointer)

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -32,7 +32,7 @@ OwnPtr<CoreDump> CoreDump::create(NonnullRefPtr<Process> process, const String& 
     auto fd = create_target_file(process, output_path);
     if (!fd)
         return {};
-    return adopt_own(*new CoreDump(move(process), fd.release_nonnull()));
+    return adopt_own_if_nonnull(new CoreDump(move(process), fd.release_nonnull()));
 }
 
 CoreDump::CoreDump(NonnullRefPtr<Process> process, NonnullRefPtr<FileDescription>&& fd)

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -109,7 +109,7 @@ public:
         auto impl = KBufferImpl::try_create_with_size(size, access, name, strategy);
         if (!impl)
             return {};
-        return adopt_own(*new KBuffer(impl.release_nonnull()));
+        return adopt_own_if_nonnull(new KBuffer(impl.release_nonnull()));
     }
 
     [[nodiscard]] static OwnPtr<KBuffer> try_create_with_bytes(ReadonlyBytes bytes, Region::Access access = Region::Access::Read | Region::Access::Write, StringView name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
@@ -117,7 +117,7 @@ public:
         auto impl = KBufferImpl::try_create_with_bytes(bytes, access, name, strategy);
         if (!impl)
             return {};
-        return adopt_own(*new KBuffer(impl.release_nonnull()));
+        return adopt_own_if_nonnull(new KBuffer(impl.release_nonnull()));
     }
 
     [[nodiscard]] static KBuffer create_with_size(size_t size, Region::Access access = Region::Access::Read | Region::Access::Write, StringView name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)

--- a/Kernel/KString.cpp
+++ b/Kernel/KString.cpp
@@ -29,7 +29,7 @@ OwnPtr<KString> KString::try_create_uninitialized(size_t length, char*& characte
         return {};
     auto* new_string = new (slot) KString(length);
     characters = new_string->m_characters;
-    return adopt_own(*new_string);
+    return adopt_own_if_nonnull(new_string);
 }
 
 OwnPtr<KString> KString::try_clone() const

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -257,7 +257,7 @@ OwnPtr<PerformanceEventBuffer> PerformanceEventBuffer::try_create_with_size(size
     auto buffer = KBuffer::try_create_with_size(buffer_size, Region::Access::Read | Region::Access::Write, "Performance events", AllocationStrategy::AllocateNow);
     if (!buffer)
         return {};
-    return adopt_own(*new PerformanceEventBuffer(buffer.release_nonnull()));
+    return adopt_own_if_nonnull(new PerformanceEventBuffer(buffer.release_nonnull()));
 }
 
 void PerformanceEventBuffer::add_process(const Process& process, ProcessEventType event_type)

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -201,7 +201,10 @@ KResult Process::poke_user_data(Userspace<u32*> address, u32 data)
         // If the region is shared, we change its vmobject to a PrivateInodeVMObject
         // to prevent the write operation from changing any shared inode data
         VERIFY(region->vmobject().is_shared_inode());
-        region->set_vmobject(PrivateInodeVMObject::create_with_inode(static_cast<SharedInodeVMObject&>(region->vmobject()).inode()));
+        auto vmobject = PrivateInodeVMObject::create_with_inode(static_cast<SharedInodeVMObject&>(region->vmobject()).inode());
+        if (!vmobject)
+            return ENOMEM;
+        region->set_vmobject(vmobject.release_nonnull());
         region->set_shared(false);
     }
     const bool was_writable = region->is_writable();

--- a/Kernel/VM/ContiguousVMObject.cpp
+++ b/Kernel/VM/ContiguousVMObject.cpp
@@ -10,15 +10,17 @@
 
 namespace Kernel {
 
-NonnullRefPtr<ContiguousVMObject> ContiguousVMObject::create_with_size(size_t size, size_t physical_alignment)
-{
-    return adopt_ref(*new ContiguousVMObject(size, physical_alignment));
-}
-
-ContiguousVMObject::ContiguousVMObject(size_t size, size_t physical_alignment)
-    : VMObject(size)
+RefPtr<ContiguousVMObject> ContiguousVMObject::create_with_size(size_t size, size_t physical_alignment)
 {
     auto contiguous_physical_pages = MM.allocate_contiguous_supervisor_physical_pages(size, physical_alignment);
+    if (contiguous_physical_pages.is_empty())
+        return {};
+    return adopt_ref_if_nonnull(new ContiguousVMObject(size, contiguous_physical_pages));
+}
+
+ContiguousVMObject::ContiguousVMObject(size_t size, NonnullRefPtrVector<PhysicalPage>& contiguous_physical_pages)
+    : VMObject(size)
+{
     for (size_t i = 0; i < page_count(); i++) {
         physical_pages()[i] = contiguous_physical_pages[i];
         dbgln_if(CONTIGUOUS_VMOBJECT_DEBUG, "Contiguous page[{}]: {}", i, physical_pages()[i]->paddr());

--- a/Kernel/VM/ContiguousVMObject.h
+++ b/Kernel/VM/ContiguousVMObject.h
@@ -7,18 +7,18 @@
 #pragma once
 
 #include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/VMObject.h>
 
 namespace Kernel {
-
 class ContiguousVMObject final : public VMObject {
 public:
     virtual ~ContiguousVMObject() override;
 
-    static NonnullRefPtr<ContiguousVMObject> create_with_size(size_t, size_t physical_alignment = PAGE_SIZE);
+    static RefPtr<ContiguousVMObject> create_with_size(size_t, size_t physical_alignment = PAGE_SIZE);
 
 private:
-    explicit ContiguousVMObject(size_t, size_t physical_alignment);
+    explicit ContiguousVMObject(size_t, NonnullRefPtrVector<PhysicalPage>&);
     explicit ContiguousVMObject(const ContiguousVMObject&);
 
     virtual const char* class_name() const override { return "ContiguousVMObject"; }

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -464,7 +464,11 @@ OwnPtr<Region> MemoryManager::allocate_contiguous_kernel_region(size_t size, Str
     if (!range.has_value())
         return {};
     auto vmobject = ContiguousVMObject::create_with_size(size, physical_alignment);
-    return allocate_kernel_region_with_vmobject(range.value(), vmobject, name, access, cacheable);
+    if (!vmobject) {
+        kernel_page_directory().range_allocator().deallocate(range.value());
+        return {};
+    }
+    return allocate_kernel_region_with_vmobject(range.value(), *vmobject, name, access, cacheable);
 }
 
 OwnPtr<Region> MemoryManager::allocate_kernel_region(size_t size, StringView name, Region::Access access, AllocationStrategy strategy, Region::Cacheable cacheable)

--- a/Kernel/VM/PrivateInodeVMObject.cpp
+++ b/Kernel/VM/PrivateInodeVMObject.cpp
@@ -9,14 +9,14 @@
 
 namespace Kernel {
 
-NonnullRefPtr<PrivateInodeVMObject> PrivateInodeVMObject::create_with_inode(Inode& inode)
+RefPtr<PrivateInodeVMObject> PrivateInodeVMObject::create_with_inode(Inode& inode)
 {
-    return adopt_ref(*new PrivateInodeVMObject(inode, inode.size()));
+    return adopt_ref_if_nonnull(new PrivateInodeVMObject(inode, inode.size()));
 }
 
 RefPtr<VMObject> PrivateInodeVMObject::clone()
 {
-    return adopt_ref(*new PrivateInodeVMObject(*this));
+    return adopt_ref_if_nonnull(new PrivateInodeVMObject(*this));
 }
 
 PrivateInodeVMObject::PrivateInodeVMObject(Inode& inode, size_t size)

--- a/Kernel/VM/PrivateInodeVMObject.h
+++ b/Kernel/VM/PrivateInodeVMObject.h
@@ -18,7 +18,7 @@ class PrivateInodeVMObject final : public InodeVMObject {
 public:
     virtual ~PrivateInodeVMObject() override;
 
-    static NonnullRefPtr<PrivateInodeVMObject> create_with_inode(Inode&);
+    static RefPtr<PrivateInodeVMObject> create_with_inode(Inode&);
     virtual RefPtr<VMObject> clone() override;
 
 private:

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -210,15 +210,16 @@ size_t Region::amount_shared() const
 
 NonnullOwnPtr<Region> Region::create_user_accessible(Process* owner, const Range& range, NonnullRefPtr<VMObject> vmobject, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable cacheable, bool shared)
 {
-    auto region = adopt_own(*new Region(range, move(vmobject), offset_in_vmobject, move(name), access, cacheable, shared));
-    if (owner)
+    auto region = adopt_own_if_nonnull(new Region(range, move(vmobject), offset_in_vmobject, move(name), access, cacheable, shared));
+    if (region && owner)
         region->m_owner = owner->make_weak_ptr();
-    return region;
+    // FIXME: Return OwnPtr and propagate failure, currently there are too many assumptions made by down stream callers.
+    return region.release_nonnull();
 }
 
-NonnullOwnPtr<Region> Region::create_kernel_only(const Range& range, NonnullRefPtr<VMObject> vmobject, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable cacheable)
+OwnPtr<Region> Region::create_kernel_only(const Range& range, NonnullRefPtr<VMObject> vmobject, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable cacheable)
 {
-    return adopt_own(*new Region(range, move(vmobject), offset_in_vmobject, move(name), access, cacheable, false));
+    return adopt_own_if_nonnull(new Region(range, move(vmobject), offset_in_vmobject, move(name), access, cacheable, false));
 }
 
 bool Region::should_cow(size_t page_index) const

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -51,7 +51,7 @@ public:
     };
 
     static NonnullOwnPtr<Region> create_user_accessible(Process*, const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable, bool shared);
-    static NonnullOwnPtr<Region> create_kernel_only(const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable = Cacheable::Yes);
+    static OwnPtr<Region> create_kernel_only(const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable = Cacheable::Yes);
 
     ~Region();
 

--- a/Kernel/VM/Space.cpp
+++ b/Kernel/VM/Space.cpp
@@ -20,7 +20,9 @@ OwnPtr<Space> Space::create(Process& process, const Space* parent)
     auto page_directory = PageDirectory::create_for_userspace(parent ? &parent->page_directory().range_allocator() : nullptr);
     if (!page_directory)
         return {};
-    auto space = adopt_own(*new Space(process, page_directory.release_nonnull()));
+    auto space = adopt_own_if_nonnull(new Space(process, page_directory.release_nonnull()));
+    if (!space)
+        return {};
     space->page_directory().set_space({}, *space);
     return space;
 }


### PR DESCRIPTION
More progress on #6369, details in the commits. 