### PR TITLE
Documentation: Remove redundancy in CodingStyle.md

### DIFF
--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -261,8 +261,7 @@ for (auto it = children.begin(); it != children.end(); ++it)
 
 ### Pointers and References
 
-[](#pointers-cpp) **Pointer and reference types in C++ code**
-Both pointer types and reference types should be written with no space between the type name and the `*` or `&`.
+[](#pointers-cpp) Both pointer types and reference types should be written with no space between the type name and the `*` or `&`.
 
 [](#pointers-out-argument) An out argument of a function should be passed by reference except rare cases where it is optional in which case it should be passed by pointer.
 


### PR DESCRIPTION
This is a fairly small change; removed the statement "Pointer and reference
types in C++ code" as it does not provide any additional knowledge that
contributors are or will be aware of after further reading into the "Pointers
and References" section. It seems unnecessary and redundant given the sentence
adjacent to it.