### PR TITLE
LibVT+Terminal+LibLine: Implement line wrapping

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -59,19 +59,19 @@ constexpr SizeType array_size(T (&)[N])
 }
 
 template<typename T>
-constexpr T min(const T& a, const T& b)
+constexpr T min(const T& a, const IdentityType<T>& b)
 {
     return b < a ? b : a;
 }
 
 template<typename T>
-constexpr T max(const T& a, const T& b)
+constexpr T max(const T& a, const IdentityType<T>& b)
 {
     return a < b ? b : a;
 }
 
 template<typename T>
-constexpr T clamp(const T& value, const T& min, const T& max)
+constexpr T clamp(const T& value, const IdentityType<T>& min, const IdentityType<T>& max)
 {
     VERIFY(max >= min);
     if (value > max)

--- a/Userland/Libraries/LibVT/Line.cpp
+++ b/Userland/Libraries/LibVT/Line.cpp
@@ -10,19 +10,101 @@ namespace VT {
 
 Line::Line(size_t length)
 {
-    set_length(length);
+    set_length(length, nullptr, nullptr);
 }
 
 Line::~Line()
 {
 }
 
-void Line::set_length(size_t new_length)
+void Line::set_length(size_t new_length, Line* next_line, CursorPosition* cursor, bool cursor_is_on_next_line)
 {
     size_t old_length = length();
     if (old_length == new_length)
         return;
-    m_cells.resize(new_length);
+
+    // Drop the empty cells
+    if (m_terminated_at.has_value())
+        m_cells.remove(m_terminated_at.value(), m_cells.size() - m_terminated_at.value());
+
+    if (!next_line)
+        return m_cells.resize(new_length);
+
+    if (old_length < new_length)
+        take_cells_from_next_line(old_length, new_length, next_line, cursor_is_on_next_line, cursor);
+    else
+        push_cells_into_next_line(old_length, new_length, next_line, cursor_is_on_next_line, cursor);
+
+    m_cells.resize(max(new_length, static_cast<size_t>(m_terminated_at.value_or(new_length))));
+}
+
+void Line::push_cells_into_next_line(size_t old_length, size_t new_length, Line* next_line, bool cursor_is_on_next_line, CursorPosition* cursor)
+{
+    // Push as many cells as _wouldn't_ fit into the next line.
+    auto cells_to_preserve = !next_line->m_terminated_at.has_value() && next_line->is_empty() ? 0 : m_terminated_at.value_or(0);
+    auto cells_to_push_into_next_line = min(old_length - new_length, length() - cells_to_preserve);
+    if (!cells_to_push_into_next_line)
+        return;
+
+    auto preserved_cells = length() - cells_to_push_into_next_line;
+    if (next_line->m_terminated_at.has_value())
+        next_line->m_terminated_at = next_line->m_terminated_at.value() + cells_to_push_into_next_line;
+
+    if (m_terminated_at.has_value() && cells_to_preserve == 0) {
+        m_terminated_at.clear();
+        if (!next_line->m_terminated_at.has_value())
+            next_line->m_terminated_at = cells_to_push_into_next_line;
+    }
+
+    if (cursor) {
+        if (cursor_is_on_next_line) {
+            cursor->column += cells_to_push_into_next_line;
+        } else if (cursor->column >= preserved_cells) {
+            cursor->row++;
+            cursor->column = cursor->column - preserved_cells;
+        }
+    }
+
+    next_line->m_cells.prepend(m_cells.span().slice_from_end(cells_to_push_into_next_line).data(), cells_to_push_into_next_line);
+    m_cells.remove(m_cells.size() - cells_to_push_into_next_line, cells_to_push_into_next_line);
+    if (m_terminated_at.has_value())
+        m_terminated_at = m_terminated_at.value() - cells_to_push_into_next_line;
+}
+
+void Line::take_cells_from_next_line(size_t old_length, size_t new_length, Line* next_line, bool cursor_is_on_next_line, CursorPosition* cursor)
+{
+    // Take as many cells as would fit from the next line
+    if (m_terminated_at.has_value())
+        return;
+
+    auto cells_to_grab_from_next_line = min(new_length - old_length, next_line->length());
+    auto clear_next_line = false;
+    if (next_line->m_terminated_at.has_value()) {
+        cells_to_grab_from_next_line = min(cells_to_grab_from_next_line, static_cast<size_t>(next_line->m_terminated_at.value()));
+        if (cells_to_grab_from_next_line == *next_line->m_terminated_at) {
+            m_terminated_at = old_length + *next_line->m_terminated_at;
+            next_line->m_terminated_at.clear();
+            clear_next_line = true;
+        } else {
+            next_line->m_terminated_at = next_line->m_terminated_at.value() - cells_to_grab_from_next_line;
+        }
+    }
+
+    if (cells_to_grab_from_next_line) {
+        if (cursor && cursor_is_on_next_line) {
+            if (cursor->column <= cells_to_grab_from_next_line) {
+                cursor->row--;
+                cursor->column += m_cells.size();
+            } else {
+                cursor->column -= cells_to_grab_from_next_line;
+            }
+        }
+        m_cells.append(next_line->m_cells.data(), cells_to_grab_from_next_line);
+        next_line->m_cells.remove(0, cells_to_grab_from_next_line);
+    }
+
+    if (clear_next_line)
+        next_line->m_cells.clear();
 }
 
 void Line::clear_range(size_t first_column, size_t last_column, const Attribute& attribute)

--- a/Userland/Libraries/LibVT/Line.h
+++ b/Userland/Libraries/LibVT/Line.h
@@ -35,6 +35,7 @@ public:
 
     void clear(const Attribute& attribute = Attribute())
     {
+        m_terminated_at.clear();
         clear_range(0, m_cells.size() - 1, attribute);
     }
     void clear_range(size_t first_column, size_t last_column, const Attribute& attribute = Attribute());
@@ -50,15 +51,26 @@ public:
 
     void set_code_point(size_t index, u32 code_point)
     {
+        if (m_terminated_at.has_value()) {
+            if (index > *m_terminated_at) {
+                m_terminated_at = index + 1;
+            }
+        }
+
         m_cells[index].code_point = code_point;
     }
 
     bool is_dirty() const { return m_dirty; }
     void set_dirty(bool b) { m_dirty = b; }
 
+    Optional<u16> termination_column() const { return m_terminated_at; }
+    void set_terminated(u16 column) { m_terminated_at = column; }
+
 private:
     Vector<Cell> m_cells;
     bool m_dirty { false };
+    // Note: The alignment is 8, so this member lives in the padding (that already existed before it was introduced)
+    [[no_unique_address]] Optional<u16> m_terminated_at;
 };
 
 }

