### PR TITLE
Meta: Ensure long messages fit in commit tweet

### DIFF
--- a/Meta/tweet-commits.js
+++ b/Meta/tweet-commits.js
@@ -1,6 +1,9 @@
 const fs = require("fs");
 const Twit = require("twit");
 const { CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET } = process.env;
+const tweetLength = 280;
+// Twitter always considers t.co links to be 23 chars, see https://help.twitter.com/en/using-twitter/how-to-tweet-a-link
+const twitterLinkLength = 23;
 
 const T = new Twit({
     consumer_key: CONSUMER_KEY,
@@ -13,11 +16,14 @@ const T = new Twit({
     const githubEvent = JSON.parse(fs.readFileSync(0).toString());
     const tweets = [];
     for (const commit of githubEvent["commits"]) {
-        tweets.push(
-            `${commit["message"].substring(0, 240)}\nAuthor: ${commit["author"]["name"]}\n${
-                commit["url"]
-            }`
-        );
+        const authorLine = `Author: ${commit["author"]["name"]}`;
+        const maxMessageLength = tweetLength - authorLine.length - twitterLinkLength - 2; // -2 for newlines
+        const commitMessage =
+            commit["message"].length > maxMessageLength
+                ? commit["message"].substring(0, maxMessageLength - 2) + "…" // Ellipsis counts as 2 characters
+                : commit["message"];
+
+        tweets.push(`${commitMessage}\n${authorLine}\n${commit["url"]}`);
     }
     for (const tweet of tweets) {
         try {


### PR DESCRIPTION
Abbreviating the commit message to 240 characters was not always enough.
As a bonus, we now add an ellipsis to abbreviated messages.

---

I wasn't able to get into my old twitter account to make sure that this will send correctly, so can someone check for me? Should be enough to just paste this into the tweet box without sending it, and seeing if it complains about the length or not:

```
LibJS: Use existing attributes if any are missing in the new descriptor

The specification defines that we should only change attributes that
exist in the incoming descriptor, but since we currently just overwrite
the existing descr…
Author: Idan Horowitz
https://github.com/SerenityOS/serenity/commit/b6a74b6bd93f1cfcd11cca9608970f5856acce00
```