### PR TITLE
PixelPaint Improvements; Add actions for selection, color swap, ...

### DIFF
--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -56,4 +56,10 @@ void Selection::draw_marching_ants(Gfx::Painter& painter, Gfx::IntRect const& re
         draw_pixel(rect.left(), y);
 }
 
+void Selection::clear()
+{
+    m_rect = {};
+    m_editor.update();
+}
+
 }

--- a/Userland/Applications/PixelPaint/Selection.h
+++ b/Userland/Applications/PixelPaint/Selection.h
@@ -19,7 +19,7 @@ public:
     explicit Selection(ImageEditor&);
 
     bool is_empty() const { return m_rect.is_empty(); }
-    void clear() { m_rect = {}; }
+    void clear();
     void set(Gfx::IntRect const& rect) { m_rect = rect; }
     Gfx::IntRect bounding_rect() const { return m_rect; }
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -207,6 +207,19 @@ int main(int argc, char** argv)
     });
     edit_menu.add_action(redo_action);
 
+    edit_menu.add_separator();
+    edit_menu.add_action(GUI::CommonActions::make_select_all_action([&](auto&) {
+        VERIFY(image_editor.image());
+        if (!image_editor.active_layer())
+            return;
+        image_editor.selection().set(image_editor.active_layer()->relative_rect());
+    }));
+    edit_menu.add_action(GUI::Action::create(
+        "Clear &Selection", { Mod_Ctrl | Mod_Shift, Key_A }, [&](auto&) {
+            image_editor.selection().clear();
+        },
+        window));
+
     auto& view_menu = menubar->add_menu("&View");
 
     auto zoom_in_action = GUI::CommonActions::make_zoom_in_action(

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -220,6 +220,21 @@ int main(int argc, char** argv)
         },
         window));
 
+    edit_menu.add_separator();
+    edit_menu.add_action(GUI::Action::create(
+        "&Swap Colors", { Mod_None, Key_X }, [&](auto&) {
+            auto old_primary_color = image_editor.primary_color();
+            image_editor.set_primary_color(image_editor.secondary_color());
+            image_editor.set_secondary_color(old_primary_color);
+        },
+        window));
+    edit_menu.add_action(GUI::Action::create(
+        "&Default Colors", { Mod_None, Key_D }, [&](auto&) {
+            image_editor.set_primary_color(Color::Black);
+            image_editor.set_secondary_color(Color::White);
+        },
+        window));
+
     auto& view_menu = menubar->add_menu("&View");
 
     auto zoom_in_action = GUI::CommonActions::make_zoom_in_action(


### PR DESCRIPTION
Its been a while since my last contribution, but todays video inspired me to make some easy additions to PixelPaint.

- PixelPaint: Add menu items for Select All and Clear Selection.
- PixelPaint: Add actions to swap colors or reset them to default values.