### PR TITLE
LibC: Don't leak memory for realloc(p, 0)

### DIFF
--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -437,8 +437,10 @@ void* realloc(void* ptr, size_t size)
 {
     if (!ptr)
         return malloc(size);
-    if (!size)
+    if (!size) {
+        free(ptr);
         return nullptr;
+    }
 
     Threading::Locker locker(malloc_lock());
     auto existing_allocation_size = malloc_size(ptr);


### PR DESCRIPTION
Previously we'd leak memory when the user called `realloc(p, 0)`. Instead this call should behave as if the user had called `free(p)`.