### PR TITLE
LibVT: Don't crash when clicking outside of the terminal's buffer area

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -592,8 +592,9 @@ VT::Position TerminalWidget::buffer_position_at(const Gfx::IntPoint& position) c
         column = 0;
     if (row >= m_terminal.rows())
         row = m_terminal.rows() - 1;
-    if (column >= m_terminal.columns())
-        column = m_terminal.columns() - 1;
+    auto& line = m_terminal.line(row);
+    if (column >= (int)line.length())
+        column = line.length() - 1;
     row += m_scrollbar->value();
     return { row, column };
 }
@@ -736,7 +737,7 @@ void TerminalWidget::doubleclick_event(GUI::MouseEvent& event)
             start_column = column;
         }
 
-        for (int column = position.column(); column < m_terminal.columns() && (line.code_point(column) == ' ') == want_whitespace; ++column) {
+        for (int column = position.column(); column < (int)line.length() && (line.code_point(column) == ' ') == want_whitespace; ++column) {
             end_column = column;
         }
 


### PR DESCRIPTION
When resizing a terminal window the number of columns may change. Previously we assumed that this also affects lines which were in the terminal's buffer while that is not necessarily true.

Steps to reproduce:

1. Open Terminal.
2. Type a command, like `ls /bin`.
3. Maximize the Terminal window and double-click in the "new" area to the right of the command's output.
4. Terminal crashes:

```
Terminal(36:36): USERSPACE(36) ASSERTION FAILED: i < m_size
../.././AK/Vector.h:141
CrashDaemon(21:21): --- Backtrace for thread #0 (TID 36) ---
CrashDaemon(21:21): 0xb31891ce: [libsystem.so] syscall2 +0xe (syscall.cpp:25 => syscall.cpp:24)
CrashDaemon(21:21): 0x619e23e4: [libc.so] raise +0x24 (syscall.h:34 => signal.cpp:20)
CrashDaemon(21:21): 0x619cb545: [libc.so] abort +0x29 (stdlib.cpp:230)
CrashDaemon(21:21): 0x619cc0aa: [libc.so] __assertion_failed +0xea (assert.cpp:31)
CrashDaemon(21:21): 0x6d90a64e: [libvt.so] VT::TerminalWidget::doubleclick_event(GUI::MouseEvent&) +0x2ce (Vector.h:141)
CrashDaemon(21:21): 0x6d908556: [libvt.so] VT::TerminalWidget::event(Core::Event&) [clone .localalias] +0x36 (TerminalWidget.cpp:208)
CrashDaemon(21:21): 0x274ecf90: [libcore.so] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0xb0 (Object.cpp:213)
CrashDaemon(21:21): 0x8b0b4a5f: [libgui.so] GUI::Window::handle_mouse_event(GUI::MouseEvent&) [clone .localalias] +0x5af (Window.cpp:364)
CrashDaemon(21:21): 0x8b0b6748: [libgui.so] GUI::Window::event(Core::Event&) +0x38 (Window.cpp:549)
CrashDaemon(21:21): 0x274ecf90: [libcore.so] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0xb0 (Object.cpp:213)
CrashDaemon(21:21): 0x274d2432: [libcore.so] Core::EventLoop::pump(Core::EventLoop::WaitMode) +0x572 (EventLoop.cpp:398)
CrashDaemon(21:21): 0x274d2c5a: [libcore.so] Core::EventLoop::exec() +0x5a (EventLoop.cpp:362)
CrashDaemon(21:21): 0x8af8d8a7: [libgui.so] GUI::Application::exec() +0x27 (Application.cpp:105)
CrashDaemon(21:21): 0xa571650e: [/bin/Terminal] main +0x190e (main.cpp:464)
CrashDaemon(21:21): 0xa5716a57: [/bin/Terminal] _start +0x57 (crt0.cpp:37)
```


https://user-images.githubusercontent.com/388571/123113929-37418100-d43f-11eb-9ef4-edfed37d7625.mp4
