### PR TITLE
LibJS: Parse only AssignmentExpressions in ComputedPropertyNames

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -783,7 +783,7 @@ NonnullRefPtr<Expression> Parser::parse_property_key()
         return create_ast_node<BigIntLiteral>({ m_parser_state.m_current_token.filename(), rule_start.position(), position() }, consume().value());
     } else if (match(TokenType::BracketOpen)) {
         consume(TokenType::BracketOpen);
-        auto result = parse_expression(0);
+        auto result = parse_expression(2);
         consume(TokenType::BracketClose);
         return result;
     } else {


### PR DESCRIPTION
The property name in an object literal can either be a literal or a computed name, in which case any AssignmentExpression can be used, we now only parse AssignmentExpression instead of the previous incorrect behaviour which allowed any Expression (Specifically, comma expressions).