### PR TITLE
Kernel: Improve the unveil() system call

### DIFF
--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -179,6 +179,9 @@ public:
         return insert(it, end);
     }
 
+    HashMap<ValueType, NonnullOwnPtr<Trie>, ValueTraits>& children() { return m_children; }
+    HashMap<ValueType, NonnullOwnPtr<Trie>, ValueTraits> const& children() const { return m_children; }
+
     ConstIterator begin() const { return ConstIterator(*this); }
     ConstIterator end() const { return ConstIterator::end(); }
 

--- a/Base/usr/share/man/man2/unveil.md
+++ b/Base/usr/share/man/man2/unveil.md
@@ -32,15 +32,23 @@ include the following characters:
 
 A single `unveil()` call may specify multiple permission characters at once.
 Subsequent `unveil()` calls may take away permissions from the ones allowed
-earlier for the same file. Note that unveiling a path with any set of
-permissions does not turn off the regular permission checks: access to a file
-which the process has unveiled for itself, but has otherwise no appropriate
-permissions for, will still be rejected. Unveiling a directory allows the
-process to access any files inside the directory.
+earlier for the same file or directory. Note that it remains possible to unveil
+subdirectories with any permissions.
+
+Note that unveiling a path with any set of permissions does not turn off the
+regular permission checks: access to a file which the process has unveiled for
+itself, but has otherwise no appropriate permissions for, will still be rejected.
+Unveiling a directory allows the process to access any files inside the
+directory.
 
 Calling `unveil()` with both `path` and `permissions` set to null locks the
-veil; no further `unveil()` calls are allowed after that.
+veil; no further `unveil()` calls are allowed after that. Although `unveil()`
+calls start to take effect the moment they are made, until the veil is locked,
+it remains possible to sometimes circumvent the restrictions set by unveiling
+files and directories contained inside a restricted directory with different
+permissions.
 
+When a process calls `fork()`, the unveil state is copied to the new process.
 The veil state is reset after the program successfully performs an `execve()`
 call.
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -102,7 +102,7 @@ public:
 private:
     friend class FileDescription;
 
-    const UnveilNode* find_matching_unveiled_path(StringView path);
+    UnveilNode const& find_matching_unveiled_path(StringView path);
     KResult validate_path_against_process_veil(StringView path, int options);
 
     bool is_vfs_root(InodeIdentifier) const;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -632,7 +632,7 @@ private:
     RefPtr<Timer> m_alarm_timer;
 
     VeilState m_veil_state { VeilState::None };
-    UnveilNode m_unveiled_paths { "/", { .full_path = "/", .unveil_inherited_from_root = true } };
+    UnveilNode m_unveiled_paths { "/", { .full_path = "/" } };
 
     OwnPtr<PerformanceEventBuffer> m_perf_event_buffer;
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -553,6 +553,7 @@ KResult Process::do_exec(NonnullRefPtr<FileDescription> main_program_description
 
     m_veil_state = VeilState::None;
     m_unveiled_paths.clear();
+    m_unveiled_paths.set_metadata({ "/", UnveilAccess::None, false });
 
     m_coredump_metadata.clear();
 

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -105,7 +105,10 @@ KResultOr<int> Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> u
         it,
         lexical_path.parts().end(),
         { new_unveiled_path, (UnveilAccess)new_permissions, true },
-        [](auto& parent, auto& it) -> Optional<UnveilMetadata> { return UnveilMetadata { String::formatted("{}/{}", parent.path(), *it), parent.permissions(), false, parent.permissions_inherited_from_root() }; });
+        [](auto& parent, auto& it) -> Optional<UnveilMetadata> {
+            auto path = LexicalPath::join(parent.path(), *it).string();
+            return UnveilMetadata { path, parent.permissions(), false, parent.permissions_inherited_from_root() };
+        });
     VERIFY(m_veil_state != VeilState::Locked);
     m_veil_state = VeilState::Dropped;
     return 0;

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -116,6 +116,7 @@ KResultOr<int> Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> u
             update_intermediate_node_permissions(matching_node, (UnveilAccess)new_permissions);
 
         matching_node.set_metadata({ matching_node.path(), (UnveilAccess)new_permissions, true });
+        m_veil_state = VeilState::Dropped;
         return 0;
     }
 

--- a/Kernel/UnveilNode.h
+++ b/Kernel/UnveilNode.h
@@ -27,13 +27,11 @@ struct UnveilMetadata {
     String full_path;
     UnveilAccess permissions { None };
     bool explicitly_unveiled { false };
-    bool unveil_inherited_from_root { false }; // true if permissions are inherited from the tree root (/).
 };
 
 struct UnveilNode final : public Trie<String, UnveilMetadata, Traits<String>, UnveilNode> {
     using Trie<String, UnveilMetadata, Traits<String>, UnveilNode>::Trie;
 
-    bool permissions_inherited_from_root() const { return this->metadata_value().unveil_inherited_from_root; }
     bool was_explicitly_unveiled() const { return this->metadata_value().explicitly_unveiled; }
     UnveilAccess permissions() const { return this->metadata_value().permissions; }
     const String& path() const { return this->metadata_value().full_path; }


### PR DESCRIPTION
This PR fixes quite a lot of bugs related to the `unveil` system call.

The following four commits all fix bugs related to unveiling `/` (the root directory). They mostly have to do with the fact that there is always a node for `/`, because it's the root node of the `UnveilNode` trie:
* Use LexicalPath to avoid two consecutive slashes in unveil path.
* Change unveil state to dropped even when node already exists.
* Don't assume there are no nodes if m_unveiled_paths.is_empty().
* Properly reset m_unveiled_paths on execve().


The other commits fix other bugs in the `unveil` implementation. The relevant bugs are described in the commit descriptions.

I also extended an clarified the `unveil(2)` man page.

Discussion in Discord has resulted in the decision to allow unveiling subfolders of already unveiled folders with any permissions as long as `unveil(nullptr, nullptr)` hasn't been called. Regardless of that, there was a bug there (fixed in dedd46a8d5d01ab83f1e7671c83100c860779b79), because if this was possible or not would depend on what other paths have already been unveiled. If you think this should not be allowed, I am happy to discuss. :^)