### PR TITLE
Kernel: Correctly decode proc_file_type from identifier

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -126,13 +126,13 @@ static inline ProcParentDirectory to_proc_parent_directory(const InodeIdentifier
 
 static inline ProcFileType to_proc_file_type(const InodeIdentifier& identifier)
 {
-    return (ProcFileType)(identifier.index().value() & 0xff);
+    return (ProcFileType)(identifier.index().value() & 0xfff);
 }
 
 static inline int to_fd(const InodeIdentifier& identifier)
 {
     VERIFY(to_proc_parent_directory(identifier) == PDI_PID_fd);
-    return (identifier.index().value() & 0xff) - FI_MaxStaticFileIndex;
+    return (identifier.index().value() & 0xfff) - FI_MaxStaticFileIndex;
 }
 
 static inline size_t to_sys_index(const InodeIdentifier& identifier)

--- a/Tests/Kernel/TestProcFS.cpp
+++ b/Tests/Kernel/TestProcFS.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <cstring>
+#include <unistd.h>
+
+TEST_CASE(test_process_fd_readlink)
+{
+    char expected_link[MAXPATHLEN];
+    char buf[MAXPATHLEN];
+
+    // Read the symlink value for stdin, stdout and stderr
+    auto link_length = readlink("/proc/self/fd/0", expected_link, sizeof(expected_link));
+    expected_link[link_length] = '\0';
+
+    link_length = readlink("/proc/self/fd/1", buf, sizeof(buf));
+    buf[link_length] = '\0';
+    EXPECT_EQ(0, strcmp(buf, expected_link));
+
+    link_length = readlink("/proc/self/fd/2", buf, sizeof(buf));
+    buf[link_length] = '\0';
+    EXPECT_EQ(0, strcmp(buf, expected_link));
+
+    // Create a new file descriptor that is a dup of 0 with various big values in order to reproduce issue #7820.
+    // We should get the same link value for each fd that was duplicated.
+
+    // 255 is the first broken file descriptor that was discovered and might be used by other software (e.g. bash)
+    auto new_fd = dup2(0, 255);
+    EXPECT_EQ(new_fd, 255);
+    link_length = readlink("/proc/self/fd/255", buf, sizeof(buf));
+    buf[link_length] = '\0';
+    EXPECT_EQ(0, strcmp(buf, expected_link));
+
+    // 215 is the last fd before we have to encode the fd using more than one byte (due to the offset by FI_MaxStaticFileIndex)
+    new_fd = dup2(0, 215);
+    EXPECT_EQ(new_fd, 215);
+    link_length = readlink("/proc/self/fd/215", buf, sizeof(buf));
+    buf[link_length] = '\0';
+    EXPECT_EQ(0, strcmp(buf, expected_link));
+
+    // 216 is the first fd that is encoded using more than one byte
+    new_fd = dup2(0, 216);
+    EXPECT_EQ(new_fd, 216);
+    link_length = readlink("/proc/self/fd/216", buf, sizeof(buf));
+    buf[link_length] = '\0';
+    EXPECT_EQ(0, strcmp(buf, expected_link));
+
+    // 1023 is the largest possible file descriptor
+    new_fd = dup2(0, 1023);
+    EXPECT_EQ(new_fd, 1023);
+    link_length = readlink("/proc/self/fd/1023", buf, sizeof(buf));
+    buf[link_length] = '\0';
+    EXPECT_EQ(0, strcmp(buf, expected_link));
+}


### PR DESCRIPTION
inode identifiers in ProcFS are encoded in a way that the parent ID is shifted 12 bits to the left and the PID is shifted by 16 bits.
This means that the rightmost 12 bits are reserved for the file type or the fd.

Since the to_fd and to_proc_file_type decoders only decoded the rightmost 8 bits, decoded values would wrap around
beyond values of 255, resulting in a different value compared to what was originally encoded.

Since fds are offset by +40 when encoded, this caused wrong behaviour when interacting with fds that have a number of 216 or higher.

Fixes: #7820