### PR TITLE
LibAudio: Various Wave playback fixes, better support for high-sample-rate files

### DIFF
--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -9,7 +9,7 @@
 PlaybackManager::PlaybackManager(NonnullRefPtr<Audio::ClientConnection> connection)
     : m_connection(connection)
 {
-    m_timer = Core::Timer::construct(100, [&]() {
+    m_timer = Core::Timer::construct(PlaybackManager::update_rate_ms, [&]() {
         if (!m_loader)
             return;
         next_buffer();
@@ -27,8 +27,10 @@ void PlaybackManager::set_loader(NonnullRefPtr<Audio::Loader>&& loader)
     m_loader = loader;
     if (m_loader) {
         m_total_length = m_loader->total_samples() / static_cast<float>(m_loader->sample_rate());
+        m_device_samples_per_buffer = PlaybackManager::buffer_size_ms / 1000.0f * m_device_sample_rate;
+        u32 source_samples_per_buffer = PlaybackManager::buffer_size_ms / 1000.0f * m_loader->sample_rate();
+        m_source_buffer_size_bytes = source_samples_per_buffer * m_loader->num_channels() * m_loader->bits_per_sample() / 8;
         m_timer->start();
-        load_next_buffer();
     } else {
         m_timer->stop();
     }
@@ -38,11 +40,8 @@ void PlaybackManager::stop()
 {
     set_paused(true);
     m_connection->clear_buffer(true);
-    m_buffers.clear();
     m_last_seek = 0;
-    m_next_buffer = nullptr;
     m_current_buffer = nullptr;
-    m_next_ptr = 0;
 
     if (m_loader)
         m_loader->reset();
@@ -68,10 +67,7 @@ void PlaybackManager::seek(const int position)
     set_paused(true);
 
     m_connection->clear_buffer(true);
-    m_next_buffer = nullptr;
     m_current_buffer = nullptr;
-    m_next_ptr = 0;
-    m_buffers.clear();
     m_loader->seek(position);
 
     if (!paused_state)
@@ -83,51 +79,8 @@ void PlaybackManager::pause()
     set_paused(true);
 }
 
-void PlaybackManager::remove_dead_buffers()
-{
-    int id = m_connection->get_playing_buffer();
-    int current_id = -1;
-    if (m_current_buffer)
-        current_id = m_current_buffer->id();
-
-    if (id >= 0 && id != current_id) {
-        while (!m_buffers.is_empty()) {
-            --m_next_ptr;
-            auto buffer = m_buffers.take_first();
-
-            if (buffer->id() == id) {
-                m_current_buffer = buffer;
-                break;
-            }
-        }
-    }
-}
-
-void PlaybackManager::load_next_buffer()
-{
-    if (m_buffers.size() < 10) {
-        for (int i = 0; i < 20 && m_loader->loaded_samples() < m_loader->total_samples(); i++) {
-            auto buffer = m_loader->get_more_samples(PLAYBACK_MANAGER_BUFFER_SIZE);
-            if (buffer) {
-                m_buffers.append(buffer);
-            }
-        }
-    }
-
-    if (m_next_ptr < m_buffers.size()) {
-        m_next_buffer = m_buffers.at(m_next_ptr++);
-        if (on_load_sample_buffer)
-            on_load_sample_buffer(*m_next_buffer);
-    } else {
-        m_next_buffer = nullptr;
-    }
-}
-
 void PlaybackManager::set_paused(bool paused)
 {
-    if (!m_next_buffer && m_loader)
-        load_next_buffer();
-
     m_paused = paused;
     m_connection->set_paused(paused);
 }
@@ -146,22 +99,24 @@ void PlaybackManager::next_buffer()
 {
     if (on_update)
         on_update();
+
     if (m_paused)
         return;
 
-    remove_dead_buffers();
-    if (!m_next_buffer) {
-        if (!m_connection->get_remaining_samples() && !m_paused) {
-            stop();
-            if (on_finished_playing)
-                on_finished_playing();
-        }
+    u32 audio_server_remaining_samples = m_connection->get_remaining_samples();
+    bool all_samples_loaded = (m_loader->loaded_samples() >= m_loader->total_samples());
+    bool audio_server_done = (audio_server_remaining_samples == 0);
+
+    if (all_samples_loaded && audio_server_done) {
+        stop();
+        if (on_finished_playing)
+            on_finished_playing();
         return;
     }
 
-    bool enqueued = m_connection->try_enqueue(*m_next_buffer);
-    if (!enqueued)
-        return;
-
-    load_next_buffer();
+    if (audio_server_remaining_samples < m_device_samples_per_buffer) {
+        m_current_buffer = m_loader->get_more_samples(m_source_buffer_size_bytes);
+        if (m_current_buffer)
+            m_connection->enqueue(*m_current_buffer);
+    }
 }

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -63,4 +63,5 @@ private:
     RefPtr<GUI::Label> m_volume_label;
 
     bool m_nonlinear_volume_slider;
+    size_t m_device_sample_rate { 44100 };
 };

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -20,7 +20,7 @@ void ClientConnection::enqueue(const Buffer& buffer)
         auto success = enqueue_buffer(buffer.anonymous_buffer(), buffer.id(), buffer.sample_count());
         if (success)
             break;
-        sleep(.1);
+        usleep(100000);
     }
 }
 

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -20,7 +20,7 @@ void ClientConnection::enqueue(const Buffer& buffer)
         auto success = enqueue_buffer(buffer.anonymous_buffer(), buffer.id(), buffer.sample_count());
         if (success)
             break;
-        sleep(1);
+        sleep(.1);
     }
 }
 

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -30,10 +30,18 @@ public:
 
     virtual void seek(const int sample_index) = 0;
 
+    // total_samples() and loaded_samples() should be independent
+    // of the number of channels.
+    //
+    // For example, with a three-second-long, stereo, 44.1KHz audio file:
+    //    num_channels() should return 2
+    //    sample_rate() should return 44100 (each channel is sampled at this rate)
+    //    total_samples() should return 132300 (sample_rate * three seconds)
     virtual int loaded_samples() = 0;
     virtual int total_samples() = 0;
     virtual u32 sample_rate() = 0;
     virtual u16 num_channels() = 0;
+
     virtual PcmSampleFormat pcm_format() = 0;
     virtual RefPtr<Core::File> file() = 0;
 };

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -30,7 +30,7 @@ WavLoaderPlugin::WavLoaderPlugin(const StringView& path)
     if (!valid)
         return;
 
