### PR TITLE
Kernel+LibVT: Remove scrolling/buffer related code smell

### DIFF
--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -58,7 +58,7 @@ protected:
 
     TTY(unsigned major, unsigned minor);
     void emit(u8, bool do_evaluate_block_conditions = false);
-    virtual void echo(u8) = 0;
+    void echo_with_processing(u8);
 
     bool can_do_backspace() const;
     void do_backspace();
@@ -80,7 +80,8 @@ protected:
 private:
     // ^CharacterDevice
     virtual bool is_tty() const final override { return true; }
-    inline void echo_with_processing(u8);
+
+    virtual void echo(u8) = 0;
 
     template<typename Functor>
     void process_output(u8, Functor put_char);

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -86,14 +86,14 @@ void ConsoleImpl::clear_in_line(u16 row, u16 first_column, u16 last_column)
     m_client.clear_in_line(row, first_column, last_column);
 }
 
-void ConsoleImpl::ICH(Parameters)
+void ConsoleImpl::scroll_left(u16 row, u16 column, size_t count)
 {
-    // FIXME: Implement this
+    m_client.scroll_left(row, column, count);
 }
 
-void ConsoleImpl::DCH(Parameters)
+void ConsoleImpl::scroll_right(u16 row, u16 column, size_t count)
 {
-    // FIXME: Implement this
+    m_client.scroll_right(row, column, count);
 }
 
 void VirtualConsole::set_graphical(bool graphical)
@@ -423,6 +423,28 @@ void VirtualConsole::scroll_down(u16 region_top, u16 region_bottom, size_t count
         clear_line(region_top + i);
     for (u16 row = region_top; row <= region_bottom; ++row)
         m_lines[row].dirty = true;
+}
+
+void VirtualConsole::scroll_left(u16 row, u16 column, size_t count)
+{
+    VERIFY(row < rows());
+    VERIFY(column < columns());
+    count = min<size_t>(count, columns() - column);
+    memmove(&cell_at(column, row), &cell_at(column + count, row), sizeof(Cell) * (columns() - column - count));
+    for (size_t i = column + count; i < columns(); ++i)
+        cell_at(i, row).clear();
+    m_lines[row].dirty = true;
+}
+
+void VirtualConsole::scroll_right(u16 row, u16 column, size_t count)
+{
+    VERIFY(row < rows());
+    VERIFY(column < columns());
+    count = min<size_t>(count, columns() - column);
+    memmove(&cell_at(column + count, row), &cell_at(column, row), sizeof(Cell) * (columns() - column - count));
+    for (size_t i = column; i < column + count; ++i)
+        cell_at(i, row).clear();
+    m_lines[row].dirty = true;
 }
 
 void VirtualConsole::clear_in_line(u16 row, u16 first_column, u16 last_column)

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -33,7 +33,7 @@ void ConsoleImpl::clear()
 {
     m_client.clear();
 }
-void ConsoleImpl::clear_including_history()
+void ConsoleImpl::clear_history()
 {
 }
 

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -377,6 +377,8 @@ String VirtualConsole::device_name() const
 void VirtualConsole::echo(u8 ch)
 {
     m_console_impl.on_input(ch);
+    if (m_active)
+        flush_dirty_lines();
 }
 
 VirtualConsole::Cell& VirtualConsole::cell_at(size_t x, size_t y)

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -353,7 +353,7 @@ void VirtualConsole::terminal_did_resize(u16 columns, u16 rows)
     dbgln("VC {}: Resized to {} x {}", index(), columns, rows);
 }
 
-void VirtualConsole::terminal_history_changed()
+void VirtualConsole::terminal_history_changed(int)
 {
     // Do nothing, I guess?
 }

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -81,6 +81,11 @@ void ConsoleImpl::put_character_at(unsigned row, unsigned column, u32 ch)
     m_last_code_point = ch;
 }
 
