### PR TITLE
Kernel+LibC: Add `*at(2)` syscalls

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -466,6 +466,12 @@ struct SC_statvfs_params {
     struct statvfs* buf;
 };
 
+struct SC_unlink_params {
+    int dirfd;
+    StringArgument path;
+    int flags;
+};
+
 void initialize();
 int sync();
 

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -398,6 +398,7 @@ struct SC_chown_params {
 };
 
 struct SC_mknod_params {
+    int dirfd;
     StringArgument path;
     u16 mode;
     u32 dev;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -390,9 +390,11 @@ struct SC_link_params {
 };
 
 struct SC_chown_params {
+    int dirfd;
     StringArgument path;
     u32 uid;
     u32 gid;
+    int flags;
 };
 
 struct SC_mknod_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -471,6 +471,12 @@ struct SC_statvfs_params {
     struct statvfs* buf;
 };
 
+struct SC_mkdir_params {
+    int dirfd;
+    StringArgument path;
+    u16 mode;
+};
+
 struct SC_unlink_params {
     int dirfd;
     StringArgument path;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -446,7 +446,7 @@ struct SC_stat_params {
     int dirfd;
     StringArgument path;
     struct stat* statbuf;
-    int follow_symlinks;
+    int flags;
 };
 
 struct SC_ptrace_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -473,6 +473,13 @@ struct SC_statvfs_params {
     struct statvfs* buf;
 };
 
+struct SC_access_params {
+    int dirfd;
+    StringArgument path;
+    int mode;
+    int flags;
+};
+
 struct SC_chmod_params {
     int dirfd;
     StringArgument path;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -471,6 +471,13 @@ struct SC_statvfs_params {
     struct statvfs* buf;
 };
 
+struct SC_chmod_params {
+    int dirfd;
+    StringArgument path;
+    u16 mode;
+    int flags;
+};
+
 struct SC_mkdir_params {
     int dirfd;
     StringArgument path;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -411,8 +411,11 @@ struct SC_symlink_params {
 };
 
 struct SC_rename_params {
+    int old_dirfd;
     StringArgument old_path;
+    int new_dirfd;
     StringArgument new_path;
+    int flags;
 };
 
 struct SC_mount_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -381,8 +381,11 @@ struct SC_readlink_params {
 };
 
 struct SC_link_params {
+    int old_dirfd;
     StringArgument old_path;
+    int new_dirfd;
     StringArgument new_path;
+    int flags;
 };
 
 struct SC_chown_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -376,6 +376,7 @@ struct SC_execve_params {
 };
 
 struct SC_readlink_params {
+    int dirfd;
     StringArgument path;
     MutableBufferArgument<char, size_t> buffer;
 };
@@ -402,6 +403,7 @@ struct SC_mknod_params {
 
 struct SC_symlink_params {
     StringArgument target;
+    int new_dirfd;
     StringArgument linkpath;
 };
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -478,9 +478,12 @@ KResult VFS::chmod(Custody& custody, mode_t mode)
     return inode.chmod(mode);
 }
 
-KResult VFS::chmod(StringView path, mode_t mode, Custody& base)
+KResult VFS::chmod(PathWithBase path_with_base, mode_t mode, AtFlags flags)
 {
-    auto custody_or_error = resolve_path(path, base);
+    if (flags & ~(AT_SYMLINK_NOFOLLOW))
+        return EINVAL;
+
+    auto custody_or_error = resolve_path(path_with_base, nullptr, (flags & AT_SYMLINK_NOFOLLOW) ? O_NOFOLLOW_NOERROR : 0);
     if (custody_or_error.is_error())
         return custody_or_error.error();
     auto& custody = *custody_or_error.value();

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -393,17 +393,18 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int optio
     return description;
 }
 
-KResult VFS::mkdir(StringView path, mode_t mode, Custody& base)
+KResult VFS::mkdir(PathWithBase path_with_base, mode_t mode)
 {
     // Unlike in basically every other case, where it's only the last
     // path component (the one being created) that is allowed not to
     // exist, POSIX allows mkdir'ed path to have trailing slashes.
     // Let's handle that case by trimming any trailing slashes.
+    auto& path = path_with_base.path;
     while (path.length() > 1 && path.ends_with("/"))
         path = path.substring_view(0, path.length() - 1);
 
     RefPtr<Custody> parent_custody;
-    if (auto result = resolve_path(path, base, &parent_custody); !result.is_error())
+    if (auto result = resolve_path(path_with_base, &parent_custody); !result.is_error())
         return EEXIST;
     else if (!parent_custody)
         return ENOENT;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -707,10 +707,10 @@ KResult VFS::unlink(PathWithBase path_with_base, AtFlags flags)
     return KSuccess;
 }
 
-KResult VFS::symlink(StringView target, StringView linkpath, Custody& base)
+KResult VFS::symlink(StringView target, PathWithBase linkpath)
 {
     RefPtr<Custody> parent_custody;
-    auto existing_custody_or_error = resolve_path(linkpath, base, &parent_custody);
+    auto existing_custody_or_error = resolve_path(linkpath, &parent_custody);
     if (!existing_custody_or_error.is_error())
         return EEXIST;
     if (!parent_custody)
@@ -724,7 +724,7 @@ KResult VFS::symlink(StringView target, StringView linkpath, Custody& base)
     if (parent_custody->is_readonly())
         return EROFS;
 
-    LexicalPath p(linkpath);
+    LexicalPath p(linkpath.path);
     dbgln_if(VFS_DEBUG, "VFS::symlink: '{}' (-> '{}') in {}", p.basename(), target, parent_inode.identifier());
     auto inode_or_error = parent_inode.create_child(p.basename(), S_IFLNK | 0644, 0, current_process->euid(), current_process->egid());
     if (inode_or_error.is_error())

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -88,7 +88,7 @@ public:
     KResult rmdir(StringView path, Custody& base);
     KResult chmod(PathWithBase, mode_t mode, AtFlags flags);
     KResult chmod(Custody&, mode_t);
-    KResult chown(StringView path, uid_t, gid_t, Custody& base);
+    KResult chown(PathWithBase, uid_t, gid_t, int flags);
     KResult chown(Custody&, uid_t, gid_t);
     KResult access(StringView path, int mode, Custody& base);
     KResultOr<InodeMetadata> lookup_metadata(StringView path, Custody& base, int options = 0);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -82,7 +82,7 @@ public:
     KResultOr<NonnullRefPtr<FileDescription>> open(StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
     KResultOr<NonnullRefPtr<FileDescription>> create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
     KResult mkdir(StringView path, mode_t mode, Custody& base);
-    KResult symlink(StringView target, StringView linkpath, Custody& base);
+    KResult symlink(StringView target, PathWithBase linkpath);
     KResult link(PathWithBase old_path, PathWithBase new_path, AtFlags flags);
     KResult unlink(PathWithBase, AtFlags flags);
     KResult rmdir(StringView path, Custody& base);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -90,7 +90,7 @@ public:
     KResult chmod(Custody&, mode_t);
     KResult chown(PathWithBase, uid_t, gid_t, int flags);
     KResult chown(Custody&, uid_t, gid_t);
-    KResult access(StringView path, int mode, Custody& base);
+    KResult access(PathWithBase, int mode, AtFlags flags);
     KResultOr<InodeMetadata> lookup_metadata(StringView path, Custody& base, int options = 0);
     KResult utime(StringView path, Custody& base, time_t atime, time_t mtime);
     KResult rename(StringView oldpath, StringView newpath, Custody& base);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -93,7 +93,7 @@ public:
     KResult access(PathWithBase, int mode, AtFlags flags);
     KResultOr<InodeMetadata> lookup_metadata(StringView path, Custody& base, int options = 0);
     KResult utime(StringView path, Custody& base, time_t atime, time_t mtime);
-    KResult rename(StringView oldpath, StringView newpath, Custody& base);
+    KResult rename(PathWithBase oldpath, PathWithBase newpath);
     KResult mknod(PathWithBase, mode_t, dev_t);
     KResultOr<NonnullRefPtr<Custody>> open_directory(StringView path, Custody& base);
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -81,7 +81,7 @@ public:
 
     KResultOr<NonnullRefPtr<FileDescription>> open(StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
     KResultOr<NonnullRefPtr<FileDescription>> create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
-    KResult mkdir(StringView path, mode_t mode, Custody& base);
+    KResult mkdir(PathWithBase path, mode_t mode);
     KResult symlink(StringView target, PathWithBase linkpath);
     KResult link(PathWithBase old_path, PathWithBase new_path, AtFlags flags);
     KResult unlink(PathWithBase, AtFlags flags);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -86,7 +86,7 @@ public:
     KResult link(PathWithBase old_path, PathWithBase new_path, AtFlags flags);
     KResult unlink(PathWithBase, AtFlags flags);
     KResult rmdir(StringView path, Custody& base);
-    KResult chmod(StringView path, mode_t, Custody& base);
+    KResult chmod(PathWithBase, mode_t mode, AtFlags flags);
     KResult chmod(Custody&, mode_t);
     KResult chown(StringView path, uid_t, gid_t, Custody& base);
     KResult chown(Custody&, uid_t, gid_t);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -82,8 +82,8 @@ public:
     KResultOr<NonnullRefPtr<FileDescription>> open(StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
     KResultOr<NonnullRefPtr<FileDescription>> create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
     KResult mkdir(StringView path, mode_t mode, Custody& base);
-    KResult link(StringView old_path, StringView new_path, Custody& base);
     KResult symlink(StringView target, StringView linkpath, Custody& base);
+    KResult link(PathWithBase old_path, PathWithBase new_path, AtFlags flags);
     KResult unlink(PathWithBase, AtFlags flags);
     KResult rmdir(StringView path, Custody& base);
     KResult chmod(StringView path, mode_t, Custody& base);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -94,7 +94,7 @@ public:
     KResultOr<InodeMetadata> lookup_metadata(StringView path, Custody& base, int options = 0);
     KResult utime(StringView path, Custody& base, time_t atime, time_t mtime);
     KResult rename(StringView oldpath, StringView newpath, Custody& base);
-    KResult mknod(StringView path, mode_t, dev_t, Custody& base);
+    KResult mknod(PathWithBase, mode_t, dev_t);
     KResultOr<NonnullRefPtr<Custody>> open_directory(StringView path, Custody& base);
 
     size_t mount_count() const { return m_mounts.size(); }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -451,6 +451,19 @@ KResultOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(Syscall::St
     return get_syscall_path_argument(path.characters, path.length);
 }
 
+KResultOr<RefPtr<Custody>> Process::get_syscall_fd_argument(int fd)
+{
+    if (fd == AT_FDCWD)
+        return current_directory();
+
+    auto description = file_description(fd);
+    if (!description)
+        return EBADF;
+    if (!description->custody())
+        return EINVAL;
+    return description->custody();
+}
+
 bool Process::dump_core()
 {
     VERIFY(is_dumpable());

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -357,7 +357,7 @@ public:
     KResultOr<int> sys$rmdir(Userspace<const char*> pathname, size_t path_length);
     KResultOr<int> sys$mount(Userspace<const Syscall::SC_mount_params*>);
     KResultOr<int> sys$umount(Userspace<const char*> mountpoint, size_t mountpoint_length);
-    KResultOr<int> sys$chmod(Userspace<const char*> pathname, size_t path_length, mode_t);
+    KResultOr<int> sys$chmod(Userspace<const Syscall::SC_chmod_params*>);
     KResultOr<int> sys$fchmod(int fd, mode_t);
     KResultOr<int> sys$chown(Userspace<const Syscall::SC_chown_params*>);
     KResultOr<int> sys$fchown(int fd, uid_t, gid_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -348,7 +348,7 @@ public:
     KResultOr<int> sys$access(Userspace<const char*> pathname, size_t path_length, int mode);
     KResultOr<int> sys$fcntl(int fd, int cmd, u32 extra_arg);
     KResultOr<int> sys$ioctl(int fd, unsigned request, FlatPtr arg);
-    KResultOr<int> sys$mkdir(Userspace<const char*> pathname, size_t path_length, mode_t mode);
+    KResultOr<int> sys$mkdir(Userspace<const Syscall::SC_mkdir_params*>);
     KResultOr<clock_t> sys$times(Userspace<tms*>);
     KResultOr<int> sys$utime(Userspace<const char*> pathname, size_t path_length, Userspace<const struct utimbuf*>);
     KResultOr<int> sys$link(Userspace<const Syscall::SC_link_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -345,7 +345,7 @@ public:
     KResultOr<int> sys$setresuid(uid_t, uid_t, uid_t);
     KResultOr<int> sys$setresgid(gid_t, gid_t, gid_t);
     KResultOr<unsigned> sys$alarm(unsigned seconds);
-    KResultOr<int> sys$access(Userspace<const char*> pathname, size_t path_length, int mode);
+    KResultOr<int> sys$access(Userspace<const Syscall::SC_access_params*>);
     KResultOr<int> sys$fcntl(int fd, int cmd, u32 extra_arg);
     KResultOr<int> sys$ioctl(int fd, unsigned request, FlatPtr arg);
     KResultOr<int> sys$mkdir(Userspace<const Syscall::SC_mkdir_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -352,7 +352,7 @@ public:
     KResultOr<clock_t> sys$times(Userspace<tms*>);
     KResultOr<int> sys$utime(Userspace<const char*> pathname, size_t path_length, Userspace<const struct utimbuf*>);
     KResultOr<int> sys$link(Userspace<const Syscall::SC_link_params*>);
-    KResultOr<int> sys$unlink(Userspace<const char*> pathname, size_t path_length);
+    KResultOr<int> sys$unlink(Userspace<const Syscall::SC_unlink_params*>);
     KResultOr<int> sys$symlink(Userspace<const Syscall::SC_symlink_params*>);
     KResultOr<int> sys$rmdir(Userspace<const char*> pathname, size_t path_length);
     KResultOr<int> sys$mount(Userspace<const Syscall::SC_mount_params*>);
@@ -550,6 +550,8 @@ private:
         return get_syscall_path_argument(user_path.unsafe_userspace_ptr(), path_length);
     }
     KResultOr<NonnullOwnPtr<KString>> get_syscall_path_argument(const Syscall::StringArgument&) const;
+
+    KResultOr<RefPtr<Custody>> get_syscall_fd_argument(int fd);
 
     bool has_tracee_thread(ProcessID tracer_pid);
 

--- a/Kernel/Syscalls/chown.cpp
+++ b/Kernel/Syscalls/chown.cpp
@@ -24,10 +24,13 @@ KResultOr<int> Process::sys$chown(Userspace<const Syscall::SC_chown_params*> use
     Syscall::SC_chown_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
+    auto dirfd = get_syscall_fd_argument(params.dirfd);
+    if (dirfd.is_error())
+        return dirfd.error();
     auto path = get_syscall_path_argument(params.path);
     if (path.is_error())
         return path.error();
-    return VFS::the().chown(path.value()->view(), params.uid, params.gid, current_directory());
+    return VFS::the().chown({ *dirfd.value(), path.value()->view() }, params.uid, params.gid, params.flags);
 }
 
 }

--- a/Kernel/Syscalls/link.cpp
+++ b/Kernel/Syscalls/link.cpp
@@ -40,10 +40,13 @@ KResultOr<int> Process::sys$symlink(Userspace<const Syscall::SC_symlink_params*>
     auto target = get_syscall_path_argument(params.target);
     if (target.is_error())
         return target.error();
+    auto new_dirfd = get_syscall_fd_argument(params.new_dirfd);
+    if (new_dirfd.is_error())
+        return new_dirfd.error();
     auto linkpath = get_syscall_path_argument(params.linkpath);
     if (linkpath.is_error())
         return linkpath.error();
-    return VFS::the().symlink(target.value()->view(), linkpath.value()->view(), current_directory());
+    return VFS::the().symlink(target.value()->view(), { *new_dirfd.value(), linkpath.value()->view() });
 }
 
 }

--- a/Kernel/Syscalls/link.cpp
+++ b/Kernel/Syscalls/link.cpp
@@ -16,13 +16,19 @@ KResultOr<int> Process::sys$link(Userspace<const Syscall::SC_link_params*> user_
     Syscall::SC_link_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
-    auto old_path = copy_string_from_user(params.old_path);
-    if (old_path.is_null())
-        return EFAULT;
-    auto new_path = copy_string_from_user(params.new_path);
-    if (new_path.is_null())
-        return EFAULT;
-    return VFS::the().link(old_path, new_path, current_directory());
+    auto old_dirfd = get_syscall_fd_argument(params.old_dirfd);
+    if (old_dirfd.is_error())
+        return old_dirfd.error();
+    auto old_path = get_syscall_path_argument(params.old_path);
+    if (old_path.is_error())
+        return old_path.error();
+    auto new_dirfd = get_syscall_fd_argument(params.new_dirfd);
+    if (new_dirfd.is_error())
+        return new_dirfd.error();
+    auto new_path = get_syscall_path_argument(params.new_path);
+    if (new_path.is_error())
+        return new_path.error();
+    return VFS::the().link({ *old_dirfd.value(), old_path.value()->view() }, { *new_dirfd.value(), new_path.value()->view() }, params.flags);
 }
 
 KResultOr<int> Process::sys$symlink(Userspace<const Syscall::SC_symlink_params*> user_params)

--- a/Kernel/Syscalls/mkdir.cpp
+++ b/Kernel/Syscalls/mkdir.cpp
@@ -10,12 +10,18 @@
 
 namespace Kernel {
 
-KResultOr<int> Process::sys$mkdir(Userspace<const char*> user_path, size_t path_length, mode_t mode)
+KResultOr<int> Process::sys$mkdir(Userspace<const Syscall::SC_mkdir_params*> user_params)
 {
     REQUIRE_PROMISE(cpath);
-    auto path = get_syscall_path_argument(user_path, path_length);
+    Syscall::SC_mkdir_params params;
+    if (!copy_from_user(&params, user_params))
+        return EFAULT;
+    auto dirfd = get_syscall_fd_argument(params.dirfd);
+    if (dirfd.is_error())
+        return dirfd.error();
+    auto path = get_syscall_path_argument(params.path);
     if (path.is_error())
         return path.error();
-    return VFS::the().mkdir(path.value()->view(), mode & ~umask(), current_directory());
+    return VFS::the().mkdir({ *dirfd.value(), path.value()->view() }, params.mode & ~umask());
 }
 }

--- a/Kernel/Syscalls/mknod.cpp
+++ b/Kernel/Syscalls/mknod.cpp
@@ -21,7 +21,10 @@ KResultOr<int> Process::sys$mknod(Userspace<const Syscall::SC_mknod_params*> use
     auto path = get_syscall_path_argument(params.path);
     if (path.is_error())
         return path.error();
-    return VFS::the().mknod(path.value()->view(), params.mode & ~umask(), params.dev, current_directory());
+    auto dirfd = get_syscall_fd_argument(params.dirfd);
+    if (dirfd.is_error())
+        return dirfd.error();
+    return VFS::the().mknod({ *dirfd.value(), path.value()->view() }, params.mode & ~umask(), params.dev);
 }
 
 }

--- a/Kernel/Syscalls/readlink.cpp
+++ b/Kernel/Syscalls/readlink.cpp
@@ -23,7 +23,10 @@ KResultOr<int> Process::sys$readlink(Userspace<const Syscall::SC_readlink_params
     if (path.is_error())
         return path.error();
 
-    auto result = VFS::the().open(path.value()->view(), O_RDONLY | O_NOFOLLOW_NOERROR, 0, current_directory());
+    auto dirfd = get_syscall_fd_argument(params.dirfd);
+    if (dirfd.is_error())
+        return dirfd.error();
+    auto result = VFS::the().open(path.value()->view(), O_RDONLY | O_NOFOLLOW_NOERROR, 0, *dirfd.value());
     if (result.is_error())
         return result.error();
     auto description = result.value();

--- a/Kernel/Syscalls/rename.cpp
+++ b/Kernel/Syscalls/rename.cpp
@@ -16,13 +16,19 @@ KResultOr<int> Process::sys$rename(Userspace<const Syscall::SC_rename_params*> u
     Syscall::SC_rename_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
+    auto old_dirfd = get_syscall_fd_argument(params.old_dirfd);
+    if (old_dirfd.is_error())
+        return old_dirfd.error();
     auto old_path = get_syscall_path_argument(params.old_path);
     if (old_path.is_error())
         return old_path.error();
+    auto new_dirfd = get_syscall_fd_argument(params.new_dirfd);
+    if (new_dirfd.is_error())
+        return new_dirfd.error();
     auto new_path = get_syscall_path_argument(params.new_path);
     if (new_path.is_error())
         return new_path.error();
-    return VFS::the().rename(old_path.value()->view(), new_path.value()->view(), current_directory());
+    return VFS::the().rename({ *old_dirfd.value(), old_path.value()->view() }, { *new_dirfd.value(), new_path.value()->view() });
 }
 
 }

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -685,8 +685,12 @@ struct rtentry {
 #define RTF_UP 0x1      /* do not delete the route */
 #define RTF_GATEWAY 0x2 /* the route is a gateway and not an end host */
 
-#define AT_FDCWD -100
+#define AT_FDCWD (-100)
 #define AT_SYMLINK_NOFOLLOW 0x100
+#define AT_REMOVEDIR 0x200
+#define AT_SYMLINK_FOLLOW 0x300
+#define AT_EACCESS 0x200
+#define AT_EMPTY_PATH 0x1000
 
 #define PURGE_ALL_VOLATILE 0x1
 #define PURGE_ALL_CLEAN_INODE 0x2

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -103,7 +103,7 @@ private:
     u32 virt$open(u32);
     int virt$pipe(FlatPtr pipefd, int flags);
     int virt$close(int);
-    int virt$mkdir(FlatPtr path, size_t path_length, mode_t mode);
+    int virt$mkdir(FlatPtr);
     int virt$rmdir(FlatPtr path, size_t path_length);
     int virt$unlink(FlatPtr);
     int virt$symlink(FlatPtr address);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -117,7 +117,7 @@ private:
     int virt$clock_nanosleep(FlatPtr);
     int virt$dbgputstr(FlatPtr characters, int length);
     int virt$dbgputch(char);
-    int virt$chmod(FlatPtr, size_t, mode_t);
+    int virt$chmod(FlatPtr);
     int virt$fchmod(int, mode_t);
     int virt$chown(FlatPtr);
     int virt$fchown(int, uid_t, gid_t);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -105,7 +105,7 @@ private:
     int virt$close(int);
     int virt$mkdir(FlatPtr path, size_t path_length, mode_t mode);
     int virt$rmdir(FlatPtr path, size_t path_length);
-    int virt$unlink(FlatPtr path, size_t path_length);
+    int virt$unlink(FlatPtr);
     int virt$symlink(FlatPtr address);
     int virt$rename(FlatPtr address);
     int virt$set_coredump_metadata(FlatPtr address);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -70,7 +70,7 @@ private:
     int virt$emuctl(FlatPtr, FlatPtr, FlatPtr);
     int virt$fork();
     int virt$execve(FlatPtr);
-    int virt$access(FlatPtr, size_t, int);
+    int virt$access(FlatPtr);
     int virt$sigaction(int, FlatPtr, FlatPtr);
     int virt$sigreturn();
     int virt$get_dir_entries(int fd, FlatPtr buffer, ssize_t);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -41,7 +41,7 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
     case SC_get_stack_bounds:
         return virt$get_stack_bounds(arg1, arg2);
     case SC_access:
-        return virt$access(arg1, arg2, arg3);
+        return virt$access(arg1);
     case SC_waitid:
         return virt$waitid(arg1);
     case SC_getcwd:
@@ -1348,10 +1348,15 @@ int Emulator::virt$getsid(pid_t pid)
     return syscall(SC_getsid, pid);
 }
 
-int Emulator::virt$access(FlatPtr path, size_t path_length, int type)
+int Emulator::virt$access(FlatPtr params_addr)
 {
-    auto host_path = mmu().copy_buffer_from_vm(path, path_length);
-    return syscall(SC_access, host_path.data(), host_path.size(), type);
+    Syscall::SC_access_params params;
+    mmu().copy_from_vm(&params, params_addr, sizeof(params));
+
+    auto path = mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length);
+    params.path.characters = (const char*)path.data();
+    params.path.length = path.size();
+    return syscall(SC_access, &path);
 }
 
 int Emulator::virt$waitid(FlatPtr params_addr)

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1208,7 +1208,7 @@ int Emulator::virt$stat(FlatPtr params_addr)
     auto path = String::copy(mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length));
     struct stat host_statbuf;
     int rc;
-    if (params.follow_symlinks)
+    if (params.flags & AT_SYMLINK_NOFOLLOW)
         rc = stat(path.characters(), &host_statbuf);
     else
         rc = lstat(path.characters(), &host_statbuf);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -163,7 +163,7 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
     case SC_dbgputch:
         return virt$dbgputch(arg1);
     case SC_chmod:
-        return virt$chmod(arg1, arg2, arg3);
+        return virt$chmod(arg1);
     case SC_fchmod:
         return virt$fchmod(arg1, arg2);
     case SC_fchown:
@@ -388,10 +388,14 @@ int Emulator::virt$dbgputstr(FlatPtr characters, int length)
     return 0;
 }
 
-int Emulator::virt$chmod(FlatPtr path_addr, size_t path_length, mode_t mode)
+int Emulator::virt$chmod(FlatPtr params_addr)
 {
-    auto path = mmu().copy_buffer_from_vm(path_addr, path_length);
-    return syscall(SC_chmod, path.data(), path.size(), mode);
+    Syscall::SC_chmod_params params;
+    mmu().copy_from_vm(&params, params_addr, sizeof(params));
+    auto path = mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length);
+    params.path.characters = (const char*)path.data();
+    params.path.length = path.size();
+    return syscall(SC_chmod, &params);
 }
 
 int Emulator::virt$chown(FlatPtr params_addr)

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -39,8 +39,12 @@ __BEGIN_DECLS
 
 int creat(const char* path, mode_t);
 int open(const char* path, int options, ...);
-#define AT_FDCWD -100
+#define AT_FDCWD (-100)
 #define AT_SYMLINK_NOFOLLOW 0x100
+#define AT_REMOVEDIR 0x200
+#define AT_SYMLINK_FOLLOW 0x300
+#define AT_EACCESS 0x200
+#define AT_EMPTY_PATH 0x1000
 int openat(int dirfd, const char* path, int options, ...);
 
 int fcntl(int fd, int cmd, ...);

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -6,6 +6,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <serenity.h>
 #include <string.h>
 #include <syscall.h>
@@ -110,6 +111,7 @@ int anon_create(size_t size, int options)
 int serenity_readlink(const char* path, size_t path_length, char* buffer, size_t buffer_size)
 {
     Syscall::SC_readlink_params small_params {
+        AT_FDCWD,
         { path, path_length },
         { buffer, buffer_size }
     };

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -64,25 +64,25 @@ int mkfifo(const char* pathname, mode_t mode)
     return mknod(pathname, mode | S_IFIFO, 0);
 }
 
-static int do_stat(int dirfd, const char* path, struct stat* statbuf, bool follow_symlinks)
+static int do_stat(int dirfd, const char* path, struct stat* statbuf, int flags)
 {
     if (!path) {
         errno = EFAULT;
         return -1;
     }
-    Syscall::SC_stat_params params { dirfd, { path, strlen(path) }, statbuf, follow_symlinks };
+    Syscall::SC_stat_params params { dirfd, { path, strlen(path) }, statbuf, flags };
     int rc = syscall(SC_stat, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
 int lstat(const char* path, struct stat* statbuf)
 {
-    return do_stat(AT_FDCWD, path, statbuf, false);
+    return do_stat(AT_FDCWD, path, statbuf, AT_SYMLINK_NOFOLLOW);
 }
 
 int stat(const char* path, struct stat* statbuf)
 {
-    return do_stat(AT_FDCWD, path, statbuf, true);
+    return do_stat(AT_FDCWD, path, statbuf, 0);
 }
 
 int fstat(int fd, struct stat* statbuf)
@@ -93,6 +93,6 @@ int fstat(int fd, struct stat* statbuf)
 
 int fstatat(int fd, const char* path, struct stat* statbuf, int flags)
 {
-    return do_stat(fd, path, statbuf, !(flags & AT_SYMLINK_NOFOLLOW));
+    return do_stat(fd, path, statbuf, flags);
 }
 }

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -22,11 +22,17 @@ mode_t umask(mode_t mask)
 
 int mkdir(const char* pathname, mode_t mode)
 {
+    return mkdirat(AT_FDCWD, pathname, mode);
+}
+
+int mkdirat(int dirfd, const char* pathname, mode_t mode)
+{
     if (!pathname) {
         errno = EFAULT;
         return -1;
     }
-    int rc = syscall(SC_mkdir, pathname, strlen(pathname), mode);
+    Syscall::SC_mkdir_params params { dirfd, { pathname, strlen(pathname) }, mode };
+    int rc = syscall(SC_mkdir, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -38,11 +38,18 @@ int mkdirat(int dirfd, const char* pathname, mode_t mode)
 
 int chmod(const char* pathname, mode_t mode)
 {
+    return fchmodat(AT_FDCWD, pathname, mode, 0);
+}
+
+int fchmodat(int dirfd, const char* pathname, mode_t mode, int flags)
+{
     if (!pathname) {
         errno = EFAULT;
         return -1;
     }
-    int rc = syscall(SC_chmod, pathname, strlen(pathname), mode);
+
+    Syscall::SC_chmod_params params { dirfd, { pathname, strlen(pathname) }, mode, flags };
+    int rc = syscall(SC_chmod, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1138,15 +1138,20 @@ int fclose(FILE* stream)
     return ok ? 0 : EOF;
 }
 
-int rename(const char* oldpath, const char* newpath)
+int renameat(int olddirfd, const char* oldpath, int newdirfd, const char* newpath)
 {
     if (!oldpath || !newpath) {
         errno = EFAULT;
         return -1;
     }
-    Syscall::SC_rename_params params { { oldpath, strlen(oldpath) }, { newpath, strlen(newpath) } };
+    Syscall::SC_rename_params params { olddirfd, { oldpath, strlen(oldpath) }, newdirfd, { newpath, strlen(newpath) }, 0 };
     int rc = syscall(SC_rename, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int rename(const char* oldpath, const char* newpath)
+{
+    return renameat(AT_FDCWD, oldpath, AT_FDCWD, newpath);
 }
 
 void dbgputch(char ch)

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -96,6 +96,7 @@ int setvbuf(FILE*, char* buf, int mode, size_t);
 void setbuf(FILE*, char* buf);
 void setlinebuf(FILE*);
 int rename(const char* oldpath, const char* newpath);
+int renameat(int olddirfd, const char* oldpath, int newdirfd, const char* newpath);
 FILE* tmpfile();
 char* tmpnam(char*);
 FILE* popen(const char* command, const char* type);

--- a/Userland/Libraries/LibC/sys/stat.h
+++ b/Userland/Libraries/LibC/sys/stat.h
@@ -73,6 +73,7 @@ mode_t umask(mode_t);
 int chmod(const char* pathname, mode_t);
 int fchmod(int fd, mode_t);
 int mkdir(const char* pathname, mode_t);
+int mkdirat(int dirfd, const char* pathname, mode_t);
 int mkfifo(const char* pathname, mode_t);
 int fstat(int fd, struct stat* statbuf);
 int lstat(const char* path, struct stat* statbuf);

--- a/Userland/Libraries/LibC/sys/stat.h
+++ b/Userland/Libraries/LibC/sys/stat.h
@@ -71,6 +71,7 @@ struct stat {
 
 mode_t umask(mode_t);
 int chmod(const char* pathname, mode_t);
+int fchmodat(int dirfd, const char* pathname, mode_t mode, int flags);
 int fchmod(int fd, mode_t);
 int mkdir(const char* pathname, mode_t);
 int mkdirat(int dirfd, const char* pathname, mode_t);

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -624,13 +624,19 @@ int setresgid(gid_t rgid, gid_t egid, gid_t sgid)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int access(const char* pathname, int mode)
+int access(const char* pathname, int flags)
+{
+    return faccessat(AT_FDCWD, pathname, flags, 0);
+}
+
+int faccessat(int dirfd, const char* pathname, int mode, int flags)
 {
     if (!pathname) {
         errno = EFAULT;
         return -1;
     }
-    int rc = syscall(SC_access, pathname, strlen(pathname), mode);
+    Syscall::SC_access_params params { dirfd, { pathname, strlen(pathname) }, mode, flags };
+    int rc = syscall(SC_access, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -457,7 +457,12 @@ int sethostname(const char* hostname, ssize_t size)
 
 ssize_t readlink(const char* path, char* buffer, size_t size)
 {
-    Syscall::SC_readlink_params params { { path, strlen(path) }, { buffer, size } };
+    return readlinkat(AT_FDCWD, path, buffer, size);
+}
+
+ssize_t readlinkat(int dirfd, const char* path, char* buffer, size_t size)
+{
+    Syscall::SC_readlink_params params { dirfd, { path, strlen(path) }, { buffer, size } };
     int rc = syscall(SC_readlink, &params);
     // Return the number of bytes placed in the buffer, not the full path size.
     __RETURN_WITH_ERRNO(rc, min((size_t)rc, size), -1);
@@ -499,11 +504,16 @@ int unlinkat(int dirfd, const char* pathname, int flags)
 
 int symlink(const char* target, const char* linkpath)
 {
+    return symlinkat(target, AT_FDCWD, linkpath);
+}
+
+int symlinkat(const char* target, int newdirfd, const char* linkpath)
+{
     if (!target || !linkpath) {
         errno = EFAULT;
         return -1;
     }
-    Syscall::SC_symlink_params params { { target, strlen(target) }, { linkpath, strlen(linkpath) } };
+    Syscall::SC_symlink_params params { { target, strlen(target) }, newdirfd, { linkpath, strlen(linkpath) } };
     int rc = syscall(SC_symlink, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -39,18 +39,28 @@ static int s_cached_pid = 0;
 
 int chown(const char* pathname, uid_t uid, gid_t gid)
 {
-    if (!pathname) {
-        errno = EFAULT;
-        return -1;
-    }
-    Syscall::SC_chown_params params { { pathname, strlen(pathname) }, uid, gid };
-    int rc = syscall(SC_chown, &params);
-    __RETURN_WITH_ERRNO(rc, rc, -1);
+    return fchownat(AT_FDCWD, pathname, uid, gid, 0);
 }
 
 int fchown(int fd, uid_t uid, gid_t gid)
 {
     int rc = syscall(SC_fchown, fd, uid, gid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int lchown(const char* pathname, uid_t uid, gid_t gid)
+{
+    return fchownat(AT_FDCWD, pathname, uid, gid, AT_SYMLINK_NOFOLLOW);
+}
+
+int fchownat(int dirfd, const char* pathname, uid_t uid, gid_t gid, int flags)
+{
+    if (!pathname) {
+        errno = EFAULT;
+        return -1;
+    }
+    Syscall::SC_chown_params params { dirfd, { pathname, strlen(pathname) }, uid, gid, flags };
+    int rc = syscall(SC_chown, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -482,7 +482,13 @@ int link(const char* old_path, const char* new_path)
 
 int unlink(const char* pathname)
 {
-    int rc = syscall(SC_unlink, pathname, strlen(pathname));
+    return unlinkat(AT_FDCWD, pathname, 0);
+}
+
+int unlinkat(int dirfd, const char* pathname, int flags)
+{
+    Syscall::SC_unlink_params params { dirfd, { pathname, strlen(pathname) }, flags };
+    int rc = syscall(SC_unlink, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -471,11 +471,16 @@ off_t lseek(int fd, off_t offset, int whence)
 
 int link(const char* old_path, const char* new_path)
 {
+    return linkat(AT_FDCWD, old_path, AT_FDCWD, new_path, 0);
+}
+
+int linkat(int old_dirfd, const char* old_path, int new_dirfd, const char* new_path, int flags)
+{
     if (!old_path || !new_path) {
         errno = EFAULT;
         return -1;
     }
-    Syscall::SC_link_params params { { old_path, strlen(old_path) }, { new_path, strlen(new_path) } };
+    Syscall::SC_link_params params { old_dirfd, { old_path, strlen(old_path) }, new_dirfd, { new_path, strlen(new_path) }, flags };
     int rc = syscall(SC_link, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -646,7 +646,7 @@ int mknod(const char* pathname, mode_t mode, dev_t dev)
         errno = EFAULT;
         return -1;
     }
-    Syscall::SC_mknod_params params { { pathname, strlen(pathname) }, mode, dev };
+    Syscall::SC_mknod_params params { AT_FDCWD, { pathname, strlen(pathname) }, mode, dev };
     int rc = syscall(SC_mknod, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -117,6 +117,8 @@ long pathconf(const char* path, int name);
 char* getlogin();
 int chown(const char* pathname, uid_t, gid_t);
 int fchown(int fd, uid_t, gid_t);
+int lchown(const char* pathname, uid_t, gid_t);
+int fchownat(int dirfd, const char* pathname, uid_t, gid_t, int flags);
 int ftruncate(int fd, off_t length);
 int truncate(const char* path, off_t length);
 int halt();

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -98,6 +98,7 @@ int ttyname_r(int fd, char* buffer, size_t);
 off_t lseek(int fd, off_t, int whence);
 int link(const char* oldpath, const char* newpath);
 int unlink(const char* pathname);
+int unlinkat(int dirfd, const char* pathname, int flags);
 int symlink(const char* target, const char* linkpath);
 int rmdir(const char* pathname);
 int dup(int old_fd);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -93,6 +93,7 @@ int usleep(useconds_t);
 int gethostname(char*, size_t);
 int sethostname(const char*, ssize_t);
 ssize_t readlink(const char* path, char* buffer, size_t);
+ssize_t readlinkat(int dirfd, const char* path, char* buffer, size_t);
 char* ttyname(int fd);
 int ttyname_r(int fd, char* buffer, size_t);
 off_t lseek(int fd, off_t, int whence);
@@ -101,6 +102,7 @@ int linkat(int old_dirfd, const char* oldpath, int new_dirfd, const char* newpat
 int unlink(const char* pathname);
 int unlinkat(int dirfd, const char* pathname, int flags);
 int symlink(const char* target, const char* linkpath);
+int symlinkat(const char* target, int newdirfd, const char* linkpath);
 int rmdir(const char* pathname);
 int dup(int old_fd);
 int dup2(int old_fd, int new_fd);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -97,6 +97,7 @@ char* ttyname(int fd);
 int ttyname_r(int fd, char* buffer, size_t);
 off_t lseek(int fd, off_t, int whence);
 int link(const char* oldpath, const char* newpath);
+int linkat(int old_dirfd, const char* oldpath, int new_dirfd, const char* newpath, int flags);
 int unlink(const char* pathname);
 int unlinkat(int dirfd, const char* pathname, int flags);
 int symlink(const char* target, const char* linkpath);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -110,6 +110,7 @@ int pipe(int pipefd[2]);
 int pipe2(int pipefd[2], int flags);
 unsigned int alarm(unsigned int seconds);
 int access(const char* pathname, int mode);
+int faccessat(int dirfd, const char* pathname, int mode, int flags);
 int isatty(int fd);
 int mknod(const char* pathname, mode_t, dev_t);
 long fpathconf(int fd, int name);


### PR DESCRIPTION
Similarly to the already implemented `openat(2)`, these syscalls add support for working with files relative to a file descriptor.

These were introduced in POSIX.1-2008 on the basis that they help avoid race conditions and allow implementing a \'per-thread cwd\'.
From the Linux `openat(2)` manpage:
> First, openat() allows an application to avoid race conditions that could occur when using open(2) to open files in directories other than the current working directory. These race conditions result from the fact that some component of the directory prefix given to open(2) could be changed in parallel with the call to open(2). Such races can be avoided by opening a file descriptor for the target directory, and then specifying that file descriptor as the dirfd argument of openat().
>
> Second, openat() allows the implementation of a per-thread "current working directory", via file descriptor(s) maintained by the application. (This functionality can also be obtained by tricks based on the use of /proc/self/fd/dirfd, but less efficiently.) 

This will be useful when implementing on-disk anonymous files (i.e. `open` with `O_TMPFILE`), so that they could be linked back into the filesystem using their file descriptors and `linkat`.

Since these syscalls are just extensions of existing functionality, it was easier to just add the extra *fd* arguments to the various syscalls instead of creating new ones. The existing library functions have been therefore reimplemented in terms of these.

I want to check if the error handling is safe and compliant before this can be merged, so this is just a draft at the moment.