### PR TITLE
Meta: Do not warn user about too modern clang-format

### DIFF
--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -31,13 +31,13 @@ if (( ${#files[@]} )); then
         CLANG_FORMAT=clang-format-11
     elif command -v clang-format >/dev/null 2>&1 ; then
         CLANG_FORMAT=clang-format
-        if ! "${CLANG_FORMAT}" --version | grep -qF ' 11.' ; then
-            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 11."
+        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) < 11) exit 1; }'; then
+            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 11 or later."
             echo "It is very likely that the resulting changes are not what you wanted."
         fi
     else
         echo "clang-format-11 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-11."
-        echo "(If you install a package 'clang-format', please make sure it's version 11.)"
+        echo "(If you install a package 'clang-format', please make sure it's version 11 or later.)"
         exit 1
     fi
 


### PR DESCRIPTION
To prevent warnings for users of varying distributions, do not warn the
user if the clang-version is higher than the expected version.