### PR TITLE
Browser: CSS calc() properties

### DIFF
--- a/Base/res/html/misc/calc.html
+++ b/Base/res/html/misc/calc.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Calc</title>
+    <style>
+        .container {
+            border: 1px solid pink;
+            width: 250px;
+        }
+
+        .box {
+            border: 1px solid black;
+            height: 100px;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>CSS calc() Tests</h1>
+    <p>The boxes change their width property.</p>
+    <p>calc(100px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(100px);"></div>
+    </div>
+
+    <p>calc(100px + 30% - (2rem * 3 + 20px))</p>
+    <div class="container">
+        <div class="box" style="width: calc(100px + 30% - (2rem * 3 + 20px));"></div>
+    </div>
+
+    <p>calc(100px + 30% - (120px / (2*4 + 3 )))</p>
+    <div class="container">
+        <div class="box" style="width: calc(100px + 30% - (120px / (2*4 + 3 )));"></div>
+    </div>
+
+    <p>calc(50% + 60px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + 50px);"></div>
+    </div>
+
+    <p>calc(50% + -60px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + -60px);"></div>
+    </div>
+
+    <p>calc(50% + 60px - 10px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + 50px - 10px);"></div>
+    </div>
+
+    <p>calc(50% + 3*20px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + 3*20px);"></div>
+    </div>
+
+    <p>calc(50% + 3 * 20px)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + 3 * 20px);"></div>
+    </div>
+
+    <p>calc(50% + 10.5pt)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + 10.5pt);"></div>
+    </div>
+
+    <p>calc(50% + .5pt)</p>
+    <div class="container">
+        <div class="box" style="width: calc(50% + .5pt);"></div>
+    </div>
+</body>
+
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -46,6 +46,7 @@
     <p>This page loaded in <b><span id="loadtime"></span></b> ms</p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="calc.html">calc Property</a></li>
         <li><a href="justify-content.html">Flexbox justify-content</a></li>
         <li><a href="lists.html">Lists</a></li>
         <li><a href="text-decoration.html">Text-decoration</a></li>

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -1,9 +1,13 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobi@tobyase.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullOwnPtrVector.h>
+#include <AK/Variant.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
@@ -37,6 +41,123 @@ float Length::relative_length_to_px(const Layout::Node& layout_node) const
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+static float resolve_calc_value(CalculatedStyleValue::CalcValue const&, const Layout::Node& layout_node, float reference_for_percent);
+static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue const&);
+static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduct> const&, const Layout::Node& layout_node, float reference_for_percent);
+static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const&, const Layout::Node& layout_node, float reference_for_percent);
+static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const&);
+static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::CalcNumberProduct> const&);
+
+float Length::resolve_calculated_value(const Layout::Node& layout_node, float reference_for_percent) const
+{
+    if (!m_calculated_style)
+        return 0.0f;
+
+    auto& expression = m_calculated_style->expression();
+
+    auto length = resolve_calc_sum(expression, layout_node, reference_for_percent);
+    return length;
+};
+
+static float resolve_calc_value(CalculatedStyleValue::CalcValue const& calc_value, const Layout::Node& layout_node, float reference_for_percent)
+{
+    return calc_value.visit(
+        [](float value) { return value; },
+        [&](Length length) {
+            return length.resolved_or_zero(layout_node, reference_for_percent).to_px(layout_node);
+        },
+        [&](NonnullOwnPtr<CalculatedStyleValue::CalcSum>& calc_sum) {
+            return resolve_calc_sum(calc_sum, layout_node, reference_for_percent);
+        },
+        [](auto&) {
+            VERIFY_NOT_REACHED();
+            return 0.0f;
+        });
+}
+
+static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::CalcNumberProduct> const& calc_number_product)
+{
+    auto value = resolve_calc_number_value(calc_number_product->first_calc_number_value);
+
+    for (auto& additional_number_value : calc_number_product->zero_or_more_additional_calc_number_values) {
+        auto additional_value = resolve_calc_number_value(additional_number_value.value);
+        if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply)
+            value *= additional_value;
+        else if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Divide)
+            value /= additional_value;
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    return value;
+}
+
+static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const& calc_number_sum)
+{
+    auto value = resolve_calc_number_product(calc_number_sum->first_calc_number_product);
+
+    for (auto& additional_product : calc_number_sum->zero_or_more_additional_calc_number_products) {
+        auto additional_value = resolve_calc_number_product(additional_product.calc_number_product);
+        if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Add)
+            value += additional_value;
+        else if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Subtract)
+            value -= additional_value;
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    return value;
+}
+
+static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue const& number_value)
+{
+    return number_value.visit(
+        [](float number) { return number; },
+        [](NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum>& calc_number_sum) {
+            return resolve_calc_number_sum(calc_number_sum);
+        });
+}
+
+static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduct> const& calc_product, const Layout::Node& layout_node, float reference_for_percent)
+{
+    auto value = resolve_calc_value(calc_product->first_calc_value, layout_node, reference_for_percent);
+
+    for (auto& additional_value : calc_product->zero_or_more_additional_calc_values) {
+        additional_value.value.visit(
+            [&](CalculatedStyleValue::CalcValue const& calc_value) {
+                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Multiply)
+                    VERIFY_NOT_REACHED();
+                auto resolved_value = resolve_calc_value(calc_value, layout_node, reference_for_percent);
+                value *= resolved_value;
+            },
+            [&](CalculatedStyleValue::CalcNumberValue const& calc_number_value) {
+                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Divide)
+                    VERIFY_NOT_REACHED();
+                auto resolved_calc_number_value = resolve_calc_number_value(calc_number_value);
+                value /= resolved_calc_number_value;
+            });
+    }
+
+    return value;
+}
+
+static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum, const Layout::Node& layout_node, float reference_for_percent)
+{
+    auto value = resolve_calc_product(calc_sum->first_calc_product, layout_node, reference_for_percent);
+
+    for (auto& additional_product : calc_sum->zero_or_more_additional_calc_products) {
+        auto additional_value = resolve_calc_product(additional_product.calc_product, layout_node, reference_for_percent);
+        if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Add)
+            value += additional_value;
+        else if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Subtract)
+            value -= additional_value;
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    return value;
 }
 
 const char* Length::unit_name() const

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -76,6 +76,8 @@ const char* Length::unit_name() const
         return "vmax";
     case Type::Vmin:
         return "vmin";
