### PR TITLE
Kernel: Implement InodeFile::stat() and simplify FileDescription::stat()

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -110,9 +110,6 @@ Thread::FileBlocker::BlockFlags FileDescription::should_unblock(Thread::FileBloc
 KResult FileDescription::stat(::stat& buffer)
 {
     Locker locker(m_lock);
-    // FIXME: This is a little awkward, why can't we always forward to File::stat()?
-    if (m_inode)
-        return metadata().stat(buffer);
     return m_file->stat(buffer);
 }
 

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -34,6 +34,7 @@ public:
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
+    virtual KResult stat(::stat& buffer) const override { return inode().metadata().stat(buffer); }
 
     virtual String absolute_path(const FileDescription&) const override;
 


### PR DESCRIPTION
This allows us to get ride of the special case for inodes in `FileDescription::stat()`. Since `FileDescription::stat()` is the only call site of `File::stat()`, there should not be any unexpected effects from this change.