### PR TITLE
Kernel: Fix "sv" being inside of "no-fbdev" instead of outside

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -188,7 +188,7 @@ UNMAP_AFTER_INIT AHCIResetMode CommandLine::ahci_reset_mode() const
 UNMAP_AFTER_INIT BootMode CommandLine::boot_mode() const
 {
     const auto boot_mode = lookup("boot_mode"sv).value_or("graphical"sv);
-    if (boot_mode == "no-fbdevsv") {
+    if (boot_mode == "no-fbdev"sv) {
         return BootMode::NoFramebufferDevices;
     } else if (boot_mode == "self-test"sv) {
         return BootMode::SelfTest;


### PR DESCRIPTION
It was previously "no-fbdevsv" when it should be "no-fbdev"sv.