### PR TITLE
LibJS: Expose Symbol.species properties as getters 

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -26,7 +26,7 @@ void ArrayBufferConstructor::initialize(GlobalObject& global_object)
     define_property(vm.names.length, Value(1), Attribute::Configurable);
     define_native_function(vm.names.isView, is_view, 1, attr);
 
-    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 ArrayBufferConstructor::~ArrayBufferConstructor()

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -38,7 +38,7 @@ void ArrayConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.isArray, is_array, 1, attr);
     define_native_function(vm.names.of, of, 0, attr);
 
-    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 Value ArrayConstructor::call()

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -95,6 +95,7 @@ public:
 
     bool define_native_function(const StringOrSymbol& property_name, AK::Function<Value(VM&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
     bool define_native_property(const StringOrSymbol& property_name, AK::Function<Value(VM&, GlobalObject&)> getter, AK::Function<void(VM&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);
+    bool define_native_accessor(StringOrSymbol const& property_name, AK::Function<Value(VM&, GlobalObject&)> getter, AK::Function<Value(VM&, GlobalObject&)> setter, PropertyAttributes attributes = default_attributes);
 
     void define_properties(Value properties);
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -36,7 +36,7 @@ void PromiseConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.reject, reject, 1, attr);
     define_native_function(vm.names.resolve, resolve, 1, attr);
 
-    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 Value PromiseConstructor::call()

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -23,7 +23,7 @@ void RegExpConstructor::initialize(GlobalObject& global_object)
     define_property(vm.names.prototype, global_object.regexp_prototype(), 0);
     define_property(vm.names.length, Value(2), Attribute::Configurable);
 
-    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 RegExpConstructor::~RegExpConstructor()

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -24,7 +24,7 @@ void SetConstructor::initialize(GlobalObject& global_object)
     define_property(vm.names.prototype, global_object.set_prototype(), 0);
     define_property(vm.names.length, Value(0), Attribute::Configurable);
 
-    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 SetConstructor::~SetConstructor()

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -26,7 +26,7 @@ void TypedArrayConstructor::initialize(GlobalObject& global_object)
     define_property(vm.names.prototype, global_object.typed_array_prototype(), 0);
     define_property(vm.names.length, Value(0), Attribute::Configurable);
 
-    define_native_property(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }
 
 TypedArrayConstructor::~TypedArrayConstructor()


### PR DESCRIPTION
This fixes 24 test262 test cases.

NOTE: The implementation for define_native_accessor feels a bit slimy to me, but i couldn't think of a much better way of doing it.