### PR TITLE
TextEditor/GMLPlayground: Don't close app if user aborts save on exit

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -672,6 +672,8 @@ bool MainWidget::request_close()
 
     if (result == GUI::MessageBox::ExecYes) {
         m_save_action->activate();
+        if (editor().document().is_modified())
+            return false;
         return true;
     }
 

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -251,6 +251,8 @@ int main(int argc, char** argv)
         auto result = GUI::MessageBox::show(window, "The document has been modified. Would you like to save?", "Unsaved changes", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
         if (result == GUI::MessageBox::ExecYes) {
             save_action->activate();
+            if (window->is_modified())
+                return GUI::Window::CloseRequestDecision::StayOpen;
             return GUI::Window::CloseRequestDecision::Close;
         }
 


### PR DESCRIPTION
When the user has modified a document in TextEditor or GML Playground, and they go to exit the app, the app asks the user if they wish to save their changes or not. If the user chooses to save changes, the save dialog modal appears. If the user then happens to click `"Cancel"` to exit the save modal, rather than still proceeding with exiting the app, this PR stops the exiting process.

It does this by checking if the document is still modified after invoking the save dialog. If it is still modified, then the save did not happen, so we should not exit.

Fixes #7247