### PR TITLE
LibJS: Generate bytecode in basic blocks instead of one big block

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -8,6 +8,7 @@
 
 #include <AK/Badge.h>
 #include <AK/NonnullOwnPtrVector.h>
+#include <AK/String.h>
 #include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
@@ -37,30 +38,32 @@ private:
     size_t m_offset { 0 };
 };
 
-class Block {
+class BasicBlock {
 public:
-    static NonnullOwnPtr<Block> create();
-    ~Block();
+    static NonnullOwnPtr<BasicBlock> create(String name);
+    ~BasicBlock();
 
     void seal();
 
     void dump() const;
     ReadonlyBytes instruction_stream() const { return ReadonlyBytes { m_buffer, m_buffer_size }; }
 
-    size_t register_count() const { return m_register_count; }
-
-    void set_register_count(Badge<Bytecode::Generator>, size_t count) { m_register_count = count; }
-
     void* next_slot() { return m_buffer + m_buffer_size; }
     void grow(size_t additional_size);
 
-private:
-    Block();
+    void terminate(Badge<Generator>) { m_is_terminated = true; }
+    bool is_terminated() const { return m_is_terminated; }
 
-    size_t m_register_count { 0 };
+    String const& name() const { return m_name; }
+
+private:
+    BasicBlock(String name);
+
     u8* m_buffer { nullptr };
     size_t m_buffer_capacity { 0 };
     size_t m_buffer_size { 0 };
+    bool m_is_terminated { false };
+    String m_name;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/OwnPtr.h>
 #include <LibJS/AST.h>
-#include <LibJS/Bytecode/Block.h>
+#include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Register.h>
@@ -16,30 +15,30 @@ namespace JS::Bytecode {
 
 Generator::Generator()
 {
-    m_block = Block::create();
 }
 
 Generator::~Generator()
 {
 }
 
-OwnPtr<Block> Generator::generate(ASTNode const& node)
+ExecutionUnit Generator::generate(ASTNode const& node)
 {
     Generator generator;
+    generator.switch_to_basic_block(generator.make_block());
     node.generate_bytecode(generator);
-    generator.m_block->set_register_count({}, generator.m_next_register);
-    generator.m_block->seal();
-    return move(generator.m_block);
+    return { move(generator.m_root_basic_blocks), generator.m_next_register };
 }
 
 void Generator::grow(size_t additional_size)
 {
-    m_block->grow(additional_size);
+    VERIFY(m_current_basic_block);
+    m_current_basic_block->grow(additional_size);
 }
 
 void* Generator::next_slot()
 {
-    return m_block->next_slot();
+    VERIFY(m_current_basic_block);
+    return m_current_basic_block->next_slot();
 }
 
 Register Generator::allocate_register()
@@ -48,19 +47,14 @@ Register Generator::allocate_register()
     return Register { m_next_register++ };
 }
 
-Label Generator::make_label() const
-{
-    return Label { m_block->instruction_stream().size() };
-}
-
 Label Generator::nearest_continuable_scope() const
 {
     return m_continuable_scopes.last();
 }
 
-void Generator::begin_continuable_scope()
+void Generator::begin_continuable_scope(Label continue_target)
 {
-    m_continuable_scopes.append(make_label());
+    m_continuable_scopes.append(continue_target);
 }
 
 void Generator::end_continuable_scope()

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -6,43 +6,73 @@
 
 #pragma once
 
+#include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
+#include <AK/SinglyLinkedList.h>
+#include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
 
+struct ExecutionUnit {
+    NonnullOwnPtrVector<BasicBlock> basic_blocks;
+    size_t number_of_registers { 0 };
+};
+
 class Generator {
 public:
-    static OwnPtr<Block> generate(ASTNode const&);
+    static ExecutionUnit generate(ASTNode const&);
 
     Register allocate_register();
 
     template<typename OpType, typename... Args>
     OpType& emit(Args&&... args)
     {
+        VERIFY(!is_current_block_terminated());
         void* slot = next_slot();
         grow(sizeof(OpType));
         new (slot) OpType(forward<Args>(args)...);
+        if constexpr (OpType::IsTerminator)
+            m_current_basic_block->terminate({});
         return *static_cast<OpType*>(slot);
     }
 
     template<typename OpType, typename... Args>
     OpType& emit_with_extra_register_slots(size_t extra_register_slots, Args&&... args)
     {
+        VERIFY(!is_current_block_terminated());
         void* slot = next_slot();
         grow(sizeof(OpType) + extra_register_slots * sizeof(Register));
         new (slot) OpType(forward<Args>(args)...);
+        if constexpr (OpType::IsTerminator)
+            m_current_basic_block->terminate({});
         return *static_cast<OpType*>(slot);
     }
 
-    Label make_label() const;
-
-    void begin_continuable_scope();
+    void begin_continuable_scope(Label continue_target);
     void end_continuable_scope();
 
-    Label nearest_continuable_scope() const;
+    [[nodiscard]] Label nearest_continuable_scope() const;
+
+    void switch_to_basic_block(BasicBlock& block)
+    {
+        m_current_basic_block = &block;
+    }
+
+    BasicBlock& make_block(String name = {})
+    {
+        if (name.is_empty())
+            name = String::number(m_next_block++);
+        m_root_basic_blocks.append(BasicBlock::create(name));
+        return m_root_basic_blocks.last();
+    }
+
+    bool is_current_block_terminated() const
+    {
+        return m_current_basic_block->is_terminated();
+    }
 
 private:
     Generator();
@@ -51,8 +81,11 @@ private:
     void grow(size_t);
     void* next_slot();
 
-    OwnPtr<Block> m_block;
+    BasicBlock* m_current_basic_block { nullptr };
+    NonnullOwnPtrVector<BasicBlock> m_root_basic_blocks;
+
     u32 m_next_register { 1 };
+    u32 m_next_block { 1 };
     Vector<Label> m_continuable_scopes;
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -36,9 +36,8 @@
     O(PutById)                    \
     O(GetById)                    \
     O(Jump)                       \
-    O(JumpIfFalse)                \
-    O(JumpIfTrue)                 \
-    O(JumpIfNotNullish)           \
+    O(JumpConditional)            \
+    O(JumpNullish)                \
     O(Call)                       \
     O(EnterScope)                 \
     O(Return)                     \
@@ -61,6 +60,8 @@ namespace JS::Bytecode {
 
 class Instruction {
 public:
+    constexpr static bool IsTerminator = false;
+
     enum class Type {
 #define __BYTECODE_OP(op) \
     op,

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/NonnullOwnPtrVector.h>
+#include "Generator.h"
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
@@ -28,12 +28,15 @@ public:
     GlobalObject& global_object() { return m_global_object; }
     VM& vm() { return m_vm; }
 
-    Value run(Bytecode::Block const&);
+    Value run(Bytecode::ExecutionUnit const&);
 
     ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
     Value& reg(Register const& r) { return registers()[r.index()]; }
 
-    void jump(Label const& label) { m_pending_jump = label.address(); }
+    void jump(Label const& label)
+    {
+        m_pending_jump = &label.block();
+    }
     void do_return(Value return_value) { m_return_value = return_value; }
 
 private:
@@ -42,7 +45,7 @@ private:
     VM& m_vm;
     GlobalObject& m_global_object;
     NonnullOwnPtrVector<RegisterWindow> m_register_windows;
-    Optional<size_t> m_pending_jump;
+    Optional<BasicBlock const*> m_pending_jump;
     Value m_return_value;
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/Label.h
+++ b/Userland/Libraries/LibJS/Bytecode/Label.h
@@ -7,20 +7,21 @@
 #pragma once
 
 #include <AK/Format.h>
+#include <LibJS/Bytecode/BasicBlock.h>
 
 namespace JS::Bytecode {
 
 class Label {
 public:
-    explicit Label(size_t address)
-        : m_address(address)
+    explicit Label(BasicBlock const& block)
+        : m_block(block)
     {
     }
 
-    size_t address() const { return m_address; }
+    auto& block() const { return m_block; }
 
 private:
-    size_t m_address { 0 };
+    BasicBlock const& m_block;
 };
 
 }
@@ -29,6 +30,6 @@ template<>
 struct AK::Formatter<JS::Bytecode::Label> : AK::Formatter<FormatString> {
     void format(FormatBuilder& builder, JS::Bytecode::Label const& value)
     {
-        return AK::Formatter<FormatString>::format(builder, "@{:x}", value.address());
+        return AK::Formatter<FormatString>::format(builder, "@{}", value.block().name());
     }
 };

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -174,31 +174,29 @@ void PutById::execute(Bytecode::Interpreter& interpreter) const
 
 void Jump::execute(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.jump(*m_target);
+    interpreter.jump(*m_true_target);
 }
 
-void JumpIfFalse::execute(Bytecode::Interpreter& interpreter) const
+void JumpConditional::execute(Bytecode::Interpreter& interpreter) const
 {
-    VERIFY(m_target.has_value());
-    auto result = interpreter.accumulator();
-    if (!result.to_boolean())
-        interpreter.jump(m_target.value());
-}
-
-void JumpIfTrue::execute(Bytecode::Interpreter& interpreter) const
-{
-    VERIFY(m_target.has_value());
+    VERIFY(m_true_target.has_value());
+    VERIFY(m_false_target.has_value());
     auto result = interpreter.accumulator();
     if (result.to_boolean())
-        interpreter.jump(m_target.value());
+        interpreter.jump(m_true_target.value());
+    else
+        interpreter.jump(m_false_target.value());
 }
 
-void JumpIfNotNullish::execute(Bytecode::Interpreter& interpreter) const
+void JumpNullish::execute(Bytecode::Interpreter& interpreter) const
 {
-    VERIFY(m_target.has_value());
+    VERIFY(m_true_target.has_value());
+    VERIFY(m_false_target.has_value());
     auto result = interpreter.accumulator();
-    if (!result.is_nullish())
-        interpreter.jump(m_target.value());
+    if (result.is_nullish())
+        interpreter.jump(m_true_target.value());
+    else
+        interpreter.jump(m_false_target.value());
 }
 
 void Call::execute(Bytecode::Interpreter& interpreter) const
@@ -321,28 +319,23 @@ String GetById::to_string() const
 
 String Jump::to_string() const
 {
-    return String::formatted("Jump {}", *m_target);
+    if (m_true_target.has_value())
+        return String::formatted("Jump {}", *m_true_target);
+    return String::formatted("Jump <empty>");
 }
 
-String JumpIfFalse::to_string() const
+String JumpConditional::to_string() const
 {
-    if (m_target.has_value())
-        return String::formatted("JumpIfFalse target:{}", m_target.value());
-    return "JumpIfFalse target:<empty>";
+    auto true_string = m_true_target.has_value() ? String::formatted("{}", *m_true_target) : "<empty>";
+    auto false_string = m_false_target.has_value() ? String::formatted("{}", *m_false_target) : "<empty>";
+    return String::formatted("JumpConditional true:{} false:{}", true_string, false_string);
 }
 
-String JumpIfTrue::to_string() const
+String JumpNullish::to_string() const
 {
-    if (m_target.has_value())
-        return String::formatted("JumpIfTrue target:{}", m_target.value());
-    return "JumpIfTrue result:{}, target:<empty>";
-}
-
-String JumpIfNotNullish::to_string() const
-{
-    if (m_target.has_value())
-        return String::formatted("JumpIfNotNullish target:{}", m_target.value());
-    return "JumpIfNotNullish target:<empty>";
+    auto true_string = m_true_target.has_value() ? String::formatted("{}", *m_true_target) : "<empty>";
+    auto false_string = m_false_target.has_value() ? String::formatted("{}", *m_false_target) : "<empty>";
+    return String::formatted("JumpNullish null:{} nonnull:{}", true_string, false_string);
 }
 
 String Call::to_string() const

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SOURCES
         AST.cpp
         Bytecode/ASTCodegen.cpp
-        Bytecode/Block.cpp
+        Bytecode/BasicBlock.cpp
         Bytecode/Generator.cpp
         Bytecode/Instruction.cpp
         Bytecode/Interpreter.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -163,7 +163,7 @@ template<class T>
 class Handle;
 
 namespace Bytecode {
-class Block;
+class BasicBlock;
 class Generator;
 class Instruction;
 class Interpreter;

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -7,7 +7,7 @@
 #include <AK/Debug.h>
 #include <AK/Function.h>
 #include <LibJS/AST.h>
-#include <LibJS/Bytecode/Block.h>
+#include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Interpreter.h>
@@ -151,15 +151,15 @@ Value ScriptFunction::execute_function_body()
 
     if (bytecode_interpreter) {
         prepare_arguments();
-        if (!m_bytecode_block) {
-            m_bytecode_block = Bytecode::Generator::generate(m_body);
-            VERIFY(m_bytecode_block);
+        if (!m_bytecode_execution_unit.has_value()) {
+            m_bytecode_execution_unit = Bytecode::Generator::generate(m_body);
             if constexpr (JS_BYTECODE_DEBUG) {
                 dbgln("Compiled Bytecode::Block for function '{}':", m_name);
-                m_bytecode_block->dump();
+                for (auto& block : m_bytecode_execution_unit->basic_blocks)
+                    block.dump();
             }
         }
-        return bytecode_interpreter->run(*m_bytecode_block);
+        return bytecode_interpreter->run(*m_bytecode_execution_unit);
     } else {
         OwnPtr<Interpreter> local_interpreter;
         ast_interpreter = vm.interpreter_if_exists();

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibJS/AST.h>
+#include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Runtime/Function.h>
 
 namespace JS {
@@ -47,7 +48,7 @@ private:
     FlyString m_name;
     NonnullRefPtr<Statement> m_body;
     const Vector<FunctionNode::Parameter> m_parameters;
-    OwnPtr<Bytecode::Block> m_bytecode_block;
+    Optional<Bytecode::ExecutionUnit> m_bytecode_execution_unit;
     ScopeObject* m_parent_scope { nullptr };
     i32 m_function_length { 0 };
     bool m_is_strict { false };

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -14,7 +14,7 @@
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibJS/AST.h>
-#include <LibJS/Bytecode/Block.h>
+#include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Console.h>
@@ -494,15 +494,15 @@ static bool parse_and_run(JS::Interpreter& interpreter, const StringView& source
         program->dump(0);
 
     if (s_dump_bytecode || s_run_bytecode) {
-        auto block = JS::Bytecode::Generator::generate(*program);
-        VERIFY(block);
-
-        if (s_dump_bytecode)
-            block->dump();
+        auto unit = JS::Bytecode::Generator::generate(*program);
+        if (s_dump_bytecode) {
+            for (auto& block : unit.basic_blocks)
+                block.dump();
+        }
 
         if (s_run_bytecode) {
             JS::Bytecode::Interpreter bytecode_interpreter(interpreter.global_object());
-            bytecode_interpreter.run(*block);
+            bytecode_interpreter.run(unit);
         }
 
         return true;


### PR DESCRIPTION
This limits the size of each block (currently set to 1K), and gets us closer to a canonical, more easily analysable bytecode format.
As a result of this, "Labels" are now simply entries to basic blocks.
Also fixes #7914 as a result of reimplementing the loop logic.

Also note that this commit makes generating code in a terminated block a hard error (e.g. no code may be inserted after a jump or a return).

Also also note that this probably conflicts with every open LibJS bytecode PR.

Super tiny example:
<details> <summary>Expand</summary>

```js
for (i = 0; i < 10; i = i + 1) {
    if (i < 4) 
        continue;
    console.log(i);
}

while (i < 4) {
    console.log("NO!");
}   

do {
    i = i - 1;
    console.log(i);
} while(i > 4);
```

->

```
1:
[   0] EnterScope
[  10] LoadImmediate value:0
[  28] SetVariable identifier:i
[  38] LoadImmediate value:undefined
[  50] Store dst:$1
[  58] Jump @4
2:
[   0] Load src:$1
[   8] LoadImmediate value:undefined
[  20] Store dst:$8
[  28] Jump @8
3:
[   0] EnterScope
[  10] GetVariable identifier:i
[  20] Store dst:$3
[  28] LoadImmediate value:4
[  40] LessThan lhs:$3
[  48] JumpConditional true:@6 false:@7
4:
[   0] GetVariable identifier:i
[  10] Store dst:$2
[  18] LoadImmediate value:10
[  30] LessThan lhs:$2
[  38] JumpConditional true:@3 false:@2
5:
[   0] GetVariable identifier:i
[  10] Store dst:$7
[  18] LoadImmediate value:1
[  30] Add lhs:$7
[  38] SetVariable identifier:i
[  48] Jump @4
6:
[   0] Jump @5
7:
[   0] GetVariable identifier:console
[  10] GetById property:log
[  20] Store dst:$4
[  28] LoadImmediate value:undefined
[  40] Store dst:$5
[  48] GetVariable identifier:i
[  58] Store dst:$6
[  60] Call callee:$4, this:$5, arguments:[$6]
[  7c] Jump @5
8:
[   0] GetVariable identifier:i
[  10] Store dst:$9
[  18] LoadImmediate value:4
[  30] LessThan lhs:$9
[  38] JumpConditional true:@9 false:@10
9:
[   0] EnterScope
[  10] GetVariable identifier:console
[  20] GetById property:log
[  30] Store dst:$10
[  38] LoadImmediate value:undefined
[  50] Store dst:$11
[  58] NewString string:"NO!"
[  68] Store dst:$12
[  70] Call callee:$10, this:$11, arguments:[$12]
[  8c] Jump @8
10:
[   0] Load src:$8
[   8] LoadImmediate value:undefined
[  20] Store dst:$13
[  28] Jump @12
11:
[   0] GetVariable identifier:i
[  10] Store dst:$14
[  18] LoadImmediate value:4
[  30] GreaterThan lhs:$14
[  38] JumpConditional true:@12 false:@13
12:
[   0] EnterScope
[  10] GetVariable identifier:i
[  20] Store dst:$15
[  28] LoadImmediate value:1
[  40] Sub lhs:$15
[  48] SetVariable identifier:i
[  58] GetVariable identifier:console
[  68] GetById property:log
[  78] Store dst:$16
[  80] LoadImmediate value:undefined
[  98] Store dst:$17
[  a0] GetVariable identifier:i
[  b0] Store dst:$18
[  b8] Call callee:$16, this:$17, arguments:[$18]
[  d4] Jump @11
13:
[   0] Load src:$13
```

</details>

The basic blocks can be given names, and if the name is empty (the default), the generator will simply use an increasing index.

Tested and confirmed working:
- [x] Non-jump-related operations (arith, strings, etc)
- [x] function calls
- [x] while loops + continue
- [x] if statements (+ else)
- [x] for loops (with/without: init, update, test)
- [x] do-while loops (+ continue)
- [x] logical expressions (+short circuit)
- [x] Conditional expressions

Tested and confirmed unchanged:
- [x] Template literals with interpolation: broken on master (``` console.log(`foo bar ${123}`); ``` does not print anything), unaffected by this PR