### PR TITLE
LibGUI: Tooltip no longer exceeds screen width, now truncates

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -27,7 +27,13 @@ public:
     void set_tooltip(const String& tooltip)
     {
         m_label->set_text(Gfx::parse_ampersand_string(tooltip));
-        set_rect(rect().x(), rect().y(), m_label->min_width() + 10, m_label->font().glyph_height() + 8);
+        int tooltip_width = m_label->min_width() + 10;
+
+        Gfx::IntRect desktop_rect = Desktop::the().rect();
+        if (tooltip_width > desktop_rect.width())
+            tooltip_width = desktop_rect.width();
+
+        set_rect(rect().x(), rect().y(), tooltip_width, m_label->font().glyph_height() + 8);
     }
 
 private:
@@ -196,6 +202,8 @@ void Application::tooltip_show_timer_did_fire()
     if (adjusted_pos.y() + m_tooltip_window->height() >= desktop_rect.height() - margin) {
         adjusted_pos = adjusted_pos.translated(0, -(m_tooltip_window->height() * 2));
     }
+    if (adjusted_pos.x() < 0)
+        adjusted_pos.set_x(0);
 
     m_tooltip_window->move_to(adjusted_pos);
     m_tooltip_window->show();


### PR DESCRIPTION
Relates to #7409 

This PR makes the tooltip a bit more useful and avoids a crash when the width of the tooltip is very large (larger than `INT16_MAX`).

Improvements made to the tooltip:

1. If the `x` position of the tooltip would've been negative (left of the screen), this is not useful to the user and they likely want to see the beginning of the tooltip and its text. This will snap the tooltip back to the left edge of the screen.
2. If the width of the tooltip exceeds the width of the screen, then set the width of the tooltip to the screen width, which causes `...` truncation that was already supported.

<img width="1136" alt="Screen Shot 2021-06-02 at 1 37 56 PM" src="https://user-images.githubusercontent.com/955163/120552800-ef39bc00-c3b4-11eb-8d8e-3365fbbf4f9f.png">
