### PR TITLE
LibJS: Add bytecode instruction handles

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -119,16 +119,16 @@ void LogicalExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     m_lhs->generate_bytecode(generator);
 
-    Bytecode::Op::Jump* test_instr;
+    Bytecode::InstructionHandle<Bytecode::Op::Jump> test_instr;
     switch (m_op) {
     case LogicalOp::And:
-        test_instr = &generator.emit<Bytecode::Op::JumpIfFalse>();
+        test_instr = generator.emit<Bytecode::Op::JumpIfFalse>();
         break;
     case LogicalOp::Or:
-        test_instr = &generator.emit<Bytecode::Op::JumpIfTrue>();
+        test_instr = generator.emit<Bytecode::Op::JumpIfTrue>();
         break;
     case LogicalOp::NullishCoalescing:
-        test_instr = &generator.emit<Bytecode::Op::JumpIfNotNullish>();
+        test_instr = generator.emit<Bytecode::Op::JumpIfNotNullish>();
         break;
     default:
         VERIFY_NOT_REACHED();
@@ -285,10 +285,10 @@ void WhileStatement::generate_bytecode(Bytecode::Generator& generator) const
     auto result_reg = generator.allocate_register();
     generator.emit<Bytecode::Op::Store>(result_reg);
     m_test->generate_bytecode(generator);
-    auto& test_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
+    auto test_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
     m_body->generate_bytecode(generator);
     generator.emit<Bytecode::Op::Jump>(test_label);
-    test_jump.set_target(generator.make_label());
+    test_jump->set_target(generator.make_label());
     generator.end_continuable_scope();
     generator.emit<Bytecode::Op::Load>(result_reg);
 }
@@ -309,7 +309,7 @@ void DoWhileStatement::generate_bytecode(Bytecode::Generator& generator) const
 
 void ForStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
-    Bytecode::Op::Jump* test_jump { nullptr };
+    Bytecode::InstructionHandle<Bytecode::Op::Jump> test_jump;
 
     if (m_init)
         m_init->generate_bytecode(generator);
@@ -321,7 +321,7 @@ void ForStatement::generate_bytecode(Bytecode::Generator& generator) const
     generator.emit<Bytecode::Op::Store>(result_reg);
     if (m_test) {
         m_test->generate_bytecode(generator);
-        test_jump = &generator.emit<Bytecode::Op::JumpIfFalse>();
+        test_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
     }
 
     m_body->generate_bytecode(generator);
@@ -387,16 +387,16 @@ void ReturnStatement::generate_bytecode(Bytecode::Generator& generator) const
 void IfStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     m_predicate->generate_bytecode(generator);
-    auto& else_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
+    auto else_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
 
     m_consequent->generate_bytecode(generator);
     if (m_alternate) {
-        auto& if_jump = generator.emit<Bytecode::Op::Jump>();
-        else_jump.set_target(generator.make_label());
+        auto if_jump = generator.emit<Bytecode::Op::Jump>();
+        else_jump->set_target(generator.make_label());
         m_alternate->generate_bytecode(generator);
-        if_jump.set_target(generator.make_label());
+        if_jump->set_target(generator.make_label());
     } else {
-        else_jump.set_target(generator.make_label());
+        else_jump->set_target(generator.make_label());
     }
 }
 
@@ -412,15 +412,15 @@ void DebuggerStatement::generate_bytecode(Bytecode::Generator&) const
 void ConditionalExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     m_test->generate_bytecode(generator);
-    auto& alternate_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
+    auto alternate_jump = generator.emit<Bytecode::Op::JumpIfFalse>();
 
     m_consequent->generate_bytecode(generator);
-    auto& end_jump = generator.emit<Bytecode::Op::Jump>();
+    auto end_jump = generator.emit<Bytecode::Op::Jump>();
 
-    alternate_jump.set_target(generator.make_label());
+    alternate_jump->set_target(generator.make_label());
     m_alternate->generate_bytecode(generator);
 
-    end_jump.set_target(generator.make_label());
+    end_jump->set_target(generator.make_label());
 }
 
 void SequenceExpression::generate_bytecode(Bytecode::Generator& generator) const

--- a/Userland/Libraries/LibJS/Bytecode/Block.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Block.cpp
@@ -4,26 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/String.h>
 #include <LibJS/Bytecode/Block.h>
 #include <LibJS/Bytecode/Op.h>
-#include <sys/mman.h>
 
 namespace JS::Bytecode {
 
 NonnullOwnPtr<Block> Block::create()
 {
     return adopt_own(*new Block);
-}
-
-Block::Block()
-{
-    // FIXME: This is not the smartest solution ever. Find something cleverer!
-    // The main issue we're working around here is that we don't want pointers into the bytecode stream to become invalidated
-    // during code generation due to dynamic buffer resizing. Otherwise we could just use a Vector.
-    m_buffer_capacity = 64 * KiB;
-    m_buffer = (u8*)mmap(nullptr, m_buffer_capacity, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
-    VERIFY(m_buffer != MAP_FAILED);
 }
 
 Block::~Block()
@@ -34,16 +22,6 @@ Block::~Block()
         ++it;
         Instruction::destroy(const_cast<Instruction&>(to_destroy));
     }
-
-    munmap(m_buffer, m_buffer_capacity);
-}
-
-void Block::seal()
-{
-    // FIXME: mprotect the instruction stream as PROT_READ
-    // This is currently not possible because instructions can have destructors (that clean up strings)
-    // Instructions should instead be destructor-less and refer to strings in a string table on the Bytecode::Block.
-    // It also doesn't work because instructions that have String members use RefPtr internally which must be in writable memory.
 }
 
 void Block::dump() const
