### PR TITLE
LibWeb: Rename "FrameHostElement" to "BrowsingContextContainer"

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -67,10 +67,10 @@ set(SOURCES
     Dump.cpp
     FontCache.cpp
     HTML/AttributeNames.cpp
+    HTML/BrowsingContextContainer.cpp
     HTML/CanvasRenderingContext2D.cpp
     HTML/EventNames.cpp
     HTML/FormAssociatedElement.cpp
-    HTML/FrameHostElement.cpp
     HTML/GlobalEventHandlers.cpp
     HTML/HTMLAnchorElement.cpp
     HTML/HTMLAreaElement.cpp

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
@@ -6,22 +6,22 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
-#include <LibWeb/HTML/FrameHostElement.h>
+#include <LibWeb/HTML/BrowsingContextContainer.h>
 #include <LibWeb/Origin.h>
 #include <LibWeb/Page/BrowsingContext.h>
 
 namespace Web::HTML {
 
-FrameHostElement::FrameHostElement(DOM::Document& document, QualifiedName qualified_name)
+BrowsingContextContainer::BrowsingContextContainer(DOM::Document& document, QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
 }
 
-FrameHostElement::~FrameHostElement()
+BrowsingContextContainer::~BrowsingContextContainer()
 {
 }
 
-void FrameHostElement::inserted()
+void BrowsingContextContainer::inserted()
 {
     HTMLElement::inserted();
     if (!is_connected())
@@ -33,24 +33,24 @@ void FrameHostElement::inserted()
     }
 }
 
-Origin FrameHostElement::content_origin() const
+Origin BrowsingContextContainer::content_origin() const
 {
     if (!m_nested_browsing_context || !m_nested_browsing_context->document())
         return {};
     return m_nested_browsing_context->document()->origin();
 }
 
-bool FrameHostElement::may_access_from_origin(const Origin& origin) const
+bool BrowsingContextContainer::may_access_from_origin(const Origin& origin) const
 {
     return origin.is_same(content_origin());
 }
 
-const DOM::Document* FrameHostElement::content_document() const
+const DOM::Document* BrowsingContextContainer::content_document() const
 {
     return m_nested_browsing_context ? m_nested_browsing_context->document() : nullptr;
 }
 
-void FrameHostElement::nested_browsing_context_did_load(Badge<FrameLoader>)
+void BrowsingContextContainer::nested_browsing_context_did_load(Badge<FrameLoader>)
 {
     dispatch_event(DOM::Event::create(EventNames::load));
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.h
@@ -10,10 +10,10 @@
 
 namespace Web::HTML {
 
-class FrameHostElement : public HTMLElement {
+class BrowsingContextContainer : public HTMLElement {
 public:
-    FrameHostElement(DOM::Document&, QualifiedName);
-    virtual ~FrameHostElement() override;
+    BrowsingContextContainer(DOM::Document&, QualifiedName);
+    virtual ~BrowsingContextContainer() override;
 
     BrowsingContext* nested_browsing_context() { return m_nested_browsing_context; }
     const BrowsingContext* nested_browsing_context() const { return m_nested_browsing_context; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -13,7 +13,7 @@
 namespace Web::HTML {
 
 HTMLIFrameElement::HTMLIFrameElement(DOM::Document& document, QualifiedName qualified_name)
-    : FrameHostElement(document, move(qualified_name))
+    : BrowsingContextContainer(document, move(qualified_name))
 {
 }
 
@@ -36,7 +36,7 @@ void HTMLIFrameElement::parse_attribute(const FlyString& name, const String& val
 
 void HTMLIFrameElement::inserted()
 {
-    FrameHostElement::inserted();
+    BrowsingContextContainer::inserted();
     if (is_connected())
         load_src(attribute(HTML::AttributeNames::src));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
-#include <LibWeb/HTML/FrameHostElement.h>
+#include <LibWeb/HTML/BrowsingContextContainer.h>
 
 namespace Web::HTML {
 
-class HTMLIFrameElement final : public FrameHostElement {
+class HTMLIFrameElement final : public BrowsingContextContainer {
 public:
     using WrapperType = Bindings::HTMLIFrameElementWrapper;
 


### PR DESCRIPTION
With the renaming of "Frame" to "BrowsingContext", this changes
"FrameHostElement" to "BrowsingContextContainer" to further
match the spec.

https://html.spec.whatwg.org/#browsing-context-container