### PR TITLE
LibGUI: ComboBox now correctly sizes height in relation to taskbar

### DIFF
--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -225,11 +225,8 @@ void ComboBox::open()
     };
 
     auto taskbar_height = GUI::Desktop::the().taskbar_height();
-    // NOTE: This is so the combobox bottom edge exactly fits the taskbar's
-    //       top edge - the value was found through trial and error though.
-    auto offset = 8;
     Gfx::IntRect list_window_rect { my_screen_rect.bottom_left(), size };
-    list_window_rect.intersect(Desktop::the().rect().shrunken(0, taskbar_height + offset));
+    list_window_rect.intersect(Desktop::the().rect().shrunken(0, taskbar_height * 2));
 
     m_editor->set_focus(true);
     if (m_selected_index.has_value()) {

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Rect.h>
+#include <Services/Taskbar/TaskbarWindow.h>
 
 namespace GUI {
 
@@ -27,7 +28,7 @@ public:
 
     Gfx::IntRect rect() const { return m_rect; }
 
-    int taskbar_height() const { return 27; }
+    int taskbar_height() const { return TaskbarWindow::taskbar_height(); }
 
     void did_receive_screen_rect(Badge<WindowServerConnection>, const Gfx::IntRect&);
 


### PR DESCRIPTION
Relates to #4910

Fixes sizing issue for `ComboBox` when it's positioned close to the `Taskbar` and the scroll pane would be too tall / cut off by the height of the `Taskbar`:

<img width="440" alt="Screen Shot 2021-06-02 at 5 36 42 PM" src="https://user-images.githubusercontent.com/955163/120564981-519cb780-c3c9-11eb-8c15-54c8467700d8.png">

Now with the fix, it aligns perfectly along the edge:

<img width="522" alt="Screen Shot 2021-06-02 at 5 18 39 PM" src="https://user-images.githubusercontent.com/955163/120564991-582b2f00-c3c9-11eb-9b2f-c2fe1a844503.png">

Zoomed in screenshot for better look at the pixels (click to open PNG for higher resolution viewing):

<img width="309" alt="Screen Shot 2021-06-02 at 5 19 02 PM" src="https://user-images.githubusercontent.com/955163/120565007-624d2d80-c3c9-11eb-8f21-1d5eb6772ac0.png">

Moved the `ComboBox` even closer, and confirmed that it still sizes perfectly:

<img width="440" alt="Screen Shot 2021-06-02 at 5 19 29 PM" src="https://user-images.githubusercontent.com/955163/120565019-67aa7800-c3c9-11eb-9f22-d937916b3a42.png">

To confirm that the logic is sound in relation to the actual height of the `Taskbar`, I increased the height of it to confirm and it indeed did adapt correctly:

<img width="486" alt="Screen Shot 2021-06-02 at 5 27 46 PM" src="https://user-images.githubusercontent.com/955163/120565031-6d07c280-c3c9-11eb-97f2-3a211474f325.png">

The old "magic number" of `offset = 8` I think started being incorrect since e9db10e3a96eae955ebb84751fd6d468de9c3078 and once I was playing around with a new `offset` value, I stumbled onto `27` being the exact number, which was the same value as the `Taskbar` height so I cleaned up the code to use the actual value.

Speaking of actual value, `LibGUI/Desktop.h` is what the `ComboBox` library looks to for the height of the `Taskbar` and this value was previously hardcoded to `27`, whereas the _actual value_ is defined and used in `Services/Taskbar/TaskbarWindow.h`.