### PR TITLE
Kernel: Remove obsolete size_t casts

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -838,7 +838,7 @@ KResultOr<size_t> Ext2FSInode::read_bytes(off_t offset, size_t count, UserOrKern
     if (is_symlink() && size() < max_inline_symlink_length) {
         VERIFY(offset == 0);
         size_t nread = min((off_t)size() - offset, static_cast<off_t>(count));
-        if (!buffer.write(((const u8*)m_raw_inode.i_block) + offset, (size_t)nread))
+        if (!buffer.write(((const u8*)m_raw_inode.i_block) + offset, nread))
             return EFAULT;
         return nread;
     }

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -61,7 +61,7 @@ KResultOr<NonnullOwnPtr<KBuffer>> Inode::read_entire(FileDescription* descriptio
             return result.error();
         nread = result.value();
         VERIFY(nread <= sizeof(buffer));
-        if (nread <= 0)
+        if (nread == 0)
             break;
         builder.append((const char*)buffer, nread);
         offset += nread;

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -760,7 +760,7 @@ KResultOr<size_t> Plan9FSInode::read_bytes(off_t offset, size_t size, UserOrKern
     }
 
     // Guard against the server returning more data than requested.
-    size_t nread = min(data.length(), (size_t)size);
+    size_t nread = min(data.length(), size);
     if (!buffer.write(data.characters_without_null_termination(), nread))
         return EFAULT;
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1503,7 +1503,7 @@ KResultOr<size_t> ProcFSInode::write_bytes(off_t offset, size_t size, const User
     VERIFY(is_persistent_inode(identifier()));
     // FIXME: Being able to write into ProcFS at a non-zero offset seems like something we should maybe support..
     VERIFY(offset == 0);
-    auto nwritten_or_error = write_callback(identifier(), buffer, (size_t)size);
+    auto nwritten_or_error = write_callback(identifier(), buffer, size);
     if (nwritten_or_error.is_error())
         dbgln("ProcFS: Writing {} bytes failed: {}", size, nwritten_or_error.error());
     return nwritten_or_error;

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -17,7 +17,7 @@ KResultOr<int> Process::sys$gethostname(Userspace<char*> buffer, size_t size)
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
     Locker locker(*g_hostname_lock, Lock::Mode::Shared);
-    if ((size_t)size < (g_hostname->length() + 1))
+    if (size < (g_hostname->length() + 1))
         return ENAMETOOLONG;
     if (!copy_to_user(buffer, g_hostname->characters(), g_hostname->length() + 1))
         return EFAULT;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -179,7 +179,7 @@ KResultOr<int> Process::sys$get_thread_name(pid_t tid, Userspace<char*> buffer, 
 
     // We must make a temporary copy here to avoid a race with sys$set_thread_name
     auto thread_name = thread->name();
-    if (thread_name.length() + 1 > (size_t)buffer_size)
+    if (thread_name.length() + 1 > buffer_size)
         return ENAMETOOLONG;
 
     if (!copy_to_user(buffer, thread_name.characters(), thread_name.length() + 1))

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -67,7 +67,7 @@ KResultOr<size_t> Process::do_write(FileDescription& description, const UserOrKe
             return seek_result.error();
     }
 
-    while ((size_t)total_nwritten < data_size) {
+    while (total_nwritten < data_size) {
         while (!description.can_write()) {
             if (!description.is_blocking()) {
                 if (total_nwritten > 0)

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -269,7 +269,7 @@ KResultOr<size_t> VirtualConsole::on_tty_write(const UserOrKernelBuffer& data, s
 {
     ScopedSpinLock global_lock(ConsoleManagement::the().tty_write_lock());
     ScopedSpinLock lock(m_lock);
-    auto result = data.read_buffered<512>((size_t)size, [&](u8 const* buffer, size_t buffer_bytes) {
+    auto result = data.read_buffered<512>(size, [&](u8 const* buffer, size_t buffer_bytes) {
         for (size_t i = 0; i < buffer_bytes; ++i)
             m_console_impl.on_input(buffer[i]);
         return buffer_bytes;

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -101,11 +101,11 @@ public:
             if (copied_or_error.is_error())
                 return copied_or_error.error();
             auto copied = copied_or_error.value();
-            VERIFY((size_t)copied <= to_copy);
-            if (!write(buffer, nwritten, (size_t)copied))
+            VERIFY(copied <= to_copy);
+            if (!write(buffer, nwritten, copied))
                 return EFAULT;
-            nwritten += (size_t)copied;
-            if ((size_t)copied < to_copy)
+            nwritten += copied;
+            if (copied < to_copy)
                 break;
         }
         return nwritten;


### PR DESCRIPTION
**Kernel: Remove obsolete size_t casts**

**Kernel: Update check in Inode::read_entire**

The nread variable can't be less than zero anymore.