### PR TITLE
Ports: Fix zlib include directory for libzip

### DIFF
--- a/Ports/libzip/patches/disable_unnecessary_options.patch
+++ b/Ports/libzip/patches/disable_unnecessary_options.patch
@@ -12,7 +12,7 @@ index 017f7cf0..125900e2 100644
 -option(ENABLE_OPENSSL "Enable use of OpenSSL" ON)
 -option(ENABLE_WINDOWS_CRYPTO "Enable use of Windows cryptography libraries" ON)
 +set(ZLIB_LIBRARY ${SERENITY_INSTALL_ROOT}/usr/local/lib/libz.a)
-+set(ZLIB_INCLUDE_DIR ${SERENITY_INSTALL_ROOT}/usr/local/include/zlib.h)
++set(ZLIB_INCLUDE_DIRS ${SERENITY_INSTALL_ROOT}/usr/local/include/zlib.h)
 +add_compile_definitions(HAVE_STRINGS_H)
  
 -option(ENABLE_BZIP2 "Enable use of BZip2" ON)


### PR DESCRIPTION
Building the libzip port was broken because it could not find zlib:
```
CMake Error in lib/CMakeLists.txt:
  Imported target "ZLIB::ZLIB" includes non-existent path

    "/usr/local/include/zlib.h"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```