### PR TITLE
Ports: .port_include.sh add install_icon function

### DIFF
--- a/Ports/README.md
+++ b/Ports/README.md
@@ -186,6 +186,11 @@ compressed file, it will be extracted.
 If a file is an `.asc` file (PGP signature) it will be imported into `gpg`'s
 keyring and can later be used for verification using [`auth_opts`](#auth_opts).
 
+#### `icon_file`
+
+The file to use for the port launcher icon. The icon file is assumed to have a
+16x16 as well as a 32x32 layer.
+
 #### `installopts`
 
 Options passed to `make install` in the default `install` function.


### PR DESCRIPTION
Fixes #7782 

Here is a pretty simple solution for the issue linked above.

It adds a `install_icon` function to the .port_include.sh file, which if a launcher command and an icon file are defined, will embed the icon into the port's launcher file.

As a first time contributor, I would be thrilled for any feedback!