### PR TITLE
Kernel: Put the SB16 DMA buffer's physical address into the first 16MB

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -387,6 +387,8 @@ endif()
 add_executable(Kernel ${SOURCES})
 add_dependencies(Kernel generate_EscapeSequenceStateMachine.h)
 
+set_target_properties(Kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/linker.ld)
+
 if (ENABLE_KERNEL_LTO)
     include(CheckIPOSupported)
     check_ipo_supported()

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -200,6 +200,9 @@ void SB16::dma_start(uint32_t length)
 
     // Write the buffer
     IO::out8(0x8b, addr >> 16);
+    auto page_number = addr >> 16;
+    VERIFY(page_number <= NumericLimits<u8>::max());
+    IO::out8(0x8b, page_number);
 
     // Enable the DMA channel
     IO::out8(0xd4, (channel % 4));

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -43,9 +43,9 @@ inline FlatPtr low_physical_to_virtual(FlatPtr physical)
     return physical + 0xc0000000;
 }
 
-inline FlatPtr virtual_to_low_physical(FlatPtr physical)
+inline FlatPtr virtual_to_low_physical(FlatPtr virtual_)
 {
-    return physical - 0xc0000000;
+    return virtual_ - 0xc0000000;
 }
 
 enum class UsedMemoryRangeType {

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -8,10 +8,19 @@ SECTIONS
 
     start_of_kernel_image = .;
 
-    .text ALIGN(4K) : AT (ADDR(.text) - KERNEL_VIRTUAL_BASE)
+    .boot ALIGN(4K) : AT (ADDR(.boot) - KERNEL_VIRTUAL_BASE)
     {
         $<TARGET_OBJECTS:boot>
         *(.multiboot)
+    }
+
+    .super_pages ALIGN(4K) : AT (ADDR(.super_pages) - KERNEL_VIRTUAL_BASE)
+    {
+        *(.super_pages)
+    }
+
+    .text ALIGN(4K) : AT (ADDR(.text) - KERNEL_VIRTUAL_BASE)
+    {
         start_of_kernel_text = .;
 
         start_of_safemem_text = .;
@@ -70,8 +79,6 @@ SECTIONS
 
         . = ALIGN(4K);
         *(.heap)
-        . = ALIGN(4K);
-        *(.super_pages)
     }
 
     end_of_kernel_image = .;


### PR DESCRIPTION
**Kernel: Fix incorrect argument name**

**Kernel: Make sure the kernel is re-linked when the linker script changes**

**Kernel: Move super_pages section into the bottom 16MB**

This ensures that pages returned by `MM.allocate_supervisor_physical_page()` have a physical address that is in the bottom 16MB and can thus be used by the SB16 driver for DMA.

Fixes #8092.

**Kernel: Add a VERIFY() to make sure our DMA address is valid**

This checks whether the address we're trying to use for DMA is low enough so as not to overflow the I/O register.