### PR TITLE
Base: Add Sectigo certs to ca_certs.ini

### DIFF
--- a/Base/etc/ca_certs.ini
+++ b/Base/etc/ca_certs.ini
@@ -313,6 +313,15 @@ country=US
 [SZAFIR ROOT CA2]
 country=PL
 
+[Sectigo RSA Domain Validation Secure Server CA]
+country=US
+
+[Sectigo RSA Extended Validation Secure Server CA]
+country=US
+
+[Sectigo RSA Organization Validation Secure Server CA]
+country=US
+
 [SecureSign RootCA11]
 country=JP
 


### PR DESCRIPTION
Adds Sectigo RSA Domain, Extended, and Organization cert subjects to ca_certs.ini. These are the new names for the old Comodo CA certs that are already trusted.

More information: https://sectigostore.com/page/sectigo-rsa-domain-validation-secure-server-ca/