### PR TITLE
GIFLoader: Use correct durations, improve fuzzing coverage

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -4,12 +4,32 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
+#include <AK/Format.h>
+#include <AK/String.h>
 #include <LibGfx/GIFLoader.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    Gfx::load_gif_from_memory(data, size);
+    Gfx::GIFImageDecoderPlugin gif_decoder(data, size);
+    auto bitmap = gif_decoder.bitmap();
+    if (bitmap) {
+        // Looks like a valid GIF. Try to load the other frames:
+        dbgln_if(GIF_DEBUG, "bitmap size: {}", bitmap->size());
+        dbgln_if(GIF_DEBUG, "codec size: {}", gif_decoder.size());
+        dbgln_if(GIF_DEBUG, "is_sniff: {}", gif_decoder.sniff());
+        dbgln_if(GIF_DEBUG, "is_animated: {}", gif_decoder.is_animated());
+        dbgln_if(GIF_DEBUG, "loop_count: {}", gif_decoder.loop_count());
+        dbgln_if(GIF_DEBUG, "frame_count: {}", gif_decoder.frame_count());
+        for (size_t i = 0; i < gif_decoder.frame_count(); ++i) {
+            auto ifd = gif_decoder.frame(i);
+            dbgln_if(GIF_DEBUG, "frame #{} size: {}", i, ifd.image->size());
+            dbgln_if(GIF_DEBUG, "frame #{} duration: {}", i, ifd.duration);
+        }
+        dbgln_if(GIF_DEBUG, "Done.");
+    }
+
     return 0;
 }

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -511,7 +511,7 @@ static bool load_gif_frame_descriptors(GIFLoadingContext& context)
                 u8 transparent = sub_block[0] & 1;
                 current_image->transparent = transparent == 1;
 
-                u16 duration = sub_block[1] + ((u16)sub_block[2] >> 8);
+                u16 duration = sub_block[1] + ((u16)sub_block[2] << 8);
                 current_image->duration = duration;
 
                 current_image->transparency_index = sub_block[3];


### PR DESCRIPTION
Here's an example that serenity used to parse wrongly:

![counting](https://user-images.githubusercontent.com/2690845/120100994-176eb400-c144-11eb-806f-42ecfaf20b1f.gif)

In every correct implementation, you can count along: 1-onethousand, 2-onethousand, 3-onethousand, 4-onethousand, 5-onethousand, 6-onethousand. In Serenity, the first frame was displayed for a much too short time (44 centiseconds instead of 300). This is due to a wrong shift that effectively zeroed the upper byte.

I noticed this bug through Browser, because an easteregg on one of my websites didn't work correctly. :)

While investigating this bug, I also noticed that the Fuzzer used to only load the first frame.