### PR TITLE
Solitaire: Correct scoring issues and invisible cards

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -139,7 +139,7 @@ void Game::start_timer_if_necessary()
     }
 }
 
-void Game::score_move(CardStack& from, CardStack& to, bool inverse = false)
+void Game::score_move(CardStack& from, CardStack& to, bool inverse)
 {
     if (from.type() == CardStack::Type::Play && to.type() == CardStack::Type::Normal) {
         update_score(5 * (inverse ? -1 : 1));
@@ -150,6 +150,11 @@ void Game::score_move(CardStack& from, CardStack& to, bool inverse = false)
     } else if (from.type() == CardStack::Type::Foundation && to.type() == CardStack::Type::Normal) {
         update_score(-15 * (inverse ? -1 : 1));
     }
+}
+
+void Game::score_flip(bool inverse)
+{
+    update_score(5 * (inverse ? -1 : 1));
 }
 
 void Game::update_score(int to_add)
@@ -200,7 +205,7 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                 if (top_card.is_upside_down()) {
                     if (top_card.rect().contains(click_location)) {
                         top_card.set_upside_down(false);
-                        update_score(5);
+                        score_flip();
                         update(top_card.rect());
                         remember_flip_for_undo(top_card);
                     }
@@ -600,6 +605,7 @@ void Game::perform_undo()
         if (on_undo_availability_change)
             on_undo_availability_change(false);
         invalidate_layout();
+        score_flip(true);
         return;
     }
 

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -338,13 +338,12 @@ void Game::move_card(CardStack& from, CardStack& to)
 
     auto card = from.pop();
 
-    card->set_moving(true);
-    m_focused_cards.clear();
-    m_focused_cards.append(card);
     mark_intersecting_stacks_dirty(card);
     to.push(card);
 
-    remember_move_for_undo(from, to, m_focused_cards);
+    NonnullRefPtrVector<Card> moved_card;
+    moved_card.append(card);
+    remember_move_for_undo(from, to, moved_card);
 
     score_move(from, to);
 

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -326,8 +326,6 @@ void Game::doubleclick_event(GUI::MouseEvent& event)
                         to_check.push(move(card));
                     }
                 }
-
-                update_score(10);
             }
             break;
         }
@@ -359,6 +357,8 @@ void Game::move_card(CardStack& from, CardStack& to)
     to.push(card);
 
     remember_move_for_undo(from, to, m_focused_cards);
+
+    score_move(from, to);
 
     update(to.bounding_box());
 }

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -163,7 +164,8 @@ private:
     void move_card(CardStack& from, CardStack& to);
     void draw_cards();
     void pop_waste_to_play_stack();
-    void auto_move_eligible_cards_to_stacks();
+    bool attempt_to_move_card_to_foundations(CardStack& from);
+    void auto_move_eligible_cards_to_foundations();
     void start_timer_if_necessary();
     void start_game_over_animation();
     void stop_game_over_animation();

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -137,6 +137,7 @@ private:
         __Count
     };
     static constexpr Array piles = { Pile1, Pile2, Pile3, Pile4, Pile5, Pile6, Pile7 };
+    static constexpr Array foundations = { Foundation1, Foundation2, Foundation3, Foundation4 };
 
     ALWAYS_INLINE const WasteRecycleRules& recycle_rules()
     {
@@ -161,7 +162,6 @@ private:
     void remember_move_for_undo(CardStack& from, CardStack& to, NonnullRefPtrVector<Card> moved_cards);
     void remember_flip_for_undo(Card& card);
     void update_score(int to_add);
-    void move_card(CardStack& from, CardStack& to);
     void draw_cards();
     void pop_waste_to_play_stack();
     bool attempt_to_move_card_to_foundations(CardStack& from);

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -155,7 +155,8 @@ private:
     }
 
     void mark_intersecting_stacks_dirty(Card& intersecting_card);
-    void score_move(CardStack& from, CardStack& to, bool inverse);
+    void score_move(CardStack& from, CardStack& to, bool inverse = false);
+    void score_flip(bool inverse = false);
     void remember_move_for_undo(CardStack& from, CardStack& to, NonnullRefPtrVector<Card> moved_cards);
     void remember_flip_for_undo(Card& card);
     void update_score(int to_add);


### PR DESCRIPTION
We were not updating the score correctly in a couple of places:
- Undoing a FlipCard move
- Anything done by auto_move_eligible_cards_to_stacks()

FlipCard scoring is now handled by score_flip(), which imitates score_move().

Auto-moves using <tab> and those done with double-click now use the same code path to hopefully make them less error-prone.

This fixes #7991 too, where an auto-move that affected multiple cards would leave all the moved cards except the last one invisible.