### PR TITLE
LibJS: Various ArrayBuffer fixes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -14,11 +14,6 @@ ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, size_t byte_size)
     return global_object.heap().allocate<ArrayBuffer>(global_object, byte_size, *global_object.array_buffer_prototype());
 }
 
-ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer& buffer)
-{
-    return global_object.heap().allocate<ArrayBuffer>(global_object, buffer, *global_object.array_buffer_prototype());
-}
-
 ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer* buffer)
 {
     return global_object.heap().allocate<ArrayBuffer>(global_object, buffer, *global_object.array_buffer_prototype());
@@ -27,12 +22,6 @@ ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer* buffer
 ArrayBuffer::ArrayBuffer(size_t byte_size, Object& prototype)
     : Object(prototype)
     , m_buffer(ByteBuffer::create_zeroed(byte_size))
-{
-}
-
-ArrayBuffer::ArrayBuffer(ByteBuffer& buffer, Object& prototype)
-    : Object(prototype)
-    , m_buffer(buffer)
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -22,12 +22,14 @@ ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer* buffer
 ArrayBuffer::ArrayBuffer(size_t byte_size, Object& prototype)
     : Object(prototype)
     , m_buffer(ByteBuffer::create_zeroed(byte_size))
+    , m_detach_key(js_undefined())
 {
 }
 
 ArrayBuffer::ArrayBuffer(ByteBuffer* buffer, Object& prototype)
     : Object(prototype)
     , m_buffer(buffer)
+    , m_detach_key(js_undefined())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -27,17 +27,24 @@ public:
     ByteBuffer& buffer() { return buffer_impl(); }
     const ByteBuffer& buffer() const { return buffer_impl(); }
 
+    Value detach_key() const { return m_detach_key; }
+    void detach_buffer() { m_buffer = Empty {}; }
+    bool is_detached() const { return m_buffer.has<Empty>(); }
+
 private:
     ByteBuffer& buffer_impl()
     {
         ByteBuffer* ptr { nullptr };
-        m_buffer.visit([&](auto* pointer) { ptr = pointer; }, [&](auto& value) { ptr = &value; });
+        m_buffer.visit([&](Empty) { VERIFY_NOT_REACHED(); }, [&](auto* pointer) { ptr = pointer; }, [&](auto& value) { ptr = &value; });
         return *ptr;
     }
 
     const ByteBuffer& buffer_impl() const { return const_cast<ArrayBuffer*>(this)->buffer_impl(); }
 
-    Variant<ByteBuffer, ByteBuffer*> m_buffer;
+    Variant<Empty, ByteBuffer, ByteBuffer*> m_buffer;
+    // The various detach related members of ArrayBuffer are not used by any ECMA262 functionality,
+    // but are required to be available for the use of various harnesses like the Test262 test runner.
+    Value m_detach_key;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -17,11 +17,9 @@ class ArrayBuffer : public Object {
 
 public:
     static ArrayBuffer* create(GlobalObject&, size_t);
-    static ArrayBuffer* create(GlobalObject&, ByteBuffer&);
     static ArrayBuffer* create(GlobalObject&, ByteBuffer*);
 
     ArrayBuffer(size_t, Object& prototype);
-    ArrayBuffer(ByteBuffer& buffer, Object& prototype);
     ArrayBuffer(ByteBuffer* buffer, Object& prototype);
     virtual ~ArrayBuffer() override;
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -45,9 +45,11 @@ Value ArrayBufferConstructor::construct(Function&)
     auto& vm = this->vm();
     auto byte_length = vm.argument(0).to_index(global_object());
     if (vm.exception()) {
-        // Re-throw more specific RangeError
-        vm.clear_exception();
-        vm.throw_exception<RangeError>(global_object(), ErrorType::InvalidLength, "array buffer");
+        if (vm.exception()->value().is_object() && is<RangeError>(vm.exception()->value().as_object())) {
+            // Re-throw more specific RangeError
+            vm.clear_exception();
+            vm.throw_exception<RangeError>(global_object(), ErrorType::InvalidLength, "array buffer");
+        }
         return {};
     }
     return ArrayBuffer::create(global_object(), byte_length);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -37,14 +37,11 @@ static ArrayBuffer* array_buffer_object_from(VM& vm, GlobalObject& global_object
 {
     // ArrayBuffer.prototype.* deliberately don't coerce |this| value to object.
     auto this_value = vm.this_value(global_object);
-    if (!this_value.is_object())
-        return nullptr;
-    auto& this_object = this_value.as_object();
-    if (!is<ArrayBuffer>(this_object)) {
+    if (!this_value.is_object() || !is<ArrayBuffer>(this_value.as_object())) {
         vm.throw_exception<TypeError>(global_object, ErrorType::NotAn, "ArrayBuffer");
         return nullptr;
     }
-    return static_cast<ArrayBuffer*>(&this_object);
+    return static_cast<ArrayBuffer*>(&this_value.as_object());
 }
 
 // 25.1.5.3 ArrayBuffer.prototype.slice, https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -24,6 +24,7 @@
     M(ConvertUndefinedToObject, "Cannot convert undefined to object")                                                                   \
     M(DescChangeNonConfigurable, "Cannot change attributes of non-configurable property '{}'")                                          \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
+    M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                                   \
     M(DivisionByZero, "Division by zero")                                                                                               \
     M(GetCapabilitiesExecutorCalledMultipleTimes, "GetCapabilitiesExecutor was called multiple times")                                  \
     M(InOperatorWithObject, "'in' operator must be used on an object")                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -140,6 +140,8 @@
     M(RegExpCompileError, "RegExp compile error: {}")                                                                                   \
     M(RegExpObjectBadFlag, "Invalid RegExp flag '{}'")                                                                                  \
     M(RegExpObjectRepeatedFlag, "Repeated RegExp flag '{}'")                                                                            \
+    M(SpeciesConstructorDidNotCreate, "Species constructor did not create {}")                                                          \
+    M(SpeciesConstructorReturned, "Species constructor returned {}")                                                                    \
     M(StringRawCannotConvert, "Cannot convert property 'raw' to object from {}")                                                        \
     M(StringRepeatCountMustBe, "repeat count must be a {} number")                                                                      \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -89,7 +89,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
     } else {
         // 27.2.5.3.1 Then Finally Functions, https://tc39.es/ecma262/#sec-thenfinallyfunctions
         auto* then_finally_function = NativeFunction::create(global_object, "", [constructor_handle = make_handle(constructor), on_finally_handle = make_handle(&on_finally.as_function())](auto& vm, auto& global_object) -> Value {
-            auto& constructor = const_cast<Object&>(*constructor_handle.cell());
+            auto& constructor = const_cast<Function&>(*constructor_handle.cell());
             auto& on_finally = const_cast<Function&>(*on_finally_handle.cell());
             auto value = vm.argument(0);
             auto result = vm.call(on_finally, js_undefined());
@@ -107,7 +107,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
 
         // 27.2.5.3.2 Catch Finally Functions, https://tc39.es/ecma262/#sec-catchfinallyfunctions
         auto* catch_finally_function = NativeFunction::create(global_object, "", [constructor_handle = make_handle(constructor), on_finally_handle = make_handle(&on_finally.as_function())](auto& vm, auto& global_object) -> Value {
-            auto& constructor = const_cast<Object&>(*constructor_handle.cell());
+            auto& constructor = const_cast<Function&>(*constructor_handle.cell());
             auto& on_finally = const_cast<Function&>(*on_finally_handle.cell());
             auto reason = vm.argument(0);
             auto result = vm.call(on_finally, js_undefined());

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -33,7 +33,12 @@ static void initialize_typed_array_from_array_buffer(GlobalObject& global_object
         if (vm.exception())
             return;
     }
-    // FIXME: 8. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+
+    if (array_buffer.is_detached()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
+        return;
+    }
+
     auto buffer_byte_length = array_buffer.byte_length();
     Checked<size_t> new_byte_length;
     if (length.is_undefined()) {
@@ -81,8 +86,12 @@ static void initialize_typed_array_from_typed_array(GlobalObject& global_object,
     if (vm.exception())
         return;
 
-    // FIXME: 4. If IsDetachedBuffer(src_data) is true, throw a TypeError exception.
-    VERIFY(src_array.viewed_array_buffer());
+    auto* source_array_buffer = src_array.viewed_array_buffer();
+    VERIFY(source_array_buffer);
+    if (source_array_buffer->is_detached()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
+        return;
+    }
 
     auto src_array_length = src_array.array_length();
     auto dest_element_size = dest_array.element_size();

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -50,6 +50,10 @@ JS_DEFINE_NATIVE_GETTER(TypedArrayPrototype::length_getter)
     auto typed_array = typed_array_from(vm, global_object);
     if (!typed_array)
         return {};
+    auto* array_buffer = typed_array->viewed_array_buffer();
+    VERIFY(array_buffer);
+    if (array_buffer->is_detached())
+        return Value(0);
     return Value(typed_array->array_length());
 }
 
@@ -95,7 +99,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_length_getter)
         return {};
     auto* array_buffer = typed_array->viewed_array_buffer();
     VERIFY(array_buffer);
-    // FIXME: If array_buffer is detached, return 0.
+    if (array_buffer->is_detached())
+        return Value(0);
     return Value(typed_array->byte_length());
 }
 
@@ -107,7 +112,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_offset_getter)
         return {};
     auto* array_buffer = typed_array->viewed_array_buffer();
     VERIFY(array_buffer);
-    // FIXME: If array_buffer is detached, return 0.
+    if (array_buffer->is_detached())
+        return Value(0);
     return Value(typed_array->byte_offset());
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1387,7 +1387,7 @@ size_t length_of_array_like(GlobalObject& global_object, const Object& object)
 }
 
 // 7.3.22 SpeciesConstructor, https://tc39.es/ecma262/#sec-speciesconstructor
-Object* species_constructor(GlobalObject& global_object, const Object& object, Object& default_constructor)
+Function* species_constructor(GlobalObject& global_object, const Object& object, Function& default_constructor)
 {
     auto& vm = global_object.vm();
     auto constructor = object.get(vm.names.constructor).value_or(js_undefined());
@@ -1403,7 +1403,7 @@ Object* species_constructor(GlobalObject& global_object, const Object& object, O
     if (species.is_nullish())
         return &default_constructor;
     if (species.is_constructor())
-        return &species.as_object();
+        return &species.as_function();
     vm.throw_exception<TypeError>(global_object, ErrorType::NotAConstructor, species.to_string_without_side_effects());
     return nullptr;
 }

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -372,7 +372,7 @@ bool same_value_non_numeric(Value lhs, Value rhs);
 TriState abstract_relation(GlobalObject&, bool left_first, Value lhs, Value rhs);
 Function* get_method(GlobalObject& global_object, Value, const PropertyName&);
 size_t length_of_array_like(GlobalObject&, const Object&);
-Object* species_constructor(GlobalObject&, const Object&, Object& default_constructor);
+Function* species_constructor(GlobalObject&, const Object&, Function& default_constructor);
 Value require_object_coercible(GlobalObject&, Value);
 MarkedValueList create_list_from_array_like(GlobalObject&, Value, AK::Function<Result<void, ErrorType>(Value)> = {});
 


### PR DESCRIPTION
This fixes 11 test262 test cases, but will likely solve/progress more cases once the `$262.detachArrayBuffer` functionality (that depends on the last commit in this PR) is merged into [linusg/libjs-test262](https://github.com/linusg/libjs-test262)