### PR TITLE
LibJS: Bind Register 0 as Numerical 0

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -157,6 +157,8 @@ Optional<Register> UnaryExpression::generate_bytecode(Bytecode::Generator& gener
 
 Optional<Register> NumericLiteral::generate_bytecode(Bytecode::Generator& generator) const
 {
+    if (m_value.is_integer() && m_value.as_i32() == 0)
+        return Register(0);
     auto dst = generator.allocate_register();
     generator.emit<Bytecode::Op::Load>(dst, m_value);
     return dst;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -13,33 +13,35 @@
 
 namespace JS {
 
-Optional<Bytecode::Register> ASTNode::generate_bytecode(Bytecode::Generator&) const
+using Bytecode::Register;
+
+Optional<Register> ASTNode::generate_bytecode(Bytecode::Generator&) const
 {
     dbgln("Missing generate_bytecode()");
     TODO();
 }
 
-Optional<Bytecode::Register> ScopeNode::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> ScopeNode::generate_bytecode(Bytecode::Generator& generator) const
 {
     generator.emit<Bytecode::Op::EnterScope>(*this);
-    Optional<Bytecode::Register> last_value_reg;
+    Optional<Register> last_value_reg;
     for (auto& child : children()) {
         last_value_reg = child.generate_bytecode(generator);
     }
     return last_value_reg;
 }
 
-Optional<Bytecode::Register> EmptyStatement::generate_bytecode(Bytecode::Generator&) const
+Optional<Register> EmptyStatement::generate_bytecode(Bytecode::Generator&) const
 {
     return {};
 }
 
-Optional<Bytecode::Register> ExpressionStatement::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> ExpressionStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     return m_expression->generate_bytecode(generator);
 }
 
-Optional<Bytecode::Register> BinaryExpression::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> BinaryExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto lhs_reg = m_lhs->generate_bytecode(generator);
     auto rhs_reg = m_rhs->generate_bytecode(generator);
@@ -121,7 +123,7 @@ Optional<Bytecode::Register> BinaryExpression::generate_bytecode(Bytecode::Gener
     }
 }
 
-Optional<Bytecode::Register> UnaryExpression::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> UnaryExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto lhs_reg = m_lhs->generate_bytecode(generator);
 
@@ -153,42 +155,42 @@ Optional<Bytecode::Register> UnaryExpression::generate_bytecode(Bytecode::Genera
     }
 }
 
-Optional<Bytecode::Register> NumericLiteral::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> NumericLiteral::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto dst = generator.allocate_register();
     generator.emit<Bytecode::Op::Load>(dst, m_value);
     return dst;
 }
 
-Optional<Bytecode::Register> BooleanLiteral::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> BooleanLiteral::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto dst = generator.allocate_register();
     generator.emit<Bytecode::Op::Load>(dst, Value(m_value));
     return dst;
 }
 
-Optional<Bytecode::Register> NullLiteral::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> NullLiteral::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto dst = generator.allocate_register();
     generator.emit<Bytecode::Op::Load>(dst, js_null());
     return dst;
 }
 
-Optional<Bytecode::Register> StringLiteral::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> StringLiteral::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto dst = generator.allocate_register();
     generator.emit<Bytecode::Op::NewString>(dst, m_value);
     return dst;
 }
 
-Optional<Bytecode::Register> Identifier::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> Identifier::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto reg = generator.allocate_register();
     generator.emit<Bytecode::Op::GetVariable>(reg, m_string);
     return reg;
 }
 
