### PR TITLE
LibJS: Tighten continuable regions and always jump to before the tests 

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -53,19 +53,22 @@ Label Generator::make_label() const
     return Label { m_block->instruction_stream().size() };
 }
 
-Label Generator::nearest_continuable_scope() const
+Vector<Bytecode::Op::Jump*>& Generator::nearest_continuable_scope()
 {
     return m_continuable_scopes.last();
 }
 
 void Generator::begin_continuable_scope()
 {
-    m_continuable_scopes.append(make_label());
+    m_continuable_scopes.empend();
 }
 
 void Generator::end_continuable_scope()
 {
-    m_continuable_scopes.take_last();
+    auto label = make_label();
+    for (auto& jump : m_continuable_scopes.take_last()) {
+        jump->set_target(label);
+    }
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -8,6 +8,7 @@
 
 #include <AK/OwnPtr.h>
 #include <LibJS/Bytecode/Label.h>
+#include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
 
@@ -42,7 +43,7 @@ public:
     void begin_continuable_scope();
     void end_continuable_scope();
 
-    Label nearest_continuable_scope() const;
+    Vector<Bytecode::Op::Jump*>& nearest_continuable_scope();
 
 private:
     Generator();
@@ -53,7 +54,7 @@ private:
 
     OwnPtr<Block> m_block;
     u32 m_next_register { 1 };
-    Vector<Label> m_continuable_scopes;
+    Vector<Vector<Bytecode::Op::Jump*>> m_continuable_scopes;
 };
 
 }


### PR DESCRIPTION
Will probably conflict with #7915, so draft until that one is merged.

Fixes #7914.