### PR TITLE
Kernel: Use KResultOr<size_t> throughout the TTY subsystem

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -289,7 +289,7 @@ KResultOr<size_t> KeyboardDevice::read(FileDescription&, u64, UserOrKernelBuffer
         if (m_queue.is_empty())
             break;
         // Don't return partial data frames.
-        if ((size - nread) < (ssize_t)sizeof(Event))
+        if (size - nread < sizeof(Event))
             break;
         auto event = m_queue.dequeue();
 

--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -18,19 +18,19 @@ class DoubleBuffer {
 public:
     explicit DoubleBuffer(size_t capacity = 65536);
 
-    [[nodiscard]] ssize_t write(const UserOrKernelBuffer&, size_t);
-    [[nodiscard]] ssize_t write(const u8* data, size_t size)
+    [[nodiscard]] KResultOr<size_t> write(const UserOrKernelBuffer&, size_t);
+    [[nodiscard]] KResultOr<size_t> write(const u8* data, size_t size)
     {
         return write(UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data)), size);
     }
-    [[nodiscard]] ssize_t read(UserOrKernelBuffer&, size_t);
-    [[nodiscard]] ssize_t read(u8* data, size_t size)
+    [[nodiscard]] KResultOr<size_t> read(UserOrKernelBuffer&, size_t);
+    [[nodiscard]] KResultOr<size_t> read(u8* data, size_t size)
     {
         auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
         return read(buffer, size);
     }
