### PR TITLE
LibProtocol: Pass URL instead of string as argument to RequestClient::start_request

### DIFF
--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -36,7 +36,7 @@ DownloadWidget::DownloadWidget(const URL& url)
     }
 
     m_elapsed_timer.start();
-    m_download = Web::ResourceLoader::the().protocol_client().start_request("GET", url.to_string());
+    m_download = Web::ResourceLoader::the().protocol_client().start_request("GET", url);
     VERIFY(m_download);
     m_download->on_progress = [this](Optional<u32> total_size, u32 downloaded_size) {
         did_progress(total_size.value(), downloaded_size);

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -16,7 +16,7 @@ RequestClient::RequestClient()
 }
 
 template<typename RequestHashMapTraits>
-RefPtr<Request> RequestClient::start_request(const String& method, const String& url, const HashMap<String, String, RequestHashMapTraits>& request_headers, ReadonlyBytes request_body)
+RefPtr<Request> RequestClient::start_request(String const& method, String const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers, ReadonlyBytes request_body)
 {
     IPC::Dictionary header_dictionary;
     for (auto& it : request_headers)
@@ -57,14 +57,14 @@ void RequestClient::request_finished(i32 request_id, bool success, u32 total_siz
     m_requests.remove(request_id);
 }
 
-void RequestClient::request_progress(i32 request_id, const Optional<u32>& total_size, u32 downloaded_size)
+void RequestClient::request_progress(i32 request_id, Optional<u32> const& total_size, u32 downloaded_size)
 {
     if (auto request = const_cast<Request*>(m_requests.get(request_id).value_or(nullptr))) {
         request->did_progress({}, total_size, downloaded_size);
     }
 }
 
-void RequestClient::headers_became_available(i32 request_id, const IPC::Dictionary& response_headers, const Optional<u32>& status_code)
+void RequestClient::headers_became_available(i32 request_id, IPC::Dictionary const& response_headers, Optional<u32> const& status_code)
 {
     if (auto request = const_cast<Request*>(m_requests.get(request_id).value_or(nullptr))) {
         HashMap<String, String, CaseInsensitiveStringTraits> headers;
@@ -82,5 +82,5 @@ void RequestClient::certificate_requested(i32 request_id)
 
 }
 
-template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(const String& method, const String& url, const HashMap<String, String>& request_headers, ReadonlyBytes request_body);
-template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(const String& method, const String& url, const HashMap<String, String, CaseInsensitiveStringTraits>& request_headers, ReadonlyBytes request_body);
+template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, String const& url, HashMap<String, String> const& request_headers, ReadonlyBytes request_body);
+template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, String const& url, HashMap<String, String, CaseInsensitiveStringTraits> const& request_headers, ReadonlyBytes request_body);

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -16,7 +16,7 @@ RequestClient::RequestClient()
 }
 
 template<typename RequestHashMapTraits>
-RefPtr<Request> RequestClient::start_request(String const& method, String const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers, ReadonlyBytes request_body)
+RefPtr<Request> RequestClient::start_request(String const& method, URL const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers, ReadonlyBytes request_body)
 {
     IPC::Dictionary header_dictionary;
     for (auto& it : request_headers)
@@ -82,5 +82,5 @@ void RequestClient::certificate_requested(i32 request_id)
 
 }
 
-template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, String const& url, HashMap<String, String> const& request_headers, ReadonlyBytes request_body);
-template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, String const& url, HashMap<String, String, CaseInsensitiveStringTraits> const& request_headers, ReadonlyBytes request_body);
+template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, URL const&, HashMap<String, String> const& request_headers, ReadonlyBytes request_body);
+template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, URL const&, HashMap<String, String, CaseInsensitiveStringTraits> const& request_headers, ReadonlyBytes request_body);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -22,7 +22,7 @@ class RequestClient final
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>
-    RefPtr<Request> start_request(const String& method, const String& url, const HashMap<String, String, RequestHashMapTraits>& request_headers = {}, ReadonlyBytes request_body = {});
+    RefPtr<Request> start_request(String const& method, String const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers = {}, ReadonlyBytes request_body = {});
 
     bool stop_request(Badge<Request>, Request&);
     bool set_certificate(Badge<Request>, Request&, String, String);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -22,7 +22,7 @@ class RequestClient final
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>
-    RefPtr<Request> start_request(String const& method, String const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers = {}, ReadonlyBytes request_body = {});
+    RefPtr<Request> start_request(String const& method, URL const&, HashMap<String, String, RequestHashMapTraits> const& request_headers = {}, ReadonlyBytes request_body = {});
 
     bool stop_request(Badge<Request>, Request&);
     bool set_certificate(Badge<Request>, Request&, String, String);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -156,7 +156,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
             headers.set(it.key, it.value);
         }
 
-        auto protocol_request = protocol_client().start_request(request.method(), url.to_string(), headers, request.body());
+        auto protocol_request = protocol_client().start_request(request.method(), url, headers, request.body());
         if (!protocol_request) {
             if (error_callback)
                 error_callback("Failed to initiate load", {});

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
     Core::EventLoop loop;
     auto protocol_client = Protocol::RequestClient::construct();
 
-    auto request = protocol_client->start_request(method, url.to_string(), request_headers, data ? StringView { data }.bytes() : ReadonlyBytes {});
+    auto request = protocol_client->start_request(method, url, request_headers, data ? StringView { data }.bytes() : ReadonlyBytes {});
     if (!request) {
         warnln("Failed to start request for '{}'", url_str);
         return 1;


### PR DESCRIPTION
This changes the `RequestClient::start_request()` method to take a `URL` instead of `String url` as argument. All callers of the method already had a `URL` object anyway, and `start_request()` in turn parses the `String` back into a `URL`. This removes this unnecessary conversion.

It also changes `RequestClient.{cpp,h}` to use east const style.