### PR TITLE
Kernel: Only call `Process::die()` once on terminating signal

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -565,6 +565,7 @@ void Process::die()
     // slave owner, we have to allow the PTY pair to be torn down.
     m_tty = nullptr;
 
+    VERIFY(m_threads_for_coredump.is_empty());
     for_each_thread([&](auto& thread) {
         m_threads_for_coredump.append(thread);
     });

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -468,9 +468,6 @@ void Thread::check_dispatch_pending_signal()
     case DispatchSignalResult::Yield:
         yield_while_not_holding_big_lock();
         break;
-    case DispatchSignalResult::Terminate:
-        process().die();
-        break;
     default:
         break;
     }


### PR DESCRIPTION
Previously, when e.g. the `SIGABRT` signal was sent to a process, `Thread::dispatch_signal()` would invoke `Process::terminate_due_to_signal()` which would then `::die()`. The result `DispatchSignalResult::Terminate` is then returned to `Thread::check_dispatch_pending_signal()` which proceeds to invoke `Process::die()` a second time.

Change the behavior of `::check_dispatch_pending_signal()` to no longer call `Process::die()` if it receives `::Terminate` as a signal handling result, since that indicates that the process was already terminated.

This fixes #7289.