### PR TITLE
LibJS: Object and Array fixes

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SOURCES
     Runtime/PromisePrototype.cpp
     Runtime/PromiseReaction.cpp
     Runtime/PromiseResolvingFunction.cpp
+    Runtime/PropertyAttributes.cpp
     Runtime/ProxyConstructor.cpp
     Runtime/ProxyObject.cpp
     Runtime/Reference.cpp

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -298,7 +298,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::unshift)
                 if (vm.exception())
                     return {};
             } else {
-                this_object->delete_property(to);
+                this_object->delete_property(to, true);
                 if (vm.exception())
                     return {};
             }
@@ -340,7 +340,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     auto element = this_object->get(index).value_or(js_undefined());
     if (vm.exception())
         return {};
-    this_object->delete_property(index);
+    this_object->delete_property(index, true);
     if (vm.exception())
         return {};
     this_object->put(vm.names.length, Value((i32)index));
@@ -382,13 +382,13 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
             if (vm.exception())
                 return {};
         } else {
-            this_object->delete_property(to);
+            this_object->delete_property(to, true);
             if (vm.exception())
                 return {};
         }
     }
 
-    this_object->delete_property(length - 1);
+    this_object->delete_property(length - 1, true);
     if (vm.exception())
         return {};
 
@@ -848,11 +848,11 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reverse)
             this_object->put(lower, upper_value);
             if (vm.exception())
                 return {};
-            this_object->delete_property(upper);
+            this_object->delete_property(upper, true);
             if (vm.exception())
                 return {};
         } else if (lower_exists && !upper_exists) {
-            this_object->delete_property(lower);
+            this_object->delete_property(lower, true);
             if (vm.exception())
                 return {};
             this_object->put(upper, lower_value);
@@ -1018,7 +1018,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::sort)
     // compare function. FIXME: For performance, a similar process could be used
     // for undefined, which are sorted to right before the empty values.
     for (size_t i = values_to_sort.size(); i < original_length; ++i) {
-        array->delete_property(i);
+        array->delete_property(i, true);
         if (vm.exception())
             return {};
     }
@@ -1229,14 +1229,14 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
             if (!from.is_empty()) {
                 this_object->put(to, from);
             } else {
-                this_object->delete_property(to);
+                this_object->delete_property(to, true);
             }
             if (vm.exception())
                 return {};
         }
 
         for (size_t i = initial_length; i > new_length; --i) {
-            this_object->delete_property(i - 1);
+            this_object->delete_property(i - 1, true);
             if (vm.exception())
                 return {};
         }
@@ -1251,7 +1251,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
             if (!from.is_empty()) {
                 this_object->put(to, from);
             } else {
-                this_object->delete_property(to);
+                this_object->delete_property(to, true);
             }
             if (vm.exception())
                 return {};
@@ -1523,7 +1523,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::copy_within)
             if (vm.exception())
                 return {};
         } else {
-            this_object->delete_property(to_i);
+            this_object->delete_property(to_i, true);
             if (vm.exception())
                 return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -531,7 +531,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
         if (!spreadable.is_undefined())
             return spreadable.to_boolean();
 
-        return object->is_array();
+        return val.is_array(global_object);
     };
 
     auto append_to_new_array = [&vm, &is_concat_spreadable, &new_array, &global_object, &n](Value arg) {
@@ -546,7 +546,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
             if (vm.exception())
                 return;
 
-            if (length + k > MAX_ARRAY_LIKE_INDEX) {
+            if (n + length > MAX_ARRAY_LIKE_INDEX) {
                 vm.throw_exception<TypeError>(global_object, ErrorType::ArrayMaxSize);
                 return;
             }

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -278,7 +278,7 @@ Value Object::get_own_property(const PropertyName& property_name, Value receiver
         if (value_here.is_accessor())
             return value_here.as_accessor().call_getter(receiver);
         if (value_here.is_native_property())
-            return call_native_property_getter(value_here.as_native_property(), receiver);
+            return call_native_property_getter(value_here.as_native_property(), this);
     }
     return value_here;
 }
@@ -937,9 +937,7 @@ bool Object::put_by_index(u32 property_index, Value value)
                 return true;
             }
             if (value_here.value.is_native_property()) {
-                // FIXME: Why doesn't put_by_index() receive the receiver value from put()?!
-                auto receiver = this;
-                call_native_property_setter(value_here.value.as_native_property(), receiver, value);
+                call_native_property_setter(value_here.value.as_native_property(), this, value);
                 return true;
             }
         }