-    [[nodiscard]] ssize_t peek(UserOrKernelBuffer&, size_t);
-    [[nodiscard]] ssize_t peek(u8* data, size_t size)
+    [[nodiscard]] KResultOr<size_t> peek(UserOrKernelBuffer&, size_t);
+    [[nodiscard]] KResultOr<size_t> peek(u8* data, size_t size)
     {
         auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
         return peek(buffer, size);

--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -81,7 +81,7 @@ DevFSInode::DevFSInode(DevFS& fs)
 {
 }
 
-KResultOr<ssize_t> DevFSInode::read_bytes(off_t, ssize_t, UserOrKernelBuffer&, FileDescription*) const
+KResultOr<size_t> DevFSInode::read_bytes(off_t, size_t, UserOrKernelBuffer&, FileDescription*) const
 {
     VERIFY_NOT_REACHED();
 }
@@ -100,7 +100,7 @@ void DevFSInode::flush_metadata()
 {
 }
 
-KResultOr<ssize_t> DevFSInode::write_bytes(off_t, ssize_t, const UserOrKernelBuffer&, FileDescription*)
+KResultOr<size_t> DevFSInode::write_bytes(off_t, size_t, const UserOrKernelBuffer&, FileDescription*)
 {
     VERIFY_NOT_REACHED();
 }
@@ -152,7 +152,7 @@ DevFSLinkInode::DevFSLinkInode(DevFS& fs, String name)
     , m_name(name)
 {
 }
-KResultOr<ssize_t> DevFSLinkInode::read_bytes(off_t offset, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const
+KResultOr<size_t> DevFSLinkInode::read_bytes(off_t offset, size_t, UserOrKernelBuffer& buffer, FileDescription*) const
 {
     Locker locker(m_lock);
     VERIFY(offset == 0);
@@ -173,7 +173,7 @@ InodeMetadata DevFSLinkInode::metadata() const
     metadata.mtime = mepoch;
     return metadata;
 }
-KResultOr<ssize_t> DevFSLinkInode::write_bytes(off_t offset, ssize_t count, const UserOrKernelBuffer& buffer, FileDescription*)
+KResultOr<size_t> DevFSLinkInode::write_bytes(off_t offset, size_t count, const UserOrKernelBuffer& buffer, FileDescription*)
 {
     Locker locker(m_lock);
     VERIFY(offset == 0);
@@ -350,7 +350,7 @@ String DevFSDeviceInode::name() const
     return m_cached_name;
 }
 
-KResultOr<ssize_t> DevFSDeviceInode::read_bytes(off_t offset, ssize_t count, UserOrKernelBuffer& buffer, FileDescription* description) const
+KResultOr<size_t> DevFSDeviceInode::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, FileDescription* description) const
 {
     Locker locker(m_lock);
     VERIFY(!!description);
@@ -376,7 +376,7 @@ InodeMetadata DevFSDeviceInode::metadata() const
     metadata.minor_device = m_attached_device->minor();
     return metadata;
 }
-KResultOr<ssize_t> DevFSDeviceInode::write_bytes(off_t offset, ssize_t count, const UserOrKernelBuffer& buffer, FileDescription* description)
+KResultOr<size_t> DevFSDeviceInode::write_bytes(off_t offset, size_t count, const UserOrKernelBuffer& buffer, FileDescription* description)
 {
     Locker locker(m_lock);
     VERIFY(!!description);

--- a/Kernel/FileSystem/DevFS.h
+++ b/Kernel/FileSystem/DevFS.h
@@ -57,11 +57,11 @@ public:
 
 protected:
     DevFSInode(DevFS&);
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
@@ -83,9 +83,9 @@ private:
     String determine_name() const;
     DevFSDeviceInode(DevFS&, const Device&);
     // ^Inode
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResult chown(uid_t, gid_t) override;
 
     NonnullRefPtr<Device> m_attached_device;
@@ -106,9 +106,9 @@ public:
 protected:
     DevFSLinkInode(DevFS&, String);
     // ^Inode
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
 
     const String m_name;
     String m_link;

--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -100,12 +100,12 @@ DevPtsFSInode::~DevPtsFSInode()
 {
 }
 
-KResultOr<ssize_t> DevPtsFSInode::read_bytes(off_t, ssize_t, UserOrKernelBuffer&, FileDescription*) const
+KResultOr<size_t> DevPtsFSInode::read_bytes(off_t, size_t, UserOrKernelBuffer&, FileDescription*) const
 {
     VERIFY_NOT_REACHED();
 }
 
-KResultOr<ssize_t> DevPtsFSInode::write_bytes(off_t, ssize_t, const UserOrKernelBuffer&, FileDescription*)
+KResultOr<size_t> DevPtsFSInode::write_bytes(off_t, size_t, const UserOrKernelBuffer&, FileDescription*)
 {
     VERIFY_NOT_REACHED();
 }

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -47,12 +47,12 @@ private:
     DevPtsFSInode(DevPtsFS&, InodeIndex, SlavePTY*);
 
     // ^Inode
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -38,12 +38,12 @@ public:
 
 private:
     // ^Inode
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& data, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& data, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode& child, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -203,7 +203,7 @@ KResultOr<NonnullOwnPtr<KBuffer>> FileDescription::read_entire_file()
     return m_inode->read_entire(this);
 }
 
-KResultOr<ssize_t> FileDescription::get_dir_entries(UserOrKernelBuffer& output_buffer, ssize_t size)
+KResultOr<size_t> FileDescription::get_dir_entries(UserOrKernelBuffer& output_buffer, size_t size)
 {
     Locker locker(m_lock, Lock::Mode::Shared);
     if (!is_directory())
@@ -212,9 +212,6 @@ KResultOr<ssize_t> FileDescription::get_dir_entries(UserOrKernelBuffer& output_b
     auto metadata = this->metadata();
     if (!metadata.is_valid())
         return EIO;
-
-    if (size < 0)
-        return EINVAL;
 
     size_t remaining = size;
     KResult error = KSuccess;

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -56,7 +56,7 @@ public:
     bool can_read() const;
     bool can_write() const;
 
-    KResultOr<ssize_t> get_dir_entries(UserOrKernelBuffer& buffer, ssize_t);
+    KResultOr<size_t> get_dir_entries(UserOrKernelBuffer& buffer, size_t);
 
     KResultOr<NonnullOwnPtr<KBuffer>> read_entire_file();
 

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -51,7 +51,7 @@ KResultOr<NonnullOwnPtr<KBuffer>> Inode::read_entire(FileDescription* descriptio
 {
     KBufferBuilder builder;
 
-    ssize_t nread;
+    size_t nread;
     u8 buffer[4096];
     off_t offset = 0;
     for (;;) {
@@ -60,17 +60,13 @@ KResultOr<NonnullOwnPtr<KBuffer>> Inode::read_entire(FileDescription* descriptio
         if (result.is_error())
             return result.error();
         nread = result.value();
-        VERIFY(nread <= (ssize_t)sizeof(buffer));
+        VERIFY(nread <= sizeof(buffer));
         if (nread <= 0)
             break;
         builder.append((const char*)buffer, nread);
         offset += nread;
-        if (nread < (ssize_t)sizeof(buffer))
+        if (nread < sizeof(buffer))
             break;
-    }
-    if (nread < 0) {
-        dmesgln("Inode::read_entire: Error: {}", nread);
-        return KResult((ErrnoCode)-nread);
     }
 
     auto entire_file = builder.build();

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -52,10 +52,10 @@ public:
     virtual KResult attach(FileDescription&) { return KSuccess; }
     virtual void detach(FileDescription&) { }
     virtual void did_seek(FileDescription&, off_t) { }
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const = 0;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const = 0;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const = 0;
     virtual RefPtr<Inode> lookup(StringView name) = 0;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& data, FileDescription*) = 0;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& data, FileDescription*) = 0;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) = 0;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) = 0;
     virtual KResult remove_child(const StringView& name) = 0;

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -171,7 +171,7 @@ public:
 
     const KBuffer& build();
 
-    static constexpr ssize_t max_header_size = 24;
+    static constexpr size_t max_header_size = 24;
 
 private:
     template<typename N>
@@ -634,9 +634,9 @@ KResult Plan9FS::post_message_and_wait_for_a_reply(Message& message)
     }
 }
 
