### PR TITLE
LibJS: Add Date.prototype.{get, set}Year()

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -133,6 +133,7 @@ namespace JS {
     P(getUTCMinutes)                         \
     P(getUTCMonth)                           \
     P(getUTCSeconds)                         \
+    P(getYear)                               \
     P(global)                                \
     P(globalThis)                            \
     P(groups)                                \
@@ -207,6 +208,7 @@ namespace JS {
     P(setMinutes)                            \
     P(setPrototypeOf)                        \
     P(setSeconds)                            \
+    P(setYear)                               \
     P(shift)                                 \
     P(sign)                                  \
     P(sin)                                   \

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -25,14 +25,13 @@ public:
 
     int date() const { return datetime().day(); }
     int day() const { return datetime().weekday(); }
-    int full_year() const { return datetime().year(); }
     int hours() const { return datetime().hour(); }
     u16 milliseconds() const { return m_milliseconds; }
     int minutes() const { return datetime().minute(); }
     int month() const { return datetime().month() - 1; }
     int seconds() const { return datetime().second(); }
     double time() const { return datetime().timestamp() * 1000.0 + milliseconds(); }
-    int year() const { return datetime().day(); }
+    int year() const { return datetime().year(); }
 
     bool is_invalid() const { return m_is_invalid; }
     void set_is_invalid(bool value) { m_is_invalid = value; }

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -42,6 +42,8 @@ void DatePrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.getDay, get_day, 0, attr);
     define_native_function(vm.names.getFullYear, get_full_year, 0, attr);
     define_native_function(vm.names.setFullYear, set_full_year, 3, attr);
+    define_native_function(vm.names.getYear, get_year, 0, attr);
+    define_native_function(vm.names.setYear, set_year, 1, attr);
     define_native_function(vm.names.getHours, get_hours, 0, attr);
     define_native_function(vm.names.setHours, set_hours, 4, attr);
     define_native_function(vm.names.getMilliseconds, get_milliseconds, 0, attr);
@@ -156,6 +158,43 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_full_year)
     auto new_day = new_day_value.as_i32();
 
     datetime.set_time(new_year, new_month, new_day, datetime.hour(), datetime.minute(), datetime.second());
+    this_object->set_is_invalid(false);
+
+    return Value(this_object->time());
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_year)
+{
+    auto* this_object = typed_this(vm, global_object);
+    if (!this_object)
+        return {};
+
+    if (this_object->is_invalid())
+        return js_nan();
+
+    return Value(this_object->year() - 1900);
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_year)
+{
+    auto* this_object = typed_this(vm, global_object);
+    if (!this_object)
+        return {};
+
+    auto& datetime = this_object->datetime();
+
+    auto new_year_value = vm.argument(0).to_number(global_object);
+    if (vm.exception())
+        return {};
+    if (!new_year_value.is_finite_number()) {
+        this_object->set_is_invalid(true);
+        return js_nan();
+    }
+    auto new_year = new_year_value.as_i32();
+    if (new_year >= 0 && new_year <= 99)
+        new_year += 1900;
+
+    datetime.set_time(new_year, datetime.month(), datetime.day(), datetime.hour(), datetime.minute(), datetime.second());
     this_object->set_is_invalid(false);
 
     return Value(this_object->time());

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -115,7 +115,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_full_year)
     if (this_object->is_invalid())
         return js_nan();
 
-    return Value(this_object->full_year());
+    return Value(this_object->year());
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_full_year)

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.h
@@ -23,6 +23,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(get_day);
     JS_DECLARE_NATIVE_FUNCTION(get_full_year);
     JS_DECLARE_NATIVE_FUNCTION(set_full_year);
+    JS_DECLARE_NATIVE_FUNCTION(get_year);
+    JS_DECLARE_NATIVE_FUNCTION(set_year);
     JS_DECLARE_NATIVE_FUNCTION(get_hours);
     JS_DECLARE_NATIVE_FUNCTION(set_hours);
     JS_DECLARE_NATIVE_FUNCTION(get_milliseconds);


### PR DESCRIPTION
The following 17 test262 test-cases now pass:
```
annexB/built-ins/Date/prototype/getYear/length
annexB/built-ins/Date/prototype/getYear/B.2.4
annexB/built-ins/Date/prototype/setYear/this-not-date
annexB/built-ins/Date/prototype/getYear/nan
annexB/built-ins/Date/prototype/getYear/name
annexB/built-ins/Date/prototype/setYear/length
annexB/built-ins/Date/prototype/setYear/B.2.5
annexB/built-ins/Date/prototype/getYear/return-value
annexB/built-ins/Date/prototype/getYear/this-not-date
annexB/built-ins/Date/prototype/setYear/name
annexB/built-ins/Date/prototype/setYear/this-time-nan
annexB/built-ins/Date/prototype/setYear/year-nan
annexB/built-ins/Date/prototype/setYear/this-time-valid
annexB/built-ins/Date/prototype/setYear/time-clip
annexB/built-ins/Date/prototype/setYear/year-number-relative
annexB/built-ins/Date/prototype/setYear/year-number-absolute
annexB/built-ins/Date/prototype/setYear/year-to-number-err
```