### PR TITLE
WindowServer: Focus windows blocked by a modal window

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -950,20 +950,11 @@ bool WindowManager::process_mouse_event_for_titlebar_buttons(MouseEvent const& e
 void WindowManager::process_mouse_event_for_window(HitTestResult& result, MouseEvent const& event)
 {
     auto& window = *result.window;
-
-    if (auto* blocking_modal_window = window.blocking_modal_window()) {
-        if (event.type() == Event::Type::MouseDown) {
-            // We're clicking on something that's blocked by a modal window.
-            // Flash the modal window to let the user know about it.
-            blocking_modal_window->frame().start_flash_animation();
-        }
-        // Don't send mouse events to windows blocked by a modal child.
-        return;
-    }
+    auto* blocking_modal_window = window.blocking_modal_window();
 
     // First check if we should initiate a move or resize (Super+LMB or Super+RMB).
     // In those cases, the event is swallowed by the window manager.
-    if (window.is_movable()) {
+    if (!blocking_modal_window && window.is_movable()) {
         if (!window.is_fullscreen() && m_keyboard_modifiers == Mod_Super && event.type() == Event::MouseDown && event.button() == MouseButton::Left) {
             start_window_move(window, event);
             return;
@@ -979,6 +970,16 @@ void WindowManager::process_mouse_event_for_window(HitTestResult& result, MouseE
             move_to_front_and_make_active(window);
         else if (window.type() == WindowType::Desktop)
             set_active_window(&window);
+    }
+
+    if (blocking_modal_window) {
+        if (event.type() == Event::Type::MouseDown) {
+            // We're clicking on something that's blocked by a modal window.
+            // Flash the modal window to let the user know about it.
+            blocking_modal_window->frame().start_flash_animation();
+        }
+        // Don't send mouse events to windows blocked by a modal child.
+        return;
     }
 
     if (result.is_frame_hit) {


### PR DESCRIPTION
If a window which has an active modal window is focused, the modal window starts blinking. In this case, the window (and modal) should still be focused. For this, the order of the checks in `WindowManager::process_mouse_event_for_window` has to be changed.

This fixes #8183.