### PR TITLE
AK: Add CharacterTypes.h as a ctype.h replacement

### DIFF
--- a/AK/CharacterTypes.h
+++ b/AK/CharacterTypes.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+// NOTE: For a quick reference for most of this, see https://www.cplusplus.com/reference/cctype/ and https://infra.spec.whatwg.org/#code-points.
+// NOTE: To avoid ambiguity when including this header, all methods contains names should contain "ascii" or "unicode".
+
+namespace AK {
+
+constexpr bool is_ascii(u32 code_point)
+{
+    return code_point < 0x80;
+}
+
+constexpr bool is_ascii_digit(u32 code_point)
+{
+    return code_point >= '0' && code_point <= '9';
+}
+
+constexpr bool is_ascii_upper_alpha(u32 code_point)
+{
+    return (code_point >= 'A' && code_point <= 'Z');
+}
+
+constexpr bool is_ascii_lower_alpha(u32 code_point)
+{
+    return (code_point >= 'a' && code_point <= 'z');
+}
+
+constexpr bool is_ascii_alpha(u32 code_point)
+{
+    return is_ascii_lower_alpha(code_point) || is_ascii_upper_alpha(code_point);
+}
+
+constexpr bool is_ascii_alphanumeric(u32 code_point)
+{
+    return is_ascii_alpha(code_point) || is_ascii_digit(code_point);
+}
+
+constexpr bool is_ascii_hex_digit(u32 code_point)
+{
+    return is_ascii_digit(code_point) || (code_point >= 'A' && code_point <= 'F') || (code_point >= 'a' && code_point <= 'f');
+}
+
+constexpr bool is_ascii_blank(u32 code_point)
+{
+    return code_point == '\t' || code_point == ' ';
+}
+
+constexpr bool is_ascii_space(u32 code_point)
+{
+    return code_point == ' ' || code_point == '\t' || code_point == '\n' || code_point == '\v' || code_point == '\f' || code_point == '\r';
+}
+
+constexpr bool is_ascii_punctuation(u32 code_point)
+{
+    return (code_point >= 0x21 && code_point <= 0x2F) || (code_point >= 0x3A && code_point <= 0x40) || (code_point >= 0x5B && code_point <= 0x60) || (code_point >= 0x7B && code_point <= 0x7E);
+}
+
+constexpr bool is_ascii_graphical(u32 code_point)
+{
+    return code_point >= 0x21 && code_point <= 0x7E;
+}
+
+constexpr bool is_ascii_printable(u32 code_point)
+{
+    return code_point >= 0x20 && code_point <= 0x7E;
+}
+
+constexpr bool is_ascii_c0_control(u32 code_point)
+{
+    return code_point < 0x20;
+}
+
+constexpr bool is_ascii_control(u32 code_point)
+{
+    return is_ascii_c0_control(code_point) || code_point == 0x7F;
+}
+
+constexpr bool is_unicode(u32 code_point)
+{
+    return code_point <= 0x10FFFF;
+}
+
+constexpr bool is_unicode_control(u32 code_point)
+{
+    return is_ascii_c0_control(code_point) || (code_point >= 0x7E && code_point <= 0x9F);
+}
+
+constexpr bool is_unicode_surrogate(u32 code_point)
+{
+    return code_point >= 0xD800 && code_point <= 0xDFFF;
+}
+
+constexpr bool is_unicode_scalar_value(u32 code_point)
+{
+    return is_unicode(code_point) && !is_unicode_surrogate(code_point);
+}
+
+constexpr bool is_unicode_noncharacter(u32 code_point)
+{
+    return is_unicode(code_point) && ((code_point >= 0xFDD0 && code_point <= 0xFDEF) || ((code_point & 0xFFFE) == 0xFFFE) || ((code_point & 0xFFFF) == 0xFFFF));
+}
+
+constexpr u32 to_ascii_lowercase(u32 code_point)
+{
+    if (is_ascii_upper_alpha(code_point))
+        return code_point + 0x20;
+    return code_point;
+}
+
+constexpr u32 to_ascii_uppercase(u32 code_point)
+{
+    if (is_ascii_lower_alpha(code_point))
+        return code_point - 0x20;
+    return code_point;
+}
+
+constexpr u32 parse_ascii_digit(u32 code_point)
+{
+    if (is_ascii_digit(code_point))
+        return code_point - '0';
+    VERIFY_NOT_REACHED();
+}
+
+constexpr u32 parse_ascii_hex_digit(u32 code_point)
+{
+    if (is_ascii_digit(code_point))
+        return parse_ascii_digit(code_point);
+    if (code_point >= 'A' && code_point <= 'F')
+        return code_point - 'A' + 10;
+    if (code_point >= 'a' && code_point <= 'f')
+        return code_point - 'a' + 10;
+    VERIFY_NOT_REACHED();
+}
+
+}
+
+using AK::is_ascii;
+using AK::is_ascii_alpha;
+using AK::is_ascii_alphanumeric;
+using AK::is_ascii_blank;
+using AK::is_ascii_c0_control;
+using AK::is_ascii_control;
+using AK::is_ascii_digit;
+using AK::is_ascii_graphical;
+using AK::is_ascii_hex_digit;
+using AK::is_ascii_lower_alpha;
+using AK::is_ascii_printable;
+using AK::is_ascii_punctuation;
+using AK::is_ascii_space;
+using AK::is_ascii_upper_alpha;
+using AK::is_unicode;
+using AK::is_unicode_control;
+using AK::is_unicode_noncharacter;
+using AK::is_unicode_scalar_value;
+using AK::is_unicode_surrogate;
+using AK::parse_ascii_digit;
+using AK::parse_ascii_hex_digit;
+using AK::to_ascii_lowercase;
+using AK::to_ascii_uppercase;

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
@@ -13,26 +14,6 @@
 #include <AK/Utf8View.h>
 
 namespace AK {
-
-constexpr bool is_ascii_alpha(u32 code_point)
-{
-    return ('a' <= code_point && code_point <= 'z') || ('A' <= code_point && code_point <= 'Z');
-}
-
-constexpr bool is_ascii_digit(u32 code_point)
-{
-    return '0' <= code_point && code_point <= '9';
-}
-
-constexpr bool is_ascii_alphanumeric(u32 code_point)
-{
-    return is_ascii_alpha(code_point) || is_ascii_digit(code_point);
-}
-
-constexpr bool is_ascii_hex_digit(u32 code_point)
-{
-    return is_ascii_digit(code_point) || (code_point >= 'a' && code_point <= 'f') || (code_point >= 'A' && code_point <= 'F');
-}
 
 // FIXME: It could make sense to force users of URL to use URLParser::parse() explicitly instead of using a constructor.
 URL::URL(StringView const& string)
@@ -403,17 +384,6 @@ String URL::percent_encode(StringView const& input, URL::PercentEncodeSet set)
     return builder.to_string();
 }
 
