### PR TITLE
LibJS: Store strings in a string table

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
@@ -47,13 +47,13 @@ void BasicBlock::seal()
     // It also doesn't work because instructions that have String members use RefPtr internally which must be in writable memory.
 }
 
-void BasicBlock::dump() const
+void BasicBlock::dump(Bytecode::Executable const& executable) const
 {
     Bytecode::InstructionStreamIterator it(instruction_stream());
     if (!m_name.is_empty())
         warnln("{}:", m_name);
     while (!it.at_end()) {
-        warnln("[{:4x}] {}", it.offset(), (*it).to_string());
+        warnln("[{:4x}] {}", it.offset(), (*it).to_string(executable));
         ++it;
     }
 }

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -45,7 +45,7 @@ public:
 
     void seal();
 
-    void dump() const;
+    void dump(Executable const&) const;
     ReadonlyBytes instruction_stream() const { return ReadonlyBytes { m_buffer, m_buffer_size }; }
 
     void* next_slot() { return m_buffer + m_buffer_size; }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -14,6 +14,7 @@
 namespace JS::Bytecode {
 
 Generator::Generator()
+    : m_string_table(make<StringTable>())
 {
 }
 
@@ -26,7 +27,7 @@ Executable Generator::generate(ASTNode const& node)
     Generator generator;
     generator.switch_to_basic_block(generator.make_block());
     node.generate_bytecode(generator);
-    return { move(generator.m_root_basic_blocks), generator.m_next_register };
+    return { move(generator.m_root_basic_blocks), move(generator.m_string_table), generator.m_next_register };
 }
 
 void Generator::grow(size_t additional_size)

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -12,13 +12,17 @@
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Register.h>
+#include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
 
 struct Executable {
     NonnullOwnPtrVector<BasicBlock> basic_blocks;
+    NonnullOwnPtr<StringTable> string_table;
     size_t number_of_registers { 0 };
+
+    String const& get_string(StringTableIndex index) const { return string_table->get(index); }
 };
 
 class Generator {
@@ -74,6 +78,11 @@ public:
         return m_current_basic_block->is_terminated();
     }
 
+    StringTableIndex intern_string(StringView const& string)
+    {
+        return m_string_table->insert(string);
+    }
+
 private:
     Generator();
     ~Generator();
@@ -83,6 +92,7 @@ private:
 
     BasicBlock* m_current_basic_block { nullptr };
     NonnullOwnPtrVector<BasicBlock> m_root_basic_blocks;
+    NonnullOwnPtr<StringTable> m_string_table;
 
     u32 m_next_register { 1 };
     u32 m_next_block { 1 };

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -73,7 +73,7 @@ public:
 
     Type type() const { return m_type; }
     size_t length() const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
     void execute(Bytecode::Interpreter&) const;
     static void destroy(Instruction&);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/TemporaryChange.h>
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Interpreter.h>
@@ -37,6 +38,8 @@ Interpreter::~Interpreter()
 Value Interpreter::run(Executable const& executable)
 {
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {:p}", &executable);
+
+    TemporaryChange restore_executable { m_current_executable, &executable };
 
     CallFrame global_call_frame;
     if (vm().call_stack().is_empty()) {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -39,6 +39,8 @@ public:
     }
     void do_return(Value return_value) { m_return_value = return_value; }
 
+    Executable const& current_executable() { return *m_current_executable; }
+
 private:
     RegisterWindow& registers() { return m_register_windows.last(); }
 
@@ -47,6 +49,7 @@ private:
     NonnullOwnPtrVector<RegisterWindow> m_register_windows;
     Optional<BasicBlock const*> m_pending_jump;
     Value m_return_value;
+    Executable const* m_current_executable { nullptr };
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Register.h>
+#include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -26,7 +26,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     Register m_src;
@@ -41,7 +41,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     Value m_value;
@@ -56,7 +56,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     Register m_dst;
@@ -96,7 +96,7 @@ private:
         }                                                       \
                                                                 \
         void execute(Bytecode::Interpreter&) const;             \
-        String to_string() const;                               \
+        String to_string(Bytecode::Executable const&) const;    \
                                                                 \
     private:                                                    \
         Register m_lhs_reg;                                     \
@@ -121,7 +121,7 @@ JS_ENUMERATE_COMMON_BINARY_OPS(JS_DECLARE_COMMON_BINARY_OP)
         }                                                      \
                                                                \
         void execute(Bytecode::Interpreter&) const;            \
