### PR TITLE
FileManager+LibGUI: React reasonably when open directories are deleted

### DIFF
--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -72,7 +73,7 @@ void Breadcrumbbar::clear_segments()
     remove_all_children();
 }
 
-void Breadcrumbbar::append_segment(String text, const Gfx::Bitmap* icon, String data, String tooltip)
+void Breadcrumbbar::append_segment(String text, Gfx::Bitmap const* icon, String data, String tooltip)
 {
     auto& button = add<BreadcrumbButton>();
     button.set_button_style(Gfx::ButtonStyle::Coolbar);
@@ -103,6 +104,23 @@ void Breadcrumbbar::append_segment(String text, const Gfx::Bitmap* icon, String 
     Segment segment { icon, text, data, button.make_weak_ptr<GUI::Button>() };
 
     m_segments.append(move(segment));
+}
+
+void Breadcrumbbar::remove_end_segments(size_t start_segment_index)
+{
+    while (segment_count() > start_segment_index) {
+        auto segment = m_segments.take_last();
+        remove_child(*segment.button);
+    }
+}
+
+Optional<size_t> Breadcrumbbar::find_segment_with_data(String const& data)
+{
+    for (size_t i = 0; i < segment_count(); ++i) {
+        if (segment_data(i) == data)
+            return i;
+    }
+    return {};
 }
 
 void Breadcrumbbar::set_selected_segment(Optional<size_t> index)

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.h
@@ -17,10 +17,12 @@ public:
     virtual ~Breadcrumbbar() override;
 
     void clear_segments();
-    void append_segment(String text, const Gfx::Bitmap* icon = nullptr, String data = {}, String tooltip = {});
+    void append_segment(String text, Gfx::Bitmap const* icon = nullptr, String data = {}, String tooltip = {});
+    void remove_end_segments(size_t segment_index);
 
     size_t segment_count() const { return m_segments.size(); }
     String segment_data(size_t index) const { return m_segments[index].data; }
+    Optional<size_t> find_segment_with_data(String const& data);
 
     void set_selected_segment(Optional<size_t> index);
     Optional<size_t> selected_segment() const { return m_selected_segment; }

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -272,11 +272,11 @@ FileSystemModel::FileSystemModel(String root_path, Mode mode)
             auto canonical_event_path = LexicalPath::canonicalized_path(event.event_path);
             if (m_root_path.starts_with(canonical_event_path)) {
                 // Deleted directory contains our root, so navigate to our nearest parent.
-                auto new_path = LexicalPath(m_root_path).dirname();
-                while (!Core::File::is_directory(new_path))
-                    new_path = LexicalPath(new_path).dirname();
+                auto new_path = LexicalPath(m_root_path).parent();
+                while (!Core::File::is_directory(new_path.string()))
+                    new_path = new_path.parent();
 
-                set_root_path(new_path);
+                set_root_path(new_path.string());
             } else if (node.parent) {
                 refresh_node(*node.parent);
             }


### PR DESCRIPTION
This fixes #8204, in two parts:

1. When FileManager has a directory open which has been deleted, it now notices, and navigates up to the nearest existing parent directory, and removes the breadcrumbs for the deleted child.
2. When you click on a breadcrumb segment, it now checks that the target directory exists before navigating to it. If it doesn't exist, we remove it from the breadcrumbbar, along with any of its children.

As noted in commit https://github.com/SerenityOS/serenity/commit/95675808db512c8d3bb63a80b44ed66192b4f799, detecting that a child directory has been deleted, and then automatically removing any breadcrumbs for it, might be better. But this seemed like a reasonable solution for now.