### PR TITLE
AK: Fix accidentally-quadratic behavior in StringBuilder

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -187,6 +187,8 @@ public:
     operator Bytes() { return bytes(); }
     operator ReadonlyBytes() const { return bytes(); }
 
+    ALWAYS_INLINE size_t capacity() const { return is_inline() ? inline_capacity : m_outline_capacity; }
+
 private:
     ByteBuffer(size_t size)
     {
@@ -236,7 +238,6 @@ private:
     }
 
     ALWAYS_INLINE bool is_inline() const { return m_size <= inline_capacity; }
-    ALWAYS_INLINE size_t capacity() const { return is_inline() ? inline_capacity : m_outline_capacity; }
 
     size_t m_size { 0 };
     union {

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -21,10 +21,11 @@ inline void StringBuilder::will_append(size_t size)
     Checked<size_t> needed_capacity = m_length;
     needed_capacity += size;
     VERIFY(!needed_capacity.has_overflow());
+    if (needed_capacity <= m_buffer.capacity())
+        return;
+
     Checked<size_t> expanded_capacity = needed_capacity;
-    // Prefer to completely use the inline buffer first
-    if (needed_capacity > inline_capacity)
-        expanded_capacity *= 2;
+    expanded_capacity *= 2;
     VERIFY(!expanded_capacity.has_overflow());
     m_buffer.grow(expanded_capacity.value());
 }


### PR DESCRIPTION
Found by OSS Fuzz:
- [#34451](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34451&sort=-id&q=proj%3Dserenity) (FuzzUTF16BEDecoder)
- And probably others: Latin1, Latin2, Hebrew, and CryllicDecoders have similar Timeouts, that might be fixed by this.

The reason is that `StringBuilder` always did the doubling, regardless whether it was necessary or not. For example, let's say `m_length=400`, and the ByteBuffer holds 800 bytes, and now we call `will_append(1)`. Then it calls `ByteBuffer::grow(802)`, for no good reason.

Note that this effect was also present in Serenity, because `(k)malloc_good_size` only rounded up to the next page size, instead of applying any multiplicative factor.

Related commit: 3908a49661a00e15621748dcb2b0424f29433571

CC @gunnarbeutner, have a look at https://accidentallyquadratic.tumblr.com/ :)