### PR TITLE
LibJS: Add the WeakRef built-in object

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -141,6 +141,8 @@ Value Interpreter::run(Executable const& executable, BasicBlock const* entry_poi
     if (vm().call_stack().size() == 1)
         vm().pop_call_frame();
 
+    vm().finish_execution_generation();
+
     return return_value;
 }
 

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -104,6 +104,9 @@ set(SOURCES
     Runtime/WeakMap.cpp
     Runtime/WeakMapConstructor.cpp
     Runtime/WeakMapPrototype.cpp
+    Runtime/WeakRef.cpp
+    Runtime/WeakRefConstructor.cpp
+    Runtime/WeakRefPrototype.cpp
     Runtime/WeakSet.cpp
     Runtime/WeakSetConstructor.cpp
     Runtime/WeakSetPrototype.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -42,6 +42,7 @@
     __JS_ENUMERATE(StringObject, string, StringPrototype, StringConstructor, void)                            \
     __JS_ENUMERATE(SymbolObject, symbol, SymbolPrototype, SymbolConstructor, void)                            \
     __JS_ENUMERATE(WeakMap, weak_map, WeakMapPrototype, WeakMapConstructor, void)                             \
+    __JS_ENUMERATE(WeakRef, weak_ref, WeakRefPrototype, WeakRefConstructor, void)                             \
     __JS_ENUMERATE(WeakSet, weak_set, WeakSetPrototype, WeakSetConstructor, void)
 
 #define JS_ENUMERATE_NATIVE_OBJECTS                 \

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -63,6 +63,8 @@ void Interpreter::run(GlobalObject& global_object, const Program& program)
     // At this point we may have already run any queued promise jobs via on_call_stack_emptied,
     // in which case this is a no-op.
     vm.run_queued_promise_jobs();
+
+    vm.finish_execution_generation();
 }
 
 GlobalObject& Interpreter::global_object()

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -137,6 +137,7 @@ namespace JS {
     P(getMonth)                              \
     P(getOwnPropertyDescriptor)              \
     P(getOwnPropertyNames)                   \
+    P(getOwnPropertySymbols)                 \
     P(getPrototypeOf)                        \
     P(getSeconds)                            \
     P(getTime)                               \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -93,6 +93,7 @@ namespace JS {
     P(defineProperties)                      \
     P(defineProperty)                        \
     P(deleteProperty)                        \
+    P(deref)                                 \
     P(description)                           \
     P(done)                                  \
     P(dotAll)                                \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -21,7 +21,6 @@
     M(ClassIsAbstract, "Abstract class {} cannot be constructed directly")                                                              \
     M(ConstructorWithoutNew, "{} constructor must be called with 'new'")                                                                \
     M(Convert, "Cannot convert {} to {}")                                                                                               \
-    M(ConvertUndefinedToObject, "Cannot convert undefined to object")                                                                   \
     M(DescChangeNonConfigurable, "Cannot change attributes of non-configurable property '{}'")                                          \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
     M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                                   \
@@ -59,7 +58,6 @@
     M(ObjectFreezeFailed, "Could not freeze object")                                                                                    \
     M(ObjectSealFailed, "Could not seal object")                                                                                        \
     M(ObjectSetPrototypeOfReturnedFalse, "Object's [[SetPrototypeOf]] method returned false")                                           \
-    M(ObjectSetPrototypeOfTwoArgs, "Object.setPrototypeOf requires at least two arguments")                                             \
     M(ObjectPreventExtensionsReturnedFalse, "Object's [[PreventExtensions]] method returned false")                                     \
     M(ObjectPrototypeNullOrUndefinedOnSuperPropertyAccess,                                                                              \
         "Object prototype must not be {} on a super property access")                                                                   \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -64,6 +64,8 @@
 #include <LibJS/Runtime/Value.h>
 #include <LibJS/Runtime/WeakMapConstructor.h>
 #include <LibJS/Runtime/WeakMapPrototype.h>
+#include <LibJS/Runtime/WeakRefConstructor.h>
+#include <LibJS/Runtime/WeakRefPrototype.h>
 #include <LibJS/Runtime/WeakSetConstructor.h>
 #include <LibJS/Runtime/WeakSetPrototype.h>
 
@@ -157,6 +159,7 @@ void GlobalObject::initialize_global_object()
     add_constructor(vm.names.String, m_string_constructor, m_string_prototype);
     add_constructor(vm.names.Symbol, m_symbol_constructor, m_symbol_prototype);
     add_constructor(vm.names.WeakMap, m_weak_map_constructor, m_weak_map_prototype);
+    add_constructor(vm.names.WeakRef, m_weak_ref_constructor, m_weak_ref_prototype);
     add_constructor(vm.names.WeakSet, m_weak_set_constructor, m_weak_set_prototype);
 
     initialize_constructor(vm.names.TypedArray, m_typed_array_constructor, m_typed_array_prototype);

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -68,8 +68,6 @@ Value ObjectConstructor::construct(Function&)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_own_property_names)
 {
-    if (!vm.argument_count())
-        return {};
     auto* object = vm.argument(0).to_object(global_object);
     if (vm.exception())
         return {};
@@ -78,8 +76,6 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_own_property_names)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_prototype_of)
 {
-    if (!vm.argument_count())
-        return {};
     auto* object = vm.argument(0).to_object(global_object);
     if (vm.exception())
         return {};
@@ -88,10 +84,6 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_prototype_of)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::set_prototype_of)
 {
-    if (vm.argument_count() < 2) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::ObjectSetPrototypeOfTwoArgs);
-        return {};
-    }
     auto* object = vm.argument(0).to_object(global_object);
     if (vm.exception())
         return {};
