### PR TITLE
LibWeb: Use correct percent encode set for form submissions

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -105,14 +105,14 @@ void HTMLFormElement::submit_form(RefPtr<HTMLElement> submitter, bool from_submi
     });
 
     if (effective_method == "get") {
-        url.set_query(urlencode(parameters));
+        url.set_query(urlencode(parameters, URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded));
     }
 
     LoadRequest request;
     request.set_url(url);
 
     if (effective_method == "post") {
-        auto body = urlencode(parameters).to_byte_buffer();
+        auto body = urlencode(parameters, URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded).to_byte_buffer();
         request.set_method("POST");
         request.set_header("Content-Type", "application/x-www-form-urlencoded");
         request.set_header("Content-Length", String::number(body.size()));

--- a/Userland/Libraries/LibWeb/URLEncoder.cpp
+++ b/Userland/Libraries/LibWeb/URLEncoder.cpp
@@ -10,13 +10,13 @@
 
 namespace Web {
 
-String urlencode(const Vector<URLQueryParam>& pairs)
+String urlencode(const Vector<URLQueryParam>& pairs, URL::PercentEncodeSet percent_encode_set)
 {
     StringBuilder builder;
     for (size_t i = 0; i < pairs.size(); ++i) {
-        builder.append(URL::percent_encode(pairs[i].name));
+        builder.append(URL::percent_encode(pairs[i].name, percent_encode_set));
         builder.append('=');
-        builder.append(URL::percent_encode(pairs[i].value));
+        builder.append(URL::percent_encode(pairs[i].value, percent_encode_set));
         if (i != pairs.size() - 1)
             builder.append('&');
     }

--- a/Userland/Libraries/LibWeb/URLEncoder.h
+++ b/Userland/Libraries/LibWeb/URLEncoder.h
@@ -16,6 +16,6 @@ struct URLQueryParam {
     String value;
 };
 
-String urlencode(const Vector<URLQueryParam>&);
+String urlencode(const Vector<URLQueryParam>&, URL::PercentEncodeSet);
 
 }


### PR DESCRIPTION
We currently only support application/x-www-form-urlencoded for
form submissions, which uses a special percent encode set when
percent encoding the body/query. However, we were not using this
percent encode set.

With the new URL implementation, we can now specify the percent encode
set to be used, allowing us to use this special percent encode set.

This is one of the fixes needed to make the Google cookie consent work.