-ssize_t Plan9FS::adjust_buffer_size(ssize_t size) const
+size_t Plan9FS::adjust_buffer_size(size_t size) const
 {
-    ssize_t max_size = m_max_message_size - Message::max_header_size;
+    size_t max_size = m_max_message_size - Message::max_header_size;
     return min(size, max_size);
 }
 
@@ -728,7 +728,7 @@ KResult Plan9FSInode::ensure_open_for_mode(int mode)
     }
 }
 
-KResultOr<ssize_t> Plan9FSInode::read_bytes(off_t offset, ssize_t size, UserOrKernelBuffer& buffer, FileDescription*) const
+KResultOr<size_t> Plan9FSInode::read_bytes(off_t offset, size_t size, UserOrKernelBuffer& buffer, FileDescription*) const
 {
     auto result = const_cast<Plan9FSInode&>(*this).ensure_open_for_mode(O_RDONLY);
     if (result.is_error())
@@ -767,7 +767,7 @@ KResultOr<ssize_t> Plan9FSInode::read_bytes(off_t offset, ssize_t size, UserOrKe
     return nread;
 }
 
-KResultOr<ssize_t> Plan9FSInode::write_bytes(off_t offset, ssize_t size, const UserOrKernelBuffer& data, FileDescription*)
+KResultOr<size_t> Plan9FSInode::write_bytes(off_t offset, size_t size, const UserOrKernelBuffer& data, FileDescription*)
 {
     auto result = ensure_open_for_mode(O_WRONLY);
     if (result.is_error())

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -123,7 +123,7 @@ private:
     KResult post_message_and_explicitly_ignore_reply(Message&);
 
     ProtocolVersion parse_protocol_version(const StringView&) const;
-    ssize_t adjust_buffer_size(ssize_t size) const;
+    size_t adjust_buffer_size(size_t size) const;
 
     void thread_main();
     void ensure_thread();
@@ -156,8 +156,8 @@ public:
     // ^Inode
     virtual InodeMetadata metadata() const override;
     virtual void flush_metadata() override;
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& data, FileDescription*) override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& data, FileDescription*) override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -38,7 +38,7 @@ private:
 
     struct ProcFSDirectoryEntry {
         ProcFSDirectoryEntry() = default;
-        ProcFSDirectoryEntry(const char* a_name, unsigned a_proc_file_type, bool a_supervisor_only, bool (*read_callback)(InodeIdentifier, KBufferBuilder&) = nullptr, ssize_t (*write_callback)(InodeIdentifier, const UserOrKernelBuffer&, size_t) = nullptr, RefPtr<ProcFSInode>&& a_inode = nullptr)
+        ProcFSDirectoryEntry(const char* a_name, unsigned a_proc_file_type, bool a_supervisor_only, bool (*read_callback)(InodeIdentifier, KBufferBuilder&) = nullptr, KResultOr<size_t> (*write_callback)(InodeIdentifier, const UserOrKernelBuffer&, size_t) = nullptr, RefPtr<ProcFSInode>&& a_inode = nullptr)
             : name(a_name)
             , proc_file_type(a_proc_file_type)
             , supervisor_only(a_supervisor_only)
@@ -52,7 +52,7 @@ private:
         unsigned proc_file_type { 0 };
         bool supervisor_only { false };
         bool (*read_callback)(InodeIdentifier, KBufferBuilder&);
-        ssize_t (*write_callback)(InodeIdentifier, const UserOrKernelBuffer&, size_t);
+        KResultOr<size_t> (*write_callback)(InodeIdentifier, const UserOrKernelBuffer&, size_t);
         RefPtr<ProcFSInode> inode;
         InodeIdentifier identifier(unsigned fsid) const;
     };
@@ -77,12 +77,12 @@ private:
     // ^Inode
     virtual KResult attach(FileDescription&) override;
     virtual void did_seek(FileDescription&, off_t) override;
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
@@ -111,12 +111,12 @@ private:
     // ^Inode
     virtual KResult attach(FileDescription&) override;
     virtual void did_seek(FileDescription&, off_t) override;
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer&, FileDescription*) const override { VERIFY_NOT_REACHED(); }
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, FileDescription*) const override { VERIFY_NOT_REACHED(); }
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override { VERIFY_NOT_REACHED(); }
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override {};
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer&, FileDescription*) override { VERIFY_NOT_REACHED(); }
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer&, FileDescription*) override { VERIFY_NOT_REACHED(); }
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -127,11 +127,10 @@ KResult TmpFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry
     return KSuccess;
 }
 
