### PR TITLE
Ports: Add PHP

### DIFF
--- a/Kernel/Syscalls/sysconf.cpp
+++ b/Kernel/Syscalls/sysconf.cpp
@@ -14,6 +14,8 @@ namespace Kernel {
 KResultOr<long> Process::sys$sysconf(int name)
 {
     switch (name) {
+    case _SC_MONOTONIC_CLOCK:
+        return 1;
     case _SC_NPROCESSORS_CONF:
     case _SC_NPROCESSORS_ONLN:
         return Processor::processor_count();

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -37,6 +37,7 @@
 #define MS_REMOUNT (1 << 5)
 
 enum {
+    _SC_MONOTONIC_CLOCK,
     _SC_NPROCESSORS_CONF,
     _SC_NPROCESSORS_ONLN,
     _SC_OPEN_MAX,

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -502,6 +502,7 @@ struct pollfd {
 #define MSG_TRUNC 0x1
 #define MSG_CTRUNC 0x2
 #define MSG_PEEK 0x4
+#define MSG_OOB 0x8
 #define MSG_DONTWAIT 0x40
 
 #define SOL_SOCKET 1

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -99,6 +99,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`patch`](patch/)                      | patch (OpenBSD)                                            | 6.6                      | https://github.com/ibara/libpuffy                                              |
 | [`pcre`](pcre/)                        | Perl-compatible Regular Expressions (PCRE)                 | 8.44                     | https://www.pcre.org/                                                          |
 | [`pcre2`](pcre2/)                      | Perl-compatible Regular Expressions (PCRE2)                | 10.34                    | https://www.pcre.org/                                                          |
+| [`php`](php/)                          | PHP                                                        | 8.0.6                    | https://www.php.net/                                                           |
 | [`pkgconf`](pkgconf/)                  | pkgconf                                                    | 1.7.3                    | https://github.com/pkgconf/pkgconf                                             |
 | [`SDLPoP`](SDLPoP/)                    | Prince of Persia game                                      |                          | https://github.com/NagyD/SDLPoP                                                |
 | [`printf`](printf/)                    | printf (OpenBSD)                                           | 6.6                      | https://github.com/ibara/libpuffy                                              |

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=php
+useconfigure="true"
+version="8.0.6"
+files="https://www.php.net/distributions/php-${version}.tar.xz php-${version}.tar.xz e9871d3b6c391fe9e89f86f6334852dcc10eeaaa8d5565beb8436e7f0cf30e20"
+auth_type=sha256
+depends=""
+configopts="
+    --disable-dom
+    --disable-opcache
+    --disable-phar
+    --disable-simplexml
+    --disable-xml
+    --disable-xmlreader
+    --disable-xmlwriter
+    --prefix=${SERENITY_INSTALL_ROOT}/usr/local
+    --without-iconv
+    --without-libxml
+    --without-pdo-sqlite
+    --without-sqlite3
+"
+
+export LIBS="-ldl"

--- a/Ports/php/patches/config.sub.patch
+++ b/Ports/php/patches/config.sub.patch
@@ -1,0 +1,11 @@
+--- php-8.0.6/build/config.sub	2021-05-04 19:26:18.000000000 +0200
++++ php-8.0.6-patched/build/config.sub	2021-06-03 22:49:12.463974784 +0200
+@@ -1366,7 +1366,7 @@
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+-	     | nsk* | powerunix)
++	     | nsk* | powerunix | serenity*)
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	qnx*)

--- a/Ports/php/patches/configure.patch
+++ b/Ports/php/patches/configure.patch
@@ -1,0 +1,11 @@
+--- php-8.0.6/configure	2021-05-04 19:26:18.000000000 +0200
++++ php-8.0.6-patched/configure	2021-06-03 23:48:41.087223727 +0200
+@@ -13587,7 +13587,7 @@
+ if test "x$ac_cv_func___inet_aton" = xyes; then :
+   found=yes
+ else
+-  found=no
++  found=yes
+ fi
+ 
+ fi

--- a/Ports/php/patches/php_fopen_wrapper.c.patch
+++ b/Ports/php/patches/php_fopen_wrapper.c.patch
@@ -1,0 +1,11 @@
+--- php-8.0.6/ext/standard/php_fopen_wrapper.c	2021-05-04 19:26:18.000000000 +0200
++++ php-8.0.6-patched/ext/standard/php_fopen_wrapper.c	2021-06-04 01:04:07.104126109 +0200
+@@ -317,7 +317,7 @@
+ 			return NULL;
+ 		}
+ 
+-#if HAVE_UNISTD_H
++#if !HAVE_UNISTD_H
+ 		dtablesize = getdtablesize();
+ #else
+ 		dtablesize = INT_MAX;

