### PR TITLE
Ports: Add port for DungeonRush

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -119,7 +119,11 @@ install_icon() {
     if [ "$convert_exists" == "0" ] && [ "$identify_exists" == "0" ]; then
         for icon_size in "16x16" "32x32"; do
             index=$(run identify "$icon" | grep "$icon_size" | grep -oE "\[[0-9]+\]" | tr -d "[]" | head -n1)
-            run convert "${icon}[${index}]" "app-${icon_size}.png"
+            if [ -n "$index" ]; then
+                run convert "${icon}[${index}]" "app-${icon_size}.png"
+            else
+                run convert "$icon" -resize $icon_size "app-${icon_size}.png"
+            fi
         done
         run objcopy --add-section serenity_icon_s="app-16x16.png" "${DESTDIR}${launcher}"
         run objcopy --add-section serenity_icon_m="app-32x32.png" "${DESTDIR}${launcher}"

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -123,6 +123,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`SDL2_gfx`](SDL2_gfx/)                | SDL2\_gfx (Graphics primitives add-on for SDL2)            | 1.0.4                    | https://sourceforge.net/projects/sdl2gfx/                                      |
 | [`SDL2_image`](SDL2_image/)            | SDL2\_image (Image loading add-on for SDL2)                | 2.0.5                    | https://www.libsdl.org/projects/SDL_image/                                     |
 | [`SDL2_mixer`](SDL2_mixer/)            | SDL2\_mixer (audio mixer add-on for SDL2)                  | 2.0.4                    | https://www.libsdl.org/projects/SDL_mixer/                                     |
+| [`SDL2_net`](SDL2_net/)                | SDL2\_net (network add-on for SDL2)                        | 2.0.1                    | https://www.libsdl.org/projects/SDL_net/                                       |
 | [`SDL2_ttf`](SDL2_ttf/)                | SDL2\_ttf (TrueType Font add-on for SDL2)                  | 2.0.15                   | https://www.libsdl.org/projects/SDL_ttf/                                       |
 | [`sed`](sed/)                          | GNU sed                                                    | 4.2.1                    | https://www.gnu.org/software/sed/                                              |
 | [`sl`](sl/)                            | Steam Locomotive (SL)                                      |                          | https://github.com/mtoyoda/sl                                                  |

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -26,6 +26,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`dmidecode`](dmidecode/)              | dmidecode                                                  | 3.3                      | https://github.com/mirror/dmidecode                                            |
 | [`doom`](doom/)                        | DOOM                                                       |                          | https://github.com/SerenityOS/SerenityDOOM                                     |
 | [`dropbear`](dropbear/)                | Dropbear SSH                                               | 2019.78                  | https://dropbear.nl/mirror/dropbear.html                                       |
+| [`dungeonrush`](dungeonrush/)          | DungeonRush                                                | 1.1-beta                 | https://github.com/Rapiz1/DungeonRush                                          |
 | [`ed`](ed/)                            | GNU ed                                                     | 1.15                     | https://www.gnu.org/software/ed/                                               |
 | [`emu2`](emu2/)                        | emu2 DOS emulator                                          | 2021.01                  | https://github.com/dmsc/emu2                                                   |
 | [`figlet`](figlet/)                    | FIGlet                                                     | 2.2.5                    | http://www.figlet.org/                                                         |

--- a/Ports/SDL2_net/package.sh
+++ b/Ports/SDL2_net/package.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=SDL2_net
+version=2.0.1
+useconfigure=true
+configopts=--with-sdl-prefix="${SERENITY_INSTALL_ROOT}/usr/local"
+files="https://www.libsdl.org/projects/SDL_net/release/SDL2_net-${version}.tar.gz SDL2_net-${version}.tar.gz 15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21"
+auth_type=sha256
+depends="SDL2"
+
+post_install() {
+    run ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_net.so -Wl,-soname,libSDL2_net.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_net.a -Wl,--no-whole-archive
+}

--- a/Ports/SDL2_net/patches/configure.patch
+++ b/Ports/SDL2_net/patches/configure.patch
@@ -1,0 +1,12 @@
+diff -Naur SDL2_net-2.0.1/config.sub SDL2_net-2.0.1.serenity/config.sub
+--- SDL2_net-2.0.1/config.sub	2016-01-03 08:57:09.000000000 +0100
++++ SDL2_net-2.0.1.serenity/config.sub	2021-06-16 10:40:58.771380293 +0200
+@@ -1364,7 +1364,7 @@
+ 	# The portable systems comes first.
+ 	# Each alternative MUST END IN A *, to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* | -serenity* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* \

