### PR TITLE
LibWeb: Fix logic issue when parsing CSS custom properties

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -219,7 +219,7 @@ static bool takes_integer_value(CSS::PropertyID property_id)
 
 static StringView parse_custom_property_name(const StringView& value)
 {
-    if (!value.starts_with("var(") && !value.ends_with(")"))
+    if (!value.starts_with("var(") || !value.ends_with(")"))
         return {};
     // FIXME: Allow for fallback
     auto first_comma_index = value.find_first_of(",");


### PR DESCRIPTION
With best wishes from De Morgan, this is the correct way to check
whether the string isn't of the form "var(...)".