### PR TITLE
WindowServer: Send events once when global cursor tracking is enabled

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1007,8 +1007,10 @@ void WindowManager::process_mouse_event(MouseEvent& event)
         return;
 
     // 2. Send the mouse event to all windows with global cursor tracking enabled.
+    // The active input tracking window is excluded here because we're sending the event to it
+    // in the next step.
     m_window_stack.for_each_visible_window_from_front_to_back([&](Window& window) {
-        if (window.global_cursor_tracking())
+        if (window.global_cursor_tracking() && &window != m_active_input_tracking_window)
             deliver_mouse_event(window, event, false);
         return IterationDecision::Continue;
     });


### PR DESCRIPTION
Previously we'd send mouse events twice if the target window had global cursor tracking enabled (e.g. because it received the initial mouse down event and therefore had automatic tracking enabled for it).

Steps to reproduce:

1. Start Hearts.
2. Click on one of the player's cards.

The Game widget receives two mouseup events which causes the card to get deselected immediately after it was selected.