### PR TITLE
CI: Skip saving the toolchain and ccache caches in PR workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,7 +68,10 @@ jobs:
         message("  set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/BuildIt.sh') }}")
         message("::set-output name=libc_headers::${{ hashFiles('Userland/Libraries/LibC/**/*.h', 'Userland/Libraries/LibPthread/**/*.h', 'Toolchain/Patches/*.patch', 'Toolchain/BuildIt.sh') }}")
     - name: Toolchain cache
-      uses: actions/cache@v2
+      # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
+      uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+      env:
+        CACHE_SKIP_SAVE: ${{ github.event_name == 'pull_request' }}
       with:
         path: ${{ github.workspace }}/Toolchain/Cache/
         # This assumes that *ALL* LibC and LibPthread headers have an impact on the Toolchain.
@@ -79,7 +82,10 @@ jobs:
       run: TRY_USE_LOCAL_TOOLCHAIN=y ${{ github.workspace }}/Toolchain/BuildIt.sh
     - name: ccache(1) cache
       # Pull the ccache *after* building the toolchain, in case building the Toolchain somehow interferes.
-      uses: actions/cache@v2
+      # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
+      uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
+      env:
+        CACHE_SKIP_SAVE: ${{ github.event_name == 'pull_request' }}
       with:
         path: /home/runner/.ccache
         # If you're here because ccache broke (it never should), increment matrix.ccache-mark.


### PR DESCRIPTION
This speeds up CI by removing some cache thrashing caused by PRs that change cache-related files (but that were not merged yet).

I've decided to take a similar step to denoland/deno#10560's and use the CACHE_SKIP_SAVE PR's merge head instead of waiting for it to get merged since it didn't make any progress for 5 months at this point.

Fixes #6728