### PR TITLE
LibWeb: Change BlockBox to not want mouse events

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockBox.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockBox.h
@@ -39,7 +39,7 @@ public:
 
 private:
     virtual bool is_block_box() const final { return true; }
-    virtual bool wants_mouse_events() const override { return true; }
+    virtual bool wants_mouse_events() const override { return false; }
     virtual bool handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta) override;
 
     bool should_clip_overflow() const;


### PR DESCRIPTION
BlockBox asks for mouse events, but does not handle them (with the exception of mousewheel).
This causes EventHandler to pass all mouse events to the BlockBox, even when it's uneeded.
This was problematic because it did not allow the context menu to open when right clicking a browser page.

This fixes #7581 