### PR TITLE
LibJS: Add %TypedArray%.prototype.{every,find,findIndex,forEach,some}

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -156,6 +156,7 @@
     M(TypedArrayInvalidByteOffset, "Invalid byte offset for {}: must be a multiple of {}, got {}")                                      \
     M(TypedArrayOutOfRangeByteOffset, "Typed array byte offset {} is out of range for buffer with length {}")                           \
     M(TypedArrayOutOfRangeByteOffsetOrLength, "Typed array range {}:{} is out of range for buffer with length {}")                      \
+    M(TypedArrayPrototypeOneArg, "TypedArray.prototype.{}() requires at least one argument")                                            \
     M(TypedArrayFailedSettingIndex, "Failed setting value of index {} of typed array")                                                  \
     M(UnknownIdentifier, "'{}' is not defined")                                                                                         \
     M(URIMalformed, "URI malformed")                                                                                                    \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -26,6 +26,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_native_accessor(vm.names.byteLength, byte_length_getter, nullptr, Attribute::Configurable);
     define_native_accessor(vm.names.byteOffset, byte_offset_getter, nullptr, Attribute::Configurable);
     define_native_function(vm.names.at, at, 1, attr);
+    define_native_function(vm.names.every, every, 1, attr);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()
@@ -42,6 +43,49 @@ static TypedArrayBase* typed_array_from(VM& vm, GlobalObject& global_object)
         return nullptr;
     }
     return static_cast<TypedArrayBase*>(this_object);
+}
+
+static Function* callback_from_args(GlobalObject& global_object, const String& name)
+{
+    auto& vm = global_object.vm();
+    if (vm.argument_count() < 1) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::TypedArrayPrototypeOneArg, name);
+        return nullptr;
+    }
+    auto callback = vm.argument(0);
+    if (!callback.is_function()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAFunction, callback.to_string_without_side_effects());
+        return nullptr;
+    }
+    return &callback.as_function();
+}
+
+static void for_each_item(VM& vm, GlobalObject& global_object, const String& name, AK::Function<IterationDecision(size_t index, Value value, Value callback_result)> callback)
+{
+    auto* typed_array = typed_array_from(vm, global_object);
+    if (!typed_array)
+        return;
+
+    auto initial_length = typed_array->array_length();
+
+    auto* callback_function = callback_from_args(global_object, name);
+    if (!callback_function)
+        return;
+
+    auto this_value = vm.argument(1);
+
+    for (size_t i = 0; i < initial_length; ++i) {
+        auto value = typed_array->get(i);
+        if (vm.exception())
+            return;
+
+        auto callback_result = vm.call(*callback_function, this_value, value, Value((i32)i), typed_array);
+        if (vm.exception())
+            return;
+
+        if (callback(i, value, callback_result) == IterationDecision::Break)
+            break;
+    }
 }
 
 // 23.2.3.18 get %TypedArray%.prototype.length, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length
@@ -79,6 +123,20 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::at)
     if (index.has_overflow() || index.value() >= length)
         return js_undefined();
     return typed_array->get(index.value());
+}
+
+// 23.2.3.7 %TypedArray%.prototype.every ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.every
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::every)
+{
+    auto result = true;
+    for_each_item(vm, global_object, "every", [&](auto, auto, auto callback_result) {
+        if (!callback_result.to_boolean()) {
+            result = false;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+    return Value(result);
 }
 
 // 23.2.3.1 get %TypedArray%.prototype.buffer, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -29,6 +29,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_native_function(vm.names.every, every, 1, attr);
     define_native_function(vm.names.find, find, 1, attr);
     define_native_function(vm.names.findIndex, find_index, 1, attr);
+    define_native_function(vm.names.forEach, for_each, 1, attr);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()
@@ -167,6 +168,15 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find_index)
         return IterationDecision::Continue;
     });
     return Value(result_index);
+}
+
+// 23.2.3.12 %TypedArray%.prototype.forEach ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::for_each)
+{
+    for_each_item(vm, global_object, "forEach", [](auto, auto, auto) {
+        return IterationDecision::Continue;
+    });
+    return js_undefined();
 }
 
 // 23.2.3.1 get %TypedArray%.prototype.buffer, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -28,6 +28,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_native_function(vm.names.at, at, 1, attr);
     define_native_function(vm.names.every, every, 1, attr);
     define_native_function(vm.names.find, find, 1, attr);
