### PR TITLE
LibJS: Implement bytecode generation for try..catch..finally

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1227,6 +1227,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<BlockStatement> m_block;

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -38,6 +38,11 @@ private:
     size_t m_offset { 0 };
 };
 
+struct UnwindInfo {
+    BasicBlock const* handler;
+    BasicBlock const* finalizer;
+};
+
 class BasicBlock {
 public:
     static NonnullOwnPtr<BasicBlock> create(String name);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -68,6 +68,8 @@ public:
         m_current_basic_block = &block;
     }
 
+    [[nodiscard]] BasicBlock& current_block() { return *m_current_basic_block; }
+
     BasicBlock& make_block(String name = {})
     {
         if (name.is_empty())

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -57,7 +57,10 @@
     O(ConcatString)               \
     O(Increment)                  \
     O(Decrement)                  \
-    O(Throw)
+    O(Throw)                      \
+    O(EnterUnwindContext)         \
+    O(LeaveUnwindContext)         \
+    O(ContinuePendingUnwind)
 
 namespace JS::Bytecode {
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -11,6 +11,8 @@
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/Handle.h>
+#include <LibJS/Runtime/Exception.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS::Bytecode {
@@ -39,6 +41,10 @@ public:
     }
     void do_return(Value return_value) { m_return_value = return_value; }
 
+    void enter_unwind_context(Optional<Label> handler_target, Optional<Label> finalizer_target);
+    void leave_unwind_context();
+    void continue_pending_unwind(Label const& resume_label);
+
     Executable const& current_executable() { return *m_current_executable; }
 
 private:
@@ -50,6 +56,8 @@ private:
     Optional<BasicBlock const*> m_pending_jump;
     Value m_return_value;
     Executable const* m_current_executable { nullptr };
+    Vector<UnwindInfo> m_unwind_contexts;
+    Handle<Exception> m_saved_exception;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -261,6 +261,21 @@ void Throw::execute(Bytecode::Interpreter& interpreter) const
     interpreter.vm().throw_exception(interpreter.global_object(), interpreter.accumulator());
 }
 
+void EnterUnwindContext::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.enter_unwind_context(m_handler_target, m_finalizer_target);
+}
+
+void LeaveUnwindContext::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.leave_unwind_context();
+}
+
+void ContinuePendingUnwind::execute(Bytecode::Interpreter& interpreter) const
+{
+    interpreter.continue_pending_unwind(m_resume_target);
+}
+
 String Load::to_string(Bytecode::Executable const&) const
 {
     return String::formatted("Load {}", m_src);
@@ -392,6 +407,23 @@ String Decrement::to_string(Bytecode::Executable const&) const
 String Throw::to_string(Bytecode::Executable const&) const
 {
     return "Throw";
+}
+
+String EnterUnwindContext::to_string(Bytecode::Executable const&) const
+{
+    auto handler_string = m_handler_target.has_value() ? String::formatted("{}", *m_handler_target) : "<empty>";
+    auto finalizer_string = m_finalizer_target.has_value() ? String::formatted("{}", *m_finalizer_target) : "<empty>";
+    return String::formatted("EnterUnwindContext handler:{} finalizer:{}", handler_string, finalizer_string);
+}
+
+String LeaveUnwindContext::to_string(Bytecode::Executable const&) const
+{
+    return "LeaveUnwindContext";
+}
+
+String ContinuePendingUnwind::to_string(Bytecode::Executable const&) const
+{
+    return String::formatted("ContinuePendingUnwind resume:{}", m_resume_target);
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -409,6 +409,50 @@ public:
     String to_string(Bytecode::Executable const&) const;
 };
 
+class EnterUnwindContext final : public Instruction {
+public:
+    EnterUnwindContext(Optional<Label> handler_target, Optional<Label> finalizer_target)
+        : Instruction(Type::EnterUnwindContext)
+        , m_handler_target(handler_target)
+        , m_finalizer_target(finalizer_target)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string(Bytecode::Executable const&) const;
+
+private:
+    Optional<Label> m_handler_target;
+    Optional<Label> m_finalizer_target;
+};
+
+class LeaveUnwindContext final : public Instruction {
+public:
+    LeaveUnwindContext()
+        : Instruction(Type::LeaveUnwindContext)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string(Bytecode::Executable const&) const;
+};
+
+class ContinuePendingUnwind final : public Instruction {
+public:
+    constexpr static bool IsTerminator = true;
+
+    ContinuePendingUnwind(Label const& resume_target)
+        : Instruction(Type::ContinuePendingUnwind)
+        , m_resume_target(resume_target)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string(Bytecode::Executable const&) const;
+
+private:
+    Label m_resume_target;
+};
 }
 
 namespace JS::Bytecode {


### PR DESCRIPTION
EnterUnwindContext pushes an unwind context (exception handler and/or finalizer) onto a stack.
LeaveUnwindContext pops the unwind context from that stack.

Upon return to the interpreter loop we check whether the VM has an exception pending. If no unwind context is available we return from the loop. If an exception handler is available we clear the VM's exception, put the exception value into the accumulator register, clear the unwind context's handler and jump to the handler. If no handler is available but a finalizer is available we save the exception value + metadata (for later use by ContinuePendingUnwind), clear the VM's exception, pop the unwind context and jump to the finalizer.

ContinuePendingUnwind checks whether a saved exception is available. If no saved exception is available it jumps to the resume label. Otherwise it stores the exception into the VM.

The Jump after LeaveUnwindContext could be integrated into the LeaveUnwindContext instruction. I've kept them separate for now to make the bytecode more readable.

```
> try { 1; throw "x" } catch (e) { 2 } finally { 3 }; 4
1:
[   0] EnterScope
[  10] EnterUnwindContext handler:@4 finalizer:@3
[  38] EnterScope
[  48] LoadImmediate 1
[  60] NewString 1 ("x")
[  70] Throw
<for non-terminated blocks: insert LeaveUnwindContext + Jump @3 here>
2:
[   0] LoadImmediate 4
3:
[   0] EnterScope
[  10] LoadImmediate 3
[  28] ContinuePendingUnwind resume:@2
4:
[   0] SetVariable 0 (e)
[  10] EnterScope
[  20] LoadImmediate 2
[  38] LeaveUnwindContext
[  3c] Jump @3

String Table:
0: e
1: x
```

TODO:

* [x] Figure out whether storing `m_saved_exception`like that is GC-safe.

TODOs for later:

* Make `return` work in `finally` blocks.
* Separate `LexicalEnvironment` for the catch block.