### PR TITLE
Profiler: Use sequential serial numbers for profiling events 

### DIFF
--- a/Userland/DevTools/Profiler/EventSerialNumber.h
+++ b/Userland/DevTools/Profiler/EventSerialNumber.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/NumericLimits.h>
+#include <AK/Types.h>
+
+namespace Profiler {
+
+// DistinctNumeric's constructor is non-explicit which makes accidentally turning
+// an unrelated u64 into a serial number all too easy.
+class EventSerialNumber {
+public:
+    constexpr EventSerialNumber() = default;
+
+    void increment()
+    {
+        m_serial++;
+    }
+
+    size_t to_number() const
+    {
+        return m_serial;
+    }
+
+    static EventSerialNumber max_valid_serial()
+    {
+        return EventSerialNumber { NumericLimits<size_t>::max() };
+    }
+
+    bool operator==(EventSerialNumber const& rhs) const
+    {
+        return m_serial == rhs.m_serial;
+    }
+
+    bool operator<(EventSerialNumber const& rhs) const
+    {
+        return m_serial < rhs.m_serial;
+    }
+
+    bool operator>(EventSerialNumber const& rhs) const
+    {
+        return m_serial > rhs.m_serial;
+    }
+
+    bool operator<=(EventSerialNumber const& rhs) const
+    {
+        return m_serial <= rhs.m_serial;
+    }
+
+    bool operator>=(EventSerialNumber const& rhs) const
+    {
+        return m_serial >= rhs.m_serial;
+    }
+
+private:
+    size_t m_serial { 0 };
+
+    constexpr explicit EventSerialNumber(size_t serial)
+        : m_serial(serial)
+    {
+    }
+};
+
+}