+    case Type::Calculated:
+        return "calculated";
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -53,10 +53,10 @@ public:
     {
         if (is_undefined())
             return fallback_for_undefined;
+        if (is_calculated())
+            return Length(resolve_calculated_value(layout_node, reference_for_percent), Type::Px);
         if (is_percentage())
             return make_px(raw_value() / 100.0f * reference_for_percent);
-        if (is_calculated())
-            return {};
         if (is_relative())
             return make_px(to_px(layout_node));
         return *this;
@@ -153,6 +153,7 @@ public:
 
 private:
     float relative_length_to_px(const Layout::Node&) const;
+    float resolve_calculated_value(const Layout::Node& layout_node, float reference_for_percent) const;
 
     const char* unit_name() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -16,6 +16,7 @@ public:
     enum class Type {
         Undefined,
         Percentage,
+        Calculated,
         Auto,
         Cm,
         In,
@@ -54,6 +55,8 @@ public:
             return fallback_for_undefined;
         if (is_percentage())
             return make_px(raw_value() / 100.0f * reference_for_percent);
+        if (is_calculated())
+            return {};
         if (is_relative())
             return make_px(to_px(layout_node));
         return *this;
@@ -71,8 +74,9 @@ public:
 
     bool is_undefined_or_auto() const { return m_type == Type::Undefined || m_type == Type::Auto; }
     bool is_undefined() const { return m_type == Type::Undefined; }
-    bool is_percentage() const { return m_type == Type::Percentage; }
+    bool is_percentage() const { return m_type == Type::Percentage || m_type == Type::Calculated; }
     bool is_auto() const { return m_type == Type::Auto; }
+    bool is_calculated() const { return m_type == Type::Calculated; }
 
     bool is_absolute() const
     {
@@ -122,6 +126,7 @@ public:
             return m_value * ((1.0f / 40.0f) * centimeter_pixels); // 1Q = 1/40th of 1cm
         case Type::Undefined:
         case Type::Percentage:
+        case Type::Calculated:
         default:
             VERIFY_NOT_REACHED();
         }
@@ -144,6 +149,8 @@ public:
         return !(*this == other);
     }
 
+    void set_calculated_style(CalculatedStyleValue* value) { m_calculated_style = value; }
+
 private:
     float relative_length_to_px(const Layout::Node&) const;
 
@@ -151,6 +158,8 @@ private:
 
     Type m_type { Type::Undefined };
     float m_value { 0 };
+
+    CalculatedStyleValue* m_calculated_style { nullptr };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/GenericLexer.h>
 #include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/SourceLocation.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSRule.h>
@@ -280,25 +281,37 @@ static StringView isolate_calc_expression(const StringView& value)
     return value.substring_view(5, substring_length);
 }
 
