### PR TITLE
LibLine: Actually cancel the search editor with Ctl-C

### DIFF
--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -264,6 +264,7 @@ void Editor::enter_search()
         m_search_editor->register_key_input_callback(ctrl('C'), [this](Editor& search_editor) {
             search_editor.finish();
             m_reset_buffer_on_search_end = true;
+            search_editor.end_search();
             search_editor.deferred_invoke([&search_editor](auto&) { search_editor.really_quit_event_loop(); });
             return false;
         });


### PR DESCRIPTION
Previously when the search editor calls on really_quit_event_loop to cancel the
search, the command loaded in m_buffer would actually execute because
really_quit_event_loop sends a new line character and then afterwards
clears the buffer.

By using end_search prior to exiting the event loop, this patch will
appropriately clear the buffer, not execute any commands, and
preserve the original loaded buffer after returning from a canceled
search.