### PR TITLE
AK: Make String::reverse() properly handle UTF-8 strings.

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -366,14 +366,21 @@ size_t String::count(const String& needle) const
     return count;
 }
 
+#define is_multibyte_character(x) (characters()[x] & 0xC0) == 0x80
 String String::reverse() const
 {
     StringBuilder reversed_string;
-    for (size_t i = length(); i-- > 0;) {
-        reversed_string.append(characters()[i]);
+    for (size_t i = length(), j; i-- > 0;) {
+        if (is_multibyte_character(i))
+            continue;
+        j = i;
+        do
+            reversed_string.append(characters()[j]);
+        while (is_multibyte_character(++j));
     }
     return reversed_string.to_string();
 }
+#undef is_multibyte_character
 
 String escape_html_entities(const StringView& html)
 {


### PR DESCRIPTION
This PR will allow the `String::reverse()` method to properly handle UTF-8 strings. Here is an example of it working on `emojis.txt` where previously the emojis would not display correctly.

![test](https://user-images.githubusercontent.com/57815710/120115487-2bd2a100-c184-11eb-85fa-73a93b00a933.png)