### PR TITLE
LibJS: Mark heap cells values stored in Set instances

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Set.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Set.cpp
@@ -34,4 +34,11 @@ Set* Set::typed_this(VM& vm, GlobalObject& global_object)
     return static_cast<Set*>(this_object);
 }
 
+void Set::visit_edges(Cell::Visitor& visitor)
+{
+    Object::visit_edges(visitor);
+    for (auto& value : m_values)
+        visitor.visit(value);
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -47,6 +47,8 @@ public:
     HashTable<Value, ValueTraits>& values() { return m_values; };
 
 private:
+    virtual void visit_edges(Visitor& visitor) override;
+
     HashTable<Value, ValueTraits> m_values; // FIXME: Replace with a HashTable that maintains a linked list of insertion order for correct iteration order
 };
 


### PR DESCRIPTION
This makes sure they dont get garbage collected while stored in a Set.

(Forgot to add this to the original set PR :sweat_smile:)