### PR TITLE
Kernel: Reimplement the dbgputch and dbgputstr syscalls

### DIFF
--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -145,7 +145,7 @@ int snprintf(char* buffer, size_t size, const char* fmt, ...)
     return ret;
 }
 
-static void debugger_out(char ch)
+extern "C" void dbgputch(char ch)
 {
     if (serial_debug)
         serial_putch(ch);
@@ -158,7 +158,7 @@ extern "C" void dbgputstr(const char* characters, size_t length)
         return;
     ScopedSpinLock lock(s_log_lock);
     for (size_t i = 0; i < length; ++i)
-        debugger_out(characters[i]);
+        dbgputch(characters[i]);
 }
 
 extern "C" void kernelputstr(const char* characters, size_t length)

--- a/Kernel/kstdio.h
+++ b/Kernel/kstdio.h
@@ -9,6 +9,7 @@
 #include <AK/Types.h>
 
 extern "C" {
+void dbgputch(char);
 void dbgputstr(const char*, size_t);
 void kernelputstr(const char*, size_t);
 void kernelcriticalputstr(const char*, size_t);


### PR DESCRIPTION
This rewrites the `dbgputch` and `dbgputstr` system calls as wrappers of `kstdio.`. For this, a `dbgputch` function was added `kstdio.h`/`kprintf.cpp`. The function already existed as `debugger_out`, but was only used as a helper function for `dbgputstr`.

This fixes a bug where only the Kernel's debug output was also sent to a serial debugger, while the userspace's debug output was only sent to the Bochs debugger.

This also fixes a bug where debug output from one process would sometimes "interrupt" the debug output from another process in the middle of a line.

**Note**: I opted for copying the string to Kernel space to avoid page faults. I don't know if there is an elegant solution to avoid doing that, as we only read from it and we don't need to validate the data, only that it's in user memory.