### PR TITLE
Browser: Fix crash on download

### DIFF
--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -94,6 +94,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    if (unveil("/tmp/portal/request", "rw") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
     unveil(nullptr, nullptr);
 
     auto app_icon = GUI::Icon::default_icon("app-browser");


### PR DESCRIPTION
This will unveil the portal for RequestServer which is used to download files in the Browser.

Fixes: #7932