### PR TITLE
AK+Kernel: Disallow implicitly lifting pointers to OwnPtr's

### DIFF
--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -576,7 +576,7 @@ KResult Plan9FS::read_and_dispatch_one_message()
         auto completion = optional_completion.value();
         ScopedSpinLock lock(completion->lock);
         completion->result = KSuccess;
-        completion->message = new Message { buffer.release_nonnull() };
+        completion->message = adopt_own_if_nonnull(new Message { buffer.release_nonnull() });
         completion->completed = true;
 
         m_completions.remove(header.tag);

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1102,7 +1102,7 @@ KResult ProcFSInode::refresh_data(FileDescription& description) const
     }
 
     if (!cached_data)
-        cached_data = new ProcFSInodeData;
+        cached_data = adopt_own_if_nonnull(new ProcFSInodeData);
     auto& buffer = static_cast<ProcFSInodeData&>(*cached_data).buffer;
     if (buffer) {
         // If we're reusing the buffer, reset the size to 0 first. This

--- a/Kernel/Interrupts/SpuriousInterruptHandler.cpp
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.cpp
@@ -18,7 +18,7 @@ UNMAP_AFTER_INIT void SpuriousInterruptHandler::initialize(u8 interrupt_number)
 void SpuriousInterruptHandler::register_handler(GenericInterruptHandler& handler)
 {
     VERIFY(!m_real_handler);
-    m_real_handler = &handler;
+    m_real_handler = adopt_own_if_nonnull(&handler);
 }
 void SpuriousInterruptHandler::unregister_handler(GenericInterruptHandler&)
 {

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -106,7 +106,7 @@ KResultOr<int> Process::sys$profiling_free_buffer(pid_t pid)
         {
             ScopedCritical critical;
 
-            perf_events = g_global_perf_events;
+            perf_events = adopt_own_if_nonnull(g_global_perf_events);
             g_global_perf_events = nullptr;
         }
 

--- a/Kernel/VirtIO/VirtIOQueue.cpp
+++ b/Kernel/VirtIO/VirtIOQueue.cpp
@@ -22,9 +22,9 @@ VirtIOQueue::VirtIOQueue(u16 queue_size, u16 notify_offset)
     // TODO: ensure alignment!!!
     u8* ptr = m_queue_region->vaddr().as_ptr();
     memset(ptr, 0, m_queue_region->size());
-    m_descriptors = reinterpret_cast<VirtIOQueueDescriptor*>(ptr);
-    m_driver = reinterpret_cast<VirtIOQueueDriver*>(ptr + size_of_descriptors);
-    m_device = reinterpret_cast<VirtIOQueueDevice*>(ptr + size_of_descriptors + size_of_driver);
+    m_descriptors = adopt_own_if_nonnull(reinterpret_cast<VirtIOQueueDescriptor*>(ptr));
+    m_driver = adopt_own_if_nonnull(reinterpret_cast<VirtIOQueueDriver*>(ptr + size_of_descriptors));
+    m_device = adopt_own_if_nonnull(reinterpret_cast<VirtIOQueueDevice*>(ptr + size_of_descriptors + size_of_driver));
 
     for (auto i = 0; i + 1 < queue_size; i++) {
         m_descriptors[i].next = i + 1; // link all of the descriptors in a line


### PR DESCRIPTION
This doesn't really _fix_ anything, it just gets rid of the API and
instead makes the users explicitly use `adopt_own_if_non_null()`.