### PR TITLE
LibWeb: Add support to inspect DOM tree in OutOfProcessWebView

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -199,7 +199,7 @@ void BrowserWindow::build_menus()
                 tab.m_dom_inspector_window->show();
                 tab.m_dom_inspector_window->move_to_front();
             } else {
-                TODO();
+                tab.m_web_content_view->inspect_dom_tree();
             }
         },
         this);

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -12,14 +12,20 @@
 #include <LibGUI/TreeView.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOMTreeJSONModel.h>
 #include <LibWeb/DOMTreeModel.h>
 #include <LibWeb/LayoutTreeModel.h>
 #include <LibWeb/StylePropertiesModel.h>
 
 namespace Browser {
 
-void InspectorWidget::set_inspected_node(Web::DOM::Node* node)
+void InspectorWidget::set_inspected_node(GUI::ModelIndex const index)
 {
+    if (!m_document) {
+        // FIXME: Handle this for OutOfProcessWebView
+        return;
+    }
+    auto* node = static_cast<Web::DOM::Node*>(index.internal_data());
     m_document->set_inspected_node(node);
     if (node && node->is_element()) {
         auto& element = downcast<Web::DOM::Element>(*node);
@@ -43,15 +49,13 @@ InspectorWidget::InspectorWidget()
     m_dom_tree_view = top_tab_widget.add_tab<GUI::TreeView>("DOM");
     m_dom_tree_view->on_selection_change = [this] {
         const auto& index = m_dom_tree_view->selection().first();
-        auto* node = static_cast<Web::DOM::Node*>(index.internal_data());
-        set_inspected_node(node);
+        set_inspected_node(index);
     };
 
     m_layout_tree_view = top_tab_widget.add_tab<GUI::TreeView>("Layout");
     m_layout_tree_view->on_selection_change = [this] {
         const auto& index = m_layout_tree_view->selection().first();
-        auto* node = static_cast<Web::Layout::Node*>(index.internal_data());
-        set_inspected_node(node->dom_node());
+        set_inspected_node(index);
     };
 
     auto& bottom_tab_widget = splitter.add<GUI::TabWidget>();
@@ -71,6 +75,18 @@ void InspectorWidget::set_document(Web::DOM::Document* document)
     m_document = document;
     m_dom_tree_view->set_model(Web::DOMTreeModel::create(*document));
     m_layout_tree_view->set_model(Web::LayoutTreeModel::create(*document));
+}
+
+void InspectorWidget::set_dom_json(String json)
+{
+    if (m_dom_json.has_value() && m_dom_json.value() == json)
+        return;
+
+    m_dom_json = json;
+    m_dom_tree_view->set_model(Web::DOMTreeJSONModel::create(m_dom_json->view()));
+
+    // FIXME: Support the LayoutTreeModel
+    // m_layout_tree_view->set_model(Web::LayoutTreeModel::create(*document));
 }
 
 }

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -17,17 +17,22 @@ public:
     virtual ~InspectorWidget();
 
     void set_document(Web::DOM::Document*);
+    void set_dom_json(String);
 
 private:
     InspectorWidget();
 
-    void set_inspected_node(Web::DOM::Node*);
+    void set_inspected_node(GUI::ModelIndex);
 
     RefPtr<GUI::TreeView> m_dom_tree_view;
     RefPtr<GUI::TreeView> m_layout_tree_view;
     RefPtr<GUI::TableView> m_style_table_view;
     RefPtr<GUI::TableView> m_computed_style_table_view;
+
+    // One of these will be available, depending on if we're
+    // in-process (m_document) or out-of-process (m_dom_json)
     RefPtr<Web::DOM::Document> m_document;
+    Optional<String> m_dom_json;
 };
 
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -11,6 +11,7 @@
 #include "BrowserWindow.h"
 #include "ConsoleWidget.h"
 #include "DownloadWidget.h"
+#include "InspectorWidget.h"
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <Applications/Browser/TabGML.h>
@@ -76,6 +77,20 @@ void Tab::view_source(const URL& url, const String& source)
     window->set_title(url.to_string());
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-text.png"));
     window->show();
+}
+
+void Tab::view_dom_tree(const String& dom_tree)
+{
+    auto window = GUI::Window::construct(&this->window());
+    window->resize(300, 500);
+    window->set_title("DOM inspector");
+    window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/inspector-object.png"));
+    window->set_main_widget<InspectorWidget>();
+
+    auto* inspector_widget = static_cast<InspectorWidget*>(window->main_widget());
+    inspector_widget->set_dom_json(dom_tree);
+    window->show();
+    window->move_to_front();
 }
 
 Tab::Tab(BrowserWindow& window, Type type)
