### PR TITLE
LibSQL: Report a syntax error for unsupported LIMIT clause syntax

### DIFF
--- a/Tests/LibSQL/TestSqlStatementParser.cpp
+++ b/Tests/LibSQL/TestSqlStatementParser.cpp
@@ -547,6 +547,7 @@ TEST_CASE(select)
     EXPECT(parse("SELECT * FROM table LIMIT 12").is_error());
     EXPECT(parse("SELECT * FROM table LIMIT 12 OFFSET;").is_error());
     EXPECT(parse("SELECT * FROM table LIMIT 12 OFFSET 15").is_error());
+    EXPECT(parse("SELECT * FROM table LIMIT 15, 16;").is_error());
 
     struct Type {
         SQL::ResultType type;

--- a/Userland/Libraries/LibSQL/Parser.cpp
+++ b/Userland/Libraries/LibSQL/Parser.cpp
@@ -321,11 +321,11 @@ NonnullRefPtr<Select> Parser::parse_select_statement(RefPtr<CommonTableExpressio
         RefPtr<Expression> offset_expression;
         if (consume_if(TokenType::Offset)) {
             offset_expression = parse_expression();
-        } else {
+        } else if (consume_if(TokenType::Comma)) {
             // Note: The limit clause may instead be defined as "offset-expression, limit-expression", effectively reversing the
             // order of the expressions. SQLite notes "this is counter-intuitive" and "to avoid confusion, programmers are strongly
             // encouraged to ... avoid using a LIMIT clause with a comma-separated offset."
-            VERIFY(!consume_if(TokenType::Comma));
+            syntax_error("LIMIT clauses of the form 'LIMIT <expr>, <expr>' are not supported");
         }
 
         limit_clause = create_ast_node<LimitClause>(move(limit_expression), move(offset_expression));


### PR DESCRIPTION
Rather than aborting when a LIMIT clause of the form 'LIMIT expr, expr'
is encountered, fail the parser with a syntax error. This will be nicer
for the user and fixes the following fuzzer bug:
https://crbug.com/oss-fuzz/34837