### PR TITLE
WindowServer: Add sanity checks to `create_window` IPC

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -465,6 +465,11 @@ Messages::WindowServer::CreateWindowResponse ClientConnection::create_window(Gfx
         }
     }
 
+    if (type < 0 || type >= (i32)WindowType::_Count) {
+        did_misbehave("CreateWindow with a bad type");
+        return nullptr;
+    }
+
     int window_id = m_next_window_id++;
     auto window = Window::construct(*this, (WindowType)type, window_id, modal, minimizable, frameless, resizable, fullscreen, accessory, parent_window);
 
@@ -492,7 +497,8 @@ Messages::WindowServer::CreateWindowResponse ClientConnection::create_window(Gfx
     window->set_alpha_hit_threshold(alpha_hit_threshold);
     window->set_size_increment(size_increment);
     window->set_base_size(base_size);
-    window->set_resize_aspect_ratio(resize_aspect_ratio);
+    if (resize_aspect_ratio.has_value() && !resize_aspect_ratio.value().is_null())
+        window->set_resize_aspect_ratio(resize_aspect_ratio);
     window->invalidate(true, true);
     if (window->type() == WindowType::Applet)
         AppletManager::the().add_applet(*window);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -208,7 +208,8 @@ void Window::nudge_into_desktop(bool force_titlebar_visible)
 
 void Window::set_minimum_size(const Gfx::IntSize& size)
 {
-    VERIFY(!size.is_empty());
+    if (size.is_null())
+        return;
 
     if (m_minimum_size == size)
         return;

--- a/Userland/Services/WindowServer/WindowType.h
+++ b/Userland/Services/WindowServer/WindowType.h
@@ -20,6 +20,7 @@ enum class WindowType {
     Desktop,
     ToolWindow,
     AppletArea,
+    _Count
 };
 
 }


### PR DESCRIPTION
Fixes #4540

It was possible to craft a program such that it would send invalid parameters to the `WindowServer`, resulting in the `WindowServer` crashing and `Taskbar` crashing as well.

This PR strengthens the `WindowServer` IPC `create_window` to guard against malformed parameters.

New parameters checked:

- `type`
- `resize_aspect_ratio`
- `minimum_size`

The issue #4540 contained a helpful program to cause these various crashes, but is slightly out of date given some code changes since when the issue was first created. Below is an updated version I used:

<details>
<summary>Test application</summary>

```c++
#include <AK/StringBuilder.h>
#include <LibGUI/Action.h>
#include <LibGUI/Application.h>
#include <LibGUI/BoxLayout.h>
#include <LibGUI/Button.h>
#include <LibGUI/Event.h>
#include <LibGUI/Icon.h>
#include <LibGUI/Label.h>
#include <LibGUI/Menu.h>
#include <LibGUI/MessageBox.h>
#include <LibGUI/Widget.h>
#include <LibGUI/Window.h>
#include <LibGUI/WindowServerConnection.h>
#include <stdio.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char** argv)
{
    auto app = GUI::Application::construct(argc, argv);
    auto window = GUI::Window::construct();
    window->set_title("TestWindowServer");
    window->set_resizable(true);
    window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/close-tab.png"));

    window->set_window_type(GUI::WindowType::Normal);
    window->set_fullscreen(false);
    window->set_background_color(Color::White);

    auto& main_widget = window->set_main_widget<GUI::Widget>();
    main_widget.set_fill_with_background_color(true);

    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
    layout.set_margins({ 4, 4, 4, 4 });

    auto& label = main_widget.add<GUI::Label>();
    label.set_text("Hello friends");

    window->show();

    auto id = window->window_id();
    Gfx::IntRect rect = { 200, 200, 200, 200 };
    Gfx::IntSize zxcv = {};

    auto result = GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::CreateWindow>(
        rect,                  // rect (validated)
        true,                  // auto_position
        true,                  // has_alpha_channel
        true,                  // modal
        true,                  // minimizable
        true,                  // resizable
        false,                 // fullscreen
        false,                 // frameless
        false,                 // accessory
        100,                   // opacity
        1234,                  // alpha_hit_threshold
        zxcv,                  // base_size
        zxcv,                  // size_increment
        zxcv,                  // minimum_size (now validated)
        zxcv,                  // resize_aspect_ratio (now validated)
        1,                     // type (now validated when int is not a valid WindowType value)
        "[UTF8] String title", // title
        id);                   // parent_window_id

    return app->exec();
}
```

</details>