### PR TITLE
LaunchServer: Fix regression in opening files with TextEditor

### DIFF
--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -331,6 +331,9 @@ bool Launcher::open_file_url(const URL& url)
                 filepath = String::formatted("{}:{}", filepath, line.value());
         }
     }
+
+    additional_parameters.append(filepath);
+
     return open_with_user_preferences(m_file_handlers, extension, additional_parameters, default_handler);
 }
 }


### PR DESCRIPTION
My previous PR had a small error in rebasing and removed a line in
open_file_url. This caused opening text files from the terminal to
always open with an empty TextEditor.

This commit fixes that problem!