+void ConsoleImpl::clear_in_line(u16 row, u16 first_column, u16 last_column)
+{
+    m_client.clear_in_line(row, first_column, last_column);
+}
+
 void ConsoleImpl::ICH(Parameters)
 {
     // FIXME: Implement this
@@ -420,13 +425,14 @@ void VirtualConsole::scroll_down(u16 region_top, u16 region_bottom, size_t count
         m_lines[row].dirty = true;
 }
 
-void VirtualConsole::clear_line(size_t y_index)
+void VirtualConsole::clear_in_line(u16 row, u16 first_column, u16 last_column)
 {
-    m_lines[y_index].dirty = true;
-    for (size_t x = 0; x < columns(); x++) {
-        auto& cell = cell_at(x, y_index);
-        cell.clear();
-    }
+    VERIFY(row < rows());
+    VERIFY(first_column <= last_column);
+    VERIFY(last_column < columns());
+    m_lines[row].dirty = true;
+    for (size_t x = first_column; x <= last_column; x++)
+        cell_at(x, row).clear();
 }
 
 void VirtualConsole::put_character_at(unsigned row, unsigned column, u32 code_point, const VT::Attribute& attribute)

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -40,6 +40,7 @@ private:
     virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) override;
     virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) override;
     virtual void put_character_at(unsigned row, unsigned column, u32 ch) override;
+    virtual void clear_in_line(u16 row, u16 first_column, u16 last_column) override;
 
     virtual void ICH(Parameters) override;
     virtual void DCH(Parameters) override;
@@ -137,7 +138,11 @@ private:
 
     void scroll_down(u16 region_top, u16 region_bottom, size_t count);
     void scroll_up(u16 region_top, u16 region_bottom, size_t count);
-    void clear_line(size_t index);
+    void clear_line(size_t index)
+    {
+        clear_in_line(index, 0, m_console_impl.columns() - 1);
+    }
+    void clear_in_line(u16 row, u16 first_column, u16 last_column);
     void put_character_at(unsigned row, unsigned column, u32 ch, const VT::Attribute&);
 
     OwnPtr<Region> m_cells;

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -39,11 +39,10 @@ private:
 
     virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) override;
     virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) override;
+    virtual void scroll_left(u16 row, u16 column, size_t count) override;
+    virtual void scroll_right(u16 row, u16 column, size_t count) override;
     virtual void put_character_at(unsigned row, unsigned column, u32 ch) override;
     virtual void clear_in_line(u16 row, u16 first_column, u16 last_column) override;
-
-    virtual void ICH(Parameters) override;
-    virtual void DCH(Parameters) override;
 };
 
 class VirtualConsole final : public TTY
@@ -138,6 +137,8 @@ private:
 
     void scroll_down(u16 region_top, u16 region_bottom, size_t count);
     void scroll_up(u16 region_top, u16 region_bottom, size_t count);
+    void scroll_left(u16 row, u16 column, size_t count);
+    void scroll_right(u16 row, u16 column, size_t count);
     void clear_line(size_t index)
     {
         clear_in_line(index, 0, m_console_impl.columns() - 1);

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -37,17 +37,12 @@ private:
     virtual void clear() override;
     virtual void clear_including_history() override;
 
-    virtual void scroll_up() override;
-    virtual void scroll_down() override;
-    virtual void linefeed() override;
+    virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) override;
+    virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) override;
     virtual void put_character_at(unsigned row, unsigned column, u32 ch) override;
-    virtual void set_window_title(const String&) override;
 
     virtual void ICH(Parameters) override;
-
-    virtual void IL(Parameters) override;
     virtual void DCH(Parameters) override;
-    virtual void DL(Parameters) override;
 };
 
 class VirtualConsole final : public TTY
@@ -140,8 +135,8 @@ private:
 
     void on_code_point(u32);
 
-    void scroll_down();
-    void scroll_up();
+    void scroll_down(u16 region_top, u16 region_bottom, size_t count);
+    void scroll_up(u16 region_top, u16 region_bottom, size_t count);
     void clear_line(size_t index);
     void put_character_at(unsigned row, unsigned column, u32 ch, const VT::Attribute&);
 

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -35,7 +35,7 @@ public:
 private:
     virtual void invalidate_cursor() override;
     virtual void clear() override;
-    virtual void clear_including_history() override;
+    virtual void clear_history() override;
 
     virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) override;
     virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) override;

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -100,7 +100,7 @@ private:
     virtual void set_window_title(const StringView&) override;
     virtual void set_window_progress(int, int) override;
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
-    virtual void terminal_history_changed() override;
+    virtual void terminal_history_changed(int) override;
     virtual void emit(const u8*, size_t) override;
     virtual void set_cursor_style(VT::CursorStyle) override;
 

