### PR TITLE
AK: Add a hex-dump Format mode and get rid of the many print_buffer() functions

### DIFF
--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -289,3 +289,11 @@ TEST_CASE(long_long_regression)
 
     EXPECT_EQ(builder.string_view(), "81985529216486895");
 }
+
+TEST_CASE(hex_dump)
+{
+    EXPECT_EQ(String::formatted("{:hex-dump}", "0000"), "30303030");
+    EXPECT_EQ(String::formatted("{:>4hex-dump}", "0000"), "30303030    0000");
+    EXPECT_EQ(String::formatted("{:>2hex-dump}", "0000"), "3030    00\n3030    00");
+    EXPECT_EQ(String::formatted("{:*>4hex-dump}", "0000"), "30303030****0000");
+}

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -24,10 +24,7 @@ namespace TLS {
 
 inline void print_buffer(ReadonlyBytes buffer)
 {
-    StringBuilder builder(buffer.size() * 2);
-    for (auto b : buffer)
-        builder.appendff("{:02x} ", b);
-    dbgln("{}", builder.string_view());
+    dbgln("{:hex-dump}", buffer);
 }
 
 inline void print_buffer(const ByteBuffer& buffer)

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -91,20 +91,10 @@ static int crc32_tests();
 
 static void print_buffer(ReadonlyBytes buffer, int split)
 {
-    for (size_t i = 0; i < buffer.size(); ++i) {
-        if (split > 0) {
-            if (i % split == 0 && i) {
-                out("    ");
-                for (size_t j = i - split; j < i; ++j) {
-                    auto ch = buffer[j];
-                    out("{}", ch >= 32 && ch <= 127 ? ch : '.'); // silly hack
-                }
-                outln();
-            }
-        }
-        out("{:02x} ", buffer[i]);
-    }
-    puts("");
+    if (split > 0)
+        out("{:>{}hex-dump}", buffer, split);
+    else
+        out("{:hex-dump}", buffer);
 }
 
 static Core::EventLoop g_loop;

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -22,24 +22,6 @@ static bool g_continue { false };
 static void (*old_signal)(int);
 static Wasm::DebuggerBytecodeInterpreter g_interpreter;
 
-static void print_buffer(ReadonlyBytes buffer, int split)
-{
-    for (size_t i = 0; i < buffer.size(); ++i) {
-        if (split > 0) {
-            if (i % split == 0 && i) {
-                out("    ");
-                for (size_t j = i - split; j < i; ++j) {
-                    auto ch = buffer[j];
-                    out("{:c}", ch >= 32 && ch <= 127 ? ch : '.'); // silly hack
-                }
-                outln();
-            }
-        }
-        out("{:02x} ", buffer[i]);
-    }
-    puts("");
-}
-
 static void sigint_handler(int)
 {
     if (!g_continue) {
@@ -143,7 +125,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
                     warnln("invalid memory index {} (not found)", args[2]);
                     continue;
                 }
-                print_buffer(mem->data(), 32);
+                warnln("{:>32hex-dump}", mem->data().bytes());
                 continue;
             }
             if (what.is_one_of("i", "instr", "instruction")) {


### PR DESCRIPTION
TL;DR:
- printing (Readonly)Bytes makes a hexdump by default
- passing a width to that makes it print that many in a character view as well
- the 4x space in the middle can be configured with the `fill` field, if you're not feeling like spaces
- I was nerd sniped into doing this