### PR TITLE
Solitaire: Adds `space` key for drawing cards, `tab` key for auto move eligible cards to foundation stacks

### DIFF
--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -160,6 +160,10 @@ private:
     void remember_flip_for_undo(Card& card);
     void update_score(int to_add);
     void move_card(CardStack& from, CardStack& to);
+    void draw_cards();
+    void pop_waste_to_play_stack();
+    void auto_move_eligible_cards_to_stacks();
+    void start_timer_if_necessary();
     void start_game_over_animation();
     void stop_game_over_animation();
     void create_new_animation_card();


### PR DESCRIPTION
Updates the Solitaire game to add two new key events:

1. Pressing `space` key will draw new card(s), the same as clicking on the draw pile
2. Pressing `tab` key will have the game attempt to move all eligible cards from the tableau stacks and play stack to the foundation stacks

Fixes #7251 