### PR TITLE
LibJS: Fix functions binding this to global object in strict mode

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -158,6 +158,12 @@ CallExpression::ThisAndCallee CallExpression::compute_this_and_callee(Interprete
 
         return { this_value, callee };
     }
+
+    if (interpreter.vm().in_strict_mode()) {
+        // If we are in strict mode, |this| should never be bound to global object by default.
+        return { js_undefined(), m_callee->execute(interpreter, global_object) };
+    }
+
     return { &global_object, m_callee->execute(interpreter, global_object) };
 }
 

--- a/Userland/Libraries/LibJS/Tests/functions/function-strict-mode.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-strict-mode.js
@@ -58,3 +58,12 @@ test('only the string "use strict" yields strict mode code', () => {
     "use stric";
     expect(isStrictMode()).toBeFalse();
 });
+
+test("strict mode does not apply global object to |this|", () => {
+    "use strict";
+    let functionThis;
+    (function () {
+        functionThis = this;
+    })();
+    expect(functionThis).toBeUndefined();
+});


### PR DESCRIPTION
This fixes an issue where `this` would be bound to the global object
by default when operating in strict mode.

According to the specification, the expected value for |this| when
no binding is provided is `undefined`.

Closes #5962.