### PR TITLE
HackStudio: Add "Show in File Manager" Action to project TreeView

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -31,6 +31,7 @@
 #include <LibCore/File.h>
 #include <LibCore/FileWatcher.h>
 #include <LibDebug/DebugSession.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
@@ -311,12 +312,14 @@ void HackStudioWidget::set_edit_mode(EditMode mode)
 NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu()
 {
     m_open_selected_action = create_open_selected_action();
+    m_show_in_file_manager_action = create_show_in_file_manager_action();
     m_new_file_action = create_new_file_action();
     m_new_directory_action = create_new_directory_action();
     m_delete_action = create_delete_action();
     auto project_tree_view_context_menu = GUI::Menu::construct("Project Files");
     project_tree_view_context_menu->add_action(*m_open_selected_action);
-    // TODO: Rename, cut, copy, duplicate with new name, show containing folder ...
+    project_tree_view_context_menu->add_action(*m_show_in_file_manager_action);
+    // TODO: Rename, cut, copy, duplicate with new name...
     project_tree_view_context_menu->add_separator();
     project_tree_view_context_menu->add_action(*m_new_file_action);
     project_tree_view_context_menu->add_action(*m_new_directory_action);
@@ -401,6 +404,19 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
     });
     open_selected_action->set_enabled(true);
     return open_selected_action;
+}
+
+NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action()
+{
+    auto show_in_file_manager_action = GUI::Action::create("Show in File Manager", [this](const GUI::Action&) {
+        auto files = selected_file_paths();
+        for (auto& file : files)
+            Desktop::Launcher::open(URL::create_with_file_protocol(m_project->root_path(), file));
+    });
+    show_in_file_manager_action->set_enabled(true);
+    show_in_file_manager_action->set_icon(GUI::Icon::default_icon("app-file-manager").bitmap_for_size(16));
+
+    return show_in_file_manager_action;
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -81,6 +81,7 @@ private:
     NonnullRefPtr<GUI::Action> create_remove_current_editor_action();
     NonnullRefPtr<GUI::Action> create_open_action();
     NonnullRefPtr<GUI::Action> create_save_action();
+    NonnullRefPtr<GUI::Action> create_show_in_file_manager_action();
     NonnullRefPtr<GUI::Action> create_add_editor_action();
     NonnullRefPtr<GUI::Action> create_add_terminal_action();
     NonnullRefPtr<GUI::Action> create_remove_current_terminal_action();
@@ -150,6 +151,7 @@ private:
     RefPtr<GUI::Action> m_new_file_action;
     RefPtr<GUI::Action> m_new_directory_action;
     RefPtr<GUI::Action> m_open_selected_action;
+    RefPtr<GUI::Action> m_show_in_file_manager_action;
     RefPtr<GUI::Action> m_delete_action;
     RefPtr<GUI::Action> m_new_project_action;
     RefPtr<GUI::Action> m_switch_to_next_editor;


### PR DESCRIPTION
This shows all selected inodes in their parent directory.

Currently, each selection makes a seperate call to LaunchServer
and opens a seperate FileManager window. In the future selections
with a shared parent could share windows.