--- a/Userland/Libraries/LibVT/Attribute.h
+++ b/Userland/Libraries/LibVT/Attribute.h
@@ -15,8 +15,6 @@
 namespace VT {
 
 struct Attribute {
-    Attribute() { reset(); }
-
     static constexpr Color default_foreground_color = Color::named(Color::ANSIColor::DefaultForeground);
     static constexpr Color default_background_color = Color::named(Color::ANSIColor::DefaultBackground);
 
@@ -25,12 +23,17 @@ struct Attribute {
         foreground_color = default_foreground_color;
         background_color = default_background_color;
         flags = Flags::NoAttributes;
+#ifndef KERNEL
+        href = {};
+        href_id = {};
+#endif
     }
+
     Color foreground_color { default_foreground_color };
     Color background_color { default_background_color };
 
-    Color effective_background_color() const { return flags & Negative ? foreground_color : background_color; }
-    Color effective_foreground_color() const { return flags & Negative ? background_color : foreground_color; }
+    constexpr Color effective_background_color() const { return flags & Negative ? foreground_color : background_color; }
+    constexpr Color effective_foreground_color() const { return flags & Negative ? background_color : foreground_color; }
 
 #ifndef KERNEL
     String href;
@@ -47,17 +50,17 @@ struct Attribute {
         Touched = 0x20,
     };
 
-    bool is_untouched() const { return !(flags & Touched); }
+    constexpr bool is_untouched() const { return !(flags & Touched); }
 
     // TODO: it would be really nice if we had a helper for enums that
     // exposed bit ops for class enums...
-    u8 flags = Flags::NoAttributes;
+    u8 flags { Flags::NoAttributes };
 
-    bool operator==(const Attribute& other) const
+    constexpr bool operator==(const Attribute& other) const
     {
         return foreground_color == other.foreground_color && background_color == other.background_color && flags == other.flags;
     }
-    bool operator!=(const Attribute& other) const
+    constexpr bool operator!=(const Attribute& other) const
     {
         return !(*this == other);
     }

--- a/Userland/Libraries/LibVT/Line.cpp
+++ b/Userland/Libraries/LibVT/Line.cpp
@@ -25,15 +25,12 @@ void Line::set_length(size_t new_length)
     m_cells.resize(new_length);
 }
 
-void Line::clear(const Attribute& attribute)
+void Line::clear_range(size_t first_column, size_t last_column, const Attribute& attribute)
 {
-    if (m_dirty) {
-        for (auto& cell : m_cells) {
-            cell = Cell { .code_point = ' ', .attribute = attribute };
-        }
-        return;
-    }
-    for (auto& cell : m_cells) {
+    VERIFY(first_column <= last_column);
+    VERIFY(last_column < m_cells.size());
+    for (size_t i = first_column; i <= last_column; ++i) {
+        auto& cell = m_cells[i];
         if (!m_dirty)
             m_dirty = cell.code_point != ' ' || cell.attribute != attribute;
         cell = Cell { .code_point = ' ', .attribute = attribute };

--- a/Userland/Libraries/LibVT/Line.h
+++ b/Userland/Libraries/LibVT/Line.h
@@ -33,7 +33,11 @@ public:
     Cell& cell_at(size_t index) { return m_cells[index]; }
     const Cell& cell_at(size_t index) const { return m_cells[index]; }
 
-    void clear(const Attribute&);
+    void clear(const Attribute& attribute = Attribute())
+    {
+        clear_range(0, m_cells.size() - 1, attribute);
+    }
+    void clear_range(size_t first_column, size_t last_column, const Attribute& attribute = Attribute());
     bool has_only_one_background_color() const;
 
     size_t length() const { return m_cells.size(); }

--- a/Userland/Libraries/LibVT/Range.h
+++ b/Userland/Libraries/LibVT/Range.h
@@ -42,6 +42,12 @@ public:
         m_end = end;
     }
 
+    void offset_row(int delta)
+    {
+        m_start = Position(m_start.row() + delta, m_start.column());
+        m_end = Position(m_end.row() + delta, m_end.column());
+    }
+
     bool operator==(const Range& other) const
     {
         return m_start == other.m_start && m_end == other.m_end;

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -32,17 +32,15 @@ void Terminal::clear()
 {
     dbgln_if(TERMINAL_DEBUG, "Clear the entire screen");
     for (size_t i = 0; i < rows(); ++i)
-        active_buffer()[i].clear(m_current_state.attribute);
+        active_buffer()[i].clear(Attribute());
     set_cursor(0, 0);
 }
 
-void Terminal::clear_including_history()
+void Terminal::clear_history()
 {
+    dbgln_if(TERMINAL_DEBUG, "Clear history");
     m_history.clear();
     m_history_start = 0;
-
-    clear();
-
     m_client.terminal_history_changed();
 }
 #endif
@@ -626,8 +624,7 @@ void Terminal::ED(Parameters params)
         clear();
         break;
     case 3:
-        // FIXME: <esc>[3J should also clear the scrollback buffer.
-        clear();
+        clear_history();
         break;
     default:
         unimplemented_csi_sequence(params, {}, 'J');

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -888,6 +888,22 @@ void Terminal::RI()
         set_cursor(cursor_row() - 1, cursor_column());
 }
 
+void Terminal::DECFI()
+{
+    if (cursor_column() == columns() - 1)
+        scroll_left(cursor_row(), 0, 1);
+    else
+        set_cursor(cursor_row(), cursor_column() + 1);
+}
+
+void Terminal::DECBI()
+{
+    if (cursor_column() == 0)
+        scroll_right(cursor_row(), 0, 1);
+    else
+        set_cursor(cursor_row(), cursor_column() - 1);
+}
+
 void Terminal::DSR(Parameters params)
 {
     if (params.size() == 1 && params[0] == 5) {
@@ -991,11 +1007,17 @@ void Terminal::execute_escape_sequence(Intermediates intermediates, bool ignore,
         case '\\':
             // ST (string terminator) -- do nothing
             return;
+        case '6':
+            DECBI();
+            return;
         case '7':
             DECSC();
             return;
         case '8':
             DECRC();
+            return;
+        case '9':
+            DECFI();
             return;
         }
     } else if (intermediates[0] == '#') {

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -907,6 +907,28 @@ void Terminal::DECBI()
         set_cursor(cursor_row(), cursor_column() - 1);
 }
 
+void Terminal::DECIC(Parameters params)
+{
+    unsigned num = 1;
+    if (params.size() >= 1 && params[0] != 0)
+        num = params[0];
+
+    num = min<unsigned>(num, columns() - cursor_column());
+    for (unsigned row = cursor_row(); row <= m_scroll_region_bottom; ++row)
+        scroll_right(row, cursor_column(), num);
+}
+
+void Terminal::DECDC(Parameters params)
+{
+    unsigned num = 1;
+    if (params.size() >= 1 && params[0] != 0)
+        num = params[0];
+
+    num = min<unsigned>(num, columns() - cursor_column());
+    for (unsigned row = cursor_row(); row <= m_scroll_region_bottom; ++row)
+        scroll_left(row, cursor_column(), num);
+}
+
 void Terminal::DSR(Parameters params)
 {
     if (params.size() == 1 && params[0] == 5) {
@@ -1146,6 +1168,18 @@ void Terminal::execute_csi_sequence(Parameters parameters, Intermediates interme
         break;
     case 'u':
         SCORC();
+        break;
+    case '}':
+        if (intermediates.size() >= 1 && intermediates[0] == '\'')
+            DECIC(parameters);
+        else
+            unimplemented_csi_sequence(parameters, intermediates, last_byte);
+        break;
+    case '~':
+        if (intermediates.size() >= 1 && intermediates[0] == '\'')
+            DECDC(parameters);
+        else
+            unimplemented_csi_sequence(parameters, intermediates, last_byte);
         break;
     default:
         unimplemented_csi_sequence(parameters, intermediates, last_byte);

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -304,6 +304,12 @@ protected:
     // RI - Reverse Index (move up)
     void RI();
 
+    // DECBI - Back Index
+    void DECBI();
+
+    // DECFI - Forward Index
+    void DECFI();
+
     // DSR - Device Status Reports
     void DSR(Parameters);
 

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -45,7 +45,7 @@ public:
     virtual void set_window_title(const StringView&) = 0;
     virtual void set_window_progress(int value, int max) = 0;
     virtual void terminal_did_resize(u16 columns, u16 rows) = 0;
-    virtual void terminal_history_changed() = 0;
+    virtual void terminal_history_changed(int delta) = 0;
     virtual void emit(const u8*, size_t) = 0;
     virtual void set_cursor_style(CursorStyle) = 0;
 };
@@ -141,10 +141,11 @@ public:
     void set_max_history_size(size_t value)
     {
         if (value == 0) {
+            auto previous_size = m_history.size();
             m_max_history_lines = 0;
             m_history_start = 0;
             m_history.clear();
-            m_client.terminal_history_changed();
+            m_client.terminal_history_changed(-previous_size);
             return;
         }
 
@@ -158,7 +159,7 @@ public:
             }
             m_history = move(new_history);
             m_history_start = 0;
-            m_client.terminal_history_changed();
+            m_client.terminal_history_changed(value - existing_line_count);
         }
         m_max_history_lines = value;
     }

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -74,12 +74,18 @@ public:
 
     void set_cursor(unsigned row, unsigned column, bool skip_debug = false);
 
+    void clear_including_history()
+    {
+        clear_history();
+        clear();
+    }
+
 #ifndef KERNEL
     void clear();
-    void clear_including_history();
+    void clear_history();
 #else
     virtual void clear() = 0;
-    virtual void clear_including_history() = 0;
+    virtual void clear_history() = 0;
 #endif
 
 #ifndef KERNEL

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -359,6 +359,12 @@ protected:
     // FIXME: Find the right names for these.
     void XTERM_WM(Parameters);
 
+    // DECIC - Insert Column
+    void DECIC(Parameters);
+
+    // DECDC - Delete Column
+    void DECDC(Parameters);
+
 #ifndef KERNEL
     TerminalClient& m_client;
 #else

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -217,10 +217,12 @@ protected:
     void scroll_up(u16 region_top, u16 region_bottom, size_t count);
     void scroll_down(u16 region_top, u16 region_bottom, size_t count);
     void put_character_at(unsigned row, unsigned column, u32 ch);
+    void clear_in_line(u16 row, u16 first_column, u16 last_column);
 #else
     virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) = 0;
     virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) = 0;
     virtual void put_character_at(unsigned row, unsigned column, u32 ch) = 0;
+    virtual void clear_in_line(u16 row, u16 first_column, u16 last_column) = 0;
 #endif
 
     void unimplemented_control_code(u8);

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -171,6 +171,11 @@ public:
         return m_needs_bracketed_paste;
     };
 
+    bool is_within_scroll_region(u16 line) const
+    {
+        return line >= m_scroll_region_top && line <= m_scroll_region_bottom;
+    }
+
 protected:
     // ^EscapeSequenceExecutor
     virtual void emit_code_point(u32) override;
@@ -199,18 +204,17 @@ protected:
     };
 
     void carriage_return();
