### PR TITLE
LibGL: Add a base class for all texture types and implement glBindTexture()

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -153,6 +153,7 @@ bool GLContextWidget::load(const String& filename)
     glGenTextures(1, &tex);
     if (texture_image) {
         // Upload texture data to the GL
+        glBindTexture(GL_TEXTURE_2D, tex);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, texture_image->width(), texture_image->height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, texture_image->scanline(0));
     } else {
         dbgln("3DFileViewer: Couldn't load texture for {}", filename);

--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SOURCES
     Tex/NameAllocator.cpp
-    Tex/Texture.cpp
+    Tex/Texture2D.cpp
     Clipper.cpp
     GLBlend.cpp
     GLColor.cpp

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -257,6 +258,7 @@ GLAPI void glReadBuffer(GLenum mode);
 GLAPI void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels);
 GLAPI void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data);
 GLAPI void glTexCoord2f(GLfloat s, GLfloat t);
+GLAPI void glBindTexture(GLenum target, GLuint texture);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -59,6 +59,7 @@ public:
     virtual void gl_read_pixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels) = 0;
     virtual void gl_tex_image_2d(GLenum target, GLint level, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data) = 0;
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) = 0;
+    virtual void gl_bind_texture(GLenum target, GLuint texture) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLTexture.cpp
+++ b/Userland/Libraries/LibGL/GLTexture.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,4 +23,9 @@ void glDeleteTextures(GLsizei n, const GLuint* textures)
 void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data)
 {
     g_gl_context->gl_tex_image_2d(target, level, internalFormat, width, height, border, format, type, data);
+}
+
+void glBindTexture(GLenum target, GLuint texture)
+{
+    g_gl_context->gl_bind_texture(target, texture);
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -313,7 +313,7 @@ void SoftwareGLContext::gl_end()
         }
 
         // FIXME: Change this when we have texture units/multi-texturing
-        m_rasterizer.submit_triangle(triangle, *m_allocated_textures.find(1)->value);
+        m_rasterizer.submit_triangle(triangle, *static_ptr_cast<Texture2D>(m_allocated_textures.find(1)->value));
     }
 
     triangle_list.clear();
@@ -667,7 +667,7 @@ void SoftwareGLContext::gl_gen_textures(GLsizei n, GLuint* textures)
     for (auto i = 0; i < n; i++) {
         GLuint name = textures[i];
 
-        m_allocated_textures.set(name, adopt_ref(*new Texture()));
+        m_allocated_textures.set(name, adopt_ref(*new Texture2D()));
     }
 }
 
@@ -696,14 +696,14 @@ void SoftwareGLContext::gl_tex_image_2d(GLenum target, GLint level, GLint intern
     // We only support symbolic constants for now
     RETURN_WITH_ERROR_IF(!(internal_format == GL_RGB || internal_format == GL_RGBA), GL_INVALID_ENUM);
     RETURN_WITH_ERROR_IF(type != GL_UNSIGNED_BYTE, GL_INVALID_VALUE);
-    RETURN_WITH_ERROR_IF(level < 0 || level > Texture::LOG2_MAX_TEXTURE_SIZE, GL_INVALID_VALUE);
-    RETURN_WITH_ERROR_IF(width < 0 || height < 0 || width > (2 + Texture::MAX_TEXTURE_SIZE) || height > (2 + Texture::MAX_TEXTURE_SIZE), GL_INVALID_VALUE);
+    RETURN_WITH_ERROR_IF(level < 0 || level > Texture2D::LOG2_MAX_TEXTURE_SIZE, GL_INVALID_VALUE);
+    RETURN_WITH_ERROR_IF(width < 0 || height < 0 || width > (2 + Texture2D::MAX_TEXTURE_SIZE) || height > (2 + Texture2D::MAX_TEXTURE_SIZE), GL_INVALID_VALUE);
     RETURN_WITH_ERROR_IF((width & 2) != 0 || (height & 2) != 0, GL_INVALID_VALUE);
     RETURN_WITH_ERROR_IF(border < 0 || border > 1, GL_INVALID_VALUE);
 
     // TODO: Load texture from the currently active texture unit
     // This is to test the functionality of texture data upload
-    m_allocated_textures.find(1)->value->upload_texture_data(target, level, internal_format, width, height, border, format, type, data);
+    static_ptr_cast<Texture2D>(m_allocated_textures.find(1)->value)->upload_texture_data(target, level, internal_format, width, height, border, format, type, data);
 }
 
 void SoftwareGLContext::gl_front_face(GLenum face)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -68,6 +68,7 @@ public:
     virtual void gl_read_pixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels) override;
     virtual void gl_tex_image_2d(GLenum target, GLint level, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data) override;
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) override;
+    virtual void gl_bind_texture(GLenum target, GLuint texture) override;
 
     virtual void present() override;
 
@@ -127,6 +128,8 @@ private:
     GLclampf m_alpha_test_ref_value = 0;
 
     GLenum m_current_read_buffer = GL_BACK;
