### PR TITLE
Kernel: Don't overrun the buffer in krealloc()

### DIFF
--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -113,7 +113,7 @@ public:
         VERIFY((u8*)a >= m_chunks && (u8*)ptr < m_chunks + m_total_chunks * CHUNK_SIZE);
         VERIFY((u8*)a + a->allocation_size_in_chunks * CHUNK_SIZE <= m_chunks + m_total_chunks * CHUNK_SIZE);
 
-        size_t old_size = a->allocation_size_in_chunks * CHUNK_SIZE;
+        size_t old_size = a->allocation_size_in_chunks * CHUNK_SIZE - sizeof(AllocationHeader);
 
         if (old_size == new_size)
             return ptr;


### PR DESCRIPTION
The `allocation_size_in_chunks` field contains the bytes necessary for the `AllocationHeader` so we need to subtract that when we try to figure out how much user data we have to copy.

Fixes #7549.