### PR TITLE
LibVideo part 3: Continue parsing more data

### DIFF
--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -20,11 +20,11 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
 
     auto document = Video::MatroskaReader::parse_matroska_from_file("/home/anon/Videos/test-webm.webm");
-    const auto& optional_track = document->track_for_track_type(Video::TrackEntry::TrackType::Video);
+    auto const& optional_track = document->track_for_track_type(Video::TrackEntry::TrackType::Video);
     if (!optional_track.has_value())
         return 1;
-    const auto& track = optional_track.value();
-    const auto video_track = track.video_track().value();
+    auto const& track = optional_track.value();
+    auto const video_track = track.video_track().value();
 
     auto image = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, Gfx::IntSize(video_track.pixel_height, video_track.pixel_width));
     auto& main_widget = window->set_main_widget<GUI::Widget>();
@@ -36,12 +36,12 @@ int main(int argc, char** argv)
     main_widget.add_child(image_widget);
 
     Video::VP9::Decoder vp9_decoder;
-    for (const auto& cluster : document->clusters()) {
-        for (const auto& block : cluster.blocks()) {
+    for (auto const& cluster : document->clusters()) {
+        for (auto const& block : cluster.blocks()) {
             if (block.track_number() != track.track_number())
                 continue;
 
-            const auto& frame = block.frame(0);
+            auto const& frame = block.frame(0);
             dbgln("Reading frame 0 from block @ {}", block.timestamp());
             vp9_decoder.parse_frame(frame);
             vp9_decoder.dump_info();

--- a/Userland/Libraries/LibVideo/CMakeLists.txt
+++ b/Userland/Libraries/LibVideo/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     VP9/ProbabilityTables.cpp
     VP9/Symbols.h
     VP9/SyntaxElementCounter.cpp
+    VP9/TreeParser.cpp
 )
 
 serenity_lib(LibVideo video)

--- a/Userland/Libraries/LibVideo/MatroskaDocument.h
+++ b/Userland/Libraries/LibVideo/MatroskaDocument.h
@@ -67,9 +67,9 @@ public:
     TrackType track_type() const { return m_track_type; }
     void set_track_type(TrackType track_type) { m_track_type = track_type; }
     FlyString language() const { return m_language; }
-    void set_language(const FlyString& language) { m_language = language; }
+    void set_language(FlyString const& language) { m_language = language; }
     FlyString codec_id() const { return m_codec_id; }
-    void set_codec_id(const FlyString& codec_id) { m_codec_id = codec_id; }
+    void set_codec_id(FlyString const& codec_id) { m_codec_id = codec_id; }
     Optional<VideoTrack> video_track() const
     {
         if (track_type() != Video)
@@ -122,8 +122,8 @@ public:
     bool discardable() const { return m_discardable; }
     void set_discardable(bool discardable) { m_discardable = discardable; }
     u64 frame_count() const { return m_frames.size(); }
-    const ByteBuffer& frame(size_t index) const { return m_frames.at(index); }
-    void add_frame(const ByteBuffer& frame) { m_frames.append(move(frame)); }
+    ByteBuffer const& frame(size_t index) const { return m_frames.at(index); }
+    void add_frame(ByteBuffer frame) { m_frames.append(move(frame)); }
 
 private:
     u64 m_track_number { 0 };
@@ -140,7 +140,7 @@ public:
     u64 timestamp() const { return m_timestamp; }
     void set_timestamp(u64 timestamp) { m_timestamp = timestamp; }
     NonnullOwnPtrVector<Block>& blocks() { return m_blocks; }
-    const NonnullOwnPtrVector<Block>& blocks() const { return m_blocks; }
+    NonnullOwnPtrVector<Block> const& blocks() const { return m_blocks; }
 
 private:
     u64 m_timestamp { 0 };
@@ -154,7 +154,7 @@ public:
     {
     }
 
-    const EBMLHeader& header() const { return m_header; }
+    EBMLHeader const& header() const { return m_header; }
 
     Optional<SegmentInformation> segment_information() const
     {
@@ -163,7 +163,7 @@ public:
         return *m_segment_information;
     }
     void set_segment_information(OwnPtr<SegmentInformation> segment_information) { m_segment_information = move(segment_information); }
-    const HashMap<u64, NonnullOwnPtr<TrackEntry>>& tracks() const { return m_tracks; }
+    HashMap<u64, NonnullOwnPtr<TrackEntry>> const& tracks() const { return m_tracks; }
     Optional<TrackEntry> track_for_track_number(u64 track_number) const
     {
         auto track = m_tracks.get(track_number);

--- a/Userland/Libraries/LibVideo/MatroskaReader.cpp
+++ b/Userland/Libraries/LibVideo/MatroskaReader.cpp
@@ -41,7 +41,7 @@ constexpr u32 BIT_DEPTH_ID = 0x6264;
 constexpr u32 SIMPLE_BLOCK_ID = 0xA3;
 constexpr u32 TIMESTAMP_ID = 0xE7;
 
-OwnPtr<MatroskaDocument> MatroskaReader::parse_matroska_from_file(const StringView& path)
+OwnPtr<MatroskaDocument> MatroskaReader::parse_matroska_from_file(StringView const& path)
 {
     auto mapped_file_result = MappedFile::map(path);
     if (mapped_file_result.is_error())
@@ -51,7 +51,7 @@ OwnPtr<MatroskaDocument> MatroskaReader::parse_matroska_from_file(const StringVi
     return parse_matroska_from_data((u8*)mapped_file->data(), mapped_file->size());
 }
 
-OwnPtr<MatroskaDocument> MatroskaReader::parse_matroska_from_data(const u8* data, size_t size)
+OwnPtr<MatroskaDocument> MatroskaReader::parse_matroska_from_data(u8 const* data, size_t size)
 {
     MatroskaReader reader(data, size);
     return reader.parse();
@@ -83,7 +83,7 @@ OwnPtr<MatroskaDocument> MatroskaReader::parse()
     return matroska_document;
 }
 
-bool MatroskaReader::parse_master_element([[maybe_unused]] const StringView& element_name, Function<bool(u64)> element_consumer)
+bool MatroskaReader::parse_master_element([[maybe_unused]] StringView const& element_name, Function<bool(u64)> element_consumer)
 {
     auto element_data_size = m_streamer.read_variable_size_integer();
     CHECK_HAS_VALUE(element_data_size);

--- a/Userland/Libraries/LibVideo/MatroskaReader.h
+++ b/Userland/Libraries/LibVideo/MatroskaReader.h
@@ -17,28 +17,28 @@ namespace Video {
 
 class MatroskaReader {
 public:
-    MatroskaReader(const u8* data, size_t size)
+    MatroskaReader(u8 const* data, size_t size)
         : m_streamer(data, size)
     {
     }
 
-    static OwnPtr<MatroskaDocument> parse_matroska_from_file(const StringView& path);
-    static OwnPtr<MatroskaDocument> parse_matroska_from_data(const u8*, size_t);
+    static OwnPtr<MatroskaDocument> parse_matroska_from_file(StringView const& path);
+    static OwnPtr<MatroskaDocument> parse_matroska_from_data(u8 const*, size_t);
 
     OwnPtr<MatroskaDocument> parse();
 
 private:
     class Streamer {
     public:
-        Streamer(const u8* data, size_t size)
+        Streamer(u8 const* data, size_t size)
             : m_data_ptr(data)
             , m_size_remaining(size)
         {
         }
 
-        const u8* data() { return m_data_ptr; }
+        u8 const* data() { return m_data_ptr; }
 
-        const char* data_as_chars() { return reinterpret_cast<const char*>(m_data_ptr); }
+        char const* data_as_chars() { return reinterpret_cast<char const*>(m_data_ptr); }
 
         u8 read_octet()
         {
@@ -141,12 +141,12 @@ private:
         void set_remaining(size_t remaining) { m_size_remaining = remaining; }
 
     private:
-        const u8* m_data_ptr { nullptr };
+        u8 const* m_data_ptr { nullptr };
         size_t m_size_remaining { 0 };
         Vector<size_t> m_octets_read { 0 };
     };
 
-    bool parse_master_element(const StringView& element_name, Function<bool(u64 element_id)> element_consumer);
+    bool parse_master_element(StringView const& element_name, Function<bool(u64 element_id)> element_consumer);
     Optional<EBMLHeader> parse_ebml_header();
 
     bool parse_segment_elements(MatroskaDocument&);

--- a/Userland/Libraries/LibVideo/VP9/BitStream.h
+++ b/Userland/Libraries/LibVideo/VP9/BitStream.h
@@ -13,7 +13,7 @@ namespace Video::VP9 {
 
 class BitStream {
 public:
-    BitStream(const u8* data, size_t size)
+    BitStream(u8 const* data, size_t size)
         : m_data_ptr(data)
         , m_bytes_remaining(size)
     {
@@ -36,7 +36,7 @@ public:
     bool exit_bool();
 
 private:
-    const u8* m_data_ptr { nullptr };
+    u8 const* m_data_ptr { nullptr };
     size_t m_bytes_remaining { 0 };
     Optional<u8> m_current_byte;
     i8 m_current_bit_position { 0 };

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -14,17 +14,14 @@ namespace Video::VP9 {
 
 Decoder::Decoder()
     : m_probability_tables(make<ProbabilityTables>())
-    , m_tree_parser(make<TreeParser>(*m_probability_tables))
+    , m_tree_parser(make<TreeParser>(*this))
 {
-    m_tree_parser->set_segmentation_tree_probs(m_segmentation_tree_probs);
 }
 
 bool Decoder::parse_frame(const ByteBuffer& frame_data)
 {
     m_bit_stream = make<BitStream>(frame_data.data(), frame_data.size());
     m_syntax_element_counter = make<SyntaxElementCounter>();
-    m_tree_parser->set_bit_stream(m_bit_stream);
-    m_tree_parser->set_syntax_element_counter(m_syntax_element_counter);
 
     if (!uncompressed_header())
         return false;
@@ -129,8 +126,6 @@ bool Decoder::uncompressed_header()
             read_interpolation_filter();
         }
     }
-
-    m_tree_parser->set_frame_is_intra(m_frame_is_intra);
 
     if (!m_error_resilient_mode) {
         m_refresh_frame_context = m_bit_stream->read_bit();
@@ -522,9 +517,8 @@ u8 Decoder::inv_recenter_nonneg(u8 v, u8 m)
 
 bool Decoder::read_coef_probs()
 {
-    auto max_tx_size = tx_mode_to_biggest_tx_size[m_tx_mode];
-    m_tree_parser->set_max_tx_size(max_tx_size);
-    for (auto tx_size = TX_4x4; tx_size <= max_tx_size; tx_size = static_cast<TXSize>(static_cast<int>(tx_size) + 1)) {
+    m_max_tx_size = tx_mode_to_biggest_tx_size[m_tx_mode];
+    for (auto tx_size = TX_4x4; tx_size <= m_max_tx_size; tx_size = static_cast<TXSize>(static_cast<int>(tx_size) + 1)) {
         auto update_probs = m_bit_stream->read_literal(1);
         if (update_probs == 1) {
             for (auto i = 0; i < 2; i++) {
@@ -774,9 +768,9 @@ bool Decoder::decode_tile()
     for (auto row = m_mi_row_start; row < m_mi_row_end; row += 8) {
         if (!clear_left_context())
             return false;
-        m_tree_parser->set_row(row);
+        m_row = row;
         for (auto col = m_mi_col_start; col < m_mi_col_end; col += 8) {
-            m_tree_parser->set_col(col);
+            m_col = col;
             if (!decode_partition(row, col, Block_64x64))
                 return false;
         }
@@ -796,15 +790,11 @@ bool Decoder::decode_partition(u32 row, u32 col, u8 block_subsize)
 {
     if (row >= m_mi_rows || col >= m_mi_cols)
         return false;
-    auto num_8x8 = num_8x8_blocks_wide_lookup[block_subsize];
-    auto half_block_8x8 = num_8x8 >> 1;
-    auto has_rows = (row + half_block_8x8) < m_mi_rows;
-    auto has_cols = (col + half_block_8x8) < m_mi_cols;
-
-    m_tree_parser->set_has_rows(has_rows);
-    m_tree_parser->set_has_cols(has_cols);
-    m_tree_parser->set_block_subsize(block_subsize);
-    m_tree_parser->set_num_8x8(num_8x8);
+    m_block_subsize = block_subsize;
+    m_num_8x8 = num_8x8_blocks_wide_lookup[block_subsize];
+    auto half_block_8x8 = m_num_8x8 >> 1;
+    m_has_rows = (row + half_block_8x8) < m_mi_rows;
+    m_has_cols = (col + half_block_8x8) < m_mi_cols;
 
     auto partition = m_tree_parser->parse_tree(SyntaxElementType::Partition);
     dbgln("Parsed partition value {}", partition);
@@ -827,14 +817,10 @@ bool Decoder::decode_partition(u32 row, u32 col, u8 block_subsize)
 bool Decoder::decode_block(u32 row, u32 col, u8 subsize)
 {
     m_mi_row = row;
-    m_tree_parser->set_mi_row(m_mi_row);
     m_mi_col = col;
-    m_tree_parser->set_mi_col(m_mi_col);
     m_mi_size = subsize;
     m_available_u = row > 0;
-    m_tree_parser->set_available_u(m_available_u);
     m_available_l = col > m_mi_col_start;
-    m_tree_parser->set_available_l(m_available_l);
     if (!mode_info())
         return false;
     // FIXME: Finish implementing

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -13,14 +13,16 @@ namespace Video::VP9 {
     return false
 
 Decoder::Decoder()
+    : m_probability_tables(make<ProbabilityTables>())
+    , m_tree_parser(make<TreeParser>(*m_probability_tables))
 {
-    m_probability_tables = make<ProbabilityTables>();
 }
 
 bool Decoder::parse_frame(const ByteBuffer& frame_data)
 {
     m_bit_stream = make<BitStream>(frame_data.data(), frame_data.size());
     m_syntax_element_counter = make<SyntaxElementCounter>();
+    m_tree_parser->set_bit_stream(m_bit_stream);
 
     if (!uncompressed_header())
         return false;
@@ -125,6 +127,8 @@ bool Decoder::uncompressed_header()
             read_interpolation_filter();
         }
     }
+
+    m_tree_parser->set_frame_is_intra(m_frame_is_intra);
 
     if (!m_error_resilient_mode) {
         m_refresh_frame_context = m_bit_stream->read_bit();
@@ -440,10 +444,10 @@ bool Decoder::compressed_header()
 bool Decoder::read_tx_mode()
 {
     if (m_lossless) {
-        m_tx_mode = Only4x4;
+        m_tx_mode = Only_4x4;
     } else {
         auto tx_mode = m_bit_stream->read_literal(2);
-        if (tx_mode == Allow32x32) {
+        if (tx_mode == Allow_32x32) {
             tx_mode += m_bit_stream->read_literal(1);
         }
         m_tx_mode = static_cast<TXMode>(tx_mode);
@@ -456,17 +460,17 @@ bool Decoder::tx_mode_probs()
     auto& tx_probs = m_probability_tables->tx_probs();
     for (auto i = 0; i < TX_SIZE_CONTEXTS; i++) {
         for (auto j = 0; j < TX_SIZES - 3; j++) {
-            tx_probs[TX8x8][i][j] = diff_update_prob(tx_probs[TX8x8][i][j]);
+            tx_probs[TX_8x8][i][j] = diff_update_prob(tx_probs[TX_8x8][i][j]);
         }
     }
     for (auto i = 0; i < TX_SIZE_CONTEXTS; i++) {
         for (auto j = 0; j < TX_SIZES - 2; j++) {
-            tx_probs[TX16x16][i][j] = diff_update_prob(tx_probs[TX16x16][i][j]);
+            tx_probs[TX_16x16][i][j] = diff_update_prob(tx_probs[TX_16x16][i][j]);
         }
     }
     for (auto i = 0; i < TX_SIZE_CONTEXTS; i++) {
         for (auto j = 0; j < TX_SIZES - 1; j++) {
-            tx_probs[TX32x32][i][j] = diff_update_prob(tx_probs[TX32x32][i][j]);
+            tx_probs[TX_32x32][i][j] = diff_update_prob(tx_probs[TX_32x32][i][j]);
         }
     }
     return true;
@@ -517,7 +521,8 @@ u8 Decoder::inv_recenter_nonneg(u8 v, u8 m)
 bool Decoder::read_coef_probs()
 {
     auto max_tx_size = tx_mode_to_biggest_tx_size[m_tx_mode];
-    for (auto tx_size = TX4x4; tx_size <= max_tx_size; tx_size = static_cast<TXSize>(static_cast<int>(tx_size) + 1)) {
+    m_tree_parser->set_max_tx_size(max_tx_size);
+    for (auto tx_size = TX_4x4; tx_size <= max_tx_size; tx_size = static_cast<TXSize>(static_cast<int>(tx_size) + 1)) {
         auto update_probs = m_bit_stream->read_literal(1);
         if (update_probs == 1) {
             for (auto i = 0; i < 2; i++) {
@@ -760,7 +765,9 @@ bool Decoder::decode_tile()
     for (auto row = m_mi_row_start; row < m_mi_row_end; row += 8) {
         if (!clear_left_context())
             return false;
+        m_tree_parser->set_row(row);
         for (auto col = m_mi_col_start; col < m_mi_col_end; col += 8) {
+            m_tree_parser->set_col(col);
             if (!decode_partition(row, col, Block_64x64))
                 return false;
         }
@@ -787,9 +794,15 @@ bool Decoder::decode_partition(u32 row, u32 col, u8 block_subsize)
     auto has_rows = (row + half_block_8x8) < m_mi_rows;
     auto has_cols = (col + half_block_8x8) < m_mi_cols;
 
-    // FIXME: Parse partition (type: T) as specified by spec in section 9.3
-    (void)has_rows;
-    (void)has_cols;
+    m_tree_parser->set_has_rows(has_rows);
+    m_tree_parser->set_has_cols(has_cols);
+    m_tree_parser->set_block_subsize(block_subsize);
+    m_tree_parser->set_num_8x8(num_8x8);
+
+    auto partition = m_tree_parser->parse_tree(SyntaxElementType::Partition);
+    dbgln("Parsed partition value {}", partition);
+
+    // FIXME: Finish implementing partition decoding
 
     return true;
 }

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -16,6 +16,7 @@ Decoder::Decoder()
     : m_probability_tables(make<ProbabilityTables>())
     , m_tree_parser(make<TreeParser>(*m_probability_tables))
 {
+    m_tree_parser->set_segmentation_tree_probs(m_segmentation_tree_probs);
 }
 
 bool Decoder::parse_frame(const ByteBuffer& frame_data)
@@ -307,18 +308,18 @@ i8 Decoder::read_delta_q()
 
 bool Decoder::segmentation_params()
 {
-    auto segmentation_enabled = m_bit_stream->read_bit();
-    if (!segmentation_enabled)
+    m_segmentation_enabled = m_bit_stream->read_bit();
+    if (!m_segmentation_enabled)
         return true;
 
-    auto segmentation_update_map = m_bit_stream->read_bit();
-    if (segmentation_update_map) {
+    m_segmentation_update_map = m_bit_stream->read_bit();
+    if (m_segmentation_update_map) {
         for (auto i = 0; i < 7; i++) {
             m_segmentation_tree_probs[i] = read_prob();
         }
-        auto segmentation_temporal_update = m_bit_stream->read_bit();
+        m_segmentation_temporal_update = m_bit_stream->read_bit();
         for (auto i = 0; i < 3; i++) {
-            m_segmentation_pred_prob[i] = segmentation_temporal_update ? read_prob() : 255;
+            m_segmentation_pred_prob[i] = m_segmentation_temporal_update ? read_prob() : 255;
         }
     }
 
@@ -808,8 +809,91 @@ bool Decoder::decode_partition(u32 row, u32 col, u8 block_subsize)
     auto partition = m_tree_parser->parse_tree(SyntaxElementType::Partition);
     dbgln("Parsed partition value {}", partition);
 
+    auto subsize = subsize_lookup[partition][block_subsize];
+    if (subsize < Block_8x8 || partition == PartitionNone) {
+        if (!decode_block(row, col, subsize))
+            return false;
+    } else if (partition == PartitionHorizontal) {
+        if (!decode_block(row, col, subsize))
+            return false;
+        // FIXME: if (hasRows)
+        //            decode_block(r + halfBlock8x8, c, subsize)
+    }
     // FIXME: Finish implementing partition decoding
 
+    return true;
+}
+
+bool Decoder::decode_block(u32 row, u32 col, u8 subsize)
+{
+    m_mi_row = row;
+    m_tree_parser->set_mi_row(m_mi_row);
+    m_mi_col = col;
+    m_tree_parser->set_mi_col(m_mi_col);
+    m_mi_size = subsize;
+    m_available_u = row > 0;
+    m_tree_parser->set_available_u(m_available_u);
+    m_available_l = col > m_mi_col_start;
+    m_tree_parser->set_available_l(m_available_l);
+    if (!mode_info())
+        return false;
+    // FIXME: Finish implementing
+    return true;
+}
+
+bool Decoder::mode_info()
+{
+    if (m_frame_is_intra)
+        return intra_frame_mode_info();
+    return inter_frame_mode_info();
+}
+
+bool Decoder::intra_frame_mode_info()
+{
+    if (!intra_segment_id())
+        return false;
+    if (!read_skip())
+        return false;
+    if (!read_tx_size(true))
+        return false;
+    // FIXME: Finish implementing
+    return true;
+}
+
+bool Decoder::intra_segment_id()
+{
+    if (m_segmentation_enabled && m_segmentation_update_map) {
+        m_segment_id = m_tree_parser->parse_tree(SyntaxElementType::SegmentID);
+    } else {
+        m_segment_id = 0;
+    }
+    return true;
+}
+
+bool Decoder::read_skip()
+{
+    if (seg_feature_active(SEG_LVL_SKIP)) {
+        m_skip = 1;
+    } else {
+        m_skip = m_tree_parser->parse_tree(SyntaxElementType::Skip);
+    }
+    return true;
+}
+
+bool Decoder::seg_feature_active(u8 feature)
+{
+    return m_segmentation_enabled && m_feature_enabled[m_segment_id][feature];
+}
+
+bool Decoder::read_tx_size(bool allow_select)
+{
+    // FIXME: Implement
+    (void)allow_select;
+    return true;
+}
+
+bool Decoder::inter_frame_mode_info()
+{
     return true;
 }
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -22,7 +22,7 @@ Decoder::Decoder()
 {
 }
 
-bool Decoder::parse_frame(const ByteBuffer& frame_data)
+bool Decoder::parse_frame(ByteBuffer const& frame_data)
 {
     m_bit_stream = make<BitStream>(frame_data.data(), frame_data.size());
     m_syntax_element_counter = make<SyntaxElementCounter>();
@@ -301,13 +301,11 @@ bool Decoder::segmentation_params()
 
     m_segmentation_update_map = m_bit_stream->read_bit();
     if (m_segmentation_update_map) {
-        for (auto i = 0; i < 7; i++) {
+        for (auto i = 0; i < 7; i++)
             m_segmentation_tree_probs[i] = read_prob();
-        }
         m_segmentation_temporal_update = m_bit_stream->read_bit();
-        for (auto i = 0; i < 3; i++) {
+        for (auto i = 0; i < 3; i++)
             m_segmentation_pred_prob[i] = m_segmentation_temporal_update ? read_prob() : 255;
-        }
     }
 
     SAFE_CALL(m_bit_stream->read_bit());

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -22,7 +22,7 @@ class Decoder {
 public:
     Decoder();
     ~Decoder();
-    bool parse_frame(const ByteBuffer&);
+    bool parse_frame(ByteBuffer const&);
     void dump_info();
 
 private:

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -19,6 +19,7 @@ namespace Video::VP9 {
 class Decoder {
 public:
     Decoder();
+    ~Decoder();
     bool parse_frame(const ByteBuffer&);
     void dump_info();
 
@@ -128,6 +129,12 @@ private:
     i8 m_loop_filter_ref_deltas[MAX_REF_FRAMES];
     i8 m_loop_filter_mode_deltas[2];
 
+    u8** m_above_nonzero_context { nullptr };
+    u8** m_left_nonzero_context { nullptr };
+    u8* m_above_seg_pred_context { nullptr };
+    u8* m_left_seg_pred_context { nullptr };
+    u8* m_above_partition_context { nullptr };
+    u8* m_left_partition_context { nullptr };
     u32 m_mi_row_start { 0 };
     u32 m_mi_row_end { 0 };
     u32 m_mi_col_start { 0 };

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -10,6 +10,7 @@
 #include "LookupTables.h"
 #include "ProbabilityTables.h"
 #include "SyntaxElementCounter.h"
+#include "TreeParser.h"
 #include <AK/ByteBuffer.h>
 #include <AK/OwnPtr.h>
 
@@ -132,6 +133,8 @@ private:
     u32 m_mi_col_start { 0 };
     u32 m_mi_col_end { 0 };
 
+    bool m_use_hp { false };
+
     TXMode m_tx_mode;
     ReferenceMode m_reference_mode;
     ReferenceFrame m_comp_fixed_ref;
@@ -140,6 +143,7 @@ private:
     OwnPtr<BitStream> m_bit_stream;
     OwnPtr<ProbabilityTables> m_probability_tables;
     OwnPtr<SyntaxElementCounter> m_syntax_element_counter;
+    NonnullOwnPtr<TreeParser> m_tree_parser;
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -167,6 +167,15 @@ private:
     u8 m_block_subsize { 0 };
     u32 m_row { 0 };
     u32 m_col { 0 };
+    TXSize m_tx_size { TX_4x4 };
+    ReferenceFrame m_ref_frame[2];
+    bool m_is_inter { false };
+    IntraMode m_default_intra_mode { DcPred };
+    u8 m_y_mode { 0 };
+    u8 m_sub_modes[4]; // FIXME: What size is this supposed to be?
+    u8 m_num_4x4_w { 0 };
+    u8 m_num_4x4_h { 0 };
+    u8 m_uv_mode { 0 }; // FIXME: Is u8 the right size?
 
     bool m_use_hp { false };
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -75,7 +75,13 @@ private:
     u8 update_mv_prob(u8 prob);
     bool setup_compound_reference_mode();
 
-    u64 m_start_bit_pos { 0 };
+    bool decode_tiles();
+    bool clear_above_context();
+    u32 get_tile_offset(u32 tile_num, u32 mis, u32 tile_size_log2);
+    bool decode_tile();
+    bool clear_left_context();
+    bool decode_partition(u32 row, u32 col, u8 block_subsize);
+
     u8 m_profile { 0 };
     u8 m_frame_to_show_map_index { 0 };
     u16 m_header_size_in_bytes { 0 };
@@ -100,15 +106,15 @@ private:
     ColorRange m_color_range;
     bool m_subsampling_x { false };
     bool m_subsampling_y { false };
-    u16 m_frame_width { 0 };
-    u16 m_frame_height { 0 };
+    u32 m_frame_width { 0 };
+    u32 m_frame_height { 0 };
     u16 m_render_width { 0 };
     u16 m_render_height { 0 };
     bool m_render_and_frame_size_different { false };
-    u16 m_mi_cols { 0 };
-    u16 m_mi_rows { 0 };
-    u16 m_sb64_cols { 0 };
-    u16 m_sb64_rows { 0 };
+    u32 m_mi_cols { 0 };
+    u32 m_mi_rows { 0 };
+    u32 m_sb64_cols { 0 };
+    u32 m_sb64_rows { 0 };
     InterpolationFilter m_interpolation_filter;
     bool m_lossless { false };
     u8 m_segmentation_tree_probs[7];
@@ -120,6 +126,11 @@ private:
     u16 m_tile_rows_log2 { 0 };
     i8 m_loop_filter_ref_deltas[MAX_REF_FRAMES];
     i8 m_loop_filter_mode_deltas[2];
+
+    u32 m_mi_row_start { 0 };
+    u32 m_mi_row_end { 0 };
+    u32 m_mi_col_start { 0 };
+    u32 m_mi_col_end { 0 };
 
     TXMode m_tx_mode;
     ReferenceMode m_reference_mode;

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -17,6 +17,8 @@
 namespace Video::VP9 {
 
 class Decoder {
+    friend class TreeParser;
+
 public:
     Decoder();
     ~Decoder();
@@ -158,6 +160,13 @@ private:
     bool m_available_l { false };
     int m_segment_id { 0 };
     int m_skip { false };
+    u8 m_num_8x8 { 0 };
+    bool m_has_rows { false };
+    bool m_has_cols { false };
+    TXSize m_max_tx_size { TX_4x4 };
+    u8 m_block_subsize { 0 };
+    u32 m_row { 0 };
+    u32 m_col { 0 };
 
     bool m_use_hp { false };
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -92,8 +92,13 @@ private:
     bool read_skip();
     bool seg_feature_active(u8 feature);
     bool read_tx_size(bool allow_select);
-
     bool inter_frame_mode_info();
+    bool inter_segment_id();
+    u8 get_segment_id();
+    bool read_is_inter();
+    bool inter_block_mode_info();
+
+    bool intra_block_mode_info();
 
     u8 m_profile { 0 };
     u8 m_frame_to_show_map_index { 0 };
@@ -158,8 +163,8 @@ private:
     u32 m_mi_size { 0 };
     bool m_available_u { false };
     bool m_available_l { false };
-    int m_segment_id { 0 };
-    int m_skip { false };
+    u8 m_segment_id { 0 };
+    bool m_skip { false };
     u8 m_num_8x8 { 0 };
     bool m_has_rows { false };
     bool m_has_cols { false };
@@ -176,6 +181,14 @@ private:
     u8 m_num_4x4_w { 0 };
     u8 m_num_4x4_h { 0 };
     u8 m_uv_mode { 0 }; // FIXME: Is u8 the right size?
+    ReferenceFrame m_left_ref_frame[2];
+    ReferenceFrame m_above_ref_frame[2];
+    Vector<Vector<Vector<ReferenceFrame>>> m_ref_frames; // TODO: Can we make these fixed sized allocations?
+    bool m_left_intra { false };
+    bool m_above_intra { false };
+    bool m_left_single { false };
+    bool m_above_single { false };
+    Vector<Vector<u8>> m_prev_segment_ids;
 
     bool m_use_hp { false };
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -83,6 +83,15 @@ private:
     bool decode_tile();
     bool clear_left_context();
     bool decode_partition(u32 row, u32 col, u8 block_subsize);
+    bool decode_block(u32 row, u32 col, u8 subsize);
+    bool mode_info();
+    bool intra_frame_mode_info();
+    bool intra_segment_id();
+    bool read_skip();
+    bool seg_feature_active(u8 feature);
+    bool read_tx_size(bool allow_select);
+
+    bool inter_frame_mode_info();
 
     u8 m_profile { 0 };
     u8 m_frame_to_show_map_index { 0 };
@@ -123,6 +132,9 @@ private:
     u8 m_segmentation_pred_prob[3];
     bool m_feature_enabled[8][4];
     u8 m_feature_data[8][4];
+    bool m_segmentation_enabled { false };
+    bool m_segmentation_update_map { false };
+    bool m_segmentation_temporal_update { false };
     bool m_segmentation_abs_or_delta_update { false };
     u16 m_tile_cols_log2 { 0 };
     u16 m_tile_rows_log2 { 0 };
@@ -139,6 +151,13 @@ private:
     u32 m_mi_row_end { 0 };
     u32 m_mi_col_start { 0 };
     u32 m_mi_col_end { 0 };
+    u32 m_mi_row { 0 };
+    u32 m_mi_col { 0 };
+    u32 m_mi_size { 0 };
+    bool m_available_u { false };
+    bool m_available_l { false };
+    int m_segment_id { 0 };
+    int m_skip { false };
 
     bool m_use_hp { false };
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -96,9 +96,16 @@ private:
     bool inter_segment_id();
     u8 get_segment_id();
     bool read_is_inter();
-    bool inter_block_mode_info();
-
     bool intra_block_mode_info();
+    bool inter_block_mode_info();
+    bool read_ref_frames();
+    bool assign_mv(bool is_compound);
+    bool read_mv(u8 ref);
+
+    /* (6.5) Motion Vector Prediction */
+    bool find_mv_refs(ReferenceFrame, int block);
+    bool find_best_ref_mvs(int ref_list);
+    bool append_sub8x8_mvs(u8 block, u8 ref_list);
 
     u8 m_profile { 0 };
     u8 m_frame_to_show_map_index { 0 };
@@ -189,6 +196,10 @@ private:
     bool m_left_single { false };
     bool m_above_single { false };
     Vector<Vector<u8>> m_prev_segment_ids;
+    InterpolationFilter m_interp_filter { EightTap };
+    InterMode m_mv[2];
+    InterMode m_near_mv[2];
+    InterMode m_nearest_mv[2];
 
     bool m_use_hp { false };
 

--- a/Userland/Libraries/LibVideo/VP9/Decoder.h
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.h
@@ -55,6 +55,26 @@ private:
     bool setup_past_independence();
     bool trailing_bits();
 
+    bool compressed_header();
+    bool read_tx_mode();
+    bool tx_mode_probs();
+    u8 diff_update_prob(u8 prob);
+    u8 decode_term_subexp();
+    u8 inv_remap_prob(u8 delta_prob, u8 prob);
+    u8 inv_recenter_nonneg(u8 v, u8 m);
+    bool read_coef_probs();
+    bool read_skip_prob();
+    bool read_inter_mode_probs();
+    bool read_interp_filter_probs();
+    bool read_is_inter_probs();
+    bool frame_reference_mode();
+    bool frame_reference_mode_probs();
+    bool read_y_mode_probs();
+    bool read_partition_probs();
+    bool mv_probs();
+    u8 update_mv_prob(u8 prob);
+    bool setup_compound_reference_mode();
+
     u64 m_start_bit_pos { 0 };
     u8 m_profile { 0 };
     u8 m_frame_to_show_map_index { 0 };
@@ -84,6 +104,7 @@ private:
     u16 m_frame_height { 0 };
     u16 m_render_width { 0 };
     u16 m_render_height { 0 };
+    bool m_render_and_frame_size_different { false };
     u16 m_mi_cols { 0 };
     u16 m_mi_rows { 0 };
     u16 m_sb64_cols { 0 };
@@ -99,6 +120,11 @@ private:
     u16 m_tile_rows_log2 { 0 };
     i8 m_loop_filter_ref_deltas[MAX_REF_FRAMES];
     i8 m_loop_filter_mode_deltas[2];
+
+    TXMode m_tx_mode;
+    ReferenceMode m_reference_mode;
+    ReferenceFrame m_comp_fixed_ref;
+    ReferenceFrame m_comp_var_ref[2];
 
     OwnPtr<BitStream> m_bit_stream;
     OwnPtr<ProbabilityTables> m_probability_tables;

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Symbols.h"
+#include <AK/Types.h>
 
 namespace Video::VP9 {
 
@@ -47,18 +48,18 @@ enum ReferenceFrame {
 };
 
 enum TXMode {
-    Only4x4 = 0,
-    Allow8x8 = 1,
-    Allow16x16 = 2,
-    Allow32x32 = 3,
+    Only_4x4 = 0,
+    Allow_8x8 = 1,
+    Allow_16x16 = 2,
+    Allow_32x32 = 3,
     TXModeSelect = 4,
 };
 
 enum TXSize {
-    TX4x4 = 0,
-    TX8x8 = 1,
-    TX16x16 = 2,
-    TX32x32 = 3,
+    TX_4x4 = 0,
+    TX_8x8 = 1,
+    TX_16x16 = 2,
+    TX_32x32 = 3,
 };
 
 enum ReferenceMode {
@@ -82,6 +83,68 @@ enum BlockSubsize : u8 {
     Block_64x32 = 11,
     Block_64x64 = 12,
     Block_Invalid = BLOCK_INVALID
+};
+
+enum Partition : u8 {
+    PartitionNone = 0,
+    PartitionHorizontal = 1,
+    PartitionVertical = 2,
+    PartitionSplit = 3,
+};
+
+enum IntraMode : u8 {
+    DcPred = 0,
+    VPred = 1,
+    HPred = 2,
+    D45Pred = 3,
+    D135Pred = 4,
+    D117Pred = 5,
+    D153Pred = 6,
+    D207Pred = 7,
+    D63Pred = 8,
+    TmPred = 9,
+};
+
+enum InterMode : u8 {
+    NearestMv = 0,
+    NearMv = 1,
+    ZeroMv = 2,
+    NewMv = 3,
+};
+
+enum MvJoint : u8 {
+    MvJointZero = 0,
+    MvJointHnzvz = 1,
+    MvJointHzvnz = 2,
+    MvJointHnzvnz = 3,
+};
+
+enum MvClass : u8 {
+    MvClass0 = 0,
+    MvClass1 = 1,
+    MvClass2 = 2,
+    MvClass3 = 3,
+    MvClass4 = 4,
+    MvClass5 = 5,
+    MvClass6 = 6,
+    MvClass7 = 7,
+    MvClass8 = 8,
+    MvClass9 = 9,
+    MvClass10 = 10,
+};
+
+enum Token : u8 {
+    ZeroToken = 0,
+    OneToken = 1,
+    TwoToken = 2,
+    ThreeToken = 3,
+    FourToken = 4,
+    DctValCat1 = 5,
+    DctValCat2 = 6,
+    DctValCat3 = 7,
+    DctValCat4 = 8,
+    DctValCat5 = 9,
+    DctValCat6 = 10,
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -41,6 +41,8 @@ enum InterpolationFilter {
 };
 
 enum ReferenceFrame {
+    // 0 is both INTRA_FRAME and NONE because the value's meaning changes depending on which index they're in on the ref_frame array
+    None = 0,
     IntraFrame = 0,
     LastFrame = 1,
     GoldenFrame = 2,

--- a/Userland/Libraries/LibVideo/VP9/Enums.h
+++ b/Userland/Libraries/LibVideo/VP9/Enums.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "Symbols.h"
+
 namespace Video::VP9 {
 
 enum FrameType {
@@ -79,6 +81,7 @@ enum BlockSubsize : u8 {
     Block_32x64 = 10,
     Block_64x32 = 11,
     Block_64x64 = 12,
+    Block_Invalid = BLOCK_INVALID
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/LookupTables.h
+++ b/Userland/Libraries/LibVideo/VP9/LookupTables.h
@@ -30,5 +30,72 @@ static constexpr u8 inv_map_table[MAX_PROB] = {
     226, 227, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 242, 243, 244, 245, 246,
     247, 248, 249, 250, 251, 252, 253, 253
 };
+static constexpr u8 num_8x8_blocks_wide_lookup[BLOCK_SIZES] = { 1, 1, 1, 1, 1, 2, 2, 2, 4, 4, 4, 8, 8 };
+static constexpr BlockSubsize subsize_lookup[PARTITION_TYPES][BLOCK_SIZES] = {
+    {
+        // PARTITION_NONE
+        Block_4x4,
+        Block_4x8,
+        Block_8x4,
+        Block_8x8,
+        Block_8x16,
+        Block_16x8,
+        Block_16x16,
+        Block_16x32,
+        Block_32x16,
+        Block_32x32,
+        Block_32x64,
+        Block_64x32,
+        Block_64x64,
+    },
+    {
+        // PARTITION_HORZ
+        Block_Invalid,
+        Block_Invalid,
+        Block_Invalid,
+        Block_8x4,
+        Block_Invalid,
+        Block_Invalid,
+        Block_16x8,
+        Block_Invalid,
+        Block_Invalid,
+        Block_32x16,
+        Block_Invalid,
+        Block_Invalid,
+        Block_64x32,
+    },
+    {
+        // PARTITION_VERT
+        Block_Invalid,
+        Block_Invalid,
+        Block_Invalid,
+        Block_4x8,
+        Block_Invalid,
+        Block_Invalid,
+        Block_8x16,
+        Block_Invalid,
+        Block_Invalid,
+        Block_16x32,
+        Block_Invalid,
+        Block_Invalid,
+        Block_32x64,
+    },
+    {
+        // PARTITION_SPLIT
+        Block_Invalid,
+        Block_Invalid,
+        Block_Invalid,
+        Block_4x4,
+        Block_Invalid,
+        Block_Invalid,
+        Block_8x8,
+        Block_Invalid,
+        Block_Invalid,
+        Block_16x16,
+        Block_Invalid,
+        Block_Invalid,
+        Block_32x32,
+    }
+};
 
 }

--- a/Userland/Libraries/LibVideo/VP9/LookupTables.h
+++ b/Userland/Libraries/LibVideo/VP9/LookupTables.h
@@ -184,4 +184,20 @@ static constexpr u8 mi_height_log2_lookup[BLOCK_SIZES] = { 0, 0, 0, 0, 1, 0, 1, 
 static constexpr u8 num_8x8_blocks_high_lookup[BLOCK_SIZES] = { 1, 1, 1, 1, 2, 1, 2, 4, 2, 4, 8, 4, 8 };
 static constexpr u8 size_group_lookup[BLOCK_SIZES] = { 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3 };
 
+static constexpr TXSize max_txsize_lookup[BLOCK_SIZES] = {
+    TX_4x4,
+    TX_4x4,
+    TX_4x4,
+    TX_8x8,
+    TX_8x8,
+    TX_8x8,
+    TX_16x16,
+    TX_16x16,
+    TX_16x16,
+    TX_32x32,
+    TX_32x32,
+    TX_32x32,
+    TX_32x32,
+};
+
 }

--- a/Userland/Libraries/LibVideo/VP9/ProbabilityTables.cpp
+++ b/Userland/Libraries/LibVideo/VP9/ProbabilityTables.cpp
@@ -1150,22 +1150,22 @@ static constexpr CoefProbs default_coef_probs = {
                     { 1, 16, 6 } } } } }
 };
 
-const ParetoTable& ProbabilityTables::pareto_table() const
+ParetoTable const& ProbabilityTables::pareto_table() const
 {
     return constant_pareto_table;
 }
 
-const KfPartitionProbs& ProbabilityTables::kf_partition_probs() const
+KfPartitionProbs const& ProbabilityTables::kf_partition_probs() const
 {
     return constant_kf_partition_probs;
 }
 
-const KfYModeProbs& ProbabilityTables::kf_y_mode_probs() const
+KfYModeProbs const& ProbabilityTables::kf_y_mode_probs() const
 {
     return constant_kf_y_mode_probs;
 }
 
-const KfUVModeProbs& ProbabilityTables::kf_uv_mode_prob() const
+KfUVModeProbs const& ProbabilityTables::kf_uv_mode_prob() const
 {
     return constant_kf_uv_mode_prob;
 }

--- a/Userland/Libraries/LibVideo/VP9/ProbabilityTables.h
+++ b/Userland/Libraries/LibVideo/VP9/ProbabilityTables.h
@@ -45,10 +45,10 @@ public:
     void load_probs(size_t index);
     void load_probs2(size_t index);
 
-    const ParetoTable& pareto_table() const;
-    const KfPartitionProbs& kf_partition_probs() const;
-    const KfYModeProbs& kf_y_mode_probs() const;
-    const KfUVModeProbs& kf_uv_mode_prob() const;
+    ParetoTable const& pareto_table() const;
+    KfPartitionProbs const& kf_partition_probs() const;
+    KfYModeProbs const& kf_y_mode_probs() const;
+    KfUVModeProbs const& kf_uv_mode_prob() const;
 
     PartitionProbs& partition_probs() { return m_current_probability_table.partition_probs; };
     YModeProbs& y_mode_probs() { return m_current_probability_table.y_mode_probs; };

--- a/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.cpp
+++ b/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.cpp
@@ -10,28 +10,28 @@ namespace Video::VP9 {
 
 void SyntaxElementCounter::clear_counts()
 {
-    __builtin_memset(counts_intra_mode, 0, BLOCK_SIZE_GROUPS * INTRA_MODES);
-    __builtin_memset(counts_uv_mode, 0, INTRA_MODES * INTRA_MODES);
-    __builtin_memset(counts_partition, 0, PARTITION_CONTEXTS * PARTITION_TYPES);
-    __builtin_memset(counts_interp_filter, 0, INTERP_FILTER_CONTEXTS * SWITCHABLE_FILTERS);
-    __builtin_memset(counts_inter_mode, 0, INTER_MODE_CONTEXTS * INTER_MODES);
-    __builtin_memset(counts_tx_size, 0, TX_SIZES * TX_SIZE_CONTEXTS * TX_SIZES);
-    __builtin_memset(counts_is_inter, 0, IS_INTER_CONTEXTS * 2);
-    __builtin_memset(counts_comp_mode, 0, COMP_MODE_CONTEXTS * 2);
-    __builtin_memset(counts_single_ref, 0, REF_CONTEXTS * 2 * 2);
-    __builtin_memset(counts_comp_ref, 0, REF_CONTEXTS * 2);
-    __builtin_memset(counts_skip, 0, SKIP_CONTEXTS * 2);
-    __builtin_memset(counts_mv_joint, 0, MV_JOINTS);
-    __builtin_memset(counts_mv_sign, 0, 2 * 2);
-    __builtin_memset(counts_mv_class, 0, 2 * MV_CLASSES);
-    __builtin_memset(counts_mv_class0_bit, 0, 2 * CLASS0_SIZE);
-    __builtin_memset(counts_mv_class0_fr, 0, 2 * CLASS0_SIZE * MV_FR_SIZE);
-    __builtin_memset(counts_mv_class0_hp, 0, 2 * 2);
-    __builtin_memset(counts_mv_bits, 0, 2 * MV_OFFSET_BITS * 2);
-    __builtin_memset(counts_mv_fr, 0, 2 * MV_FR_SIZE);
-    __builtin_memset(counts_mv_hp, 0, 2 * 2);
-    __builtin_memset(counts_token, 0, TX_SIZES * BLOCK_TYPES * REF_TYPES * COEF_BANDS * PREV_COEF_CONTEXTS * UNCONSTRAINED_NODES);
-    __builtin_memset(counts_more_coefs, 0, TX_SIZES * BLOCK_TYPES * REF_TYPES * COEF_BANDS * PREV_COEF_CONTEXTS * 2);
+    __builtin_memset(m_counts_intra_mode, 0, BLOCK_SIZE_GROUPS * INTRA_MODES);
+    __builtin_memset(m_counts_uv_mode, 0, INTRA_MODES * INTRA_MODES);
+    __builtin_memset(m_counts_partition, 0, PARTITION_CONTEXTS * PARTITION_TYPES);
+    __builtin_memset(m_counts_interp_filter, 0, INTERP_FILTER_CONTEXTS * SWITCHABLE_FILTERS);
+    __builtin_memset(m_counts_inter_mode, 0, INTER_MODE_CONTEXTS * INTER_MODES);
+    __builtin_memset(m_counts_tx_size, 0, TX_SIZES * TX_SIZE_CONTEXTS * TX_SIZES);
+    __builtin_memset(m_counts_is_inter, 0, IS_INTER_CONTEXTS * 2);
+    __builtin_memset(m_counts_comp_mode, 0, COMP_MODE_CONTEXTS * 2);
+    __builtin_memset(m_counts_single_ref, 0, REF_CONTEXTS * 2 * 2);
+    __builtin_memset(m_counts_comp_ref, 0, REF_CONTEXTS * 2);
+    __builtin_memset(m_counts_skip, 0, SKIP_CONTEXTS * 2);
+    __builtin_memset(m_counts_mv_joint, 0, MV_JOINTS);
+    __builtin_memset(m_counts_mv_sign, 0, 2 * 2);
+    __builtin_memset(m_counts_mv_class, 0, 2 * MV_CLASSES);
+    __builtin_memset(m_counts_mv_class0_bit, 0, 2 * CLASS0_SIZE);
+    __builtin_memset(m_counts_mv_class0_fr, 0, 2 * CLASS0_SIZE * MV_FR_SIZE);
+    __builtin_memset(m_counts_mv_class0_hp, 0, 2 * 2);
+    __builtin_memset(m_counts_mv_bits, 0, 2 * MV_OFFSET_BITS * 2);
+    __builtin_memset(m_counts_mv_fr, 0, 2 * MV_FR_SIZE);
+    __builtin_memset(m_counts_mv_hp, 0, 2 * 2);
+    __builtin_memset(m_counts_token, 0, TX_SIZES * BLOCK_TYPES * REF_TYPES * COEF_BANDS * PREV_COEF_CONTEXTS * UNCONSTRAINED_NODES);
+    __builtin_memset(m_counts_more_coefs, 0, TX_SIZES * BLOCK_TYPES * REF_TYPES * COEF_BANDS * PREV_COEF_CONTEXTS * 2);
 }
 
 }

--- a/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.h
+++ b/Userland/Libraries/LibVideo/VP9/SyntaxElementCounter.h
@@ -46,29 +46,28 @@ class SyntaxElementCounter final {
 public:
     void clear_counts();
 
-private:
-    u8 counts_intra_mode[BLOCK_SIZE_GROUPS][INTRA_MODES];
-    u8 counts_uv_mode[INTRA_MODES][INTRA_MODES];
-    u8 counts_partition[PARTITION_CONTEXTS][PARTITION_TYPES];
-    u8 counts_interp_filter[INTERP_FILTER_CONTEXTS][SWITCHABLE_FILTERS];
-    u8 counts_inter_mode[INTER_MODE_CONTEXTS][INTER_MODES];
-    u8 counts_tx_size[TX_SIZES][TX_SIZE_CONTEXTS][TX_SIZES];
-    u8 counts_is_inter[IS_INTER_CONTEXTS][2];
-    u8 counts_comp_mode[COMP_MODE_CONTEXTS][2];
-    u8 counts_single_ref[REF_CONTEXTS][2][2];
-    u8 counts_comp_ref[REF_CONTEXTS][2];
-    u8 counts_skip[SKIP_CONTEXTS][2];
-    u8 counts_mv_joint[MV_JOINTS];
-    u8 counts_mv_sign[2][2];
-    u8 counts_mv_class[2][MV_CLASSES];
-    u8 counts_mv_class0_bit[2][CLASS0_SIZE];
-    u8 counts_mv_class0_fr[2][CLASS0_SIZE][MV_FR_SIZE];
-    u8 counts_mv_class0_hp[2][2];
-    u8 counts_mv_bits[2][MV_OFFSET_BITS][2];
-    u8 counts_mv_fr[2][MV_FR_SIZE];
-    u8 counts_mv_hp[2][2];
-    u8 counts_token[TX_SIZES][BLOCK_TYPES][REF_TYPES][COEF_BANDS][PREV_COEF_CONTEXTS][UNCONSTRAINED_NODES];
-    u8 counts_more_coefs[TX_SIZES][BLOCK_TYPES][REF_TYPES][COEF_BANDS][PREV_COEF_CONTEXTS][2];
+    u8 m_counts_intra_mode[BLOCK_SIZE_GROUPS][INTRA_MODES];
+    u8 m_counts_uv_mode[INTRA_MODES][INTRA_MODES];
+    u8 m_counts_partition[PARTITION_CONTEXTS][PARTITION_TYPES];
+    u8 m_counts_interp_filter[INTERP_FILTER_CONTEXTS][SWITCHABLE_FILTERS];
+    u8 m_counts_inter_mode[INTER_MODE_CONTEXTS][INTER_MODES];
+    u8 m_counts_tx_size[TX_SIZES][TX_SIZE_CONTEXTS][TX_SIZES];
+    u8 m_counts_is_inter[IS_INTER_CONTEXTS][2];
+    u8 m_counts_comp_mode[COMP_MODE_CONTEXTS][2];
+    u8 m_counts_single_ref[REF_CONTEXTS][2][2];
+    u8 m_counts_comp_ref[REF_CONTEXTS][2];
+    u8 m_counts_skip[SKIP_CONTEXTS][2];
+    u8 m_counts_mv_joint[MV_JOINTS];
+    u8 m_counts_mv_sign[2][2];
+    u8 m_counts_mv_class[2][MV_CLASSES];
+    u8 m_counts_mv_class0_bit[2][CLASS0_SIZE];
+    u8 m_counts_mv_class0_fr[2][CLASS0_SIZE][MV_FR_SIZE];
+    u8 m_counts_mv_class0_hp[2][2];
+    u8 m_counts_mv_bits[2][MV_OFFSET_BITS][2];
+    u8 m_counts_mv_fr[2][MV_FR_SIZE];
+    u8 m_counts_mv_hp[2][2];
+    u8 m_counts_token[TX_SIZES][BLOCK_TYPES][REF_TYPES][COEF_BANDS][PREV_COEF_CONTEXTS][UNCONSTRAINED_NODES];
+    u8 m_counts_more_coefs[TX_SIZES][BLOCK_TYPES][REF_TYPES][COEF_BANDS][PREV_COEF_CONTEXTS][2];
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -10,7 +10,8 @@
 
 namespace Video::VP9 {
 
-int TreeParser::parse_tree(SyntaxElementType type)
+template<typename T>
+T TreeParser::parse_tree(SyntaxElementType type)
 {
     auto tree_selection = select_tree(type);
     int value;
@@ -25,8 +26,14 @@ int TreeParser::parse_tree(SyntaxElementType type)
         value = -n;
     }
     count_syntax_element(type, value);
-    return value;
+    return static_cast<T>(value);
 }
+
+template int TreeParser::parse_tree(SyntaxElementType);
+template bool TreeParser::parse_tree(SyntaxElementType);
+template u8 TreeParser::parse_tree(SyntaxElementType);
+template IntraMode TreeParser::parse_tree(SyntaxElementType);
+template TXSize TreeParser::parse_tree(SyntaxElementType);
 
 /*
  * Select a tree value based on the type of syntax element being parsed, as well as some parser state, as specified in section 9.3.1

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -265,7 +265,7 @@ void TreeParser::count_syntax_element(SyntaxElementType type, int value)
     }
 }
 
-TreeParser::TreeSelection::TreeSelection(const int* values)
+TreeParser::TreeSelection::TreeSelection(int const* values)
     : m_is_single_value(false)
     , m_value { .m_tree = values }
 {

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -34,6 +34,8 @@ template bool TreeParser::parse_tree(SyntaxElementType);
 template u8 TreeParser::parse_tree(SyntaxElementType);
 template IntraMode TreeParser::parse_tree(SyntaxElementType);
 template TXSize TreeParser::parse_tree(SyntaxElementType);
+template InterpolationFilter TreeParser::parse_tree(SyntaxElementType);
+template ReferenceMode TreeParser::parse_tree(SyntaxElementType);
 
 /*
  * Select a tree value based on the type of syntax element being parsed, as well as some parser state, as specified in section 9.3.1

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TreeParser.h"
+#include "LookupTables.h"
+
+namespace Video::VP9 {
+
+int TreeParser::parse_tree(SyntaxElementType type)
+{
+    auto tree_selection = select_tree(type);
+    if (tree_selection.is_single_value())
+        return tree_selection.get_single_value();
+    auto tree = tree_selection.get_tree_value();
+    int n = 0;
+    do {
+        n = tree[n + m_bit_stream->read_bool(select_tree_probability(type, n >> 1))];
+    } while (n > 0);
+    return -n;
+}
+
+/*
+ * Select a tree value based on the type of syntax element being parsed, as well as some parser state, as specified in section 9.3.1
+ */
+TreeParser::TreeSelection TreeParser::select_tree(SyntaxElementType type)
+{
+    switch (type) {
+    case SyntaxElementType::Partition:
+        if (m_has_rows && m_has_cols)
+            return { partition_tree };
+        if (m_has_cols)
+            return { cols_partition_tree };
+        if (m_has_rows)
+            return { rows_partition_tree };
+        return { PartitionSplit };
+    case SyntaxElementType::DefaultIntraMode:
+    case SyntaxElementType::DefaultUVMode:
+    case SyntaxElementType::IntraMode:
+    case SyntaxElementType::SubIntraMode:
+    case SyntaxElementType::UVMode:
+        return { intra_mode_tree };
+    case SyntaxElementType::SegmentID:
+        return { segment_tree };
+    case SyntaxElementType::Skip:
+    case SyntaxElementType::SegIDPredicted:
+    case SyntaxElementType::IsInter:
+    case SyntaxElementType::CompMode:
+    case SyntaxElementType::CompRef:
+    case SyntaxElementType::SingleRefP1:
+    case SyntaxElementType::SingleRefP2:
+    case SyntaxElementType::MVSign:
+    case SyntaxElementType::MVClass0Bit:
+    case SyntaxElementType::MVBit:
+    case SyntaxElementType::MoreCoefs:
+        return { binary_tree };
+    case SyntaxElementType::TXSize:
+        if (m_max_tx_size == TX_32x32)
+            return { tx_size_32_tree };
+        if (m_max_tx_size == TX_16x16)
+            return { tx_size_16_tree };
+        return { tx_size_8_tree };
+    case SyntaxElementType::InterMode:
+        return { inter_mode_tree };
+    case SyntaxElementType::InterpFilter:
+        return { interp_filter_tree };
+    case SyntaxElementType::MVJoint:
+        return { mv_joint_tree };
+    case SyntaxElementType::MVClass:
+        return { mv_class_tree };
+    case SyntaxElementType::MVClass0FR:
+    case SyntaxElementType::MVFR:
+        return { mv_fr_tree };
+    case SyntaxElementType::MVClass0HP:
+    case SyntaxElementType::MVHP:
+        if (m_use_hp)
+            return { binary_tree };
+        return { 1 };
+    case SyntaxElementType::Token:
+        return { token_tree };
+    }
+    VERIFY_NOT_REACHED();
+}
+
+/*
+ * Select a probability with which to read a boolean when decoding a tree, as specified in section 9.3.2
+ */
+u8 TreeParser::select_tree_probability(SyntaxElementType type, u8 node)
+{
+    switch (type) {
+    case SyntaxElementType::Partition:
+        return calculate_partition_probability(node);
+    case SyntaxElementType::DefaultIntraMode:
+        break;
+    case SyntaxElementType::DefaultUVMode:
+        break;
+    case SyntaxElementType::IntraMode:
+        break;
+    case SyntaxElementType::SubIntraMode:
+        break;
+    case SyntaxElementType::UVMode:
+        break;
+    case SyntaxElementType::SegmentID:
+        break;
+    case SyntaxElementType::Skip:
+        break;
+    case SyntaxElementType::SegIDPredicted:
+        break;
+    case SyntaxElementType::IsInter:
+        break;
+    case SyntaxElementType::CompMode:
+        break;
+    case SyntaxElementType::CompRef:
+        break;
+    case SyntaxElementType::SingleRefP1:
+        break;
+    case SyntaxElementType::SingleRefP2:
+        break;
+    case SyntaxElementType::MVSign:
+        break;
+    case SyntaxElementType::MVClass0Bit:
+        break;
+    case SyntaxElementType::MVBit:
+        break;
+    case SyntaxElementType::TXSize:
+        break;
+    case SyntaxElementType::InterMode:
+        break;
+    case SyntaxElementType::InterpFilter:
+        break;
+    case SyntaxElementType::MVJoint:
+        break;
+    case SyntaxElementType::MVClass:
+        break;
+    case SyntaxElementType::MVClass0FR:
+        break;
+    case SyntaxElementType::MVClass0HP:
+        break;
+    case SyntaxElementType::MVFR:
+        break;
+    case SyntaxElementType::MVHP:
+        break;
+    case SyntaxElementType::Token:
+        break;
+    case SyntaxElementType::MoreCoefs:
+        break;
+    }
+    TODO();
+}
+
+u8 TreeParser::calculate_partition_probability(u8 node)
+{
+    int node2;
+    if (m_has_rows && m_has_cols) {
+        node2 = node;
+    } else if (m_has_cols) {
+        node2 = 1;
+    } else {
+        node2 = 2;
+    }
+
+    u32 above = 0;
+    u32 left = 0;
+    auto bsl = mi_width_log2_lookup[m_block_subsize];
+    auto block_offset = mi_width_log2_lookup[Block_64x64] - bsl;
+    for (auto i = 0; i < m_num_8x8; i++) {
+        above |= m_above_partition_context[m_col + i];
+        left |= m_left_partition_context[m_row + i];
+    }
+    above = (above & (1 << block_offset)) > 0;
+    left = (left & (1 << block_offset)) > 0;
+    auto ctx = bsl * 4 + left * 2 + above;
+    if (m_frame_is_intra)
+        return m_probability_tables.kf_partition_probs()[ctx][node2];
+    return m_probability_tables.partition_probs()[ctx][node2];
+}
+
+TreeParser::TreeSelection::TreeSelection(const int* values)
+    : m_is_single_value(false)
+    , m_value { .m_tree = values }
+{
+}
+
+TreeParser::TreeSelection::TreeSelection(int value)
+    : m_is_single_value(true)
+    , m_value { .m_value = value }
+{
+}
+
+}

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.cpp
@@ -108,9 +108,9 @@ u8 TreeParser::select_tree_probability(SyntaxElementType type, u8 node)
     case SyntaxElementType::UVMode:
         break;
     case SyntaxElementType::SegmentID:
-        break;
+        return m_segmentation_tree_probs[node];
     case SyntaxElementType::Skip:
-        break;
+        return calculate_skip_probability();
     case SyntaxElementType::SegIDPredicted:
         break;
     case SyntaxElementType::IsInter:
@@ -182,6 +182,18 @@ u8 TreeParser::calculate_partition_probability(u8 node)
     return m_probability_tables.partition_probs()[m_ctx][node2];
 }
 
+u8 TreeParser::calculate_skip_probability()
+{
+    m_ctx = 0;
+    if (m_available_u) {
+        // FIXME: m_ctx += m_skips[m_mi_row - 1][m_mi_col];
+    }
+    if (m_available_l) {
+        // FIXME: m_ctx += m_skips[m_mi_row][m_mi_col - 1];
+    }
+    return m_probability_tables.skip_prob()[m_ctx];
+}
+
 void TreeParser::count_syntax_element(SyntaxElementType type, int value)
 {
     switch (type) {
@@ -195,6 +207,7 @@ void TreeParser::count_syntax_element(SyntaxElementType type, int value)
     case SyntaxElementType::UVMode:
         break;
     case SyntaxElementType::Skip:
+        m_syntax_element_counter->m_counts_skip[m_ctx][value]++;
         break;
     case SyntaxElementType::IsInter:
         break;

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -41,7 +41,8 @@ public:
         TreeSelectionValue m_value;
     };
 
-    int parse_tree(SyntaxElementType type);
+    template<typename T = int>
+    T parse_tree(SyntaxElementType type);
     TreeSelection select_tree(SyntaxElementType type);
     u8 select_tree_probability(SyntaxElementType type, u8 node);
     void count_syntax_element(SyntaxElementType type, int value);

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -25,16 +25,16 @@ public:
     class TreeSelection {
     public:
         union TreeSelectionValue {
-            const int* m_tree;
+            int const* m_tree;
             int m_value;
         };
 
-        TreeSelection(const int* values);
+        TreeSelection(int const* values);
         TreeSelection(int value);
 
         bool is_single_value() const { return m_is_single_value; }
         int get_single_value() const { return m_value.m_value; }
-        const int* get_tree_value() const { return m_value.m_tree; }
+        int const* get_tree_value() const { return m_value.m_tree; }
 
     private:
         bool m_is_single_value;

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Hunter Salyer <thefalsehonesty@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "BitStream.h"
+#include "Enums.h"
+#include "ProbabilityTables.h"
+#include "SyntaxElementCounter.h"
+
+namespace Video::VP9 {
+
+class TreeParser {
+public:
+    explicit TreeParser(ProbabilityTables& probability_tables)
+        : m_probability_tables(probability_tables)
+    {
+    }
+
+    class TreeSelection {
+    public:
+        union TreeSelectionValue {
+            const int* m_tree;
+            int m_value;
+        };
+
+        TreeSelection(const int* values);
+        TreeSelection(int value);
+
+        bool is_single_value() const { return m_is_single_value; }
+        int get_single_value() const { return m_value.m_value; }
+        const int* get_tree_value() const { return m_value.m_tree; }
+
+    private:
+        bool m_is_single_value;
+        TreeSelectionValue m_value;
+    };
+
+    int parse_tree(SyntaxElementType type);
+    TreeSelection select_tree(SyntaxElementType type);
+    u8 select_tree_probability(SyntaxElementType type, u8 node);
+
+    void set_bit_stream(BitStream* bit_stream) { m_bit_stream = bit_stream; }
+    void set_has_rows(bool has_rows) { m_has_rows = has_rows; }
+    void set_has_cols(bool has_cols) { m_has_cols = has_cols; }
+    void set_max_tx_size(TXSize max_tx_size) { m_max_tx_size = max_tx_size; }
+    void set_use_hp(bool use_hp) { m_use_hp = use_hp; }
+    void set_block_subsize(u8 block_subsize) { m_block_subsize = block_subsize; }
+    void set_num_8x8(u8 num_8x8) { m_num_8x8 = num_8x8; }
+    void set_above_partition_context(u8* above_partition_context) { m_above_partition_context = above_partition_context; }
+    void set_left_partition_context(u8* left_partition_context) { m_left_partition_context = left_partition_context; }
+    void set_col(u32 col) { m_col = col; }
+    void set_row(u32 row) { m_row = row; }
+    void set_frame_is_intra(bool frame_is_intra) { m_frame_is_intra = frame_is_intra; }
+
+private:
+    u8 calculate_partition_probability(u8 node);
+
+    ProbabilityTables& m_probability_tables;
+    BitStream* m_bit_stream { nullptr };
+
+    bool m_has_rows { false };
+    bool m_has_cols { false };
+    TXSize m_max_tx_size { TX_4x4 };
+    bool m_use_hp { false };
+    u8 m_block_subsize { 0 };
+    u8 m_num_8x8 { 0 };
+    u8* m_above_partition_context { nullptr };
+    u8* m_left_partition_context { nullptr };
+    u32 m_col { 0 };
+    u32 m_row { 0 };
+    bool m_frame_is_intra { false };
+};
+
+}

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -57,9 +57,15 @@ public:
     void set_row(u32 row) { m_row = row; }
     void set_frame_is_intra(bool frame_is_intra) { m_frame_is_intra = frame_is_intra; }
     void set_syntax_element_counter(SyntaxElementCounter* syntax_element_counter) { m_syntax_element_counter = syntax_element_counter; }
+    void set_segmentation_tree_probs(u8* segmentation_tree_probs) { m_segmentation_tree_probs = segmentation_tree_probs; }
+    void set_available_u(bool available_u) { m_available_u = available_u; }
+    void set_available_l(bool available_l) { m_available_l = available_l; }
+    void set_mi_row(u32 mi_row) { m_mi_row = mi_row; }
+    void set_mi_col(u32 mi_col) { m_mi_col = mi_col; }
 
 private:
     u8 calculate_partition_probability(u8 node);
+    u8 calculate_skip_probability();
 
     ProbabilityTables& m_probability_tables;
     BitStream* m_bit_stream { nullptr };
@@ -79,6 +85,11 @@ private:
     u32 m_col { 0 };
     u32 m_row { 0 };
     bool m_frame_is_intra { false };
+    u8* m_segmentation_tree_probs { nullptr };
+    bool m_available_u { false };
+    bool m_available_l { false };
+    u32 m_mi_col { 0 };
+    u32 m_mi_row { 0 };
 };
 
 }

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -42,6 +42,7 @@ public:
     int parse_tree(SyntaxElementType type);
     TreeSelection select_tree(SyntaxElementType type);
     u8 select_tree_probability(SyntaxElementType type, u8 node);
+    void count_syntax_element(SyntaxElementType type, int value);
 
     void set_bit_stream(BitStream* bit_stream) { m_bit_stream = bit_stream; }
     void set_has_rows(bool has_rows) { m_has_rows = has_rows; }
@@ -55,12 +56,17 @@ public:
     void set_col(u32 col) { m_col = col; }
     void set_row(u32 row) { m_row = row; }
     void set_frame_is_intra(bool frame_is_intra) { m_frame_is_intra = frame_is_intra; }
+    void set_syntax_element_counter(SyntaxElementCounter* syntax_element_counter) { m_syntax_element_counter = syntax_element_counter; }
 
 private:
     u8 calculate_partition_probability(u8 node);
 
     ProbabilityTables& m_probability_tables;
     BitStream* m_bit_stream { nullptr };
+    SyntaxElementCounter* m_syntax_element_counter { nullptr };
+
+    // m_ctx is a member variable because it is required for syntax element counting (section 9.3.4)
+    u8 m_ctx { 0 };
 
     bool m_has_rows { false };
     bool m_has_cols { false };

--- a/Userland/Libraries/LibVideo/VP9/TreeParser.h
+++ b/Userland/Libraries/LibVideo/VP9/TreeParser.h
@@ -13,10 +13,12 @@
 
 namespace Video::VP9 {
 
+class Decoder;
+
 class TreeParser {
 public:
-    explicit TreeParser(ProbabilityTables& probability_tables)
-        : m_probability_tables(probability_tables)
+    explicit TreeParser(Decoder& decoder)
+        : m_decoder(decoder)
     {
     }
 
@@ -44,52 +46,13 @@ public:
     u8 select_tree_probability(SyntaxElementType type, u8 node);
     void count_syntax_element(SyntaxElementType type, int value);
 
-    void set_bit_stream(BitStream* bit_stream) { m_bit_stream = bit_stream; }
-    void set_has_rows(bool has_rows) { m_has_rows = has_rows; }
-    void set_has_cols(bool has_cols) { m_has_cols = has_cols; }
-    void set_max_tx_size(TXSize max_tx_size) { m_max_tx_size = max_tx_size; }
-    void set_use_hp(bool use_hp) { m_use_hp = use_hp; }
-    void set_block_subsize(u8 block_subsize) { m_block_subsize = block_subsize; }
-    void set_num_8x8(u8 num_8x8) { m_num_8x8 = num_8x8; }
-    void set_above_partition_context(u8* above_partition_context) { m_above_partition_context = above_partition_context; }
-    void set_left_partition_context(u8* left_partition_context) { m_left_partition_context = left_partition_context; }
-    void set_col(u32 col) { m_col = col; }
-    void set_row(u32 row) { m_row = row; }
-    void set_frame_is_intra(bool frame_is_intra) { m_frame_is_intra = frame_is_intra; }
-    void set_syntax_element_counter(SyntaxElementCounter* syntax_element_counter) { m_syntax_element_counter = syntax_element_counter; }
-    void set_segmentation_tree_probs(u8* segmentation_tree_probs) { m_segmentation_tree_probs = segmentation_tree_probs; }
-    void set_available_u(bool available_u) { m_available_u = available_u; }
-    void set_available_l(bool available_l) { m_available_l = available_l; }
-    void set_mi_row(u32 mi_row) { m_mi_row = mi_row; }
-    void set_mi_col(u32 mi_col) { m_mi_col = mi_col; }
-
 private:
     u8 calculate_partition_probability(u8 node);
     u8 calculate_skip_probability();
 
-    ProbabilityTables& m_probability_tables;
-    BitStream* m_bit_stream { nullptr };
-    SyntaxElementCounter* m_syntax_element_counter { nullptr };
-
+    Decoder& m_decoder;
     // m_ctx is a member variable because it is required for syntax element counting (section 9.3.4)
     u8 m_ctx { 0 };
-
-    bool m_has_rows { false };
-    bool m_has_cols { false };
-    TXSize m_max_tx_size { TX_4x4 };
-    bool m_use_hp { false };
-    u8 m_block_subsize { 0 };
-    u8 m_num_8x8 { 0 };
-    u8* m_above_partition_context { nullptr };
-    u8* m_left_partition_context { nullptr };
-    u32 m_col { 0 };
-    u32 m_row { 0 };
-    bool m_frame_is_intra { false };
-    u8* m_segmentation_tree_probs { nullptr };
-    bool m_available_u { false };
-    bool m_available_l { false };
-    u32 m_mi_col { 0 };
-    u32 m_mi_row { 0 };
 };
 
 }

--- a/Userland/Utilities/matroska.cpp
+++ b/Userland/Utilities/matroska.cpp
@@ -23,28 +23,28 @@ int main(int, char**)
         outln("Writing app is \"{}\"", segment_information.value().writing_app().as_string().to_string().characters());
     }
     outln("Document has {} tracks", document->tracks().size());
-    for (const auto& track_entry : document->tracks()) {
-        const auto& track = *track_entry.value;
+    for (auto const& track_entry : document->tracks()) {
+        auto const& track = *track_entry.value;
         outln("\tTrack #{} with TrackID {}", track.track_number(), track.track_uid());
         outln("\tTrack has TrackType {}", static_cast<u8>(track.track_type()));
         outln("\tTrack has Language \"{}\"", track.language().characters());
         outln("\tTrack has CodecID \"{}\"", track.codec_id().characters());
 
         if (track.track_type() == Video::TrackEntry::TrackType::Video) {
-            const auto video_track = track.video_track().value();
+            auto const video_track = track.video_track().value();
             outln("\t\tVideo is {} pixels wide by {} pixels tall", video_track.pixel_width, video_track.pixel_height);
         } else if (track.track_type() == Video::TrackEntry::TrackType::Audio) {
-            const auto audio_track = track.audio_track().value();
+            auto const audio_track = track.audio_track().value();
             outln("\t\tAudio has {} channels with a bit depth of {}", audio_track.channels, audio_track.bit_depth);
         }
     }
 
     outln("Document has {} clusters", document->clusters().size());
-    for (const auto& cluster : document->clusters()) {
+    for (auto const& cluster : document->clusters()) {
         outln("\tCluster timestamp is {}", cluster.timestamp());
 
         outln("\tCluster has {} blocks", cluster.blocks().size());
-        for (const auto& block : cluster.blocks()) {
+        for (auto const& block : cluster.blocks()) {
             (void)block;
             outln("\t\tBlock for track #{} has {} frames", block.track_number(), block.frame_count());
             outln("\t\tBlock's timestamp is {}", block.timestamp());


### PR DESCRIPTION
This PR brings Serenity's in-tree LibVideo up to date with all of the work I had left on my fork. This PR is a little hefty admittedly, but there was no logical splitting point anywhere in this commit tree, so I decided to just throw it all in one PR.

With this PR, we finish parsing compressed header data and start to get into the weeds of parsing tiles and blocks. These patches implements most parsing up to section 6.4.18 of the spec.

![image](https://user-images.githubusercontent.com/20765494/122684250-55567980-d1d2-11eb-8e62-0ffaa94b393a.png)
(Note: not to scale :stuck_out_tongue:)