### PR TITLE
SoundPlayer: Enable stop button when play button clicked

### DIFF
--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -72,6 +72,7 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
         bool paused = this->manager().toggle_pause();
         set_paused(paused);
         m_play_button->set_icon(paused ? *m_play_icon : *m_pause_icon);
+        m_stop_button->set_enabled(has_loaded_file());
     };
 
     m_stop_button = menubar.add<GUI::Button>();


### PR DESCRIPTION
Previously, if you play a file, then stop, then play again, the stop
button will be permanently disabled until you open a file again.

The stop button should be enabled whenever a file is loaded.

This commit fixes the GUI bug by enabling the stop button whenever the
play button is clicked (if a file is currently loaded).