### PR TITLE
LibWeb+LibJS: Some more Wasm JS API stuff: Memory imports + some caching

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -196,15 +196,15 @@ jobs:
       run: |
         sudo apt-get purge -y clang-11
         sudo apt-get update
-        sudo apt-get install ninja-build binaryen
+        sudo apt-get install ninja-build wabt
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100
       if: ${{ runner.os == 'Linux' }}
     - name: Install macOS dependencies
-      run: brew install ninja binaryen
+      run: brew install ninja wabt
       if: ${{ runner.os == 'macOS' }}
     - name: Check versions
-      run: set +e; clang --version; clang++ --version; ninja --version; wasm-as --version
+      run: set +e; clang --version; clang++ --version; ninja --version; wat2wasm --version
 
     # === PREPARE FOR BUILDING ===
 

--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -380,7 +380,7 @@ def main():
             with NamedTemporaryFile("w+") as temp:
                 temp.write(mod[1])
                 temp.flush()
-                rc = call(["wasm-as", "-n", "-all", temp.name, "-o", outpath])
+                rc = call(["wat2wasm", temp.name, "-o", outpath])
                 if rc != 0:
                     print("Failed to compile", name, "module index", index, "skipping that test", file=stderr)
                     continue

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -251,7 +251,6 @@ bool Object::test_integrity_level(IntegrityLevel level)
 Value Object::get_own_property(const PropertyName& property_name, Value receiver, AllowSideEffects allow_side_effects) const
 {
     VERIFY(property_name.is_valid());
-    VERIFY(!receiver.is_empty());
 
     Value value_here;
 
@@ -269,6 +268,7 @@ Value Object::get_own_property(const PropertyName& property_name, Value receiver
 
     VERIFY(!value_here.is_empty());
     if (allow_side_effects == AllowSideEffects::Yes) {
+        VERIFY(!receiver.is_empty());
         if (value_here.is_accessor())
             return value_here.as_accessor().call_getter(receiver);
         if (value_here.is_native_property())

--- a/Userland/Libraries/LibWasm/Constants.h
+++ b/Userland/Libraries/LibWasm/Constants.h
@@ -36,4 +36,8 @@ static constexpr auto extern_global_tag = 0x03;
 
 static constexpr auto page_size = 64 * KiB;
 
+// Limits
+static constexpr auto max_allowed_call_stack_depth = 1000;
+static constexpr auto max_allowed_executed_instructions_per_call = 64 * 1024 * 1024;
+
 }

--- a/Userland/Libraries/LibWasm/Tests/Parser/test-basic-load.js
+++ b/Userland/Libraries/LibWasm/Tests/Parser/test-basic-load.js
@@ -26,7 +26,7 @@ test("parsing can pass", () => {
         0x01, 0x05, 0x63, 0x6c, 0x61, 0x6e, 0x67, 0x06, 0x31, 0x31, 0x2e, 0x31, 0x2e, 0x30,
     ]);
     // This just checks that the function actually works
-    parseWebAssemblyModule(binary);
+    expect(() => parseWebAssemblyModule(binary)).toThrowWithMessage(TypeError, "Link failed");
 });
 
 test("parsing can fail", () => {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -221,6 +221,8 @@ set(SOURCES
     UIEvents/EventNames.cpp
     UIEvents/MouseEvent.cpp
     URLEncoder.cpp
+    WebAssembly/WebAssemblyMemoryConstructor.cpp
+    WebAssembly/WebAssemblyMemoryPrototype.cpp
     WebAssembly/WebAssemblyObject.cpp
     WebAssembly/WebAssemblyObjectPrototype.cpp
     WebContentClient.cpp

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Heap/Heap.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/WebAssembly/WebAssemblyMemoryConstructor.h>
+#include <LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h>
+#include <LibWeb/WebAssembly/WebAssemblyObject.h>
+
+namespace Web::Bindings {
+
+WebAssemblyMemoryConstructor::WebAssemblyMemoryConstructor(JS::GlobalObject& global_object)
+    : NativeFunction(*global_object.function_prototype())
+{
+}
+
+WebAssemblyMemoryConstructor::~WebAssemblyMemoryConstructor()
+{
+}
+
+JS::Value WebAssemblyMemoryConstructor::call()
+{
+    vm().throw_exception<JS::TypeError>(global_object(), JS::ErrorType::ConstructorWithoutNew, "WebAssemblyMemory");
+    return {};
+}
+
+JS::Value WebAssemblyMemoryConstructor::construct(Function&)
+{
+    auto& vm = this->vm();
+    auto& global_object = this->global_object();
+
+    auto descriptor = vm.argument(0).to_object(global_object);
+    if (vm.exception())
+        return {};
+
+    auto initial_value = descriptor->get_own_property("initial", {}, JS::AllowSideEffects::No);
+    auto maximum_value = descriptor->get_own_property("maximum", {}, JS::AllowSideEffects::No);
+
+    if (initial_value.is_empty()) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Number");
+        return {};
+    }
+
+    auto initial = initial_value.to_u32(global_object);
+    if (vm.exception())
+        return {};
+
+    Optional<u32> maximum;
+
+    if (!maximum_value.is_empty()) {
+        maximum = maximum_value.to_u32(global_object);
+        if (vm.exception())
+            return {};
+    }
+
+    auto address = WebAssemblyObject::s_abstract_machine.store().allocate(Wasm::MemoryType { Wasm::Limits { initial, maximum } });
+    if (!address.has_value()) {
+        vm.throw_exception<JS::TypeError>(global_object, "Wasm Memory allocation failed");
+        return {};
+    }
+
+    return vm.heap().allocate<WebAssemblyMemoryObject>(global_object, global_object, *address);
+}
+
+void WebAssemblyMemoryConstructor::initialize(JS::GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    auto& window = static_cast<WindowObject&>(global_object);
+
+    NativeFunction::initialize(global_object);
+    define_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssembly.Memory"));
+    define_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace Web::Bindings {
+
+class WebAssemblyMemoryConstructor : public JS::NativeFunction {
+    JS_OBJECT(WebAssemblyMemoryConstructor, JS::NativeFunction);
+
+public:
+    explicit WebAssemblyMemoryConstructor(JS::GlobalObject&);
+    virtual void initialize(JS::GlobalObject&) override;
+    virtual ~WebAssemblyMemoryConstructor() override;
+
+    virtual JS::Value call() override;
+    virtual JS::Value construct(JS::Function& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "WebAssemblyMemoryConstructor.h"
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Bindings {
+
+class WebAssemblyMemoryPrototype final : public JS::Object {
+    JS_OBJECT(WebAssemblyMemoryPrototype, JS::Object);
+
+public:
+    explicit WebAssemblyMemoryPrototype(JS::GlobalObject& global_object)
+        : JS::Object(global_object)
+    {
+    }
+
+    virtual void initialize(JS::GlobalObject&) override;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(grow);
+    JS_DECLARE_NATIVE_GETTER(buffer_getter);
+};
+
+}

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -251,8 +251,7 @@ JS::Value to_js_value(Wasm::Value& wasm_value, JS::GlobalObject& global_object)
 {
     switch (wasm_value.type().kind()) {
     case Wasm::ValueType::I64:
-        // FIXME: This is extremely silly...
-        return global_object.heap().allocate<JS::BigInt>(global_object, Crypto::SignedBigInteger::from_base10(String::number(wasm_value.to<i64>().value())));
+        return global_object.heap().allocate<JS::BigInt>(global_object, Crypto::SignedBigInteger::create_from(wasm_value.to<i64>().value()));
     case Wasm::ValueType::I32:
         return JS::Value(wasm_value.to<i32>().value());
     case Wasm::ValueType::F64:

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.h
@@ -95,19 +95,15 @@ private:
 };
 
 class WebAssemblyMemoryObject final : public JS::Object {
-    JS_OBJECT(WebAssemblyModuleObject, JS::Object);
+    JS_OBJECT(WebAssemblyMemoryObject, JS::Object);
 
 public:
     explicit WebAssemblyMemoryObject(JS::GlobalObject&, Wasm::MemoryAddress);
-    virtual void initialize(JS::GlobalObject&) override;
     virtual ~WebAssemblyMemoryObject() override = default;
 
     auto address() const { return m_address; }
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(grow);
-    JS_DECLARE_NATIVE_GETTER(buffer);
-
     Wasm::MemoryAddress m_address;
 };
 


### PR DESCRIPTION
TL;DR, now `new WebAssembly.Memory({ initial: 10 })` works, and can be used to resolve a memory import.
Also caches the stuff that need to be cached and exist :P