-KResultOr<ssize_t> TmpFSInode::read_bytes(off_t offset, ssize_t size, UserOrKernelBuffer& buffer, FileDescription*) const
+KResultOr<size_t> TmpFSInode::read_bytes(off_t offset, size_t size, UserOrKernelBuffer& buffer, FileDescription*) const
 {
     Locker locker(m_lock, Lock::Mode::Shared);
     VERIFY(!is_directory());
-    VERIFY(size >= 0);
     VERIFY(offset >= 0);
 
     if (!m_content)
@@ -148,7 +147,7 @@ KResultOr<ssize_t> TmpFSInode::read_bytes(off_t offset, ssize_t size, UserOrKern
     return size;
 }
 
-KResultOr<ssize_t> TmpFSInode::write_bytes(off_t offset, ssize_t size, const UserOrKernelBuffer& buffer, FileDescription*)
+KResultOr<size_t> TmpFSInode::write_bytes(off_t offset, size_t size, const UserOrKernelBuffer& buffer, FileDescription*)
 {
     Locker locker(m_lock);
     VERIFY(!is_directory());

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -54,12 +54,12 @@ public:
     const TmpFS& fs() const { return static_cast<const TmpFS&>(Inode::fs()); }
 
     // ^Inode
-    virtual KResultOr<ssize_t> read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual KResultOr<ssize_t> write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
+    virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -97,7 +97,7 @@ private:
     };
 
     Atomic<FreeSlab*> m_freelist { nullptr };
-    Atomic<ssize_t, AK::MemoryOrder::memory_order_relaxed> m_num_allocated;
+    Atomic<size_t, AK::MemoryOrder::memory_order_relaxed> m_num_allocated;
     size_t m_slab_count;
     void* m_base { nullptr };
     void* m_end { nullptr };

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -270,17 +270,17 @@ KResultOr<size_t> IPv4Socket::receive_byte_buffered(FileDescription& description
 
     VERIFY(!m_receive_buffer.is_empty());
 
-    int nreceived;
+    KResultOr<size_t> nreceived_or_error { 0 };
     if (flags & MSG_PEEK)
-        nreceived = m_receive_buffer.peek(buffer, buffer_length);
+        nreceived_or_error = m_receive_buffer.peek(buffer, buffer_length);
     else
-        nreceived = m_receive_buffer.read(buffer, buffer_length);
+        nreceived_or_error = m_receive_buffer.read(buffer, buffer_length);
 
-    if (nreceived > 0 && !(flags & MSG_PEEK))
-        Thread::current()->did_ipv4_socket_read((size_t)nreceived);
+    if (!nreceived_or_error.is_error() && nreceived_or_error.value() > 0 && !(flags & MSG_PEEK))
+        Thread::current()->did_ipv4_socket_read(nreceived_or_error.value());
 
     set_can_read(!m_receive_buffer.is_empty());
-    return nreceived;
+    return nreceived_or_error;
 }
 
 KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& description, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*> addr, Userspace<socklen_t*> addr_length, Time& packet_timestamp)
@@ -418,8 +418,8 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
         auto nreceived_or_error = protocol_receive(ReadonlyBytes { packet.data(), packet.size() }, scratch_buffer, m_scratch_buffer.value().size(), 0);
         if (nreceived_or_error.is_error())
             return false;
-        ssize_t nwritten = m_receive_buffer.write(scratch_buffer, nreceived_or_error.value());
-        if (nwritten < 0)
+        auto nwritten_or_error = m_receive_buffer.write(scratch_buffer, nreceived_or_error.value());
+        if (nwritten_or_error.is_error())
             return false;
         set_can_read(!m_receive_buffer.is_empty());
     } else {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -270,7 +270,7 @@ public:
     KResultOr<int> sys$inode_watcher_add_watch(Userspace<const Syscall::SC_inode_watcher_add_watch_params*> user_params);
     KResultOr<int> sys$inode_watcher_remove_watch(int fd, int wd);
     KResultOr<int> sys$dbgputch(u8);
-    KResultOr<size_t> sys$dbgputstr(Userspace<const u8*>, int length);
+    KResultOr<size_t> sys$dbgputstr(Userspace<const u8*>, size_t);
     KResultOr<int> sys$dump_backtrace();
     KResultOr<pid_t> sys$gettid();
     KResultOr<int> sys$donate(pid_t tid);
@@ -290,10 +290,10 @@ public:
     KResultOr<mode_t> sys$umask(mode_t);
     KResultOr<int> sys$open(Userspace<const Syscall::SC_open_params*>);
     KResultOr<int> sys$close(int fd);
-    KResultOr<ssize_t> sys$read(int fd, Userspace<u8*>, ssize_t);
-    KResultOr<ssize_t> sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count);
-    KResultOr<ssize_t> sys$write(int fd, Userspace<const u8*>, ssize_t);
-    KResultOr<ssize_t> sys$writev(int fd, Userspace<const struct iovec*> iov, int iov_count);
+    KResultOr<size_t> sys$read(int fd, Userspace<u8*>, size_t);
+    KResultOr<size_t> sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count);
+    KResultOr<size_t> sys$write(int fd, Userspace<const u8*>, size_t);
+    KResultOr<size_t> sys$writev(int fd, Userspace<const struct iovec*> iov, int iov_count);
     KResultOr<int> sys$fstat(int fd, Userspace<stat*>);
     KResultOr<int> sys$stat(Userspace<const Syscall::SC_stat_params*>);
     KResultOr<int> sys$lseek(int fd, Userspace<off_t*>, int whence);
