### PR TITLE
LaunchServer: Prevent opening files with nonexistent programs

### DIFF
--- a/Base/home/anon/.config/LaunchServer.ini
+++ b/Base/home/anon/.config/LaunchServer.ini
@@ -17,6 +17,7 @@ font=/bin/FontEditor
 sheets=/bin/Spreadsheet
 gml=/bin/Playground
 pdf=/bin/PDFViewer
+directory=/bin/FileManager
 *=/bin/TextEditor
 
 [Protocol]

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -87,7 +87,8 @@ void Launcher::load_handlers(const String& af_dir)
         HashTable<String> protocols;
         for (auto& protocol : af->launcher_protocols())
             protocols.set(protocol);
-        m_handlers.set(app_executable, { Handler::Type::Default, app_name, app_executable, file_types, protocols });
+        if (access(app_executable.characters(), X_OK) == 0)
+            m_handlers.set(app_executable, { Handler::Type::Default, app_name, app_executable, file_types, protocols });
     },
         af_dir);
 }
@@ -98,12 +99,16 @@ void Launcher::load_config(const Core::ConfigFile& cfg)
         auto handler = cfg.read_entry("FileType", key).trim_whitespace();
         if (handler.is_empty())
             continue;
+        if (access(handler.characters(), X_OK) != 0)
+            continue;
         m_file_handlers.set(key.to_lowercase(), handler);
     }
 
     for (auto key : cfg.keys("Protocol")) {
         auto handler = cfg.read_entry("Protocol", key).trim_whitespace();
         if (handler.is_empty())
+            continue;
+        if (access(handler.characters(), X_OK) != 0)
             continue;
         m_protocol_handlers.set(key.to_lowercase(), handler);
     }


### PR DESCRIPTION
This PR prevents LaunchServer from trying to open files with nonexistent   
programs and also allows it to properly report an error before spawning a child   
process. For example, now FileManager will pop up a MessageBox showing the user   
that a file could not be opened instead of failing silently. This PR addresses   
issues #8120 and #8121.   
 
Main changes:    
- Add calls to `access` in `load_handlers` and `load_config`, to check if the   
  program is installed and executable on the system before registering it as a   
  handler.   

- Add a variable to control the handler for directories in   
  `/home/anon/.config/LaunchServer.ini`.   

- Remove hard coded handlers in `Launcher.cpp` in favor of using variables read   
  from the config file   
 
I am quite new to the codebase so I readily welcome feedback on anything I need   
to change. I am still trying to learn the system.   

