### PR TITLE
LibGUI: Don't delete within a line if the line is empty

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -879,6 +879,9 @@ void TextDocument::remove(const TextRange& unnormalized_range)
     if (range.start().line() == range.end().line()) {
         // Delete within same line.
         auto& line = this->line(range.start().line());
+        if (line.length() == 0)
+            return;
+
         bool whole_line_is_selected = range.start().column() == 0 && range.end().column() == line.length();
 
         if (whole_line_is_selected) {


### PR DESCRIPTION
`TextDocument::remove()` used to attempt to clear a line, even when it was empty.
Usually, this is not an issue, since you can't normally select an empty line.
However, if `TextEditor` is using the `VimEditingEngine`, and the user is in visual mode, attempting to delete an empty line would cause a crash.

To fix this, we simply ignore the deletion if the user is trying to delete an empty line.

Fixes #6013