### PR TITLE
WindowServer: Add initial support for rendering on multiple screens

### DIFF
--- a/Base/etc/WindowServer.ini
+++ b/Base/etc/WindowServer.ini
@@ -1,4 +1,10 @@
-[Screen]
+[Screens]
+MainScreen=0
+
+[Screen0]
+Device=/dev/fb0
+Left=0
+Top=0
 Width=1024
 Height=768
 ScaleFactor=1

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -80,23 +80,19 @@ void MonitorSettingsWidget::create_frame()
 
 void MonitorSettingsWidget::load_current_settings()
 {
-    auto ws_config = Core::ConfigFile::open("/etc/WindowServer.ini");
-
-    int scale_factor = ws_config->read_num_entry("Screen", "ScaleFactor", 1);
-    if (scale_factor != 1 && scale_factor != 2) {
-        dbgln("unexpected ScaleFactor {}, setting to 1", scale_factor);
-        scale_factor = 1;
+    m_screen_layout = GUI::WindowServerConnection::the().get_screen_layout();
+    auto& screen = m_screen_layout.screens[m_screen_layout.main_screen_index];
+    if (screen.scale_factor != 1 && screen.scale_factor != 2) {
+        dbgln("unexpected ScaleFactor {}, setting to 1", screen.scale_factor);
+        screen.scale_factor = 1;
     }
-    (scale_factor == 1 ? m_display_scale_radio_1x : m_display_scale_radio_2x)->set_checked(true);
-    m_monitor_widget->set_desktop_scale_factor(scale_factor);
+    (screen.scale_factor == 1 ? m_display_scale_radio_1x : m_display_scale_radio_2x)->set_checked(true);
+    m_monitor_widget->set_desktop_scale_factor(screen.scale_factor);
 
     // Let's attempt to find the current resolution and select it!
-    Gfx::IntSize find_size;
-    find_size.set_width(ws_config->read_num_entry("Screen", "Width", 1024));
-    find_size.set_height(ws_config->read_num_entry("Screen", "Height", 768));
-    auto index = m_resolutions.find_first_index(find_size).value_or(0);
-    Gfx::IntSize m_current_resolution = m_resolutions.at(index);
-    m_monitor_widget->set_desktop_resolution(m_current_resolution);
+    auto index = m_resolutions.find_first_index(screen.resolution).value_or(0);
+    Gfx::IntSize current_resolution = m_resolutions.at(index);
+    m_monitor_widget->set_desktop_resolution(current_resolution);
     m_resolution_combo->set_selected_index(index);
 
     m_monitor_widget->update();
@@ -104,28 +100,19 @@ void MonitorSettingsWidget::load_current_settings()
 
 void MonitorSettingsWidget::apply_settings()
 {
-    // Store the current screen resolution and scale factor in case the user wants to revert to it.
-    auto ws_config(Core::ConfigFile::open("/etc/WindowServer.ini"));
-    Gfx::IntSize current_resolution;
-    current_resolution.set_width(ws_config->read_num_entry("Screen", "Width", 1024));
-    current_resolution.set_height(ws_config->read_num_entry("Screen", "Height", 768));
-    int current_scale_factor = ws_config->read_num_entry("Screen", "ScaleFactor", 1);
-    if (current_scale_factor != 1 && current_scale_factor != 2) {
-        dbgln("unexpected ScaleFactor {}, setting to 1", current_scale_factor);
-        current_scale_factor = 1;
-    }
+    // TODO: implement multi-screen support
+    auto& main_screen = m_screen_layout.screens[m_screen_layout.main_screen_index];
+    main_screen.resolution = m_monitor_widget->desktop_resolution();
+    main_screen.scale_factor = (m_display_scale_radio_2x->is_checked() ? 2 : 1);
 
-    if (current_resolution != m_monitor_widget->desktop_resolution() || current_scale_factor != m_monitor_widget->desktop_scale_factor()) {
-        u32 display_index = 0; // TODO: implement multiple display support
-        auto result = GUI::WindowServerConnection::the().set_resolution(display_index, m_monitor_widget->desktop_resolution(), m_monitor_widget->desktop_scale_factor());
-        if (!result.success()) {
-            GUI::MessageBox::show(nullptr, String::formatted("Reverting to resolution {}x{} @ {}x", result.resolution().width(), result.resolution().height(), result.scale_factor()),
-                "Unable to set resolution", GUI::MessageBox::Type::Error);
-        } else {
+    // Fetch the latest configuration again, in case it has been changed by someone else.
+    // This isn't technically race free, but if the user automates changing settings we can't help...
+    auto current_layout = GUI::WindowServerConnection::the().get_screen_layout();
+    if (m_screen_layout != current_layout) {
+        auto result = GUI::WindowServerConnection::the().set_screen_layout(m_screen_layout, false);
+        if (result.success()) {
             auto box = GUI::MessageBox::construct(window(), String::formatted("Do you want to keep the new settings? They will be reverted after 10 seconds."),
-                String::formatted("New screen resolution: {}x{} @ {}x", m_monitor_widget->desktop_resolution().width(), m_monitor_widget->desktop_resolution().height(),
-                    m_monitor_widget->desktop_scale_factor()),
-                GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
+                "Apply new screen layout", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
             box->set_icon(window()->icon());
 
             // If after 10 seconds the user doesn't close the message box, just close it.
@@ -135,12 +122,15 @@ void MonitorSettingsWidget::apply_settings()
 
             // If the user selects "No", closes the window or the window gets closed by the 10 seconds timer, revert the changes.
             if (box->exec() != GUI::MessageBox::ExecYes) {
-                result = GUI::WindowServerConnection::the().set_resolution(display_index, current_resolution, current_scale_factor);
-                if (!result.success()) {
-                    GUI::MessageBox::show(nullptr, String::formatted("Reverting to resolution {}x{} @ {}x", result.resolution().width(), result.resolution().height(), result.scale_factor()),
-                        "Unable to set resolution", GUI::MessageBox::Type::Error);
+                auto save_result = GUI::WindowServerConnection::the().save_screen_layout();
+                if (!save_result.success()) {
+                    GUI::MessageBox::show(window(), String::formatted("Error saving settings: {}", save_result.error_msg()),
+                        "Unable to save setting", GUI::MessageBox::Type::Error);
                 }
             }
+        } else {
+            GUI::MessageBox::show(window(), String::formatted("Error setting screen layout: {}", result.error_msg()),
+                "Unable to apply changes", GUI::MessageBox::Type::Error);
         }
     }
 }

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -116,7 +116,8 @@ void MonitorSettingsWidget::apply_settings()
     }
 
     if (current_resolution != m_monitor_widget->desktop_resolution() || current_scale_factor != m_monitor_widget->desktop_scale_factor()) {
-        auto result = GUI::WindowServerConnection::the().set_resolution(m_monitor_widget->desktop_resolution(), m_monitor_widget->desktop_scale_factor());
+        u32 display_index = 0; // TODO: implement multiple display support
+        auto result = GUI::WindowServerConnection::the().set_resolution(display_index, m_monitor_widget->desktop_resolution(), m_monitor_widget->desktop_scale_factor());
         if (!result.success()) {
             GUI::MessageBox::show(nullptr, String::formatted("Reverting to resolution {}x{} @ {}x", result.resolution().width(), result.resolution().height(), result.scale_factor()),
                 "Unable to set resolution", GUI::MessageBox::Type::Error);
@@ -134,7 +135,7 @@ void MonitorSettingsWidget::apply_settings()
 
             // If the user selects "No", closes the window or the window gets closed by the 10 seconds timer, revert the changes.
             if (box->exec() != GUI::MessageBox::ExecYes) {
-                result = GUI::WindowServerConnection::the().set_resolution(current_resolution, current_scale_factor);
+                result = GUI::WindowServerConnection::the().set_resolution(display_index, current_resolution, current_scale_factor);
                 if (!result.success()) {
                     GUI::MessageBox::show(nullptr, String::formatted("Reverting to resolution {}x{} @ {}x", result.resolution().width(), result.resolution().height(), result.scale_factor()),
                         "Unable to set resolution", GUI::MessageBox::Type::Error);

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -11,6 +11,7 @@
 #include <LibGUI/ColorInput.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/RadioButton.h>
+#include <WindowServer/ScreenLayout.h>
 
 namespace DisplaySettings {
 
@@ -27,6 +28,7 @@ private:
     void create_resolution_list();
     void load_current_settings();
 
+    WindowServer::ScreenLayout m_screen_layout;
     Vector<Gfx::IntSize> m_resolutions;
 
     RefPtr<DisplaySettings::MonitorWidget> m_monitor_widget;

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -59,10 +59,13 @@ enum class TimerShouldFireWhenNotVisible {
 #define C_OBJECT(klass)                                                \
 public:                                                                \
     virtual const char* class_name() const override { return #klass; } \
-    template<class... Args>                                            \
+    template<typename Klass = klass, class... Args>                    \
     static inline NonnullRefPtr<klass> construct(Args&&... args)       \
     {                                                                  \
-        return adopt_ref(*new klass(forward<Args>(args)...));          \
+        auto obj = adopt_ref(*new Klass(forward<Args>(args)...));      \
+        if constexpr (requires { declval<Klass>().did_construct(); })  \
+            obj->did_construct();                                      \
+        return obj;                                                    \
     }
 
 #define C_OBJECT_ABSTRACT(klass) \

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCES
     RegularEditingEngine.cpp
     ResizeCorner.cpp
     RunningProcessesModel.cpp
+    ScreenLayout.cpp
     ScrollableContainerWidget.cpp
     Scrollbar.cpp
     SeparatorWidget.cpp

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -25,11 +25,17 @@ Desktop::Desktop()
 {
 }
 
-void Desktop::did_receive_screen_rect(Badge<WindowServerConnection>, const Gfx::IntRect& rect)
+void Desktop::did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index)
 {
-    if (m_rect == rect)
-        return;
-    m_rect = rect;
+    m_main_screen_index = main_screen_index;
+    m_rects = rects;
+    if (!m_rects.is_empty()) {
+        m_bounding_rect = m_rects[0];
+        for (size_t i = 1; i < m_rects.size(); i++)
+            m_bounding_rect = m_bounding_rect.united(m_rects[i]);
+    } else {
+        m_bounding_rect = {};
+    }
 }
 
 void Desktop::set_background_color(const StringView& background_color)

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -11,11 +11,17 @@
 #include <LibGUI/Forward.h>
 #include <LibGfx/Rect.h>
 #include <Services/Taskbar/TaskbarWindow.h>
+#include <Services/WindowServer/ScreenLayout.h>
 
 namespace GUI {
 
+using ScreenLayout = WindowServer::ScreenLayout;
+
 class Desktop {
 public:
+    // Most people will probably have 4 screens or less
+    static constexpr size_t default_screen_rect_count = 4;
+
     static Desktop& the();
     Desktop();
 
@@ -35,7 +41,7 @@ public:
     void did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>&, size_t);
 
 private:
-    Vector<Gfx::IntRect, 4> m_rects;
+    Vector<Gfx::IntRect, default_screen_rect_count> m_rects;
     size_t m_main_screen_index { 0 };
     Gfx::IntRect m_bounding_rect;
 };

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -26,14 +26,18 @@ public:
     String wallpaper() const;
     bool set_wallpaper(const StringView& path, bool save_config = true);
 
-    Gfx::IntRect rect() const { return m_rect; }
+    Gfx::IntRect rect() const { return m_bounding_rect; }
+    const Vector<Gfx::IntRect, 4>& rects() const { return m_rects; }
+    size_t main_screen_index() const { return m_main_screen_index; }
 
     int taskbar_height() const { return TaskbarWindow::taskbar_height(); }
 
-    void did_receive_screen_rect(Badge<WindowServerConnection>, const Gfx::IntRect&);
+    void did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>&, size_t);
 
 private:
-    Gfx::IntRect m_rect;
+    Vector<Gfx::IntRect, 4> m_rects;
+    size_t m_main_screen_index { 0 };
+    Gfx::IntRect m_bounding_rect;
 };
 
 }

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -52,7 +52,7 @@ public:
         DragMove,
         Drop,
         ThemeChange,
-        ScreenRectChange,
+        ScreenRectsChange,
         ActionEnter,
         ActionLeave,
 
@@ -392,18 +392,21 @@ public:
     }
 };
 
-class ScreenRectChangeEvent final : public Event {
+class ScreenRectsChangeEvent final : public Event {
 public:
-    explicit ScreenRectChangeEvent(const Gfx::IntRect& rect)
-        : Event(Type::ScreenRectChange)
-        , m_rect(rect)
+    explicit ScreenRectsChangeEvent(const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index)
+        : Event(Type::ScreenRectsChange)
+        , m_rects(rects)
+        , m_main_screen_index(main_screen_index)
     {
     }
 
-    const Gfx::IntRect& rect() const { return m_rect; }
+    const Vector<Gfx::IntRect, 4>& rects() const { return m_rects; }
+    size_t main_screen_index() const { return m_main_screen_index; }
 
 private:
-    Gfx::IntRect m_rect;
+    Vector<Gfx::IntRect, 4> m_rects;
+    size_t m_main_screen_index;
 };
 
 class FocusEvent final : public Event {

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -52,7 +52,7 @@ class Painter;
 class RadioButton;
 class ResizeCorner;
 class ResizeEvent;
-class ScreenRectChangeEvent;
+class ScreenRectsChangeEvent;
 class Scrollbar;
 class AbstractScrollableWidget;
 class Slider;

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -85,3 +85,7 @@ enum class ModelRole;
 enum class SortOrder;
 
 }
+
+namespace WindowServer {
+class ScreenLayout;
+}

--- a/Userland/Libraries/LibGUI/ScreenLayout.cpp
+++ b/Userland/Libraries/LibGUI/ScreenLayout.cpp
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Services/WindowServer/ScreenLayout.ipp>

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -506,7 +506,7 @@ void Widget::theme_change_event(ThemeChangeEvent&)
 {
 }
 
-void Widget::screen_rect_change_event(ScreenRectChangeEvent&)
+void Widget::screen_rects_change_event(ScreenRectsChangeEvent&)
 {
 }
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -312,7 +312,7 @@ protected:
     virtual void drag_leave_event(Event&);
     virtual void drop_event(DropEvent&);
     virtual void theme_change_event(ThemeChangeEvent&);
-    virtual void screen_rect_change_event(ScreenRectChangeEvent&);
+    virtual void screen_rects_change_event(ScreenRectsChangeEvent&);
 
     virtual void did_begin_inspection() override;
     virtual void did_end_inspection() override;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -495,11 +495,11 @@ void Window::handle_theme_change_event(ThemeChangeEvent& event)
     dispatch_theme_change(*m_main_widget.ptr(), dispatch_theme_change);
 }
 
-void Window::handle_screen_rect_change_event(ScreenRectChangeEvent& event)
+void Window::handle_screen_rects_change_event(ScreenRectsChangeEvent& event)
 {
     if (!m_main_widget)
         return;
-    auto dispatch_screen_rect_change = [&](auto& widget, auto recursive) {
+    auto dispatch_screen_rects_change = [&](auto& widget, auto recursive) {
         widget.dispatch_event(event, this);
         widget.for_each_child_widget([&](auto& widget) -> IterationDecision {
             widget.dispatch_event(event, this);
@@ -507,8 +507,8 @@ void Window::handle_screen_rect_change_event(ScreenRectChangeEvent& event)
             return IterationDecision::Continue;
         });
     };
-    dispatch_screen_rect_change(*m_main_widget.ptr(), dispatch_screen_rect_change);
-    screen_rect_change_event(event);
+    dispatch_screen_rects_change(*m_main_widget.ptr(), dispatch_screen_rects_change);
+    screen_rects_change_event(event);
 }
 
 void Window::handle_drag_move_event(DragEvent& event)
@@ -578,8 +578,8 @@ void Window::event(Core::Event& event)
     if (event.type() == Event::ThemeChange)
         return handle_theme_change_event(static_cast<ThemeChangeEvent&>(event));
 
-    if (event.type() == Event::ScreenRectChange)
-        return handle_screen_rect_change_event(static_cast<ScreenRectChangeEvent&>(event));
+    if (event.type() == Event::ScreenRectsChange)
+        return handle_screen_rects_change_event(static_cast<ScreenRectsChangeEvent&>(event));
 
     Core::Object::event(event);
 }
@@ -811,7 +811,7 @@ void Window::wm_event(WMEvent&)
 {
 }
 
-void Window::screen_rect_change_event(ScreenRectChangeEvent&)
+void Window::screen_rects_change_event(ScreenRectsChangeEvent&)
 {
 }
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -203,7 +203,7 @@ public:
 protected:
     Window(Core::Object* parent = nullptr);
     virtual void wm_event(WMEvent&);
-    virtual void screen_rect_change_event(ScreenRectChangeEvent&);
+    virtual void screen_rects_change_event(ScreenRectsChangeEvent&);
 
 private:
     void update_cursor();
@@ -218,7 +218,7 @@ private:
     void handle_became_active_or_inactive_event(Core::Event&);
     void handle_close_request();
     void handle_theme_change_event(ThemeChangeEvent&);
-    void handle_screen_rect_change_event(ScreenRectChangeEvent&);
+    void handle_screen_rects_change_event(ScreenRectsChangeEvent&);
     void handle_drag_move_event(DragEvent&);
     void handle_left_event();
 

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibIPC/ServerConnection.h>
+#include <WindowServer/ScreenLayout.h>
 #include <WindowServer/WindowManagerClientEndpoint.h>
 #include <WindowServer/WindowManagerServerEndpoint.h>
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -48,12 +48,12 @@ WindowServerConnection::WindowServerConnection()
     //       All we have to do is wait for it to arrive. This avoids a round-trip during application startup.
     auto message = wait_for_specific_message<Messages::WindowClient::FastGreet>();
     set_system_theme_from_anonymous_buffer(message->theme_buffer());
-    Desktop::the().did_receive_screen_rect({}, message->screen_rect());
+    Desktop::the().did_receive_screen_rects({}, message->screen_rects(), message->main_screen_index());
     Gfx::FontDatabase::set_default_font_query(message->default_font_query());
     Gfx::FontDatabase::set_fixed_width_font_query(message->fixed_width_font_query());
 }
 
-void WindowServerConnection::fast_greet(Gfx::IntRect const&, Core::AnonymousBuffer const&, String const&, String const&)
+void WindowServerConnection::fast_greet(Vector<Gfx::IntRect> const&, u32, Core::AnonymousBuffer const&, String const&, String const&)
 {
     // NOTE: This message is handled in the constructor.
 }
@@ -311,11 +311,11 @@ void WindowServerConnection::menu_item_left(i32 menu_id, u32 identifier)
     Core::EventLoop::current().post_event(*app, make<ActionEvent>(GUI::Event::ActionLeave, *action));
 }
 
-void WindowServerConnection::screen_rect_changed(Gfx::IntRect const& rect)
+void WindowServerConnection::screen_rects_changed(Vector<Gfx::IntRect> const& rects, u32 main_screen_index)
 {
-    Desktop::the().did_receive_screen_rect({}, rect);
-    Window::for_each_window({}, [rect](auto& window) {
-        Core::EventLoop::current().post_event(window, make<ScreenRectChangeEvent>(rect));
+    Desktop::the().did_receive_screen_rects({}, rects, main_screen_index);
+    Window::for_each_window({}, [&](auto& window) {
+        Core::EventLoop::current().post_event(window, make<ScreenRectsChangeEvent>(rects, main_screen_index));
     });
 }
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibIPC/ServerConnection.h>
+#include <WindowServer/ScreenLayout.h>
 #include <WindowServer/WindowClientEndpoint.h>
 #include <WindowServer/WindowServerEndpoint.h>
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -22,7 +22,7 @@ public:
 private:
     WindowServerConnection();
 
-    virtual void fast_greet(Gfx::IntRect const&, Core::AnonymousBuffer const&, String const&, String const&) override;
+    virtual void fast_greet(Vector<Gfx::IntRect> const&, u32, Core::AnonymousBuffer const&, String const&, String const&) override;
     virtual void paint(i32, Gfx::IntSize const&, Vector<Gfx::IntRect> const&) override;
     virtual void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, bool, Vector<String> const&) override;
     virtual void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32) override;
@@ -43,7 +43,7 @@ private:
     virtual void menu_item_entered(i32, u32) override;
     virtual void menu_item_left(i32, u32) override;
     virtual void menu_visibility_did_change(i32, bool) override;
-    virtual void screen_rect_changed(Gfx::IntRect const&) override;
+    virtual void screen_rects_changed(Vector<Gfx::IntRect> const&, u32) override;
     virtual void set_wallpaper_finished(bool) override;
     virtual void drag_dropped(i32, Gfx::IntPoint const&, String const&, HashMap<String, ByteBuffer> const&) override;
     virtual void drag_accepted() override;

--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -16,6 +16,10 @@ class Emoji;
 class Font;
 class GlyphBitmap;
 class ImageDecoder;
+
+template<typename T>
+class Line;
+
 class Painter;
 class Palette;
 class PaletteImpl;
@@ -33,6 +37,9 @@ class Size;
 
 template<typename T>
 class Rect;
+
+using IntLine = Line<int>;
+using FloatLine = Line<float>;
 
 using IntRect = Rect<int>;
 using FloatRect = Rect<float>;

--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/StdLibExtras.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <math.h>
+#include <stdlib.h>
+
+namespace Gfx {
+
+template<typename T>
+class Line {
+public:
+    Line() { }
+
+    Line(Point<T> a, Point<T> b)
+        : m_a(a)
+        , m_b(b)
+    {
+    }
+
+    template<typename U>
+    Line(U a, U b)
+        : m_a(a)
+        , m_b(b)
+    {
+    }
+
+    template<typename U>
+    explicit Line(Line<U> const& other)
+        : m_a(other.a())
+        , m_b(other.b())
+    {
+    }
+
+    bool intersects(Line const& other) const
+    {
+        return intersected(other).has_value();
+    }
+
+    Optional<Point<T>> intersected(Line const& other) const
+    {
+        auto cross_product = [](Point<T> const& p1, Point<T> const& p2) {
+            return p1.x() * p2.y() - p1.y() * p2.x();
+        };
+        auto r = m_b - m_a;
+        auto s = other.m_b - other.m_a;
+        auto delta_a = other.m_a - m_a;
+        auto num = cross_product(delta_a, r);
+        auto denom = cross_product(r, s);
+        if (denom == 0) {
+            if (num == 0) {
+                // Lines are collinear, check if line ends are touching
+                if (m_a == other.m_a || m_a == other.m_b)
+                    return m_a;
+                if (m_b == other.m_a || m_b == other.m_b)
+                    return m_b;
+                // Check if they're overlapping
+                if (!(m_b.x() - m_a.x() < 0 && m_b.x() - other.m_a.x() < 0 && other.m_b.x() - m_a.x() && other.m_b.x() - other.m_a.x())) {
+                    // Overlapping
+                    // TODO find center point?
+                }
+                if (!(m_b.y() - m_a.y() < 0 && m_b.y() - other.m_a.y() < 0 && other.m_b.y() - m_a.y() && other.m_b.y() - other.m_a.y())) {
+                    // Overlapping
+                    // TODO find center point?
+                }
+                return {};
+            } else {
+                // Lines are parallel and not intersecting
+                return {};
+            }
+        }
+        auto u = static_cast<float>(num) / static_cast<float>(denom);
+        if (u < 0.0f || u > 1.0f) {
+            // Lines are not parallel and don't intersect
+            return {};
+        }
+        auto t = static_cast<float>(cross_product(delta_a, s)) / static_cast<float>(denom);
+        if (t < 0.0f || t > 1.0f) {
+            // Lines are not parallel and don't intersect
+            return {};
+        }
+        // TODO: round if we're dealing with int
+        return Point<T> { m_a.x() + static_cast<T>(t * r.x()), m_a.y() + static_cast<T>(t * r.y()) };
+    }
+
+    float length() const
+    {
+        return m_a.distance_from(m_b);
+    }
+
+    Point<T> closest_to(Point<T> const& point) const
+    {
+        if (m_a == m_b)
+            return m_a;
+        auto delta_a = point.x() - m_a.x();
+        auto delta_b = point.y() - m_a.y();
+        auto delta_c = m_b.x() - m_a.x();
+        auto delta_d = m_b.y() - m_a.y();
+        auto len_sq = delta_c * delta_c + delta_d * delta_d;
+        float param = -1.0;
+        if (len_sq != 0)
+            param = static_cast<float>(delta_a * delta_c + delta_b * delta_d) / static_cast<float>(len_sq);
+        if (param < 0)
+            return m_a;
+        if (param > 1)
+            return m_b;
+        // TODO: round if we're dealing with int
+        return { static_cast<T>(m_a.x() + param * delta_c), static_cast<T>(m_a.y() + param * delta_d) };
+    }
+
+    Line<T> shortest_line_to(Point<T> const& point) const
+    {
+        return { closest_to(point), point };
+    }
+
+    float distance_to(Point<T> const& point) const
+    {
+        return shortest_line_to(point).length();
+    }
+
+    Point<T> const& a() const { return m_a; }
+    Point<T> const& b() const { return m_b; }
+
+    void set_a(Point<T> const& a) { m_a = a; }
+    void set_b(Point<T> const& b) { m_b = b; }
+
+    String to_string() const;
+
+private:
+    Point<T> m_a;
+    Point<T> m_b;
+};
+
+template<>
+inline String IntLine::to_string() const
+{
+    return String::formatted("[{},{} -> {}x{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
+}
+
+template<>
+inline String FloatLine::to_string() const
+{
+    return String::formatted("[{},{} {}x{}]", m_a.x(), m_a.y(), m_b.x(), m_b.y());
+}
+
+}

--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -7,11 +7,182 @@
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibGfx/Line.h>
 #include <LibGfx/Rect.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 
 namespace Gfx {
+
+template<typename T>
+
+Rect<T>::RelativeLocation::RelativeLocation(Rect<T> const& base_rect, Rect<T> const& other_rect)
+{
+    if (base_rect.is_empty() || other_rect.is_empty())
+        return;
+    auto parts = base_rect.shatter(other_rect);
+    for (auto& part : parts) {
+        if (part.x() < other_rect.x()) {
+            if (part.y() < other_rect.y())
+                m_top_left = true;
+            if ((part.y() >= other_rect.y() && part.y() < other_rect.bottom()) || (part.y() <= other_rect.bottom() && part.bottom() > other_rect.y()))
+                m_left = true;
+            if (part.y() >= other_rect.bottom() || part.bottom() > other_rect.y())
+                m_bottom_left = true;
+        }
+        if (part.x() >= other_rect.x() || part.right() > other_rect.x()) {
+            if (part.y() < other_rect.y())
+                m_top = true;
+            if (part.y() >= other_rect.bottom() || part.bottom() > other_rect.bottom())
+                m_bottom = true;
+        }
+        if (part.x() >= other_rect.right() || part.right() > other_rect.right()) {
+            if (part.y() < other_rect.y())
+                m_top_right = true;
+            if ((part.y() >= other_rect.y() && part.y() < other_rect.bottom()) || (part.y() <= other_rect.bottom() && part.bottom() > other_rect.y()))
+                m_right = true;
+            if (part.y() >= other_rect.bottom() || part.bottom() > other_rect.y())
+                m_bottom_right = true;
+        }
+    }
+}
+
+template<typename T>
+Vector<Point<T>, 2> Rect<T>::intersected(Line<T> const& line) const
+{
+    if (is_empty())
+        return {};
+    Vector<Point<T>, 2> points;
+    if (auto point = line.intersected({ top_left(), top_right() }); point.has_value())
+        points.append({ point.value().x(), y() });
+    if (auto point = line.intersected({ bottom_left(), bottom_right() }); point.has_value()) {
+        points.append({ point.value().x(), bottom() });
+        if (points.size() == 2)
+            return points;
+    }
+    if (height() > 2) {
+        if (auto point = line.intersected({ { x(), y() + 1 }, { x(), bottom() - 1 } }); point.has_value()) {
+            points.append({ x(), point.value().y() });
+            if (points.size() == 2)
+                return points;
+        }
+        if (auto point = line.intersected({ { right(), y() + 1 }, { right(), bottom() - 1 } }); point.has_value())
+            points.append({ right(), point.value().y() });
+    }
+    return points;
+}
+
+template<typename T>
+float Rect<T>::center_point_distance_to(Rect<T> const& other) const
+{
+    return Line { center(), other.center() }.length();
+}
+
+template<typename T>
+Vector<Point<T>, 2> Rect<T>::closest_outside_center_points(Rect<T> const& other) const
+{
+    if (intersects(other))
+        return {};
+    Line centers_line { center(), other.center() };
+    auto points_this = intersected(centers_line);
+    VERIFY(points_this.size() == 1);
+    auto points_other = other.intersected(centers_line);
+    VERIFY(points_other.size() == 1);
+    return { points_this[0], points_other[0] };
+}
+
+template<typename T>
+float Rect<T>::outside_center_point_distance_to(Rect<T> const& other) const
+{
+    auto points = closest_outside_center_points(other);
+    if (points.is_empty())
+        return 0.0;
+    return Line { points[0], points[0] }.length();
+}
+
+template<typename T>
+Rect<T> Rect<T>::constrained_to(Rect<T> const& constrain_rect) const
+{
+    if (constrain_rect.contains(*this))
+        return *this;
+    T move_x = 0, move_y = 0;
+    if (right() > constrain_rect.right())
+        move_x = constrain_rect.right() - right();
+    if (bottom() > constrain_rect.bottom())
+        move_y = constrain_rect.bottom() - bottom();
+    if (x() < constrain_rect.x())
+        move_x = x() - constrain_rect.x();
+    if (y() < constrain_rect.y())
+        move_y = y() - constrain_rect.y();
+    auto rect = *this;
+    if (move_x != 0 || move_y != 0)
+        rect.translate_by(move_x, move_y);
+    return rect;
+}
+
+template<typename T>
+Rect<T> Rect<T>::aligned_within(Size<T> const& rect_size, Point<T> const& align_at, TextAlignment alignment) const
+{
+    if (rect_size.is_empty())
+        return {};
+    if (!size().contains(rect_size))
+        return {};
+    if (!contains(align_at))
+        return {};
+
+    Rect<T> rect;
+    switch (alignment) {
+    case TextAlignment::TopLeft:
+        rect = { align_at, rect_size };
+        break;
+    case TextAlignment::CenterLeft:
+        rect = { { align_at.x(), align_at.y() - rect_size.height() / 2 }, rect_size };
+        break;
+    case TextAlignment::Center:
+        rect = { { align_at.x() - rect_size.width() / 2, align_at.y() - rect_size.height() / 2 }, rect_size };
+        break;
+    case TextAlignment::CenterRight:
+        rect = { { align_at.x() - rect_size.width() / 2, align_at.y() }, rect_size };
+        break;
+    case TextAlignment::TopRight:
+        rect = { { align_at.x() - rect_size.width(), align_at.y() }, rect_size };
+        break;
+    case TextAlignment::BottomLeft:
+        rect = { { align_at.x(), align_at.y() - rect_size.width() }, rect_size };
+        break;
+    case TextAlignment::BottomRight:
+        rect = { { align_at.x() - rect_size.width(), align_at.y() - rect_size.width() }, rect_size };
+        break;
+    }
+    return rect.constrained_to(*this);
+}
+
+template<typename T>
+Point<T> Rect<T>::closest_to(Point<T> const& point) const
+{
+    if (is_empty())
+        return {};
+    Optional<Point<T>> closest_point;
+    float closest_distance = 0.0;
+    auto check_distance = [&](const Line<T>& line) {
+        auto point_on_line = line.closest_to(point);
+        auto distance = Line { point_on_line, point }.length();
+        if (!closest_point.has_value() || distance < closest_distance) {
+            closest_point = point_on_line;
+            closest_distance = distance;
+        }
+    };
+
+    check_distance({ top_left(), top_right() });
+    check_distance({ bottom_left(), bottom_right() });
+    if (height() > 2) {
+        check_distance({ { x(), y() + 1 }, { x(), bottom() - 1 } });
+        check_distance({ { right(), y() + 1 }, { right(), bottom() - 1 } });
+    }
+    VERIFY(closest_point.has_value());
+    VERIFY(side(closest_point.value()) != Side::None);
+    return closest_point.value();
+}
 
 template<typename T>
 void Rect<T>::intersect(Rect<T> const& other)

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -71,7 +71,7 @@ void OutOfProcessWebView::create_client()
 
     client().async_update_system_theme(Gfx::current_system_theme_buffer());
     client().async_update_system_fonts(Gfx::FontDatabase::default_font_query(), Gfx::FontDatabase::fixed_width_font_query());
-    client().async_update_screen_rect(GUI::Desktop::the().rect());
+    client().async_update_screen_rects(GUI::Desktop::the().rects(), GUI::Desktop::the().main_screen_index());
 }
 
 void OutOfProcessWebView::load(const URL& url)
@@ -192,9 +192,9 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
     request_repaint();
 }
 
-void OutOfProcessWebView::screen_rect_change_event(GUI::ScreenRectChangeEvent& event)
+void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
-    client().async_update_screen_rect(event.rect());
+    client().async_update_screen_rects(event.rects(), event.main_screen_index());
 }
 
 void OutOfProcessWebView::notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id)

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -74,7 +74,7 @@ private:
     virtual void mousewheel_event(GUI::MouseEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void theme_change_event(GUI::ThemeChangeEvent&) override;
-    virtual void screen_rect_change_event(GUI::ScreenRectChangeEvent&) override;
+    virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
 
     // ^AbstractScrollableWidget
     virtual void did_scroll() override;

--- a/Userland/Services/NotificationServer/ClientConnection.h
+++ b/Userland/Services/NotificationServer/ClientConnection.h
@@ -7,6 +7,9 @@
 #pragma once
 
 #include <LibIPC/ClientConnection.h>
+#include <WindowServer/ScreenLayout.h>
+
+// Must be included after WindowServer/ScreenLayout.h
 #include <NotificationServer/NotificationClientEndpoint.h>
 #include <NotificationServer/NotificationServerEndpoint.h>
 

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -129,9 +129,9 @@ void NotificationWindow::set_image(const Gfx::ShareableBitmap& image)
     }
 }
 
-void NotificationWindow::screen_rect_change_event(GUI::ScreenRectChangeEvent& event)
+void NotificationWindow::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
-    update_notification_window_locations(event.rect());
+    update_notification_window_locations(event.rects()[event.main_screen_index()]);
 }
 
 }

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -27,7 +27,7 @@ public:
 private:
     NotificationWindow(i32 client_id, const String& text, const String& title, const Gfx::ShareableBitmap&);
 
