### PR TITLE
HackStudio: Fix ClassViewWidget crash

### DIFF
--- a/Userland/DevTools/HackStudio/ClassViewWidget.cpp
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.cpp
@@ -148,8 +148,7 @@ void ClassViewModel::add_declaration(const GUI::AutocompleteProvider::Declaratio
             auto& scope = scope_parts[i];
             ClassViewNode* next { nullptr };
             for (auto& child : parent->children) {
-                VERIFY(child.declaration);
-                if (child.declaration->name == scope) {
+                if (child.name == scope) {
                     next = &child;
                     break;
                 }

--- a/Userland/DevTools/HackStudio/ClassViewWidget.cpp
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.cpp
@@ -118,6 +118,7 @@ static ClassViewNode& add_child_node(NonnullOwnPtrVector<ClassViewNode>& childre
 
     size_t inserted_index = 0;
     ClassViewNode& node = *node_ptr;
+    // Insert into parent's children list, sorted lexicographically by name.
     children.insert_before_matching(
         move(node_ptr), [&node](auto& other_node) {
             return strncmp(node.name.characters_without_null_termination(), other_node->name.characters_without_null_termination(), min(node.name.length(), other_node->name.length())) < 0;


### PR DESCRIPTION
 HackStudio: Use Node's name when inserting to the ClassView tree

Previously, when traversing the ClassView tree to find the parent of a new node, we used the name of the node's declaration to find the path to the parent in the tree.

However, some nodes in the tree do not have a matching declaration, which caused a VERIFY failure.

To fix this, we now use the node's name when walking the tree.
We can do this because the node's name should be identical to the name of its declaration.

Closes #7702.