### PR TITLE
Kernel: Increase m_bytes_out only once during transmission

### DIFF
--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -42,7 +42,6 @@ void NetworkAdapter::send(const MACAddress& destination, const ARPPacket& packet
     eth->set_source(mac_address());
     eth->set_destination(destination);
     eth->set_ether_type(EtherType::ARP);
-    m_bytes_out += size_in_bytes;
     memcpy(eth->payload(), &packet, sizeof(ARPPacket));
     send_packet({ (const u8*)eth, size_in_bytes });
 }


### PR DESCRIPTION
We were accidentally increasing m_bytes_out by the packet size and then immediately calling send_packet(), which did the same thing as well.