### PR TITLE
Utilities: Change `unzip -o` to `unzip -d` and implement `-q`

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -206,7 +206,7 @@ void do_unzip_archive(const Vector<String>& selected_file_paths, GUI::Window* wi
     }
 
     if (!unzip_pid) {
-        int rc = execlp("/bin/unzip", "/bin/unzip", "-o", output_directory_path.characters(), archive_file_path.characters(), nullptr);
+        int rc = execlp("/bin/unzip", "/bin/unzip", "-d", output_directory_path.characters(), archive_file_path.characters(), nullptr);
         if (rc < 0) {
             perror("execlp");
             _exit(1);

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(map_size_limit, "Maximum chunk size to map", "map-size-limit", 0, "size");
-    args_parser.add_option(output_directory_path, "Directory to receive the archive content", "output-directory", 'o', "path");
+    args_parser.add_option(output_directory_path, "Directory to receive the archive content", "output-directory", 'd', "path");
     args_parser.add_positional_argument(path, "File to unzip", "path", Core::ArgsParser::Required::Yes);
     args_parser.parse(argc, argv);
 

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -14,14 +14,15 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-static bool unpack_zip_member(Archive::ZipMember zip_member)
+static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
 {
     if (zip_member.is_directory) {
         if (mkdir(zip_member.name.characters(), 0755) < 0) {
             perror("mkdir");
             return false;
         }
-        outln(" extracting: {}", zip_member.name);
+        if (!quiet)
+            outln(" extracting: {}", zip_member.name);
         return true;
     }
     auto new_file = Core::File::construct(zip_member.name);
@@ -30,7 +31,8 @@ static bool unpack_zip_member(Archive::ZipMember zip_member)
         return false;
     }
 
-    outln(" extracting: {}", zip_member.name);
+    if (!quiet)
+        outln(" extracting: {}", zip_member.name);
 
     // TODO: verify CRC32s match!
     switch (zip_member.compression_method) {
@@ -73,11 +75,13 @@ int main(int argc, char** argv)
 {
     const char* path;
     int map_size_limit = 32 * MiB;
+    bool quiet { false };
     String output_directory_path;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(map_size_limit, "Maximum chunk size to map", "map-size-limit", 0, "size");
     args_parser.add_option(output_directory_path, "Directory to receive the archive content", "output-directory", 'd', "path");
+    args_parser.add_option(quiet, "Be less verbose", "quiet", 'q');
     args_parser.add_positional_argument(path, "File to unzip", "path", Core::ArgsParser::Required::Yes);
     args_parser.parse(argc, argv);
 
@@ -107,7 +111,8 @@ int main(int argc, char** argv)
     }
     auto& mapped_file = *file_or_error.value();
 
-    warnln("Archive: {}", zip_file_path);
+    if (!quiet)
+        warnln("Archive: {}", zip_file_path);
 
     auto zip_file = Archive::Zip::try_create(mapped_file.bytes());
     if (!zip_file.has_value()) {
@@ -130,7 +135,7 @@ int main(int argc, char** argv)
     }
 
     auto success = zip_file->for_each_member([&](auto zip_member) {
-        return unpack_zip_member(zip_member) ? IterationDecision::Continue : IterationDecision::Break;
+        return unpack_zip_member(zip_member, quiet) ? IterationDecision::Continue : IterationDecision::Break;
     });
 
     return success ? 0 : 1;


### PR DESCRIPTION
* `unzip`: Implement the "shut up" option `-q`
* `unzip`: Change the target directory `-o` option to `-d`

These two changes together with #8037 and #8039 allow for a successful run of composer on Serenity!

![image](https://user-images.githubusercontent.com/3210731/121812799-9a762b00-cc69-11eb-862e-58b588e97268.png)