### PR TITLE
LibGUI: Add support for an alternate keyboard shortcut in Action

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -281,7 +281,7 @@ Tab::Tab(BrowserWindow& window, Type type)
     }
 
     auto focus_location_box_action = GUI::Action::create(
-        "Focus location box", { Mod_Ctrl, Key_L }, [this](auto&) {
+        "Focus location box", { Mod_Ctrl, Key_L }, Key_F6, [this](auto&) {
             m_location_box->select_all();
             m_location_box->set_focus(true);
         },

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -186,9 +186,19 @@ NonnullRefPtr<Action> Action::create(String text, const Shortcut& shortcut, Func
     return adopt_ref(*new Action(move(text), shortcut, move(callback), parent));
 }
 
+NonnullRefPtr<Action> Action::create(String text, const Shortcut& shortcut, const Shortcut& alternate_shortcut, Function<void(Action&)> callback, Core::Object* parent)
+{
+    return adopt_ref(*new Action(move(text), shortcut, alternate_shortcut, move(callback), parent));
+}
+
 NonnullRefPtr<Action> Action::create(String text, const Shortcut& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
-    return adopt_ref(*new Action(move(text), shortcut, move(icon), move(callback), parent));
+    return adopt_ref(*new Action(move(text), shortcut, Shortcut {}, move(icon), move(callback), parent));
+}
+
+NonnullRefPtr<Action> Action::create(String text, const Shortcut& shortcut, const Shortcut& alternate_shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
+{
+    return adopt_ref(*new Action(move(text), shortcut, alternate_shortcut, move(icon), move(callback), parent));
 }
 
 NonnullRefPtr<Action> Action::create_checkable(String text, Function<void(Action&)> callback, Core::Object* parent)
@@ -208,30 +218,36 @@ NonnullRefPtr<Action> Action::create_checkable(String text, const Shortcut& shor
 
 NonnullRefPtr<Action> Action::create_checkable(String text, const Shortcut& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent)
 {
-    return adopt_ref(*new Action(move(text), shortcut, move(icon), move(callback), parent, true));
+    return adopt_ref(*new Action(move(text), shortcut, Shortcut {}, move(icon), move(callback), parent, true));
 }
 
 Action::Action(String text, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
-    : Action(move(text), Shortcut {}, nullptr, move(on_activation_callback), parent, checkable)
+    : Action(move(text), Shortcut {}, Shortcut {}, nullptr, move(on_activation_callback), parent, checkable)
 {
 }
 
 Action::Action(String text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
-    : Action(move(text), Shortcut {}, move(icon), move(on_activation_callback), parent, checkable)
+    : Action(move(text), Shortcut {}, Shortcut {}, move(icon), move(on_activation_callback), parent, checkable)
 {
 }
 
 Action::Action(String text, const Shortcut& shortcut, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
-    : Action(move(text), shortcut, nullptr, move(on_activation_callback), parent, checkable)
+    : Action(move(text), shortcut, Shortcut {}, nullptr, move(on_activation_callback), parent, checkable)
 {
 }
 
-Action::Action(String text, const Shortcut& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
+Action::Action(String text, const Shortcut& shortcut, const Shortcut& alternate_shortcut, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
+    : Action(move(text), shortcut, alternate_shortcut, nullptr, move(on_activation_callback), parent, checkable)
+{
+}
+
+Action::Action(String text, const Shortcut& shortcut, const Shortcut& alternate_shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> on_activation_callback, Core::Object* parent, bool checkable)
     : Core::Object(parent)
     , on_activation(move(on_activation_callback))
     , m_text(move(text))
     , m_icon(move(icon))
     , m_shortcut(shortcut)
+    , m_alternate_shortcut(alternate_shortcut)
     , m_checkable(checkable)
 {
     if (parent && is<Widget>(*parent)) {

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -141,7 +141,7 @@ NonnullRefPtr<Action> make_go_home_action(Function<void(Action&)> callback, Core
 
 NonnullRefPtr<Action> make_reload_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("&Reload", { Mod_Ctrl, Key_R }, Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"), move(callback), parent);
+    return Action::create("&Reload", { Mod_Ctrl, Key_R }, Key_F5, Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_select_all_action(Function<void(Action&)> callback, Core::Object* parent)

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -61,7 +61,9 @@ public:
     static NonnullRefPtr<Action> create(String text, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create(String text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create(String text, const Shortcut& shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create(String text, const Shortcut& shortcut, const Shortcut& alternate_shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create(String text, const Shortcut& shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
+    static NonnullRefPtr<Action> create(String text, const Shortcut& shortcut, const Shortcut& alternate_shortcut, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create_checkable(String text, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create_checkable(String text, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> callback, Core::Object* parent = nullptr);
     static NonnullRefPtr<Action> create_checkable(String text, const Shortcut& shortcut, Function<void(Action&)> callback, Core::Object* parent = nullptr);
@@ -76,6 +78,7 @@ public:
     void set_status_tip(String status_tip) { m_status_tip = move(status_tip); }
 
     Shortcut shortcut() const { return m_shortcut; }
+    Shortcut alternate_shortcut() const { return m_alternate_shortcut; }
     const Gfx::Bitmap* icon() const { return m_icon.ptr(); }
     void set_icon(const Gfx::Bitmap*);
 
@@ -113,7 +116,8 @@ public:
 private:
     Action(String, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
     Action(String, const Shortcut&, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
-    Action(String, const Shortcut&, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
+    Action(String, const Shortcut&, const Shortcut&, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
+    Action(String, const Shortcut&, const Shortcut&, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
     Action(String, RefPtr<Gfx::Bitmap> icon, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
 
     template<typename Callback>
@@ -125,6 +129,7 @@ private:
     String m_status_tip;
     RefPtr<Gfx::Bitmap> m_icon;
     Shortcut m_shortcut;
+    Shortcut m_alternate_shortcut;
     bool m_enabled { true };
     bool m_checkable { false };
     bool m_checked { false };

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -77,8 +77,8 @@ public:
     String const& status_tip() const { return m_status_tip; }
     void set_status_tip(String status_tip) { m_status_tip = move(status_tip); }
 
-    Shortcut shortcut() const { return m_shortcut; }
-    Shortcut alternate_shortcut() const { return m_alternate_shortcut; }
+    Shortcut const& shortcut() const { return m_shortcut; }
+    Shortcut const& alternate_shortcut() const { return m_alternate_shortcut; }
     const Gfx::Bitmap* icon() const { return m_icon.ptr(); }
     void set_icon(const Gfx::Bitmap*);
 

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -113,11 +113,13 @@ void Application::quit(int exit_code)
 void Application::register_global_shortcut_action(Badge<Action>, Action& action)
 {
     m_global_shortcut_actions.set(action.shortcut(), &action);
+    m_global_shortcut_actions.set(action.alternate_shortcut(), &action);
 }
 
 void Application::unregister_global_shortcut_action(Badge<Action>, Action& action)
 {
     m_global_shortcut_actions.remove(action.shortcut());
+    m_global_shortcut_actions.remove(action.alternate_shortcut());
 }
 
 Action* Application::action_for_key_event(const KeyEvent& event)

--- a/Userland/Libraries/LibGUI/Shortcut.h
+++ b/Userland/Libraries/LibGUI/Shortcut.h
@@ -19,6 +19,11 @@ public:
         , m_key(key)
     {
     }
+    Shortcut(KeyCode key)
+        : m_modifiers(0)
+        , m_key(key)
+    {
+    }
 
     bool is_valid() const { return m_key != KeyCode::Key_Invalid; }
     u8 modifiers() const { return m_modifiers; }

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -829,7 +829,7 @@ Action* Widget::action_for_key_event(const KeyEvent& event)
 
     Action* found_action = nullptr;
     for_each_child_of_type<Action>([&](auto& action) {
-        if (action.shortcut() == shortcut) {
+        if (action.shortcut() == shortcut || action.alternate_shortcut() == shortcut) {
             found_action = &action;
             return IterationDecision::Break;
         }

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -982,7 +982,7 @@ Action* Window::action_for_key_event(const KeyEvent& event)
     Shortcut shortcut(event.modifiers(), (KeyCode)event.key());
     Action* found_action = nullptr;
     for_each_child_of_type<Action>([&](auto& action) {
-        if (action.shortcut() == shortcut) {
+        if (action.shortcut() == shortcut || action.alternate_shortcut() == shortcut) {
             found_action = &action;
             return IterationDecision::Break;
         }


### PR DESCRIPTION
This patch adds the `alternate_shortcut` member to `LibGUI::Action`, which enables one `Action` to have two keyboard shortcuts.

Note that the string used in menus and tooltips only shows the main shortcut, which is the same behaviour as in Firefox and Chrome.

This patch also adds F5 to the "reload" common action and F6 for focusing the location box in the browser.

This is the first time I'm touching `LibGUI`, so I might have done something really dumb. Feedback is welcome!