### PR TITLE
Texteditor: Small fixes when asking to save & disabling preview mode

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -728,6 +728,7 @@ void MainWidget::set_preview_mode(PreviewMode mode)
         update_markdown_preview();
     } else {
         m_no_preview_action->set_checked(true);
+        m_editor->set_fixed_width(-1);
         set_web_view_visible(false);
     }
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -80,6 +80,8 @@ void TextEditor::create_actions()
     m_redo_action->set_enabled(false);
     m_cut_action = CommonActions::make_cut_action([&](auto&) { cut(); }, this);
     m_copy_action = CommonActions::make_copy_action([&](auto&) { copy(); }, this);
+    m_cut_action->set_enabled(false);
+    m_copy_action->set_enabled(false);
     m_paste_action = CommonActions::make_paste_action([&](auto&) { paste(); }, this);
     m_delete_action = CommonActions::make_delete_action([&](auto&) { do_delete(); }, this);
     if (is_multi_line()) {


### PR DESCRIPTION
Some small improvements to TextEditor.

**Set cut and copy actions to disabled on init** and enable them first when a selection is made. This is mostly an indicator to the user that it's not possible to use these actions with nothing selected. Previously they would simply not do anything when clicked.

**Reset editor width when disabling preview mode.**
When disabling preview mode after adjusting the splitter the editor would still be fixed width and therefore not fill out the window. This is one of the solutions that @trflynn89 proposed in #7462. I believe it's an ok fix in this particular case, but with splitters containing more elements his other solution might be better suited.
Fixes #7462

~~**Don't discard changes if user closes save dialog.**
This breaks out the save-if-modified-logic into it's own function, getting rid of some code duplication and makes sure that the  logic in https://github.com/SerenityOS/serenity/commit/97202615405e2ec8128083c8780587747be3895c also applies when the user aborts a save dialog on new/open and not just on exit.~~ Dropping this one since it was fixed in 928364e10251e0faff36559630b7d0f1f907cb7a.