### PR TITLE
AK: Reimplement any_of in terms of find_if

### DIFF
--- a/AK/AnyOf.h
+++ b/AK/AnyOf.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Find.h>
 #include <AK/Iterator.h>
 
 namespace AK {
@@ -16,12 +17,7 @@ constexpr bool any_of(
     const SimpleIterator<Container, ValueType>& end,
     const auto& predicate)
 {
-    for (auto iter = begin; iter != end; ++iter) {
-        if (predicate(*iter)) {
-            return true;
-        }
-    }
-    return false;
+    return find_if(begin, end, predicate) != end;
 }
 
 }


### PR DESCRIPTION
Problem:
- Now that a generic free-function form of `find_if` is implemented
  the code in `any_of` is redundant.

Solution:
- Follow the "don't repeat yourself" mantra and make the code DRY by
  implementing `any_of` in terms of `find_if`.