### PR TITLE
Utilities: Do not allow creating users with existing usernames

### DIFF
--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -64,6 +64,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    if (getpwnam(username)) {
+        warnln("user {} already exists!", username);
+        return 1;
+    }
+
     if (uid < 0) {
         warnln("invalid uid {}!", uid);
         return 3;


### PR DESCRIPTION
Previously useradd would not check if a username already existed on the
system, and would instead add the user anyway and just increment the
uid. useradd should instead return an error when the user attempts to
create already existing users.