@@ -262,6 +277,10 @@ Tab::Tab(BrowserWindow& window, Type type)
 
     hooks().on_get_source = [this](auto& url, auto& source) {
         view_source(url, source);
+    };
+
+    hooks().on_get_dom_tree = [this](auto& dom_tree) {
+        view_dom_tree(dom_tree);
     };
 
     hooks().on_js_console_output = [this](auto& method, auto& line) {

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -79,6 +79,7 @@ private:
     void update_bookmark_button(const String& url);
     void start_download(const URL& url);
     void view_source(const URL& url, const String& source);
+    void view_dom_tree(const String&);
 
     Type m_type;
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SOURCES
     DOM/Timer.cpp
     DOM/Window.cpp
     DOMTreeModel.cpp
+    DOMTreeJSONModel.cpp
     Dump.cpp
     FontCache.cpp
     HTML/AttributeNames.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -920,4 +920,14 @@ void Document::set_cookie(String cookie_string, Cookie::Source source)
         page->client().page_did_set_cookie(m_url, cookie.value(), source);
 }
 
+String Document::dump_dom_tree_as_json() const
+{
+    StringBuilder builder;
+    JsonObjectSerializer json(builder);
+    serialize_tree_as_json(json);
+
+    json.finish();
+    return builder.to_string();
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -263,6 +263,8 @@ public:
 
     virtual EventTarget* get_parent(const Event&) override;
 
+    String dump_dom_tree_as_json() const;
+
 private:
     explicit Document(const URL&);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -606,4 +606,36 @@ RefPtr<Document> Node::owner_document() const
     return m_document;
 }
 
