### PR TITLE
LibTextCodec: Add ISO-8859-15 (aka Latin-9) encoding

### DIFF
--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -48,6 +48,11 @@ public:
     virtual String to_utf8(const StringView&) override;
 };
 
+class Latin9Decoder final : public Decoder {
+public:
+    virtual String to_utf8(const StringView&) override;
+};
+
 Decoder* decoder_for(const String& encoding);
 Optional<String> get_standardized_encoding(const String& encoding);
 bool is_standardized_encoding(const String& encoding);


### PR DESCRIPTION
Note that the euro sign € (U+20A0) isn't supported by any Serenity font, at least to my knowledge.