### PR TITLE
WebServer+LibHTTP: Make WebServer more robust and add HTTP basic authentication support

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -29,28 +29,35 @@ public:
         String value;
     };
 
+    struct BasicAuthenticationCredentials {
+        String username;
+        String password;
+    };
+
     HttpRequest();
     ~HttpRequest();
 
-    const String& resource() const { return m_resource; }
-    const Vector<Header>& headers() const { return m_headers; }
+    String const& resource() const { return m_resource; }
+    Vector<Header> const& headers() const { return m_headers; }
 
-    const URL& url() const { return m_url; }
-    void set_url(const URL& url) { m_url = url; }
+    URL const& url() const { return m_url; }
+    void set_url(URL const& url) { m_url = url; }
 
     Method method() const { return m_method; }
     void set_method(Method method) { m_method = method; }
 
-    const ByteBuffer& body() const { return m_body; }
+    ByteBuffer const& body() const { return m_body; }
     void set_body(ReadonlyBytes body) { m_body = ByteBuffer::copy(body); }
     void set_body(ByteBuffer&& body) { m_body = move(body); }
 
     String method_name() const;
     ByteBuffer to_raw_request() const;
 
-    void set_headers(const HashMap<String, String>&);
+    void set_headers(HashMap<String, String> const&);
 
     static Optional<HttpRequest> from_raw_request(ReadonlyBytes);
+    static Optional<Header> get_http_basic_authentication_header(URL const&);
+    static Optional<BasicAuthenticationCredentials> parse_http_basic_authentication_header(String const&);
 
 private:
     URL m_url;

--- a/Userland/Libraries/LibHTTP/HttpResponse.cpp
+++ b/Userland/Libraries/LibHTTP/HttpResponse.cpp
@@ -18,4 +18,63 @@ HttpResponse::~HttpResponse()
 {
 }
 
+StringView HttpResponse::reason_phrase_for_code(int code)
+{
+    VERIFY(code >= 100 && code <= 599);
+
+    static HashMap<int, StringView> s_reason_phrases = {
+        { 100, "Continue"sv },
+        { 101, "Switching Protocols"sv },
+        { 200, "OK"sv },
+        { 201, "Created"sv },
+        { 202, "Accepted"sv },
+        { 203, "Non-Authoritative Information"sv },
+        { 204, "No Content"sv },
+        { 205, "Reset Content"sv },
+        { 206, "Partial Content"sv },
+        { 300, "Multiple Choices"sv },
+        { 301, "Moved Permanently"sv },
+        { 302, "Found"sv },
+        { 303, "See Other"sv },
+        { 304, "Not Modified"sv },
+        { 305, "Use Proxy"sv },
+        { 307, "Temporary Redirect"sv },
+        { 400, "Bad Request"sv },
+        { 401, "Unauthorized"sv },
+        { 402, "Payment Required"sv },
+        { 403, "Forbidden"sv },
+        { 404, "Not Found"sv },
+        { 405, "Method Not Allowed"sv },
+        { 406, "Not Acceptable"sv },
+        { 407, "Proxy Authentication Required"sv },
+        { 408, "Request Timeout"sv },
+        { 409, "Conflict"sv },
+        { 410, "Gone"sv },
+        { 411, "Length Required"sv },
+        { 412, "Precondition Failed"sv },
+        { 413, "Payload Too Large"sv },
+        { 414, "URI Too Long"sv },
+        { 415, "Unsupported Media Type"sv },
+        { 416, "Range Not Satisfiable"sv },
+        { 417, "Expectation Failed"sv },
+        { 426, "Upgrade Required"sv },
+        { 500, "Internal Server Error"sv },
+        { 501, "Not Implemented"sv },
+        { 502, "Bad Gateway"sv },
+        { 503, "Service Unavailable"sv },
+        { 504, "Gateway Timeout"sv },
+        { 505, "HTTP Version Not Supported"sv }
+    };
+
+    if (s_reason_phrases.contains(code))
+        return s_reason_phrases.ensure(code);
+
+    // NOTE: "A client MUST understand the class of any status code, as indicated by the first
+    //       digit, and treat an unrecognized status code as being equivalent to the x00 status
+    //       code of that class." (RFC 7231, section 6)
+    auto generic_code = (code / 100) * 100;
+    VERIFY(s_reason_phrases.contains(generic_code));
+    return s_reason_phrases.ensure(generic_code);
+}
+
 }

--- a/Userland/Libraries/LibHTTP/HttpResponse.h
+++ b/Userland/Libraries/LibHTTP/HttpResponse.h
@@ -21,7 +21,10 @@ public:
     }
 
     int code() const { return m_code; }
