### PR TITLE
Kernel: Don't log profile data before/after the process/thread lifetime

### DIFF
--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -257,11 +257,11 @@ void* kmalloc(size_t size)
         PANIC("kmalloc: Out of memory (requested size: {})", size);
     }
 
-    Process* current_process = Process::current();
-    if (!current_process && Scheduler::colonel_initialized())
-        current_process = Scheduler::colonel();
-    if (current_process)
-        PerformanceManager::add_kmalloc_perf_event(*current_process, size, (FlatPtr)ptr);
+    Thread* current_thread = Thread::current();
+    if (!current_thread)
+        current_thread = Processor::idle_thread();
+    if (current_thread)
+        PerformanceManager::add_kmalloc_perf_event(*current_thread, size, (FlatPtr)ptr);
 
     return ptr;
 }
@@ -277,11 +277,11 @@ void kfree(void* ptr)
     ++g_nested_kfree_calls;
 
     if (g_nested_kfree_calls == 1) {
-        Process* current_process = Process::current();
-        if (!current_process && Scheduler::colonel_initialized())
-            current_process = Scheduler::colonel();
-        if (current_process)
-            PerformanceManager::add_kfree_perf_event(*current_process, 0, (FlatPtr)ptr);
+        Thread* current_thread = Thread::current();
+        if (!current_thread)
+            current_thread = Processor::idle_thread();
+        if (current_thread)
+            PerformanceManager::add_kfree_perf_event(*current_thread, 0, (FlatPtr)ptr);
     }
 
     g_kmalloc_global->m_heap.deallocate(ptr);

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -445,11 +445,6 @@ void Scheduler::prepare_for_idle_loop()
     scheduler_data.m_in_scheduler = true;
 }
 
-bool Scheduler::colonel_initialized()
-{
-    return !!s_colonel_process;
-}
-
 Process* Scheduler::colonel()
 {
     VERIFY(s_colonel_process);

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -43,7 +43,6 @@ public:
     static void leave_on_first_switch(u32 flags);
     static void prepare_after_exec();
     static void prepare_for_idle_loop();
-    static bool colonel_initialized();
     static Process* colonel();
     static void idle_loop(void*);
     static void invoke_async();

--- a/Kernel/Syscalls/exit.cpp
+++ b/Kernel/Syscalls/exit.cpp
@@ -19,6 +19,7 @@ void Process::sys$exit(int status)
     }
 
     auto* current_thread = Thread::current();
+    current_thread->set_profiling_suppressed();
     PerformanceManager::add_thread_exit_event(*current_thread);
 
     die();

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -88,6 +88,7 @@ void Process::sys$exit_thread(Userspace<void*> exit_value, Userspace<void*> stac
     }
 
     auto current_thread = Thread::current();
+    current_thread->set_profiling_suppressed();
     PerformanceManager::add_thread_exit_event(*current_thread);
 
     if (stack_location) {

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1131,6 +1131,9 @@ public:
         return m_nested_profiler_calls.fetch_sub(1, AK::MemoryOrder::memory_order_acquire);
     }
 
+    bool is_profiling_suppressed() const { return m_is_profiling_suppressed; }
+    void set_profiling_suppressed() { m_is_profiling_suppressed = true; }
+
 private:
     Thread(NonnullRefPtr<Process>, NonnullOwnPtr<Region>, NonnullRefPtr<Timer>);
 
@@ -1272,6 +1275,8 @@ private:
     Atomic<u32> m_nested_profiler_calls { 0 };
 
     RefPtr<Timer> m_block_timer;
+
+    bool m_is_profiling_suppressed { false };
 
     void yield_without_holding_big_lock();
     void donate_without_holding_big_lock(RefPtr<Thread>&, const char*);


### PR DESCRIPTION
There were a few cases where we could end up logging profiling events before or after the associated process or thread exists in the profile:

After enabling profiling we might end up with CPU samples before we had a chance to synthesize process/thread creation events.

After a thread exits we would still log associated `kmalloc`/`kfree` events. Instead we now just ignore those events.