### PR TITLE
Spreadsheet: Don't cancel drag-select when moving over a cell corner / Some perf improvements for importing

### DIFF
--- a/Userland/Applications/Spreadsheet/Cell.cpp
+++ b/Userland/Applications/Spreadsheet/Cell.cpp
@@ -113,14 +113,9 @@ void Cell::update_data(Badge<Sheet>)
     m_evaluated_formats.background_color.clear();
     m_evaluated_formats.foreground_color.clear();
     if (!m_js_exception) {
-        StringBuilder builder;
         for (auto& fmt : m_conditional_formats) {
             if (!fmt.condition.is_empty()) {
-                builder.clear();
-                builder.append("return (");
-                builder.append(fmt.condition);
-                builder.append(')');
-                auto [value, exception] = m_sheet->evaluate(builder.string_view(), this);
+                auto [value, exception] = m_sheet->evaluate(fmt.condition, this);
                 if (exception) {
                     m_js_exception = move(exception);
                 } else {

--- a/Userland/Applications/Spreadsheet/CellSyntaxHighlighter.cpp
+++ b/Userland/Applications/Spreadsheet/CellSyntaxHighlighter.cpp
@@ -37,7 +37,7 @@ void CellSyntaxHighlighter::rehighlight(const Palette& palette)
     if (m_cell && m_cell->exception()) {
         auto& traceback = m_cell->exception()->traceback();
         auto& range = traceback.first().source_range;
-        GUI::TextRange text_range { { range.start.line - 1, range.start.column }, { range.end.line - 1, range.end.column - 1 } };
+        GUI::TextRange text_range { { range.start.line - 1, range.start.column }, { range.end.line - 1, range.end.column } };
         m_client->spans().prepend(
             GUI::TextDocumentSpan {
                 text_range,

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -147,7 +147,7 @@ auto CSVImportDialogPage::make_reader() -> Optional<Reader::XSV>
     if (should_trim_trailing)
         behaviours = behaviours | Reader::ParserBehaviour::TrimTrailingFieldSpaces;
 
-    return Reader::XSV(m_csv, traits, behaviours);
+    return Reader::XSV(m_csv, move(traits), behaviours);
 };
 
 void CSVImportDialogPage::update_preview()
@@ -195,6 +195,7 @@ Result<NonnullRefPtrVector<Sheet>, String> ImportDialog::make_and_run_for(String
             NonnullRefPtrVector<Sheet> sheets;
 
             if (reader.has_value()) {
+                reader->parse();
                 if (reader.value().has_error())
                     return String::formatted("CSV Import failed: {}", reader.value().error_string());
 

--- a/Userland/Applications/Spreadsheet/Readers/Test/TestXSV.cpp
+++ b/Userland/Applications/Spreadsheet/Readers/Test/TestXSV.cpp
@@ -18,6 +18,7 @@ TEST_CASE(should_parse_valid_data)
                       4, 5, 6
                       """x", y"z, 9)~~~";
         auto csv = Reader::CSV { data, Reader::default_behaviours() | Reader::ParserBehaviour::ReadHeaders | Reader::ParserBehaviour::TrimLeadingFieldSpaces };
+        csv.parse();
         EXPECT(!csv.has_error());
 
         EXPECT_EQ(csv[0]["Foo"], "1");
@@ -31,6 +32,7 @@ TEST_CASE(should_parse_valid_data)
                       4, "5 "       , 6
                       """x", y"z, 9                       )~~~";
         auto csv = Reader::CSV { data, Reader::default_behaviours() | Reader::ParserBehaviour::ReadHeaders | Reader::ParserBehaviour::TrimLeadingFieldSpaces | Reader::ParserBehaviour::TrimTrailingFieldSpaces };
+        csv.parse();
         EXPECT(!csv.has_error());
 
         EXPECT_EQ(csv[0]["Foo"], "1");
@@ -46,6 +48,7 @@ TEST_CASE(should_fail_nicely)
         auto data = R"~~~(Foo, Bar, Baz
                       x, y)~~~";
         auto csv = Reader::CSV { data, Reader::default_behaviours() | Reader::ParserBehaviour::ReadHeaders | Reader::ParserBehaviour::TrimLeadingFieldSpaces };
+        csv.parse();
         EXPECT(csv.has_error());
         EXPECT_EQ(csv.error(), Reader::ReadError::NonConformingColumnCount);
     }
@@ -54,6 +57,7 @@ TEST_CASE(should_fail_nicely)
         auto data = R"~~~(Foo, Bar, Baz
                       x, y, "z)~~~";
         auto csv = Reader::CSV { data, Reader::default_behaviours() | Reader::ParserBehaviour::ReadHeaders | Reader::ParserBehaviour::TrimLeadingFieldSpaces };
+        csv.parse();
         EXPECT(csv.has_error());
         EXPECT_EQ(csv.error(), Reader::ReadError::QuoteFailure);
     }
@@ -66,6 +70,7 @@ TEST_CASE(should_iterate_rows)
                       4, 5, 6
                       """x", y"z, 9)~~~";
     auto csv = Reader::CSV { data, Reader::default_behaviours() | Reader::ParserBehaviour::ReadHeaders | Reader::ParserBehaviour::TrimLeadingFieldSpaces };
+    csv.parse();
     EXPECT(!csv.has_error());
 
     bool ran = false;
@@ -82,6 +87,7 @@ BENCHMARK_CASE(fairly_big_data)
 
     auto data = file_or_error.value()->read_all();
     auto csv = Reader::CSV { data, Reader::default_behaviours() | Reader::ParserBehaviour::ReadHeaders };
+    csv.parse();
 
     EXPECT(!csv.has_error());
     EXPECT_EQ(csv.size(), 100000u);

--- a/Userland/Applications/Spreadsheet/Readers/XSV.cpp
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.cpp
@@ -11,12 +11,12 @@ namespace Reader {
 
 ParserBehaviour operator&(ParserBehaviour left, ParserBehaviour right)
 {
-    return static_cast<ParserBehaviour>(static_cast<u32>(left) & static_cast<u32>(right));
+    return static_cast<ParserBehaviour>(to_underlying(left) & to_underlying(right));
 }
 
 ParserBehaviour operator|(ParserBehaviour left, ParserBehaviour right)
 {
-    return static_cast<ParserBehaviour>(static_cast<u32>(left) | static_cast<u32>(right));
+    return static_cast<ParserBehaviour>(to_underlying(left) | to_underlying(right));
 }
 
 void XSV::set_error(ReadError error)
@@ -43,8 +43,22 @@ Vector<String> XSV::headers() const
     return headers;
 }
 
+void XSV::parse_preview()
+{
+    reset();
+    if ((m_behaviours & ParserBehaviour::ReadHeaders) != ParserBehaviour::None)
+        read_headers();
+
+    while (!has_error() && !m_lexer.is_eof()) {
+        if (m_rows.size() >= 10)
+            break;
+        m_rows.append(read_row());
+    }
+}
+
 void XSV::parse()
 {
+    reset();
     if ((m_behaviours & ParserBehaviour::ReadHeaders) != ParserBehaviour::None)
         read_headers();
 

--- a/Userland/Applications/Spreadsheet/Readers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.h
@@ -59,17 +59,18 @@ constexpr ParserBehaviour default_behaviours()
 
 class XSV {
 public:
-    XSV(StringView source, const ParserTraits& traits, ParserBehaviour behaviours = default_behaviours())
+    XSV(StringView source, ParserTraits traits, ParserBehaviour behaviours = default_behaviours())
         : m_source(source)
         , m_lexer(m_source)
         , m_traits(traits)
         , m_behaviours(behaviours)
     {
-        parse();
+        parse_preview();
     }
 
     virtual ~XSV() { }
 
+    void parse();
     bool has_error() const { return m_error != ReadError::None; }
     ReadError error() const { return m_error; }
     String error_string() const
@@ -180,8 +181,15 @@ private:
         }
     };
     void set_error(ReadError error);
-    void parse();
+    void parse_preview();
     void read_headers();
+    void reset()
+    {
+        m_lexer = GenericLexer { m_source };
+        m_rows.clear();
+        m_names.clear();
+        m_error = ReadError::None;
+    }
     Vector<Field> read_row(bool header_row = false);
     Field read_one_field();
     Field read_one_quoted_field();
@@ -189,7 +197,7 @@ private:
 
     StringView m_source;
     GenericLexer m_lexer;
-    const ParserTraits& m_traits;
+    ParserTraits m_traits;
     ParserBehaviour m_behaviours;
     Vector<Field> m_names;
     Vector<Vector<Field>> m_rows;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -209,8 +209,12 @@ Optional<Position> Sheet::parse_cell_name(const StringView& name) const
 Optional<size_t> Sheet::column_index(const StringView& column_name) const
 {
     auto index = convert_from_string(column_name);
-    if (m_columns.size() <= index || m_columns[index] != column_name)
-        return {};
+    if (m_columns.size() <= index || m_columns[index] != column_name) {
+        auto it = m_columns.find(column_name);
+        if (it == m_columns.end())
+            return {};
+        index = it.index();
+    }
 
     return index;
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -83,14 +83,13 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
         ScopeGuard sheet_update_enabler { [&] { sheet.enable_updates(); } };
 
         auto holding_left_button = !!(event.buttons() & GUI::MouseButton::Left);
-        auto rect = content_rect(index);
-        auto distance = rect.center().absolute_relative_distance_to(event.position());
-        if (distance.x() >= rect.width() / 2 - 5 && distance.y() >= rect.height() / 2 - 5) {
+        if (m_is_dragging_for_copy) {
             set_override_cursor(Gfx::StandardCursor::Crosshair);
             m_should_intercept_drag = false;
             if (holding_left_button) {
                 m_has_committed_to_dragging = true;
                 // Force a drag to happen by moving the mousedown position to the center of the cell.
+                auto rect = content_rect(index);
                 m_left_mousedown_position = rect.center();
             }
         } else if (!m_should_intercept_drag) {
@@ -123,6 +122,17 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
     }
 
     TableView::mousemove_event(event);
+}
+
+void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
+{
+    if (this->model()) {
+        auto index = index_at_event_position(event.position());
+        auto rect = content_rect(index);
+        auto distance = rect.center().absolute_relative_distance_to(event.position());
+        m_is_dragging_for_copy = distance.x() >= rect.width() / 2 - 5 && distance.y() >= rect.height() / 2 - 5;
+    }
+    AbstractTableView::mousedown_event(event);
 }
 
 void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -73,10 +73,12 @@ private:
     }
     virtual void did_scroll() override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
 
     bool m_should_intercept_drag { false };
     bool m_has_committed_to_dragging { false };
+    bool m_is_dragging_for_copy { false };
     GUI::ModelIndex m_starting_selection_index;
     RefPtr<Core::Timer> m_horizontal_scroll_end_timer;
     RefPtr<Core::Timer> m_vertical_scroll_end_timer;


### PR DESCRIPTION
- Fixes #4277.
- Un-borks conditional formatting
- Allows the user to address custom column names
- Makes the XSV parser parse only 10 rows for preview purposes, and exposes `.parse()` for a full parse.