-static Optional<NonnullOwnPtr<CSS::CalculatedStyleValue::CalcSum>> parse_calc_expression(const StringView& expression_string)
+struct CalcToken {
+    enum class Type {
+        Undefined,
+        Number,
+        Unit,
+        Whitespace,
+        Plus,
+        Minus,
+        Asterisk,
+        Slash,
+        OpenBracket,
+        CloseBracket,
+    } type { Type::Undefined };
+    String value {};
+};
+
+static void eat_white_space(Vector<CalcToken>&);
+static Optional<CSS::CalculatedStyleValue::CalcValue> parse_calc_value(Vector<CalcToken>&);
+static OwnPtr<CSS::CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(Vector<CalcToken>&);
+static Optional<CSS::CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(Vector<CalcToken>&);
+static OwnPtr<CSS::CalculatedStyleValue::CalcProduct> parse_calc_product(Vector<CalcToken>&);
+static OwnPtr<CSS::CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(Vector<CalcToken>&);
+static OwnPtr<CSS::CalculatedStyleValue::CalcSum> parse_calc_sum(Vector<CalcToken>&);
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(Vector<CalcToken>& tokens);
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(Vector<CalcToken>& tokens);
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(Vector<CalcToken>& tokens);
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(Vector<CalcToken>& tokens);
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcSum> parse_calc_expression(const StringView& expression_string)
 {
     // First, tokenize
-
-    struct CalcToken {
-        enum class Type {
-            Undefined,
-            Number,
-            Unit,
-            Whitespace,
-            Plus,
-            Minus,
-            Asterisk,
-            Slash,
-            OpenBracket,
-            CloseBracket,
-        } type { Type::Undefined };
-        String value {};
-    };
 
     Vector<CalcToken> tokens;
 
@@ -367,7 +380,255 @@ static Optional<NonnullOwnPtr<CSS::CalculatedStyleValue::CalcSum>> parse_calc_ex
         VERIFY_NOT_REACHED();
     }
 
