### PR TITLE
PDFViewer: Update the page number when scrolling between pages

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -90,6 +90,8 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
             if (scrollbar.value() == scrollbar.max()) {
                 if (m_current_page_index < m_document->get_page_count() - 1) {
                     m_current_page_index++;
+                    if (on_page_change)
+                        on_page_change(m_current_page_index);
                     scrollbar.set_value(0);
                 }
             } else {
@@ -99,6 +101,8 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
             if (scrollbar.value() == 0) {
                 if (m_current_page_index > 0) {
                     m_current_page_index--;
+                    if (on_page_change)
+                        on_page_change(m_current_page_index);
                     scrollbar.set_value(scrollbar.max());
                 }
             } else {

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -47,6 +47,8 @@ public:
     ALWAYS_INLINE const RefPtr<PDF::Document>& document() const { return m_document; }
     void set_document(RefPtr<PDF::Document>);
 
+    Function<void(u32 new_page)> on_page_change;
+
 protected:
     PDFViewer();
 

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -30,6 +30,9 @@ PDFViewerWidget::PDFViewerWidget()
     m_sidebar->set_fixed_width(0);
 
     m_viewer = splitter.add<PDFViewer>();
+    m_viewer->on_page_change = [&](auto new_page) {
+        m_page_text_box->set_current_number(new_page + 1);
+    };
 }
 
 void PDFViewerWidget::initialize_menubar(GUI::Menubar& menubar)


### PR DESCRIPTION
Scrolling between pages now updates the current page number box in the PDFViewer.