### PR TITLE
Kernel/ACPI: Sprinkle links to the specification all over

### DIFF
--- a/Kernel/ACPI/Definitions.h
+++ b/Kernel/ACPI/Definitions.h
@@ -16,6 +16,8 @@ namespace Kernel {
 namespace ACPI {
 
 namespace FADTFlags {
+
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#fixed-acpi-description-table-fixed-feature-flags
 enum class FeatureFlags : u32 {
     WBINVD = 1 << 0,
     WBINVD_FLUSH = 1 << 1,
@@ -41,6 +43,7 @@ enum class FeatureFlags : u32 {
     LOW_POWER_S0_IDLE_CAPABLE = 1 << 21
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#fixed-acpi-description-table-boot-ia-pc-boot-architecture-flags
 enum class IA_PC_Flags : u8 {
     Legacy_Devices = 1 << 0,
     PS2_8042 = 1 << 1,
@@ -110,6 +113,8 @@ enum class BitWidth {
 }
 
 namespace Structures {
+
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#root-system-description-pointer-rsdp-structure
 struct [[gnu::packed]] RSDPDescriptor {
     char sig[8];
     u8 checksum;
@@ -126,6 +131,7 @@ struct [[gnu::packed]] RSDPDescriptor20 {
     u8 reserved[3];
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#system-description-table-header
 struct [[gnu::packed]] SDTHeader {
     char sig[4];
     u32 length;
@@ -138,11 +144,13 @@ struct [[gnu::packed]] SDTHeader {
     u32 creator_revision;
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#root-system-description-table-rsdt
 struct [[gnu::packed]] RSDT {
     SDTHeader h;
     u32 table_ptrs[];
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#extended-system-description-table-xsdt
 struct [[gnu::packed]] XSDT {
     SDTHeader h;
     u64 table_ptrs[];
@@ -167,6 +175,7 @@ struct [[gnu::packed]] HPET {
     u8 page_protection;
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#fixed-acpi-description-table-fadt
 struct [[gnu::packed]] FADT {
     SDTHeader h;
     u32 firmware_ctrl;
@@ -225,6 +234,8 @@ struct [[gnu::packed]] FADT {
     GenericAddressStructure sleep_status;
     u64 hypervisor_vendor_identity;
 };
+
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#interrupt-controller-structure-types
 enum class MADTEntryType {
     LocalAPIC = 0x0,
     IOAPIC = 0x1,
@@ -250,6 +261,8 @@ struct [[gnu::packed]] MADTEntryHeader {
 };
 
 namespace MADTEntries {
+
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#i-o-apic-structure
 struct [[gnu::packed]] IOAPIC {
     MADTEntryHeader h;
     u8 ioapic_id;
@@ -258,6 +271,7 @@ struct [[gnu::packed]] IOAPIC {
     u32 gsi_base;
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#processor-local-apic-structure
 struct [[gnu::packed]] ProcessorLocalAPIC {
     MADTEntryHeader h;
     u8 acpi_processor_id;
@@ -265,6 +279,7 @@ struct [[gnu::packed]] ProcessorLocalAPIC {
     u32 flags;
 };
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#interrupt-source-override-structure
 struct [[gnu::packed]] InterruptSourceOverride {
     MADTEntryHeader h;
     u8 bus;
@@ -274,6 +289,7 @@ struct [[gnu::packed]] InterruptSourceOverride {
 };
 }
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#multiple-apic-description-table-madt-format
 struct [[gnu::packed]] MADT {
     SDTHeader h;
     u32 lapic_address;

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -169,7 +169,8 @@ void Parser::access_generic_address(const Structures::GenericAddressStructure& s
         return;
     }
     case GenericAddressStructure::AddressSpace::PCIConfigurationSpace: {
-        // According to the ACPI specification 6.2, page 168, PCI addresses must be confined to devices on Segment group 0, bus 0.
+        // According to https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#address-space-format,
+        // PCI addresses must be confined to devices on Segment group 0, bus 0.
         auto pci_address = PCI::Address(0, 0, ((structure.address >> 24) & 0xFF), ((structure.address >> 16) & 0xFF));
         dbgln("ACPI: Sending value {:x} to {}", value, pci_address);
         u32 offset_in_pci_address = structure.address & 0xFFFF;
@@ -189,7 +190,8 @@ void Parser::access_generic_address(const Structures::GenericAddressStructure& s
 
 bool Parser::validate_reset_register()
 {
-    // According to the ACPI spec 6.2, page 152, The reset register can only be located in I/O bus, PCI bus or memory-mapped.
+    // According to https://uefi.org/specs/ACPI/6.4/04_ACPI_Hardware_Specification/ACPI_Hardware_Specification.html#reset-register,
+    // the reset register can only be located in I/O bus, PCI bus or memory-mapped.
     auto fadt = map_typed<Structures::FADT>(m_fadt);
     return (fadt->reset_reg.address_space == (u8)GenericAddressStructure::AddressSpace::PCIConfigurationSpace || fadt->reset_reg.address_space == (u8)GenericAddressStructure::AddressSpace::SystemMemory || fadt->reset_reg.address_space == (u8)GenericAddressStructure::AddressSpace::SystemIO);
 }
@@ -297,6 +299,7 @@ static bool validate_table(const Structures::SDTHeader& v_header, size_t length)
     return false;
 }
 
+// https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#finding-the-rsdp-on-ia-pc-systems
 UNMAP_AFTER_INIT Optional<PhysicalAddress> StaticParsing::find_rsdp()
 {
     StringView signature("RSD PTR ");


### PR DESCRIPTION
The latest version of the ACPI specification (6.4) now has a web
version, making it possible to link directly to the relevant sections
of the specification.

I added links to the stuff that was easy to find.

The spec can be found here: https://uefi.org/specs/ACPI/6.4/index.html