-    return {};
+    // Then, parse
+
+    return parse_calc_sum(tokens);
+}
+
+static void eat_white_space(Vector<CalcToken>& tokens)
+{
+    while (tokens.size() > 0 && tokens.first().type == CalcToken::Type::Whitespace)
+        tokens.take_first();
+}
+
+static Optional<CSS::CalculatedStyleValue::CalcValue> parse_calc_value(Vector<CalcToken>& tokens)
+{
+    auto current_token = tokens.take_first();
+
+    if (current_token.type == CalcToken::Type::OpenBracket) {
+        auto parsed_calc_sum = parse_calc_sum(tokens);
+        if (!parsed_calc_sum)
+            return {};
+        return (CSS::CalculatedStyleValue::CalcValue) { parsed_calc_sum.release_nonnull() };
+    }
+
+    if (current_token.type != CalcToken::Type::Number)
+        return {};
+
+    auto try_the_number = try_parse_float(current_token.value);
+    if (!try_the_number.has_value())
+        return {};
+
+    float the_number = try_the_number.value();
+
+    if (tokens.first().type != CalcToken::Type::Unit)
+        return (CSS::CalculatedStyleValue::CalcValue) { the_number };
+
+    auto type = length_type_from_unit(tokens.take_first().value);
+
+    if (type == CSS::Length::Type::Undefined)
+        return {};
+
+    return (CSS::CalculatedStyleValue::CalcValue) { CSS::Length(the_number, type) };
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(Vector<CalcToken>& tokens)
+{
+    auto product_with_operator = make<CSS::CalculatedStyleValue::CalcProductPartWithOperator>();
+
+    eat_white_space(tokens);
+
+    auto op = tokens.first();
+    if (op.type == CalcToken::Type::Asterisk) {
+        tokens.take_first();
+        eat_white_space(tokens);
+        product_with_operator->op = CSS::CalculatedStyleValue::CalcProductPartWithOperator::Multiply;
+        auto parsed_calc_value = parse_calc_value(tokens);
+        if (!parsed_calc_value.has_value())
+            return nullptr;
+        product_with_operator->value = { parsed_calc_value.release_value() };
+
+    } else if (op.type == CalcToken::Type::Slash) {
+        tokens.take_first();
+        eat_white_space(tokens);
+        product_with_operator->op = CSS::CalculatedStyleValue::CalcProductPartWithOperator::Divide;
+        auto parsed_calc_number_value = parse_calc_number_value(tokens);
+        if (!parsed_calc_number_value.has_value())
+            return nullptr;
+        product_with_operator->value = { parsed_calc_number_value.release_value() };
+    } else {
+        return nullptr;
+    }
+
+    return product_with_operator;
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(Vector<CalcToken>& tokens)
+{
+    auto number_product_with_operator = make<CSS::CalculatedStyleValue::CalcNumberProductPartWithOperator>();
+
+    eat_white_space(tokens);
+
+    auto op = tokens.first();
+    if (op.type == CalcToken::Type::Asterisk) {
+        tokens.take_first();
+        eat_white_space(tokens);
+        number_product_with_operator->op = CSS::CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply;
+    } else if (op.type == CalcToken::Type::Slash) {
+        tokens.take_first();
+        eat_white_space(tokens);
+        number_product_with_operator->op = CSS::CalculatedStyleValue::CalcNumberProductPartWithOperator::Divide;
+    } else {
+        return nullptr;
+    }
+    auto parsed_calc_value = parse_calc_number_value(tokens);
+    if (!parsed_calc_value.has_value())
+        return nullptr;
+    number_product_with_operator->value = parsed_calc_value.release_value();
+
+    return number_product_with_operator;
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(Vector<CalcToken>& tokens)
+{
+    auto calc_number_product = make<CSS::CalculatedStyleValue::CalcNumberProduct>();
+
+    auto first_calc_number_value_or_error = parse_calc_number_value(tokens);
+    if (!first_calc_number_value_or_error.has_value())
+        return nullptr;
+    calc_number_product->first_calc_number_value = first_calc_number_value_or_error.release_value();
+
+    while (tokens.size() > 0) {
+        auto number_product_with_operator = parse_calc_number_product_part_with_operator(tokens);
+        if (!number_product_with_operator)
+            break;
+        calc_number_product->zero_or_more_additional_calc_number_values.append(number_product_with_operator.release_nonnull());
+    }
+
+    return calc_number_product;
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(Vector<CalcToken>& tokens)
+{
+    if (tokens.size() < 3)
+        return nullptr;
+    if (!((tokens[0].type == CalcToken::Type::Plus
+              || tokens[0].type == CalcToken::Type::Minus)
+            && tokens[1].type == CalcToken::Type::Whitespace))
+        return nullptr;
+
+    auto op_token = tokens.take_first().type;
+    tokens.take_first(); // Whitespace;
+
+    CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Operation op;
+    if (op_token == CalcToken::Type::Plus)
+        op = CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Operation::Add;
+    else if (op_token == CalcToken::Type::Minus)
+        op = CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Operation::Subtract;
+    else
+        return nullptr;
+
+    auto calc_number_product = parse_calc_number_product(tokens);
+    if (!calc_number_product)
+        return nullptr;
+    return make<CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator>(op, calc_number_product.release_nonnull());
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(Vector<CalcToken>& tokens)
+{
+    if (tokens.take_first().type != CalcToken::Type::OpenBracket)
+        return nullptr;
+
+    auto first_calc_number_product_or_error = parse_calc_number_product(tokens);
+    if (!first_calc_number_product_or_error)
+        return nullptr;
+
+    NonnullOwnPtrVector<CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator> additional {};
+    while (tokens.size() > 0 && tokens.first().type != CalcToken::Type::CloseBracket) {
+        auto calc_sum_part = parse_calc_number_sum_part_with_operator(tokens);
+        if (!calc_sum_part)
+            return nullptr;
+        additional.append(calc_sum_part.release_nonnull());
+    }
+
+    eat_white_space(tokens);
+
+    auto calc_number_sum = make<CSS::CalculatedStyleValue::CalcNumberSum>(first_calc_number_product_or_error.release_nonnull(), move(additional));
+    return calc_number_sum;
+}
+
+static Optional<CSS::CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(Vector<CalcToken>& tokens)
+{
+    if (tokens.first().type == CalcToken::Type::OpenBracket) {
+        auto calc_number_sum = parse_calc_number_sum(tokens);
+        if (calc_number_sum)
+            return { calc_number_sum.release_nonnull() };
+    }
+
+    if (tokens.first().type != CalcToken::Type::Number)
+        return {};
+
+    auto the_number_string = tokens.take_first().value;
+    auto try_the_number = try_parse_float(the_number_string);
+    if (!try_the_number.has_value())
+        return {};
+    return try_the_number.value();
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcProduct> parse_calc_product(Vector<CalcToken>& tokens)
+{
+    auto calc_product = make<CSS::CalculatedStyleValue::CalcProduct>();
+
+    auto first_calc_value_or_error = parse_calc_value(tokens);
+    if (!first_calc_value_or_error.has_value())
+        return nullptr;
+    calc_product->first_calc_value = first_calc_value_or_error.release_value();
+
+    while (tokens.size() > 0) {
+        auto product_with_operator = parse_calc_product_part_with_operator(tokens);
+        if (!product_with_operator)
+            break;
+        calc_product->zero_or_more_additional_calc_values.append(product_with_operator.release_nonnull());
+    }
+
+    return calc_product;
+}
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(Vector<CalcToken>& tokens)
+{
+    // The following has to have the shape of <Whitespace><+ or -><Whitespace>
+    // But the first whitespace gets eaten in parse_calc_product_part_with_operator().
+    if (tokens.size() < 3)
+        return {};
+    if (!((tokens[0].type == CalcToken::Type::Plus
+              || tokens[0].type == CalcToken::Type::Minus)
+            && tokens[1].type == CalcToken::Type::Whitespace))
+        return nullptr;
+
+    auto op_token = tokens.take_first().type;
+    tokens.take_first(); // Whitespace;
+
+    CSS::CalculatedStyleValue::CalcSumPartWithOperator::Operation op;
+    if (op_token == CalcToken::Type::Plus)
+        op = CSS::CalculatedStyleValue::CalcSumPartWithOperator::Operation::Add;
+    else if (op_token == CalcToken::Type::Minus)
+        op = CSS::CalculatedStyleValue::CalcSumPartWithOperator::Operation::Subtract;
+    else
+        return nullptr;
+
+    auto calc_product = parse_calc_product(tokens);
+    if (!calc_product)
+        return nullptr;
+    return make<CSS::CalculatedStyleValue::CalcSumPartWithOperator>(op, calc_product.release_nonnull());
+};
+
+static OwnPtr<CSS::CalculatedStyleValue::CalcSum> parse_calc_sum(Vector<CalcToken>& tokens)
+{
+    auto parsed_calc_product = parse_calc_product(tokens);
+    if (!parsed_calc_product)
+        return nullptr;
+
+    NonnullOwnPtrVector<CSS::CalculatedStyleValue::CalcSumPartWithOperator> additional {};
+    while (tokens.size() > 0 && tokens.first().type != CalcToken::Type::CloseBracket) {
+        auto calc_sum_part = parse_calc_sum_part_with_operator(tokens);
+        if (!calc_sum_part)
+            return nullptr;
+        additional.append(calc_sum_part.release_nonnull());
+    }
+
+    eat_white_space(tokens);
+
+    return make<CSS::CalculatedStyleValue::CalcSum>(parsed_calc_product.release_nonnull(), move(additional));
 }
 
 RefPtr<CSS::StyleValue> parse_css_value(const CSS::DeprecatedParsingContext& context, const StringView& string, CSS::PropertyID property_id)
@@ -401,8 +662,8 @@ RefPtr<CSS::StyleValue> parse_css_value(const CSS::DeprecatedParsingContext& con
     if (string.starts_with("calc(")) {
         auto calc_expression_string = isolate_calc_expression(string);
         auto calc_expression = parse_calc_expression(calc_expression_string);
-        if (calc_expression.has_value())
-            return CSS::CalculatedStyleValue::create(calc_expression_string, calc_expression.release_value());
+        if (calc_expression)
+            return CSS::CalculatedStyleValue::create(calc_expression_string, calc_expression.release_nonnull());
     }
 
     auto value_id = CSS::value_id_from_string(string);

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -146,66 +146,107 @@ static Optional<float> try_parse_float(const StringView& string)
     return is_negative ? -value : value;
 }
 
+static CSS::Length::Type length_type_from_unit(const StringView& view)
+{
+    if (view.ends_with('%'))
+        return CSS::Length::Type::Percentage;
+    if (view.ends_with("px", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Px;
+    if (view.ends_with("pt", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Pt;
+    if (view.ends_with("pc", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Pc;
+    if (view.ends_with("mm", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Mm;
+    if (view.ends_with("rem", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Rem;
+    if (view.ends_with("em", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Em;
+    if (view.ends_with("ex", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Ex;
+    if (view.ends_with("vw", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Vw;
+    if (view.ends_with("vh", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Vh;
+    if (view.ends_with("vmax", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Vmax;
+    if (view.ends_with("vmin", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Vmin;
+    if (view.ends_with("cm", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Cm;
+    if (view.ends_with("in", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::In;
+    if (view.ends_with("Q", CaseSensitivity::CaseInsensitive))
+        return CSS::Length::Type::Q;
+    if (view == "0")
+        return CSS::Length::Type::Px;
+
+    return CSS::Length::Type::Undefined;
+}
+
 static CSS::Length parse_length(const CSS::DeprecatedParsingContext& context, const StringView& view, bool& is_bad_length)
 {
-    CSS::Length::Type type = CSS::Length::Type::Undefined;
+    CSS::Length::Type type = length_type_from_unit(view);
     Optional<float> value;
 
-    if (view.ends_with('%')) {
-        type = CSS::Length::Type::Percentage;
+    switch (type) {
+    case CSS::Length::Type::Percentage:
         value = try_parse_float(view.substring_view(0, view.length() - 1));
-    } else if (view.ends_with("px", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Px;
+        break;
+    case CSS::Length::Type::Px:
+        if (view == "0")
+            value = 0;
+        else
+            value = try_parse_float(view.substring_view(0, view.length() - 2));
+        break;
+    case CSS::Length::Type::Pt:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("pt", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Pt;
+        break;
+    case CSS::Length::Type::Pc:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("pc", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Pc;
+        break;
+    case CSS::Length::Type::Mm:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("mm", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Mm;
-        value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("rem", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Rem;
+        break;
+    case CSS::Length::Type::Rem:
         value = try_parse_float(view.substring_view(0, view.length() - 3));
-    } else if (view.ends_with("em", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Em;
+        break;
+    case CSS::Length::Type::Em:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("ex", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Ex;
+        break;
+    case CSS::Length::Type::Ex:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("vw", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Vw;
+        break;
+    case CSS::Length::Type::Vw:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("vh", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Vh;
+        break;
+    case CSS::Length::Type::Vh:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("vmax", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Vmax;
+        break;
+    case CSS::Length::Type::Vmax:
         value = try_parse_float(view.substring_view(0, view.length() - 4));
-    } else if (view.ends_with("vmin", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Vmin;
+        break;
+    case CSS::Length::Type::Vmin:
         value = try_parse_float(view.substring_view(0, view.length() - 4));
-    } else if (view.ends_with("cm", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Cm;
+        break;
+    case CSS::Length::Type::Cm:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("in", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::In;
+        break;
+    case CSS::Length::Type::In:
         value = try_parse_float(view.substring_view(0, view.length() - 2));
-    } else if (view.ends_with("Q", CaseSensitivity::CaseInsensitive)) {
-        type = CSS::Length::Type::Q;
+        break;
+    case CSS::Length::Type::Q:
         value = try_parse_float(view.substring_view(0, view.length() - 1));
-    } else if (view == "0") {
-        type = CSS::Length::Type::Px;
-        value = 0;
-    } else if (context.in_quirks_mode()) {
-        type = CSS::Length::Type::Px;
-        value = try_parse_float(view);
-    } else {
-        value = try_parse_float(view);
-        if (value.has_value())
-            is_bad_length = true;
+        break;
+    default:
+        if (context.in_quirks_mode()) {
+            type = CSS::Length::Type::Px;
+            value = try_parse_float(view);
+        } else {
+            value = try_parse_float(view);
+            if (value.has_value())
+                is_bad_length = true;
+        }
     }
 
     if (!value.has_value())

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -55,6 +55,13 @@ Length StyleProperties::length_or_fallback(CSS::PropertyID id, const Length& fal
     auto value = property(id);
     if (!value.has_value())
         return fallback;
+
+    if (value.value()->is_calculated()) {
+        Length length = Length(0, Length::Type::Calculated);
+        length.set_calculated_style(verify_cast<CalculatedStyleValue>(value.value().ptr()));
+        return length;
+    }
+
     return value.value()->to_length();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -8,12 +8,16 @@
 
 #pragma once
 
+#include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/URL.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
@@ -223,6 +227,7 @@ public:
         CustomProperty,
         Numeric,
         ValueList,
+        Calculated,
     };
 
     Type type() const { return m_type; }
@@ -237,11 +242,19 @@ public:
     bool is_position() const { return type() == Type::Position; }
     bool is_custom_property() const { return type() == Type::CustomProperty; }
     bool is_numeric() const { return type() == Type::Numeric; }
-    bool is_value_list() const { return type() == Type::ValueList; }
+    bool is_value_list() const
+    {
+        return type() == Type::ValueList;
+    }
 
     bool is_builtin_or_dynamic() const
     {
         return is_inherit() || is_initial() || is_custom_property();
+    }
+
+    bool is_calculated() const
+    {
+        return type() == Type::Calculated;
     }
 
     virtual String to_string() const = 0;
@@ -359,6 +372,113 @@ private:
     }
 
     Length m_length;
+};
+
+class CalculatedStyleValue : public StyleValue {
+public:
+    struct CalcSum;
+    struct CalcSumPartWithOperator;
+    struct CalcProduct;
+    struct CalcProductPartWithOperator;
+    struct CalcNumberSum;
+    struct CalcNumberSumPartWithOperator;
+    struct CalcNumberProduct;
+    struct CalcNumberProductPartWithOperator;
+
+    using CalcNumberValue = Variant<float, NonnullOwnPtr<CalcNumberSum>>;
+    using CalcValue = Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>>;
+
+    // This represents that: https://drafts.csswg.org/css-values-3/#calc-syntax
+    struct CalcSum {
+        CalcSum(NonnullOwnPtr<CalcProduct> first_calc_product, NonnullOwnPtrVector<CalcSumPartWithOperator> additional)
+            : first_calc_product(move(first_calc_product))
+            , zero_or_more_additional_calc_products(move(additional)) {};
+
+        NonnullOwnPtr<CalcProduct> first_calc_product;
+        NonnullOwnPtrVector<CalcSumPartWithOperator> zero_or_more_additional_calc_products;
+    };
+
+    struct CalcNumberSum {
+        CalcNumberSum(NonnullOwnPtr<CalcNumberProduct> first_calc_number_product, NonnullOwnPtrVector<CalcNumberSumPartWithOperator> additional)
+            : first_calc_number_product(move(first_calc_number_product))
+            , zero_or_more_additional_calc_number_products(move(additional)) {};
+
+        NonnullOwnPtr<CalcNumberProduct> first_calc_number_product;
+        NonnullOwnPtrVector<CalcNumberSumPartWithOperator> zero_or_more_additional_calc_number_products;
+    };
+
+    struct CalcProduct {
+        CalcValue first_calc_value;
+        NonnullOwnPtrVector<CalcProductPartWithOperator> zero_or_more_additional_calc_values;
+    };
+
+    struct CalcSumPartWithOperator {
+        enum Operation {
+            Add,
+            Subtract,
+        };
+
+        CalcSumPartWithOperator(Operation op, NonnullOwnPtr<CalcProduct> calc_product)
+            : op(op)
+            , calc_product(move(calc_product)) {};
+
+        Operation op;
+        NonnullOwnPtr<CalcProduct> calc_product;
+    };
+
+    struct CalcProductPartWithOperator {
+        enum {
+            Multiply,
+            Divide,
+        } op;
+        Variant<CalcValue, CalcNumberValue> value;
+    };
+
+    struct CalcNumberProduct {
+        CalcNumberValue first_calc_number_value;
+        NonnullOwnPtrVector<CalcNumberProductPartWithOperator> zero_or_more_additional_calc_number_values;
+    };
+
+    struct CalcNumberProductPartWithOperator {
+        enum {
+            Multiply,
+            Divide,
+        } op;
+        CalcNumberValue value;
+    };
+
+    struct CalcNumberSumPartWithOperator {
+        enum Operation {
+            Add,
+            Subtract,
+        };
+
+        CalcNumberSumPartWithOperator(Operation op, NonnullOwnPtr<CalcNumberProduct> calc_number_product)
+            : op(op)
+            , calc_number_product(move(calc_number_product)) {};
+
+        Operation op;
+        NonnullOwnPtr<CalcNumberProduct> calc_number_product;
+    };
+
+    static NonnullRefPtr<CalculatedStyleValue> create(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)
+    {
+        return adopt_ref(*new CalculatedStyleValue(expression_string, move(calc_sum)));
+    }
+
+    String to_string() const override { return m_expression_string; }
+    NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
+
+private:
+    explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)
+        : StyleValue(Type::Calculated)
+        , m_expression_string(expression_string)
+        , m_expression(move(calc_sum))
+    {
+    }
+
+    String m_expression_string;
+    NonnullOwnPtr<CalcSum> m_expression;
 };
 
 class InitialStyleValue final : public StyleValue {
@@ -491,5 +611,4 @@ inline CSS::ValueID StyleValue::to_identifier() const
         return static_cast<const IdentifierStyleValue&>(*this).id();
     return CSS::ValueID::Invalid;
 }
-
 }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -14,6 +14,7 @@ enum class Source;
 }
 
 namespace Web::CSS {
+class CalculatedStyleValue;
 class CSSRule;
 class CSSImportRule;
 class CSSStyleDeclaration;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -58,14 +58,7 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
     auto is_row = (flex_direction == CSS::FlexDirection::Row || flex_direction == CSS::FlexDirection::RowReverse);
     auto main_size_is_infinite = false;
     auto get_pixel_size = [](Box& box, const CSS::Length& length) {
-        if (length.is_undefined())
-            return 0.0f;
-
-        if (!length.is_percentage())
-            return length.to_px(box);
-
-        auto percent = length.raw_value() / 100.0f;
-        return box.containing_block()->width() * percent;
+        return length.resolved(CSS::Length::make_px(0), box, box.containing_block()->width()).to_px(box);
     };
     auto layout_for_maximum_main_size = [&](Box& box) {
         if (is_row)


### PR DESCRIPTION
This adds support for calc() properties into the Browser. [This](https://drafts.csswg.org/css-values-3/#calc-syntax) syntax gets parsed and it's values calculated when needed.

- Nested calc's are supported.
- For now only Lengths can be targeted by calc-expressions, however everything that could take a value (int/rational) also could take a calc(). I don't think that's widely used though (calc in z-index or flex-grow doesn't seem terribly convenient...).
    But to keep that abstraction I couldn't just yank all the stuff into LengthStyleType but had to make it its own.
- Apparently people (eg GitHub) use var() _inside_ of calc(). Not yet supported.
