### PR TITLE
HexEditor: Fix off-by-one bugs in selected text length calculations

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -113,6 +113,13 @@ bool HexEditor::write_to_file(const String& path)
     return true;
 }
 
+size_t HexEditor::selection_size()
+{
+    if (!has_selection())
+        return 0;
+    return abs(m_selection_end - m_selection_start) + 1;
+}
+
 bool HexEditor::copy_selected_hex_to_clipboard()
 {
     if (!has_selection())
@@ -561,7 +568,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
 
 void HexEditor::select_all()
 {
-    highlight(0, m_buffer.size());
+    highlight(0, m_buffer.size() - 1);
     set_position(0);
 }
 
@@ -575,7 +582,7 @@ void HexEditor::highlight(int start, int end)
 int HexEditor::find_and_highlight(ByteBuffer& needle, int start)
 {
     auto end_of_match = find(needle, start);
-    highlight(end_of_match - needle.size(), end_of_match);
+    highlight(end_of_match - needle.size(), end_of_match - 1);
     return end_of_match;
 }
 

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -37,6 +37,7 @@ public:
 
     void select_all();
     bool has_selection() const { return !(m_selection_start == -1 || m_selection_end == -1 || (m_selection_end - m_selection_start) < 0 || m_buffer.is_empty()); }
+    size_t selection_size();
     int selection_start_offset() const { return m_selection_start; }
     bool copy_selected_text_to_clipboard();
     bool copy_selected_hex_to_clipboard();

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -51,7 +51,7 @@ HexEditorWidget::HexEditorWidget()
         m_statusbar->set_text(1, String::formatted("Edit Mode: {}", edit_mode == HexEditor::EditMode::Hex ? "Hex" : "Text"));
         m_statusbar->set_text(2, String::formatted("Selection Start: {}", selection_start));
         m_statusbar->set_text(3, String::formatted("Selection End: {}", selection_end));
-        m_statusbar->set_text(4, String::formatted("Selected Bytes: {}", abs(selection_end - selection_start)));
+        m_statusbar->set_text(4, String::formatted("Selected Bytes: {}", m_editor->selection_size()));
     };
 
     m_editor->on_change = [this] {


### PR DESCRIPTION
find_and_highlight() selected +1 too many bytes.

'Select All' selected +1 too many bytes past the end of
the buffer.

Status bar 'Selected Bytes' count was off by -1 when more
than zero bytes were selected.