### PR TITLE
LibJS: Fix `AbstractInequals` returning result of `AbstractEquals`

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -225,7 +225,7 @@ private:
 class AbstractInequals final : public Instruction {
 public:
     AbstractInequals(Register dst, Register src1, Register src2)
-        : Instruction(Type::AbstractEquals)
+        : Instruction(Type::AbstractInequals)
         , m_dst(dst)
         , m_src1(src1)
         , m_src2(src2)


### PR DESCRIPTION
Small error in the class definition.

Previously `2 != 2` would incorrectly return `true`.