### PR TITLE
LibSQL: Limit the number of nested subqueries

### DIFF
--- a/Tests/LibSQL/TestSqlExpressionParser.cpp
+++ b/Tests/LibSQL/TestSqlExpressionParser.cpp
@@ -603,7 +603,7 @@ TEST_CASE(in_selection_expression)
     validate("15 NOT IN (SELECT * FROM table)", true);
 }
 
-TEST_CASE(stack_limit)
+TEST_CASE(expression_tree_depth_limit)
 {
     auto too_deep_expression = String::formatted("{:+^{}}1", "", SQL::Limits::maximum_expression_tree_depth);
     EXPECT(!parse(too_deep_expression.substring_view(1)).is_error());

--- a/Tests/LibSQL/TestSqlStatementParser.cpp
+++ b/Tests/LibSQL/TestSqlStatementParser.cpp
@@ -738,3 +738,10 @@ TEST_CASE(common_table_expression)
     validate("WITH table (column1, column2) AS (SELECT * FROM table) DELETE FROM table;", { false, { { "table", { "column1", "column2" } } } });
     validate("WITH RECURSIVE table AS (SELECT * FROM table) DELETE FROM table;", { true, { { "table", {} } } });
 }
+
+TEST_CASE(nested_subquery_limit)
+{
+    auto subquery = String::formatted("{:(^{}}table{:)^{}}", "", SQL::Limits::maximum_subquery_depth - 1, "", SQL::Limits::maximum_subquery_depth - 1);
+    EXPECT(!parse(String::formatted("SELECT * FROM {};", subquery)).is_error());
+    EXPECT(parse(String::formatted("SELECT * FROM ({});", subquery)).is_error());
+}

--- a/Userland/Libraries/LibSQL/Parser.h
+++ b/Userland/Libraries/LibSQL/Parser.h
@@ -17,6 +17,7 @@ namespace SQL {
 namespace Limits {
 // https://www.sqlite.org/limits.html
 constexpr size_t maximum_expression_tree_depth = 1000;
+constexpr size_t maximum_subquery_depth = 100;
 }
 
 class Parser {
@@ -54,6 +55,7 @@ private:
         Token m_token;
         Vector<Error> m_errors;
         size_t m_current_expression_depth { 0 };
+        size_t m_current_subquery_depth { 0 };
     };
 
     NonnullRefPtr<Statement> parse_statement();


### PR DESCRIPTION
SQLite hasn't documented a limit on https://www.sqlite.org/limits.html
for the maximum number of nested subqueries. However, its parser is
generated with Yacc and has an internal limit of 100 for general nested
statements.

Fixes https://crbug.com/oss-fuzz/35022.