### PR TITLE
LibGUI: fix mismatch between visual lines and lines in move up and down

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -637,7 +637,11 @@ void EditingEngine::move_selected_lines_up()
         return;
 
     auto& lines = m_editor->document().lines();
-    lines.insert((int)last_line, lines.take((int)first_line - 1));
+    int moved_line_index = (int)first_line - 1;
+    auto moved_line = lines.take(moved_line_index);
+    m_editor->document_did_remove_line(moved_line_index);
+    lines.insert(last_line, move(moved_line));
+    m_editor->document_did_insert_line(last_line);
     m_editor->set_cursor({ first_line - 1, 0 });
 
     if (m_editor->has_selection()) {
@@ -662,7 +666,11 @@ void EditingEngine::move_selected_lines_down()
     if (last_line >= lines.size() - 1)
         return;
 
-    lines.insert((int)first_line, lines.take((int)last_line + 1));
+    int moved_line_index = (int)last_line + 1;
+    auto moved_line = lines.take(moved_line_index);
+    m_editor->document_did_remove_line(moved_line_index);
+    lines.insert(first_line, move(moved_line));
+    m_editor->document_did_insert_line(first_line);
     m_editor->set_cursor({ first_line + 1, 0 });
 
     if (m_editor->has_selection()) {

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -192,6 +192,16 @@ public:
 
     void delete_text_range(TextRange);
 
+    // ^TextDocument::Client
+    virtual void document_did_append_line() override;
+    virtual void document_did_insert_line(size_t) override;
+    virtual void document_did_remove_line(size_t) override;
+    virtual void document_did_remove_all_lines() override;
+    virtual void document_did_change() override;
+    virtual void document_did_set_text() override;
+    virtual void document_did_set_cursor(const TextPosition&) override;
+    virtual void document_did_update_undo_stack() override;
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 
@@ -223,16 +233,6 @@ protected:
 
 private:
     friend class TextDocumentLine;
-
-    // ^TextDocument::Client
-    virtual void document_did_append_line() override;
-    virtual void document_did_insert_line(size_t) override;
-    virtual void document_did_remove_line(size_t) override;
-    virtual void document_did_remove_all_lines() override;
-    virtual void document_did_change() override;
-    virtual void document_did_set_text() override;
-    virtual void document_did_set_cursor(const TextPosition&) override;
-    virtual void document_did_update_undo_stack() override;
 
     // ^Syntax::HighlighterClient
     virtual Vector<TextDocumentSpan>& spans() final { return document().spans(); }


### PR DESCRIPTION
fixes: #8071

I don't think 3d696e4 is correct, but I don't know what would be a better solution.

`EditingEngine::move_selected_lines_up` and `move_selected_lines_down` were changing the utf32 lines but were not forwarding thoses changes to the visual lines causing a problematic data mismatch in certain cases, like while moving empty lines.

There might be a performance performance impact by doing things that way, as it might be possible to do the remove and insert and then recompute visual lines (or even just swap them ?).
But at worst it's only while using `move_selected_lines_up` or `move_selected_lines_down`. And I havn't noticed anything special while testing this.