@@ -53,12 +31,6 @@ void Block::dump() const
         warnln("[{:4x}] {}", it.offset(), (*it).to_string());
         ++it;
     }
-}
-
-void Block::grow(size_t additional_size)
-{
-    m_buffer_size += additional_size;
-    VERIFY(m_buffer_size <= m_buffer_capacity);
 }
 
 void InstructionStreamIterator::operator++()

--- a/Userland/Libraries/LibJS/Bytecode/Block.h
+++ b/Userland/Libraries/LibJS/Bytecode/Block.h
@@ -8,6 +8,7 @@
 
 #include <AK/Badge.h>
 #include <AK/NonnullOwnPtrVector.h>
+#include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
@@ -42,25 +43,20 @@ public:
     static NonnullOwnPtr<Block> create();
     ~Block();
 
-    void seal();
-
     void dump() const;
-    ReadonlyBytes instruction_stream() const { return ReadonlyBytes { m_buffer, m_buffer_size }; }
+    ReadonlyBytes instruction_stream() const { return m_buffer.span(); }
 
     size_t register_count() const { return m_register_count; }
 
     void set_register_count(Badge<Bytecode::Generator>, size_t count) { m_register_count = count; }
 
-    void* next_slot() { return m_buffer + m_buffer_size; }
-    void grow(size_t additional_size);
+    Vector<u8>& buffer() { return m_buffer; }
 
 private:
-    Block();
+    Block() = default;
 
     size_t m_register_count { 0 };
-    u8* m_buffer { nullptr };
-    size_t m_buffer_capacity { 0 };
-    size_t m_buffer_size { 0 };
+    Vector<u8> m_buffer;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -10,7 +10,6 @@
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Register.h>
-#include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
 
@@ -28,18 +27,7 @@ OwnPtr<Block> Generator::generate(ASTNode const& node)
     Generator generator;
     node.generate_bytecode(generator);
     generator.m_block->set_register_count({}, generator.m_next_register);
-    generator.m_block->seal();
     return move(generator.m_block);
-}
-
-void Generator::grow(size_t additional_size)
-{
-    m_block->grow(additional_size);
-}
-
-void* Generator::next_slot()
-{
-    return m_block->next_slot();
 }
 
 Register Generator::allocate_register()

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <LibJS/Bytecode/Block.h>
 #include <LibJS/Bytecode/Label.h>
-#include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
@@ -20,21 +20,15 @@ public:
     Register allocate_register();
 
     template<typename OpType, typename... Args>
-    OpType& emit(Args&&... args)
+    InstructionHandle<OpType> emit(Args&&... args)
     {
-        void* slot = next_slot();
-        grow(sizeof(OpType));
-        new (slot) OpType(forward<Args>(args)...);
-        return *static_cast<OpType*>(slot);
+        return make_instruction<OpType>(0, forward<Args>(args)...);
     }
 
     template<typename OpType, typename... Args>
-    OpType& emit_with_extra_register_slots(size_t extra_register_slots, Args&&... args)
+    InstructionHandle<OpType> emit_with_extra_register_slots(size_t extra_register_slots, Args&&... args)
     {
-        void* slot = next_slot();
-        grow(sizeof(OpType) + extra_register_slots * sizeof(Register));
-        new (slot) OpType(forward<Args>(args)...);
-        return *static_cast<OpType*>(slot);
+        return make_instruction<OpType>(extra_register_slots, forward<Args>(args)...);
     }
 
     Label make_label() const;
@@ -48,8 +42,15 @@ private:
     Generator();
     ~Generator();
 
-    void grow(size_t);
-    void* next_slot();
+    template<typename OpType, typename... Args>
+    InstructionHandle<OpType> make_instruction(size_t extra_register_slots, Args&&... args)
+    {
+        auto& buffer = m_block->buffer();
+        auto offset = buffer.size();
+        buffer.resize(buffer.size() + sizeof(OpType) + extra_register_slots * sizeof(Register));
+        new (buffer.data() + offset) OpType(forward<Args>(args)...);
+        return InstructionHandle<OpType>(offset, m_block);
+    }
 
     OwnPtr<Block> m_block;
     u32 m_next_register { 1 };

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Bytecode/Block.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Op.h>
 

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -166,6 +166,8 @@ namespace Bytecode {
 class Block;
 class Generator;
 class Instruction;
+template<typename OpType>
+class InstructionHandle;
 class Interpreter;
 class Register;
 }


### PR DESCRIPTION
This change removes the mmap inside of `Block` in favor of a growing vector of bytes. This is favorable for two reasons:
  - We don't take more space than we need
  - There is no limit to the growth of the vector (previously, if the `Block` overstepped its 64kb boundary, it would just crash)

However, if that vector happens to resize, any pointer pointing into that vector would become invalid. To avoid this, this commit adds an `InstructionHandle<Op>` class which just stores a block and an offset into that block.