### PR TITLE
LibJS: Add the FinalizationRegistry built-in object

### DIFF
--- a/Tests/AK/TestSinglyLinkedList.cpp
+++ b/Tests/AK/TestSinglyLinkedList.cpp
@@ -59,3 +59,14 @@ TEST_CASE(should_find_const_with_predicate)
 
     EXPECT_EQ(sut.end(), sut.find_if([](const auto v) { return v == 42; }));
 }
+
+TEST_CASE(removal_during_iteration)
+{
+    auto list = make_list();
+    auto size = list.size_slow();
+
+    for (auto it = list.begin(); it != list.end(); ++it, --size) {
+        VERIFY(list.size_slow() == size);
+        it.remove(list);
+    }
+}

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -30,14 +30,14 @@ void Track::fill_sample(Sample& sample)
     Audio::Frame new_sample;
 
     for (size_t note = 0; note < note_count; ++note) {
-        if (!m_roll_iters[note].is_end()) {
-            if (m_roll_iters[note]->on_sample == m_time) {
+        if (!m_roll_iterators[note].is_end()) {
+            if (m_roll_iterators[note]->on_sample == m_time) {
                 set_note(note, On);
-            } else if (m_roll_iters[note]->off_sample == m_time) {
+            } else if (m_roll_iterators[note]->off_sample == m_time) {
                 set_note(note, Off);
-                ++m_roll_iters[note];
-                if (m_roll_iters[note].is_end())
-                    m_roll_iters[note] = m_roll_notes[note].begin();
+                ++m_roll_iterators[note];
+                if (m_roll_iterators[note].is_end())
+                    m_roll_iterators[note] = m_roll_notes[note].begin();
             }
         }
 
@@ -118,7 +118,7 @@ void Track::reset()
     memset(m_envelope, 0, sizeof(m_envelope));
 
     for (size_t note = 0; note < note_count; ++note)
-        m_roll_iters[note] = m_roll_notes[note].begin();
+        m_roll_iterators[note] = m_roll_notes[note].begin();
 }
 
 String Track::set_recorded_sample(const StringView& path)
@@ -259,9 +259,9 @@ void Track::sync_roll(int note)
 {
     auto it = m_roll_notes[note].find_if([&](auto& roll_note) { return roll_note.off_sample > m_time; });
     if (it.is_end())
-        m_roll_iters[note] = m_roll_notes[note].begin();
+        m_roll_iterators[note] = m_roll_notes[note].begin();
     else
-        m_roll_iters[note] = it;
+        m_roll_iterators[note] = it;
 }
 
 void Track::set_roll_note(int note, u32 on_sample, u32 off_sample)
@@ -281,14 +281,14 @@ void Track::set_roll_note(int note, u32 on_sample, u32 off_sample)
         if (it->on_sample <= new_roll_note.on_sample && it->off_sample >= new_roll_note.on_sample) {
             if (m_time >= it->on_sample && m_time <= it->off_sample)
                 set_note(note, Off);
-            m_roll_notes[note].remove(it);
+            it.remove(m_roll_notes[note]);
             sync_roll(note);
             return;
         }
         if ((new_roll_note.on_sample == 0 || it->on_sample >= new_roll_note.on_sample - 1) && it->on_sample <= new_roll_note.off_sample) {
             if (m_time >= new_roll_note.off_sample && m_time <= it->off_sample)
                 set_note(note, Off);
-            m_roll_notes[note].remove(it);
+            it.remove(m_roll_notes[note]);
             it = m_roll_notes[note].begin();
             continue;
         }

--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -86,5 +86,5 @@ private:
     const u32& m_time;
 
     SinglyLinkedList<RollNote> m_roll_notes[note_count];
-    RollIter m_roll_iters[note_count];
+    RollIter m_roll_iterators[note_count];
 };

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -48,6 +48,9 @@ set(SOURCES
     Runtime/ErrorPrototype.cpp
     Runtime/ErrorTypes.cpp
     Runtime/Exception.cpp
+    Runtime/FinalizationRegistry.cpp
+    Runtime/FinalizationRegistryConstructor.cpp
+    Runtime/FinalizationRegistryPrototype.cpp
     Runtime/FunctionConstructor.cpp
     Runtime/Function.cpp
     Runtime/FunctionPrototype.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -25,26 +25,27 @@
     void name([[maybe_unused]] JS::VM& vm, [[maybe_unused]] JS::GlobalObject& global_object, [[maybe_unused]] JS::Value value)
 
 // NOTE: Proxy is not included here as it doesn't have a prototype - m_proxy_constructor is initialized separately.
-#define JS_ENUMERATE_NATIVE_OBJECTS_EXCLUDING_TEMPLATES                                                       \
-    __JS_ENUMERATE(AggregateError, aggregate_error, AggregateErrorPrototype, AggregateErrorConstructor, void) \
-    __JS_ENUMERATE(Array, array, ArrayPrototype, ArrayConstructor, void)                                      \
-    __JS_ENUMERATE(ArrayBuffer, array_buffer, ArrayBufferPrototype, ArrayBufferConstructor, void)             \
-    __JS_ENUMERATE(BigIntObject, bigint, BigIntPrototype, BigIntConstructor, void)                            \
-    __JS_ENUMERATE(BooleanObject, boolean, BooleanPrototype, BooleanConstructor, void)                        \
-    __JS_ENUMERATE(DataView, data_view, DataViewPrototype, DataViewConstructor, void)                         \
-    __JS_ENUMERATE(Date, date, DatePrototype, DateConstructor, void)                                          \
-    __JS_ENUMERATE(Error, error, ErrorPrototype, ErrorConstructor, void)                                      \
-    __JS_ENUMERATE(Function, function, FunctionPrototype, FunctionConstructor, void)                          \
-    __JS_ENUMERATE(Map, map, MapPrototype, MapConstructor, void)                                              \
-    __JS_ENUMERATE(NumberObject, number, NumberPrototype, NumberConstructor, void)                            \
-    __JS_ENUMERATE(Object, object, ObjectPrototype, ObjectConstructor, void)                                  \
-    __JS_ENUMERATE(Promise, promise, PromisePrototype, PromiseConstructor, void)                              \
-    __JS_ENUMERATE(RegExpObject, regexp, RegExpPrototype, RegExpConstructor, void)                            \
-    __JS_ENUMERATE(Set, set, SetPrototype, SetConstructor, void)                                              \
-    __JS_ENUMERATE(StringObject, string, StringPrototype, StringConstructor, void)                            \
-    __JS_ENUMERATE(SymbolObject, symbol, SymbolPrototype, SymbolConstructor, void)                            \
-    __JS_ENUMERATE(WeakMap, weak_map, WeakMapPrototype, WeakMapConstructor, void)                             \
-    __JS_ENUMERATE(WeakRef, weak_ref, WeakRefPrototype, WeakRefConstructor, void)                             \
+#define JS_ENUMERATE_NATIVE_OBJECTS_EXCLUDING_TEMPLATES                                                                               \
+    __JS_ENUMERATE(AggregateError, aggregate_error, AggregateErrorPrototype, AggregateErrorConstructor, void)                         \
+    __JS_ENUMERATE(Array, array, ArrayPrototype, ArrayConstructor, void)                                                              \
+    __JS_ENUMERATE(ArrayBuffer, array_buffer, ArrayBufferPrototype, ArrayBufferConstructor, void)                                     \
+    __JS_ENUMERATE(BigIntObject, bigint, BigIntPrototype, BigIntConstructor, void)                                                    \
+    __JS_ENUMERATE(BooleanObject, boolean, BooleanPrototype, BooleanConstructor, void)                                                \
+    __JS_ENUMERATE(DataView, data_view, DataViewPrototype, DataViewConstructor, void)                                                 \
+    __JS_ENUMERATE(Date, date, DatePrototype, DateConstructor, void)                                                                  \
+    __JS_ENUMERATE(Error, error, ErrorPrototype, ErrorConstructor, void)                                                              \
+    __JS_ENUMERATE(FinalizationRegistry, finalization_registry, FinalizationRegistryPrototype, FinalizationRegistryConstructor, void) \
+    __JS_ENUMERATE(Function, function, FunctionPrototype, FunctionConstructor, void)                                                  \
+    __JS_ENUMERATE(Map, map, MapPrototype, MapConstructor, void)                                                                      \
+    __JS_ENUMERATE(NumberObject, number, NumberPrototype, NumberConstructor, void)                                                    \
+    __JS_ENUMERATE(Object, object, ObjectPrototype, ObjectConstructor, void)                                                          \
+    __JS_ENUMERATE(Promise, promise, PromisePrototype, PromiseConstructor, void)                                                      \
+    __JS_ENUMERATE(RegExpObject, regexp, RegExpPrototype, RegExpConstructor, void)                                                    \
+    __JS_ENUMERATE(Set, set, SetPrototype, SetConstructor, void)                                                                      \
+    __JS_ENUMERATE(StringObject, string, StringPrototype, StringConstructor, void)                                                    \
+    __JS_ENUMERATE(SymbolObject, symbol, SymbolPrototype, SymbolConstructor, void)                                                    \
+    __JS_ENUMERATE(WeakMap, weak_map, WeakMapPrototype, WeakMapConstructor, void)                                                     \
+    __JS_ENUMERATE(WeakRef, weak_ref, WeakRefPrototype, WeakRefConstructor, void)                                                     \
     __JS_ENUMERATE(WeakSet, weak_set, WeakSetPrototype, WeakSetConstructor, void)
 
 #define JS_ENUMERATE_NATIVE_OBJECTS                 \

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -64,6 +64,8 @@ void Interpreter::run(GlobalObject& global_object, const Program& program)
     // in which case this is a no-op.
     vm.run_queued_promise_jobs();
 
+    vm.run_queued_finalization_registry_cleanup_jobs();
+
     vm.finish_execution_generation();
 }
 

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -75,6 +75,7 @@ namespace JS {
     P(ceil)                                  \
     P(charAt)                                \
     P(charCodeAt)                            \
+    P(cleanupSome)                           \
     P(clear)                                 \
     P(clz32)                                 \
     P(concat)                                \
@@ -310,6 +311,7 @@ namespace JS {
     P(undefined)                             \
     P(unescape)                              \
     P(unicode)                               \
+    P(unregister)                            \
     P(unshift)                               \
     P(value)                                 \
     P(valueOf)                               \
@@ -321,6 +323,7 @@ struct CommonPropertyNames {
     PropertyName catch_ { "catch", PropertyName::StringMayBeNumber::No };
     PropertyName delete_ { "delete", PropertyName::StringMayBeNumber::No };
     PropertyName for_ { "for", PropertyName::StringMayBeNumber::No };
+    PropertyName register_ { "register", PropertyName::StringMayBeNumber::No };
     PropertyName return_ { "return", PropertyName::StringMayBeNumber::No };
     PropertyName throw_ { "throw", PropertyName::StringMayBeNumber::No };
 #define __ENUMERATE(x) PropertyName x { #x, PropertyName::StringMayBeNumber::No };

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -26,6 +26,7 @@
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
     M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                                   \
     M(DivisionByZero, "Division by zero")                                                                                               \
+    M(FinalizationRegistrySameTargetAndValue, "Target and held value must not be the same")                                             \
     M(GetCapabilitiesExecutorCalledMultipleTimes, "GetCapabilitiesExecutor was called multiple times")                                  \
     M(InOperatorWithObject, "'in' operator must be used on an object")                                                                  \
     M(InstanceOfOperatorBadPrototype, "'prototype' property of {} is not an object")                                                    \

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/FinalizationRegistry.h>
+
+namespace JS {
+
+FinalizationRegistry* FinalizationRegistry::create(GlobalObject& global_object, Function& cleanup_callback)
+{
+    return global_object.heap().allocate<FinalizationRegistry>(global_object, *global_object.finalization_registry_prototype(), cleanup_callback);
+}
+
+FinalizationRegistry::FinalizationRegistry(Object& prototype, Function& cleanup_callback)
+    : Object(prototype)
+    , WeakContainer(heap())
+    , m_cleanup_callback(&cleanup_callback)
+{
+}
+
+FinalizationRegistry::~FinalizationRegistry()
+{
+}
+
+void FinalizationRegistry::add_finalization_record(Cell& target, Value held_value, Object* unregister_token)
+{
+    VERIFY(!held_value.is_empty());
+    m_records.append({ &target, held_value, unregister_token });
+}
+
+bool FinalizationRegistry::remove_by_token(Object& unregister_token)
+{
+    auto removed = false;
+    for (auto it = m_records.begin(); it != m_records.end(); ++it) {
+        if (it->unregister_token == &unregister_token) {
+            it.remove(m_records);
+            removed = true;
+        }
+    }
+    return removed;
+}
+
+void FinalizationRegistry::remove_sweeped_cells(Badge<Heap>, Vector<Cell*>& cells)
+{
+    auto any_cells_were_sweeped = false;
+    for (auto cell : cells) {
+        for (auto& record : m_records) {
+            if (record.target != cell)
+                continue;
+            record.target = nullptr;
+            any_cells_were_sweeped = true;
+            break;
+        }
+    }
+    if (any_cells_were_sweeped)
+        vm().enqueue_finalization_registry_cleanup_job(*this);
+}
+
+// 9.13 CleanupFinalizationRegistry ( finalizationRegistry ), https://tc39.es/ecma262/#sec-cleanup-finalization-registry
+void FinalizationRegistry::cleanup(Function* callback)
+{
+    auto& vm = this->vm();
+    auto cleanup_callback = callback ?: m_cleanup_callback;
+    for (auto it = m_records.begin(); it != m_records.end(); ++it) {
+        if (it->target != nullptr)
+            continue;
+        (void)vm.call(*cleanup_callback, js_undefined(), it->held_value);
+        it.remove(m_records);
+        if (vm.exception())
+            return;
+    }
+}
+
+void FinalizationRegistry::visit_edges(Cell::Visitor& visitor)
+{
+    Object::visit_edges(visitor);
+    visitor.visit(m_cleanup_callback);
+    for (auto& record : m_records) {
+        visitor.visit(record.held_value);
+        visitor.visit(record.unregister_token);
+    }
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SinglyLinkedList.h>
+#include <LibJS/Runtime/Function.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Value.h>
+#include <LibJS/Runtime/WeakContainer.h>
+
+namespace JS {
+
+class FinalizationRegistry final
+    : public Object
+    , public WeakContainer {
+    JS_OBJECT(FinalizationRegistry, Object);
+
+public:
+    static FinalizationRegistry* create(GlobalObject&, Function&);
+
+    explicit FinalizationRegistry(Object& prototype, Function&);
+    virtual ~FinalizationRegistry() override;
+
+    void add_finalization_record(Cell& target, Value held_value, Object* unregister_token);
+    bool remove_by_token(Object& unregister_token);
+    void cleanup(Function* callback = nullptr);
+
+    virtual void remove_sweeped_cells(Badge<Heap>, Vector<Cell*>&) override;
+
+private:
+    virtual void visit_edges(Visitor& visitor) override;
+
+    Function* m_cleanup_callback { nullptr };
+
+    struct FinalizationRecord {
+        Cell* target { nullptr };
+        Value held_value;
+        Object* unregister_token { nullptr };
+    };
+    SinglyLinkedList<FinalizationRecord> m_records;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/FinalizationRegistry.h>
+#include <LibJS/Runtime/FinalizationRegistryConstructor.h>
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace JS {
+
+FinalizationRegistryConstructor::FinalizationRegistryConstructor(GlobalObject& global_object)
+    : NativeFunction(vm().names.FinalizationRegistry, *global_object.function_prototype())
+{
+}
+
+void FinalizationRegistryConstructor::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    NativeFunction::initialize(global_object);
+
+    // 26.2.2.1 FinalizationRegistry.prototype, https://tc39.es/ecma262/#sec-finalization-registry.prototype
+    define_property(vm.names.prototype, global_object.finalization_registry_prototype(), 0);
+
+    define_property(vm.names.length, Value(1), Attribute::Configurable);
+}
+
+FinalizationRegistryConstructor::~FinalizationRegistryConstructor()
+{
+}
+
+// 26.2.1.1 FinalizationRegistry ( cleanupCallback ), https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback
+Value FinalizationRegistryConstructor::call()
+{
+    auto& vm = this->vm();
+    vm.throw_exception<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, vm.names.FinalizationRegistry);
+    return {};
+}
+
+// 26.2.1.1 FinalizationRegistry ( cleanupCallback ), https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback
+Value FinalizationRegistryConstructor::construct(Function&)
+{
+    auto& vm = this->vm();
+    auto cleanup_callback = vm.argument(0);
+    if (!cleanup_callback.is_function()) {
+        vm.throw_exception<TypeError>(global_object(), ErrorType::NotAFunction, cleanup_callback.to_string_without_side_effects());
+        return {};
+    }
+
+    // FIXME: Use OrdinaryCreateFromConstructor(NewTarget, "%FinalizationRegistry.prototype%")
+    return FinalizationRegistry::create(global_object(), cleanup_callback.as_function());
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS {
+
+class FinalizationRegistryConstructor final : public NativeFunction {
+    JS_OBJECT(FinalizationRegistryConstructor, NativeFunction);
+
+public:
+    explicit FinalizationRegistryConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~FinalizationRegistryConstructor() override;
+
+    virtual Value call() override;
+    virtual Value construct(Function&) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/FinalizationRegistryPrototype.h>
+
+namespace JS {
+
+FinalizationRegistryPrototype::FinalizationRegistryPrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void FinalizationRegistryPrototype::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    Object::initialize(global_object);
+
+    // 26.2.3.4 FinalizationRegistry.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-finalization-registry.prototype-@@tostringtag
+    define_property(vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.FinalizationRegistry.as_string()), Attribute::Configurable);
+}
+
+FinalizationRegistryPrototype::~FinalizationRegistryPrototype()
+{
+}
+
+FinalizationRegistry* FinalizationRegistryPrototype::typed_this(VM& vm, GlobalObject& global_object)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return nullptr;
+    if (!is<FinalizationRegistry>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "FinalizationRegistry");
+        return nullptr;
+    }
+    return static_cast<FinalizationRegistry*>(this_object);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -17,6 +17,11 @@ void FinalizationRegistryPrototype::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Object::initialize(global_object);
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+
+    define_native_function(vm.names.cleanupSome, cleanup_some, 0, attr);
+    define_native_function(vm.names.register_, register_, 2, attr);
+    define_native_function(vm.names.unregister, unregister, 1, attr);
 
     // 26.2.3.4 FinalizationRegistry.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-finalization-registry.prototype-@@tostringtag
     define_property(vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.FinalizationRegistry.as_string()), Attribute::Configurable);
@@ -36,6 +41,70 @@ FinalizationRegistry* FinalizationRegistryPrototype::typed_this(VM& vm, GlobalOb
         return nullptr;
     }
     return static_cast<FinalizationRegistry*>(this_object);
+}
+
+// @STAGE 2@ FinalizationRegistry.prototype.cleanupSome ( [ callback ] ), https://github.com/tc39/proposal-cleanup-some/blob/master/spec/finalization-registry.html
+JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::cleanup_some)
+{
+    auto* finalization_registry = typed_this(vm, global_object);
+    if (!finalization_registry)
+        return {};
+
+    auto callback = vm.argument(0);
+    if (vm.argument_count() > 0 && !callback.is_function()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAFunction, callback.to_string_without_side_effects());
+        return {};
+    }
+
+    finalization_registry->cleanup(callback.is_undefined() ? nullptr : &callback.as_function());
+
+    return js_undefined();
+}
+
+// 26.2.3.2 FinalizationRegistry.prototype.register ( target, heldValue [ , unregisterToken ] ), https://tc39.es/ecma262/#sec-finalization-registry.prototype.register
+JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::register_)
+{
+    auto* finalization_registry = typed_this(vm, global_object);
+    if (!finalization_registry)
+        return {};
+
+    auto target = vm.argument(0);
+    if (!target.is_object()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObject, target.to_string_without_side_effects());
+        return {};
+    }
+
+    auto held_value = vm.argument(1);
+    if (same_value(target, held_value)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::FinalizationRegistrySameTargetAndValue);
+        return {};
+    }
+
+    auto unregister_token = vm.argument(2);
+    if (!unregister_token.is_object() && !unregister_token.is_undefined()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObject, unregister_token.to_string_without_side_effects());
+        return {};
+    }
+
+    finalization_registry->add_finalization_record(target.as_cell(), held_value, unregister_token.is_undefined() ? nullptr : &unregister_token.as_object());
+
+    return js_undefined();
+}
+
+// 26.2.3.3 FinalizationRegistry.prototype.unregister ( unregisterToken ), https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister
+JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::unregister)
+{
+    auto* finalization_registry = typed_this(vm, global_object);
+    if (!finalization_registry)
+        return {};
+
+    auto unregister_token = vm.argument(0);
+    if (!unregister_token.is_object()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObject, unregister_token.to_string_without_side_effects());
+        return {};
+    }
+
+    return Value(finalization_registry->remove_by_token(unregister_token.as_object()));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/FinalizationRegistry.h>
+
+namespace JS {
+
+class FinalizationRegistryPrototype final : public Object {
+    JS_OBJECT(FinalizationRegistryPrototype, Object);
+
+public:
+    FinalizationRegistryPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~FinalizationRegistryPrototype() override;
+
+private:
+    static FinalizationRegistry* typed_this(VM&, GlobalObject&);
+}

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
@@ -20,4 +20,10 @@ public:
 
 private:
     static FinalizationRegistry* typed_this(VM&, GlobalObject&);
+
+    JS_DECLARE_NATIVE_FUNCTION(cleanup_some);
+    JS_DECLARE_NATIVE_FUNCTION(register_);
+    JS_DECLARE_NATIVE_FUNCTION(unregister);
+};
+
 }

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -33,6 +33,8 @@
 #include <LibJS/Runtime/DatePrototype.h>
 #include <LibJS/Runtime/ErrorConstructor.h>
 #include <LibJS/Runtime/ErrorPrototype.h>