-#ifndef KERNEL
-    void scroll_up();
-    void scroll_down();
+    inline void scroll_up(size_t count = 1);
+    inline void scroll_down(size_t count = 1);
     void linefeed();
+#ifndef KERNEL
+    void scroll_up(u16 region_top, u16 region_bottom, size_t count);
+    void scroll_down(u16 region_top, u16 region_bottom, size_t count);
     void put_character_at(unsigned row, unsigned column, u32 ch);
-    void set_window_title(const String&);
 #else
-    virtual void scroll_up() = 0;
-    virtual void scroll_down() = 0;
-    virtual void linefeed() = 0;
+    virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) = 0;
+    virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) = 0;
     virtual void put_character_at(unsigned row, unsigned column, u32 ch) = 0;
-    virtual void set_window_title(const String&) = 0;
 #endif
 
     void unimplemented_control_code(u8);
@@ -307,18 +311,18 @@ protected:
     // SD - Scroll Down (called "Pan Up" in VT510)
     void SD(Parameters);
 
-#ifndef KERNEL
     // IL - Insert Line
     void IL(Parameters);
+
+#ifndef KERNEL
     // DCH - Delete Character
     void DCH(Parameters);
+#else
+    virtual void DCH(Parameters) = 0;
+#endif
+
     // DL - Delete Line
     void DL(Parameters);
