### PR TITLE
LibJS: Add bytecode generation for function expressions

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -222,6 +222,8 @@ public:
         bool is_rest { false };
     };
 
+    virtual ~FunctionNode() { }
+
     FlyString const& name() const { return m_name; }
     Statement const& body() const { return *m_body; }
     Vector<Parameter> const& parameters() const { return m_parameters; };
@@ -294,6 +296,7 @@ public:
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual void generate_bytecode(Bytecode::Generator&) const override;
 
     void set_name_if_possible(FlyString new_name)
     {
@@ -305,6 +308,8 @@ public:
     }
     bool cannot_auto_rename() const { return m_cannot_auto_rename; }
     void set_cannot_auto_rename() { m_cannot_auto_rename = true; }
+
+    bool is_arrow_function() const { return m_is_arrow_function; }
 
 private:
     bool m_cannot_auto_rename { false };

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -605,6 +605,11 @@ void FunctionDeclaration::generate_bytecode(Bytecode::Generator&) const
 {
 }
 
+void FunctionExpression::generate_bytecode(Bytecode::Generator& generator) const
+{
+    generator.emit<Bytecode::Op::NewFunction>(*this);
+}
+
 void VariableDeclaration::generate_bytecode(Bytecode::Generator& generator) const
 {
     for (auto& declarator : m_declarations) {

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -218,7 +218,13 @@ void Call::execute(Bytecode::Interpreter& interpreter) const
 void NewFunction::execute(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    interpreter.accumulator() = ScriptFunction::create(interpreter.global_object(), m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.is_generator(), m_function_node.is_strict_mode());
+
+    if (!is<FunctionExpression>(m_function_node)) {
+        interpreter.accumulator() = ScriptFunction::create(interpreter.global_object(), m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.is_generator(), m_function_node.is_strict_mode());
+    } else {
+        auto& function_expression_node = downcast<FunctionExpression>(m_function_node);
+        interpreter.accumulator() = ScriptFunction::create(interpreter.global_object(), m_function_node.name(), m_function_node.body(), m_function_node.parameters(), m_function_node.function_length(), vm.current_scope(), m_function_node.is_generator(), m_function_node.is_strict_mode() || vm.in_strict_mode(), function_expression_node.is_arrow_function());
+    }
 }
 
 void Return::execute(Bytecode::Interpreter& interpreter) const


### PR DESCRIPTION
FunctionExpression inherits FunctionNode, so we can pass it straight
into the NewFunction op.

However, FunctionExpressions have slightly different semantics.
To implement them, a virtual destructor was added to FunctionNode
to make it polymorphic, allowing is<> and downcast<> to work.