### PR TITLE
LibGfx: Reject ICOs with height == NumericLimits<i32>::min()

### DIFF
--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -210,6 +210,13 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
             printf("load_ico_bmp: width %d < 0\n", info.width);
         return false;
     }
+
+    if (info.height == NumericLimits<i32>::min()) {
+        if constexpr (ICO_DEBUG)
+            printf("load_ico_bmp: height == NumericLimits<i32>::min()\n");
+        return false;
+    }
+
     bool topdown = false;
     if (info.height < 0) {
         topdown = true;

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -169,22 +169,17 @@ static bool load_ico_directory(ICOLoadingContext& context)
     for (size_t i = 0; i < image_count.value(); ++i) {
         auto maybe_desc = decode_ico_direntry(stream);
         if (!maybe_desc.has_value()) {
-            if constexpr (ICO_DEBUG)
-                printf("load_ico_directory: error loading entry: %lu\n", i);
+            dbgln_if(ICO_DEBUG, "load_ico_directory: error loading entry: {}", i);
             return false;
         }
 
         auto& desc = maybe_desc.value();
         if (desc.offset + desc.size < desc.offset // detect integer overflow
             || (desc.offset + desc.size) > context.data_size) {
-            if constexpr (ICO_DEBUG)
-                printf("load_ico_directory: offset: %lu size: %lu doesn't fit in ICO size: %lu\n",
-                    desc.offset, desc.size, context.data_size);
+            dbgln_if(ICO_DEBUG, "load_ico_directory: offset: {} size: {} doesn't fit in ICO size: {}", desc.offset, desc.size, context.data_size);
             return false;
         }
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_directory: index %zu width: %u height: %u offset: %lu size: %lu\n",
-                i, desc.width, desc.height, desc.offset, desc.size);
+        dbgln_if(ICO_DEBUG, "load_ico_directory: index {} width: {} height: {} offset: {} size: {}", i, desc.width, desc.height, desc.offset, desc.size);
         context.images.append(desc);
     }
     context.largest_index = find_largest_image(context);
@@ -200,20 +195,17 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
 
     memcpy(&info, context.data + desc.offset, sizeof(info));
     if (info.size != sizeof(info)) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: info size: %u, expected: %lu\n", info.size, sizeof(info));
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: info size: {}, expected: {}", info.size, sizeof(info));
         return false;
     }
 
     if (info.width < 0) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: width %d < 0\n", info.width);
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: width {} < 0", info.width);
         return false;
     }
 
     if (info.height == NumericLimits<i32>::min()) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: height == NumericLimits<i32>::min()\n");
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: height == NumericLimits<i32>::min()");
         return false;
     }
 
@@ -224,32 +216,25 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
     }
 
     if (info.planes != 1) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: planes: %d != 1", info.planes);
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: planes: {} != 1", info.planes);
         return false;
     }
 
     if (info.bpp != 32) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: unsupported bpp: %u\n", info.bpp);
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: unsupported bpp: {}", info.bpp);
         return false;
     }
 
-    if constexpr (ICO_DEBUG)
-        printf("load_ico_bmp: width: %d height: %d direction: %s bpp: %d size_image: %u\n",
-            info.width, info.height, topdown ? "TopDown" : "BottomUp", info.bpp, info.size_image);
+    dbgln_if(ICO_DEBUG, "load_ico_bmp: width: {} height: {} direction: {} bpp: {} size_image: {}",
+        info.width, info.height, topdown ? "TopDown" : "BottomUp", info.bpp, info.size_image);
 
     if (info.compression != 0 || info.palette_size != 0 || info.important_colors != 0) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: following fields must be 0: compression: %u palette_size: %u important_colors: %u\n",
-                info.compression, info.palette_size, info.important_colors);
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: following fields must be 0: compression: {} palette_size: {} important_colors: {}", info.compression, info.palette_size, info.important_colors);
         return false;
     }
 
     if (info.width != desc.width || info.height != 2 * desc.height) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: size mismatch: ico %dx%d, bmp %dx%d\n",
-                desc.width, desc.height, info.width, info.height);
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: size mismatch: ico {}x{}, bmp {}x{}", desc.width, desc.height, info.width, info.height);
         return false;
     }
 
@@ -258,9 +243,7 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
     size_t required_len = desc.height * (desc.width * sizeof(BMP_ARGB) + mask_row_len);
     size_t available_len = desc.size - sizeof(info);
     if (required_len > available_len) {
-        if constexpr (ICO_DEBUG)
-            printf("load_ico_bmp: required_len: %lu > available_len: %lu\n",
-                required_len, available_len);
+        dbgln_if(ICO_DEBUG, "load_ico_bmp: required_len: {} > available_len: {}", required_len, available_len);
         return false;
     }
 
@@ -306,15 +289,13 @@ static bool load_ico_bitmap(ICOLoadingContext& context, Optional<size_t> index)
     if (png_decoder.sniff()) {
         desc.bitmap = png_decoder.bitmap();
         if (!desc.bitmap) {
-            if constexpr (ICO_DEBUG)
-                printf("load_ico_bitmap: failed to load PNG encoded image index: %lu\n", real_index);
+            dbgln_if(ICO_DEBUG, "load_ico_bitmap: failed to load PNG encoded image index: {}", real_index);
             return false;
         }
         return true;
     } else {
         if (!load_ico_bmp(context, desc)) {
-            if constexpr (ICO_DEBUG)
-                printf("load_ico_bitmap: failed to load BMP encoded image index: %lu\n", real_index);
+            dbgln_if(ICO_DEBUG, "load_ico_bitmap: failed to load BMP encoded image index: {}", real_index);
             return false;
         }
         return true;


### PR DESCRIPTION
Bitmap files use negative height values to signify that the image should be rendered top down, but if the height value equals to the minimum value negating it to get the actual height results in UB. (Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34773)