### PR TITLE
AK: Fix missing lines in StringView::lines()

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -99,12 +99,13 @@ Vector<StringView> StringView::lines(bool consider_cr) const
             if (last_ch_was_cr) {
                 substart = i + 1;
                 split_view = false;
-                last_ch_was_cr = false;
             }
         }
         if (ch == '\r') {
             split_view = true;
             last_ch_was_cr = true;
+        } else {
+            last_ch_was_cr = false;
         }
         if (split_view) {
             size_t sublen = i - substart;

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -77,7 +77,7 @@ TEST_CASE(ends_with)
 
 TEST_CASE(lines)
 {
-    String test_string = "a\nb\r\nc\rd";
+    String test_string = "a\rb\nc\r\nd";
     StringView test_string_view = test_string.view();
     Vector<StringView> test_string_vector = test_string_view.lines();
     EXPECT_EQ(test_string_vector.size(), 4u);


### PR DESCRIPTION
It appears to me that StringView::lines() will drop an entire line if it is surrounded by “\r” and “\n” separators on the left and right sides respectively.

This patch addresses this issue.
The modified test should highlight the bug.