### PR TITLE
LibJS: Throw TypeError on write to non-writable property in strict mode

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -23,6 +23,7 @@
     M(Convert, "Cannot convert {} to {}")                                                                                               \
     M(ConvertUndefinedToObject, "Cannot convert undefined to object")                                                                   \
     M(DescChangeNonConfigurable, "Cannot change attributes of non-configurable property '{}'")                                          \
+    M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
     M(DivisionByZero, "Division by zero")                                                                                               \
     M(FunctionArgsNotObject, "Argument array must be an object")                                                                        \
     M(GetCapabilitiesExecutorCalledMultipleTimes, "GetCapabilitiesExecutor was called multiple times")                                  \

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -637,6 +637,8 @@ bool Object::put_own_property(const StringOrSymbol& property_name, Value value, 
     auto value_here = m_storage[metadata.value().offset];
     if (!new_property && mode == PutOwnPropertyMode::Put && !value_here.is_accessor() && !metadata.value().attributes.is_writable()) {
         dbgln_if(OBJECT_DEBUG, "Disallow write to non-writable property");
+        if (throw_exceptions && vm().in_strict_mode())
+            vm().throw_exception<TypeError>(global_object(), ErrorType::DescWriteNonWritable, property_name.to_display_string());
         return false;
     }
 

--- a/Userland/Libraries/LibJS/Tests/non-writable-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/non-writable-assignment.js
@@ -1,0 +1,12 @@
+test("normal mode", () => {
+    expect(() => {
+        NaN = 5; // NaN is a non-writable global variable
+    }).not.toThrow();
+});
+
+test("strict mode", () => {
+    expect(() => {
+        "use strict";
+        NaN = 5; // NaN is a non-writable global variable
+    }).toThrowWithMessage(TypeError, "Cannot write to non-writable property 'NaN'");
+});


### PR DESCRIPTION
Fixes 20 test262 test cases.