### PR TITLE
Kernel: Enable VERIFY() checks even if the DEBUG macro is not defined

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -2402,7 +2402,6 @@ void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_regs, con
 }
 }
 
-#ifdef DEBUG
 void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func)
 {
     asm volatile("cli");
@@ -2411,7 +2410,6 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
 
     abort();
 }
-#endif
 
 [[noreturn]] void abort()
 {

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -2413,7 +2413,6 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
 
 [[noreturn]] void abort()
 {
-#ifdef DEBUG
     // Switch back to the current process's page tables if there are any.
     // Otherwise stack walking will be a disaster.
     auto process = Process::current();
@@ -2422,7 +2421,6 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
 
     Kernel::dump_backtrace();
     Processor::halt();
-#endif
 
     abort();
 }

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -9,14 +9,9 @@
 #define __STRINGIFY_HELPER(x) #x
 #define __STRINGIFY(x) __STRINGIFY_HELPER(x)
 
-#ifdef DEBUG
 [[noreturn]] void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func);
-#    define VERIFY(expr) (static_cast<bool>(expr) ? void(0) : __assertion_failed(#    expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
-#    define VERIFY_NOT_REACHED() VERIFY(false)
-#else
-#    define VERIFY(expr)
-#    define VERIFY_NOT_REACHED() _abort()
-#endif
+#define VERIFY(expr) (static_cast<bool>(expr) ? void(0) : __assertion_failed(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#define VERIFY_NOT_REACHED() VERIFY(false)
 
 extern "C" {
 [[noreturn]] void _abort();


### PR DESCRIPTION
**Kernel: Enable VERIFY() checks even if the DEBUG macro is not defined**

Fixes #7910.

**Kernel: Print stack traces for crashes in release builds**

Previously we'd just reset the CPU and reboot.