### PR TITLE
Ports/PHP: Enable SQLite3 and iconv extensions

### DIFF
--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -4,7 +4,7 @@ useconfigure="true"
 version="8.0.6"
 files="https://www.php.net/distributions/php-${version}.tar.xz php-${version}.tar.xz e9871d3b6c391fe9e89f86f6334852dcc10eeaaa8d5565beb8436e7f0cf30e20"
 auth_type=sha256
-depends=""
+depends="libiconv sqlite"
 configopts="
     --disable-dom
     --disable-opcache
@@ -14,10 +14,10 @@ configopts="
     --disable-xmlreader
     --disable-xmlwriter
     --prefix=${SERENITY_INSTALL_ROOT}/usr/local
-    --without-iconv
+    --with-iconv=${SERENITY_INSTALL_ROOT}/usr/local
     --without-libxml
-    --without-pdo-sqlite
-    --without-sqlite3
 "
 
 export LIBS="-ldl"
+export SQLITE_CFLAGS="y"
+export SQLITE_LIBS="-lsqlite3 -lpthread"


### PR DESCRIPTION
We already had both `sqlite` and `libiconv` in our ports, so enable them for PHP as well.

![image](https://user-images.githubusercontent.com/3210731/120791906-0f908480-c535-11eb-8beb-c7e4c80670f3.png)