### PR TITLE
Kernel: Fix assertion failure on large TTY writes

### DIFF
--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -97,7 +97,6 @@ KResultOr<size_t> TTY::write(FileDescription&, u64, const UserOrKernelBuffer& bu
             });
         }
         auto bytes_written_or_error = on_tty_write(UserOrKernelBuffer::for_kernel_buffer(modified_data), modified_data_size);
-        VERIFY(bytes_written_or_error.is_error() || bytes_written_or_error.value() != 0);
         if (bytes_written_or_error.is_error() || !(m_termios.c_oflag & OPOST) || !(m_termios.c_oflag & ONLCR))
             return bytes_written_or_error;
         auto bytes_written = bytes_written_or_error.value();


### PR DESCRIPTION
The `File::can_write` mechanism lets us check that writes won't block,
meaning some bytes can be immediately written to the underlying device.
This means calling `File::write` in a situation where no data could be
written is a logic error, which we `VERIFY()` in `Process::do_write()`.

TTY, in particular, processes the write in 256-byte buffered chunks.
Previously, we would assert that none of these sub-writes returned zero.
This was a logic error, as this rejected some successful writes. For
example, if there was exactly enough free space in `SlavePty`'s internal
buffer for the previous sub-write to complete fully. This made it
impossible to perform writes larger than `SlavePty`'s internal buffer.

Note that it's not an issue if `on_tty_write` returns zero, as partial
writes are handled correctly by the `buffer.read_buffered` helper. We
won't spin in a loop trying to write to a full buffer.

Fixes #8090

cc @ccapitalK 