### PR TITLE
ChessEngine: Greatly reduce memory usage.

### DIFF
--- a/Userland/Libraries/LibChess/Chess.cpp
+++ b/Userland/Libraries/LibChess/Chess.cpp
@@ -579,14 +579,12 @@ bool Board::apply_move(const Move& move, Color color)
 
 bool Board::apply_illegal_move(const Move& move, Color color)
 {
-    Board clone = *this;
-    clone.m_previous_states = {};
-    clone.m_moves = {};
+    auto state = Traits<Board>::hash(*this);
     auto state_count = 0;
-    if (m_previous_states.contains(clone))
-        state_count = m_previous_states.get(clone).value();
+    if (m_previous_states.contains(state))
+        state_count = m_previous_states.get(state).value();
 
-    m_previous_states.set(clone, state_count + 1);
+    m_previous_states.set(state, state_count + 1);
     m_moves.append(move);
 
     m_turn = opposing_color(color);
@@ -758,7 +756,7 @@ Board::Result Board::game_result() const
         if (m_moves_since_capture == 50 * 2)
             return Result::FiftyMoveRule;
 
-        auto repeats = m_previous_states.get(*this);
+        auto repeats = m_previous_states.get(Traits<Board>::hash(*this));
         if (repeats.has_value()) {
             if (repeats.value() == 3)
                 return Result::ThreeFoldRepetition;

--- a/Userland/Libraries/LibChess/Chess.h
+++ b/Userland/Libraries/LibChess/Chess.h
@@ -15,7 +15,7 @@
 
 namespace Chess {
 
-enum class Type {
+enum class Type : u8 {
     Pawn,
     Knight,
     Bishop,
@@ -28,7 +28,7 @@ enum class Type {
 String char_for_piece(Type type);
 Chess::Type piece_for_char_promotion(const StringView& str);
 
-enum class Color {
+enum class Color : u8 {
     White,
     Black,
     None,
@@ -55,8 +55,8 @@ struct Piece {
 constexpr Piece EmptyPiece = { Color::None, Type::None };
 
 struct Square {
-    int rank; // zero indexed;
-    int file;
+    i8 rank; // zero indexed;
+    i8 file;
     Square(const StringView& name);
     Square(const int& rank, const int& file)
         : rank(rank)
@@ -88,10 +88,10 @@ struct Move {
     Square to;
     Type promote_to;
     Piece piece;
-    bool is_check = false;
-    bool is_mate = false;
-    bool is_capture = false;
-    bool is_ambiguous = false;
+    bool is_check : 1 = false;
+    bool is_mate : 1 = false;
+    bool is_capture : 1 = false;
+    bool is_ambiguous : 1 = false;
     Square ambiguous { 50, 50 };
     Move(const StringView& long_algebraic);
     Move(const Square& from, const Square& to, const Type& promote_to = Type::None)
@@ -161,16 +161,17 @@ private:
     bool apply_illegal_move(const Move&, Color color);
 
     Piece m_board[8][8];
-    Color m_turn { Color::White };
-    Color m_resigned { Color::None };
     Optional<Move> m_last_move;
-    int m_moves_since_capture { 0 };
-    int m_moves_since_pawn_advance { 0 };
+    short m_moves_since_capture { 0 };
+    short m_moves_since_pawn_advance { 0 };
 
-    bool m_white_can_castle_kingside { true };
-    bool m_white_can_castle_queenside { true };
-    bool m_black_can_castle_kingside { true };
-    bool m_black_can_castle_queenside { true };
+    Color m_turn : 2 { Color::White };
+    Color m_resigned : 2 { Color::None };
+
+    bool m_white_can_castle_kingside : 1 { true };
+    bool m_white_can_castle_queenside : 1 { true };
+    bool m_black_can_castle_kingside : 1 { true };
+    bool m_black_can_castle_queenside : 1 { true };
 
     // We trust that hash collisions will not happen to save lots of memory and time.
     HashMap<unsigned, int> m_previous_states;

--- a/Userland/Libraries/LibChess/Chess.h
+++ b/Userland/Libraries/LibChess/Chess.h
@@ -172,7 +172,8 @@ private:
     bool m_black_can_castle_kingside { true };
     bool m_black_can_castle_queenside { true };
 
-    HashMap<Board, int> m_previous_states;
+    // We trust that hash collisions will not happen to save lots of memory and time.
+    HashMap<unsigned, int> m_previous_states;
     Vector<Move> m_moves;
     friend struct Traits<Board>;
 };
@@ -276,7 +277,7 @@ void Board::generate_moves(Callback callback, Color color) const
 
 template<>
 struct AK::Traits<Chess::Piece> : public GenericTraits<Chess::Piece> {
-    static unsigned hash(Chess::Piece piece)
+    static unsigned hash(const Chess::Piece& piece)
     {
         return pair_int_hash(static_cast<u32>(piece.color), static_cast<u32>(piece.type));
     }
@@ -284,7 +285,7 @@ struct AK::Traits<Chess::Piece> : public GenericTraits<Chess::Piece> {
 
 template<>
 struct AK::Traits<Chess::Board> : public GenericTraits<Chess::Board> {
-    static unsigned hash(Chess::Board chess)
+    static unsigned hash(const Chess::Board chess)
     {
         unsigned hash = 0;
         hash = pair_int_hash(hash, static_cast<u32>(chess.m_white_can_castle_queenside));

--- a/Userland/Services/ChessEngine/ChessEngine.cpp
+++ b/Userland/Services/ChessEngine/ChessEngine.cpp
@@ -42,9 +42,6 @@ void ChessEngine::handle_go(const GoCommand& command)
 
     MCTSTree mcts(m_board);
 
-    // FIXME: optimize simulations enough for use.
-    mcts.set_eval_method(MCTSTree::EvalMethod::Heuristic);
-
     int rounds = 0;
     while (elapsed_time.elapsed() <= command.movetime.value()) {
         mcts.do_round();

--- a/Userland/Services/ChessEngine/MCTSTree.cpp
+++ b/Userland/Services/ChessEngine/MCTSTree.cpp
@@ -8,13 +8,12 @@
 #include <AK/String.h>
 #include <stdlib.h>
 
-MCTSTree::MCTSTree(const Chess::Board& board, double exploration_parameter, MCTSTree* parent)
+MCTSTree::MCTSTree(const Chess::Board& board, MCTSTree* parent)
     : m_parent(parent)
-    , m_exploration_parameter(exploration_parameter)
-    , m_board(board)
+    , m_board(make<Chess::Board>(board))
+    , m_last_move(board.last_move())
+    , m_turn(board.turn())
 {
-    if (m_parent)
-        m_eval_method = m_parent->eval_method();
 }
 
 MCTSTree& MCTSTree::select_leaf()
@@ -25,7 +24,7 @@ MCTSTree& MCTSTree::select_leaf()
     MCTSTree* node = nullptr;
     double max_uct = -double(INFINITY);
     for (auto& child : m_children) {
-        double uct = child.uct(m_board.turn());
+        double uct = child.uct(m_turn);
         if (uct >= max_uct) {
             max_uct = uct;
             node = &child;
@@ -40,13 +39,15 @@ MCTSTree& MCTSTree::expand()
     VERIFY(!expanded() || m_children.size() == 0);
 
     if (!m_moves_generated) {
-        m_board.generate_moves([&](Chess::Move move) {
-            Chess::Board clone = m_board;
+        m_board->generate_moves([&](Chess::Move move) {
+            Chess::Board clone = *m_board;
             clone.apply_move(move);
-            m_children.append(make<MCTSTree>(clone, m_exploration_parameter, this));
+            m_children.append(make<MCTSTree>(clone, this));
             return IterationDecision::Continue;
         });
         m_moves_generated = true;
+        if (m_children.size() != 0)
+            m_board = nullptr; // Release the board to save memory.
     }
 
     if (m_children.size() == 0) {
@@ -63,8 +64,7 @@ MCTSTree& MCTSTree::expand()
 
 int MCTSTree::simulate_game() const
 {
-    VERIFY_NOT_REACHED();
-    Chess::Board clone = m_board;
+    Chess::Board clone = *m_board;
     while (!clone.game_finished()) {
         clone.apply_move(clone.random_move());
     }
@@ -73,10 +73,10 @@ int MCTSTree::simulate_game() const
 
 int MCTSTree::heuristic() const
 {
-    if (m_board.game_finished())
-        return m_board.game_score();
+    if (m_board->game_finished())
+        return m_board->game_score();
 
-    double winchance = max(min(double(m_board.material_imbalance()) / 6, 1.0), -1.0);
+    double winchance = max(min(double(m_board->material_imbalance()) / 6, 1.0), -1.0);
 
     double random = double(rand()) / RAND_MAX;
     if (winchance >= random)
@@ -101,7 +101,7 @@ void MCTSTree::do_round()
     auto& node = select_leaf().expand();
 
     int result;
-    if (m_eval_method == EvalMethod::Simulation) {
+    if constexpr (s_eval_method == EvalMethod::Simulation) {
         result = node.simulate_game();
     } else {
         result = node.heuristic();
@@ -111,7 +111,7 @@ void MCTSTree::do_round()
 
 Chess::Move MCTSTree::best_move() const
 {
-    int score_multiplier = (m_board.turn() == Chess::Color::White) ? 1 : -1;
+    int score_multiplier = (m_turn == Chess::Color::White) ? 1 : -1;
 
     Chess::Move best_move = { { 0, 0 }, { 0, 0 } };
     double best_score = -double(INFINITY);
@@ -119,8 +119,7 @@ Chess::Move MCTSTree::best_move() const
     for (auto& node : m_children) {
         double node_score = node.expected_value() * score_multiplier;
         if (node_score >= best_score) {
-            // The best move is the last move made in the child.
-            best_move = node.m_board.moves()[node.m_board.moves().size() - 1];
+            best_move = node.m_last_move.value();
             best_score = node_score;
         }
     }
@@ -143,7 +142,7 @@ double MCTSTree::uct(Chess::Color color) const
 
     // Fun fact: Szepesvári was my data structures professor.
     double expected = expected_value() * ((color == Chess::Color::White) ? 1 : -1);
-    return expected + m_exploration_parameter * sqrt(log(m_parent->m_simulations) / m_simulations);
+    return expected + s_exploration_parameter * sqrt(log(m_parent->m_simulations) / m_simulations);
 }
 
 bool MCTSTree::expanded() const

--- a/Userland/Services/ChessEngine/MCTSTree.h
+++ b/Userland/Services/ChessEngine/MCTSTree.h
@@ -8,6 +8,7 @@
 
 #include <AK/Function.h>
 #include <AK/NonnullOwnPtrVector.h>
+#include <AK/OwnPtr.h>
 #include <LibChess/Chess.h>
 #include <math.h>
 
@@ -18,7 +19,7 @@ public:
         Heuristic,
     };
 
-    MCTSTree(const Chess::Board& board, double exploration_parameter = sqrt(2), MCTSTree* parent = nullptr);
+    MCTSTree(const Chess::Board& board, MCTSTree* parent = nullptr);
 
     MCTSTree& select_leaf();
     MCTSTree& expand();
@@ -32,16 +33,19 @@ public:
     double uct(Chess::Color color) const;
     bool expanded() const;
 
-    EvalMethod eval_method() const { return m_eval_method; }
-    void set_eval_method(EvalMethod method) { m_eval_method = method; }
-
 private:
+    // While static parameters are less configurable, they don't take up any
+    // memory in the tree, which I believe to be a worthy tradeoff.
+    static constexpr double s_exploration_parameter { sqrt(2) };
+    // FIXME: Optimize simulations enough for use.
+    static constexpr EvalMethod s_eval_method { EvalMethod::Heuristic };
+
     NonnullOwnPtrVector<MCTSTree> m_children;
     MCTSTree* m_parent { nullptr };
     int m_white_points { 0 };
     int m_simulations { 0 };
-    bool m_moves_generated { false };
-    double m_exploration_parameter;
-    EvalMethod m_eval_method { EvalMethod::Simulation };
-    Chess::Board m_board;
+    OwnPtr<Chess::Board> m_board;
+    Optional<Chess::Move> m_last_move;
+    Chess::Color m_turn : 2;
+    bool m_moves_generated : 1 { false };
 };


### PR DESCRIPTION
This PR primarily reduces the memory usage of ChessEngine, to partly alliveate #7678, but this also has the effect of more than doubling the number of rounds of MCTS that the Engine will perform. this has greatly reduced (but not eliminated) the nonsense sacrifices.