+
+    GLuint m_bound_texture_2d = 0;
 
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -414,7 +414,7 @@ SoftwareRasterizer::SoftwareRasterizer(const Gfx::IntSize& min_size)
 {
 }
 
-void SoftwareRasterizer::submit_triangle(const GLTriangle& triangle, const Texture& texture)
+void SoftwareRasterizer::submit_triangle(const GLTriangle& triangle, const Texture2D& texture)
 {
     rasterize_triangle(m_options, *m_render_target, *m_depth_buffer, triangle, [&texture](const FloatVector2& uv, const FloatVector4& color) -> FloatVector4 {
         // TODO: We'd do some kind of multitexturing/blending here

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -414,6 +414,13 @@ SoftwareRasterizer::SoftwareRasterizer(const Gfx::IntSize& min_size)
 {
 }
 
+void SoftwareRasterizer::submit_triangle(const GLTriangle& triangle)
+{
+    rasterize_triangle(m_options, *m_render_target, *m_depth_buffer, triangle, [](const FloatVector2&, const FloatVector4& color) -> FloatVector4 {
+        return color;
+    });
+}
+
 void SoftwareRasterizer::submit_triangle(const GLTriangle& triangle, const Texture2D& texture)
 {
     rasterize_triangle(m_options, *m_render_target, *m_depth_buffer, triangle, [&texture](const FloatVector2& uv, const FloatVector4& color) -> FloatVector4 {

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -32,6 +32,7 @@ public:
     SoftwareRasterizer(const Gfx::IntSize& min_size);
 
     void submit_triangle(const GLTriangle& triangle, const Texture2D& texture);
+    void submit_triangle(const GLTriangle& triangle);
     void resize(const Gfx::IntSize& min_size);
     void clear_color(const FloatVector4&);
     void clear_depth(float);

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -9,7 +9,7 @@
 #include "DepthBuffer.h"
 #include "GL/gl.h"
 #include "GLStruct.h"
-#include "Tex/Texture.h"
+#include "Tex/Texture2D.h"
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Vector4.h>
@@ -31,7 +31,7 @@ class SoftwareRasterizer final {
 public:
     SoftwareRasterizer(const Gfx::IntSize& min_size);
 
-    void submit_triangle(const GLTriangle& triangle, const Texture& texture);
+    void submit_triangle(const GLTriangle& triangle, const Texture2D& texture);
     void resize(const Gfx::IntSize& min_size);
     void clear_color(const FloatVector4&);
     void clear_depth(float);

--- a/Userland/Libraries/LibGL/Tex/Texture.h
+++ b/Userland/Libraries/LibGL/Tex/Texture.h
@@ -1,78 +1,23 @@
 /*
- * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/RefCounted.h>
-#include <AK/Vector.h>
-#include <LibGL/GL/gl.h>
-#include <LibGfx/Vector2.h>
-#include <LibGfx/Vector4.h>
 
 namespace GL {
 
-class Texture final : public RefCounted<Texture> {
+class Texture : public RefCounted<Texture> {
 public:
-    // FIXME: These shouldn't really belong here, they're context specific.
-    static constexpr u16 MAX_TEXTURE_SIZE = 2048;
-    static constexpr u8 LOG2_MAX_TEXTURE_SIZE = 11;
+    virtual ~Texture() { }
 
-    class MipMap {
-    public:
-        MipMap() = default;
-        ~MipMap() = default;
-
-        void set_width(GLsizei width) { m_width = width; }
-        void set_height(GLsizei height) { m_height = height; }
-        GLsizei width() const { return m_width; }
-        GLsizei height() const { return m_height; }
-
-        Vector<u32>& pixel_data() { return m_pixel_data; }
-        const Vector<u32>& pixel_data() const { return m_pixel_data; }
-
-    private:
-        GLsizei m_width;
-        GLsizei m_height;
-        Vector<u32> m_pixel_data;
-    };
-
-    // To quote the Khronos documentation:
-    // "You could say that a texture object contains a sampler object, which you access through the texture interface."
-    // FIXME: Better name?
-    struct TextureSamplerParamaters {
-        GLint m_min_filter { GL_NEAREST_MIPMAP_LINEAR };
-        GLint m_mag_filter { GL_LINEAR };
-        GLint m_wrap_s_mode { GL_REPEAT };
-        GLint m_wrap_t_mode { GL_REPEAT };
-    };
-
-public:
-    Texture() = default;
-    ~Texture() { }
-
-    void upload_texture_data(GLenum target, GLint lod, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* pixels);
-    void replace_sub_texture_data(GLint lod, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* data);
-    FloatVector4 sample_texel(const FloatVector2& uv) const;
-
-    GLenum internal_format() const { return m_internal_format; }
-
-private:
-    template<typename TCallback>
-    void swizzle(Vector<u32>& pixels, TCallback&& callback)
-    {
-        for (auto& pixel : pixels)
-            pixel = callback(pixel);
-    }
-
-private:
-    // FIXME: Mipmaps are currently unused, but we have the plumbing for it at least
-    Array<MipMap, LOG2_MAX_TEXTURE_SIZE> m_mipmaps;
-    GLenum m_internal_format;
-    TextureSamplerParamaters m_sampler_params;
+    virtual bool is_texture_1d() const { return false; }
+    virtual bool is_texture_2d() const { return false; }
+    virtual bool is_texture_3d() const { return false; }
+    virtual bool is_cube_map() const { return false; }
 };
 
 }

--- a/Userland/Libraries/LibGL/Tex/Texture2D.cpp
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.cpp
@@ -6,12 +6,12 @@
 
 #include <AK/Format.h>
 #include <LibGL/GL/gl.h>
-#include <LibGL/Tex/Texture.h>
+#include <LibGL/Tex/Texture2D.h>
 #include <string.h>
 
 namespace GL {
 
-void Texture::upload_texture_data(GLenum, GLint lod, GLint internal_format, GLsizei width, GLsizei height, GLint, GLenum format, GLenum, const GLvoid* pixels)
+void Texture2D::upload_texture_data(GLenum, GLint lod, GLint internal_format, GLsizei width, GLsizei height, GLint, GLenum format, GLenum, const GLvoid* pixels)
 {
     // NOTE: Some target, format, and internal formats are currently unsupported.
     // Considering we control this library, and `gl.h` itself, we don't need to add any
@@ -112,7 +112,7 @@ void Texture::upload_texture_data(GLenum, GLint lod, GLint internal_format, GLsi
     mip.set_height(height);
 }
 
-FloatVector4 Texture::sample_texel(const FloatVector2& uv) const
+FloatVector4 Texture2D::sample_texel(const FloatVector2& uv) const
 {
     auto& mip = m_mipmaps.at(0);
 

--- a/Userland/Libraries/LibGL/Tex/Texture2D.h
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Texture.h"
+
+#include <AK/Array.h>
+#include <AK/RefCounted.h>
+#include <AK/Vector.h>
+#include <LibGL/GL/gl.h>
+#include <LibGfx/Vector2.h>
+#include <LibGfx/Vector4.h>
+
+namespace GL {
+
+class Texture2D final : public Texture {
+public:
+    // FIXME: These shouldn't really belong here, they're context specific.
+    static constexpr u16 MAX_TEXTURE_SIZE = 2048;
+    static constexpr u8 LOG2_MAX_TEXTURE_SIZE = 11;
+
+    class MipMap {
+    public:
+        MipMap() = default;
+        ~MipMap() = default;
+
+        void set_width(GLsizei width) { m_width = width; }
+        void set_height(GLsizei height) { m_height = height; }
+        GLsizei width() const { return m_width; }
+        GLsizei height() const { return m_height; }
+
+        Vector<u32>& pixel_data() { return m_pixel_data; }
+        const Vector<u32>& pixel_data() const { return m_pixel_data; }
+
+    private:
+        GLsizei m_width;
+        GLsizei m_height;
+        Vector<u32> m_pixel_data;
+    };
+
+    // To quote the Khronos documentation:
+    // "You could say that a texture object contains a sampler object, which you access through the texture interface."
+    // FIXME: Better name?
+    struct TextureSamplerParamaters {
+        GLint m_min_filter { GL_NEAREST_MIPMAP_LINEAR };
+        GLint m_mag_filter { GL_LINEAR };
+        GLint m_wrap_s_mode { GL_REPEAT };
+        GLint m_wrap_t_mode { GL_REPEAT };
+    };
+
+public:
+    Texture2D() = default;
+    ~Texture2D() { }
+
+    virtual bool is_texture_2d() const override { return true; }
+
+    void upload_texture_data(GLenum target, GLint lod, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* pixels);
+    void replace_sub_texture_data(GLint lod, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* data);
+    FloatVector4 sample_texel(const FloatVector2& uv) const;
+
+    GLenum internal_format() const { return m_internal_format; }
+
+private:
+    template<typename TCallback>
+    void swizzle(Vector<u32>& pixels, TCallback&& callback)
+    {
+        for (auto& pixel : pixels)
+            pixel = callback(pixel);
+    }
+
+private:
+    // FIXME: Mipmaps are currently unused, but we have the plumbing for it at least
+    Array<MipMap, LOG2_MAX_TEXTURE_SIZE> m_mipmaps;
+    GLenum m_internal_format;
+    TextureSamplerParamaters m_sampler_params;
+};
+
+}


### PR DESCRIPTION
Since there will be more than just 2D textures (1D, 3D, cube maps, texture arrays) it makes sense to introduce this indirection already.
Textures are now only allocated once they are bound to a texture target with `glBindTexture()`. This also determines their type than can not be changed afterwards.

ref #7062