### PR TITLE
LibJS: Rewrite Array.prototype.slice to be spec compliant

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype-generic-functions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype-generic-functions.js
@@ -39,6 +39,18 @@ describe("ability to work with generic non-array objects", () => {
         expect(removed[1]).toBeUndefined();
     });
 
+    test("slice", () => {
+        const o = { length: 3, 0: "hello", 2: "serenity" };
+        const slice = Array.prototype.slice.call(o, 0, 2);
+        expect(o).toHaveLength(3);
+        expect(o[0]).toBe("hello");
+        expect(o[1]).toBeUndefined();
+        expect(o[2]).toBe("serenity");
+        expect(slice).toHaveLength(2);
+        expect(slice[0]).toBe("hello");
+        expect(slice[1]).toBeUndefined();
+    });
+
     test("join", () => {
         expect(Array.prototype.join.call({})).toBe("");
         expect(Array.prototype.join.call({ length: "foo" })).toBe("");

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.slice.js
@@ -37,3 +37,18 @@ test("basic functionality", () => {
     expect(array).toEqual(["hello", "friends", "serenity", 1]);
     expect(slice).toEqual(["hello", "friends", "serenity", 1]);
 });
+
+// FIXME: These tests are currently skipped because an invalid array length in this case is 2**32 or above.
+//        The codebase currently uses size_t for lengths, which is currently the same as u32 when building for Serenity.
+//        This means these lengths wrap around to 0, making the test not work correctly.
+test.skip("Invalid lengths", () => {
+    var length = Math.pow(2, 32);
+
+    var obj = {
+        length: length,
+    };
+
+    expect(() => {
+        Array.prototype.slice.call(obj, 0);
+    }).toThrowWithMessage(RangeError, "Invalid array length");
+});


### PR DESCRIPTION
This makes it generic in the process (which is required by jQuery)
This fixes 19 test262 test cases :^)