-#else
-    virtual void IL(Parameters) = 0;
-    virtual void DCH(Parameters) = 0;
-    virtual void DL(Parameters) = 0;
-#endif
 
     // CHA - Cursor Horizontal Absolute
     void CHA(Parameters);

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -216,11 +216,15 @@ protected:
 #ifndef KERNEL
     void scroll_up(u16 region_top, u16 region_bottom, size_t count);
     void scroll_down(u16 region_top, u16 region_bottom, size_t count);
+    void scroll_left(u16 row, u16 column, size_t count);
+    void scroll_right(u16 row, u16 column, size_t count);
     void put_character_at(unsigned row, unsigned column, u32 ch);
     void clear_in_line(u16 row, u16 first_column, u16 last_column);
 #else
     virtual void scroll_up(u16 region_top, u16 region_bottom, size_t count) = 0;
     virtual void scroll_down(u16 region_top, u16 region_bottom, size_t count) = 0;
+    virtual void scroll_left(u16 row, u16 column, size_t count) = 0;
+    virtual void scroll_right(u16 row, u16 column, size_t count) = 0;
     virtual void put_character_at(unsigned row, unsigned column, u32 ch) = 0;
     virtual void clear_in_line(u16 row, u16 first_column, u16 last_column) = 0;
 #endif
