### PR TITLE
2048: Fix move success detection

### DIFF
--- a/Userland/Games/2048/Game.cpp
+++ b/Userland/Games/2048/Game.cpp
@@ -187,7 +187,6 @@ static size_t get_number_of_free_cells(Game::Board const& board)
 Game::Board::SlideResult Game::Board::slide_tiles(Direction direction)
 {
     size_t successful_merge_score = 0;
-    Tiles new_tiles;
 
     switch (direction) {
     case Direction::Left:
@@ -215,7 +214,11 @@ Game::Board::SlideResult Game::Board::slide_tiles(Direction direction)
         break;
     }
 
-    bool moved = new_tiles != m_tiles;
+    bool moved = false;
+    for (auto& t : m_sliding_tiles) {
+        if (t.row_from != t.row_to || t.column_from != t.column_to)
+            moved = true;
+    }
 
     return { moved, successful_merge_score };
 }


### PR DESCRIPTION
Whether or not tiles moved used to be determined by comparing new_tiles
with m_tiles. This is no longer possible since the slide is done
in-place.

This fix makes the game look through the m_sliding_tiles, which contains
previous and current position for each tile on the board, to determine
whether any tile moved at all. If not, the move is deemed unsuccessful.