### PR TITLE
LibJS: Add missing ECMA-262 section/title/URL comments to Map

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -21,7 +21,10 @@ void MapConstructor::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     NativeFunction::initialize(global_object);
+
+    // 24.1.2.1 Map.prototype, https://tc39.es/ecma262/#sec-map.prototype
     define_property(vm.names.prototype, global_object.map_prototype(), 0);
+
     define_property(vm.names.length, Value(0), Attribute::Configurable);
 
     define_native_accessor(vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
@@ -31,6 +34,7 @@ MapConstructor::~MapConstructor()
 {
 }
 
+// 24.1.1.1 Map ( [ iterable ] ), https://tc39.es/ecma262/#sec-map-iterable
 Value MapConstructor::call()
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -31,6 +31,7 @@ MapIteratorPrototype::~MapIteratorPrototype()
 {
 }
 
+// 24.1.5.2.1 %MapIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(MapIteratorPrototype::next)
 {
     auto this_value = vm.this_value(global_object);


### PR DESCRIPTION
As mentioned on Discord earlier, we'll add these to all new functions
going forward - this is the backfill. Reasons:

- It makes you look at the spec, implementing based on MDN or V8
  behavior is a no-go
- It makes finding the various functions that are non-compliant easier,
  in the future everything should either have such a comment or, if it's
  not from the spec at all, a comment explaining why that is the case
- It makes it easier to check whether a certain abstract operation is
  implemented in LibJS, not all of them use the same name as the spec.
  E.g. RejectPromise() is Promise::reject()
- It makes it easier to reason about vm.arguments(), e.g. when the
  function has a rest parameter
- It makes it easier to see whether a certain function is from a
  proposal or Annex B

Also:

- Add arguments to all functions and abstract operations that already
  had a comment
- Fix some outdated section numbers
- Replace some ecma-international.org URLs with tc39.es