### PR TITLE
LibGUI: Distribute remaining pixels in BoxLayout to fill the entire area

### DIFF
--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -150,13 +150,18 @@ void BoxLayout::run(Widget& widget)
     // Pass 2: Distribute remaining available size evenly, respecting each item's maximum size.
     while (unfinished_items && available_size > 0) {
         int slice = available_size / unfinished_items;
+        // If available_size does not divide evenly by unfinished_items,
+        // there are some extra pixels that have to be distributed.
+        int pixels = available_size - slice * unfinished_items;
         available_size = 0;
 
         for (auto& item : items) {
             if (item.final)
                 continue;
 
-            int item_size_with_full_slice = item.size + slice;
+            int pixel = pixels ? 1 : 0;
+            pixels -= pixel;
+            int item_size_with_full_slice = item.size + slice + pixel;
             item.size = item_size_with_full_slice;
 
             if (item.max_size >= 0)


### PR DESCRIPTION
Previously, the layout algorithm preferred to give every item an equally
sized slice of the remaining space. This meant that not the entire area
was used when the remaining size did not divide evenly by the number of
items. This caused, for example, the ResizeCorner in HexEditor to be a
couple of pixels left of the actual corner for some sizes of the window.

Now, the remaining pixels are distributed on a first come, first served
basis. However, only one pixel is distributed at a time. This means
items towards the left might me a pixel larger than their siblings
towards the right.

The changes are also noticeable in the Widget Gallery. If you slowly increase
the width of the main window, you'll notice some elements don't move, but will
then suddenly jump by 2 or 4 pixels depending on how many items are in that
row. With the changes the items resize continuously.