### PR TITLE
LibJS: Implement the various builtin generator objects

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -59,7 +59,10 @@ set(SOURCES
     Runtime/FunctionConstructor.cpp
     Runtime/Function.cpp
     Runtime/FunctionPrototype.cpp
+    Runtime/GeneratorFunctionConstructor.cpp
+    Runtime/GeneratorFunctionPrototype.cpp
     Runtime/GeneratorObject.cpp
+    Runtime/GeneratorObjectPrototype.cpp
     Runtime/GlobalObject.cpp
     Runtime/IndexedProperties.cpp
     Runtime/IteratorOperations.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -36,6 +36,7 @@
     __JS_ENUMERATE(Error, error, ErrorPrototype, ErrorConstructor, void)                                                              \
     __JS_ENUMERATE(FinalizationRegistry, finalization_registry, FinalizationRegistryPrototype, FinalizationRegistryConstructor, void) \
     __JS_ENUMERATE(Function, function, FunctionPrototype, FunctionConstructor, void)                                                  \
+    __JS_ENUMERATE(GeneratorFunction, generator_function, GeneratorFunctionPrototype, GeneratorFunctionConstructor, void)             \
     __JS_ENUMERATE(Map, map, MapPrototype, MapConstructor, void)                                                                      \
     __JS_ENUMERATE(NumberObject, number, NumberPrototype, NumberConstructor, void)                                                    \
     __JS_ENUMERATE(Object, object, ObjectPrototype, ObjectConstructor, void)                                                          \
@@ -158,6 +159,9 @@ struct PromiseCapability;
 // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct prototype
 class ProxyObject;
 class ProxyConstructor;
+
+// Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct constructor
+class GeneratorObjectPrototype;
 
 class TypedArrayConstructor;
 class TypedArrayPrototype;

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -31,11 +31,13 @@ FunctionConstructor::~FunctionConstructor()
 {
 }
 
+// 20.2.1.1 Function ( p1, p2, … , pn, body ), https://tc39.es/ecma262/#sec-function-p1-p2-pn-body
 Value FunctionConstructor::call()
 {
     return construct(*this);
 }
 
+// 20.2.1.1 Function ( p1, p2, … , pn, body ), https://tc39.es/ecma262/#sec-function-p1-p2-pn-body
 Value FunctionConstructor::construct(Function&)
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -14,6 +14,8 @@ class FunctionConstructor final : public NativeFunction {
     JS_OBJECT(FunctionConstructor, NativeFunction);
 
 public:
+    static RefPtr<FunctionExpression> create_dynamic_function_node(GlobalObject& global_object, Function& new_target, FunctionKind kind);
+
     explicit FunctionConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~FunctionConstructor() override;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/FunctionConstructor.h>
+#include <LibJS/Runtime/Function.h>
+#include <LibJS/Runtime/GeneratorFunctionConstructor.h>
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace JS {
+
+GeneratorFunctionConstructor::GeneratorFunctionConstructor(GlobalObject& global_object)
+    : NativeFunction(*static_cast<Object*>(global_object.function_constructor()))
+{
+}
+
+void GeneratorFunctionConstructor::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    NativeFunction::initialize(global_object);
+
+    // 27.3.2.1 GeneratorFunction.length, https://tc39.es/ecma262/#sec-generatorfunction.length
+    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    // 27.3.2.2 GeneratorFunction.prototype, https://tc39.es/ecma262/#sec-generatorfunction.length
+    define_property(vm.names.prototype, global_object.generator_function_prototype(), 0);
+}
+
+GeneratorFunctionConstructor::~GeneratorFunctionConstructor()
+{
+}
+
+// 27.3.1.1 GeneratorFunction ( p1, p2, … , pn, body ), https://tc39.es/ecma262/#sec-generatorfunction
+Value GeneratorFunctionConstructor::call()
+{
+    return construct(*this);
+}
+
+// 27.3.1.1 GeneratorFunction ( p1, p2, … , pn, body ), https://tc39.es/ecma262/#sec-generatorfunction
+Value GeneratorFunctionConstructor::construct(Function&)
+{
+    TODO();
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS {
+
+// 27.3.1 %GeneratorFunction%, https://tc39.es/ecma262/#sec-generatorfunction-constructor
+class GeneratorFunctionConstructor final : public NativeFunction {
+    JS_OBJECT(GeneratorFunctionConstructor, NativeFunction);
+
+public:
+    explicit GeneratorFunctionConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~GeneratorFunctionConstructor() override;
+
+    virtual Value call() override;
+    virtual Value construct(Function& new_target) override;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GeneratorFunctionConstructor.h>
+#include <LibJS/Runtime/GeneratorFunctionPrototype.h>
+#include <LibJS/Runtime/GeneratorObjectPrototype.h>
+
+namespace JS {
+
+GeneratorFunctionPrototype::GeneratorFunctionPrototype(GlobalObject& global_object)
+    : Object(*global_object.function_prototype())
+{
+}
+
+void GeneratorFunctionPrototype::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    Object::initialize(global_object);
+
+    // 27.3.3.2 %GeneratorFunction.prototype% prototype, https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype
+    define_property(vm.names.prototype, global_object.generator_object_prototype(), Attribute::Configurable);
+    // 27.3.3.3 %GeneratorFunction.prototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-generatorfunction.prototype-@@tostringtag
+    define_property(vm.well_known_symbol_to_string_tag(), js_string(vm, "GeneratorFunction"), Attribute::Configurable);
+}
+
+GeneratorFunctionPrototype::~GeneratorFunctionPrototype()
+{
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Function.h>
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace JS {
+
+// 27.3.3 %GeneratorFunction.prototype%, https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object
+class GeneratorFunctionPrototype final : public Object {
+    JS_OBJECT(GeneratorFunctionPrototype, Object);
+
+public:
+    explicit GeneratorFunctionPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~GeneratorFunctionPrototype() override;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -16,20 +16,15 @@ class GeneratorObject final : public Object {
 
 public:
     static GeneratorObject* create(GlobalObject&, Value, ScriptFunction*, ScopeObject*, Bytecode::RegisterWindow);
-    explicit GeneratorObject(GlobalObject&);
+    GeneratorObject(GlobalObject&, Object& prototype);
     virtual void initialize(GlobalObject&) override;
     virtual ~GeneratorObject() override;
     void visit_edges(Cell::Visitor&) override;
 
-    static GeneratorObject* typed_this(VM&, GlobalObject&);
+    Value next_impl(VM&, GlobalObject&, Optional<Value> value_to_throw);
+    void set_done() { m_done = true; }
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(next);
-    JS_DECLARE_NATIVE_FUNCTION(return_);
-    JS_DECLARE_NATIVE_FUNCTION(throw_);
-
-    Value next_impl(VM&, GlobalObject&, Optional<Value> value_to_throw);
-
     ScopeObject* m_scope { nullptr };
     ScriptFunction* m_generating_function { nullptr };
     Value m_previous_value;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Runtime/GeneratorObject.h>
+#include <LibJS/Runtime/GeneratorObjectPrototype.h>
+
+namespace JS {
+
+static GeneratorObject* typed_this(VM& vm, GlobalObject& global_object)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return {};
+    if (!is<GeneratorObject>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Generator");
+        return nullptr;
+    }
+    return static_cast<GeneratorObject*>(this_object);
+}
+
+GeneratorObjectPrototype::GeneratorObjectPrototype(GlobalObject& global_object)
+    : Object(*global_object.iterator_prototype())
+{
+}
+
+void GeneratorObjectPrototype::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    Object::initialize(global_object);
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.next, next, 1, attr);
+    define_native_function(vm.names.return_, return_, 1, attr);
+    define_native_function(vm.names.throw_, throw_, 1, attr);
+
+    // 27.5.1.5 Generator.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-generator.prototype-@@tostringtag
+    define_property(vm.well_known_symbol_to_string_tag(), js_string(vm, "Generator"), Attribute::Configurable);
+}
+
+GeneratorObjectPrototype::~GeneratorObjectPrototype()
+{
+}
+
+// 27.5.1.2 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.next
+JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::next)
+{
+    auto generator_object = typed_this(vm, global_object);
+    if (!generator_object)
+        return {};
+    return generator_object->next_impl(vm, global_object, {});
+}
+
+// 27.5.1.3 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.return
+JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::return_)
+{
+    auto generator_object = typed_this(vm, global_object);
+    if (!generator_object)
+        return {};
+    generator_object->set_done();
+    return generator_object->next_impl(vm, global_object, {});
+}
+
+// 27.5.1.4 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.throw
+JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::throw_)
+{
+    auto generator_object = typed_this(vm, global_object);
+    if (!generator_object)
+        return {};
+    return generator_object->next_impl(vm, global_object, vm.argument(0));
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace JS {
+
+// 27.5.1 %GeneratorFunction.prototype.prototype%, https://tc39.es/ecma262/#sec-properties-of-generator-prototype
+class GeneratorObjectPrototype final : public Object {
+    JS_OBJECT(GeneratorObjectPrototype, Object);
+
+public:
+    explicit GeneratorObjectPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~GeneratorObjectPrototype() override;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(next);
+    JS_DECLARE_NATIVE_FUNCTION(return_);
+    JS_DECLARE_NATIVE_FUNCTION(throw_);
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -37,6 +37,9 @@ public:
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct prototype
     ProxyConstructor* proxy_constructor() { return m_proxy_constructor; }
 
+    // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct constructor
+    GeneratorObjectPrototype* generator_object_prototype() { return m_generator_object_prototype; }
+
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* snake_name##_constructor() { return m_##snake_name##_constructor; } \
     Object* snake_name##_prototype() { return m_##snake_name##_prototype; }
@@ -80,6 +83,9 @@ private:
 
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct prototype
     ProxyConstructor* m_proxy_constructor { nullptr };
+
+    // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct constructor
+    GeneratorObjectPrototype* m_generator_object_prototype { nullptr };
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* m_##snake_name##_constructor { nullptr };                           \


### PR DESCRIPTION
The objects added are:
- `%GeneratorFunction%`
- `%GeneratorFunction.prototype%`
- `%GeneratorFunction.prototype.prototype%`
- `%Generator%.prototype`

The relations between all of these objects can be visualized with [this image from the spec](https://tc39.es/ecma262/img/figure-2.png).

Test262 diff:
+19 ✅
-31 ❌
+12 💥️