### PR TITLE
LibGUI: Show pressed state for Space and Return key events

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -146,11 +146,27 @@ void AbstractButton::leave_event(Core::Event&)
 void AbstractButton::keydown_event(KeyEvent& event)
 {
     if (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Space) {
-        click(event.modifiers());
+        m_being_pressed = true;
+        update();
+        event.accept();
+        return;
+    } else if (m_being_pressed && event.key() == KeyCode::Key_Escape) {
+        m_being_pressed = false;
+        update();
         event.accept();
         return;
     }
     Widget::keydown_event(event);
+}
+
+void AbstractButton::keyup_event(KeyEvent& event)
+{
+    if (m_being_pressed && (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Space)) {
+        click(event.modifiers());
+        event.accept();
+        return;
+    }
+    Widget::keyup_event(event);
 }
 
 void AbstractButton::paint_text(Painter& painter, const Gfx::IntRect& rect, const Gfx::Font& font, Gfx::TextAlignment text_alignment)

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -46,6 +46,7 @@ protected:
     virtual void mousemove_event(MouseEvent&) override;
     virtual void mouseup_event(MouseEvent&) override;
     virtual void keydown_event(KeyEvent&) override;
+    virtual void keyup_event(KeyEvent&) override;
     virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;
     virtual void change_event(Event&) override;


### PR DESCRIPTION
Does not perform the action until the user releases the key. Also allows the user to press Esc while the button is being pressed to cancel the button action.

Fixes #5479