### PR TITLE
AK: Replace ByteBuffer::grow with resize()/ensure_capacity()

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -50,7 +50,7 @@ public:
     {
         if (this != &other) {
             if (m_size > other.size())
-                internal_trim(other.size(), true);
+                trim(other.size(), true);
             else
                 resize(other.size());
             __builtin_memcpy(data(), other.data(), other.size());
@@ -126,11 +126,6 @@ public:
     [[nodiscard]] void* end_pointer() { return data() + m_size; }
     [[nodiscard]] void const* end_pointer() const { return data() + m_size; }
 
-    void trim(size_t size)
-    {
-        internal_trim(size, false);
-    }
-
     [[nodiscard]] ByteBuffer slice(size_t offset, size_t size) const
     {
         // I cannot hand you a slice I don't have
@@ -151,7 +146,7 @@ public:
     ALWAYS_INLINE void resize(size_t new_size)
     {
         if (new_size <= m_size) {
-            trim(new_size);
+            trim(new_size, false);
             return;
         }
         ensure_capacity(new_size);
@@ -217,7 +212,7 @@ private:
         other.m_inline = true;
     }
 
-    void internal_trim(size_t size, bool may_discard_existing_data)
+    void trim(size_t size, bool may_discard_existing_data)
     {
         VERIFY(size <= m_size);
         if (!m_inline && size <= inline_capacity) {

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -215,15 +215,19 @@ private:
     void trim(size_t size, bool may_discard_existing_data)
     {
         VERIFY(size <= m_size);
-        if (!m_inline && size <= inline_capacity) {
-            // m_inline_buffer and m_outline_buffer are part of a union, so save the pointer
-            auto outline_buffer = m_outline_buffer;
-            if (!may_discard_existing_data)
-                __builtin_memcpy(m_inline_buffer, outline_buffer, size);
-            kfree(outline_buffer);
-            m_inline = true;
-        }
+        if (!m_inline && size <= inline_capacity)
+            shrink_into_inline_buffer(size, may_discard_existing_data);
         m_size = size;
+    }
+
+    NEVER_INLINE void shrink_into_inline_buffer(size_t size, bool may_discard_existing_data)
+    {
+        // m_inline_buffer and m_outline_buffer are part of a union, so save the pointer
+        auto outline_buffer = m_outline_buffer;
+        if (!may_discard_existing_data)
+            __builtin_memcpy(m_inline_buffer, outline_buffer, size);
+        kfree(outline_buffer);
+        m_inline = true;
     }
 
     NEVER_INLINE void ensure_capacity_slowpath(size_t new_capacity)

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -26,12 +26,12 @@ inline void StringBuilder::will_append(size_t size)
     if (needed_capacity > inline_capacity)
         expanded_capacity *= 2;
     VERIFY(!expanded_capacity.has_overflow());
-    m_buffer.resize(expanded_capacity.value());
+    m_buffer.ensure_capacity(expanded_capacity.value());
 }
 
 StringBuilder::StringBuilder(size_t initial_capacity)
-    : m_buffer(decltype(m_buffer)::create_uninitialized(initial_capacity))
 {
+    m_buffer.ensure_capacity(initial_capacity);
 }
 
 void StringBuilder::append(const StringView& str)
@@ -39,7 +39,7 @@ void StringBuilder::append(const StringView& str)
     if (str.is_empty())
         return;
     will_append(str.length());
-    memcpy(data() + m_length, str.characters_without_null_termination(), str.length());
+    m_buffer.append(str.characters_without_null_termination(), str.length());
     m_length += str.length();
 }
 
@@ -51,7 +51,7 @@ void StringBuilder::append(const char* characters, size_t length)
 void StringBuilder::append(char ch)
 {
     will_append(1);
-    data()[m_length] = ch;
+    m_buffer.append(&ch, 1);
     m_length += 1;
 }
 

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -18,7 +18,7 @@ namespace AK {
 
 inline void StringBuilder::will_append(size_t size)
 {
-    Checked<size_t> needed_capacity = m_length;
+    Checked<size_t> needed_capacity = m_buffer.size();
     needed_capacity += size;
     VERIFY(!needed_capacity.has_overflow());
     // Prefer to completely use the existing capacity first
@@ -41,7 +41,6 @@ void StringBuilder::append(const StringView& str)
         return;
     will_append(str.length());
     m_buffer.append(str.characters_without_null_termination(), str.length());
-    m_length += str.length();
 }
 
 void StringBuilder::append(const char* characters, size_t length)
@@ -53,7 +52,6 @@ void StringBuilder::append(char ch)
 {
     will_append(1);
     m_buffer.append(&ch, 1);
-    m_length += 1;
 }
 
 void StringBuilder::appendvf(const char* fmt, va_list ap)
@@ -83,13 +81,12 @@ String StringBuilder::build() const
 
 StringView StringBuilder::string_view() const
 {
-    return StringView { data(), m_length };
+    return StringView { data(), m_buffer.size() };
 }
 
 void StringBuilder::clear()
 {
     m_buffer.clear();
-    m_length = 0;
 }
 
 void StringBuilder::append_code_point(u32 code_point)

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -21,10 +21,11 @@ inline void StringBuilder::will_append(size_t size)
     Checked<size_t> needed_capacity = m_length;
     needed_capacity += size;
     VERIFY(!needed_capacity.has_overflow());
+    // Prefer to completely use the existing capacity first
+    if (needed_capacity <= m_buffer.capacity())
+        return;
     Checked<size_t> expanded_capacity = needed_capacity;
-    // Prefer to completely use the inline buffer first
-    if (needed_capacity > inline_capacity)
-        expanded_capacity *= 2;
+    expanded_capacity *= 2;
     VERIFY(!expanded_capacity.has_overflow());
     m_buffer.ensure_capacity(expanded_capacity.value());
 }

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -26,7 +26,7 @@ inline void StringBuilder::will_append(size_t size)
     if (needed_capacity > inline_capacity)
         expanded_capacity *= 2;
     VERIFY(!expanded_capacity.has_overflow());
-    m_buffer.grow(expanded_capacity.value());
+    m_buffer.resize(expanded_capacity.value());
 }
 
 StringBuilder::StringBuilder(size_t initial_capacity)

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -44,9 +44,9 @@ public:
     [[nodiscard]] StringView string_view() const;
     void clear();
 
-    [[nodiscard]] size_t length() const { return m_length; }
-    [[nodiscard]] bool is_empty() const { return m_length == 0; }
-    void trim(size_t count) { m_length -= count; }
+    [[nodiscard]] size_t length() const { return m_buffer.size(); }
+    [[nodiscard]] bool is_empty() const { return m_buffer.is_empty(); }
+    void trim(size_t count) { m_buffer.resize(m_buffer.size() - count); }
 
     template<class SeparatorType, class CollectionType>
     void join(const SeparatorType& separator, const CollectionType& collection)
@@ -68,7 +68,6 @@ private:
 
     static constexpr size_t inline_capacity = 128;
     AK::Detail::ByteBuffer<inline_capacity> m_buffer;
-    size_t m_length { 0 };
 };
 
 }

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -207,7 +207,7 @@ int main(int, char**)
         VERIFY(script_size < REPRL_MAX_DATA_SIZE);
         ByteBuffer data_buffer;
         if (data_buffer.size() < script_size)
