### PR TITLE
Kernel: Fix error propagation if Thread::WaitBlocker constructor fails

### DIFF
--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -599,7 +599,6 @@ Thread::WaitBlocker::WaitBlocker(int wait_options, idtype_t id_type, pid_t id, K
         if (!m_waitee || m_waitee->ppid() != Process::current()->pid()) {
             m_result = ECHILD;
             m_error = true;
-            return;
         }
         break;
     }
@@ -608,7 +607,6 @@ Thread::WaitBlocker::WaitBlocker(int wait_options, idtype_t id_type, pid_t id, K
         if (!m_waitee_group) {
             m_result = ECHILD;
             m_error = true;
-            return;
         }
         break;
     }


### PR DESCRIPTION
There is logic at the end of the constructor that sets m_should_block
to false if we encountered errors. We were missing this step due to the
erroneous early return, the code then ended up waiting and then
asserting on unblock since the WaitBlocker is in a invalid state.

This fix is to not return early, and let normal control flow handle it.

Fixes: #7857

Verified with `stress-ng --yield=10` locally.