-Optional<Bytecode::Register> AssignmentExpression::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> AssignmentExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     if (is<Identifier>(*m_lhs)) {
         auto& identifier = static_cast<Identifier const&>(*m_lhs);
@@ -266,7 +268,7 @@ Optional<Bytecode::Register> AssignmentExpression::generate_bytecode(Bytecode::G
     TODO();
 }
 
-Optional<Bytecode::Register> WhileStatement::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> WhileStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     generator.begin_continuable_scope();
     auto test_label = generator.make_label();
@@ -280,7 +282,7 @@ Optional<Bytecode::Register> WhileStatement::generate_bytecode(Bytecode::Generat
     return body_result_reg;
 }
 
-Optional<Bytecode::Register> DoWhileStatement::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> DoWhileStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     generator.begin_continuable_scope();
     auto head_label = generator.make_label();
@@ -292,7 +294,7 @@ Optional<Bytecode::Register> DoWhileStatement::generate_bytecode(Bytecode::Gener
     return body_result_reg;
 }
 
-Optional<Bytecode::Register> ObjectExpression::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> ObjectExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto reg = generator.allocate_register();
     generator.emit<Bytecode::Op::NewObject>(reg);
@@ -304,7 +306,7 @@ Optional<Bytecode::Register> ObjectExpression::generate_bytecode(Bytecode::Gener
     return reg;
 }
 
-Optional<Bytecode::Register> MemberExpression::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> MemberExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto object_reg = object().generate_bytecode(generator);
 
@@ -318,12 +320,12 @@ Optional<Bytecode::Register> MemberExpression::generate_bytecode(Bytecode::Gener
     }
 }
 
-Optional<Bytecode::Register> FunctionDeclaration::generate_bytecode(Bytecode::Generator&) const
+Optional<Register> FunctionDeclaration::generate_bytecode(Bytecode::Generator&) const
 {
     return {};
 }
 
-Optional<Bytecode::Register> CallExpression::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> CallExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto callee_reg = m_callee->generate_bytecode(generator);
 
@@ -331,7 +333,7 @@ Optional<Bytecode::Register> CallExpression::generate_bytecode(Bytecode::Generat
     auto this_reg = generator.allocate_register();
     generator.emit<Bytecode::Op::Load>(this_reg, js_undefined());
 
-    Vector<Bytecode::Register> argument_registers;
+    Vector<Register> argument_registers;
     for (auto& arg : m_arguments)
         argument_registers.append(*arg.value->generate_bytecode(generator));
     auto dst_reg = generator.allocate_register();
@@ -339,9 +341,9 @@ Optional<Bytecode::Register> CallExpression::generate_bytecode(Bytecode::Generat
     return dst_reg;
 }
 
-Optional<Bytecode::Register> ReturnStatement::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> ReturnStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
-    Optional<Bytecode::Register> argument_reg;
+    Optional<Register> argument_reg;
     if (m_argument)
         argument_reg = m_argument->generate_bytecode(generator);
 
@@ -349,7 +351,7 @@ Optional<Bytecode::Register> ReturnStatement::generate_bytecode(Bytecode::Genera
     return argument_reg;
 }
 
-Optional<Bytecode::Register> IfStatement::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> IfStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto result_reg = generator.allocate_register();
     auto predicate_reg = m_predicate->generate_bytecode(generator);
@@ -372,13 +374,13 @@ Optional<Bytecode::Register> IfStatement::generate_bytecode(Bytecode::Generator&
     return result_reg;
 }
 
-Optional<Bytecode::Register> ContinueStatement::generate_bytecode(Bytecode::Generator& generator) const
+Optional<Register> ContinueStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     generator.emit<Bytecode::Op::Jump>(generator.nearest_continuable_scope());
     return {};
 }
 
