### PR TITLE
Kernel: Allow building the kernel with -O0

### DIFF
--- a/Kernel/Arch/x86/Interrupts.h
+++ b/Kernel/Arch/x86/Interrupts.h
@@ -15,13 +15,17 @@ class GenericInterruptHandeler;
 
 extern "C" void interrupt_common_asm_entry();
 
-#define GENERATE_GENERIC_INTERRUPT_HANDLER_ASM_ENTRY(isr_number) \
-    extern "C" void interrupt_##isr_number##_asm_entry();        \
-    asm(".globl interrupt_" #isr_number "_asm_entry\n"           \
-        "interrupt_" #isr_number "_asm_entry:\n"                 \
-        "    pushw $" #isr_number "\n"                           \
-        "    pushw $0\n"                                         \
-        "    jmp interrupt_common_asm_entry\n");
+#define GENERATE_GENERIC_INTERRUPT_HANDLER_ASM_ENTRY(isr_number)                  \
+    extern "C" void interrupt_##isr_number##_asm_entry();                         \
+    static void interrupt_##isr_number##_asm_entry_dummy() __attribute__((used)); \
+    NEVER_INLINE void interrupt_##isr_number##_asm_entry_dummy()                  \
+    {                                                                             \
+        asm(".globl interrupt_" #isr_number "_asm_entry\n"                        \
+            "interrupt_" #isr_number "_asm_entry:\n"                              \
+            "    pushw $" #isr_number "\n"                                        \
+            "    pushw $0\n"                                                      \
+            "    jmp interrupt_common_asm_entry\n");                              \
+    }
 
 void register_interrupt_handler(u8 number, void (*handler)());
 void register_user_callable_interrupt_handler(u8 number, void (*handler)());

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -16,43 +16,47 @@ namespace Kernel {
 extern "C" void syscall_handler(TrapFrame*) __attribute__((used));
 extern "C" void syscall_asm_entry();
 
-// clang-format off
+static void syscall_asm_entry_dummy() __attribute__((used));
+NEVER_INLINE void syscall_asm_entry_dummy()
+{
+    // clang-format off
 #if ARCH(I386)
-asm(
-    ".globl syscall_asm_entry\n"
-    "syscall_asm_entry:\n"
-    "    pushl $0x0\n"
-    "    pusha\n"
-    "    pushl %ds\n"
-    "    pushl %es\n"
-    "    pushl %fs\n"
-    "    pushl %gs\n"
-    "    pushl %ss\n"
-    "    mov $" __STRINGIFY(GDT_SELECTOR_DATA0) ", %ax\n"
-    "    mov %ax, %ds\n"
-    "    mov %ax, %es\n"
-    "    mov $" __STRINGIFY(GDT_SELECTOR_PROC) ", %ax\n"
-    "    mov %ax, %fs\n"
-    "    cld\n"
-    "    xor %esi, %esi\n"
-    "    xor %edi, %edi\n"
-    "    pushl %esp \n" // set TrapFrame::regs
-    "    subl $" __STRINGIFY(TRAP_FRAME_SIZE - 4) ", %esp \n"
-    "    movl %esp, %ebx \n"
-    "    pushl %ebx \n" // push pointer to TrapFrame
-    "    call enter_trap_no_irq \n"
-    "    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
-    "    call syscall_handler \n"
-    "    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
-    "    jmp common_trap_exit \n");
+    asm(
+        ".globl syscall_asm_entry\n"
+        "syscall_asm_entry:\n"
+        "    pushl $0x0\n"
+        "    pusha\n"
+        "    pushl %ds\n"
+        "    pushl %es\n"
+        "    pushl %fs\n"
+        "    pushl %gs\n"
+        "    pushl %ss\n"
+        "    mov $" __STRINGIFY(GDT_SELECTOR_DATA0) ", %ax\n"
+        "    mov %ax, %ds\n"
+        "    mov %ax, %es\n"
+        "    mov $" __STRINGIFY(GDT_SELECTOR_PROC) ", %ax\n"
+        "    mov %ax, %fs\n"
+        "    cld\n"
+        "    xor %esi, %esi\n"
+        "    xor %edi, %edi\n"
+        "    pushl %esp \n" // set TrapFrame::regs
+        "    subl $" __STRINGIFY(TRAP_FRAME_SIZE - 4) ", %esp \n"
+        "    movl %esp, %ebx \n"
+        "    pushl %ebx \n" // push pointer to TrapFrame
+        "    call enter_trap_no_irq \n"
+        "    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
+        "    call syscall_handler \n"
+        "    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
+        "    jmp common_trap_exit \n");
 #elif ARCH(X86_64)
     asm(
-    ".globl syscall_asm_entry\n"
-    "syscall_asm_entry:\n"
-    "    cli\n"
-    "    hlt\n");
+        ".globl syscall_asm_entry\n"
+        "syscall_asm_entry:\n"
+        "    cli\n"
+        "    hlt\n");
 #endif
-// clang-format on
+    // clang-format on
+}
 
 namespace Syscall {
 


### PR DESCRIPTION
Unfortunately the kernel doesn't run with -O0 but at least it can be successfully built with this change.

Trying to run the image (still) fails with:

```
[init_stage2(2:2)]: ASSERTION FAILED: s_next_eternal_ptr < s_end_of_eternal_range
[init_stage2(2:2)]: ../../Kernel/Heap/kmalloc.cpp:241 in void* kmalloc_eternal(size_t)
[#0 init_stage2(2:2)]: 0xc0863009 (next: 0xc22bfcb0)
[#0 init_stage2(2:2)]: 0xc0862fad (next: 0xc22bfce0)
[#0 init_stage2(2:2)]: 0xc09372b8 (next: 0xc22bfd20)
[#0 init_stage2(2:2)]: 0xc09a2f14 (next: 0xc22bfd90)
[#0 init_stage2(2:2)]: 0xc09a382f (next: 0xc22bfe50)
[#0 init_stage2(2:2)]: 0xc083a7f7 (next: 0xc22bff90)
[#0 init_stage2(2:2)]: 0xc085ca37 (next: 0x00000000)
qemu-system-i386: terminating on signal 2
```