### PR TITLE
Kernel: Fix crash when changing screen resolution

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -151,19 +151,12 @@ void VirtualConsole::refresh_after_resolution_change()
     }
 
     // Note: A potential loss of displayed data occur when resolution width shrinks.
-    if (columns() < old_columns_count) {
-        for (size_t row = 0; row < rows(); row++) {
-            auto& line = m_lines[row];
-            memcpy(new_cells->vaddr().offset((row)*columns() * sizeof(Cell)).as_ptr(), m_cells->vaddr().offset((row) * (old_columns_count) * sizeof(Cell)).as_ptr(), columns() * sizeof(Cell));
-            line.dirty = true;
-        }
-    } else {
-        // Handle Growth of resolution
-        for (size_t row = 0; row < rows(); row++) {
-            auto& line = m_lines[row];
-            memcpy(new_cells->vaddr().offset((row)*columns() * sizeof(Cell)).as_ptr(), m_cells->vaddr().offset((row) * (old_columns_count) * sizeof(Cell)).as_ptr(), old_columns_count * sizeof(Cell));
-            line.dirty = true;
-        }
+    auto common_rows_count = min(old_rows_count, rows());
+    auto common_columns_count = min(old_columns_count, columns());
+    for (size_t row = 0; row < common_rows_count; row++) {
+        auto& line = m_lines[row];
+        memcpy(new_cells->vaddr().offset(row * columns() * sizeof(Cell)).as_ptr(), m_cells->vaddr().offset(row * old_columns_count * sizeof(Cell)).as_ptr(), common_columns_count * sizeof(Cell));
+        line.dirty = true;
     }
 
     // Update the new cells Region


### PR DESCRIPTION
Steps to reproduce:

1. Change resolution to 640x480.
2. Change resolution to 1280x1024.
3. Observe the following kernel panic:

```
(gdb) bt
#0  Kernel::halt_this () at ../../Kernel/Arch/i386/CPU.cpp:949
#1  0xc0bb02b8 in Kernel::Processor::halt () at ../../Kernel/Arch/i386/CPU.cpp:2222
#2  0xc0772728 in Kernel::__panic (file=<optimized out>, line=<optimized out>, function=<optimized out>) at ../../Kernel/Panic.cpp:18
#3  0xc0bb19a9 in Kernel::handle_crash (regs=..., description=<optimized out>, signal=11, out_of_memory=false) at ../../Kernel/Arch/i386/CPU.cpp:172
#4  0xc0bb7d05 in Kernel::page_fault_handler (trap=0xc43fcb00) at ../../Kernel/Arch/i386/CPU.cpp:331
#5  0xc0ba77b0 in page_fault_asm_entry () at ../../Kernel/Arch/i386/CPU.cpp:111
#6  0xc43fcb00 in ?? ()
#7  0xc0a08128 in Kernel::VirtualConsole::refresh_after_resolution_change (this=<optimized out>) at ../../Kernel/TTY/VirtualConsole.cpp:164
#8  0xc09cdc97 in Kernel::ConsoleManagement::resolution_was_changed (this=0xc175b6c8 <kmalloc_eternal_heap+1337032>) at ../../Kernel/TTY/ConsoleManagement.cpp:21
#9  0xc02e2de5 in Kernel::Graphics::FramebufferConsole::set_resolution (this=0xc142f164 <kmalloc_pool_heap+106852>, width=1280, height=1024, pitch=5120) at ../../Kernel/Graphics/Console/FramebufferConsole.cpp:221
#10 0xc02ea957 in Kernel::BochsGraphicsAdapter::try_to_set_resolution (this=0xc175b6a0 <kmalloc_eternal_heap+1336992>, output_port_index=0, width=<optimized out>, height=<optimized out>) at ../.././AK/RefPtr.h:27
#11 0xc02f83a8 in Kernel::FramebufferDevice::ioctl (this=0xc175b6e4 <kmalloc_eternal_heap+1337060>, request=14, arg=9434928) at ../../Kernel/Graphics/FramebufferDevice.cpp:192
#12 0xc08ab684 in Kernel::Process::sys$ioctl (this=0xc1521000 <kmalloc_pool_heap+1097728>, fd=8, request=14, arg=9434928) at ../../Kernel/Syscalls/ioctl.cpp:22
#13 0xc07ff8b6 in Kernel::Syscall::handle (regs=..., function=<optimized out>, arg1=<optimized out>, arg2=<optimized out>, arg3=<optimized out>) at ../../Kernel/Syscall.cpp:123
#14 0xc080129a in Kernel::syscall_handler (trap=<optimized out>) at ../../Kernel/Syscall.cpp:190
#15 0xc07fe8d1 in Kernel::syscall_asm_entry_dummy () at ../../Kernel/Syscall.cpp:24
#16 0xc43fcf48 in ?? ()
```
```