### PR TITLE
AK: Do not VERIFY while iterating invalid code point bytes in UTF8View, return a U+FFFD 'REPLACEMENT CHARACTER' instead

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -215,7 +215,7 @@ URL URLParser::parse(Badge<URL>, const StringView& raw_input, URL const* base_ur
     Utf8CodePointIterator iterator = input.begin();
 
     auto get_remaining = [&input, &iterator] {
-        return input.substring_view(iterator - input.begin() + iterator.code_point_length_in_bytes()).as_string();
+        return input.substring_view(iterator - input.begin() + iterator.underlying_code_point_length_in_bytes()).as_string();
     };
 
     // NOTE: "continue" should only be used to prevent incrementing the iterator, as this is done at the end of the loop.

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -33,7 +33,13 @@ public:
         return m_ptr - other.m_ptr;
     }
 
-    size_t code_point_length_in_bytes() const;
+    // Note : These methods return the information about the underlying UTF-8 bytes.
+    // If the UTF-8 string encoding is not valid at the iterator's position, then the underlying bytes might be different from the
+    // decoded character's re-encoded bytes (which will be an `0xFFFD REPLACEMENT CHARACTER` with an UTF-8 length of three bytes).
+    // If your code relies on the decoded character being equivalent to the re-encoded character, use the `UTF8View::validate()`
+    // method on the view prior to using its iterator.
+    size_t underlying_code_point_length_in_bytes() const;
+    ReadonlyBytes underlying_code_point_bytes() const;
     bool done() const { return m_length == 0; }
 
 private:

--- a/Tests/AK/TestUtf8.cpp
+++ b/Tests/AK/TestUtf8.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/ByteBuffer.h>
 #include <AK/Utf8View.h>
 
 TEST_CASE(decode_ascii)
@@ -33,12 +34,15 @@ TEST_CASE(decode_utf8)
     EXPECT(valid_bytes == (size_t)utf8.byte_length());
 
     u32 expected[] = { 1055, 1088, 1080, 1074, 1077, 1090, 44, 32, 1084, 1080, 1088, 33, 32, 128512, 32, 947, 949, 953, 940, 32, 963, 959, 965, 32, 954, 972, 963, 956, 959, 962, 32, 12371, 12435, 12395, 12385, 12399, 19990, 30028 };
+    String expected_underlying_bytes[] = { "П", "р", "и", "в", "е", "т", ",", " ", "м", "и", "р", "!", " ", "😀", " ", "γ", "ε", "ι", "ά", " ", "σ", "ο", "υ", " ", "κ", "ό", "σ", "μ", "ο", "ς", " ", "こ", "ん", "に", "ち", "は", "世", "界" };
     size_t expected_size = sizeof(expected) / sizeof(expected[0]);
 
     size_t i = 0;
-    for (u32 code_point : utf8) {
+    for (auto it = utf8.begin(); it != utf8.end(); ++it) {
+        u32 code_point = *it;
         VERIFY(i < expected_size);
         EXPECT_EQ(code_point, expected[i]);
+        EXPECT_EQ(it.underlying_code_point_bytes(), expected_underlying_bytes[i].bytes());
         i++;
     }
     EXPECT_EQ(i, expected_size);
@@ -102,4 +106,79 @@ TEST_CASE(iterate_utf8)
         *iterator;
         return Test::Crash::Failure::DidNotCrash;
     });
