### PR TITLE
Shell: Add TMPDIR environment variable

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -41,4 +41,6 @@ export PROMPT="\\X\\u@\\h:\\w\\a\\e[$prompt_color;1m\\h\\e[0m:\\e[34;1m\\w\\e[0m
 
 export HISTORY_AUTOSAVE_TIME_MS=10000
 
+export TMPDIR=/tmp
+
 PROGRAMS_ALLOWED_TO_MODIFY_DEFAULT_TERMIOS=(stty)


### PR DESCRIPTION
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html

> TMPDIR  This variable shall represent a pathname of a directory made available for programs that need a place to create temporary files.

Ports like PHP benefit from having this environment variable set, and there exist a lot of scripts that assume the presence of such an environment variable.