-    virtual void screen_rect_change_event(GUI::ScreenRectChangeEvent&) override;
+    virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
 
     Gfx::IntRect m_original_rect;
     i32 m_id;

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -58,7 +58,7 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
     set_window_type(GUI::WindowType::Taskbar);
     set_title("Taskbar");
 
-    on_screen_rect_change(GUI::Desktop::the().rect());
+    on_screen_rects_change(GUI::Desktop::the().rects(), GUI::Desktop::the().main_screen_index());
 
     auto& main_widget = set_main_widget<TaskbarWidget>();
     main_widget.set_layout<GUI::HorizontalBoxLayout>();
@@ -148,8 +148,9 @@ void TaskbarWindow::create_quick_launch_bar()
     quick_launch_bar.set_fixed_size(total_width, 24);
 }
 
-void TaskbarWindow::on_screen_rect_change(const Gfx::IntRect& rect)
+void TaskbarWindow::on_screen_rects_change(const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index)
 {
+    const auto& rect = rects[main_screen_index];
     Gfx::IntRect new_rect { rect.x(), rect.bottom() - taskbar_height() + 1, rect.width(), taskbar_height() };
     set_rect(new_rect);
     update_applet_area();
@@ -332,7 +333,7 @@ void TaskbarWindow::wm_event(GUI::WMEvent& event)
     }
 }
 
-void TaskbarWindow::screen_rect_change_event(GUI::ScreenRectChangeEvent& event)
+void TaskbarWindow::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
-    on_screen_rect_change(event.rect());
+    on_screen_rects_change(event.rects(), event.main_screen_index());
 }

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -21,7 +21,7 @@ public:
 private:
     explicit TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu);
     void create_quick_launch_bar();
-    void on_screen_rect_change(const Gfx::IntRect&);
+    void on_screen_rects_change(const Vector<Gfx::IntRect, 4>&, size_t);
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
     void add_window_button(::Window&, const WindowIdentifier&);
     void remove_window_button(::Window&, bool);
@@ -29,7 +29,7 @@ private:
     ::Window* find_window_owner(::Window&) const;
 
     virtual void wm_event(GUI::WMEvent&) override;
-    virtual void screen_rect_change_event(GUI::ScreenRectChangeEvent&) override;
+    virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
 
     void update_applet_area();
 

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -72,9 +72,9 @@ void ClientConnection::update_system_fonts(String const& default_font_query, Str
     Gfx::FontDatabase::set_fixed_width_font_query(fixed_width_font_query);
 }
 
-void ClientConnection::update_screen_rect(const Gfx::IntRect& rect)
+void ClientConnection::update_screen_rects(const Vector<Gfx::IntRect>& rects, u32 main_screen)
 {
-    m_page_host->set_screen_rect(rect);
+    m_page_host->set_screen_rects(rects, main_screen);
 }
 
 void ClientConnection::load_url(const URL& url)

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -34,7 +34,7 @@ private:
 
     virtual void update_system_theme(Core::AnonymousBuffer const&) override;
     virtual void update_system_fonts(String const&, String const&) override;
-    virtual void update_screen_rect(Gfx::IntRect const&) override;
+    virtual void update_screen_rects(Vector<Gfx::IntRect> const&, u32) override;
     virtual void load_url(URL const&) override;
     virtual void load_html(String const&, URL const&) override;
     virtual void paint(Gfx::IntRect const&, i32) override;

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -28,7 +28,7 @@ public:
 
     void set_palette_impl(const Gfx::PaletteImpl&);
     void set_viewport_rect(const Gfx::IntRect&);
