### PR TITLE
SoundPlayer: Fix playback slider page stepping

### DIFF
--- a/Userland/Applications/SoundPlayer/Common.h
+++ b/Userland/Applications/SoundPlayer/Common.h
@@ -19,17 +19,29 @@ public:
             GUI::Slider::set_value(value);
     }
 
+    bool mouse_is_down() const { return m_mouse_is_down; }
+
 protected:
     AutoSlider(Orientation orientation)
         : GUI::Slider(orientation)
     {
     }
 
+    virtual void mousedown_event(GUI::MouseEvent& event) override
+    {
+        m_mouse_is_down = true;
+        GUI::Slider::mousedown_event(event);
+    }
+
     virtual void mouseup_event(GUI::MouseEvent& event) override
     {
+        m_mouse_is_down = false;
         if (on_knob_released && is_enabled())
             on_knob_released(value());
 
         GUI::Slider::mouseup_event(event);
     }
+
+private:
+    bool m_mouse_is_down { false };
 };


### PR DESCRIPTION
Fixes a bug that was preventing the playback slider from changing
value when clicking ahead/behind the current position.

Sets the page step to 1/10th of the range of the playback slider.

cc @ngc6302h 

### Testing

- [x] Loaded a `.wav` file in SoundPlayer, verified I can page ahead and behind by clicking on the playback slider outside of the rectangle