### PR TITLE
LibJS: Object & PropertyName fixes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -804,7 +804,7 @@ void Object::ensure_shape_is_unique()
     m_shape = m_shape->create_unique_clone();
 }
 
-Value Object::get_by_index(u32 property_index) const
+Value Object::get_by_index(u32 property_index, bool without_side_effects) const
 {
     const Object* object = this;
     while (object) {
@@ -813,7 +813,7 @@ Value Object::get_by_index(u32 property_index) const
             if (property_index < string.length())
                 return js_string(heap(), string.substring(property_index, 1));
         } else if (static_cast<size_t>(property_index) < object->m_indexed_properties.array_like_size()) {
-            auto result = object->m_indexed_properties.get(const_cast<Object*>(this), property_index);
+            auto result = object->m_indexed_properties.get(const_cast<Object*>(this), property_index, !without_side_effects);
             if (vm().exception())
                 return {};
             if (result.has_value() && !result.value().value.is_empty())
@@ -831,13 +831,13 @@ Value Object::get(const PropertyName& property_name, Value receiver, bool withou
     VERIFY(property_name.is_valid());
 
     if (property_name.is_number())
-        return get_by_index(property_name.as_number());
+        return get_by_index(property_name.as_number(), without_side_effects);
 
     if (property_name.is_string() && property_name.string_may_be_number()) {
         auto& property_string = property_name.as_string();
         i32 property_index = property_string.to_int().value_or(-1);
         if (property_index >= 0)
-            return get_by_index(property_index);
+            return get_by_index(property_index, without_side_effects);
     }
 
     if (receiver.is_empty())

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -190,11 +190,6 @@ bool Object::set_integrity_level(IntegrityLevel level)
     case IntegrityLevel::Sealed:
         for (auto& key : keys) {
             auto property_name = PropertyName::from_value(global_object(), key);
-            if (property_name.is_string() && property_name.string_may_be_number()) {
-                i32 property_index = property_name.as_string().to_int().value_or(-1);
-                if (property_index >= 0)
-                    property_name = property_index;
-            }
             update_property(property_name, ~Attribute::Configurable);
             if (vm.exception())
                 return {};
@@ -203,11 +198,6 @@ bool Object::set_integrity_level(IntegrityLevel level)
     case IntegrityLevel::Frozen:
         for (auto& key : keys) {
             auto property_name = PropertyName::from_value(global_object(), key);
-            if (property_name.is_string() && property_name.string_may_be_number()) {
-                i32 property_index = property_name.as_string().to_int().value_or(-1);
-                if (property_index >= 0)
-                    property_name = property_index;
-            }
             auto property_descriptor = get_own_property_descriptor(property_name);
             if (!property_descriptor.has_value())
                 continue;
@@ -389,11 +379,6 @@ Optional<PropertyDescriptor> Object::get_own_property_descriptor(const PropertyN
         value = existing_value.value().value;
         attributes = existing_value.value().attributes;
     } else {
-        if (property_name.is_string() && property_name.string_may_be_number()) {
-            i32 property_index = property_name.as_string().to_int().value_or(-1);
-            if (property_index >= 0)
-                return get_own_property_descriptor(property_index);
-        }
         auto metadata = shape().lookup(property_name.to_string_or_symbol());
         if (!metadata.has_value())
             return {};
@@ -537,11 +522,6 @@ bool Object::define_property(const PropertyName& property_name, Value value, Pro
     if (property_name.is_number())
         return put_own_property_by_index(property_name.as_number(), value, attributes, PutOwnPropertyMode::DefineProperty, throw_exceptions);
 
-    if (property_name.is_string() && property_name.string_may_be_number()) {
-        i32 property_index = property_name.as_string().to_int().value_or(-1);
-        if (property_index >= 0)
-            return put_own_property_by_index(property_index, value, attributes, PutOwnPropertyMode::DefineProperty, throw_exceptions);
-    }
     return put_own_property(property_name.to_string_or_symbol(), value, attributes, PutOwnPropertyMode::DefineProperty, throw_exceptions);
 }
 
@@ -767,12 +747,6 @@ bool Object::delete_property(const PropertyName& property_name)
     if (property_name.is_number())
         return m_indexed_properties.remove(property_name.as_number());
 
-    if (property_name.is_string() && property_name.string_may_be_number()) {
-        i32 property_index = property_name.as_string().to_int().value_or(-1);
-        if (property_index >= 0)
-            return m_indexed_properties.remove(property_index);
-    }
-
     auto metadata = shape().lookup(property_name.to_string_or_symbol());
     if (!metadata.has_value())
         return true;
@@ -827,13 +801,6 @@ Value Object::get(const PropertyName& property_name, Value receiver, bool withou
 
     if (property_name.is_number())
         return get_by_index(property_name.as_number(), without_side_effects);
-
-    if (property_name.is_string() && property_name.string_may_be_number()) {
-        auto& property_string = property_name.as_string();
-        i32 property_index = property_string.to_int().value_or(-1);
-        if (property_index >= 0)
-            return get_by_index(property_index, without_side_effects);
-    }
 
     if (receiver.is_empty())
         receiver = Value(this);
@@ -895,13 +862,6 @@ bool Object::put(const PropertyName& property_name, Value value, Value receiver)
         return put_by_index(property_name.as_number(), value);
 
     VERIFY(!value.is_empty());
-
-    if (property_name.is_string() && property_name.string_may_be_number()) {
-        auto& property_string = property_name.as_string();
-        i32 property_index = property_string.to_int().value_or(-1);
-        if (property_index >= 0)
-            return put_by_index(property_index, value);
-    }
 
     auto string_or_symbol = property_name.to_string_or_symbol();
 
@@ -1036,12 +996,6 @@ bool Object::has_own_property(const PropertyName& property_name) const
 
     if (property_name.is_number())
         return has_indexed_property(property_name.as_number());
-
-    if (property_name.is_string() && property_name.string_may_be_number()) {
-        i32 property_index = property_name.as_string().to_int().value_or(-1);
-        if (property_index >= 0)
-            return has_indexed_property(property_index);
-    }
 
     return shape().lookup(property_name.to_string_or_symbol()).has_value();
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -583,13 +583,8 @@ bool Object::define_accessor(const PropertyName& property_name, Function* getter
 {
     VERIFY(property_name.is_valid());
 
-    Accessor* accessor { nullptr };
-    auto property_metadata = shape().lookup(property_name.to_string_or_symbol());
-    if (property_metadata.has_value()) {
-        auto existing_property = get_direct(property_metadata.value().offset);
-        if (existing_property.is_accessor())
-            accessor = &existing_property.as_accessor();
-    }
+    auto existing_property = get_own_property(property_name, this, true);
+    auto* accessor = existing_property.is_accessor() ? &existing_property.as_accessor() : nullptr;
     if (!accessor) {
         accessor = Accessor::create(vm(), getter, setter);
         bool definition_success = define_property(property_name, accessor, attributes, throw_exceptions);

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -163,7 +163,7 @@ protected:
     explicit Object(GlobalObjectTag);
     Object(ConstructWithoutPrototypeTag, GlobalObject&);
 
-    virtual Value get_by_index(u32 property_index) const;
+    virtual Value get_by_index(u32 property_index, bool without_side_effects = false) const;
     virtual bool put_by_index(u32 property_index, Value);
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -77,10 +77,10 @@ public:
         return true;
     }
 
-    virtual Value get_by_index(u32 property_index) const override
+    virtual Value get_by_index(u32 property_index, bool without_side_effects = false) const override
     {
         if (property_index >= m_array_length)
-            return Base::get_by_index(property_index);
+            return Base::get_by_index(property_index, without_side_effects);
 
         if constexpr (sizeof(UnderlyingBufferDataType) < 4) {
             return Value((i32)data()[property_index]);

--- a/Userland/Libraries/LibWeb/Bindings/HTMLCollectionWrapperCustom.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/HTMLCollectionWrapperCustom.cpp
@@ -22,11 +22,11 @@ JS::Value HTMLCollectionWrapper::get(JS::PropertyName const& name, JS::Value rec
     return JS::Value { wrap(global_object(), *item) };
 }
 
-JS::Value HTMLCollectionWrapper::get_by_index(u32 property_index) const
+JS::Value HTMLCollectionWrapper::get_by_index(u32 property_index, bool without_side_effects) const
 {
     auto* item = const_cast<DOM::HTMLCollection&>(impl()).item(property_index);
     if (!item)
-        return Base::get_by_index(property_index);
+        return Base::get_by_index(property_index, without_side_effects);
     return wrap(global_object(), *item);
 }
 

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -791,7 +791,7 @@ public:
     }
     if (interface.extended_attributes.contains("CustomGetByIndex")) {
         generator.append(R"~~~(
-    virtual JS::Value get_by_index(u32 property_index) const override;
+    virtual JS::Value get_by_index(u32 property_index, bool without_side_effects = false) const override;
 )~~~");
     }
     if (interface.extended_attributes.contains("CustomPut")) {


### PR DESCRIPTION
This fixes ~70 test262 test cases.

Since the third commit is the main attraction, here's its message:

**LibJS: Automatically & lazily coerce PropertyNames into numbers**
This commit expands on 5eef07d232fc179f0640bbb8cff575cd239c4d65 by automatically trying to coerce Type::String PropertyNames into numbers when a caller checks if the PropertyName is_number/is_string.
This has several benefits:
 - We no longer have to duplicate the number coercion code to every function that accepts a PropertyNumber. (Or more likely, forget to.)
 - This keeps the lazy nature of only doing the coercion when and if there is a semantic difference to the different PropertyName types, which means this shouldnt cause any performance drop.
 - Since this coercion changes the state of the PropertyName itself the result is essentially cached and can speed up any repeat uses of the same PropertyName instance.