### PR TITLE
LibC+Ports: Various fixes for scummvm

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -10,9 +10,7 @@
 #    include <Kernel/Assertions.h>
 #else
 #    include <assert.h>
-#    ifndef __serenity__
-#        define VERIFY assert
-#        define VERIFY_NOT_REACHED() assert(false)
-#        define TODO VERIFY_NOT_REACHED
-#    endif
+#    define VERIFY assert
+#    define VERIFY_NOT_REACHED() assert(false)
+#    define TODO VERIFY_NOT_REACHED
 #endif

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/Format.h>
 #include <AK/NonnullRefPtr.h>

--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -4,7 +4,7 @@ useconfigure="true"
 version="2.2.0"
 files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.gz scummvm-${version}.tar.gz 6ec5bd63b73861c10ca9869f27a74989a9ad6013bad30a1ef70de6ec146c2cb5"
 auth_type=sha256
-depends="libtheora SDL2"
+depends="freetype libiconv libjpeg libpng libtheora SDL2"
 configopts="
     --enable-c++11
     --enable-release-mode
@@ -15,6 +15,9 @@ configopts="
 launcher_name=ScummVM
 launcher_category=Games
 launcher_command=/usr/local/bin/scummvm
+
+export FREETYPE2_CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/freetype2"
+export FREETYPE2_LIBS="-lfreetype"
 
 post_install() {
     if command -v convert >/dev/null; then

--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -10,7 +10,7 @@ configopts="
     --enable-release-mode
     --enable-optimizations
     --opengl-mode=none
-    --with-sdl-prefix=${SERENITY_BUILD_DIR}/Root/usr/local
+    --with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local
 "
 launcher_name=ScummVM
 launcher_category=Games

--- a/Ports/scummvm/patches/configure.patch
+++ b/Ports/scummvm/patches/configure.patch
@@ -1,5 +1,5 @@
 --- scummvm-2.2.0/configure	2020-09-13 23:05:37.000000000 +0200
-+++ scummvm-2.2.0-patched/configure	2021-04-04 01:21:54.809774246 +0200
++++ scummvm-2.2.0-patched/configure	2021-06-07 14:15:33.369406722 +0200
 @@ -3917,7 +3917,7 @@
  	amigaos* | cygwin* | dreamcast | ds | gamecube | mingw* | morphos | n64 | ps3 | psp2 | psp | riscos | wii)
  		_posix=no
@@ -9,3 +9,12 @@
  		_posix=yes
  		;;
  	os2-emx*)
+@@ -5073,6 +5073,8 @@
+ # Check for FreeType2 to be present
+ #
+ find_freetype() {
++    _freetype_found="true"
++    return
+         # Wrapper function which tries to find freetype
+         # either by calling freetype-config or by using
+         # pkg-config.

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -19,16 +19,12 @@ __BEGIN_DECLS
             if (__builtin_expect(!(expr), 0))                                      \
                 __assertion_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)); \
         } while (0)
-#    define VERIFY_NOT_REACHED() assert(false)
 #else
 #    define assert(expr) ((void)(0))
 #    define VERIFY_NOT_REACHED() _abort()
 #endif
 
 [[noreturn]] void _abort();
-
-#define VERIFY assert
-#define TODO VERIFY_NOT_REACHED
 
 #ifndef __cplusplus
 #    define static_assert _Static_assert

--- a/Userland/Libraries/LibC/pthread_forward.cpp
+++ b/Userland/Libraries/LibC/pthread_forward.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibC/assert.h>
+#include <AK/Assertions.h>
 #include <LibC/bits/pthread_forward.h>
 
 static PthreadFunctions s_pthread_functions;

--- a/Userland/Libraries/LibM/math.cpp
+++ b/Userland/Libraries/LibM/math.cpp
@@ -1413,4 +1413,19 @@ float fminf(float x, float y) NOEXCEPT
 
     return x < y ? x : y;
 }
+
+long double nearbyintl(long double value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode { fegetround() });
+}
+
+double nearbyint(double value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode { fegetround() });
+}
+
+float nearbyintf(float value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode { fegetround() });
+}
 }


### PR DESCRIPTION
**LibC+AK: Remove our custom macros from <assert.h>**

Other software might not expect these to be defined and behave differently if they _are_ defined, e.g. scummvm which checks if
the `TODO` macro is defined and fails to build if it is.

**LibM: Implement nearbyint, nearbyintl and nearbyintf**

These are used by the ultima engine for scummvm.

**Ports/ScummVM: Use SERENITY_INSTALL_ROOT instead of _BUILD_DIR**

**Ports/ScummVM: Add freetype, libiconv, libjpeg and libpng to build deps**