### PR TITLE
Meta: Check installed QEMU version

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -43,6 +43,10 @@ SERENITY_RUN="${SERENITY_RUN:-$1}"
     fi
 }
 
+SERENITY_QEMU_MIN_REQ_VERSION=5
+installed_major_version=$("$SERENITY_QEMU_BIN" -version | head -n 1 | grep -Po "(?<=QEMU emulator version )([1-9]\d*|0)")
+[ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ] && die "Required QEMU >= 5.0! Found $($SERENITY_QEMU_BIN -version | head -n 1)"
+
 [ -z "$SERENITY_COMMON_QEMU_ARGS" ] && SERENITY_COMMON_QEMU_ARGS="
 $SERENITY_EXTRA_QEMU_ARGS
 -s -m $SERENITY_RAM_SIZE


### PR DESCRIPTION
`ninja install` fails with a clueless error message if the installed QEMU version is less than 5.0.

Error message displayed: `qemu-system-i386: -device megasas,bus=bridge1: Unsupported PCI slot 0 for standard hotplug controller. Valid slots are between 1 and 31.`