+    define_native_function(vm.names.findIndex, find_index, 1, attr);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()
@@ -152,6 +153,20 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find)
         return IterationDecision::Continue;
     });
     return result;
+}
+
+// 23.2.3.11 %TypedArray%.prototype.findIndex ( predicate [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find_index)
+{
+    auto result_index = -1;
+    for_each_item(vm, global_object, "findIndex", [&](auto index, auto, auto callback_result) {
+        if (callback_result.to_boolean()) {
+            result_index = index;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+    return Value(result_index);
 }
 
 // 23.2.3.1 get %TypedArray%.prototype.buffer, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -27,6 +27,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_native_accessor(vm.names.byteOffset, byte_offset_getter, nullptr, Attribute::Configurable);
     define_native_function(vm.names.at, at, 1, attr);
     define_native_function(vm.names.every, every, 1, attr);
+    define_native_function(vm.names.find, find, 1, attr);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()
@@ -137,6 +138,20 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::every)
         return IterationDecision::Continue;
     });
     return Value(result);
+}
+
+// 23.2.3.10 %TypedArray%.prototype.find ( predicate [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.find
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find)
+{
+    auto result = js_undefined();
+    for_each_item(vm, global_object, "find", [&](auto, auto value, auto callback_result) {
+        if (callback_result.to_boolean()) {
+            result = value;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+    return result;
 }
 
 // 23.2.3.1 get %TypedArray%.prototype.buffer, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,6 +31,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_native_function(vm.names.find, find, 1, attr);
     define_native_function(vm.names.findIndex, find_index, 1, attr);
     define_native_function(vm.names.forEach, for_each, 1, attr);
+    define_native_function(vm.names.some, some, 1, attr);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()
@@ -177,6 +179,20 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::for_each)
         return IterationDecision::Continue;
     });
     return js_undefined();
