### PR TITLE
AK: Tests and edge case fixes for LEB128 decoder

### DIFF
--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/NumericLimits.h>
 #include <AK/Stream.h>
 #include <AK/Types.h>
 
@@ -29,13 +30,18 @@ struct LEB128 {
                 input_stream.set_fatal_error();
                 return false;
             }
-
             u8 byte = 0;
             input_stream >> byte;
             if (input_stream.has_any_error())
                 return false;
 
-            result = (result) | (static_cast<ValueType>(byte & ~(1 << 7)) << (num_bytes * 7));
+            ValueType masked_byte = byte & ~(1 << 7);
+            const bool shift_too_large_for_result = (num_bytes * 7 > sizeof(ValueType) * 8) && (masked_byte != 0);
+            const bool shift_too_large_for_byte = ((masked_byte << (num_bytes * 7)) >> (num_bytes * 7)) != masked_byte;
+            if (shift_too_large_for_result || shift_too_large_for_byte)
+                return false;
+
+            result = (result) | (masked_byte << (num_bytes * 7));
             if (!(byte & (1 << 7)))
                 break;
             ++num_bytes;
@@ -47,15 +53,18 @@ struct LEB128 {
     template<typename StreamT, typename ValueType = ssize_t>
     static bool read_signed(StreamT& stream, ValueType& result)
     {
-        using UValueType = MakeUnsigned<ValueType>;
+        // Note: We read into a u64 to simplify the parsing logic;
+        //    result is range checked into ValueType after parsing.
+        static_assert(sizeof(ValueType) <= sizeof(u64), "Error checking logic assumes 64 bits or less!");
         [[maybe_unused]] size_t backup_offset = 0;
         if constexpr (requires { stream.offset(); })
             backup_offset = stream.offset();
         InputStream& input_stream { stream };
 
-        result = 0;
+        i64 temp = 0;
         size_t num_bytes = 0;
         u8 byte = 0;
+        result = 0;
 
         do {
             if (input_stream.unreliable_eof()) {
@@ -68,14 +77,31 @@ struct LEB128 {
             input_stream >> byte;
             if (input_stream.has_any_error())
                 return false;
-            result = (result) | (static_cast<UValueType>(byte & ~(1 << 7)) << (num_bytes * 7));
+
+            // note: 64 bit assumptions!
+            u64 masked_byte = byte & ~(1 << 7);
+            const bool shift_too_large_for_result = (num_bytes * 7 >= 64) && (masked_byte != ((temp < 0) ? 0x7Fu : 0u));
+            const bool shift_too_large_for_byte = (num_bytes * 7) == 63 && masked_byte != 0x00 && masked_byte != 0x7Fu;
+
+            if (shift_too_large_for_result || shift_too_large_for_byte)
+                return false;
+
+            temp = (temp) | (masked_byte << (num_bytes * 7));
             ++num_bytes;
         } while (byte & (1 << 7));
 
-        if (num_bytes * 7 < sizeof(UValueType) * 4 && (byte & 0x40)) {
+        if ((num_bytes * 7) < 64 && (byte & 0x40)) {
             // sign extend
-            result |= ((UValueType)(-1) << (num_bytes * 7));
+            temp |= ((u64)(-1) << (num_bytes * 7));
         }
+
+        // Now that we've accumulated into an i64, make sure it fits into result
+        if constexpr (sizeof(ValueType) < sizeof(u64)) {
+            if (temp > NumericLimits<ValueType>::max() || temp < NumericLimits<ValueType>::min())
+                return false;
+        }
+
+        result = static_cast<ValueType>(temp);
 
         return true;
     }

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -31,6 +31,7 @@ set(AK_TEST_SOURCES
     TestIntrusiveList.cpp
     TestIntrusiveRedBlackTree.cpp
     TestJSON.cpp
+    TestLEB128.cpp
     TestLexicalPath.cpp
     TestMACAddress.cpp
     TestMemMem.cpp

--- a/Tests/AK/TestLEB128.cpp
+++ b/Tests/AK/TestLEB128.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LEB128.h>
+#include <AK/MemoryStream.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(single_byte)
+{
+    u32 output = {};
+    i32 output_signed = {};
+    u8 buf[] = { 0x00 };
+    InputMemoryStream stream({ buf, sizeof(buf) });
+
+    // less than/eq 0b0011_1111, signed == unsigned == raw byte
+    for (u8 i = 0u; i <= 0x3F; ++i) {
+        buf[0] = i;
+
+        stream.seek(0);
+        EXPECT(LEB128::read_unsigned(stream, output));
+        EXPECT_EQ(output, i);
+        EXPECT(!stream.handle_any_error());
+
+        stream.seek(0);
+        EXPECT(LEB128::read_signed(stream, output_signed));
+        EXPECT_EQ(output_signed, i);
+        EXPECT(!stream.handle_any_error());
+    }
+
+    // 0b0100_0000 to 0b0111_1111 unsigned == byte, signed = {{ 26'b(-1), 6'b(byte) }}
+    for (u8 i = 0x40u; i < 0x80; ++i) {
+        buf[0] = i;
+
+        stream.seek(0);
+        EXPECT(LEB128::read_unsigned(stream, output));
+        EXPECT_EQ(output, i);
+        EXPECT(!stream.handle_any_error());
+
+        stream.seek(0);
+        EXPECT(LEB128::read_signed(stream, output_signed));
+        EXPECT_EQ(output_signed, (i | (-1 & (~0x3F))));
+        EXPECT(!stream.handle_any_error());
+    }
+    // MSB set, but input too short
+    for (u16 i = 0x80; i <= 0xFF; ++i) {
+        buf[0] = static_cast<u8>(i);
+
+        stream.seek(0);
+        EXPECT(!LEB128::read_unsigned(stream, output));
+        EXPECT(stream.handle_any_error());
+
+        stream.seek(0);
+        EXPECT(!LEB128::read_signed(stream, output_signed));
+        EXPECT(stream.handle_any_error());
+    }
+}
+
+TEST_CASE(two_bytes)
+{
+    u32 output = {};
+    i32 output_signed = {};
+    u8 buf[] = { 0x00, 0x1 };
+    InputMemoryStream stream({ buf, sizeof(buf) });
+
+    // Only test with first byte expecting more, otherwise equivalent to single byte case
+    for (u16 i = 0x80; i <= 0xFF; ++i) {
+        buf[0] = static_cast<u8>(i);
+
+        // less than/eq 0b0011_1111: signed == unsigned == (j << 7) + (7 MSB of i)
+        for (u8 j = 0u; j <= 0x3F; ++j) {
+            buf[1] = j;
+
+            stream.seek(0);
+            EXPECT(LEB128::read_unsigned(stream, output));
+            EXPECT_EQ(output, (static_cast<u32>(j) << 7) + (i & 0x7F));
+            EXPECT(!stream.handle_any_error());
+
+            stream.seek(0);
+            EXPECT(LEB128::read_signed(stream, output_signed));
+            EXPECT_EQ(output_signed, (static_cast<i32>(j) << 7) + (i & 0x7F));
+            EXPECT(!stream.handle_any_error());
+        }
+
+        // 0b0100_0000 to 0b0111_1111: unsigned == (j << 7) + (7 MSB of i), signed == {{ 19'b(-1), 6'b(j), 7'b(i) }}
+        for (u8 j = 0x40u; j < 0x80; ++j) {
+            buf[1] = j;
+
+            stream.seek(0);
+            EXPECT(LEB128::read_unsigned(stream, output));
+            EXPECT_EQ(output, (static_cast<u32>(j) << 7) + (i & 0x7F));
+            EXPECT(!stream.handle_any_error());
+
+            stream.seek(0);
+            EXPECT(LEB128::read_signed(stream, output_signed));
+            EXPECT_EQ(output_signed, ((static_cast<i32>(j) << 7) + (i & 0x7F)) | (-1 & (~0x3FFF)));
+            EXPECT(!stream.handle_any_error());
+        }
+
+        // MSB set on last byte, but input too short
+        for (u16 j = 0x80; j <= 0xFF; ++j) {
+            buf[1] = static_cast<u8>(j);
+
+            stream.seek(0);
+            EXPECT(!LEB128::read_unsigned(stream, output));
+            EXPECT(stream.handle_any_error());
+
+            stream.seek(0);
+            EXPECT(!LEB128::read_signed(stream, output_signed));
+            EXPECT(stream.handle_any_error());
+        }
+    }
+}


### PR DESCRIPTION
Add comprehensive tests for 1 and 2 byte LEB128 encoded values (i.e. cover all possible inputs).

Fix improper shifting around the upper bound of the result types for both signed and unsigned encodings, and add tests.

This patch [fixes](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34537&q=proj%3A%20serenity) [a](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34538&q=proj%3A%20serenity) [number](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34567&q=proj%3A%20serenity) of [oss-fuzz](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34580&q=proj%3A%20serenity) [issues](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34578&q=proj%3A%20serenity) :^)

Note for the signed decoding.. I couldn't figure out a good way to detect that our shift was going to be bad for 32-bit integers. And the reference I looked at (llvm) did it for 64 bit integers in a way that made a lot more sense than (for example) the andriod runtime's ... flexible... way of doing it for 32 bit integers. So I sidestepped the algorithmic problem by always decoding as int64_t, and then checking the numeric limits for the value type afterwards to make sure we didn't decode something that's too large.