### PR TITLE
LibJS: Add support for typed equality checks

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -79,6 +79,12 @@ Optional<Bytecode::Register> BinaryExpression::generate_bytecode(Bytecode::Gener
     case BinaryOp::AbstractEquals:
         generator.emit<Bytecode::Op::AbstractEquals>(dst_reg, *lhs_reg, *rhs_reg);
         return dst_reg;
+    case BinaryOp::TypedInequals:
+        generator.emit<Bytecode::Op::TypedInequals>(dst_reg, *lhs_reg, *rhs_reg);
+        return dst_reg;
+    case BinaryOp::TypedEquals:
+        generator.emit<Bytecode::Op::TypedEquals>(dst_reg, *lhs_reg, *rhs_reg);
+        return dst_reg;
     case BinaryOp::BitwiseAnd:
         generator.emit<Bytecode::Op::BitwiseAnd>(dst_reg, *lhs_reg, *rhs_reg);
         return dst_reg;

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -23,6 +23,8 @@
     O(LessThanEquals)             \
     O(AbstractInequals)           \
     O(AbstractEquals)             \
+    O(TypedInequals)              \
+    O(TypedEquals)                \
     O(NewString)                  \
     O(NewObject)                  \
     O(GetVariable)                \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -112,6 +112,16 @@ void AbstractEquals::execute(Bytecode::Interpreter& interpreter) const
     interpreter.reg(m_dst) = Value(abstract_eq(interpreter.global_object(), interpreter.reg(m_src1), interpreter.reg(m_src2)));
 }
 
+void TypedInequals::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.reg(m_dst) = Value(!strict_eq(interpreter.reg(m_src1), interpreter.reg(m_src2)));
+}
+
+void TypedEquals::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.reg(m_dst) = Value(strict_eq(interpreter.reg(m_src1), interpreter.reg(m_src2)));
+}
+
 void BitwiseAnd::execute(Bytecode::Interpreter& interpreter) const
 {
     interpreter.reg(m_dst) = Value(bitwise_and(interpreter.global_object(), interpreter.reg(m_src1), interpreter.reg(m_src2)));
@@ -291,6 +301,16 @@ String AbstractInequals::to_string() const
 String AbstractEquals::to_string() const
 {
     return String::formatted("AbstractEquals dst:{}, src1:{}, src2:{}", m_dst, m_src1, m_src2);
+}
+
+String TypedInequals::to_string() const
+{
+    return String::formatted("TypedInequals dst:{}, src1:{}, src2:{}", m_dst, m_src1, m_src2);
+}
+
+String TypedEquals::to_string() const
+{
+    return String::formatted("TypedEquals dst:{}, src1:{}, src2:{}", m_dst, m_src1, m_src2);
 }
 
 String BitwiseAnd::to_string() const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -260,6 +260,44 @@ private:
     Register m_src2;
 };
 
+class TypedInequals final : public Instruction {
+public:
+    TypedInequals(Register dst, Register src1, Register src2)
+        : Instruction(Type::TypedInequals)
+        , m_dst(dst)
+        , m_src1(src1)
+        , m_src2(src2)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string() const;
+
+private:
+    Register m_dst;
+    Register m_src1;
+    Register m_src2;
+};
+
+class TypedEquals final : public Instruction {
+public:
+    TypedEquals(Register dst, Register src1, Register src2)
+        : Instruction(Type::TypedEquals)
+        , m_dst(dst)
+        , m_src1(src1)
+        , m_src2(src2)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string() const;
+
+private:
+    Register m_dst;
+    Register m_src1;
+    Register m_src2;
+};
+
 class BitwiseAnd final : public Instruction {
 public:
     BitwiseAnd(Register dst, Register src1, Register src2)


### PR DESCRIPTION
Retry of #7889 after dodgy rebase.

Adds support for `!==` and `===`.