### PR TITLE
LibJS: Fix two UBSAN errors

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1020,7 +1020,7 @@ Value right_shift(GlobalObject& global_object, Value lhs, Value rhs)
         if (!rhs_numeric.is_finite_number())
             return lhs_numeric;
         auto lhs_i32 = lhs_numeric.to_i32(global_object);
-        auto rhs_u32 = rhs_numeric.to_u32(global_object);
+        auto rhs_u32 = rhs_numeric.to_u32(global_object) % 32;
         return Value(lhs_i32 >> rhs_u32);
     }
     if (both_bigint(lhs_numeric, rhs_numeric)) {

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -637,7 +637,9 @@ u32 Value::to_u32(GlobalObject& global_object) const
     if (signbit(value))
         int_val = -int_val;
     auto int32bit = fmod(int_val, NumericLimits<u32>::max() + 1.0);
-    return static_cast<u32>(int32bit);
+    // Cast to i64 here to ensure that the double --> u32 cast doesn't invoke undefined behavior
+    // Otherwise, negative numbers cause a UBSAN warning.
+    return static_cast<u32>(static_cast<i64>(int32bit));
 }
 
 // 7.1.8 ToInt16 ( argument ), https://tc39.es/ecma262/#sec-toint16


### PR DESCRIPTION
LibJS: Ensure shift values in shift_right are modded by 32

The unsigned shift right implementation was already doing this, but
the spec requires a mod32 of rhs before the shift for the signed shift
right implementation as well. Caught by UBSAN and oss-fuzz.

LibJS: Avoid undefined static cast of negative values in to_u32

If the value we get after fmod in Value::to_u32 is negative, UBSAN
complains that -N is out of bounds for u32. An extra static cast to i64
makes it stop complaining. An alternative implementation could add 2^32
if the fmod'd value is negative. Caught by UBSAN and oss-fuzz.

Fixes both issues from https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29400