@@ -976,7 +974,7 @@ bool Object::put(const PropertyName& property_name, Value value, Value receiver)
                 return true;
             }
             if (value_here.is_native_property()) {
-                call_native_property_setter(value_here.as_native_property(), receiver, value);
+                call_native_property_setter(value_here.as_native_property(), this, value);
                 return true;
             }
         }

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -621,7 +621,7 @@ bool Object::put_own_property(const StringOrSymbol& property_name, Value value, 
 
     if (!is_extensible() && new_property) {
         dbgln_if(OBJECT_DEBUG, "Disallow define_property of non-extensible object");
-        if (throw_exceptions && vm().in_strict_mode())
+        if (throw_exceptions)
             vm().throw_exception<TypeError>(global_object(), ErrorType::NonExtensibleDefine, property_name.to_display_string());
         return false;
     }
@@ -729,7 +729,7 @@ bool Object::put_own_property_by_index(u32 property_index, Value value, Property
 
     if (!is_extensible() && new_property) {
         dbgln_if(OBJECT_DEBUG, "Disallow define_property of non-extensible object");
-        if (throw_exceptions && vm().in_strict_mode())
+        if (throw_exceptions)
             vm().throw_exception<TypeError>(global_object(), ErrorType::NonExtensibleDefine, property_index);
         return false;
     }
@@ -780,7 +780,6 @@ bool Object::delete_property(PropertyName const& property_name, bool force_throw
         }
         return true;
     }
-
 
     auto metadata = shape().lookup(property_name.to_string_or_symbol());
     if (!metadata.has_value())
@@ -923,7 +922,7 @@ bool Object::put(const PropertyName& property_name, Value value, Value receiver)
         if (vm().exception())
             return false;
     }
-    return put_own_property(string_or_symbol, value, default_attributes, PutOwnPropertyMode::Put);
+    return put_own_property(string_or_symbol, value, default_attributes, PutOwnPropertyMode::Put, vm().in_strict_mode());
 }
 
 bool Object::define_native_function(PropertyName const& property_name, AK::Function<Value(VM&, GlobalObject&)> native_function, i32 length, PropertyAttributes attribute)

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -99,7 +99,7 @@ public:
 
     void define_properties(Value properties);
 
-    virtual bool delete_property(const PropertyName&);
+    virtual bool delete_property(PropertyName const&, bool force_throw_exception = false);
 
     virtual bool is_array() const { return false; }
     virtual bool is_function() const { return false; }

