### PR TITLE
LibCoreDump: Don't subtract one from the first stack frame's EIP

### DIFF
--- a/Userland/Libraries/LibCoreDump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoreDump/Backtrace.cpp
@@ -53,11 +53,16 @@ Backtrace::Backtrace(const Reader& coredump, const ELF::Core::ThreadInfo& thread
 {
     uint32_t* ebp = (uint32_t*)m_thread_info.regs.ebp;
     uint32_t* eip = (uint32_t*)m_thread_info.regs.eip;
+    bool first_frame = true;
     while (ebp && eip) {
         // We use eip - 1 because the return address from a function frame
         // is the instruction that comes after the 'call' instruction.
+        // However, because the first frame represents the faulting
+        // instruction rather than the return address we don't subtract
+        // 1 there.
         VERIFY((FlatPtr)eip > 0);
-        add_entry(coredump, (FlatPtr)eip - 1);
+        add_entry(coredump, (FlatPtr)eip - (first_frame ? 0 : 1));
+        first_frame = false;
         auto next_eip = coredump.peek_memory((FlatPtr)(ebp + 1));
         auto next_ebp = coredump.peek_memory((FlatPtr)(ebp));
         if (!next_eip.has_value() || !next_ebp.has_value())


### PR DESCRIPTION
The first stack frame represents the current instruction pointer rather than the return address so we shouldn't subtract one from it.

Fixes #8162.