### PR TITLE
LibJS: Store and return undefined Symbol description

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Symbol.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.cpp
@@ -10,7 +10,7 @@
 
 namespace JS {
 
-Symbol::Symbol(String description, bool is_global)
+Symbol::Symbol(Optional<String> description, bool is_global)
     : m_description(move(description))
     , m_is_global(is_global)
 {
@@ -20,12 +20,12 @@ Symbol::~Symbol()
 {
 }
 
-Symbol* js_symbol(Heap& heap, String description, bool is_global)
+Symbol* js_symbol(Heap& heap, Optional<String> description, bool is_global)
 {
     return heap.allocate_without_global_object<Symbol>(move(description), is_global);
 }
 
-Symbol* js_symbol(VM& vm, String description, bool is_global)
+Symbol* js_symbol(VM& vm, Optional<String> description, bool is_global)
 {
     return js_symbol(vm.heap(), move(description), is_global);
 }

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -16,21 +16,22 @@ class Symbol final : public Cell {
     AK_MAKE_NONMOVABLE(Symbol);
 
 public:
-    Symbol(String, bool);
+    Symbol(Optional<String>, bool);
     virtual ~Symbol();
 
-    const String& description() const { return m_description; }
+    String description() const { return m_description.value_or(""); }
+    const Optional<String>& raw_description() const { return m_description; }
     bool is_global() const { return m_is_global; }
     String to_string() const { return String::formatted("Symbol({})", description()); }
 
 private:
     virtual const char* class_name() const override { return "Symbol"; }
 
-    String m_description;
+    Optional<String> m_description;
     bool m_is_global;
 };
 
-Symbol* js_symbol(Heap&, String description, bool is_global);
-Symbol* js_symbol(VM&, String description, bool is_global);
+Symbol* js_symbol(Heap&, Optional<String> description, bool is_global);
+Symbol* js_symbol(VM&, Optional<String> description, bool is_global);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -42,8 +42,8 @@ SymbolConstructor::~SymbolConstructor()
 // 20.4.1.1 Symbol ( [ description ] ), https://tc39.es/ecma262/#sec-symbol-description
 Value SymbolConstructor::call()
 {
-    if (!vm().argument_count())
-        return js_symbol(heap(), "", false);
+    if (vm().argument(0).is_undefined())
+        return js_symbol(heap(), {}, false);
     return js_symbol(heap(), vm().argument(0).to_string(global_object()), false);
 }
 
@@ -57,13 +57,7 @@ Value SymbolConstructor::construct(Function&)
 // 20.4.2.2 Symbol.for ( key ), https://tc39.es/ecma262/#sec-symbol.for
 JS_DEFINE_NATIVE_FUNCTION(SymbolConstructor::for_)
 {
-    String description;
-    if (!vm.argument_count()) {
-        description = "undefined";
-    } else {
-        description = vm.argument(0).to_string(global_object);
-    }
-
+    String description = vm.argument(0).to_string(global_object);
     return global_object.vm().get_global_symbol(description);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.h
@@ -23,7 +23,7 @@ public:
     Symbol& primitive_symbol() { return m_symbol; }
     const Symbol& primitive_symbol() const { return m_symbol; }
 
-    const String& description() const { return m_symbol.description(); }
+    String description() const { return m_symbol.description(); }
     bool is_global() const { return m_symbol.is_global(); }
 
     virtual Value value_of() const override

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -58,7 +58,10 @@ JS_DEFINE_NATIVE_GETTER(SymbolPrototype::description_getter)
     auto symbol_value = this_symbol_value(global_object, vm.this_value(global_object));
     if (vm.exception())
         return {};
-    return js_string(vm, symbol_value.as_symbol().description());
+    auto& description = symbol_value.as_symbol().raw_description();
+    if (!description.has_value())
+        return js_undefined();
+    return js_string(vm, *description);
 }
 
 // 20.4.3.3 Symbol.prototype.toString ( ), https://tc39.es/ecma262/#sec-symbol.prototype.tostring


### PR DESCRIPTION
Instead of the current incorrect behaviour of just defaulting to an empty string.