### PR TITLE
Taskbar: Check for non-installed programs

### DIFF
--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -87,8 +87,10 @@ Vector<String> discover_apps_and_categories()
 {
     HashTable<String> seen_app_categories;
     Desktop::AppFile::for_each([&](auto af) {
-        g_apps.append({ af->executable(), af->name(), af->category() });
-        seen_app_categories.set(af->category());
+        if (access(af->executable().characters(), X_OK) == 0) {
+            g_apps.append({ af->executable(), af->name(), af->category() });
+            seen_app_categories.set(af->category());
+        }
     });
     quick_sort(g_apps, [](auto& a, auto& b) { return a.name < b.name; });
 


### PR DESCRIPTION
This adds check in discover_apps_and_categories() to check executable specified in .af files exist before registering them for start menu.
This PR Fixes issue #8119
