### PR TITLE
LibJS: Use an enum class instead of 'bool is_generator'

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -100,7 +100,7 @@ Value FunctionDeclaration::execute(Interpreter& interpreter, GlobalObject&) cons
 Value FunctionExpression::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
-    return ScriptFunction::create(global_object, name(), body(), parameters(), function_length(), interpreter.current_scope(), is_generator(), is_strict_mode() || interpreter.vm().in_strict_mode(), is_arrow_function());
+    return ScriptFunction::create(global_object, name(), body(), parameters(), function_length(), interpreter.current_scope(), kind(), is_strict_mode() || interpreter.vm().in_strict_mode(), is_arrow_function());
 }
 
 Value ExpressionStatement::execute(Interpreter& interpreter, GlobalObject& global_object) const
@@ -1157,7 +1157,7 @@ void BindingPattern::dump(int indent) const
 void FunctionNode::dump(int indent, String const& class_name) const
 {
     print_indent(indent);
-    outln("{}{} '{}'", class_name, m_is_generator ? "*" : "", name());
+    outln("{}{} '{}'", class_name, m_kind == FunctionKind::Generator ? "*" : "", name());
     if (!m_parameters.is_empty()) {
         print_indent(indent + 1);
         outln("(Parameters)");

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -26,6 +26,11 @@ class VariableDeclaration;
 class FunctionDeclaration;
 class Identifier;
 
+enum class FunctionKind {
+    Generator,
+    Regular,
+};
+
 template<class T, class... Args>
 static inline NonnullRefPtr<T>
 create_ast_node(SourceRange range, Args&&... args)
@@ -228,16 +233,16 @@ public:
     i32 function_length() const { return m_function_length; }
     bool is_strict_mode() const { return m_is_strict_mode; }
     bool is_arrow_function() const { return m_is_arrow_function; }
-    bool is_generator() const { return m_is_generator; }
+    FunctionKind kind() const { return m_kind; }
 
 protected:
-    FunctionNode(FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode, bool is_arrow_function)
+    FunctionNode(FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, FunctionKind kind, bool is_strict_mode, bool is_arrow_function)
         : m_name(name)
         , m_body(move(body))
         , m_parameters(move(parameters))
         , m_variables(move(variables))
         , m_function_length(function_length)
-        , m_is_generator(is_generator)
+        , m_kind(kind)
         , m_is_strict_mode(is_strict_mode)
         , m_is_arrow_function(is_arrow_function)
     {
@@ -260,7 +265,7 @@ private:
     Vector<Parameter> const m_parameters;
     NonnullRefPtrVector<VariableDeclaration> m_variables;
     const i32 m_function_length;
-    bool m_is_generator;
+    FunctionKind m_kind;
     bool m_is_strict_mode;
     bool m_is_arrow_function { false };
 };
@@ -271,9 +276,9 @@ class FunctionDeclaration final
 public:
     static bool must_have_name() { return true; }
 
-    FunctionDeclaration(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode = false)
+    FunctionDeclaration(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, FunctionKind kind, bool is_strict_mode = false)
         : Declaration(move(source_range))
-        , FunctionNode(name, move(body), move(parameters), function_length, move(variables), is_generator, is_strict_mode, false)
+        , FunctionNode(name, move(body), move(parameters), function_length, move(variables), kind, is_strict_mode, false)
     {
     }
 
@@ -288,9 +293,9 @@ class FunctionExpression final
 public:
     static bool must_have_name() { return false; }
 
-    FunctionExpression(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_generator, bool is_strict_mode, bool is_arrow_function = false)
+    FunctionExpression(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, FunctionKind kind, bool is_strict_mode, bool is_arrow_function = false)
         : Expression(source_range)
-        , FunctionNode(name, move(body), move(parameters), function_length, move(variables), is_generator, is_strict_mode, is_arrow_function)
+        , FunctionNode(name, move(body), move(parameters), function_length, move(variables), kind, is_strict_mode, is_arrow_function)
     {
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -218,7 +218,7 @@ void Call::execute(Bytecode::Interpreter& interpreter) const
 void NewFunction::execute(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    interpreter.accumulator() = ScriptFunction::create(interpreter.global_object(), m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.is_generator(), m_function_node.is_strict_mode(), m_function_node.is_arrow_function());
+    interpreter.accumulator() = ScriptFunction::create(interpreter.global_object(), m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.kind(), m_function_node.is_strict_mode(), m_function_node.is_arrow_function());
 }
 
 void Return::execute(Bytecode::Interpreter& interpreter) const

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -79,7 +79,7 @@ void Interpreter::enter_scope(const ScopeNode& scope_node, ScopeType scope_type,
 {
     ScopeGuard guard([&] {
         for (auto& declaration : scope_node.functions()) {
-            auto* function = ScriptFunction::create(global_object, declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), current_scope(), declaration.is_generator(), declaration.is_strict_mode());
+            auto* function = ScriptFunction::create(global_object, declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), current_scope(), declaration.kind(), declaration.is_strict_mode());
             vm().set_variable(declaration.name(), function, global_object);
         }
     });

--- a/Userland/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -16,9 +16,9 @@ class ScriptFunction final : public Function {
     JS_OBJECT(ScriptFunction, Function);
 
 public:
-    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, bool is_generator, bool is_strict, bool is_arrow_function = false);
+    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, FunctionKind, bool is_strict, bool is_arrow_function = false);
 
-    ScriptFunction(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, Object& prototype, bool is_generator, bool is_strict, bool is_arrow_function = false);
+    ScriptFunction(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, ScopeObject* parent_scope, Object& prototype, FunctionKind, bool is_strict, bool is_arrow_function = false);
     virtual void initialize(GlobalObject&) override;
     virtual ~ScriptFunction();
 
@@ -53,7 +53,7 @@ private:
     Optional<Bytecode::Executable> m_bytecode_executable;
     ScopeObject* m_parent_scope { nullptr };
     i32 m_function_length { 0 };
-    bool m_is_generator { false };
+    FunctionKind m_kind { FunctionKind::Regular };
     bool m_is_strict { false };
     bool m_is_arrow_function { false };
     bool m_is_class_constructor { false };

--- a/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/GlobalEventHandlers.cpp
@@ -49,7 +49,7 @@ void GlobalEventHandlers::set_event_handler_attribute(const FlyString& name, HTM
             dbgln("Failed to parse script in event handler attribute '{}'", name);
             return;
         }
-        auto* function = JS::ScriptFunction::create(self.script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, false, false, false);
+        auto* function = JS::ScriptFunction::create(self.script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, JS::FunctionKind::Regular, false, false);
         VERIFY(function);
         listener = adopt_ref(*new DOM::EventListener(JS::make_handle(static_cast<JS::Function*>(function))));
     }

--- a/Userland/Libraries/LibWeb/HTML/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WebSocket.cpp
@@ -246,7 +246,7 @@ void WebSocket::set_event_handler_attribute(const FlyString& name, HTML::EventHa
             dbgln("Failed to parse script in event handler attribute '{}'", name);
             return;
         }
-        auto* function = JS::ScriptFunction::create(script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, false, false, false);
+        auto* function = JS::ScriptFunction::create(script_execution_context()->interpreter().global_object(), name, program->body(), program->parameters(), program->function_length(), nullptr, JS::FunctionKind::Regular, false, false);
         VERIFY(function);
         listener = adopt_ref(*new DOM::EventListener(JS::make_handle(static_cast<JS::Function*>(function))));
     }


### PR DESCRIPTION
This avoid confusion in the order of the multiple boolean parameters
that exist.