### PR TITLE
LibJS: Generate bytecode for throw statements

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1245,6 +1245,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_argument;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -666,6 +667,12 @@ void UpdateExpression::generate_bytecode(Bytecode::Generator& generator) const
     }
 
     TODO();
+}
+
+void ThrowStatement::generate_bytecode(Bytecode::Generator& generator) const
+{
+    m_argument->generate_bytecode(generator);
+    generator.emit<Bytecode::Op::Throw>();
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -56,7 +56,8 @@
     O(InstanceOf)                 \
     O(ConcatString)               \
     O(Increment)                  \
-    O(Decrement)
+    O(Decrement)                  \
+    O(Throw)
 
 namespace JS::Bytecode {
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -65,6 +65,8 @@ Value Interpreter::run(Executable const& executable)
         while (!pc.at_end()) {
             auto& instruction = *pc;
             instruction.execute(*this);
+            if (vm().exception())
+                break;
             if (m_pending_jump.has_value()) {
                 block = m_pending_jump.release_value();
                 will_jump = true;
@@ -81,6 +83,9 @@ Value Interpreter::run(Executable const& executable)
             break;
 
         if (pc.at_end() && !will_jump)
+            break;
+
+        if (vm().exception())
             break;
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -255,6 +256,11 @@ void Decrement::execute(Bytecode::Interpreter& interpreter) const
         interpreter.accumulator() = js_bigint(interpreter.vm().heap(), old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 }));
 }
 
+void Throw::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.vm().throw_exception(interpreter.global_object(), interpreter.accumulator());
+}
+
 String Load::to_string(Bytecode::Executable const&) const
 {
     return String::formatted("Load {}", m_src);
@@ -381,6 +387,11 @@ String Increment::to_string(Bytecode::Executable const&) const
 String Decrement::to_string(Bytecode::Executable const&) const
 {
     return "Decrement";
+}
+
+String Throw::to_string(Bytecode::Executable const&) const
+{
+    return "Throw";
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -388,6 +389,19 @@ class Decrement final : public Instruction {
 public:
     Decrement()
         : Instruction(Type::Decrement)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string(Bytecode::Executable const&) const;
+};
+
+class Throw final : public Instruction {
+public:
+    constexpr static bool IsTerminator = true;
+
+    Throw()
+        : Instruction(Type::Throw)
     {
     }
 


### PR DESCRIPTION
**LibJS: Generate bytecode for throw statements**

**LibJS: Stop bytecode execution after we've encountered an exception**

```
> console.log("Hello"); throw 3; console.log("World");
Hello
>
```