### PR TITLE
LibC+LibELF: Implement dladdr()

### DIFF
--- a/Userland/Libraries/LibC/dlfcn.cpp
+++ b/Userland/Libraries/LibC/dlfcn.cpp
@@ -10,3 +10,4 @@
 DlCloseFunction __dlclose;
 DlOpenFunction __dlopen;
 DlSymFunction __dlsym;
+DlAddrFunction __dladdr;

--- a/Userland/Libraries/LibDl/dlfcn.cpp
+++ b/Userland/Libraries/LibDl/dlfcn.cpp
@@ -60,3 +60,15 @@ void* dlsym(void* handle, const char* symbol_name)
     }
     return result.value();
 }
+
+int dladdr(void* addr, Dl_info* info)
+{
+    auto result = __dladdr(addr, info);
+    if (result.is_error()) {
+        // FIXME: According to the man page glibc does _not_ make the error
+        // available via dlerror(), however we do. Does this break anything?
+        store_error(result.error().text);
+        return 0;
+    }
+    return 1;
+}

--- a/Userland/Libraries/LibDl/dlfcn.h
+++ b/Userland/Libraries/LibDl/dlfcn.h
@@ -16,9 +16,17 @@ __BEGIN_DECLS
 #define RTLD_GLOBAL 8
 #define RTLD_LOCAL 16
 
+typedef struct __Dl_info {
+    const char* dli_fname;
+    void* dli_fbase;
+    const char* dli_sname;
+    void* dli_saddr;
+} Dl_info;
+
 int dlclose(void*);
 char* dlerror();
 void* dlopen(const char*, int);
 void* dlsym(void*, const char*);
+int dladdr(void*, Dl_info*);
 
 __END_DECLS

--- a/Userland/Libraries/LibDl/dlfcn_integration.h
+++ b/Userland/Libraries/LibDl/dlfcn_integration.h
@@ -23,12 +23,17 @@ struct DlErrorMessage {
     String text;
 };
 
+struct __Dl_info;
+typedef struct __Dl_info Dl_info;
+
 typedef Result<void, DlErrorMessage> (*DlCloseFunction)(void*);
 typedef Result<void*, DlErrorMessage> (*DlOpenFunction)(const char*, int);
 typedef Result<void*, DlErrorMessage> (*DlSymFunction)(void*, const char*);
+typedef Result<void, DlErrorMessage> (*DlAddrFunction)(void*, Dl_info*);
 
 extern "C" {
 extern DlCloseFunction __dlclose;
 extern DlOpenFunction __dlopen;
 extern DlSymFunction __dlsym;
+extern DlAddrFunction __dladdr;
 }

--- a/Userland/Utilities/crash.cpp
+++ b/Userland/Utilities/crash.cpp
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <Kernel/IO.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Object.h>
 #include <LibTest/CrashTest.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,6 +44,7 @@ int main(int argc, char** argv)
     bool do_read_cpu_counter = false;
     bool do_pledge_violation = false;
     bool do_failing_assertion = false;
+    bool do_deref_null_refptr = false;
 
     auto args_parser = Core::ArgsParser();
     args_parser.set_general_help(
@@ -67,6 +69,7 @@ int main(int argc, char** argv)
     args_parser.add_option(do_read_cpu_counter, "Read the x86 TSC (Time Stamp Counter) directly", nullptr, 'c');
     args_parser.add_option(do_pledge_violation, "Violate pledge()'d promises", nullptr, 'p');
     args_parser.add_option(do_failing_assertion, "Perform a failing assertion", nullptr, 'n');
+    args_parser.add_option(do_deref_null_refptr, "Dereference a null RefPtr", nullptr, 'R');
 
     if (argc != 2) {
         args_parser.print_usage(stderr, argv[0]);
@@ -275,6 +278,14 @@ int main(int argc, char** argv)
     if (do_failing_assertion || do_all_crash_types) {
         Crash("Perform a failing assertion", [] {
             VERIFY(1 == 2);
+            return Crash::Failure::DidNotCrash;
+        }).run(run_type);
+    }
+
+    if (do_deref_null_refptr || do_all_crash_types) {
+        Crash("Dereference a null RefPtr", [] {
+            RefPtr<Core::Object> p;
+            *p;
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }


### PR DESCRIPTION
**LibC+LibELF: Implement dladdr()**

This implements the `dladdr()` function which lets the caller look up the symbol name, symbol address as well as library name and library base address for an arbitrary address.

**Utilities: Add support for testing null deferencing a RefPtr**

This adds the new flag `-R` for the `crash` utility which tests what happens when we dereference a null `RefPtr`. This is useful for testing the output of the assertion message.