### PR TITLE
PixelPaint: Support non-rectangular selections with an alpha channel

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     PixelPaintWindowGML.h
     RectangleTool.cpp
     RectangleSelectTool.cpp
+    Mask.cpp
     Selection.cpp
     SprayTool.cpp
     ToolboxWidget.cpp

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -42,6 +42,7 @@ public:
 
     Layer* layer_at_editor_position(Gfx::IntPoint const&);
 
+    float scale() const { return m_scale; }
     void scale_centered_on_position(Gfx::IntPoint const&, float);
     void reset_scale_and_position();
     void scale_by(float);

--- a/Userland/Applications/PixelPaint/Mask.cpp
+++ b/Userland/Applications/PixelPaint/Mask.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021, Davipb <daviparca@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Mask.h"
+
+namespace PixelPaint {
+
+Mask::Mask(Gfx::IntRect bounding_rect, u8 default_value)
+    : m_bounding_rect(bounding_rect)
+{
+    auto data_size = bounding_rect.size().area();
+    m_data.resize(data_size);
+
+    for (auto& x : m_data) {
+        x = default_value;
+    }
+}
+
+size_t Mask::to_index(int x, int y) const
+{
+    VERIFY(m_bounding_rect.contains(x, y));
+
+    int dx = x - m_bounding_rect.x();
+    int dy = y - m_bounding_rect.y();
+    return dy * m_bounding_rect.width() + dx;
+}
+
+u8 Mask::get(int x, int y) const
+{
+    if (is_null() || !m_bounding_rect.contains(x, y)) {
+        return 0;
+    }
+
+    return m_data[to_index(x, y)];
+}
+
+void Mask::set(int x, int y, u8 value)
+{
+    VERIFY(!is_null());
+    VERIFY(m_bounding_rect.contains(x, y));
+
+    m_data[to_index(x, y)] = value;
+}
+
+Mask Mask::with_bounding_rect(Gfx::IntRect inner_rect) const
+{
+    auto result = Mask::empty(inner_rect);
+
+    result.for_each_pixel([&](int x, int y) {
+        result.set(x, y, get(x, y));
+    });
+
+    return result;
+}
+
+void Mask::shrink_to_fit()
+{
+    int topmost = NumericLimits<int>::max();
+    int bottommost = NumericLimits<int>::min();
+    int leftmost = NumericLimits<int>::max();
+    int rightmost = NumericLimits<int>::min();
+
+    bool empty = true;
+    for_each_pixel([&](auto x, auto y) {
+        if (get(x, y) == 0) {
+            return;
+        }
+
+        empty = false;
+
+        topmost = min(topmost, y);
+        bottommost = max(bottommost, y);
+
+        leftmost = min(leftmost, x);
+        rightmost = max(rightmost, x);
+    });
+
+    if (empty) {
+        m_bounding_rect = {};
+        m_data.clear();
+        return;
+    }
+
+    Gfx::IntRect new_bounding_rect(
+        leftmost,
+        topmost,
+        rightmost - leftmost + 1,
+        bottommost - topmost + 1);
+
+    *this = with_bounding_rect(new_bounding_rect);
+}
+
+void Mask::invert()
+{
+    for_each_pixel([&](int x, int y) {
+        set(x, y, 0xFF - get(x, y));
+    });
+}
+
+void Mask::add(Mask const& other)
+{
+    combine(other, [](int a, int b) { return a + b; });
+}
+
+void Mask::subtract(Mask const& other)
+{
+    combine(other, [](int a, int b) { return a - b; });
+}
+
+void Mask::intersect(Mask const& other)
+{
+    combinef(other, [](float a, float b) { return a * b; });
+}
+
+}

