### PR TITLE
LibSQL: Return an error for empty common table expression lists

### DIFF
--- a/Tests/LibSQL/TestSqlStatementParser.cpp
+++ b/Tests/LibSQL/TestSqlStatementParser.cpp
@@ -682,6 +682,8 @@ TEST_CASE(select)
 
 TEST_CASE(common_table_expression)
 {
+    EXPECT(parse("WITH").is_error());
+    EXPECT(parse("WITH;").is_error());
     EXPECT(parse("WITH DELETE FROM table;").is_error());
     EXPECT(parse("WITH table DELETE FROM table;").is_error());
     EXPECT(parse("WITH table AS DELETE FROM table;").is_error());

--- a/Userland/Libraries/LibSQL/Parser.h
+++ b/Userland/Libraries/LibSQL/Parser.h
@@ -59,7 +59,7 @@ private:
     NonnullRefPtr<Update> parse_update_statement(RefPtr<CommonTableExpressionList>);
     NonnullRefPtr<Delete> parse_delete_statement(RefPtr<CommonTableExpressionList>);
     NonnullRefPtr<Select> parse_select_statement(RefPtr<CommonTableExpressionList>);
-    NonnullRefPtr<CommonTableExpressionList> parse_common_table_expression_list();
+    RefPtr<CommonTableExpressionList> parse_common_table_expression_list();
 
     NonnullRefPtr<Expression> parse_primary_expression();
     NonnullRefPtr<Expression> parse_secondary_expression(NonnullRefPtr<Expression> primary);


### PR DESCRIPTION
SQL::CommonTableExpressionList is required to be non-empty. Return an
error if zero common table expressions were parsed.

Fixes #7627