### PR TITLE
AffineTransform: Check for overflow in hypotenuse

### DIFF
--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -17,8 +17,14 @@ bool AffineTransform::is_identity() const
 
 static float hypotenuse(float x, float y)
 {
-    // FIXME: This won't handle overflow :(
-    return sqrt(x * x + y * y);
+    Checked<float> hypotenuse_equation = sqrtf(x * x + y * y);
+
+    if(hypotenuse_equation.has_overflow())
+    {
+        dbgln("Overflow while computing hypotenuse");
+        return NumericLimits<float>::max();
+    }
+    else{return hypotenuse_equation.value();}
 }
 
 float AffineTransform::x_scale() const


### PR DESCRIPTION
If an overflow occurs it will return the largest float.
Also replaced the square root function with the float archetype.
For now, Checked<float>::multiplication_would_overflow 
and Checked<float>::addition_would_overflow do not work.