### PR TITLE
LibGUI: Make HeaderView act only on the visible sections

### DIFF
--- a/Userland/Libraries/LibGUI/HeaderView.h
+++ b/Userland/Libraries/LibGUI/HeaderView.h
@@ -51,6 +51,13 @@ private:
     virtual void context_menu_event(ContextMenuEvent&) override;
     virtual void leave_event(Core::Event&) override;
 
+    struct VisibleSectionRange {
+        int start_offset { 0 };
+        int start { 0 };
+        int end { 0 };
+    };
+    VisibleSectionRange visible_section_range() const;
+
     Gfx::IntRect section_resize_grabbable_rect(int) const;
 
     void paint_horizontal(Painter&);


### PR DESCRIPTION
i.e. Drawing them, or handling mouse events on them.
Fixes #7505.