### PR TITLE
LibRegex: Various performance improvements

### DIFF
--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -90,64 +90,67 @@ static const char* character_class_name(CharClass ch_class)
 OwnPtr<OpCode> ByteCode::s_opcodes[(size_t)OpCodeId::Last + 1];
 bool ByteCode::s_opcodes_initialized { false };
 
+void ByteCode::ensure_opcodes_initialized()
+{
+    if (s_opcodes_initialized)
+        return;
+    for (u32 i = (u32)OpCodeId::First; i <= (u32)OpCodeId::Last; ++i) {
+        switch ((OpCodeId)i) {
+        case OpCodeId::Exit:
+            s_opcodes[i] = make<OpCode_Exit>();
+            break;
+        case OpCodeId::Jump:
+            s_opcodes[i] = make<OpCode_Jump>();
+            break;
+        case OpCodeId::Compare:
+            s_opcodes[i] = make<OpCode_Compare>();
+            break;
+        case OpCodeId::CheckEnd:
+            s_opcodes[i] = make<OpCode_CheckEnd>();
+            break;
+        case OpCodeId::CheckBoundary:
+            s_opcodes[i] = make<OpCode_CheckBoundary>();
+            break;
+        case OpCodeId::ForkJump:
+            s_opcodes[i] = make<OpCode_ForkJump>();
+            break;
+        case OpCodeId::ForkStay:
+            s_opcodes[i] = make<OpCode_ForkStay>();
+            break;
+        case OpCodeId::FailForks:
+            s_opcodes[i] = make<OpCode_FailForks>();
+            break;
+        case OpCodeId::Save:
+            s_opcodes[i] = make<OpCode_Save>();
+            break;
+        case OpCodeId::Restore:
+            s_opcodes[i] = make<OpCode_Restore>();
+            break;
+        case OpCodeId::GoBack:
+            s_opcodes[i] = make<OpCode_GoBack>();
+            break;
+        case OpCodeId::CheckBegin:
+            s_opcodes[i] = make<OpCode_CheckBegin>();
+            break;
+        case OpCodeId::SaveLeftCaptureGroup:
+            s_opcodes[i] = make<OpCode_SaveLeftCaptureGroup>();
+            break;
+        case OpCodeId::SaveRightCaptureGroup:
+            s_opcodes[i] = make<OpCode_SaveRightCaptureGroup>();
+            break;
+        case OpCodeId::SaveLeftNamedCaptureGroup:
+            s_opcodes[i] = make<OpCode_SaveLeftNamedCaptureGroup>();
+            break;
+        case OpCodeId::SaveRightNamedCaptureGroup:
+            s_opcodes[i] = make<OpCode_SaveRightNamedCaptureGroup>();
+            break;
+        }
+    }
+    s_opcodes_initialized = true;
+}
+
 ALWAYS_INLINE OpCode& ByteCode::get_opcode_by_id(OpCodeId id) const
 {
-    if (!s_opcodes_initialized) {
-        for (u32 i = (u32)OpCodeId::First; i <= (u32)OpCodeId::Last; ++i) {
-            switch ((OpCodeId)i) {
-            case OpCodeId::Exit:
-                s_opcodes[i] = make<OpCode_Exit>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::Jump:
-                s_opcodes[i] = make<OpCode_Jump>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::Compare:
-                s_opcodes[i] = make<OpCode_Compare>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::CheckEnd:
-                s_opcodes[i] = make<OpCode_CheckEnd>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::CheckBoundary:
-                s_opcodes[i] = make<OpCode_CheckBoundary>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::ForkJump:
-                s_opcodes[i] = make<OpCode_ForkJump>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::ForkStay:
-                s_opcodes[i] = make<OpCode_ForkStay>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::FailForks:
-                s_opcodes[i] = make<OpCode_FailForks>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::Save:
-                s_opcodes[i] = make<OpCode_Save>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::Restore:
-                s_opcodes[i] = make<OpCode_Restore>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::GoBack:
-                s_opcodes[i] = make<OpCode_GoBack>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::CheckBegin:
-                s_opcodes[i] = make<OpCode_CheckBegin>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::SaveLeftCaptureGroup:
-                s_opcodes[i] = make<OpCode_SaveLeftCaptureGroup>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::SaveRightCaptureGroup:
-                s_opcodes[i] = make<OpCode_SaveRightCaptureGroup>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::SaveLeftNamedCaptureGroup:
-                s_opcodes[i] = make<OpCode_SaveLeftNamedCaptureGroup>(*const_cast<ByteCode*>(this));
-                break;
-            case OpCodeId::SaveRightNamedCaptureGroup:
-                s_opcodes[i] = make<OpCode_SaveRightNamedCaptureGroup>(*const_cast<ByteCode*>(this));
-                break;
-            }
-        }
-        s_opcodes_initialized = true;
-    }
-
     VERIFY(id >= OpCodeId::First && id <= OpCodeId::Last);
 
     auto& opcode = s_opcodes[(u32)id];

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -528,15 +528,13 @@ ALWAYS_INLINE bool OpCode_Compare::compare_string(const MatchInput& input, Match
         auto str_view1 = StringView(str, length);
         auto str_view2 = StringView(&input.view.u8view()[state.string_position], length);
 
-        String str1, str2;
-        if (input.regex_options & AllFlags::Insensitive) {
-            str1 = str_view1.to_string().to_lowercase();
-            str2 = str_view2.to_string().to_lowercase();
-            str_view1 = str1.view();
-            str_view2 = str2.view();
-        }
+        bool string_equals;
+        if (input.regex_options & AllFlags::Insensitive)
+            string_equals = str_view1.equals_ignoring_case(str_view2);
+        else
+            string_equals = str_view1 == str_view2;
 
-        if (str_view1 == str_view2) {
+        if (string_equals) {
             state.string_position += length;
             if (length == 0)
                 had_zero_length_match = true;

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -87,69 +87,71 @@ static const char* character_class_name(CharClass ch_class)
     }
 }
 
-HashMap<u32, OwnPtr<OpCode>> ByteCode::s_opcodes {};
+OwnPtr<OpCode> ByteCode::s_opcodes[(size_t)OpCodeId::Last + 1];
+bool ByteCode::s_opcodes_initialized { false };
 
 ALWAYS_INLINE OpCode* ByteCode::get_opcode_by_id(OpCodeId id) const
 {
-    if (!s_opcodes.size()) {
+    if (!s_opcodes_initialized) {
         for (u32 i = (u32)OpCodeId::First; i <= (u32)OpCodeId::Last; ++i) {
             switch ((OpCodeId)i) {
             case OpCodeId::Exit:
-                s_opcodes.set(i, make<OpCode_Exit>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_Exit>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::Jump:
-                s_opcodes.set(i, make<OpCode_Jump>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_Jump>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::Compare:
-                s_opcodes.set(i, make<OpCode_Compare>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_Compare>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::CheckEnd:
-                s_opcodes.set(i, make<OpCode_CheckEnd>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_CheckEnd>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::CheckBoundary:
-                s_opcodes.set(i, make<OpCode_CheckBoundary>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_CheckBoundary>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::ForkJump:
-                s_opcodes.set(i, make<OpCode_ForkJump>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_ForkJump>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::ForkStay:
-                s_opcodes.set(i, make<OpCode_ForkStay>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_ForkStay>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::FailForks:
-                s_opcodes.set(i, make<OpCode_FailForks>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_FailForks>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::Save:
-                s_opcodes.set(i, make<OpCode_Save>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_Save>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::Restore:
-                s_opcodes.set(i, make<OpCode_Restore>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_Restore>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::GoBack:
-                s_opcodes.set(i, make<OpCode_GoBack>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_GoBack>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::CheckBegin:
-                s_opcodes.set(i, make<OpCode_CheckBegin>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_CheckBegin>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::SaveLeftCaptureGroup:
-                s_opcodes.set(i, make<OpCode_SaveLeftCaptureGroup>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_SaveLeftCaptureGroup>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::SaveRightCaptureGroup:
-                s_opcodes.set(i, make<OpCode_SaveRightCaptureGroup>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_SaveRightCaptureGroup>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::SaveLeftNamedCaptureGroup:
-                s_opcodes.set(i, make<OpCode_SaveLeftNamedCaptureGroup>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_SaveLeftNamedCaptureGroup>(*const_cast<ByteCode*>(this));
                 break;
             case OpCodeId::SaveRightNamedCaptureGroup:
-                s_opcodes.set(i, make<OpCode_SaveRightNamedCaptureGroup>(*const_cast<ByteCode*>(this)));
+                s_opcodes[i] = make<OpCode_SaveRightNamedCaptureGroup>(*const_cast<ByteCode*>(this));
                 break;
             }
         }
+        s_opcodes_initialized = true;
     }
 
     if (id > OpCodeId::Last)
         return nullptr;
 
-    return const_cast<OpCode*>(s_opcodes.get((u32)id).value())->set_bytecode(*const_cast<ByteCode*>(this));
+    return const_cast<OpCode*>(s_opcodes[(u32)id]->set_bytecode(*const_cast<ByteCode*>(this)));
 }
 
 OpCode* ByteCode::get_opcode(MatchState& state) const

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -151,7 +151,9 @@ ALWAYS_INLINE OpCode* ByteCode::get_opcode_by_id(OpCodeId id) const
     if (id > OpCodeId::Last)
         return nullptr;
 
-    return const_cast<OpCode*>(s_opcodes[(u32)id]->set_bytecode(*const_cast<ByteCode*>(this)));
+    auto* opcode = &*s_opcodes[(u32)id];
+    opcode->set_bytecode(*const_cast<ByteCode*>(this));
+    return opcode;
 }
 
 OpCode* ByteCode::get_opcode(MatchState& state) const

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -501,12 +501,12 @@ public:
 
     ALWAYS_INLINE void set_bytecode(ByteCode& bytecode) { m_bytecode = &bytecode; }
 
-    ALWAYS_INLINE void reset_state() { m_state.clear(); }
+    ALWAYS_INLINE void reset_state() { m_state = nullptr; }
 
     ALWAYS_INLINE const MatchState& state() const
     {
-        VERIFY(m_state.has_value());
-        return *m_state.value();
+        VERIFY(m_state);
+        return *m_state;
     }
 
     const String to_string() const
@@ -520,7 +520,7 @@ public:
 
 protected:
     ByteCode* m_bytecode { nullptr };
-    Optional<MatchState*> m_state;
+    MatchState* m_state { nullptr };
 };
 
 class OpCode_Exit final : public OpCode {

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -501,8 +501,6 @@ public:
 
     ALWAYS_INLINE void set_bytecode(ByteCode& bytecode) { m_bytecode = &bytecode; }
 
-    ALWAYS_INLINE void reset_state() { m_state = nullptr; }
-
     ALWAYS_INLINE const MatchState& state() const
     {
         VERIFY(m_state);

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -129,7 +129,11 @@ class OpCode;
 
 class ByteCode : public Vector<ByteCodeValueType> {
 public:
-    ByteCode() = default;
+    ByteCode()
+    {
+        ensure_opcodes_initialized();
+    }
+
     ByteCode(const ByteCode&) = default;
     virtual ~ByteCode() = default;
 
@@ -449,6 +453,7 @@ private:
             empend((ByteCodeValueType)view[i]);
     }
 
+    void ensure_opcodes_initialized();
     ALWAYS_INLINE OpCode& get_opcode_by_id(OpCodeId id) const;
     static OwnPtr<OpCode> s_opcodes[(size_t)OpCodeId::Last + 1];
     static bool s_opcodes_initialized;
@@ -476,11 +481,7 @@ const char* execution_result_name(ExecutionResult result);
 
 class OpCode {
 public:
-    OpCode(ByteCode& bytecode)
-        : m_bytecode(&bytecode)
-    {
-    }
-
+    OpCode() = default;
     virtual ~OpCode() = default;
 
     virtual OpCodeId opcode_id() const = 0;
@@ -518,16 +519,12 @@ public:
     ALWAYS_INLINE const ByteCode& bytecode() const { return *m_bytecode; }
 
 protected:
-    ByteCode* m_bytecode;
+    ByteCode* m_bytecode { nullptr };
     Optional<MatchState*> m_state;
 };
 
 class OpCode_Exit final : public OpCode {
 public:
-    OpCode_Exit(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Exit; }
     ALWAYS_INLINE size_t size() const override { return 1; }
@@ -536,10 +533,6 @@ public:
 
 class OpCode_FailForks final : public OpCode {
 public:
-    OpCode_FailForks(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -549,10 +542,6 @@ public:
 
 class OpCode_Save final : public OpCode {
 public:
-    OpCode_Save(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Save; }
     ALWAYS_INLINE size_t size() const override { return 1; }
@@ -561,10 +550,6 @@ public:
 
 class OpCode_Restore final : public OpCode {
 public:
-    OpCode_Restore(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Restore; }
     ALWAYS_INLINE size_t size() const override { return 1; }
@@ -573,10 +558,6 @@ public:
 
 class OpCode_GoBack final : public OpCode {
 public:
-    OpCode_GoBack(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::GoBack; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -586,10 +567,6 @@ public:
 
 class OpCode_Jump final : public OpCode {
 public:
-    OpCode_Jump(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Jump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -602,10 +579,6 @@ public:
 
 class OpCode_ForkJump final : public OpCode {
 public:
-    OpCode_ForkJump(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkJump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -618,10 +591,6 @@ public:
 
 class OpCode_ForkStay final : public OpCode {
 public:
-    OpCode_ForkStay(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkStay; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -634,10 +603,6 @@ public:
 
 class OpCode_CheckBegin final : public OpCode {
 public:
-    OpCode_CheckBegin(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBegin; }
     ALWAYS_INLINE size_t size() const override { return 1; }
@@ -646,10 +611,6 @@ public:
 
 class OpCode_CheckEnd final : public OpCode {
 public:
-    OpCode_CheckEnd(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckEnd; }
     ALWAYS_INLINE size_t size() const override { return 1; }
@@ -658,10 +619,6 @@ public:
 
 class OpCode_CheckBoundary final : public OpCode {
 public:
-    OpCode_CheckBoundary(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBoundary; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -672,10 +629,6 @@ public:
 
 class OpCode_SaveLeftCaptureGroup final : public OpCode {
 public:
-    OpCode_SaveLeftCaptureGroup(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -685,10 +638,6 @@ public:
 
 class OpCode_SaveRightCaptureGroup final : public OpCode {
 public:
-    OpCode_SaveRightCaptureGroup(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
@@ -698,10 +647,6 @@ public:
 
 class OpCode_SaveLeftNamedCaptureGroup final : public OpCode {
 public:
-    OpCode_SaveLeftNamedCaptureGroup(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 3; }
@@ -715,10 +660,6 @@ public:
 
 class OpCode_SaveRightNamedCaptureGroup final : public OpCode {
 public:
-    OpCode_SaveRightNamedCaptureGroup(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 3; }
@@ -732,10 +673,6 @@ public:
 
 class OpCode_Compare final : public OpCode {
 public:
-    OpCode_Compare(ByteCode& bytecode)
-        : OpCode(bytecode)
-    {
-    }
     ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Compare; }
     ALWAYS_INLINE size_t size() const override { return arguments_size() + 3; }

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -496,17 +496,9 @@ public:
     ALWAYS_INLINE const char* name() const;
     static const char* name(const OpCodeId);
 
-    ALWAYS_INLINE OpCode* set_state(MatchState& state)
-    {
-        m_state = &state;
-        return this;
-    }
+    ALWAYS_INLINE void set_state(MatchState& state) { m_state = &state; }
 
-    ALWAYS_INLINE OpCode* set_bytecode(ByteCode& bytecode)
-    {
-        m_bytecode = &bytecode;
-        return this;
-    }
+    ALWAYS_INLINE void set_bytecode(ByteCode& bytecode) { m_bytecode = &bytecode; }
 
     ALWAYS_INLINE void reset_state() { m_state.clear(); }
 

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -450,7 +450,8 @@ private:
     }
 
     ALWAYS_INLINE OpCode* get_opcode_by_id(OpCodeId id) const;
-    static HashMap<u32, OwnPtr<OpCode>> s_opcodes;
+    static OwnPtr<OpCode> s_opcodes[(size_t)OpCodeId::Last + 1];
+    static bool s_opcodes_initialized;
 };
 
 #define ENUMERATE_EXECUTION_RESULTS                          \

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -439,7 +439,7 @@ public:
         bytecode_to_repeat = move(bytecode);
     }
 
-    OpCode* get_opcode(MatchState& state) const;
+    OpCode& get_opcode(MatchState& state) const;
 
 private:
     void insert_string(const StringView& view)
@@ -449,7 +449,7 @@ private:
             empend((ByteCodeValueType)view[i]);
     }
 
-    ALWAYS_INLINE OpCode* get_opcode_by_id(OpCodeId id) const;
+    ALWAYS_INLINE OpCode& get_opcode_by_id(OpCodeId id) const;
     static OwnPtr<OpCode> s_opcodes[(size_t)OpCodeId::Last + 1];
     static bool s_opcodes_initialized;
 };

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -39,19 +39,14 @@ public:
         auto& bytecode = regex.parser_result.bytecode;
 
         for (;;) {
-            auto* opcode = bytecode.get_opcode(state);
-            if (!opcode) {
-                dbgln("Wrong opcode... failed!");
-                return;
-            }
-
-            print_opcode("PrintBytecode", *opcode, state);
+            auto& opcode = bytecode.get_opcode(state);
+            print_opcode("PrintBytecode", opcode, state);
             out(m_file, "{}", m_debug_stripline);
 
-            if (is<OpCode_Exit>(*opcode))
+            if (is<OpCode_Exit>(opcode))
                 break;
 
-            state.instruction_position += opcode->size();
+            state.instruction_position += opcode.size();
         }
 
         fflush(m_file);

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -301,15 +301,10 @@ Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& sta
 
     for (;;) {
         ++output.operations;
-        auto* opcode = bytecode.get_opcode(state);
-
-        if (!opcode) {
-            dbgln("Wrong opcode... failed!");
-            return {};
-        }
+        auto& opcode = bytecode.get_opcode(state);
 
 #if REGEX_DEBUG
-        s_regex_dbg.print_opcode("VM", *opcode, state, recursion_level, false);
+        s_regex_dbg.print_opcode("VM", opcode, state, recursion_level, false);
 #endif
 
         ExecutionResult result;
@@ -317,14 +312,14 @@ Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& sta
             --input.fail_counter;
             result = ExecutionResult::Failed_ExecuteLowPrioForks;
         } else {
-            result = opcode->execute(input, state, output);
+            result = opcode.execute(input, state, output);
         }
 
 #if REGEX_DEBUG
-        s_regex_dbg.print_result(*opcode, bytecode, input, state, result);
+        s_regex_dbg.print_result(opcode, bytecode, input, state, result);
 #endif
 
-        state.instruction_position += opcode->size();
+        state.instruction_position += opcode.size();
 
         switch (result) {
         case ExecutionResult::Fork_PrioLow:

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -293,7 +293,7 @@ Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& sta
     if (recursion_level > c_max_recursion)
         return false;
 
-    Vector<MatchState> fork_low_prio_states;
+    Vector<MatchState, 64> reversed_fork_low_prio_states;
     MatchState fork_high_prio_state;
     Optional<bool> success;
 
@@ -323,7 +323,7 @@ Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& sta
 
         switch (result) {
         case ExecutionResult::Fork_PrioLow:
-            fork_low_prio_states.prepend(state);
+            reversed_fork_low_prio_states.append(state);
             continue;
         case ExecutionResult::Fork_PrioHigh:
             fork_high_prio_state = state;
@@ -344,8 +344,13 @@ Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& sta
             return true;
         case ExecutionResult::Failed:
             return false;
-        case ExecutionResult::Failed_ExecuteLowPrioForks:
-            return execute_low_prio_forks(input, state, output, fork_low_prio_states, recursion_level + 1);
+        case ExecutionResult::Failed_ExecuteLowPrioForks: {
+            Vector<MatchState> fork_low_prio_states;
+            fork_low_prio_states.ensure_capacity(reversed_fork_low_prio_states.size());
+            for (ssize_t i = reversed_fork_low_prio_states.size() - 1; i >= 0; i--)
+                fork_low_prio_states.unchecked_append(move(reversed_fork_low_prio_states[i]));
+            return execute_low_prio_forks(input, state, output, move(fork_low_prio_states), recursion_level + 1);
+        }
         }
     }
 


### PR DESCRIPTION
Before:

Finished 0 tests and 31 benchmarks in 10451ms (0ms tests, 10435ms benchmarks, 16ms other).

After:

Finished 0 tests and 31 benchmarks in 7084ms (0ms tests, 7069ms benchmarks, 15ms other).

**LibRegex: Use a plain array to store opcodes**

Using a hash map is unnecessary because the number of opcodes and their IDs never change.

**LibRegex: Remove return value for setters**

**LibRegex: Make get_opcode() return a reference**

Previously this would return a pointer which could be null if the requested opcode was invalid. This should never be the case though so let's `VERIFY()` that instead.

**LibRegex: Avoid making unnecessary string copies**

**LibRegex: Avoid prepending items to vectors**

**LibRegex: Avoid initialization checks in get_opcode_by_id()**

**LibRegex: Use a plain pointer for OpCode::m_state**

**LibRegex: Remove unused code**