### PR TITLE
LibJS: Various goodies and generator functions (only in bytecode)

### DIFF
--- a/AK/NonnullRefPtrVector.h
+++ b/AK/NonnullRefPtrVector.h
@@ -13,6 +13,7 @@ namespace AK {
 
 template<typename T, size_t inline_capacity>
 class NonnullRefPtrVector : public NonnullPtrVector<NonnullRefPtr<T>, inline_capacity> {
+    using NonnullPtrVector<NonnullRefPtr<T>, inline_capacity>::NonnullPtrVector;
 };
 
 }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -259,6 +259,12 @@ Value CallExpression::execute(Interpreter& interpreter, GlobalObject& global_obj
     return result;
 }
 
+Value YieldExpression::execute(Interpreter&, GlobalObject&) const
+{
+    // This should be transformed to a return.
+    VERIFY_NOT_REACHED();
+}
+
 Value ReturnStatement::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
@@ -1151,7 +1157,7 @@ void BindingPattern::dump(int indent) const
 void FunctionNode::dump(int indent, const String& class_name) const
 {
     print_indent(indent);
-    outln("{} '{}'", class_name, name());
+    outln("{}{} '{}'", class_name, m_is_generator ? "*" : "", name());
     if (!m_parameters.is_empty()) {
         print_indent(indent + 1);
         outln("(Parameters)");
@@ -1191,6 +1197,13 @@ void FunctionDeclaration::dump(int indent) const
 void FunctionExpression::dump(int indent) const
 {
     FunctionNode::dump(indent, class_name());
+}
+
+void YieldExpression::dump(int indent) const
+{
+    ASTNode::dump(indent);
+    if (argument())
+        argument()->dump(indent + 1);
 }
 
 void ReturnStatement::dump(int indent) const

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -40,7 +40,7 @@ public:
     virtual void generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;
 
-    const SourceRange& source_range() const { return m_source_range; }
+    SourceRange const& source_range() const { return m_source_range; }
     SourceRange& source_range() { return m_source_range; }
 
     String class_name() const;
@@ -62,7 +62,7 @@ public:
     {
     }
 
-    const FlyString& label() const { return m_label; }
+    FlyString const& label() const { return m_label; }
     void set_label(FlyString string) { m_label = string; }
 
 protected:
@@ -100,7 +100,7 @@ public:
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
-    const Expression& expression() const { return m_expression; };
+    Expression const& expression() const { return m_expression; };
 
 private:
     NonnullRefPtr<Expression> m_expression;
@@ -120,15 +120,15 @@ public:
         m_children.append(move(child));
     }
 
-    const NonnullRefPtrVector<Statement>& children() const { return m_children; }
+    NonnullRefPtrVector<Statement> const& children() const { return m_children; }
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
     void add_variables(NonnullRefPtrVector<VariableDeclaration>);
     void add_functions(NonnullRefPtrVector<FunctionDeclaration>);
-    const NonnullRefPtrVector<VariableDeclaration>& variables() const { return m_variables; }
-    const NonnullRefPtrVector<FunctionDeclaration>& functions() const { return m_functions; }
+    NonnullRefPtrVector<VariableDeclaration> const& variables() const { return m_variables; }
+    NonnullRefPtrVector<FunctionDeclaration> const& functions() const { return m_functions; }
 
 protected:
     ScopeNode(SourceRange source_range)
@@ -222,15 +222,15 @@ public:
         bool is_rest { false };
     };
 
-    const FlyString& name() const { return m_name; }
-    const Statement& body() const { return *m_body; }
-    const Vector<Parameter>& parameters() const { return m_parameters; };
+    FlyString const& name() const { return m_name; }
+    Statement const& body() const { return *m_body; }
+    Vector<Parameter> const& parameters() const { return m_parameters; };
     i32 function_length() const { return m_function_length; }
     bool is_strict_mode() const { return m_is_strict_mode; }
     bool is_generator() const { return m_is_generator; }
 
 protected:
-    FunctionNode(const FlyString& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode)
+    FunctionNode(FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode)
         : m_name(name)
         , m_body(move(body))
         , m_parameters(move(parameters))
@@ -241,9 +241,9 @@ protected:
     {
     }
 
-    void dump(int indent, const String& class_name) const;
+    void dump(int indent, String const& class_name) const;
 
