### PR TITLE
LibJS: Add Number.parseInt

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -42,6 +42,7 @@ void NumberConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.isInteger, is_integer, 1, attr);
     define_native_function(vm.names.isNaN, is_nan, 1, attr);
     define_native_function(vm.names.isSafeInteger, is_safe_integer, 1, attr);
+    define_property(vm.names.parseInt, global_object.get(vm.names.parseInt), attr);
     define_property(vm.names.parseFloat, global_object.get(vm.names.parseFloat), attr);
     define_property(vm.names.EPSILON, Value(EPSILON_VALUE), 0);
     define_property(vm.names.MAX_VALUE, Value(NumericLimits<double>::max()), 0);

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.parseInt.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.parseInt.js
@@ -1,0 +1,5 @@
+test("basic functionality", () => {
+    // Ensuring it's the same function as the global
+    // parseInt() is enough as that already has tests :^)
+    expect(Number.parseInt).toBe(parseInt);
+});


### PR DESCRIPTION
This is initialized to be the same function object as the initial value
of the parseInt function on the global object.