@@ -306,12 +310,8 @@ protected:
     // DECSCUSR - Set Cursor Style
     void DECSCUSR(Parameters);
 
-#ifndef KERNEL
     // ICH - Insert Character
     void ICH(Parameters);
-#else
-    virtual void ICH(Parameters) = 0;
-#endif
 
     // SU - Scroll Up (called "Pan Down" in VT510)
     void SU(Parameters);
@@ -322,12 +322,8 @@ protected:
     // IL - Insert Line
     void IL(Parameters);
 
-#ifndef KERNEL
     // DCH - Delete Character
     void DCH(Parameters);
-#else
-    virtual void DCH(Parameters) = 0;
-#endif
 
     // DL - Delete Line
     void DL(Parameters);

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -947,13 +947,16 @@ int TerminalWidget::last_selection_column_on_row(int row) const
     return row == normalized_selection_end.row() || m_rectangle_selection ? normalized_selection_end.column() : m_terminal.columns() - 1;
 }
 
-void TerminalWidget::terminal_history_changed()
+void TerminalWidget::terminal_history_changed(int delta)
 {
     bool was_max = m_scrollbar->value() == m_scrollbar->max();
     m_scrollbar->set_max(m_terminal.history_size());
     if (was_max)
         m_scrollbar->set_value(m_scrollbar->max());
     m_scrollbar->update();
+    // If the history buffer wrapped around, the selection needs to be offset accordingly.
+    if (m_selection.is_valid() && delta < 0)
+        m_selection.offset_row(delta);
 }
 
 void TerminalWidget::terminal_did_resize(u16 columns, u16 rows)

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -119,7 +119,7 @@ private:
     virtual void set_window_title(const StringView&) override;
     virtual void set_window_progress(int value, int max) override;
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
-    virtual void terminal_history_changed() override;
+    virtual void terminal_history_changed(int delta) override;
     virtual void emit(const u8*, size_t) override;
     virtual void set_cursor_style(CursorStyle) override;
 


### PR DESCRIPTION
This PR is intended to clean up `Terminal` so that  we don't have to add `#ifndef KERNEL` around various features. The following changes are planned:

- [x] Fix correctness issues around `ICH`/`DCH` escape sequences.
- [x] Create new scroll API which takes the origin row as a parameter
- [x] Make `IL`/`DL` use the new scroll API, so that we no longer need to `#ifdef` it
- [x] Improve scrolling performance by reducing Vector inserts and element allocations
- [x] Implement escape sequences possible with the new APIs

~Move screen buffer-related code to a separate class and make `Terminal` take it as a *template?* parameter. This way, we can have different storage implementations in the kernel and userland, without the `Terminal` code being affected.~ (it would make this PR too large)