### PR TITLE
AK+LibWasm+LibJS: Disallow Variant.has() on types that aren't contained

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1609,7 +1609,7 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
             init = parse_expression(2);
         } else if (!for_loop_variable_declaration && declaration_kind == DeclarationKind::Const) {
             syntax_error("Missing initializer in 'const' variable declaration");
-        } else if (target.has<BindingPattern>()) {
+        } else if (target.has<NonnullRefPtr<BindingPattern>>()) {
             syntax_error("Missing initializer in destructuring assignment");
         }
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/Interpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Interpreter.cpp
@@ -482,12 +482,12 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
             return;
         }
         auto element = table_instance->elements()[index.value()];
-        if (!element.has_value() || !element->ref().has<FunctionAddress>()) {
+        if (!element.has_value() || !element->ref().has<Reference::Func>()) {
             dbgln("LibWasm: call_indirect attempted with invalid address element (not a function)");
             m_do_trap = true;
             return;
         }
-        auto address = element->ref().get<FunctionAddress>();
+        auto address = element->ref().get<Reference::Func>().address;
         dbgln_if(WASM_TRACE_DEBUG, "call_indirect({} -> {})", index.value(), address.value());
         call_address(configuration, address);
         return;


### PR DESCRIPTION
Checking for this (and get()'ing it) is always invalid, so let's just
disallow it.
This also finds two bugs where the code is checking for types that can
never actually be in the variant (which was actually a refactor
artifact).