### PR TITLE
LibJS: Add the String.prototype.trim{Left, Right} aliases

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -256,6 +256,8 @@ namespace JS {
     P(trace)                                 \
     P(trim)                                  \
     P(trimEnd)                               \
+    P(trimLeft)                              \
+    P(trimRight)                             \
     P(trimStart)                             \
     P(trunc)                                 \
     P(undefined)                             \

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -78,7 +78,9 @@ void StringPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.padEnd, pad_end, 1, attr);
     define_native_function(vm.names.trim, trim, 0, attr);
     define_native_function(vm.names.trimStart, trim_start, 0, attr);
+    define_property(vm.names.trimLeft, get(vm.names.trimStart, {}, true), attr);
     define_native_function(vm.names.trimEnd, trim_end, 0, attr);
+    define_property(vm.names.trimRight, get(vm.names.trimEnd, {}, true), attr);
     define_native_function(vm.names.concat, concat, 1, attr);
     define_native_function(vm.names.substr, substr, 2, attr);
     define_native_function(vm.names.substring, substring, 2, attr);


### PR DESCRIPTION
These are the same as trim{Start, End} respectively.

This allowes 8 new test262 test cases to pass.