### PR TITLE
Spreadsheet: Keep value when clicking out of a cell

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -186,6 +186,9 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
             m_table_view->stop_editing();
             m_table_view->dispatch_event(event);
         };
+        delegate->on_cell_focusout = [this](auto& index, auto& value) {
+            m_table_view->model()->set_data(index, value);
+        };
         return delegate;
     };
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -124,10 +124,14 @@ private:
                 commit();
                 on_cursor_key_pressed(event);
             };
+            textbox->on_focusout = [this] {
+                on_cell_focusout(index(), value());
+            };
             return textbox;
         }
 
         Function<void(GUI::KeyEvent&)> on_cursor_key_pressed;
+        Function<void(const GUI::ModelIndex&, const GUI::Variant&)> on_cell_focusout;
 
     private:
         bool m_has_set_initial_value { false };


### PR DESCRIPTION
Fixes #7590 