### PR TITLE
Ports: fix gcc for mac users

### DIFF
--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -15,7 +15,7 @@ post_fetch() {
 
 pre_configure() {
     patch_internal
-    run sed -i 's@-fno-exceptions @@' gcc/config/serenity.h
+    run sed -i '' 's@-fno-exceptions @@' gcc/config/serenity.h
 }
 
 build() {


### PR DESCRIPTION
This commit fixes fixes the gcc port for people using BSD `sed`.  Credit goes to matthewbjones#8780 on Discord for the fix.