### PR TITLE
LookupServer: Improve /etc/hosts parsing, consider hostname for lookup, watch /etc/hosts

### DIFF
--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -57,6 +57,15 @@ public:
             octet(SubnetClass::D));
     }
 
+    String to_string_reversed() const
+    {
+        return String::formatted("{}.{}.{}.{}",
+            octet(SubnetClass::D),
+            octet(SubnetClass::C),
+            octet(SubnetClass::B),
+            octet(SubnetClass::A));
+    }
+
     static Optional<IPv4Address> from_string(const StringView& string)
     {
         if (string.is_null())

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -75,11 +75,6 @@ void DNSName::randomize_case()
     m_name = builder.to_string();
 }
 
-bool DNSName::operator==(const DNSName& other) const
-{
-    return as_string() == other.as_string();
-}
-
 OutputStream& operator<<(OutputStream& stream, const DNSName& name)
 {
     auto parts = name.as_string().split_view('.');

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -23,7 +23,7 @@ public:
 
     void randomize_case();
 
-    bool operator==(const DNSName&) const;
+    bool operator==(const DNSName& other) const { return Traits::equals(*this, other); }
 
     class Traits : public AK::Traits<DNSName> {
     public:

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -10,6 +10,7 @@
 #include "DNSPacket.h"
 #include "DNSServer.h"
 #include "MulticastDNS.h"
+#include <LibCore/FileWatcher.h>
 #include <LibCore/Object.h>
 
 namespace LookupServer {
@@ -35,6 +36,7 @@ private:
     RefPtr<DNSServer> m_dns_server;
     RefPtr<MulticastDNS> m_mdns;
     Vector<String> m_nameservers;
+    RefPtr<Core::FileWatcher> m_file_watcher;
     HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_etc_hosts;
     HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_lookup_cache;
 };

--- a/Userland/Services/LookupServer/main.cpp
+++ b/Userland/Services/LookupServer/main.cpp
@@ -30,6 +30,11 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         return 1;
     }
 
+    if (unveil("/etc/hosts", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
     if (unveil(nullptr, nullptr) < 0) {
         perror("unveil");
         return 1;


### PR DESCRIPTION
This PR has ~~two~~ three aspects:
* Improve parsing of `/etc/hosts`. It no longer uses ad-hoc IP address parsing, rather relying on `IPv4Address::from_string()`. It also adds some debug output if lines contained in `/etc/hosts` are invalid.
* When looking up a DNS name, first check if the requested name is the hostname. If this is the case and the requested record type is `A`, return `127.0.0.1`.
* `/etc/hosts` is now being watched by LookupServer, so changes to it during runtime of the system actually take effect.