+}
+
+// 23.2.3.25 %TypedArray%.prototype.some ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.some
+JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::some)
+{
+    auto result = false;
+    for_each_item(vm, global_object, "some", [&](auto, auto, auto callback_result) {
+        if (callback_result.to_boolean()) {
+            result = true;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+    return Value(result);
 }
 
 // 23.2.3.1 get %TypedArray%.prototype.buffer, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -28,6 +28,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(every);
     JS_DECLARE_NATIVE_FUNCTION(find);
     JS_DECLARE_NATIVE_FUNCTION(find_index);
+    JS_DECLARE_NATIVE_FUNCTION(for_each);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -26,6 +26,7 @@ private:
 
     JS_DECLARE_NATIVE_FUNCTION(at);
     JS_DECLARE_NATIVE_FUNCTION(every);
+    JS_DECLARE_NATIVE_FUNCTION(find);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -29,6 +30,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(find);
     JS_DECLARE_NATIVE_FUNCTION(find_index);
     JS_DECLARE_NATIVE_FUNCTION(for_each);
+    JS_DECLARE_NATIVE_FUNCTION(some);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -25,6 +25,7 @@ private:
     JS_DECLARE_NATIVE_GETTER(byte_offset_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(at);
+    JS_DECLARE_NATIVE_FUNCTION(every);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -27,6 +27,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(at);
     JS_DECLARE_NATIVE_FUNCTION(every);
     JS_DECLARE_NATIVE_FUNCTION(find);
+    JS_DECLARE_NATIVE_FUNCTION(find_index);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
@@ -1,0 +1,70 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.every).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.every).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function errorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().every();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.every() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().every(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => errorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+test("basic functionality", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T([2, 4, 6]);
+        expect(typedArray.every(value => value === 2)).toBeFalse();
+        expect(typedArray.every(value => value === 4)).toBeFalse();
+        expect(typedArray.every(value => value === 6)).toBeFalse();
+        expect(typedArray.every(value => value % 2 === 0)).toBeTrue();
+        expect(typedArray.every(value => value % 2 === 1)).toBeFalse();
+        expect(typedArray.every(value => value < 2)).toBeFalse();
+        expect(typedArray.every(value => value > 2)).toBeFalse();
+        expect(typedArray.every(value => value >= 2)).toBeTrue();
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T([2n, 4n, 6n]);
+        expect(typedArray.every(value => value === 2n)).toBeFalse();
+        expect(typedArray.every(value => value === 4n)).toBeFalse();
+        expect(typedArray.every(value => value === 6n)).toBeFalse();
+        expect(typedArray.every(value => value % 2n === 0n)).toBeTrue();
+        expect(typedArray.every(value => value % 2n === 1n)).toBeFalse();
+        expect(typedArray.every(value => value < 2n)).toBeFalse();
+        expect(typedArray.every(value => value > 2n)).toBeFalse();
+        expect(typedArray.every(value => value >= 2n)).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.find.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.find.js
@@ -1,0 +1,108 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.find).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.find).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function errorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().find();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.find() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().find(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => errorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+describe("normal behaviour", () => {
+    test("basic functionality", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1, 2, 3]);
+
+            expect(typedArray.find(value => value === 1)).toBe(1);
+            expect(typedArray.find(value => value === 2)).toBe(2);
+            expect(typedArray.find(value => value === 3)).toBe(3);
+            expect(typedArray.find((value, index) => index === 1)).toBe(2);
+            expect(typedArray.find(value => value == "1")).toBe(1);
+            expect(typedArray.find(value => value === 10)).toBeUndefined();
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1n, 2n, 3n]);
+
+            expect(typedArray.find(value => value === 1n)).toBe(1n);
+            expect(typedArray.find(value => value === 2n)).toBe(2n);
+            expect(typedArray.find(value => value === 3n)).toBe(3n);
+            expect(typedArray.find((value, index) => index === 1)).toBe(2n);
+            expect(typedArray.find(value => value == 1)).toBe(1n);
+            expect(typedArray.find(value => value == "1")).toBe(1n);
+            expect(typedArray.find(value => value === 1)).toBeUndefined();
+        });
+    });
+
+    test("never calls callback with empty array", () => {
+        function emptyTest(T) {
+            var callbackCalled = 0;
+            expect(
+                new T().find(() => {
+                    callbackCalled++;
+                })
+            ).toBeUndefined();
+            expect(callbackCalled).toBe(0);
+        }
+
+        TYPED_ARRAYS.forEach(T => emptyTest(T));
+        BIGINT_TYPED_ARRAYS.forEach(T => emptyTest(T));
+    });
+
+    test("calls callback once for every item", () => {
+        TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            expect(
+                new T([1, 2, 3]).find(() => {
+                    callbackCalled++;
+                })
+            ).toBeUndefined();
+            expect(callbackCalled).toBe(3);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            expect(
+                new T([1n, 2n, 3n]).find(() => {
+                    callbackCalled++;
+                })
+            ).toBeUndefined();
+            expect(callbackCalled).toBe(3);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findIndex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findIndex.js
@@ -1,0 +1,108 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.findIndex).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.findIndex).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function errorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().findIndex();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.findIndex() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().findIndex(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => errorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+describe("normal behaviour", () => {
+    test("basic functionality", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1, 2, 3]);
+
+            expect(typedArray.findIndex(value => value === 1)).toBe(0);
+            expect(typedArray.findIndex(value => value === 2)).toBe(1);
+            expect(typedArray.findIndex(value => value === 3)).toBe(2);
+            expect(typedArray.findIndex((value, index) => index === 1)).toBe(1);
+            expect(typedArray.findIndex(value => value == "1")).toBe(0);
+            expect(typedArray.findIndex(value => value === 10)).toBe(-1);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1n, 2n, 3n]);
+
+            expect(typedArray.findIndex(value => value === 1n)).toBe(0);
+            expect(typedArray.findIndex(value => value === 2n)).toBe(1);
+            expect(typedArray.findIndex(value => value === 3n)).toBe(2);
+            expect(typedArray.findIndex((value, index) => index === 1)).toBe(1);
+            expect(typedArray.findIndex(value => value == 1)).toBe(0);
+            expect(typedArray.findIndex(value => value == "1")).toBe(0);
+            expect(typedArray.findIndex(value => value === 1)).toBe(-1);
+        });
+    });
+
+    test("never calls callback with empty array", () => {
+        function emptyTest(T) {
+            var callbackCalled = 0;
+            expect(
+                new T().findIndex(() => {
+                    callbackCalled++;
+                })
+            ).toBe(-1);
+            expect(callbackCalled).toBe(0);
+        }
+
+        TYPED_ARRAYS.forEach(T => emptyTest(T));
+        BIGINT_TYPED_ARRAYS.forEach(T => emptyTest(T));
+    });
+
+    test("calls callback once for every item", () => {
+        TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            expect(
+                new T([1, 2, 3]).findIndex(() => {
+                    callbackCalled++;
+                })
+            ).toBe(-1);
+            expect(callbackCalled).toBe(3);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            expect(
+                new T([1n, 2n, 3n]).findIndex(() => {
+                    callbackCalled++;
+                })
+            ).toBe(-1);
+            expect(callbackCalled).toBe(3);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
@@ -1,0 +1,145 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.forEach).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.forEach).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function errorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().forEach();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.forEach() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().forEach(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => errorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+describe("normal behaviour", () => {
+    test("never calls callback with empty array", () => {
+        function emptyTest(T) {
+            var callbackCalled = 0;
+            expect(
+                new T().forEach(() => {
+                    callbackCalled++;
+                })
+            ).toBeUndefined();
+            expect(callbackCalled).toBe(0);
+        }
+
+        TYPED_ARRAYS.forEach(T => emptyTest(T));
+        BIGINT_TYPED_ARRAYS.forEach(T => emptyTest(T));
+    });
+
+    test("calls callback once for every item", () => {
+        TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            expect(
+                new T([1, 2, 3]).forEach(() => {
+                    callbackCalled++;
+                })
+            ).toBeUndefined();
+            expect(callbackCalled).toBe(3);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            expect(
+                new T([1n, 2n, 3n]).forEach(() => {
+                    callbackCalled++;
+                })
+            ).toBeUndefined();
+            expect(callbackCalled).toBe(3);
+        });
+    });
+
+    test("callback receives value and index", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1, 2, 3]);
+            typedArray.forEach((value, index) => {
+                expect(value).toBe(typedArray[index]);
+                expect(index).toBe(typedArray[index] - 1);
+            });
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1n, 2n, 3n]);
+            typedArray.forEach((value, index) => {
+                expect(value).toBe(typedArray[index]);
+                expect(index).toBe(parseInt(typedArray[index] - 1n));
+            });
+        });
+    });
+
+    test("callback receives array", () => {
+        TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            const typedArray = new T([1, 2, 3]);
+            typedArray.forEach((_, __, array) => {
+                callbackCalled++;
+                expect(typedArray).toEqual(array);
+            });
+            expect(callbackCalled).toBe(3);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            var callbackCalled = 0;
+            const typedArray = new T([1n, 2n, 3n]);
+            typedArray.forEach((_, __, array) => {
+                callbackCalled++;
+                expect(typedArray).toEqual(array);
+            });
+            expect(callbackCalled).toBe(3);
+        });
+    });
+
+    test("this value can be modified", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1, 2, 3]);
+            [4, 5, 6].forEach(function (value, index) {
+                this[index] = value;
+            }, typedArray);
+            expect(typedArray[0]).toBe(4);
+            expect(typedArray[1]).toBe(5);
+            expect(typedArray[2]).toBe(6);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const typedArray = new T([1n, 2n, 3n]);
+            [4n, 5n, 6n].forEach(function (value, index) {
+                this[index] = value;
+            }, typedArray);
+            expect(typedArray[0]).toBe(4n);
+            expect(typedArray[1]).toBe(5n);
+            expect(typedArray[2]).toBe(6n);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
@@ -1,0 +1,68 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.some).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.some).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function errorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().some();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.some() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().some(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => errorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+test("basic functionality", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T([2, 4, 6]);
+        expect(typedArray.some(value => value === 2)).toBeTrue();
+        expect(typedArray.some(value => value === 4)).toBeTrue();
+        expect(typedArray.some(value => value === 6)).toBeTrue();
+        expect(typedArray.some(value => value % 2 === 0)).toBeTrue();
+        expect(typedArray.some(value => value % 2 === 1)).toBeFalse();
+        expect(typedArray.some(value => value < 2)).toBeFalse();
+        expect(typedArray.some(value => value > 2)).toBeTrue();
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T([2n, 4n, 6n]);
+        expect(typedArray.some(value => value === 2n)).toBeTrue();
+        expect(typedArray.some(value => value === 4n)).toBeTrue();
+        expect(typedArray.some(value => value === 6n)).toBeTrue();
+        expect(typedArray.some(value => value % 2n === 0n)).toBeTrue();
+        expect(typedArray.some(value => value % 2n === 1n)).toBeFalse();
+        expect(typedArray.some(value => value < 2n)).toBeFalse();
+        expect(typedArray.some(value => value > 2n)).toBeTrue();
+    });
+});


### PR DESCRIPTION
This fixes 121 test262 cases.
The reason for these 5 in particular is that they all use `for_each_item` with almost no extra stuff needed (i.e. creating a return array)