### PR TITLE
LibVT: Don't return a history size if alternate buffer is used

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -156,7 +156,7 @@ public:
         }
         m_max_history_lines = value;
     }
-    size_t history_size() const { return m_history.size(); }
+    size_t history_size() const { return m_use_alternate_screen_buffer ? 0 : m_history.size(); }
 #endif
 
     void inject_string(const StringView&);


### PR DESCRIPTION
The line history is unavailable if the alternate screen buffer is currently enabled. However, since TerminalWidget uses the history size to offset its line numbers when rendering, it will try to render inaccessible lines once the history is not empty anymore.

This is easily reproduced by scrolling the Terminal far enough to start filling the history and then opening vim.