### PR TITLE
AK: Improve the URL parser

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -228,10 +228,12 @@ URL URLParser::parse(Badge<URL>, StringView const& raw_input, URL const* base_ur
             code_point = *iterator;
 
         if constexpr (URL_PARSER_DEBUG) {
-            if (code_point)
-                dbgln("URLParser::parse: State {:2d} with code point '{:c}' (U+{:04X}).", (int)state, code_point, code_point);
+            if (!code_point)
+                dbgln("URLParser::parse: {} state with EOF.", state_name(state));
+            else if (is_ascii_printable(code_point))
+                dbgln("URLParser::parse: {} state with code point U+{:04X} ({:c}).", state_name(state), code_point, code_point);
             else
-                dbgln("URLParser::parse: State {:2d} with code point EOF (U+0000).", (int)state);
+                dbgln("URLParser::parse: {} state with code point U+{:04X}.", state_name(state), code_point);
         }
 
         switch (state) {

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -22,12 +22,12 @@ constexpr bool is_url_code_point(u32 code_point)
     return is_ascii_alphanumeric(code_point) || code_point >= 0xA0 || "!$&'()*+,-./:;=?@_~"sv.contains(code_point);
 }
 
-static void report_validation_error(const SourceLocation& location = SourceLocation::current())
+static void report_validation_error(SourceLocation const& location = SourceLocation::current())
 {
     dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Validation error! {}", location);
 }
 
-static Optional<String> parse_opaque_host(const StringView& input)
+static Optional<String> parse_opaque_host(StringView const& input)
 {
     auto forbidden_host_code_points_excluding_percent = "\0\t\n\r #/:<>?@[\\]^|"sv;
     for (auto code_point : forbidden_host_code_points_excluding_percent) {
@@ -41,7 +41,7 @@ static Optional<String> parse_opaque_host(const StringView& input)
     return URL::percent_encode(input, URL::PercentEncodeSet::C0Control);
 }
 
-static Optional<String> parse_ipv4_address(const StringView& input)
+static Optional<String> parse_ipv4_address(StringView const& input)
 {
     // FIXME: Implement the correct IPv4 parser as specified by https://url.spec.whatwg.org/#concept-ipv4-parser.
     return input;
@@ -49,7 +49,7 @@ static Optional<String> parse_ipv4_address(const StringView& input)
 
 // https://url.spec.whatwg.org/#concept-host-parser
 // NOTE: This is a very bare-bones implementation.
-static Optional<String> parse_host(const StringView& input, bool is_not_special = false)
+static Optional<String> parse_host(StringView const& input, bool is_not_special = false)
 {
     if (input.starts_with('[')) {
         if (!input.ends_with(']')) {
@@ -81,7 +81,7 @@ static Optional<String> parse_host(const StringView& input, bool is_not_special 
     return ipv4_host;
 }
 
-constexpr bool starts_with_windows_drive_letter(const StringView& input)
+constexpr bool starts_with_windows_drive_letter(StringView const& input)
 {
     if (input.length() < 2)
         return false;
@@ -92,29 +92,29 @@ constexpr bool starts_with_windows_drive_letter(const StringView& input)
     return "/\\?#"sv.contains(input[2]);
 }
 
-constexpr bool is_windows_drive_letter(const StringView& input)
+constexpr bool is_windows_drive_letter(StringView const& input)
 {
     return input.length() == 2 && is_ascii_alpha(input[0]) && (input[1] == ':' || input[1] == '|');
 }
 
-constexpr bool is_normalized_windows_drive_letter(const StringView& input)
+constexpr bool is_normalized_windows_drive_letter(StringView const& input)
 {
     return input.length() == 2 && is_ascii_alpha(input[0]) && input[1] == ':';
 }
 
-constexpr bool is_single_dot_path_segment(const StringView& input)
+constexpr bool is_single_dot_path_segment(StringView const& input)
 {
     return input == "."sv || input.equals_ignoring_case("%2e"sv);
 }
 
-constexpr bool is_double_dot_path_segment(const StringView& input)
+constexpr bool is_double_dot_path_segment(StringView const& input)
 {
     return input == ".."sv || input.equals_ignoring_case(".%2e"sv) || input.equals_ignoring_case("%2e."sv) || input.equals_ignoring_case("%2e%2e"sv);
 }
 
 // https://fetch.spec.whatwg.org/#data-urls
 // FIXME: This only loosely follow the spec, as we use the same class for "regular" and data URLs, unlike the spec.
-Optional<URL> URLParser::parse_data_url(const StringView& raw_input)
+Optional<URL> URLParser::parse_data_url(StringView const& raw_input)
 {
     dbgln_if(URL_PARSER_DEBUG, "URLParser::parse_data_url: Parsing '{}'.", raw_input);
     VERIFY(raw_input.starts_with("data:"));
@@ -154,7 +154,7 @@ Optional<URL> URLParser::parse_data_url(const StringView& raw_input)
 // NOTE: Since the URL class's member variables contain percent decoded data, we have to deviate from the URL parser specification when setting
 //       some of those values. Because the specification leaves all values percent encoded in their URL data structure, we have to percent decode
 //       everything before setting the member variables.
-URL URLParser::parse(Badge<URL>, const StringView& raw_input, URL const* base_url)
+URL URLParser::parse(Badge<URL>, StringView const& raw_input, URL const* base_url)
 {
     dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Parsing '{}'", raw_input);
     if (raw_input.is_empty())

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -174,7 +174,7 @@ URL URLParser::parse(Badge<URL>, StringView const& raw_input, URL const* base_ur
     size_t start_index = 0;
     size_t end_index = raw_input.length();
     for (size_t i = 0; i < raw_input.length(); ++i) {
-        if (raw_input[i] <= 0x20) {
+        if (0 <= raw_input[i] && raw_input[i] <= 0x20) {
             ++start_index;
             has_validation_error = true;
         } else {
@@ -182,7 +182,7 @@ URL URLParser::parse(Badge<URL>, StringView const& raw_input, URL const* base_ur
         }
     }
     for (ssize_t i = raw_input.length() - 1; i >= 0; --i) {
-        if (raw_input[i] <= 0x20) {
+        if (0 <= raw_input[i] && raw_input[i] <= 0x20) {
             --end_index;
             has_validation_error = true;
         } else {

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -12,37 +12,56 @@
 
 namespace AK {
 
+#define ENUMERATE_STATES                 \
+    STATE(SchemeStart)                   \
+    STATE(Scheme)                        \
+    STATE(NoScheme)                      \
+    STATE(SpecialRelativeOrAuthority)    \
+    STATE(PathOrAuthority)               \
+    STATE(Relative)                      \
+    STATE(RelativeSlash)                 \
+    STATE(SpecialAuthoritySlashes)       \
+    STATE(SpecialAuthorityIgnoreSlashes) \
+    STATE(Authority)                     \
+    STATE(Host)                          \
+    STATE(Hostname)                      \
+    STATE(Port)                          \
+    STATE(File)                          \
+    STATE(FileSlash)                     \
+    STATE(FileHost)                      \
+    STATE(PathStart)                     \
+    STATE(Path)                          \
+    STATE(CannotBeABaseUrlPath)          \
+    STATE(Query)                         \
+    STATE(Fragment)
+
 class URLParser {
 public:
     enum class State {
-        SchemeStart,
-        Scheme,
-        NoScheme,
-        SpecialRelativeOrAuthority,
-        PathOrAuthority,
-        Relative,
-        RelativeSlash,
-        SpecialAuthoritySlashes,
-        SpecialAuthorityIgnoreSlashes,
-        Authority,
-        Host,
-        Hostname,
-        Port,
-        File,
-        FileSlash,
-        FileHost,
-        PathStart,
-        Path,
-        CannotBeABaseUrlPath,
-        Query,
-        Fragment
+#define STATE(state) state,
+        ENUMERATE_STATES
+#undef STATE
     };
+
+    static char const* state_name(State const& state)
+    {
+        switch (state) {
+#define STATE(state)   \
+    case State::state: \
+        return #state;
+            ENUMERATE_STATES
+#undef STATE
+        }
+        VERIFY_NOT_REACHED();
+    }
 
     static URL parse(Badge<URL>, StringView const& input, URL const* base_url = nullptr);
 
 private:
     static Optional<URL> parse_data_url(StringView const& raw_input);
 };
+
+#undef ENUMERATE_STATES
 
 }
 

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -38,10 +38,10 @@ public:
         Fragment
     };
 
-    static URL parse(Badge<URL>, const StringView& input, const URL* base_url = nullptr);
+    static URL parse(Badge<URL>, StringView const& input, URL const* base_url = nullptr);
 
 private:
-    static Optional<URL> parse_data_url(const StringView& raw_input);
+    static Optional<URL> parse_data_url(StringView const& raw_input);
 };
 
 }

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -328,3 +328,12 @@ TEST_CASE(leading_and_trailing_whitespace)
     EXPECT(url.is_valid());
     EXPECT_EQ(url.to_string(), "https://foo.com/");
 }
+
+TEST_CASE(unicode)
+{
+    URL url { "http://example.com/_ünicöde_téxt_©" };
+    EXPECT(url.is_valid());
+    EXPECT_EQ(url.path(), "/_ünicöde_téxt_©");
+    EXPECT(url.query().is_null());
+    EXPECT(url.fragment().is_null());
+}


### PR DESCRIPTION
This PR improves the URL parser in a few ways:

* It now uses east const style. :^)
* A bug was fixed where non-ASCII bytes were trimmed from the start and end of a URL.
* The parser state is now printed as a string when `URL_PARSER_DEBUG` is active.
* `U+0000` was previously used as "the EOF code point". This lead to problems when the URL contained null bytes (this shouldn't happen, but its still nice to support it). Now `0xFFFFFFFF` is used (which is equivalent to the `-1` used by LibC, but for `u32`).

According to my tests, this fixes [oss-fuzz#34858](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34858&sort=-opened&can=1&q=proj%3Aserenity), [oss-fuzz#34863](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34863&sort=-opened&can=1&q=proj%3Aserenity), [oss-fuzz#34864](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34864&sort=-opened&can=1&q=proj%3Aserenity) and [oss-fuzz#34911](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34911&sort=-opened&q=proj%3Aserenity&can=1).