--- a/Ports/SDL2_net/patches/ifconf.patch
+++ b/Ports/SDL2_net/patches/ifconf.patch
@@ -1,0 +1,14 @@
+diff -Naur SDL2_net-2.0.1/SDLnet.c SDL2_net-2.0.1.serenity/SDLnet.c
+--- SDL2_net-2.0.1/SDLnet.c	2016-01-03 08:57:09.000000000 +0100
++++ SDL2_net-2.0.1.serenity/SDLnet.c	2021-06-16 10:48:32.073734588 +0200
+@@ -184,6 +184,10 @@
+     return inet_ntoa(in);
+ }
+ 
++#ifdef __serenity__
++#undef SIOCGIFCONF
++#endif
++
+ int SDLNet_GetLocalAddresses(IPaddress *addresses, int maxcount)
+ {
+     int count = 0;

--- a/Ports/SDL2_net/patches/select.patch
+++ b/Ports/SDL2_net/patches/select.patch
@@ -1,0 +1,11 @@
+diff -Naur SDL2_net-2.0.1/SDLnetsys.h SDL2_net-2.0.1.serenity/SDLnetsys.h
+--- SDL2_net-2.0.1/SDLnetsys.h	2021-06-16 10:42:24.609750625 +0200
++++ SDL2_net-2.0.1.serenity/SDLnetsys.h	2016-01-03 08:57:09.000000000 +0100
+@@ -46,6 +46,7 @@
+ #include <iphlpapi.h>
+ #else /* UNIX */
+ #include <sys/types.h>
++#include <sys/select.h>
+ #ifdef __FreeBSD__
+ #include <sys/socket.h>
+ #endif

--- a/Ports/dungeonrush/package.sh
+++ b/Ports/dungeonrush/package.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=DungeonRush
+version=1.1-beta
+useconfigure=true
+files="https://github.com/Rapiz1/DungeonRush/archive/refs/tags/v${version}.tar.gz v${version}.tar.gz 295b83cb023bf5d21318992daee125399892bdf16a87c835dfc90b841c929eda"
+auth_type=sha256
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
+depends="SDL2 SDL2_image SDL2_mixer SDL2_ttf SDL2_net"
+launcher_name="DungeonRush"
+launcher_category=Games
+launcher_command=/opt/DungeonRush/dungeon_rush
+icon_file=dungeonrush.png
+
+configure() {
+    run cmake $configopts
+}
+
+install() {
+    run mkdir -p "${SERENITY_INSTALL_ROOT}/opt/DungeonRush"
+    run cp -r bin/dungeon_rush res "${SERENITY_INSTALL_ROOT}/opt/DungeonRush"
+}

--- a/Ports/dungeonrush/patches/cwd.patch
+++ b/Ports/dungeonrush/patches/cwd.patch
@@ -1,0 +1,12 @@
+diff -Naur DungeonRush-1.1-beta/src/main.c DungeonRush-1.1-beta.serenity/src/main.c
+--- DungeonRush-1.1-beta/src/main.c	2020-11-21 14:22:39.000000000 +0100
++++ DungeonRush-1.1-beta.serenity/src/main.c	2021-06-16 11:02:22.409585466 +0200
+@@ -12,6 +12,8 @@
+ #endif
+ 
+ int main(int argc, char** args) {
++  // The game tries to open its resource files using relative paths
++  chdir("/opt/DungeonRush");
+   prngSrand(time(NULL));
+   // Start up SDL and create window
+   if (!init()) {

--- a/Ports/dungeonrush/patches/sw-renderer.patch
+++ b/Ports/dungeonrush/patches/sw-renderer.patch
@@ -1,0 +1,12 @@
+diff -Naur DungeonRush-1.1-beta/src/res.c DungeonRush-1.1-beta.serenity/src/res.c
+--- DungeonRush-1.1-beta/src/res.c	2020-11-21 14:22:39.000000000 +0100
++++ DungeonRush-1.1-beta.serenity/src/res.c	2021-06-16 11:00:12.654195338 +0200
+@@ -89,6 +89,8 @@
+ int soundsCount;
+ Mix_Chunk *sounds[AUDIO_SOUND_SIZE];
+ 
++#define SOFTWARE_ACC
++
+ bool init() {
+   // Initialization flag
+   bool success = true;

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -2,7 +2,7 @@
 port=libiconv
 version=1.16
 useconfigure=true
-configopts=--enable-shared
+configopts="--enable-shared --disable-nls"
 files="https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz libiconv-${version}.tar.gz
 https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz.sig libiconv-${version}.tar.gz.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"

--- a/Userland/Libraries/LibC/sys/select.h
+++ b/Userland/Libraries/LibC/sys/select.h
@@ -10,6 +10,7 @@
 #include <signal.h>
 #include <string.h>
 #include <sys/cdefs.h>
+#include <sys/time.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS


### PR DESCRIPTION
Brought to you by the "Oh look, it's using SDL2" department:

![image](https://user-images.githubusercontent.com/388571/122219354-a6532e80-ceaf-11eb-918d-251838cb525b.png)

**Ports: Add port for SDL2_net**

**Ports: Disable gettext support for libiconv**

libiconv and gettext have a circular dependency. In an ideal world we'd build libiconv without gettext support first, then gettext and finally libiconv again with gettext support.

However, if the libiconv port detects gettext on the host system while the gettext port hasn't been built yet things break.

This disables gettext support for the libiconv port for now.

**LibC: Make sure the definition for struct timeval is available**

Ideally we'd have a separate header with just struct timeval and include that (i.e. in a way similar to how macOS, FreeBSD and glibc do this).

**Ports: Add port for DungeonRush**