### PR TITLE
Ports: Make `curl` detect our OpenSSL port

### DIFF
--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -2,11 +2,7 @@
 port=curl
 version=7.77.0
 useconfigure=true
-configopts="--disable-ntlm-wb --with-ssl"
-files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2
-https://curl.se/download/curl-${version}.tar.bz2.asc curl-${version}.tar.bz2.asc"
-
-depends="zlib openssl"
-auth_type="sig"
-auth_import_key="27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2"
-auth_opts="curl-${version}.tar.bz2.asc curl-${version}.tar.bz2"
+files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2 6c0c28868cb82593859fc43b9c8fdb769314c855c05cf1b56b023acf855df8ea"
+auth_type=sha256
+depends="openssl zlib"
+configopts="--disable-ntlm-wb --with-openssl=${SERENITY_INSTALL_ROOT}/usr/local"


### PR DESCRIPTION
Without a proper prefix, curl's `configure` script will probably pick up the host's OpenSSL library. This change makes sure the script always looks at the library present in the Serenity build dir.