+}
+
+TEST_CASE(decode_invalid_ut8)
+{
+    // Test case 1 : Getting an extension byte as first byte of the code point
+    {
+        char raw_data[] = { 'a', 'b', (char)0xA0, 'd', 0 };
+        Utf8View view { raw_data };
+        u32 expected_characters[] = { 'a', 'b', 0xFFFD, 'd' };
+        String expected_underlying_bytes[] = { "a", "b", "\xA0", "d" };
+        size_t expected_size = sizeof(expected_characters) / sizeof(expected_characters[0]);
+        size_t i = 0;
+        for (auto it = view.begin(); it != view.end(); ++it) {
+            u32 code_point = *it;
+            VERIFY(i < expected_size);
+            EXPECT_EQ(code_point, expected_characters[i]);
+            EXPECT_EQ(it.underlying_code_point_bytes(), expected_underlying_bytes[i].bytes());
+            i++;
+        }
+        VERIFY(i == expected_size);
+    }
+
+    // Test case 2 : Getting a non-extension byte when an extension byte is expected
+    {
+        char raw_data[] = { 'a', 'b', (char)0xC0, 'd', 'e', 0 };
+        Utf8View view { raw_data };
+        u32 expected_characters[] = { 'a', 'b', 0xFFFD, 'd', 'e' };
+        String expected_underlying_bytes[] = { "a", "b", "\xC0", "d", "e" };
+        size_t expected_size = sizeof(expected_characters) / sizeof(expected_characters[0]);
+        size_t i = 0;
+        for (auto it = view.begin(); it != view.end(); ++it) {
+            u32 code_point = *it;
+            VERIFY(i < expected_size);
+            EXPECT_EQ(code_point, expected_characters[i]);
+            EXPECT_EQ(it.underlying_code_point_bytes(), expected_underlying_bytes[i].bytes());
+            i++;
+        }
+        VERIFY(i == expected_size);
+    }
+
+    // Test case 3 : Not enough bytes before the end of the string
+    {
+        char raw_data[] = { 'a', 'b', (char)0x90, 'd', 0 };
+        Utf8View view { raw_data };
+        u32 expected_characters[] = { 'a', 'b', 0xFFFD, 'd' };
+        String expected_underlying_bytes[] = { "a", "b", "\x90", "d" };
+        size_t expected_size = sizeof(expected_characters) / sizeof(expected_characters[0]);
+        size_t i = 0;
+        for (auto it = view.begin(); it != view.end(); ++it) {
+            u32 code_point = *it;
+            VERIFY(i < expected_size);
+            EXPECT_EQ(code_point, expected_characters[i]);
+            EXPECT_EQ(it.underlying_code_point_bytes(), expected_underlying_bytes[i].bytes());
+            i++;
+        }
+        VERIFY(i == expected_size);
+    }
+
+    // Test case 4 : Not enough bytes at the end of the string
+    {
+        char raw_data[] = { 'a', 'b', 'c', (char)0x90, 0 };
+        Utf8View view { raw_data };
+        u32 expected_characters[] = { 'a', 'b', 'c', 0xFFFD };
+        String expected_underlying_bytes[] = { "a", "b", "c", "\x90" };
+        size_t expected_size = sizeof(expected_characters) / sizeof(expected_characters[0]);
+        size_t i = 0;
+        for (auto it = view.begin(); it != view.end(); ++it) {
+            u32 code_point = *it;
+            VERIFY(i < expected_size);
+            EXPECT_EQ(code_point, expected_characters[i]);
+            EXPECT_EQ(it.underlying_code_point_bytes(), expected_underlying_bytes[i].bytes());
+            i++;
+        }
+        VERIFY(i == expected_size);
+    }
 }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -126,7 +126,7 @@ void TextNode::compute_text_for_rendering(bool collapse, bool previous_is_empty_
         skip_over_whitespace();
     for (; it != utf8_view.end(); ++it) {
         if (!is_ascii_space(*it)) {
-            builder.append(utf8_view.as_string().characters_without_null_termination() + utf8_view.byte_offset_of(it), it.code_point_length_in_bytes());
+            builder.append(StringView { it.underlying_code_point_bytes() });
         } else {
             builder.append(' ');
             skip_over_whitespace();

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -26,7 +26,7 @@ void EditEventHandler::handle_delete_character_after(const DOM::Position& cursor
 
     auto& node = *static_cast<DOM::Text*>(const_cast<DOM::Node*>(cursor_position.node()));
     auto& text = node.data();
-    auto code_point_length = Utf8View(text).iterator_at_byte_offset(cursor_position.offset()).code_point_length_in_bytes();
+    auto code_point_length = Utf8View(text).iterator_at_byte_offset(cursor_position.offset()).underlying_code_point_length_in_bytes();
 
     StringBuilder builder;
     builder.append(text.substring_view(0, cursor_position.offset()));


### PR DESCRIPTION
# Overview

This PR makes it so we output the 0xFFFD 'REPLACEMENT CHARACTER' code point when encountering invalid bytes in an `UTF8CodepointIterator`, and keep iterating the view after skipping one byte.

The previous behavior was to always `VERIFY` that the UTF-8 bytes were valid, causing crashes every time a string was read prior to checking its validity with `UTF8View::validate()`. This caused crashes in applications (#5896) and was encountered by fuzzers (for example, [on `LibJS`](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29252&sort=-id&q=proj%3Dserenity)).

## Alternate Implementations

### Expect the callers to validate the view before iterating on it

This was the current implementation so far, but it is not only cumbersome but inefficient. Moreover, there was no way for callers to easily iterate on correct part of the strings : the only option was to reject the input altogether.

As this still caused issues in many parts of the code, this retrospectively doesn't seem like the best way to do this. The `AK::UTF8CodepointIterator` being more lenient will give more flexibility to the implementations, with a fallback in case they don't want to handle this complexity.

### Return an `Optional<u32>` and let the callers manually handle invalid code points.

One alternative would be to stop returning an `u32` and to instead return an `Optional<u32>`, and then leave the decision to the consumer whether to replace the code point or to stop iterating the string. This requires more extensive changes all over the codebase to handle this new behavior, but isn't hard by itself.

An attempt was made here: [DexesTTP/optional-utf8](https://github.com/Dexesttp/serenity/tree/tasks/optional-utf8)

However, this alternative breaks symmetry with the `UTF32View` and `StringView` API, which would require either heavy refactoring and/or code duplication in the currently templated code found in [`Gfx::Painter::draw_text_line`](https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibGfx/Painter.cpp#L1200) and generic lambda found in [`Shell/find_offset_into_node()`](https://github.com/SerenityOS/serenity/blob/master/Userland/Shell/Shell.h#L367).

### Skip the estimated code point length instead of one single byte

The current implementation skips one single byte, therefore returning possibly several followup replacement characters in case one single multi-byte invalid code point is encountered.

The UTF-8 specification would only encounter this kind of behavior at the very end of the string (e.g. where a 3-byte code point is expected, but only 2 bytes are available). Our implementation would return two `U+FFFD` glyphs in this case : one for the first byte, and one for the second byte which couldn't be decoded directly.

Our current implementation allows to distinguish between a truncated glyph (outputed as two replacement characters) and a corrupted byte in the non-final position (outputed as one replacement character and the normal character for the following byte). As such, this seemed like the better implementation.