### PR TITLE
LibGL: Implement very basic version of glGetFloatv

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -201,6 +201,9 @@ extern "C" {
 #define GL_NEAREST_MIPMAP_LINEAR 0x2602
 #define GL_REPEAT 0x2603
 
+// OpenGL State & GLGet
+#define GL_MODELVIEW_MATRIX 0x0BA6
+
 //
 // OpenGL typedefs
 //
@@ -294,6 +297,7 @@ GLAPI void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsize
 GLAPI void glTexCoord2f(GLfloat s, GLfloat t);
 GLAPI void glBindTexture(GLenum target, GLuint texture);
 GLAPI void glActiveTexture(GLenum texture);
+GLAPI void glGetFloatv(GLenum pname, GLfloat* params);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -61,6 +61,7 @@ public:
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) = 0;
     virtual void gl_bind_texture(GLenum target, GLuint texture) = 0;
     virtual void gl_active_texture(GLenum texture) = 0;
+    virtual void gl_get_floatv(GLenum pname, GLfloat* params) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -84,3 +84,8 @@ void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format
 {
     g_gl_context->gl_read_pixels(x, y, width, height, format, type, pixels);
 }
+
+void glGetFloatv(GLenum pname, GLfloat* params)
+{
+    g_gl_context->gl_get_floatv(pname, params);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -71,6 +71,7 @@ public:
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) override;
     virtual void gl_bind_texture(GLenum target, GLuint texture) override;
     virtual void gl_active_texture(GLenum texture) override;
+    virtual void gl_get_floatv(GLenum pname, GLfloat* params) override;
 
     virtual void present() override;
 


### PR DESCRIPTION
Implements a very basic version of glGetFloatv. See https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glGet.xml for details about this API.

I've only added support for GL_MODELVIEW_MATRIX. As far as I can tell this is the only required usage in order to get glQuake running on serenity (see #7062). I'm open to implementing more functionality either now or in the future :)