### PR TITLE
LibWeb: Set a detach key for ArrayBuffers returned from WASM

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -37,4 +37,10 @@ ArrayBuffer::~ArrayBuffer()
 {
 }
 
+void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
+{
+    Object::visit_edges(visitor);
+    visitor.visit(m_detach_key);
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -28,10 +28,14 @@ public:
     const ByteBuffer& buffer() const { return buffer_impl(); }
 
     Value detach_key() const { return m_detach_key; }
+    void set_detach_key(Value detach_key) { m_detach_key = detach_key; }
+
     void detach_buffer() { m_buffer = Empty {}; }
     bool is_detached() const { return m_buffer.has<Empty>(); }
 
 private:
+    virtual void visit_edges(Visitor&) override;
+
     ByteBuffer& buffer_impl()
     {
         ByteBuffer* ptr { nullptr };

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -441,7 +441,9 @@ JS_DEFINE_NATIVE_GETTER(WebAssemblyMemoryObject::buffer)
     if (!memory)
         return JS::js_undefined();
 
-    return JS::ArrayBuffer::create(global_object, &memory->data());
+    auto array_buffer = JS::ArrayBuffer::create(global_object, &memory->data());
+    array_buffer->set_detach_key(JS::js_string(vm, "WebAssembly.Memory"));
+    return array_buffer;
 }
 
 }


### PR DESCRIPTION
As required by the specification:
`Set buffer.[[ArrayBufferDetachKey]] to "WebAssembly.Memory".`