### PR TITLE
LibGUI/TabWidget: Make sure we don't act on two mouseup events

### DIFF
--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -358,20 +358,19 @@ void TabWidget::mouseup_event(MouseEvent& event)
     if (event.button() != MouseButton::Left)
         return;
 
-    if (!m_close_button_enabled)
+    if (!m_close_button_enabled || m_pressed_close_button_index == -1)
         return;
 
-    for (size_t i = 0; i < m_tabs.size(); ++i) {
-        auto close_button_rect = this->close_button_rect(i);
-        if (close_button_rect.contains(event.position())) {
-            auto* widget = m_tabs[i].widget;
-            deferred_invoke([this, widget](auto&) {
-                if (on_tab_close_click && widget)
-                    on_tab_close_click(*widget);
-            });
-            m_pressed_close_button_index = -1;
-            return;
-        }
+    auto close_button_rect = this->close_button_rect(m_pressed_close_button_index);
+
+    if (close_button_rect.contains(event.position())) {
+        auto* widget = m_tabs[m_pressed_close_button_index].widget;
+        deferred_invoke([this, widget](auto&) {
+            if (on_tab_close_click && widget)
+                on_tab_close_click(*widget);
+        });
+        m_pressed_close_button_index = -1;
+        return;
     }
 }
 


### PR DESCRIPTION
After b5251a70c68bf1caf910701224a45b62bcccfadd, the window manager for some reason sends out two mouseup events in quick succession. This makes `on_tab_close_click` being invoked twice with the same widget triggering an assertion fail when it tries to remove it twice.

Even though this is not normal behavior there is no harm in making sure that there is no chance of it being called twice, and this fixes the assertion fail until the bug in WindowManager is sorted out.

Also added some optimization, the looping trough all the close_button_rect's was not necessary, previously it was possible to click anywhere on TabWidget an as long as you released the mousebutton on top of a close button, it would trigger. Now you have to click and release on the same button for it to trigger.