### PR TITLE
PixelPaint: use correct snapshot in undo/redo actions, update UI

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -364,20 +364,4 @@ void Image::did_change()
         client->image_did_change();
 }
 
-ImageUndoCommand::ImageUndoCommand(Image& image)
-    : m_snapshot(image.take_snapshot())
-    , m_image(image)
-{
-}
-
-void ImageUndoCommand::undo()
-{
-    m_image.restore_snapshot(*m_snapshot);
-}
-
-void ImageUndoCommand::redo()
-{
-    undo();
-}
-
 }

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -86,16 +86,4 @@ private:
     HashTable<ImageClient*> m_clients;
 };
 
-class ImageUndoCommand : public GUI::Command {
-public:
-    ImageUndoCommand(Image& image);
-
-    virtual void undo() override;
-    virtual void redo() override;
-
-private:
-    RefPtr<Image> m_snapshot;
-    Image& m_image;
-};
-
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -50,6 +50,8 @@ void ImageEditor::did_complete_action()
     if (!m_image)
         return;
     store_snapshot();
+    if (on_undo_redo_change)
+        on_undo_redo_change(m_active_snapshot > 0, m_active_snapshot + 1 < m_snapshots.size());
 }
 
 void ImageEditor::store_snapshot()
@@ -307,6 +309,8 @@ void ImageEditor::set_active_tool(Tool* tool)
 void ImageEditor::layers_did_change()
 {
     update();
+    if (on_undo_redo_change)
+        on_undo_redo_change(m_active_snapshot > 0, m_active_snapshot + 1 < m_snapshots.size());
 }
 
 Color ImageEditor::color_for(GUI::MouseButton button) const

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -36,6 +36,7 @@ public:
     void set_active_tool(Tool*);
 
     void did_complete_action();
+    void store_snapshot();
     bool undo();
     bool redo();
 
@@ -92,8 +93,9 @@ private:
     void relayout();
 
     RefPtr<Image> m_image;
+    size_t m_active_snapshot { 0 };
+    NonnullRefPtrVector<Image> m_snapshots;
     RefPtr<Layer> m_active_layer;
-    OwnPtr<GUI::UndoStack> m_undo_stack;
 
     Tool* m_active_tool { nullptr };
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -62,6 +62,8 @@ public:
 
     Function<void(Layer*)> on_active_layer_change;
 
+    Function<void(bool, bool)> on_undo_redo_change;
+
     Gfx::FloatRect layer_rect_to_editor_rect(Layer const&, Gfx::IntRect const&) const;
     Gfx::FloatRect image_rect_to_editor_rect(Gfx::IntRect const&) const;
     Gfx::FloatRect editor_rect_to_image_rect(Gfx::IntRect const&) const;

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -181,13 +181,20 @@ int main(int argc, char** argv)
         VERIFY(image_editor.image());
         image_editor.undo();
     });
+    undo_action->set_enabled(false);
     edit_menu.add_action(undo_action);
 
     auto redo_action = GUI::CommonActions::make_redo_action([&](auto&) {
         VERIFY(image_editor.image());
         image_editor.redo();
     });
+    redo_action->set_enabled(false);
     edit_menu.add_action(redo_action);
+
+    image_editor.on_undo_redo_change = [&undo_action, &redo_action](bool undo_enabled, bool redo_enabled) {
+        undo_action->set_enabled(undo_enabled);
+        redo_action->set_enabled(redo_enabled);
+    };
 
     auto& view_menu = menubar->add_menu("&View");
 


### PR DESCRIPTION
This fixes undo problems in PixelPaint by changing the model from undo commands to snapshots list. I've additionally added UI update callback to enable/disable the icons.

Fixes #5814