### PR TITLE
LibJS: Use OrderedHashTable in the Set built-in and OrderedHashMap in the Map built-in

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -156,3 +156,4 @@ private:
 }
 
 using AK::HashMap;
+using AK::OrderedHashMap;

--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -22,13 +22,13 @@ public:
     explicit Map(Object& prototype);
     virtual ~Map() override;
 
-    HashMap<Value, Value, ValueTraits> const& entries() const { return m_entries; };
-    HashMap<Value, Value, ValueTraits>& entries() { return m_entries; };
+    OrderedHashMap<Value, Value, ValueTraits> const& entries() const { return m_entries; };
+    OrderedHashMap<Value, Value, ValueTraits>& entries() { return m_entries; };
 
 private:
     virtual void visit_edges(Visitor& visitor) override;
 
-    HashMap<Value, Value, ValueTraits> m_entries; // FIXME: Replace with a HashMap that maintains a linked list of insertion order for correct iteration order
+    OrderedHashMap<Value, Value, ValueTraits> m_entries;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.h
@@ -33,7 +33,7 @@ private:
     Map& m_map;
     bool m_done { false };
     Object::PropertyKind m_iteration_kind;
-    HashMap<Value, Value, ValueTraits>::IteratorType m_iterator;
+    OrderedHashMap<Value, Value, ValueTraits>::IteratorType m_iterator;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -22,13 +22,13 @@ public:
     explicit Set(Object& prototype);
     virtual ~Set() override;
 
-    HashTable<Value, ValueTraits> const& values() const { return m_values; };
-    HashTable<Value, ValueTraits>& values() { return m_values; };
+    OrderedHashTable<Value, ValueTraits> const& values() const { return m_values; };
+    OrderedHashTable<Value, ValueTraits>& values() { return m_values; };
 
 private:
     virtual void visit_edges(Visitor& visitor) override;
 
-    HashTable<Value, ValueTraits> m_values; // FIXME: Replace with a HashTable that maintains a linked list of insertion order for correct iteration order
+    OrderedHashTable<Value, ValueTraits> m_values;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.h
@@ -33,7 +33,7 @@ private:
     Set& m_set;
     bool m_done { false };
     Object::PropertyKind m_iteration_kind;
-    HashTable<Value, ValueTraits>::Iterator m_iterator;
+    OrderedHashTable<Value, ValueTraits>::Iterator m_iterator;
 };
 
 }


### PR DESCRIPTION
This ensures insertion-order iteration. (This fixes 6 test262 test cases)