### PR TITLE
Revert "Meta: Use Intel 82574 instead of Intel 82540 in the run script"

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -109,7 +109,7 @@ elif [ "$SERENITY_RUN" = "qn" ]; then
     # Meta/run.sh qn: qemu without network
     "$SERENITY_QEMU_BIN" \
         $SERENITY_COMMON_QEMU_ARGS \
-        -device e1000e \
+        -device e1000 \
         -kernel Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
 elif [ "$SERENITY_RUN" = "qtap" ]; then
@@ -121,7 +121,7 @@ elif [ "$SERENITY_RUN" = "qtap" ]; then
         $SERENITY_VIRT_TECH_ARG \
         $SERENITY_PACKET_LOGGING_ARG \
         -netdev tap,ifname=tap0,id=br0 \
-        -device e1000e,netdev=br0 \
+        -device e1000,netdev=br0 \
         -kernel Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
     sudo ip tuntap del dev tap0 mode tap
@@ -132,7 +132,7 @@ elif [ "$SERENITY_RUN" = "qgrub" ]; then
         $SERENITY_VIRT_TECH_ARG \
         $SERENITY_PACKET_LOGGING_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
-        -device e1000e,netdev=breh
+        -device e1000,netdev=breh
 elif [ "$SERENITY_RUN" = "q35_cmd" ]; then
     # Meta/run.sh q35_cmd: qemu (q35 chipset) with SerenityOS with custom commandline
     shift
@@ -142,7 +142,7 @@ elif [ "$SERENITY_RUN" = "q35_cmd" ]; then
         $SERENITY_COMMON_QEMU_Q35_ARGS \
         $SERENITY_VIRT_TECH_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
-        -device e1000e,netdev=breh \
+        -device e1000,netdev=breh \
         -kernel Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
 elif [ "$SERENITY_RUN" = "qcmd" ]; then
@@ -154,7 +154,7 @@ elif [ "$SERENITY_RUN" = "qcmd" ]; then
         $SERENITY_COMMON_QEMU_ARGS \
         $SERENITY_VIRT_TECH_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
-        -device e1000e,netdev=breh \
+        -device e1000,netdev=breh \
         -kernel Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
 elif [ "$SERENITY_RUN" = "ci" ]; then
@@ -180,7 +180,7 @@ else
         $SERENITY_VIRT_TECH_ARG \
         $SERENITY_PACKET_LOGGING_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23,hostfwd=tcp:127.0.0.1:8000-10.0.2.15:8000,hostfwd=tcp:127.0.0.1:2222-10.0.2.15:22 \
-        -device e1000e,netdev=breh \
+        -device e1000,netdev=breh \
         -kernel Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
 fi


### PR DESCRIPTION
With the e1000e patch applied QEMU networking doesn't work for me, e.g. ping doesn't get responses in time:

![image](https://user-images.githubusercontent.com/388571/121645439-7f05f700-ca94-11eb-9a77-26a4c5056983.png)

cc @supercomputer7 