### PR TITLE
AK: Allow deferring clear() for the Function class

### DIFF
--- a/AK/Function.h
+++ b/AK/Function.h
@@ -205,6 +205,7 @@ private:
     template<typename Callable>
     void init_with_callable(Callable&& callable)
     {
+        VERIFY(m_call_nesting_level == 0);
         using WrapperType = CallableWrapper<Callable>;
         if constexpr (sizeof(WrapperType) > inline_capacity) {
             *bit_cast<CallableWrapperBase**>(&m_storage) = new WrapperType(move(callable));

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -270,8 +270,12 @@ void Game::timer_event(Core::TimerEvent&)
         if (m_animation_current_step >= m_animation_steps) {
             stop_timer();
             m_animation_playing = false;
-            if (m_animation_did_finish)
-                (*m_animation_did_finish)();
+            if (m_animation_did_finish) {
+                // The did_finish handler might end up destroying/replacing the handler
+                // so we have to save it first.
+                OwnPtr<Function<void()>> animation_did_finish = move(m_animation_did_finish);
+                (*animation_did_finish)();
+            }
         }
         m_animation_current_step++;
     }


### PR DESCRIPTION
**Hearts: Don't destroy the animation handler while running it**

**AK: Allow deferring clear() for the Function class**

Ideally a `Function` should not be `clear()`ed while it's running. Unfortunately a number of callers do just that and identifying all of
them would require inspecting all call sites for `operator()` and `clear()`.

Instead this adds support for deferring `clear()` until after the function has finished executing.

**AK: Verify that functions aren't modified while they're being invoked**

A `Function` object should not be set to a different functor while the original functor is currently executing.