### PR TITLE
LibTLS: Correct `TLSv12::check_connection_state` return value and connection finish state

### DIFF
--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -205,7 +205,7 @@ bool TLSv12::check_connection_state(bool read)
                 m_context.tls_buffer.size(),
                 m_context.application_buffer.size());
         } else {
-            m_context.connection_finished = false;
+            m_context.connection_finished = true;
             dbgln_if(TLS_DEBUG, "FINISHED");
         }
         if (!m_context.application_buffer.size()) {

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -186,6 +186,7 @@ bool TLSv12::check_connection_state(bool read)
         // an abrupt closure (the server is a jerk)
         dbgln_if(TLS_DEBUG, "Socket not open, assuming abrupt closure");
         m_context.connection_finished = true;
+        return false;
     }
     if (m_context.critical_error) {
         dbgln_if(TLS_DEBUG, "CRITICAL ERROR {} :(", m_context.critical_error);


### PR DESCRIPTION
Fixes #8211