### PR TITLE
Playground: Ask to save changes even when the document was never saved

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -249,7 +249,7 @@ MainWidget::MainWidget()
             auto save_document_first_result = GUI::MessageBox::show(window(), "Save changes to current document first?", "Warning", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
             if (save_document_first_result == GUI::Dialog::ExecResult::ExecYes)
                 m_save_action->activate();
-            if (save_document_first_result == GUI::Dialog::ExecResult::ExecCancel)
+            if (save_document_first_result != GUI::Dialog::ExecResult::ExecNo && editor().document().is_modified())
                 return;
         }
 
@@ -268,7 +268,7 @@ MainWidget::MainWidget()
             auto save_document_first_result = GUI::MessageBox::show(window(), "Save changes to current document first?", "Warning", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
             if (save_document_first_result == GUI::Dialog::ExecResult::ExecYes)
                 m_save_action->activate();
-            if (save_document_first_result == GUI::Dialog::ExecResult::ExecCancel)
+            if (save_document_first_result != GUI::Dialog::ExecResult::ExecNo && editor().document().is_modified())
                 return;
         }
 

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -186,6 +186,11 @@ int main(int argc, char** argv)
     });
 
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
+        Optional<String> open_path = GUI::FilePicker::get_open_filepath(window);
+
+        if (!open_path.has_value())
+            return;
+
         if (window->is_modified()) {
             auto save_document_first_result = GUI::MessageBox::show(window, "Save changes to current document first?", "Warning", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
             if (save_document_first_result == GUI::Dialog::ExecResult::ExecYes)
@@ -193,11 +198,6 @@ int main(int argc, char** argv)
             if (save_document_first_result != GUI::Dialog::ExecResult::ExecNo && window->is_modified())
                 return;
         }
-
-        Optional<String> open_path = GUI::FilePicker::get_open_filepath(window);
-
-        if (!open_path.has_value())
-            return;
 
         auto file = Core::File::construct(open_path.value());
         if (!file->open(Core::OpenMode::ReadOnly) && file->error() != ENOENT) {

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -159,16 +159,30 @@ int main(int argc, char** argv)
     auto menubar = GUI::Menubar::construct();
     auto& file_menu = menubar->add_menu("&File");
 
-    auto save_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        Optional<String> save_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "gml");
-        if (!save_path.has_value())
+    auto save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
+        Optional<String> new_save_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "gml");
+        if (!new_save_path.has_value())
             return;
 
-        if (!editor.write_to_file(save_path.value())) {
+        if (!editor.write_to_file(new_save_path.value())) {
             GUI::MessageBox::show(window, "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
             return;
         }
+        file_path = new_save_path.value();
         update_title();
+    });
+
+    auto save_action = GUI::CommonActions::make_save_action([&](auto&) {
+        if (!file_path.is_empty()) {
+            if (!editor.write_to_file(file_path)) {
+                GUI::MessageBox::show(window, "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
+                return;
+            }
+            update_title();
+            return;
+        }
+
+        save_as_action->activate();
     });
 
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
@@ -202,6 +216,7 @@ int main(int argc, char** argv)
     }));
 
     file_menu.add_action(save_action);
+    file_menu.add_action(save_as_action);
     file_menu.add_separator();
 
     file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) {

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -172,11 +172,11 @@ int main(int argc, char** argv)
     });
 
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        if (!file_path.is_empty() && window->is_modified()) {
+        if (window->is_modified()) {
             auto save_document_first_result = GUI::MessageBox::show(window, "Save changes to current document first?", "Warning", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
             if (save_document_first_result == GUI::Dialog::ExecResult::ExecYes)
                 save_action->activate();
-            if (save_document_first_result == GUI::Dialog::ExecResult::ExecCancel)
+            if (save_document_first_result != GUI::Dialog::ExecResult::ExecNo && window->is_modified())
                 return;
         }
 


### PR DESCRIPTION
**Playground: Ask to save changes even when the document was never saved**

This makes sure to ask the user whether they want to save changes to their current document when opening a file even if the document has never been saved before.

**Playground: Add a menu action to save the file**

There was already 'Save As' and now we also have 'Save'.

**Playground: Prompt to save changes after the user picked a file to open**

There's no point in saving the file - and potentially having to ask the user for a file name - if the user abandons the 'Open' action by clicking 'Cancel' in the file picker. This now also matches TextEditor's behavior.

**TextEditor: Don't open files when the user cancelled saving changes**

Steps to reproduce:

1. Start TextEditor and make some changes to the document.
2. Try to open an existing file.
3. When prompted choose to save the changes to the existing document.
4. Close the file picker by clicking 'Cancel'.
5. Note how the file was opened anyway and your changes were lost.

Same applies to the 'New File' action.