### PR TITLE
Kernel: Clean up i686 support

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -1003,15 +1003,16 @@ UNMAP_AFTER_INIT void Processor::cpu_detect()
 
     u32 max_extended_leaf = CPUID(0x80000000).eax();
 
-    VERIFY(max_extended_leaf >= 0x80000001);
-    CPUID extended_processor_info(0x80000001);
-    if (extended_processor_info.edx() & (1 << 20))
-        set_feature(CPUFeature::NX);
-    if (extended_processor_info.edx() & (1 << 27))
-        set_feature(CPUFeature::RDTSCP);
-    if (extended_processor_info.edx() & (1 << 11)) {
-        // Only available in 64 bit mode
-        set_feature(CPUFeature::SYSCALL);
+    if (max_extended_leaf >= 0x80000001) {
+        CPUID extended_processor_info(0x80000001);
+        if (extended_processor_info.edx() & (1 << 20))
+            set_feature(CPUFeature::NX);
+        if (extended_processor_info.edx() & (1 << 27))
+            set_feature(CPUFeature::RDTSCP);
+        if (extended_processor_info.edx() & (1 << 11)) {
+            // Only available in 64 bit mode
+            set_feature(CPUFeature::SYSCALL);
+        }
     }
 
     if (max_extended_leaf >= 0x80000007) {

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -971,6 +971,8 @@ UNMAP_AFTER_INIT void Processor::cpu_detect()
         set_feature(CPUFeature::PGE);
     if (processor_info.edx() & (1 << 23))
         set_feature(CPUFeature::MMX);
+    if (processor_info.edx() & (1 << 24))
+        set_feature(CPUFeature::FXSR);
     if (processor_info.edx() & (1 << 25))
         set_feature(CPUFeature::SSE);
     if (processor_info.edx() & (1 << 26))
@@ -1137,6 +1139,8 @@ String Processor::features_string() const
             return "syscall";
         case CPUFeature::MMX:
             return "mmx";
+        case CPUFeature::FXSR:
+            return "fxsr";
         case CPUFeature::SSE2:
             return "sse2";
         case CPUFeature::SSE3:

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -548,6 +548,7 @@ enum class CPUFeature : u32 {
     SSE4_2 = (1 << 20),
     XSAVE = (1 << 21),
     AVX = (1 << 22),
+    FXSR = (1 << 23),
 };
 
 class Thread;


### PR DESCRIPTION
With these changes, SerenityOS can boot on a canonical i686 CPU, which is defined to be a Pentium Pro processor or better. The original Pentium CPU doesn't support CMOV nor PAE and SerenityOS will therefore not work on it as-is.

Sadly, the museum collection in my basement does not include a Pentium Pro artifact, so I can't test this with period-correct physical hardware... That being said, experiments with QEMU suggests that it should work in theory.