### PR TITLE
LibWasm: Implement some more instructions / Meta: Remove -Wmaybe-uninitialized

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -87,10 +87,7 @@ ByteBuffer decode_base64(const StringView& input)
             output.append(out2);
     }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     return ByteBuffer::copy(output.data(), output.size());
-#pragma GCC diagnostic pop
 }
 
 String encode_base64(ReadonlyBytes input)

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -421,7 +421,7 @@ public:
         }
     }
 
-    T take_last()
+    ALWAYS_INLINE T take_last()
     {
         VERIFY(!is_empty());
         auto value = move(raw_last());

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ add_compile_options(-Wno-unknown-warning-option)
 add_compile_options(-Wundef)
 add_compile_options(-Wunused)
 add_compile_options(-Wwrite-strings)
+add_compile_options(-Wno-maybe-uninitialized)
 
 add_compile_options(-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.)
 add_compile_options(-fno-exceptions)

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -120,15 +120,7 @@ KResultOr<FlatPtr> handle(RegisterState& regs, FlatPtr function, FlatPtr arg1, F
         return ENOSYS;
     }
 
-    // This appears to be a bogus warning, as s_syscall_table is always
-    // initialized, and the index (function) is always bounded.
-    // TODO: Figure out how to avoid the suppression.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-
     return (process.*(s_syscall_table[function]))(arg1, arg2, arg3);
-
-#pragma GCC diagnostic pop
 }
 
 }

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -142,10 +142,7 @@ void Label::wrap_text()
         case '\t':
         case ' ': {
             if (start.has_value())
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
                 words.append(m_text.substring(start.value(), i - start.value()));
-#pragma GCC diagnostic pop
             start.clear();
             continue;
         }

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -457,6 +457,9 @@ void Linker::link(HashMap<Linker::Name, ExternValue> const& exports)
     if (m_unresolved_imports.is_empty())
         return;
 
+    if (exports.is_empty())
+        return;
+
     HashTable<Name> resolved_imports;
     for (auto& import_ : m_unresolved_imports) {
         auto export_ = exports.get(import_);

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -472,10 +472,10 @@ public:
     Stack() = default;
 
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return m_data.is_empty(); }
-    FLATTEN void push(EntryType entry) { m_data.append(move(entry)); }
-    FLATTEN auto pop() { return m_data.take_last(); }
-    FLATTEN auto& peek() const { return m_data.last(); }
-    FLATTEN auto& peek() { return m_data.last(); }
+    ALWAYS_INLINE void push(EntryType entry) { m_data.append(move(entry)); }
+    ALWAYS_INLINE auto pop() { return m_data.take_last(); }
+    ALWAYS_INLINE auto& peek() const { return m_data.last(); }
+    ALWAYS_INLINE auto& peek() { return m_data.last(); }
 
     ALWAYS_INLINE auto size() const { return m_data.size(); }
     ALWAYS_INLINE auto& entries() const { return m_data; }

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -396,6 +396,13 @@ ALWAYS_INLINE static i32 ctz(T value)
         VERIFY_NOT_REACHED();
 }
 
+template<typename InputT, typename OutputT>
+ALWAYS_INLINE static OutputT extend_signed(InputT value)
+{
+    // Note: C++ will take care of sign extension.
+    return value;
+}
+
 template<typename T>
 ALWAYS_INLINE static T float_max(T lhs, T rhs)
 {
@@ -970,6 +977,16 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         UNARY_MAP(i32, bit_cast<float>, float);
     case Instructions::f64_reinterpret_i64.value():
         UNARY_MAP(i64, bit_cast<double>, double);
+    case Instructions::i32_extend8_s.value():
+        UNARY_MAP(i32, (extend_signed<i8, i32>), i32);
+    case Instructions::i32_extend16_s.value():
+        UNARY_MAP(i32, (extend_signed<i16, i32>), i32);
+    case Instructions::i64_extend8_s.value():
+        UNARY_MAP(i64, (extend_signed<i8, i64>), i64);
+    case Instructions::i64_extend16_s.value():
+        UNARY_MAP(i64, (extend_signed<i16, i64>), i64);
+    case Instructions::i64_extend32_s.value():
+        UNARY_MAP(i64, (extend_signed<i32, i64>), i64);
     case Instructions::i32_trunc_sat_f32_s.value():
     case Instructions::i32_trunc_sat_f32_u.value():
     case Instructions::i32_trunc_sat_f64_s.value():
@@ -988,11 +1005,6 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::table_grow.value():
     case Instructions::table_size.value():
     case Instructions::table_fill.value():
-    case Instructions::i32_extend8_s.value():
-    case Instructions::i32_extend16_s.value():
-    case Instructions::i64_extend8_s.value():
-    case Instructions::i64_extend16_s.value():
-    case Instructions::i64_extend32_s.value():
     default:
     unimplemented:;
         dbgln("Instruction '{}' not implemented", instruction_name(instruction.opcode()));

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -396,6 +396,34 @@ ALWAYS_INLINE static i32 ctz(T value)
         VERIFY_NOT_REACHED();
 }
 
