### PR TITLE
LibJS: Correct behaviour of direct vs. indirect eval

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 Base/home/anon/Source/js
+Userland/Libraries/LibJS/Tests/eval-aliasing.js
+

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -220,6 +220,11 @@ Value CallExpression::execute(Interpreter& interpreter, GlobalObject& global_obj
         }
     }
 
+    if (!is<NewExpression>(*this) && is<Identifier>(*m_callee) && static_cast<Identifier const&>(*m_callee).string() == vm.names.eval.as_string() && &callee.as_function() == global_object.eval_function()) {
+        auto script_value = arguments.size() == 0 ? js_undefined() : arguments[0];
+        return perform_eval(script_value, global_object, vm.in_strict_mode() ? CallerMode::Strict : CallerMode::NonStrict, EvalMode::Direct);
+    }
+
     vm.call_frame().current_node = interpreter.current_node();
     Object* new_object = nullptr;
     Value result;

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -226,11 +226,15 @@ Associativity Parser::operator_associativity(TokenType type) const
     }
 }
 
-NonnullRefPtr<Program> Parser::parse_program()
+NonnullRefPtr<Program> Parser::parse_program(bool starts_in_strict_mode)
 {
     auto rule_start = push_start();
     ScopePusher scope(*this, ScopePusher::Var | ScopePusher::Let | ScopePusher::Function);
     auto program = adopt_ref(*new Program({ m_filename, rule_start.position(), position() }));
+    if (starts_in_strict_mode) {
+        program->set_strict_mode();
+        m_state.strict_mode = true;
+    }
 
     bool first = true;
     while (!done()) {

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -37,7 +37,7 @@ class Parser {
 public:
     explicit Parser(Lexer lexer);
 
-    NonnullRefPtr<Program> parse_program();
+    NonnullRefPtr<Program> parse_program(bool starts_in_strict_mode = false);
 
     template<typename FunctionNodeType>
     NonnullRefPtr<FunctionNodeType> parse_function_node(u8 parse_options = FunctionNodeParseOptions::CheckForFunctionAndName);

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -25,6 +25,16 @@ Function* species_constructor(GlobalObject&, Object const&, Function& default_co
 GlobalObject* get_function_realm(GlobalObject&, Function const&);
 Object* get_prototype_from_constructor(GlobalObject&, Function const& constructor, Object* (GlobalObject::*intrinsic_default_prototype)());
 
+enum class CallerMode {
+    Strict,
+    NonStrict
+};
+enum class EvalMode {
+    Direct,
+    Indirect
+};
+Value perform_eval(Value, GlobalObject&, CallerMode, EvalMode);
+
 // 10.1.13 OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] ), https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor
 template<typename T, typename... Args>
 T* ordinary_create_from_constructor(GlobalObject& global_object, Function const& constructor, Object* (GlobalObject::*intrinsic_default_prototype)(), Args&&... args)

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -36,6 +36,8 @@ public:
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct constructor
     GeneratorObjectPrototype* generator_object_prototype() { return m_generator_object_prototype; }
 
+    Function* eval_function() const { return m_eval_function; }
+
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* snake_name##_constructor() { return m_##snake_name##_constructor; } \
     Object* snake_name##_prototype() { return m_##snake_name##_prototype; }
@@ -95,6 +97,8 @@ private:
     Object* m_##snake_name##_prototype { nullptr };
     JS_ENUMERATE_ITERATOR_PROTOTYPES
 #undef __JS_ENUMERATE
+
+    Function* m_eval_function;
 };
 
 template<typename ConstructorType>

--- a/Userland/Libraries/LibJS/Tests/eval-aliasing.js
+++ b/Userland/Libraries/LibJS/Tests/eval-aliasing.js
@@ -1,0 +1,15 @@
+test("variable named 'eval' pointing to another function calls that function", function () {
+    var testValue = "inner";
+    // This breaks prettier as it considers this to be a parse error
+    // before even trying to do any linting
+    var eval = () => {
+        return "wat";
+    };
+    expect(eval("testValue")).toEqual("wat");
+});
+
+test("variable named 'eval' pointing to real eval works as a direct eval", function () {
+    var testValue = "inner";
+    var eval = globalThis.eval;
+    expect(eval("testValue")).toEqual("inner");
+});


### PR DESCRIPTION
eval only has direct access to the local scope when accessed through
the name eval. This includes locals named eval, because of course it
does.