### PR TITLE
LibC: Improve `strerror` and `strerror_r`

### DIFF
--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -357,7 +357,7 @@ int sys_nerr = EMAXERRNO;
 int strerror_r(int errnum, char* buf, size_t buflen)
 {
     auto saved_errno = errno;
-    if (errnum >= EMAXERRNO) {
+    if (errnum < 0 || errnum >= EMAXERRNO) {
         auto rc = strlcpy(buf, "unknown error", buflen);
         if (rc >= buflen)
             dbgln("strerror_r(): Invalid error number '{}' specified and the output buffer is too small.", errnum);

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -377,7 +377,6 @@ int strerror_r(int errnum, char* buf, size_t buflen)
 char* strerror(int errnum)
 {
     if (errnum < 0 || errnum >= EMAXERRNO) {
-        dbgln("strerror() missing string for errnum={}", errnum);
         return const_cast<char*>("Unknown error");
     }
     return const_cast<char*>(sys_errlist[errnum]);


### PR DESCRIPTION
* `strerror_r`: fail if `errnum` is less than 0 - this mimics the behavior of `strerror`
* `strerror`: prevent debug spam; some applications like `openssl` like to map out the entire error range and cause a lot of debug lines