### PR TITLE
Added the the time duration in the status bar of Profiler

### DIFF
--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -186,6 +186,7 @@ int main(int argc, char** argv)
             auto start = normalized_start_time - start_of_trace;
             auto end = normalized_end_time - start_of_trace;
             builder.appendff(", Selection: {} - {} ms", start, end);
+            builder.appendff(", Duration: {} ms", end - start);
         }
         statusbar.set_text(builder.to_string());
     };


### PR DESCRIPTION
Added code to chow the time duration of a selected time-frame in the status bar of Profiler. The way it looks on my machine: https://imgur.com/mo5Zgyu

Related issue: #7748