### PR TITLE
Revert "AK: Fix accidentally-quadratic behavior in StringBuilder"

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -187,8 +187,6 @@ public:
     operator Bytes() { return bytes(); }
     operator ReadonlyBytes() const { return bytes(); }
 
-    ALWAYS_INLINE size_t capacity() const { return is_inline() ? inline_capacity : m_outline_capacity; }
-
 private:
     ByteBuffer(size_t size)
     {
@@ -238,6 +236,7 @@ private:
     }
 
     ALWAYS_INLINE bool is_inline() const { return m_size <= inline_capacity; }
+    ALWAYS_INLINE size_t capacity() const { return is_inline() ? inline_capacity : m_outline_capacity; }
 
     size_t m_size { 0 };
     union {

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -21,11 +21,10 @@ inline void StringBuilder::will_append(size_t size)
     Checked<size_t> needed_capacity = m_length;
     needed_capacity += size;
     VERIFY(!needed_capacity.has_overflow());
-    if (needed_capacity <= m_buffer.capacity())
-        return;
-
     Checked<size_t> expanded_capacity = needed_capacity;
-    expanded_capacity *= 2;
+    // Prefer to completely use the inline buffer first
+    if (needed_capacity > inline_capacity)
+        expanded_capacity *= 2;
     VERIFY(!expanded_capacity.has_overflow());
     m_buffer.grow(expanded_capacity.value());
 }


### PR DESCRIPTION
This reverts commit 2d011961c94ac81700c366537f52208a4c55db92.

Somehow, this broke `Browser`, and presumably many other things.

7b4dc590e7480176988d58f1fad1f9bd02abce08: Browser works fine on gifsuite
2d011961c94ac81700c366537f52208a4c55db92: Browser crashes on gifsuite

I still don't see how, but `@shroud` apparently does. So I'll leave fixing OSS-Fuzz #34451to them! :)