-constexpr u8 parse_hex_digit(u8 digit)
-{
-    if (digit >= '0' && digit <= '9')
-        return digit - '0';
-    if (digit >= 'a' && digit <= 'f')
-        return digit - 'a' + 10;
-    if (digit >= 'A' && digit <= 'F')
-        return digit - 'A' + 10;
-    VERIFY_NOT_REACHED();
-}
-
 String URL::percent_decode(StringView const& input)
 {
     if (!input.contains('%'))
@@ -427,9 +397,9 @@ String URL::percent_decode(StringView const& input)
             builder.append_code_point(*it);
         } else {
             ++it;
-            u8 byte = parse_hex_digit(*it) << 4;
+            u8 byte = parse_ascii_hex_digit(*it) << 4;
             ++it;
-            byte += parse_hex_digit(*it);
+            byte += parse_ascii_hex_digit(*it);
             builder.append(byte);
         }
     }

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/Optional.h>
 #include <AK/SourceLocation.h>
@@ -14,26 +15,6 @@
 #include <AK/Utf8View.h>
 
 namespace AK {
-
-constexpr bool is_ascii_alpha(u32 code_point)
-{
-    return ('a' <= code_point && code_point <= 'z') || ('A' <= code_point && code_point <= 'Z');
-}
-
-constexpr bool is_ascii_digit(u32 code_point)
-{
-    return '0' <= code_point && code_point <= '9';
-}
-
-constexpr bool is_ascii_alphanumeric(u32 code_point)
-{
-    return is_ascii_alpha(code_point) || is_ascii_digit(code_point);
-}
-
-constexpr bool is_ascii_hex_digit(u32 code_point)
-{
-    return is_ascii_digit(code_point) || (code_point >= 'a' && code_point <= 'f') || (code_point >= 'A' && code_point <= 'F');
-}
 
 constexpr bool is_url_code_point(u32 code_point)
 {

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -10,6 +10,7 @@ set(AK_TEST_SOURCES
     TestBitCast.cpp
     TestBitmap.cpp
     TestByteBuffer.cpp
+    TestCharacterTypes.cpp
     TestChecked.cpp
     TestCircularDeque.cpp
     TestCircularDuplexStream.cpp

--- a/Tests/AK/TestCharacterTypes.cpp
+++ b/Tests/AK/TestCharacterTypes.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/CharacterTypes.h>
+#include <ctype.h>
+
+#define ASCII 0x80
+#define UNICODE 0x10FFFF + 100
+
+void compare_bool_output_over(u32 range, auto& old_function, auto& new_function)
+{
+    bool result1 = false;
+    bool result2 = false;
+    for (u32 i = 0; i < range; ++i) {
+        EXPECT_EQ(result1 = (old_function(i) > 0), result2 = (new_function(i) > 0));
+        if (result1 != result2)
+            dbgln("Function input value was {}.", i);
+    }
+}
+
+void compare_value_output_over(u32 range, auto& old_function, auto& new_function)
+{
+    i64 result1 = 0;
+    i64 result2 = 0;
+    for (u32 i = 0; i < range; ++i) {
+        EXPECT_EQ(result1 = old_function(i), result2 = new_function(i));
+        if (result1 != result2)
+            dbgln("Function input value was {}.", i);
+    }
+}
+
+TEST_CASE(is_ascii)
+{
+    compare_bool_output_over(UNICODE, isascii, is_ascii);
+}
+
+TEST_CASE(is_ascii_alphanumeric)
+{
+    compare_bool_output_over(ASCII, isalnum, is_ascii_alphanumeric);
+}
+
+TEST_CASE(is_ascii_blank)
+{
+    compare_bool_output_over(ASCII, isblank, is_ascii_blank);
+}
+
+TEST_CASE(is_ascii_c0_control)
+{
+    compare_bool_output_over(ASCII - 1, iscntrl, is_ascii_c0_control);
+}
+
+TEST_CASE(is_ascii_control)
+{
+    compare_bool_output_over(ASCII, iscntrl, is_ascii_control);
+}
+
+TEST_CASE(is_ascii_digit)
+{
+    compare_bool_output_over(ASCII, isdigit, is_ascii_digit);
+}
+
+TEST_CASE(is_ascii_graphical)
+{
+    compare_bool_output_over(ASCII, isgraph, is_ascii_graphical);
+}
+
+TEST_CASE(is_ascii_hex_digit)
+{
+    compare_bool_output_over(ASCII, isxdigit, is_ascii_hex_digit);
+}
+
+TEST_CASE(is_ascii_lower_alpha)
+{
+    compare_bool_output_over(ASCII, islower, is_ascii_lower_alpha);
+}
+
+TEST_CASE(is_ascii_printable)
+{
+    compare_bool_output_over(ASCII, isprint, is_ascii_printable);
+}
+
+TEST_CASE(is_ascii_punctuation)
+{
+    compare_bool_output_over(ASCII, ispunct, is_ascii_punctuation);
+}
+
+TEST_CASE(is_ascii_space)
+{
+    compare_bool_output_over(ASCII, isspace, is_ascii_space);
+}
+
+TEST_CASE(is_ascii_upper_alpha)
+{
+    compare_bool_output_over(ASCII, isupper, is_ascii_upper_alpha);
+}
+
+TEST_CASE(to_ascii_lowercase)
+{
+    compare_value_output_over(UNICODE, tolower, to_ascii_lowercase);
+}
+
+TEST_CASE(to_ascii_uppercase)
+{
+    compare_value_output_over(UNICODE, toupper, to_ascii_uppercase);
+}
+
+TEST_CASE(parse_ascii_digit)
+{
+    EXPECT_EQ(parse_ascii_digit('0'), 0u);
+    EXPECT_EQ(parse_ascii_digit('9'), 9u);
+    EXPECT_CRASH("parsing invalid ASCII digit", [] {
+        parse_ascii_digit('a');
+        return Test::Crash::Failure::DidNotCrash;
+    });
+    EXPECT_CRASH("parsing invalid unicode digit", [] {
+        parse_ascii_digit(0x00A9);
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}
+
+TEST_CASE(parse_ascii_hex_digit)
+{
+    EXPECT_EQ(parse_ascii_hex_digit('0'), 0u);
+    EXPECT_EQ(parse_ascii_hex_digit('F'), 15u);
+    EXPECT_EQ(parse_ascii_hex_digit('f'), 15u);
+    EXPECT_CRASH("parsing invalid ASCII hex digit", [] {
+        parse_ascii_hex_digit('g');
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/CharacterTypes.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
@@ -12,7 +13,6 @@
 #include <LibGUI/TextDocument.h>
 #include <LibGUI/TextEditor.h>
 #include <LibRegex/Regex.h>
-#include <ctype.h>
 
 namespace GUI {
 
@@ -104,7 +104,7 @@ size_t TextDocumentLine::first_non_whitespace_column() const
 {
     for (size_t i = 0; i < length(); ++i) {
         auto code_point = code_points()[i];
-        if (!isspace(code_point))
+        if (!is_ascii_space(code_point))
             return i;
     }
     return length();
@@ -114,7 +114,7 @@ Optional<size_t> TextDocumentLine::last_non_whitespace_column() const
 {
     for (ssize_t i = length() - 1; i >= 0; --i) {
         auto code_point = code_points()[i];
-        if (!isspace(code_point))
+        if (!is_ascii_space(code_point))
             return i;
     }
     return {};
@@ -124,7 +124,7 @@ bool TextDocumentLine::ends_in_whitespace() const
 {
     if (!length())
         return false;
-    return isspace(code_points()[length() - 1]);
+    return is_ascii_space(code_points()[length() - 1]);
 }
 
 bool TextDocumentLine::can_select() const
@@ -638,11 +638,11 @@ TextPosition TextDocument::first_word_break_before(const TextPosition& position,
     if (target.column() == line.length())
         modifier = 1;
 
-    auto is_start_alphanumeric = isalnum(line.code_points()[target.column() - modifier]);
+    auto is_start_alphanumeric = is_ascii_alphanumeric(line.code_points()[target.column() - modifier]);
 
     while (target.column() > 0) {
         auto prev_code_point = line.code_points()[target.column() - 1];
-        if ((is_start_alphanumeric && !isalnum(prev_code_point)) || (!is_start_alphanumeric && isalnum(prev_code_point)))
+        if ((is_start_alphanumeric && !is_ascii_alphanumeric(prev_code_point)) || (!is_start_alphanumeric && is_ascii_alphanumeric(prev_code_point)))
             break;
         target.set_column(target.column() - 1);
     }
@@ -662,11 +662,11 @@ TextPosition TextDocument::first_word_break_after(const TextPosition& position) 
         return TextPosition(position.line() + 1, 0);
     }
 
-    auto is_start_alphanumeric = isalnum(line.code_points()[target.column()]);
+    auto is_start_alphanumeric = is_ascii_alphanumeric(line.code_points()[target.column()]);
 
     while (target.column() < line.length()) {
         auto next_code_point = line.code_points()[target.column()];
-        if ((is_start_alphanumeric && !isalnum(next_code_point)) || (!is_start_alphanumeric && isalnum(next_code_point)))
+        if ((is_start_alphanumeric && !is_ascii_alphanumeric(next_code_point)) || (!is_start_alphanumeric && is_ascii_alphanumeric(next_code_point)))
             break;
         target.set_column(target.column() + 1);
     }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
@@ -25,7 +26,6 @@
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 #include <LibSyntax/Highlighter.h>
-#include <ctype.h>
 #include <fcntl.h>
 #include <math.h>
 #include <stdio.h>
@@ -1226,12 +1226,12 @@ size_t TextEditor::number_of_selected_words() const
     bool in_word = false;
     auto selected_text = this->selected_text();
     for (char c : selected_text) {
-        if (in_word && isspace(c)) {
+        if (in_word && is_ascii_space(c)) {
             in_word = false;
             word_count++;
             continue;
         }
-        if (!in_word && !isspace(c))
+        if (!in_word && !is_ascii_space(c))
             in_word = true;
     }
     if (in_word)
@@ -1555,7 +1555,7 @@ void TextEditor::recompute_visual_lines(size_t line_index)
         auto glyph_spacing = font().glyph_spacing();
         for (size_t i = 0; i < line.length(); ++i) {
             auto code_point = line.code_points()[i];
-            if (isspace(code_point)) {
+            if (is_ascii_space(code_point)) {
                 last_whitespace_index = i;
                 line_width_since_last_whitespace = 0;
             }

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/Hex.h>
 #include <AK/Platform.h>
 #include <AK/TemporaryChange.h>
@@ -56,7 +57,6 @@
 #include <LibJS/Runtime/TypedArrayConstructor.h>
 #include <LibJS/Runtime/TypedArrayPrototype.h>
 #include <LibJS/Runtime/Value.h>
-#include <ctype.h>
 
 namespace JS {
 
@@ -249,16 +249,10 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::parse_int)
     }
 
     auto parse_digit = [&](u32 code_point, i32 radix) -> Optional<i32> {
-        i32 digit = -1;
-
-        if (isdigit(code_point))
-            digit = code_point - '0';
-        else if (islower(code_point))
-            digit = 10 + (code_point - 'a');
-        else if (isupper(code_point))
-            digit = 10 + (code_point - 'A');
-
-        if (digit == -1 || digit >= radix)
+        if (!is_ascii_hex_digit(code_point) || radix <= 0)
+            return {};
+        auto digit = parse_ascii_hex_digit(code_point);
+        if (digit >= (u32)radix)
             return {};
         return digit;
     };

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Editor.h"
+#include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/GenericLexer.h>
 #include <AK/JsonObject.h>
@@ -19,7 +20,6 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/Notifier.h>
-#include <ctype.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
@@ -1338,7 +1338,7 @@ void Editor::refresh_display()
     auto print_character_at = [this](size_t i) {
         StringBuilder builder;
         auto c = m_buffer[i];
-        bool should_print_masked = isascii(c) && iscntrl(c) && c != '\n';
+        bool should_print_masked = is_ascii_control(c) && c != '\n';
         bool should_print_caret = c < 64 && should_print_masked;
         if (should_print_caret)
             builder.appendff("^{:c}", c + 64);
@@ -1722,7 +1722,7 @@ Editor::VTState Editor::actual_rendered_string_length_step(StringMetrics& metric
             current_line.length = 0;
             return state;
         }
-        if (isascii(c) && iscntrl(c) && c != '\n')
+        if (is_ascii_control(c) && c != '\n')
             current_line.masked_chars.append({ index, 1, c < 64 ? 2u : 4u }); // if the character cannot be represented as ^c, represent it as \xbb.
         // FIXME: This will not support anything sophisticated
         ++current_line.length;
@@ -1740,7 +1740,7 @@ Editor::VTState Editor::actual_rendered_string_length_step(StringMetrics& metric
         // FIXME: This does not support non-VT (aside from set-title) escapes
         return state;
     case Bracket:
-        if (isdigit(c)) {
+        if (is_ascii_digit(c)) {
             return BracketArgsSemi;
         }
         return state;
@@ -1748,7 +1748,7 @@ Editor::VTState Editor::actual_rendered_string_length_step(StringMetrics& metric
         if (c == ';') {
             return Bracket;
         }
-        if (!isdigit(c))
+        if (!is_ascii_digit(c))
             state = Free;
         return state;
     case Title:
@@ -1848,7 +1848,7 @@ Vector<size_t, 2> Editor::vt_dsr()
             m_incomplete_data.append(c);
             continue;
         case SawBracket:
-            if (isdigit(c)) {
+            if (is_ascii_digit(c)) {
                 state = InFirstCoordinate;
                 coordinate_buffer.append(c);
                 continue;
@@ -1856,7 +1856,7 @@ Vector<size_t, 2> Editor::vt_dsr()
             m_incomplete_data.append(c);
             continue;
         case InFirstCoordinate:
-            if (isdigit(c)) {
+            if (is_ascii_digit(c)) {
                 coordinate_buffer.append(c);
                 continue;
             }
@@ -1872,7 +1872,7 @@ Vector<size_t, 2> Editor::vt_dsr()
             m_incomplete_data.append(c);
             continue;
         case SawSemicolon:
-            if (isdigit(c)) {
+            if (is_ascii_digit(c)) {
                 state = InSecondCoordinate;
                 coordinate_buffer.append(c);
                 continue;
@@ -1880,7 +1880,7 @@ Vector<size_t, 2> Editor::vt_dsr()
             m_incomplete_data.append(c);
             continue;
         case InSecondCoordinate:
-            if (isdigit(c)) {
+            if (is_ascii_digit(c)) {
                 coordinate_buffer.append(c);
                 continue;
             }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
 #include <LibCore/Timer.h>
@@ -53,7 +54,6 @@
 #include <LibWeb/Page/BrowsingContext.h>
 #include <LibWeb/SVG/TagNames.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
-#include <ctype.h>
 
 namespace Web::DOM {
 
@@ -253,7 +253,7 @@ String Document::title() const
     StringBuilder builder;
     bool last_was_space = false;
     for (auto code_point : Utf8View(raw_title)) {
-        if (isspace(code_point)) {
+        if (is_ascii_space(code_point)) {
             last_was_space = true;
         } else {
             if (last_was_space && !builder.is_empty())

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -12,6 +12,7 @@
 #include "Screen.h"
 #include "Window.h"
 #include "WindowManager.h"
+#include <AK/CharacterTypes.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/CharacterBitmap.h>
 #include <LibGfx/Font.h>
@@ -20,7 +21,6 @@
 #include <LibGfx/Triangle.h>
 #include <WindowServer/ClientConnection.h>
 #include <WindowServer/WindowClientEndpoint.h>
-#include <ctype.h>
 
 namespace WindowServer {
 
@@ -629,14 +629,14 @@ void Menu::set_visible(bool visible)
 void Menu::add_item(NonnullOwnPtr<MenuItem> item)
 {
     if (auto alt_shortcut = find_ampersand_shortcut_character(item->text())) {
-        m_alt_shortcut_character_to_item_indices.ensure(tolower(alt_shortcut)).append(m_items.size());
+        m_alt_shortcut_character_to_item_indices.ensure(to_ascii_lowercase(alt_shortcut)).append(m_items.size());
     }
     m_items.append(move(item));
 }
 
 const Vector<size_t>* Menu::items_with_alt_shortcut(u32 alt_shortcut) const
 {
-    auto it = m_alt_shortcut_character_to_item_indices.find(tolower(alt_shortcut));
+    auto it = m_alt_shortcut_character_to_item_indices.find(to_ascii_lowercase(alt_shortcut));
     if (it == m_alt_shortcut_character_to_item_indices.end())
         return nullptr;
     return &it->value;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -13,8 +13,8 @@
 #include "Screen.h"
 #include "WindowManager.h"
 #include <AK/Badge.h>
+#include <AK/CharacterTypes.h>
 #include <WindowServer/WindowClientEndpoint.h>
-#include <ctype.h>
 
 namespace WindowServer {
 
@@ -460,7 +460,7 @@ void Window::handle_keydown_event(const KeyEvent& event)
     if (event.modifiers() == Mod_Alt && event.code_point() && menubar()) {
         Menu* menu_to_open = nullptr;
         menubar()->for_each_menu([&](Menu& menu) {
-            if (tolower(menu.alt_shortcut_character()) == tolower(event.code_point())) {
+            if (to_ascii_lowercase(menu.alt_shortcut_character()) == to_ascii_lowercase(event.code_point())) {
                 menu_to_open = &menu;
                 return IterationDecision::Break;
             }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -7,6 +7,7 @@
 #include "Shell.h"
 #include "Execution.h"
 #include "Formatter.h"
+#include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/Function.h>
 #include <AK/LexicalPath.h>
@@ -1188,10 +1189,8 @@ Shell::SpecialCharacterEscapeMode Shell::special_character_escape_mode(u32 code_
         return SpecialCharacterEscapeMode::QuotedAsEscape;
     default:
         // FIXME: Should instead use unicode's "graphic" property (categories L, M, N, P, S, Zs)
-        if (code_point < NumericLimits<i32>::max()) {
-            if (isascii(static_cast<i32>(code_point)))
-                return isprint(static_cast<i32>(code_point)) ? SpecialCharacterEscapeMode::Untouched : SpecialCharacterEscapeMode::QuotedAsHex;
-        }
+        if (is_ascii(code_point))
+            return is_ascii_printable(code_point) ? SpecialCharacterEscapeMode::Untouched : SpecialCharacterEscapeMode::QuotedAsHex;
         return SpecialCharacterEscapeMode::Untouched;
     }
 }


### PR DESCRIPTION
This PR introduces `AK/CharacterTypes.h`, which aims to mostly replace `ctype.h`. In comparison to the LibC header, it uses all `constexpr` functions, all of which support Unicode codepoints. To avoid polluting the global namespace with generic names, all functions contain `ascii` or `unicode` in their name.

I have also added some tests to crudely validate that the functions behave equivalently to the ones from `ctype.h`, at least for ASCII inputs.

This avoids narrowing conversion bugs, where e.g. `U+AA20` (whatever that is) would be a space according to `isspace`.

I searched for all usages of `ctype.h` with some regex magic and as a first step, replaced (hopefully) all cases where the functions conversion could have caused bugs. There are still a lot more usages of those which could be replaced.