--- a/Userland/Libraries/LibVT/Position.h
+++ b/Userland/Libraries/LibVT/Position.h
@@ -51,4 +51,15 @@ private:
     int m_column { -1 };
 };
 
+struct CursorPosition {
+    u16 row { 0 };
+    u16 column { 0 };
+
+    void clamp(u16 max_row, u16 max_column)
+    {
+        row = min(row, max_row);
+        column = min(column, max_column);
+    }
+};
+
 }

--- a/Userland/Libraries/LibVT/Position.h
+++ b/Userland/Libraries/LibVT/Position.h
@@ -52,8 +52,8 @@ private:
 };
 
 struct CursorPosition {
-    u16 row { 0 };
-    u16 column { 0 };
+    size_t row { 0 };
+    size_t column { 0 };
 
     void clamp(u16 max_row, u16 max_column)
     {

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -432,6 +432,9 @@ protected:
     Vector<bool> m_horizontal_tabs;
     u32 m_last_code_point { 0 };
     size_t m_max_history_lines { 1024 };
+
+    Optional<u16> m_column_before_carriage_return;
+    bool m_controls_are_logically_generated { false };
 };
 
 }

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -194,17 +194,6 @@ protected:
     virtual void receive_dcs_char(u8 byte) override;
     virtual void execute_dcs_sequence() override;
 
-    struct CursorPosition {
-        u16 row { 0 };
-        u16 column { 0 };
-
-        void clamp(u16 max_row, u16 max_column)
-        {
-            row = min(row, max_row);
-            column = min(column, max_column);
-        }
-    };
-
     struct BufferState {
         Attribute attribute;
         CursorPosition cursor;

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -339,6 +339,11 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
             if ((!visual_beep_active && !has_only_one_background_color) || should_reverse_fill_for_cursor_or_selection)
                 painter.clear_rect(cell_rect, terminal_color_to_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.effective_foreground_color() : attribute.effective_background_color()));
 
+            if constexpr (TERMINAL_DEBUG) {
+                if (line.termination_column() == column)
+                    painter.clear_rect(cell_rect, Gfx::Color::Magenta);
+            }
+
             enum class UnderlineStyle {
                 None,
                 Dotted,


### PR DESCRIPTION
Fixes #287.
This is working.

History rewrap demo:

https://user-images.githubusercontent.com/14001776/122958386-0b1ef500-d398-11eb-90f0-b8463b5ac1ca.mp4

Things to figure out / fix:
- [x] Resizing to a small window with the buffer being full messes up the last line's placement
- [x] History is not re-wrapped on resize
- [x] LibLine can't handle having its origin changed, it should probably just change its origin to whatever the current line is when the resize happens
- [x] To deal with the above, the cursor should move with the lines:
- [x] Spill from the above, the cursor should move correctly when making the window smaller.