-    const HashMap<String, String, CaseInsensitiveStringTraits>& headers() const { return m_headers; }
+    StringView reason_phrase() const { return reason_phrase_for_code(m_code); }
+    HashMap<String, String, CaseInsensitiveStringTraits> const& headers() const { return m_headers; }
+
+    static StringView reason_phrase_for_code(int code);
 
 private:
     HttpResponse(int code, HashMap<String, String, CaseInsensitiveStringTraits>&&);

--- a/Userland/Services/WebServer/CMakeLists.txt
+++ b/Userland/Services/WebServer/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Client.cpp
+    Configuration.cpp
     main.cpp
 )
 

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -116,6 +116,11 @@ void Client::handle_request(ReadonlyBytes raw_request)
         return;
     }
 
+    if (file->is_device()) {
+        send_error_response(403, request);
+        return;
+    }
+
     Core::InputFileStream stream { file };
 
     send_response(stream, request, Core::guess_mime_type_based_on_filename(real_path));

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -11,6 +11,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
 #include <AK/MemoryStream.h>
+#include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <LibCore/DateTime.h>
@@ -211,9 +212,12 @@ void Client::handle_directory_listing(String const& requested_path, String const
     builder.append("<code><table>\n");
 
     Core::DirIterator dt(real_path);
-    while (dt.has_next()) {
-        auto name = dt.next_path();
+    Vector<String> names;
+    while (dt.has_next())
+        names.append(dt.next_path());
+    quick_sort(names);
 
+    for (auto& name : names) {
         StringBuilder path_builder;
         path_builder.append(real_path);
         path_builder.append('/');

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Client.h"
 #include <AK/Base64.h>
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
@@ -21,16 +20,17 @@
 #include <LibCore/MimeData.h>
 #include <LibHTTP/HttpRequest.h>
 #include <LibHTTP/HttpResponse.h>
+#include <WebServer/Client.h>
+#include <WebServer/Configuration.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 namespace WebServer {
 
-Client::Client(NonnullRefPtr<Core::TCPSocket> socket, String const& root, Core::Object* parent)
+Client::Client(NonnullRefPtr<Core::TCPSocket> socket, Core::Object* parent)
     : Core::Object(parent)
     , m_socket(socket)
-    , m_root_path(root)
 {
 }
 
@@ -84,8 +84,7 @@ void Client::handle_request(ReadonlyBytes raw_request)
     dbgln_if(WEBSERVER_DEBUG, "Canonical requested path: '{}'", requested_path);
 
     StringBuilder path_builder;
-    path_builder.append(m_root_path);
-    path_builder.append('/');
+    path_builder.append(Configuration::the().root_path());
     path_builder.append(requested_path);
     auto real_path = path_builder.to_string();
 

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -265,11 +265,7 @@ void Client::send_error_response(unsigned code, StringView const& message, HTTP:
 
 void Client::log_response(unsigned code, HTTP::HttpRequest const& request)
 {
-    printf("%s :: %03u :: %s %s\n",
-        Core::DateTime::now().to_string().characters(),
-        code,
-        request.method_name().characters(),
-        request.resource().characters());
+    outln("{} :: {:03d} :: {} {}", Core::DateTime::now().to_string(), code, request.method_name(), request.resource());
 }
 
 }

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -33,7 +34,10 @@ Client::Client(NonnullRefPtr<Core::TCPSocket> socket, String const& root, Core::
 
 void Client::die()
 {
-    remove_from_parent();
+    deferred_invoke([this](auto& object) {
+        NonnullRefPtr protector { object };
+        remove_from_parent();
+    });
 }
 
 void Client::start()

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -237,6 +237,10 @@ void Client::handle_directory_listing(String const& requested_path, String const
         builder.appendff("<td><div class=\"{}\"></div></td>", is_directory ? "folder" : "file");
         builder.append("<td><a href=\"");
         builder.append(URL::percent_encode(name));
+        // NOTE: For directories, we append a slash so we don't always hit the redirect case,
+        //       which adds a slash anyways.
+        if (is_directory)
+            builder.append('/');
         builder.append("\">");
         builder.append(escape_html_entities(name));
         builder.append("</a></td><td>&nbsp;</td>");

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -18,15 +18,13 @@
 #include <LibCore/FileStream.h>
 #include <LibCore/MimeData.h>
 #include <LibHTTP/HttpRequest.h>
-#include <inttypes.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <unistd.h>
 
 namespace WebServer {
 
-Client::Client(NonnullRefPtr<Core::TCPSocket> socket, const String& root, Core::Object* parent)
+Client::Client(NonnullRefPtr<Core::TCPSocket> socket, String const& root, Core::Object* parent)
     : Core::Object(parent)
     , m_socket(socket)
     , m_root_path(root)
@@ -119,7 +117,7 @@ void Client::handle_request(ReadonlyBytes raw_request)
     send_response(stream, request, Core::guess_mime_type_based_on_filename(real_path));
 }
 
-void Client::send_response(InputStream& response, const HTTP::HttpRequest& request, const String& content_type)
+void Client::send_response(InputStream& response, HTTP::HttpRequest const& request, String const& content_type)
 {
     StringBuilder builder;
     builder.append("HTTP/1.0 200 OK\r\n");
@@ -145,7 +143,7 @@ void Client::send_response(InputStream& response, const HTTP::HttpRequest& reque
     } while (true);
 }
 
-void Client::send_redirect(StringView redirect_path, const HTTP::HttpRequest& request)
+void Client::send_redirect(StringView redirect_path, HTTP::HttpRequest const& request)
 {
     StringBuilder builder;
     builder.append("HTTP/1.0 301 Moved Permanently\r\n");
@@ -181,7 +179,7 @@ static String file_image_data()
     return cache;
 }
 
-void Client::handle_directory_listing(const String& requested_path, const String& real_path, const HTTP::HttpRequest& request)
+void Client::handle_directory_listing(String const& requested_path, String const& real_path, HTTP::HttpRequest const& request)
 {
     StringBuilder builder;
 
@@ -246,7 +244,7 @@ void Client::handle_directory_listing(const String& requested_path, const String
     send_response(stream, request, "text/html");
 }
 
-void Client::send_error_response(unsigned code, const StringView& message, const HTTP::HttpRequest& request)
+void Client::send_error_response(unsigned code, StringView const& message, HTTP::HttpRequest const& request)
 {
     StringBuilder builder;
     builder.appendff("HTTP/1.0 {} ", code);
@@ -261,7 +259,7 @@ void Client::send_error_response(unsigned code, const StringView& message, const
     log_response(code, request);
 }
 
-void Client::log_response(unsigned code, const HTTP::HttpRequest& request)
+void Client::log_response(unsigned code, HTTP::HttpRequest const& request)
 {
     printf("%s :: %03u :: %s %s\n",
         Core::DateTime::now().to_string().characters(),

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -19,7 +19,7 @@ public:
     void start();
 
 private:
-    Client(NonnullRefPtr<Core::TCPSocket>, String const&, Core::Object* parent);
+    Client(NonnullRefPtr<Core::TCPSocket>, Core::Object* parent);
 
     void handle_request(ReadonlyBytes);
     void send_response(InputStream&, HTTP::HttpRequest const&, String const& content_type);
@@ -30,7 +30,6 @@ private:
     void handle_directory_listing(String const& requested_path, String const& real_path, HTTP::HttpRequest const&);
 
     NonnullRefPtr<Core::TCPSocket> m_socket;
-    String m_root_path;
 };
 
 }

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -24,7 +24,7 @@ private:
     void handle_request(ReadonlyBytes);
     void send_response(InputStream&, HTTP::HttpRequest const&, String const& content_type);
     void send_redirect(StringView redirect, HTTP::HttpRequest const&);
-    void send_error_response(unsigned code, StringView const& message, HTTP::HttpRequest const&);
+    void send_error_response(unsigned code, HTTP::HttpRequest const&);
     void die();
     void log_response(unsigned code, HTTP::HttpRequest const&);
     void handle_directory_listing(String const& requested_path, String const& real_path, HTTP::HttpRequest const&);

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -24,10 +24,11 @@ private:
     void handle_request(ReadonlyBytes);
     void send_response(InputStream&, HTTP::HttpRequest const&, String const& content_type);
     void send_redirect(StringView redirect, HTTP::HttpRequest const&);
-    void send_error_response(unsigned code, HTTP::HttpRequest const&);
+    void send_error_response(unsigned code, HTTP::HttpRequest const&, Vector<String> const& headers = {});
     void die();
     void log_response(unsigned code, HTTP::HttpRequest const&);
     void handle_directory_listing(String const& requested_path, String const& real_path, HTTP::HttpRequest const&);
+    bool verify_credentials(Vector<HTTP::HttpRequest::Header> const&);
 
     NonnullRefPtr<Core::TCPSocket> m_socket;
 };

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -19,15 +19,15 @@ public:
     void start();
 
 private:
-    Client(NonnullRefPtr<Core::TCPSocket>, const String&, Core::Object* parent);
+    Client(NonnullRefPtr<Core::TCPSocket>, String const&, Core::Object* parent);
 
     void handle_request(ReadonlyBytes);
-    void send_response(InputStream&, const HTTP::HttpRequest&, const String& content_type);
-    void send_redirect(StringView redirect, const HTTP::HttpRequest& request);
-    void send_error_response(unsigned code, const StringView& message, const HTTP::HttpRequest&);
+    void send_response(InputStream&, HTTP::HttpRequest const&, String const& content_type);
+    void send_redirect(StringView redirect, HTTP::HttpRequest const&);
+    void send_error_response(unsigned code, StringView const& message, HTTP::HttpRequest const&);
     void die();
-    void log_response(unsigned code, const HTTP::HttpRequest&);
-    void handle_directory_listing(const String& requested_path, const String& real_path, const HTTP::HttpRequest&);
+    void log_response(unsigned code, HTTP::HttpRequest const&);
+    void handle_directory_listing(String const& requested_path, String const& real_path, HTTP::HttpRequest const&);
 
     NonnullRefPtr<Core::TCPSocket> m_socket;
     String m_root_path;

--- a/Userland/Services/WebServer/Configuration.cpp
+++ b/Userland/Services/WebServer/Configuration.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <WebServer/Configuration.h>
+
+namespace WebServer {
+
+static Configuration* s_configuration = nullptr;
+
+Configuration::Configuration(String root_path)
+    : m_root_path(move(root_path))
+{
+    VERIFY(!s_configuration);
+    s_configuration = this;
+}
+
+Configuration const& Configuration::the()
+{
+    VERIFY(s_configuration);
+    return *s_configuration;
+}
+
+}

--- a/Userland/Services/WebServer/Configuration.h
+++ b/Userland/Services/WebServer/Configuration.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/String.h>
+#include <LibHTTP/HttpRequest.h>
 
 namespace WebServer {
 
@@ -15,13 +17,16 @@ public:
     Configuration(String root_path);
 
     String const& root_path() const { return m_root_path; }
+    Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> const& credentials() const { return m_credentials; }
 
     void set_root_path(String root_path) { m_root_path = move(root_path); }
+    void set_credentials(Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> credentials) { m_credentials = move(credentials); }
 
     static Configuration const& the();
 
 private:
     String m_root_path;
+    Optional<HTTP::HttpRequest::BasicAuthenticationCredentials> m_credentials;
 };
 
 }

--- a/Userland/Services/WebServer/Configuration.h
+++ b/Userland/Services/WebServer/Configuration.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace WebServer {
+
+class Configuration {
+public:
+    Configuration(String root_path);
+
+    String const& root_path() const { return m_root_path; }
+
+    void set_root_path(String root_path) { m_root_path = move(root_path); }
+
+    static Configuration const& the();
+
+private:
+    String m_root_path;
+};
+
+}

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -1,15 +1,17 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Client.h"
 #include <AK/MappedFile.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/TCPServer.h>
+#include <WebServer/Client.h>
+#include <WebServer/Configuration.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -51,6 +53,8 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    WebServer::Configuration configuration(real_root_path);
+
     Core::EventLoop loop;
 
     auto server = Core::TCPServer::construct();
@@ -58,7 +62,7 @@ int main(int argc, char** argv)
     server->on_ready_to_accept = [&] {
         auto client_socket = server->accept();
         VERIFY(client_socket);
-        auto client = WebServer::Client::construct(client_socket.release_nonnull(), real_root_path, server);
+        auto client = WebServer::Client::construct(client_socket.release_nonnull(), server);
         client->start();
     };
 

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/TCPServer.h>
+#include <LibHTTP/HttpRequest.h>
 #include <WebServer/Client.h>
 #include <WebServer/Configuration.h>
 #include <stdio.h>
@@ -19,14 +20,18 @@ int main(int argc, char** argv)
 {
     String default_listen_address = "0.0.0.0";
     u16 default_port = 8000;
-    const char* root_path = "/www";
+    String root_path = "/www";
 
     String listen_address = default_listen_address;
     int port = default_port;
+    String username;
+    String password;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(listen_address, "IP address to listen on", "listen-address", 'l', "listen_address");
     args_parser.add_option(port, "Port to listen on", "port", 'p', "port");
+    args_parser.add_option(username, "HTTP basic authentication username", "user", 'U', "username");
+    args_parser.add_option(password, "HTTP basic authentication password", "pass", 'P', "password");
     args_parser.add_positional_argument(root_path, "Path to serve the contents of", "path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
@@ -38,6 +43,11 @@ int main(int argc, char** argv)
 
     if ((u16)port != port) {
         warnln("Invalid port number: {}", port);
+        return 1;
+    }
+
+    if (username.is_empty() != password.is_empty()) {
+        warnln("Both username and password are required for HTTP basic authentication.");
         return 1;
     }
 
@@ -54,6 +64,9 @@ int main(int argc, char** argv)
     }
 
     WebServer::Configuration configuration(real_root_path);
+
+    if (!username.is_empty() && !password.is_empty())
+        configuration.set_credentials(HTTP::HttpRequest::BasicAuthenticationCredentials { username, password });
 
     Core::EventLoop loop;
 


### PR DESCRIPTION
This fixes various bugs in WebServer. It also adds support for HTTP basic authentication to it, which can be enabled with the `--username` and `--password` command line flags.

WebServer now works much better than before, but the most severe issue remains: If the client is too slow in sending the request, everything blows up. See #7880.