### PR TITLE
LibJS: Implement bytecode ops for logical expressions

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -557,6 +557,7 @@ public:
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual Optional<Bytecode::Register> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     LogicalOp m_op;

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -35,6 +35,7 @@
     O(Jump)                       \
     O(JumpIfFalse)                \
     O(JumpIfTrue)                 \
+    O(JumpIfNullish)              \
     O(Call)                       \
     O(EnterScope)                 \
     O(Return)                     \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -153,7 +153,7 @@ void JumpIfFalse::execute(Bytecode::Interpreter& interpreter) const
 {
     VERIFY(m_target.has_value());
     auto result = interpreter.reg(m_result);
-    if (!result.as_bool())
+    if (!result.to_boolean())
         interpreter.jump(m_target.value());
 }
 
@@ -161,7 +161,7 @@ void JumpIfTrue::execute(Bytecode::Interpreter& interpreter) const
 {
     VERIFY(m_target.has_value());
     auto result = interpreter.reg(m_result);
-    if (result.as_bool())
+    if (result.to_boolean())
         interpreter.jump(m_target.value());
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -165,6 +165,14 @@ void JumpIfTrue::execute(Bytecode::Interpreter& interpreter) const
         interpreter.jump(m_target.value());
 }
 
+void JumpIfNullish::execute(Bytecode::Interpreter& interpreter) const
+{
+    VERIFY(m_target.has_value());
+    auto result = interpreter.reg(m_result);
+    if (result.is_nullish())
+        interpreter.jump(m_target.value());
+}
+
 void Call::execute(Bytecode::Interpreter& interpreter) const
 {
     auto callee = interpreter.reg(m_callee);
@@ -270,6 +278,13 @@ String JumpIfTrue::to_string() const
     if (m_target.has_value())
         return String::formatted("JumpIfTrue result:{}, target:{}", m_result, m_target.value());
     return String::formatted("JumpIfTrue result:{}, target:<empty>", m_result);
+}
+
+String JumpIfNullish::to_string() const
+{
+    if (m_target.has_value())
+        return String::formatted("JumpIfNullish result:{}, target:{}", m_result, m_target.value());
+    return String::formatted("JumpIfNullish result:{}, target:<empty>", m_result);
 }
 
 String Call::to_string() const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -284,6 +284,25 @@ private:
     Optional<Label> m_target;
 };
 
+class JumpIfNullish final : public Instruction {
+public:
+    explicit JumpIfNullish(Register result, Optional<Label> target = {})
+        : Instruction(Type::JumpIfNullish)
+        , m_result(result)
+        , m_target(move(target))
+    {
+    }
+
+    void set_target(Optional<Label> target) { m_target = move(target); }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string() const;
+
+private:
+    Register m_result;
+    Optional<Label> m_target;
+};
+
 // NOTE: This instruction is variable-width depending on the number of arguments!
 class Call final : public Instruction {
 public:


### PR DESCRIPTION
 **LibJS: Convert values to boolean for JumpIfTrue/JumpIfFalse**

`Value::as_bool()` might fail if the underlying value isn't already a boolean value.

**LibJS: Implement bytecode ops for logical expressions**