### PR TITLE
LibJS: Make sure that if expressions yield the correct value

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -21,10 +21,11 @@ Optional<Bytecode::Register> ASTNode::generate_bytecode(Bytecode::Generator&) co
 Optional<Bytecode::Register> ScopeNode::generate_bytecode(Bytecode::Generator& generator) const
 {
     generator.emit<Bytecode::Op::EnterScope>(*this);
+    Optional<Bytecode::Register> last_value_reg;
     for (auto& child : children()) {
-        [[maybe_unused]] auto reg = child.generate_bytecode(generator);
+        last_value_reg = child.generate_bytecode(generator);
     }
-    return {};
+    return last_value_reg;
 }
 
 Optional<Bytecode::Register> EmptyStatement::generate_bytecode(Bytecode::Generator&) const

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -11,6 +11,7 @@
 
 #define ENUMERATE_BYTECODE_OPS(O) \
     O(Load)                       \
+    O(LoadRegister)               \
     O(Add)                        \
     O(Sub)                        \
     O(Mul)                        \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -52,6 +52,11 @@ void Load::execute(Bytecode::Interpreter& interpreter) const
     interpreter.reg(m_dst) = m_value;
 }
 
+void LoadRegister::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.reg(m_dst) = interpreter.reg(m_src);
+}
+
 void Add::execute(Bytecode::Interpreter& interpreter) const
 {
     interpreter.reg(m_dst) = add(interpreter.global_object(), interpreter.reg(m_src1), interpreter.reg(m_src2));
@@ -282,6 +287,11 @@ void Return::execute(Bytecode::Interpreter& interpreter) const
 String Load::to_string() const
 {
     return String::formatted("Load dst:{}, value:{}", m_dst, m_value.to_string_without_side_effects());
+}
+
+String LoadRegister::to_string() const
+{
+    return String::formatted("LoadRegister dst:{}, src:{}", m_dst, m_src);
 }
 
 String Add::to_string() const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -32,6 +32,23 @@ private:
     Value m_value;
 };
 
+class LoadRegister final : public Instruction {
+public:
+    LoadRegister(Register dst, Register src)
+        : Instruction(Type::LoadRegister)
+        , m_dst(dst)
+        , m_src(src)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string() const;
+
+private:
+    Register m_dst;
+    Register m_src;
+};
+
 class Add final : public Instruction {
 public:
     Add(Register dst, Register src1, Register src2)


### PR DESCRIPTION
**LibJS: Make sure scope expressions yield the correct value**

When evaluated as an expression "{ 3 }" should yield 3. This updates the bytecode interpreter to make it so.

**LibJS: Make sure that if expressions yield the correct value**

When evaluated as an expression "if (true) { 3 } else { 5 }" should yield 3. This updates the bytecode interpreter to make it so.