### PR TITLE
LibJS: Add missing exception check in Date.prototype.toJSON

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -846,6 +846,9 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_json)
         return {};
 
     auto time_value = Value(this_object).to_primitive(global_object, Value::PreferredType::Number);
+    if (vm.exception())
+        return {};
+
     if (time_value.is_number() && !time_value.is_finite_number())
         return js_null();
 


### PR DESCRIPTION
It was missing an exception check on the call to to_primitive.
This fixes test/built-ins/Date/prototype/toJSON/called-as-function.js
from test262 crashing, but does not fix the test itself.