### PR TITLE
Kernel: Don't crash when writing a coredump with an unnamed region

### DIFF
--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -246,7 +246,9 @@ ByteBuffer CoreDump::create_notes_regions_data() const
 
         memory_region_info_buffer.append((void*)&info, sizeof(info));
         // NOTE: The region name *is* null-terminated, so the following is ok:
-        memory_region_info_buffer.append(region->name().characters_without_null_termination(), region->name().length() + 1);
+        auto name = region->name();
+        if (!name.is_null())
+            memory_region_info_buffer.append(name.characters_without_null_termination(), name.length() + 1);
 
         regions_data += memory_region_info_buffer;
     }


### PR DESCRIPTION
Previously we'd try to call `ByteBuffer::append(nullptr, 1)` when we came across a VM region that had no name:

```
[#0 FinalizerTask(4:4)]: Generating coredump for pid: 31
[FinalizerTask(4:4)]: RTC: Year: 2021, month: 5, day: 28, hour: 13, minute: 53, second: 4
[FinalizerTask(4:4)]: ASSERTION FAILED: data != nullptr
[FinalizerTask(4:4)]: ../.././AK/ByteBuffer.h:164 in void AK::Detail::ByteBuffer<inline_capacity>::append(const void*, size_t) [with long unsigned int inline_capacity = 32; size_t = long unsigned int]
[#0 FinalizerTask(4:4)]: 0xc0a7c135  abort +0x50
[#0 FinalizerTask(4:4)]: 0xc0a749a6  Kernel::Processor::capture_stack_trace(Kernel::Thread&, unsigned long)::{lambda(unsigned int)#1}::operator()(unsigned int) const +0x0
[#0 FinalizerTask(4:4)]: 0xc01450f7  Kernel::CoreDump::create_notes_regions_data() const +0xfd9
[#0 FinalizerTask(4:4)]: 0xc014c58b  Kernel::CoreDump::create_notes_segment_data() const +0x9af
[#0 FinalizerTask(4:4)]: 0xc014da21  Kernel::CoreDump::write() +0x6f7
[#0 FinalizerTask(4:4)]: 0xc068759a  Kernel::Process::dump_core() +0x86c
[#0 FinalizerTask(4:4)]: 0xc0691b9e  Kernel::Process::finalize() +0x26e
[#0 FinalizerTask(4:4)]: 0xc08efb66  Kernel::Thread::drop_thread_count(bool) +0x320
[#0 FinalizerTask(4:4)]: 0xc0902477  Kernel::Thread::finalize() +0xbcf
[#0 FinalizerTask(4:4)]: 0xc09079ac  Kernel::Thread::finalize_dying_threads() +0x560
[#0 FinalizerTask(4:4)]: 0xc08e3b45  Kernel::finalizer_task(void*) +0x133
[#0 FinalizerTask(4:4)]: 0xc0a72b22  exit_kernel_thread +0x0
qemu-system-i386: terminating on signal 2
```