### PR TITLE
LibJS: Add the WeakSet built-in object

### DIFF
--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -32,6 +32,19 @@ TESTJS_GLOBAL_FUNCTION(run_queued_promise_jobs, runQueuedPromiseJobs)
     return JS::js_undefined();
 }
 
+TESTJS_GLOBAL_FUNCTION(get_weak_set_size, getWeakSetSize)
+{
+    auto* object = vm.argument(0).to_object(global_object);
+    if (!object)
+        return {};
+    if (!is<JS::WeakSet>(object)) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "WeakSet");
+        return {};
+    }
+    auto* weak_set = static_cast<JS::WeakSet*>(object);
+    return JS::Value(weak_set->values().size());
+}
+
 TESTJS_RUN_FILE_FUNCTION(const String& test_file, JS::Interpreter&)
 {
     if (!test262_parser_tests)

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -96,6 +96,9 @@ set(SOURCES
     Runtime/TypedArrayPrototype.cpp
     Runtime/VM.cpp
     Runtime/Value.cpp
+    Runtime/WeakSet.cpp
+    Runtime/WeakSetConstructor.cpp
+    Runtime/WeakSetPrototype.cpp
     Runtime/WithScope.cpp
     SyntaxHighlighter.cpp
     Token.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -39,7 +39,8 @@
     __JS_ENUMERATE(RegExpObject, regexp, RegExpPrototype, RegExpConstructor, void)                \
     __JS_ENUMERATE(Set, set, SetPrototype, SetConstructor, void)                                  \
     __JS_ENUMERATE(StringObject, string, StringPrototype, StringConstructor, void)                \
-    __JS_ENUMERATE(SymbolObject, symbol, SymbolPrototype, SymbolConstructor, void)
+    __JS_ENUMERATE(SymbolObject, symbol, SymbolPrototype, SymbolConstructor, void)                \
+    __JS_ENUMERATE(WeakSet, weak_set, WeakSetPrototype, WeakSetConstructor, void)
 
 #define JS_ENUMERATE_NATIVE_OBJECTS                 \
     JS_ENUMERATE_NATIVE_OBJECTS_EXCLUDING_TEMPLATES \

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -16,6 +16,7 @@
 #include <LibJS/Heap/HeapBlock.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/WeakSet.h>
 #include <setjmp.h>
 
 namespace JS {
@@ -182,18 +183,22 @@ void Heap::sweep_dead_cells(bool print_report, const Core::ElapsedTimer& measure
     dbgln_if(HEAP_DEBUG, "sweep_dead_cells:");
     Vector<HeapBlock*, 32> empty_blocks;
     Vector<HeapBlock*, 32> full_blocks_that_became_usable;
+    Vector<Cell*> sweeped_cells;
 
     size_t collected_cells = 0;
     size_t live_cells = 0;
     size_t collected_cell_bytes = 0;
     size_t live_cell_bytes = 0;
 
+    auto should_store_sweeped_cells = !m_weak_sets.is_empty();
     for_each_block([&](auto& block) {
         bool block_has_live_cells = false;
         bool block_was_full = block.is_full();
         block.template for_each_cell_in_state<Cell::State::Live>([&](Cell* cell) {
             if (!cell->is_marked()) {
                 dbgln_if(HEAP_DEBUG, "  ~ {}", cell);
+                if (should_store_sweeped_cells)
+                    sweeped_cells.append(cell);
                 block.deallocate(cell);
                 ++collected_cells;
                 collected_cell_bytes += block.cell_size();
@@ -220,6 +225,9 @@ void Heap::sweep_dead_cells(bool print_report, const Core::ElapsedTimer& measure
         dbgln_if(HEAP_DEBUG, " - HeapBlock usable again @ {}: cell_size={}", block, block->cell_size());
         allocator_for_size(block->cell_size()).block_did_become_usable({}, *block);
     }
+
+    for (auto* weak_set : m_weak_sets)
+        weak_set->remove_sweeped_cells({}, sweeped_cells);
 
     if constexpr (HEAP_DEBUG) {
         for_each_block([&](auto& block) {
@@ -270,6 +278,18 @@ void Heap::did_destroy_marked_value_list(Badge<MarkedValueList>, MarkedValueList
 {
     VERIFY(m_marked_value_lists.contains(&list));
     m_marked_value_lists.remove(&list);
+}
+
+void Heap::did_create_weak_set(Badge<WeakSet>, WeakSet& set)
+{
+    VERIFY(!m_weak_sets.contains(&set));
+    m_weak_sets.set(&set);
+}
+
+void Heap::did_destroy_weak_set(Badge<WeakSet>, WeakSet& set)
+{
+    VERIFY(m_weak_sets.contains(&set));
+    m_weak_sets.remove(&set);
 }
 
 void Heap::defer_gc(Badge<DeferGC>)

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -70,6 +70,9 @@ public:
     void did_create_marked_value_list(Badge<MarkedValueList>, MarkedValueList&);
     void did_destroy_marked_value_list(Badge<MarkedValueList>, MarkedValueList&);
 
+    void did_create_weak_set(Badge<WeakSet>, WeakSet&);
+    void did_destroy_weak_set(Badge<WeakSet>, WeakSet&);
+
     void defer_gc(Badge<DeferGC>);
     void undefer_gc(Badge<DeferGC>);
 
@@ -105,6 +108,8 @@ private:
     HashTable<HandleImpl*> m_handles;
 
     HashTable<MarkedValueList*> m_marked_value_lists;
+
+    HashTable<WeakSet*> m_weak_sets;
 
     BlockAllocator m_block_allocator;
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -60,6 +60,8 @@
 #include <LibJS/Runtime/TypedArrayConstructor.h>
 #include <LibJS/Runtime/TypedArrayPrototype.h>
 #include <LibJS/Runtime/Value.h>
+#include <LibJS/Runtime/WeakSetConstructor.h>
+#include <LibJS/Runtime/WeakSetPrototype.h>
 
 namespace JS {
 
@@ -143,6 +145,7 @@ void GlobalObject::initialize_global_object()
     add_constructor(vm.names.Set, m_set_constructor, m_set_prototype);
     add_constructor(vm.names.String, m_string_constructor, m_string_prototype);
     add_constructor(vm.names.Symbol, m_symbol_constructor, m_symbol_prototype);
+    add_constructor(vm.names.WeakSet, m_weak_set_constructor, m_weak_set_prototype);
 
     initialize_constructor(vm.names.TypedArray, m_typed_array_constructor, m_typed_array_prototype);
 

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/WeakSet.h>
+
+namespace JS {
+
+WeakSet* WeakSet::create(GlobalObject& global_object)
+{
+    return global_object.heap().allocate<WeakSet>(global_object, *global_object.weak_set_prototype());
+}
+
+WeakSet::WeakSet(Object& prototype)
+    : Object(prototype)
+{
+}
+
+WeakSet::~WeakSet()
+{
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -16,10 +16,18 @@ WeakSet* WeakSet::create(GlobalObject& global_object)
 WeakSet::WeakSet(Object& prototype)
     : Object(prototype)
 {
+    heap().did_create_weak_set({}, *this);
 }
 
 WeakSet::~WeakSet()
 {
+    heap().did_destroy_weak_set({}, *this);
+}
+
+void WeakSet::remove_sweeped_cells(Badge<Heap>, Vector<Cell*>& cells)
+{
+    for (auto* cell : cells)
+        m_values.remove(cell);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashTable.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace JS {
+
+class WeakSet : public Object {
+    JS_OBJECT(WeakSet, Object);
+
+public:
+    static WeakSet* create(GlobalObject&);
+
+    explicit WeakSet(Object& prototype);
+    virtual ~WeakSet() override;
+
+    HashTable<Object*> const& values() const { return m_values; };
+    HashTable<Object*>& values() { return m_values; };
+
+private:
+    HashTable<Object*> m_values;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -21,11 +21,13 @@ public:
     explicit WeakSet(Object& prototype);
     virtual ~WeakSet() override;
 
-    HashTable<Object*> const& values() const { return m_values; };
-    HashTable<Object*>& values() { return m_values; };
+    HashTable<Cell*> const& values() const { return m_values; };
+    HashTable<Cell*>& values() { return m_values; };
+
+    void remove_sweeped_cells(Badge<Heap>, Vector<Cell*>&);
 
 private:
-    HashTable<Object*> m_values;
+    HashTable<Cell*> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS {
+
+class WeakSetConstructor final : public NativeFunction {
+    JS_OBJECT(WeakSetConstructor, NativeFunction);
+
+public:
+    explicit WeakSetConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~WeakSetConstructor() override;
+
+    virtual Value call() override;
+    virtual Value construct(Function&) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -18,6 +18,11 @@ void WeakSetPrototype::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Object::initialize(global_object);
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+
+    define_native_function(vm.names.add, add, 1, attr);
+    define_native_function(vm.names.delete_, delete_, 1, attr);
+    define_native_function(vm.names.has, has, 1, attr);
 
     define_property(vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakSet), Attribute::Configurable);
 }
@@ -36,6 +41,43 @@ WeakSet* WeakSetPrototype::typed_this(VM& vm, GlobalObject& global_object)
         return nullptr;
     }
     return static_cast<WeakSet*>(this_object);
+}
+
+JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::add)
+{
+    auto* weak_set = typed_this(vm, global_object);
+    if (!weak_set)
+        return {};
+    auto value = vm.argument(0);
+    if (!value.is_object()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObject, value.to_string_without_side_effects());
+        return {};
+    }
+    weak_set->values().set(&value.as_object(), AK::HashSetExistingEntryBehavior::Keep);
+    return weak_set;
+}
+
+JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::delete_)
+{
+    auto* weak_set = typed_this(vm, global_object);
+    if (!weak_set)
+        return {};
+    auto value = vm.argument(0);
+    if (!value.is_object())
+        return Value(false);
+    return Value(weak_set->values().remove(&value.as_object()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::has)
+{
+    auto* weak_set = typed_this(vm, global_object);
+    if (!weak_set)
+        return {};
+    auto value = vm.argument(0);
+    if (!value.is_object())
+        return Value(false);
+    auto& values = weak_set->values();
+    return Value(values.find(&value.as_object()) != values.end());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/HashTable.h>
+#include <LibJS/Runtime/WeakSetPrototype.h>
+
+namespace JS {
+
+WeakSetPrototype::WeakSetPrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void WeakSetPrototype::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    Object::initialize(global_object);
+
+    define_property(vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakSet), Attribute::Configurable);
+}
+
+WeakSetPrototype::~WeakSetPrototype()
+{
+}
+
+WeakSet* WeakSetPrototype::typed_this(VM& vm, GlobalObject& global_object)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return {};
+    if (!is<WeakSet>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "WeakSet");
+        return nullptr;
+    }
+    return static_cast<WeakSet*>(this_object);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -20,4 +20,10 @@ public:
 
 private:
     static WeakSet* typed_this(VM&, GlobalObject&);
+
+    JS_DECLARE_NATIVE_FUNCTION(add);
+    JS_DECLARE_NATIVE_FUNCTION(delete_);
+    JS_DECLARE_NATIVE_FUNCTION(has);
+};
+
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/WeakSet.h>
+
+namespace JS {
+
+class WeakSetPrototype final : public Object {
+    JS_OBJECT(WeakSetPrototype, Object);
+
+public:
+    WeakSetPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~WeakSetPrototype() override;
+
+private:
+    static WeakSet* typed_this(VM&, GlobalObject&);
+}

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.js
@@ -1,0 +1,30 @@
+test("constructor properties", () => {
+    expect(WeakSet).toHaveLength(0);
+    expect(WeakSet.name).toBe("WeakSet");
+});
+
+describe("errors", () => {
+    test("invalid array iterators", () => {
+        [-100, Infinity, NaN, {}, 152n].forEach(value => {
+            expect(() => {
+                new WeakSet(value);
+            }).toThrowWithMessage(TypeError, "is not iterable");
+        });
+    });
+    test("called without new", () => {
+        expect(() => {
+            WeakSet();
+        }).toThrowWithMessage(TypeError, "WeakSet constructor must be called with 'new'");
+    });
+});
+
+describe("normal behavior", () => {
+    test("typeof", () => {
+        expect(typeof new WeakSet()).toBe("object");
+    });
+
+    test("constructor with single array argument", () => {
+        var a = new WeakSet([{ a: 1 }, { a: 2 }, { a: 3 }]);
+        expect(a instanceof WeakSet).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
@@ -1,0 +1,16 @@
+test("basic functionality", () => {
+    expect(WeakSet.prototype.add).toHaveLength(1);
+
+    const weakSet = new WeakSet([{ a: 1 }, { a: 2 }, { a: 3 }]);
+    expect(weakSet.add({ a: 4 })).toBe(weakSet);
+    expect(weakSet.add({ a: 1 })).toBe(weakSet);
+});
+
+test("invalid values", () => {
+    const weakSet = new WeakSet();
+    [-100, Infinity, NaN, "hello", 152n].forEach(value => {
+        expect(() => {
+            weakSet.add(value);
+        }).toThrowWithMessage(TypeError, "is not an object");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
@@ -14,3 +14,13 @@ test("invalid values", () => {
         }).toThrowWithMessage(TypeError, "is not an object");
     });
 });
+
+test("automatic removal of garbage-collected values", () => {
+    const weakSet = new WeakSet();
+    {
+        expect(weakSet.add({ a: 1 })).toBe(weakSet);
+        expect(getWeakSetSize(weakSet)).toBe(1);
+    }
+    gc();
+    expect(getWeakSetSize(weakSet)).toBe(0);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.delete.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.delete.js
@@ -1,0 +1,9 @@
+test("basic functionality", () => {
+    expect(WeakSet.prototype.delete).toHaveLength(1);
+
+    var original = [{ a: 1 }, { a: 2 }, { a: 3 }];
+    const weakSet = new WeakSet(original);
+    expect(weakSet.delete(original[0])).toBeTrue();
+    expect(weakSet.delete(original[0])).toBeFalse();
+    expect(weakSet.delete(null)).toBeFalse();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.has.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.has.js
@@ -1,0 +1,12 @@
+test("length is 1", () => {
+    expect(WeakSet.prototype.has).toHaveLength(1);
+});
+
+test("basic functionality", () => {
+    var original = [{ a: 1 }, { a: 2 }, { a: 3 }];
+    var weakSet = new WeakSet(original);
+
+    expect(new WeakSet().has()).toBeFalse();
+    expect(weakSet.has(original[0])).toBeTrue();
+    expect(weakSet.has({ a: 1 })).toBeFalse();
+});

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -26,6 +26,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/WeakSet.h>
 #include <LibTest/Results.h>
 #include <fcntl.h>
 #include <sys/time.h>


### PR DESCRIPTION
The first two commits fix all WeakSet related test262 test cases. (aside from 5 test cases that rely on other missing js built-ins in libjs)

Note about the third commit: While this (optional as per the spec) "optimization" is pretty important (without it we could end up with infinitely large WeakSets) i feel like my implementation adds too much overhead to the garbage collection pass, so if any heap/garbage collection experts want to chime in with improvements, it would be greatly appreciated :)