### PR TITLE
LibJS: Fix the return value for TemplateLiteral

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -649,6 +649,8 @@ void TemplateLiteral::generate_bytecode(Bytecode::Generator& generator) const
             generator.emit<Bytecode::Op::ConcatString>(string_reg);
         }
     }
+
+    generator.emit<Bytecode::Op::Load>(string_reg);
 }
 
 void UpdateExpression::generate_bytecode(Bytecode::Generator& generator) const


### PR DESCRIPTION
This ensures that the bytecode generated for TemplateLiterals returns the correct value.