### PR TITLE
AutocompleteBox: Enable hover over

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1358,10 +1358,6 @@ void TextEditor::leave_event(Core::Event&)
 {
     if (m_in_drag_select)
         m_automatic_selection_scroll_timer->start();
-    if (m_autocomplete_timer)
-        m_autocomplete_timer->stop();
-    if (m_autocomplete_box)
-        m_autocomplete_box->close();
 }
 
 void TextEditor::did_change()

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1397,6 +1397,10 @@ void WindowManager::set_active_window(Window* window, bool make_input)
     auto* previously_active_window = m_active_window.ptr();
 
     if (previously_active_window) {
+        for (auto& child_window : previously_active_window->child_windows()) {
+            if (child_window && child_window->type() == WindowType::Tooltip)
+                child_window->request_close();
+        }
         Core::EventLoop::current().post_event(*previously_active_window, make<Event>(Event::WindowDeactivated));
         previously_active_window->invalidate(true, true);
         m_active_window = nullptr;


### PR DESCRIPTION
Enables hovering over the autocomplete_box and also closes it when the parent_window is deactivated.
Fixes #7165 . This is my first PR and thanks to @alimpfard, @gunnarbeutner and others for the help at Discord, and not to mention @AnandBaburajan for helping me to get my first PR open.