### PR TITLE
PixelPaint: Support opening more image file formats

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -22,7 +22,7 @@
 
 namespace PixelPaint {
 
-RefPtr<Image> Image::create_with_size(const Gfx::IntSize& size)
+RefPtr<Image> Image::create_with_size(Gfx::IntSize const& size)
 {
     if (size.is_empty())
         return nullptr;
@@ -33,12 +33,12 @@ RefPtr<Image> Image::create_with_size(const Gfx::IntSize& size)
     return adopt_ref(*new Image(size));
 }
 
-Image::Image(const Gfx::IntSize& size)
+Image::Image(Gfx::IntSize const& size)
     : m_size(size)
 {
 }
 
-void Image::paint_into(GUI::Painter& painter, const Gfx::IntRect& dest_rect)
+void Image::paint_into(GUI::Painter& painter, Gfx::IntRect const& dest_rect)
 {
     float scale = (float)dest_rect.width() / (float)rect().width();
     Gfx::PainterStateSaver saver(painter);
@@ -115,7 +115,7 @@ RefPtr<Image> Image::create_from_file(String const& file_path)
     return create_from_pixel_paint_file(file_path);
 }
 
-void Image::save(const String& file_path) const
+void Image::save(String const& file_path) const
 {
     // Build json file
     StringBuilder builder;
@@ -147,7 +147,7 @@ void Image::save(const String& file_path) const
     fclose(file);
 }
 
-void Image::export_bmp(const String& file_path)
+void Image::export_bmp(String const& file_path)
 {
     auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, m_size);
     GUI::Painter painter(*bitmap);
@@ -160,7 +160,7 @@ void Image::export_bmp(const String& file_path)
     fclose(file);
 }
 
-void Image::export_png(const String& file_path)
+void Image::export_png(String const& file_path)
 {
     auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, m_size);
     VERIFY(bitmap);
@@ -194,7 +194,7 @@ RefPtr<Image> Image::take_snapshot() const
     return snapshot;
 }
 
-void Image::restore_snapshot(const Image& snapshot)
+void Image::restore_snapshot(Image const& snapshot)
 {
     m_layers.clear();
     select_layer(nullptr);
@@ -208,7 +208,7 @@ void Image::restore_snapshot(const Image& snapshot)
     did_modify_layer_stack();
 }
 
-size_t Image::index_of(const Layer& layer) const
+size_t Image::index_of(Layer const& layer) const
 {
     for (size_t i = 0; i < m_layers.size(); ++i) {
         if (&m_layers.at(i) == &layer)
@@ -308,7 +308,7 @@ void Image::remove_client(ImageClient& client)
     m_clients.remove(&client);
 }
 
-void Image::layer_did_modify_bitmap(Badge<Layer>, const Layer& layer)
+void Image::layer_did_modify_bitmap(Badge<Layer>, Layer const& layer)
 {
     auto layer_index = index_of(layer);
     for (auto* client : m_clients)
@@ -317,7 +317,7 @@ void Image::layer_did_modify_bitmap(Badge<Layer>, const Layer& layer)
     did_change();
 }
 
-void Image::layer_did_modify_properties(Badge<Layer>, const Layer& layer)
+void Image::layer_did_modify_properties(Badge<Layer>, Layer const& layer)
 {
     auto layer_index = index_of(layer);
     for (auto* client : m_clients)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -37,7 +37,8 @@ protected:
 class Image : public RefCounted<Image> {
 public:
     static RefPtr<Image> create_with_size(const Gfx::IntSize&);
-    static RefPtr<Image> create_from_file(const String& file_path);
+    static RefPtr<Image> create_from_file(String const& file_path);
+    static RefPtr<Image> create_from_bitmap(RefPtr<Gfx::Bitmap> bitmap);
 
     size_t layer_count() const { return m_layers.size(); }
     const Layer& layer(size_t index) const { return m_layers.at(index); }
@@ -73,6 +74,8 @@ public:
 
 private:
     explicit Image(const Gfx::IntSize&);
+
+    static RefPtr<Image> create_from_pixel_paint_file(String const& file_path);
 
     void did_change();
     void did_modify_layer_stack();

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -36,7 +36,7 @@ protected:
 
 class Image : public RefCounted<Image> {
 public:
-    static RefPtr<Image> create_with_size(const Gfx::IntSize&);
+    static RefPtr<Image> create_with_size(Gfx::IntSize const&);
     static RefPtr<Image> create_from_file(String const& file_path);
     static RefPtr<Image> create_from_bitmap(RefPtr<Gfx::Bitmap> bitmap);
 
@@ -49,12 +49,12 @@ public:
 
     void add_layer(NonnullRefPtr<Layer>);
     RefPtr<Image> take_snapshot() const;
-    void restore_snapshot(const Image&);
+    void restore_snapshot(Image const&);
 
-    void paint_into(GUI::Painter&, const Gfx::IntRect& dest_rect);
-    void save(const String& file_path) const;
-    void export_bmp(const String& file_path);
-    void export_png(const String& file_path);
+    void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect);
+    void save(String const& file_path) const;
+    void export_bmp(String const& file_path);
+    void export_png(String const& file_path);
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);
@@ -67,8 +67,8 @@ public:
     void add_client(ImageClient&);
     void remove_client(ImageClient&);
 
-    void layer_did_modify_bitmap(Badge<Layer>, const Layer&);
-    void layer_did_modify_properties(Badge<Layer>, const Layer&);
+    void layer_did_modify_bitmap(Badge<Layer>, Layer const&);
+    void layer_did_modify_properties(Badge<Layer>, Layer const&);
 
     size_t index_of(const Layer&) const;
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 
     const char* image_file = nullptr;
     Core::ArgsParser args_parser;
-    args_parser.add_positional_argument(image_file, "Pixel Paint image file (*.pp) to open", "path", Core::ArgsParser::Required::No);
+    args_parser.add_positional_argument(image_file, "Image file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
     auto app_icon = GUI::Icon::default_icon("app-pixel-paint");


### PR DESCRIPTION
Previously we could only open *.pp files to edit, this allows to also open ~~png and bmp files~~ all file formats supported by Gfx::Bitmap::load_from_file