### PR TITLE
Hearts: Improve the AI again

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -327,10 +327,7 @@ size_t Game::pick_card(Player& player)
             auto prefer_card = [this, &player](Card& card) {
                 return !other_player_has_lower_value_card(player, card) && other_player_has_higher_value_card(player, card);
             };
-            auto lower_value_card_in_play = [this, &player](Card& card) {
-                return other_player_has_lower_value_card(player, card);
-            };
-            return player.pick_lead_card(move(valid_card), move(prefer_card), move(lower_value_card_in_play));
+            return player.pick_lead_card(move(valid_card), move(prefer_card));
         }
     }
     auto* high_card = &m_trick[0];

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -356,8 +356,12 @@ size_t Game::pick_card(Player& player)
         RETURN_CARD_IF_VALID(player.pick_low_points_high_value_card(m_trick[0].type()));
         if (is_first_trick)
             return player.pick_low_points_high_value_card().value();
-        else
-            return player.pick_max_points_card();
+        else {
+            auto ignore_card = [this, &player](Card& card) {
+                return !other_player_has_higher_value_card(player, card);
+            };
+            return player.pick_max_points_card(move(ignore_card));
+        }
     }
     RETURN_CARD_IF_VALID(player.pick_lower_value_card(*high_card));
     bool is_third_player = m_trick.size() == 2;
@@ -382,8 +386,10 @@ size_t Game::pick_card(Player& player)
         RETURN_CARD_IF_VALID(player.pick_slightly_higher_value_card(*high_card));
     if (is_first_trick)
         return player.pick_low_points_high_value_card().value();
-    else
-        return player.pick_max_points_card();
+    auto ignore_card = [this, &player](Card& card) {
+        return !other_player_has_higher_value_card(player, card);
+    };
+    return player.pick_max_points_card(move(ignore_card));
 }
 
 void Game::let_player_play_card()

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -397,6 +397,11 @@ void Game::let_player_play_card()
 
     if (player.is_human) {
         m_human_can_play = true;
+        if constexpr (HEARTS_DEBUG) {
+            auto card_index = pick_card(player);
+            auto& card = player.hand[card_index];
+            card->set_inverted(true);
+        }
         update();
         return;
     }

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -50,6 +50,7 @@ private:
     int calculate_score(Player& player);
     bool other_player_has_lower_value_card(Player& player, Card& card);
     bool other_player_has_higher_value_card(Player& player, Card& card);
+    bool other_player_has_queen_of_spades(Player& player);
 
     void reposition_hand(Player&);
     bool is_card_highlighted(Card& card);

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -39,8 +39,7 @@ Vector<CardWithIndex> Player::hand_sorted_by_points_and_value() const
     return sorted_hand;
 }
 
-size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Card&)> prefer_card,
-    Function<bool(Card&)> lower_value_card_in_play)
+size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Card&)> prefer_card)
 {
     auto sorted_hand = hand_sorted_by_points_and_value();
 
@@ -51,27 +50,17 @@ size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Ca
         dbgln("----");
     }
 
-    ssize_t fallback_index = -1;
     ssize_t last_index = -1;
     for (auto& cwi : sorted_hand) {
         if (!valid_play(*cwi.card))
             continue;
-        if (lower_value_card_in_play(*cwi.card)) {
-            // Allow falling back to this card if no other suitable card is in play.
-            fallback_index = cwi.index;
-            continue;
-        }
         if (prefer_card(*cwi.card)) {
             dbgln_if(HEARTS_DEBUG, "Preferring card {}", *cwi.card);
             return cwi.index;
         }
         last_index = cwi.index;
     }
