### PR TITLE
Ports/PHP: Enable XML extensions

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -68,6 +68,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`libtiff`](libtiff/)                  | libtiff                                                    | 4.2.0                    | http://www.libtiff.org/                                                        |
 | [`libtool`](libtool/)                  | libtool                                                    | 2.4                      | https://www.gnu.org/software/libtool/                                          |
 | [`libvorbis`](libvorbis/)              | libvorbis                                                  | 1.3.7                    | https://github.com/xiph/vorbis                                                 |
+| [`libxml2`](libxml2/)                  | libxml2                                                    | 2.9.12                   | http://www.xmlsoft.org/                                                        |
 | [`libzip`](libzip/)                    | libzip                                                     | 1.7.3                    | https://libzip.org/                                                            |
 | [`links`](links/)                      | Links web browser                                          | 2.22                     | http://links.twibright.com/                                                    |
 | [`lua`](lua/)                          | Lua                                                        | 5.3.5                    | https://www.lua.org/                                                           |

--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=libxml2
+useconfigure="true"
+version="2.9.12"
+files="ftp://xmlsoft.org/libxml2/libxml2-${version}.tar.gz libxml2-${version}.tar.gz c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
+auth_type=sha256
+depends="libiconv"
+configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+
+install() {
+    # Leave out DESTDIR - otherwise the prefix breaks
+    run make install
+
+    # Link shared library
+    run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.so -Wl,-soname,libxml2.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.a -Wl,--no-whole-archive
+}

--- a/Ports/libxml2/patches/config.sub.patch
+++ b/Ports/libxml2/patches/config.sub.patch
@@ -1,0 +1,11 @@
+--- libxml2-2.9.12/config.sub	2021-05-13 20:54:55.000000000 +0200
++++ libxml2-2.9.12-patched/config.sub	2021-06-04 14:55:35.184278060 +0200
+@@ -1360,7 +1360,7 @@
+ 	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+-	     | midnightbsd*)
++	     | midnightbsd* | serenity*)
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	qnx*)

--- a/Ports/libxml2/patches/nanohttp.c.patch
+++ b/Ports/libxml2/patches/nanohttp.c.patch
@@ -1,0 +1,13 @@
+--- libxml2-2.9.12/nanohttp.c	2020-07-17 17:18:23.000000000 +0200
++++ libxml2-2.9.12-patched/nanohttp.c	2021-06-04 14:56:42.336021798 +0200
+@@ -121,6 +121,10 @@
+ #define XML_NANO_HTTP_READ	2
+ #define XML_NANO_HTTP_NONE	4
+ 
++#ifndef ESHUTDOWN
++#define ESHUTDOWN ENOTCONN
++#endif
++
+ typedef struct xmlNanoHTTPCtxt {
+     char *protocol;	/* the protocol name */
+     char *hostname;	/* the host name */

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -4,20 +4,19 @@ useconfigure="true"
 version="8.0.6"
 files="https://www.php.net/distributions/php-${version}.tar.xz php-${version}.tar.xz e9871d3b6c391fe9e89f86f6334852dcc10eeaaa8d5565beb8436e7f0cf30e20"
 auth_type=sha256
-depends="libiconv sqlite"
+depends="libiconv libxml2 sqlite zlib"
 configopts="
-    --disable-dom
     --disable-opcache
     --disable-phar
-    --disable-simplexml
-    --disable-xml
-    --disable-xmlreader
-    --disable-xmlwriter
     --prefix=${SERENITY_INSTALL_ROOT}/usr/local
     --with-iconv=${SERENITY_INSTALL_ROOT}/usr/local
-    --without-libxml
 "
 
+export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2/"
 export LIBS="-ldl"
+export LIBXML_CFLAGS="y"
+export LIBXML_LIBS="-lxml2"
 export SQLITE_CFLAGS="y"
 export SQLITE_LIBS="-lsqlite3 -lpthread"
+export ZLIB_CFLAGS="y"
+export ZLIB_LIBS="-lz"


### PR DESCRIPTION
And in order to enable the default PHP XML extensions, also add the `libxml2` port.