### PR TITLE
LibGL: Implement primitive Texture Unit handling

### DIFF
--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     Tex/NameAllocator.cpp
     Tex/Texture2D.cpp
+    Tex/TextureUnit.cpp
     Clipper.cpp
     GLBlend.cpp
     GLColor.cpp

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -161,6 +161,40 @@ extern "C" {
 // Texture targets
 #define GL_TEXTURE_2D 0x0DE1
 
+// Texture Unit indices
+#define GL_TEXTURE0 0x84C0
+#define GL_TEXTURE1 0x84C1
+#define GL_TEXTURE2 0x84C2
+#define GL_TEXTURE3 0x84C3
+#define GL_TEXTURE4 0x84C4
+#define GL_TEXTURE5 0x84C5
+#define GL_TEXTURE6 0x84C6
+#define GL_TEXTURE7 0x84C7
+#define GL_TEXTURE8 0x84C8
+#define GL_TEXTURE9 0x84C9
+#define GL_TEXTURE10 0x84CA
+#define GL_TEXTURE11 0x84CB
+#define GL_TEXTURE12 0x84CC
+#define GL_TEXTURE13 0x84CD
+#define GL_TEXTURE14 0x84CE
+#define GL_TEXTURE15 0x84CF
+#define GL_TEXTURE16 0x84D0
+#define GL_TEXTURE17 0x84D1
+#define GL_TEXTURE18 0x84D2
+#define GL_TEXTURE19 0x84D3
+#define GL_TEXTURE20 0x84D4
+#define GL_TEXTURE21 0x84D5
+#define GL_TEXTURE22 0x84D6
+#define GL_TEXTURE23 0x84D7
+#define GL_TEXTURE24 0x84D8
+#define GL_TEXTURE25 0x84D9
+#define GL_TEXTURE26 0x84DA
+#define GL_TEXTURE27 0x84DB
+#define GL_TEXTURE28 0x84DC
+#define GL_TEXTURE29 0x84DD
+#define GL_TEXTURE30 0x84DE
+#define GL_TEXTURE31 0x84DF
+
 // Texture Environment and Parameters
 #define GL_NEAREST 0x2600
 #define GL_LINEAR 0x2601
@@ -259,6 +293,7 @@ GLAPI void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum 
 GLAPI void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data);
 GLAPI void glTexCoord2f(GLfloat s, GLfloat t);
 GLAPI void glBindTexture(GLenum target, GLuint texture);
+GLAPI void glActiveTexture(GLenum texture);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -60,6 +60,7 @@ public:
     virtual void gl_tex_image_2d(GLenum target, GLint level, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data) = 0;
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) = 0;
     virtual void gl_bind_texture(GLenum target, GLuint texture) = 0;
+    virtual void gl_active_texture(GLenum texture) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLTexture.cpp
+++ b/Userland/Libraries/LibGL/GLTexture.cpp
@@ -29,3 +29,10 @@ void glBindTexture(GLenum target, GLuint texture)
 {
     g_gl_context->gl_bind_texture(target, texture);
 }
+
+// Note: This is an _extremely_ misleading API name. This sets the active
+// texture unit, NOT the active texture itself...
+void glActiveTexture(GLenum texture)
+{
+    g_gl_context->gl_active_texture(texture);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1286,6 +1286,13 @@ void SoftwareGLContext::gl_bind_texture(GLenum target, GLuint texture)
     }
 }
 
+void SoftwareGLContext::gl_active_texture(GLenum texture)
+{
+    RETURN_WITH_ERROR_IF(texture < GL_TEXTURE0 || texture > GL_TEXTURE31, GL_INVALID_ENUM);
+
+    m_active_texture_unit = &m_texture_units.at(texture - GL_TEXTURE0);
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -131,8 +131,6 @@ private:
 
     GLenum m_current_read_buffer = GL_BACK;
 
-    GLuint m_bound_texture_2d = 0;
-
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 
     Clipper m_clipper;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -12,6 +12,7 @@
 #include "SoftwareRasterizer.h"
 #include "Tex/NameAllocator.h"
 #include "Tex/Texture.h"
+#include "Tex/TextureUnit.h"
 #include <AK/HashMap.h>
 #include <AK/RefPtr.h>
 #include <AK/Tuple.h>
@@ -138,6 +139,8 @@ private:
     // Texture objects
     TextureNameAllocator m_name_allocator;
     HashMap<GLuint, RefPtr<Texture>> m_allocated_textures;
+    Array<TextureUnit, 32> m_texture_units;
+    TextureUnit* m_active_texture_unit { &m_texture_units[0] };
 
     SoftwareRasterizer m_rasterizer;
 

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -70,6 +70,7 @@ public:
     virtual void gl_tex_image_2d(GLenum target, GLint level, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data) override;
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) override;
     virtual void gl_bind_texture(GLenum target, GLuint texture) override;
