### PR TITLE
LibGUI+SoundPlayer: Add Slider option to jump to cursor

### DIFF
--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -53,6 +53,7 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
 
     m_playback_progress_slider = m_player_view->add<AutoSlider>(Orientation::Horizontal);
     m_playback_progress_slider->set_fixed_height(20);
+    m_playback_progress_slider->set_jump_to_cursor(true);
     m_playback_progress_slider->set_min(0);
     m_playback_progress_slider->set_max(total_samples);
     m_playback_progress_slider->set_page_step(total_samples / 10);

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -24,6 +24,7 @@ public:
     int max() const { return m_max; }
     int step() const { return m_step; }
     int page_step() const { return m_page_step; }
+    bool jump_to_cursor() const { return m_jump_to_cursor; }
 
     void set_range(int min, int max);
     void set_value(int);
@@ -32,6 +33,7 @@ public:
     void set_max(int max) { set_range(min(), max); }
     void set_step(int step) { m_step = step; }
     void set_page_step(int page_step);
+    void set_jump_to_cursor(bool b) { m_jump_to_cursor = b; }
 
     Function<void(int)> on_change;
 
@@ -46,6 +48,7 @@ private:
     int m_max { 0 };
     int m_step { 1 };
     int m_page_step { 10 };
+    bool m_jump_to_cursor { false };
     Orientation m_orientation { Orientation::Horizontal };
 };
 

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -87,10 +87,26 @@ void Slider::mousedown_event(MouseEvent& event)
             m_drag_origin = event.position();
             m_drag_origin_value = value();
             return;
+        }
+
+        const auto mouse_offset = event.position().primary_offset_for_orientation(orientation());
+
+        if (jump_to_cursor()) {
+            float normalized_mouse_offset = 0.0f;
+            if (orientation() == Orientation::Vertical) {
+                normalized_mouse_offset = static_cast<float>(mouse_offset) / static_cast<float>(height());
+            } else {
+                normalized_mouse_offset = static_cast<float>(mouse_offset) / static_cast<float>(width());
+            }
+
+            int new_value = static_cast<int>(min() + ((max() - min()) * normalized_mouse_offset));
+            set_value(new_value);
         } else {
-            if (event.position().primary_offset_for_orientation(orientation()) > knob_rect().last_edge_for_orientation(orientation()))
+            auto knob_first_edge = knob_rect().first_edge_for_orientation(orientation());
+            auto knob_last_edge = knob_rect().last_edge_for_orientation(orientation());
+            if (mouse_offset > knob_last_edge)
                 set_value(value() + page_step());
-            else if (event.position().primary_offset_for_orientation(orientation()) < knob_rect().first_edge_for_orientation(orientation()))
+            else if (mouse_offset < knob_first_edge)
                 set_value(value() - page_step());
         }
     }


### PR DESCRIPTION
When the cursor is clicked outside of the slider knob,
the current behavior is that it will step up or down by the
Slider page step amount.

This commit adds an option to jump the slider knob
directly to the where the mouse cursor is on mouse down events.

This behavior is disabled by default. It must be enabled with
`Slider::set_jump_to_cursor()`.

Jump to cursor is enabled in SoundPlayer since most music players
have this behavior.

### Testing

- [x] Default page-step behavior still works.
- [x] Jump-to-cursor works for horizontal sliders.
- [x] Jump-to-cursor works for vertical sliders.