### PR TITLE
Ports: Add a port for wget (and a few prerequisites in LibC)

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -126,6 +126,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`vim`](vim/)                          | Vim                                                        | 8.2.2772                 | https://www.vim.org/                                                           |
 | [`vitetris`](vitetris/)                | vitetris                                                   | 0.59.1                   | https://github.com/vicgeralds/vitetris                                         |
 | [`vttest`](vttest/)                    | vttest                                                     | 20210210                 | https://invisible-island.net/vttest/                                           |
+| [`wget`](wget/)                        | GNU Wget                                                   | 1.21.1                   | https://www.gnu.org/software/wget/                                             |
 | [`xz`](xz/)                            | xz                                                         | 5.2.5                    | https://tukaani.org/xz/                                                        |
 | [`yasm`](yasm/)                        | Yasm Modular Assembler                                     | 1.3.0                    | https://yasm.tortall.net/                                                      |
 | [`zlib`](zlib/)                        | zlib                                                       | 1.2.11                   | https://www.zlib.net/                                                          |

--- a/Ports/wget/package.sh
+++ b/Ports/wget/package.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=wget
+version=1.21.1
+useconfigure="true"
+depends="openssl"
+files="https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz wget-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/wget/wget-${version}.tar.gz.sig wget-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+auth_type="sig"
+auth_opts="--keyring ./gnu-keyring.gpg wget-${version}.tar.gz.sig"
+configopts="--with-ssl=openssl --disable-ipv6"
+
+export OPENSSL_LIBS="-lssl -lcrypto -ldl"

--- a/Ports/wget/patches/configure.patch
+++ b/Ports/wget/patches/configure.patch
@@ -1,0 +1,12 @@
+diff -ur a/build-aux/config.sub b/build-aux/config.sub
+--- a/build-aux/config.sub	2021-01-09 10:57:19.000000000 +0100
++++ b/build-aux/config.sub	2021-04-19 14:45:56.132333538 +0200
+@@ -1691,7 +1691,7 @@
+ 	# Now accept the basic system types.
+ 	# The portable systems comes first.
+ 	# Each alternative MUST end in a * to match a version number.
+-	gnu* | android* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	gnu* | android* | bsd* | mach* | minix* | genix* | ultrix* | serenity* | irix* \
+ 	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]* \
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
+ 	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -56,6 +56,7 @@ set(LIBC_SOURCES
     utime.cpp
     utsname.cpp
     wchar.cpp
+    wctype.cpp
 )
 
 file(GLOB AK_SOURCES CONFIGURE_DEPENDS "../../../AK/*.cpp")

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -40,6 +40,7 @@ public:
     void setbuf(u8* data, int mode, size_t size) { m_buffer.setbuf(data, mode, size); }
 
     bool flush();
+    void purge();
     bool close();
 
     int fileno() const { return m_fd; }
@@ -190,6 +191,11 @@ bool FILE::flush()
     }
 
     return true;
+}
+
+void FILE::purge()
+{
+    m_buffer.drop();
 }
 
 ssize_t FILE::do_read(u8* data, size_t size)
@@ -1322,5 +1328,11 @@ int __fwriting(FILE* stream)
     }
 
     return (stream->flags() & FILE::Flags::LastWrite);
+}
+
+void __fpurge(FILE* stream)
+{
+    ScopedFileLock lock(stream);
+    stream->purge();
 }
 }

--- a/Userland/Libraries/LibC/stdio_ext.h
+++ b/Userland/Libraries/LibC/stdio_ext.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdio.h>
+
+__BEGIN_DECLS
+
+int __freading(FILE*);
+int __fwriting(FILE*);
+
+__END_DECLS

--- a/Userland/Libraries/LibC/stdio_ext.h
+++ b/Userland/Libraries/LibC/stdio_ext.h
@@ -12,5 +12,6 @@ __BEGIN_DECLS
 
 int __freading(FILE*);
 int __fwriting(FILE*);