@@ -247,11 +239,6 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::is)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::keys)
 {
-    if (!vm.argument_count()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::ConvertUndefinedToObject);
-        return {};
-    }
-
     auto* obj_arg = vm.argument(0).to_object(global_object);
     if (vm.exception())
         return {};
@@ -261,10 +248,6 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::keys)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::values)
 {
-    if (!vm.argument_count()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::ConvertUndefinedToObject);
-        return {};
-    }
     auto* obj_arg = vm.argument(0).to_object(global_object);
     if (vm.exception())
         return {};
@@ -274,10 +257,6 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::values)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::entries)
 {
-    if (!vm.argument_count()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::ConvertUndefinedToObject);
-        return {};
-    }
     auto* obj_arg = vm.argument(0).to_object(global_object);
     if (vm.exception())
         return {};

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -33,6 +33,7 @@ void ObjectConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.is, is, 2, attr);
     define_native_function(vm.names.getOwnPropertyDescriptor, get_own_property_descriptor, 2, attr);
     define_native_function(vm.names.getOwnPropertyNames, get_own_property_names, 1, attr);
+    define_native_function(vm.names.getOwnPropertySymbols, get_own_property_symbols, 1, attr);
     define_native_function(vm.names.getPrototypeOf, get_prototype_of, 1, attr);
     define_native_function(vm.names.setPrototypeOf, set_prototype_of, 2, attr);
     define_native_function(vm.names.isExtensible, is_extensible, 1, attr);
@@ -72,6 +73,14 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_own_property_names)
     if (vm.exception())
         return {};
     return Array::create_from(global_object, object->get_own_properties(PropertyKind::Key, false, GetOwnPropertyReturnType::StringOnly));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_own_property_symbols)
+{
+    auto* object = vm.argument(0).to_object(global_object);
+    if (vm.exception())
+        return {};
+    return Array::create_from(global_object, object->get_own_properties(PropertyKind::Key, false, GetOwnPropertyReturnType::SymbolOnly));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_prototype_of)

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -30,6 +30,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(is);
     JS_DECLARE_NATIVE_FUNCTION(get_own_property_descriptor);
     JS_DECLARE_NATIVE_FUNCTION(get_own_property_names);
+    JS_DECLARE_NATIVE_FUNCTION(get_own_property_symbols);
     JS_DECLARE_NATIVE_FUNCTION(get_prototype_of);
     JS_DECLARE_NATIVE_FUNCTION(set_prototype_of);
     JS_DECLARE_NATIVE_FUNCTION(is_extensible);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -166,6 +166,9 @@ public:
     bool underscore_is_last_value() const { return m_underscore_is_last_value; }
     void set_underscore_is_last_value(bool b) { m_underscore_is_last_value = b; }
 
