### PR TITLE
LibTLS: Followup to the TLS refactor, fix for the SHA_384 cipher

### DIFF
--- a/Userland/Libraries/LibTLS/CipherSuite.h
+++ b/Userland/Libraries/LibTLS/CipherSuite.h
@@ -10,20 +10,77 @@ namespace TLS {
 
 enum class CipherSuite {
     Invalid = 0,
-    AES_128_GCM_SHA256 = 0x1301,
-    AES_256_GCM_SHA384 = 0x1302,
-    AES_128_CCM_SHA256 = 0x1304,
-    AES_128_CCM_8_SHA256 = 0x1305,
 
-    // We support these
+    // Weak cipher suites, but we support them
+    // RFC 5246 - Original TLS v1.2 ciphers
     RSA_WITH_AES_128_CBC_SHA = 0x002F,
     RSA_WITH_AES_256_CBC_SHA = 0x0035,
     RSA_WITH_AES_128_CBC_SHA256 = 0x003C,
     RSA_WITH_AES_256_CBC_SHA256 = 0x003D,
+
+    // RFC 5288 - DH, DHE and RSA for AES-GCM
     RSA_WITH_AES_128_GCM_SHA256 = 0x009C,
     RSA_WITH_AES_256_GCM_SHA384 = 0x009D,
+
+    // All recommended cipher suites (according to https://ciphersuite.info/cs/)
+    // RFC 5288 - DH, DHE and RSA for AES-GCM
+    DHE_DSS_WITH_AES_128_GCM_SHA256 = 0x00A2,
+    DHE_DSS_WITH_AES_256_GCM_SHA384 = 0x00A3,
+
+    // RFC 5289 - ECDHE for AES-GCM
+    ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 = 0xC02B,
+    ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 = 0xC02C,
+
+    // RFC 5487 - Pre-shared keys
+    DHE_PSK_WITH_AES_128_GCM_SHA256 = 0x00AA,
+    DHE_PSK_WITH_AES_256_GCM_SHA384 = 0x00AB,
+
+    // RFC 6209 - ARIA suites
+    DHE_DSS_WITH_ARIA_128_GCM_SHA256 = 0xC056,
+    DHE_DSS_WITH_ARIA_256_GCM_SHA384 = 0xC057,
+    ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256 = 0xC05C,
+    ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384 = 0xC05D,
+    DHE_PSK_WITH_ARIA_128_GCM_SHA256 = 0xC06C,
+    DHE_PSK_WITH_ARIA_256_GCM_SHA384 = 0xC06D,
+
+    // RFC 6367 - Camellia Cipher Suites
+    DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256 = 0xC080,
+    DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384 = 0xC081,
+    ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256 = 0xC086,
+    ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384 = 0xC087,
+    DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256 = 0xC090,
+    DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384 = 0xC091,
+
+    // RFC 6655 - DHE, PSK and RSA with AES-CCM
+    DHE_PSK_WITH_AES_128_CCM = 0xC0A6,
+    DHE_PSK_WITH_AES_256_CCM = 0xC0A7,
+
+    // RFC 7251 - ECDHE with AES-CCM
+    ECDHE_ECDSA_WITH_AES_128_CCM = 0xC0AC,
+    ECDHE_ECDSA_WITH_AES_256_CCM = 0xC0AD,
+    ECDHE_ECDSA_WITH_AES_128_CCM_8 = 0xC0AE,
+    ECDHE_ECDSA_WITH_AES_256_CCM_8 = 0xC0AF,
+
+    // RFC 7905 - ChaCha20-Poly1305 Cipher Suites
+    ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 = 0xCCA9,
+    ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 = 0xCCAC,
+    DHE_PSK_WITH_CHACHA20_POLY1305 = 0xCCAD,
+
+    // RFC 8442 - ECDHE_PSK with AES-GCM and AES-CCM
+    ECDHE_PSK_WITH_AES_128_GCM_SHA256 = 0xD001,
+    ECDHE_PSK_WITH_AES_256_GCM_SHA384 = 0xD002,
+    ECDHE_PSK_WITH_AES_128_CCM_8_SHA256 = 0xD003,
+    ECDHE_PSK_WITH_AES_128_CCM_SHA256 = 0xD005,
+
+    // RFC 8446 - TLS v1.3
+    AES_128_GCM_SHA256 = 0x1301,
+    AES_256_GCM_SHA384 = 0x1302,
+    CHACHA20_POLY1305_SHA256 = 0x1303,
+    AES_128_CCM_SHA256 = 0x1304,
+    AES_128_CCM_8_SHA256 = 0x1305,
 };
 
+// Defined in RFC 5246 section 7.4.1.4.1
 enum class HashAlgorithm : u8 {
     None = 0,
     MD5 = 1,
@@ -34,11 +91,18 @@ enum class HashAlgorithm : u8 {
     SHA512 = 6,
 };
 
+// Defined in RFC 5246 section 7.4.1.4.1
 enum class SignatureAlgorithm : u8 {
     Anonymous = 0,
     RSA = 1,
     DSA = 2,
     ECDSA = 3,
+};
+
+// Defined in RFC 5246 section 7.4.1.4.1
+struct SignatureAndHashAlgorithm {
+    HashAlgorithm hash;
+    SignatureAlgorithm signature;
 };
 
 enum class CipherAlgorithm {
@@ -67,10 +131,5 @@ constexpr size_t cipher_key_size(CipherAlgorithm algorithm)
         return 0;
     }
 }
-
-struct SignatureAndHashAlgorithm {
-    HashAlgorithm hash;
-    SignatureAlgorithm signature;
-};
 
 }

