### PR TITLE
LibWasm: (basic) Tables / LibWasm: Unreadable-ify code / LibJS/Tests: Catch exceptions in describe()

### DIFF
--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -234,10 +234,7 @@ def gentest(entry, main_name):
 
 def gen_parse_module(name):
     return (
-        f'let content;\n    '
-        f'try {{\n        '
-        f'content = readBinaryWasmFile("Fixtures/SpecTests/{name}.wasm");\n    '
-        f'}} catch {{ read_okay = false; }}\n    '
+        f'let content = readBinaryWasmFile("Fixtures/SpecTests/{name}.wasm");\n    '
         f'const module = parseWebAssemblyModule(content)\n    '
     )
 
@@ -260,12 +257,10 @@ def main():
                 continue
 
         sep = ""
-        print(f'''{{
-let readOkay = true;
+        print(f'''describe({json.dumps(testname)}, () => {{
 {gen_parse_module(testname)}
-if (readOkay) {{
 {sep.join(gentest(x, testname) for x in description["tests"])}
-}}}}
+}});
 ''')
 
 

--- a/Userland/Libraries/LibJS/Tests/test-common.js
+++ b/Userland/Libraries/LibJS/Tests/test-common.js
@@ -441,7 +441,15 @@ class ExpectationError extends Error {
 
     describe = (message, callback) => {
         suiteMessage = message;
-        callback();
+        if (!__TestResults__[suiteMessage]) __TestResults__[suiteMessage] = {};
+        try {
+            callback();
+        } catch (e) {
+            __TestResults__[suiteMessage][defaultSuiteMessage] = {
+                result: "fail",
+                details: String(e),
+            };
+        }
         suiteMessage = defaultSuiteMessage;
     };
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -11,7 +11,7 @@
 
 namespace Wasm {
 
-Optional<FunctionAddress> Store::allocate(ModuleInstance& module, const Module::Function& function)
+Optional<FunctionAddress> Store::allocate(ModuleInstance& module, Module::Function const& function)
 {
     FunctionAddress address { m_functions.size() };
     if (function.type().value() > module.types().size())
@@ -29,7 +29,7 @@ Optional<FunctionAddress> Store::allocate(HostFunction&& function)
     return address;
 }
 
-Optional<TableAddress> Store::allocate(const TableType& type)
+Optional<TableAddress> Store::allocate(TableType const& type)
 {
     TableAddress address { m_tables.size() };
     Vector<Optional<Reference>> elements;
@@ -38,21 +38,21 @@ Optional<TableAddress> Store::allocate(const TableType& type)
     return address;
 }
 
-Optional<MemoryAddress> Store::allocate(const MemoryType& type)
+Optional<MemoryAddress> Store::allocate(MemoryType const& type)
 {
     MemoryAddress address { m_memories.size() };
     m_memories.empend(MemoryInstance { type });
     return address;
 }
 
-Optional<GlobalAddress> Store::allocate(const GlobalType& type, Value value)
+Optional<GlobalAddress> Store::allocate(GlobalType const& type, Value value)
 {
     GlobalAddress address { m_globals.size() };
     m_globals.append(GlobalInstance { move(value), type.is_mutable() });
     return address;
 }
 
-Optional<ElementAddress> Store::allocate(const ValueType& type, Vector<Reference> references)
+Optional<ElementAddress> Store::allocate(ValueType const& type, Vector<Reference> references)
 {
     ElementAddress address { m_elements.size() };
     m_elements.append(ElementInstance { type, move(references) });
@@ -99,13 +99,13 @@ ElementInstance* Store::get(ElementAddress address)
     return &m_elements[value];
 }
 
-InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<ExternValue> externs)
+InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<ExternValue> externs)
 {
     auto main_module_instance_pointer = make<ModuleInstance>();
     auto& main_module_instance = *main_module_instance_pointer;
     Optional<InstantiationResult> instantiation_result;
 
-    module.for_each_section_of_type<TypeSection>([&](const TypeSection& section) {
+    module.for_each_section_of_type<TypeSection>([&](TypeSection const& section) {
         main_module_instance.types() = section.types();
     });
 
@@ -147,7 +147,7 @@ InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<Ex
     if (auto result = allocate_all_initial_phase(module, main_module_instance, externs, global_values); result.has_value())
         return result.release_value();
 
-    module.for_each_section_of_type<ElementSection>([&](const ElementSection& section) {
+    module.for_each_section_of_type<ElementSection>([&](ElementSection const& section) {
         for (auto& segment : section.segments()) {
             Vector<Reference> references;
             for (auto& entry : segment.init) {
@@ -190,7 +190,7 @@ InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<Ex
     if (auto result = allocate_all_final_phase(module, main_module_instance, elements); result.has_value())
         return result.release_value();
 
-    module.for_each_section_of_type<ElementSection>([&](const ElementSection& section) {
+    module.for_each_section_of_type<ElementSection>([&](ElementSection const& section) {
         size_t index = 0;
         for (auto& segment : section.segments()) {
             auto current_index = index;
@@ -256,10 +256,10 @@ InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<Ex
     if (instantiation_result.has_value())
         return instantiation_result.release_value();
 
-    module.for_each_section_of_type<DataSection>([&](const DataSection& data_section) {
+    module.for_each_section_of_type<DataSection>([&](DataSection const& data_section) {
         for (auto& segment : data_section.data()) {
             segment.value().visit(
-                [&](const DataSection::Data::Active& data) {
+                [&](DataSection::Data::Active const& data) {
                     Configuration config { m_store };
                     config.set_frame(Frame {
                         main_module_instance,
@@ -274,8 +274,8 @@ InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<Ex
                     }
                     size_t offset = 0;
                     result.values().first().value().visit(
-                        [&](const auto& value) { offset = value; },
-                        [&](const Reference&) { instantiation_result = InstantiationError { "Data segment offset returned a reference" }; });
+                        [&](auto const& value) { offset = value; },
+                        [&](Reference const&) { instantiation_result = InstantiationError { "Data segment offset returned a reference" }; });
                     if (instantiation_result.has_value() && instantiation_result->is_error())
                         return;
                     if (main_module_instance.memories().size() <= data.index.value()) {
@@ -293,13 +293,13 @@ InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<Ex
                         instance->data().overwrite(offset, data.init.data(), data.init.size());
                     }
                 },
-                [&](const DataSection::Data::Passive&) {
+                [&](DataSection::Data::Passive const&) {
                     // FIXME: What do we do here?
                 });
         }
     });
 
-    module.for_each_section_of_type<StartSection>([&](const StartSection& section) {
+    module.for_each_section_of_type<StartSection>([&](StartSection const& section) {
         auto& functions = main_module_instance.functions();
         auto index = section.function().index();
         if (functions.size() <= index.value()) {
@@ -315,16 +315,16 @@ InstantiationResult AbstractMachine::instantiate(const Module& module, Vector<Ex
     return InstantiationResult { move(main_module_instance_pointer) };
 }
 
-Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(const Module& module, ModuleInstance& module_instance, Vector<ExternValue>& externs, Vector<Value>& global_values)
+Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(Module const& module, ModuleInstance& module_instance, Vector<ExternValue>& externs, Vector<Value>& global_values)
 {
     Optional<InstantiationError> result;
 
     for (auto& entry : externs) {
         entry.visit(
-            [&](const FunctionAddress& address) { module_instance.functions().append(address); },
-            [&](const TableAddress& address) { module_instance.tables().append(address); },
-            [&](const MemoryAddress& address) { module_instance.memories().append(address); },
-            [&](const GlobalAddress& address) { module_instance.globals().append(address); });
+            [&](FunctionAddress const& address) { module_instance.functions().append(address); },
+            [&](TableAddress const& address) { module_instance.tables().append(address); },
+            [&](MemoryAddress const& address) { module_instance.memories().append(address); },
+            [&](GlobalAddress const& address) { module_instance.globals().append(address); });
     }
 
     // FIXME: What if this fails?
@@ -335,7 +335,7 @@ Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(const M
         module_instance.functions().append(*address);
     }
 
-    module.for_each_section_of_type<TableSection>([&](const TableSection& section) {
+    module.for_each_section_of_type<TableSection>([&](TableSection const& section) {
         for (auto& table : section.tables()) {
             auto table_address = m_store.allocate(table.type());
             VERIFY(table_address.has_value());
@@ -343,7 +343,7 @@ Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(const M
         }
     });
 
-    module.for_each_section_of_type<MemorySection>([&](const MemorySection& section) {
+    module.for_each_section_of_type<MemorySection>([&](MemorySection const& section) {
         for (auto& memory : section.memories()) {
             auto memory_address = m_store.allocate(memory.type());
             VERIFY(memory_address.has_value());
@@ -351,7 +351,7 @@ Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(const M
         }
     });
 
-    module.for_each_section_of_type<GlobalSection>([&](const GlobalSection& section) {
+    module.for_each_section_of_type<GlobalSection>([&](GlobalSection const& section) {
         size_t index = 0;
         for (auto& entry : section.entries()) {
             auto address = m_store.allocate(entry.type(), move(global_values[index]));
@@ -360,29 +360,29 @@ Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(const M
             index++;
         }
     });
-    module.for_each_section_of_type<ExportSection>([&](const ExportSection& section) {
+    module.for_each_section_of_type<ExportSection>([&](ExportSection const& section) {
         for (auto& entry : section.entries()) {
             Variant<FunctionAddress, TableAddress, MemoryAddress, GlobalAddress, Empty> address { Empty {} };
             entry.description().visit(
-                [&](const FunctionIndex& index) {
+                [&](FunctionIndex const& index) {
                     if (module_instance.functions().size() > index.value())
                         address = FunctionAddress { module_instance.functions()[index.value()] };
                     else
                         dbgln("Failed to export '{}', the exported address ({}) was out of bounds (min: 0, max: {})", entry.name(), index.value(), module_instance.functions().size());
                 },
-                [&](const TableIndex& index) {
+                [&](TableIndex const& index) {
                     if (module_instance.tables().size() > index.value())
                         address = TableAddress { module_instance.tables()[index.value()] };
                     else
                         dbgln("Failed to export '{}', the exported address ({}) was out of bounds (min: 0, max: {})", entry.name(), index.value(), module_instance.tables().size());
                 },
-                [&](const MemoryIndex& index) {
+                [&](MemoryIndex const& index) {
                     if (module_instance.memories().size() > index.value())
                         address = MemoryAddress { module_instance.memories()[index.value()] };
                     else
                         dbgln("Failed to export '{}', the exported address ({}) was out of bounds (min: 0, max: {})", entry.name(), index.value(), module_instance.memories().size());
                 },
-                [&](const GlobalIndex& index) {
+                [&](GlobalIndex const& index) {
                     if (module_instance.globals().size() > index.value())
                         address = GlobalAddress { module_instance.globals()[index.value()] };
                     else
@@ -404,9 +404,9 @@ Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(const M
     return result;
 }
 
-Optional<InstantiationError> AbstractMachine::allocate_all_final_phase(const Module& module, ModuleInstance& module_instance, Vector<Vector<Reference>>& elements)
+Optional<InstantiationError> AbstractMachine::allocate_all_final_phase(Module const& module, ModuleInstance& module_instance, Vector<Vector<Reference>>& elements)
 {
-    module.for_each_section_of_type<ElementSection>([&](const ElementSection& section) {
+    module.for_each_section_of_type<ElementSection>([&](ElementSection const& section) {
         size_t index = 0;
         for (auto& segment : section.segments()) {
             auto address = m_store.allocate(segment.type, move(elements[index]));
@@ -431,7 +431,7 @@ Result AbstractMachine::invoke(Interpreter& interpreter, FunctionAddress address
     return configuration.call(interpreter, address, move(arguments));
 }
 
-void Linker::link(const ModuleInstance& instance)
+void Linker::link(ModuleInstance const& instance)
 {
     populate();
     if (m_unresolved_imports.is_empty())
@@ -450,7 +450,7 @@ void Linker::link(const ModuleInstance& instance)
         m_unresolved_imports.remove(entry);
 }
 
-void Linker::link(const HashMap<Linker::Name, ExternValue>& exports)
+void Linker::link(HashMap<Linker::Name, ExternValue> const& exports)
 {
     populate();
     if (m_unresolved_imports.is_empty())
@@ -498,7 +498,7 @@ void Linker::populate()
 
     // There better be at most one import section!
     bool already_seen_an_import_section = false;
-    m_module.for_each_section_of_type<ImportSection>([&](const ImportSection& section) {
+    m_module.for_each_section_of_type<ImportSection>([&](ImportSection const& section) {
         if (already_seen_an_import_section) {
             if (!m_error.has_value())
                 m_error = LinkError {};

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -130,7 +130,7 @@ public:
         }
     }
 
-    Value(const Value& value)
+    Value(Value const& value)
         : m_value(AnyValueType { value.m_value })
         , m_type(value.m_type)
     {
@@ -149,7 +149,7 @@ public:
         return *this;
     }
 
-    Value& operator=(const Value& value)
+    Value& operator=(Value const& value)
     {
         m_value = value.m_value;
         m_type = value.m_type;
@@ -167,7 +167,7 @@ public:
                 else if constexpr (!IsFloatingPoint<T> && IsSame<decltype(value), MakeSigned<T>>)
                     result = value;
             },
-            [&](const Reference& value) {
+            [&](Reference const& value) {
                 if constexpr (IsSame<T, Reference>) {
                     result = value;
                 } else if constexpr (IsSame<T, Reference::Func>) {
@@ -279,7 +279,7 @@ private:
 
 class WasmFunction {
 public:
-    explicit WasmFunction(const FunctionType& type, const ModuleInstance& module, const Module::Function& code)
+    explicit WasmFunction(FunctionType const& type, ModuleInstance const& module, Module::Function const& code)
         : m_type(type)
         , m_module(module)
         , m_code(code)
@@ -292,13 +292,13 @@ public:
 
 private:
     FunctionType m_type;
-    const ModuleInstance& m_module;
-    const Module::Function& m_code;
+    ModuleInstance const& m_module;
+    Module::Function const& m_code;
 };
 
 class HostFunction {
 public:
-    explicit HostFunction(AK::Function<Result(Configuration&, Vector<Value>&)> function, const FunctionType& type)
+    explicit HostFunction(AK::Function<Result(Configuration&, Vector<Value>&)> function, FunctionType const& type)
         : m_function(move(function))
         , m_type(type)
     {
@@ -316,7 +316,7 @@ using FunctionInstance = Variant<WasmFunction, HostFunction>;
 
 class TableInstance {
 public:
-    explicit TableInstance(const TableType& type, Vector<Optional<Reference>> elements)
+    explicit TableInstance(TableType const& type, Vector<Optional<Reference>> elements)
         : m_elements(move(elements))
         , m_type(type)
     {
@@ -328,12 +328,12 @@ public:
 
 private:
     Vector<Optional<Reference>> m_elements;
-    const TableType& m_type;
+    TableType const& m_type;
 };
 
 class MemoryInstance {
 public:
-    explicit MemoryInstance(const MemoryType& type)
+    explicit MemoryInstance(MemoryType const& type)
         : m_type(type)
     {
         grow(m_type.limits().min() * Constants::page_size);
@@ -360,7 +360,7 @@ public:
     }
 
 private:
-    const MemoryType& m_type;
+    MemoryType const& m_type;
     size_t m_size { 0 };
     ByteBuffer m_data;
 };
@@ -406,12 +406,12 @@ class Store {
 public:
     Store() = default;
 
-    Optional<FunctionAddress> allocate(ModuleInstance& module, const Module::Function& function);
+    Optional<FunctionAddress> allocate(ModuleInstance& module, Module::Function const& function);
     Optional<FunctionAddress> allocate(HostFunction&&);
-    Optional<TableAddress> allocate(const TableType&);
-    Optional<MemoryAddress> allocate(const MemoryType&);
-    Optional<GlobalAddress> allocate(const GlobalType&, Value);
-    Optional<ElementAddress> allocate(const ValueType&, Vector<Reference>);
+    Optional<TableAddress> allocate(TableType const&);
+    Optional<MemoryAddress> allocate(MemoryType const&);
+    Optional<GlobalAddress> allocate(GlobalType const&, Value);
+    Optional<ElementAddress> allocate(ValueType const&, Vector<Reference>);
 
     FunctionInstance* get(FunctionAddress);
     TableInstance* get(TableAddress);
@@ -445,7 +445,7 @@ private:
 
 class Frame {
 public:
-    explicit Frame(const ModuleInstance& module, Vector<Value> locals, const Expression& expression, size_t arity)
+    explicit Frame(ModuleInstance const& module, Vector<Value> locals, Expression const& expression, size_t arity)
         : m_module(module)
         , m_locals(move(locals))
         , m_expression(expression)
@@ -460,9 +460,9 @@ public:
     auto arity() const { return m_arity; }
 
 private:
-    const ModuleInstance& m_module;
+    ModuleInstance const& m_module;
     Vector<Value> m_locals;
-    const Expression& m_expression;
+    Expression const& m_expression;
     size_t m_arity { 0 };
 };
 
@@ -492,7 +492,7 @@ public:
     explicit AbstractMachine() = default;
 
     // Load and instantiate a module, and link it into this interpreter.
-    InstantiationResult instantiate(const Module&, Vector<ExternValue>);
+    InstantiationResult instantiate(Module const&, Vector<ExternValue>);
     Result invoke(FunctionAddress, Vector<Value>);
     Result invoke(Interpreter&, FunctionAddress, Vector<Value>);
 
@@ -500,8 +500,8 @@ public:
     auto& store() { return m_store; }
 
 private:
-    Optional<InstantiationError> allocate_all_initial_phase(const Module&, ModuleInstance&, Vector<ExternValue>&, Vector<Value>& global_values);
-    Optional<InstantiationError> allocate_all_final_phase(const Module&, ModuleInstance&, Vector<Vector<Reference>>& elements);
+    Optional<InstantiationError> allocate_all_initial_phase(Module const&, ModuleInstance&, Vector<ExternValue>&, Vector<Value>& global_values);
+    Optional<InstantiationError> allocate_all_final_phase(Module const&, ModuleInstance&, Vector<Vector<Reference>>& elements);
     Store m_store;
 };
 
@@ -513,16 +513,16 @@ public:
         ImportSection::Import::ImportDesc type;
     };
 
-    explicit Linker(const Module& module)
+    explicit Linker(Module const& module)
         : m_module(module)
     {
     }
 
     // Link a module, the import 'module name' is ignored with this.
-    void link(const ModuleInstance&);
+    void link(ModuleInstance const&);
 
     // Link a bunch of qualified values, also matches 'module name'.
-    void link(const HashMap<Name, ExternValue>&);
+    void link(HashMap<Name, ExternValue> const&);
 
     auto& unresolved_imports()
     {
@@ -535,7 +535,7 @@ public:
 private:
     void populate();
 
-    const Module& m_module;
+    Module const& m_module;
     HashMap<Name, ExternValue> m_resolved_imports;
     HashTable<Name> m_unresolved_imports;
     Vector<Name> m_ordered_imports;
@@ -547,6 +547,6 @@ private:
 template<>
 struct AK::Traits<Wasm::Linker::Name> : public AK::GenericTraits<Wasm::Linker::Name> {
     static constexpr bool is_trivial() { return false; }
-    static unsigned hash(const Wasm::Linker::Name& entry) { return pair_int_hash(entry.module.hash(), entry.name.hash()); }
-    static bool equals(const Wasm::Linker::Name& a, const Wasm::Linker::Name& b) { return a.name == b.name && a.module == b.module; }
+    static unsigned hash(Wasm::Linker::Name const& entry) { return pair_int_hash(entry.module.hash(), entry.name.hash()); }
+    static bool equals(Wasm::Linker::Name const& a, Wasm::Linker::Name const& b) { return a.name == b.name && a.module == b.module; }
 };

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -23,7 +23,7 @@ Optional<Label> Configuration::nth_label(size_t i)
     return {};
 }
 
-void Configuration::unwind(Badge<CallFrameHandle>, const CallFrameHandle& frame_handle)
+void Configuration::unwind(Badge<CallFrameHandle>, CallFrameHandle const& frame_handle)
 {
     if (m_stack.size() == frame_handle.stack_size && frame_handle.frame_index == m_current_frame_index)
         return;
@@ -92,18 +92,18 @@ void Configuration::dump_stack()
         Printer { memory_stream }.print(vs...);
         dbgln(format.view(), StringView(memory_stream.copy_into_contiguous_buffer()).trim_whitespace());
     };
-    for (const auto& entry : stack().entries()) {
+    for (auto const& entry : stack().entries()) {
         entry.visit(
-            [&](const Value& v) {
+            [&](Value const& v) {
                 print_value("    {}", v);
             },
-            [&](const Frame& f) {
+            [&](Frame const& f) {
                 dbgln("    frame({})", f.arity());
                 for (auto& local : f.locals()) {
                     print_value("        {}", local);
                 }
             },
-            [](const Label& l) {
+            [](Label const& l) {
                 dbgln("    label({}) -> {}", l.arity(), l.continuation());
             });
     }

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -66,6 +66,9 @@ Result Configuration::execute(Interpreter& interpreter)
     if (interpreter.did_trap())
         return Trap {};
 
+    if (stack().size() <= frame().arity() + 1)
+        return Trap {};
+
     Vector<Value> results;
     results.ensure_capacity(frame().arity());
     for (size_t i = 0; i < frame().arity(); ++i)

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -57,7 +57,7 @@ public:
         Configuration& configuration;
     };
 
-    void unwind(Badge<CallFrameHandle>, const CallFrameHandle&);
+    void unwind(Badge<CallFrameHandle>, CallFrameHandle const&);
     Result call(Interpreter&, FunctionAddress, Vector<Value> arguments);
     Result execute(Interpreter&);
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/Interpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Interpreter.cpp
@@ -73,7 +73,7 @@ void BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelInd
 }
 
 template<typename ReadType, typename PushType>
-void BytecodeInterpreter::load_and_push(Configuration& configuration, const Instruction& instruction)
+void BytecodeInterpreter::load_and_push(Configuration& configuration, Instruction const& instruction)
 {
     auto& address = configuration.frame().module().memories().first();
     auto memory = configuration.store().get(address);
@@ -98,7 +98,7 @@ void BytecodeInterpreter::load_and_push(Configuration& configuration, const Inst
     configuration.stack().peek() = Value(static_cast<PushType>(read_value<ReadType>(slice)));
 }
 
-void BytecodeInterpreter::store_to_memory(Configuration& configuration, const Instruction& instruction, ReadonlyBytes data)
+void BytecodeInterpreter::store_to_memory(Configuration& configuration, Instruction const& instruction, ReadonlyBytes data)
 {
     auto& address = configuration.frame().module().memories().first();
     auto memory = configuration.store().get(address);
@@ -120,8 +120,8 @@ void BytecodeInterpreter::call_address(Configuration& configuration, FunctionAdd
 {
     auto instance = configuration.store().get(address);
     TRAP_IF_NOT(instance);
-    const FunctionType* type { nullptr };
-    instance->visit([&](const auto& function) { type = &function.type(); });
+    FunctionType const* type { nullptr };
+    instance->visit([&](auto const& function) { type = &function.type(); });
     TRAP_IF_NOT(type);
     TRAP_IF_NOT(configuration.stack().entries().size() > type->parameters().size());
     Vector<Value> args;
@@ -396,7 +396,7 @@ ALWAYS_INLINE static i32 ctz(T value)
         VERIFY_NOT_REACHED();
 }
 
-void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPointer& ip, const Instruction& instruction)
+void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPointer& ip, Instruction const& instruction)
 {
     dbgln_if(WASM_TRACE_DEBUG, "Executing instruction {} at ip {}", instruction_name(instruction.opcode()), ip.value());
 
@@ -973,7 +973,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     }
 }
 
-void DebuggerBytecodeInterpreter::interpret(Configuration& configuration, InstructionPointer& ip, const Instruction& instruction)
+void DebuggerBytecodeInterpreter::interpret(Configuration& configuration, InstructionPointer& ip, Instruction const& instruction)
 {
     if (pre_interpret_hook) {
         auto result = pre_interpret_hook(configuration, ip, instruction);

--- a/Userland/Libraries/LibWasm/AbstractMachine/Interpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Interpreter.h
@@ -37,11 +37,11 @@ struct BytecodeInterpreter : public Interpreter {
     };
 
 protected:
-    virtual void interpret(Configuration&, InstructionPointer&, const Instruction&);
+    virtual void interpret(Configuration&, InstructionPointer&, Instruction const&);
     void branch_to_label(Configuration&, LabelIndex);
     template<typename ReadT, typename PushT>
-    void load_and_push(Configuration&, const Instruction&);
-    void store_to_memory(Configuration&, const Instruction&, ReadonlyBytes data);
+    void load_and_push(Configuration&, Instruction const&);
+    void store_to_memory(Configuration&, Instruction const&, ReadonlyBytes data);
     void call_address(Configuration&, FunctionAddress);
 
     template<typename V, typename T>
@@ -66,11 +66,11 @@ protected:
 struct DebuggerBytecodeInterpreter : public BytecodeInterpreter {
     virtual ~DebuggerBytecodeInterpreter() override = default;
 
-    Function<bool(Configuration&, InstructionPointer&, const Instruction&)> pre_interpret_hook;
-    Function<bool(Configuration&, InstructionPointer&, const Instruction&, const Interpreter&)> post_interpret_hook;
+    Function<bool(Configuration&, InstructionPointer&, Instruction const&)> pre_interpret_hook;
+    Function<bool(Configuration&, InstructionPointer&, Instruction const&, Interpreter const&)> post_interpret_hook;
 
 private:
-    virtual void interpret(Configuration&, InstructionPointer&, const Instruction&) override;
+    virtual void interpret(Configuration&, InstructionPointer&, Instruction const&) override;
 };
 
 }

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -948,7 +948,7 @@ ParseResult<ElementSection::SegmentType0> ElementSection::SegmentType0::parse(In
     if (indices.is_error())
         return indices.error();
 
-    return SegmentType0 { ValueType(ValueType::FunctionReference), indices.release_value(), Active { 0, expression.release_value() } };
+    return SegmentType0 { indices.release_value(), Active { 0, expression.release_value() } };
 }
 
 ParseResult<ElementSection::SegmentType1> ElementSection::SegmentType1::parse(InputStream& stream)
@@ -963,7 +963,7 @@ ParseResult<ElementSection::SegmentType1> ElementSection::SegmentType1::parse(In
     if (indices.is_error())
         return indices.error();
 
-    return SegmentType1 { ValueType(ValueType::FunctionReference), indices.release_value() };
+    return SegmentType1 { indices.release_value() };
 }
 
 ParseResult<ElementSection::SegmentType2> ElementSection::SegmentType2::parse(InputStream& stream)
@@ -1008,7 +1008,7 @@ ParseResult<ElementSection::SegmentType7> ElementSection::SegmentType7::parse(In
     return ParseError::NotImplemented;
 }
 
-ParseResult<ElementSection::AnyElementType> ElementSection::Element::parse(InputStream& stream)
+ParseResult<ElementSection::Element> ElementSection::Element::parse(InputStream& stream)
 {
     ScopeLogger<WASM_BINPARSER_DEBUG> logger("Element");
     u8 tag;
@@ -1021,49 +1021,55 @@ ParseResult<ElementSection::AnyElementType> ElementSection::Element::parse(Input
         if (auto result = SegmentType0::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            Vector<Instruction> instructions;
+            for (auto& index : result.value().function_indices)
+                instructions.empend(Instructions::ref_func, index);
+            return Element { ValueType(ValueType::FunctionReference), { Expression { move(instructions) } }, move(result.value().mode) };
         }
     case 0x01:
         if (auto result = SegmentType1::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            Vector<Instruction> instructions;
+            for (auto& index : result.value().function_indices)
+                instructions.empend(Instructions::ref_func, index);
+            return Element { ValueType(ValueType::FunctionReference), { Expression { move(instructions) } }, Passive {} };
         }
     case 0x02:
         if (auto result = SegmentType2::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            return ParseError::NotImplemented;
         }
     case 0x03:
         if (auto result = SegmentType3::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            return ParseError::NotImplemented;
         }
     case 0x04:
         if (auto result = SegmentType4::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            return ParseError::NotImplemented;
         }
     case 0x05:
         if (auto result = SegmentType5::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            return ParseError::NotImplemented;
         }
     case 0x06:
         if (auto result = SegmentType6::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            return ParseError::NotImplemented;
         }
     case 0x07:
         if (auto result = SegmentType7::parse(stream); result.is_error()) {
             return result.error();
         } else {
-            return AnyElementType { result.release_value() };
+            return ParseError::NotImplemented;
         }
     default:
         return ParseError::InvalidTag;

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -11,7 +11,7 @@
 
 namespace Wasm {
 
-ParseError with_eof_check(const InputStream& stream, ParseError error_if_not_eof)
+ParseError with_eof_check(InputStream const& stream, ParseError error_if_not_eof)
 {
     if (stream.unreliable_eof())
         return ParseError::UnexpectedEof;
@@ -1358,9 +1358,9 @@ ParseResult<Module> Module::parse(InputStream& stream)
 
 void Module::populate_sections()
 {
-    const FunctionSection* function_section { nullptr };
-    for_each_section_of_type<FunctionSection>([&](const FunctionSection& section) { function_section = &section; });
-    for_each_section_of_type<CodeSection>([&](const CodeSection& section) {
+    FunctionSection const* function_section { nullptr };
+    for_each_section_of_type<FunctionSection>([&](FunctionSection const& section) { function_section = &section; });
+    for_each_section_of_type<CodeSection>([&](CodeSection const& section) {
         // FIXME: This should be considered invalid once validation is implemented.
         if (!function_section)
             return;

--- a/Userland/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Userland/Libraries/LibWasm/Printer/Printer.cpp
@@ -15,7 +15,7 @@ struct Names {
     static HashMap<OpCode, String> instruction_names;
 };
 
-String instruction_name(const OpCode& opcode)
+String instruction_name(OpCode const& opcode)
 {
     return Names::instruction_names.get(opcode).value_or("<unknown>");
 }
@@ -26,7 +26,7 @@ void Printer::print_indent()
         m_stream.write_or_error("  "sv.bytes());
 }
 
-void Printer::print(const Wasm::BlockType& type)
+void Printer::print(Wasm::BlockType const& type)
 {
     print_indent();
     print("(type block ");
@@ -51,7 +51,7 @@ void Printer::print(const Wasm::BlockType& type)
     VERIFY_NOT_REACHED();
 }
 
-void Printer::print(const Wasm::CodeSection& section)
+void Printer::print(Wasm::CodeSection const& section)
 {
     print_indent();
     print("(section code\n");
@@ -64,12 +64,12 @@ void Printer::print(const Wasm::CodeSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::CodeSection::Code& code)
+void Printer::print(Wasm::CodeSection::Code const& code)
 {
     print(code.func());
 }
 
-void Printer::print(const Wasm::CustomSection& section)
+void Printer::print(Wasm::CustomSection const& section)
 {
     print_indent();
     print("(section custom\n");
@@ -84,7 +84,7 @@ void Printer::print(const Wasm::CustomSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::DataCountSection& section)
+void Printer::print(Wasm::DataCountSection const& section)
 {
     print_indent();
     print("(section data count\n");
@@ -97,7 +97,7 @@ void Printer::print(const Wasm::DataCountSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::DataSection& section)
+void Printer::print(Wasm::DataSection const& section)
 {
     print_indent();
     print("(section data\n");
@@ -110,14 +110,14 @@ void Printer::print(const Wasm::DataSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::DataSection::Data& data)
+void Printer::print(Wasm::DataSection::Data const& data)
 {
     print_indent();
     print("(data with value\n");
     {
         TemporaryChange change { m_indent, m_indent + 1 };
         data.value().visit(
-            [this](const DataSection::Data::Passive& value) {
+            [this](DataSection::Data::Passive const& value) {
                 print_indent();
                 print("(passive init {}xu8 (", value.init.size());
                 bool first = true;
@@ -130,7 +130,7 @@ void Printer::print(const Wasm::DataSection::Data& data)
                 }
                 print(")\n");
             },
-            [this](const DataSection::Data::Active& value) {
+            [this](DataSection::Data::Active const& value) {
                 print_indent();
                 print("(active init {}xu8 (", value.init.size());
                 bool first = true;
@@ -164,7 +164,7 @@ void Printer::print(const Wasm::DataSection::Data& data)
     print(")\n");
 }
 
-void Printer::print(const Wasm::ElementSection& section)
+void Printer::print(Wasm::ElementSection const& section)
 {
     print_indent();
     print("(section element\n");
@@ -177,7 +177,7 @@ void Printer::print(const Wasm::ElementSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::ElementSection::Element& element)
+void Printer::print(Wasm::ElementSection::Element const& element)
 {
     print_indent();
     print("(element ");
@@ -199,7 +199,7 @@ void Printer::print(const Wasm::ElementSection::Element& element)
         print_indent();
         print("(mode ");
         element.mode.visit(
-            [this](const ElementSection::Active& active) {
+            [this](ElementSection::Active const& active) {
                 print("\n");
                 {
                     TemporaryChange change { m_indent, m_indent + 1 };
@@ -213,13 +213,13 @@ void Printer::print(const Wasm::ElementSection::Element& element)
                 }
                 print_indent();
             },
-            [this](const ElementSection::Passive&) { print("passive"); },
-            [this](const ElementSection::Declarative&) { print("declarative"); });
+            [this](ElementSection::Passive const&) { print("passive"); },
+            [this](ElementSection::Declarative const&) { print("declarative"); });
         print(")\n");
     }
 }
 
-void Printer::print(const Wasm::ExportSection& section)
+void Printer::print(Wasm::ExportSection const& section)
 {
     print_indent();
     print("(section export\n");
@@ -232,7 +232,7 @@ void Printer::print(const Wasm::ExportSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::ExportSection::Export& entry)
+void Printer::print(Wasm::ExportSection::Export const& entry)
 {
     print_indent();
     print("(export `{}' as\n", entry.name());
@@ -240,23 +240,23 @@ void Printer::print(const Wasm::ExportSection::Export& entry)
         TemporaryChange change { m_indent, m_indent + 1 };
         print_indent();
         entry.description().visit(
-            [this](const FunctionIndex& index) { print("(function index {})\n", index.value()); },
-            [this](const TableIndex& index) { print("(table index {})\n", index.value()); },
-            [this](const MemoryIndex& index) { print("(memory index {})\n", index.value()); },
-            [this](const GlobalIndex& index) { print("(global index {})\n", index.value()); });
+            [this](FunctionIndex const& index) { print("(function index {})\n", index.value()); },
+            [this](TableIndex const& index) { print("(table index {})\n", index.value()); },
+            [this](MemoryIndex const& index) { print("(memory index {})\n", index.value()); },
+            [this](GlobalIndex const& index) { print("(global index {})\n", index.value()); });
     }
     print_indent();
     print(")\n");
 }
 
-void Printer::print(const Wasm::Expression& expression)
+void Printer::print(Wasm::Expression const& expression)
 {
     TemporaryChange change { m_indent, m_indent + 1 };
     for (auto& instr : expression.instructions())
         print(instr);
 }
 
-void Printer::print(const Wasm::CodeSection::Func& func)
+void Printer::print(Wasm::CodeSection::Func const& func)
 {
     print_indent();
     print("(function\n");
@@ -283,7 +283,7 @@ void Printer::print(const Wasm::CodeSection::Func& func)
     print(")\n");
 }
 
-void Printer::print(const Wasm::FunctionSection& section)
+void Printer::print(Wasm::FunctionSection const& section)
 {
     print_indent();
     print("(section function\n");
@@ -298,7 +298,7 @@ void Printer::print(const Wasm::FunctionSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::FunctionType& type)
+void Printer::print(Wasm::FunctionType const& type)
 {
     print_indent();
     print("(type function\n");
@@ -330,7 +330,7 @@ void Printer::print(const Wasm::FunctionType& type)
     print(")\n");
 }
 
-void Printer::print(const Wasm::GlobalSection& section)
+void Printer::print(Wasm::GlobalSection const& section)
 {
     print_indent();
     print("(section global\n");
@@ -343,7 +343,7 @@ void Printer::print(const Wasm::GlobalSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::GlobalSection::Global& entry)
+void Printer::print(Wasm::GlobalSection::Global const& entry)
 {
     print_indent();
     print("(global\n");
@@ -373,7 +373,7 @@ void Printer::print(const Wasm::GlobalSection::Global& entry)
     print(")\n");
 }
 
-void Printer::print(const Wasm::GlobalType& type)
+void Printer::print(Wasm::GlobalType const& type)
 {
     print_indent();
     print("(type global {}mutable\n", type.is_mutable() ? "" : "im");
@@ -385,7 +385,7 @@ void Printer::print(const Wasm::GlobalType& type)
     print(")\n");
 }
 
-void Printer::print(const Wasm::ImportSection& section)
+void Printer::print(Wasm::ImportSection const& section)
 {
     print_indent();
     print("(section import\n");
@@ -398,15 +398,15 @@ void Printer::print(const Wasm::ImportSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::ImportSection::Import& import)
+void Printer::print(Wasm::ImportSection::Import const& import)
 {
     print_indent();
     print("(import `{}' from `{}' as\n", import.name(), import.module());
     {
         TemporaryChange change { m_indent, m_indent + 1 };
         import.description().visit(
-            [this](const auto& type) { print(type); },
-            [this](const TypeIndex& index) {
+            [this](auto const& type) { print(type); },
+            [this](TypeIndex const& index) {
                 print_indent();
                 print("(type index {})\n", index.value());
             });
@@ -415,7 +415,7 @@ void Printer::print(const Wasm::ImportSection::Import& import)
     print(")\n");
 }
 
-void Printer::print(const Wasm::Instruction& instruction)
+void Printer::print(Wasm::Instruction const& instruction)
 {
     print_indent();
     print("({}", instruction_name(instruction.opcode()));
@@ -424,29 +424,29 @@ void Printer::print(const Wasm::Instruction& instruction)
     } else {
         print(" ");
         instruction.arguments().visit(
-            [&](const BlockType& type) { print(type); },
-            [&](const DataIndex& index) { print("(data index {})", index.value()); },
-            [&](const ElementIndex& index) { print("(element index {})", index.value()); },
-            [&](const FunctionIndex& index) { print("(function index {})", index.value()); },
-            [&](const GlobalIndex& index) { print("(global index {})", index.value()); },
-            [&](const LabelIndex& index) { print("(label index {})", index.value()); },
-            [&](const LocalIndex& index) { print("(local index {})", index.value()); },
-            [&](const TableIndex& index) { print("(table index {})", index.value()); },
-            [&](const Instruction::IndirectCallArgs& args) { print("(indirect (type index {}) (table index {}))", args.type.value(), args.table.value()); },
-            [&](const Instruction::MemoryArgument& args) { print("(memory (align {}) (offset {}))", args.align, args.offset); },
-            [&](const Instruction::StructuredInstructionArgs& args) { print("(structured (else {}) (end {}))", args.else_ip.has_value() ? String::number(args.else_ip->value()) : "(none)", args.end_ip.value()); },
-            [&](const Instruction::TableBranchArgs&) { print("(table_branch ...)"); },
-            [&](const Instruction::TableElementArgs& args) { print("(table_element (table index {}) (element index {}))", args.table_index.value(), args.element_index.value()); },
-            [&](const Instruction::TableTableArgs& args) { print("(table_table (table index {}) (table index {}))", args.lhs.value(), args.rhs.value()); },
-            [&](const ValueType& type) { print(type); },
-            [&](const Vector<ValueType>&) { print("(types...)"); },
-            [&](const auto& value) { print("{}", value); });
+            [&](BlockType const& type) { print(type); },
+            [&](DataIndex const& index) { print("(data index {})", index.value()); },
+            [&](ElementIndex const& index) { print("(element index {})", index.value()); },
+            [&](FunctionIndex const& index) { print("(function index {})", index.value()); },
+            [&](GlobalIndex const& index) { print("(global index {})", index.value()); },
+            [&](LabelIndex const& index) { print("(label index {})", index.value()); },
+            [&](LocalIndex const& index) { print("(local index {})", index.value()); },
+            [&](TableIndex const& index) { print("(table index {})", index.value()); },
+            [&](Instruction::IndirectCallArgs const& args) { print("(indirect (type index {}) (table index {}))", args.type.value(), args.table.value()); },
+            [&](Instruction::MemoryArgument const& args) { print("(memory (align {}) (offset {}))", args.align, args.offset); },
+            [&](Instruction::StructuredInstructionArgs const& args) { print("(structured (else {}) (end {}))", args.else_ip.has_value() ? String::number(args.else_ip->value()) : "(none)", args.end_ip.value()); },
+            [&](Instruction::TableBranchArgs const&) { print("(table_branch ...)"); },
+            [&](Instruction::TableElementArgs const& args) { print("(table_element (table index {}) (element index {}))", args.table_index.value(), args.element_index.value()); },
+            [&](Instruction::TableTableArgs const& args) { print("(table_table (table index {}) (table index {}))", args.lhs.value(), args.rhs.value()); },
+            [&](ValueType const& type) { print(type); },
+            [&](Vector<ValueType> const&) { print("(types...)"); },
+            [&](auto const& value) { print("{}", value); });
 
         print(")\n");
     }
 }
 
-void Printer::print(const Wasm::Limits& limits)
+void Printer::print(Wasm::Limits const& limits)
 {
     print_indent();
     print("(limits min={}", limits.min());
@@ -457,7 +457,7 @@ void Printer::print(const Wasm::Limits& limits)
     print(")\n");
 }
 
-void Printer::print(const Wasm::Locals& local)
+void Printer::print(Wasm::Locals const& local)
 {
     print_indent();
     print("(local x{} of type\n", local.n());
@@ -469,7 +469,7 @@ void Printer::print(const Wasm::Locals& local)
     print(")\n");
 }
 
-void Printer::print(const Wasm::MemorySection& section)
+void Printer::print(Wasm::MemorySection const& section)
 {
     print_indent();
     print("(section memory\n");
@@ -482,7 +482,7 @@ void Printer::print(const Wasm::MemorySection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::MemorySection::Memory& memory)
+void Printer::print(Wasm::MemorySection::Memory const& memory)
 {
     print_indent();
     print("(memory\n");
@@ -494,7 +494,7 @@ void Printer::print(const Wasm::MemorySection::Memory& memory)
     print(")\n");
 }
 
-void Printer::print(const Wasm::MemoryType& type)
+void Printer::print(Wasm::MemoryType const& type)
 {
     print_indent();
     print("(type memory\n");
@@ -506,20 +506,20 @@ void Printer::print(const Wasm::MemoryType& type)
     print(")\n");
 }
 
-void Printer::print(const Wasm::Module& module)
+void Printer::print(Wasm::Module const& module)
 {
     print_indent();
     {
         TemporaryChange change { m_indent, m_indent + 1 };
         print("(module\n");
         for (auto& section : module.sections())
-            section.visit([this](const auto& value) { print(value); });
+            section.visit([this](auto const& value) { print(value); });
     }
     print_indent();
     print(")\n");
 }
 
-void Printer::print(const Wasm::Module::Function& func)
+void Printer::print(Wasm::Module::Function const& func)
 {
     print_indent();
     print("(function\n");
@@ -546,7 +546,7 @@ void Printer::print(const Wasm::Module::Function& func)
     print(")\n");
 }
 
-void Printer::print(const Wasm::StartSection& section)
+void Printer::print(Wasm::StartSection const& section)
 {
     print_indent();
     print("(section start\n");
@@ -558,13 +558,13 @@ void Printer::print(const Wasm::StartSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::StartSection::StartFunction& function)
+void Printer::print(Wasm::StartSection::StartFunction const& function)
 {
     print_indent();
     print("(start function index {})\n", function.index().value());
 }
 
-void Printer::print(const Wasm::TableSection& section)
+void Printer::print(Wasm::TableSection const& section)
 {
     print_indent();
     print("(section table\n");
@@ -577,7 +577,7 @@ void Printer::print(const Wasm::TableSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::TableSection::Table& table)
+void Printer::print(Wasm::TableSection::Table const& table)
 {
     print_indent();
     print("(table\n");
@@ -589,7 +589,7 @@ void Printer::print(const Wasm::TableSection::Table& table)
     print(")\n");
 }
 
-void Printer::print(const Wasm::TableType& type)
+void Printer::print(Wasm::TableType const& type)
 {
     print_indent();
     print("(type table min:{}", type.limits().min());
@@ -604,7 +604,7 @@ void Printer::print(const Wasm::TableType& type)
     print(")\n");
 }
 
-void Printer::print(const Wasm::TypeSection& section)
+void Printer::print(Wasm::TypeSection const& section)
 {
     print_indent();
     print("(section type\n");
@@ -617,22 +617,22 @@ void Printer::print(const Wasm::TypeSection& section)
     print(")\n");
 }
 
-void Printer::print(const Wasm::ValueType& type)
+void Printer::print(Wasm::ValueType const& type)
 {
     print_indent();
     print("(type {})\n", ValueType::kind_name(type.kind()));
 }
 
-void Printer::print(const Wasm::Value& value)
+void Printer::print(Wasm::Value const& value)
 {
     print_indent();
-    print("{} ", value.value().visit([&]<typename T>(const T& value) {
+    print("{} ", value.value().visit([&]<typename T>(T const& value) {
         if constexpr (IsSame<Wasm::Reference, T>)
             return String::formatted(
                 "addr({})",
                 value.ref().visit(
-                    [](const Wasm::Reference::Null&) { return String("null"); },
-                    [](const auto& ref) { return String::number(ref.address.value()); }));
+                    [](Wasm::Reference::Null const&) { return String("null"); },
+                    [](auto const& ref) { return String::number(ref.address.value()); }));
         else
             return String::formatted("{}", value);
     }));
@@ -640,14 +640,14 @@ void Printer::print(const Wasm::Value& value)
     print(value.type());
 }
 
-void Printer::print(const Wasm::Reference& value)
+void Printer::print(Wasm::Reference const& value)
 {
     print_indent();
     print(
         "addr({})\n",
         value.ref().visit(
-            [](const Wasm::Reference::Null&) { return String("null"); },
-            [](const auto& ref) { return String::number(ref.address.value()); }));
+            [](Wasm::Reference::Null const&) { return String("null"); },
+            [](auto const& ref) { return String::number(ref.address.value()); }));
 }
 
 }

--- a/Userland/Libraries/LibWasm/Printer/Printer.h
+++ b/Userland/Libraries/LibWasm/Printer/Printer.h
@@ -10,6 +10,8 @@
 
 namespace Wasm {
 
+class Value;
+
 String instruction_name(const OpCode& opcode);
 
 struct Printer {
@@ -28,14 +30,7 @@ struct Printer {
     void print(const Wasm::DataSection&);
     void print(const Wasm::DataSection::Data&);
     void print(const Wasm::ElementSection&);
-    void print(const Wasm::ElementSection::SegmentType0&);
-    void print(const Wasm::ElementSection::SegmentType1&);
-    void print(const Wasm::ElementSection::SegmentType2&);
-    void print(const Wasm::ElementSection::SegmentType3&);
-    void print(const Wasm::ElementSection::SegmentType4&);
-    void print(const Wasm::ElementSection::SegmentType5&);
-    void print(const Wasm::ElementSection::SegmentType6&);
-    void print(const Wasm::ElementSection::SegmentType7&);
+    void print(const Wasm::ElementSection::Element&);
     void print(const Wasm::ExportSection&);
     void print(const Wasm::ExportSection::Export&);
     void print(const Wasm::Expression&);
@@ -54,6 +49,7 @@ struct Printer {
     void print(const Wasm::MemoryType&);
     void print(const Wasm::Module&);
     void print(const Wasm::Module::Function&);
+    void print(const Wasm::Reference&);
     void print(const Wasm::StartSection&);
     void print(const Wasm::StartSection::StartFunction&);
     void print(const Wasm::TableSection&);
@@ -61,6 +57,7 @@ struct Printer {
     void print(const Wasm::TableType&);
     void print(const Wasm::TypeSection&);
     void print(const Wasm::ValueType&);
+    void print(const Wasm::Value&);
 
 private:
     void print_indent();

--- a/Userland/Libraries/LibWasm/Printer/Printer.h
+++ b/Userland/Libraries/LibWasm/Printer/Printer.h
@@ -12,7 +12,7 @@ namespace Wasm {
 
 class Value;
 
-String instruction_name(const OpCode& opcode);
+String instruction_name(OpCode const& opcode);
 
 struct Printer {
     explicit Printer(OutputStream& stream, size_t initial_indent = 0)
@@ -21,43 +21,43 @@ struct Printer {
     {
     }
 
-    void print(const Wasm::BlockType&);
-    void print(const Wasm::CodeSection&);
-    void print(const Wasm::CodeSection::Code&);
-    void print(const Wasm::CodeSection::Func&);
-    void print(const Wasm::CustomSection&);
-    void print(const Wasm::DataCountSection&);
-    void print(const Wasm::DataSection&);
-    void print(const Wasm::DataSection::Data&);
-    void print(const Wasm::ElementSection&);
-    void print(const Wasm::ElementSection::Element&);
-    void print(const Wasm::ExportSection&);
-    void print(const Wasm::ExportSection::Export&);
-    void print(const Wasm::Expression&);
-    void print(const Wasm::FunctionSection&);
-    void print(const Wasm::FunctionType&);
-    void print(const Wasm::GlobalSection&);
-    void print(const Wasm::GlobalSection::Global&);
-    void print(const Wasm::GlobalType&);
-    void print(const Wasm::ImportSection&);
-    void print(const Wasm::ImportSection::Import&);
-    void print(const Wasm::Instruction&);
-    void print(const Wasm::Limits&);
-    void print(const Wasm::Locals&);
-    void print(const Wasm::MemorySection&);
-    void print(const Wasm::MemorySection::Memory&);
-    void print(const Wasm::MemoryType&);
-    void print(const Wasm::Module&);
-    void print(const Wasm::Module::Function&);
-    void print(const Wasm::Reference&);
-    void print(const Wasm::StartSection&);
-    void print(const Wasm::StartSection::StartFunction&);
-    void print(const Wasm::TableSection&);
-    void print(const Wasm::TableSection::Table&);
-    void print(const Wasm::TableType&);
-    void print(const Wasm::TypeSection&);
-    void print(const Wasm::ValueType&);
-    void print(const Wasm::Value&);
+    void print(Wasm::BlockType const&);
+    void print(Wasm::CodeSection const&);
+    void print(Wasm::CodeSection::Code const&);
+    void print(Wasm::CodeSection::Func const&);
+    void print(Wasm::CustomSection const&);
+    void print(Wasm::DataCountSection const&);
+    void print(Wasm::DataSection const&);
+    void print(Wasm::DataSection::Data const&);
+    void print(Wasm::ElementSection const&);
+    void print(Wasm::ElementSection::Element const&);
+    void print(Wasm::ExportSection const&);
+    void print(Wasm::ExportSection::Export const&);
+    void print(Wasm::Expression const&);
+    void print(Wasm::FunctionSection const&);
+    void print(Wasm::FunctionType const&);
+    void print(Wasm::GlobalSection const&);
+    void print(Wasm::GlobalSection::Global const&);
+    void print(Wasm::GlobalType const&);
+    void print(Wasm::ImportSection const&);
+    void print(Wasm::ImportSection::Import const&);
+    void print(Wasm::Instruction const&);
+    void print(Wasm::Limits const&);
+    void print(Wasm::Locals const&);
+    void print(Wasm::MemorySection const&);
+    void print(Wasm::MemorySection::Memory const&);
+    void print(Wasm::MemoryType const&);
+    void print(Wasm::Module const&);
+    void print(Wasm::Module::Function const&);
+    void print(Wasm::Reference const&);
+    void print(Wasm::StartSection const&);
+    void print(Wasm::StartSection::StartFunction const&);
+    void print(Wasm::TableSection const&);
+    void print(Wasm::TableSection::Table const&);
+    void print(Wasm::TableType const&);
+    void print(Wasm::TypeSection const&);
+    void print(Wasm::ValueType const&);
+    void print(Wasm::Value const&);
 
 private:
     void print_indent();

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -56,7 +56,7 @@ TYPEDEF_DISTINCT_ORDERED_ID(size_t, LabelIndex);
 TYPEDEF_DISTINCT_ORDERED_ID(size_t, DataIndex);
 TYPEDEF_DISTINCT_NUMERIC_GENERAL(u64, true, true, false, true, false, true, InstructionPointer);
 
-ParseError with_eof_check(const InputStream& stream, ParseError error_if_not_eof);
+ParseError with_eof_check(InputStream const& stream, ParseError error_if_not_eof);
 
 template<typename T>
 struct GenericIndexParser {
@@ -220,7 +220,7 @@ public:
     {
     }
 
-    const auto& types() const { return m_types; }
+    auto const& types() const { return m_types; }
 
     static ParseResult<ResultType> parse(InputStream& stream);
 
@@ -999,8 +999,8 @@ public:
     auto& functions() const { return m_functions; }
     auto& type(TypeIndex index) const
     {
-        const FunctionType* type = nullptr;
-        for_each_section_of_type<TypeSection>([&](const TypeSection& section) {
+        FunctionType const* type = nullptr;
+        for_each_section_of_type<TypeSection>([&](TypeSection const& section) {
             type = &section.types().at(index.value());
         });
 

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -763,13 +763,12 @@ public:
         // FIXME: Implement me!
         static ParseResult<SegmentType0> parse(InputStream& stream);
 
-        ValueType type;
         Vector<FunctionIndex> function_indices;
         Active mode;
     };
     struct SegmentType1 {
         static ParseResult<SegmentType1> parse(InputStream& stream);
-        ValueType type;
+
         Vector<FunctionIndex> function_indices;
     };
     struct SegmentType2 {
@@ -797,23 +796,17 @@ public:
         static ParseResult<SegmentType7> parse(InputStream& stream);
     };
 
-    using AnyElementType = Variant<
-        SegmentType0,
-        SegmentType1,
-        SegmentType2,
-        SegmentType3,
-        SegmentType4,
-        SegmentType5,
-        SegmentType6,
-        SegmentType7>;
-
     struct Element {
-        static ParseResult<AnyElementType> parse(InputStream&);
+        static ParseResult<Element> parse(InputStream&);
+
+        ValueType type;
+        Vector<Expression> init;
+        Variant<Active, Passive, Declarative> mode;
     };
 
     static constexpr u8 section_id = 9;
 
-    explicit ElementSection(Vector<AnyElementType> segs)
+    explicit ElementSection(Vector<Element> segs)
         : m_segments(move(segs))
     {
     }
@@ -823,7 +816,7 @@ public:
     static ParseResult<ElementSection> parse(InputStream& stream);
 
 private:
-    Vector<AnyElementType> m_segments;
+    Vector<Element> m_segments;
 };
 
 class Locals {

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -49,7 +49,7 @@ static void sigint_handler(int)
     g_continue = false;
 }
 
-static bool post_interpret_hook(Wasm::Configuration&, Wasm::InstructionPointer& ip, const Wasm::Instruction& instr, const Wasm::Interpreter& interpreter)
+static bool post_interpret_hook(Wasm::Configuration&, Wasm::InstructionPointer& ip, Wasm::Instruction const& instr, Wasm::Interpreter const& interpreter)
 {
     if (interpreter.did_trap()) {
         g_continue = false;
@@ -61,7 +61,7 @@ static bool post_interpret_hook(Wasm::Configuration&, Wasm::InstructionPointer& 
     return true;
 }
 
-static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPointer& ip, const Wasm::Instruction& instr)
+static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPointer& ip, Wasm::Instruction const& instr)
 {
     static bool always_print_stack = false;
     static bool always_print_instruction = false;
@@ -235,7 +235,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
     }
 }
 
-static Optional<Wasm::Module> parse(const StringView& filename)
+static Optional<Wasm::Module> parse(StringView const& filename)
 {
     auto result = Core::File::open(filename, Core::OpenMode::ReadOnly);
     if (result.is_error()) {
@@ -253,15 +253,15 @@ static Optional<Wasm::Module> parse(const StringView& filename)
     return parse_result.release_value();
 }
 
-static void print_link_error(const Wasm::LinkError& error)
+static void print_link_error(Wasm::LinkError const& error)
 {
-    for (const auto& missing : error.missing_imports)
+    for (auto const& missing : error.missing_imports)
         warnln("Missing import '{}'", missing);
 }
 
 int main(int argc, char* argv[])
 {
-    const char* filename = nullptr;
+    char const* filename = nullptr;
     bool print = false;
     bool attempt_instantiate = false;
     bool debug = false;
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
         .long_name = "link",
         .short_name = 'l',
         .value_name = "file",
-        .accept_value = [&](const char* str) {
+        .accept_value = [&](char const* str) {
             if (auto v = StringView { str }; !v.is_empty()) {
                 modules_to_link_in.append(v);
                 return true;
@@ -297,7 +297,7 @@ int main(int argc, char* argv[])
         .long_name = "arg",
         .short_name = 0,
         .value_name = "u64",
-        .accept_value = [&](const char* str) -> bool {
+        .accept_value = [&](char const* str) -> bool {
             if (auto v = StringView { str }.to_uint<u64>(); v.has_value()) {
                 values_to_push.append(v.value());
                 return true;
@@ -415,20 +415,20 @@ int main(int argc, char* argv[])
         auto module_instance = result.release_value();
 
         auto stream = Core::OutputFileStream::standard_output();
-        auto print_func = [&](const auto& address) {
+        auto print_func = [&](auto const& address) {
             Wasm::FunctionInstance* fn = machine.store().get(address);
             stream.write(String::formatted("- Function with address {}, ptr = {}\n", address.value(), fn).bytes());
             if (fn) {
                 stream.write(String::formatted("    wasm function? {}\n", fn->has<Wasm::WasmFunction>()).bytes());
                 fn->visit(
-                    [&](const Wasm::WasmFunction& func) {
+                    [&](Wasm::WasmFunction const& func) {
                         Wasm::Printer printer { stream, 3 };
                         stream.write("    type:\n"sv.bytes());
                         printer.print(func.type());
                         stream.write("    code:\n"sv.bytes());
                         printer.print(func.code());
                     },
-                    [](const Wasm::HostFunction&) {});
+                    [](Wasm::HostFunction const&) {});
             }
         };
         if (print) {
@@ -483,7 +483,7 @@ int main(int argc, char* argv[])
                     instance->get<Wasm::WasmFunction>().code().body(),
                     1,
                 });
-                const Wasm::Instruction instr { Wasm::Instructions::nop };
+                Wasm::Instruction instr { Wasm::Instructions::nop };
                 Wasm::InstructionPointer ip { 0 };
                 g_continue = false;
                 pre_interpret_hook(config, ip, instr);

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -204,17 +204,8 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
             if (!result.values().is_empty())
                 warnln("Returned:");
             for (auto& value : result.values()) {
-                auto str = value.value().visit(
-                    [&]<typename T>(const T& value) {
-                        if constexpr (requires { value.value(); })
-                            return String::formatted("  -> addr{} ", value.value());
-                        else if constexpr (IsSame<Wasm::Value::Null, T>)
-                            return String::formatted("  ->addr(null)");
-                        else
-                            return String::formatted("  -> {} ", value);
-                    });
-                g_stdout.write(str.bytes());
-                g_printer.print(value.type());
+                g_stdout.write("  -> "sv.bytes());
+                g_printer.print(value);
             }
             continue;
         }
@@ -541,17 +532,9 @@ int main(int argc, char* argv[])
             if (!result.values().is_empty())
                 warnln("Returned:");
             for (auto& value : result.values()) {
-                value.value().visit(
-                    [&]<typename T>(const T& value) {
-                        if constexpr (requires { value.value(); })
-                            out("  -> addr{} ", value.value());
-                        else if constexpr (IsSame<Wasm::Value::Null, T>)
-                            out("  ->addr(null)");
-                        else
-                            out("  -> {} ", value);
-                    });
                 Wasm::Printer printer { stream };
-                printer.print(value.type());
+                g_stdout.write("  -> "sv.bytes());
+                g_printer.print(value);
             }
         }
     }


### PR DESCRIPTION
- **LibWasm: Make memory ops always work with LE data**
Wasm memory ops always read LE data, not LEB-128.

- **LibWasm: Load and instantiate tables**
This makes it possible for applications to actually use `call.indirect`.
None of the table operation instructions are implemented, so tables cannot be modified yet.

- **LibWasm: Unreadable-ify code**
You know what this is about already.


TL;DR: Game-Of-Life application written in Rust (by @Lubrsi)
![photo_2021-06-04_03-50-28](https://user-images.githubusercontent.com/14001776/120723959-088f5500-c4e8-11eb-8216-0ff8d4376455.jpg)