--- a/Userland/Libraries/LibJS/Runtime/PropertyAttributes.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PropertyAttributes.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, David Tuin <david.tuin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PropertyAttributes.h"
+
+namespace JS {
+
+PropertyAttributes PropertyAttributes::overwrite(PropertyAttributes attr) const
+{
+    PropertyAttributes combined = m_bits;
+    if (attr.has_configurable()) {
+        if (attr.is_configurable()) {
+            combined.set_configurable();
+        } else {
+            combined.m_bits &= ~Attribute::Configurable;
+        }
+        combined.set_has_configurable();
+    }
+
+    if (attr.has_enumerable()) {
+        if (attr.is_enumerable()) {
+            combined.set_enumerable();
+        } else {
+            combined.m_bits &= ~Attribute::Enumerable;
+        }
+        combined.set_has_configurable();
+    }
+
+    if (attr.has_writable()) {
+        if (attr.is_writable()) {
+            combined.set_writable();
+        } else {
+            combined.m_bits &= ~Attribute::Writable;
+        }
+        combined.set_has_writable();
+    }
+
+    if (attr.has_getter()) {
+        combined.set_has_getter();
+    }
+
+    if (attr.has_setter()) {
+        combined.set_has_setter();
+    }
+    return combined;
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -61,6 +61,8 @@ public:
     bool operator==(const PropertyAttributes& other) const { return m_bits == other.m_bits; }
     bool operator!=(const PropertyAttributes& other) const { return m_bits != other.m_bits; }
 
+    PropertyAttributes overwrite(PropertyAttributes attr) const;
+
     u8 bits() const { return m_bits; }
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyName.h
@@ -113,6 +113,19 @@ public:
     bool try_coerce_into_number()
     {
         VERIFY(m_string_may_be_number);
+        if (m_string.is_empty()) {
+            m_string_may_be_number = false;
+            return false;
+        }
+
+        if (char first = m_string.characters()[0]; first < '0' || first > '9') {
+            m_string_may_be_number = false;
+            return false;
+        } else if (m_string.length() > 1 && first == '0') {
+            m_string_may_be_number = false;
+            return false;
+        }
+
         i32 property_index = m_string.to_int(TrimWhitespace::No).value_or(-1);
         if (property_index < 0) {
             m_string_may_be_number = false;

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -375,7 +375,7 @@ bool ProxyObject::put(const PropertyName& name, Value value, Value receiver)
     return true;
 }
 
-bool ProxyObject::delete_property(const PropertyName& name)
+bool ProxyObject::delete_property(PropertyName const& name, bool force_throw_exception)
 {
     auto& vm = this->vm();
     if (m_is_revoked) {
@@ -386,7 +386,7 @@ bool ProxyObject::delete_property(const PropertyName& name)
     if (vm.exception())
         return false;
     if (!trap)
-        return m_target.delete_property(name);
+        return m_target.delete_property(name, force_throw_exception);
     auto trap_result = vm.call(*trap, Value(&m_handler), Value(&m_target), name.to_value(vm));
     if (vm.exception())
         return false;

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -37,7 +37,7 @@ public:
     virtual bool has_property(const PropertyName& name) const override;
     virtual Value get(const PropertyName& name, Value receiver, AllowSideEffects = AllowSideEffects::Yes) const override;
     virtual bool put(const PropertyName& name, Value value, Value receiver) override;
-    virtual bool delete_property(const PropertyName& name) override;
+    virtual bool delete_property(PropertyName const& name, bool force_throw_exception = false) override;
 
     bool is_revoked() const { return m_is_revoked; }
     void revoke() { m_is_revoked = true; }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -101,6 +101,15 @@ public:
         return viewed_array_buffer()->template get_value<T>(indexed_position.value(), true, ArrayBuffer::Order::Unordered);
     }
 
+    // 10.4.5.2 [[HasProperty]] ( P ), https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-hasproperty-p
+    bool has_property(const PropertyName& name) const override
+    {
+        if (name.is_number()) {
+            return is_valid_integer_index(name.as_number());
+        }
+        return Object::has_property(name);
+    }
+
     Span<const UnderlyingBufferDataType> data() const
     {
         return { reinterpret_cast<const UnderlyingBufferDataType*>(m_viewed_array_buffer->buffer().data() + m_byte_offset), m_array_length };

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.concat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.concat.js
@@ -40,4 +40,14 @@ describe("normal behavior", () => {
         expect(concatenated[4]).toBe(1);
         expect(concatenated[5]).toEqual([2, 3]);
     });
+
+    test("Proxy is concatenated as array", () => {
+        var proxy = new Proxy([9, 8], {});
+        var concatenated = array.concat(proxy);
+        expect(array).toHaveLength(1);
+        expect(concatenated).toHaveLength(3);
+        expect(concatenated[0]).toBe("hello");
+        expect(concatenated[1]).toBe(9);
+        expect(concatenated[2]).toBe(8);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.shift.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.shift.js
@@ -26,7 +26,7 @@ test("Issue #5884, GenericIndexedPropertyStorage::take_first() loses elements", 
     const a = [];
     for (let i = 0; i < 300; i++) {
         // NOTE: We use defineProperty to prevent the array from using SimpleIndexedPropertyStorage
-        Object.defineProperty(a, i, { value: i, writable: false });
+        Object.defineProperty(a, i, { value: i, configurable: true });
     }
     expect(a.length).toBe(300);
     for (let i = 0; i < 300; i++) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/array-index-from-string.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/array-index-from-string.js
@@ -1,0 +1,49 @@
+describe("normal behavior", () => {
+    var arr = [3, 4, 5];
+
+    test("basic", () => {
+        expect(arr["0"]).toBe(3);
+        expect(arr["1"]).toBe(4);
+        expect(arr["2"]).toBe(5);
+    });
+
+    test("above length", () => {
+        expect(arr["3"]).toBeUndefined();
+    });
+});
+
+describe("strings with extra characters", () => {
+    var arr = [3, 4, 5];
+
+    test("whitespace", () => {
+        expect(arr[" 0"]).toBeUndefined();
+        expect(arr["0 "]).toBeUndefined();
+        expect(arr["  0"]).toBeUndefined();
+        expect(arr["  0  "]).toBeUndefined();
+        expect(arr["  3  "]).toBeUndefined();
+    });
+
+    test("leading 0", () => {
+        expect(arr["00"]).toBeUndefined();
+        expect(arr["01"]).toBeUndefined();
+        expect(arr["02"]).toBeUndefined();
+        expect(arr["03"]).toBeUndefined();
+    });
+
+    test("leading +/-", () => {
+        ["+", "-"].forEach(op => {
+            expect(arr[op + "0"]).toBeUndefined();
+            expect(arr[op + "1"]).toBeUndefined();
+
+            expect(arr[op + "-0"]).toBeUndefined();
+            expect(arr[op + "+0"]).toBeUndefined();
+        });
+    });
+
+    test("combined", () => {
+        expect(arr["+00"]).toBeUndefined();
+        expect(arr[" +0"]).toBeUndefined();
+        expect(arr["  +0 "]).toBeUndefined();
+        expect(arr["  00 "]).toBeUndefined();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/array-index-number-whitespace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/array-index-number-whitespace.js
@@ -1,7 +1,0 @@
-test("indexing the array doesn't strip whitespace if it's a number", () => {
-    var a = [];
-    a[1] = 1;
-
-    expect(a["1"]).toBe(1);
-    expect(a[" 1 "]).toBeUndefined();
-});


### PR DESCRIPTION
Just trying to fix all the Array (concat to start) test262 tests. 
This is more or less a continuation of #8152.
Ran into this issue. Then found a number of regressions repeat ad infinitum.
It is a little bit messy. 
For example overwriting the attributes which is different in `put_own_property` and `put_own_property_by_index` currently.
