### PR TITLE
LibGUI: IconView search highlighting now properly wraps multiple lines

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -662,7 +662,7 @@ bool AbstractView::is_highlighting_searching(const ModelIndex& index) const
     return index == m_highlighted_search_index;
 }
 
-void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index, bool is_selected, const Gfx::IntRect& text_rect, const StringView& item_text, const Gfx::Font& font, Gfx::TextAlignment alignment, Gfx::TextElision elision)
+void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index, bool is_selected, const Gfx::IntRect& text_rect, const StringView& item_text, const Gfx::Font& font, Gfx::TextAlignment alignment, Gfx::TextElision elision, size_t search_highlighting_offset)
 {
     Color text_color;
     if (is_selected)
@@ -672,22 +672,28 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index
     if (is_highlighting_searching(index)) {
         Utf8View searching_text(searching());
         auto searching_length = searching_text.length();
+        if (searching_length > search_highlighting_offset)
+            searching_length -= search_highlighting_offset;
+        else if (search_highlighting_offset > 0)
+            searching_length = 0;
 
         // Highlight the text background first
+        auto background_searching_length = searching_length;
         painter.draw_text([&](const Gfx::IntRect& rect, u32) {
-            if (searching_length > 0) {
-                searching_length--;
+            if (background_searching_length > 0) {
+                background_searching_length--;
                 painter.fill_rect(rect.inflated(0, 2), palette().highlight_searching());
             }
         },
             text_rect, item_text, font, alignment, elision);
 
         // Then draw the text
+        auto text_searching_length = searching_length;
         auto highlight_text_color = palette().highlight_searching_text();
         searching_length = searching_text.length();
         painter.draw_text([&](const Gfx::IntRect& rect, u32 code_point) {
-            if (searching_length > 0) {
-                searching_length--;
+            if (text_searching_length > 0) {
+                text_searching_length--;
                 painter.draw_glyph_or_emoji(rect.location(), code_point, font, highlight_text_color);
             } else {
                 painter.draw_glyph_or_emoji(rect.location(), code_point, font, text_color);

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -150,7 +150,7 @@ protected:
     virtual void did_change_hovered_index([[maybe_unused]] const ModelIndex& old_index, [[maybe_unused]] const ModelIndex& new_index) { }
     virtual void did_change_cursor_index([[maybe_unused]] const ModelIndex& old_index, [[maybe_unused]] const ModelIndex& new_index) { }
 
-    void draw_item_text(Gfx::Painter&, const ModelIndex&, bool, const Gfx::IntRect&, const StringView&, const Gfx::Font&, Gfx::TextAlignment, Gfx::TextElision);
+    void draw_item_text(Gfx::Painter&, const ModelIndex&, bool, const Gfx::IntRect&, const StringView&, const Gfx::Font&, Gfx::TextAlignment, Gfx::TextElision, size_t search_highlighting_offset = 0);
 
     void set_suppress_update_on_selection_change(bool value) { m_suppress_update_on_selection_change = value; }
 

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -543,6 +543,7 @@ void IconView::paint_event(PaintEvent& event)
 
             const auto& lines = item_data.wrapped_text_lines;
             size_t number_of_text_lines = min((size_t)text_rect.height() / font->glyph_height(), lines.size());
+            size_t previous_line_lengths = 0;
             for (size_t line_index = 0; line_index < number_of_text_lines; ++line_index) {
                 Gfx::IntRect line_rect;
                 line_rect.set_width(text_rect.width());
@@ -555,7 +556,8 @@ void IconView::paint_event(PaintEvent& event)
                 if (number_of_text_lines - 1 == line_index && lines.size() > number_of_text_lines)
                     line_rect.inflate(-(6 + 2 * font->max_glyph_width()), 0);
 
-                draw_item_text(painter, item_data.index, item_data.selected, line_rect, lines[line_index], font, Gfx::TextAlignment::Center, Gfx::TextElision::Right);
+                draw_item_text(painter, item_data.index, item_data.selected, line_rect, lines[line_index], font, Gfx::TextAlignment::Center, Gfx::TextElision::Right, previous_line_lengths);
+                previous_line_lengths += lines[line_index].length();
             }
         } else {
             draw_item_text(painter, item_data.index, item_data.selected, item_data.text_rect, item_data.text, font, Gfx::TextAlignment::Center, Gfx::TextElision::Right);


### PR DESCRIPTION
Fixes #3826

Updates `IconView` to pass in new `search_highlighting_offset` to `draw_item_text` of `AbstractView`, so that when `IconView` is wrapping text over multiple lines and a search is occurring, the `draw_item_text` function now properly highlights the search term over multiple lines:

![Screen Recording 2021-06-02 at 10 41 55 PM](https://user-images.githubusercontent.com/955163/120588106-d7cdf380-c3f3-11eb-8439-e23958dcc3db.gif)