### PR TITLE
LibGUI/TabWidget: Add close button to tabs

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -60,6 +60,7 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     auto& top_line = *widget.find_descendant_of_type_named<GUI::HorizontalSeparator>("top_line");
 
     m_tab_widget = *widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
+    m_tab_widget->set_close_button_enabled(true);
 
     m_tab_widget->on_tab_count_change = [&top_line](size_t tab_count) {
         top_line.set_visible(tab_count > 1);
@@ -72,6 +73,11 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
     };
 
     m_tab_widget->on_middle_click = [](auto& clicked_widget) {
+        auto& tab = static_cast<Browser::Tab&>(clicked_widget);
+        tab.on_tab_close_request(tab);
+    };
+
+    m_tab_widget->on_tab_close_click = [](auto& clicked_widget) {
         auto& tab = static_cast<Browser::Tab&>(clicked_widget);
         tab.on_tab_close_request(tab);
     };

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv)
     auto& toolbox = *main_widget.find_descendant_of_type_named<PixelPaint::ToolboxWidget>("toolbox");
     auto& tab_widget = *main_widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
     tab_widget.set_container_margins({ 4, 4, 5, 5 });
+    tab_widget.set_close_button_enabled(true);
 
     auto& palette_widget = *main_widget.find_descendant_of_type_named<PixelPaint::PaletteWidget>("palette_widget");
 
@@ -522,6 +523,13 @@ int main(int argc, char** argv)
         tab_widget.set_active_widget(&image_editor);
         image_editor.set_focus(true);
         return image_editor;
+    };
+
+    tab_widget.on_tab_close_click = [&](auto& widget) {
+        auto& image_editor = downcast<PixelPaint::ImageEditor>(widget);
+        tab_widget.deferred_invoke([&](auto&) {
+            tab_widget.remove_tab(image_editor);
+        });
     };
 
     tab_widget.on_change = [&](auto& widget) {

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -65,9 +65,12 @@ public:
     void set_bar_visible(bool bar_visible);
     bool is_bar_visible() const { return m_bar_visible; };
 
+    void set_close_button_enabled(bool close_button_enabled) { m_close_button_enabled = close_button_enabled; };
+
     Function<void(size_t)> on_tab_count_change;
     Function<void(Widget&)> on_change;
     Function<void(Widget&)> on_middle_click;
+    Function<void(Widget&)> on_tab_close_click;
     Function<void(Widget&, const ContextMenuEvent&)> on_context_menu_request;
 
 protected:
@@ -77,6 +80,7 @@ protected:
     virtual void child_event(Core::ChildEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
     virtual void mousedown_event(MouseEvent&) override;
+    virtual void mouseup_event(MouseEvent&) override;
     virtual void mousemove_event(MouseEvent&) override;
     virtual void leave_event(Core::Event&) override;
     virtual void keydown_event(KeyEvent&) override;
@@ -85,6 +89,7 @@ protected:
 private:
     Gfx::IntRect child_rect_for_size(const Gfx::IntSize&) const;
     Gfx::IntRect button_rect(int index) const;
+    Gfx::IntRect close_button_rect(int index) const;
     Gfx::IntRect bar_rect() const;
     Gfx::IntRect container_rect() const;
     void update_bar();
@@ -102,10 +107,13 @@ private:
     Vector<TabData> m_tabs;
     TabPosition m_tab_position { TabPosition::Top };
     int m_hovered_tab_index { -1 };
+    int m_hovered_close_button_index { -1 };
+    int m_pressed_close_button_index { -1 };
     GUI::Margins m_container_margins { 2, 2, 2, 2 };
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::Center };
     bool m_uniform_tabs { false };
     bool m_bar_visible { true };
+    bool m_close_button_enabled { false };
 };
 
 }


### PR DESCRIPTION
This PR adds the option to show a close button on tabs and implements it Browser and PixelPaint. There are some magic pixel tweakings that I don't particularly like being hard coded but I tried to keep it to a minimum. It's mostly to keep the "popout" effect when a tab is active.

There's still some work left on the tab-behaviour in PixelPaint like saving on close etc.

Fixes #7989

![Screenshot_20210619_135826](https://user-images.githubusercontent.com/69970419/122641635-ea8c3c00-d106-11eb-866e-4748cac54096.png)