+void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) const
+{
+    object.add("name", node_name().view());
+    object.add("internal_id", (size_t)this);
+    if (is_document())
+        object.add("type", "document");
+    else if (is_element()) {
+        object.add("type", "element");
+
+        auto element = downcast<DOM::Element>(this);
+        if (element->has_attributes()) {
+            auto attributes = object.add_object("attributes");
+            element->for_each_attribute([&attributes](auto& name, auto& value) {
+                attributes.add(name, value);
+            });
+        }
+    } else if (is_text()) {
+        object.add("type", "text");
+
+        auto text_node = downcast<DOM::Text>(this);
+        object.add("text", text_node->data());
+    }
+
+    if (has_child_nodes()) {
+        auto children = object.add_array("children");
+        for_each_child([&children](DOM::Node& child) {
+            JsonObjectSerializer<StringBuilder> child_object = children.add_object();
+            child.serialize_tree_as_json(child_object);
+        });
+    }
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/JsonObjectSerializer.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/TypeCasts.h>
@@ -161,6 +162,9 @@ public:
     ExceptionOr<void> ensure_pre_insertion_validity(NonnullRefPtr<Node> node, RefPtr<Node> child) const;
 
     bool is_host_including_inclusive_ancestor_of(const Node&) const;
+
+    // Used for dumping the DOM Tree
+    void serialize_tree_as_json(JsonObjectSerializer<StringBuilder>&) const;
 
 protected:
     Node(Document&, NodeType);

--- a/Userland/Libraries/LibWeb/DOMTreeJSONModel.cpp
+++ b/Userland/Libraries/LibWeb/DOMTreeJSONModel.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2020, Adam Hodgen <ant1441@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "DOMTreeJSONModel.h"
+#include <AK/JsonObject.h>
+#include <AK/StringBuilder.h>
+#include <ctype.h>
+
+namespace Web {
+
+DOMTreeJSONModel::DOMTreeJSONModel(JsonObject dom_tree)
+    : m_dom_tree(dom_tree)
+{
+    m_document_icon.set_bitmap_for_size(16, Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-html.png"));
+    m_element_icon.set_bitmap_for_size(16, Gfx::Bitmap::load_from_file("/res/icons/16x16/inspector-object.png"));
+    m_text_icon.set_bitmap_for_size(16, Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-unknown.png"));
+}
+
+DOMTreeJSONModel::~DOMTreeJSONModel()
+{
+}
+
+GUI::ModelIndex DOMTreeJSONModel::index(int row, int column, const GUI::ModelIndex& parent) const
+{
+    if (!parent.is_valid()) {
+        return create_index(row, column, (void*)get_internal_id(m_dom_tree));
+    }
+
+    auto parent_node = find_node(parent);
+    auto children = get_children(parent_node);
+    auto child_node = children[row].as_object();
+
+    auto child_internal_id = (void*)get_internal_id(child_node);
+    return create_index(row, column, child_internal_id);
+}
+
+GUI::ModelIndex DOMTreeJSONModel::parent_index(const GUI::ModelIndex& index) const
+{
+    // FIXME: Handle the template element (child elements are not stored in it, all of its children are in its document fragment "content")
+    //        Probably in the JSON generation in Node.cpp?
+    if (!index.is_valid())
+        return {};
+
+    auto node = find_node(index);
+
+    auto node_internal_id = get_internal_id(node);
+    auto parent_node = find_parent_of_child_with_internal_id(node_internal_id);
+    if (!parent_node.has_value())
+        return {};
+    auto parent_node_internal_id = get_internal_id(parent_node.value());
+
+    // If the parent is the root document, we know it has index 0, 0
+    if (parent_node_internal_id == get_internal_id(m_dom_tree)) {
+        return create_index(0, 0, (void*)parent_node_internal_id);
+    }
+
+    // Otherwise, we need to find the grandparent, to find the index of parent within that
+    auto grandparent_node = find_parent_of_child_with_internal_id(parent_node_internal_id);
+    VERIFY(grandparent_node.has_value());
+
+    auto grandparent_children = get_children(*grandparent_node);
+    if (grandparent_children.is_empty())
+        return {};
+
+    for (int grandparent_child_index = 0; grandparent_child_index < grandparent_children.size(); ++grandparent_child_index) {
+        auto child = grandparent_children[grandparent_child_index].as_object();
+        if (get_internal_id(child) == parent_node_internal_id)
+            return create_index(grandparent_child_index, 0, (void*)(parent_node_internal_id));
+    }
+    return {};
+}
+
+int DOMTreeJSONModel::row_count(const GUI::ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return 1;
+
+    auto child = find_node(index);
+    return get_children(child).size();
+}
+
+int DOMTreeJSONModel::column_count(const GUI::ModelIndex&) const
+{
+    return 1;
+}
+
+static String with_whitespace_collapsed(const StringView& string)
+{
+    StringBuilder builder;
+    for (size_t i = 0; i < string.length(); ++i) {
+        if (isspace(string[i])) {
+            builder.append(' ');
+            while (i < string.length()) {
+                if (isspace(string[i])) {
+                    ++i;
+                    continue;
+                }
+                builder.append(string[i]);
+                break;
+            }
+            continue;
+        }
+        builder.append(string[i]);
+    }
+    return builder.to_string();
+}
+
+GUI::Variant DOMTreeJSONModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+{
+    auto node = find_node(index);
+    auto node_name = node.get("name").as_string();
+    auto type = node.get("type").as_string_or("unknown");
+
+    if (role == GUI::ModelRole::Icon) {
+        if (type == "document")
+            return m_document_icon;
+        if (type == "element")
+            return m_element_icon;
+        // FIXME: More node type icons?
+        return m_text_icon;
+    }
+    if (role == GUI::ModelRole::Display) {
+        if (type == "text")
+            return with_whitespace_collapsed(node.get("text").as_string());
+        if (type != "element")
+            return node_name;
+
+        StringBuilder builder;
+        builder.append('<');
+        builder.append(node_name.to_lowercase());
+        if (node.has("attributes")) {
+            auto attributes = node.get("attributes").as_object();
+            attributes.for_each_member([&builder](auto& name, JsonValue& value) {
+                builder.append(' ');
+                builder.append(name);
+                builder.append('=');
+                builder.append('"');
+                builder.append(value.to_string());
+                builder.append('"');
+            });
+        }
+        builder.append('>');
+        return builder.to_string();
+    }
+    return {};
+}
+
+void DOMTreeJSONModel::update()
+{
+    did_update();
+}
+
+Optional<JsonObject> DOMTreeJSONModel::find_parent_of_child_with_internal_id(size_t internal_id) const
+{
+    return find_parent_of_child_with_internal_id(m_dom_tree, internal_id);
+}
+
+Optional<JsonObject> DOMTreeJSONModel::find_parent_of_child_with_internal_id(JsonObject node, size_t internal_id) const
+{
+    auto children = get_children(node);
+
+    for (int i = 0; i < children.size(); ++i) {
+        auto child = children[i].as_object();
+        auto child_internal_id = get_internal_id(child);
+        if (child_internal_id == internal_id)
+            return node;
+        auto maybe_node = find_parent_of_child_with_internal_id(child, internal_id);
+        if (maybe_node.has_value())
+            return maybe_node;
+    }
+    return {};
+}
+
+Optional<JsonObject> DOMTreeJSONModel::find_child_with_internal_id(size_t internal_id) const
+{
+    return find_child_with_internal_id(m_dom_tree, internal_id);
+}
+
+Optional<JsonObject> DOMTreeJSONModel::find_child_with_internal_id(JsonObject node, size_t internal_id) const
+{
+    auto node_internal_id = get_internal_id(node);
+    if (node_internal_id == internal_id) {
+        return node;
+    }
+    auto children = get_children(node);
+
+    for (int i = 0; i < children.size(); ++i) {
+        auto child = children[i].as_object();
+        auto maybe_node = find_child_with_internal_id(child, internal_id);
+        if (maybe_node.has_value())
+            return maybe_node;
+    }
+    return {};
+}
+
+size_t DOMTreeJSONModel::get_internal_id(JsonObject const& o)
+{
+    return o.get("internal_id").as_u32();
+}
+
+JsonArray DOMTreeJSONModel::get_children(JsonObject const& o)
+{
+    auto maybe_children = o.get("children");
+    if (maybe_children.is_null())
+        return {};
+    return maybe_children.as_array();
+}
+
+JsonObject DOMTreeJSONModel::find_node(GUI::ModelIndex index) const
+{
+    auto internal_id = (size_t)(index.internal_data());
+
+    auto maybe_node = find_child_with_internal_id(internal_id);
+    if (!maybe_node.has_value()) {
+        dbgln("Failed to find node with internal_id={}", internal_id);
+        VERIFY_NOT_REACHED();
+    }
+    return maybe_node.value();
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOMTreeJSONModel.h
+++ b/Userland/Libraries/LibWeb/DOMTreeJSONModel.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2020, Adam Hodgen <ant1441@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <LibGUI/Model.h>
+#include <LibWeb/Forward.h>
+
+namespace Web {
+
+class DOMTreeJSONModel final : public GUI::Model {
+public:
+    static NonnullRefPtr<DOMTreeJSONModel> create(StringView dom_tree)
+    {
+        auto json_or_error = JsonValue::from_string(dom_tree);
+        if (!json_or_error.has_value())
+            VERIFY_NOT_REACHED();
+
+        return adopt_ref(*new DOMTreeJSONModel(json_or_error.value().as_object()));
+    }
+
+    virtual ~DOMTreeJSONModel() override;
+
+    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
+    virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
+    virtual void update() override;
+
+private:
+    explicit DOMTreeJSONModel(JsonObject);
+
+    Optional<JsonObject> find_parent_of_child_with_internal_id(size_t) const;
+    Optional<JsonObject> find_parent_of_child_with_internal_id(JsonObject, size_t) const;
+
+    Optional<JsonObject> find_child_with_internal_id(size_t) const;
+    Optional<JsonObject> find_child_with_internal_id(JsonObject, size_t) const;
+
+    JsonObject find_node(GUI::ModelIndex) const;
+
+    static size_t get_internal_id(const JsonObject& o);
+    static JsonArray get_children(const JsonObject& o);
+
+    GUI::Icon m_document_icon;
+    GUI::Icon m_element_icon;
+    GUI::Icon m_text_icon;
+    JsonObject m_dom_tree;
+};
+
+}

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -335,6 +335,12 @@ void OutOfProcessWebView::notify_server_did_get_source(const URL& url, const Str
         on_get_source(url, source);
 }
 
+void OutOfProcessWebView::notify_server_did_get_dom_tree(const String& dom_tree)
+{
+    if (on_get_dom_tree)
+        on_get_dom_tree(dom_tree);
+}
+
 void OutOfProcessWebView::notify_server_did_js_console_output(const String& method, const String& line)
 {
     if (on_js_console_output)
@@ -389,6 +395,11 @@ void OutOfProcessWebView::debug_request(const String& request, const String& arg
 void OutOfProcessWebView::get_source()
 {
     client().async_get_source();
+}
+
+void OutOfProcessWebView::inspect_dom_tree()
+{
+    client().async_inspect_dom_tree();
 }
 
 void OutOfProcessWebView::js_console_initialize()

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -31,6 +31,7 @@ public:
 
     void debug_request(const String& request, const String& argument = {});
     void get_source();
+    void inspect_dom_tree();
     void js_console_initialize();
     void js_console_input(const String& js_source);
 
@@ -57,6 +58,7 @@ public:
     bool notify_server_did_request_confirm(Badge<WebContentClient>, const String& message);
     String notify_server_did_request_prompt(Badge<WebContentClient>, const String& message, const String& default_);
     void notify_server_did_get_source(const URL& url, const String& source);
+    void notify_server_did_get_dom_tree(const String& dom_tree);
     void notify_server_did_js_console_output(const String& method, const String& line);
     void notify_server_did_change_favicon(const Gfx::Bitmap& favicon);
     String notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url, Cookie::Source source);

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -136,6 +136,11 @@ void WebContentClient::did_get_source(URL const& url, String const& source)
     m_view.notify_server_did_get_source(url, source);
 }
 
+void WebContentClient::did_get_dom_tree(const String& dom_tree)
+{
+    m_view.notify_server_did_get_dom_tree(dom_tree);
+}
+
 void WebContentClient::did_js_console_output(String const& method, String const& line)
 {
     m_view.notify_server_did_js_console_output(method, line);

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -49,6 +49,7 @@ private:
     virtual void did_request_link_context_menu(Gfx::IntPoint const&, URL const&, String const&, unsigned) override;
     virtual void did_request_image_context_menu(Gfx::IntPoint const&, URL const&, String const&, unsigned, Gfx::ShareableBitmap const&) override;
     virtual void did_get_source(URL const&, String const&) override;
+    virtual void did_get_dom_tree(String const&) override;
     virtual void did_js_console_output(String const&, String const&) override;
     virtual void did_change_favicon(Gfx::ShareableBitmap const&) override;
     virtual void did_request_alert(String const&) override;

--- a/Userland/Libraries/LibWeb/WebViewHooks.h
+++ b/Userland/Libraries/LibWeb/WebViewHooks.h
@@ -27,6 +27,7 @@ public:
     Function<void(const URL&)> on_url_drop;
     Function<void(DOM::Document*)> on_set_document;
     Function<void(const URL&, const String&)> on_get_source;
+    Function<void(const String&)> on_get_dom_tree;
     Function<void(const String& method, const String& line)> on_js_console_output;
     Function<String(const URL& url, Cookie::Source source)> on_get_cookie;
     Function<void(const URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source)> on_set_cookie;

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Badge.h>
 #include <AK/Debug.h>
+#include <AK/JsonObject.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/SystemTheme.h>
@@ -213,6 +214,13 @@ void ClientConnection::get_source()
 {
     if (auto* doc = page().top_level_browsing_context().document()) {
         async_did_get_source(doc->url(), doc->source());
+    }
+}
+
+void ClientConnection::inspect_dom_tree()
+{
+    if (auto* doc = page().top_level_browsing_context().document()) {
+        async_did_get_dom_tree(doc->dump_dom_tree_as_json());
     }
 }
 

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -48,6 +48,7 @@ private:
     virtual void remove_backing_store(i32) override;
     virtual void debug_request(String const&, String const&) override;
     virtual void get_source() override;
+    virtual void inspect_dom_tree() override;
     virtual void js_console_initialize() override;
     virtual void js_console_input(String const&) override;
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -23,6 +23,7 @@ endpoint WebContentClient
     did_request_confirm(String message) => (bool result)
     did_request_prompt(String message, String default_) => (String response)
     did_get_source(URL url, String source) =|
+    did_get_dom_tree(String dom_tree) =|
     did_js_console_output(String method, String line) =|
     did_change_favicon(Gfx::ShareableBitmap favicon) =|
     did_request_cookie(URL url, u8 source) => (String cookie)

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -22,6 +22,7 @@ endpoint WebContentServer
 
     debug_request(String request, String argument) =|
     get_source() =|
+    inspect_dom_tree() =|
     js_console_initialize() =|
     js_console_input(String js_source) =|
 }


### PR DESCRIPTION
This introduces a mechanism for inspecting the DOM tree when using the `OutOfProcessWebView`.
An IPC mechanism is implemented to request a JSON representation of the DOM tree.

A new `DOMTreeJSONModel` is added, to process the JSON representation as required.

The original mechanism is still used for the `InProcessWebView`.
The new mechanism could be used in both cases, but as the new way does not have feature
parity, we will leave the original in place for now.

## Caveats:
* Performance is not the best. I believe this is due to inefficient navigation of the JSON tree.
* The JSON object could become extremely large for large pages.
  This could be handled by adding more IPC calls to query details on individual elements,
  rather than including all details in the JSON object.
* Text Nodes do not have their content displayed.
* The 'selected' element is not highlighted
  An IPC call for marking an element 'selected' could be added.
* The layout tree view is not currently supported.
* Styles and Computed Styles are not currently supported.

Fixes #5267
