### PR TITLE
Kernel: Implement offset for `lseek` with `SEEK_END`

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -136,7 +136,9 @@ KResultOr<off_t> FileDescription::seek(off_t offset, int whence)
     case SEEK_END:
         if (!metadata().is_valid())
             return EIO;
-        new_offset = metadata().size;
+        if (Checked<off_t>::addition_would_overflow(metadata().size, offset))
+            return EOVERFLOW;
+        new_offset = metadata().size + offset;
         break;
     default:
         return EINVAL;


### PR DESCRIPTION
We forgot to actually use the `offset` provided to `lseek` when using `SEEK_END`.

https://pubs.opengroup.org/onlinepubs/9699919799/functions/fseek.html

Without this fix, a call to `lseek` with `SEEK_END` will always result in the file pointer sitting at the end of the file.