### PR TITLE
AK: Reimplement all_of in terms of find_if

### DIFF
--- a/AK/AllOf.h
+++ b/AK/AllOf.h
@@ -6,22 +6,21 @@
 
 #pragma once
 
+#include <AK/Find.h>
 #include <AK/Iterator.h>
 
 namespace AK {
 
 template<typename Container, typename ValueType>
 constexpr bool all_of(
-    const SimpleIterator<Container, ValueType>& begin,
-    const SimpleIterator<Container, ValueType>& end,
-    const auto& predicate)
+    SimpleIterator<Container, ValueType> const& begin,
+    SimpleIterator<Container, ValueType> const& end,
+    auto const& predicate)
 {
-    for (auto iter = begin; iter != end; ++iter) {
-        if (!predicate(*iter)) {
-            return false;
-        }
-    }
-    return true;
+    constexpr auto negated_predicate = [](auto const& pred) {
+        return [&](auto const& elem) { return !pred(elem); };
+    };
+    return find_if(begin, end, negated_predicate(predicate)) == end;
 }
 
 }


### PR DESCRIPTION
Problem:
- Now that a generic free-function form of `find_if` is implemented
  the code in `all_of` is redundant.

Solution:
- Follow the "don't repeat yourself" mantra and make the code DRY by
  implementing `all_of` in terms of `find_if`.
- One tricky part is that since captures are not permitted in
  `constexpr` lambdas, the lambda created to negate the predicate
  needs to be created by a function which does not capture and takes
  the predicate at run-time instead. This allows `all_of` to continue
  to work in a `constexpr` context.