-        String to_string() const;                              \
+        String to_string(Bytecode::Executable const&) const;   \
     };
 
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
@@ -129,17 +129,17 @@ JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
 
 class NewString final : public Instruction {
 public:
-    NewString(String string)
+    NewString(StringTableIndex string)
         : Instruction(Type::NewString)
         , m_string(move(string))
     {
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
-    String m_string;
+    StringTableIndex m_string;
 };
 
 class NewObject final : public Instruction {
@@ -150,7 +150,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 };
 
 class NewBigInt final : public Instruction {
@@ -162,7 +162,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     Crypto::SignedBigInteger m_bigint;
@@ -180,7 +180,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
     size_t length() const { return sizeof(*this) + sizeof(Register) * m_element_count; }
 
@@ -198,7 +198,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     Register m_lhs;
@@ -206,52 +206,52 @@ private:
 
 class SetVariable final : public Instruction {
 public:
-    SetVariable(FlyString identifier)
+    SetVariable(StringTableIndex identifier)
         : Instruction(Type::SetVariable)
         , m_identifier(move(identifier))
     {
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
-    FlyString m_identifier;
+    StringTableIndex m_identifier;
 };
 
 class GetVariable final : public Instruction {
 public:
-    GetVariable(FlyString identifier)
+    GetVariable(StringTableIndex identifier)
         : Instruction(Type::GetVariable)
         , m_identifier(move(identifier))
     {
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
-    FlyString m_identifier;
+    StringTableIndex m_identifier;
 };
 
 class GetById final : public Instruction {
 public:
-    GetById(FlyString property)
+    GetById(StringTableIndex property)
         : Instruction(Type::GetById)
         , m_property(move(property))
     {
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
-    FlyString m_property;
+    StringTableIndex m_property;
 };
 
 class PutById final : public Instruction {
 public:
-    PutById(Register base, FlyString property)
+    PutById(Register base, StringTableIndex property)
         : Instruction(Type::PutById)
         , m_base(base)
         , m_property(move(property))
@@ -259,11 +259,11 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     Register m_base;
-    FlyString m_property;
+    StringTableIndex m_property;
 };
 
 class Jump : public Instruction {
@@ -291,7 +291,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 protected:
     Optional<Label> m_true_target;
@@ -306,7 +306,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 };
 
 class JumpNullish final : public Jump {
@@ -317,7 +317,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 };
 
 // NOTE: This instruction is variable-width depending on the number of arguments!
@@ -334,7 +334,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
     size_t length() const { return sizeof(*this) + sizeof(Register) * m_argument_count; }
 
@@ -354,7 +354,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 
 private:
     ScopeNode const& m_scope_node;
@@ -370,7 +370,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 };
 
 class Increment final : public Instruction {
@@ -381,7 +381,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 };
 
 class Decrement final : public Instruction {
@@ -392,7 +392,7 @@ public:
     }
 
     void execute(Bytecode::Interpreter&) const;
-    String to_string() const;
+    String to_string(Bytecode::Executable const&) const;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/StringTable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/StringTable.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Bytecode/StringTable.h>
+
+namespace JS::Bytecode {
+
+StringTableIndex StringTable::insert(StringView string)
+{
+    for (size_t i = 0; i < m_strings.size(); i++) {
+        if (m_strings[i] == string)
+            return i;
+    }
+    m_strings.append(string);
+    return m_strings.size() - 1;
+}
+
+String const& StringTable::get(StringTableIndex index) const
+{
+    return m_strings[index.value()];
+}
+
+void StringTable::dump() const
+{
+    outln("String Table:");
+    for (size_t i = 0; i < m_strings.size(); i++)
+        outln("{}: {}", i, m_strings[i]);
+}
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Userland/Libraries/LibJS/Bytecode/StringTable.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DistinctNumeric.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace JS::Bytecode {
+
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, false, true, false, false, false, false, StringTableIndex);
+
+class StringTable {
+    AK_MAKE_NONMOVABLE(StringTable);
+    AK_MAKE_NONCOPYABLE(StringTable);
+
+public:
+    StringTable() = default;
+
+    StringTableIndex insert(StringView string);
+    String const& get(StringTableIndex) const;
+    void dump() const;
+    bool is_empty() const { return m_strings.is_empty(); }
+
+private:
+    Vector<String> m_strings;
+};
+
+}

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Bytecode/Instruction.cpp
     Bytecode/Interpreter.cpp
     Bytecode/Op.cpp
+    Bytecode/StringTable.cpp
     Console.cpp
     Heap/CellAllocator.cpp
     Heap/BlockAllocator.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -166,6 +166,7 @@ class Handle;
 
 namespace Bytecode {
 class BasicBlock;
+struct Executable;
 class Generator;
 class Instruction;
 class Interpreter;

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -156,7 +156,7 @@ Value ScriptFunction::execute_function_body()
             if constexpr (JS_BYTECODE_DEBUG) {
                 dbgln("Compiled Bytecode::Block for function '{}':", m_name);
                 for (auto& block : m_bytecode_executable->basic_blocks)
-                    block.dump();
+                    block.dump(*m_bytecode_executable);
             }
         }
         return bytecode_interpreter->run(*m_bytecode_executable);

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -516,7 +516,11 @@ static bool parse_and_run(JS::Interpreter& interpreter, const StringView& source
         auto unit = JS::Bytecode::Generator::generate(*program);
         if (s_dump_bytecode) {
             for (auto& block : unit.basic_blocks)
-                block.dump();
+                block.dump(unit);
+            if (!unit.string_table->is_empty()) {
+                outln();
+                unit.string_table->dump();
+            }
         }
 
         if (s_run_bytecode) {


### PR DESCRIPTION
**LibJS: Store strings in a string table**

Instead of using `String`s in the bytecode ops this adds a global string table to the `Executable` struct which individual operations can refer to using indices. This brings bytecode ops one step closer to being pointer free.