### PR TITLE
Lagom: Add an install target

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -260,6 +260,8 @@ if (BUILD_LAGOM)
             )
         endforeach()
     endif()
+
+    install(TARGETS Lagom LagomCore)
 endif()
 
 if (ENABLE_FUZZER_SANITIZER OR ENABLE_OSS_FUZZ)


### PR DESCRIPTION
This is used by libjs-test262-runner to be able to copy the libraries
within its own build directory in order to link with them.