### PR TITLE
Kernel: Use m_inode to stat in FileDescription::stat() if available

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -110,6 +110,9 @@ Thread::FileBlocker::BlockFlags FileDescription::should_unblock(Thread::FileBloc
 KResult FileDescription::stat(::stat& buffer)
 {
     Locker locker(m_lock);
+    // FIXME: This is due to the Device class not overriding File::stat().
+    if (m_inode)
+        return m_inode->metadata().stat(buffer);
     return m_file->stat(buffer);
 }
 


### PR DESCRIPTION
This is necessary since the `Device` class does not hold a reference to its inode (because there could be multiple), and thus doesn't override `File::stat()`. For simplicity, we should just always stat via the inode if there is one, since that shouldn't ever be the wrong thing.

This partially reverts #7867, which only implemented the functionality for `InodeFile` and ignored `Device`. Since it's non-trivial to fix, I have re-implemented the workaround we used beforehand. This fixes the `fstat` system call for device files, which was broken since #7867 was merged. Sorry about that :^)