### PR TITLE
CI: Make sure the first word of each commit is capitalized

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -37,6 +37,14 @@ jobs:
           pattern: '^\S.*?: .+'
           error: 'Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)'
 
+      - name: Check first word of title for capitalization
+        if: ${{ success() || failure() }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^\S.*?: [A-Z0-9]'
+          error: 'First word of commit after the subsystem isn\'t capitalized'
+
       - name: Check title
         if: ${{ success() || failure() }}
         uses: tim-actions/commit-message-checker-with-regex@v0.3.1


### PR DESCRIPTION
The first word for each commit should be a verb anyway, and this
automates @alimpfard's nits. :^)