### PR TITLE
LibCards: Don't draw the first card smaller than the others

### DIFF
--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -82,8 +82,8 @@ Card::Card(Type type, uint8_t value)
         auto target_size = Gfx::IntSize(static_cast<int>(aspect_ratio * (height - 5)), height - 5);
 
         bg_painter.fill_rect_with_rounded_corners(paint_rect, Color::Black, 5, 5, 5, 5);
-        paint_rect.shrink(2, 2);
-        bg_painter.fill_rect_with_rounded_corners(paint_rect, Color::White, 4, 4, 4, 4);
+        auto inner_paint_rect = paint_rect.shrunken(2, 2);
+        bg_painter.fill_rect_with_rounded_corners(inner_paint_rect, Color::White, 4, 4, 4, 4);
 
         bg_painter.draw_scaled_bitmap(
             { { (width - target_size.width()) / 2, (height - target_size.height()) / 2 }, target_size },


### PR DESCRIPTION
This fixes the issue mentioned in #7746. :)