### PR TITLE
Hearts: Play the first valid card (left-to-right) when pressing space

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -392,6 +392,19 @@ size_t Game::pick_card(Player& player)
     return player.pick_max_points_card(move(ignore_card));
 }
 
+size_t Game::pick_first_card_ltr(Player& player)
+{
+    for (size_t i = 0; i < player.hand.size(); i++) {
+        auto& card = player.hand[i];
+        if (card.is_null())
+            continue;
+        if (is_valid_play(player, *card)) {
+            return i;
+        }
+    }
+    VERIFY_NOT_REACHED();
+}
+
 void Game::let_player_play_card()
 {
     auto& player = current_player();
@@ -567,6 +580,9 @@ void Game::keydown_event(GUI::KeyEvent& event)
             play_card(m_players[0], pick_card(m_players[0]));
         else if (m_state == State::PassingSelect)
             select_cards_for_passing();
+    } else if (event.key() == KeyCode::Key_Space) {
+        if (m_human_can_play && m_state == State::Play)
+            play_card(m_players[0], pick_first_card_ltr(m_players[0]));
     } else if (event.shift() && event.key() == KeyCode::Key_F11)
         dump_state();
 }

--- a/Userland/Games/Hearts/Game.h
+++ b/Userland/Games/Hearts/Game.h
@@ -44,6 +44,7 @@ private:
     void continue_game_after_delay(int interval_ms = 750);
     void advance_game();
     size_t pick_card(Player& player);
+    size_t pick_first_card_ltr(Player& player);
     size_t player_index(Player& player);
     Player& current_player();
     bool game_ended() const { return m_trick_number == 13; }


### PR DESCRIPTION
Implements the `Space` key to play the first valid card from the player's hand, going left-to-right.

Note: This functionality won't work until PR #7682 is merged, or an similar fix, as the `KeyEvent` for `KeyCode::Key_Space` will never arrive to `Game::keydown_event(GUI::KeyEvent& event)` handler after the user has clicked the focused button "OK" that becomes no longer visible, as that button is still swallowing events for `KeyCode::Key_Space` and `KeyCode::Key_Return` behind the scenes, even when not visible.

Fixes #7654