### PR TITLE
Browser+LibGUI: Add Ctrl+Return key combo

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -150,6 +150,22 @@ Tab::Tab(BrowserWindow& window, Type type)
         view().set_focus(true);
     };
 
+    m_location_box->on_ctrl_return_pressed = [this] {
+        auto trimmed_text = m_location_box->text().trim("."sv, TrimMode::Both);
+
+        if (trimmed_text.contains("/"sv) || trimmed_text.contains("."sv) || trimmed_text.contains(":"sv)) {
+            m_location_box->on_return_pressed();
+        } else {
+            StringBuilder builder;
+            builder.append(trimmed_text);
+            builder.append(".com");
+
+            auto url = url_from_user_input(builder.build());
+            load(url);
+            view().set_focus(true);
+        }
+    };
+
     m_location_box->add_custom_context_menu_action(GUI::Action::create("Paste && Go", [this](auto&) {
         m_location_box->set_text(GUI::Clipboard::the().data());
         m_location_box->on_return_pressed();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -765,6 +765,12 @@ void TextEditor::keydown_event(KeyEvent& event)
             return;
         }
 
+        if (event.modifiers() == KeyModifier::Mod_Ctrl && event.key() == KeyCode::Key_Return) {
+            if (on_ctrl_return_pressed)
+                on_ctrl_return_pressed();
+            return;
+        }
+
         if (event.key() == KeyCode::Key_Return) {
             if (on_return_pressed)
                 on_return_pressed();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -144,6 +144,7 @@ public:
     Function<void()> on_mousedown;
     Function<void()> on_return_pressed;
     Function<void()> on_shift_return_pressed;
+    Function<void()> on_ctrl_return_pressed;
     Function<void()> on_escape_pressed;
     Function<void()> on_up_pressed;
     Function<void()> on_down_pressed;


### PR DESCRIPTION
The Ctrl+Return key combo is used in browsers to autocomplete incomplete URLs in the location bar.

It exists in most browsers outside of Serenity, I looked at both Chrome and Firefox to see what decisions they make for a variety of partial URLs.

## SerenityOS Browser
Any period at start or end:
- Strip the period and append .com
    + e.g. "example." or ".example" -> "example.com"

Anything more complex:
- Don't do TLD verification, instead act like the user pressed Return
    + e.g. "example.faketld" or "example.ch" or "sub.example.ch" -> follow URL as given
- Don't insert .com before a path
    + e.g. "example/a" or "sub.example.com/b" or "http://example.se/a/b/c" -> follow URL as given

## What other browsers do
Chrome and Firefox try to add a few more smarts by verifying the TLD and identifying the path separately to a possible hostname.

Known TLD
- Both: prepend www. but use the already entered TLD
    + e.g. "example.ch" -> "www.example.ch"

Unknown TLD
- Firefox: searches the string with your default search engine
    + e.g. "example.faketld" would be used a search query
- Chrome: appends .com after the unknown TLD
    + e.g. "example.faketld" -> "www.example.faketld.com"

Additional period at start or end:
- Firefox: searches the string with your default search engine
    + e.g. "example." or ".example" would be used a search query
- Chrome: strips the period out
    + e.g. "example." or ".example" -> "www.example.com"

Path:
- Both: inserts .com before the path
    + e.g. "example/a" -> "www.example.com/a"