### PR TITLE
LibJS: Optimize insertion order in the Exception constructor 

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Exception.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Exception.cpp
@@ -18,18 +18,18 @@ Exception::Exception(Value value)
 {
     auto& vm = this->vm();
     m_traceback.ensure_capacity(vm.call_stack().size());
-    for (auto* call_frame : vm.call_stack()) {
+    for (ssize_t i = vm.call_stack().size() - 1; i >= 0; i--) {
+        auto* call_frame = vm.call_stack()[i];
         auto function_name = call_frame->function_name;
         if (function_name.is_empty())
             function_name = "<anonymous>";
-        m_traceback.prepend({
-            .function_name = move(function_name),
+        m_traceback.empend(
+            move(function_name),
             // We might not have an AST node associated with the call frame, e.g. in promise
             // reaction jobs (which aren't called anywhere from the source code).
             // They're not going to generate any _unhandled_ exceptions though, so a meaningless
             // source range is fine.
-            .source_range = call_frame->current_node ? call_frame->current_node->source_range() : SourceRange {},
-        });
+            call_frame->current_node ? call_frame->current_node->source_range() : SourceRange {});
     }
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Exception.h
+++ b/Userland/Libraries/LibJS/Runtime/Exception.h
@@ -26,14 +26,14 @@ public:
     virtual ~Exception() override = default;
 
     Value value() const { return m_value; }
-    const Vector<TracebackFrame>& traceback() const { return m_traceback; }
+    const Vector<TracebackFrame, 32>& traceback() const { return m_traceback; }
 
 private:
     virtual const char* class_name() const override { return "Exception"; }
     virtual void visit_edges(Visitor&) override;
 
     Value m_value;
-    Vector<TracebackFrame> m_traceback;
+    Vector<TracebackFrame, 32> m_traceback;
 };
 
 }


### PR DESCRIPTION
**LibJS: Optimize insertion order in the Exception constructor**

By inserting the stack frames in the correct order we can improve the runtime for the test-js test suite by about 20%.

**LibJS: Avoid allocations in the Exception constructor**