### PR TITLE
AudioServer: Put the m_zero_filled_buffer variable into the .bss segment

### DIFF
--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -14,6 +14,8 @@
 
 namespace AudioServer {
 
+u8 Mixer::m_zero_filled_buffer[4096];
+
 Mixer::Mixer()
     : m_device(Core::File::construct("/dev/audio", this))
     , m_sound_thread(Threading::Thread::construct(
@@ -31,8 +33,6 @@ Mixer::Mixer()
     pthread_mutex_init(&m_pending_mutex, nullptr);
     pthread_cond_init(&m_pending_cond, nullptr);
 
-    m_zero_filled_buffer = (u8*)malloc(4096);
-    bzero(m_zero_filled_buffer, 4096);
     m_sound_thread->start();
 }
 
@@ -86,7 +86,7 @@ void Mixer::mix()
         }
 
         if (m_muted) {
-            m_device->write(m_zero_filled_buffer, 4096);
+            m_device->write(m_zero_filled_buffer, sizeof(m_zero_filled_buffer));
         } else {
             Array<u8, 4096> buffer;
             OutputMemoryStream stream { buffer };

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -117,7 +117,7 @@ private:
     bool m_muted { false };
     int m_main_volume { 100 };
 
-    u8* m_zero_filled_buffer { nullptr };
+    static u8 m_zero_filled_buffer[4096];
 
     void mix();
 };


### PR DESCRIPTION
This way we don't have to allocate this at runtime. I'm intentionally not using `static constexpr` here because that would put the variable into the `.rodata` segment and would therefore increase the binary by 4kB.

The old code also failed to `free()` the buffer in the destructor, however that wasn't much of an issue because the `Mixer` object exists throughout the program's entire lifetime.