### PR TITLE
LibJS: Stop inheriting from Set in SetPrototype

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Set.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Set.cpp
@@ -22,18 +22,6 @@ Set::~Set()
 {
 }
 
-Set* Set::typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<Set>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Set");
-        return nullptr;
-    }
-    return static_cast<Set*>(this_object);
-}
-
 void Set::visit_edges(Cell::Visitor& visitor)
 {
     Object::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -41,8 +41,6 @@ public:
     explicit Set(Object& prototype);
     virtual ~Set() override;
 
-    static Set* typed_this(VM&, GlobalObject&);
-
     HashTable<Value, ValueTraits> const& values() const { return m_values; };
     HashTable<Value, ValueTraits>& values() { return m_values; };
 

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -11,14 +11,14 @@
 namespace JS {
 
 SetPrototype::SetPrototype(GlobalObject& global_object)
-    : Set(*global_object.object_prototype())
+    : Object(*global_object.object_prototype())
 {
 }
 
 void SetPrototype::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
-    Set::initialize(global_object);
+    Object::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
 
     define_native_function(vm.names.add, add, 1, attr);
@@ -38,6 +38,18 @@ void SetPrototype::initialize(GlobalObject& global_object)
 
 SetPrototype::~SetPrototype()
 {
+}
+
+Set* SetPrototype::typed_this(VM& vm, GlobalObject& global_object)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return {};
+    if (!is<Set>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Set");
+        return nullptr;
+    }
+    return static_cast<Set*>(this_object);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::add)

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.h
@@ -10,8 +10,8 @@
 
 namespace JS {
 
-class SetPrototype final : public Set {
-    JS_OBJECT(SetPrototype, Set);
+class SetPrototype final : public Object {
+    JS_OBJECT(SetPrototype, Object);
 
 public:
     SetPrototype(GlobalObject&);
@@ -19,6 +19,8 @@ public:
     virtual ~SetPrototype() override;
 
 private:
+    static Set* typed_this(VM&, GlobalObject&);
+
     JS_DECLARE_NATIVE_FUNCTION(add);
     JS_DECLARE_NATIVE_FUNCTION(clear);
     JS_DECLARE_NATIVE_FUNCTION(delete_);


### PR DESCRIPTION
This makes sure that is\<Set> checks done on the Set prototype instead of on Set instances return false, thereby emulating the behaviour of the RequireInternalSlot abstract operation. (This fixes 2 test262 test cases)