### PR TITLE
LibJS: Annotate Cell Allocation for ASAN

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -10,7 +10,8 @@
 
 #include <AK/Assertions.h>
 
-constexpr unsigned round_up_to_power_of_two(unsigned value, unsigned power_of_two)
+template<typename T, typename U>
+constexpr auto round_up_to_power_of_two(T value, U power_of_two) requires(IsIntegral<T>&& IsIntegral<U>)
 {
     return ((value - 1) & ~(power_of_two - 1)) + power_of_two;
 }

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -23,7 +23,10 @@ namespace JS {
 Heap::Heap(VM& vm)
     : m_vm(vm)
 {
-    m_allocators.append(make<CellAllocator>(16));
+    if constexpr (HeapBlock::min_possible_cell_size <= 16) {
+        m_allocators.append(make<CellAllocator>(16));
+    }
+    static_assert(HeapBlock::min_possible_cell_size <= 24, "Heap Cell tracking uses too much data!");
     m_allocators.append(make<CellAllocator>(32));
     m_allocators.append(make<CellAllocator>(64));
     m_allocators.append(make<CellAllocator>(128));

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
@@ -6,10 +6,15 @@
 
 #include <AK/Assertions.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Platform.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Heap/HeapBlock.h>
 #include <stdio.h>
 #include <sys/mman.h>
+
+#ifdef HAS_ADDRESS_SANITIZER
+#    include <sanitizer/asan_interface.h>
+#endif
 
 namespace JS {
 
@@ -27,6 +32,7 @@ HeapBlock::HeapBlock(Heap& heap, size_t cell_size)
     , m_cell_size(cell_size)
 {
     VERIFY(cell_size >= sizeof(FreelistEntry));
+    ASAN_POISON_MEMORY_REGION(m_storage, block_size);
 }
 
 void HeapBlock::deallocate(Cell* cell)
@@ -35,11 +41,22 @@ void HeapBlock::deallocate(Cell* cell)
     VERIFY(!m_freelist || is_valid_cell_pointer(m_freelist));
     VERIFY(cell->state() == Cell::State::Live);
     VERIFY(!cell->is_marked());
+
     cell->~Cell();
     auto* freelist_entry = new (cell) FreelistEntry();
     freelist_entry->set_state(Cell::State::Dead);
     freelist_entry->next = m_freelist;
     m_freelist = freelist_entry;
+
+#ifdef HAS_ADDRESS_SANITIZER
+    auto dword_after_freelist = round_up_to_power_of_two(reinterpret_cast<uintptr_t>(freelist_entry) + sizeof(FreelistEntry), 8);
+    VERIFY((dword_after_freelist - reinterpret_cast<uintptr_t>(freelist_entry)) <= m_cell_size);
+    VERIFY(m_cell_size >= sizeof(FreelistEntry));
+    // We can't poision the cell tracking data, nor the FreeListEntry's vtable or next pointer
+    // This means there's sizeof(FreelistEntry) data at the front of each cell that is always read/write
+    // On x86_64, this ends up being 24 bytes due to the size of the FreeListEntry's vtable, while on x86, it's only 12 bytes.
+    ASAN_POISON_MEMORY_REGION(reinterpret_cast<void*>(dword_after_freelist), m_cell_size - sizeof(FreelistEntry));
+#endif
 }
 
 }

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -101,6 +101,9 @@ private:
     size_t m_next_lazy_freelist_index { 0 };
     FreelistEntry* m_freelist { nullptr };
     alignas(Cell) u8 m_storage[];
+
+public:
+    static constexpr size_t min_possible_cell_size = sizeof(FreelistEntry);
 };
 
 }

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -96,11 +96,6 @@ private:
         return reinterpret_cast<Cell*>(&m_storage[index * cell_size()]);
     }
 
-    FreelistEntry* init_freelist_entry(size_t index)
-    {
-        return new (&m_storage[index * cell_size()]) FreelistEntry();
-    }
-
     Heap& m_heap;
     size_t m_cell_size { 0 };
     size_t m_next_lazy_freelist_index { 0 };


### PR DESCRIPTION
Annotate heap block allocations for address sanitizer.

Mark the entirety of a heap block's storage poisoned at construction.
Unpoison all of a Cell's memory before allocating it, and re-poison as
much as possible on deallocation. Unfortunately, the entirety of the
FreelistEntry must be kept unpoisoned in order for reallocation to work
correctly.

Decreasing the size of FreelistEntry or adding a larger redzone to Cells
would make the instrumentation even better.