### PR TITLE
Userland: Remove dummy IPC methods

### DIFF
--- a/Userland/DevTools/IPCCompiler/main.cpp
+++ b/Userland/DevTools/IPCCompiler/main.cpp
@@ -190,10 +190,10 @@ int main(int argc, char** argv)
     auto parse_messages = [&] {
         for (;;) {
             consume_whitespace();
-            parse_message();
-            consume_whitespace();
             if (lexer.peek() == '}')
                 break;
+            parse_message();
+            consume_whitespace();
         }
     };
 
@@ -366,7 +366,7 @@ public:
     static i32 static_message_id() { return (int)MessageID::@message.pascal_name@; }
     virtual const char* message_name() const override { return "@endpoint.name@::@message.pascal_name@"; }
 
-    static OwnPtr<@message.pascal_name@> decode(InputMemoryStream& stream, int sockfd)
+    static OwnPtr<@message.pascal_name@> decode(InputMemoryStream& stream, [[maybe_unused]] int sockfd)
     {
         IPC::Decoder decoder { stream, sockfd };
 )~~~");
@@ -629,7 +629,7 @@ public:
 
     static u32 static_magic() { return @endpoint.magic@; }
 
-    static OwnPtr<IPC::Message> decode_message(ReadonlyBytes buffer, int sockfd)
+    static OwnPtr<IPC::Message> decode_message(ReadonlyBytes buffer, [[maybe_unused]] int sockfd)
     {
         InputMemoryStream stream { buffer };
         u32 message_endpoint_magic = 0;

--- a/Userland/DevTools/Inspector/InspectorServerClient.h
+++ b/Userland/DevTools/Inspector/InspectorServerClient.h
@@ -25,8 +25,6 @@ private:
         : IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>(*this, "/tmp/portal/inspector")
     {
     }
-
-    virtual void dummy() override { }
 };
 
 }

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -43,7 +43,6 @@ private:
         : IPC::ServerConnection<LaunchClientEndpoint, LaunchServerEndpoint>(*this, "/tmp/portal/launch")
     {
     }
-    virtual void dummy() override { }
 };
 
 static LaunchServerConnection& connection()

--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -30,7 +30,6 @@ private:
         , m_notification(notification)
     {
     }
-    virtual void dummy() override { }
     Notification* m_notification;
 };
 

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -20,10 +20,6 @@ void Client::die()
         on_death();
 }
 
-void Client::dummy()
-{
-}
-
 Optional<DecodedImage> Client::decode_image(const ByteBuffer& encoded_data)
 {
     if (encoded_data.is_empty())

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -38,8 +38,6 @@ private:
     Client();
 
     virtual void die() override;
-
-    virtual void dummy() override;
 };
 
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
@@ -1,4 +1,3 @@
 endpoint ImageDecoderClient
 {
-    dummy() =|
 }

--- a/Userland/Services/InspectorServer/InspectorClient.ipc
+++ b/Userland/Services/InspectorServer/InspectorClient.ipc
@@ -1,4 +1,3 @@
 endpoint InspectorClient
 {
-    dummy() =|
 }

--- a/Userland/Services/LaunchServer/LaunchClient.ipc
+++ b/Userland/Services/LaunchServer/LaunchClient.ipc
@@ -1,4 +1,3 @@
 endpoint LaunchClient
 {
-    dummy() =|
 }

--- a/Userland/Services/LookupServer/LookupClient.ipc
+++ b/Userland/Services/LookupServer/LookupClient.ipc
@@ -1,4 +1,3 @@
 endpoint LookupClient
 {
-    dummy() =|
 }

--- a/Userland/Services/NotificationServer/NotificationClient.ipc
+++ b/Userland/Services/NotificationServer/NotificationClient.ipc
@@ -1,4 +1,3 @@
 endpoint NotificationClient
 {
-    dummy() =|
 }


### PR DESCRIPTION
They're not used anywhere and are unnecessary boilerplate code. So let's remove them and update IPCCompiler to allow for empty endpoint declarations.