### PR TITLE
LibGUI/TreeView: Select parent on collapse

### DIFF
--- a/Userland/Libraries/LibGUI/ModelIndex.cpp
+++ b/Userland/Libraries/LibGUI/ModelIndex.cpp
@@ -19,6 +19,17 @@ Variant ModelIndex::data(ModelRole role) const
     return model()->data(*this, role);
 }
 
+bool ModelIndex::is_parent_of(const ModelIndex& child) const
+{
+    auto current_index = child.parent();
+    while (current_index.is_valid()) {
+        if (current_index == *this)
+            return true;
+        current_index = current_index.parent();
+    }
+    return false;
+}
+
 ModelIndex ModelIndex::sibling(int row, int column) const
 {
     if (!is_valid())

--- a/Userland/Libraries/LibGUI/ModelIndex.h
+++ b/Userland/Libraries/LibGUI/ModelIndex.h
@@ -26,6 +26,7 @@ public:
     void* internal_data() const { return m_internal_data; }
 
     ModelIndex parent() const;
+    bool is_parent_of(const ModelIndex&) const;
 
     bool operator==(const ModelIndex& other) const
     {

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -148,6 +148,10 @@ void TreeView::toggle_index(const ModelIndex& index)
     VERIFY(model()->row_count(index));
     auto& metadata = ensure_metadata_for_index(index);
     metadata.open = !metadata.open;
+
+    if (!metadata.open && index.is_parent_of(cursor_index()))
+        set_cursor(index, SelectionUpdate::Set);
+
     if (on_toggle)
         on_toggle(index, metadata.open);
     update_column_sizes();


### PR DESCRIPTION
When collapsing a tree that contains the current selection, the parent node becomes selected instead.