-    m_resampler = make<ResampleHelper>(m_sample_rate, 44100);
+    m_resampler = make<ResampleHelper>(m_sample_rate, m_device_sample_rate);
 }
 
 WavLoaderPlugin::WavLoaderPlugin(const ByteBuffer& buffer)
@@ -46,7 +46,7 @@ WavLoaderPlugin::WavLoaderPlugin(const ByteBuffer& buffer)
     if (!valid)
         return;
 
-    m_resampler = make<ResampleHelper>(m_sample_rate, 44100);
+    m_resampler = make<ResampleHelper>(m_sample_rate, m_device_sample_rate);
 }
 
 RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_input)

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -54,15 +54,23 @@ RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_i
     if (!m_stream)
         return nullptr;
 
-    size_t bytes_per_sample = (m_num_channels * (pcm_bits_per_sample(m_sample_format) / 8));
+    int remaining_samples = m_total_samples - m_loaded_samples;
+    if (remaining_samples <= 0) {
+        return nullptr;
+    }
 
-    // Might truncate if not evenly divisible
-    size_t samples_to_read = static_cast<int>(max_bytes_to_read_from_input) / bytes_per_sample;
+    // One "sample" contains data from all channels.
+    // In the Wave spec, this is also called a block.
+    size_t bytes_per_sample = m_num_channels * pcm_bits_per_sample(m_sample_format) / 8;
+
+    // Might truncate if not evenly divisible by the sample size
+    int max_samples_to_read = static_cast<int>(max_bytes_to_read_from_input) / bytes_per_sample;
+    int samples_to_read = min(max_samples_to_read, remaining_samples);
     size_t bytes_to_read = samples_to_read * bytes_per_sample;
 
-    dbgln_if(AWAVLOADER_DEBUG, "Read {} bytes ({} samples) WAV with num_channels {} sample rate {}, "
+    dbgln_if(AWAVLOADER_DEBUG, "Read {} bytes WAV with num_channels {} sample rate {}, "
                                "bits per sample {}, sample format {}",
-        bytes_to_read, samples_to_read, m_num_channels, m_sample_rate,
+        bytes_to_read, m_num_channels, m_sample_rate,
         pcm_bits_per_sample(m_sample_format), sample_format_name(m_sample_format));
 
     ByteBuffer sample_data = ByteBuffer::create_zeroed(bytes_to_read);
@@ -79,7 +87,6 @@ RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_i
 
     // m_loaded_samples should contain the amount of actually loaded samples
     m_loaded_samples += samples_to_read;
-    m_loaded_samples = min(m_total_samples, m_loaded_samples);
     return buffer;
 }
 
@@ -89,15 +96,16 @@ void WavLoaderPlugin::seek(const int sample_index)
     if (sample_index < 0 || sample_index >= m_total_samples)
         return;
 
-    m_loaded_samples = sample_index;
-    size_t byte_position = m_byte_offset_of_data_samples + sample_index * m_num_channels * (pcm_bits_per_sample(m_sample_format) / 8);
+    size_t sample_offset = m_byte_offset_of_data_samples + (sample_index * m_num_channels * (pcm_bits_per_sample(m_sample_format) / 8));
 
-    // AK::InputStream does not define seek.
+    // AK::InputStream does not define seek, hence the special-cases for file and stream.
     if (m_file) {
-        m_file->seek(byte_position);
+        m_file->seek(sample_offset);
     } else {
-        m_memory_stream->seek(byte_position);
+        m_memory_stream->seek(sample_offset);
     }
