### PR TITLE
Taskbar: Allow creating menus for sub-categories 

### DIFF
--- a/Base/res/icons/SystemMenu.ini
+++ b/Base/res/icons/SystemMenu.ini
@@ -2,6 +2,7 @@
 Demos=/res/icons/16x16/demos.png
 Development=/res/icons/16x16/development.png
 Games=/res/icons/16x16/games.png
+Games/Puzzles=/res/icons/16x16/games.png
 Graphics=/res/icons/16x16/graphics.png
 Internet=/res/icons/16x16/internet.png
 Settings=/res/icons/16x16/settings.png

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -95,29 +95,45 @@ ensure_build() {
     fi
 }
 
-install_launcher() {
-    if [ -z "$launcher_name" ] || [ -z "${launcher_category}" ] || [ -z "${launcher_command}" ]; then
-        return
+install_main_launcher() {
+    if [ -n "$launcher_name" ] && [ -n "$launcher_category" ] && [ -n "$launcher_command" ]; then
+        install_launcher "$launcher_name" "$launcher_category" "$launcher_command"
     fi
-    script_name="${launcher_name,,}"
-    script_name="${script_name// /}"
-    mkdir -p $DESTDIR/usr/local/libexec
-    cat >$DESTDIR/usr/local/libexec/$script_name <<SCRIPT
+}
+
+install_launcher() {
+    if [ "$#" -lt 3 ]; then
+        echo "Syntax: install_launcher <name> <category> <command>"
+        exit 1
+    fi
+    launcher_name="$1"
+    launcher_category="$2"
+    launcher_command="$3"
+    launcher_filename="${launcher_name,,}"
+    launcher_filename="${launcher_filename// /}"
+    case "$launcher_command" in
+        *\ *)
+            mkdir -p $DESTDIR/usr/local/libexec
+            launcher_executable="/usr/local/libexec/$launcher_filename"
+            cat >"$DESTDIR/$launcher_executable" <<SCRIPT
 #!/bin/sh
 set -e
 exec $(printf '%q ' $launcher_command)
 SCRIPT
-    chmod +x $DESTDIR/usr/local/libexec/$script_name
-
-    chmod +x $DESTDIR/usr/local/libexec
+            chmod +x "$DESTDIR/$launcher_executable"
+            ;;
+        *)
+            launcher_executable="$launcher_command"
+            ;;
+    esac
     mkdir -p $DESTDIR/res/apps
-    cat >$DESTDIR/res/apps/$script_name.af <<CONFIG
+    cat >$DESTDIR/res/apps/$launcher_filename.af <<CONFIG
 [App]
 Name=$launcher_name
-Executable=/usr/local/libexec/$script_name
+Executable=$launcher_executable
 Category=$launcher_category
 CONFIG
