### PR TITLE
Userland: Add additional HTTP/1.1 methods

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -27,6 +27,18 @@ String HttpRequest::method_name() const
         return "HEAD";
     case Method::POST:
         return "POST";
+    case Method::PUT:
+        return "PUT";
+    case Method::DELETE:
+        return "DELETE";
+    case Method::TRACE:
+        return "TRACE";
+    case Method::OPTIONS:
+        return "OPTIONS";
+    case Method::CONNECT:
+        return "CONNECT";
+    case Method::PATCH:
+        return "PATCH";
     default:
         VERIFY_NOT_REACHED();
     }
@@ -160,6 +172,18 @@ Optional<HttpRequest> HttpRequest::from_raw_request(ReadonlyBytes raw_request)
         request.m_method = Method::HEAD;
     else if (method == "POST")
         request.m_method = Method::POST;
+    else if (method == "PUT")
+        request.m_method = Method::PUT;
+    else if (method == "DELETE")
+        request.m_method = Method::DELETE;
+    else if (method == "TRACE")
+        request.m_method = Method::TRACE;
+    else if (method == "OPTIONS")
+        request.m_method = Method::OPTIONS;
+    else if (method == "CONNECT")
+        request.m_method = Method::CONNECT;
+    else if (method == "PATCH")
+        request.m_method = Method::PATCH;
     else
         return {};
 

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -21,7 +21,13 @@ public:
         Invalid,
         HEAD,
         GET,
-        POST
+        POST,
+        PUT,
+        DELETE,
+        TRACE,
+        OPTIONS,
+        CONNECT,
+        PATCH
     };
 
     struct Header {

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -65,6 +65,20 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ClientConnection& clie
     HTTP::HttpRequest request;
     if (method.equals_ignoring_case("post"))
         request.set_method(HTTP::HttpRequest::Method::POST);
+    else if (method.equals_ignoring_case("head"))
+        request.set_method(HTTP::HttpRequest::Method::HEAD);
+    else if (method.equals_ignoring_case("put"))
+        request.set_method(HTTP::HttpRequest::Method::PUT);
+    else if (method.equals_ignoring_case("delete"))
+        request.set_method(HTTP::HttpRequest::Method::DELETE);
+    else if (method.equals_ignoring_case("trace"))
+        request.set_method(HTTP::HttpRequest::Method::TRACE);
+    else if (method.equals_ignoring_case("options"))
+        request.set_method(HTTP::HttpRequest::Method::OPTIONS);
+    else if (method.equals_ignoring_case("connect"))
+        request.set_method(HTTP::HttpRequest::Method::CONNECT);
+    else if (method.equals_ignoring_case("patch"))
+        request.set_method(HTTP::HttpRequest::Method::PATCH);
     else
         request.set_method(HTTP::HttpRequest::Method::GET);
     request.set_url(url);

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -146,6 +146,7 @@ int main(int argc, char** argv)
     const char* url_str = nullptr;
     bool save_at_provided_name = false;
     const char* data = nullptr;
+    const char* method_param = nullptr;
     String method = "GET";
     HashMap<String, String, CaseInsensitiveStringTraits> request_headers;
 
@@ -169,10 +170,15 @@ int main(int argc, char** argv)
             request_headers.set(header.substring_view(0, split.value()), header.substring_view(split.value() + 1));
             return true;
         } });
+    args_parser.add_option(method_param, "(HTTP only) Set the method for the HTTP request", "method", 'm', "method");
     args_parser.add_positional_argument(url_str, "URL to download from", "url");
     args_parser.parse(argc, argv);
 
-    if (data) {
+    if (method_param) {
+        // If method is specified, use it.
+        method = method_param;
+    } else if (data) {
+        // If data is provided, default to POST.
         method = "POST";
         // FIXME: Content-Type?
     }


### PR DESCRIPTION
This is my first pull request to Serenity! I'm adding additional HTTP methods to LibHTTP, ProtocolServer, and a new argument to the pro utility to add support there, as well as for testing my new code.