### PR TITLE
Toolchain: Add `gettext` as a dependency to `Dockerfile`

### DIFF
--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y \
         cmake \
         curl \
         genext2fs \
+        gettext \
         git \
         imagemagick \
         libmpfr-dev \


### PR DESCRIPTION
We need `msgfmt` inside of the `gettext` package in order to build the git port.