### PR TITLE
KeyboardMapper: Fix crash upon loading an invalid JSON file

### DIFF
--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -126,7 +126,10 @@ void KeyboardMapperWidget::create_frame()
 void KeyboardMapperWidget::load_from_file(String filename)
 {
     auto result = Keyboard::CharacterMapFile::load_from_file(filename);
-    VERIFY(result.has_value());
+    if (!result.has_value()) {
+        dbgln("Failed to load character map from file {}", filename);
+        return;
+    }
 
     m_filename = filename;
     m_character_map = result.value();


### PR DESCRIPTION
This solves https://github.com/SerenityOS/serenity/issues/7699 .
It would be nice to add also GUI alert about failure, but I will leave that for future.