### PR TITLE
Kernel: Make sure we pass an absolute path to the shebang interpreter

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -849,6 +849,7 @@ KResult Process::exec(String path, Vector<String> arguments, Vector<String> envi
     if (!shebang_result.is_error()) {
         auto shebang_words = shebang_result.release_value();
         auto shebang_path = shebang_words.first();
+        arguments[0] = move(path);
         if (!arguments.try_prepend(move(shebang_words)))
             return ENOMEM;
         return exec(move(shebang_path), move(arguments), move(environment), ++recursion_depth);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -851,7 +851,7 @@ KResult Process::exec(String path, Vector<String> arguments, Vector<String> envi
         auto shebang_path = shebang_words.first();
         if (!arguments.try_prepend(move(shebang_words)))
             return ENOMEM;
-        return exec(shebang_path, move(arguments), move(environment), ++recursion_depth);
+        return exec(move(shebang_path), move(arguments), move(environment), ++recursion_depth);
     }
 
     // #2) ELF32 for i386


### PR DESCRIPTION
A binary in $PATH with a shebang line gets argv[0] passed to its interpreter, which might not necessarily be the correct path to the
file to interpret. For example:
```
  # composer lives in /usr/local/bin/
  # pwd = /home/anon
  composer ...

  # In the execve syscall shebang handling:
  # arguments[0] = composer
  # path = /usr/local/bin/composer
```
Overwrite the first argument we pass to the interpreter to the absolute path of the binary that was invoked to make sure the interpreter can always find the file.