### PR TITLE
LibGUI: Make "Return" after tab return to original column in TableView

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -194,6 +194,7 @@ void AbstractTableView::set_column_header_alignment(int column, Gfx::TextAlignme
 
 void AbstractTableView::mousedown_event(MouseEvent& event)
 {
+    m_tab_moves = 0;
     if (!model())
         return AbstractView::mousedown_event(event);
 
@@ -403,13 +404,20 @@ void AbstractTableView::layout_headers()
 void AbstractTableView::keydown_event(KeyEvent& event)
 {
     if (is_tab_key_navigation_enabled()) {
-        if (event.modifiers() == KeyModifier::Mod_Shift && event.key() == KeyCode::Key_Tab) {
-            move_cursor(CursorMovement::Left, SelectionUpdate::Set);
-            event.accept();
-            return;
-        }
         if (!event.modifiers() && event.key() == KeyCode::Key_Tab) {
             move_cursor(CursorMovement::Right, SelectionUpdate::Set);
+            event.accept();
+            ++m_tab_moves;
+            return;
+        } else if (is_navigation(event)) {
+            if (event.key() == KeyCode::Key_Return) {
+                move_cursor_relative(0, -m_tab_moves, SelectionUpdate::Set);
+            }
+            m_tab_moves = 0;
+        }
+
+        if (event.modifiers() == KeyModifier::Mod_Shift && event.key() == KeyCode::Key_Tab) {
+            move_cursor(CursorMovement::Left, SelectionUpdate::Set);
             event.accept();
             return;
         }
@@ -418,4 +426,22 @@ void AbstractTableView::keydown_event(KeyEvent& event)
     AbstractView::keydown_event(event);
 }
 
+bool AbstractTableView::is_navigation(GUI::KeyEvent& event)
+{
+    switch (event.key()) {
+    case KeyCode::Key_Tab:
+    case KeyCode::Key_Left:
+    case KeyCode::Key_Right:
+    case KeyCode::Key_Up:
+    case KeyCode::Key_Down:
+    case KeyCode::Key_Return:
+    case KeyCode::Key_Home:
+    case KeyCode::Key_End:
+    case KeyCode::Key_PageUp:
+    case KeyCode::Key_PageDown:
+        return true;
+    default:
+        return false;
+    }
+}
 }

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -98,6 +98,7 @@ protected:
 
 private:
     void layout_headers();
+    bool is_navigation(GUI::KeyEvent&);
 
     RefPtr<HeaderView> m_column_header;
     RefPtr<HeaderView> m_row_header;
@@ -110,6 +111,7 @@ private:
 
     int m_vertical_padding { 8 };
     int m_horizontal_padding { font().glyph_height() / 2 };
+    int m_tab_moves { 0 };
 };
 
 }


### PR DESCRIPTION
From the original issue:
> When you press Tab to move to the right, it is expected for the selection to move back to the original column.
>
> An example:
> In A1: \<TAB\>
> In B1: \<TAB\>
> In C1: \<ENTER\>
> Now you are in C2, whereas you should land in A2.

Specifically, this pull request adds a counter for the number of consecutive Tab moves, and whenever the "Return" key is pressed, the cursor will move down as well as return to the original column in accordance with the Tab move counter.

Any moves not due to Tab (key or mouse events) reset the counter to zero. Shift-Tab is not considered a tab move.

Fixes #7591 