@@ -312,7 +312,7 @@ public:
     KResultOr<int> sys$purge(int mode);
     KResultOr<int> sys$select(Userspace<const Syscall::SC_select_params*>);
     KResultOr<int> sys$poll(Userspace<const Syscall::SC_poll_params*>);
-    KResultOr<ssize_t> sys$get_dir_entries(int fd, Userspace<void*>, ssize_t);
+    KResultOr<size_t> sys$get_dir_entries(int fd, Userspace<void*>, size_t);
     KResultOr<int> sys$getcwd(Userspace<char*>, size_t);
     KResultOr<int> sys$chdir(Userspace<const char*>, size_t);
     KResultOr<int> sys$fchdir(int fd);
@@ -321,8 +321,8 @@ public:
     KResultOr<int> sys$clock_gettime(clockid_t, Userspace<timespec*>);
     KResultOr<int> sys$clock_settime(clockid_t, Userspace<const timespec*>);
     KResultOr<int> sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
-    KResultOr<int> sys$gethostname(Userspace<char*>, ssize_t);
-    KResultOr<int> sys$sethostname(Userspace<const char*>, ssize_t);
+    KResultOr<int> sys$gethostname(Userspace<char*>, size_t);
+    KResultOr<int> sys$sethostname(Userspace<const char*>, size_t);
     KResultOr<int> sys$uname(Userspace<utsname*>);
     KResultOr<int> sys$readlink(Userspace<const Syscall::SC_readlink_params*>);
     KResultOr<int> sys$ttyname(int fd, Userspace<char*>, size_t);
@@ -333,8 +333,8 @@ public:
     KResultOr<int> sys$sigaction(int signum, Userspace<const sigaction*> act, Userspace<sigaction*> old_act);
     KResultOr<int> sys$sigprocmask(int how, Userspace<const sigset_t*> set, Userspace<sigset_t*> old_set);
     KResultOr<int> sys$sigpending(Userspace<sigset_t*>);
-    KResultOr<int> sys$getgroups(ssize_t, Userspace<gid_t*>);
-    KResultOr<int> sys$setgroups(ssize_t, Userspace<const gid_t*>);
+    KResultOr<int> sys$getgroups(size_t, Userspace<gid_t*>);
+    KResultOr<int> sys$setgroups(size_t, Userspace<const gid_t*>);
     KResultOr<int> sys$pipe(int pipefd[2], int flags);
     KResultOr<int> sys$killpg(pid_t pgrp, int sig);
     KResultOr<int> sys$seteuid(uid_t);
@@ -367,8 +367,8 @@ public:
     KResultOr<int> sys$accept4(Userspace<const Syscall::SC_accept4_params*>);
     KResultOr<int> sys$connect(int sockfd, Userspace<const sockaddr*>, socklen_t);
     KResultOr<int> sys$shutdown(int sockfd, int how);
-    KResultOr<ssize_t> sys$sendmsg(int sockfd, Userspace<const struct msghdr*>, int flags);
-    KResultOr<ssize_t> sys$recvmsg(int sockfd, Userspace<struct msghdr*>, int flags);
+    KResultOr<size_t> sys$sendmsg(int sockfd, Userspace<const struct msghdr*>, int flags);
+    KResultOr<size_t> sys$recvmsg(int sockfd, Userspace<struct msghdr*>, int flags);
     KResultOr<int> sys$getsockopt(Userspace<const Syscall::SC_getsockopt_params*>);
     KResultOr<int> sys$setsockopt(Userspace<const Syscall::SC_setsockopt_params*>);
     KResultOr<int> sys$getsockname(Userspace<const Syscall::SC_getsockname_params*>);
