### PR TITLE
LibJS: Perform constant folding and dead code elimination

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -557,6 +557,7 @@ public:
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     LogicalOp m_op;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -659,6 +659,7 @@ public:
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     String m_value;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -37,6 +37,7 @@ class ASTNode : public RefCounted<ASTNode> {
 public:
     virtual ~ASTNode() { }
     virtual Value execute(Interpreter&, GlobalObject&) const = 0;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const { return {}; };
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;
 
@@ -97,6 +98,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -530,6 +532,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -537,6 +540,8 @@ private:
     BinaryOp m_op;
     NonnullRefPtr<Expression> m_lhs;
     NonnullRefPtr<Expression> m_rhs;
+
+    Value evaluate_expression(GlobalObject&, Value, Value) const;
 };
 
 enum class LogicalOp {
@@ -556,6 +561,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -585,12 +591,15 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     UnaryOp m_op;
     NonnullRefPtr<Expression> m_lhs;
+
+    Value evaluate_expression(VM&, GlobalObject&, Value) const;
 };
 
 class SequenceExpression final : public Expression {
@@ -626,6 +635,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -642,6 +652,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -658,6 +669,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -675,6 +687,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -694,6 +707,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 };

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -221,6 +221,13 @@ Optional<Bytecode::Register> NullLiteral::generate_bytecode(Bytecode::Generator&
     return dst;
 }
 
