### PR TITLE
LibSQL: Reduce run time of TestSqlDatabase

### DIFF
--- a/Tests/LibSQL/TestSqlDatabase.cpp
+++ b/Tests/LibSQL/TestSqlDatabase.cpp
@@ -176,13 +176,3 @@ TEST_CASE(insert_100_into_table)
 {
     insert_and_verify(100);
 }
-
-TEST_CASE(insert_1000_into_table)
-{
-    insert_and_verify(1000);
-}
-
-TEST_CASE(insert_10000_into_table)
-{
-    insert_and_verify(10000);
-}


### PR DESCRIPTION
Scanning tables is a linear process using pointers in the table's
tuples, and does not involve more 'stochastic' code paths like index
traversals. Therefore the 1000 and 10000 row tests were basically
overkill and added nothing we can't find out with less rows.