### PR TITLE
Ports: Fix less by disabling wctype

### DIFF
--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -9,3 +9,8 @@ https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 depends="ncurses"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg less-${version}.tar.gz.sig"
+
+post_configure() {
+    run_replace_in_file "s/#define HAVE_WCTYPE 1/\/* #undef HAVE_WCTYPE *\//" defines.h
+    run touch stamp-h # prevent config.status from overwriting our changes
+}


### PR DESCRIPTION
The commit c2b47c067 (LibC: Add stubs for wctype and is wctype, 2021-05-27) introduced the wctype.h header, which caused the `less` port to try to build with wchar support. This patches the configure script to force it to build without wide-char support.
Specifically, the configure script tried to build a test program with a few wchar functions, which were implicitly declared and somehow still linked, causing it to succeed (maybe contamination from the host?)