### PR TITLE
LibCrypto: Fix Hash::MD5's movability

### DIFF
--- a/Userland/Libraries/LibCrypto/Hash/MD5.cpp
+++ b/Userland/Libraries/LibCrypto/Hash/MD5.cpp
@@ -58,9 +58,10 @@ void MD5::update(const u8* input, size_t length)
     m_count[1] += (u32)length >> 29;
 
     auto part_length = 64 - index;
+    auto buffer = Bytes { m_data_buffer, sizeof(m_data_buffer) };
     if (length >= part_length) {
-        m_buffer.overwrite(index, input, part_length);
-        transform(m_buffer.data());
+        buffer.overwrite(index, input, part_length);
+        transform(buffer.data());
 
         for (offset = part_length; offset + 63 < length; offset += 64)
             transform(&input[offset]);
@@ -69,7 +70,7 @@ void MD5::update(const u8* input, size_t length)
     }
 
     VERIFY(length < part_length || length - offset <= 64);
-    m_buffer.overwrite(index, &input[offset], length - offset);
+    buffer.overwrite(index, &input[offset], length - offset);
 }
 MD5::DigestType MD5::digest()
 {

--- a/Userland/Libraries/LibCrypto/Hash/MD5.h
+++ b/Userland/Libraries/LibCrypto/Hash/MD5.h
@@ -57,11 +57,6 @@ class MD5 final : public HashFunction<512, MD5Digest> {
 public:
     using HashFunction::update;
 
-    MD5()
-    {
-        m_buffer = Bytes { m_data_buffer, sizeof(m_data_buffer) };
-    }
-
     virtual void update(const u8*, size_t) override;
     virtual DigestType digest() override;
     virtual DigestType peek() override;
@@ -98,7 +93,6 @@ private:
 
     u32 m_A { MD5Constants::init_A }, m_B { MD5Constants::init_B }, m_C { MD5Constants::init_C }, m_D { MD5Constants::init_D };
     u32 m_count[2] { 0, 0 };
-    Bytes m_buffer;
 
     u8 m_data_buffer[64] {};
 };


### PR DESCRIPTION
Because `MD5` stored a `Bytes {}` wrapper to its internal data buffer, it was not actually movable.
However, its use in several parts of the system (such as `HashManager`) assumed it was, leading to crashes.

Fixes #8135