-    const NonnullRefPtrVector<VariableDeclaration>& variables() const { return m_variables; }
+    NonnullRefPtrVector<VariableDeclaration> const& variables() const { return m_variables; }
 
 protected:
     void set_name(FlyString name)
@@ -255,7 +255,7 @@ protected:
 private:
     FlyString m_name;
     NonnullRefPtr<Statement> m_body;
-    const Vector<Parameter> m_parameters;
+    Vector<Parameter> const m_parameters;
     NonnullRefPtrVector<VariableDeclaration> m_variables;
     const i32 m_function_length;
     bool m_is_generator;
@@ -268,7 +268,7 @@ class FunctionDeclaration final
 public:
     static bool must_have_name() { return true; }
 
-    FunctionDeclaration(SourceRange source_range, const FlyString& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode = false)
+    FunctionDeclaration(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode = false)
         : Declaration(move(source_range))
         , FunctionNode(name, move(body), move(parameters), function_length, move(variables), is_generator, is_strict_mode)
     {
@@ -285,7 +285,7 @@ class FunctionExpression final
 public:
     static bool must_have_name() { return false; }
 
-    FunctionExpression(SourceRange source_range, const FlyString& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode, bool is_arrow_function = false)
+    FunctionExpression(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode, bool is_arrow_function = false)
         : Expression(source_range)
         , FunctionNode(name, move(body), move(parameters), function_length, move(variables), is_generator, is_strict_mode)
         , m_is_arrow_function(is_arrow_function)
@@ -329,7 +329,7 @@ public:
     {
     }
 
-    const Expression* argument() const { return m_argument; }
+    Expression const* argument() const { return m_argument; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -347,7 +347,7 @@ public:
     {
     }
 
-    const Expression* argument() const { return m_argument; }
+    Expression const* argument() const { return m_argument; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -367,9 +367,9 @@ public:
     {
     }
 
-    const Expression& predicate() const { return *m_predicate; }
-    const Statement& consequent() const { return *m_consequent; }
-    const Statement* alternate() const { return m_alternate; }
+    Expression const& predicate() const { return *m_predicate; }
+    Statement const& consequent() const { return *m_consequent; }
+    Statement const* alternate() const { return m_alternate; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -390,8 +390,8 @@ public:
     {
     }
 
-    const Expression& test() const { return *m_test; }
-    const Statement& body() const { return *m_body; }
+    Expression const& test() const { return *m_test; }
+    Statement const& body() const { return *m_body; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -411,8 +411,8 @@ public:
     {
     }
 
-    const Expression& test() const { return *m_test; }
-    const Statement& body() const { return *m_body; }
+    Expression const& test() const { return *m_test; }
+    Statement const& body() const { return *m_body; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -432,8 +432,8 @@ public:
     {
     }
 
-    const Expression& object() const { return *m_object; }
-    const Statement& body() const { return *m_body; }
+    Expression const& object() const { return *m_object; }
+    Statement const& body() const { return *m_body; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -454,10 +454,10 @@ public:
     {
     }
 
-    const ASTNode* init() const { return m_init; }
-    const Expression* test() const { return m_test; }
-    const Expression* update() const { return m_update; }
-    const Statement& body() const { return *m_body; }
+    ASTNode const* init() const { return m_init; }
+    Expression const* test() const { return m_test; }
+    Expression const* update() const { return m_update; }
+    Statement const& body() const { return *m_body; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -480,9 +480,9 @@ public:
     {
     }
 
-    const ASTNode& lhs() const { return *m_lhs; }
-    const Expression& rhs() const { return *m_rhs; }
-    const Statement& body() const { return *m_body; }
+    ASTNode const& lhs() const { return *m_lhs; }
+    Expression const& rhs() const { return *m_rhs; }
+    Statement const& body() const { return *m_body; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -503,9 +503,9 @@ public:
     {
     }
 
-    const ASTNode& lhs() const { return *m_lhs; }
-    const Expression& rhs() const { return *m_rhs; }
-    const Statement& body() const { return *m_body; }
+    ASTNode const& lhs() const { return *m_lhs; }
+    Expression const& rhs() const { return *m_rhs; }
+    Statement const& body() const { return *m_body; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -733,8 +733,8 @@ public:
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
 
-    const String& pattern() const { return m_pattern; }
-    const String& flags() const { return m_flags; }
+    String const& pattern() const { return m_pattern; }
+    String const& flags() const { return m_flags; }
 
 private:
     String m_pattern;
@@ -743,13 +743,13 @@ private:
 
 class Identifier final : public Expression {
 public:
-    explicit Identifier(SourceRange source_range, const FlyString& string)
+    explicit Identifier(SourceRange source_range, FlyString const& string)
         : Expression(move(source_range))
         , m_string(string)
     {
     }
 
-    const FlyString& string() const { return m_string; }
+    FlyString const& string() const { return m_string; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -777,7 +777,7 @@ public:
     {
     }
 
-    const Expression& key() const { return *m_key; }
+    Expression const& key() const { return *m_key; }
     Kind kind() const { return m_kind; }
     bool is_static() const { return m_is_static; }
 
@@ -891,7 +891,7 @@ private:
     ThisAndCallee compute_this_and_callee(Interpreter&, GlobalObject&) const;
 
     NonnullRefPtr<Expression> m_callee;
-    const Vector<Argument> m_arguments;
+    Vector<Argument> const m_arguments;
 };
 
 class NewExpression final : public CallExpression {
@@ -995,7 +995,7 @@ public:
     }
 
     auto& target() const { return m_target; }
-    const Expression* init() const { return m_init; }
+    Expression const* init() const { return m_init; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -1020,7 +1020,7 @@ public:
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
-    const NonnullRefPtrVector<VariableDeclarator>& declarations() const { return m_declarations; }
+    NonnullRefPtrVector<VariableDeclarator> const& declarations() const { return m_declarations; }
 
 private:
     DeclarationKind m_declaration_kind;
@@ -1045,8 +1045,8 @@ public:
     {
     }
 
-    const Expression& key() const { return m_key; }
-    const Expression& value() const
+    Expression const& key() const { return m_key; }
+    Expression const& value() const
     {
         VERIFY(m_value);
         return *m_value;
@@ -1089,7 +1089,7 @@ public:
     {
     }
 
-    const Vector<RefPtr<Expression>>& elements() const { return m_elements; }
+    Vector<RefPtr<Expression>> const& elements() const { return m_elements; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -1118,12 +1118,12 @@ public:
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
-    const NonnullRefPtrVector<Expression>& expressions() const { return m_expressions; }
-    const NonnullRefPtrVector<Expression>& raw_strings() const { return m_raw_strings; }
+    NonnullRefPtrVector<Expression> const& expressions() const { return m_expressions; }
+    NonnullRefPtrVector<Expression> const& raw_strings() const { return m_raw_strings; }
 
 private:
-    const NonnullRefPtrVector<Expression> m_expressions;
-    const NonnullRefPtrVector<Expression> m_raw_strings;
+    NonnullRefPtrVector<Expression> const m_expressions;
+    NonnullRefPtrVector<Expression> const m_raw_strings;
 };
 
 class TaggedTemplateLiteral final : public Expression {
@@ -1140,8 +1140,8 @@ public:
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
-    const NonnullRefPtr<Expression> m_tag;
-    const NonnullRefPtr<TemplateLiteral> m_template_literal;
+    NonnullRefPtr<Expression> const m_tag;
+    NonnullRefPtr<TemplateLiteral> const m_template_literal;
 };
 
 class MemberExpression final : public Expression {
@@ -1160,8 +1160,8 @@ public:
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
     bool is_computed() const { return m_computed; }
-    const Expression& object() const { return *m_object; }
-    const Expression& property() const { return *m_property; }
+    Expression const& object() const { return *m_object; }
+    Expression const& property() const { return *m_property; }
 
     PropertyName computed_property_name(Interpreter&, GlobalObject&) const;
 
@@ -1215,15 +1215,15 @@ private:
 
 class CatchClause final : public ASTNode {
 public:
-    CatchClause(SourceRange source_range, const FlyString& parameter, NonnullRefPtr<BlockStatement> body)
+    CatchClause(SourceRange source_range, FlyString const& parameter, NonnullRefPtr<BlockStatement> body)
         : ASTNode(move(source_range))
         , m_parameter(parameter)
         , m_body(move(body))
     {
     }
 
-    const FlyString& parameter() const { return m_parameter; }
-    const BlockStatement& body() const { return m_body; }
+    FlyString const& parameter() const { return m_parameter; }
+    BlockStatement const& body() const { return m_body; }
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
@@ -1243,9 +1243,9 @@ public:
     {
     }
 
-    const BlockStatement& block() const { return m_block; }
-    const CatchClause* handler() const { return m_handler; }
-    const BlockStatement* finalizer() const { return m_finalizer; }
+    BlockStatement const& block() const { return m_block; }
+    CatchClause const* handler() const { return m_handler; }
+    BlockStatement const* finalizer() const { return m_finalizer; }
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
@@ -1265,7 +1265,7 @@ public:
     {
     }
 
-    const Expression& argument() const { return m_argument; }
+    Expression const& argument() const { return m_argument; }
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
@@ -1284,8 +1284,8 @@ public:
     {
     }
 
-    const Expression* test() const { return m_test; }
-    const NonnullRefPtrVector<Statement>& consequent() const { return m_consequent; }
+    Expression const* test() const { return m_test; }
+    NonnullRefPtrVector<Statement> const& consequent() const { return m_consequent; }
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
@@ -1322,7 +1322,7 @@ public:
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
 
-    const FlyString& target_label() const { return m_target_label; }
+    FlyString const& target_label() const { return m_target_label; }
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
@@ -1340,7 +1340,7 @@ public:
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
-    const FlyString& target_label() const { return m_target_label; }
+    FlyString const& target_label() const { return m_target_label; }
 
 private:
     FlyString m_target_label;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -660,7 +660,23 @@ void ReturnStatement::generate_bytecode(Bytecode::Generator& generator) const
 {
     if (m_argument)
         m_argument->generate_bytecode(generator);
-    generator.emit<Bytecode::Op::Return>();
+
+    if (generator.is_in_generator_function())
+        generator.emit<Bytecode::Op::Yield>(nullptr);
+    else
+        generator.emit<Bytecode::Op::Return>();
+}
+
+void YieldExpression::generate_bytecode(Bytecode::Generator& generator) const
+{
+    VERIFY(generator.is_in_generator_function());
+
+    if (m_argument)
+        m_argument->generate_bytecode(generator);
+
+    auto& continuation_block = generator.make_block();
+    generator.emit<Bytecode::Op::Yield>(Bytecode::Label { continuation_block });
+    generator.switch_to_basic_block(continuation_block);
 }
 
 void IfStatement::generate_bytecode(Bytecode::Generator& generator) const

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -44,6 +44,8 @@ struct UnwindInfo {
 };
 
 class BasicBlock {
+    AK_MAKE_NONCOPYABLE(BasicBlock);
+
 public:
     static NonnullOwnPtr<BasicBlock> create(String name);
     ~BasicBlock();
@@ -54,6 +56,7 @@ public:
     ReadonlyBytes instruction_stream() const { return ReadonlyBytes { m_buffer, m_buffer_size }; }
 
     void* next_slot() { return m_buffer + m_buffer_size; }
+    bool can_grow(size_t additional_size) const { return m_buffer_size + additional_size <= m_buffer_capacity; }
     void grow(size_t additional_size);
 
     void terminate(Badge<Generator>) { m_is_terminated = true; }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Instruction.h>
+#include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/Register.h>
 #include <LibJS/Forward.h>
 

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -28,7 +28,7 @@ struct Executable {
 
 class Generator {
 public:
-    static Executable generate(ASTNode const&);
+    static Executable generate(ASTNode const&, bool is_in_generator_function = false);
 
     Register allocate_register();
 
@@ -109,6 +109,10 @@ public:
         return m_string_table->insert(string);
     }
 
+    bool is_in_generator_function() const { return m_is_in_generator_function; }
+    void enter_generator_context() { m_is_in_generator_function = true; }
+    void leave_generator_context() { m_is_in_generator_function = false; }
+
 private:
     Generator();
     ~Generator();
@@ -122,6 +126,7 @@ private:
 
     u32 m_next_register { 2 };
     u32 m_next_block { 1 };
+    bool m_is_in_generator_function { false };
     Vector<Label> m_continuable_scopes;
     Vector<Label> m_breakable_scopes;
 };

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -61,7 +61,8 @@
     O(PushLexicalEnvironment)     \
     O(EnterUnwindContext)         \
     O(LeaveUnwindContext)         \
-    O(ContinuePendingUnwind)
+    O(ContinuePendingUnwind)      \
+    O(Yield)
 
 namespace JS::Bytecode {
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -215,8 +215,7 @@ void Call::execute(Bytecode::Interpreter& interpreter) const
 void NewFunction::execute(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto& global_object = interpreter.global_object();
-    interpreter.accumulator() = ScriptFunction::create(global_object, m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.is_strict_mode());
+    interpreter.accumulator() = ScriptFunction::create(interpreter.global_object(), m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.is_generator(), m_function_node.is_strict_mode());
 }
 
 void Return::execute(Bytecode::Interpreter& interpreter) const
@@ -275,6 +274,18 @@ void PushLexicalEnvironment::execute(Bytecode::Interpreter& interpreter) const
         resolved_variables.set(interpreter.current_executable().get_string(it.key), it.value);
     auto* block_lexical_environment = interpreter.vm().heap().allocate<LexicalEnvironment>(interpreter.global_object(), move(resolved_variables), interpreter.vm().current_scope());
     interpreter.vm().call_frame().scope = block_lexical_environment;
+}
+
+void Yield::execute(Bytecode::Interpreter& interpreter) const
+{
+    auto yielded_value = interpreter.accumulator().value_or(js_undefined());
+    auto object = JS::Object::create_empty(interpreter.global_object());
+    object->put("result", yielded_value);
+    if (m_continuation_label.has_value())
+        object->put("continuation", Value(static_cast<double>(reinterpret_cast<u64>(&m_continuation_label->block()))));
+    else
+        object->put("continuation", Value(0));
+    interpreter.do_return(object);
 }
 
 String Load::to_string(Bytecode::Executable const&) const
@@ -440,6 +451,13 @@ String PushLexicalEnvironment::to_string(const Bytecode::Executable& executable)
         builder.append("}");
     }
     return builder.to_string();
+}
+
+String Yield::to_string(Bytecode::Executable const&) const
+{
+    if (m_continuation_label.has_value())
+        return String::formatted("Yield continuation:@{}", m_continuation_label->block().name());
+    return String::formatted("Yield return");
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -184,8 +184,6 @@ public:
     void execute(Bytecode::Interpreter&) const;
     String to_string(Bytecode::Executable const&) const;
 
-    size_t length() const { return sizeof(*this) + sizeof(Register) * m_element_count; }
-
 private:
     size_t m_element_count { 0 };
     Register m_elements[];
@@ -455,6 +453,28 @@ private:
     Label m_resume_target;
 };
 
+class Yield final : public Instruction {
+public:
+    constexpr static bool IsTerminator = true;
+
+    explicit Yield(Label continuation_label)
+        : Instruction(Type::Yield)
+        , m_continuation_label(continuation_label)
+    {
+    }
+
+    explicit Yield(std::nullptr_t)
+        : Instruction(Type::Yield)
+    {
+    }
+
+    void execute(Bytecode::Interpreter&) const;
+    String to_string(Bytecode::Executable const&) const;
+
+private:
+    Optional<Label> m_continuation_label;
+};
+
 class PushLexicalEnvironment final : public Instruction {
 public:
     PushLexicalEnvironment(HashMap<u32, Variable> variables)
@@ -465,6 +485,7 @@ public:
     void execute(Bytecode::Interpreter&) const;
     String to_string(Bytecode::Executable const&) const;
 
+private:
     HashMap<u32, Variable> m_variables;
 };
 }

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCES
     Runtime/FunctionConstructor.cpp
     Runtime/Function.cpp
     Runtime/FunctionPrototype.cpp
+    Runtime/GeneratorObject.cpp
     Runtime/GlobalObject.cpp
     Runtime/IndexedProperties.cpp
     Runtime/IteratorOperations.cpp

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -79,7 +79,7 @@ void Interpreter::enter_scope(const ScopeNode& scope_node, ScopeType scope_type,
 {
     ScopeGuard guard([&] {
         for (auto& declaration : scope_node.functions()) {
-            auto* function = ScriptFunction::create(global_object, declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), current_scope(), declaration.is_strict_mode());
+            auto* function = ScriptFunction::create(global_object, declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), current_scope(), declaration.is_generator(), declaration.is_strict_mode());
             vm().set_variable(declaration.name(), function, global_object);
         }
     });

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -77,6 +77,7 @@ public:
     NonnullRefPtr<NewExpression> parse_new_expression();
     NonnullRefPtr<ClassDeclaration> parse_class_declaration();
     NonnullRefPtr<ClassExpression> parse_class_expression(bool expect_class_name);
+    NonnullRefPtr<YieldExpression> parse_yield_expression();
     NonnullRefPtr<Expression> parse_property_key();
     NonnullRefPtr<AssignmentExpression> parse_assignment_expression(AssignmentOp, NonnullRefPtr<Expression> lhs, int min_precedence, Associativity);
 
@@ -200,6 +201,7 @@ private:
         bool m_allow_super_property_lookup { false };
         bool m_allow_super_constructor_call { false };
         bool m_in_function_context { false };
+        bool m_in_generator_function_context { false };
         bool m_in_arrow_function_context { false };
         bool m_in_break_context { false };
         bool m_in_continue_context { false };

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -293,6 +293,8 @@ struct CommonPropertyNames {
     FlyString catch_ { "catch" };
     FlyString delete_ { "delete" };
     FlyString for_ { "for" };
+    FlyString return_ { "return" };
+    FlyString throw_ { "throw" };
 #define __ENUMERATE(x) FlyString x { #x };
     ENUMERATE_STANDARD_PROPERTY_NAMES(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/TemporaryChange.h>
+#include <LibJS/Bytecode/Generator.h>
+#include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Runtime/GeneratorObject.h>
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace JS {
+
+GeneratorObject* GeneratorObject::create(GlobalObject& global_object, Value initial_value, ScriptFunction* generating_function, ScopeObject* generating_scope, Bytecode::RegisterWindow frame)
+{
+    auto object = global_object.heap().allocate<GeneratorObject>(global_object, global_object);
+    object->m_generating_function = generating_function;
+    object->m_scope = generating_scope;
+    object->m_frame = move(frame);
+    object->m_previous_value = initial_value;
+    return object;
+}
+
+GeneratorObject::GeneratorObject(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void GeneratorObject::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    Object::initialize(global_object);
+    define_native_function(vm.names.next, next);
+    define_native_function(vm.names.return_, return_);
+    define_native_function(vm.names.throw_, throw_);
+}
+
+GeneratorObject::~GeneratorObject()
+{
+}
+
+void GeneratorObject::visit_edges(Cell::Visitor& visitor)
+{
+    Object::visit_edges(visitor);
+    visitor.visit(m_scope);
+    visitor.visit(m_generating_function);
+    if (m_previous_value.is_object())
+        visitor.visit(&m_previous_value.as_object());
+}
+
+GeneratorObject* GeneratorObject::typed_this(VM& vm, GlobalObject& global_object)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return {};
+    if (!is<GeneratorObject>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Generator");
+        return nullptr;
+    }
+    return static_cast<GeneratorObject*>(this_object);
+}
+
+Value GeneratorObject::next_impl(VM& vm, GlobalObject& global_object, Optional<Value> value_to_throw)
+{
+    auto bytecode_interpreter = Bytecode::Interpreter::current();
+    VERIFY(bytecode_interpreter);
+
+    auto generated_value = [](Value value) {
+        if (value.is_object())
+            return value.as_object().get("result");
+        return value.is_empty() ? js_undefined() : value;
+    };
+
+    auto generated_continuation = [&](Value value) -> Bytecode::BasicBlock const* {
+        if (value.is_object())
+            return reinterpret_cast<Bytecode::BasicBlock const*>(static_cast<u64>(value.as_object().get("continuation").to_double(global_object)));
+        return nullptr;
+    };
+
+    Value previous_generated_value { generated_value(m_previous_value) };
+
+    if (vm.exception())
+        return {};
+
+    auto result = Object::create_empty(global_object);
+    result->put("value", previous_generated_value);
+
+    if (m_done) {
+        result->put("done", Value(true));
+        return result;
+    }
+
+    // Extract the continuation
+    auto next_block = generated_continuation(m_previous_value);
+    if (vm.exception())
+        return {};
+
+    if (!next_block) {
+        // The generator has terminated, now we can simply return done=true.
+        m_done = true;
+        result->put("done", Value(true));
+        return result;
+    }
+
+    // Make sure it's an actual block
+    VERIFY(!m_generating_function->bytecode_executable()->basic_blocks.find_if([next_block](auto& block) { return block == next_block; }).is_end());
+
+    // Restore the snapshot registers
+    bytecode_interpreter->enter_frame(m_frame);
+
+    // Pretend that 'yield' returned the passed value, or threw
+    if (value_to_throw.has_value()) {
+        vm.throw_exception(global_object, value_to_throw.release_value());
+        bytecode_interpreter->accumulator() = js_undefined();
+    } else {
+        bytecode_interpreter->accumulator() = vm.argument(0);
+    }
+
+    // Temporarily switch to the captured scope
+    TemporaryChange change { vm.call_frame().scope, m_scope };
+
+    m_previous_value = bytecode_interpreter->run(*m_generating_function->bytecode_executable(), next_block);
+
+    bytecode_interpreter->leave_frame();
+
+    m_done = generated_continuation(m_previous_value) == nullptr;
+
+    result->put("value", generated_value(m_previous_value));
+    result->put("done", Value(m_done));
+
+    if (vm.exception())
+        return {};
+
+    return result;
+}
+
+JS_DEFINE_NATIVE_FUNCTION(GeneratorObject::next)
+{
+    auto object = typed_this(vm, global_object);
+    if (!object)
+        return {};
+    return object->next_impl(vm, global_object, {});
+}
+
+JS_DEFINE_NATIVE_FUNCTION(GeneratorObject::return_)
+{
+    auto object = typed_this(vm, global_object);
+    if (!object)
+        return {};
+    object->m_done = true;
+    return object->next_impl(vm, global_object, {});
+}
+
+JS_DEFINE_NATIVE_FUNCTION(GeneratorObject::throw_)
+{
+    auto object = typed_this(vm, global_object);
+    if (!object)
+        return {};
+    return object->next_impl(vm, global_object, vm.argument(0));
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/ScriptFunction.h>
+
+namespace JS {
+
+class GeneratorObject final : public Object {
+    JS_OBJECT(GeneratorObject, Object);
+
+public:
+    static GeneratorObject* create(GlobalObject&, Value, ScriptFunction*, ScopeObject*, Bytecode::RegisterWindow);
+    explicit GeneratorObject(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~GeneratorObject() override;
+    void visit_edges(Cell::Visitor&) override;
+
+    static GeneratorObject* typed_this(VM&, GlobalObject&);
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(next);
+    JS_DECLARE_NATIVE_FUNCTION(return_);
+    JS_DECLARE_NATIVE_FUNCTION(throw_);
+
+    Value next_impl(VM&, GlobalObject&, Optional<Value> value_to_throw);
+
+    ScopeObject* m_scope { nullptr };
+    ScriptFunction* m_generating_function { nullptr };
+    Value m_previous_value;
+    Bytecode::RegisterWindow m_frame;
+    bool m_done { false };
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -13,7 +13,9 @@
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/GeneratorObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/ScriptFunction.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -31,18 +33,19 @@ static ScriptFunction* typed_this(VM& vm, GlobalObject& global_object)
     return static_cast<ScriptFunction*>(this_object);
 }
 
-ScriptFunction* ScriptFunction::create(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, bool is_strict, bool is_arrow_function)
+ScriptFunction* ScriptFunction::create(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, bool is_generator, bool is_strict, bool is_arrow_function)
 {
-    return global_object.heap().allocate<ScriptFunction>(global_object, global_object, name, body, move(parameters), m_function_length, parent_scope, *global_object.function_prototype(), is_strict, is_arrow_function);
+    return global_object.heap().allocate<ScriptFunction>(global_object, global_object, name, body, move(parameters), m_function_length, parent_scope, *global_object.function_prototype(), is_generator, is_strict, is_arrow_function);
 }
 
-ScriptFunction::ScriptFunction(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, Object& prototype, bool is_strict, bool is_arrow_function)
+ScriptFunction::ScriptFunction(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, Object& prototype, bool is_generator, bool is_strict, bool is_arrow_function)
     : Function(prototype, is_arrow_function ? vm().this_value(global_object) : Value(), {})
     , m_name(name)
     , m_body(body)
     , m_parameters(move(parameters))
     , m_parent_scope(parent_scope)
     , m_function_length(m_function_length)
+    , m_is_generator(is_generator)
     , m_is_strict(is_strict)
     , m_is_arrow_function(is_arrow_function)
 {
@@ -152,15 +155,20 @@ Value ScriptFunction::execute_function_body()
     if (bytecode_interpreter) {
         prepare_arguments();
         if (!m_bytecode_executable.has_value()) {
-            m_bytecode_executable = Bytecode::Generator::generate(m_body);
+            m_bytecode_executable = Bytecode::Generator::generate(m_body, m_is_generator);
             if constexpr (JS_BYTECODE_DEBUG) {
                 dbgln("Compiled Bytecode::Block for function '{}':", m_name);
                 for (auto& block : m_bytecode_executable->basic_blocks)
                     block.dump(*m_bytecode_executable);
             }
         }
-        return bytecode_interpreter->run(*m_bytecode_executable);
+        auto result = bytecode_interpreter->run(*m_bytecode_executable);
+        if (!m_is_generator)
+            return result;
+
+        return GeneratorObject::create(global_object(), result, this, vm.call_frame().scope, bytecode_interpreter->snapshot_frame());
     } else {
+        VERIFY(!m_is_generator);
         OwnPtr<Interpreter> local_interpreter;
         ast_interpreter = vm.interpreter_if_exists();
 

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -16,9 +16,9 @@ class ScriptFunction final : public Function {
     JS_OBJECT(ScriptFunction, Function);
 
 public:
-    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, bool is_strict, bool is_arrow_function = false);
+    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, bool is_generator, bool is_strict, bool is_arrow_function = false);
 
-    ScriptFunction(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, Object& prototype, bool is_strict, bool is_arrow_function = false);
+    ScriptFunction(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, Object& prototype, bool is_generator, bool is_strict, bool is_arrow_function = false);
     virtual void initialize(GlobalObject&) override;
     virtual ~ScriptFunction();
 
@@ -32,6 +32,8 @@ public:
     void set_name(const FlyString& name) { m_name = name; };
 
     void set_is_class_constructor() { m_is_class_constructor = true; };
+
+    auto& bytecode_executable() const { return m_bytecode_executable; }
 
 protected:
     virtual bool is_strict_mode() const final { return m_is_strict; }
@@ -51,6 +53,7 @@ private:
     Optional<Bytecode::Executable> m_bytecode_executable;
     ScopeObject* m_parent_scope { nullptr };
     i32 m_function_length { 0 };
+    bool m_is_generator { false };
     bool m_is_strict { false };
     bool m_is_arrow_function { false };
     bool m_is_class_constructor { false };

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
@@ -49,7 +49,7 @@ void GlobalEventHandlers::set_event_handler_attribute(const FlyString& name, HTM
             dbgln("Failed to parse script in event handler attribute '{}'", name);
             return;
         }
-        auto* function = JS::ScriptFunction::create(self.script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, false, false);
+        auto* function = JS::ScriptFunction::create(self.script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, false, false, false);
         VERIFY(function);
         listener = adopt_ref(*new DOM::EventListener(JS::make_handle(static_cast<JS::Function*>(function))));
     }

--- a/Userland/Libraries/LibWeb/HTML/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WebSocket.cpp
@@ -246,7 +246,7 @@ void WebSocket::set_event_handler_attribute(const FlyString& name, HTML::EventHa
             dbgln("Failed to parse script in event handler attribute '{}'", name);
             return;
         }
-        auto* function = JS::ScriptFunction::create(script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, false, false);
+        auto* function = JS::ScriptFunction::create(script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, false, false, false);
         VERIFY(function);
         listener = adopt_ref(*new DOM::EventListener(JS::make_handle(static_cast<JS::Function*>(function))));
     }


### PR DESCRIPTION
- **LibJS: Automatically split linear bytecode into multiple blocks**
All your basic block size limit concerns should now be gone!
Generate _all_ the linear code :^)
- **LibJS: Resolve the `this` value in call expression bytecode**
I wanted `gen.next()` to work.
- **LibJS: Implement generator functions (only in bytecode mode)**
This simply `TODO()`'s in non-bytecode mode, which is likely going to convert some "cannot parse"'s to ":yaksplode:"'s in test262.