### PR TITLE
Kernel: Add operator delete for KString

### DIFF
--- a/Kernel/KString.cpp
+++ b/Kernel/KString.cpp
@@ -57,4 +57,9 @@ OwnPtr<KString> KString::try_clone() const
     return try_create(view());
 }
 
+void KString::operator delete(void* string)
+{
+    kfree(string);
+}
+
 }

--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -21,6 +21,8 @@ public:
     static OwnPtr<KString> try_create(StringView const&);
     static NonnullOwnPtr<KString> must_create(StringView const&);
 
+    void operator delete(void*);
+
     OwnPtr<KString> try_clone() const;
 
     bool is_empty() const { return m_length == 0; }


### PR DESCRIPTION
This doesn't change anything because our global operator delete also calls `kfree()` - however instead of relying on this implementation detail this makes this dependency more explicit.