### PR TITLE
Profiler: Fix loading profiles which previously would crash the profiler

### DIFF
--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -267,7 +267,7 @@ Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const St
             event.executable = perf_event.get("executable").to_string();
 
             auto old_process = current_processes.get(event.pid).value();
-            old_process->end_valid = event.timestamp - 1;
+            old_process->end_valid = event.timestamp;
 
             current_processes.remove(event.pid);
 
@@ -282,7 +282,7 @@ Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const St
             continue;
         } else if (event.type == "process_exit"sv) {
             auto old_process = current_processes.get(event.pid).value();
-            old_process->end_valid = event.timestamp - 1;
+            old_process->end_valid = event.timestamp;
 
             current_processes.remove(event.pid);
             continue;


### PR DESCRIPTION
The profiler tried to be clever when handling `process_exit` events by subtracting one from the timestamp. This was supposed to ensure that events after a process' death would be attributed to the new process in case the old process used `execve()`. However, if there was another event (e.g. a CPU sample) at the exact same time the process_exit event was recorded the profile would fail to load because we didn't find the process anymore.

This changes introduces a new problem where samples would be attributed to the incorrect process if a CPU sample for the old process, a `process_exit` as well as a `process_create` event plus another CPU sample event for the new process happened at the exact same time. I think it's a reasonable compromise though.