### PR TITLE
LibELF + LibDebug: Reduce allocations during symbolification

### DIFF
--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -17,7 +17,7 @@ namespace Debug {
 
 DebugInfo::DebugInfo(NonnullOwnPtr<const ELF::Image> elf, String source_root, FlatPtr base_address)
     : m_elf(move(elf))
-    , m_source_root(source_root)
+    , m_source_root(move(source_root))
     , m_base_address(base_address)
     , m_dwarf_info(*m_elf)
 {
@@ -78,7 +78,7 @@ void DebugInfo::parse_scopes_impl(const Dwarf::DIE& die)
 
 void DebugInfo::prepare_lines()
 {
-    auto section = elf().lookup_section(".debug_line");
+    auto section = elf().lookup_section(".debug_line"sv);
     if (!section.has_value())
         return;
 

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -13,15 +13,15 @@ namespace Debug::Dwarf {
 DwarfInfo::DwarfInfo(const ELF::Image& elf)
     : m_elf(elf)
 {
-    m_debug_info_data = section_data(".debug_info");
-    m_abbreviation_data = section_data(".debug_abbrev");
-    m_debug_strings_data = section_data(".debug_str");
-    m_debug_line_strings_data = section_data(".debug_line_str");
+    m_debug_info_data = section_data(".debug_info"sv);
+    m_abbreviation_data = section_data(".debug_abbrev"sv);
+    m_debug_strings_data = section_data(".debug_str"sv);
+    m_debug_line_strings_data = section_data(".debug_line_str"sv);
 
     populate_compilation_units();
 }
 
-ReadonlyBytes DwarfInfo::section_data(const String& section_name) const
+ReadonlyBytes DwarfInfo::section_data(const StringView& section_name) const
 {
     auto section = m_elf.lookup_section(section_name);
     if (!section.has_value())

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
@@ -60,7 +60,7 @@ public:
 private:
     void populate_compilation_units();
 
-    ReadonlyBytes section_data(const String& section_name) const;
+    ReadonlyBytes section_data(const StringView& section_name) const;
 
     const ELF::Image& m_elf;
     ReadonlyBytes m_debug_info_data;

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -271,7 +271,7 @@ Optional<Image::RelocationSection> Image::Section::relocations() const
     return static_cast<RelocationSection>(relocation_section.value());
 }
 
-Optional<Image::Section> Image::lookup_section(const String& name) const
+Optional<Image::Section> Image::lookup_section(const StringView& name) const
 {
     VERIFY(m_valid);
     for (unsigned i = 0; i < section_count(); ++i) {
@@ -288,7 +288,7 @@ StringView Image::Symbol::raw_data() const
     return { section.raw_data() + (value() - section.address()), size() };
 }
 
-Optional<Image::Symbol> Image::find_demangled_function(const String& name) const
+Optional<Image::Symbol> Image::find_demangled_function(const StringView& name) const
 {
     Optional<Image::Symbol> found;
     for_each_symbol([&](const Image::Symbol& symbol) {

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -189,7 +189,7 @@ public:
     template<VoidFunction<ProgramHeader> F>
     void for_each_program_header(F) const;
 
-    Optional<Section> lookup_section(String const& name) const;
+    Optional<Section> lookup_section(StringView const& name) const;
 
     bool is_executable() const { return header().e_type == ET_EXEC; }
     bool is_relocatable() const { return header().e_type == ET_REL; }
@@ -199,7 +199,7 @@ public:
     FlatPtr base_address() const { return (FlatPtr)m_buffer; }
     size_t size() const { return m_size; }
 
-    Optional<Symbol> find_demangled_function(const String& name) const;
+    Optional<Symbol> find_demangled_function(const StringView& name) const;
 
     bool has_symbols() const { return symbol_count(); }
     String symbolicate(u32 address, u32* offset = nullptr) const;


### PR DESCRIPTION
Avoid promotion of static strings to AK::String, instead use
AK::StringView and operator ""sv, to force string view's instead
which avoids allocation of String. This code path isn't hot enough
that it makes a huge difference, but every bit counts.