### PR TITLE
Solitaire: Add undo functionality

### DIFF
--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -37,10 +37,12 @@ public:
 
     Mode mode() const { return m_mode; }
     void setup(Mode);
+    void perform_undo();
 
     Function<void(uint32_t)> on_score_update;
     Function<void()> on_game_start;
     Function<void(GameOverReason, uint32_t)> on_game_end;
+    Function<void(bool)> on_undo_availability_change;
 
 private:
     Game();
@@ -103,6 +105,19 @@ private:
         int8_t punishment { 0 };
     };
 
+    struct LastMove {
+        enum class Type {
+            Invalid,
+            MoveCards,
+            FlipCard
+        };
+
+        Type type { Type::Invalid };
+        CardStack* from { nullptr };
+        NonnullRefPtrVector<Card> cards;
+        CardStack* to { nullptr };
+    };
+
     enum StackLocation {
         Stock,
         Waste,
@@ -140,6 +155,9 @@ private:
     }
 
     void mark_intersecting_stacks_dirty(Card& intersecting_card);
+    void score_move(CardStack& from, CardStack& to, bool inverse);
+    void remember_move_for_undo(CardStack& from, CardStack& to, NonnullRefPtrVector<Card> moved_cards);
+    void remember_flip_for_undo(Card& card);
     void update_score(int to_add);
     void move_card(CardStack& from, CardStack& to);
     void start_game_over_animation();
@@ -163,6 +181,7 @@ private:
 
     Mode m_mode { Mode::SingleCardDraw };
 
+    LastMove m_last_move;
     NonnullRefPtrVector<Card> m_focused_cards;
     NonnullRefPtrVector<Card> m_new_deck;
     CardStack m_stacks[StackLocation::__Count];

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -177,6 +177,12 @@ int main(int argc, char** argv)
         game.setup(mode);
     }));
     game_menu.add_separator();
+    auto undo_action = GUI::CommonActions::make_undo_action([&](auto&) {
+        game.perform_undo();
+    });
+    undo_action->set_enabled(false);
+    game_menu.add_action(undo_action);
+    game_menu.add_separator();
     game_menu.add_action(single_card_draw_action);
     game_menu.add_action(three_card_draw_action);
     game_menu.add_separator();
@@ -190,6 +196,11 @@ int main(int argc, char** argv)
     window->set_menubar(move(menubar));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
+
+    game.on_undo_availability_change = [&](bool undo_available) {
+        undo_action->set_enabled(undo_available);
+    };
+
     game.setup(mode);
 
     return app->exec();


### PR DESCRIPTION
Adds the ability to undo your most-recent move in Solitaire.

A new menu is added to the GUI:
<img width="239" alt="Screen Shot 2021-06-01 at 1 48 16 PM" src="https://user-images.githubusercontent.com/955163/120381706-05c21380-c2e0-11eb-9626-393e027594a3.png">

If no undo is available, both the menu and hotkey `Ctrl+Z` are disabled.

If you can undo your most recent move, the menu and hotkey `Ctrl+Z` is enabled.

After performing an undo, the undo will be disabled as you can only undo your most-recent move and no more than that.

Fixes #7250 