### PR TITLE
CMake: Verify the GCC host version is new enough to build serenity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
     "and that's all there is.")
 endif()
 
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.2)
+  message(FATAL_ERROR
+      "A GCC version less than 10.2 was detected (${CMAKE_CXX_COMPILER_VERSION}), this is unsupported.\n"
+      "Please re-read the build instructions documentation, and upgrade your host compiler.\n")
+endif()
+
 set(CMAKE_INSTALL_MESSAGE NEVER)
 
 enable_testing()


### PR DESCRIPTION
There are lots of people who have issues building serenity because
they don't read the build directions closely enough and have an
unsupported GCC version as their host compiler. Instead of repeatedly
having to answer these kinds of questions, lets just error out upfront.