### PR TITLE
Kernel: Allow VGA-capable graphics adapters to exist with legacy VGA

### DIFF
--- a/Kernel/Graphics/BochsGraphicsAdapter.cpp
+++ b/Kernel/Graphics/BochsGraphicsAdapter.cpp
@@ -49,7 +49,8 @@ UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initi
 }
 
 UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::Address pci_address)
-    : PCI::DeviceController(pci_address)
+    : GraphicsDevice(pci_address)
+    , PCI::DeviceController(pci_address)
     , m_mmio_registers(PCI::get_BAR2(pci_address) & 0xfffffff0)
 {
     // We assume safe resolutio is 1024x768x32

--- a/Kernel/Graphics/GraphicsDevice.h
+++ b/Kernel/Graphics/GraphicsDevice.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Devices/BlockDevice.h>
+#include <Kernel/PCI/Definitions.h>
 #include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {
@@ -23,6 +24,7 @@ public:
     virtual ~GraphicsDevice() = default;
     virtual void initialize_framebuffer_devices() = 0;
     virtual Type type() const = 0;
+    PCI::Address device_pci_address() const { return m_pci_address; }
     virtual void enable_consoles() = 0;
     virtual void disable_consoles() = 0;
     bool consoles_enabled() const { return m_consoles_enabled; }
@@ -35,8 +37,12 @@ public:
     virtual bool set_y_offset(size_t output_port_index, size_t y) = 0;
 
 protected:
-    GraphicsDevice() = default;
+    GraphicsDevice(PCI::Address pci_address)
+        : m_pci_address(pci_address)
+    {
+    }
 
+    const PCI::Address m_pci_address;
     bool m_consoles_enabled { false };
 };
 

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -45,8 +45,6 @@ public:
     void activate_graphical_mode();
 
 private:
-    RefPtr<GraphicsDevice> determine_graphics_device(PCI::Address address, PCI::ID id) const;
-
     NonnullRefPtrVector<GraphicsDevice> m_graphics_devices;
     NonnullOwnPtr<Region> m_vga_font_region;
     RefPtr<Graphics::Console> m_console;

--- a/Kernel/Graphics/VGACompatibleAdapter.cpp
+++ b/Kernel/Graphics/VGACompatibleAdapter.cpp
@@ -36,7 +36,8 @@ UNMAP_AFTER_INIT void VGACompatibleAdapter::initialize_framebuffer_devices()
 }
 
 UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address)
-    : PCI::DeviceController(address)
+    : GraphicsDevice(address)
+    , PCI::DeviceController(address)
 {
     m_framebuffer_console = Graphics::TextModeConsole::initialize(*this);
     // FIXME: This is a very wrong way to do this...
@@ -44,7 +45,8 @@ UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address
 }
 
 UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address, PhysicalAddress framebuffer_address, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch)
-    : PCI::DeviceController(address)
+    : GraphicsDevice(address)
+    , PCI::DeviceController(address)
     , m_framebuffer_address(framebuffer_address)
     , m_framebuffer_width(framebuffer_width)
     , m_framebuffer_height(framebuffer_height)

--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -99,11 +99,21 @@ public:
     operator bool() const { return !is_null(); }
 
     // Disable default implementations that would use surprising integer promotion.
-    bool operator==(const Address&) const = delete;
     bool operator<=(const Address&) const = delete;
     bool operator>=(const Address&) const = delete;
     bool operator<(const Address&) const = delete;
     bool operator>(const Address&) const = delete;
+
+    bool operator==(const Address& other) const
+    {
+        if (this == &other)
+            return true;
+        return m_seg == other.m_seg && m_bus == other.m_bus && m_device == other.m_device && m_function == other.m_function;
+    }
+    bool operator!=(const Address& other) const
+    {
+        return !(*this == other);
+    }
 
     u16 seg() const { return m_seg; }
     u8 bus() const { return m_bus; }


### PR DESCRIPTION
If we have a VGA-capable graphics adapter that we support, we should
prefer it over any legacy VGA because we wouldn't use it in legacy VGA
mode in this case.

This solves the problem where we would only use the legacy VGA card
when both a legacy VGA card as well as a VGA-mode capable adapter is
present.

_This has been cherry-picked from #8032_