### PR TITLE
LibGUI: Fixes Widget->set_visible(false) still maintains focus bug

### DIFF
--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -726,6 +726,8 @@ void Widget::set_visible(bool visible)
         parent->invalidate_layout();
     if (m_visible)
         update();
+    if (!m_visible && is_focused())
+        set_focus(false);
 
     if (m_visible) {
         ShowEvent e;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -654,11 +654,15 @@ void Window::set_focused_widget(Widget* widget, FocusSource source)
     WeakPtr<Widget> previously_focused_widget = m_focused_widget;
     m_focused_widget = widget;
 
+    if (!m_focused_widget && m_previously_focused_widget)
+        m_focused_widget = m_previously_focused_widget;
+
     if (previously_focused_widget) {
         Core::EventLoop::current().post_event(*previously_focused_widget, make<FocusEvent>(Event::FocusOut, source));
         previously_focused_widget->update();
         if (previously_focused_widget && previously_focused_widget->on_focus_change)
             previously_focused_widget->on_focus_change(previously_focused_widget->is_focused(), source);
+        m_previously_focused_widget = previously_focused_widget;
     }
     if (m_focused_widget) {
         Core::EventLoop::current().post_event(*m_focused_widget, make<FocusEvent>(Event::FocusIn, source));

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -228,6 +228,8 @@ private:
     void flip(const Vector<Gfx::IntRect, 32>& dirty_rects);
     void force_update();
 
+    WeakPtr<Widget> m_previously_focused_widget;
+
     OwnPtr<WindowBackingStore> m_front_store;
     OwnPtr<WindowBackingStore> m_back_store;
 


### PR DESCRIPTION
Previously, when setting a `Widget->set_visible(false)`, if that `Widget->has_focus()` it will continue to have focus, even though it's not visible to the user anymore.

Now calling `Widget->set_visible(false)` will remove focus from the Widget if it had focus, and the Window will give focus back to the Widget that had it previously, if there was one.

I noticed this bug when working on #7654 The Hearts game `Game::keydown_event(GUI::KeyEvent& event)` would work for all keys initially when the game first launches. On the screen there is a disabled button with the text "Pass Left" Once you select your three cards, the button "Pass Left" becomes enabled. Up to this point, `keydown_event` would fire for all keys, including `Space` and `Return`. Once you click "Pass Left", the button text changes to "OK" and now the button has focus. Clicking the "OK" dismisses the button, by setting `set_visible(false)`. However, at this point, `keydown_event` will not work for either `Space` or `Return`, but will for any other key.

This is because `AbstractButton` overrides the default `Widget` function `keydown_event` which can be seen here: https://github.com/SerenityOS/serenity/blob/06b5d292d754b172567fa561668a3bfbbe120a2c/Libraries/LibGUI/AbstractButton.cpp#L158

If this evaluates to true, it `event.accept()` the `KeyEvent`, preventing it from bubbling further up, even though the button is not visible to the user and the button shouldn't have focus anymore.