### PR TITLE
Kernel: More UNMAP_AFTER_INIT annotations

### DIFF
--- a/Kernel/Devices/PCISerialDevice.cpp
+++ b/Kernel/Devices/PCISerialDevice.cpp
@@ -10,7 +10,7 @@ namespace Kernel {
 
 static SerialDevice* s_the = nullptr;
 
-void PCISerialDevice::detect()
+UNMAP_AFTER_INIT void PCISerialDevice::detect()
 {
     size_t current_device_minor = 68;
     PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -119,7 +119,7 @@ namespace Kernel {
 #define INTERRUPT_SRPD (1 << 16)
 
 // https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf Section 5.2
-static bool is_valid_device_id(u16 device_id)
+UNMAP_AFTER_INIT static bool is_valid_device_id(u16 device_id)
 {
     // FIXME: It would be nice to distinguish which particular device it is.
     //        Especially since it's needed to determine which registers we can access.

--- a/Kernel/Net/NE2000NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000NetworkAdapter.cpp
@@ -228,7 +228,7 @@ void NE2000NetworkAdapter::handle_irq(const RegisterState&)
     out8(REG_RW_INTERRUPTSTATUS, status);
 }
 
-int NE2000NetworkAdapter::ram_test()
+UNMAP_AFTER_INIT int NE2000NetworkAdapter::ram_test()
 {
     IOAddress io(PCI::get_BAR0(pci_address()) & ~3);
     int errors = 0;

--- a/Kernel/PCI/Access.cpp
+++ b/Kernel/PCI/Access.cpp
@@ -53,34 +53,34 @@ PhysicalID Access::get_physical_id(Address address) const
     VERIFY_NOT_REACHED();
 }
 
-u8 Access::early_read8_field(Address address, u32 field)
+UNMAP_AFTER_INIT u8 Access::early_read8_field(Address address, u32 field)
 {
     dbgln_if(PCI_DEBUG, "PCI: Early reading 8-bit field {:#08x} for {}", field, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     return IO::in8(PCI_VALUE_PORT + (field & 3));
 }
 
-u16 Access::early_read16_field(Address address, u32 field)
+UNMAP_AFTER_INIT u16 Access::early_read16_field(Address address, u32 field)
 {
     dbgln_if(PCI_DEBUG, "PCI: Early reading 16-bit field {:#08x} for {}", field, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     return IO::in16(PCI_VALUE_PORT + (field & 2));
 }
 
-u32 Access::early_read32_field(Address address, u32 field)
+UNMAP_AFTER_INIT u32 Access::early_read32_field(Address address, u32 field)
 {
     dbgln_if(PCI_DEBUG, "PCI: Early reading 32-bit field {:#08x} for {}", field, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     return IO::in32(PCI_VALUE_PORT);
 }
 
-u16 Access::early_read_type(Address address)
+UNMAP_AFTER_INIT u16 Access::early_read_type(Address address)
 {
     dbgln_if(PCI_DEBUG, "PCI: Early reading type for {}", address);
     return (early_read8_field(address, PCI_CLASS) << 8u) | early_read8_field(address, PCI_SUBCLASS);
 }
 
-void Access::enumerate_functions(int type, u8 bus, u8 device, u8 function, Function<void(Address, ID)>& callback, bool recursive)
+UNMAP_AFTER_INIT void Access::enumerate_functions(int type, u8 bus, u8 device, u8 function, Function<void(Address, ID)>& callback, bool recursive)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating function type={}, bus={}, device={}, function={}", type, bus, device, function);
     Address address(0, bus, device, function);
@@ -95,7 +95,7 @@ void Access::enumerate_functions(int type, u8 bus, u8 device, u8 function, Funct
     }
 }
 
-void Access::enumerate_device(int type, u8 bus, u8 device, Function<void(Address, ID)>& callback, bool recursive)
+UNMAP_AFTER_INIT void Access::enumerate_device(int type, u8 bus, u8 device, Function<void(Address, ID)>& callback, bool recursive)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating device type={}, bus={}, device={}", type, bus, device);
     Address address(0, bus, device, 0);
@@ -111,26 +111,26 @@ void Access::enumerate_device(int type, u8 bus, u8 device, Function<void(Address
     }
 }
 
-void Access::enumerate_bus(int type, u8 bus, Function<void(Address, ID)>& callback, bool recursive)
+UNMAP_AFTER_INIT void Access::enumerate_bus(int type, u8 bus, Function<void(Address, ID)>& callback, bool recursive)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating bus type={}, bus={}", type, bus);
     for (u8 device = 0; device < 32; ++device)
         enumerate_device(type, bus, device, callback, recursive);
 }
 
-void Access::enumerate(Function<void(Address, ID)>& callback) const
+UNMAP_AFTER_INIT void Access::enumerate(Function<void(Address, ID)>& callback) const
 {
     for (auto& physical_id : m_physical_ids) {
         callback(physical_id.address(), physical_id.id());
     }
 }
 
-void enumerate(Function<void(Address, ID)> callback)
+UNMAP_AFTER_INIT void enumerate(Function<void(Address, ID)> callback)
 {
     Access::the().enumerate(callback);
 }
 
-Optional<u8> get_capabilities_pointer(Address address)
+UNMAP_AFTER_INIT Optional<u8> get_capabilities_pointer(Address address)
 {
     dbgln_if(PCI_DEBUG, "PCI: Getting capabilities pointer for {}", address);
     if (PCI::read16(address, PCI_STATUS) & (1 << 4)) {
@@ -146,7 +146,7 @@ PhysicalID get_physical_id(Address address)
     return Access::the().get_physical_id(address);
 }
 
-Vector<Capability> get_capabilities(Address address)
+UNMAP_AFTER_INIT Vector<Capability> get_capabilities(Address address)
 {
     dbgln_if(PCI_DEBUG, "PCI: Getting capabilities for {}", address);
     auto capabilities_pointer = PCI::get_capabilities_pointer(address);

--- a/Kernel/PCI/MMIOAccess.cpp
+++ b/Kernel/PCI/MMIOAccess.cpp
@@ -35,7 +35,7 @@ u8 MMIOAccess::segment_end_bus(u32 seg) const
     return segment.value().get_end_bus();
 }
 
-PhysicalAddress MMIOAccess::determine_memory_mapped_bus_region(u32 segment, u8 bus) const
+UNMAP_AFTER_INIT PhysicalAddress MMIOAccess::determine_memory_mapped_bus_region(u32 segment, u8 bus) const
 {
     VERIFY(bus >= segment_start_bus(segment) && bus <= segment_end_bus(segment));
     auto seg = m_segments.get(segment);

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -20,7 +20,7 @@ static void finalizer_task(void*)
     }
 };
 
-void FinalizerTask::spawn()
+UNMAP_AFTER_INIT void FinalizerTask::spawn()
 {
     RefPtr<Thread> finalizer_thread;
     auto finalizer_process = Process::create_kernel_process(finalizer_thread, "FinalizerTask", finalizer_task, nullptr);

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -11,7 +11,7 @@
 
 namespace Kernel {
 
-void SyncTask::spawn()
+UNMAP_AFTER_INIT void SyncTask::spawn()
 {
     RefPtr<Thread> syncd_thread;
     Process::create_kernel_process(syncd_thread, "SyncTask", [] {

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -12,7 +12,7 @@
 
 namespace Kernel {
 
-void VirtIO::detect()
+UNMAP_AFTER_INIT void VirtIO::detect()
 {
     if (kernel_command_line().disable_virtio())
         return;
@@ -37,7 +37,7 @@ void VirtIO::detect()
     });
 }
 
-VirtIODevice::VirtIODevice(PCI::Address address, String class_name)
+UNMAP_AFTER_INIT VirtIODevice::VirtIODevice(PCI::Address address, String class_name)
     : PCI::Device(address, PCI::get_interrupt_line(address))
     , m_class_name(move(class_name))
     , m_io_base(IOAddress(PCI::get_BAR0(pci_address()) & ~1))

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -10,7 +10,7 @@ namespace Kernel {
 
 unsigned VirtIOConsole::next_device_id = 0;
 
-VirtIOConsole::VirtIOConsole(PCI::Address address)
+UNMAP_AFTER_INIT VirtIOConsole::VirtIOConsole(PCI::Address address)
     : CharacterDevice(229, next_device_id++)
     , VirtIODevice(address, "VirtIOConsole")
 {

--- a/Kernel/VirtIO/VirtIORNG.cpp
+++ b/Kernel/VirtIO/VirtIORNG.cpp
@@ -8,7 +8,7 @@
 
 namespace Kernel {
 
-VirtIORNG::VirtIORNG(PCI::Address address)
+UNMAP_AFTER_INIT VirtIORNG::VirtIORNG(PCI::Address address)
     : CharacterDevice(10, 183)
     , VirtIODevice(address, "VirtIORNG")
 {

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -13,12 +13,12 @@ namespace Kernel {
 
 WorkQueue* g_io_work;
 
-void WorkQueue::initialize()
+UNMAP_AFTER_INIT void WorkQueue::initialize()
 {
     g_io_work = new WorkQueue("IO WorkQueue");
 }
 
-WorkQueue::WorkQueue(const char* name)
+UNMAP_AFTER_INIT WorkQueue::WorkQueue(const char* name)
 {
     RefPtr<Thread> thread;
     Process::create_kernel_process(thread, name, [this] {


### PR DESCRIPTION
Annotate more detection / enumeration / creation functions as `UNMAP_AFTER_INIT`.

Before: 
> Unmapped 940 KiB of kernel text after init! :^)

After:
> Unmapped 1008 KiB of kernel text after init! :^)