-    void set_screen_rect(const Gfx::IntRect& rect) { m_screen_rect = rect; };
+    void set_screen_rects(const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index]; };
 
     void set_should_show_line_box_borders(bool b) { m_should_show_line_box_borders = b; }
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -2,7 +2,7 @@ endpoint WebContentServer
 {
     update_system_theme(Core::AnonymousBuffer theme_buffer) =|
     update_system_fonts(String default_font_query, String fixed_width_font_query) =|
-    update_screen_rect(Gfx::IntRect rect) =|
+    update_screen_rects(Vector<Gfx::IntRect> rects, u32 main_screen_index) =|
 
     load_url(URL url) =|
     load_html(String html, URL url) =|

--- a/Userland/Services/WindowServer/Button.cpp
+++ b/Userland/Services/WindowServer/Button.cpp
@@ -9,6 +9,7 @@
 #include <LibGfx/StylePainter.h>
 #include <WindowServer/Button.h>
 #include <WindowServer/Event.h>
+#include <WindowServer/Screen.h>
 #include <WindowServer/WindowManager.h>
 
 namespace WindowServer {
@@ -23,7 +24,7 @@ Button::~Button()
 {
 }
 
-void Button::paint(Gfx::Painter& painter)
+void Button::paint(Screen& screen, Gfx::Painter& painter)
 {
     auto palette = WindowManager::the().palette();
     Gfx::PainterStateSaver saver(painter);
@@ -31,10 +32,11 @@ void Button::paint(Gfx::Painter& painter)
     Gfx::StylePainter::paint_button(painter, rect(), palette, Gfx::ButtonStyle::Normal, m_pressed, m_hovered);
 
     if (m_icon) {
-        auto icon_location = rect().center().translated(-(m_icon->width() / 2), -(m_icon->height() / 2));
+        auto& bitmap = m_icon->bitmap(screen.scale_factor());
+        auto icon_location = rect().center().translated(-(bitmap.width() / 2), -(bitmap.height() / 2));
         if (m_pressed)
             painter.translate(1, 1);
-        painter.blit(icon_location, *m_icon, m_icon->rect());
+        painter.blit(icon_location, bitmap, bitmap.rect());
     }
 }
 

--- a/Userland/Services/WindowServer/Button.h
+++ b/Userland/Services/WindowServer/Button.h
@@ -11,10 +11,12 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <WindowServer/MultiScaleBitmaps.h>
 
 namespace WindowServer {
 
 class MouseEvent;
+class Screen;
 class WindowFrame;
 
 class Button : public Weakable<Button> {
@@ -28,7 +30,7 @@ public:
     Gfx::IntRect rect() const { return { {}, m_relative_rect.size() }; }
     Gfx::IntRect screen_rect() const;
 
-    void paint(Gfx::Painter&);
+    void paint(Screen&, Gfx::Painter&);
 
     void on_mouse_event(const MouseEvent&);
 
@@ -38,12 +40,12 @@ public:
 
     bool is_visible() const { return m_visible; }
 
-    void set_icon(const Gfx::Bitmap& icon) { m_icon = icon; }
+    void set_icon(const RefPtr<MultiScaleBitmaps>& icon) { m_icon = icon; }
 
 private:
     WindowFrame& m_frame;
     Gfx::IntRect m_relative_rect;
-    RefPtr<Gfx::Bitmap> m_icon;
+    RefPtr<MultiScaleBitmaps> m_icon;
     bool m_pressed { false };
     bool m_visible { true };
     bool m_hovered { false };

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     Menu.cpp
     MenuItem.cpp
     MenuManager.cpp
+    MultiScaleBitmaps.cpp
     Screen.cpp
     ScreenLayout.cpp
     Window.cpp

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     MenuItem.cpp
     MenuManager.cpp
     Screen.cpp
+    ScreenLayout.cpp
     Window.cpp
     WindowFrame.cpp
     WindowManager.cpp

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -297,14 +297,23 @@ Messages::WindowServer::GetWallpaperResponse ClientConnection::get_wallpaper()
     return Compositor::the().wallpaper_path();
 }
 
-Messages::WindowServer::SetResolutionResponse ClientConnection::set_resolution(u32 screen_index, Gfx::IntSize const& resolution, int scale_factor)
+Messages::WindowServer::SetScreenLayoutResponse ClientConnection::set_screen_layout(ScreenLayout const& screen_layout, bool save)
 {
-    if (auto* screen = Screen::find_by_index(screen_index)) {
-        bool success = WindowManager::the().set_resolution(*screen, resolution.width(), resolution.height(), scale_factor);
-        return { success, screen->size(), screen->scale_factor() };
-    }
-    dbgln("Setting resolution: Invalid screen index {}", screen_index);
-    return { false, {}, 0 };
+    String error_msg;
+    bool success = WindowManager::the().set_screen_layout(ScreenLayout(screen_layout), save, error_msg);
+    return { success, move(error_msg) };
+}
+
+Messages::WindowServer::GetScreenLayoutResponse ClientConnection::get_screen_layout()
+{
+    return { WindowManager::the().get_screen_layout() };
+}
+
+Messages::WindowServer::SaveScreenLayoutResponse ClientConnection::save_screen_layout()
+{
+    String error_msg;
+    bool success = WindowManager::the().save_screen_layout(error_msg);
+    return { success, move(error_msg) };
 }
 
 void ClientConnection::set_window_title(i32 window_id, String const& title)

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -682,7 +682,7 @@ void ClientConnection::set_window_custom_cursor(i32 window_id, Gfx::ShareableBit
         return;
     }
 
-    window.set_cursor(Cursor::create(*cursor.bitmap()));
+    window.set_cursor(Cursor::create(*cursor.bitmap(), 1));
     Compositor::the().invalidate_cursor();
 }
 

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -18,6 +18,7 @@
 #include <LibIPC/ClientConnection.h>
 #include <WindowServer/Event.h>
 #include <WindowServer/Menu.h>
+#include <WindowServer/ScreenLayout.h>
 #include <WindowServer/WindowClientEndpoint.h>
 #include <WindowServer/WindowServerEndpoint.h>
 
@@ -27,6 +28,7 @@ class Compositor;
 class Window;
 class Menu;
 class Menubar;
+class ScreenLayout;
 class WMClientConnection;
 
 class ClientConnection final
@@ -125,7 +127,9 @@ private:
     virtual void set_background_color(String const&) override;
     virtual void set_wallpaper_mode(String const&) override;
     virtual Messages::WindowServer::GetWallpaperResponse get_wallpaper() override;
-    virtual Messages::WindowServer::SetResolutionResponse set_resolution(u32, Gfx::IntSize const&, int) override;
+    virtual Messages::WindowServer::SetScreenLayoutResponse set_screen_layout(ScreenLayout const&, bool) override;
+    virtual Messages::WindowServer::GetScreenLayoutResponse get_screen_layout() override;
+    virtual Messages::WindowServer::SaveScreenLayoutResponse save_screen_layout() override;
     virtual void set_window_cursor(i32, i32) override;
     virtual void set_window_custom_cursor(i32, Gfx::ShareableBitmap const&) override;
     virtual void popup_menu(i32, Gfx::IntPoint const&) override;

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -40,7 +40,7 @@ public:
     static ClientConnection* from_client_id(int client_id);
     static void for_each_client(Function<void(ClientConnection&)>);
 
-    void notify_about_new_screen_rect(const Gfx::IntRect&);
+    void notify_about_new_screen_rects(const Vector<Gfx::IntRect, 4>&, size_t);
     void post_paint_message(Window&, bool ignore_occlusion = false);
 
     Menu* find_menu_by_id(int menu_id)
@@ -125,7 +125,7 @@ private:
     virtual void set_background_color(String const&) override;
     virtual void set_wallpaper_mode(String const&) override;
     virtual Messages::WindowServer::GetWallpaperResponse get_wallpaper() override;
-    virtual Messages::WindowServer::SetResolutionResponse set_resolution(Gfx::IntSize const&, int) override;
+    virtual Messages::WindowServer::SetResolutionResponse set_resolution(u32, Gfx::IntSize const&, int) override;
     virtual void set_window_cursor(i32, i32) override;
     virtual void set_window_custom_cursor(i32, Gfx::ShareableBitmap const&) override;
     virtual void popup_menu(i32, Gfx::IntPoint const&) override;
@@ -153,7 +153,7 @@ private:
     virtual Messages::WindowServer::GetDoubleClickSpeedResponse get_double_click_speed() override;
     virtual void set_window_modified(i32, bool) override;
     virtual Messages::WindowServer::IsWindowModifiedResponse is_window_modified(i32) override;
-    virtual Messages::WindowServer::GetDesktopDisplayScaleResponse get_desktop_display_scale() override;
+    virtual Messages::WindowServer::GetDesktopDisplayScaleResponse get_desktop_display_scale(u32) override;
 
     Window* window_from_id(i32 window_id);
 

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -151,7 +151,7 @@ private:
     virtual Messages::WindowServer::GetMouseAccelerationResponse get_mouse_acceleration() override;
     virtual void set_scroll_step_size(u32) override;
     virtual Messages::WindowServer::GetScrollStepSizeResponse get_scroll_step_size() override;
-    virtual Messages::WindowServer::GetScreenBitmapResponse get_screen_bitmap(Optional<Gfx::IntRect> const&) override;
+    virtual Messages::WindowServer::GetScreenBitmapResponse get_screen_bitmap(Optional<Gfx::IntRect> const&, Optional<u32> const&) override;
     virtual Messages::WindowServer::GetScreenBitmapAroundCursorResponse get_screen_bitmap_around_cursor(Gfx::IntSize const&) override;
     virtual void set_double_click_speed(i32) override;
     virtual Messages::WindowServer::GetDoubleClickSpeedResponse get_double_click_speed() override;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -815,6 +815,9 @@ void Compositor::step_animations()
 
 void Compositor::screen_resolution_changed()
 {
+    // Screens may be gone now, invalidate any references to them
+    m_current_cursor_screen = nullptr;
+
     init_bitmaps();
     invalidate_occlusions();
     compose();

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -919,7 +919,7 @@ void Compositor::ScreenData::draw_cursor(Screen& screen, const Gfx::IntRect& cur
     auto& current_cursor = compositor.m_current_cursor ? *compositor.m_current_cursor : wm.active_cursor();
     auto screen_rect = screen.rect();
     m_cursor_back_painter->blit({ 0, 0 }, *m_back_bitmap, current_cursor.rect().translated(cursor_rect.location()).intersected(screen_rect).translated(-screen_rect.location()));
-    m_back_painter->blit(cursor_rect.location(), current_cursor.bitmap(), current_cursor.source_rect(compositor.m_current_cursor_frame));
+    m_back_painter->blit(cursor_rect.location(), current_cursor.bitmap(screen.scale_factor()), current_cursor.source_rect(compositor.m_current_cursor_frame));
     m_last_cursor_rect = cursor_rect;
     VERIFY(compositor.m_current_cursor_screen == &screen);
     m_cursor_back_is_valid = true;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -64,6 +64,13 @@ Compositor::Compositor()
     init_bitmaps();
 }
 
+const Gfx::Bitmap* Compositor::cursor_bitmap_for_screenshot(Badge<ClientConnection>, Screen& screen) const
+{
+    if (!m_current_cursor)
+        return nullptr;
+    return &m_current_cursor->bitmap(screen.scale_factor());
+}
+
 const Gfx::Bitmap& Compositor::front_bitmap_for_screenshot(Badge<ClientConnection>, Screen& screen) const
 {
     return *m_screen_data[screen.index()].m_front_bitmap;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -61,28 +61,44 @@ Compositor::Compositor()
         },
         this);
 
-    m_screen_can_set_buffer = Screen::the().can_set_buffer();
     init_bitmaps();
 }
 
-void Compositor::init_bitmaps()
+const Gfx::Bitmap& Compositor::front_bitmap_for_screenshot(Badge<ClientConnection>, Screen& screen) const
 {
-    auto& screen = Screen::the();
+    return *m_screen_data[screen.index()].m_front_bitmap;
+}
+
+void Compositor::ScreenData::init_bitmaps(Screen& screen)
+{
     auto size = screen.size();
 
     m_front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor(), screen.pitch(), screen.scanline(0));
     m_front_painter = make<Gfx::Painter>(*m_front_bitmap);
+    m_front_painter->translate(-screen.rect().location());
 
-    if (m_screen_can_set_buffer)
+    if (screen.can_set_buffer())
         m_back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor(), screen.pitch(), screen.scanline(screen.physical_height()));
     else
         m_back_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor());
     m_back_painter = make<Gfx::Painter>(*m_back_bitmap);
+    m_back_painter->translate(-screen.rect().location());
 
     m_temp_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor());
     m_temp_painter = make<Gfx::Painter>(*m_temp_bitmap);
+    m_temp_painter->translate(-screen.rect().location());
 
     m_buffers_are_flipped = false;
+    m_screen_can_set_buffer = screen.can_set_buffer();
+}
+
+void Compositor::init_bitmaps()
+{
+    m_screen_data.resize(Screen::count());
+    Screen::for_each([&](auto& screen) {
+        m_screen_data[screen.index()].init_bitmaps(screen);
+        return IterationDecision::Continue;
+    });
 
     invalidate_screen();
 }
