### PR TITLE
LibTest+test-js: Add back the lost test262 parser test option (plus misc fixes to make it run)

### DIFF
--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -9,6 +9,8 @@
 
 TEST_ROOT("Userland/Libraries/LibJS/Tests");
 
+TESTJS_PROGRAM_FLAG(test262_parser_tests, "Run test262 parser tests", "test262-parser-tests", 0);
+
 TESTJS_GLOBAL_FUNCTION(is_strict_mode, isStrictMode, 0)
 {
     return JS::Value(vm.in_strict_mode());
@@ -28,4 +30,64 @@ TESTJS_GLOBAL_FUNCTION(run_queued_promise_jobs, runQueuedPromiseJobs)
 {
     vm.run_queued_promise_jobs();
     return JS::js_undefined();
+}
+
+TESTJS_RUN_FILE_FUNCTION(const String& test_file, JS::Interpreter&)
+{
+    if (!test262_parser_tests)
+        return Test::JS::RunFileHookResult::RunAsNormal;
+
+    auto start_time = Test::JS::get_time_in_ms();
+
+    LexicalPath path(test_file);
+    auto& dirname = path.dirname();
+    enum {
+        Early,
+        Fail,
+        Pass,
+        ExplicitPass,
+    } expectation { Pass };
+
+    if (dirname.ends_with("early"))
+        expectation = Early;
+    else if (dirname.ends_with("fail"))
+        expectation = Fail;
+    else if (dirname.ends_with("pass-explicit"))
+        expectation = ExplicitPass;
+    else if (dirname.ends_with("pass"))
+        expectation = Pass;
+    else
+        return Test::JS::RunFileHookResult::SkipFile;
+
+    auto parse_result = Test::JS::parse_file(test_file);
+    bool test_passed = true;
+    String message;
+    String expectation_string;
+
+    switch (expectation) {
+    case Early:
+    case Fail:
+        expectation_string = "File should not parse";
+        test_passed = parse_result.is_error();
+        if (!test_passed)
+            message = "Expected the file to fail parsing, but it did not";
+        break;
+    case Pass:
+    case ExplicitPass:
+        expectation_string = "File should parse";
+        test_passed = !parse_result.is_error();
+        if (!test_passed)
+            message = "Expected the file to parse, but it did not";
+        break;
+    }
+
+    auto test_result = test_passed ? Test::Result::Pass : Test::Result::Fail;
+
+    return Test::JS::JSFileResult {
+        LexicalPath::relative_path(test_file, Test::JS::g_test_root),
+        {},
+        Test::JS::get_time_in_ms() - start_time,
+        test_result,
+        { Test::Suite { "Parse file", test_result, { { expectation_string, test_result, message } } } }
+    };
 }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1482,6 +1482,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
                 consume();
                 if (!match(TokenType::Identifier)) {
                     syntax_error("Expected a binding pattern as the value of a named element in destructuring object");
+                    break;
                 } else {
                     auto identifier_start = position();
                     auto token = consume(TokenType::Identifier);
@@ -1523,6 +1524,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
                     syntax_error("Expected a binding pattern after ... in destructuring list");
                 else
                     syntax_error("Expected a binding pattern or identifier in destructuring list");
+                break;
             } else {
                 RefPtr<Expression> initializer;
                 if (match(TokenType::Equals)) {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1961,7 +1961,9 @@ NonnullRefPtr<Statement> Parser::parse_for_in_of_statement(NonnullRefPtr<ASTNode
         auto declarations = static_cast<VariableDeclaration&>(*lhs).declarations();
         if (declarations.size() > 1)
             syntax_error("multiple declarations not allowed in for..in/of");
-        if (declarations.first().init() != nullptr)
+        if (declarations.size() < 1)
+            syntax_error("need exactly one variable declaration in for..in/of");
+        else if (declarations.first().init() != nullptr)
             syntax_error("variable initializer not allowed in for..in/of");
     }
     auto in_or_of = consume();


### PR DESCRIPTION
Fixes #7566.