-            data_buffer.grow(script_size - data_buffer.size());
+            data_buffer.resize(script_size - data_buffer.size());
         VERIFY(data_buffer.size() >= script_size);
         memcpy(data_buffer.data(), reprl_input, script_size);
 

--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -61,7 +61,7 @@ ByteBuffer IODevice::read(size_t max_size)
     int nread = ::read(m_fd, buffer_ptr, remaining_buffer_space);
     if (nread < 0) {
         if (taken_from_buffered) {
-            buffer.trim(taken_from_buffered);
+            buffer.resize(taken_from_buffered);
             return buffer;
         }
         set_error(errno);
@@ -70,12 +70,12 @@ ByteBuffer IODevice::read(size_t max_size)
     if (nread == 0) {
         set_eof(true);
         if (taken_from_buffered) {
-            buffer.trim(taken_from_buffered);
+            buffer.resize(taken_from_buffered);
             return buffer;
         }
         return {};
     }
-    buffer.trim(taken_from_buffered + nread);
+    buffer.resize(taken_from_buffered + nread);
     return buffer;
 }
 
@@ -195,7 +195,7 @@ String IODevice::read_line(size_t max_size)
             Vector<u8> new_buffered_data;
             new_buffered_data.append(m_buffered_data.data() + line_index, m_buffered_data.size() - line_index);
             m_buffered_data = move(new_buffered_data);