+    u32 execution_generation() const { return m_execution_generation; }
+    void finish_execution_generation() { ++m_execution_generation; }
+
     void unwind(ScopeType type, FlyString label = {})
     {
         m_unwind_until = type;
@@ -279,6 +282,8 @@ private:
     Shape* m_scope_object_shape { nullptr };
 
     bool m_underscore_is_last_value { false };
+
+    u32 m_execution_generation { 0 };
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/WeakContainer.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakContainer.h
@@ -19,12 +19,22 @@ public:
     }
     virtual ~WeakContainer()
     {
-        m_heap.did_destroy_weak_container({}, *this);
+        deregister();
     }
 
     virtual void remove_sweeped_cells(Badge<Heap>, Vector<Cell*>&) = 0;
 
+protected:
+    void deregister()
+    {
+        if (!m_registered)
+            return;
+        m_heap.did_destroy_weak_container({}, *this);
+        m_registered = false;
+    }
+
 private:
+    bool m_registered { true };
     Heap& m_heap;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/WeakRef.h>
+
+namespace JS {
+
+WeakRef* WeakRef::create(GlobalObject& global_object, Object* object)
+{
+    return global_object.heap().allocate<WeakRef>(global_object, *global_object.weak_ref_prototype(), object);
+}
+
+WeakRef::WeakRef(Object& prototype, Object* object)
+    : Object(prototype)
+    , WeakContainer(heap())
+    , m_value(object)
+    , m_last_execution_generation(vm().execution_generation())
+{
+}
+
+WeakRef::~WeakRef()
+{
+}
+
+void WeakRef::remove_sweeped_cells(Badge<Heap>, Vector<Cell*>& cells)
+{
+    VERIFY(m_value);
+    for (auto* cell : cells) {
+        if (m_value != cell)
+            continue;
+        m_value = nullptr;
+        // This is an optimization, we deregister from the garbage collector early (even if we were not garbage collected ourself yet)
+        // to reduce the garbage collection overhead, which we can do because a cleared weak ref cannot be reused.
+        WeakContainer::deregister();
+        break;
+    }
+}
+
+void WeakRef::visit_edges(Visitor& visitor)
+{
+    Object::visit_edges(visitor);
+
+    if (vm().execution_generation() == m_last_execution_generation)
+        visitor.visit(m_value);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/WeakContainer.h>
+
+namespace JS {
+
+class WeakRef final
+    : public Object
+    , public WeakContainer {
+    JS_OBJECT(WeakRef, Object);
+
+public:
+    static WeakRef* create(GlobalObject&, Object*);
+
+    explicit WeakRef(Object& prototype, Object*);
+    virtual ~WeakRef() override;
+
+    Object* value() const { return m_value; };
+
+    void update_execution_generation() { m_last_execution_generation = vm().execution_generation(); };
+
+    virtual void remove_sweeped_cells(Badge<Heap>, Vector<Cell*>&) override;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    Object* m_value { nullptr };
+    u32 m_last_execution_generation { 0 };
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS {
+
+class WeakRefConstructor final : public NativeFunction {
+    JS_OBJECT(WeakRefConstructor, NativeFunction);
+
+public:
+    explicit WeakRefConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~WeakRefConstructor() override;
+
+    virtual Value call() override;
+    virtual Value construct(Function&) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/WeakRefPrototype.h>
+
+namespace JS {
+
+WeakRefPrototype::WeakRefPrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void WeakRefPrototype::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    Object::initialize(global_object);
+
+    define_property(vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakRef), Attribute::Configurable);
+}
+
+WeakRefPrototype::~WeakRefPrototype()
+{
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -18,11 +18,28 @@ void WeakRefPrototype::initialize(GlobalObject& global_object)
     auto& vm = this->vm();
     Object::initialize(global_object);
 
+    define_native_function(vm.names.deref, deref, 0, Attribute::Writable | Attribute::Configurable);
+
     define_property(vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakRef), Attribute::Configurable);
 }
 
 WeakRefPrototype::~WeakRefPrototype()
 {
+}
+
+// 26.1.3.2 WeakRef.prototype.deref ( ), https://tc39.es/ecma262/#sec-weak-ref.prototype.deref
+JS_DEFINE_NATIVE_FUNCTION(WeakRefPrototype::deref)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return {};
+    if (!is<WeakRef>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "WeakRef");
+        return {};
+    }
+    auto& weak_ref = static_cast<WeakRef&>(*this_object);
+    weak_ref.update_execution_generation();
+    return weak_ref.value() ?: js_undefined();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
@@ -17,6 +17,9 @@ public:
     WeakRefPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~WeakRefPrototype() override;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(deref);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/WeakRef.h>
+
+namespace JS {
+
+class WeakRefPrototype final : public Object {
+    JS_OBJECT(WeakRefPrototype, Object);
+
+public:
+    WeakRefPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~WeakRefPrototype() override;
+};
+
+}

--- a/Userland/Libraries/LibJS/Tests/builtins/Object/Object.getOwnPropertySymbols.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Object/Object.getOwnPropertySymbols.js
@@ -1,0 +1,16 @@
+test("use with array", () => {
+    let names = Object.getOwnPropertySymbols([1, 2, 3]);
+    console.log(names);
+    expect(names).toEqual([]);
+});
+
+test("use with object", () => {
+    let names = Object.getOwnPropertySymbols({ [Symbol.iterator]: 1, [Symbol.species]: 2 });
+    expect(names).toEqual([Symbol.iterator, Symbol.species]);
+});
+
+test("use with object with string keys", () => {
+    let symbol = Symbol("bar");
+    let names = Object.getOwnPropertySymbols({ foo: 1, [symbol]: 2, baz: 3 });
+    expect(names).toEqual([symbol]);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Object/Object.setPrototypeOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Object/Object.setPrototypeOf.js
@@ -12,16 +12,6 @@ describe("correct behavior", () => {
 });
 
 describe("errors", () => {
-    test("requires two arguments", () => {
-        expect(() => {
-            Object.setPrototypeOf();
-        }).toThrowWithMessage(TypeError, "Object.setPrototypeOf requires at least two arguments");
-
-        expect(() => {
-            Object.setPrototypeOf({});
-        }).toThrowWithMessage(TypeError, "Object.setPrototypeOf requires at least two arguments");
-    });
-
     test("prototype must be an object", () => {
         expect(() => {
             Object.setPrototypeOf({}, "foo");

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakRef/WeakRef.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakRef/WeakRef.js
@@ -1,0 +1,30 @@
+test("constructor properties", () => {
+    expect(WeakRef).toHaveLength(1);
+    expect(WeakRef.name).toBe("WeakRef");
+});
+
+describe("errors", () => {
+    test("invalid array iterators", () => {
+        [-100, Infinity, NaN, 152n, undefined].forEach(value => {
+            expect(() => {
+                new WeakRef(value);
+            }).toThrowWithMessage(TypeError, "is not an object");
+        });
+    });
+    test("called without new", () => {
+        expect(() => {
+            WeakRef();
+        }).toThrowWithMessage(TypeError, "WeakRef constructor must be called with 'new'");
+    });
+});
+
+describe("normal behavior", () => {
+    test("typeof", () => {
+        expect(typeof new WeakRef({})).toBe("object");
+    });
+
+    test("constructor with single object argument", () => {
+        var a = new WeakRef({});
+        expect(a instanceof WeakRef).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakRef/WeakRef.prototype.deref.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakRef/WeakRef.prototype.deref.js
@@ -1,0 +1,21 @@
+test("length is 0", () => {
+    expect(WeakRef.prototype.deref).toHaveLength(0);
+});
+
+test("basic functionality", () => {
+    var original = { a: 1 };
+    var weakRef = new WeakRef(original);
+
+    expect(weakRef.deref()).toBe(original);
+});
+
+test("kept alive for current synchronous execution sequence", () => {
+    var weakRef;
+    {
+        weakRef = new WeakRef({ a: 1 });
+    }
+    weakRef.deref();
+    gc();
+    // This is fine 🔥
+    expect(weakRef.deref()).not.toBe(undefined);
+});

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -655,6 +655,8 @@ JS::Interpreter& Document::interpreter()
                     dbgln("  {} at {}:{}:{}", function_name, source_range.filename, source_range.start.line, source_range.start.column);
                 }
             }
+
+            vm.finish_execution_generation();
         };
         m_interpreter = JS::Interpreter::create<Bindings::WindowObject>(vm, *m_window);
     }


### PR DESCRIPTION
This also adds the Object.getOwnPropertySymbols method (as it was used by one of the WeakRef test262 test cases)

This fixes 24 test262 test cases.