+Optional<Bytecode::Register> BigIntLiteral::generate_bytecode(Bytecode::Generator& generator) const
+{
+    auto dst = generator.allocate_register();
+    generator.emit<Bytecode::Op::NewBigInt>(dst, Crypto::SignedBigInteger::from_base10(m_value.substring(0, m_value.length() - 1)));
+    return dst;
+}
+
 Optional<Bytecode::Register> StringLiteral::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto dst = generator.allocate_register();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -14,7 +14,9 @@
 
 namespace JS::Bytecode {
 
-Generator::Generator()
+Generator::Generator(JS::Interpreter& interpreter, GlobalObject& global_object)
+    : m_interpreter(interpreter)
+    , m_global_object(global_object)
 {
     m_block = Block::create();
 }
@@ -23,9 +25,9 @@ Generator::~Generator()
 {
 }
 
-OwnPtr<Block> Generator::generate(ASTNode const& node)
+OwnPtr<Block> Generator::generate(JS::Interpreter& interpreter, GlobalObject& global_object, ASTNode const& node)
 {
-    Generator generator;
+    Generator generator { interpreter, global_object };
     [[maybe_unused]] auto dummy = node.generate_bytecode(generator);
     generator.m_block->set_register_count({}, generator.m_next_register);
     generator.m_block->seal();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -15,7 +15,7 @@ namespace JS::Bytecode {
 
 class Generator {
 public:
-    static OwnPtr<Block> generate(ASTNode const&);
+    static OwnPtr<Block> generate(JS::Interpreter&, GlobalObject&, ASTNode const&);
 
     Register allocate_register();
 
@@ -37,6 +37,9 @@ public:
         return *static_cast<OpType*>(slot);
     }
 
+    [[nodiscard]] JS::Interpreter& interpreter() const { return m_interpreter; }
+    [[nodiscard]] GlobalObject& global_object() const { return m_global_object; }
+
     Label make_label() const;
 
     void begin_continuable_scope();
@@ -45,12 +48,14 @@ public:
     Label nearest_continuable_scope() const;
 
 private:
-    Generator();
+    Generator(JS::Interpreter&, GlobalObject&);
     ~Generator();
 
     void grow(size_t);
     void* next_slot();
 
+    JS::Interpreter& m_interpreter;
+    GlobalObject& m_global_object;
     OwnPtr<Block> m_block;
     u32 m_next_register { 1 };
     Vector<Label> m_continuable_scopes;

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -35,6 +35,7 @@
     O(Jump)                       \
     O(JumpIfFalse)                \
     O(JumpIfTrue)                 \
+    O(JumpIfNullish)              \
     O(Call)                       \
     O(EnterScope)                 \
     O(Return)                     \

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -26,6 +26,7 @@
     O(AbstractEquals)             \
     O(TypedInequals)              \
     O(TypedEquals)                \
+    O(NewBigInt)                  \
     O(NewString)                  \
     O(NewObject)                  \
     O(GetVariable)                \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -153,7 +153,7 @@ void JumpIfFalse::execute(Bytecode::Interpreter& interpreter) const
 {
     VERIFY(m_target.has_value());
     auto result = interpreter.reg(m_result);
-    if (!result.as_bool())
+    if (!result.to_boolean())
         interpreter.jump(m_target.value());
 }
 
@@ -161,7 +161,7 @@ void JumpIfTrue::execute(Bytecode::Interpreter& interpreter) const
 {
     VERIFY(m_target.has_value());
     auto result = interpreter.reg(m_result);
-    if (result.as_bool())
+    if (result.to_boolean())
         interpreter.jump(m_target.value());
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -165,6 +165,14 @@ void JumpIfTrue::execute(Bytecode::Interpreter& interpreter) const
         interpreter.jump(m_target.value());
 }
 
+void JumpIfNullish::execute(Bytecode::Interpreter& interpreter) const
+{
+    VERIFY(m_target.has_value());
+    auto result = interpreter.reg(m_result);
+    if (result.is_nullish())
+        interpreter.jump(m_target.value());
+}
+
 void Call::execute(Bytecode::Interpreter& interpreter) const
 {
     auto callee = interpreter.reg(m_callee);
@@ -270,6 +278,13 @@ String JumpIfTrue::to_string() const
     if (m_target.has_value())
         return String::formatted("JumpIfTrue result:{}, target:{}", m_result, m_target.value());
     return String::formatted("JumpIfTrue result:{}, target:<empty>", m_result);
+}
+
+String JumpIfNullish::to_string() const
+{
+    if (m_target.has_value())
+        return String::formatted("JumpIfNullish result:{}, target:{}", m_result, m_target.value());
+    return String::formatted("JumpIfNullish result:{}, target:<empty>", m_result);
 }
 
 String Call::to_string() const

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/Op.h>
+#include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/ScriptFunction.h>
 #include <LibJS/Runtime/Value.h>
@@ -111,6 +112,11 @@ static Value typeof_(GlobalObject& global_object, Value value)
     }
 
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DEFINE_COMMON_UNARY_OP)
+
+void NewBigInt::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.reg(m_dst) = js_bigint(interpreter.vm().heap(), m_bigint);
+}
 
 void NewString::execute(Bytecode::Interpreter& interpreter) const
 {
@@ -229,6 +235,11 @@ String Load::to_string() const
 String LoadRegister::to_string() const
 {
     return String::formatted("LoadRegister dst:{}, src:{}", m_dst, m_src);
+}
+
+String NewBigInt::to_string() const
+{
+    return String::formatted("NewBigInt dst:{}, bigint:\"{}\"", m_dst, m_bigint.to_base10());
 }
 
 String NewString::to_string() const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -284,6 +284,25 @@ private:
     Optional<Label> m_target;
 };
 
+class JumpIfNullish final : public Instruction {
+public:
+    explicit JumpIfNullish(Register result, Optional<Label> target = {})
+        : Instruction(Type::JumpIfNullish)
+        , m_result(result)
+        , m_target(move(target))
+    {
+    }
+
+    void set_target(Optional<Label> target) { m_target = move(target); }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string() const;
+
+private:
+    Register m_result;
+    Optional<Label> m_target;
+};
+
 // NOTE: This instruction is variable-width depending on the number of arguments!
 class Call final : public Instruction {
 public:

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Register.h>
@@ -157,6 +158,22 @@ private:
     Register m_dst;
 };
 
