### PR TITLE
AK: Verify that m_impl is non-null in String::operator[]

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -160,6 +160,7 @@ public:
 
     [[nodiscard]] ALWAYS_INLINE const char& operator[](size_t i) const
     {
+        VERIFY(!is_null());
         return (*m_impl)[i];
     }
 


### PR DESCRIPTION
I have added a verification that the string is non-null to `String::operator[]`.

This helps to find bugs where null strings are indexed into with operator[], as this would previously only report a RefPtr null dereference, which made it a lot harder to find what is actually going on.