### PR TITLE
LibGUI+Everywhere: Fix off-by-one error in highlighting system

### DIFF
--- a/Userland/DevTools/Playground/GMLAutocompleteProvider.cpp
+++ b/Userland/DevTools/Playground/GMLAutocompleteProvider.cpp
@@ -107,7 +107,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     Vector<GUI::AutocompleteProvider::Entry> class_entries, identifier_entries;
     switch (state) {
     case Free:
-        if (last_seen_token && last_seen_token->m_end.column + 1 != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
+        if (last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
             // After some token, but with extra space, not on a new line.
             // Nothing to put here.
             break;
@@ -121,7 +121,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     case InClassName:
         if (class_names.is_empty())
             break;
-        if (last_seen_token && last_seen_token->m_end.column + 1 != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
+        if (last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
             // After a class name, but haven't seen braces.
             // TODO: Suggest braces?
             break;
@@ -136,7 +136,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     case InIdentifier: {
         if (class_names.is_empty())
             break;
-        if (last_seen_token && last_seen_token->m_end.column + 1 != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
+        if (last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
             // After an identifier, but with extra space
             // TODO: Maybe suggest a colon?
             break;
@@ -158,7 +158,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     }
     case AfterClassName: {
         if (last_seen_token && last_seen_token->m_end.line == cursor.line()) {
-            if (last_seen_token->m_type != GUI::GMLToken::Type::Identifier || last_seen_token->m_end.column + 1 != cursor.column()) {
+            if (last_seen_token->m_type != GUI::GMLToken::Type::Identifier || last_seen_token->m_end.column != cursor.column()) {
                 // Inside braces, but on the same line as some other stuff (and not the continuation of one!)
                 // The user expects nothing here.
                 break;

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -5,10 +5,10 @@
  */
 
 #include "Lexer.h"
+#include <AK/CharacterTypes.h>
 #include <AK/HashTable.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
-#include <ctype.h>
 
 namespace Cpp {
 
@@ -38,14 +38,14 @@ char Lexer::consume()
     return ch;
 }
 
-static bool is_valid_first_character_of_identifier(char ch)
+constexpr bool is_valid_first_character_of_identifier(char ch)
 {
-    return isalpha(ch) || ch == '_' || ch == '$';
+    return is_ascii_alpha(ch) || ch == '_' || ch == '$';
 }
 
-static bool is_valid_nonfirst_character_of_identifier(char ch)
+constexpr bool is_valid_nonfirst_character_of_identifier(char ch)
 {
-    return is_valid_first_character_of_identifier(ch) || isdigit(ch);
+    return is_valid_first_character_of_identifier(ch) || is_ascii_digit(ch);
 }
 
 constexpr char const* s_known_keywords[] = {
@@ -268,7 +268,7 @@ Vector<Token> Lexer::lex()
         }
         case 'x': {
             size_t hex_digits = 0;
-            while (isxdigit(peek(2 + hex_digits)))
+            while (is_ascii_hex_digit(peek(2 + hex_digits)))
                 ++hex_digits;
             return 2 + hex_digits;
         }
@@ -277,7 +277,7 @@ Vector<Token> Lexer::lex()
             bool is_unicode = true;
             size_t number_of_digits = peek(1) == 'u' ? 4 : 8;
             for (size_t i = 0; i < number_of_digits; ++i) {
-                if (!isxdigit(peek(2 + i))) {
+                if (!is_ascii_hex_digit(peek(2 + i))) {
                     is_unicode = false;
                     break;
                 }
@@ -307,9 +307,9 @@ Vector<Token> Lexer::lex()
 
     while (m_index < m_input.length()) {
         auto ch = peek();
-        if (isspace(ch)) {
+        if (is_ascii_space(ch)) {
             begin_token();
-            while (isspace(peek()))
+            while (is_ascii_space(peek()))
                 consume();
             commit_token(Token::Type::Whitespace);
             continue;
@@ -535,7 +535,7 @@ Vector<Token> Lexer::lex()
                 commit_token(Token::Type::IncludeStatement);
 
                 begin_token();
-                while (isspace(peek()))
+                while (is_ascii_space(peek()))
                     consume();
                 commit_token(Token::Type::Whitespace);
 
@@ -667,7 +667,7 @@ Vector<Token> Lexer::lex()
             commit_token(Token::Type::SingleQuotedString);
             continue;
         }
-        if (isdigit(ch) || (ch == '.' && isdigit(peek(1)))) {
+        if (is_ascii_digit(ch) || (ch == '.' && is_ascii_digit(peek(1)))) {
             begin_token();
             consume();
 
@@ -686,7 +686,7 @@ Vector<Token> Lexer::lex()
                 if (ch == '+' || ch == '-') {
                     ++length;
                 }
-                for (ch = peek(length); isdigit(ch); ch = peek(length)) {
+                for (ch = peek(length); is_ascii_digit(ch); ch = peek(length)) {
                     ++length;
                 }
                 return length;
@@ -720,7 +720,7 @@ Vector<Token> Lexer::lex()
                     is_hex = true;
                 }
 
-                for (char ch = peek(); (is_hex ? isxdigit(ch) : isdigit(ch)) || (ch == '\'' && peek(1) != '\'') || ch == '.'; ch = peek()) {
+                for (char ch = peek(); (is_hex ? is_ascii_hex_digit(ch) : is_ascii_digit(ch)) || (ch == '\'' && peek(1) != '\'') || ch == '.'; ch = peek()) {
                     if (ch == '.') {
                         if (type == Token::Type::Integer) {
                             type = Token::Type::Float;

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -534,10 +534,13 @@ Vector<Token> Lexer::lex()
             if (directive == "#include") {
                 commit_token(Token::Type::IncludeStatement);
 
-                begin_token();
-                while (is_ascii_space(peek()))
-                    consume();
-                commit_token(Token::Type::Whitespace);
+                if (is_ascii_space(peek())) {
+                    begin_token();
+                    do {
+                        consume();
+                    } while (is_ascii_space(peek()));
+                    commit_token(Token::Type::Whitespace);
+                }
 
                 begin_token();
                 if (peek() == '<' || peek() == '"') {

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -12,7 +12,7 @@
 
 namespace Cpp {
 
-Lexer::Lexer(const StringView& input)
+Lexer::Lexer(StringView const& input)
     : m_input(input)
 {
 }
@@ -48,7 +48,7 @@ static bool is_valid_nonfirst_character_of_identifier(char ch)
     return is_valid_first_character_of_identifier(ch) || isdigit(ch);
 }
 
-constexpr const char* s_known_keywords[] = {
+constexpr char const* s_known_keywords[] = {
     "alignas",
     "alignof",
     "and",
@@ -125,7 +125,7 @@ constexpr const char* s_known_keywords[] = {
     "xor_eq"
 };
 
-constexpr const char* s_known_types[] = {
+constexpr char const* s_known_types[] = {
     "ByteBuffer",
     "CircularDeque",
     "CircularQueue",
@@ -186,7 +186,7 @@ constexpr const char* s_known_types[] = {
     "wchar_t"
 };
 
-static bool is_keyword(const StringView& string)
+static bool is_keyword(StringView const& string)
 {
     static HashTable<String> keywords(array_size(s_known_keywords));
     if (keywords.is_empty()) {
@@ -195,7 +195,7 @@ static bool is_keyword(const StringView& string)
     return keywords.contains(string);
 }
 
-static bool is_known_type(const StringView& string)
+static bool is_known_type(StringView const& string)
 {
     static HashTable<String> types(array_size(s_known_types));
     if (types.is_empty()) {

--- a/Userland/Libraries/LibCpp/Lexer.h
+++ b/Userland/Libraries/LibCpp/Lexer.h
@@ -14,7 +14,7 @@ namespace Cpp {
 
 class Lexer {
 public:
-    Lexer(const StringView&);
+    Lexer(StringView const&);
 
     Vector<Token> lex();
 

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
@@ -13,7 +13,7 @@
 
 namespace Cpp {
 
-static Syntax::TextStyle style_for_token_type(const Gfx::Palette& palette, Cpp::Token::Type type)
+static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, Cpp::Token::Type type)
 {
     switch (type) {
     case Cpp::Token::Type::Keyword:
@@ -55,7 +55,7 @@ bool SyntaxHighlighter::is_navigatable(void* token) const
     return cpp_token == Cpp::Token::Type::IncludePath;
 }
 
-void SyntaxHighlighter::rehighlight(const Palette& palette)
+void SyntaxHighlighter::rehighlight(Palette const& palette)
 {
     auto text = m_client->get_text();
     Cpp::Lexer lexer(text);

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
@@ -63,10 +63,11 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
 
     Vector<GUI::TextDocumentSpan> spans;
     for (auto& token : tokens) {
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ {}:{} - {}:{}", token.type_as_string(), token.start().line, token.start().column, token.end().line, token.end().column);
+        // FIXME: The +1 for the token end column is a quick hack due to not wanting to modify the lexer (which is also used by the parser). Maybe there's a better way to do this.
+        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ {}:{} - {}:{}", token.type_as_string(), token.start().line, token.start().column, token.end().line, token.end().column + 1);
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.start().line, token.start().column });
-        span.range.set_end({ token.end().line, token.end().column });
+        span.range.set_end({ token.end().line, token.end().column + 1 });
         auto style = style_for_token_type(palette, token.type());
         span.attributes.color = style.color;
         span.attributes.bold = style.bold;

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.h
@@ -19,7 +19,7 @@ public:
     virtual bool is_navigatable(void*) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::Cpp; }
-    virtual void rehighlight(const Palette&) override;
+    virtual void rehighlight(Palette const&) override;
 
 protected:
     virtual Vector<MatchingTokenPair> matching_token_pairs() const override;

--- a/Userland/Libraries/LibGUI/GMLLexer.cpp
+++ b/Userland/Libraries/LibGUI/GMLLexer.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "GMLLexer.h"
+#include <AK/CharacterTypes.h>
 #include <AK/Vector.h>
-#include <ctype.h>
 
 namespace GUI {
 
@@ -36,19 +36,19 @@ char GMLLexer::consume()
     return ch;
 }
 
-static bool is_valid_identifier_start(char ch)
+constexpr bool is_valid_identifier_start(char ch)
 {
-    return isalpha(ch) || ch == '_';
+    return is_ascii_alpha(ch) || ch == '_';
 }
 
-static bool is_valid_identifier_character(char ch)
+constexpr bool is_valid_identifier_character(char ch)
 {
-    return isalnum(ch) || ch == '_';
+    return is_ascii_alphanumeric(ch) || ch == '_';
 }
 
-static bool is_valid_class_character(char ch)
+constexpr bool is_valid_class_character(char ch)
 {
-    return isalnum(ch) || ch == '_' || ch == ':';
+    return is_ascii_alphanumeric(ch) || ch == '_' || ch == ':';
 }
 
 Vector<GMLToken> GMLLexer::lex()
@@ -83,9 +83,9 @@ Vector<GMLToken> GMLLexer::lex()
     };
 
     while (m_index < m_input.length()) {
-        if (isspace(peek(0))) {
+        if (is_ascii_space(peek(0))) {
             begin_token();
-            while (isspace(peek()))
+            while (is_ascii_space(peek()))
                 consume();
             continue;
         }
@@ -132,7 +132,7 @@ Vector<GMLToken> GMLLexer::lex()
             consume();
             commit_token(GMLToken::Type::Colon);
 
-            while (isspace(peek()))
+            while (is_ascii_space(peek()))
                 consume();
 
             if (peek(0) == '@') {

--- a/Userland/Libraries/LibGUI/GMLLexer.cpp
+++ b/Userland/Libraries/LibGUI/GMLLexer.cpp
@@ -10,7 +10,7 @@
 
 namespace GUI {
 
-GMLLexer::GMLLexer(const StringView& input)
+GMLLexer::GMLLexer(StringView const& input)
     : m_input(input)
 {
 }

--- a/Userland/Libraries/LibGUI/GMLLexer.cpp
+++ b/Userland/Libraries/LibGUI/GMLLexer.cpp
@@ -26,7 +26,6 @@ char GMLLexer::consume()
 {
     VERIFY(m_index < m_input.length());
     char ch = m_input[m_index++];
-    m_previous_position = m_position;
     if (ch == '\n') {
         m_position.line++;
         m_position.column = 0;
@@ -68,7 +67,7 @@ Vector<GMLToken> GMLLexer::lex()
         token.m_view = m_input.substring_view(token_start_index, m_index - token_start_index);
         token.m_type = type;
         token.m_start = token_start_position;
-        token.m_end = m_previous_position;
+        token.m_end = m_position;
         tokens.append(token);
     };
 

--- a/Userland/Libraries/LibGUI/GMLLexer.h
+++ b/Userland/Libraries/LibGUI/GMLLexer.h
@@ -63,7 +63,6 @@ private:
 
     StringView m_input;
     size_t m_index { 0 };
-    GMLPosition m_previous_position { 0, 0 };
     GMLPosition m_position { 0, 0 };
 };
 

--- a/Userland/Libraries/LibGUI/GMLLexer.h
+++ b/Userland/Libraries/LibGUI/GMLLexer.h
@@ -33,7 +33,7 @@ struct GMLToken {
 #undef __TOKEN
     };
 
-    const char* to_string() const
+    char const* to_string() const
     {
         switch (m_type) {
 #define __TOKEN(x) \
@@ -53,7 +53,7 @@ struct GMLToken {
 
 class GMLLexer {
 public:
-    GMLLexer(const StringView&);
+    GMLLexer(StringView const&);
 
     Vector<GMLToken> lex();
 

--- a/Userland/Libraries/LibGUI/INILexer.cpp
+++ b/Userland/Libraries/LibGUI/INILexer.cpp
@@ -10,7 +10,7 @@
 
 namespace GUI {
 
-IniLexer::IniLexer(const StringView& input)
+IniLexer::IniLexer(StringView const& input)
     : m_input(input)
 {
 }

--- a/Userland/Libraries/LibGUI/INILexer.cpp
+++ b/Userland/Libraries/LibGUI/INILexer.cpp
@@ -26,7 +26,6 @@ char IniLexer::consume()
 {
     VERIFY(m_index < m_input.length());
     char ch = m_input[m_index++];
-    m_previous_position = m_position;
     if (ch == '\n') {
         m_position.line++;
         m_position.column = 0;
@@ -47,9 +46,9 @@ Vector<IniToken> IniLexer::lex()
         IniToken token;
         token.m_type = type;
         token.m_start = m_position;
+        consume();
         token.m_end = m_position;
         tokens.append(token);
-        consume();
     };
 
     auto begin_token = [&] {

--- a/Userland/Libraries/LibGUI/INILexer.cpp
+++ b/Userland/Libraries/LibGUI/INILexer.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "INILexer.h"
+#include <AK/CharacterTypes.h>
 #include <AK/Vector.h>
-#include <ctype.h>
 
 namespace GUI {
 
@@ -61,16 +61,16 @@ Vector<IniToken> IniLexer::lex()
         IniToken token;
         token.m_type = type;
         token.m_start = token_start_position;
-        token.m_end = m_previous_position;
+        token.m_end = m_position;
         tokens.append(token);
     };
 
     while (m_index < m_input.length()) {
         auto ch = peek();
 
-        if (isspace(ch)) {
+        if (is_ascii_space(ch)) {
             begin_token();
-            while (isspace(peek()))
+            while (is_ascii_space(peek()))
                 consume();
             commit_token(IniToken::Type::Whitespace);
             continue;

--- a/Userland/Libraries/LibGUI/INILexer.h
+++ b/Userland/Libraries/LibGUI/INILexer.h
@@ -33,7 +33,7 @@ struct IniToken {
 #undef __TOKEN
     };
 
-    const char* to_string() const
+    char const* to_string() const
     {
         switch (m_type) {
 #define __TOKEN(x) \
@@ -52,7 +52,7 @@ struct IniToken {
 
 class IniLexer {
 public:
-    IniLexer(const StringView&);
+    IniLexer(StringView const&);
 
     Vector<IniToken> lex();
 

--- a/Userland/Libraries/LibGUI/INILexer.h
+++ b/Userland/Libraries/LibGUI/INILexer.h
@@ -62,7 +62,6 @@ private:
 
     StringView m_input;
     size_t m_index { 0 };
-    IniPosition m_previous_position { 0, 0 };
     IniPosition m_position { 0, 0 };
 };
 

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -72,7 +72,7 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
             return;
 
         start = position;
-        for (size_t i = 0; i < str.length() - 1; ++i)
+        for (size_t i = 0; i < str.length(); ++i)
             advance_position(str[i]);
 
         GUI::TextDocumentSpan span;
@@ -85,7 +85,6 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
         span.is_skippable = is_trivia;
         span.data = reinterpret_cast<void*>(static_cast<size_t>(type));
         spans.append(span);
-        advance_position(str[str.length() - 1]);
 
         dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{}{} @ '{}' {}:{} - {}:{}",
             token.name(),

--- a/Userland/Libraries/LibSQL/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibSQL/SyntaxHighlighter.cpp
@@ -5,15 +5,13 @@
  */
 
 #include <AK/Debug.h>
-#include <LibGUI/TextEditor.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 #include <LibSQL/Lexer.h>
 #include <LibSQL/SyntaxHighlighter.h>
 
 namespace SQL {
 
-static Syntax::TextStyle style_for_token_type(const Gfx::Palette& palette, TokenType type)
+static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, TokenType type)
 {
     switch (Token::category(type)) {
     case TokenCategory::Keyword:
@@ -41,7 +39,7 @@ bool SyntaxHighlighter::is_identifier(void* token) const
     return sql_token == SQL::TokenType::Identifier;
 }
 
-void SyntaxHighlighter::rehighlight(const Palette& palette)
+void SyntaxHighlighter::rehighlight(Palette const& palette)
 {
     auto text = m_client->get_text();
 
@@ -49,7 +47,7 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
 
     Vector<GUI::TextDocumentSpan> spans;
 
-    auto append_token = [&](StringView str, const SQL::Token& token) {
+    auto append_token = [&](StringView str, SQL::Token const& token) {
         if (str.is_empty())
             return;
 
@@ -78,12 +76,11 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
             span.range.end().line(), span.range.end().column());
     };
 
-    bool was_eof = false;
-    for (auto token = lexer.next(); !was_eof; token = lexer.next()) {
+    for (;;) {
+        auto token = lexer.next();
         append_token(token.value(), token);
-
         if (token.type() == SQL::TokenType::Eof)
-            was_eof = true;
+            break;
     }
 
     m_client->do_set_spans(move(spans));

--- a/Userland/Libraries/LibSQL/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibSQL/SyntaxHighlighter.cpp
@@ -52,8 +52,8 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
             return;
 
         GUI::TextPosition position { token.line_number() - 1, token.line_column() - 1 };
-        for (size_t i = 0; i < str.length() - 1; ++i) {
-            if (str[i] == '\n') {
+        for (char c : str) {
+            if (c == '\n') {
                 position.set_line(position.line() + 1);
                 position.set_column(0);
             } else

--- a/Userland/Libraries/LibSQL/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibSQL/SyntaxHighlighter.h
@@ -18,7 +18,7 @@ public:
     virtual bool is_identifier(void*) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::SQL; }
-    virtual void rehighlight(const Palette&) override;
+    virtual void rehighlight(Palette const&) override;
 
 protected:
     virtual Vector<MatchingTokenPair> matching_token_pairs() const override;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -57,9 +57,11 @@ String HTMLToken::to_string() const
         builder.append("' }");
     }
 
-    builder.appendff("@{}:{}-{}:{}",
-        m_start_position.line, m_start_position.column,
-        m_end_position.line, m_end_position.column);
+    if (type() == HTMLToken::Type::Character) {
+        builder.appendff("@{}:{}", m_start_position.line, m_start_position.column);
+    } else {
+        builder.appendff("@{}:{}-{}:{}", m_start_position.line, m_start_position.column, m_end_position.line, m_end_position.column);
+    }
 
     return builder.to_string();
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -276,6 +276,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::Comment);
+                    m_current_token.m_start_position = nth_last_position(2);
                     RECONSUME_IN(BogusComment);
                 }
                 ON_EOF
@@ -301,7 +302,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    m_current_token.m_end_position = nth_last_position(1);
+                    m_current_token.m_end_position = nth_last_position(0);
                     SWITCH_TO(SelfClosingStartTag);
                 }
                 ON('>')
@@ -325,7 +326,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_end_position = nth_last_position(1);
+                    m_current_token.m_end_position = nth_last_position(0);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -370,6 +371,7 @@ _StartOfFunction:
                 DONT_CONSUME_NEXT_INPUT_CHARACTER;
                 if (consume_next_if_match("--")) {
                     create_new_token(HTMLToken::Type::Comment);
+                    m_current_token.m_start_position = nth_last_position(4);
                     SWITCH_TO(CommentStart);
                 }
                 if (consume_next_if_match("DOCTYPE", CaseSensitivity::CaseInsensitive)) {
@@ -1053,6 +1055,7 @@ _StartOfFunction:
                 }
                 ON('=')
                 {
+                    m_current_token.m_tag.attributes.last().name_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeValue);
                 }
                 ON_ASCII_UPPER_ALPHA
@@ -1214,7 +1217,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(2);
+                    m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('&')
@@ -1224,7 +1227,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(2);
+                    m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(1);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON(0)
@@ -1274,7 +1277,7 @@ _StartOfFunction:
 
             BEGIN_STATE(AfterAttributeValueQuoted)
             {
-                m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(2);
+                m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(1);
                 ON_WHITESPACE
                 {
                     SWITCH_TO(BeforeAttributeName);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -207,6 +207,15 @@ Optional<u32> HTMLTokenizer::peek_code_point(size_t offset) const
     return *it;
 }
 
+HTMLToken::Position HTMLTokenizer::nth_last_position(size_t n)
+{
+    if (n + 1 > m_source_positions.size()) {
+        dbgln_if(TOKENIZER_TRACE_DEBUG, "(Tokenizer::nth_last_position) Invalid position requested: {}th-last of {}. Returning (0-0).", n, m_source_positions.size());
+        return HTMLToken::Position { 0, 0 };
+    };
+    return m_source_positions.at(m_source_positions.size() - 1 - n);
+}
+
 Optional<HTMLToken> HTMLTokenizer::next_token()
 {
     {
@@ -2639,7 +2648,7 @@ void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
         m_last_emitted_start_tag = token;
-    token.m_end_position = m_source_positions.last();
+    token.m_end_position = nth_last_position(0);
 }
 
 bool HTMLTokenizer::current_end_tag_token_is_appropriate() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -147,7 +147,7 @@ private:
     bool consumed_as_part_of_an_attribute() const;
 
     void restore_to(const Utf8CodePointIterator& new_iterator);
-    auto& nth_last_position(size_t n = 0) { return m_source_positions.at(m_source_positions.size() - 1 - n); }
+    HTMLToken::Position nth_last_position(size_t n = 0);
 
     State m_state { State::Data };
     State m_return_state { State::Data };

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
@@ -19,7 +19,7 @@ public:
     virtual bool is_navigatable(void*) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::HTML; }
-    virtual void rehighlight(const Palette&) override;
+    virtual void rehighlight(Palette const&) override;
 
 protected:
     virtual Vector<MatchingTokenPair> matching_token_pairs() const override;

--- a/Userland/Shell/SyntaxHighlighter.cpp
+++ b/Userland/Shell/SyntaxHighlighter.cpp
@@ -44,7 +44,7 @@ private:
                 break;
             --new_line.line_number;
 
-            auto line = m_document.line(new_line.line_number);
+            auto& line = m_document.line(new_line.line_number);
             new_line.line_column = line.length();
         }
         if (offset > 0)
@@ -52,7 +52,7 @@ private:
 
         return new_line;
     }
-    void set_offset_range_end(GUI::TextRange& range, const AST::Position::Line& line, size_t offset = 1)
+    void set_offset_range_end(GUI::TextRange& range, const AST::Position::Line& line, size_t offset = 0)
     {
         auto new_line = offset_line(line, offset);
         range.set_end({ new_line.line_number, new_line.line_column });
@@ -142,7 +142,7 @@ private:
 
         auto& start_span = span_for_node(node);
         start_span.attributes.color = m_palette.syntax_punctuation();
-        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 1 });
+        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 2 });
         start_span.data = (void*)static_cast<size_t>(AugmentedTokenKind::OpenParen);
 
         auto& end_span = span_for_node(node);
@@ -178,7 +178,7 @@ private:
 
         auto& start_span = span_for_node(node);
         start_span.attributes.color = m_palette.syntax_punctuation();
-        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column });
+        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 1 });
     }
     virtual void visit(const AST::DoubleQuotedString* node) override
     {
@@ -186,7 +186,7 @@ private:
 
         auto& start_span = span_for_node(node);
         start_span.attributes.color = m_palette.syntax_string();
-        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column });
+        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 1 });
         start_span.is_skippable = true;
 
         auto& end_span = span_for_node(node);
@@ -231,7 +231,7 @@ private:
         // "for"
         auto& for_span = span_for_node(node);
         // FIXME: "fo\\\nr" is valid too
-        for_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 2 });
+        for_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 3 });
         for_span.attributes.color = m_palette.syntax_keyword();
 
         // "in"
@@ -288,7 +288,7 @@ private:
         if (node->does_capture_stdout()) {
             auto& start_span = span_for_node(node);
             start_span.attributes.color = m_palette.syntax_punctuation();
-            start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 1 });
+            start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 2 });
             start_span.data = (void*)static_cast<size_t>(AugmentedTokenKind::OpenParen);
 
             auto& end_span = span_for_node(node);
@@ -305,7 +305,7 @@ private:
         // "if"
         auto& if_span = span_for_node(node);
         // FIXME: "i\\\nf" is valid too
-        if_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 1 });
+        if_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 2 });
         if_span.attributes.color = m_palette.syntax_keyword();
 
         // "else"
@@ -327,7 +327,7 @@ private:
         // ${
         auto& start_span = span_for_node(node);
         start_span.attributes.color = m_palette.syntax_punctuation();
-        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 1 });
+        start_span.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 2 });
         start_span.data = (void*)static_cast<size_t>(AugmentedTokenKind::OpenParen);
 
         // Function name
@@ -356,7 +356,7 @@ private:
         // "match"
         auto& match_expr = span_for_node(node);
         // FIXME: "mat\\\nch" is valid too
-        match_expr.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 4 });
+        match_expr.range.set_end({ node->position().start_line.line_number, node->position().start_line.line_column + 5 });
         match_expr.attributes.color = m_palette.syntax_keyword();
 
         // "as"
@@ -365,7 +365,7 @@ private:
 
             auto& as_span = span_for_node(node);
             as_span.range.set_start({ position.start_line.line_number, position.start_line.line_column });
-            as_span.range.set_end({ position.end_line.line_number, position.end_line.line_column });
+            as_span.range.set_end({ position.end_line.line_number, position.end_line.line_column + 1 });
             as_span.attributes.color = m_palette.syntax_keyword();
         }
     }
@@ -395,13 +395,16 @@ private:
         NodeVisitor::visit(node);
 
         auto& start_span = span_for_node(node->start());
-        set_offset_range_start(start_span.range, node->start()->position().start_line, 1);
-        set_offset_range_end(start_span.range, node->start()->position().start_line, 0);
+        auto& start_position = node->start()->position();
+        set_offset_range_start(start_span.range, start_position.start_line, 1);
+        start_span.range.set_end({ start_position.start_line.line_number, start_position.start_line.line_column + 1 });
         start_span.attributes.color = m_palette.syntax_punctuation();
 
         auto& end_span = span_for_node(node->start());
-        set_offset_range_start(end_span.range, node->end()->position().end_line, 1);
-        set_offset_range_end(end_span.range, node->end()->position().end_line, 0);
+        auto& end_position = node->end()->position();
+        set_offset_range_start(end_span.range, end_position.end_line, 1);
+        start_span.range.set_end({ end_position.start_line.line_number, end_position.start_line.line_column + 1 });
+
         end_span.attributes.color = m_palette.syntax_punctuation();
     }
     virtual void visit(const AST::ReadRedirection* node) override
@@ -424,7 +427,7 @@ private:
                 continue;
             auto& span = span_for_node(node);
             set_offset_range_start(span.range, position.start_line);
-            set_offset_range_end(span.range, position.end_line, 1);
+            set_offset_range_end(span.range, position.end_line);
             span.attributes.color = m_palette.syntax_punctuation();
             span.attributes.bold = true;
             span.is_skippable = true;
@@ -495,7 +498,7 @@ private:
 
             auto& start_span = span_for_node(decl.name);
             start_span.range.set_start({ decl.name->position().end_line.line_number, decl.name->position().end_line.line_column });
-            start_span.range.set_end({ decl.value->position().start_line.line_number, decl.value->position().start_line.line_column });
+            start_span.range.set_end({ decl.value->position().start_line.line_number, decl.value->position().start_line.line_column + 1 });
             start_span.attributes.color = m_palette.syntax_punctuation();
             start_span.data = (void*)static_cast<size_t>(AugmentedTokenKind::OpenParen);
         }
@@ -545,6 +548,12 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
         ast->visit(visitor);
 
     quick_sort(spans, [](auto& a, auto& b) { return a.range.start() < b.range.start() && a.range.end() < b.range.end(); });
+
+    if constexpr (SYNTAX_HIGHLIGHTING_DEBUG) {
+        for (auto& span : spans) {
+            dbgln("Kind {}, range {}.", reinterpret_cast<size_t>(span.data), span.range);
+        }
+    }
 
     m_client->do_set_spans(move(spans));
     m_has_brace_buddies = false;


### PR DESCRIPTION
This fixes an off-by-one error in TextEditor's rendering of the syntax highlighting as generated by `Syntax::Highlighter` and its subclasses.

Before, a single character span was e.g. (0-3) to (0-3), but this was considered invalid by `GUI::TextRange`. Now, a single character span would be e.g. (0-3) to (0-4). 

*Note:* While this is a question of how it is defined, the new approach turned out to be much better. At many places, I could just remove `+ 1` and `- 1`, which tells me that the new approch is more sensible. :^)

This fix requires all `Syntax::Highlighter` subclasses to be adjusted, as they all relied on the previous implementation. This was quite straight-forward for all highlighters but the HTML syntax highlighter.

For the HTML syntax highlighter, I modified `HTMLTokenizer` to not crash only because it couldn't get a source position from `m_source_positions`. This should make the tokenizer more robust and should otherwise only affect the syntax highlighting system. I found some more off-by-x errors in the generation of the source positions, which I adjusted experimentally. Thus, the HTML syntax highlighter is still far from perfect, but it should be much better now than before.

This fixes the bug where single character HTML tags weren't highlighted properly. This also fixes #7349.

While at it, I changed many files to use the new east `const` coding style, and changes some files to use `CharacterTypes.h` over `ctype.h`.

**Edit:** Since the C++ parser tests broke, I refrained from changing `Cpp::Lexer`. To unbreak C++ syntax highlighting, I have just fixed the off-by-one error in `SyntaxHighlighter` for the moment. A `FIXME` has been added with a note that this should probably be properly fixed in the `Lexer`.