### PR TITLE
Kernel: Fix use-after-free in sys$mremap

### DIFF
--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -12,6 +12,9 @@
 namespace Kernel {
 
 class KString {
+    AK_MAKE_NONCOPYABLE(KString);
+    AK_MAKE_NONMOVABLE(KString);
+
 public:
     static OwnPtr<KString> try_create_uninitialized(size_t, char*&);
     static NonnullOwnPtr<KString> must_create_uninitialized(size_t, char*&);

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -68,6 +68,7 @@ public:
 
     bool is_cacheable() const { return m_cacheable; }
     StringView name() const { return m_name ? m_name->view() : StringView {}; }
+    OwnPtr<KString> take_name() { return move(m_name); }
     Region::Access access() const { return static_cast<Region::Access>(m_access); }
 
     void set_name(OwnPtr<KString> name) { m_name = move(name); }


### PR DESCRIPTION
**Kernel: Fix use-after-free in sys$mremap**

Now that `Region::name()` has been changed to return a `StringView` we can't rely on keeping a copy of the region's name past the region's destruction just by holding a copy of the `StringView`.

**Kernel: Make KString non-copyable and non-movable**

The user is supposed to hold these in an `OwnPtr` but bad things would happen if the user takes these out of the `OwnPtr` so let's make the class non-copyable and non-movable.