### PR TITLE
AK: Honor variable precision argument when formatting

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -452,7 +452,13 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
                 }
             }
             if (*p == '*') {
-                state.field_width = NextArgument<int>()(ap);
+                if (state.dot) {
+                    state.has_fraction_length = true;
+                    state.fraction_length = NextArgument<int>()(ap);
+                } else {
+                    state.field_width = NextArgument<int>()(ap);
+                }
+
                 if (*(p + 1))
                     goto one_more;
             }


### PR DESCRIPTION
printf didn't check whether the additional integer variable belongs to the field width specifier or to the precision specifier, and always applied it to the field width instead.

Implement the case distinction that we already use in literal width and precision specifiers for the variable version as well so that they are correctly attributed.