### PR TITLE
CMake: Hide KMALLOC_VERIFY_NO_SPINLOCK_HELD so folks don't find it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ endif()
 if (ENABLE_ALL_DEBUG_FACILITIES)
     set(ENABLE_ALL_THE_DEBUG_MACROS ON)
     set(ENABLE_EXTRA_KERNEL_DEBUG_SYMBOLS ON)
+
+    # Immediately finds violations during boot, shouldn't be discoverable
+    # by people who aren't working on fixing issues. Use this check to make
+    # sure this code continues to build instead of all_debug_macros to avoid
+    # people filing bugs.
+    set(KMALLOC_VERIFY_NO_SPINLOCK_HELD ON)
 endif()
 
 if (ENABLE_ALL_THE_DEBUG_MACROS)

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -68,7 +68,6 @@ set(PORTABLE_IMAGE_LOADER_DEBUG ON)
 set(SYNTAX_HIGHLIGHTING_DEBUG ON)
 set(KEYBOARD_SHORTCUTS_DEBUG ON)
 set(KMALLOC_DEBUG ON)
-set(KMALLOC_VERIFY_NO_SPINLOCK_HELD ON)
 set(MARKDOWN_DEBUG ON)
 set(REGEX_DEBUG ON)
 set(TLS_DEBUG ON)
@@ -208,3 +207,5 @@ set(WEBSERVER_DEBUG ON)
 # set(DEFINE_DEBUG_REGISTER ON)
 # Clogs up build: The WrapperGenerator stuff is run at compile time.
 # set(WRAPPER_GENERATOR_DEBUG ON)
+# Immediately finds violations during boot, shouldn't be discoverable by people who aren't working on fixing.
+# set(KMALLOC_VERIFY_NO_SPINLOCK_HELD ON)


### PR DESCRIPTION
Since I introduced this functionality there has been a steady stream of
people building with `ALL_THE_DEBUG_MACROS` and trying to boot the
system, and immediately hitting this assert. I have no idea why people
try to build with all the debugging enabled, but I'm tired of seeing the
bug reports about asserts we know are going to happen at this point.

So I'm hiding this value under the new ENABLE_ALL_DEBUG_FACILITIES flag
instead. This is only set by CI, and hopefully no-one will try to build
with this thing (It's documented as not recommended).

Fixes: #7527