### PR TITLE
LibJS: Add functionality for determining whether an AST node is constant

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -109,6 +109,11 @@ Value ExpressionStatement::execute(Interpreter& interpreter, GlobalObject& globa
     return m_expression->execute(interpreter, global_object);
 }
 
+Optional<Value> ExpressionStatement::constant_execute(Interpreter& interpreter, GlobalObject& global_object) const
+{
+    return m_expression->constant_execute(interpreter, global_object);
+}
+
 CallExpression::ThisAndCallee CallExpression::compute_this_and_callee(Interpreter& interpreter, GlobalObject& global_object) const
 {
     auto& vm = interpreter.vm();
@@ -568,6 +573,11 @@ Value BinaryExpression::execute(Interpreter& interpreter, GlobalObject& global_o
     if (interpreter.exception())
         return {};
 
+    return evaluate_expression(global_object, move(lhs_result), move(rhs_result));
+}
+
+Value BinaryExpression::evaluate_expression(GlobalObject& global_object, Value lhs_result, Value rhs_result) const
+{
     switch (m_op) {
     case BinaryOp::Addition:
         return add(global_object, lhs_result, rhs_result);
@@ -616,6 +626,17 @@ Value BinaryExpression::execute(Interpreter& interpreter, GlobalObject& global_o
     }
 
     VERIFY_NOT_REACHED();
+}
+
+Optional<Value> BinaryExpression::constant_execute(Interpreter& interpreter, GlobalObject& global_object) const
+{
+    auto lhs_result = m_lhs->constant_execute(interpreter, global_object);
+    if (!lhs_result.has_value())
+        return {};
+    auto rhs_result = m_rhs->constant_execute(interpreter, global_object);
+    if (!rhs_result.has_value())
+        return {};
+    return evaluate_expression(global_object, lhs_result.release_value(), rhs_result.release_value());
 }
 
 Value LogicalExpression::execute(Interpreter& interpreter, GlobalObject& global_object) const
@@ -717,6 +738,11 @@ Value UnaryExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
             return {};
     }
 
+    return evaluate_expression(vm, global_object, move(lhs_result));
+}
+
+Value UnaryExpression::evaluate_expression(VM& vm, GlobalObject& global_object, Value lhs_result) const
+{
     switch (m_op) {
     case UnaryOp::BitwiseNot:
         return bitwise_not(global_object, lhs_result);
@@ -735,6 +761,14 @@ Value UnaryExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
     }
 
     VERIFY_NOT_REACHED();
+}
+
+Optional<Value> UnaryExpression::constant_execute(Interpreter& interpreter, GlobalObject& global_object) const
+{
+    auto lhs_result = m_lhs->constant_execute(interpreter, global_object);
+    if (!lhs_result.has_value())
+        return {};
+    return evaluate_expression(interpreter.vm(), global_object, lhs_result.release_value());
 }
 
 Value SuperExpression::execute(Interpreter& interpreter, GlobalObject&) const
@@ -1813,33 +1847,58 @@ Value MetaProperty::execute(Interpreter& interpreter, GlobalObject&) const
     VERIFY_NOT_REACHED();
 }
 
-Value StringLiteral::execute(Interpreter& interpreter, GlobalObject&) const
+Value StringLiteral::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
+    return constant_execute(interpreter, global_object).value();
+}
+
+Optional<Value> StringLiteral::constant_execute(Interpreter& interpreter, GlobalObject&) const
+{
     return js_string(interpreter.heap(), m_value);
 }
 
-Value NumericLiteral::execute(Interpreter& interpreter, GlobalObject&) const
+Value NumericLiteral::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
+    return constant_execute(interpreter, global_object).value();
+}
+
+Optional<Value> NumericLiteral::constant_execute(Interpreter&, GlobalObject&) const
+{
     return Value(m_value);
 }
 
-Value BigIntLiteral::execute(Interpreter& interpreter, GlobalObject&) const
+Value BigIntLiteral::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
+    return constant_execute(interpreter, global_object).value();
+}
+
+Optional<Value> BigIntLiteral::constant_execute(Interpreter& interpreter, GlobalObject&) const
+{
     return js_bigint(interpreter.heap(), Crypto::SignedBigInteger::from_base10(m_value.substring(0, m_value.length() - 1)));
 }
 
-Value BooleanLiteral::execute(Interpreter& interpreter, GlobalObject&) const
+Value BooleanLiteral::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
+    return constant_execute(interpreter, global_object).value();
+}
+
+Optional<Value> BooleanLiteral::constant_execute(Interpreter&, GlobalObject&) const
+{
     return Value(m_value);
 }
 
-Value NullLiteral::execute(Interpreter& interpreter, GlobalObject&) const
+Value NullLiteral::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
+    return constant_execute(interpreter, global_object).value();
+}
+
+Optional<Value> NullLiteral::constant_execute(Interpreter&, GlobalObject&) const
+{
     return js_null();
 }
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -37,6 +37,7 @@ class ASTNode : public RefCounted<ASTNode> {
 public:
     virtual ~ASTNode() { }
     virtual Value execute(Interpreter&, GlobalObject&) const = 0;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const { return {}; };
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;
 
@@ -97,6 +98,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -530,6 +532,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -537,6 +540,8 @@ private:
     BinaryOp m_op;
     NonnullRefPtr<Expression> m_lhs;
     NonnullRefPtr<Expression> m_rhs;
+
+    Value evaluate_expression(GlobalObject&, Value, Value) const;
 };
 
 enum class LogicalOp {
@@ -584,12 +589,15 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     UnaryOp m_op;
     NonnullRefPtr<Expression> m_lhs;
+
+    Value evaluate_expression(VM&, GlobalObject&, Value) const;
 };
 
 class SequenceExpression final : public Expression {
@@ -625,6 +633,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -641,6 +650,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -657,6 +667,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -673,6 +684,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
@@ -692,6 +704,7 @@ public:
     }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual Optional<Value> constant_execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 };

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -153,7 +153,7 @@ void JumpIfFalse::execute(Bytecode::Interpreter& interpreter) const
 {
     VERIFY(m_target.has_value());
     auto result = interpreter.reg(m_result);
-    if (!result.as_bool())
+    if (!result.to_boolean())
         interpreter.jump(m_target.value());
 }
 
@@ -161,7 +161,7 @@ void JumpIfTrue::execute(Bytecode::Interpreter& interpreter) const
 {
     VERIFY(m_target.has_value());
     auto result = interpreter.reg(m_result);
-    if (result.as_bool())
+    if (result.to_boolean())
         interpreter.jump(m_target.value());
 }
 


### PR DESCRIPTION
**LibJS: Convert values to boolean for JumpIfTrue/JumpIfFalse**

Value::as_bool() might fail if the underlying value isn't already a boolean value.

**LibJS: Add functionality for determining whether an AST node is constant**

This adds the constant_execute() method the ASTNode class which can be used to check whether an ASTNode represents a value that can be statically determined.

This can be used to implement constant folding, dead code elimination and branch elimination for AST nodes.