### PR TITLE
Ports/PHP: Enable OpenSSL, Phar and Zlib extensions

### DIFF
--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -10,6 +10,7 @@ configopts="
     --prefix=${SERENITY_INSTALL_ROOT}/usr/local
     --with-iconv=${SERENITY_INSTALL_ROOT}/usr/local
     --with-zlib
+    --without-pcre-jit
 "
 
 export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2/"

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -7,7 +7,6 @@ auth_type=sha256
 depends="libiconv libxml2 sqlite zlib"
 configopts="
     --disable-opcache
-    --disable-phar
     --prefix=${SERENITY_INSTALL_ROOT}/usr/local
     --with-iconv=${SERENITY_INSTALL_ROOT}/usr/local
 "

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -4,11 +4,12 @@ useconfigure="true"
 version="8.0.6"
 files="https://www.php.net/distributions/php-${version}.tar.xz php-${version}.tar.xz e9871d3b6c391fe9e89f86f6334852dcc10eeaaa8d5565beb8436e7f0cf30e20"
 auth_type=sha256
-depends="libiconv libxml2 sqlite zlib"
+depends="libiconv libxml2 openssl sqlite zlib"
 configopts="
     --disable-opcache
     --prefix=${SERENITY_INSTALL_ROOT}/usr/local
     --with-iconv=${SERENITY_INSTALL_ROOT}/usr/local
+    --with-openssl
     --with-zlib
     --without-pcre-jit
 "
@@ -17,6 +18,8 @@ export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2/"
 export LIBS="-ldl"
 export LIBXML_CFLAGS="y"
 export LIBXML_LIBS="-lxml2"
+export OPENSSL_CFLAGS="y"
+export OPENSSL_LIBS="-lssl -lcrypto"
 export SQLITE_CFLAGS="y"
 export SQLITE_LIBS="-lsqlite3 -lpthread"
 export ZLIB_CFLAGS="y"

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -9,6 +9,7 @@ configopts="
     --disable-opcache
     --prefix=${SERENITY_INSTALL_ROOT}/usr/local
     --with-iconv=${SERENITY_INSTALL_ROOT}/usr/local
+    --with-zlib
 "
 
 export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2/"

--- a/Ports/php/patches/configure-disable-pharcmd.patch
+++ b/Ports/php/patches/configure-disable-pharcmd.patch
@@ -1,0 +1,13 @@
+--- php-8.0.6/configure	2021-06-04 20:36:10.053986191 +0200
++++ php-8.0.6-patched/configure	2021-06-04 20:36:20.769935808 +0200
+@@ -91478,8 +91478,8 @@
+ CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
+ 
+ if test "$PHP_PHAR" != "no" && test "$PHP_CLI" != "no"; then
+-  pharcmd=pharcmd
+-  pharcmd_install=install-pharcmd
++  pharcmd=
++  pharcmd_install=
+ else
+   pharcmd=
+   pharcmd_install=


### PR DESCRIPTION
Phar support allows us to run `composer`!

![image](https://user-images.githubusercontent.com/3210731/120888345-1f24d180-c5f8-11eb-8eb2-8a4387c420dd.png)

* Phar extension enabled
  * The `phar` command is excluded from the build, since this requires a functional PHP binary on the host machine
* OpenSSL extension enabled
* Zlib extension enabled
* PCRE JIT disabled: it tries to `mmap()` memory that is readable, writable _and_ executable at the same time. SerenityOS does not like this one bit, so let's disable JIT for now.

There are still some issues with `composer`; it hangs when trying to create a project, for example. These issues will be ironed out in follow-up PRs.