### PR TITLE
LibJS: Rename Value::{is_integer => is_integral_number}

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -52,7 +52,7 @@ Value ArrayConstructor::call()
 
     if (vm().argument_count() == 1 && vm().argument(0).is_number()) {
         auto array_length_value = vm().argument(0);
-        if (!array_length_value.is_integer() || array_length_value.as_i32() < 0) {
+        if (!array_length_value.is_integral_number() || array_length_value.as_i32() < 0) {
             vm().throw_exception<RangeError>(global_object(), ErrorType::InvalidLength, "array");
             return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -46,7 +46,7 @@ Value BigIntConstructor::call()
     if (vm().exception())
         return {};
     if (primitive.is_number()) {
-        if (!primitive.is_integer()) {
+        if (!primitive.is_integral_number()) {
             vm().throw_exception<RangeError>(global_object(), ErrorType::BigIntIntArgument);
             return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -266,7 +266,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
     if (base.is_positive_infinity())
         return exponent.as_double() > 0 ? js_infinity() : Value(0);
     if (base.is_negative_infinity()) {
-        auto is_odd_integral_number = exponent.is_integer() && (exponent.as_i32() % 2 != 0);
+        auto is_odd_integral_number = exponent.is_integral_number() && (exponent.as_i32() % 2 != 0);
         if (exponent.as_double() > 0)
             return is_odd_integral_number ? js_negative_infinity() : js_infinity();
         else
@@ -275,7 +275,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
     if (base.is_positive_zero())
         return exponent.as_double() > 0 ? Value(0) : js_infinity();
     if (base.is_negative_zero()) {
-        auto is_odd_integral_number = exponent.is_integer() && (exponent.as_i32() % 2 != 0);
+        auto is_odd_integral_number = exponent.is_integral_number() && (exponent.as_i32() % 2 != 0);
         if (exponent.as_double() > 0)
             return is_odd_integral_number ? Value(-0.0) : Value(0);
         else
@@ -301,7 +301,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
             return js_infinity();
     }
     VERIFY(exponent.is_finite_number() && !exponent.is_positive_zero() && !exponent.is_negative_zero());
-    if (base.as_double() < 0 && !exponent.is_integer())
+    if (base.as_double() < 0 && !exponent.is_integral_number())
         return js_nan();
     return Value(::pow(base.as_double(), exponent.as_double()));
 }

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -86,7 +86,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberConstructor::is_finite)
 // 21.1.2.3 Number.isInteger ( number ), https://tc39.es/ecma262/#sec-number.isinteger
 JS_DEFINE_NATIVE_FUNCTION(NumberConstructor::is_integer)
 {
-    return Value(vm.argument(0).is_integer());
+    return Value(vm.argument(0).is_integral_number());
 }
 
 // 21.1.2.4 Number.isNaN ( number ), https://tc39.es/ecma262/#sec-number.isnan

--- a/Userland/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyName.h
@@ -31,7 +31,7 @@ public:
             return {};
         if (value.is_symbol())
             return &value.as_symbol();
-        if (value.is_integer() && value.as_i32() >= 0)
+        if (value.is_integral_number() && value.as_i32() >= 0)
             return value.as_i32();
         auto string = value.to_string(global_object);
         if (string.is_null())

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -129,7 +129,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_code_point)
         auto next_code_point = vm.argument(i).to_number(global_object);
         if (vm.exception())
             return {};
-        if (!next_code_point.is_integer()) {
+        if (!next_code_point.is_integral_number()) {
             vm.throw_exception<RangeError>(global_object, ErrorType::InvalidCodePoint, next_code_point.to_string_without_side_effects());
             return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1255,7 +1255,7 @@ bool abstract_eq(GlobalObject& global_object, Value lhs, Value rhs)
     if ((lhs.is_bigint() && rhs.is_number()) || (lhs.is_number() && rhs.is_bigint())) {
         if (lhs.is_nan() || lhs.is_infinity() || rhs.is_nan() || rhs.is_infinity())
             return false;
-        if ((lhs.is_number() && !lhs.is_integer()) || (rhs.is_number() && !rhs.is_integer()))
+        if ((lhs.is_number() && !lhs.is_integral_number()) || (rhs.is_number() && !rhs.is_integral_number()))
             return false;
         if (lhs.is_number())
             return Crypto::SignedBigInteger { lhs.to_i32(global_object) } == rhs.as_bigint().big_integer();
@@ -1368,11 +1368,11 @@ TriState abstract_relation(GlobalObject& global_object, bool left_first, Value l
 
     bool x_lower_than_y;
     if (x_numeric.is_number()) {
-        x_lower_than_y = x_numeric.is_integer()
+        x_lower_than_y = x_numeric.is_integral_number()
             ? Crypto::SignedBigInteger { x_numeric.to_i32(global_object) } < y_numeric.as_bigint().big_integer()
             : (Crypto::SignedBigInteger { x_numeric.to_i32(global_object) } < y_numeric.as_bigint().big_integer() || Crypto::SignedBigInteger { x_numeric.to_i32(global_object) + 1 } < y_numeric.as_bigint().big_integer());
     } else {
-        x_lower_than_y = y_numeric.is_integer()
+        x_lower_than_y = y_numeric.is_integral_number()
             ? x_numeric.as_bigint().big_integer() < Crypto::SignedBigInteger { y_numeric.to_i32(global_object) }
             : (x_numeric.as_bigint().big_integer() < Crypto::SignedBigInteger { y_numeric.to_i32(global_object) } || x_numeric.as_bigint().big_integer() < Crypto::SignedBigInteger { y_numeric.to_i32(global_object) + 1 });
     }

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -73,7 +73,7 @@ public:
     bool is_negative_infinity() const { return is_number() && __builtin_isinf_sign(as_double()) < 0; }
     bool is_positive_zero() const { return is_number() && bit_cast<u64>(as_double()) == 0; }
     bool is_negative_zero() const { return is_number() && bit_cast<u64>(as_double()) == NEGATIVE_ZERO_BITS; }
-    bool is_integer() const { return is_finite_number() && (i32)as_double() == as_double(); }
+    bool is_integral_number() const { return is_finite_number() && (i32)as_double() == as_double(); }
     bool is_finite_number() const
     {
         if (!is_number())


### PR DESCRIPTION
The implementation matches the specification, so lets match the name as well. :^)