+template<typename T>
+ALWAYS_INLINE static T float_max(T lhs, T rhs)
+{
+    if (isnan(lhs))
+        return lhs;
+    if (isnan(rhs))
+        return rhs;
+    if (isinf(lhs))
+        return lhs > 0 ? lhs : rhs;
+    if (isinf(rhs))
+        return rhs > 0 ? rhs : lhs;
+    return max(lhs, rhs);
+}
+
+template<typename T>
+ALWAYS_INLINE static T float_min(T lhs, T rhs)
+{
+    if (isnan(lhs))
+        return lhs;
+    if (isnan(rhs))
+        return rhs;
+    if (isinf(lhs))
+        return lhs > 0 ? rhs : lhs;
+    if (isinf(rhs))
+        return rhs > 0 ? lhs : rhs;
+    return min(lhs, rhs);
+}
+
 void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPointer& ip, Instruction const& instruction)
 {
     dbgln_if(WASM_TRACE_DEBUG, "Executing instruction {} at ip {}", instruction_name(instruction.opcode()), ip.value());
@@ -843,9 +871,9 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::f32_div.value():
         BINARY_NUMERIC_OPERATION(float, /, float);
     case Instructions::f32_min.value():
-        BINARY_PREFIX_NUMERIC_OPERATION(float, min, float);
+        BINARY_PREFIX_NUMERIC_OPERATION(float, float_min, float);
     case Instructions::f32_max.value():
-        BINARY_PREFIX_NUMERIC_OPERATION(float, max, float);
+        BINARY_PREFIX_NUMERIC_OPERATION(float, float_max, float);
     case Instructions::f32_copysign.value():
         BINARY_PREFIX_NUMERIC_OPERATION(float, copysignf, float);
     case Instructions::f64_abs.value():
@@ -871,9 +899,9 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::f64_div.value():
         BINARY_NUMERIC_OPERATION(double, /, double);
     case Instructions::f64_min.value():
-        BINARY_PREFIX_NUMERIC_OPERATION(double, min, double);
+        BINARY_PREFIX_NUMERIC_OPERATION(double, float_min, double);
     case Instructions::f64_max.value():
-        BINARY_PREFIX_NUMERIC_OPERATION(double, max, double);
+        BINARY_PREFIX_NUMERIC_OPERATION(double, float_max, double);
     case Instructions::f64_copysign.value():
         BINARY_PREFIX_NUMERIC_OPERATION(double, copysign, double);
     case Instructions::i32_wrap_i64.value():

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -25,16 +25,16 @@ public:
         m_stack.push(move(frame));
         m_stack.push(label);
     }
-    auto& frame() const { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
-    auto& frame() { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
-    auto& ip() const { return m_ip; }
-    auto& ip() { return m_ip; }
-    auto& depth() const { return m_depth; }
-    auto& depth() { return m_depth; }
-    auto& stack() const { return m_stack; }
-    auto& stack() { return m_stack; }
-    auto& store() const { return m_store; }
-    auto& store() { return m_store; }
+    ALWAYS_INLINE auto& frame() const { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
+    ALWAYS_INLINE auto& frame() { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
+    ALWAYS_INLINE auto& ip() const { return m_ip; }
+    ALWAYS_INLINE auto& ip() { return m_ip; }
+    ALWAYS_INLINE auto& depth() const { return m_depth; }
+    ALWAYS_INLINE auto& depth() { return m_depth; }
+    ALWAYS_INLINE auto& stack() const { return m_stack; }
+    ALWAYS_INLINE auto& stack() { return m_stack; }
+    ALWAYS_INLINE auto& store() const { return m_store; }
+    ALWAYS_INLINE auto& store() { return m_store; }
 
     struct CallFrameHandle {
         explicit CallFrameHandle(Configuration& configuration)

--- a/Userland/Utilities/crash.cpp
+++ b/Userland/Utilities/crash.cpp
@@ -118,10 +118,7 @@ int main(int argc, char** argv)
             if (!uninitialized_memory)
                 return Crash::Failure::UnexpectedError;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             [[maybe_unused]] volatile auto x = uninitialized_memory[0][0];
-#pragma GCC diagnostic pop
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }
@@ -144,10 +141,7 @@ int main(int argc, char** argv)
             if (!uninitialized_memory)
                 return Crash::Failure::UnexpectedError;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             uninitialized_memory[4][0] = 1;
-#pragma GCC diagnostic pop
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }


### PR DESCRIPTION
These commits are normal, boring commits:

- **wasm: Add a help command to the shell mode and start it on --shell**
- **LibWasm: Implement spec-compliant float min/max ops**
- **LibWasm: Implement sign extension instructions**
- **LibWasm: Implement saturating float truncation instructions**


These commits depend on disabling `-Wmaybe-uninitialized`, if we don't reach a decision, I will drop them.

- **AK: Make a bunch of Variant methods ALWAYS_INLINE**
- **AK: Make Vector::take_last() ALWAYS_INLINE**
- **LibWasm: ALWAYS_INLINE some very hot functions**

Notes about `-Wmaybe-uninitialized`:
I'd honestly want to disable it conditionally in very specific parts of Variant (particularly `Detail::Variant`), but `#pragma GCC diagnostic ignore` only works on the _call sites_, so disabling it like that is simply too ugly.

- **Meta: Disable -Wmaybe-uninitialized**
It's prone to finding "technically uninitialized but can never happen"
cases, particularly in Optional<T> and Variant<Ts...>.
The general case seems to be that it cannot infer the dependency
between Variant's index (or Optional's boolean state) and a particular
alternative (or Optional's buffer) being untouched.
So it can flag cases like this:
```c++
if (index == StaticIndexForF)
    new (new_buffer) F(move(*bit_cast<F*>(old_buffer)));
```
The code in that branch can _technically_ make a partially initialized
`F`, but that path can never be taken since the buffer holding an
object of type `F` and the condition being true are correlated, and so
will never be taken _unless_ the buffer holds an object of type `F`.