+class NewBigInt final : public Instruction {
+public:
+    explicit NewBigInt(Register dst, Crypto::SignedBigInteger bigint)
+        : Instruction(Type::NewBigInt)
+        , m_dst(dst)
+        , m_bigint(move(bigint))
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string() const;
+
+private:
+    Register m_dst;
+    Crypto::SignedBigInteger m_bigint;
+};
 class SetVariable final : public Instruction {
 public:
     SetVariable(FlyString identifier, Register src)

--- a/Userland/Libraries/LibJS/Bytecode/VirtualRegister.h
+++ b/Userland/Libraries/LibJS/Bytecode/VirtualRegister.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/AST.h>
+#include <LibJS/Bytecode/Generator.h>
+#include <LibJS/Runtime/BigInt.h>
+
+namespace JS::Bytecode {
+
+class VirtualRegister {
+public:
+    explicit VirtualRegister(Generator& generator, NonnullRefPtr<ASTNode> ast_node)
+        : m_generator(generator)
+        , m_ast_node(ast_node)
+    {
+        m_value = ast_node->constant_execute(generator.interpreter(), generator.global_object());
+    }
+
+    bool is_constant() const
+    {
+        return m_value.has_value();
+    }
+
+    Value& operator*()
+    {
+        VERIFY(is_constant());
+        return *m_value;
+    }
+
+    Value* operator->()
+    {
+        VERIFY(is_constant());
+        return &*m_value;
+    }
+
+    Optional<Register> materialize()
+    {
+        if (m_value.has_value())
+            return emit_constant_value(m_generator, *m_value);
+        return m_ast_node->generate_bytecode(m_generator);
+    }
+
+private:
+    Generator& m_generator;
+    NonnullRefPtr<ASTNode> m_ast_node;
+    Optional<Value> m_value;
+
+    static Register emit_constant_value(Bytecode::Generator& generator, Value& value)
+    {
+        auto dst = generator.allocate_register();
+        if (value.is_string()) {
+            generator.emit<Bytecode::Op::NewString>(dst, value.as_string().string());
+        } else if (value.is_bigint()) {
+            generator.emit<Bytecode::Op::NewBigInt>(dst, value.as_bigint().big_integer());
+        } else {
+            // This should only emit Load ops for Values which don't depend on the VM heap
+            generator.emit<Bytecode::Op::Load>(dst, value);
+        }
+        return dst;
+    }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -152,7 +152,7 @@ Value ScriptFunction::execute_function_body()
     if (bytecode_interpreter) {
         prepare_arguments();
         if (!m_bytecode_block) {
-            m_bytecode_block = Bytecode::Generator::generate(m_body);
+            m_bytecode_block = Bytecode::Generator::generate(vm.interpreter(), global_object(), m_body);
             VERIFY(m_bytecode_block);
             if constexpr (JS_BYTECODE_DEBUG) {
                 dbgln("Compiled Bytecode::Block for function '{}':", m_name);

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -495,7 +495,7 @@ static bool parse_and_run(JS::Interpreter& interpreter, const StringView& source
         program->dump(0);
 
     if (s_dump_bytecode || s_run_bytecode) {
-        auto block = JS::Bytecode::Generator::generate(*program);
+        auto block = JS::Bytecode::Generator::generate(interpreter, interpreter.global_object(), *program);
         VERIFY(block);
 
         if (s_dump_bytecode)


### PR DESCRIPTION
**LibJS: Convert values to boolean for JumpIfTrue/JumpIfFalse**

`Value::as_bool()` might fail if the underlying value isn't already a boolean value.

**LibJS: Perform constant folding and dead code elimination**

This adds a new method `constant_execute()` to the `ASTNode` class which can be used to determine an AST node's value if the expression represents a constant value.

This functionality is then used to perform constant folding for unary and binary expressions.

```
> "Hello World!" + (3 * 9) + z + typeof(7n) + 9
[   0] EnterScope
[  10] NewString dst:$1, string:"Hello World!27"
[  20] GetVariable dst:$2, identifier:z
[  30] Add dst:$3, src1:$1, src2:$2
[  40] NewString dst:$4, string:"bigint"
[  50] Add dst:$5, src1:$3, src2:$4
[  60] Load dst:$6, value:9
[  78] Add dst:$7, src1:$5, src2:$6
```

This also adds dead code elimination for scope expressions:

```
> { 7 * 8; true }
[   0] EnterScope
[  10] EnterScope
[  20] Load dst:$1, value:true
```

It is also used to perform branch elimination:

```
> if (true) 7 else 8
[   0] EnterScope
[  10] Load dst:$1, value:7
```