### PR TITLE
Userland: Allow building SerenityOS with -funsigned-char

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -177,7 +177,8 @@ URL URLParser::parse(Badge<URL>, StringView const& raw_input, URL const* base_ur
     size_t start_index = 0;
     size_t end_index = raw_input.length();
     for (size_t i = 0; i < raw_input.length(); ++i) {
-        if (0 <= raw_input[i] && raw_input[i] <= 0x20) {
+        i8 ch = raw_input[i];
+        if (0 <= ch && ch <= 0x20) {
             ++start_index;
             has_validation_error = true;
         } else {
@@ -185,7 +186,8 @@ URL URLParser::parse(Badge<URL>, StringView const& raw_input, URL const* base_ur
         }
     }
     for (ssize_t i = raw_input.length() - 1; i >= 0; --i) {
-        if (0 <= raw_input[i] && raw_input[i] <= 0x20) {
+        i8 ch = raw_input[i];
+        if (0 <= ch && ch <= 0x20) {
             --end_index;
             has_validation_error = true;
         } else {

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -139,9 +139,10 @@ void Lexer::consume()
     auto did_reach_eof = [this] {
         if (m_position != m_source.length())
             return false;
+        m_eof = true;
+        m_current_char = '\0';
         m_position++;
         m_line_column++;
-        m_current_char = EOF;
         return true;
     };
 
@@ -276,7 +277,7 @@ bool Lexer::match(char a, char b, char c, char d) const
 
 bool Lexer::is_eof() const
 {
-    return m_current_char == EOF;
+    return m_eof;
 }
 
 bool Lexer::is_line_terminator() const
@@ -540,7 +541,7 @@ Token Lexer::next()
         } else {
             consume();
         }
-    } else if (m_current_char == EOF) {
+    } else if (m_eof) {
         if (unterminated_comment) {
             token_type = TokenType::Invalid;
             token_message = "Unterminated multi-line comment";

--- a/Userland/Libraries/LibJS/Lexer.h
+++ b/Userland/Libraries/LibJS/Lexer.h
@@ -46,6 +46,7 @@ private:
     size_t m_position { 0 };
     Token m_current_token;
     char m_current_char { 0 };
+    bool m_eof { false };
 
     StringView m_filename;
     size_t m_line_number { 1 };

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -40,7 +40,7 @@ static Value parse_simplified_iso8601(const String& iso_8601)
 
     int year = -1, month = -1, day = -1;
     int hours = -1, minutes = -1, seconds = -1, milliseconds = -1;
-    char timezone = -1;
+    int timezone = -1;
     int timezone_hours = -1, timezone_minutes = -1;
     auto lex_year = [&]() {
         if (lexer.consume_specific('+'))

--- a/Userland/Libraries/LibRegex/RegexLexer.cpp
+++ b/Userland/Libraries/LibRegex/RegexLexer.cpp
@@ -36,11 +36,11 @@ Lexer::Lexer(const StringView source)
 {
 }
 
-ALWAYS_INLINE char Lexer::peek(size_t offset) const
+ALWAYS_INLINE int Lexer::peek(size_t offset) const
 {
     if ((m_position + offset) >= m_source.length())
         return EOF;
-    return m_source[m_position + offset];
+    return (unsigned char)m_source[m_position + offset];
 }
 
 void Lexer::back(size_t offset)
@@ -90,6 +90,7 @@ char Lexer::skip()
 {
     auto c = peek();
     consume();
+    VERIFY(c != EOF);
     return c;
 }
 

--- a/Userland/Libraries/LibRegex/RegexLexer.h
+++ b/Userland/Libraries/LibRegex/RegexLexer.h
@@ -76,7 +76,7 @@ public:
     const auto& source() const { return m_source; }
 
 private:
-    ALWAYS_INLINE char peek(size_t offset = 0) const;
+    ALWAYS_INLINE int peek(size_t offset = 0) const;
     ALWAYS_INLINE void consume();
 
     StringView m_source {};

--- a/Userland/Libraries/LibSQL/Lexer.cpp
+++ b/Userland/Libraries/LibSQL/Lexer.cpp
@@ -121,7 +121,8 @@ void Lexer::consume()
     auto did_reach_eof = [this] {
         if (m_position != m_source.length())
             return false;
-        m_current_char = EOF;
+        m_eof = true;
+        m_current_char = '\0';
         ++m_line_column;
         ++m_position;
         return true;
@@ -325,7 +326,7 @@ bool Lexer::is_line_break() const
 
 bool Lexer::is_eof() const
 {
-    return m_current_char == EOF;
+    return m_eof;
 }
 
 }

--- a/Userland/Libraries/LibSQL/Lexer.h
+++ b/Userland/Libraries/LibSQL/Lexer.h
@@ -50,6 +50,7 @@ private:
     size_t m_line_number { 1 };
     size_t m_line_column { 0 };
     char m_current_char { 0 };
+    bool m_eof { false };
     size_t m_position { 0 };
 };
 

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -388,7 +388,7 @@ public:
     }
 
 private:
-    char m_name { -1 };
+    char m_name { 0 };
 };
 
 class TildeValue final : public Value {
@@ -1290,7 +1290,7 @@ private:
     virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, const HitTestResult&) override;
     virtual HitTestResult hit_test_position(size_t) const override;
 
-    char m_name { -1 };
+    char m_name { 0 };
 };
 
 class Juxtaposition final : public Node {


### PR DESCRIPTION
Some of the code assumed that chars were always signed while that is not the case on ARM hosts.

Also, some of the code tried to use `EOF` (-1) in a way similar to what `fgetc()` does, however instead of storing the characters in an `int` variable a `char` was used.

While this seemed to work it also meant that character 0xFF would be incorrectly seen as an end-of-file.

Careful reading of `fgetc()` reveals that `fgetc()` stores character data in an `int` where valid characters are in the range of 0-255 and the `EOF` value is explicitly outside of that range (usually -1).