-    if (last_index == -1) {
-        dbgln_if(HEARTS_DEBUG, "Falling back to card {}", *hand[fallback_index]);
-        return fallback_index;
-    } else
-        return last_index;
+    return last_index;
 }
 
 Optional<size_t> Player::pick_low_points_high_value_card(Optional<Card::Type> type)

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -73,18 +73,16 @@ size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Ca
 
 Optional<size_t> Player::pick_low_points_high_value_card(Optional<Card::Type> type)
 {
+    auto sorted_hand = hand_sorted_by_fn(compare_card_value);
     int min_points = -1;
     Optional<size_t> card_index;
-    for (ssize_t i = hand.size() - 1; i >= 0; i--) {
-        auto& card = hand[i];
-        if (card.is_null())
+    for (auto& cwi : sorted_hand) {
+        if (type.has_value() && cwi.card->type() != type.value())
             continue;
-        if (type.has_value() && card->type() != type.value())
-            continue;
-        auto points = hearts_card_points(*card);
+        auto points = hearts_card_points(*cwi.card);
         if (min_points == -1 || points < min_points) {
             min_points = points;
-            card_index = i;
+            card_index = cwi.index;
         }
     }
     VERIFY(card_index.has_value() || type.has_value());

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -107,13 +107,17 @@ Optional<size_t> Player::pick_slightly_higher_value_card(Card& other_card)
     return {};
 }
 
-size_t Player::pick_max_points_card()
+size_t Player::pick_max_points_card(Function<bool(Card&)> ignore_card)
 {
     auto queen_of_spades_maybe = pick_specific_card(Card::Type::Spades, CardValue::Queen);
     if (queen_of_spades_maybe.has_value())
         return queen_of_spades_maybe.value();
-    if (has_card_of_type(Card::Type::Hearts))
-        return pick_last_card();
+    if (has_card_of_type(Card::Type::Hearts)) {
+        auto highest_hearts_card_index = pick_last_card();
+        auto& card = hand[highest_hearts_card_index];
+        if (!ignore_card(*card))
+            return highest_hearts_card_index;
+    }
     return pick_low_points_high_value_card().value();
 }
 

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -38,7 +38,7 @@ public:
     Optional<size_t> pick_low_points_high_value_card(Optional<Card::Type> type = {});
     Optional<size_t> pick_lower_value_card(Card& other_card);
     Optional<size_t> pick_slightly_higher_value_card(Card& other_card);
-    size_t pick_max_points_card();
+    size_t pick_max_points_card(Function<bool(Card&)>);
     Optional<size_t> pick_specific_card(Card::Type type, CardValue value);
     size_t pick_last_card();
     bool has_card_of_type(Card::Type type);

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -42,7 +42,7 @@ public:
     Optional<size_t> pick_specific_card(Card::Type type, CardValue value);
     size_t pick_last_card();
     bool has_card_of_type(Card::Type type);
-    Vector<CardWithIndex> hand_sorted_by_points_and_value() const;
+    Vector<CardWithIndex> hand_sorted_by_fn(bool (*)(CardWithIndex&, CardWithIndex&)) const;
 
     void sort_hand() { quick_sort(hand, hearts_card_less); }
     void remove_cards(NonnullRefPtrVector<Card> const& cards);

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -34,7 +34,7 @@ public:
     }
 
     NonnullRefPtrVector<Card> pick_cards_to_pass(PassingDirection);
-    size_t pick_lead_card(Function<bool(Card&)>, Function<bool(Card&)>, Function<bool(Card&)>);
+    size_t pick_lead_card(Function<bool(Card&)>, Function<bool(Card&)>);
     Optional<size_t> pick_low_points_high_value_card(Optional<Card::Type> type = {});
     Optional<size_t> pick_lower_value_card(Card& other_card);
     Optional<size_t> pick_slightly_higher_value_card(Card& other_card);


### PR DESCRIPTION
**Hearts: Pick better lead cards**

Previously the AI would prefer playing a lead card for which no other player had a card with a higher value even though it also had a card for which a higher value card was still in play.

**Hearts: Pick better cards when we're the third player**

When we're the third player in a trick and we don't have a lower value card we would previously pick a slightly higher value card. Instead we should pick the highest value card unless there are points in the current trick or the lead card is spades and the higher value card we would've picked is higher than the queen and another player still has the queen.

The rationale is that we have to take the trick anyway so we might as well get rid of our highest value card. If the trailing player has a lower value card of the same type we take the trick but don't gain any points. If they don't have a card of the same type it doesn't matter whether we play a high value or low value card.

**Hearts: Make debugging AI suggestions easier**

When building Hearts with `HEARTS_DEBUG` we highlight the card the AI would have picked. This makes comparing AI and human decisions easier.

**Hearts: Pick better non-matching cards**

When we don't have a matching card for the lead card rather than always preferring to play hearts we should try to get rid of our
high value cards first if no other player has hearts cards higher than what we have.

**Hearts: Prefer to pass high value cards**

Previously we'd prefer to pass high points cards. Instead we should prefer to pass high value cards first.

**Hearts: Fix sorting for pick_low_points_high_value_card**

Previously the function did not sort the hand at all which means we wouldn't necessarily pick the card with the highest value.