### PR TITLE
LibJS: Make JumpIf{True,False,Nullish} inherit from Jump

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -126,7 +126,7 @@ Optional<Bytecode::Register> LogicalExpression::generate_bytecode(Bytecode::Gene
     auto result_reg = generator.allocate_register();
     auto lhs_reg = m_lhs->generate_bytecode(generator);
 
-    Bytecode::Instruction* test_instr;
+    Bytecode::Op::Jump* test_instr;
     switch (m_op) {
     case LogicalOp::And:
         test_instr = &generator.emit<Bytecode::Op::JumpIfTrue>(*lhs_reg);
@@ -145,20 +145,7 @@ Optional<Bytecode::Register> LogicalExpression::generate_bytecode(Bytecode::Gene
     auto& end_jump = generator.emit<Bytecode::Op::Jump>();
 
     auto rhs_label = generator.make_label();
-
-    switch (m_op) {
-    case LogicalOp::And:
-        static_cast<Bytecode::Op::JumpIfTrue*>(test_instr)->set_target(rhs_label);
-        break;
-    case LogicalOp::Or:
-        static_cast<Bytecode::Op::JumpIfFalse*>(test_instr)->set_target(rhs_label);
-        break;
-    case LogicalOp::NullishCoalescing:
-        static_cast<Bytecode::Op::JumpIfNullish*>(test_instr)->set_target(rhs_label);
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
+    test_instr->set_target(rhs_label);
 
     auto rhs_reg = m_rhs->generate_bytecode(generator);
     generator.emit<Bytecode::Op::LoadRegister>(result_reg, *rhs_reg);

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -387,10 +387,8 @@ Optional<Bytecode::Register> IfStatement::generate_bytecode(Bytecode::Generator&
 {
     auto result_reg = generator.allocate_register();
     auto predicate_reg = m_predicate->generate_bytecode(generator);
-    auto& if_jump = generator.emit<Bytecode::Op::JumpIfTrue>(*predicate_reg);
     auto& else_jump = generator.emit<Bytecode::Op::JumpIfFalse>(*predicate_reg);
 
-    if_jump.set_target(generator.make_label());
     auto consequent_reg = m_consequent->generate_bytecode(generator);
     generator.emit<Bytecode::Op::LoadRegister>(result_reg, *consequent_reg);
     auto& end_jump = generator.emit<Bytecode::Op::Jump>();

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -397,6 +397,8 @@ Optional<Bytecode::Register> IfStatement::generate_bytecode(Bytecode::Generator&
     if (m_alternate) {
         auto alternative_reg = m_alternate->generate_bytecode(generator);
         generator.emit<Bytecode::Op::LoadRegister>(result_reg, *alternative_reg);
+    } else {
+        generator.emit<Bytecode::Op::Load>(result_reg, js_undefined());
     }
 
     end_jump.set_target(generator.make_label());

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -229,8 +229,14 @@ private:
     Register m_src;
 };
 
-class Jump final : public Instruction {
+class Jump : public Instruction {
 public:
+    explicit Jump(Type type, Optional<Label> target = {})
+        : Instruction(type)
+        , m_target(move(target))
+    {
+    }
+
     explicit Jump(Optional<Label> target = {})
         : Instruction(Type::Jump)
         , m_target(move(target))
@@ -242,65 +248,53 @@ public:
     void execute(Bytecode::Interpreter&) const;
     String to_string() const;
 
-private:
+protected:
     Optional<Label> m_target;
 };
 
-class JumpIfFalse final : public Instruction {
+class JumpIfFalse final : public Jump {
 public:
     explicit JumpIfFalse(Register result, Optional<Label> target = {})
-        : Instruction(Type::JumpIfFalse)
+        : Jump(Type::JumpIfFalse, move(target))
         , m_result(result)
-        , m_target(move(target))
     {
     }
-
-    void set_target(Optional<Label> target) { m_target = move(target); }
 
     void execute(Bytecode::Interpreter&) const;
     String to_string() const;
 
 private:
     Register m_result;
-    Optional<Label> m_target;
 };
 
-class JumpIfTrue final : public Instruction {
+class JumpIfTrue : public Jump {
 public:
     explicit JumpIfTrue(Register result, Optional<Label> target = {})
-        : Instruction(Type::JumpIfTrue)
+        : Jump(Type::JumpIfTrue, move(target))
         , m_result(result)
-        , m_target(move(target))
     {
     }
-
-    void set_target(Optional<Label> target) { m_target = move(target); }
 
     void execute(Bytecode::Interpreter&) const;
     String to_string() const;
 
 private:
     Register m_result;
-    Optional<Label> m_target;
 };
 
-class JumpIfNullish final : public Instruction {
+class JumpIfNullish final : public Jump {
 public:
     explicit JumpIfNullish(Register result, Optional<Label> target = {})
-        : Instruction(Type::JumpIfNullish)
+        : Jump(Type::JumpIfNullish, move(target))
         , m_result(result)
-        , m_target(move(target))
     {
     }
-
-    void set_target(Optional<Label> target) { m_target = move(target); }
 
     void execute(Bytecode::Interpreter&) const;
     String to_string() const;
 
 private:
     Register m_result;
-    Optional<Label> m_target;
 };
 
 // NOTE: This instruction is variable-width depending on the number of arguments!


### PR DESCRIPTION
**LibJS: Make JumpIf{True,False,Nullish} inherit from Jump**

This saves a few lines in `LogicalExpression::generate_bytecode`.

**LibJS: Remove redundant jump for IfStatements**

**LibJS: Make if yield undefined for the else branch if it is missing**