### PR TITLE
LibC: Don't clear errno on success

### DIFF
--- a/Userland/Libraries/LibC/errno.h
+++ b/Userland/Libraries/LibC/errno.h
@@ -15,7 +15,6 @@
             errno = -rc;                           \
             return (bad_ret);                      \
         }                                          \
-        errno = 0;                                 \
         return (good_ret);                         \
     } while (0)
 


### PR DESCRIPTION
POSIX (`errno(3p)`) states that errno should not be set to zero.

This helps with applications that don't expect errno to get updated unless an intermediate syscall also fails.