### PR TITLE
AK: Declare malloc_good_size as extern "C"

### DIFF
--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -10,7 +10,9 @@
 #    include <new>
 
 #    ifndef AK_OS_MACOS
+extern "C" {
 inline size_t malloc_good_size(size_t size) { return size; }
+}
 #    else
 #        include <malloc/malloc.h>
 #    endif


### PR DESCRIPTION
This would otherwise cause an error with clang when `__serenity__` wasn't
defined.