### PR TITLE
LibJS: Add the global escape() & unescape() methods

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -99,6 +99,7 @@ namespace JS {
     P(entries)                               \
     P(enumerable)                            \
     P(error)                                 \
+    P(escape)                                \
     P(eval)                                  \
     P(every)                                 \
     P(exec)                                  \
@@ -263,6 +264,7 @@ namespace JS {
     P(trimStart)                             \
     P(trunc)                                 \
     P(undefined)                             \
+    P(unescape)                              \
     P(unicode)                               \
     P(unshift)                               \
     P(value)                                 \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -68,6 +68,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(decode_uri);
     JS_DECLARE_NATIVE_FUNCTION(encode_uri_component);
     JS_DECLARE_NATIVE_FUNCTION(decode_uri_component);
+    JS_DECLARE_NATIVE_FUNCTION(escape);
+    JS_DECLARE_NATIVE_FUNCTION(unescape);
 
     NonnullOwnPtr<Console> m_console;
 

--- a/Userland/Libraries/LibJS/Tests/builtins/functions/escapeUnescape.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/functions/escapeUnescape.js
@@ -1,0 +1,21 @@
+test("escape", () => {
+    [
+        ["abc123", "abc123"],
+        ["äöü", "%E4%F6%FC"],
+        ["ć", "%u0107"],
+        ["@*_+-./", "@*_+-./"],
+    ].forEach(test => {
+        expect(escape(test[0])).toBe(test[1]);
+    });
+});
+
+test("unescape", () => {
+    [
+        ["abc123", "abc123"],
+        ["%E4%F6%FC", "äöü"],
+        ["%u0107", "ć"],
+        ["@*_+-./", "@*_+-./"],
+    ].forEach(test => {
+        expect(unescape(test[0])).toBe(test[1]);
+    });
+});


### PR DESCRIPTION
This makes 34 new test262 test cases pass (AKA all escape/unescape test cases besides the utf16 surrogate pairs test)