### PR TITLE
AK: Clean up the URL class

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -35,7 +35,7 @@ constexpr bool is_ascii_hex_digit(u32 code_point)
 }
 
 // FIXME: It could make sense to force users of URL to use URLParser::parse() explicitly instead of using a constructor.
-URL::URL(const StringView& string)
+URL::URL(StringView const& string)
     : URL(URLParser::parse({}, string))
 {
     if constexpr (URL_PARSER_DEBUG) {
@@ -58,7 +58,7 @@ String URL::path() const
     return builder.to_string();
 }
 
-URL URL::complete_url(const String& string) const
+URL URL::complete_url(String const& string) const
 {
     if (!is_valid())
         return {};
@@ -66,31 +66,31 @@ URL URL::complete_url(const String& string) const
     return URLParser::parse({}, string, this);
 }
 
-void URL::set_scheme(const String& scheme)
+void URL::set_scheme(String scheme)
 {
-    m_scheme = scheme;
+    m_scheme = move(scheme);
     m_valid = compute_validity();
 }
 
-void URL::set_username(const String& username)
+void URL::set_username(String username)
 {
-    m_username = username;
+    m_username = move(username);
     m_valid = compute_validity();
 }
 
-void URL::set_password(const String& password)
+void URL::set_password(String password)
 {
-    m_password = password;
+    m_password = move(password);
     m_valid = compute_validity();
 }
 
-void URL::set_host(const String& host)
+void URL::set_host(String host)
 {
-    m_host = host;
+    m_host = move(host);
     m_valid = compute_validity();
 }
 
-void URL::set_port(const u16 port)
+void URL::set_port(u16 port)
 {
     if (port == default_port_for_scheme(m_scheme)) {
         m_port = 0;
@@ -100,20 +100,20 @@ void URL::set_port(const u16 port)
     m_valid = compute_validity();
 }
 
-void URL::set_paths(const Vector<String>& paths)
+void URL::set_paths(Vector<String> paths)
 {
-    m_paths = paths;
+    m_paths = move(paths);
     m_valid = compute_validity();
 }
 
-void URL::set_query(const String& query)
+void URL::set_query(String query)
 {
-    m_query = query;
+    m_query = move(query);
 }
 
-void URL::set_fragment(const String& fragment)
+void URL::set_fragment(String fragment)
 {
-    m_fragment = fragment;
+    m_fragment = move(fragment);
 }
 
 // FIXME: This is by no means complete.
@@ -154,12 +154,12 @@ bool URL::compute_validity() const
     return true;
 }
 
-bool URL::scheme_requires_port(const StringView& scheme)
+bool URL::scheme_requires_port(StringView const& scheme)
 {
     return (default_port_for_scheme(scheme) != 0);
 }
 
-u16 URL::default_port_for_scheme(const StringView& scheme)
+u16 URL::default_port_for_scheme(StringView const& scheme)
 {
     if (scheme == "http")
         return 80;
@@ -178,7 +178,7 @@ u16 URL::default_port_for_scheme(const StringView& scheme)
     return 0;
 }
 
-URL URL::create_with_file_scheme(const String& path, const String& fragment, const String& hostname)
+URL URL::create_with_file_scheme(String const& path, String const& fragment, String const& hostname)
 {
     LexicalPath lexical_path(path);
     if (!lexical_path.is_valid() || !lexical_path.is_absolute())
@@ -197,7 +197,7 @@ URL URL::create_with_file_scheme(const String& path, const String& fragment, con
     return url;
 }
 
-URL URL::create_with_url_or_path(const String& url_or_path)
+URL URL::create_with_url_or_path(String const& url_or_path)
 {
     URL url = url_or_path;
     if (url.is_valid())
@@ -207,20 +207,8 @@ URL URL::create_with_url_or_path(const String& url_or_path)
     return URL::create_with_file_scheme(path);
 }
 
-URL URL::create_with_data(const StringView& mime_type, const StringView& payload, bool is_base64)
-{
-    URL url;
-    url.set_scheme("data");
-    url.m_valid = true;
-    url.m_data_payload = payload;
-    url.m_data_mime_type = mime_type;
-    url.m_data_payload_is_base64 = is_base64;
-
-    return url;
-}
-
 // https://url.spec.whatwg.org/#special-scheme
-bool URL::is_special_scheme(const StringView& scheme)
+bool URL::is_special_scheme(StringView const& scheme)
 {
     return scheme.is_one_of("ftp", "file", "http", "https", "ws", "wss");
 }
@@ -337,7 +325,7 @@ String URL::serialize_for_display() const
     return builder.to_string();
 }
 
-bool URL::equals(const URL& other, ExcludeFragment exclude_fragments) const
+bool URL::equals(URL const& other, ExcludeFragment exclude_fragments) const
 {
     if (!m_valid || !other.m_valid)
         return false;
@@ -404,7 +392,7 @@ void URL::append_percent_encoded_if_necessary(StringBuilder& builder, u32 code_p
         builder.append_code_point(code_point);
 }
 
-String URL::percent_encode(const StringView& input, URL::PercentEncodeSet set)
+String URL::percent_encode(StringView const& input, URL::PercentEncodeSet set)
 {
     StringBuilder builder;
     for (auto code_point : Utf8View(input)) {
@@ -424,7 +412,7 @@ constexpr u8 parse_hex_digit(u8 digit)
     VERIFY_NOT_REACHED();
 }
 
-String URL::percent_decode(const StringView& input)
+String URL::percent_decode(StringView const& input)
 {
     if (!input.contains('%'))
         return input;

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -327,6 +327,8 @@ String URL::serialize_for_display() const
 
 bool URL::equals(URL const& other, ExcludeFragment exclude_fragments) const
 {
+    if (this == &other)
+        return true;
     if (!m_valid || !other.m_valid)
         return false;
     return serialize(exclude_fragments) == other.serialize(exclude_fragments);

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -36,43 +36,43 @@ public:
     };
 
     URL() = default;
-    URL(const StringView&);
-    URL(const char* string)
+    URL(StringView const&);
+    URL(char const* string)
         : URL(StringView(string))
     {
     }
-    URL(const String& string)
+    URL(String const& string)
         : URL(string.view())
     {
     }
 
-    bool is_valid() const { return m_valid; }
+    bool const& is_valid() const { return m_valid; }
 
-    String scheme() const { return m_scheme; }
-    String protocol() const { return m_scheme; }
-    String username() const { return m_username; }
-    String password() const { return m_password; }
-    String host() const { return m_host; }
-    const Vector<String>& paths() const { return m_paths; }
-    String query() const { return m_query; }
-    String fragment() const { return m_fragment; }
+    String const& scheme() const { return m_scheme; }
+    String const& protocol() const { return m_scheme; }
+    String const& username() const { return m_username; }
+    String const& password() const { return m_password; }
+    String const& host() const { return m_host; }
+    Vector<String> const& paths() const { return m_paths; }
+    String const& query() const { return m_query; }
+    String const& fragment() const { return m_fragment; }
     u16 port() const { return m_port ? m_port : default_port_for_scheme(m_scheme); }
-    bool cannot_be_a_base_url() const { return m_cannot_be_a_base_url; }
+    bool const& cannot_be_a_base_url() const { return m_cannot_be_a_base_url; }
 
     bool includes_credentials() const { return !m_username.is_empty() || !m_password.is_empty(); }
     bool is_special() const { return is_special_scheme(m_scheme); }
 
-    void set_scheme(const String&);
-    void set_protocol(const String& protocol) { set_scheme(protocol); }
-    void set_username(const String&);
-    void set_password(const String&);
-    void set_host(const String&);
-    void set_port(const u16);
-    void set_paths(const Vector<String>&);
-    void set_query(const String&);
-    void set_fragment(const String&);
-    void set_cannot_be_a_base_url(const bool value) { m_cannot_be_a_base_url = value; }
-    void append_path(const String& path) { m_paths.append(path); }
+    void set_scheme(String);
+    void set_protocol(String protocol) { set_scheme(move(protocol)); }
+    void set_username(String);
+    void set_password(String);
+    void set_host(String);
+    void set_port(u16);
+    void set_paths(Vector<String>);
+    void set_query(String);
+    void set_fragment(String);
+    void set_cannot_be_a_base_url(bool value) { m_cannot_be_a_base_url = value; }
+    void append_path(String path) { m_paths.append(path); }
 
     String path() const;
     String basename() const;
@@ -83,27 +83,27 @@ public:
     String to_string() const { return serialize(); }
     String to_string_encoded() const { return serialize(); }
 
-    bool equals(const URL& other, ExcludeFragment = ExcludeFragment::No) const;
+    bool equals(URL const& other, ExcludeFragment = ExcludeFragment::No) const;
 
-    URL complete_url(const String&) const;
+    URL complete_url(String const&) const;
 
     bool data_payload_is_base64() const { return m_data_payload_is_base64; }
-    const String& data_mime_type() const { return m_data_mime_type; }
-    const String& data_payload() const { return m_data_payload; }
+    String const& data_mime_type() const { return m_data_mime_type; }
+    String const& data_payload() const { return m_data_payload; }
 
-    static URL create_with_url_or_path(const String&);
-    static URL create_with_file_scheme(const String& path, const String& fragment = {}, const String& hostname = {});
-    static URL create_with_file_protocol(const String& path, const String& fragment = {}) { return create_with_file_scheme(path, fragment); }
-    static URL create_with_data(const StringView& mime_type, const StringView& payload, bool is_base64 = false);
+    static URL create_with_url_or_path(String const&);
+    static URL create_with_file_scheme(String const& path, String const& fragment = {}, String const& hostname = {});
+    static URL create_with_file_protocol(String const& path, String const& fragment = {}) { return create_with_file_scheme(path, fragment); }
+    static URL create_with_data(String mime_type, String payload, bool is_base64 = false) { return URL(move(mime_type), move(payload), is_base64); };
 
-    static bool scheme_requires_port(const StringView&);
-    static u16 default_port_for_scheme(const StringView&);
-    static bool is_special_scheme(const StringView&);
+    static bool scheme_requires_port(StringView const&);
+    static u16 default_port_for_scheme(StringView const&);
+    static bool is_special_scheme(StringView const&);
 
-    static String percent_encode(const StringView& input, PercentEncodeSet set = PercentEncodeSet::Userinfo);
-    static String percent_decode(const StringView& input);
+    static String percent_encode(StringView const& input, PercentEncodeSet set = PercentEncodeSet::Userinfo);
+    static String percent_decode(StringView const& input);
 
-    bool operator==(const URL& other) const
+    bool operator==(URL const& other) const
     {
         if (this == &other)
             return true;
@@ -148,7 +148,7 @@ private:
 
 template<>
 struct Formatter<URL> : Formatter<StringView> {
-    void format(FormatBuilder& builder, const URL& value)
+    void format(FormatBuilder& builder, URL const& value)
     {
         Formatter<StringView>::format(builder, value.serialize());
     }
@@ -156,7 +156,7 @@ struct Formatter<URL> : Formatter<StringView> {
 
 template<>
 struct Traits<URL> : public GenericTraits<URL> {
-    static unsigned hash(const URL& url) { return url.to_string().hash(); }
+    static unsigned hash(URL const& url) { return url.to_string().hash(); }
 };
 
 }

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -79,9 +79,7 @@ public:
 
     String serialize(ExcludeFragment = ExcludeFragment::No) const;
     String serialize_for_display() const;
-
     String to_string() const { return serialize(); }
-    String to_string_encoded() const { return serialize(); }
 
     bool equals(URL const& other, ExcludeFragment = ExcludeFragment::No) const;
 

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -101,12 +101,7 @@ public:
     static String percent_encode(StringView const& input, PercentEncodeSet set = PercentEncodeSet::Userinfo);
     static String percent_decode(StringView const& input);
 
-    bool operator==(URL const& other) const
-    {
-        if (this == &other)
-            return true;
-        return equals(other, ExcludeFragment::No);
-    }
+    bool operator==(URL const& other) const { return equals(other, ExcludeFragment::No); }
 
 private:
     URL(String&& data_mime_type, String&& data_payload, bool payload_is_base64)

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -156,7 +156,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
             headers.set(it.key, it.value);
         }
 
-        auto protocol_request = protocol_client().start_request(request.method(), url.to_string_encoded(), headers, request.body());
+        auto protocol_request = protocol_client().start_request(request.method(), url.to_string(), headers, request.body());
         if (!protocol_request) {
             if (error_callback)
                 error_callback("Failed to initiate load", {});

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -52,7 +52,8 @@ void OutOfProcessWebView::handle_web_content_process_crash()
         builder.appendff(" on {}", escape_html_entities(m_url.host()));
     }
     builder.append("</h1>");
-    builder.appendff("The web page <a href=\"{}\">{}</a> has crashed.<br><br>You can reload the page to try again.", escape_html_entities(m_url.to_string_encoded()), escape_html_entities(m_url.to_string()));
+    auto escaped_url = escape_html_entities(m_url.to_string());
+    builder.appendff("The web page <a href=\"{}\">{}</a> has crashed.<br><br>You can reload the page to try again.", escaped_url, escaped_url);
     builder.append("</body></html>");
     load_html(builder.to_string(), m_url);
 }


### PR DESCRIPTION
This PR cleans up the `AK::URL` class:

* Use correct constness for getters, setters and other methods.
* Use east `const` style.
* Remove unnecessary `URL::to_string_encoded()`
* Move identity check (`this == &other`) from `operator==` to `equals`.