### PR TITLE
Kernel: Perform output processing on echo

### DIFF
--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -80,6 +80,10 @@ protected:
 private:
     // ^CharacterDevice
     virtual bool is_tty() const final override { return true; }
+    inline void echo_with_processing(u8);
+
+    template<typename Functor>
+    void process_output(u8, Functor put_char);
 
     CircularDeque<u8, TTY_BUFFER_SIZE> m_input_buffer;
     // FIXME: use something like AK::Bitmap but which takes a size template parameter


### PR DESCRIPTION
Previously, we would echo characters back just as they were passed to
us, even in canonical mode. This caused newlines to not work correctly
in some programs.

Fixes #7802