### PR TITLE
LibCrypto: Fix bound checks when reading bitmaps

### DIFF
--- a/Userland/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.cpp
@@ -176,7 +176,7 @@ Result<const BitmapView, DecodeError> Decoder::decode_bit_string(ReadonlyBytes d
         return DecodeError::InvalidInputFormat;
 
     auto unused_bits = data[0];
-    auto total_size_in_bits = data.size() * 8;
+    auto total_size_in_bits = (data.size() - 1) * 8;
 
     if (unused_bits > total_size_in_bits)
         return DecodeError::Overflow;

--- a/Userland/Libraries/LibCrypto/PK/RSA.h
+++ b/Userland/Libraries/LibCrypto/PK/RSA.h
@@ -31,8 +31,6 @@ public:
     {
     }
 
-    //--stuff it should do
-
     const Integer& modulus() const { return m_modulus; }
     const Integer& public_exponent() const { return m_public_exponent; }
     size_t length() const { return m_length; }
@@ -66,7 +64,6 @@ public:
     {
     }
 
-    //--stuff it should do
     const Integer& modulus() const { return m_modulus; }
     const Integer& private_exponent() const { return m_private_exponent; }
     const Integer& public_exponent() const { return m_public_exponent; }


### PR DESCRIPTION
This only affects malformed RSA keys. Instead of accepting and
continuing with potentially broken pointers (and in ASAN, crashing), we
now consider bitmaps malformed, and stop parsing.

Found by OSS Fuzz: #31698, long-standing-bug:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31698

Fun fact: The "if" only exists because of OSS Fuzz.
8cc279ed74dc0b16a187052d2454c26c8c6ecaf2

CC @alimpfard