### PR TITLE
AK: Fixing fuzzer bugs in the URL parser

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -246,13 +246,13 @@ u32 Utf8CodePointIterator::operator*() const
 
     if (!first_byte_makes_sense) {
         // The first byte of the code point doesn't make sense: output a replacement character
-        dbgln("First byte doesn't make sense, bytes: {}", StringView { (const char*)m_ptr, m_length });
+        dbgln("First byte doesn't make sense: {:#02x}.", m_ptr[0]);
         return 0xFFFD;
     }
 
     if (code_point_length_in_bytes > m_length) {
         // There is not enough data left for the full code point: output a replacement character
-        dbgln("Not enough bytes (need {}, have {}), first byte is: {:#02x}, '{}'", code_point_length_in_bytes, m_length, m_ptr[0], (const char*)m_ptr);
+        dbgln("Not enough bytes (need {}, have {}), first byte is: {:#02x}.", code_point_length_in_bytes, m_length, m_ptr[0]);
         return 0xFFFD;
     }
 


### PR DESCRIPTION
* Do not print full string when printing debug output in `Utf8CodePointIterator` (fixes [oss-fuzz#35050](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35050&sort=-opened&can=1&q=proj%3Aserenity)).
* Don't create `Utf8View` from temporary `String`, because it leads to use-after-free reads (fixes [oss-fuzz#34973](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34973&sort=-opened&can=1&q=proj%3Aserenity)).

Together with the second bug, I replace most usages of `StringBuilder::to_string()` with `StringBuilder::string_view()`, since they were mostly use as arguments to functions taking `StringView const&`.