-            line.trim(line_index);
+            line.resize(line_index);
             return String::copy(line, Chomp);
         }
     }

--- a/Userland/Libraries/LibCore/UDPServer.cpp
+++ b/Userland/Libraries/LibCore/UDPServer.cpp
@@ -72,7 +72,7 @@ ByteBuffer UDPServer::receive(size_t size, sockaddr_in& in)
         return {};
     }
 
-    buf.trim(rlen);
+    buf.resize(rlen);
     return buf;
 }
 

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -165,8 +165,7 @@ UnsignedBigInteger random_number(const UnsignedBigInteger& min, const UnsignedBi
     UnsignedBigInteger base;
     auto size = range.trimmed_length() * sizeof(u32) + 2;
     // "+2" is intentional (see below).
-    ByteBuffer buffer;
-    buffer.grow(size);
+    auto buffer = ByteBuffer::create_uninitialized(size);
     auto* buf = buffer.data();
 
     fill_with_random(buf, size);

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -117,8 +117,7 @@ bool TLSv12::compute_master_secret_from_pre_master_secret(size_t length)
         return false;
     }
 
-    m_context.master_key.clear();
-    m_context.master_key.grow(length);
+    m_context.master_key.resize(length);
 
     pseudorandom_function(
         m_context.master_key,

--- a/Userland/Libraries/LibTLS/TLSPacketBuilder.h
+++ b/Userland/Libraries/LibTLS/TLSPacketBuilder.h
@@ -75,7 +75,7 @@ public:
         m_current_length += bytes;
 
         if (m_packet_data.size() < m_current_length) {
-            m_packet_data.grow(m_current_length);
+            m_packet_data.resize(m_current_length);
         }
 
         m_packet_data.overwrite(old_length, data, bytes);

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -332,7 +332,7 @@ public:
         if (m_type.limits().max().value_or(new_size) < new_size)
             return false;
         auto previous_size = m_size;
-        m_data.grow(new_size);
+        m_data.resize(new_size);
         m_size = new_size;
         // The spec requires that we zero out everything on grow
         __builtin_memset(m_data.offset_pointer(previous_size), 0, size_to_grow);


### PR DESCRIPTION
**AK: Replace ByteBuffer::grow with resize()/ensure_capacity()**

Previously `ByteBuffer::grow()` behaved like `Vector<T>::resize()`. However the function name was somewhat ambiguous - and so this patch updates `ByteBuffer` to behave more like `Vector<T>` by replacing `grow()` with `resize()` and adding an `ensure_capacity()` method.

This also lets the user change the buffer's capacity without affecting the size which was not previously possible.

Additionally this patch makes the `capacity()` method public (again).

**AK: Remove the public ByteBuffer::trim method**

This removes the public `trim()` method because it is no longer necessary. Callers can instead use `resize()`.

**AK: Split the ByteBuffer::trim method into two methods**

This allows us to mark the slow part (i.e. where we copy the buffer) as `NEVER_INLINE` because this should almost never get called and therefore should also not get inlined into callers.

**AK: Use ByteBuffer::append for the StringBuilder class**

Previously the StringBuilder class would use `memcpy()` to write directly into the `ByteBuffer`'s buffer. Instead we should use the `append()` method which ensures we don't overrun the buffer.

**AK: Fix accidentally-quadratic behavior in StringBuilder**

Found by OSS Fuzz:

Related commit: 3908a49

Co-authored-by: Ben Wiederhake <BenWiederhake.GitHub@gmx.de>

**AK: Remove the m_length member for StringBuilder**

Instead we can just use `ByteBuffer::size()` which already keeps track of the buffer's size.