### PR TITLE
LibWeb: Return null in Window.{top,parent} if browsing context is null

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -339,25 +339,33 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::btoa)
     return JS::js_string(vm, move(encoded));
 }
 
+// https://html.spec.whatwg.org/multipage/browsers.html#dom-top
 JS_DEFINE_NATIVE_GETTER(WindowObject::top_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
         return {};
+
     auto* this_browsing_context = impl->document().browsing_context();
-    VERIFY(this_browsing_context);
+    if (!this_browsing_context)
+        return JS::js_null();
+
     VERIFY(this_browsing_context->top_level_browsing_context().document());
     auto& top_window = this_browsing_context->top_level_browsing_context().document()->window();
     return top_window.wrapper();
 }
 
+// https://html.spec.whatwg.org/multipage/browsers.html#dom-parent
 JS_DEFINE_NATIVE_GETTER(WindowObject::parent_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
         return {};
+
     auto* this_browsing_context = impl->document().browsing_context();
-    VERIFY(this_browsing_context);
+    if (!this_browsing_context)
+        return JS::js_null();
+
     if (this_browsing_context->parent()) {
         VERIFY(this_browsing_context->parent()->document());
         auto& parent_window = this_browsing_context->parent()->document()->window();


### PR DESCRIPTION
We were asserting that it exists, but the spec says to return null in
this case.

Top: https://html.spec.whatwg.org/multipage/browsers.html#dom-top
Parent: https://html.spec.whatwg.org/multipage/browsers.html#dom-parent