### PR TITLE
Kernel: Block writes while we're establishing the TCP connection

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -584,6 +584,9 @@ bool TCPSocket::can_write(const FileDescription& file_description, size_t size) 
     if (!IPv4Socket::can_write(file_description, size))
         return false;
 
+    if (m_state == State::SynSent || m_state == State::SynReceived)
+        return false;
+
     if (!file_description.is_blocking())
         return true;
 


### PR DESCRIPTION
Previously we would not block the caller until the connection was established and would instead return `EPIPE` for the first `send()` call which then likely caused the caller to abandon the socket.

This was broken by 0625342.