### PR TITLE
LibWeb: Fix redirects when response has no data

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -229,11 +229,6 @@ void FrameLoader::resource_did_load()
 {
     auto url = resource()->url();
 
-    if (!resource()->has_encoded_data()) {
-        load_error_page(url, "No data");
-        return;
-    }
-
     // FIXME: Also check HTTP status code before redirecting
     auto location = resource()->response_headers().get("Location");
     if (location.has_value()) {
@@ -247,6 +242,11 @@ void FrameLoader::resource_did_load()
         return;
     }
     m_redirects_count = 0;
+
+    if (!resource()->has_encoded_data()) {
+        load_error_page(url, "No data");
+        return;
+    }
 
     if (resource()->has_encoding()) {
         dbgln("This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());


### PR DESCRIPTION
This makes redirects work when the HTTP server responds with just headers and
no data.