### PR TITLE
Ports: Adds Another World VM interpreter implementation.

### DIFF
--- a/Ports/Another-World/package.sh
+++ b/Ports/Another-World/package.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=Another-World
+useconfigure=true
+version=git
+depends="SDL2 zlib"
+workdir=Another-World-Bytecode-Interpreter-master
+configopts="-DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt -DSDL2_INCLUDE_DIR=${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2"
+files="https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter/archive/refs/heads/master.zip master.zip 326de7622e5f83a83fce76e6032240157a9dde83c0d65319095c7e0b312af317"
+auth_type=sha256
+launcher_name="Another World"
+launcher_category=Games
+launcher_command="/opt/Another-World/raw --datapath=/opt/Another-World"
+
+configure() {
+    run cmake $configopts
+}
+
+install() {
+    run mkdir -p "${SERENITY_INSTALL_ROOT}/opt/Another-World"
+    run cp -r raw "${SERENITY_INSTALL_ROOT}/opt/Another-World"
+    echo "INFO: Copy BANK* and MEMLIST.BIN files from MS-DOS distribution of the game to the /opt/Another_World directory"
+}

--- a/Ports/Another-World/patches/fix_cmakelists.patch
+++ b/Ports/Another-World/patches/fix_cmakelists.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 38f6ba8..d56ca64 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,8 +24,7 @@ add_executable(raw
+         src/vm.cpp
+ )
+ 
+-find_package(SDL2 REQUIRED)
+-include_directories(${SDL2_INCLUDE_DIRS})
+-target_link_libraries(raw ${SDL2_LIBRARIES})
++include_directories(${SDL2_INCLUDE_DIR})
++target_link_libraries(raw SDL2)
+ target_link_libraries(raw z)
+ 

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -4,6 +4,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 
 | Port                                   | Name                                                       | Version                  | Website                                                                        |
 |----------------------------------------|------------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------|
+| [`Another-World`](Another-World/)      | Another World Bytecode Interpreter                         |                          | https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter           |
 | [`bash`](bash/)                        | GNU Bash                                                   | 5.0                      | https://www.gnu.org/software/bash/                                             |
 | [`bc`](bc/)                            | bc                                                         | 2.5.1                    | https://github.com/gavinhoward/bc                                              |
 | [`binutils`](binutils/)                | GNU Binutils                                               | 2.36.1                   | https://www.gnu.org/software/binutils/                                         |


### PR DESCRIPTION
Making the [Another World Bytecode Interpreter](https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter) to compile and link. Most of the change is to find SDL2 headers and library.

Game runs when game data from the MS-DOS version are provided to the installation directory (see install() in the package.sh).