### PR TITLE
LibGUI/FileIconProvider: Return s_file_icon when stat() fails

### DIFF
--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -122,7 +122,7 @@ Icon FileIconProvider::icon_for_path(const String& path)
 {
     struct stat stat;
     if (::stat(path.characters(), &stat) < 0)
-        return {};
+        return s_file_icon;
     return icon_for_path(path, stat.st_mode);
 }
 
@@ -225,8 +225,6 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
             target_path = Core::File::real_path_for(String::formatted("{}/{}", LexicalPath(path).dirname(), raw_symlink_target));
         }
         auto target_icon = icon_for_path(target_path);
-        if (target_icon.sizes().is_empty())
-            return s_symlink_icon;
 
         Icon generated_icon;
         for (auto size : target_icon.sizes()) {


### PR DESCRIPTION
Previously when using `icon_for_path()`, without specifying t_mode, on an anonymous file it would return an empty Icon causing problems downstream. For example the locator in HackStudio crashed when trying to access an icon for `/proc/10/fd/14`.

Accessing an anonymous file seem to be the only time this happens, an icon could be made for that case even though it's rare.