### PR TITLE
LibC: Fix race condition in pthread_mutex_unlock()

### DIFF
--- a/Userland/Libraries/LibC/pthread_integration.cpp
+++ b/Userland/Libraries/LibC/pthread_integration.cpp
@@ -119,7 +119,7 @@ int __pthread_mutex_unlock(pthread_mutex_t* mutex)
         return 0;
     }
     mutex->owner = 0;
-    mutex->lock = 0;
+    AK::atomic_store(&mutex->lock, 0u, AK::memory_order_release);
     return 0;
 }
 

--- a/Userland/Libraries/LibC/pthread_integration.cpp
+++ b/Userland/Libraries/LibC/pthread_integration.cpp
@@ -96,7 +96,7 @@ int __pthread_mutex_lock(pthread_mutex_t* mutex)
     pthread_t this_thread = __pthread_self();
     for (;;) {
         u32 expected = 0;
-        if (!AK::atomic_compare_exchange_strong(&mutex->lock, expected, 1u, AK::memory_order_acq_rel)) {
+        if (!AK::atomic_compare_exchange_strong(&mutex->lock, expected, 1u, AK::memory_order_acquire)) {
             if (mutex->type == __PTHREAD_MUTEX_RECURSIVE && mutex->owner == this_thread) {
                 mutex->level++;
                 return 0;
@@ -128,7 +128,7 @@ int pthread_mutex_unlock(pthread_mutex_t*) __attribute__((weak, alias("__pthread
 int __pthread_mutex_trylock(pthread_mutex_t* mutex)
 {
     u32 expected = 0;
-    if (!AK::atomic_compare_exchange_strong(&mutex->lock, expected, 1u, AK::memory_order_acq_rel)) {
+    if (!AK::atomic_compare_exchange_strong(&mutex->lock, expected, 1u, AK::memory_order_acquire)) {
         if (mutex->type == __PTHREAD_MUTEX_RECURSIVE && mutex->owner == pthread_self()) {
             mutex->level++;
             return 0;


### PR DESCRIPTION
**LibC: Remove reinterpret_cast in pthread_mutex_{try,}lock**

**LibC: Fix race condition in pthread_mutex_unlock()**

This ensures the store to `mutex->lock` doesn't get re-ordered before the store to `mutex->owner` which could otherwise result in a locked owner-less mutex if another thread tries to acquire the lock at the same time.

**LibC: Use memory_order_acquire instead of memory_order_acq_rel**

Acquire ordering should be sufficient for `pthread_mutex_lock` and `pthread_mutex_trylock`.