### PR TITLE
Kernel: Ensure that an unveil node with no permission is never accepted

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -851,7 +851,7 @@ KResult VFS::validate_path_against_process_veil(StringView path, int options)
         return EINVAL;
 
     auto* unveiled_path = find_matching_unveiled_path(path);
-    if (!unveiled_path) {
+    if (!unveiled_path || unveiled_path->permissions() == UnveilAccess::None) {
         dbgln("Rejecting path '{}' since it hasn't been unveiled.", path);
         dump_backtrace();
         return ENOENT;

--- a/Tests/Kernel/TestKernelUnveil.cpp
+++ b/Tests/Kernel/TestKernelUnveil.cpp
@@ -52,4 +52,8 @@ TEST_CASE(test_failures)
     res = unveil("/bin", "w");
     if (res >= 0)
         FAIL("unveil permitted after unveil state locked");
+
+    res = access("/bin/id", F_OK);
+    if (res == 0)
+        FAIL("access(..., F_OK) permitted after locked veil without relevant unveil");
 }


### PR DESCRIPTION
Otherwise nodes inheriting from root may still be accessed with
`access(..., F_OK)`.
Also adds a test case to TestKernelUnveil about this behaviour.