--- a/Ports/php/patches/php_network.h.patch
+++ b/Ports/php/patches/php_network.h.patch
@@ -1,0 +1,10 @@
+--- php-8.0.6/main/php_network.h	2021-05-04 19:26:18.000000000 +0200
++++ php-8.0.6-patched/main/php_network.h	2021-06-04 01:54:05.976580933 +0200
+@@ -63,6 +63,7 @@
+ PHPAPI zend_string *php_socket_error_str(long err);
+ END_EXTERN_C()
+ 
++#include <arpa/inet.h>
+ #ifdef HAVE_NETINET_IN_H
+ # include <netinet/in.h>
+ #endif

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -865,6 +865,14 @@ lldiv_t lldiv(long long numerator, long long denominator)
     return result;
 }
 
+int mblen(char const* s, size_t n)
+{
+    // FIXME: Implement locale support
+    if (!s)
+        return 0;
+    return (MB_CUR_MAX > n) ? n : MB_CUR_MAX;
+}
+
 size_t mbstowcs(wchar_t*, const char*, size_t)
 {
     dbgln("FIXME: Implement mbstowcs()");

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -59,6 +59,7 @@ char* mktemp(char*);
 int mkstemp(char*);
 char* mkdtemp(char*);
 void* bsearch(const void* key, const void* base, size_t nmemb, size_t size, int (*compar)(const void*, const void*));
+int mblen(char const*, size_t);
 size_t mbstowcs(wchar_t*, const char*, size_t);
 int mbtowc(wchar_t*, const char*, size_t);
 int wctomb(char*, wchar_t);

--- a/Userland/Libraries/LibC/sys/socket.h
+++ b/Userland/Libraries/LibC/sys/socket.h
@@ -47,6 +47,7 @@ __BEGIN_DECLS
 #define MSG_TRUNC 0x1
 #define MSG_CTRUNC 0x2
 #define MSG_PEEK 0x4
+#define MSG_OOB 0x8
 #define MSG_DONTWAIT 0x40
 
 typedef uint16_t sa_family_t;

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -160,6 +160,26 @@ int execl(const char* filename, const char* arg0, ...)
     return execve(filename, const_cast<char* const*>(args.data()), environ);
 }
 
+int execle(char const* filename, char const* arg0, ...)
+{
+    Vector<char const*> args;
+    args.append(arg0);
+
+    va_list ap;
+    va_start(ap, arg0);
+    char const* arg;
+    do {
+        arg = va_arg(ap, char const*);
+        args.append(arg);
+    } while (arg);
+
+    auto argv = const_cast<char* const*>(args.data());
+    auto envp = const_cast<char* const*>(va_arg(ap, char* const*));
+    va_end(ap);
+
+    return execve(filename, argv, envp);
+}
+
 int execlp(const char* filename, const char* arg0, ...)
 {
     Vector<const char*, 16> args;

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -49,6 +49,7 @@ int execve(const char* filename, char* const argv[], char* const envp[]);
 int execvpe(const char* filename, char* const argv[], char* const envp[]);
 int execvp(const char* filename, char* const argv[]);
 int execl(const char* filename, const char* arg, ...);
+int execle(const char* filename, const char* arg, ...);
 int execlp(const char* filename, const char* arg, ...);
 int chroot(const char* path);
 int chroot_with_mount_flags(const char* path, int mount_flags);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -141,7 +141,9 @@ enum {
 #define MS_RDONLY (1 << 4)
 #define MS_REMOUNT (1 << 5)
 
+#define _POSIX_MONOTONIC_CLOCK 200112L
 #define _POSIX_SAVED_IDS
+#define _POSIX_TIMERS 200809L
 
 /*
  * We aren't fully compliant (don't support policies, and don't have a wide
@@ -151,6 +153,7 @@ enum {
 #define _POSIX_VDISABLE '\0'
 
 enum {
+    _SC_MONOTONIC_CLOCK,
     _SC_NPROCESSORS_CONF,
     _SC_NPROCESSORS_ONLN,
     _SC_OPEN_MAX,
@@ -160,6 +163,7 @@ enum {
     _SC_CLK_TCK,
 };
 
+#define _SC_MONOTONIC_CLOCK _SC_MONOTONIC_CLOCK
 #define _SC_NPROCESSORS_CONF _SC_NPROCESSORS_CONF
 #define _SC_NPROCESSORS_ONLN _SC_NPROCESSORS_ONLN
 #define _SC_OPEN_MAX _SC_OPEN_MAX


### PR DESCRIPTION
Because why not!

![Screenshot_20210604_014335](https://user-images.githubusercontent.com/3210731/120726530-919e9000-c4d8-11eb-82cf-c1205007d28b.png)

* Currently, the kernel panics when you run `php` and press `Ctrl + C` which is nice (#7764)
* Basic functionality works
* DOM, Iconv, OPCache, Phar, SQLite and XML support is disabled
* Running `composer` would require Phar support so that would be something for the backlog