--- a/Userland/Applications/PixelPaint/Mask.h
+++ b/Userland/Applications/PixelPaint/Mask.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Davipb <daviparca@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+
+namespace PixelPaint {
+
+class Mask {
+public:
+    Mask() = default;
+
+    Mask(Mask const&) = default;
+    Mask& operator=(Mask const&) = default;
+
+    Mask(Mask&&) = default;
+    Mask& operator=(Mask&&) = default;
+
+    [[nodiscard]] static Mask empty(Gfx::IntRect rect) { return { rect, 0x00 }; }
+    [[nodiscard]] static Mask full(Gfx::IntRect rect) { return { rect, 0xFF }; }
+
+    [[nodiscard]] bool is_null() const { return m_data.is_empty(); }
+    [[nodiscard]] Gfx::IntRect bounding_rect() const { return m_bounding_rect; }
+
+    [[nodiscard]] u8 get(int x, int y) const;
+    [[nodiscard]] u8 get(Gfx::IntPoint point) const { return get(point.x(), point.y()); }
+    [[nodiscard]] float getf(int x, int y) const { return (float)get(x, y) / 255.0f; }
+    [[nodiscard]] float getf(Gfx::IntPoint point) const { return getf(point.x(), point.y()); }
+
+    void set(int x, int y, u8);
+    void set(Gfx::IntPoint point, u8 value) { set(point.x(), point.y(), value); }
+    void setf(int x, int y, float value) { set(x, y, (u8)clamp(value * 255.0f, 0.0f, 255.0f)); }
+    void setf(Gfx::IntPoint point, float value) { setf(point.x(), point.y(), value); }
+
+    void shrink_to_fit();
+    [[nodiscard]] Mask with_bounding_rect(Gfx::IntRect) const;
+
+    void invert();
+    void add(Mask const& other);
+    void subtract(Mask const& other);
+    void intersect(Mask const& other);
+
+    template<typename Func>
+    void for_each_pixel(Func func) const
+    {
+        for (int x = m_bounding_rect.left(); x <= m_bounding_rect.right(); x++) {
+            for (int y = m_bounding_rect.top(); y <= m_bounding_rect.bottom(); y++) {
+                func(x, y);
+            }
+        }
+    }
+
+private:
+    Gfx::IntRect m_bounding_rect {};
+    Vector<u8> m_data {};
+
+    Mask(Gfx::IntRect, u8 default_value);
+
+    [[nodiscard]] size_t to_index(int x, int y) const;
+
+    template<typename Func>
+    void combine(Mask const& other, Func func)
+    {
+        auto new_bounding_rect = m_bounding_rect.united(other.m_bounding_rect);
+        auto new_me = Mask::empty(new_bounding_rect);
+
+        new_me.for_each_pixel([&](auto x, auto y) {
+            // Widen to int then clamp before narrowing back to avoid annoying overflow checks in the combine functions
+            auto my_alpha = static_cast<int>(get(x, y));
+            auto other_alpha = static_cast<int>(other.get(x, y));
+            auto new_alpha = static_cast<u8>(clamp(func(my_alpha, other_alpha), 0, 0xFF));
+
+            new_me.set(x, y, new_alpha);
+        });
+
+        *this = move(new_me);
+        shrink_to_fit();
+    }
+
+    template<typename Func>
+    void combinef(Mask const& other, Func func)
+    {
+        auto new_bounding_rect = m_bounding_rect.united(other.m_bounding_rect);
+        auto new_me = Mask::empty(new_bounding_rect);
+
+        new_me.for_each_pixel([&](auto x, auto y) {
+            auto my_alpha = getf(x, y);
+            auto other_alpha = other.getf(x, y);
+            auto new_alpha = func(my_alpha, other_alpha);
+
+            new_me.setf(x, y, new_alpha);
+        });
+
+        *this = move(new_me);
+        shrink_to_fit();
+    }
+};
+
+}

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
@@ -60,7 +60,7 @@ void RectangleSelectTool::on_mouseup(Layer&, GUI::MouseEvent&, GUI::MouseEvent& 
     m_editor->update();
 
     auto rect_in_image = Gfx::IntRect::from_two_points(m_selection_start, m_selection_end);
-    m_editor->selection().set(rect_in_image);
+    m_editor->selection().merge(rect_in_image, Selection::MergeMode::Set);
 }
 
 void RectangleSelectTool::on_keydown(GUI::KeyEvent& key_event)

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
@@ -7,7 +7,14 @@
 #include "RectangleSelectTool.h"
 #include "ImageEditor.h"
 #include "Layer.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/ItemListModel.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Model.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Slider.h>
 
 namespace PixelPaint {
 
@@ -60,7 +67,42 @@ void RectangleSelectTool::on_mouseup(Layer&, GUI::MouseEvent&, GUI::MouseEvent& 
     m_editor->update();
 
     auto rect_in_image = Gfx::IntRect::from_two_points(m_selection_start, m_selection_end);
-    m_editor->selection().merge(rect_in_image, Selection::MergeMode::Set);
+    auto mask = Mask::full(rect_in_image);
+
+    auto feathering = ((mask.bounding_rect().size().to_type<float>() * .5f) * m_edge_feathering).to_type<int>();
+
+    // Multiply the alpha instead of setting it to ensure corners are feathered correctly
+    auto multiply_alpha = [&mask](int x, int y, float alpha) {
+        Gfx::IntPoint point { x, y };
+        point += mask.bounding_rect().top_left();
+
+        float old_alpha = mask.getf(point);
+        mask.setf(point, old_alpha * alpha);
+    };
+
+    // Horizontal feathering
+    for (int offset = 0; offset < feathering.width(); offset++) {
+        // Add 1 to offset before dividing to ensure the first pixel won't always be transparent
+        float alpha = (float)(offset + 1) / (float)feathering.width();
+
+        for (int y = 0; y < mask.bounding_rect().height(); y++) {
+            multiply_alpha(offset, y, alpha);
+            multiply_alpha(mask.bounding_rect().width() - offset - 1, y, alpha);
+        }
+    }
+
+    // Vertical feathering
+    for (int offset = 0; offset < feathering.height(); offset++) {
+        // Add 1 to offset before dividing to ensure the first pixel won't always be transparent
+        float alpha = (float)(offset + 1) / (float)feathering.height();
+
+        for (int x = 0; x < mask.bounding_rect().width(); x++) {
+            multiply_alpha(x, offset, alpha);
+            multiply_alpha(x, mask.bounding_rect().height() - offset - 1, alpha);
+        }
+    }
+
+    m_editor->selection().merge(mask, m_merge_mode);
 }
 
 void RectangleSelectTool::on_keydown(GUI::KeyEvent& key_event)
@@ -91,6 +133,75 @@ void RectangleSelectTool::on_second_paint(Layer const&, GUI::PaintEvent& event)
     auto rect_in_editor = m_editor->image_rect_to_editor_rect(rect_in_image);
 
     m_editor->selection().draw_marching_ants(painter, rect_in_editor.to_type<int>());
+}
+
+GUI::Widget* RectangleSelectTool::get_properties_widget()
+{
+    if (m_properties_widget) {
+        return m_properties_widget.ptr();
+    }
+
+    m_properties_widget = GUI::Widget::construct();
+    m_properties_widget->set_layout<GUI::VerticalBoxLayout>();
+
+    auto& feather_container = m_properties_widget->add<GUI::Widget>();
+    feather_container.set_fixed_height(20);
+    feather_container.set_layout<GUI::HorizontalBoxLayout>();
+
+    auto& feather_label = feather_container.add<GUI::Label>();
+    feather_label.set_text("Feather:");
+    feather_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    feather_label.set_fixed_size(80, 20);
+
+    int feather_slider_max = 10000;
+    auto& feather_slider = feather_container.add<GUI::HorizontalSlider>();
+    feather_slider.set_fixed_height(20);
+    feather_slider.set_range(0, feather_slider_max);
+    feather_slider.set_value((int)floorf(m_edge_feathering * (float)feather_slider_max));
+    feather_slider.on_change = [this, feather_slider_max](int value) {
+        m_edge_feathering = (float)value / (float)feather_slider_max;
+    };
+
+    auto& mode_container = m_properties_widget->add<GUI::Widget>();
+    mode_container.set_fixed_height(20);
+    mode_container.set_layout<GUI::HorizontalBoxLayout>();
+
+    auto& mode_label = mode_container.add<GUI::Label>();
+    mode_label.set_text("Mode:");
+    mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    mode_label.set_fixed_size(80, 20);
+
+    for (int i = 0; i < (int)Selection::MergeMode::__Count; i++) {
+        switch ((Selection::MergeMode)i) {
+        case Selection::MergeMode::Set:
+            m_merge_mode_names.append("Set");
+            break;
+        case Selection::MergeMode::Add:
+            m_merge_mode_names.append("Add");
+            break;
+        case Selection::MergeMode::Subtract:
+            m_merge_mode_names.append("Subtract");
+            break;
+        case Selection::MergeMode::Intersect:
+            m_merge_mode_names.append("Intersect");
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    auto& mode_combo = mode_container.add<GUI::ComboBox>();
+    mode_combo.set_only_allow_values_from_model(true);
+    mode_combo.set_model(*GUI::ItemListModel<String>::create(m_merge_mode_names));
+    mode_combo.set_selected_index((int)m_merge_mode);
+    mode_combo.on_change = [this](auto&&, GUI::ModelIndex const& index) {
+        VERIFY(index.row() >= 0);
+        VERIFY(index.row() < (int)Selection::MergeMode::__Count);
+
+        m_merge_mode = (Selection::MergeMode)index.row();
+    };
+
+    return m_properties_widget.ptr();
 }
 
 }

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.h
@@ -6,7 +6,11 @@
 
 #pragma once
 
+#include "Selection.h"
 #include "Tool.h"
+
+#include <AK/Vector.h>
+#include <LibGUI/Widget.h>
 
 namespace PixelPaint {
 
@@ -21,6 +25,7 @@ public:
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
+    virtual GUI::Widget* get_properties_widget() override;
 
 private:
     enum class MovingMode {
@@ -29,6 +34,10 @@ private:
         None,
     };
 
+    RefPtr<GUI::Widget> m_properties_widget;
+    Vector<String> m_merge_mode_names {};
+    Selection::MergeMode m_merge_mode { Selection::MergeMode::Set };
+    float m_edge_feathering { 0.0f };
     bool m_selecting { false };
     MovingMode m_moving_mode { MovingMode::None };
     Gfx::IntPoint m_selection_start;

--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -107,6 +107,26 @@ void Selection::clear()
     m_editor.update();
 }
 
+void Selection::merge(Mask const& mask, MergeMode mode)
+{
+    switch (mode) {
+    case MergeMode::Set:
+        m_mask = mask;
+        break;
+    case MergeMode::Add:
+        m_mask.add(mask);
+        break;
+    case MergeMode::Subtract:
+        m_mask.subtract(mask);
+        break;
+    case MergeMode::Intersect:
+        m_mask.intersect(mask);
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 void Selection::draw_marching_ants_pixel(Gfx::Painter& painter, int x, int y) const
 {
     int pattern_index = x + y + m_marching_ants_offset;

--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -14,7 +14,7 @@ constexpr int marching_ant_length = 4;
 
 void Selection::paint(Gfx::Painter& painter)
 {
-    draw_marching_ants(painter, m_editor.image_rect_to_editor_rect(m_rect).to_type<int>());
+    draw_marching_ants(painter, m_mask);
 }
 
 Selection::Selection(ImageEditor& editor)
@@ -31,38 +31,91 @@ Selection::Selection(ImageEditor& editor)
 
 void Selection::draw_marching_ants(Gfx::Painter& painter, Gfx::IntRect const& rect) const
 {
-    int offset = m_marching_ants_offset;
-
-    auto draw_pixel = [&](int x, int y) {
-        if ((offset % (marching_ant_length * 2)) < marching_ant_length) {
-            painter.set_pixel(x, y, Color::Black);
-        } else {
-            painter.set_pixel(x, y, Color::White);
-        }
-        offset++;
-    };
-
     // Top line
     for (int x = rect.left(); x <= rect.right(); ++x)
-        draw_pixel(x, rect.top());
+        draw_marching_ants_pixel(painter, x, rect.top());
 
     // Right line
     for (int y = rect.top() + 1; y <= rect.bottom(); ++y)
-        draw_pixel(rect.right(), y);
+        draw_marching_ants_pixel(painter, rect.right(), y);
 
     // Bottom line
     for (int x = rect.right() - 1; x >= rect.left(); --x)
-        draw_pixel(x, rect.bottom());
+        draw_marching_ants_pixel(painter, x, rect.bottom());
 
     // Left line
     for (int y = rect.bottom() - 1; y > rect.top(); --y)
-        draw_pixel(rect.left(), y);
+        draw_marching_ants_pixel(painter, rect.left(), y);
+}
+
+void Selection::draw_marching_ants(Gfx::Painter& painter, Mask const& mask) const
+{
+    // If the zoom is < 100%, we can skip pixels to save a lot of time drawing the ants
+    int step = max(1, (int)floorf(1.0f / m_editor.scale()));
+
+    // Only check the visible selection area when drawing for performance
+    auto rect = m_editor.rect();
+    rect = Gfx::enclosing_int_rect(m_editor.editor_rect_to_image_rect(rect));
+    rect.inflate(step * 2, step * 2); // prevent borders from having visible ants if the selection extends beyond it
+
+    // Scan the image horizontally to find vertical borders
+    for (int y = rect.top(); y <= rect.bottom(); y += step) {
+
+        bool previous_selected = false;
+        for (int x = rect.left(); x <= rect.right(); x += step) {
+            bool this_selected = mask.get(x, y) > 0;
+
+            if (this_selected != previous_selected) {
+                Gfx::IntRect image_pixel { x, y, 1, 1 };
+                auto pixel = m_editor.image_rect_to_editor_rect(image_pixel).to_type<int>();
+                auto end = max(pixel.top(), pixel.bottom()); // for when the zoom is < 100%
+
+                for (int pixel_y = pixel.top(); pixel_y <= end; pixel_y++) {
+                    draw_marching_ants_pixel(painter, pixel.left(), pixel_y);
+                }
+            }
+
+            previous_selected = this_selected;
+        }
+    }
+
+    // Scan the image vertically to find horizontal borders
+    for (int x = rect.left(); x <= rect.right(); x += step) {
+
+        bool previous_selected = false;
+        for (int y = rect.top(); y <= rect.bottom(); y += step) {
+            bool this_selected = mask.get(x, y) > 0;
+
+            if (this_selected != previous_selected) {
+                Gfx::IntRect image_pixel { x, y, 1, 1 };
+                auto pixel = m_editor.image_rect_to_editor_rect(image_pixel).to_type<int>();
+                auto end = max(pixel.left(), pixel.right()); // for when the zoom is < 100%
+
+                for (int pixel_x = pixel.left(); pixel_x <= end; pixel_x++) {
+                    draw_marching_ants_pixel(painter, pixel_x, pixel.top());
+                }
+            }
+
+            previous_selected = this_selected;
+        }
+    }
 }
 
 void Selection::clear()
 {
-    m_rect = {};
+    m_mask = {};
     m_editor.update();
+}
+
+void Selection::draw_marching_ants_pixel(Gfx::Painter& painter, int x, int y) const
+{
+    int pattern_index = x + y + m_marching_ants_offset;
+
+    if (pattern_index % (marching_ant_length * 2) < marching_ant_length) {
+        painter.set_pixel(x, y, Color::Black);
+    } else {
+        painter.set_pixel(x, y, Color::White);
+    }
 }
 
 }

--- a/Userland/Applications/PixelPaint/Selection.h
+++ b/Userland/Applications/PixelPaint/Selection.h
@@ -18,12 +18,27 @@ class ImageEditor;
 // Coordinates are image-relative.
 class Selection {
 public:
+    enum class MergeMode {
+        Set,
+        Add,
+        Subtract,
+        Intersect,
+        __Count,
+    };
+
     explicit Selection(ImageEditor&);
 
     bool is_empty() const { return m_mask.is_null(); }
     void clear();
-    void set(Gfx::IntRect const& rect) { m_mask = Mask::full(rect); }
+    void merge(Mask const&, MergeMode);
+    void merge(Gfx::IntRect const& rect, MergeMode mode) { merge(Mask::full(rect), mode); }
     Gfx::IntRect bounding_rect() const { return m_mask.bounding_rect(); }
+
+    [[nodiscard]] bool is_selected(int x, int y) const { return m_mask.get(x, y) > 0; }
+    [[nodiscard]] bool is_selected(Gfx::IntPoint const& point) const { return is_selected(point.x(), point.y()); }
+
+    [[nodiscard]] u8 get_selection_alpha(int x, int y) const { return m_mask.get(x, y); }
+    [[nodiscard]] u8 get_selection_alpha(Gfx::IntPoint const& point) const { return get_selection_alpha(point.x(), point.y()); }
 
     void paint(Gfx::Painter&);
 

--- a/Userland/Applications/PixelPaint/Selection.h
+++ b/Userland/Applications/PixelPaint/Selection.h
@@ -9,6 +9,8 @@
 #include <LibCore/Timer.h>
 #include <LibGfx/Rect.h>
 
+#include "Mask.h"
+
 namespace PixelPaint {
 
 class ImageEditor;
@@ -18,24 +20,27 @@ class Selection {
 public:
     explicit Selection(ImageEditor&);
 
-    bool is_empty() const { return m_rect.is_empty(); }
+    bool is_empty() const { return m_mask.is_null(); }
     void clear();
-    void set(Gfx::IntRect const& rect) { m_rect = rect; }
-    Gfx::IntRect bounding_rect() const { return m_rect; }
+    void set(Gfx::IntRect const& rect) { m_mask = Mask::full(rect); }
+    Gfx::IntRect bounding_rect() const { return m_mask.bounding_rect(); }
 
     void paint(Gfx::Painter&);
 
     void draw_marching_ants(Gfx::Painter&, Gfx::IntRect const&) const;
+    void draw_marching_ants(Gfx::Painter&, Mask const&) const;
 
     void begin_interactive_selection() { m_in_interactive_selection = true; }
     void end_interactive_selection() { m_in_interactive_selection = false; }
 
 private:
     ImageEditor& m_editor;
-    Gfx::IntRect m_rect;
+    Mask m_mask;
     RefPtr<Core::Timer> m_marching_ants_timer;
     int m_marching_ants_offset { 0 };
     bool m_in_interactive_selection { false };
+
+    void draw_marching_ants_pixel(Gfx::Painter&, int x, int y) const;
 };
 
 }

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -237,7 +237,7 @@ int main(int argc, char** argv)
         auto* editor = current_image_editor();
         if (!editor->active_layer())
             return;
-        editor->selection().set(editor->active_layer()->relative_rect());
+        editor->selection().merge(editor->active_layer()->relative_rect(), PixelPaint::Selection::MergeMode::Set);
     }));
     edit_menu.add_action(GUI::Action::create(
         "Clear &Selection", { Mod_Ctrl | Mod_Shift, Key_A }, [&](auto&) {


### PR DESCRIPTION
This PR expands PixelPaint's selection mechanism to support arbitrary selection of individual pixels, with an 8-bit alpha value for each pixel indicating "how selected" it is (this will allow for anti-aliased circular selection tools in the future).

New properties were added to the rectangular selection tool to test these changes: a "feather" value sets by how much the rectangle borders will be smoothed, and a "mode" value sets how to merge the rectangle with an existing selection (if any).

![pp](https://user-images.githubusercontent.com/892216/122684777-f139b280-d1dd-11eb-80d4-1b1c00ff7916.gif)
