### PR TITLE
Taskbar: Make sure LibGUI/Desktop.h is usable in ports

### DIFF
--- a/Userland/Services/Taskbar/CMakeLists.txt
+++ b/Userland/Services/Taskbar/CMakeLists.txt
@@ -9,3 +9,4 @@ set(SOURCES
 
 serenity_bin(Taskbar)
 target_link_libraries(Taskbar LibGUI LibDesktop)
+serenity_install_headers(Services/Taskbar)


### PR DESCRIPTION
Now that `Desktop.h` includes `Services/Taskbar/TaskbarWindow.h` we have to install Taskbar's header files so that `Desktop.h` can be used in ports or when building software in-target.