--- a/Userland/DevTools/Profiler/Process.cpp
+++ b/Userland/DevTools/Profiler/Process.cpp
@@ -8,19 +8,19 @@
 
 namespace Profiler {
 
-Thread* Process::find_thread(pid_t tid, u64 timestamp)
+Thread* Process::find_thread(pid_t tid, EventSerialNumber serial)
 {
     auto it = threads.find(tid);
     if (it == threads.end())
         return nullptr;
     for (auto& thread : it->value) {
-        if (thread.start_valid < timestamp && (thread.end_valid == 0 || thread.end_valid > timestamp))
+        if (thread.start_valid < serial && (thread.end_valid == EventSerialNumber {} || thread.end_valid > serial))
             return &thread;
     }
     return nullptr;
 }
 
-void Process::handle_thread_create(pid_t tid, u64 timestamp)
+void Process::handle_thread_create(pid_t tid, EventSerialNumber serial)
 {
     auto it = threads.find(tid);
     if (it == threads.end()) {
@@ -28,16 +28,16 @@ void Process::handle_thread_create(pid_t tid, u64 timestamp)
         it = threads.find(tid);
     }
 
-    auto thread = Thread { tid, timestamp, 0 };
+    auto thread = Thread { tid, serial, {} };
     it->value.append(move(thread));
 }
 
-void Process::handle_thread_exit(pid_t tid, u64 timestamp)
+void Process::handle_thread_exit(pid_t tid, EventSerialNumber serial)
 {
-    auto* thread = find_thread(tid, timestamp);
+    auto* thread = find_thread(tid, serial);
     if (!thread)
         return;
-    thread->end_valid = timestamp;
+    thread->end_valid = serial;
 }
 
 HashMap<String, OwnPtr<MappedObject>> g_mapped_object_cache;

--- a/Userland/DevTools/Profiler/Process.h
+++ b/Userland/DevTools/Profiler/Process.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "EventSerialNumber.h"
 #include <AK/HashMap.h>
 #include <AK/MappedFile.h>
 #include <AK/OwnPtr.h>
@@ -42,12 +43,12 @@ private:
 
 struct Thread {
     pid_t tid;
-    u64 start_valid;
-    u64 end_valid { 0 };
+    EventSerialNumber start_valid;
+    EventSerialNumber end_valid;
 
-    bool valid_at(u64 timestamp) const
+    bool valid_at(EventSerialNumber serial) const
     {
-        return timestamp >= start_valid && (end_valid == 0 || timestamp <= end_valid);
+        return serial >= start_valid && (end_valid == EventSerialNumber {} || serial <= end_valid);
     }
 };
 
@@ -57,16 +58,16 @@ struct Process {
     String basename;
     HashMap<int, Vector<Thread>> threads {};
     LibraryMetadata library_metadata {};
-    u64 start_valid;
-    u64 end_valid { 0 };
+    EventSerialNumber start_valid;
+    EventSerialNumber end_valid;
 
-    Thread* find_thread(pid_t tid, u64 timestamp);
-    void handle_thread_create(pid_t tid, u64 timestamp);
-    void handle_thread_exit(pid_t tid, u64 timestamp);
+    Thread* find_thread(pid_t tid, EventSerialNumber serial);
+    void handle_thread_create(pid_t tid, EventSerialNumber serial);
+    void handle_thread_exit(pid_t tid, EventSerialNumber serial);
 
-    bool valid_at(u64 timestamp) const
+    bool valid_at(EventSerialNumber serial) const
     {
-        return timestamp >= start_valid && (end_valid == 0 || timestamp <= end_valid);
+        return serial >= start_valid && (end_valid == EventSerialNumber {} || serial <= end_valid);
     }
 };
 

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -40,10 +40,6 @@ Profile::Profile(Vector<Process> processes, Vector<Event> events)
     m_model = ProfileModel::create(*this);
     m_samples_model = SamplesModel::create(*this);
 
-    for (auto& event : m_events) {
-        m_deepest_stack_depth = max((u32)event.frames.size(), m_deepest_stack_depth);
-    }
-
     rebuild_tree();
 }
 

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -126,8 +126,8 @@ private:
 
 struct ProcessFilter {
     pid_t pid { 0 };
-    u64 start_valid { 0 };
-    u64 end_valid { 0 };
+    EventSerialNumber start_valid;
+    EventSerialNumber end_valid;
 
     bool operator==(ProcessFilter const& rhs) const
     {
@@ -143,10 +143,10 @@ public:
     GUI::Model& samples_model();
     GUI::Model* disassembly_model();
 
-    const Process* find_process(pid_t pid, u64 timestamp) const
+    const Process* find_process(pid_t pid, EventSerialNumber serial) const
     {
-        auto it = m_processes.find_if([&](auto& entry) {
-            return entry.pid == pid && entry.valid_at(timestamp);
+        auto it = m_processes.find_if([&pid, &serial](auto& entry) {
+            return entry.pid == pid && entry.valid_at(serial);
         });
         return it.is_end() ? nullptr : &(*it);
     }
@@ -163,6 +163,7 @@ public:
     };
 
     struct Event {
+        EventSerialNumber serial;
         u64 timestamp { 0 };
         String type;
         FlatPtr ptr { 0 };
@@ -190,11 +191,11 @@ public:
     void clear_timestamp_filter_range();
     bool has_timestamp_filter_range() const { return m_has_timestamp_filter_range; }
 
-    void add_process_filter(pid_t pid, u64 start_valid, u64 end_valid);
-    void remove_process_filter(pid_t pid, u64 start_valid, u64 end_valid);
+    void add_process_filter(pid_t pid, EventSerialNumber start_valid, EventSerialNumber end_valid);
+    void remove_process_filter(pid_t pid, EventSerialNumber start_valid, EventSerialNumber end_valid);
     void clear_process_filter();
     bool has_process_filter() const { return !m_process_filters.is_empty(); }
-    bool process_filter_contains(pid_t pid, u32 timestamp);
+    bool process_filter_contains(pid_t pid, EventSerialNumber serial);
 
     bool is_inverted() const { return m_inverted; }
     void set_inverted(bool);

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -185,7 +185,6 @@ public:
     u64 length_in_ms() const { return m_last_timestamp - m_first_timestamp; }
     u64 first_timestamp() const { return m_first_timestamp; }
     u64 last_timestamp() const { return m_last_timestamp; }
-    u32 deepest_stack_depth() const { return m_deepest_stack_depth; }
 
     void set_timestamp_filter_range(u64 start, u64 end);
     void clear_timestamp_filter_range();
@@ -245,7 +244,6 @@ private:
 
     Vector<ProcessFilter> m_process_filters;
 
-    u32 m_deepest_stack_depth { 0 };
     bool m_inverted { false };
     bool m_show_top_functions { false };
     bool m_show_percentages { false };

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -74,7 +74,7 @@ GUI::Variant SamplesModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
             return event.tid;
 
         if (index.column() == Column::ExecutableName) {
-            if (auto* process = m_profile.find_process(event.pid, event.timestamp))
+            if (auto* process = m_profile.find_process(event.pid, event.serial))
                 return process->executable;
             return "";
         }

--- a/Userland/DevTools/Profiler/TimelineTrack.cpp
+++ b/Userland/DevTools/Profiler/TimelineTrack.cpp
@@ -73,7 +73,7 @@ void TimelineTrack::paint_event(GUI::PaintEvent& event)
         if (event.pid != m_process.pid)
             continue;
 
-        if (!m_process.valid_at(event.timestamp))
+        if (!m_process.valid_at(event.serial))
             continue;
 
         auto& histogram = event.in_kernel ? kernel_histogram : usermode_histogram;

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
     for (auto& process : profile->processes()) {
         bool matching_event_found = false;
         for (auto& event : profile->events()) {
-            if (event.pid == process.pid && process.valid_at(event.timestamp)) {
+            if (event.pid == process.pid && process.valid_at(event.serial)) {
                 matching_event_found = true;
                 break;
             }
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
         auto& timeline_header = timeline_header_container->add<TimelineHeader>(*profile, process);
         timeline_header.set_shrink_to_fit(true);
         timeline_header.on_selection_change = [&](bool selected) {
-            auto end_valid = process.end_valid == 0 ? profile->last_timestamp() : process.end_valid;
+            auto end_valid = process.end_valid == EventSerialNumber {} ? EventSerialNumber::max_valid_serial() : process.end_valid;
             if (selected)
                 profile->add_process_filter(process.pid, process.start_valid, end_valid);
             else


### PR DESCRIPTION
**Profiler: Use sequential serial numbers for profiling events**

Previously Profiler was using timestamps to distinguish processes. However it is possible that separate processes with the same PID exist at the exact same timestamp (e.g. for `execve`). This changes Profiler to use unique serial numbers for each event instead.

**Profiler: Remove m_deepest_stack_depth**

This isn't used anymore so let's remove it entirely.