+void __fpurge(FILE*);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -373,6 +373,25 @@ int putenv(char* new_var)
     return 0;
 }
 
+static const char* __progname = NULL;
+
+const char* getprogname()
+{
+    return __progname;
+}
+
+void setprogname(const char* progname)
+{
+    for (int i = strlen(progname) - 1; i >= 0; i--) {
+        if (progname[i] == '/') {
+            __progname = progname + i + 1;
+            return;
+        }
+    }
+
+    __progname = progname;
+}
+
 double strtod(const char* str, char** endptr)
 {
     // Parse spaces, sign, and base

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -31,6 +31,8 @@ int putenv(char*);
 int unsetenv(const char*);
 int clearenv(void);
 int setenv(const char* name, const char* value, int overwrite);
+const char* getprogname();
+void setprogname(const char*);
 int atoi(const char*);
 long atol(const char*);
 long long atoll(const char*);

--- a/Userland/Libraries/LibC/sys/types.h
+++ b/Userland/Libraries/LibC/sys/types.h
@@ -32,8 +32,6 @@ typedef char* caddr_t;
 
 typedef int id_t;
 
-typedef __WINT_TYPE__ wint_t;
-
 typedef uint32_t ino_t;
 typedef int64_t off_t;
 

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -153,4 +153,10 @@ long long wcstoll(const wchar_t*, wchar_t**, int)
     dbgln("FIXME: Implement wcstoll()");
     TODO();
 }
+
+wint_t btowc(int)
+{
+    dbgln("FIXME: Implement btowc()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -15,6 +15,8 @@ __BEGIN_DECLS
 #    define WEOF (0xffffffffu)
 #endif
 
+typedef __WINT_TYPE__ wint_t;
+
 size_t wcslen(const wchar_t*);
 wchar_t* wcscpy(wchar_t*, const wchar_t*);
 wchar_t* wcsncpy(wchar_t*, const wchar_t*, size_t);
@@ -27,5 +29,6 @@ wchar_t* wcsncat(wchar_t*, const wchar_t*, size_t);
 wchar_t* wcstok(wchar_t*, const wchar_t*, wchar_t**);
 long wcstol(const wchar_t*, wchar_t**, int);
 long long wcstoll(const wchar_t*, wchar_t**, int);
+wint_t btowc(int c);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -16,6 +16,7 @@ __BEGIN_DECLS
 #endif
 
 typedef __WINT_TYPE__ wint_t;
+typedef unsigned long int wctype_t;
 
 size_t wcslen(const wchar_t*);
 wchar_t* wcscpy(wchar_t*, const wchar_t*);

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <assert.h>
+#include <wctype.h>
+
+extern "C" {
+
+wctype_t wctype(const char*)
+{
+    dbgln("FIXME: Implement wctype()");
+    TODO();
+}
+
+int iswctype(wint_t, wctype_t)
+{
+    dbgln("FIXME: Implement iswctype()");
+    TODO();
+}
+}

--- a/Userland/Libraries/LibC/wctype.h
+++ b/Userland/Libraries/LibC/wctype.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <wchar.h>
+
+__BEGIN_DECLS
+
+wctype_t wctype(const char* name);
+int iswctype(wint_t wc, wctype_t desc);
+
+__END_DECLS


### PR DESCRIPTION
* `__freading`, `__fwriting` and `__fpurge` are helper routines that allow internal access to the FILE structure. Those were originally introduced by Solaris but are currently supported by most major libc implementations. I'm not too happy about having to introduce and update two separate flags for "last operation was a read" and "last operation was a write", but there are cases where neither apply.
* `getprogname` and `setprogname` are technically from libbsd, but we already have things like `arc4random` and `strlcpy`, so I assumed it would be fine.
* `btowc`, `wctype` and `iswctype` are just required for compiling (but aren't neccessarily used during a normal HTTP download), so stubs work for now.