-Optional<Bytecode::Register> DebuggerStatement::generate_bytecode(Bytecode::Generator&) const
+Optional<Register> DebuggerStatement::generate_bytecode(Bytecode::Generator&) const
 {
     return {};
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -84,10 +84,6 @@ Value Interpreter::run(Bytecode::Block const& block)
     auto return_value = m_return_value.value_or(js_undefined());
     m_return_value = {};
 
-    // NOTE: The return value from a called function is put into $0 in the caller context.
-    if (!m_register_windows.is_empty())
-        m_register_windows.last()[0] = return_value;
-
     if (vm().call_stack().size() == 1)
         vm().pop_call_frame();
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -52,6 +52,7 @@ Value Interpreter::run(Bytecode::Block const& block)
 
     m_register_windows.append(make<RegisterWindow>());
     registers().resize(block.register_count());
+    registers()[0] = Value(0);
 
     Bytecode::InstructionStreamIterator pc(block.instruction_stream());
     while (!pc.at_end()) {


### PR DESCRIPTION
Previously we were redundantly binding the return value to 0, which then wasn't used, due to Call using the Return Value of the Functions as a Value and writing it directly into a register.

With this in place we should be able to cut down on some `Load $n Value(0)` Instructions.
In the Future we might want to preallocate more numerical Literals, like Python (-5 - +256) or Java (-128 - +127)


dumb test_code:
```js
x = 0;
  
y = 100;

while (y!=0){
        x= x+ y;
        y= y- 1;
}

console.log(0);
console.log(x);
```
old:
```
[   0] EnterScope
[  10] Load dst:$1, value:0
[  28] SetVariable identifier:x, src:$1
[  40] Load dst:$2, value:100
[  58] SetVariable identifier:y, src:$2
[  70] GetVariable dst:$3, identifier:y
[  80] Load dst:$4, value:0
[  98] AbstractInequals dst:$5, src1:$3, src2:$4
[  a8] JumpIfFalse result:$5, target:@180
[  c0] EnterScope
[  d0] GetVariable dst:$6, identifier:x
[  e0] GetVariable dst:$7, identifier:y
[  f0] Add dst:$8, src1:$6, src2:$7
[ 100] SetVariable identifier:x, src:$8
[ 118] GetVariable dst:$9, identifier:y
[ 128] Load dst:$10, value:1
[ 140] Sub dst:$11, src1:$9, src2:$10
[ 150] SetVariable identifier:y, src:$11
[ 168] Jump @70
[ 180] GetVariable dst:$12, identifier:console
[ 190] GetById dst:$13, base:$12, property:log
[ 1a8] Load dst:$14, value:undefined
[ 1c0] Load dst:$15, value:0
[ 1d8] Call dst:$16, callee:$13, this:$14, arguments:[$15]
[ 1f4] GetVariable dst:$17, identifier:console
[ 204] GetById dst:$18, base:$17, property:log
[ 21c] Load dst:$19, value:undefined
[ 234] GetVariable dst:$20, identifier:x
[ 244] Call dst:$21, callee:$18, this:$19, arguments:[$20]
```


new:
```
[   0] EnterScope
[  10] SetVariable identifier:x, src:$0
[  28] Load dst:$1, value:100
[  40] SetVariable identifier:y, src:$1
[  58] GetVariable dst:$2, identifier:y
[  68] AbstractInequals dst:$3, src1:$2, src2:$0
[  78] JumpIfFalse result:$3, target:@150
[  90] EnterScope
[  a0] GetVariable dst:$4, identifier:x
[  b0] GetVariable dst:$5, identifier:y
[  c0] Add dst:$6, src1:$4, src2:$5
[  d0] SetVariable identifier:x, src:$6
[  e8] GetVariable dst:$7, identifier:y
[  f8] Load dst:$8, value:1
[ 110] Sub dst:$9, src1:$7, src2:$8
[ 120] SetVariable identifier:y, src:$9
[ 138] Jump @58
[ 150] GetVariable dst:$10, identifier:console
[ 160] GetById dst:$11, base:$10, property:log
[ 178] Load dst:$12, value:undefined
[ 190] Call dst:$13, callee:$11, this:$12, arguments:[$0]
[ 1ac] GetVariable dst:$14, identifier:console
[ 1bc] GetById dst:$15, base:$14, property:log
[ 1d4] Load dst:$16, value:undefined
[ 1ec] GetVariable dst:$17, identifier:x
[ 1fc] Call dst:$18, callee:$15, this:$16, arguments:[$17]
```