### PR TITLE
Kernel: Process::exec(): Check if path is a regular file

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -827,6 +827,9 @@ KResult Process::exec(String path, Vector<String> arguments, Vector<String> envi
     auto description = file_or_error.release_value();
     auto metadata = description->metadata();
 
+    if (!metadata.is_regular_file())
+        return EACCES;
+
     // Always gonna need at least 3 bytes. these are for #!X
     if (metadata.size < 3)
         return ENOEXEC;


### PR DESCRIPTION
https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html

> [EACCES] The new process image file is not a regular file and the implementation does not support execution of files of its type.

Let's check whether the passed `path` is indeed a regular file.