@@ -101,7 +117,6 @@ void Compositor::did_construct_window_manager(Badge<WindowManager>)
 void Compositor::compose()
 {
     auto& wm = WindowManager::the();
-    auto& ws = Screen::the();
 
     {
         auto& current_cursor = wm.active_cursor();
@@ -122,11 +137,26 @@ void Compositor::compose()
     }
 
     auto dirty_screen_rects = move(m_dirty_screen_rects);
-    dirty_screen_rects.add(m_last_geometry_label_damage_rect.intersected(ws.rect()));
-    dirty_screen_rects.add(m_last_dnd_rect.intersected(ws.rect()));
-    if (m_invalidated_cursor) {
-        if (wm.dnd_client())
-            dirty_screen_rects.add(wm.dnd_rect().intersected(ws.rect()));
+    auto* dnd_client = wm.dnd_client();
+    if (!m_last_geometry_label_damage_rect.is_empty() || !m_last_dnd_rect.is_empty() || (m_invalidated_cursor && dnd_client)) {
+        Screen::for_each([&](auto& screen) {
+            if (!m_last_geometry_label_damage_rect.is_empty()) {
+                auto rect = m_last_geometry_label_damage_rect.intersected(screen.rect());
+                if (!rect.is_empty())
+                    dirty_screen_rects.add(rect);
+            }
+            if (!m_last_dnd_rect.is_empty()) {
+                auto rect = m_last_dnd_rect.intersected(screen.rect());
+                if (!rect.is_empty())
+                    dirty_screen_rects.add(rect);
+            }
+            if (m_invalidated_cursor && dnd_client) {
+                auto rect = wm.dnd_rect().intersected(screen.rect());
+                if (!rect.is_empty())
+                    dirty_screen_rects.add(rect);
+            }
+            return IterationDecision::Continue;
+        });
     }
 
     // Mark window regions as dirty that need to be re-rendered
@@ -180,61 +210,81 @@ void Compositor::compose()
             dbgln("dirty screen: {}", r);
     }
 
-    Gfx::DisjointRectSet flush_rects;
-    Gfx::DisjointRectSet flush_transparent_rects;
-    Gfx::DisjointRectSet flush_special_rects;
+    auto& cursor_screen = ScreenInput::the().cursor_location_screen();
+
+    for (auto& screen_data : m_screen_data) {
+        screen_data.m_flush_rects.clear_with_capacity();
+        screen_data.m_flush_transparent_rects.clear_with_capacity();
+        screen_data.m_flush_special_rects.clear_with_capacity();
+    }
+
     auto cursor_rect = current_cursor_rect();
+
     bool need_to_draw_cursor = false;
-
-    auto back_painter = *m_back_painter;
-    auto temp_painter = *m_temp_painter;
-
-    auto check_restore_cursor_back = [&](const Gfx::IntRect& rect) {
-        if (!need_to_draw_cursor && rect.intersects(cursor_rect)) {
+    Gfx::IntRect previous_cursor_rect;
+    Screen* previous_cursor_screen = nullptr;
+    auto check_restore_cursor_back = [&](Screen& screen, const Gfx::IntRect& rect) {
+        if (&screen == &cursor_screen && !previous_cursor_screen && !need_to_draw_cursor && rect.intersects(cursor_rect)) {
             // Restore what's behind the cursor if anything touches the area of the cursor
             need_to_draw_cursor = true;
-            restore_cursor_back();
+            auto& screen_data = m_screen_data[cursor_screen.index()];
+            if (screen_data.restore_cursor_back(cursor_screen, previous_cursor_rect))
+                previous_cursor_screen = &screen;
         }
     };
 
-    auto prepare_rect = [&](const Gfx::IntRect& rect) {
+    if (&cursor_screen != m_current_cursor_screen) {
+        // Cursor moved to another screen, restore on the cursor's background on the previous screen
+        need_to_draw_cursor = true;
+        if (m_current_cursor_screen) {
+            auto& screen_data = m_screen_data[m_current_cursor_screen->index()];
+            if (screen_data.restore_cursor_back(*m_current_cursor_screen, previous_cursor_rect))
+                previous_cursor_screen = m_current_cursor_screen;
+        }
+        m_current_cursor_screen = &cursor_screen;
+    }
+
+    auto prepare_rect = [&](Screen& screen, const Gfx::IntRect& rect) {
+        auto& screen_data = m_screen_data[screen.index()];
         dbgln_if(COMPOSE_DEBUG, "    -> flush opaque: {}", rect);
-        VERIFY(!flush_rects.intersects(rect));
-        VERIFY(!flush_transparent_rects.intersects(rect));
-        flush_rects.add(rect);
-        check_restore_cursor_back(rect);
+        VERIFY(!screen_data.m_flush_rects.intersects(rect));
+        VERIFY(!screen_data.m_flush_transparent_rects.intersects(rect));
+        screen_data.m_flush_rects.add(rect);
+        check_restore_cursor_back(screen, rect);
     };
 
-    auto prepare_transparency_rect = [&](const Gfx::IntRect& rect) {
+    auto prepare_transparency_rect = [&](Screen& screen, const Gfx::IntRect& rect) {
+        auto& screen_data = m_screen_data[screen.index()];
         dbgln_if(COMPOSE_DEBUG, "   -> flush transparent: {}", rect);
-        VERIFY(!flush_rects.intersects(rect));
-        for (auto& r : flush_transparent_rects.rects()) {
+        VERIFY(!screen_data.m_flush_rects.intersects(rect));
+        for (auto& r : screen_data.m_flush_transparent_rects.rects()) {
             if (r == rect)
                 return;
         }
 
-        flush_transparent_rects.add(rect);
-        check_restore_cursor_back(rect);
+        screen_data.m_flush_transparent_rects.add(rect);
+        check_restore_cursor_back(screen, rect);
     };
 
-    if (!m_cursor_back_bitmap || m_invalidated_cursor)
-        check_restore_cursor_back(cursor_rect);
+    if (!m_screen_data[cursor_screen.index()].m_cursor_back_bitmap || m_invalidated_cursor)
+        check_restore_cursor_back(cursor_screen, cursor_rect);
 
-    auto paint_wallpaper = [&](Gfx::Painter& painter, const Gfx::IntRect& rect) {
+    auto paint_wallpaper = [&](Screen& screen, Gfx::Painter& painter, const Gfx::IntRect& rect, const Gfx::IntRect& screen_rect) {
         // FIXME: If the wallpaper is opaque and covers the whole rect, no need to fill with color!
         painter.fill_rect(rect, background_color);
         if (m_wallpaper) {
             if (m_wallpaper_mode == WallpaperMode::Center) {
-                Gfx::IntPoint offset { (ws.width() - m_wallpaper->width()) / 2, (ws.height() - m_wallpaper->height()) / 2 };
-                painter.blit_offset(rect.location(), *m_wallpaper, rect, offset);
+                Gfx::IntPoint offset { (screen.width() - m_wallpaper->width()) / 2, (screen.height() - m_wallpaper->height()) / 2 };
+                painter.blit_offset(rect.location(), *m_wallpaper, rect.translated(-screen_rect.location()), offset);
             } else if (m_wallpaper_mode == WallpaperMode::Tile) {
                 painter.draw_tiled_bitmap(rect, *m_wallpaper);
             } else if (m_wallpaper_mode == WallpaperMode::Stretch) {
-                float hscale = (float)m_wallpaper->width() / (float)ws.width();
-                float vscale = (float)m_wallpaper->height() / (float)ws.height();
+                float hscale = (float)m_wallpaper->width() / (float)screen.width();
+                float vscale = (float)m_wallpaper->height() / (float)screen.height();
 
                 // TODO: this may look ugly, we should scale to a backing bitmap and then blit
-                auto src_rect = Gfx::FloatRect { rect.x() * hscale, rect.y() * vscale, rect.width() * hscale, rect.height() * vscale };
+                auto relative_rect = rect.translated(-screen_rect.location());
+                auto src_rect = Gfx::FloatRect { relative_rect.x() * hscale, relative_rect.y() * vscale, relative_rect.width() * hscale, relative_rect.height() * vscale };
                 painter.draw_scaled_bitmap(rect, *m_wallpaper, src_rect);
             } else {
                 VERIFY_NOT_REACHED();
@@ -243,29 +293,39 @@ void Compositor::compose()
     };
 
     m_opaque_wallpaper_rects.for_each_intersected(dirty_screen_rects, [&](const Gfx::IntRect& render_rect) {
-        dbgln_if(COMPOSE_DEBUG, "  render wallpaper opaque: {}", render_rect);
-        prepare_rect(render_rect);
-        paint_wallpaper(back_painter, render_rect);
+        Screen::for_each([&](auto& screen) {
+            auto screen_rect = screen.rect();
+            auto screen_render_rect = screen_rect.intersected(render_rect);
+            if (!screen_render_rect.is_empty()) {
+                auto& back_painter = *m_screen_data[screen.index()].m_back_painter;
+                dbgln_if(COMPOSE_DEBUG, "  render wallpaper opaque: {} on screen #{}", screen_render_rect, screen.index());
+                prepare_rect(screen, render_rect);
+                paint_wallpaper(screen, back_painter, render_rect, screen_rect);
+            }
+            return IterationDecision::Continue;
+        });
         return IterationDecision::Continue;
     });
 
     auto compose_window = [&](Window& window) -> IterationDecision {
-        auto frame_rect = window.frame().render_rect();
-        if (!frame_rect.intersects(ws.rect()))
+        if (window.screens().is_empty()) {
+            // This window doesn't intersect with any screens, so there's nothing to render
             return IterationDecision::Continue;
+        }
+        auto frame_rect = window.frame().render_rect();
         auto window_rect = window.rect();
         auto frame_rects = frame_rect.shatter(window_rect);
 
         dbgln_if(COMPOSE_DEBUG, "  window {} frame rect: {}", window.title(), frame_rect);
 
         RefPtr<Gfx::Bitmap> backing_store = window.backing_store();
-        auto compose_window_rect = [&](Gfx::Painter& painter, const Gfx::IntRect& rect) {
+        auto compose_window_rect = [&](Screen& screen, Gfx::Painter& painter, const Gfx::IntRect& rect) {
             if (!window.is_fullscreen()) {
                 rect.for_each_intersected(frame_rects, [&](const Gfx::IntRect& intersected_rect) {
                     Gfx::PainterStateSaver saver(painter);
                     painter.add_clip_rect(intersected_rect);
                     dbgln_if(COMPOSE_DEBUG, "    render frame: {}", intersected_rect);
-                    window.frame().paint(painter, intersected_rect);
+                    window.frame().paint(screen, painter, intersected_rect);
                     return IterationDecision::Continue;
                 });
             }
@@ -359,12 +419,18 @@ void Compositor::compose()
         auto& opaque_rects = window.opaque_rects();
         if (!opaque_rects.is_empty()) {
             opaque_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
-                dbgln_if(COMPOSE_DEBUG, "    render opaque: {}", render_rect);
+                for (auto* screen : window.screens()) {
+                    auto screen_render_rect = render_rect.intersected(screen->rect());
+                    if (screen_render_rect.is_empty())
+                        continue;
+                    dbgln_if(COMPOSE_DEBUG, "    render opaque: {} on screen #{}", screen_render_rect, screen->index());
 
-                prepare_rect(render_rect);
-                Gfx::PainterStateSaver saver(back_painter);
-                back_painter.add_clip_rect(render_rect);
-                compose_window_rect(back_painter, render_rect);
+                    prepare_rect(*screen, screen_render_rect);
+                    auto& back_painter = *m_screen_data[screen->index()].m_back_painter;
+                    Gfx::PainterStateSaver saver(back_painter);
+                    back_painter.add_clip_rect(screen_render_rect);
+                    compose_window_rect(*screen, back_painter, screen_render_rect);
+                }
                 return IterationDecision::Continue;
             });
         }
@@ -374,22 +440,36 @@ void Compositor::compose()
         auto& transparency_wallpaper_rects = window.transparency_wallpaper_rects();
         if (!transparency_wallpaper_rects.is_empty()) {
             transparency_wallpaper_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
-                dbgln_if(COMPOSE_DEBUG, "    render wallpaper: {}", render_rect);
+                for (auto* screen : window.screens()) {
+                    auto screen_rect = screen->rect();
+                    auto screen_render_rect = render_rect.intersected(screen_rect);
+                    if (screen_render_rect.is_empty())
+                        continue;
+                    dbgln_if(COMPOSE_DEBUG, "    render wallpaper: {} on screen #{}", screen_render_rect, screen->index());
 
-                prepare_transparency_rect(render_rect);
-                paint_wallpaper(temp_painter, render_rect);
+                    auto& temp_painter = *m_screen_data[screen->index()].m_temp_painter;
+                    prepare_transparency_rect(*screen, screen_render_rect);
+                    paint_wallpaper(*screen, temp_painter, screen_render_rect, screen_rect);
+                }
                 return IterationDecision::Continue;
             });
         }
         auto& transparency_rects = window.transparency_rects();
         if (!transparency_rects.is_empty()) {
             transparency_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
-                dbgln_if(COMPOSE_DEBUG, "    render transparent: {}", render_rect);
+                for (auto* screen : window.screens()) {
+                    auto screen_rect = screen->rect();
+                    auto screen_render_rect = render_rect.intersected(screen_rect);
+                    if (screen_render_rect.is_empty())
+                        continue;
+                    dbgln_if(COMPOSE_DEBUG, "    render transparent: {} on screen #{}", screen_render_rect, screen->index());
 
-                prepare_transparency_rect(render_rect);
-                Gfx::PainterStateSaver saver(temp_painter);
-                temp_painter.add_clip_rect(render_rect);
-                compose_window_rect(temp_painter, render_rect);
+                    prepare_transparency_rect(*screen, screen_render_rect);
+                    auto& temp_painter = *m_screen_data[screen->index()].m_temp_painter;
+                    Gfx::PainterStateSaver saver(temp_painter);
+                    temp_painter.add_clip_rect(screen_render_rect);
+                    compose_window_rect(*screen, temp_painter, screen_render_rect);
+                }
                 return IterationDecision::Continue;
             });
         }
@@ -411,24 +491,35 @@ void Compositor::compose()
 
         // Check that there are no overlapping transparent and opaque flush rectangles
         VERIFY(![&]() {
-            for (auto& rect_transparent : flush_transparent_rects.rects()) {
-                for (auto& rect_opaque : flush_rects.rects()) {
-                    if (rect_opaque.intersects(rect_transparent)) {
-                        dbgln("Transparent rect {} overlaps opaque rect: {}: {}", rect_transparent, rect_opaque, rect_opaque.intersected(rect_transparent));
-                        return true;
+            bool is_overlapping = false;
+            Screen::for_each([&](auto& screen) {
+                auto& screen_data = m_screen_data[screen.index()];
+                auto& flush_transparent_rects = screen_data.m_flush_transparent_rects;
+                auto& flush_rects = screen_data.m_flush_rects;
+                for (auto& rect_transparent : flush_transparent_rects.rects()) {
+                    for (auto& rect_opaque : flush_rects.rects()) {
+                        if (rect_opaque.intersects(rect_transparent)) {
+                            dbgln("Transparent rect {} overlaps opaque rect: {}: {}", rect_transparent, rect_opaque, rect_opaque.intersected(rect_transparent));
+                            is_overlapping = true;
+                            return IterationDecision::Break;
+                        }
                     }
                 }
-            }
-            return false;
+                return IterationDecision::Continue;
+            });
+            return is_overlapping;
         }());
 
         // Copy anything rendered to the temporary buffer to the back buffer
-        for (auto& rect : flush_transparent_rects.rects())
-            back_painter.blit(rect.location(), *m_temp_bitmap, rect);
+        Screen::for_each([&](auto& screen) {
+            auto screen_rect = screen.rect();
+            auto& screen_data = m_screen_data[screen.index()];
+            for (auto& rect : screen_data.m_flush_transparent_rects.rects())
+                screen_data.m_back_painter->blit(rect.location(), *screen_data.m_temp_bitmap, rect.translated(-screen_rect.location()));
+            return IterationDecision::Continue;
+        });
 
-        Gfx::IntRect geometry_label_damage_rect;
-        if (draw_geometry_label(geometry_label_damage_rect))
-            flush_special_rects.add(geometry_label_damage_rect);
+        draw_geometry_label(cursor_screen);
     }
 
     m_invalidated_any = false;
@@ -438,34 +529,50 @@ void Compositor::compose()
     if (wm.dnd_client()) {
         auto dnd_rect = wm.dnd_rect();
 
-        // TODO: render once into a backing bitmap, then just blit...
-        auto render_dnd = [&]() {
-            back_painter.fill_rect(dnd_rect, wm.palette().selection().with_alpha(200));
-            back_painter.draw_rect(dnd_rect, wm.palette().selection());
-            if (!wm.dnd_text().is_empty()) {
-                auto text_rect = dnd_rect;
-                if (wm.dnd_bitmap())
-                    text_rect.translate_by(wm.dnd_bitmap()->width() + 8, 0);
-                back_painter.draw_text(text_rect, wm.dnd_text(), Gfx::TextAlignment::CenterLeft, wm.palette().selection_text());
-            }
-            if (wm.dnd_bitmap()) {
-                back_painter.blit(dnd_rect.top_left().translated(4, 4), *wm.dnd_bitmap(), wm.dnd_bitmap()->rect());
-            }
-        };
+        Screen::for_each([&](auto& screen) {
+            auto screen_rect = screen.rect();
+            auto render_dnd_rect = screen_rect.intersected(dnd_rect);
+            if (render_dnd_rect.is_empty())
+                return IterationDecision::Continue;
+            auto& screen_data = m_screen_data[screen.index()];
+            auto& back_painter = *screen_data.m_back_painter;
 
-        dirty_screen_rects.for_each_intersected(dnd_rect, [&](const Gfx::IntRect& render_rect) {
-            Gfx::PainterStateSaver saver(back_painter);
-            back_painter.add_clip_rect(render_rect);
-            render_dnd();
+            // TODO: render once into a backing bitmap, then just blit...
+            auto render_dnd = [&]() {
+                back_painter.fill_rect(dnd_rect, wm.palette().selection().with_alpha(200));
+                back_painter.draw_rect(dnd_rect, wm.palette().selection());
+                if (!wm.dnd_text().is_empty()) {
+                    auto text_rect = dnd_rect;
+                    if (wm.dnd_bitmap())
+                        text_rect.translate_by(wm.dnd_bitmap()->width() + 8, 0);
+                    back_painter.draw_text(text_rect, wm.dnd_text(), Gfx::TextAlignment::CenterLeft, wm.palette().selection_text());
+                }
+                if (wm.dnd_bitmap()) {
+                    back_painter.blit(dnd_rect.top_left().translated(4, 4), *wm.dnd_bitmap(), wm.dnd_bitmap()->rect());
+                }
+            };
+
+            dirty_screen_rects.for_each_intersected(dnd_rect, [&](const Gfx::IntRect& render_rect) {
+                auto screen_render_rect = render_rect.intersected(screen_rect);
+                if (screen_render_rect.is_empty())
+                    return IterationDecision::Continue;
+                Gfx::PainterStateSaver saver(back_painter);
+                back_painter.add_clip_rect(screen_render_rect);
+                render_dnd();
+                return IterationDecision::Continue;
+            });
+            screen_data.m_flush_transparent_rects.for_each_intersected(dnd_rect, [&](const Gfx::IntRect& render_rect) {
+                auto screen_render_rect = render_rect.intersected(screen_rect);
+                if (screen_render_rect.is_empty())
+                    return IterationDecision::Continue;
+                Gfx::PainterStateSaver saver(back_painter);
+                back_painter.add_clip_rect(screen_render_rect);
+                render_dnd();
+                return IterationDecision::Continue;
+            });
+            m_last_dnd_rect = dnd_rect;
             return IterationDecision::Continue;
         });
-        flush_transparent_rects.for_each_intersected(dnd_rect, [&](const Gfx::IntRect& render_rect) {
-            Gfx::PainterStateSaver saver(back_painter);
-            back_painter.add_clip_rect(render_rect);
-            render_dnd();
-            return IterationDecision::Continue;
-        });
-        m_last_dnd_rect = dnd_rect;
     } else {
         if (!m_last_dnd_rect.is_empty()) {
             invalidate_screen(m_last_dnd_rect);
@@ -473,78 +580,98 @@ void Compositor::compose()
         }
     }
 
-    run_animations(flush_special_rects);
+    bool did_render_animation = false;
+    Screen::for_each([&](auto& screen) {
+        auto& screen_data = m_screen_data[screen.index()];
+        did_render_animation |= render_animation_frame(screen, screen_data.m_flush_special_rects);
+        return IterationDecision::Continue;
+    });
 
     if (need_to_draw_cursor) {
-        flush_rects.add(cursor_rect);
-        if (cursor_rect != m_last_cursor_rect)
-            flush_rects.add(m_last_cursor_rect);
-        draw_cursor(cursor_rect);
+        auto& screen_data = m_screen_data[cursor_screen.index()];
+        screen_data.draw_cursor(cursor_screen, cursor_rect);
+        screen_data.m_flush_rects.add(cursor_rect);
+        if (previous_cursor_screen && cursor_rect != previous_cursor_rect)
+            m_screen_data[previous_cursor_screen->index()].m_flush_rects.add(previous_cursor_rect);
     }
 
-    if (m_flash_flush) {
-        for (auto& rect : flush_rects.rects())
-            m_front_painter->fill_rect(rect, Color::Yellow);
-    }
+    Screen::for_each([&](auto& screen) {
+        flush(screen);
+        return IterationDecision::Continue;
+    });
 
-    if (m_screen_can_set_buffer)
-        flip_buffers();
-
-    for (auto& rect : flush_rects.rects())
-        flush(rect);
-    for (auto& rect : flush_transparent_rects.rects())
-        flush(rect);
-    for (auto& rect : flush_special_rects.rects())
-        flush(rect);
+    if (did_render_animation)
+        step_animations();
 }
 
-void Compositor::flush(const Gfx::IntRect& a_rect)
+void Compositor::flush(Screen& screen)
 {
-    auto rect = Gfx::IntRect::intersection(a_rect, Screen::the().rect());
-
-    // Almost everything in Compositor is in logical coordinates, with the painters having
-    // a scale applied. But this routine accesses the backbuffer pixels directly, so it
-    // must work in physical coordinates.
-    rect = rect * Screen::the().scale_factor();
-    Gfx::RGBA32* front_ptr = m_front_bitmap->scanline(rect.y()) + rect.x();
-    Gfx::RGBA32* back_ptr = m_back_bitmap->scanline(rect.y()) + rect.x();
-    size_t pitch = m_back_bitmap->pitch();
-
-    // NOTE: The meaning of a flush depends on whether we can flip buffers or not.
-    //
-    //       If flipping is supported, flushing means that we've flipped, and now we
-    //       copy the changed bits from the front buffer to the back buffer, to keep
-    //       them in sync.
-    //
-    //       If flipping is not supported, flushing means that we copy the changed
-    //       rects from the backing bitmap to the display framebuffer.
-
-    Gfx::RGBA32* to_ptr;
-    const Gfx::RGBA32* from_ptr;
-
-    if (m_screen_can_set_buffer) {
-        to_ptr = back_ptr;
-        from_ptr = front_ptr;
-    } else {
-        to_ptr = front_ptr;
-        from_ptr = back_ptr;
+    auto& screen_data = m_screen_data[screen.index()];
+    if (m_flash_flush) {
+        for (auto& rect : screen_data.m_flush_rects.rects())
+            screen_data.m_front_painter->fill_rect(rect, Color::Yellow);
     }
 
-    for (int y = 0; y < rect.height(); ++y) {
-        fast_u32_copy(to_ptr, from_ptr, rect.width());
-        from_ptr = (const Gfx::RGBA32*)((const u8*)from_ptr + pitch);
-        to_ptr = (Gfx::RGBA32*)((u8*)to_ptr + pitch);
-    }
+    if (screen_data.m_screen_can_set_buffer)
+        screen_data.flip_buffers(screen);
+
+    auto screen_rect = screen.rect();
+    auto do_flush = [&](const Gfx::IntRect& a_rect) {
+        auto rect = Gfx::IntRect::intersection(a_rect, screen_rect);
+        if (rect.is_empty())
+            return;
+        rect.translate_by(-screen_rect.location());
+
+        // Almost everything in Compositor is in logical coordinates, with the painters having
+        // a scale applied. But this routine accesses the backbuffer pixels directly, so it
+        // must work in physical coordinates.
+        rect = rect * screen.scale_factor();
+        Gfx::RGBA32* front_ptr = screen_data.m_front_bitmap->scanline(rect.y()) + rect.x();
+        Gfx::RGBA32* back_ptr = screen_data.m_back_bitmap->scanline(rect.y()) + rect.x();
+        size_t pitch = screen_data.m_back_bitmap->pitch();
+
+        // NOTE: The meaning of a flush depends on whether we can flip buffers or not.
+        //
+        //       If flipping is supported, flushing means that we've flipped, and now we
+        //       copy the changed bits from the front buffer to the back buffer, to keep
+        //       them in sync.
+        //
+        //       If flipping is not supported, flushing means that we copy the changed
+        //       rects from the backing bitmap to the display framebuffer.
+
+        Gfx::RGBA32* to_ptr;
+        const Gfx::RGBA32* from_ptr;
+
+        if (screen_data.m_screen_can_set_buffer) {
+            to_ptr = back_ptr;
+            from_ptr = front_ptr;
+        } else {
+            to_ptr = front_ptr;
+            from_ptr = back_ptr;
+        }
+
+        for (int y = 0; y < rect.height(); ++y) {
+            fast_u32_copy(to_ptr, from_ptr, rect.width());
+            from_ptr = (const Gfx::RGBA32*)((const u8*)from_ptr + pitch);
+            to_ptr = (Gfx::RGBA32*)((u8*)to_ptr + pitch);
+        }
+    };
+    for (auto& rect : screen_data.m_flush_rects.rects())
+        do_flush(rect);
+    for (auto& rect : screen_data.m_flush_transparent_rects.rects())
+        do_flush(rect);
+    for (auto& rect : screen_data.m_flush_special_rects.rects())
+        do_flush(rect);
 }
 
 void Compositor::invalidate_screen()
 {
-    invalidate_screen(Screen::the().rect());
+    invalidate_screen(Screen::bounding_rect());
 }
 
 void Compositor::invalidate_screen(const Gfx::IntRect& screen_rect)
 {
-    m_dirty_screen_rects.add(screen_rect.intersected(Screen::the().rect()));
+    m_dirty_screen_rects.add(screen_rect.intersected(Screen::bounding_rect()));
 
     if (m_invalidated_any)
         return;
@@ -623,19 +750,21 @@ bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callba
     return true;
 }
 
-void Compositor::flip_buffers()
+void Compositor::ScreenData::flip_buffers(Screen& screen)
 {
     VERIFY(m_screen_can_set_buffer);
     swap(m_front_bitmap, m_back_bitmap);
     swap(m_front_painter, m_back_painter);
-    Screen::the().set_buffer(m_buffers_are_flipped ? 0 : 1);
+    screen.set_buffer(m_buffers_are_flipped ? 0 : 1);
     m_buffers_are_flipped = !m_buffers_are_flipped;
 }
 
-void Compositor::run_animations(Gfx::DisjointRectSet& flush_rects)
+static const int minimize_animation_steps = 10;
+
+bool Compositor::render_animation_frame(Screen& screen, Gfx::DisjointRectSet& flush_rects)
 {
-    static const int minimize_animation_steps = 10;
-    auto& painter = *m_back_painter;
+    bool did_render_any = false;
+    auto& painter = *m_screen_data[screen.index()].m_back_painter;
     Gfx::PainterStateSaver saver(painter);
     painter.set_draw_op(Gfx::Painter::DrawOp::Invert);
 
@@ -658,12 +787,24 @@ void Compositor::run_animations(Gfx::DisjointRectSet& flush_rects)
                 from_rect.height() - (int)(height_delta_per_step * animation_index)
             };
 
-            dbgln_if(MINIMIZE_ANIMATION_DEBUG, "Minimize animation from {} to {} frame# {} {}", from_rect, to_rect, animation_index, rect);
+            dbgln_if(MINIMIZE_ANIMATION_DEBUG, "Minimize animation from {} to {} frame# {} {} on screen #{}", from_rect, to_rect, animation_index, rect, screen.index());
 
             painter.draw_rect(rect, Color::Transparent); // Color doesn't matter, we draw inverted
             flush_rects.add(rect);
             invalidate_screen(rect);
 
+            did_render_any = true;
+        }
+        return IterationDecision::Continue;
+    });
+
+    return did_render_any;
+}
+
+void Compositor::step_animations()
+{
+    WindowManager::the().window_stack().for_each_window([&](Window& window) {
+        if (window.in_minimize_animation()) {
             window.step_minimize_animation();
             if (window.minimize_animation_index() >= minimize_animation_steps)
                 window.end_minimize_animation();
@@ -672,33 +813,18 @@ void Compositor::run_animations(Gfx::DisjointRectSet& flush_rects)
     });
 }
 
-bool Compositor::set_resolution(int desired_width, int desired_height, int scale_factor)
+void Compositor::screen_resolution_changed()
 {
-    auto screen_rect = Screen::the().rect();
-    if (screen_rect.width() == desired_width && screen_rect.height() == desired_height && Screen::the().scale_factor() == scale_factor)
-        return true;
-
-    // Make sure it's impossible to set an invalid resolution
-    if (!(desired_width >= 640 && desired_height >= 480 && scale_factor >= 1)) {
-        dbgln("Compositor: Tried to set invalid resolution: {}x{}", desired_width, desired_height);
-        return false;
-    }
-
-    int old_scale_factor = Screen::the().scale_factor();
-    bool success = Screen::the().set_resolution(desired_width, desired_height, scale_factor);
-    if (success && old_scale_factor != scale_factor)
-        WindowManager::the().reload_icon_bitmaps_after_scale_change();
     init_bitmaps();
     invalidate_occlusions();
     compose();
-    return success;
 }
 
 Gfx::IntRect Compositor::current_cursor_rect() const
 {
     auto& wm = WindowManager::the();
     auto& current_cursor = m_current_cursor ? *m_current_cursor : wm.active_cursor();
-    return { Screen::the().cursor_location().translated(-current_cursor.params().hotspot()), current_cursor.size() };
+    return { ScreenInput::the().cursor_location().translated(-current_cursor.params().hotspot()), current_cursor.size() };
 }
 
 void Compositor::invalidate_cursor(bool compose_immediately)
@@ -714,13 +840,13 @@ void Compositor::invalidate_cursor(bool compose_immediately)
         start_compose_async_timer();
 }
 
-bool Compositor::draw_geometry_label(Gfx::IntRect& geometry_label_damage_rect)
+void Compositor::draw_geometry_label(Screen& screen)
 {
     auto& wm = WindowManager::the();
     auto* window_being_moved_or_resized = wm.m_move_window ? wm.m_move_window.ptr() : (wm.m_resize_window ? wm.m_resize_window.ptr() : nullptr);
     if (!window_being_moved_or_resized) {
         m_last_geometry_label_damage_rect = {};
-        return false;
+        return;
     }
     auto geometry_string = window_being_moved_or_resized->rect().to_string();
     if (!window_being_moved_or_resized->size_increment().is_null()) {
@@ -731,7 +857,7 @@ bool Compositor::draw_geometry_label(Gfx::IntRect& geometry_label_damage_rect)
 
     auto geometry_label_rect = Gfx::IntRect { 0, 0, wm.font().width(geometry_string) + 16, wm.font().glyph_height() + 10 };
     geometry_label_rect.center_within(window_being_moved_or_resized->rect());
-    auto desktop_rect = wm.desktop_rect();
+    auto desktop_rect = wm.desktop_rect(screen);
     if (geometry_label_rect.left() < desktop_rect.left())
         geometry_label_rect.set_left(desktop_rect.left());
     if (geometry_label_rect.top() < desktop_rect.top())
@@ -741,14 +867,17 @@ bool Compositor::draw_geometry_label(Gfx::IntRect& geometry_label_damage_rect)
     if (geometry_label_rect.bottom() > desktop_rect.bottom())
         geometry_label_rect.set_bottom_without_resize(desktop_rect.bottom());
 
-    auto& back_painter = *m_back_painter;
+    auto& screen_data = m_screen_data[screen.index()];
+    auto& back_painter = *screen_data.m_back_painter;
+    auto geometry_label_damage_rect = geometry_label_rect.inflated(2, 2);
+    Gfx::PainterStateSaver saver(back_painter);
+    back_painter.add_clip_rect(geometry_label_damage_rect);
+
     back_painter.fill_rect(geometry_label_rect.translated(1, 1), Color(Color::Black).with_alpha(80));
     Gfx::StylePainter::paint_button(back_painter, geometry_label_rect.translated(-1, -1), wm.palette(), Gfx::ButtonStyle::Normal, false);
     back_painter.draw_text(geometry_label_rect.translated(-1, -1), geometry_string, Gfx::TextAlignment::Center, wm.palette().window_text());
 
-    geometry_label_damage_rect = geometry_label_rect.inflated(2, 2);
     m_last_geometry_label_damage_rect = geometry_label_damage_rect;
-    return true;
 }
 
 void Compositor::change_cursor(const Cursor* cursor)
@@ -774,28 +903,34 @@ void Compositor::change_cursor(const Cursor* cursor)
     }
 }
 
-void Compositor::draw_cursor(const Gfx::IntRect& cursor_rect)
+void Compositor::ScreenData::draw_cursor(Screen& screen, const Gfx::IntRect& cursor_rect)
 {
     auto& wm = WindowManager::the();
 
-    if (!m_cursor_back_bitmap || m_cursor_back_bitmap->size() != cursor_rect.size() || m_cursor_back_bitmap->scale() != Screen::the().scale_factor()) {
-        m_cursor_back_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, cursor_rect.size(), Screen::the().scale_factor());
+    if (!m_cursor_back_bitmap || m_cursor_back_bitmap->size() != cursor_rect.size() || m_cursor_back_bitmap->scale() != screen.scale_factor()) {
+        m_cursor_back_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, cursor_rect.size(), screen.scale_factor());
         m_cursor_back_painter = make<Gfx::Painter>(*m_cursor_back_bitmap);
     }
 
-    auto& current_cursor = m_current_cursor ? *m_current_cursor : wm.active_cursor();
-    m_cursor_back_painter->blit({ 0, 0 }, *m_back_bitmap, current_cursor.rect().translated(cursor_rect.location()).intersected(Screen::the().rect()));
-    m_back_painter->blit(cursor_rect.location(), current_cursor.bitmap(), current_cursor.source_rect(m_current_cursor_frame));
+    auto& compositor = Compositor::the();
+    auto& current_cursor = compositor.m_current_cursor ? *compositor.m_current_cursor : wm.active_cursor();
+    auto screen_rect = screen.rect();
+    m_cursor_back_painter->blit({ 0, 0 }, *m_back_bitmap, current_cursor.rect().translated(cursor_rect.location()).intersected(screen_rect).translated(-screen_rect.location()));
+    m_back_painter->blit(cursor_rect.location(), current_cursor.bitmap(), current_cursor.source_rect(compositor.m_current_cursor_frame));
     m_last_cursor_rect = cursor_rect;
+    VERIFY(compositor.m_current_cursor_screen == &screen);
+    m_cursor_back_is_valid = true;
 }
 
-void Compositor::restore_cursor_back()
+bool Compositor::ScreenData::restore_cursor_back(Screen& screen, Gfx::IntRect& last_cursor_rect)
 {
-    if (!m_cursor_back_bitmap || m_cursor_back_bitmap->scale() != m_back_bitmap->scale())
-        return;
+    if (!m_cursor_back_is_valid || !m_cursor_back_bitmap || m_cursor_back_bitmap->scale() != m_back_bitmap->scale())
+        return false;
 
-    auto last_cursor_rect = m_last_cursor_rect.intersected(Screen::the().rect());
+    last_cursor_rect = m_last_cursor_rect.intersected(screen.rect());
     m_back_painter->blit(last_cursor_rect.location(), *m_cursor_back_bitmap, { { 0, 0 }, last_cursor_rect.size() });
+    m_cursor_back_is_valid = false;
+    return true;
 }
 
 void Compositor::notify_display_links()
@@ -863,14 +998,17 @@ void Compositor::recompute_occlusions()
 
     dbgln_if(OCCLUSIONS_DEBUG, "OCCLUSIONS:");
 
-    auto screen_rect = Screen::the().rect();
-
+    auto& main_screen = Screen::main();
     if (auto* fullscreen_window = wm.active_fullscreen_window()) {
+        // TODO: support fullscreen windows on all screens
+        auto screen_rect = main_screen.rect();
         WindowManager::the().window_stack().for_each_visible_window_from_front_to_back([&](Window& w) {
             auto& visible_opaque = w.opaque_rects();
             auto& transparency_rects = w.transparency_rects();
             auto& transparency_wallpaper_rects = w.transparency_wallpaper_rects();
+            w.screens().clear_with_capacity();
             if (&w == fullscreen_window) {
+                w.screens().append(&main_screen);
                 if (w.is_opaque()) {
                     visible_opaque = screen_rect;
                     transparency_rects.clear();
@@ -890,28 +1028,39 @@ void Compositor::recompute_occlusions()
 
         m_opaque_wallpaper_rects.clear();
     } else {
-        Gfx::DisjointRectSet visible_rects(screen_rect);
+        Gfx::DisjointRectSet visible_rects;
+        visible_rects.add_many(Screen::rects());
         bool have_transparent = false;
         WindowManager::the().window_stack().for_each_visible_window_from_front_to_back([&](Window& w) {
             w.transparency_wallpaper_rects().clear();
             auto& visible_opaque = w.opaque_rects();
+            visible_opaque.clear();
             auto& transparency_rects = w.transparency_rects();
-            if (w.is_minimized()) {
-                visible_opaque.clear();
-                transparency_rects.clear();
+            transparency_rects.clear();
+            w.screens().clear_with_capacity();
+            if (w.is_minimized())
                 return IterationDecision::Continue;
-            }
 
-            auto transparent_render_rects = w.frame().transparent_render_rects().intersected(screen_rect);
-            auto opaque_render_rects = w.frame().opaque_render_rects().intersected(screen_rect);
-            if (transparent_render_rects.is_empty() && opaque_render_rects.is_empty()) {
-                visible_opaque.clear();
-                transparency_rects.clear();
+            auto transparent_frame_render_rects = w.frame().transparent_render_rects();
+            auto opaque_frame_render_rects = w.frame().opaque_render_rects();
+            Gfx::DisjointRectSet visible_opaque_rects;
+            Screen::for_each([&](auto& screen) {
+                auto screen_rect = screen.rect();
+                if (auto transparent_render_rects = transparent_frame_render_rects.intersected(screen_rect); !transparent_render_rects.is_empty()) {
+                    if (transparency_rects.is_empty())
+                        transparency_rects = move(transparent_render_rects);
+                    else
+                        transparency_rects.add(transparent_render_rects);
+                }
+                if (auto opaque_render_rects = opaque_frame_render_rects.intersected(screen_rect); !opaque_render_rects.is_empty()) {
+                    if (visible_opaque_rects.is_empty())
+                        visible_opaque_rects = move(opaque_render_rects);
+                    else
+                        visible_opaque_rects.add(opaque_render_rects);
+                }
                 return IterationDecision::Continue;
-            }
-
-            visible_opaque = visible_rects.intersected(opaque_render_rects);
-            transparency_rects = move(transparent_render_rects);
+            });
+            visible_opaque = visible_rects.intersected(visible_opaque_rects);
 
             auto render_rect = w.frame().render_rect();
 
@@ -967,8 +1116,31 @@ void Compositor::recompute_occlusions()
                 return IterationDecision::Continue;
             });
 
+            bool have_opaque = !visible_opaque.is_empty();
             if (!transparency_rects.is_empty())
                 have_transparent = true;
+            if (have_transparent || have_opaque) {
+                // Figure out what screens this window is rendered on
+                // We gather this information so we can more quickly
+                // render the window on each of the screens that it
+                // needs to be rendered on.
+                Screen::for_each([&](auto& screen) {
+                    auto screen_rect = screen.rect();
+                    for (auto& r : visible_opaque.rects()) {
+                        if (r.intersects(screen_rect)) {
+                            w.screens().append(&screen);
+                            return IterationDecision::Continue;
+                        }
+                    }
+                    for (auto& r : transparency_rects.rects()) {
+                        if (r.intersects(screen_rect)) {
+                            w.screens().append(&screen);
+                            return IterationDecision::Continue;
+                        }
+                    }
+                    return IterationDecision::Continue;
+                });
+            }
 
             VERIFY(!visible_opaque.intersects(transparency_rects));
 
@@ -1008,12 +1180,14 @@ void Compositor::recompute_occlusions()
     }
 
     wm.window_stack().for_each_visible_window_from_back_to_front([&](Window& w) {
-        auto window_frame_rect = w.frame().render_rect().intersected(screen_rect);
-        if (w.is_minimized() || window_frame_rect.is_empty())
+        auto window_frame_rect = w.frame().render_rect();
+        if (w.is_minimized() || window_frame_rect.is_empty() || w.screens().is_empty())
             return IterationDecision::Continue;
 
         if constexpr (OCCLUSIONS_DEBUG) {
-            dbgln("  Window {} frame rect: {}", w.title(), window_frame_rect);
+            dbgln("  Window {} frame rect: {} rendered on screens: {}", w.title(), window_frame_rect, w.screens().size());
+            for (auto& s : w.screens())
+                dbgln("    screen: #{}", s->index());
             for (auto& r : w.opaque_rects().rects())
                 dbgln("    opaque: {}", r);
             for (auto& r : w.transparency_wallpaper_rects().rects())

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -48,6 +48,8 @@ public:
 
     void invalidate_cursor(bool = false);
     Gfx::IntRect current_cursor_rect() const;
+    const Cursor* current_cursor() const { return m_current_cursor; }
+    void current_cursor_was_reloaded(const Cursor* new_cursor) { m_current_cursor = new_cursor; }
 
     void increment_display_link_count(Badge<ClientConnection>);
     void decrement_display_link_count(Badge<ClientConnection>);

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -56,6 +56,7 @@ public:
 
     void did_construct_window_manager(Badge<WindowManager>);
 
+    const Gfx::Bitmap* cursor_bitmap_for_screenshot(Badge<ClientConnection>, Screen&) const;
     const Gfx::Bitmap& front_bitmap_for_screenshot(Badge<ClientConnection>, Screen&) const;
 
 private:

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -11,6 +11,7 @@
 #include <LibCore/Object.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/DisjointRectSet.h>
+#include <WindowServer/Screen.h>
 
 namespace WindowServer {
 
@@ -36,7 +37,7 @@ public:
     void invalidate_screen();
     void invalidate_screen(const Gfx::IntRect&);
 
-    bool set_resolution(int desired_width, int desired_height, int scale_factor);
+    void screen_resolution_changed();
 
     bool set_background_color(const String& background_color);
 
@@ -55,46 +56,58 @@ public:
 
     void did_construct_window_manager(Badge<WindowManager>);
 
-    const Gfx::Bitmap& front_bitmap_for_screenshot(Badge<ClientConnection>) const { return *m_front_bitmap; }
+    const Gfx::Bitmap& front_bitmap_for_screenshot(Badge<ClientConnection>, Screen&) const;
 
 private:
     Compositor();
     void init_bitmaps();
-    void flip_buffers();
-    void flush(const Gfx::IntRect&);
-    void run_animations(Gfx::DisjointRectSet&);
+    bool render_animation_frame(Screen&, Gfx::DisjointRectSet&);
+    void step_animations();
     void notify_display_links();
     void start_compose_async_timer();
     void recompute_occlusions();
     bool any_opaque_window_above_this_one_contains_rect(const Window&, const Gfx::IntRect&);
     void change_cursor(const Cursor*);
-    void draw_cursor(const Gfx::IntRect&);
-    void restore_cursor_back();
-    bool draw_geometry_label(Gfx::IntRect&);
+    void draw_geometry_label(Screen&);
+    void flush(Screen&);
 
     RefPtr<Core::Timer> m_compose_timer;
     RefPtr<Core::Timer> m_immediate_compose_timer;
     bool m_flash_flush { false };
-    bool m_buffers_are_flipped { false };
-    bool m_screen_can_set_buffer { false };
     bool m_occlusions_dirty { true };
     bool m_invalidated_any { true };
     bool m_invalidated_window { false };
     bool m_invalidated_cursor { false };
 
-    RefPtr<Gfx::Bitmap> m_front_bitmap;
-    RefPtr<Gfx::Bitmap> m_back_bitmap;
-    RefPtr<Gfx::Bitmap> m_temp_bitmap;
-    OwnPtr<Gfx::Painter> m_back_painter;
-    OwnPtr<Gfx::Painter> m_front_painter;
-    OwnPtr<Gfx::Painter> m_temp_painter;
+    struct ScreenData {
+        RefPtr<Gfx::Bitmap> m_front_bitmap;
+        RefPtr<Gfx::Bitmap> m_back_bitmap;
+        RefPtr<Gfx::Bitmap> m_temp_bitmap;
+        OwnPtr<Gfx::Painter> m_back_painter;
+        OwnPtr<Gfx::Painter> m_front_painter;
+        OwnPtr<Gfx::Painter> m_temp_painter;
+        RefPtr<Gfx::Bitmap> m_cursor_back_bitmap;
+        OwnPtr<Gfx::Painter> m_cursor_back_painter;
+        Gfx::IntRect m_last_cursor_rect;
+        bool m_buffers_are_flipped { false };
+        bool m_screen_can_set_buffer { false };
+        bool m_cursor_back_is_valid { false };
+
+        Gfx::DisjointRectSet m_flush_rects;
+        Gfx::DisjointRectSet m_flush_transparent_rects;
+        Gfx::DisjointRectSet m_flush_special_rects;
+
+        void init_bitmaps(Screen&);
+        void flip_buffers(Screen&);
+        void draw_cursor(Screen&, const Gfx::IntRect&);
+        bool restore_cursor_back(Screen&, Gfx::IntRect&);
+    };
+    friend class ScreenData;
+    Vector<ScreenData, default_screen_count> m_screen_data;
 
     Gfx::DisjointRectSet m_dirty_screen_rects;
     Gfx::DisjointRectSet m_opaque_wallpaper_rects;
 
-    RefPtr<Gfx::Bitmap> m_cursor_back_bitmap;
-    OwnPtr<Gfx::Painter> m_cursor_back_painter;
-    Gfx::IntRect m_last_cursor_rect;
     Gfx::IntRect m_last_dnd_rect;
     Gfx::IntRect m_last_geometry_label_damage_rect;
 
@@ -103,6 +116,7 @@ private:
     RefPtr<Gfx::Bitmap> m_wallpaper;
 
     const Cursor* m_current_cursor { nullptr };
+    Screen* m_current_cursor_screen { nullptr };
     unsigned m_current_cursor_frame { 0 };
     RefPtr<Core::Timer> m_cursor_timer;
 

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -81,9 +81,9 @@ EventLoop::~EventLoop()
 
 void EventLoop::drain_mouse()
 {
-    auto& screen = Screen::the();
+    auto& screen_input = ScreenInput::the();
     MousePacket state;
-    state.buttons = screen.mouse_button_state();
+    state.buttons = screen_input.mouse_button_state();
     unsigned buttons = state.buttons;
     MousePacket packets[32];
 
@@ -114,7 +114,7 @@ void EventLoop::drain_mouse()
         if (buttons != state.buttons) {
             state.buttons = buttons;
             dbgln_if(WSMESSAGELOOP_DEBUG, "EventLoop: Mouse Button Event");
-            screen.on_receive_mouse_data(state);
+            screen_input.on_receive_mouse_data(state);
             if (state.is_relative) {
                 state.x = 0;
                 state.y = 0;
@@ -123,21 +123,21 @@ void EventLoop::drain_mouse()
         }
     }
     if (state.is_relative && (state.x || state.y || state.z))
-        screen.on_receive_mouse_data(state);
+        screen_input.on_receive_mouse_data(state);
     if (!state.is_relative)
-        screen.on_receive_mouse_data(state);
+        screen_input.on_receive_mouse_data(state);
 }
 
 void EventLoop::drain_keyboard()
 {
-    auto& screen = Screen::the();
+    auto& screen_input = ScreenInput::the();
     for (;;) {
         ::KeyEvent event;
         ssize_t nread = read(m_keyboard_fd, (u8*)&event, sizeof(::KeyEvent));
         if (nread == 0)
             break;
         VERIFY(nread == sizeof(::KeyEvent));
-        screen.on_receive_keyboard_data(event);
+        screen_input.on_receive_keyboard_data(event);
     }
 }
 

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -136,7 +136,7 @@ Window& Menu::ensure_menu_window()
         next_item_location.translate_by(0, height);
     }
 
-    int window_height_available = Screen::the().height() - frame_thickness() * 2;
+    int window_height_available = Screen::main().height() - frame_thickness() * 2; // TODO: we don't know yet on what screen!
     int max_window_height = (window_height_available / item_height()) * item_height() + frame_thickness() * 2;
     int content_height = m_items.is_empty() ? 0 : (m_items.last().rect().bottom() + 1) + frame_thickness();
     int window_height = min(max_window_height, content_height);
@@ -584,14 +584,15 @@ void Menu::do_popup(const Gfx::IntPoint& position, bool make_input, bool as_subm
     redraw_if_theme_changed();
 
     const int margin = 30;
+    auto& screen = Screen::closest_to_location(position);
     Gfx::IntPoint adjusted_pos = position;
 
-    if (adjusted_pos.x() + window.width() >= Screen::the().width() - margin) {
+    if (adjusted_pos.x() + window.width() >= screen.width() - margin) {
         adjusted_pos = adjusted_pos.translated(-window.width(), 0);
     } else {
         adjusted_pos.set_x(adjusted_pos.x() + 1);
     }
-    if (adjusted_pos.y() + window.height() >= Screen::the().height() - margin) {
+    if (adjusted_pos.y() + window.height() >= screen.height() - margin) {
         adjusted_pos = adjusted_pos.translated(0, -min(window.height(), adjusted_pos.y()));
         if (as_submenu)
             adjusted_pos = adjusted_pos.translated(0, item_height());

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
@@ -38,6 +38,8 @@ bool MultiScaleBitmaps::load(StringView const& filename, StringView const& defau
     Optional<Gfx::BitmapFormat> bitmap_format;
     bool did_load_any = false;
 
+    m_bitmaps.clear(); // If we're reloading the bitmaps get rid of the old ones
+
     auto add_bitmap = [&](StringView const& path, int scale_factor) {
         auto bitmap = Gfx::Bitmap::load_from_file(path, scale_factor);
         if (bitmap) {

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "MultiScaleBitmaps.h"
+#include "Screen.h"
+
+namespace WindowServer {
+
+const Gfx::Bitmap& MultiScaleBitmaps::bitmap(int scale_factor) const
+{
+    auto it = m_bitmaps.find(scale_factor);
+    if (it == m_bitmaps.end()) {
+        it = m_bitmaps.find(1);
+        if (it == m_bitmaps.end())
+            it = m_bitmaps.begin();
+    }
+    // We better found *something*
+    if (it == m_bitmaps.end()) {
+        dbgln("Could not find any bitmap in this MultiScaleBitmaps");
+        VERIFY_NOT_REACHED();
+    }
+    return it->value;
+}
+
+RefPtr<MultiScaleBitmaps> MultiScaleBitmaps::create(StringView const& filename, StringView const& default_filename)
+{
+    auto per_scale_bitmap = adopt_ref(*new MultiScaleBitmaps());
+    if (per_scale_bitmap->load(filename, default_filename))
+        return per_scale_bitmap;
+    return {};
+}
+
+bool MultiScaleBitmaps::load(StringView const& filename, StringView const& default_filename)
+{
+    Optional<Gfx::BitmapFormat> bitmap_format;
+    bool did_load_any = false;
+
+    auto add_bitmap = [&](StringView const& path, int scale_factor) {
+        auto bitmap = Gfx::Bitmap::load_from_file(path, scale_factor);
+        if (bitmap) {
+            auto bitmap_format = bitmap->format();
+            if (m_format == Gfx::BitmapFormat::Invalid || m_format == bitmap_format) {
+                if (m_format == Gfx::BitmapFormat::Invalid)
+                    m_format = bitmap_format;
+
+                did_load_any = true;
+                m_bitmaps.set(scale_factor, bitmap.release_nonnull());
+            } else {
+                dbgln("Bitmap {} (scale {}) has format inconsistent with the other per-scale bitmaps", path, bitmap->scale());
+            }
+        }
+    };
+
+    Screen::for_each_scale_factor_in_use([&](int scale_factor) {
+        add_bitmap(filename, scale_factor);
+        return IterationDecision::Continue;
+    });
+    if (!did_load_any && !default_filename.is_null() && !default_filename.is_empty()) {
+        Screen::for_each_scale_factor_in_use([&](int scale_factor) {
+            add_bitmap(default_filename, scale_factor);
+            return IterationDecision::Continue;
+        });
+    }
+    return did_load_any;
+}
+
+}

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.h
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.h
@@ -20,10 +20,10 @@ public:
     Gfx::Bitmap const& default_bitmap() const { return bitmap(1); }
     Gfx::Bitmap const& bitmap(int scale_factor) const;
     Gfx::BitmapFormat format() const { return m_format; }
+    bool load(StringView const& filename, StringView const& default_filename = {});
 
 private:
     MultiScaleBitmaps() = default;
-    bool load(StringView const& filename, StringView const& default_filename);
 
     HashMap<int, NonnullRefPtr<Gfx::Bitmap>> m_bitmaps;
     Gfx::BitmapFormat m_format { Gfx::BitmapFormat::Invalid };

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.h
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <LibGfx/Bitmap.h>
+
+namespace WindowServer {
+
+class MultiScaleBitmaps : public RefCounted<MultiScaleBitmaps> {
+public:
+    static RefPtr<MultiScaleBitmaps> create(StringView const& filename, StringView const& default_filename = {});
+
+    Gfx::Bitmap const& default_bitmap() const { return bitmap(1); }
+    Gfx::Bitmap const& bitmap(int scale_factor) const;
+    Gfx::BitmapFormat format() const { return m_format; }
+
+private:
+    MultiScaleBitmaps() = default;
+    bool load(StringView const& filename, StringView const& default_filename);
+
+    HashMap<int, NonnullRefPtr<Gfx::Bitmap>> m_bitmaps;
+    Gfx::BitmapFormat m_format { Gfx::BitmapFormat::Invalid };
+};
+
+}

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -19,21 +19,37 @@
 
 namespace WindowServer {
 
-static Screen* s_the;
+NonnullOwnPtrVector<Screen, default_screen_count> Screen::s_screens;
+Screen* Screen::s_main_screen { nullptr };
+Gfx::IntRect Screen::s_bounding_screens_rect {};
 
-Screen& Screen::the()
+ScreenInput& ScreenInput::the()
 {
-    VERIFY(s_the);
-    return *s_the;
+    static ScreenInput s_the;
+    return s_the;
 }
 
-Screen::Screen(unsigned desired_width, unsigned desired_height, int scale_factor)
+Screen& ScreenInput::cursor_location_screen()
 {
-    VERIFY(!s_the);
-    s_the = this;
-    m_framebuffer_fd = open("/dev/fb0", O_RDWR | O_CLOEXEC);
+    auto* screen = Screen::find_by_location(m_cursor_location);
+    VERIFY(screen);
+    return *screen;
+}
+
+const Screen& ScreenInput::cursor_location_screen() const
+{
+    auto* screen = Screen::find_by_location(m_cursor_location);
+    VERIFY(screen);
+    return *screen;
+}
+
+Screen::Screen(const String& device, const Gfx::IntRect& virtual_rect, int scale_factor)
+    : m_virtual_rect(virtual_rect)
+    , m_scale_factor(scale_factor)
+{
+    m_framebuffer_fd = open(device.characters(), O_RDWR | O_CLOEXEC);
     if (m_framebuffer_fd < 0) {
-        perror("failed to open /dev/fb0");
+        perror(String::formatted("failed to open {}", device).characters());
         VERIFY_NOT_REACHED();
     }
 
@@ -41,8 +57,10 @@ Screen::Screen(unsigned desired_width, unsigned desired_height, int scale_factor
         m_can_set_buffer = true;
     }
 
-    set_resolution(desired_width, desired_height, scale_factor);
-    m_physical_cursor_location = physical_rect().center();
+    // If the cursor is not in a valid screen (yet), force it into one
+    dbgln("Screen() current physical cursor location: {} rect: {}", ScreenInput::the().cursor_location(), rect());
+    if (!find_by_location(ScreenInput::the().cursor_location()))
+        ScreenInput::the().set_cursor_location(rect().center());
 }
 
 Screen::~Screen()
@@ -50,35 +68,84 @@ Screen::~Screen()
     close(m_framebuffer_fd);
 }
 
-bool Screen::set_resolution(int width, int height, int new_scale_factor)
+void Screen::init()
 {
+    do_set_resolution(true, m_virtual_rect.width(), m_virtual_rect.height(), m_scale_factor);
+}
+
+Screen& Screen::closest_to_rect(const Gfx::IntRect& rect)
+{
+    Screen* best_screen = nullptr;
+    int best_area = 0;
+    for (auto& screen : s_screens) {
+        auto r = screen.rect().intersected(rect);
+        int area = r.width() * r.height();
+        if (!best_screen || area > best_area) {
+            best_screen = &screen;
+            best_area = area;
+        }
+    }
+    if (!best_screen) {
+        // TODO: try to find the best screen in close proximity
+        best_screen = &Screen::main();
+    }
+    return *best_screen;
+}
+
+Screen& Screen::closest_to_location(const Gfx::IntPoint& point)
+{
+    for (auto& screen : s_screens) {
+        if (screen.rect().contains(point))
+            return screen;
+    }
+    // TODO: guess based on how close the point is to the next screen rectangle
+    return Screen::main();
+}
+
+void Screen::update_bounding_rect()
+{
+    if (!s_screens.is_empty()) {
+        s_bounding_screens_rect = s_screens[0].rect();
+        for (size_t i = 1; i < s_screens.size(); i++)
+            s_bounding_screens_rect = s_bounding_screens_rect.united(s_screens[i].rect());
+    } else {
+        s_bounding_screens_rect = {};
+    }
+}
+
+bool Screen::do_set_resolution(bool initial, int width, int height, int new_scale_factor)
+{
+    // Remember the screen that the cursor is on. Make sure it stays on the same screen if we change its resolution...
+    auto& screen_with_cursor = ScreenInput::the().cursor_location_screen();
+
     int new_physical_width = width * new_scale_factor;
     int new_physical_height = height * new_scale_factor;
-    if (physical_width() == new_physical_width && physical_height() == new_physical_height) {
-        VERIFY(scale_factor() != new_scale_factor);
-        on_change_resolution(m_pitch, physical_width(), physical_height(), new_scale_factor);
+    if (!initial && physical_width() == new_physical_width && physical_height() == new_physical_height) {
+        VERIFY(initial || scale_factor() != new_scale_factor);
+        on_change_resolution(initial, m_pitch, physical_width(), physical_height(), new_scale_factor, screen_with_cursor);
         return true;
     }
 
     FBResolution physical_resolution { 0, (unsigned)new_physical_width, (unsigned)new_physical_height };
     int rc = fb_set_resolution(m_framebuffer_fd, &physical_resolution);
-    dbgln_if(WSSCREEN_DEBUG, "fb_set_resolution() - return code {}", rc);
+    dbgln_if(WSSCREEN_DEBUG, "Screen #{}: fb_set_resolution() - return code {}", index(), rc);
 
     if (rc == 0) {
-        on_change_resolution(physical_resolution.pitch, physical_resolution.width, physical_resolution.height, new_scale_factor);
+        on_change_resolution(initial, physical_resolution.pitch, physical_resolution.width, physical_resolution.height, new_scale_factor, screen_with_cursor);
         return true;
     }
     if (rc == -1) {
-        dbgln("Invalid resolution {}x{}", width, height);
-        on_change_resolution(physical_resolution.pitch, physical_resolution.width, physical_resolution.height, new_scale_factor);
+        int err = errno;
+        dbgln("Screen #{}: Failed to set resolution {}x{}: {}", index(), width, height, strerror(err));
+        on_change_resolution(initial, physical_resolution.pitch, physical_resolution.width, physical_resolution.height, new_scale_factor, screen_with_cursor);
         return false;
     }
     VERIFY_NOT_REACHED();
 }
 
-void Screen::on_change_resolution(int pitch, int new_physical_width, int new_physical_height, int new_scale_factor)
+void Screen::on_change_resolution(bool initial, int pitch, int new_physical_width, int new_physical_height, int new_scale_factor, Screen& screen_with_cursor)
 {
-    if (physical_width() != new_physical_width || physical_height() != new_physical_height) {
+    if (initial || physical_width() != new_physical_width || physical_height() != new_physical_height) {
         if (m_framebuffer) {
             size_t previous_size_in_bytes = m_size_in_bytes;
             int rc = munmap(m_framebuffer, previous_size_in_bytes);
@@ -93,11 +160,15 @@ void Screen::on_change_resolution(int pitch, int new_physical_width, int new_phy
     }
 
     m_pitch = pitch;
-    m_width = new_physical_width / new_scale_factor;
-    m_height = new_physical_height / new_scale_factor;
+    m_virtual_rect.set_width(new_physical_width / new_scale_factor);
+    m_virtual_rect.set_height(new_physical_height / new_scale_factor);
     m_scale_factor = new_scale_factor;
+    update_bounding_rect();
 
-    m_physical_cursor_location.constrain(physical_rect());
+    if (this == &screen_with_cursor) {
+        auto& screen_input = ScreenInput::the();
+        screen_input.set_cursor_location(screen_input.cursor_location().constrained(rect()));
+    }
 }
 
 void Screen::set_buffer(int index)
@@ -107,31 +178,35 @@ void Screen::set_buffer(int index)
     VERIFY(rc == 0);
 }
 
-void Screen::set_acceleration_factor(double factor)
+void ScreenInput::set_acceleration_factor(double factor)
 {
     VERIFY(factor >= mouse_accel_min && factor <= mouse_accel_max);
     m_acceleration_factor = factor;
 }
 
-void Screen::set_scroll_step_size(unsigned step_size)
+void ScreenInput::set_scroll_step_size(unsigned step_size)
 {
     VERIFY(step_size >= scroll_step_size_min);
     m_scroll_step_size = step_size;
 }
 
-void Screen::on_receive_mouse_data(const MousePacket& packet)
+void ScreenInput::on_receive_mouse_data(const MousePacket& packet)
 {
-    auto prev_location = m_physical_cursor_location / m_scale_factor;
+    auto& current_screen = cursor_location_screen();
+    auto prev_location = m_cursor_location;
     if (packet.is_relative) {
-        m_physical_cursor_location.translate_by(packet.x * m_acceleration_factor, packet.y * m_acceleration_factor);
-        dbgln_if(WSSCREEN_DEBUG, "Screen: New Relative mouse point @ {}", m_physical_cursor_location);
+        m_cursor_location.translate_by(packet.x * m_acceleration_factor, packet.y * m_acceleration_factor);
+        dbgln_if(WSSCREEN_DEBUG, "Screen: New Relative mouse point @ {}", m_cursor_location);
     } else {
-        m_physical_cursor_location = { packet.x * physical_width() / 0xffff, packet.y * physical_height() / 0xffff };
-        dbgln_if(WSSCREEN_DEBUG, "Screen: New Absolute mouse point @ {}", m_physical_cursor_location);
+        m_cursor_location = { packet.x * current_screen.physical_width() / 0xffff, packet.y * current_screen.physical_height() / 0xffff };
+        dbgln_if(WSSCREEN_DEBUG, "Screen: New Absolute mouse point @ {}", m_cursor_location);
     }
 
-    m_physical_cursor_location.constrain(physical_rect());
-    auto new_location = m_physical_cursor_location / m_scale_factor;
+    auto* moved_to_screen = Screen::find_by_location(m_cursor_location);
+    if (!moved_to_screen) {
+        m_cursor_location = m_cursor_location.constrained(current_screen.rect());
+        moved_to_screen = &current_screen;
+    }
 
     unsigned buttons = packet.buttons;
     unsigned prev_buttons = m_mouse_button_state;
@@ -140,7 +215,7 @@ void Screen::on_receive_mouse_data(const MousePacket& packet)
     auto post_mousedown_or_mouseup_if_needed = [&](MouseButton button) {
         if (!(changed_buttons & (unsigned)button))
             return;
-        auto message = make<MouseEvent>(buttons & (unsigned)button ? Event::MouseDown : Event::MouseUp, new_location, buttons, button, m_modifiers);
+        auto message = make<MouseEvent>(buttons & (unsigned)button ? Event::MouseDown : Event::MouseUp, m_cursor_location, buttons, button, m_modifiers);
         Core::EventLoop::current().post_event(WindowManager::the(), move(message));
     };
     post_mousedown_or_mouseup_if_needed(MouseButton::Left);
@@ -148,23 +223,23 @@ void Screen::on_receive_mouse_data(const MousePacket& packet)
     post_mousedown_or_mouseup_if_needed(MouseButton::Middle);
     post_mousedown_or_mouseup_if_needed(MouseButton::Back);
     post_mousedown_or_mouseup_if_needed(MouseButton::Forward);
-    if (new_location != prev_location) {
-        auto message = make<MouseEvent>(Event::MouseMove, new_location, buttons, MouseButton::None, m_modifiers);
+    if (m_cursor_location != prev_location) {
+        auto message = make<MouseEvent>(Event::MouseMove, m_cursor_location, buttons, MouseButton::None, m_modifiers);
         if (WindowManager::the().dnd_client())
             message->set_mime_data(WindowManager::the().dnd_mime_data());
         Core::EventLoop::current().post_event(WindowManager::the(), move(message));
     }
 
     if (packet.z) {
-        auto message = make<MouseEvent>(Event::MouseWheel, new_location, buttons, MouseButton::None, m_modifiers, packet.z * m_scroll_step_size);
+        auto message = make<MouseEvent>(Event::MouseWheel, m_cursor_location, buttons, MouseButton::None, m_modifiers, packet.z * m_scroll_step_size);
         Core::EventLoop::current().post_event(WindowManager::the(), move(message));
     }
 
-    if (new_location != prev_location)
+    if (m_cursor_location != prev_location)
         Compositor::the().invalidate_cursor();
 }
 
-void Screen::on_receive_keyboard_data(::KeyEvent kernel_event)
+void ScreenInput::on_receive_keyboard_data(::KeyEvent kernel_event)
 {
     m_modifiers = kernel_event.modifiers();
     auto message = make<KeyEvent>(kernel_event.is_press() ? Event::KeyDown : Event::KeyUp, kernel_event.key, kernel_event.code_point, kernel_event.modifiers(), kernel_event.scancode);

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -9,6 +9,7 @@
 #include "ScreenLayout.h"
 #include <AK/NonnullOwnPtrVector.h>
 #include <Kernel/API/KeyCode.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
@@ -23,6 +24,8 @@ constexpr unsigned scroll_step_size_min = 1;
 
 // Most people will probably have 4 screens or less
 constexpr size_t default_screen_count = 4;
+// We currently only support 2 scale factors: 1x and 2x
+constexpr size_t default_scale_factors_in_use_count = 2;
 
 class Screen;
 
@@ -125,6 +128,17 @@ public:
         return IterationDecision::Continue;
     }
 
+    template<typename F>
+    static IterationDecision for_each_scale_factor_in_use(F f)
+    {
+        for (auto& scale_factor : s_scale_factors_in_use) {
+            IterationDecision decision = f(scale_factor);
+            if (decision != IterationDecision::Continue)
+                return decision;
+        }
+        return IterationDecision::Continue;
+    }
+
     void make_main_screen() { s_main_screen = this; }
     bool is_main_screen() const { return s_main_screen == this; }
 
@@ -158,6 +172,7 @@ private:
             s_screens[i].m_index = i;
     }
     static void update_bounding_rect();
+    static void update_scale_factors_in_use();
 
     bool is_opened() const { return m_framebuffer_fd >= 0; }
 
@@ -165,6 +180,7 @@ private:
     static Screen* s_main_screen;
     static Gfx::IntRect s_bounding_screens_rect;
     static ScreenLayout s_layout;
+    static Vector<int, default_scale_factors_in_use_count> s_scale_factors_in_use;
     size_t m_index { 0 };
 
     size_t m_size_in_bytes;

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/NonnullOwnPtrVector.h>
 #include <Kernel/API/KeyCode.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Rect.h>
@@ -19,34 +20,17 @@ constexpr double mouse_accel_max = 3.5;
 constexpr double mouse_accel_min = 0.5;
 constexpr unsigned scroll_step_size_min = 1;
 
-class Screen {
+// Most people will probably have 4 screens or less
+constexpr size_t default_screen_count = 4;
+
+class Screen;
+
+class ScreenInput {
 public:
-    Screen(unsigned width, unsigned height, int scale_factor);
-    ~Screen();
+    static ScreenInput& the();
 
-    bool set_resolution(int width, int height, int scale_factor);
-    bool can_set_buffer() { return m_can_set_buffer; }
-    void set_buffer(int index);
-
-    int physical_width() const { return width() * scale_factor(); }
-    int physical_height() const { return height() * scale_factor(); }
-    size_t pitch() const { return m_pitch; }
-
-    int width() const { return m_width; }
-    int height() const { return m_height; }
-    int scale_factor() const { return m_scale_factor; }
-
-    Gfx::RGBA32* scanline(int y);
-
-    static Screen& the();
-
-    Gfx::IntSize physical_size() const { return { physical_width(), physical_height() }; }
-    Gfx::IntRect physical_rect() const { return { { 0, 0 }, physical_size() }; }
-
-    Gfx::IntSize size() const { return { width(), height() }; }
-    Gfx::IntRect rect() const { return { { 0, 0 }, size() }; }
-
-    Gfx::IntPoint cursor_location() const { return m_physical_cursor_location / m_scale_factor; }
+    Screen& cursor_location_screen();
+    const Screen& cursor_location_screen() const;
     unsigned mouse_button_state() const { return m_mouse_button_state; }
 
     double acceleration_factor() const { return m_acceleration_factor; }
@@ -58,8 +42,130 @@ public:
     void on_receive_mouse_data(const MousePacket&);
     void on_receive_keyboard_data(::KeyEvent);
 
+    Gfx::IntPoint cursor_location() const { return m_cursor_location; }
+    void set_cursor_location(const Gfx::IntPoint point) { m_cursor_location = point; }
+
 private:
-    void on_change_resolution(int pitch, int physical_width, int physical_height, int scale_factor);
+    Gfx::IntPoint m_cursor_location;
+    unsigned m_mouse_button_state { 0 };
+    unsigned m_modifiers { 0 };
+    double m_acceleration_factor { 1.0 };
+    unsigned m_scroll_step_size { 1 };
+};
+
+class Screen {
+public:
+    template<typename... Args>
+    static Screen* create(Args&&... args)
+    {
+        auto screen = adopt_own(*new Screen(forward<Args>(args)...));
+        if (!screen->is_opened())
+            return nullptr;
+        auto* screen_ptr = screen.ptr();
+        s_screens.append(move(screen));
+        update_indices();
+        update_bounding_rect();
+        if (!s_main_screen)
+            s_main_screen = screen_ptr;
+        screen_ptr->init();
+        return screen_ptr;
+    }
+    ~Screen();
+
+    static Screen& main()
+    {
+        VERIFY(s_main_screen);
+        return *s_main_screen;
+    }
+
+    static Screen& closest_to_rect(const Gfx::IntRect&);
+    static Screen& closest_to_location(const Gfx::IntPoint&);
+
+    static Screen* find_by_index(size_t index)
+    {
+        if (index >= s_screens.size())
+            return nullptr;
+        return &s_screens[index];
+    }
+
+    static Vector<Gfx::IntRect, 4> rects()
+    {
+        Vector<Gfx::IntRect, 4> rects;
+        for (auto& screen : s_screens)
+            rects.append(screen.rect());
+        return rects;
+    }
+
+    static Screen* find_by_location(const Gfx::IntPoint& point)
+    {
+        for (auto& screen : s_screens) {
+            if (screen.rect().contains(point))
+                return &screen;
+        }
+        return nullptr;
+    }
+
+    static const Gfx::IntRect& bounding_rect() { return s_bounding_screens_rect; }
+
+    static size_t count() { return s_screens.size(); }
+    size_t index() const { return m_index; }
+
+    template<typename F>
+    static IterationDecision for_each(F f)
+    {
+        for (auto& screen : s_screens) {
+            IterationDecision decision = f(screen);
+            if (decision != IterationDecision::Continue)
+                return decision;
+        }
+        return IterationDecision::Continue;
+    }
+
+    void make_main_screen() { s_main_screen = this; }
+    bool is_main_screen() const { return s_main_screen == this; }
+
+    template<typename... Args>
+    bool set_resolution(Args&&... args)
+    {
+        return do_set_resolution(false, forward<Args>(args)...);
+    }
+    bool can_set_buffer() { return m_can_set_buffer; }
+    void set_buffer(int index);
+
+    int physical_width() const { return width() * scale_factor(); }
+    int physical_height() const { return height() * scale_factor(); }
+    size_t pitch() const { return m_pitch; }
+
+    int width() const { return m_virtual_rect.width(); }
+    int height() const { return m_virtual_rect.height(); }
+    int scale_factor() const { return m_scale_factor; }
+
+    Gfx::RGBA32* scanline(int y);
+
+    Gfx::IntSize physical_size() const { return { physical_width(), physical_height() }; }
+
+    Gfx::IntSize size() const { return { m_virtual_rect.width(), m_virtual_rect.height() }; }
+    Gfx::IntRect rect() const { return m_virtual_rect; }
+
+private:
+    Screen(const String& device, const Gfx::IntRect& virtual_rect, int scale_factor);
+    void init();
+    bool do_set_resolution(bool initial, int width, int height, int scale_factor);
+    static void update_indices()
+    {
+        for (size_t i = 0; i < s_screens.size(); i++)
+            s_screens[i].m_index = i;
+    }
+    static void update_bounding_rect();
+
+    bool is_opened() const { return m_framebuffer_fd >= 0; }
+
+    void on_change_resolution(bool initial, int pitch, int physical_width, int physical_height, int scale_factor, Screen& screen_with_cursor);
+
+    static NonnullOwnPtrVector<Screen, default_screen_count> s_screens;
+    static Screen* s_main_screen;
+    static Gfx::IntRect s_bounding_screens_rect;
+    size_t m_index { 0 };
 
     size_t m_size_in_bytes;
 
@@ -67,16 +173,9 @@ private:
     bool m_can_set_buffer { false };
 
     int m_pitch { 0 };
-    int m_width { 0 };
-    int m_height { 0 };
+    Gfx::IntRect m_virtual_rect;
     int m_framebuffer_fd { -1 };
     int m_scale_factor { 1 };
-
-    Gfx::IntPoint m_physical_cursor_location;
-    unsigned m_mouse_button_state { 0 };
-    unsigned m_modifiers { 0 };
-    double m_acceleration_factor { 1.0 };
-    unsigned m_scroll_step_size { 1 };
 };
 
 inline Gfx::RGBA32* Screen::scanline(int y)

--- a/Userland/Services/WindowServer/ScreenLayout.cpp
+++ b/Userland/Services/WindowServer/ScreenLayout.cpp
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ScreenLayout.ipp"

--- a/Userland/Services/WindowServer/ScreenLayout.h
+++ b/Userland/Services/WindowServer/ScreenLayout.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibCore/ConfigFile.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/Size.h>
+#include <LibIPC/Forward.h>
+
+namespace WindowServer {
+
+class ScreenLayout {
+public:
+    struct Screen {
+        String device;
+        Gfx::IntPoint location;
+        Gfx::IntSize resolution;
+        int scale_factor;
+
+        Gfx::IntRect virtual_rect() const
+        {
+            return { location, { resolution.width() / scale_factor, resolution.height() / scale_factor } };
+        }
+
+        auto operator<=>(const Screen&) const = default;
+    };
+
+    Vector<Screen> screens;
+    unsigned main_screen_index { 0 };
+
+    bool is_valid(String* error_msg = nullptr) const;
+    void normalize();
+    bool load_config(const Core::ConfigFile& config_file, String* error_msg = nullptr);
+    bool save_config(Core::ConfigFile& config_file, bool sync = true) const;
+
+    // TODO: spaceship operator
+    bool operator!=(const ScreenLayout& other) const;
+    bool operator==(const ScreenLayout& other) const
+    {
+        return !(*this != other);
+    }
+};
+
+}
+
+namespace IPC {
+
+bool encode(Encoder&, const WindowServer::ScreenLayout::Screen&);
+bool decode(Decoder&, WindowServer::ScreenLayout::Screen&);
+bool encode(Encoder&, const WindowServer::ScreenLayout&);
+bool decode(Decoder&, WindowServer::ScreenLayout&);
+
+}

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Services/WindowServer/ScreenLayout.h>
+
+// Must be included after LibIPC/Forward.h
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace WindowServer {
+
+bool ScreenLayout::is_valid(String* error_msg) const
+{
+    if (screens.is_empty()) {
+        if (error_msg)
+            *error_msg = "Must have at least one screen";
+        return false;
+    }
+    if (main_screen_index >= screens.size()) {
+        if (error_msg)
+            *error_msg = String::formatted("Invalid main screen index: {}", main_screen_index);
+        return false;
+    }
+    int smallest_x = 0;
+    int smallest_y = 0;
+    for (size_t i = 0; i < screens.size(); i++) {
+        auto& screen = screens[i];
+        if (screen.device.is_null() || screen.device.is_empty()) {
+            if (error_msg)
+                *error_msg = String::formatted("Screen #{} has no path", i);
+            return false;
+        }
+        for (size_t j = 0; j < screens.size(); j++) {
+            auto& other_screen = screens[j];
+            if (&other_screen == &screen)
+                continue;
+            if (screen.device == other_screen.device) {
+                if (error_msg)
+                    *error_msg = String::formatted("Screen #{} is using same device as screen #{}", i, j);
+                return false;
+            }
+            if (screen.virtual_rect().intersects(other_screen.virtual_rect())) {
+                if (error_msg)
+                    *error_msg = String::formatted("Screen #{} overlaps with screen #{}", i, j);
+                return false;
+            }
+        }
+        if (screen.location.x() < 0 || screen.location.y() < 0) {
+            if (error_msg)
+                *error_msg = String::formatted("Screen #{} has invalid location: {}", i, screen.location);
+            return false;
+        }
+        if (screen.resolution.width() <= 0 || screen.resolution.height() <= 0) {
+            if (error_msg)
+                *error_msg = String::formatted("Screen #{} has invalid resolution: {}", i, screen.resolution);
+            return false;
+        }
+        if (screen.scale_factor < 1) {
+            if (error_msg)
+                *error_msg = String::formatted("Screen #{} has invalid scale factor: {}", i, screen.scale_factor);
+            return false;
+        }
+        if (i == 0 || screen.location.x() < smallest_x)
+            smallest_x = screen.location.x();
+        if (i == 0 || screen.location.y() < smallest_y)
+            smallest_y = screen.location.y();
+    }
+    if (smallest_x != 0 || smallest_y != 0) {
+        if (error_msg)
+            *error_msg = "Screen layout has not been normalized";
+        return false;
+    }
+    Vector<const Screen*, 16> reachable_screens { &screens[main_screen_index] };
+    bool did_reach_another_screen;
+    do {
+        did_reach_another_screen = false;
+        auto* latest_reachable_screen = reachable_screens[reachable_screens.size() - 1];
+        for (auto& screen : screens) {
+            if (&screen == latest_reachable_screen || reachable_screens.contains_slow(&screen))
+                continue;
+            if (screen.virtual_rect().is_adjacent(latest_reachable_screen->virtual_rect())) {
+                reachable_screens.append(&screen);
+                did_reach_another_screen = true;
+                break;
+            }
+        }
+    } while (did_reach_another_screen);
+    if (reachable_screens.size() != screens.size()) {
+        for (size_t i = 0; i < screens.size(); i++) {
+            auto& screen = screens[i];
+            if (!reachable_screens.contains_slow(&screen)) {
+                if (error_msg)
+                    *error_msg = String::formatted("Screen #{} {} cannot be reached from main screen #{} {}", i, screen.virtual_rect(), main_screen_index, screens[main_screen_index].virtual_rect());
+                break;
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+void ScreenLayout::normalize()
+{
+    int smallest_x = 0;
+    int smallest_y = 0;
+    for (size_t i = 0; i < screens.size(); i++) {
+        auto& screen = screens[i];
+        if (i == 0 || screen.location.x() < smallest_x)
+            smallest_x = screen.location.x();
+        if (i == 0 || screen.location.y() < smallest_y)
+            smallest_y = screen.location.y();
+    }
+    if (smallest_x != 0 || smallest_y != 0) {
+        for (auto& screen : screens)
+            screen.location.translate_by(-smallest_x, -smallest_y);
+    }
+}
+
+bool ScreenLayout::load_config(const Core::ConfigFile& config_file, String* error_msg)
+{
+    screens.clear_with_capacity();
+    main_screen_index = config_file.read_num_entry("Screens", "DefaultScreen", 0);
+    for (size_t index = 0;; index++) {
+        auto group_name = String::formatted("Screen{}", index);
+        if (!config_file.has_group(group_name))
+            break;
+        screens.append({ config_file.read_entry(group_name, "Device"),
+            { config_file.read_num_entry(group_name, "Left"), config_file.read_num_entry(group_name, "Top") },
+            { config_file.read_num_entry(group_name, "Width"), config_file.read_num_entry(group_name, "Height") },
+            config_file.read_num_entry(group_name, "ScaleFactor", 1) });
+    }
+    if (!is_valid(error_msg)) {
+        *this = {};
+        return false;
+    }
+    return true;
+}
+
+bool ScreenLayout::save_config(Core::ConfigFile& config_file, bool sync) const
+{
+    config_file.write_num_entry("Screens", "DefaultScreen", main_screen_index);
+
+    size_t index = 0;
+    while (index < screens.size()) {
+        auto& screen = screens[index];
+        auto group_name = String::formatted("Screen{}", index);
+        config_file.write_entry(group_name, "Device", screen.device);
+        config_file.write_num_entry(group_name, "Left", screen.location.x());
+        config_file.write_num_entry(group_name, "Top", screen.location.y());
+        config_file.write_num_entry(group_name, "Width", screen.resolution.width());
+        config_file.write_num_entry(group_name, "Height", screen.resolution.height());
+        config_file.write_num_entry(group_name, "ScaleFactor", screen.scale_factor);
+        index++;
+    }
+    // Prune screens no longer in the layout
+    for (;;) {
+        auto group_name = String::formatted("Screen{}", index++);
+        if (!config_file.has_group(group_name))
+            break;
+        config_file.remove_group(group_name);
+    }
+
+    if (sync && !config_file.sync())
+        return false;
+    return true;
+}
+
+bool ScreenLayout::operator!=(const ScreenLayout& other) const
+{
+    if (this == &other)
+        return false;
+    if (main_screen_index != other.main_screen_index)
+        return true;
+    if (screens.size() != other.screens.size())
+        return true;
+    for (size_t i = 0; i < screens.size(); i++) {
+        if (screens[i] != other.screens[i])
+            return true;
+    }
+    return false;
+}
+
+}
+
+namespace IPC {
+
+bool encode(Encoder& encoder, const WindowServer::ScreenLayout::Screen& screen)
+{
+    encoder << screen.device << screen.location << screen.resolution << screen.scale_factor;
+    return true;
+}
+
+bool decode(Decoder& decoder, WindowServer::ScreenLayout::Screen& screen)
+{
+    String device;
+    if (!decoder.decode(device))
+        return false;
+    Gfx::IntPoint location;
+    if (!decoder.decode(location))
+        return false;
+    Gfx::IntSize resolution;
+    if (!decoder.decode(resolution))
+        return false;
+    int scale_factor = 0;
+    if (!decoder.decode(scale_factor))
+        return false;
+    screen = { device, location, resolution, scale_factor };
+    return true;
+}
+
+bool encode(Encoder& encoder, const WindowServer::ScreenLayout& screen_layout)
+{
+    encoder << screen_layout.screens << screen_layout.main_screen_index;
+    return true;
+}
+
+bool decode(Decoder& decoder, WindowServer::ScreenLayout& screen_layout)
+{
+    Vector<WindowServer::ScreenLayout::Screen> screens;
+    if (!decoder.decode(screens))
+        return false;
+    unsigned main_screen_index = 0;
+    if (!decoder.decode(main_screen_index))
+        return false;
+    screen_layout = { move(screens), main_screen_index };
+    return true;
+}
+
+}

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -96,7 +96,7 @@ void WMClientConnection::start_window_resize(i32 client_id, i32 window_id)
     auto& window = *(*it).value;
     // FIXME: We are cheating a bit here by using the current cursor location and hard-coding the left button.
     //        Maybe the client should be allowed to specify what initiated this request?
-    WindowManager::the().start_window_resize(window, Screen::the().cursor_location(), MouseButton::Left);
+    WindowManager::the().start_window_resize(window, ScreenInput::the().cursor_location(), MouseButton::Left);
 }
 
 void WMClientConnection::set_window_minimized(i32 client_id, i32 window_id, bool minimized)

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -139,7 +139,7 @@ void Window::set_rect(const Gfx::IntRect& rect)
     }
 
     invalidate(true, old_rect.size() != rect.size());
-    m_frame.notify_window_rect_changed(old_rect, rect); // recomputes occlusions
+    m_frame.window_rect_changed(old_rect, rect); // recomputes occlusions
 }
 
 void Window::set_rect_without_repaint(const Gfx::IntRect& rect)
@@ -159,7 +159,7 @@ void Window::set_rect_without_repaint(const Gfx::IntRect& rect)
     }
 
     invalidate(true, old_rect.size() != rect.size());
-    m_frame.notify_window_rect_changed(old_rect, rect); // recomputes occlusions
+    m_frame.window_rect_changed(old_rect, rect); // recomputes occlusions
 }
 
 bool Window::apply_minimum_size(Gfx::IntRect& rect)

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -988,7 +988,10 @@ Optional<HitTestResult> Window::hit_test(Gfx::IntPoint const& position, bool inc
 {
     if (!m_hit_testing_enabled)
         return {};
-    if (!frame().rect().contains(position))
+    // We need to check the (possibly constrained) render rect to make sure
+    // we don't hit-test on a window that is constrained to a screen, but somehow
+    // (partially) moved into another screen where it's not rendered
+    if (!frame().rect().intersected(frame().render_rect()).contains(position))
         return {};
     if (!rect().contains(position)) {
         if (include_frame)

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -1,6 +1,6 @@
 endpoint WindowClient
 {
-    fast_greet(Gfx::IntRect screen_rect, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query) =|
+    fast_greet(Vector<Gfx::IntRect> screen_rects, u32 main_screen_index, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query) =|
 
     paint(i32 window_id, Gfx::IntSize window_size, Vector<Gfx::IntRect> rects) =|
     mouse_move(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta, bool is_drag, Vector<String> mime_types) =|
@@ -25,7 +25,7 @@ endpoint WindowClient
     menu_item_left(i32 menu_id, u32 identifier) =|
     menu_visibility_did_change(i32 menu_id, bool visible) =|
 
-    screen_rect_changed(Gfx::IntRect rect) =|
+    screen_rects_changed(Vector<Gfx::IntRect> rects, u32 main_screen_index) =|
 
     set_wallpaper_finished(bool success) =|
 

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -41,8 +41,6 @@ static RefPtr<MultiScaleBitmaps> s_restore_icon;
 static RefPtr<MultiScaleBitmaps> s_close_icon;
 static RefPtr<MultiScaleBitmaps> s_close_modified_icon;
 
-static String s_last_title_button_icons_path;
-
 static RefPtr<MultiScaleBitmaps> s_active_window_shadow;
 static RefPtr<MultiScaleBitmaps> s_inactive_window_shadow;
 static RefPtr<MultiScaleBitmaps> s_menu_shadow;
@@ -126,46 +124,31 @@ void WindowFrame::reload_config()
 {
     String icons_path = WindowManager::the().palette().title_button_icons_path();
 
-    StringBuilder full_path;
-    if (!s_minimize_icon || s_last_title_button_icons_path != icons_path) {
+    auto reload_icon = [&](RefPtr<MultiScaleBitmaps>& icon, StringView const& path, StringView const& default_path) {
+        StringBuilder full_path;
         full_path.append(icons_path);
-        full_path.append("window-minimize.png");
-        s_minimize_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/downward-triangle.png");
-        full_path.clear();
-    }
-    if (!s_maximize_icon || s_last_title_button_icons_path != icons_path) {
-        full_path.append(icons_path);
-        full_path.append("window-maximize.png");
-        s_maximize_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/upward-triangle.png");
-        full_path.clear();
-    }
-    if (!s_restore_icon || s_last_title_button_icons_path != icons_path) {
-        full_path.append(icons_path);
-        full_path.append("window-restore.png");
-        s_restore_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/window-restore.png");
-        full_path.clear();
-    }
-    if (!s_close_icon || s_last_title_button_icons_path != icons_path) {
-        full_path.append(icons_path);
-        full_path.append("window-close.png");
-        s_close_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/window-close.png");
-        full_path.clear();
-    }
-    if (!s_close_modified_icon || s_last_title_button_icons_path != icons_path) {
-        full_path.append(icons_path);
-        full_path.append("window-close-modified.png");
-        s_close_modified_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/window-close-modified.png");
-        full_path.clear();
-    }
+        full_path.append(path);
+        if (icon)
+            icon->load(full_path.to_string(), default_path);
+        else
+            icon = MultiScaleBitmaps::create(full_path.to_string(), default_path);
+    };
 
-    s_last_title_button_icons_path = icons_path;
+    reload_icon(s_minimize_icon, "window-minimize.png", "/res/icons/16x16/downward-triangle.png");
+    reload_icon(s_maximize_icon, "window-maximize.png", "/res/icons/16x16/upward-triangle.png");
+    reload_icon(s_restore_icon, "window-restore.png", "/res/icons/16x16/window-restore.png");
+    reload_icon(s_close_icon, "window-close.png", "/res/icons/16x16/window-close.png");
+    reload_icon(s_close_modified_icon, "window-close-modified.png", "/res/icons/16x16/window-close-modified.png");
 
     auto load_shadow = [](const String& path, String& last_path, RefPtr<MultiScaleBitmaps>& shadow_bitmap) {
         if (path.is_empty()) {
             last_path = String::empty();
             shadow_bitmap = nullptr;
         } else if (!shadow_bitmap || last_path != path) {
-            shadow_bitmap = MultiScaleBitmaps::create(path);
+            if (shadow_bitmap)
+                shadow_bitmap->load(path);
+            else
+                shadow_bitmap = MultiScaleBitmaps::create(path);
             if (shadow_bitmap)
                 last_path = path;
             else

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -13,6 +13,7 @@
 #include <WindowServer/Button.h>
 #include <WindowServer/Compositor.h>
 #include <WindowServer/Event.h>
+#include <WindowServer/MultiScaleBitmaps.h>
 #include <WindowServer/Screen.h>
 #include <WindowServer/Window.h>
 #include <WindowServer/WindowFrame.h>
@@ -34,20 +35,19 @@ static Gfx::WindowTheme::WindowType to_theme_window_type(WindowType type)
     }
 }
 
-static RefPtr<Gfx::Bitmap> s_minimize_icon;
-static RefPtr<Gfx::Bitmap> s_maximize_icon;
-static RefPtr<Gfx::Bitmap> s_restore_icon;
-static RefPtr<Gfx::Bitmap> s_close_icon;
-static RefPtr<Gfx::Bitmap> s_close_modified_icon;
+static RefPtr<MultiScaleBitmaps> s_minimize_icon;
+static RefPtr<MultiScaleBitmaps> s_maximize_icon;
+static RefPtr<MultiScaleBitmaps> s_restore_icon;
+static RefPtr<MultiScaleBitmaps> s_close_icon;
+static RefPtr<MultiScaleBitmaps> s_close_modified_icon;
 
 static String s_last_title_button_icons_path;
-static int s_last_title_button_icons_scale;
 
-static RefPtr<Gfx::Bitmap> s_active_window_shadow;
-static RefPtr<Gfx::Bitmap> s_inactive_window_shadow;
-static RefPtr<Gfx::Bitmap> s_menu_shadow;
-static RefPtr<Gfx::Bitmap> s_taskbar_shadow;
-static RefPtr<Gfx::Bitmap> s_tooltip_shadow;
+static RefPtr<MultiScaleBitmaps> s_active_window_shadow;
+static RefPtr<MultiScaleBitmaps> s_inactive_window_shadow;
+static RefPtr<MultiScaleBitmaps> s_menu_shadow;
+static RefPtr<MultiScaleBitmaps> s_taskbar_shadow;
+static RefPtr<MultiScaleBitmaps> s_tooltip_shadow;
 static String s_last_active_window_shadow_path;
 static String s_last_inactive_window_shadow_path;
 static String s_last_menu_shadow_path;
@@ -117,7 +117,7 @@ void WindowFrame::set_button_icons()
 
     m_close_button->set_icon(m_window.is_modified() ? *s_close_modified_icon : *s_close_icon);
     if (m_window.is_minimizable())
-        m_minimize_button->set_icon(*s_minimize_icon);
+        m_minimize_button->set_icon(s_minimize_icon);
     if (m_window.is_resizable())
         m_maximize_button->set_icon(m_window.is_maximized() ? *s_restore_icon : *s_maximize_icon);
 }
@@ -125,54 +125,47 @@ void WindowFrame::set_button_icons()
 void WindowFrame::reload_config()
 {
     String icons_path = WindowManager::the().palette().title_button_icons_path();
-    int icons_scale = WindowManager::the().compositor_icon_scale(); // TODO: We'll need to load icons for all scales in use!
 
     StringBuilder full_path;
-    if (!s_minimize_icon || s_last_title_button_icons_path != icons_path || s_last_title_button_icons_scale != icons_scale) {
+    if (!s_minimize_icon || s_last_title_button_icons_path != icons_path) {
         full_path.append(icons_path);
         full_path.append("window-minimize.png");
-        if (!(s_minimize_icon = Gfx::Bitmap::load_from_file(full_path.to_string(), icons_scale)))
-            s_minimize_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/downward-triangle.png", icons_scale);
+        s_minimize_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/downward-triangle.png");
         full_path.clear();
     }
-    if (!s_maximize_icon || s_last_title_button_icons_path != icons_path || s_last_title_button_icons_scale != icons_scale) {
+    if (!s_maximize_icon || s_last_title_button_icons_path != icons_path) {
         full_path.append(icons_path);
         full_path.append("window-maximize.png");
-        if (!(s_maximize_icon = Gfx::Bitmap::load_from_file(full_path.to_string(), icons_scale)))
-            s_maximize_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/upward-triangle.png", icons_scale);
+        s_maximize_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/upward-triangle.png");
         full_path.clear();
     }
-    if (!s_restore_icon || s_last_title_button_icons_path != icons_path || s_last_title_button_icons_scale != icons_scale) {
+    if (!s_restore_icon || s_last_title_button_icons_path != icons_path) {
         full_path.append(icons_path);
         full_path.append("window-restore.png");
-        if (!(s_restore_icon = Gfx::Bitmap::load_from_file(full_path.to_string(), icons_scale)))
-            s_restore_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/window-restore.png", icons_scale);
+        s_restore_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/window-restore.png");
         full_path.clear();
     }
-    if (!s_close_icon || s_last_title_button_icons_path != icons_path || s_last_title_button_icons_scale != icons_scale) {
+    if (!s_close_icon || s_last_title_button_icons_path != icons_path) {
         full_path.append(icons_path);
         full_path.append("window-close.png");
-        if (!(s_close_icon = Gfx::Bitmap::load_from_file(full_path.to_string(), icons_scale)))
-            s_close_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/window-close.png", icons_scale);
+        s_close_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/window-close.png");
         full_path.clear();
     }
-    if (!s_close_modified_icon || s_last_title_button_icons_path != icons_path || s_last_title_button_icons_scale != icons_scale) {
+    if (!s_close_modified_icon || s_last_title_button_icons_path != icons_path) {
         full_path.append(icons_path);
         full_path.append("window-close-modified.png");
-        if (!(s_close_modified_icon = Gfx::Bitmap::load_from_file(full_path.to_string(), icons_scale)))
-            s_close_modified_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/window-close-modified.png", icons_scale);
+        s_close_modified_icon = MultiScaleBitmaps::create(full_path.to_string(), "/res/icons/16x16/window-close-modified.png");
         full_path.clear();
     }
 
     s_last_title_button_icons_path = icons_path;
-    s_last_title_button_icons_scale = icons_scale;
 
-    auto load_shadow = [](const String& path, String& last_path, RefPtr<Gfx::Bitmap>& shadow_bitmap) {
+    auto load_shadow = [](const String& path, String& last_path, RefPtr<MultiScaleBitmaps>& shadow_bitmap) {
         if (path.is_empty()) {
             last_path = String::empty();
             shadow_bitmap = nullptr;
-        } else if (!shadow_bitmap || shadow_bitmap->scale() != s_last_title_button_icons_scale || last_path != path) {
-            shadow_bitmap = Gfx::Bitmap::load_from_file(path, s_last_title_button_icons_scale);
+        } else if (!shadow_bitmap || last_path != path) {
+            shadow_bitmap = MultiScaleBitmaps::create(path);
             if (shadow_bitmap)
                 last_path = path;
             else
@@ -186,7 +179,7 @@ void WindowFrame::reload_config()
     load_shadow(WindowManager::the().palette().tooltip_shadow_path(), s_last_tooltip_shadow_path, s_tooltip_shadow);
 }
 
-Gfx::Bitmap* WindowFrame::shadow_bitmap() const
+MultiScaleBitmaps* WindowFrame::shadow_bitmap() const
 {
     if (m_window.is_frameless())
         return nullptr;
@@ -317,7 +310,7 @@ void WindowFrame::paint(Screen& screen, Gfx::Painter& painter, const Gfx::IntRec
         cached->paint(*this, painter, rect);
 }
 
-void WindowFrame::RenderedCache::paint(WindowFrame& frame, Gfx::Painter& painter, const Gfx::IntRect& rect)
+void WindowFrame::PerScaleRenderedCache::paint(WindowFrame& frame, Gfx::Painter& painter, const Gfx::IntRect& rect)
 {
     auto frame_rect = frame.unconstrained_render_rect();
     auto window_rect = frame.window().rect();
@@ -357,7 +350,7 @@ void WindowFrame::RenderedCache::paint(WindowFrame& frame, Gfx::Painter& painter
     }
 }
 
-void WindowFrame::render(Screen&, Gfx::Painter& painter)
+void WindowFrame::render(Screen& screen, Gfx::Painter& painter)
 {
     if (m_window.is_frameless())
         return;
@@ -371,9 +364,8 @@ void WindowFrame::render(Screen&, Gfx::Painter& painter)
     else
         return;
 
-    for (auto& button : m_buttons) {
-        button.paint(painter);
-    }
+    for (auto& button : m_buttons)
+        button.paint(screen, painter);
 }
 
 void WindowFrame::theme_changed()
@@ -386,13 +378,13 @@ void WindowFrame::theme_changed()
     m_has_alpha_channel = Gfx::WindowTheme::current().frame_uses_alpha(window_state_for_theme(), WindowManager::the().palette());
 }
 
-auto WindowFrame::render_to_cache(Screen& screen) -> RenderedCache*
+auto WindowFrame::render_to_cache(Screen& screen) -> PerScaleRenderedCache*
 {
     auto scale = screen.scale_factor();
-    RenderedCache* rendered_cache;
+    PerScaleRenderedCache* rendered_cache;
     auto cached_it = m_rendered_cache.find(scale);
     if (cached_it == m_rendered_cache.end()) {
-        auto new_rendered_cache = make<RenderedCache>();
+        auto new_rendered_cache = make<PerScaleRenderedCache>();
         rendered_cache = new_rendered_cache.ptr();
         m_rendered_cache.set(scale, move(new_rendered_cache));
     } else {
@@ -402,7 +394,7 @@ auto WindowFrame::render_to_cache(Screen& screen) -> RenderedCache*
     return rendered_cache;
 }
 
-void WindowFrame::RenderedCache::render(WindowFrame& frame, Screen& screen)
+void WindowFrame::PerScaleRenderedCache::render(WindowFrame& frame, Screen& screen)
 {
     if (!m_dirty)
         return;
@@ -417,7 +409,7 @@ void WindowFrame::RenderedCache::render(WindowFrame& frame, Screen& screen)
     Gfx::IntPoint shadow_offset;
 
     if (shadow_bitmap) {
-        auto total_shadow_size = shadow_bitmap->height();
+        auto total_shadow_size = shadow_bitmap->bitmap(screen.scale_factor()).height();
         frame_rect_including_shadow.inflate(total_shadow_size, total_shadow_size);
         auto offset = total_shadow_size / 2;
         shadow_offset = { offset, offset };
@@ -481,7 +473,7 @@ void WindowFrame::RenderedCache::render(WindowFrame& frame, Screen& screen)
         painter.clear_rect({ rect.location() - frame_rect_to_update.location(), rect.size() }, { 255, 255, 255, 0 });
 
     if (m_shadow_dirty && shadow_bitmap)
-        frame.paint_simple_rect_shadow(painter, { { 0, 0 }, frame_rect_including_shadow.size() }, *shadow_bitmap);
+        frame.paint_simple_rect_shadow(painter, { { 0, 0 }, frame_rect_including_shadow.size() }, shadow_bitmap->bitmap(screen.scale_factor()));
 
     {
         Gfx::PainterStateSaver save(painter);
@@ -535,7 +527,7 @@ void WindowFrame::set_opacity(float opacity)
 Gfx::IntRect WindowFrame::inflated_for_shadow(const Gfx::IntRect& frame_rect) const
 {
     if (auto* shadow = shadow_bitmap()) {
-        auto total_shadow_size = shadow->height();
+        auto total_shadow_size = shadow->default_bitmap().height();
         return frame_rect.inflated(total_shadow_size, total_shadow_size);
     }
     return frame_rect;
@@ -678,7 +670,7 @@ Optional<HitTestResult> WindowFrame::hit_test(Gfx::IntPoint const& position)
     return cached->hit_test(*this, position, window_relative_position);
 }
 
-Optional<HitTestResult> WindowFrame::RenderedCache::hit_test(WindowFrame& frame, Gfx::IntPoint const& position, Gfx::IntPoint const& window_relative_position)
+Optional<HitTestResult> WindowFrame::PerScaleRenderedCache::hit_test(WindowFrame& frame, Gfx::IntPoint const& position, Gfx::IntPoint const& window_relative_position)
 {
     HitTestResult result {
         .window = frame.window(),

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -54,6 +54,7 @@ public:
 
     Gfx::IntRect rect() const;
     Gfx::IntRect render_rect() const;
+    Gfx::IntRect unconstrained_render_rect() const;
     Gfx::DisjointRectSet opaque_render_rects() const;
     Gfx::DisjointRectSet transparent_render_rects() const;
 
@@ -130,6 +131,8 @@ private:
 
     Gfx::WindowTheme::WindowState window_state_for_theme() const;
     String computed_title() const;
+
+    Gfx::IntRect constrained_render_rect_to_screen(const Gfx::IntRect&) const;
 
     Window& m_window;
     NonnullOwnPtrVector<Button> m_buttons;

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -67,7 +67,7 @@ public:
     bool handle_titlebar_icon_mouse_event(MouseEvent const&);
     void handle_border_mouse_event(MouseEvent const&);
 
-    void notify_window_rect_changed(const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect);
+    void window_rect_changed(const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect);
     void invalidate_titlebar();
     void invalidate(Gfx::IntRect relative_rect);
     void invalidate();

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -19,12 +19,13 @@ namespace WindowServer {
 class Button;
 class Menu;
 class MouseEvent;
-class Window;
+class MultiScaleBitmaps;
 class Screen;
+class Window;
 
 class WindowFrame {
 public:
-    class RenderedCache {
+    class PerScaleRenderedCache {
         friend class WindowFrame;
 
     public:
@@ -60,7 +61,7 @@ public:
 
     void paint(Screen&, Gfx::Painter&, const Gfx::IntRect&);
     void render(Screen&, Gfx::Painter&);
-    RenderedCache* render_to_cache(Screen&);
+    PerScaleRenderedCache* render_to_cache(Screen&);
 
     void handle_mouse_event(MouseEvent const&);
     void handle_titlebar_mouse_event(MouseEvent const&);
@@ -123,7 +124,7 @@ private:
     void paint_normal_frame(Gfx::Painter&);
     void paint_tool_window_frame(Gfx::Painter&);
     void paint_menubar(Gfx::Painter&);
-    Gfx::Bitmap* shadow_bitmap() const;
+    MultiScaleBitmaps* shadow_bitmap() const;
     Gfx::IntRect inflated_for_shadow(const Gfx::IntRect&) const;
 
     void handle_menubar_mouse_event(const MouseEvent&);
@@ -140,7 +141,7 @@ private:
     Button* m_maximize_button { nullptr };
     Button* m_minimize_button { nullptr };
 
-    HashMap<int, NonnullOwnPtr<RenderedCache>> m_rendered_cache;
+    HashMap<int, NonnullOwnPtr<PerScaleRenderedCache>> m_rendered_cache;
 
     RefPtr<Core::Timer> m_flash_timer;
     size_t m_flash_counter { 0 };

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -59,22 +59,31 @@ void WindowManager::reload_config()
     m_config = Core::ConfigFile::open("/etc/WindowServer.ini");
 
     m_double_click_speed = m_config->read_num_entry("Input", "DoubleClickSpeed", 250);
-    m_hidden_cursor = get_cursor("Hidden");
-    m_arrow_cursor = get_cursor("Arrow");
-    m_hand_cursor = get_cursor("Hand");
-    m_help_cursor = get_cursor("Help");
-    m_resize_horizontally_cursor = get_cursor("ResizeH");
-    m_resize_vertically_cursor = get_cursor("ResizeV");
-    m_resize_diagonally_tlbr_cursor = get_cursor("ResizeDTLBR");
-    m_resize_diagonally_bltr_cursor = get_cursor("ResizeDBLTR");
-    m_resize_column_cursor = get_cursor("ResizeColumn");
-    m_resize_row_cursor = get_cursor("ResizeRow");
-    m_i_beam_cursor = get_cursor("IBeam");
-    m_disallowed_cursor = get_cursor("Disallowed");
-    m_move_cursor = get_cursor("Move");
-    m_drag_cursor = get_cursor("Drag");
-    m_wait_cursor = get_cursor("Wait");
-    m_crosshair_cursor = get_cursor("Crosshair");
+
+    auto* current_cursor = Compositor::the().current_cursor();
+    auto reload_cursor = [&](RefPtr<Cursor>& cursor, const String& name) {
+        bool is_current_cursor = current_cursor && current_cursor == cursor.ptr();
+        cursor = get_cursor(name);
+        if (is_current_cursor)
+            Compositor::the().current_cursor_was_reloaded(cursor.ptr());
+    };
+
+    reload_cursor(m_hidden_cursor, "Hidden");
+    reload_cursor(m_arrow_cursor, "Arrow");
+    reload_cursor(m_hand_cursor, "Hand");
+    reload_cursor(m_help_cursor, "Help");
+    reload_cursor(m_resize_horizontally_cursor, "ResizeH");
+    reload_cursor(m_resize_vertically_cursor, "ResizeV");
+    reload_cursor(m_resize_diagonally_tlbr_cursor, "ResizeDTLBR");
+    reload_cursor(m_resize_diagonally_bltr_cursor, "ResizeDBLTR");
+    reload_cursor(m_resize_column_cursor, "ResizeColumn");
+    reload_cursor(m_resize_row_cursor, "ResizeRow");
+    reload_cursor(m_i_beam_cursor, "IBeam");
+    reload_cursor(m_disallowed_cursor, "Disallowed");
+    reload_cursor(m_move_cursor, "Move");
+    reload_cursor(m_drag_cursor, "Drag");
+    reload_cursor(m_wait_cursor, "Wait");
+    reload_cursor(m_crosshair_cursor, "Crosshair");
 
     WindowFrame::reload_config();
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -48,14 +48,10 @@ WindowManager::~WindowManager()
 {
 }
 
-NonnullRefPtr<Cursor> WindowManager::get_cursor(String const& name)
+RefPtr<Cursor> WindowManager::get_cursor(String const& name)
 {
     static auto const s_default_cursor_path = "/res/cursors/arrow.x2y2.png";
-    auto path = m_config->read_entry("Cursor", name, s_default_cursor_path);
-    auto gb = Gfx::Bitmap::load_from_file(path, compositor_icon_scale());
-    if (gb)
-        return Cursor::create(*gb, path);
-    return Cursor::create(*Gfx::Bitmap::load_from_file(s_default_cursor_path), s_default_cursor_path);
+    return Cursor::create(m_config->read_entry("Cursor", name, s_default_cursor_path), s_default_cursor_path);
 }
 
 void WindowManager::reload_config()
@@ -1179,7 +1175,7 @@ void WindowManager::process_key_event(KeyEvent& event)
     }
 
     if (event.type() == Event::KeyDown && (event.modifiers() == (Mod_Ctrl | Mod_Super | Mod_Shift) && event.key() == Key_I)) {
-        reload_icon_bitmaps_after_scale_change(!m_allow_hidpi_icons);
+        reload_icon_bitmaps_after_scale_change();
         Compositor::the().invalidate_screen();
         return;
     }
@@ -1595,16 +1591,8 @@ Gfx::IntPoint WindowManager::get_recommended_window_position(Gfx::IntPoint const
     return point;
 }
 
-int WindowManager::compositor_icon_scale() const
+void WindowManager::reload_icon_bitmaps_after_scale_change()
 {
-    if (!m_allow_hidpi_icons)
-        return 1;
-    return Screen::main().scale_factor(); // TODO: There is no *one* scale factor...
-}
-
-void WindowManager::reload_icon_bitmaps_after_scale_change(bool allow_hidpi_icons)
-{
-    m_allow_hidpi_icons = allow_hidpi_icons;
     reload_config();
     m_window_stack.for_each_window([&](Window& window) {
         auto& window_frame = window.frame();

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -21,6 +21,7 @@
 #include <WindowServer/Event.h>
 #include <WindowServer/MenuManager.h>
 #include <WindowServer/Menubar.h>
+#include <WindowServer/ScreenLayout.h>
 #include <WindowServer/WMClientConnection.h>
 #include <WindowServer/WindowSwitcher.h>
 #include <WindowServer/WindowType.h>
@@ -129,7 +130,9 @@ public:
     Gfx::Font const& font() const;
     Gfx::Font const& window_title_font() const;
 
-    bool set_resolution(Screen&, int width, int height, int scale);
+    bool set_screen_layout(ScreenLayout&&, bool, String&);
+    ScreenLayout get_screen_layout() const;
+    bool save_screen_layout(String&);
 
     void set_acceleration_factor(double);
     void set_scroll_step_size(unsigned);

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -79,7 +79,7 @@ public:
     void notify_progress_changed(Window&);
     void notify_modified_changed(Window&);
 
-    Gfx::IntRect maximized_window_rect(Window const&) const;
+    Gfx::IntRect maximized_window_rect(Window const&, bool relative_to_window_screen = false) const;
 
     ClientConnection const* dnd_client() const { return m_dnd_client.ptr(); }
     String const& dnd_text() const { return m_dnd_text; }
@@ -105,8 +105,8 @@ public:
 
     void move_to_front_and_make_active(Window&);
 
-    Gfx::IntRect desktop_rect() const;
-    Gfx::IntRect arena_rect_for_type(WindowType) const;
+    Gfx::IntRect desktop_rect(Screen&) const;
+    Gfx::IntRect arena_rect_for_type(Screen&, WindowType) const;
 
     Cursor const& active_cursor() const;
     Cursor const& hidden_cursor() const { return *m_hidden_cursor; }
@@ -129,9 +129,7 @@ public:
     Gfx::Font const& font() const;
     Gfx::Font const& window_title_font() const;
 
-    bool set_resolution(int width, int height, int scale);
-    Gfx::IntSize resolution() const;
-    int scale_factor() const;
+    bool set_resolution(Screen&, int width, int height, int scale);
 
     void set_acceleration_factor(double);
     void set_scroll_step_size(unsigned);

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -224,8 +224,7 @@ public:
 
     Gfx::IntPoint get_recommended_window_position(Gfx::IntPoint const& desired);
 
-    int compositor_icon_scale() const;
-    void reload_icon_bitmaps_after_scale_change(bool allow_hidpi_icons = true);
+    void reload_icon_bitmaps_after_scale_change();
 
     void reevaluate_hovered_window(Window* = nullptr);
     Window* hovered_window() const { return m_hovered_window.ptr(); }
@@ -233,7 +232,7 @@ public:
     WindowStack& window_stack() { return m_window_stack; }
 
 private:
-    NonnullRefPtr<Cursor> get_cursor(String const& name);
+    RefPtr<Cursor> get_cursor(String const& name);
 
     void process_mouse_event(MouseEvent&);
     void process_event_for_doubleclick(Window& window, MouseEvent& event);
@@ -257,7 +256,6 @@ private:
 
     void do_move_to_front(Window&, bool, bool);
 
-    bool m_allow_hidpi_icons { true };
     RefPtr<Cursor> m_hidden_cursor;
     RefPtr<Cursor> m_arrow_cursor;
     RefPtr<Cursor> m_hand_cursor;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -125,7 +125,7 @@ endpoint WindowServer
     set_scroll_step_size(u32 step_size) => ()
     get_scroll_step_size() => (u32 step_size)
 
-    get_screen_bitmap(Optional<Gfx::IntRect> rect) => (Gfx::ShareableBitmap bitmap)
+    get_screen_bitmap(Optional<Gfx::IntRect> rect, Optional<u32> screen_index) => (Gfx::ShareableBitmap bitmap)
     get_screen_bitmap_around_cursor(Gfx::IntSize size) => (Gfx::ShareableBitmap bitmap)
 
     pong() =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -93,7 +93,7 @@ endpoint WindowServer
     set_background_color(String background_color) =|
     set_wallpaper_mode(String mode) =|
 
-    set_resolution(Gfx::IntSize resolution, int scale_factor) => (bool success, Gfx::IntSize resolution, int scale_factor)
+    set_resolution(u32 screen_index, Gfx::IntSize resolution, int scale_factor) => (bool success, Gfx::IntSize resolution, int scale_factor)
     set_window_icon_bitmap(i32 window_id, Gfx::ShareableBitmap icon) =|
 
     get_wallpaper() => (String path)
@@ -130,5 +130,5 @@ endpoint WindowServer
     set_double_click_speed(int speed) => ()
     get_double_click_speed() => (int speed)
 
-    get_desktop_display_scale() => (int desktop_display_scale)
+    get_desktop_display_scale(u32 screen_index) => (int desktop_display_scale)
 }

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -93,7 +93,10 @@ endpoint WindowServer
     set_background_color(String background_color) =|
     set_wallpaper_mode(String mode) =|
 
-    set_resolution(u32 screen_index, Gfx::IntSize resolution, int scale_factor) => (bool success, Gfx::IntSize resolution, int scale_factor)
+    set_screen_layout(::WindowServer::ScreenLayout screen_layout, bool save) => (bool success, String error_msg)
+    get_screen_layout() => (::WindowServer::ScreenLayout screen_layout)
+    save_screen_layout() => (bool success, String error_msg)
+
     set_window_icon_bitmap(i32 window_id, Gfx::ShareableBitmap icon) =|
 
     get_wallpaper() => (String path)

--- a/Userland/Services/WindowServer/WindowSwitcher.cpp
+++ b/Userland/Services/WindowServer/WindowSwitcher.cpp
@@ -221,7 +221,7 @@ void WindowSwitcher::refresh()
     int space_for_window_rect = 180;
     m_rect.set_width(thumbnail_width() + longest_title_width + space_for_window_rect + padding() * 2 + item_padding() * 2);
     m_rect.set_height(window_count * item_height() + padding() * 2);
-    m_rect.center_within(Screen::the().rect());
+    m_rect.center_within(Screen::main().rect());
     if (!m_switcher_window)
         m_switcher_window = Window::construct(*this, WindowType::WindowSwitcher);
     m_switcher_window->set_rect(m_rect);

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -75,10 +75,47 @@ int main(int, char**)
         return 1;
     }
 
-    int scale = wm_config->read_num_entry("Screen", "ScaleFactor", 1);
-    WindowServer::Screen screen(wm_config->read_num_entry("Screen", "Width", 1024 / scale), wm_config->read_num_entry("Screen", "Height", 768 / scale), scale);
-    screen.set_acceleration_factor(atof(wm_config->read_entry("Mouse", "AccelerationFactor", "1.0").characters()));
-    screen.set_scroll_step_size(wm_config->read_num_entry("Mouse", "ScrollStepSize", 4));
+    // First check which screens are explicitly configured
+    AK::HashTable<String> fb_devices_configured;
+    int main_screen_index = wm_config->read_num_entry("Screens", "MainScreen", 0);
+    for (int screen_index = 0;; screen_index++) {
+        auto group_name = String::formatted("Screen{}", screen_index);
+        if (!wm_config->has_group(group_name))
+            break;
+
+        int scale = wm_config->read_num_entry(group_name, "ScaleFactor", 1);
+        auto device_path = wm_config->read_entry(group_name, "Device", {});
+        if (device_path.is_null() || device_path.is_empty()) {
+            dbgln("Screen {} misses Device setting", screen_index);
+            break;
+        }
+
+        Gfx::IntRect virtual_rect {
+            wm_config->read_num_entry(group_name, "Left", 0 / scale),
+            wm_config->read_num_entry(group_name, "Top", 0 / scale),
+            wm_config->read_num_entry(group_name, "Width", 1024 / scale),
+            wm_config->read_num_entry("Screen", "Height", 768 / scale)
+        };
+        auto* screen = WindowServer::Screen::create(device_path, virtual_rect, scale);
+        if (!screen) {
+            dbgln("Screen {} failed to be created", screen_index);
+            break;
+        }
+
+        if (main_screen_index == screen_index)
+            screen->make_main_screen();
+
+        // Remember that we used this device for a screen already
+        fb_devices_configured.set(device_path);
+    }
+
+    // TODO: Enumerate the /dev/fbX devices and set up any ones we find that we haven't already used
+
+    auto& screen_input = WindowServer::ScreenInput::the();
+    screen_input.set_cursor_location(WindowServer::Screen::main().rect().center());
+    screen_input.set_acceleration_factor(atof(wm_config->read_entry("Mouse", "AccelerationFactor", "1.0").characters()));
+    screen_input.set_scroll_step_size(wm_config->read_num_entry("Mouse", "ScrollStepSize", 4));
+
     WindowServer::Compositor::the();
     auto wm = WindowServer::WindowManager::construct(*palette);
     auto am = WindowServer::AppletManager::construct();

--- a/Userland/Utilities/chres.cpp
+++ b/Userland/Utilities/chres.cpp
@@ -26,9 +26,16 @@ int main(int argc, char** argv)
     // A Core::EventLoop is all we need, but WindowServerConnection needs a full Application object.
     char* dummy_argv[] = { argv[0] };
     auto app = GUI::Application::construct(1, dummy_argv);
-    auto result = GUI::WindowServerConnection::the().set_resolution(screen, Gfx::IntSize { width, height }, scale);
-    if (!result.success()) {
-        warnln("failed to set resolution");
+    auto screen_layout = GUI::WindowServerConnection::the().get_screen_layout();
+    if (screen < 0 || (size_t)screen >= screen_layout.screens.size()) {
+        warnln("invalid screen index: {}", screen);
+        return 1;
+    }
+    auto& main_screen = screen_layout.screens[screen];
+    main_screen.resolution = { width, height };
+    auto set_result = GUI::WindowServerConnection::the().set_screen_layout(screen_layout, true);
+    if (!set_result.success()) {
+        warnln("failed to set resolution: {}", set_result.error_msg());
         return 1;
     }
 }

--- a/Userland/Utilities/chres.cpp
+++ b/Userland/Utilities/chres.cpp
@@ -10,12 +10,14 @@
 
 int main(int argc, char** argv)
 {
+    int screen = -1;
     int width = -1;
     int height = -1;
     int scale = 1;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Change the screen resolution.");
+    args_parser.add_positional_argument(screen, "Screen", "screen");
     args_parser.add_positional_argument(width, "Width", "width");
     args_parser.add_positional_argument(height, "Height", "height");
     args_parser.add_positional_argument(scale, "Scale Factor", "scale", Core::ArgsParser::Required::No);
@@ -24,7 +26,7 @@ int main(int argc, char** argv)
     // A Core::EventLoop is all we need, but WindowServerConnection needs a full Application object.
     char* dummy_argv[] = { argv[0] };
     auto app = GUI::Application::construct(1, dummy_argv);
-    auto result = GUI::WindowServerConnection::the().set_resolution(Gfx::IntSize { width, height }, scale);
+    auto result = GUI::WindowServerConnection::the().set_resolution(screen, Gfx::IntSize { width, height }, scale);
     if (!result.success()) {
         warnln("failed to set resolution");
         return 1;

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -21,10 +21,12 @@ int main(int argc, char** argv)
     String output_path;
     bool output_to_clipboard = false;
     int delay = 0;
+    int screen = -1;
 
     args_parser.add_positional_argument(output_path, "Output filename", "output", Core::ArgsParser::Required::No);
     args_parser.add_option(output_to_clipboard, "Output to clipboard", "clipboard", 'c');
     args_parser.add_option(delay, "Seconds to wait before taking a screenshot", "delay", 'd', "seconds");
+    args_parser.add_option(screen, "The index of the screen (default: -1 for all screens)", "screen", 's', "index");
 
     args_parser.parse(argc, argv);
 
@@ -34,7 +36,12 @@ int main(int argc, char** argv)
 
     auto app = GUI::Application::construct(argc, argv);
     sleep(delay);
-    auto shared_bitmap = GUI::WindowServerConnection::the().get_screen_bitmap({});
+    Optional<u32> screen_index;
+    if (screen >= 0)
+        screen_index = (u32)screen;
+    dbgln("getting screenshot...");
+    auto shared_bitmap = GUI::WindowServerConnection::the().get_screen_bitmap({}, screen_index);
+    dbgln("got screenshot");
 
     auto* bitmap = shared_bitmap.bitmap();
     if (!bitmap) {


### PR DESCRIPTION
_**NOTE:** In order to actually use multiple screens, multi-framebuffer support will need to be added to #7130. It was originally part of this PR but recent changes in #7130 would require a complete rewrite of that._

This allows WindowServer to use multiple framebuffer devices and compose
the desktop with any arbitrary layout. Currently, it is assumed that it
is configured contiguous and non-overlapping, but this should eventually
be enforced.

To make rendering efficient, each window now also tracks on which screens
it needs to be rendered. This way we don't have to iterate all the windows
for each screen but instead use the same rendering loop and then only render
to the screen (or screens) that the window actually uses.

![multiscreen_5](https://user-images.githubusercontent.com/10320822/121815692-e8247080-cc34-11eb-96c6-2fba9c902dea.gif)

The following is an example of mixed scale-factors. All 4 screens are at the same 1024x768 resolution, but the two screens on the right are high-dpi screens stacked on top of each other and configured for 2x scaling:
![multiscreen_scale_mix2](https://user-images.githubusercontent.com/10320822/122496214-9bc89000-cfa8-11eb-9839-905ab26f2160.gif)

Remaining problems:
- [ ] ~Absolute mouse coordinates are the same for each screen, not sure how to solve this (use relative coordinates in combination with `VIRTIO_GPU_CMD_MOVE_CURSOR`, but I don't see that working well, either)~ _Out of scope_
- [x] Fix mouse pointer rendering glitches when booting with `vmmouse=off` (as a work-around for the absolute pointer problem)
- [x] Enforce contigous layouts
- [x] Load icons for all scaling factors in use (so that when screens are set up to use different scaling factors things will render nicely on all of them)
- [x] Solve #5003 as how we're doing it right now makes it difficult to use different scaling factors on each screen. It should already be supported as-is but we need to treat the output resolution as configured...
- [x] Allow windows to be docked to the sides of all screens, not just the main screen
- [x] Fix window location/size label rendering glitches
- [x] Magnifier tracking cursor to other screens
- [x] Desktop window should cover all screens