### PR TITLE
LibLine: Add forward cycle to search editor

### DIFF
--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -253,9 +253,16 @@ void Editor::enter_search()
             search_editor.m_refresh_needed = true;
         };
 
-        // Whenever the search editor gets a ^R, cycle between history entries.
+        // Whenever the search editor gets a ^R, backward cycle between history entries.
         m_search_editor->register_key_input_callback(ctrl('R'), [this](Editor& search_editor) {
             ++m_search_offset;
+            search_editor.m_refresh_needed = true;
+            return false; // Do not process this key event
+        });
+
+        // Whenever the search editor gets a ^S, forward cycle between history entries.
+        m_search_editor->register_key_input_callback(ctrl('S'), [this](Editor& search_editor) {
+            --m_search_offset;
             search_editor.m_refresh_needed = true;
             return false; // Do not process this key event
         });


### PR DESCRIPTION
This patch adds the abliity to forward cycle between history entries by
pressing Ctrl+S. This is useful when you have gone too far with the
Ctrl+R backward cycle, and wish to go back to the previous entries.