### PR TITLE
HackStudio: Remove unnecessary unveil in ShellLanguageServer

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
@@ -47,8 +47,10 @@ int mode_server()
         return 1;
     }
 
-    if (unveil("/usr/include", "r") < 0)
+    if (unveil("/usr/include", "r") < 0) {
         perror("unveil");
+        return 1;
+    }
 
     // unveil will be sealed later, when we know the project's root path.
     return event_loop.exec();

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
@@ -31,9 +31,6 @@ int main(int, char**)
         perror("unveil");
         return 1;
     }
-    if (unveil("/", "b") < 0) {
-        perror("unveil");
-        return 1;
-    }
+
     return event_loop.exec();
 }


### PR DESCRIPTION
Remove unveil for `/` with only browse permissions that was causing application freeze upon opening .sh file with `/` as project root. This unveil call was unnecessary since the unveil is sealed subsequently in `ClientConnection::greet()` once the project root is known. 

Fixes https://github.com/SerenityOS/serenity/issues/7971