### PR TITLE
Ports: Remove note about ssh needing port numbers explicitly specified

### DIFF
--- a/Ports/openssh/ReadMe.md
+++ b/Ports/openssh/ReadMe.md
@@ -6,6 +6,3 @@
 - Cannot determine compatibility flags.
   This means there may be some weird bugs when connecting to certain SSH implementations.
 - SSHD does not work as it requires socketpair. It will start, but will crash on connection.
-
-# Note on connecting to servers
-You have to specify the port number when using ssh. It seemingly doesn't default to 22.


### PR DESCRIPTION
This is no longer true, I'm not sure where this got fixed, but I can
successfully connect via IP without specifying a port number using
the latest HEAD of master.