### PR TITLE
LibCards: Draw card stacks with rounded corners

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -21,20 +21,20 @@ Game::Game()
 {
     srand(time(nullptr));
 
-    m_stacks[Stock] = CardStack({ 10, 10 }, CardStack::Type::Stock);
-    m_stacks[Waste] = CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Waste);
-    m_stacks[Play] = CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Play);
-    m_stacks[Foundation4] = CardStack({ Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation);
-    m_stacks[Foundation3] = CardStack({ Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation);
-    m_stacks[Foundation2] = CardStack({ Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation);
-    m_stacks[Foundation1] = CardStack({ Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation);
-    m_stacks[Pile1] = CardStack({ 10, 10 + Card::height + 10 }, CardStack::Type::Normal);
-    m_stacks[Pile2] = CardStack({ 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal);
-    m_stacks[Pile3] = CardStack({ 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal);
-    m_stacks[Pile4] = CardStack({ 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal);
-    m_stacks[Pile5] = CardStack({ 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal);
-    m_stacks[Pile6] = CardStack({ 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal);
-    m_stacks[Pile7] = CardStack({ 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal);
+    m_stacks.append(adopt_ref(*new CardStack({ 10, 10 }, CardStack::Type::Stock)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Waste)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 }, CardStack::Type::Play, m_stacks.ptr_at(Waste))));
+    m_stacks.append(adopt_ref(*new CardStack({ Game::width - 4 * Card::width - 40, 10 }, CardStack::Type::Foundation)));
+    m_stacks.append(adopt_ref(*new CardStack({ Game::width - 3 * Card::width - 30, 10 }, CardStack::Type::Foundation)));
+    m_stacks.append(adopt_ref(*new CardStack({ Game::width - 2 * Card::width - 20, 10 }, CardStack::Type::Foundation)));
+    m_stacks.append(adopt_ref(*new CardStack({ Game::width - Card::width - 10, 10 }, CardStack::Type::Foundation)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + Card::width + 10, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + 2 * Card::width + 20, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + 3 * Card::width + 30, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + 4 * Card::width + 40, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + 5 * Card::width + 50, 10 + Card::height + 10 }, CardStack::Type::Normal)));
+    m_stacks.append(adopt_ref(*new CardStack({ 10 + 6 * Card::width + 60, 10 + Card::height + 10 }, CardStack::Type::Normal)));
 }
 
 Game::~Game()

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -188,7 +188,7 @@ private:
     LastMove m_last_move;
     NonnullRefPtrVector<Card> m_focused_cards;
     NonnullRefPtrVector<Card> m_new_deck;
-    CardStack m_stacks[StackLocation::__Count];
+    NonnullRefPtrVector<CardStack> m_stacks;
     CardStack* m_focused_stack { nullptr };
     Gfx::IntPoint m_mouse_down_location;
 

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -81,9 +81,9 @@ Card::Card(Type type, uint8_t value)
         float aspect_ratio = image->width() / static_cast<float>(image->height());
         auto target_size = Gfx::IntSize(static_cast<int>(aspect_ratio * (height - 5)), height - 5);
 
-        bg_painter.fill_rect_with_rounded_corners(paint_rect, Color::Black, 5, 5, 5, 5);
+        bg_painter.fill_rect_with_rounded_corners(paint_rect, Color::Black, card_radius);
         auto inner_paint_rect = paint_rect.shrunken(2, 2);
-        bg_painter.fill_rect_with_rounded_corners(inner_paint_rect, Color::White, 4, 4, 4, 4);
+        bg_painter.fill_rect_with_rounded_corners(inner_paint_rect, Color::White, card_radius - 1);
 
         bg_painter.draw_scaled_bitmap(
             { { (width - target_size.width()) / 2, (height - target_size.height()) / 2 }, target_size },
@@ -96,9 +96,9 @@ Card::Card(Type type, uint8_t value)
     auto& font = Gfx::FontDatabase::default_font().bold_variant();
 
     auto label = labels[value];
-    painter.fill_rect_with_rounded_corners(paint_rect, Color::Black, 5, 5, 5, 5);
+    painter.fill_rect_with_rounded_corners(paint_rect, Color::Black, card_radius);
     paint_rect.shrink(2, 2);
-    painter.fill_rect_with_rounded_corners(paint_rect, Color::White, 4, 4, 4, 4);
+    painter.fill_rect_with_rounded_corners(paint_rect, Color::White, card_radius - 1);
 
     paint_rect.set_height(paint_rect.height() / 2);
     paint_rect.shrink(10, 6);

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -23,6 +23,7 @@ public:
     static constexpr int width = 80;
     static constexpr int height = 100;
     static constexpr int card_count = 13;
+    static constexpr int card_radius = 5;
     static constexpr Array<StringView, card_count> labels = {
         "A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"
     };

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -8,11 +8,12 @@
 
 #include "Card.h"
 #include <AK/Format.h>
+#include <AK/RefCounted.h>
 #include <AK/Vector.h>
 
 namespace Cards {
 
-class CardStack final {
+class CardStack final : public RefCounted<CardStack> {
 public:
     enum Type {
         Invalid,
@@ -25,6 +26,7 @@ public:
 
     CardStack();
     CardStack(const Gfx::IntPoint& position, Type type);
+    CardStack(const Gfx::IntPoint& position, Type type, NonnullRefPtr<CardStack> associated_stack);
 
     bool is_empty() const { return m_stack.is_empty(); }
     bool is_focused() const { return m_focused; }
@@ -75,6 +77,7 @@ private:
 
     void calculate_bounding_box();
 
+    RefPtr<CardStack> m_associated_stack;
     NonnullRefPtrVector<Card> m_stack;
     Vector<Gfx::IntPoint> m_stack_positions;
     Gfx::IntPoint m_position;

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -247,6 +247,11 @@ void Painter::fill_rect_with_gradient(const IntRect& a_rect, Color gradient_star
     return fill_rect_with_gradient(Orientation::Horizontal, a_rect, gradient_start, gradient_end);
 }
 
+void Painter::fill_rect_with_rounded_corners(const IntRect& a_rect, Color color, int radius)
+{
+    return fill_rect_with_rounded_corners(a_rect, color, radius, radius, radius, radius);
+}
+
 void Painter::fill_rect_with_rounded_corners(const IntRect& a_rect, Color color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius)
 {
     // Fasttrack for rects without any border radii

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -36,6 +36,7 @@ public:
     void fill_rect_with_checkerboard(const IntRect&, const IntSize&, Color color_dark, Color color_light);
     void fill_rect_with_gradient(Orientation, const IntRect&, Color gradient_start, Color gradient_end);
     void fill_rect_with_gradient(const IntRect&, Color gradient_start, Color gradient_end);
+    void fill_rect_with_rounded_corners(const IntRect&, Color, int radius);
     void fill_rect_with_rounded_corners(const IntRect&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
     void fill_ellipse(const IntRect&, Color);
     void draw_rect(const IntRect&, Color, bool rough = false);


### PR DESCRIPTION
Just a bit of polish so the box drawn for the card stacks don't have a corner sticking out behind the cards:

![sl](https://user-images.githubusercontent.com/5600524/120796244-9aa75580-c508-11eb-9939-ef471d93a8a5.png)
