### PR TITLE
Solitaire: Maybe fix rare crash from completing a game with TAB

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -85,7 +85,7 @@ void Game::set_background_fill_enabled(bool enabled)
 
 void Game::start_game_over_animation()
 {
-    if (m_game_over_animation)
+    if (m_game_over_animation || m_start_game_over_animation_next_frame)
         return;
 
     m_last_move = {};


### PR DESCRIPTION
This fixes #8122.

The crash happens very rarely and is hard to reproduce so it is
hard to know for certain, but I am confident this fixes it.

I previously delayed the start of the game-over animation by one
frame, but neglected to check m_start_game_over_animation_next_frame
wasn't set. This means multiple calls to start_game_over_animation()
on the same frame (or rather, before the first timer_event) would
each call Object::start_timer(). Now that we do check the flag,
that should no longer be possible.