### PR TITLE
ConsoleManagement: Fix crash when switching to console 5 & 6

### DIFF
--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -70,7 +70,7 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
     default:
         if (m_modifiers & Mod_Alt) {
             switch (ch) {
-            case 0x02 ... 0x07: // 1 to 6
+            case 0x02 ... 0x01 + ConsoleManagement::s_max_virtual_consoles:
                 g_io_work->queue([this, ch]() {
                     ConsoleManagement::the().switch_to(ch - 0x02);
                 });

--- a/Kernel/TTY/ConsoleManagement.cpp
+++ b/Kernel/TTY/ConsoleManagement.cpp
@@ -44,7 +44,7 @@ UNMAP_AFTER_INIT ConsoleManagement::ConsoleManagement()
 
 UNMAP_AFTER_INIT void ConsoleManagement::initialize()
 {
-    for (size_t index = 0; index < 4; index++) {
+    for (size_t index = 0; index < s_max_virtual_consoles; index++) {
         // FIXME: Better determine the debug TTY we chose...
         if (index == 1) {
             m_consoles.append(VirtualConsole::create_with_preset_log(index, ConsoleDevice::the().logbuffer()));

--- a/Kernel/TTY/ConsoleManagement.h
+++ b/Kernel/TTY/ConsoleManagement.h
@@ -20,6 +20,8 @@ class ConsoleManagement {
 public:
     ConsoleManagement();
 
+    static constexpr unsigned s_max_virtual_consoles = 6;
+
     static bool is_initialized();
     static ConsoleManagement& the();
 


### PR DESCRIPTION
The changes in commit 20743e8aede1de46195dd61ad18002cd52db7d3a removed the s_max_virtual_consoles constant and hardcoded the number of consoles to 4. But in PS2KeyboardDevice the keyboard shortcuts for switching to consoles were hardcoded to 6.

I reintroduced the constant and added it in both places.