+    virtual void gl_active_texture(GLenum texture) override;
 
     virtual void present() override;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -10,6 +10,8 @@
 #include "GL/gl.h"
 #include "GLStruct.h"
 #include "Tex/Texture2D.h"
+#include "Tex/TextureUnit.h"
+#include <AK/Array.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Vector4.h>
@@ -31,7 +33,7 @@ class SoftwareRasterizer final {
 public:
     SoftwareRasterizer(const Gfx::IntSize& min_size);
 
-    void submit_triangle(const GLTriangle& triangle, const Texture2D& texture);
+    void submit_triangle(const GLTriangle& triangle, const Array<TextureUnit, 32>& texture_units);
     void submit_triangle(const GLTriangle& triangle);
     void resize(const Gfx::IntSize& min_size);
     void clear_color(const FloatVector4&);

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.cpp
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGL/GL/gl.h>
+#include <LibGL/Tex/TextureUnit.h>
+
+namespace GL {
+
+void TextureUnit::bind_texture_to_target(GLenum texture_target, const RefPtr<Texture>& texture)
+{
+    switch (texture_target) {
+    case GL_TEXTURE_2D:
+        m_texture_target_2d = texture;
+        m_currently_bound_texture = texture;
+        m_currently_bound_target = GL_TEXTURE_2D;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void TextureUnit::unbind_texture(GLenum texture_target)
+{
+    switch (texture_target) {
+    case GL_TEXTURE_2D:
+        m_texture_target_2d = nullptr;
+        m_currently_bound_target = 0;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    m_currently_bound_texture = nullptr;
+}
+
+}

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.h
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/OwnPtr.h>
+#include <LibGL/Tex/Texture2D.h>
+
+namespace GL {
+
+class TextureUnit {
+public:
+    TextureUnit() = default;
+
+    void bind_texture_to_target(GLenum texture_target, const RefPtr<Texture>& texture);
+    void unbind_texture(GLenum texture_target);
+    const RefPtr<Texture>& get_bound_texture() const { return m_currently_bound_texture; }
+
+    GLenum currently_bound_target() const { return m_currently_bound_target; }
+    bool is_bound() const { return m_currently_bound_texture != nullptr; }
+
+private:
+    RefPtr<Texture2D> m_texture_target_2d { nullptr };
+    RefPtr<Texture> m_currently_bound_texture { nullptr };
+    GLenum m_currently_bound_target;
+};
+
+}

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.h
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.h
@@ -17,14 +17,16 @@ public:
 
     void bind_texture_to_target(GLenum texture_target, const RefPtr<Texture>& texture);
     void unbind_texture(GLenum texture_target);
-    const RefPtr<Texture>& get_bound_texture() const { return m_currently_bound_texture; }
+
+    RefPtr<Texture2D>& bound_texture_2d() const { return m_texture_target_2d; }
+    RefPtr<Texture>& bound_texture() const { return m_currently_bound_texture; }
 
     GLenum currently_bound_target() const { return m_currently_bound_target; }
-    bool is_bound() const { return m_currently_bound_texture != nullptr; }
+    bool is_bound() const { return !m_currently_bound_texture.is_null(); }
 
 private:
-    RefPtr<Texture2D> m_texture_target_2d { nullptr };
-    RefPtr<Texture> m_currently_bound_texture { nullptr };
+    mutable RefPtr<Texture2D> m_texture_target_2d { nullptr };
+    mutable RefPtr<Texture> m_currently_bound_texture { nullptr };
     GLenum m_currently_bound_target;
 };
 


### PR DESCRIPTION
Some really primitive texture unit stuff. The spec and documentation is a little bit confusing on what and how this is actually supposed to work outside of "A Texture Image unit contains a whole bunch of state [paraphrased]", however, we are no longer reliant on having a single texture object bound at a time, or looking up textures in the allocated texture list. 

We currently don't do any texture blending, which will be part of another PR (outside of the scope of this).