### PR TITLE
LibCore: Do not write disabled spwd values in generate_shadow_file

### DIFF
--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -224,18 +224,24 @@ String Account::generate_shadow_file() const
         if (p->sp_namp == m_username) {
             builder.appendff("{}:{}:{}:{}:{}:{}:{}:{}:{}\n",
                 m_username, m_password_hash,
-                p->sp_lstchg, p->sp_min,
-                p->sp_max, p->sp_warn,
-                p->sp_inact, p->sp_expire,
-                p->sp_flag);
+                (p->sp_lstchg == -1) ? "" : String::formatted("{}", p->sp_lstchg),
+                (p->sp_min == -1) ? "" : String::formatted("{}", p->sp_min),
+                (p->sp_max == -1) ? "" : String::formatted("{}", p->sp_max),
+                (p->sp_warn == -1) ? "" : String::formatted("{}", p->sp_warn),
+                (p->sp_inact == -1) ? "" : String::formatted("{}", p->sp_inact),
+                (p->sp_expire == -1) ? "" : String::formatted("{}", p->sp_expire),
+                (p->sp_flag == 0) ? "" : String::formatted("{}", p->sp_flag));
 
         } else {
             builder.appendff("{}:{}:{}:{}:{}:{}:{}:{}:{}\n",
                 p->sp_namp, p->sp_pwdp,
-                p->sp_lstchg, p->sp_min,
-                p->sp_max, p->sp_warn,
-                p->sp_inact, p->sp_expire,
-                p->sp_flag);
+                (p->sp_lstchg == -1) ? "" : String::formatted("{}", p->sp_lstchg),
+                (p->sp_min == -1) ? "" : String::formatted("{}", p->sp_min),
+                (p->sp_max == -1) ? "" : String::formatted("{}", p->sp_max),
+                (p->sp_warn == -1) ? "" : String::formatted("{}", p->sp_warn),
+                (p->sp_inact == -1) ? "" : String::formatted("{}", p->sp_inact),
+                (p->sp_expire == -1) ? "" : String::formatted("{}", p->sp_expire),
+                (p->sp_flag == 0) ? "" : String::formatted("{}", p->sp_flag));
         }
     }
     endspent();


### PR DESCRIPTION
When LibC/shadow.cpp parses shadow entries in getspent, it sets the
spwd member value to disabled (-1) if the value is empty. When
Core::Account::sync calls getspent to generate a new shadow file, it
would receive the -1 values and write them in the shadow file. This
would cause the /etc/shadow file to be cluttered with disabled values
after any password change.

This patch checks if the spwd member value is disabled, and prints the
appropriate value to the shadow file.

Before:

<img width="1023" alt="Screen Shot 2021-05-29 at 9 13 50 AM" src="https://user-images.githubusercontent.com/54456386/120075956-6d265c00-c071-11eb-9106-bb299a162e29.png">

After:

<img width="1024" alt="Screen Shot 2021-05-29 at 10 55 45 AM" src="https://user-images.githubusercontent.com/54456386/120075959-71527980-c071-11eb-9932-aec95bb3c6ae.png">

