### PR TITLE
LibJS: Only set element in array literal to an empty value if it's null

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -346,7 +346,6 @@ void ArrayExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     Vector<Bytecode::Register> element_regs;
     for (auto& element : m_elements) {
-        generator.emit<Bytecode::Op::LoadImmediate>(Value {});
         if (element) {
             element->generate_bytecode(generator);
 
@@ -354,6 +353,8 @@ void ArrayExpression::generate_bytecode(Bytecode::Generator& generator) const
                 TODO();
                 continue;
             }
+        } else {
+            generator.emit<Bytecode::Op::LoadImmediate>(Value {});
         }
         auto element_reg = generator.allocate_register();
         generator.emit<Bytecode::Op::Store>(element_reg);


### PR DESCRIPTION
This avoids an unnecessary empty load that immediately gets overridden.

For example, `[1,,]` would appear as:
```
[   0] EnterScope
[  10] LoadImmediate value:<empty>
[  28] LoadImmediate value:1
[  40] Store dst:$1
[  48] LoadImmediate value:<empty>
[  60] Store dst:$2
[  68] NewArray, elements:[$1,$2]
```

But now appears as:
```
[   0] EnterScope
[  10] LoadImmediate value:1
[  28] Store dst:$1
[  30] LoadImmediate value:<empty>
[  48] Store dst:$2
[  50] NewArray, elements:[$1,$2]
```