### PR TITLE
Terminal: Close find & settings windows on exit, add key combo to search forwards

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -190,6 +190,10 @@ static RefPtr<GUI::Window> create_find_window(VT::TerminalWidget& terminal)
         find_backwards.click();
     };
 
+    find_textbox.on_shift_return_pressed = [&]() {
+        find_forwards.click();
+    };
+
     auto& match_case = search.add<GUI::CheckBox>("Case sensitive");
     auto& wrap_around = search.add<GUI::CheckBox>("Wrap around");
 

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -393,6 +393,13 @@ int main(int argc, char** argv)
 
     window->set_menubar(menubar);
 
+    window->on_close = [&]() {
+        if (find_window)
+            find_window->close();
+        if (settings_window)
+            settings_window->close();
+    };
+
     if (unveil("/res", "r") < 0) {
         perror("unveil");
         return 1;

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -18,7 +18,6 @@
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/FontPicker.h>
-#include <LibGUI/GroupBox.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
@@ -28,12 +27,10 @@
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 #include <LibVT/TerminalWidget.h>
 #include <assert.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <pty.h>
 #include <pwd.h>
 #include <serenity.h>
@@ -43,7 +40,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/select.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -731,6 +731,12 @@ void TextEditor::keydown_event(KeyEvent& event)
         if (event.key() == KeyCode::Key_Tab)
             return AbstractScrollableWidget::keydown_event(event);
 
+        if (event.modifiers() == KeyModifier::Mod_Shift && event.key() == KeyCode::Key_Return) {
+            if (on_shift_return_pressed)
+                on_shift_return_pressed();
+            return;
+        }
+
         if (event.key() == KeyCode::Key_Return) {
             if (on_return_pressed)
                 on_return_pressed();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -138,6 +138,7 @@ public:
     Function<void(bool modified)> on_modified_change;
     Function<void()> on_mousedown;
     Function<void()> on_return_pressed;
+    Function<void()> on_shift_return_pressed;
     Function<void()> on_escape_pressed;
     Function<void()> on_up_pressed;
     Function<void()> on_down_pressed;


### PR DESCRIPTION
Since the Find and Settings windows are not children of the main window they did not close automatically when exiting Terminal, this PR forces them to close when exiting.
The reason for not adding them as children is that when set as a child, the textbox in the Find window loses focus when switching back to the terminal and cannot regain it afterwards without reopening the window. I'm working on a different style of find-widget that would behave more like the one in TextEditor or HackStudio but that is a future PR.

Also som cleanup of unused headers and added functionality of using shift+return to search forwards.

Fixes #7465