### PR TITLE
LibGUI/WindowServer: Add IPC call for set_maximized & FileManager: Store state on exit

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -430,7 +430,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     auto top = config->read_num_entry("Window", "Top", 75);
     auto width = config->read_num_entry("Window", "Width", 640);
     auto height = config->read_num_entry("Window", "Height", 480);
-    window->set_rect({ left, top, width, height });
+    auto was_maximized = config->read_bool_entry("Window", "Maximized", false);
 
     auto& widget = window->set_main_widget<GUI::Widget>();
 
@@ -1141,6 +1141,10 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
     window->show();
 
+    window->set_rect({ left, top, width, height });
+    if (was_maximized)
+        window->set_maximized(true);
+
     // Read directory read mode from config.
     auto dir_view_mode = config->read_entry("DirectoryView", "ViewMode", "Icon");
 
@@ -1163,10 +1167,13 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
     // Write window position to config file on close request.
     window->on_close_request = [&] {
-        config->write_num_entry("Window", "Left", window->x());
-        config->write_num_entry("Window", "Top", window->y());
-        config->write_num_entry("Window", "Width", window->width());
-        config->write_num_entry("Window", "Height", window->height());
+        config->write_bool_entry("Window", "Maximized", window->is_maximized());
+        if (!window->is_maximized()) {
+            config->write_num_entry("Window", "Left", window->x());
+            config->write_num_entry("Window", "Top", window->y());
+            config->write_num_entry("Window", "Width", window->width());
+            config->write_num_entry("Window", "Height", window->height());
+        }
         config->sync();
 
         return GUI::Window::CloseRequestDecision::Close;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -915,6 +915,11 @@ bool Window::is_maximized() const
     return WindowServerConnection::the().is_maximized(m_window_id);
 }
 
+void Window::set_maximized(bool maximized)
+{
+    WindowServerConnection::the().async_set_maximized(m_window_id, maximized);
+}
+
 void Window::schedule_relayout()
 {
     if (m_layout_pending)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -40,6 +40,7 @@ public:
     void set_fullscreen(bool);
 
     bool is_maximized() const;
+    void set_maximized(bool);
 
     bool is_frameless() const { return m_frameless; }
     void set_frameless(bool);

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -332,6 +332,16 @@ Messages::WindowServer::IsMaximizedResponse ClientConnection::is_maximized(i32 w
     return it->value->is_maximized();
 }
 
+void ClientConnection::set_maximized(i32 window_id, bool maximized)
+{
+    auto it = m_windows.find(window_id);
+    if (it == m_windows.end()) {
+        did_misbehave("SetMaximized: Bad window ID");
+        return;
+    }
+    it->value->set_maximized(maximized);
+}
+
 void ClientConnection::set_window_icon_bitmap(i32 window_id, Gfx::ShareableBitmap const& icon)
 {
     auto it = m_windows.find(window_id);

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -104,6 +104,7 @@ private:
     virtual void set_window_title(i32, String const&) override;
     virtual Messages::WindowServer::GetWindowTitleResponse get_window_title(i32) override;
     virtual Messages::WindowServer::IsMaximizedResponse is_maximized(i32) override;
+    virtual void set_maximized(i32, bool) override;
     virtual void start_window_resize(i32) override;
     virtual Messages::WindowServer::SetWindowRectResponse set_window_rect(i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::GetWindowRectResponse get_window_rect(i32) override;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -68,6 +68,7 @@ endpoint WindowServer
     start_window_resize(i32 window_id) =|
 
     is_maximized(i32 window_id) => (bool maximized)
+    set_maximized(i32 window_id, bool maximized) =|
 
     invalidate_rect(i32 window_id, Vector<Gfx::IntRect> rects, bool ignore_occlusion) =|
     did_finish_painting(i32 window_id, Vector<Gfx::IntRect> rects) =|


### PR DESCRIPTION
**LibGUI/WindowServer:** Add an IPC call and method for `set_maximized` to allow for window clients to maximize themselves.

**FileManager:** Store maximized state on exit and set the right window size/state on launch. Previously a maximized window would be stored with the right size but as a non-maximized window.

Of course this functionality would be nice to have in most applications, and stored automatically by WindowServer instead of the respective applications perhaps?