### PR TITLE
LibMarkdown: Wrap non-inline code blocks in <pre>

### DIFF
--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -31,6 +31,8 @@ String CodeBlock::render_to_html() const
     String style_language = this->style_language();
     Text::Style style = this->style();
 
+    builder.append("<pre>");
+
     if (style.strong)
         builder.append("<b>");
     if (style.emph)
@@ -53,7 +55,7 @@ String CodeBlock::render_to_html() const
     if (style.strong)
         builder.append("</b>");
 
-    builder.append('\n');
+    builder.append("</pre>\n");
 
     return builder.build();
 }


### PR DESCRIPTION
This fixes #7131

The parser already distinguishes between inline code (handled in [Text.cpp](https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibMarkdown/Text.cpp#L210)) and triple-tick code blocks, so only `CodeBlock::render_to_html()` needed to change. Blank lines within a code block still cause issues, but that's an HTML issue. (#7121)