### PR TITLE
LibGfx: Fix drawing rounded corners when using display scaling

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -352,6 +352,10 @@ void Painter::fill_rounded_corner(const IntRect& a_rect, int radius, Color color
     if (translated_a_rect.y() < rect.y())
         clip_offset = rect.y() - translated_a_rect.y();
 
+    radius *= scale();
+    rect *= scale();
+    clip_offset *= scale();
+
     RGBA32* dst = m_target->scanline(rect.top()) + rect.left();
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
 


### PR DESCRIPTION
Before:

![2x-before](https://user-images.githubusercontent.com/388571/123000131-74f6c900-d3af-11eb-98e1-46fcc689d659.png)

After:

![2x-after](https://user-images.githubusercontent.com/388571/123000137-77f1b980-d3af-11eb-8a9a-192747648607.png)

cc @TobyAsE