### PR TITLE
KeyboardMapper: Add GUI alert and fix debug message

### DIFF
--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -127,7 +127,8 @@ void KeyboardMapperWidget::load_from_file(String filename)
 {
     auto result = Keyboard::CharacterMapFile::load_from_file(filename);
     if (!result.has_value()) {
-        dbgln("Failed to load character map from file {}", filename);
+        auto error_message = String::formatted("Failed to load character map from file {}", filename);
+        GUI::MessageBox::show(window(), error_message, "Error", GUI::MessageBox::Type::Error);
         return;
     }
 

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -25,14 +25,16 @@ Optional<CharacterMapData> CharacterMapFile::load_from_file(const String& filena
     auto file = Core::File::construct(path);
     file->open(Core::OpenMode::ReadOnly);
     if (!file->is_open()) {
-        dbgln("Failed to open {}: {}", filename, file->error_string());
+        dbgln("Failed to open {}: {}", path, file->error_string());
         return {};
     }
 
     auto file_contents = file->read_all();
     auto json_result = JsonValue::from_string(file_contents);
-    if (!json_result.has_value())
+    if (!json_result.has_value()) {
+        dbgln("Failed to load character map from file {}", path);
         return {};
+    }
     auto json = json_result.value().as_object();
 
     Vector<u32> map = read_map(json, "map");


### PR DESCRIPTION
In `KeyboardMapper` a GUI alert was added in place of `dbgln`. The `dbgln` was moved to the corresponding place in `LibKeyboard/CharacterMapFile.cpp`. Additionally the debug message now reports with full path. Previously only filename was reported, but the code just before will change the path if filename does not end in `.json`.
