### PR TITLE
Documentation: Fix QEMU 5 Ubuntu required version confusion 

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -10,7 +10,17 @@ Ensure your [QEMU](https://www.qemu.org/) version is >= 5 with `qemu-system-i386
 
 Ensure your gcc version is >= 10 with `gcc --version`. Otherwise, install it.
 
-On Ubuntu it's in the repositories of 20.04 (Focal) and later - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
+Make sure you have all the dependencies installed (`ninja` is optional, but is faster in practice):
+
+#### Debian / Ubuntu
+
+```console
+sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync
+```
+
+##### GCC 10
+
+On Ubuntu gcc-10 is available in the repositories of 20.04 (Focal) and later - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
 
 ```console
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -37,12 +47,13 @@ sudo sed -i '$d' /etc/apt/sources.list
 sudo apt update
 ```
 
-Make sure you have all the dependencies installed (`ninja` is optional, but is faster in practice):
+##### QEMU 5
 
-#### Debian / Ubuntu
+QUEMU version 5 is available in Ubuntu 20.10. For earlier versions, you can build it using the `Toolchain/BuildQemu.sh` script.
+You may need the gtk+ 3.0 dev package:
 
 ```console
-sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync
+sudo apt install libgtk-3-dev
 ```
 
 #### Fedora

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -6,9 +6,9 @@
 
 Ensure your CMake version is >= 3.16 with `cmake --version`. If your system doesn't provide a suitable version of CMake, you can download a binary release from the [CMake website](https://cmake.org/download).
 
-Ensure your gcc version is >= 10 with `gcc --version`. Otherwise, install it.
-
 Ensure your [QEMU](https://www.qemu.org/) version is >= 5 with `qemu-system-i386 -version`. Otherwise, install it. You can also build it using the `Toolchain/BuildQemu.sh` script.
+
+Ensure your gcc version is >= 10 with `gcc --version`. Otherwise, install it.
 
 On Ubuntu it's in the repositories of 20.04 (Focal) and later - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
 


### PR DESCRIPTION
PR #7970 added a line clarifying the requirement for QEMU 5.
Unfortunately, this location this line was added changed the meaning
of the following line, referencing the availability of GCC in Ubuntu
20.04.
    
QEMU 5 is not available in Ubuntu 20.04, so this change is incorrect,
as well as misleading.