### PR TITLE
LibJS: Small fixes for Array.prototype.concat

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -527,7 +527,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
         if (!spreadable.is_undefined())
             return spreadable.to_boolean();
 
-        return object->is_array();
+        return val.is_array(global_object);
     };
 
     auto append_to_new_array = [&vm, &is_concat_spreadable, &new_array, &global_object, &n](Value arg) {
@@ -542,7 +542,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
             if (vm.exception())
                 return;
 
-            if (length + k > MAX_ARRAY_LIKE_INDEX) {
+            if (n + length > MAX_ARRAY_LIKE_INDEX) {
                 vm.throw_exception<TypeError>(global_object, ErrorType::ArrayMaxSize);
                 return;
             }
@@ -554,7 +554,10 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
                     auto k_value = obj.get(k).value_or(js_undefined());
                     if (vm.exception())
                         return;
+
                     new_array->put(n, k_value);
+                    if (vm.exception())
+                        return;
                 }
                 ++n;
                 ++k;
@@ -565,6 +568,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
                 return;
             }
             new_array->put(n, arg);
+            if (vm.exception())
+                return;
             ++n;
         }
     };

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -272,7 +272,7 @@ Value Object::get_own_property(const PropertyName& property_name, Value receiver
         if (value_here.is_accessor())
             return value_here.as_accessor().call_getter(receiver);
         if (value_here.is_native_property())
-            return call_native_property_getter(value_here.as_native_property(), receiver);
+            return call_native_property_getter(value_here.as_native_property(), this);
     }
     return value_here;
 }
@@ -869,9 +869,7 @@ bool Object::put_by_index(u32 property_index, Value value)
                 return true;
             }
             if (value_here.value.is_native_property()) {
-                // FIXME: Why doesn't put_by_index() receive the receiver value from put()?!
-                auto receiver = this;
-                call_native_property_setter(value_here.value.as_native_property(), receiver, value);
+                call_native_property_setter(value_here.value.as_native_property(), this, value);
                 return true;
             }
         }
@@ -908,7 +906,7 @@ bool Object::put(const PropertyName& property_name, Value value, Value receiver)
                 return true;
             }
             if (value_here.is_native_property()) {
-                call_native_property_setter(value_here.as_native_property(), receiver, value);
+                call_native_property_setter(value_here.as_native_property(), this, value);
                 return true;
             }
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.concat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.concat.js
@@ -40,4 +40,14 @@ describe("normal behavior", () => {
         expect(concatenated[4]).toBe(1);
         expect(concatenated[5]).toEqual([2, 3]);
     });
+
+    test("Proxy is concatenated as array", () => {
+        var proxy = new Proxy([9, 8], {});
+        var concatenated = array.concat(proxy);
+        expect(array).toHaveLength(1);
+        expect(concatenated).toHaveLength(3);
+        expect(concatenated[0]).toBe("hello");
+        expect(concatenated[1]).toBe(9);
+        expect(concatenated[2]).toBe(8);
+    });
 });


### PR DESCRIPTION
Spotted a small typo in concat and then found more issues.
Let me know if I should split changes like this up.

Fixes ~5 test262 tests.