### PR TITLE
Kernel: Make sure the kernel's ELF PHDRs don't use rwx

### DIFF
--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -5,7 +5,7 @@
 .set multiboot_flags,         MULTIBOOT_PAGE_ALIGN | MULTIBOOT_MEMORY_INFO
 .set multiboot_checksum,      -(MULTIBOOT_MAGIC + multiboot_flags)
 
-.section .multiboot
+.section .multiboot, "a"
 .align 4
 
 .long MULTIBOOT_MAGIC
@@ -56,7 +56,7 @@ boot_pd3_pts:
 boot_pd3_pt1023:
 .skip 4096
 
-.section .text
+.section .boot_text, "ax"
 
 .global start
 .type start, @function

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -270,6 +270,7 @@ set(KERNEL_SOURCES
 
 set(KERNEL_SOURCES
     ${KERNEL_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/Arch/${KERNEL_ARCH}/Boot/boot.S
     ${CMAKE_CURRENT_SOURCE_DIR}/Arch/${KERNEL_ARCH}/CPU.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Arch/${KERNEL_ARCH}/InterruptEntry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Arch/${KERNEL_ARCH}/ProcessorInfo.cpp
@@ -358,19 +359,9 @@ add_compile_definitions(KERNEL)
 #       It's needed because CLion doesn't understand the way we switch compilers mid-build.
 add_compile_definitions(__serenity__)
 
-add_link_options(LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib)
-
-# HACK: This is to work around a bug in CMake dependency resolution, the
-#       kernel won't re-link when boot.S changes without this.
-set_source_files_properties(init.cpp
-    PROPERTIES
-    OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Arch/${KERNEL_ARCH}/Boot/boot.S
-)
-
-add_library(boot OBJECT Arch/${KERNEL_ARCH}/Boot/boot.S)
+add_link_options(LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld -nostdlib)
 
 add_library(kernel_heap STATIC ${KERNEL_HEAP_SOURCES})
-file(GENERATE OUTPUT linker.ld INPUT linker.ld)
 
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
     include_directories(/usr/local/include/c++/${GCC_VERSION}/)
@@ -387,7 +378,7 @@ endif()
 add_executable(Kernel ${SOURCES})
 add_dependencies(Kernel generate_EscapeSequenceStateMachine.h)
 
-set_target_properties(Kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/linker.ld)
+set_target_properties(Kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)
 
 if (ENABLE_KERNEL_LTO)
     include(CheckIPOSupported)
@@ -395,7 +386,7 @@ if (ENABLE_KERNEL_LTO)
     set_property(TARGET Kernel PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 target_link_libraries(Kernel kernel_heap gcc stdc++)
-add_dependencies(Kernel boot kernel_heap)
+add_dependencies(Kernel kernel_heap)
 install(TARGETS Kernel RUNTIME DESTINATION boot)
 
 add_custom_command(

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -2,22 +2,33 @@ ENTRY(start)
 
 KERNEL_VIRTUAL_BASE = 0xc0000000;
 
+PHDRS
+{
+  boot_text PT_LOAD ;
+  boot_bss PT_LOAD ;
+  text PT_LOAD ;
+  data PT_LOAD ;
+  bss PT_LOAD ;
+}
+
 SECTIONS
 {
     . = KERNEL_VIRTUAL_BASE + 0x00100000;
 
     start_of_kernel_image = .;
 
-    .boot ALIGN(4K) : AT (ADDR(.boot) - KERNEL_VIRTUAL_BASE)
+    .boot_text ALIGN(4K) : AT (ADDR(.boot_text) - KERNEL_VIRTUAL_BASE)
     {
-        $<TARGET_OBJECTS:boot>
-        *(.multiboot)
-    }
+        KEEP(*(.boot_text))
+        KEEP(*(.multiboot))
+    } :boot_text
 
-    .super_pages ALIGN(4K) : AT (ADDR(.super_pages) - KERNEL_VIRTUAL_BASE)
+    .boot_bss ALIGN(4K) (NOLOAD) : AT (ADDR(.boot_bss) - KERNEL_VIRTUAL_BASE)
     {
+        KEEP(*(.page_tables))
+        KEEP(*(.stack))
         *(.super_pages)
-    }
+    } :boot_bss
 
     .text ALIGN(4K) : AT (ADDR(.text) - KERNEL_VIRTUAL_BASE)
     {
@@ -31,7 +42,7 @@ SECTIONS
         end_of_safemem_atomic_text = .;
 
         *(.text*)
-    }
+    } :text
 
     .unmap_after_init ALIGN(4K) : AT (ADDR(.unmap_after_init) - KERNEL_VIRTUAL_BASE)
     {
@@ -40,7 +51,7 @@ SECTIONS
         end_of_unmap_after_init = .;
 
         end_of_kernel_text = .;
-    }
+    } :text
 
     .rodata ALIGN(4K) : AT (ADDR(.rodata) - KERNEL_VIRTUAL_BASE)
     {
@@ -53,21 +64,21 @@ SECTIONS
         end_ctors = .;
 
         *(.rodata*)
-    }
+    } :data
 
     .data ALIGN(4K) : AT (ADDR(.data) - KERNEL_VIRTUAL_BASE)
     {
         start_of_kernel_data = .;
         *(.data*)
         end_of_kernel_data = .;
-    }
+    } :data
 
     .ro_after_init ALIGN(4K) (NOLOAD) : AT(ADDR(.ro_after_init) - KERNEL_VIRTUAL_BASE)
     {
         start_of_ro_after_init = .;
         *(.ro_after_init);
         end_of_ro_after_init = .;
-    }
+    } :data
 
     .bss ALIGN(4K) (NOLOAD) : AT (ADDR(.bss) - KERNEL_VIRTUAL_BASE)
     {
@@ -79,7 +90,7 @@ SECTIONS
 
         . = ALIGN(4K);
         *(.heap)
-    }
+    } :bss
 
     end_of_kernel_image = .;
 }


### PR DESCRIPTION
This doesn't really matter in terms of writability for the kernel text because we set up proper page mappings anyway which prohibit writing to the text segment. However, this makes the profiler happy which previously died when validating the kernel's ELF program headers.