+#include <LibJS/Runtime/FinalizationRegistryConstructor.h>
+#include <LibJS/Runtime/FinalizationRegistryPrototype.h>
 #include <LibJS/Runtime/FunctionConstructor.h>
 #include <LibJS/Runtime/FunctionPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -155,6 +157,7 @@ void GlobalObject::initialize_global_object()
     add_constructor(vm.names.DataView, m_data_view_constructor, m_data_view_prototype);
     add_constructor(vm.names.Date, m_date_constructor, m_date_prototype);
     add_constructor(vm.names.Error, m_error_constructor, m_error_prototype);
+    add_constructor(vm.names.FinalizationRegistry, m_finalization_registry_constructor, m_finalization_registry_prototype);
     add_constructor(vm.names.Function, m_function_constructor, m_function_prototype);
     add_constructor(vm.names.Map, m_map_constructor, m_map_prototype);
     add_constructor(vm.names.Number, m_number_constructor, m_number_prototype);

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/FinalizationRegistry.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/IteratorOperations.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -555,6 +556,20 @@ void VM::run_queued_promise_jobs()
 void VM::enqueue_promise_job(NativeFunction& job)
 {
     m_promise_jobs.append(&job);
+}
+
+void VM::run_queued_finalization_registry_cleanup_jobs()
+{
+    while (!m_finalization_registry_cleanup_jobs.is_empty()) {
+        auto* registry = m_finalization_registry_cleanup_jobs.take_first();
+        registry->cleanup();
+    }
+}
+
+// 9.10.4.1 HostEnqueueFinalizationRegistryCleanupJob ( finalizationRegistry ), https://tc39.es/ecma262/#sec-host-cleanup-finalization-registry
+void VM::enqueue_finalization_registry_cleanup_job(FinalizationRegistry& registry)
+{
+    m_finalization_registry_cleanup_jobs.append(&registry);
 }
 
 // 27.2.1.9 HostPromiseRejectionTracker ( promise, operation ), https://tc39.es/ecma262/#sec-host-promise-rejection-tracker

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -244,6 +244,9 @@ public:
     void run_queued_promise_jobs();
     void enqueue_promise_job(NativeFunction&);
 
