### PR TITLE
AK: Guard inline assembly with ARCH(I386) and provide alternative

### DIFF
--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -17,16 +17,26 @@
 
 ALWAYS_INLINE void fast_u32_copy(u32* dest, const u32* src, size_t count)
 {
+#if ARCH(I386)
     asm volatile(
         "rep movsl\n"
         : "+S"(src), "+D"(dest), "+c"(count)::"memory");
+#else
+    __builtin_memcpy(dest, src, count * 4);
+#endif
 }
 
 ALWAYS_INLINE void fast_u32_fill(u32* dest, u32 value, size_t count)
 {
+#if ARCH(I386)
     asm volatile(
         "rep stosl\n"
         : "=D"(dest), "=c"(count)
         : "D"(dest), "c"(count), "a"(value)
         : "memory");
+#else
+    for (auto* p = dest; p < (dest + count); ++p) {
+        *p = value;
+    }
+#endif
 }


### PR DESCRIPTION
For non-x86 targets, it's not very nice to define inline functions in
AK/Memory.h with asm volatile implementations. Guard this inline
assembly with ARCH(I386) and provide portable alternatives. Since we
always compile with optimizations, the hand-vectorized memset and
memcpy seem to be of dubious value, but we'll keep them here until
proven one way or another.

This should fix the Lagom build on native M1 macOS that was reported
on Discord the other day.

-----

As a note, there are only 8 uses of these APIs in the entire codebase:

fast_u32_copy:

1) Gfx::Painter::blit for source == BGRx8888 or BGRA8888
2) WindowServer::Compositor::flush()
    
fast_u32_fill:

1) Kernel/VM/MemoryManager.cpp -- could be converted to memset without any heartache on my part
2) UserspaceEmulator::SoftMMU::fast_fill_memory32 for doing a vectorized memset and shadow memset at the same time
3) Gfx::Bitmap::fill(Color)
4) GIFLoader.cpp, helper clear_rect(Bitmap, IntRect, Color) -- to fill a rect with a color (not clear...).
5) Gfx::Painter::clear_rect -- looks suspiciously similar to the previous item...
6) Painter::fill_physical_scanline_with_draw_op(DrawOp::Copy)