### PR TITLE
WindowServer: Position popup menu with offset of 1 pixel

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -588,6 +588,8 @@ void Menu::do_popup(const Gfx::IntPoint& position, bool make_input, bool as_subm
 
     if (adjusted_pos.x() + window.width() >= Screen::the().width() - margin) {
         adjusted_pos = adjusted_pos.translated(-window.width(), 0);
+    } else {
+        adjusted_pos.set_x(adjusted_pos.x() + 1);
     }
     if (adjusted_pos.y() + window.height() >= Screen::the().height() - margin) {
         adjusted_pos = adjusted_pos.translated(0, -min(window.height(), adjusted_pos.y()));


### PR DESCRIPTION
Fixes #5474

Updates the positioning of a popup menu to be offset right by 1 pixel, so its top-left corner is no longer right under the exact positioning of the mouse cursor that caused the click event to open the popup menu.

As discussed in #5474 this has the nice benefit that you can right-click again immediately to dismiss the popup.

![Screen Recording 2021-06-02 at 04 59 46 PM](https://user-images.githubusercontent.com/955163/120562641-07fd9e00-c3c4-11eb-9da1-74b29ad56e0d.gif)


