### PR TITLE
LibGUI: MessageBox and Dialog improvements for long text and positioning

### DIFF
--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/EventLoop.h>
+#include <LibGUI/Desktop.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Event.h>
 
@@ -29,6 +30,8 @@ int Dialog::exec()
         auto& parent_window = *static_cast<Window*>(parent());
         if (parent_window.is_visible()) {
             center_within(parent_window);
+            if (rect().intersects(Desktop::the().rect()))
+                center_on_screen();
         } else {
             center_on_screen();
         }

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
+#include <LibGUI/Desktop.h>
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
@@ -136,8 +137,11 @@ void MessageBox::build()
         add_button("Cancel", Dialog::ExecCancel);
     button_container.layout()->add_spacer();
 
+    Gfx::IntRect desktop_rect = Desktop::the().rect();
     int width = (button_count * button_width) + ((button_count - 1) * button_container.layout()->spacing()) + 32;
     width = max(width, text_width + icon_width + 56);
+    if (width > desktop_rect.width() - 32)
+        width = desktop_rect.width() - 32;
 
     set_rect(x(), y(), width, 96);
     set_resizable(false);


### PR DESCRIPTION
Just like with tooltips #7707, this PR prevents a `MessageBox` from being wider than the screen.

Glitch:
<img width="1024" alt="Screen Shot 2021-06-03 at 4 19 05 PM" src="https://user-images.githubusercontent.com/955163/120719547-b6b6e280-c487-11eb-92df-88234c4e2170.png">

Improvement:
<img width="1019" alt="Screen Shot 2021-06-03 at 4 16 08 PM" src="https://user-images.githubusercontent.com/955163/120719569-be768700-c487-11eb-9cd1-cbe4c49c9601.png">

This PR also improves where a `Dialog` appears on the screen. By default, it'll try to position it centered to the parent `Window`, but if that results the `Dialog` going off the edge of the screen, it'll then switch to positioning it center to the screen.

Glitch:
<img width="1023" alt="Screen Shot 2021-06-03 at 4 18 50 PM" src="https://user-images.githubusercontent.com/955163/120719653-df3edc80-c487-11eb-975f-6da6254c1a1b.png">

Improvement:
<img width="1024" alt="Screen Shot 2021-06-03 at 4 17 10 PM" src="https://user-images.githubusercontent.com/955163/120719674-e5cd5400-c487-11eb-8bb2-1dc62a9e3c0b.png">

