### PR TITLE
rm: Allow empty paths if -f is specified

### DIFF
--- a/Userland/Utilities/rm.cpp
+++ b/Userland/Utilities/rm.cpp
@@ -27,8 +27,13 @@ int main(int argc, char** argv)
     args_parser.add_option(recursive, "Delete directories recursively", "recursive", 'r');
     args_parser.add_option(force, "Force", "force", 'f');
     args_parser.add_option(verbose, "Verbose", "verbose", 'v');
-    args_parser.add_positional_argument(paths, "Path(s) to remove", "path");
+    args_parser.add_positional_argument(paths, "Path(s) to remove", "path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
+
+    if (!force && paths.is_empty()) {
+        args_parser.print_usage(stderr, argv[0]);
+        return 1;
+    }
 
     bool had_errors = false;
     for (auto& path : paths) {


### PR DESCRIPTION
On most (if not all) systems rm ignores an empty paths array if -f or --force is specified.

This helps with scripts that may pass an empty variable where the file paths are supposed to go.