### PR TITLE
LibWeb: CSS Custom Properties performance improvement

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -217,7 +217,7 @@ static bool takes_integer_value(CSS::PropertyID property_id)
     return property_id == CSS::PropertyID::ZIndex || property_id == CSS::PropertyID::FontWeight || property_id == CSS::PropertyID::Custom;
 }
 
-static StringView parse_custom_property_name(StringView value)
+static StringView parse_custom_property_name(const StringView& value)
 {
     if (!value.starts_with("var(") && !value.ends_with(")"))
         return {};

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.h
@@ -30,7 +30,7 @@ public:
     DOM::Document& document() { return m_document; }
     const DOM::Document& document() const { return m_document; }
 
-    NonnullRefPtr<StyleProperties> resolve_style(const DOM::Element&) const;
+    NonnullRefPtr<StyleProperties> resolve_style(DOM::Element&) const;
 
     Vector<MatchingRule> collect_matching_rules(const DOM::Element&) const;
     void sort_matching_rules(Vector<MatchingRule>&) const;
@@ -38,8 +38,8 @@ public:
         Optional<StyleProperty> style {};
         u32 specificity { 0 };
     };
-    CustomPropertyResolutionTuple resolve_custom_property_with_specificity(const DOM::Element&, const String&) const;
-    Optional<StyleProperty> resolve_custom_property(const DOM::Element&, const String&) const;
+    CustomPropertyResolutionTuple resolve_custom_property_with_specificity(DOM::Element&, const String&) const;
+    Optional<StyleProperty> resolve_custom_property(DOM::Element&, const String&) const;
 
     static bool is_inherited_property(CSS::PropertyID);
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -8,6 +8,8 @@
 
 #include <AK/FlyString.h>
 #include <AK/String.h>
+#include <LibWeb/CSS/CSSStyleDeclaration.h>
+#include <LibWeb/CSS/StyleResolver.h>
 #include <LibWeb/DOM/Attribute.h>
 #include <LibWeb/DOM/ExceptionOr.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
@@ -91,6 +93,15 @@ public:
     const ShadowRoot* shadow_root() const { return m_shadow_root; }
     void set_shadow_root(RefPtr<ShadowRoot>);
 
+    Optional<CSS::StyleResolver::CustomPropertyResolutionTuple> resolve_custom_property(const String& custom_property_name)
+    {
+        return m_custom_properties.get(custom_property_name);
+    }
+    void add_custom_property(const String& custom_property_name, CSS::StyleResolver::CustomPropertyResolutionTuple style_property)
+    {
+        m_custom_properties.set(custom_property_name, style_property);
+    }
+
 protected:
     RefPtr<Layout::Node> create_layout_node() override;
 
@@ -107,6 +118,7 @@ private:
     RefPtr<CSS::CSSStyleDeclaration> m_inline_style;
 
     RefPtr<CSS::StyleProperties> m_specified_css_values;
+    HashMap<String, CSS::StyleResolver::CustomPropertyResolutionTuple> m_custom_properties;
 
     Vector<FlyString> m_classes;
 


### PR DESCRIPTION
This PR improves the formerly quite poor performance of the CSS custom property resolution.

Firstly it avoids a String copy Linus requested on the other PR which got merged.

Secondly using memoization the resolution speed was increased considerably. The Profiler keeps crashing on me, so I can't really quantify the speed increase but it is definitely noticeable.