### PR TITLE
LibJS: Add the Symbol.species getter to the appropriate built-ins

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -25,6 +25,8 @@ void ArrayBufferConstructor::initialize(GlobalObject& global_object)
     define_property(vm.names.prototype, global_object.array_buffer_prototype(), 0);
     define_property(vm.names.length, Value(1), Attribute::Configurable);
     define_native_function(vm.names.isView, is_view, 1, attr);
+
+    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 ArrayBufferConstructor::~ArrayBufferConstructor()
@@ -60,6 +62,11 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferConstructor::is_view)
         return Value(true);
     // FIXME: Check for DataView as well
     return Value(false);
+}
+
+JS_DEFINE_NATIVE_GETTER(ArrayBufferConstructor::symbol_species_getter)
+{
+    return vm.this_value(global_object);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
@@ -25,6 +25,8 @@ private:
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(is_view);
+
+    JS_DECLARE_NATIVE_GETTER(symbol_species_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -37,6 +37,8 @@ void ArrayConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.from, from, 1, attr);
     define_native_function(vm.names.isArray, is_array, 1, attr);
     define_native_function(vm.names.of, of, 0, attr);
+
+    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 Value ArrayConstructor::call()
@@ -149,6 +151,11 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::of)
     for (size_t i = 0; i < vm.argument_count(); ++i)
         array->indexed_properties().append(vm.argument(i));
     return array;
+}
+
+JS_DEFINE_NATIVE_GETTER(ArrayConstructor::symbol_species_getter)
+{
+    return vm.this_value(global_object);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
@@ -27,6 +27,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(from);
     JS_DECLARE_NATIVE_FUNCTION(is_array);
     JS_DECLARE_NATIVE_FUNCTION(of);
+
+    JS_DECLARE_NATIVE_GETTER(symbol_species_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -35,6 +35,8 @@ void PromiseConstructor::initialize(GlobalObject& global_object)
     // define_native_function(vm.names.race, race, 1, attr);
     define_native_function(vm.names.reject, reject, 1, attr);
     define_native_function(vm.names.resolve, resolve, 1, attr);
+
+    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 Value PromiseConstructor::call()
@@ -111,6 +113,11 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::resolve)
         return {};
     auto value = vm.argument(0);
     return promise_resolve(global_object, *constructor, value);
+}
+
+JS_DEFINE_NATIVE_GETTER(PromiseConstructor::symbol_species_getter)
+{
+    return vm.this_value(global_object);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.h
@@ -30,6 +30,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(race);
     JS_DECLARE_NATIVE_FUNCTION(reject);
     JS_DECLARE_NATIVE_FUNCTION(resolve);
+
+    JS_DECLARE_NATIVE_GETTER(symbol_species_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -22,6 +22,8 @@ void RegExpConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
     define_property(vm.names.prototype, global_object.regexp_prototype(), 0);
     define_property(vm.names.length, Value(2), Attribute::Configurable);
+
+    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 RegExpConstructor::~RegExpConstructor()
@@ -49,6 +51,11 @@ Value RegExpConstructor::construct(Function&)
             return {};
     }
     return RegExpObject::create(global_object(), pattern, flags);
+}
+
+JS_DEFINE_NATIVE_GETTER(RegExpConstructor::symbol_species_getter)
+{
+    return vm.this_value(global_object);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -23,6 +23,8 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
+
+    JS_DECLARE_NATIVE_GETTER(symbol_species_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -25,6 +25,8 @@ void TypedArrayConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
     define_property(vm.names.prototype, global_object.typed_array_prototype(), 0);
     define_property(vm.names.length, Value(0), Attribute::Configurable);
+
+    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 TypedArrayConstructor::~TypedArrayConstructor()
@@ -40,6 +42,11 @@ Value TypedArrayConstructor::construct(Function&)
 {
     vm().throw_exception<TypeError>(global_object(), ErrorType::ClassIsAbstract, "TypedArray");
     return {};
+}
+
+JS_DEFINE_NATIVE_GETTER(TypedArrayConstructor::symbol_species_getter)
+{
+    return vm.this_value(global_object);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
@@ -24,6 +24,8 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
+
+    JS_DECLARE_NATIVE_GETTER(symbol_species_getter);
 };
 
 }


### PR DESCRIPTION
I assume this doesnt interfere with any of the new-fangled Bytecode stuff, i havent read all of the code yet :sweat_smile:
(This fixes 24 test262 test cases)