### PR TITLE
LibJS: Seal Bytecode Blocks and munmap them

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Block.h
+++ b/Userland/Libraries/LibJS/Bytecode/Block.h
@@ -42,7 +42,9 @@ public:
     static NonnullOwnPtr<Block> create();
     ~Block();
 
-    void seal();
+    void seal() const;
+    void unseal();
+
     void dump() const;
     ReadonlyBytes instruction_stream() const { return ReadonlyBytes { m_buffer, m_buffer_size }; }
 


### PR DESCRIPTION
This still does not fix the issue of existence of the Constructors, but unseals before invoking them.

Also unmap the memory we have allocated upon destruction