### PR TITLE
WebServer: Put dbgln's behind WEBSERVER_DEBUG

### DIFF
--- a/AK/Debug.h.in
+++ b/AK/Debug.h.in
@@ -422,6 +422,10 @@
 #cmakedefine01 WASM_TRACE_DEBUG
 #endif
 
+#ifndef WEBSERVER_DEBUG
+#cmakedefine01 WEBSERVER_DEBUG
+#endif
+
 #ifndef WINDOWMANAGER_DEBUG
 #cmakedefine01 WINDOWMANAGER_DEBUG
 #endif

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -186,6 +186,7 @@ set(WASM_TRACE_DEBUG ON)
 set(PDF_DEBUG ON)
 set(SOLITAIRE_DEBUG ON)
 set(DDS_DEBUG ON)
+set(WEBSERVER_DEBUG ON)
 
 # False positive: DEBUG is a flag but it works differently.
 # set(DEBUG ON)


### PR DESCRIPTION
These dbgln's caused excessive load in the WebServer process,
accounting for ~67% of the processing time when serving a webpage
with a bunch of resources like serenityos.org/happy/2nd/.

Before:
![webserver-dbgln-before](https://user-images.githubusercontent.com/6866019/120108743-d6d46200-c166-11eb-8a2c-da653bf6f48d.png)

After:
![webserver-dbgln-after](https://user-images.githubusercontent.com/6866019/120108749-db007f80-c166-11eb-9b81-6cc8dfa52691.png)