--- a/Userland/Libraries/LibTLS/CipherSuite.h
+++ b/Userland/Libraries/LibTLS/CipherSuite.h
@@ -105,6 +105,49 @@ struct SignatureAndHashAlgorithm {
     SignatureAlgorithm signature;
 };
 
+enum class KeyExchangeAlgorithm {
+    Invalid,
+    // Defined in RFC 5246 section 7.4.2 / RFC 4279 section 4
+    RSA_PSK,
+    // Defined in RFC 5246 section 7.4.3
+    DHE_DSS,
+    DHE_RSA,
+    DH_anon,
+    RSA,
+    DH_DSS,
+    DH_RSA,
+    // Defined in RFC 4492 section 2
+    ECDHE_RSA,
+    ECDH_ECDSA,
+    ECDH_RSA,
+    ECDHE_ECDSA,
+    ECDH_anon,
+};
+
+// Defined in RFC 5246 section 7.4.1.4.1
+constexpr SignatureAlgorithm signature_for_key_exchange_algorithm(KeyExchangeAlgorithm algorithm)
+{
+    switch (algorithm) {
+    case KeyExchangeAlgorithm::RSA:
+    case KeyExchangeAlgorithm::DHE_RSA:
+    case KeyExchangeAlgorithm::DH_RSA:
+    case KeyExchangeAlgorithm::RSA_PSK:
+    case KeyExchangeAlgorithm::ECDH_RSA:
+    case KeyExchangeAlgorithm::ECDHE_RSA:
+        return SignatureAlgorithm::RSA;
+    case KeyExchangeAlgorithm::DHE_DSS:
+    case KeyExchangeAlgorithm::DH_DSS:
+        return SignatureAlgorithm::DSA;
+    case KeyExchangeAlgorithm::ECDH_ECDSA:
+    case KeyExchangeAlgorithm::ECDHE_ECDSA:
+        return SignatureAlgorithm::ECDSA;
+    case KeyExchangeAlgorithm::DH_anon:
+    case KeyExchangeAlgorithm::ECDH_anon:
+    default:
+        return SignatureAlgorithm::Anonymous;
+    }
+}
+
 enum class CipherAlgorithm {
     Invalid,
     AES_128_CBC,

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -140,12 +140,17 @@ ByteBuffer TLSv12::build_handshake_finished()
     PacketBuilder builder { MessageType::Handshake, m_context.options.version, 12 + 64 };
     builder.append((u8)HandshakeType::Finished);
 
-    constexpr u32 out_size = 12;
+    // RFC 5246 section 7.4.9: "In previous versions of TLS, the verify_data was always 12 octets
+    //                          long.  In the current version of TLS, it depends on the cipher
+    //                          suite.  Any cipher suite which does not explicitly specify
+    //                          verify_data_length has a verify_data_length equal to 12."
+    // Simplification: Assume that verify_data_length is always 12.
+    constexpr u32 verify_data_length = 12;
 
-    builder.append_u24(out_size);
+    builder.append_u24(verify_data_length);
 
-    u8 out[out_size];
-    auto outbuffer = Bytes { out, out_size };
+    u8 out[verify_data_length];
+    auto outbuffer = Bytes { out, verify_data_length };
     auto dummy = ByteBuffer::create_zeroed(0);
 
     auto digest = m_context.handshake_hash.digest();

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -283,24 +283,37 @@ ByteBuffer TLSv12::build_client_key_exchange()
     PacketBuilder builder { MessageType::Handshake, m_context.options.version };
     builder.append((u8)HandshakeType::ClientKeyExchange);
 
-    switch (get_signature_algorithm(m_context.cipher)) {
-    case SignatureAlgorithm::Anonymous:
-        dbgln("Client key exchange for Anonymous signature is not implemented");
-        TODO();
-        break;
-    case SignatureAlgorithm::RSA:
+    switch (get_key_exchange_algorithm(m_context.cipher)) {
+    case KeyExchangeAlgorithm::RSA:
         build_rsa_pre_master_secret(builder);
         break;
-    case SignatureAlgorithm::DSA:
-        dbgln("Client key exchange for DSA signature is not implemented");
+    case KeyExchangeAlgorithm::DHE_DSS:
+        dbgln("Client key exchange for DHE_DSS is not implemented");
         TODO();
         break;
-    case SignatureAlgorithm::ECDSA:
-        dbgln("Client key exchange for ECDSA signature is not implemented");
+    case KeyExchangeAlgorithm::DH_DSS:
+    case KeyExchangeAlgorithm::DH_RSA:
+        dbgln("Client key exchange for DH algorithms is not implemented");
+        TODO();
+        break;
+    case KeyExchangeAlgorithm::DHE_RSA:
+        dbgln("Client key exchange for DHE_RSA is not implemented");
+        TODO();
+        break;
+    case KeyExchangeAlgorithm::DH_anon:
+        dbgln("Client key exchange for DH_anon is not implemented");
+        TODO();
+        break;
+    case KeyExchangeAlgorithm::ECDHE_RSA:
+    case KeyExchangeAlgorithm::ECDH_ECDSA:
+    case KeyExchangeAlgorithm::ECDH_RSA:
+    case KeyExchangeAlgorithm::ECDHE_ECDSA:
+    case KeyExchangeAlgorithm::ECDH_anon:
+        dbgln("Client key exchange for ECDHE algorithms is not implemented");
         TODO();
         break;
     default:
-        dbgln("Unknonwn client key exchange signature algorithm");
+        dbgln("Unknonwn client key exchange algorithm");
         VERIFY_NOT_REACHED();
         break;
     }

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -201,23 +201,36 @@ ByteBuffer TLSv12::build_server_key_exchange()
 
 ssize_t TLSv12::handle_server_key_exchange(ReadonlyBytes)
 {
-    switch (get_signature_algorithm(m_context.cipher)) {
-    case SignatureAlgorithm::Anonymous:
-        dbgln("Client key exchange for Anonymous signature is not implemented");
-        TODO();
-        break;
-    case SignatureAlgorithm::RSA:
-    case SignatureAlgorithm::DSA:
+    switch (get_key_exchange_algorithm(m_context.cipher)) {
+    case KeyExchangeAlgorithm::RSA:
+    case KeyExchangeAlgorithm::DH_DSS:
+    case KeyExchangeAlgorithm::DH_RSA:
         // RFC 5246 section 7.4.3. Server Key Exchange Message
         // It is not legal to send the server key exchange message for RSA, DH_DSS, DH_RSA
-        dbgln("Server key exchange received for RSA or DSA is not legal");
+        dbgln("Server key exchange received for RSA, DH_DSS or DH_RSA is not legal");
         return (i8)Error::UnexpectedMessage;
-    case SignatureAlgorithm::ECDSA:
-        dbgln("Client key exchange for ECDSA signature is not implemented");
+    case KeyExchangeAlgorithm::DHE_DSS:
+        dbgln("Server key exchange for DHE_DSS is not implemented");
+        TODO();
+        break;
+    case KeyExchangeAlgorithm::DHE_RSA:
+        dbgln("Server key exchange for DHE_RSA is not implemented");
+        TODO();
+        break;
+    case KeyExchangeAlgorithm::DH_anon:
+        dbgln("Server key exchange for DH_anon is not implemented");
+        TODO();
+        break;
+    case KeyExchangeAlgorithm::ECDHE_RSA:
+    case KeyExchangeAlgorithm::ECDH_ECDSA:
+    case KeyExchangeAlgorithm::ECDH_RSA:
+    case KeyExchangeAlgorithm::ECDHE_ECDSA:
+    case KeyExchangeAlgorithm::ECDH_anon:
+        dbgln("Server key exchange for ECDHE algorithms is not implemented");
         TODO();
         break;
     default:
-        dbgln("Unknonwn client key exchange signature algorithm");
+        dbgln("Unknonwn server key exchange algorithm");
         VERIFY_NOT_REACHED();
         break;
     }

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -81,8 +81,8 @@ ssize_t TLSv12::handle_server_hello(ReadonlyBytes buffer, WritePacketStage& writ
     m_context.cipher = cipher;
     dbgln_if(TLS_DEBUG, "Cipher: {}", (u16)cipher);
 
-    // The handshake hash function is _always_ SHA256
-    m_context.handshake_hash.initialize(Crypto::Hash::HashKind::SHA256);
+    // Simplification: We only support handshake hash functions via HMAC
+    m_context.handshake_hash.initialize(hmac_hash());
 
     // Compression method
     if (buffer.size() - res < 1)

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -168,10 +168,6 @@ enum ClientVerificationStaus {
 // GCM specifically asks us to transmit only the nonce, the counter is zero
 // and the fixed IV is derived from the premaster key.
 #define ENUMERATE_CIPHERS(C)                                                                                                                    \
-    C(false, CipherSuite::AES_128_GCM_SHA256, SignatureAlgorithm::Anonymous, CipherAlgorithm::AES_128_GCM, Crypto::Hash::SHA256, 8, true)       \
-    C(false, CipherSuite::AES_256_GCM_SHA384, SignatureAlgorithm::Anonymous, CipherAlgorithm::AES_256_GCM, Crypto::Hash::SHA384, 8, true)       \
-    C(false, CipherSuite::AES_128_CCM_SHA256, SignatureAlgorithm::Anonymous, CipherAlgorithm::AES_128_CCM, Crypto::Hash::SHA256, 16, false)     \
-    C(false, CipherSuite::AES_128_CCM_8_SHA256, SignatureAlgorithm::Anonymous, CipherAlgorithm::AES_128_CCM_8, Crypto::Hash::SHA256, 16, false) \
     C(true, CipherSuite::RSA_WITH_AES_128_CBC_SHA, SignatureAlgorithm::RSA, CipherAlgorithm::AES_128_CBC, Crypto::Hash::SHA1, 16, false)        \
     C(true, CipherSuite::RSA_WITH_AES_256_CBC_SHA, SignatureAlgorithm::RSA, CipherAlgorithm::AES_256_CBC, Crypto::Hash::SHA1, 16, false)        \
     C(true, CipherSuite::RSA_WITH_AES_128_CBC_SHA256, SignatureAlgorithm::RSA, CipherAlgorithm::AES_128_CBC, Crypto::Hash::SHA256, 16, false)   \

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -447,6 +447,20 @@ private:
         }
     }
 
+    Crypto::Hash::HashKind hmac_hash() const
+    {
+        switch (mac_length()) {
+        case Crypto::Hash::SHA512::DigestSize:
+            return Crypto::Hash::HashKind::SHA512;
+        case Crypto::Hash::SHA384::DigestSize:
+            return Crypto::Hash::HashKind::SHA384;
+        case Crypto::Hash::SHA256::DigestSize:
+        case Crypto::Hash::SHA1::DigestSize:
+        default:
+            return Crypto::Hash::HashKind::SHA256;
+        }
+    }
+
     size_t iv_length() const
     {
         switch (m_context.cipher) {


### PR DESCRIPTION
Followup to #7270 

This PR continues to refactor the TLS code to prepare to implement other algorithms:
- Add all the recommended TLS v1.2 cipher suites to the `CipherSuite` enum
- Prepares selecting the proper `KeyExchangeAlgorithm` by implementing said enum as defined in RFC 5246
- Allows using bigger hash sizes for the HMAC validation, which fixes an issue with the RSA_WITH_AES_256_GCM_SHA384 cipher introduced in the last PR.

Fixes #7348 