+
+    m_loaded_samples = sample_index;
 }
 
 // Specification reference: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
@@ -180,11 +188,11 @@ bool WavLoaderPlugin::parse_header()
     read_u32();
     CHECK_OK("Data rate");
 
-    read_u16();
+    u16 block_size_bytes = read_u16();
     CHECK_OK("Block size");
 
     u16 bits_per_sample = read_u16();
-    CHECK_OK("Bits per sample"); // incomplete read check
+    CHECK_OK("Bits per sample");
 
     if (audio_format == WAVE_FORMAT_EXTENSIBLE) {
         ok = ok && (fmt_size == 40);
@@ -228,6 +236,9 @@ bool WavLoaderPlugin::parse_header()
         }
     }
 
+    ok = ok && (block_size_bytes == (m_num_channels * (bits_per_sample / 8)));
+    CHECK_OK("Block size sanity check");
+
     dbgln_if(AWAVLOADER_DEBUG, "WAV format {} at {} bit, {} channels, rate {}Hz ",
         sample_format_name(m_sample_format), pcm_bits_per_sample(m_sample_format), m_num_channels, m_sample_rate);
 
@@ -262,12 +273,11 @@ bool WavLoaderPlugin::parse_header()
     ok = ok && data_sz < maximum_wav_size;
     CHECK_OK("Data was too large");
 
-    int bytes_per_sample = (bits_per_sample / 8) * m_num_channels;
-    m_total_samples = data_sz / bytes_per_sample;
+    m_total_samples = data_sz / block_size_bytes;
 
     dbgln_if(AWAVLOADER_DEBUG, "WAV data size {}, bytes per sample {}, total samples {}",
         data_sz,
-        bytes_per_sample,
+        block_size_bytes,
         m_total_samples);
 
     m_byte_offset_of_data_samples = bytes_read;

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -41,6 +41,8 @@ public:
     virtual bool has_error() override { return !m_error_string.is_null(); }
     virtual const char* error_string() override { return m_error_string.characters(); }
 
+    // The Buffer returned contains input data resampled at the
+    // destination audio device sample rate.
     virtual RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
 
     virtual void reset() override { return seek(0); }
@@ -64,6 +66,11 @@ private:
     OwnPtr<AK::InputStream> m_stream;
     AK::InputMemoryStream* m_memory_stream;
     String m_error_string;
+
+    // TODO: We should probably move resampling into the audio server.
+    //
+    // It would avoid duplicate resampling code and would allow clients
+    // to be agnostic of the destination audio device's sample rate.
     OwnPtr<ResampleHelper> m_resampler;
 
     u32 m_sample_rate { 0 };
@@ -71,6 +78,8 @@ private:
     PcmSampleFormat m_sample_format;
     size_t m_byte_offset_of_data_samples { 0 };
 
+    // FIXME: Get this value from the audio server
+    int m_device_sample_rate { 44100 };
     int m_loaded_samples { 0 };
     int m_total_samples { 0 };
 };


### PR DESCRIPTION
This PR fixes several small issues related to Wave playback. It also adds better support for high-sample rate files (e.g. 96 KHz).

### LibAudio: Avoid reading past the end of sample data 

Prior code in `WavLoader::get_more_samples()` would attempt to
read the requested number of samples without actually checking
whether that many samples were remaining in the stream.
This was the cause of an audible pop at the end of a track, due
to reading non-audio data that is sometimes at the end of a Wave file.

Now we only attempt to read up to the end of sample data, but no
further.

Also, added comments to clarify the meaning of "sample", and how it
should be independent of the number of channels.

### LibAudio: Sleep less when the audio buffer is full 

When using `aplay` to play audio files with a sample rate of 96000,
there were occasional one-second gaps in playback. This is
because the Audio::ClientConnection sleeps for a full second when
the audio buffer is full.

One second is too long to sleep, especially for high-bitrate files.
Changing the sleep to a more reasonable value like 100 ms ensures
we attempt to enqueue again before the audio buffer runs empty.

### SoundPlayer: Handle any input file sample rate

This commit addresses two issues:
1. If you play a 96 KHz Wave file, the slider position is incorrect,
   because it is assumed all files are 44.1 KHz.
2. For high-bitrate files, there are audio dropouts due to not
   buffering enough audio data.

Issue 1 is addressed by scaling the number of played samples by the
ratio between the source and destination sample rates.

Issue 2 is addressed by buffering a certain number of milliseconds
worth of audio data (instead of a fixed number of bytes).
This makes the the buffer size independent of the source sample rate.

Some of the code is redesigned to be simpler. The code that did the
book-keeping of which buffers need to be loaded and which have been
already played has been removed. Instead, we enqueue a new buffer based
on a low watermark of samples remaining in the audio server queue.

Other small fixes include:
1. Disable the stop button when playback is finished.
2. Remove hard-coded instances of 44100.
3. Update the GUI every 50 ms (was 100), which improves visualizations.