### PR TITLE
Inspector: Improve method for checking if a process is inspectable

### DIFF
--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -88,6 +88,11 @@ void RemoteProcess::set_property(FlatPtr object, const StringView& name, const J
     m_client->async_set_object_property(m_pid, object, name, value.to_string());
 }
 
+bool RemoteProcess::is_inspectable()
+{
+    return m_client->is_inspectable(m_pid);
+}
+
 void RemoteProcess::update()
 {
     {

--- a/Userland/DevTools/Inspector/RemoteProcess.h
+++ b/Userland/DevTools/Inspector/RemoteProcess.h
@@ -32,6 +32,8 @@ public:
 
     void set_property(FlatPtr object, const StringView& name, const JsonValue& value);
 
+    bool is_inspectable();
+
     Function<void()> on_update;
 
 private:

--- a/Userland/Services/InspectorServer/ClientConnection.cpp
+++ b/Userland/Services/InspectorServer/ClientConnection.cpp
@@ -81,4 +81,13 @@ Messages::InspectorServer::IdentifyResponse ClientConnection::identify(pid_t pid
     return { response };
 }
 
+Messages::InspectorServer::IsInspectableResponse ClientConnection::is_inspectable(pid_t pid)
+{
+    auto process = InspectableProcess::from_pid(pid);
+    if (!process)
+        return false;
+
+    return true;
+}
+
 }

--- a/Userland/Services/InspectorServer/ClientConnection.h
+++ b/Userland/Services/InspectorServer/ClientConnection.h
@@ -28,6 +28,7 @@ private:
     virtual Messages::InspectorServer::SetInspectedObjectResponse set_inspected_object(pid_t, u64 object_id) override;
     virtual Messages::InspectorServer::SetObjectPropertyResponse set_object_property(pid_t, u64 object_id, String const& name, String const& value) override;
     virtual Messages::InspectorServer::IdentifyResponse identify(pid_t) override;
+    virtual Messages::InspectorServer::IsInspectableResponse is_inspectable(pid_t) override;
 };
 
 }

--- a/Userland/Services/InspectorServer/InspectorServer.ipc
+++ b/Userland/Services/InspectorServer/InspectorServer.ipc
@@ -4,4 +4,5 @@ endpoint InspectorServer
     set_inspected_object(i32 pid, u64 object_id) => (bool success)
     set_object_property(i32 pid, u64 object_id, String name, String value) => (bool success)
     identify(i32 pid) => (String json)
+    is_inspectable(i32 pid) => (bool inspectable)
 }


### PR DESCRIPTION
Improves the logic for the Inspector app to verify that the given `pid` is indeed inspectable.

The commit c9e849a defines whether or not a process is inspectable, defaulting to `No`.

The commit 4a2dd5b previously attempted to check whether or not a process could be inspected, but this seems to always fail and exit even when a process is indeed inspectable.

Two changes in this PR:

1. The `InspectorServer` IPC is updated to expose a new `is_inspectable` call, since the `InspectorServer` keeps track of what is currently inspectable.
2. The `Inspector` app uses this new IPC to determine if the selected / specified process is inspectable. If it is not, and you chose that process via the GUI, then the GUI reappears allowing you to select a different process. If you specified the `pid` via the command-line, then the app exits.

Fixes #7456 