### PR TITLE
AK: Inline *String::is_one_of<Ts...>()

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -76,17 +76,13 @@ public:
 
     static void did_destroy_impl(Badge<StringImpl>, StringImpl&);
 
-    template<typename T, typename... Rest>
-    bool is_one_of(const T& string, Rest... rest) const
+    template<typename... Ts>
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
     {
-        if (*this == string)
-            return true;
-        return is_one_of(rest...);
+        return (... || this->operator==(forward<Ts>(strings)));
     }
 
 private:
-    bool is_one_of() const { return false; }
-
     RefPtr<StringImpl> m_impl;
 };
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -282,17 +282,13 @@ public:
     Vector<size_t> find_all(const String& needle) const;
     [[nodiscard]] String reverse() const;
 
-    template<typename T, typename... Rest>
-    [[nodiscard]] bool is_one_of(const T& string, Rest... rest) const
+    template<typename... Ts>
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
     {
-        if (*this == string)
-            return true;
-        return is_one_of(rest...);
+        return (... || this->operator==(forward<Ts>(strings)));
     }
 
 private:
-    [[nodiscard]] bool is_one_of() const { return false; }
-
     RefPtr<StringImpl> m_impl;
 };
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -209,17 +209,13 @@ public:
 
     [[nodiscard]] bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
 
-    template<typename T, typename... Rest>
-    [[nodiscard]] bool is_one_of(const T& string, Rest... rest) const
+    template<typename... Ts>
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
     {
-        if (*this == string)
-            return true;
-        return is_one_of(rest...);
+        return (... || this->operator==(forward<Ts>(strings)));
     }
 
 private:
-    [[nodiscard]] bool is_one_of() const { return false; }
-
     friend class String;
     const char* m_characters { nullptr };
     size_t m_length { 0 };


### PR DESCRIPTION
Previously this was generating a crazy number of symbols, and it was
also pretty-damn-slow as it was defined recursively, which made the
compiler incapable of inlining it (due to the many many layers of
recursion before it terminated).
This commit replaces the recursion with a pack expansion and marks it
always-inline.

> CxByte: FlyStrings flying across the sky
> shroud: Closely followed by its 114 variations.
> shroud: `$ objdump -dx Build/i686/Userland/Libraries/LibWeb/libweb.so | c++filt | grep is_one_of | grep ' .text' | wc -l`
> `114`

Now:
```
$ objdump -dx Build/i686/Userland/Libraries/LibWeb/libweb.so | c++filt | grep is_one_of | grep ' .text' | wc -l
0
```

cc @gunnarbeutner.