### PR TITLE
LibGUI: Add update() when changing widget color or palette

### DIFF
--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -891,16 +891,19 @@ Vector<Widget&> Widget::child_widgets() const
 void Widget::set_palette(const Palette& palette)
 {
     m_palette = palette.impl();
+    update();
 }
 
 void Widget::set_background_role(ColorRole role)
 {
     m_background_role = role;
+    update();
 }
 
 void Widget::set_foreground_role(ColorRole role)
 {
     m_foreground_role = role;
+    update();
 }
 
 Gfx::Palette Widget::palette() const


### PR DESCRIPTION
For context:

I've been working on a GUI app and whenever I went to set palette/role I'd have to manually call `update()`. I chatted with @awesomekling and he felt like the GUI toolkit should be calling the `update()` on the developers behalf. 