-    unset script_name
+    unset launcher_filename
 }
 # Checks if a function is defined. In this case, if the function is not defined in the port's script, then we will use our defaults. This way, ports don't need to include these functions every time, but they can override our defaults if needed.
 func_defined() {
@@ -285,7 +301,6 @@ func_defined build || build() {
 }
 func_defined install || install() {
     run make DESTDIR=$DESTDIR $installopts install
-    install_launcher
 }
 func_defined post_install || post_install() {
     echo
@@ -397,6 +412,7 @@ do_install() {
     ensure_build
     echo "Installing $port!"
     install
+    install_main_launcher
     post_install
     addtodb "${1:-}"
 }

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -105,7 +105,6 @@ install_launcher() {
     cat >$DESTDIR/usr/local/libexec/$script_name <<SCRIPT
 #!/bin/sh
 set -e
-cd -- "\$(dirname -- "\$(which -- $(printf %q "${launcher_command%% *}"))")"
 exec $(printf '%q ' $launcher_command)
 SCRIPT
     chmod +x $DESTDIR/usr/local/libexec/$script_name

--- a/Ports/SDLPoP/package.sh
+++ b/Ports/SDLPoP/package.sh
@@ -18,5 +18,4 @@ configure() {
 install() {
     mkdir -p "${SERENITY_INSTALL_ROOT}/opt/PrinceOfPersia"
     run cp -r prince data SDLPoP.ini "${SERENITY_INSTALL_ROOT}/opt/PrinceOfPersia" 
-    install_launcher
 }

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -17,5 +17,11 @@ configure() {
 
 install() {
     run mkdir -p "${SERENITY_INSTALL_ROOT}/opt/Super_Mario"
-    run cp -r uMario app.ico icon2.ico files "${SERENITY_INSTALL_ROOT}/opt/Super_Mario" 
+    run cp -r uMario files "${SERENITY_INSTALL_ROOT}/opt/Super_Mario"
+    if command -v convert >/dev/null; then
+        run convert "app.ico[0]" app-16x16.png
+        run convert "app.ico[1]" app-32x32.png
+        run objcopy --add-section serenity_icon_s="app-16x16.png" "${SERENITY_INSTALL_ROOT}/opt/Super_Mario/uMario"
+        run objcopy --add-section serenity_icon_m="app-32x32.png" "${SERENITY_INSTALL_ROOT}/opt/Super_Mario/uMario"
+    fi
 }

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -18,5 +18,4 @@ configure() {
 install() {
     run mkdir -p "${SERENITY_INSTALL_ROOT}/opt/Super_Mario"
     run cp -r uMario app.ico icon2.ico files "${SERENITY_INSTALL_ROOT}/opt/Super_Mario" 
-    install_launcher
 }

--- a/Ports/Super-Mario/patches/cwd.patch
+++ b/Ports/Super-Mario/patches/cwd.patch
@@ -1,0 +1,21 @@
+diff -Naur Super-Mario-Clone-Cpp-master/src/main.cpp Super-Mario-Clone-Cpp-master.serenity/src/main.cpp
+--- Super-Mario-Clone-Cpp-master/src/main.cpp	2019-08-01 15:39:15.000000000 +0200
++++ Super-Mario-Clone-Cpp-master.serenity/src/main.cpp	2021-06-03 23:54:26.881221759 +0200
+@@ -1,10 +1,15 @@
+ #include "header.h"
+ #include "Core.h"
++#include <unistd.h>
+ 
+ int main(int argc, const char* argv[]) {
+-    CCore oCore;
++    chdir("/opt/Super_Mario");
+ 
+-    oCore.mainLoop();
++    {
++        CCore oCore;
++
++        oCore.mainLoop();
++    }
+     
+     return 0;
+ }

--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -17,5 +17,4 @@ configure() {
 
 install() {
     run cp cmatrix "${SERENITY_INSTALL_ROOT}/bin"
-    install_launcher
 }

--- a/Ports/openttd/package.sh
+++ b/Ports/openttd/package.sh
@@ -47,6 +47,4 @@ install() {
     )
 
     ln -sf /usr/local/games/openttd $DESTDIR/usr/local/bin/openttd
-
-    install_launcher
 }

--- a/Ports/opentyrian/package.sh
+++ b/Ports/opentyrian/package.sh
@@ -17,5 +17,4 @@ configure() {
 
 install() {
     run make install
-    install_launcher
 }

--- a/Ports/stpuzzles/package.sh
+++ b/Ports/stpuzzles/package.sh
@@ -13,4 +13,8 @@ configure() {
 
 install() {
     run make install
+
+    for puzzle in bridges cube dominosa fifteen filling flip flood galaxies guess inertia keen lightup loopy magnets map mines mosaic net netslide palisade pattern pearl pegs range rect samegame signpost singles sixteen slant solo tents towers tracks twiddle undead unequal unruly untangle; do
+        install_launcher "$puzzle" "Games/Puzzles" "/usr/local/bin/$puzzle"
+    done
 }


### PR DESCRIPTION
**Taskbar: Allow creating menus for sub-categories**

This change allows creating sub-categories in app files, e.g. with `Category=Games/Puzzles`.

**Ports: Don't crash when starting uMario outside of /opt/Super_Mario**

Previously this port would just crash. There was a workaround in the way the app launcher started the game but I'd really like to
get rid of that hack.

**Ports: Don't set the current working directory in the launcher script**

This removes the hack for launching Super Mario.

**Ports: Create launchers for the stpuzzles port**

This changes the `.port_include.sh` script so that ports can more easily create more than one launcher by making the install_launcher function available to the port's `package.sh` script.

This creates launchers for the stpuzzles port in the `Games/Puzzles` category.

![image](https://user-images.githubusercontent.com/388571/120716572-8478a580-c4c6-11eb-90f2-a073adeb044e.png)

**Ports: Embed icon into the Super Mario port**