+    void run_queued_finalization_registry_cleanup_jobs();
+    void enqueue_finalization_registry_cleanup_job(FinalizationRegistry&);
+
     void promise_rejection_tracker(const Promise&, Promise::RejectionOperation) const;
 
     AK::Function<void()> on_call_stack_emptied;
@@ -271,6 +274,8 @@ private:
     HashMap<String, Symbol*> m_global_symbol_map;
 
     Vector<NativeFunction*> m_promise_jobs;
+
+    Vector<FinalizationRegistry*> m_finalization_registry_cleanup_jobs;
 
     PrimitiveString* m_empty_string { nullptr };
     PrimitiveString* m_single_ascii_character_strings[128] {};

--- a/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.js
@@ -1,0 +1,33 @@
+test("constructor properties", () => {
+    expect(FinalizationRegistry).toHaveLength(1);
+    expect(FinalizationRegistry.name).toBe("FinalizationRegistry");
+});
+
+describe("errors", () => {
+    test("invalid callbacks", () => {
+        [-100, Infinity, NaN, 152n, undefined].forEach(value => {
+            expect(() => {
+                new FinalizationRegistry(value);
+            }).toThrowWithMessage(TypeError, "is not a function");
+        });
+    });
+    test("called without new", () => {
+        expect(() => {
+            FinalizationRegistry();
+        }).toThrowWithMessage(
+            TypeError,
+            "FinalizationRegistry constructor must be called with 'new'"
+        );
+    });
+});
+
+describe("normal behavior", () => {
+    test("typeof", () => {
+        expect(typeof new FinalizationRegistry(() => {})).toBe("object");
+    });
+
+    test("constructor with single callback argument", () => {
+        var a = new FinalizationRegistry(() => {});
+        expect(a instanceof FinalizationRegistry).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.cleanupSome.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.cleanupSome.js
@@ -1,0 +1,35 @@
+test("length is 0", () => {
+    expect(FinalizationRegistry.prototype.cleanupSome).toHaveLength(0);
+});
+
+function registerInDifferentScope(registry) {
+    registry.register({}, {});
+}
+
+test("basic functionality", () => {
+    var registry = new FinalizationRegistry(() => {});
+
+    var count = 0;
+    var increment = () => {
+        count++;
+    };
+
+    registry.cleanupSome(increment);
+
+    expect(count).toBe(0);
+
+    registerInDifferentScope(registry);
+    gc();
+
+    registry.cleanupSome(increment);
+
+    expect(count).toBe(1);
+});
+
+test("errors", () => {
+    var registry = new FinalizationRegistry(() => {});
+
+    expect(() => {
+        registry.cleanupSome(5);
+    }).toThrowWithMessage(TypeError, "is not a function");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.register.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.register.js
@@ -1,0 +1,35 @@
+test("length is 2", () => {
+    expect(FinalizationRegistry.prototype.register).toHaveLength(2);
+});
+
+test("basic functionality", () => {
+    var registry = new FinalizationRegistry(() => {});
+
+    var target1 = {};
+    var heldValue1 = {};
+
+    registry.register(target1, heldValue1);
+
+    var target2 = {};
+    var heldValue2 = {};
+    var token = {};
+
+    registry.register(target2, heldValue2, token);
+});
+
+test("errors", () => {
+    var registry = new FinalizationRegistry(() => {});
+
+    expect(() => {
+        registry.register(5, {});
+    }).toThrowWithMessage(TypeError, "is not an object");
+
+    expect(() => {
+        var a = {};
+        registry.register(a, a);
+    }).toThrowWithMessage(TypeError, "Target and held value must not be the same");
+
+    expect(() => {
+        registry.register({}, {}, 5);
+    }).toThrowWithMessage(TypeError, "is not an object");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.unregister.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.unregister.js
@@ -1,0 +1,25 @@
+test("length is 2", () => {
+    expect(FinalizationRegistry.prototype.unregister).toHaveLength(1);
+});
+
+test("basic functionality", () => {
+    var registry = new FinalizationRegistry(() => {});
+
+    var target = {};
+    var heldValue = {};
+    var token = {};
+
+    registry.register(target, heldValue, token);
+
+    expect(registry.unregister({})).toBe(false);
+    expect(registry.unregister(token)).toBe(true);
+    expect(registry.unregister(token)).toBe(false);
+});
+
+test("errors", () => {
+    var registry = new FinalizationRegistry(() => {});
+
+    expect(() => {
+        registry.unregister(5);
+    }).toThrowWithMessage(TypeError, "is not an object");
+});

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -630,6 +630,7 @@ JS::Interpreter& Document::interpreter()
         vm.on_call_stack_emptied = [this] {
             auto& vm = m_interpreter->vm();
             vm.run_queued_promise_jobs();
+            vm.run_queued_finalization_registry_cleanup_jobs();
             // Note: This is not an exception check for the promise jobs, they will just leave any
             // exception that already exists intact and never throw a new one (without cleaning it
             // up, that is). Taking care of any previous unhandled exception just happens to be the


### PR DESCRIPTION
This fixes 51 test262 test cases (Note that there are 8 more test cases that look like they should pass, but currently dont due to parser errors related to class declarations).

As part of this PR the FinalizationRegistery.prototype.cleanupSome method was added, which is actually still a stage 2 proposal, but since test262 test cases already exist for it, i decided to go for it :)