### PR TITLE
Kernel: Return EPIPE when trying to write to an unconnected socket

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -170,7 +170,7 @@ bool IPv4Socket::can_read(const FileDescription&, size_t) const
 
 bool IPv4Socket::can_write(const FileDescription&, size_t) const
 {
-    return is_connected();
+    return true;
 }
 
 PortAllocationResult IPv4Socket::allocate_local_port_if_needed()
@@ -205,6 +205,9 @@ KResultOr<size_t> IPv4Socket::sendto(FileDescription&, const UserOrKernelBuffer&
         m_peer_address = IPv4Address((const u8*)&ia.sin_addr.s_addr);
         m_peer_port = ntohs(ia.sin_port);
     }
+
+    if (!is_connected() && m_peer_address.is_zero())
+        return EPIPE;
 
     auto routing_decision = route_to(m_peer_address, m_local_address, bound_interface());
     if (routing_decision.is_zero())


### PR DESCRIPTION
When attempting to write to a socket that is not connected or - for connection-less protocols - doesn't have a peer address set we should return EPIPE instead of blocking the thread.

Reference: https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html

```
[EPIPE]
    A write was attempted on a socket that is shut down for writing, or is no
    longer connected. In the latter case, if the socket is of type SOCK_STREAM,
    a SIGPIPE signal shall also be sent to the thread.
```

Freeciv accidentally relies on getting `EPIPE` when writing to a TCP listener socket. See https://osdn.net/projects/freeciv/ticket/42471.