### PR TITLE
LibPthread: Correct error check in `sem_post` and `sem_wait`

### DIFF
--- a/Userland/Libraries/LibPthread/semaphore.cpp
+++ b/Userland/Libraries/LibPthread/semaphore.cpp
@@ -111,7 +111,7 @@ int sem_post(sem_t* sem)
     }
 
     rc = pthread_mutex_unlock(&sem->mtx);
-    if (errno != 0) {
+    if (rc != 0) {
         errno = rc;
         return -1;
     }
@@ -153,7 +153,7 @@ int sem_unlink(const char*)
 int sem_wait(sem_t* sem)
 {
     auto rc = pthread_mutex_lock(&sem->mtx);
-    if (errno != 0) {
+    if (rc != 0) {
         errno = rc;
         return -1;
     }


### PR DESCRIPTION
Simple typo fix. I'm guessing that this was exposed by d5bf9182dd2d2678dc43f38109282850c63bd63a