### PR TITLE
Kernel: Rename instances of IO port 0xe9 to BOCHS_DEBUG_PORT

### DIFF
--- a/Kernel/ConsoleDevice.cpp
+++ b/Kernel/ConsoleDevice.cpp
@@ -10,8 +10,8 @@
 #include <Kernel/SpinLock.h>
 #include <Kernel/kstdio.h>
 
-// Bytes output to 0xE9 end up on the Bochs console. It's very handy.
-#define CONSOLE_OUT_TO_E9
+// Output bytes to kernel debug port 0xE9 (Bochs console). It's very handy.
+#define CONSOLE_OUT_TO_BOCHS_DEBUG_PORT
 
 static AK::Singleton<ConsoleDevice> s_the;
 static Kernel::SpinLock g_console_lock;
@@ -67,9 +67,8 @@ Kernel::KResultOr<size_t> ConsoleDevice::write(FileDescription&, u64, const Kern
 void ConsoleDevice::put_char(char ch)
 {
     Kernel::ScopedSpinLock lock(g_console_lock);
-#ifdef CONSOLE_OUT_TO_E9
-    //if (ch != 27)
-    IO::out8(0xe9, ch);
+#ifdef CONSOLE_OUT_TO_BOCHS_DEBUG_PORT
+    IO::out8(IO::BOCHS_DEBUG_PORT, ch);
 #endif
     m_logbuffer.enqueue(ch);
 }

--- a/Kernel/IO.h
+++ b/Kernel/IO.h
@@ -13,6 +13,10 @@
 
 namespace IO {
 
+// Every character written to this IO port is written to the Bochs console
+// (e.g. the console where Qemu is running).
+static constexpr u16 BOCHS_DEBUG_PORT = 0xE9;
+
 inline u8 in8(u16 port)
 {
     u8 value;

--- a/Kernel/Syscalls/debug.cpp
+++ b/Kernel/Syscalls/debug.cpp
@@ -19,7 +19,7 @@ KResultOr<int> Process::sys$dump_backtrace()
 
 KResultOr<int> Process::sys$dbgputch(u8 ch)
 {
-    IO::out8(0xe9, ch);
+    IO::out8(IO::BOCHS_DEBUG_PORT, ch);
     return 0;
 }
 
@@ -33,7 +33,7 @@ KResultOr<size_t> Process::sys$dbgputstr(Userspace<const u8*> characters, int le
         return EFAULT;
     return buffer.value().read_buffered<1024>(length, [&](u8 const* buffer, size_t buffer_size) {
         for (size_t i = 0; i < buffer_size; ++i)
-            IO::out8(0xe9, buffer[i]);
+            IO::out8(IO::BOCHS_DEBUG_PORT, buffer[i]);
         return buffer_size;
     });
 }

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -73,7 +73,7 @@ static void critical_console_out(char ch)
         serial_putch(ch);
     // No need to output things to the real ConsoleDevice as no one is likely
     // to read it (because we are in a fatal situation, so only print things and halt)
-    IO::out8(0xe9, ch);
+    IO::out8(IO::BOCHS_DEBUG_PORT, ch);
     // We emit chars directly to the string. this is necessary in few cases,
     // especially when we want to avoid any memory allocations...
     if (GraphicsManagement::is_initialized() && GraphicsManagement::the().console()) {
@@ -91,7 +91,7 @@ static void console_out(char ch)
     if (ConsoleDevice::is_initialized()) {
         ConsoleDevice::the().put_char(ch);
     } else {
-        IO::out8(0xe9, ch);
+        IO::out8(IO::BOCHS_DEBUG_PORT, ch);
     }
     if (ConsoleManagement::is_initialized()) {
         ConsoleManagement::the().debug_tty()->emit_char(ch);
@@ -149,7 +149,7 @@ static void debugger_out(char ch)
 {
     if (serial_debug)
         serial_putch(ch);
-    IO::out8(0xe9, ch);
+    IO::out8(IO::BOCHS_DEBUG_PORT, ch);
 }
 
 extern "C" void dbgputstr(const char* characters, size_t length)

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -209,3 +209,7 @@ set(WEBSERVER_DEBUG ON)
 # set(WRAPPER_GENERATOR_DEBUG ON)
 # Immediately finds violations during boot, shouldn't be discoverable by people who aren't working on fixing.
 # set(KMALLOC_VERIFY_NO_SPINLOCK_HELD ON)
+# False positive: CONSOLE_OUT_TO_BOCHS_DEBUG_PORT is a flag for ConsoleDevice, not a feature.
+# set(CONSOLE_OUT_TO_BOCHS_DEBUG_PORT)
+# False positive: BOCHS_DEBUG_PORT represents an IO port constant
+# set(BOCHS_DEBUG_PORT)


### PR DESCRIPTION
First time contributor. Just a simple renaming.

## Problem

I was baffled by the `0xe9` magic number that showed up in several calls to `IO::out8` in the kernel. After light digging, this is apparently the port used by the Bochs console. 

It would be nice if this were a named constant, to make it clear this is not the normal console, but a kernel debug console.

## Solution

* `IO.h`: Create new constant `BOCHS_DEBUG_PORT`
* Wherever IO port 0xe9 is used, replace it with `IO::BOCHS_DEBUG_PORT`

## Testing

- [x] Kernel kprintf statements still show up normally in Qemu