### PR TITLE
LibAudio: Make Loader::seek() treat its input as a sample index

### DIFF
--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -27,7 +27,8 @@ public:
     virtual RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) = 0;
 
     virtual void reset() = 0;
-    virtual void seek(const int position) = 0;
+
+    virtual void seek(const int sample_index) = 0;
 
     virtual int loaded_samples() = 0;
     virtual int total_samples() = 0;

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -44,7 +44,10 @@ public:
     virtual RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
 
     virtual void reset() override { return seek(0); }
-    virtual void seek(const int position) override;
+
+    // sample_index 0 is the start of the raw audio sample data
+    // within the file/stream.
+    virtual void seek(const int sample_index) override;
 
     virtual int loaded_samples() override { return m_loaded_samples; }
     virtual int total_samples() override { return m_total_samples; }
@@ -66,6 +69,7 @@ private:
     u32 m_sample_rate { 0 };
     u16 m_num_channels { 0 };
     PcmSampleFormat m_sample_format;
+    size_t m_byte_offset_of_data_samples { 0 };
 
     int m_loaded_samples { 0 };
     int m_total_samples { 0 };


### PR DESCRIPTION
This fixes a bug where if you try to play a Wave file a second
time (or loop with `aplay -l`), the second time will be pure
noise.

The function `Audio::Loader::seek` is meant to seek to a specific
audio sample, e.g. seek(0) should go to the first audio sample.
However, WavLoader was interpreting seek(0) as the beginning
of the file or stream, which contains non-audio header data.

This fixes the bug by capturing the byte offset of the start of the
audio data, and offseting the raw file/stream seek by that amount.

### Testing

- [x] `aplay -l` successfully loops [this wave file](https://discord.com/channels/830522505605283862/830721144674844703/836254564734599168)