### PR TITLE
LibJS: Various fixes to parseInt & parseFloat

### DIFF
--- a/AK/CharacterTypes.h
+++ b/AK/CharacterTypes.h
@@ -140,6 +140,17 @@ constexpr u32 parse_ascii_hex_digit(u32 code_point)
     VERIFY_NOT_REACHED();
 }
 
+constexpr u32 parse_ascii_base36_digit(u32 code_point)
+{
+    if (is_ascii_digit(code_point))
+        return parse_ascii_digit(code_point);
+    if (code_point >= 'A' && code_point <= 'Z')
+        return code_point - 'A' + 10;
+    if (code_point >= 'a' && code_point <= 'z')
+        return code_point - 'a' + 10;
+    VERIFY_NOT_REACHED();
+}
+
 }
 
 using AK::is_ascii;
@@ -161,6 +172,7 @@ using AK::is_unicode_control;
 using AK::is_unicode_noncharacter;
 using AK::is_unicode_scalar_value;
 using AK::is_unicode_surrogate;
+using AK::parse_ascii_base36_digit;
 using AK::parse_ascii_digit;
 using AK::parse_ascii_hex_digit;
 using AK::to_ascii_lowercase;

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -251,9 +251,9 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::parse_int)
     }
 
     auto parse_digit = [&](u32 code_point, i32 radix) -> Optional<i32> {
-        if (!is_ascii_hex_digit(code_point) || radix <= 0)
+        if (!is_ascii_alphanumeric(code_point) || radix <= 0)
             return {};
-        auto digit = parse_ascii_hex_digit(code_point);
+        auto digit = parse_ascii_base36_digit(code_point);
         if (digit >= (u32)radix)
             return {};
         return digit;

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -106,7 +106,7 @@ void GlobalObject::initialize_global_object()
     define_native_function(vm.names.isNaN, is_nan, 1, attr);
     define_native_function(vm.names.isFinite, is_finite, 1, attr);
     define_native_function(vm.names.parseFloat, parse_float, 1, attr);
-    define_native_function(vm.names.parseInt, parse_int, 1, attr);
+    define_native_function(vm.names.parseInt, parse_int, 2, attr);
     define_native_function(vm.names.eval, eval, 1, attr);
     define_native_function(vm.names.encodeURI, encode_uri, 1, attr);
     define_native_function(vm.names.decodeURI, decode_uri, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -202,12 +202,13 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::parse_float)
 {
     if (vm.argument(0).is_number())
         return vm.argument(0);
-    auto string = vm.argument(0).to_string(global_object);
+    auto input_string = vm.argument(0).to_string(global_object);
     if (vm.exception())
         return {};
-    for (size_t length = string.length(); length > 0; --length) {
+    auto trimmed_string = input_string.trim_whitespace(TrimMode::Left);
+    for (size_t length = trimmed_string.length(); length > 0; --length) {
         // This can't throw, so no exception check is fine.
-        auto number = Value(js_string(vm, string.substring(0, length))).to_number(global_object);
+        auto number = Value(js_string(vm, trimmed_string.substring(0, length))).to_number(global_object);
         if (!number.is_nan())
             return number;
     }

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -566,7 +566,8 @@ i32 Value::to_i32_slow_case(GlobalObject& global_object) const
     auto int_val = floor(abs);
     if (signbit(value))
         int_val = -int_val;
-    auto int32bit = fmod(int_val, 4294967296.0);
+    auto remainder = fmod(int_val, 4294967296.0);
+    auto int32bit = remainder >= 0.0 ? remainder : remainder + 4294967296.0; // The notation “x modulo y” computes a value k of the same sign as y
     if (int32bit >= 2147483648.0)
         int32bit -= 4294967296.0;
     return static_cast<i32>(int32bit);

--- a/Userland/Libraries/LibJS/Tests/parseInt.js
+++ b/Userland/Libraries/LibJS/Tests/parseInt.js
@@ -29,15 +29,15 @@ test("basic parseInt() functionality", () => {
     expect(parseInt(4.7, 10)).toBe(4);
     expect(parseInt("0e0", 16)).toBe(224);
     expect(parseInt("123_456")).toBe(123);
-
-    // FIXME: expect(parseInt(4.7 * 1e22, 10)).toBe(4);
-    // FIXME: expect(parseInt(0.00000000000434, 10)).toBe(4);
-    // FIXME: expect(parseInt(0.0000001,11)).toBe(1);
-    // FIXME: expect(parseInt(0.000000124,10)).toBe(1);
-    // FIXME: expect(parseInt(1e-7,10)).toBe(1);
-    // FIXME: expect(parseInt(1000000000000100000000,10)).toBe(1);
-    // FIXME: expect(parseInt(123000000000010000000000,10)).toBe(1);
-    // FIXME: expect(parseInt(1e+21,10)).toBe(1);
+    expect(parseInt("UVWXYZ", 36)).toBe(1867590395);
+    expect(parseInt(4.7 * 1e22, 10)).toBe(4);
+    expect(parseInt(0.00000000000434, 10)).toBe(4);
+    expect(parseInt(0.0000001, 11)).toBe(1);
+    expect(parseInt(0.000000124, 10)).toBe(1);
+    expect(parseInt(1e-7, 10)).toBe(1);
+    expect(parseInt(1000000000000100000000, 10)).toBe(1);
+    expect(parseInt(123000000000010000000000, 10)).toBe(1);
+    expect(parseInt(1e21, 10)).toBe(1);
     // FIXME: expect(parseInt('900719925474099267n')).toBe(900719925474099300)
 });
 


### PR DESCRIPTION
This fixes 20 test262 test cases.