### PR TITLE
LibGUI: Set TextEditor to unmodified after saving size=0 files

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1170,24 +1170,25 @@ bool TextEditor::write_to_file(const String& path)
         return false;
     }
 
-    if (file_size == 0)
-        return true;
-
-    for (size_t i = 0; i < line_count(); ++i) {
-        auto& line = this->line(i);
-        if (line.length()) {
-            auto line_as_utf8 = line.to_utf8();
-            ssize_t nwritten = write(fd, line_as_utf8.characters(), line_as_utf8.length());
-            if (nwritten < 0) {
+    if (file_size == 0) {
+        // A size 0 file doesn't need a data copy.
+    } else {
+        for (size_t i = 0; i < line_count(); ++i) {
+            auto& line = this->line(i);
+            if (line.length()) {
+                auto line_as_utf8 = line.to_utf8();
+                ssize_t nwritten = write(fd, line_as_utf8.characters(), line_as_utf8.length());
+                if (nwritten < 0) {
+                    perror("write");
+                    return false;
+                }
+            }
+            char ch = '\n';
+            ssize_t nwritten = write(fd, &ch, 1);
+            if (nwritten != 1) {
                 perror("write");
                 return false;
             }
-        }
-        char ch = '\n';
-        ssize_t nwritten = write(fd, &ch, 1);
-        if (nwritten != 1) {
-            perror("write");
-            return false;
         }
     }
     document().set_unmodified();


### PR DESCRIPTION
This fixes #7946

Previously, `TextEditor::write_to_file()` would not mark its document as unmodified if the file size was 0. This caused a desync in the
Text Editor app between the window's `is_modified` state and the `TextEditor`'s. It's already noted in the comments of the app's
save action code that propagating the modified state automatically would be good, and it would solve issues like this, but I'm not yet
familiar enough with the code to try a change like that.