### PR TITLE
Everywhere: Use new discord invite url :^)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Everyone is welcome to work on the project, and while we have lots of fun, it's 
 
 ## Communication
 
-Join our Discord server: [SerenityOS Discord](https://discord.com/invite/29gCcKsXkF)
+Join our Discord server: [SerenityOS Discord](https://discord.gg/serenityos)
 
 ## Issue policy
 

--- a/Meta/Websites/serenityos.org/index.html
+++ b/Meta/Websites/serenityos.org/index.html
@@ -20,7 +20,7 @@
 <p><b>Project:</b></p>
 <ul>
     <li><a href="https://github.com/SerenityOS/serenity">SerenityOS on GitHub</a></li>
-    <li><a href="https://discord.com/invite/29gCcKsXkF">SerenityOS Discord Server</a> <font color=red>(join here to chat!)</font></li>
+    <li><a href="https://discord.gg/serenityos">SerenityOS Discord Server</a> <font color=red>(join here to chat!)</font></li>
     <li><a href="faq/">Frequently asked questions</a></li>
     <li><a href="bounty/">Bug bounty program</a></li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Graphical Unix-like operating system for x86 computers.
 
 [![Build status](https://github.com/SerenityOS/serenity/workflows/Build,%20lint,%20and%20test/badge.svg)](https://github.com/SerenityOS/serenity/actions?query=workflow%3A"Build%2C%20lint%2C%20and%20test")
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/serenity.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:serenity)
-[![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/29gCcKsXkF)  
+[![Discord](https://img.shields.io/discord/830522505605283862.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/serenityos)
 
 ## About
 
@@ -102,7 +102,7 @@ FAQ: [Frequently Asked Questions](https://github.com/SerenityOS/serenity/blob/ma
 
 ## Get in touch
 
-Join our Discord server: [SerenityOS Discord](https://discord.com/invite/29gCcKsXkF)
+Join our Discord server: [SerenityOS Discord](https://discord.gg/serenityos)
 
 ## Author
 


### PR DESCRIPTION
Replaces all instances of the previous discord invite link with a shiny new vanity url.