@@ -529,7 +529,7 @@ private:
     void delete_perf_events_buffer();
 
     KResult do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags, const Elf32_Ehdr& main_program_header);
-    KResultOr<ssize_t> do_write(FileDescription&, const UserOrKernelBuffer&, size_t);
+    KResultOr<size_t> do_write(FileDescription&, const UserOrKernelBuffer&, size_t);
 
     KResultOr<int> do_statvfs(String path, statvfs* buf);
 

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -41,7 +41,7 @@ KResultOr<size_t> StorageDevice::read(FileDescription&, u64 offset, UserOrKernel
 {
     unsigned index = offset / block_size();
     u16 whole_blocks = len / block_size();
-    ssize_t remaining = len % block_size();
+    size_t remaining = len % block_size();
 
     unsigned blocks_per_page = PAGE_SIZE / block_size();
 
@@ -106,7 +106,7 @@ KResultOr<size_t> StorageDevice::write(FileDescription&, u64 offset, const UserO
 {
     unsigned index = offset / block_size();
     u16 whole_blocks = len / block_size();
-    ssize_t remaining = len % block_size();
+    size_t remaining = len % block_size();
 
     unsigned blocks_per_page = PAGE_SIZE / block_size();
 

--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -21,6 +21,9 @@ KResultOr<int> Process::sys$anon_create(size_t size, int options)
     if (size % PAGE_SIZE)
         return EINVAL;
 
+    if (size > NumericLimits<ssize_t>::max())
+        return EINVAL;
+
     int new_fd = alloc_fd();
     if (new_fd < 0)
         return new_fd;

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -45,6 +45,9 @@ KResultOr<int> Process::sys$getcwd(Userspace<char*> buffer, size_t size)
 {
     REQUIRE_PROMISE(rpath);
 
+    if (size > NumericLimits<ssize_t>::max())
+        return EINVAL;
+
     auto path = current_directory().absolute_path();
 
     size_t ideal_size = path.length() + 1;

--- a/Kernel/Syscalls/get_dir_entries.cpp
+++ b/Kernel/Syscalls/get_dir_entries.cpp
@@ -9,10 +9,10 @@
 
 namespace Kernel {
 
-KResultOr<ssize_t> Process::sys$get_dir_entries(int fd, Userspace<void*> user_buffer, ssize_t user_size)
+KResultOr<size_t> Process::sys$get_dir_entries(int fd, Userspace<void*> user_buffer, size_t user_size)
 {
     REQUIRE_PROMISE(stdio);
-    if (user_size < 0)
+    if (user_size > NumericLimits<ssize_t>::max())
         return EINVAL;
     auto description = file_description(fd);
     if (!description)

--- a/Kernel/Syscalls/getrandom.cpp
+++ b/Kernel/Syscalls/getrandom.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 KResultOr<size_t> Process::sys$getrandom(Userspace<void*> buffer, size_t buffer_size, [[maybe_unused]] unsigned flags)
 {
     REQUIRE_PROMISE(stdio);
-    if (buffer_size <= 0)
+    if (buffer_size > NumericLimits<ssize_t>::max())
         return EINVAL;
 
     auto data_buffer = UserOrKernelBuffer::for_user_buffer(buffer, buffer_size);

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -48,14 +48,12 @@ KResultOr<int> Process::sys$getresgid(Userspace<gid_t*> rgid, Userspace<gid_t*> 
     return 0;
 }
 
-KResultOr<int> Process::sys$getgroups(ssize_t count, Userspace<gid_t*> user_gids)
+KResultOr<int> Process::sys$getgroups(size_t count, Userspace<gid_t*> user_gids)
 {
     REQUIRE_PROMISE(stdio);
-    if (count < 0)
-        return EINVAL;
     if (!count)
         return extra_gids().size();
-    if (count != (int)extra_gids().size())
+    if (count != extra_gids().size())
         return EINVAL;
 
     if (!copy_to_user(user_gids, extra_gids().data(), sizeof(gid_t) * count))

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -11,10 +11,10 @@ namespace Kernel {
 extern String* g_hostname;
 extern Lock* g_hostname_lock;
 
-KResultOr<int> Process::sys$gethostname(Userspace<char*> buffer, ssize_t size)
+KResultOr<int> Process::sys$gethostname(Userspace<char*> buffer, size_t size)
 {
     REQUIRE_PROMISE(stdio);
-    if (size < 0)
+    if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
     Locker locker(*g_hostname_lock, Lock::Mode::Shared);
     if ((size_t)size < (g_hostname->length() + 1))
@@ -24,13 +24,11 @@ KResultOr<int> Process::sys$gethostname(Userspace<char*> buffer, ssize_t size)
     return 0;
 }
 
-KResultOr<int> Process::sys$sethostname(Userspace<const char*> hostname, ssize_t length)
+KResultOr<int> Process::sys$sethostname(Userspace<const char*> hostname, size_t length)
 {
     REQUIRE_NO_PROMISES;
     if (!is_superuser())
         return EPERM;
-    if (length < 0)
-        return EINVAL;
     Locker locker(*g_hostname_lock, Lock::Mode::Exclusive);
     if (length > 64)
         return ENAMETOOLONG;

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 using BlockFlags = Thread::FileBlocker::BlockFlags;
 
-KResultOr<ssize_t> Process::sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count)
+KResultOr<size_t> Process::sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count)
 {
     REQUIRE_PROMISE(stdio);
     if (iov_count < 0)
@@ -68,13 +68,13 @@ KResultOr<ssize_t> Process::sys$readv(int fd, Userspace<const struct iovec*> iov
     return nread;
 }
 
-KResultOr<ssize_t> Process::sys$read(int fd, Userspace<u8*> buffer, ssize_t size)
+KResultOr<size_t> Process::sys$read(int fd, Userspace<u8*> buffer, size_t size)
 {
     REQUIRE_PROMISE(stdio);
-    if (size < 0)
-        return EINVAL;
     if (size == 0)
         return 0;
+    if (size > NumericLimits<ssize_t>::max())
+        return EINVAL;
     dbgln_if(IO_DEBUG, "sys$read({}, {}, {})", fd, buffer.ptr(), size);
     auto description = file_description(fd);
     if (!description)

--- a/Kernel/Syscalls/setuid.cpp
+++ b/Kernel/Syscalls/setuid.cpp
@@ -148,11 +148,9 @@ KResultOr<int> Process::sys$setresgid(gid_t new_rgid, gid_t new_egid, gid_t new_
     return 0;
 }
 
-KResultOr<int> Process::sys$setgroups(ssize_t count, Userspace<const gid_t*> user_gids)
+KResultOr<int> Process::sys$setgroups(size_t count, Userspace<const gid_t*> user_gids)
 {
     REQUIRE_PROMISE(id);
-    if (count < 0)
-        return EINVAL;
     if (!is_superuser())
         return EPERM;
 

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -78,10 +78,10 @@ void MasterPTY::notify_slave_closed(Badge<SlavePTY>)
         m_slave = nullptr;
 }
 
-ssize_t MasterPTY::on_slave_write(const UserOrKernelBuffer& data, ssize_t size)
+KResultOr<size_t> MasterPTY::on_slave_write(const UserOrKernelBuffer& data, size_t size)
 {
     if (m_closed)
-        return -EIO;
+        return EIO;
     return m_buffer.write(data, size);
 }
 

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -21,7 +21,7 @@ public:
 
     unsigned index() const { return m_index; }
     String pts_name() const;
-    ssize_t on_slave_write(const UserOrKernelBuffer&, ssize_t);
+    KResultOr<size_t> on_slave_write(const UserOrKernelBuffer&, size_t);
     bool can_write_from_slave() const;
     void notify_slave_closed(Badge<SlavePTY>);
     bool is_closed() const { return m_closed; }

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -40,11 +40,11 @@ void SlavePTY::echo(u8 ch)
 {
     if (should_echo_input()) {
         auto buffer = UserOrKernelBuffer::for_kernel_buffer(&ch);
-        m_master->on_slave_write(buffer, 1);
+        [[maybe_unused]] auto result = m_master->on_slave_write(buffer, 1);
     }
 }
 
-void SlavePTY::on_master_write(const UserOrKernelBuffer& buffer, ssize_t size)
+void SlavePTY::on_master_write(const UserOrKernelBuffer& buffer, size_t size)
 {
     auto result = buffer.read_buffered<128>(size, [&](u8 const* data, size_t data_size) {
         for (size_t i = 0; i < data_size; ++i)
@@ -55,7 +55,7 @@ void SlavePTY::on_master_write(const UserOrKernelBuffer& buffer, ssize_t size)
         evaluate_block_conditions();
 }
 
-ssize_t SlavePTY::on_tty_write(const UserOrKernelBuffer& data, ssize_t size)
+KResultOr<size_t> SlavePTY::on_tty_write(const UserOrKernelBuffer& data, size_t size)
 {
     m_time_of_last_write = kgettimeofday().to_truncated_seconds();
     return m_master->on_slave_write(data, size);

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -17,7 +17,7 @@ class SlavePTY final : public TTY {
 public:
     virtual ~SlavePTY() override;
 
-    void on_master_write(const UserOrKernelBuffer&, ssize_t);
+    void on_master_write(const UserOrKernelBuffer&, size_t);
     unsigned index() const { return m_index; }
 
     time_t time_of_last_write() const { return m_time_of_last_write; }
@@ -27,7 +27,7 @@ public:
 private:
     // ^TTY
     virtual String const& tty_name() const override;
-    virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) override;
+    virtual KResultOr<size_t> on_tty_write(const UserOrKernelBuffer&, size_t) override;
     virtual void echo(u8) override;
 
     // ^CharacterDevice

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -53,7 +53,7 @@ public:
     virtual mode_t required_mode() const override { return 0620; }
 
 protected:
-    virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) = 0;
+    virtual KResultOr<size_t> on_tty_write(const UserOrKernelBuffer&, size_t) = 0;
     void set_size(unsigned short columns, unsigned short rows);
 
     TTY(unsigned major, unsigned minor);

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -265,7 +265,7 @@ void VirtualConsole::on_key_pressed(KeyEvent event)
     });
 }
 
-ssize_t VirtualConsole::on_tty_write(const UserOrKernelBuffer& data, ssize_t size)
+KResultOr<size_t> VirtualConsole::on_tty_write(const UserOrKernelBuffer& data, size_t size)
 {
     ScopedSpinLock global_lock(ConsoleManagement::the().tty_write_lock());
     ScopedSpinLock lock(m_lock);
@@ -276,9 +276,7 @@ ssize_t VirtualConsole::on_tty_write(const UserOrKernelBuffer& data, ssize_t siz
     });
     if (m_active)
         flush_dirty_lines();
-    if (result.is_error())
-        return result.error();
-    return (ssize_t)result.value();
+    return result;
 }
 
 void VirtualConsole::set_active(bool active)

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -91,7 +91,7 @@ private:
     virtual void on_key_pressed(KeyEvent) override;
 
     // ^TTY
-    virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) override;
+    virtual KResultOr<size_t> on_tty_write(const UserOrKernelBuffer&, size_t) override;
     virtual String const& tty_name() const override { return m_tty_name; }
     virtual void echo(u8) override;
 

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -133,12 +133,13 @@ public:
             auto to_copy = min(sizeof(buffer), len - nread);
             if (!read(buffer, nread, to_copy))
                 return EFAULT;
-            ssize_t copied = f(buffer, to_copy);
-            if (copied < 0)
-                return copied;
-            VERIFY((size_t)copied <= to_copy);
-            nread += (size_t)copied;
-            if ((size_t)copied < to_copy)
+            KResultOr<size_t> copied_or_error = f(buffer, to_copy);
+            if (copied_or_error.is_error())
+                return copied_or_error.error();
+            auto copied = copied_or_error.value();
+            VERIFY(copied <= to_copy);
+            nread += copied;
+            if (copied < to_copy)
                 break;
         }
         return nread;

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -44,7 +44,7 @@ public:
     [[nodiscard]] bool is_kernel_buffer() const;
     [[nodiscard]] const void* user_or_kernel_ptr() const { return m_buffer; }
 
-    [[nodiscard]] UserOrKernelBuffer offset(ssize_t offset) const
+    [[nodiscard]] UserOrKernelBuffer offset(size_t offset) const
     {
         if (!m_buffer)
             return *this;
@@ -97,9 +97,10 @@ public:
         size_t nwritten = 0;
         while (nwritten < len) {
             auto to_copy = min(sizeof(buffer), len - nwritten);
-            ssize_t copied = f(buffer, to_copy);
-            if (copied < 0)
-                return copied;
+            KResultOr<size_t> copied_or_error = f(buffer, to_copy);
+            if (copied_or_error.is_error())
+                return copied_or_error.error();
+            auto copied = copied_or_error.value();
             VERIFY((size_t)copied <= to_copy);
             if (!write(buffer, nwritten, (size_t)copied))
                 return EFAULT;

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -541,7 +541,7 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region, Scoped
     // Reading the page may block, so release the MM lock temporarily
     mm_lock.unlock();
 
-    KResultOr<ssize_t> result(KSuccess);
+    KResultOr<size_t> result(KSuccess);
     {
         ScopedLockRelease release_paging_lock(vmobject().m_paging_lock);
         auto buffer = UserOrKernelBuffer::for_kernel_buffer(page_buffer);


### PR DESCRIPTION
**Kernel: Use KResultOr<size_t> throughout the TTY subsystem**

Previously the `VirtualConsole::on_tty_write()` method would return an incorrect value when an error had occurred. This prompted me to update the TTY subsystem to use `KResultOr<size_t>` everywhere.

**Kernel: Use KResultOr<size_t> for the DoubleBuffer class**

**Kernel: Remove various other uses of ssize_t**