### PR TITLE
LibJS: Add register allocation pass to bytecode compiler 

### DIFF
--- a/AK/Ordering.h
+++ b/AK/Ordering.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@ualberta.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <compare>
+// Unfortunatly, operator<=> is unusable on fundamental types without including <compare>
+
+namespace AK {
+
+class StrongOrdering {
+public:
+    template<typename T>
+    constexpr StrongOrdering(const T& other)
+    {
+        if (other < 0) {
+            m_value = -1;
+        } else if (other > 0) {
+            m_value = 1;
+        } else {
+            m_value = 0;
+        }
+    }
+
+    bool constexpr operator==(const StrongOrdering& other) const { return m_value == other.m_value; }
+
+    bool constexpr operator==(int zero) const { return m_value == zero; }
+    bool constexpr operator<(int zero) const { return m_value < zero; }
+    bool constexpr operator<=(int zero) const { return m_value <= zero; }
+    bool constexpr operator>(int zero) const { return m_value > zero; }
+    bool constexpr operator>=(int zero) const { return m_value >= zero; }
+
+    StrongOrdering constexpr operator<=>(int) const { return *this; }
+
+    static const StrongOrdering LessThan;
+    static const StrongOrdering Equivalent;
+    static const StrongOrdering Equal;
+    static const StrongOrdering Greater;
+
+private:
+    i8 m_value;
+};
+
+constexpr StrongOrdering StrongOrdering::LessThan(-1);
+constexpr StrongOrdering StrongOrdering::Equivalent(0);
+constexpr StrongOrdering StrongOrdering::Equal(0);
+constexpr StrongOrdering StrongOrdering::Greater(1);
+
+}
+
+using AK::StrongOrdering;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -911,10 +911,11 @@ void CallExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
     auto callee_reg = generator.allocate_register();
     auto this_reg = generator.allocate_register();
-    generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
-    generator.emit<Bytecode::Op::Store>(this_reg);
 
     if (is<NewExpression>(this)) {
+        generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
+        generator.emit<Bytecode::Op::Store>(this_reg);
+
         m_callee->generate_bytecode(generator);
         generator.emit<Bytecode::Op::Store>(callee_reg);
     } else if (is<SuperExpression>(*m_callee)) {
@@ -934,6 +935,9 @@ void CallExpression::generate_bytecode(Bytecode::Generator& generator) const
             generator.emit<Bytecode::Op::Store>(callee_reg);
         }
     } else {
+        generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
+        generator.emit<Bytecode::Op::Store>(this_reg);
+
         // FIXME: this = global object in sloppy mode.
         m_callee->generate_bytecode(generator);
         generator.emit<Bytecode::Op::Store>(callee_reg);

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -15,7 +15,7 @@ namespace JS::Bytecode {
 
 class InstructionStreamIterator {
 public:
-    explicit InstructionStreamIterator(ReadonlyBytes bytes)
+    explicit InstructionStreamIterator(Bytes bytes)
         : m_bytes(bytes)
     {
     }
@@ -29,12 +29,14 @@ public:
     }
 
     Instruction const& operator*() const { return dereference(); }
+    Instruction& operator*() { return dereference(); }
     void operator++();
 
 private:
     Instruction const& dereference() const { return *reinterpret_cast<Instruction const*>(m_bytes.data() + offset()); }
+    Instruction& dereference() { return *reinterpret_cast<Instruction*>(m_bytes.data() + offset()); }
 
-    ReadonlyBytes m_bytes;
+    Bytes m_bytes;
     size_t m_offset { 0 };
 };
 
@@ -53,7 +55,7 @@ public:
     void seal();
 
     void dump(Executable const&) const;
-    ReadonlyBytes instruction_stream() const { return ReadonlyBytes { m_buffer, m_buffer_size }; }
+    Bytes instruction_stream() const { return Bytes { m_buffer, m_buffer_size }; }
     size_t size() const { return m_buffer_size; }
 
     void* next_slot() { return m_buffer + m_buffer_size; }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -95,6 +95,9 @@ public:
     void replace_references(BasicBlock const&, BasicBlock const&);
     static void destroy(Instruction&);
 
+    Vector<Register*> write_registers();
+    Vector<Register*> read_registers();
+
 protected:
     explicit Instruction(Type type)
         : m_type(type)

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -191,6 +191,8 @@ Bytecode::PassManager& Interpreter::optimization_pipeline(Interpreter::Optimizat
         pm->add<Passes::MergeBlocks>();
         pm->add<Passes::GenerateCFG>();
         pm->add<Passes::PlaceBlocks>();
+        pm->add<Passes::GenerateCFG>();
+        pm->add<Passes::AllocateRegisters>();
     } else {
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibJS/Bytecode/Pass/AllocateRegisters.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/AllocateRegisters.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@ualberta.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NumericLimits.h>
+#include <AK/QuickSort.h>
+#include <LibJS/Bytecode/BasicBlock.h>
+#include <LibJS/Bytecode/PassManager.h>
+
+// This pass implements a simple linear-pass register allocator to reduce the
+// number of registers used in an executable, as described in the following paper:
+// Poletto, Massimiliano; Sarkar, Vivek (1999). "Linear scan register allocation".
+
+namespace JS::Bytecode::Passes {
+
+// This pass assumes that the registers are in single static Assignment form
+
+void AllocateRegisters::id_basic_blocks()
+{
+    m_basic_block_ids.clear();
+
+    for (size_t i = 0; i < m_executable->executable.basic_blocks.size(); ++i) {
+        m_basic_block_ids.set(&(m_executable->executable.basic_blocks[i]), i);
+    }
+}
+
+void AllocateRegisters::find_block_range(const BasicBlock* basic_block, size_t max_bb)
+{
+    for (auto i = InstructionStreamIterator(basic_block->instruction_stream()); !i.at_end(); ++i) {
+        auto& inst = *i;
+
+        for (auto& reg : inst.write_registers()) {
+            // Verify that our program is in SSA.
+            VERIFY(!m_has_been_written[reg->index()]);
+            m_has_been_written[reg->index()] = true;
+
+            m_is_live[reg->index()] = true;
+            m_live_ranges[reg->index()].reg = reg->index();
+            m_live_ranges[reg->index()].start = { block_id(basic_block), i.offset() };
+            m_live_ranges[reg->index()].finish = { 0, 0 };
+        }
+
+        for (auto& reg : inst.read_registers()) {
+            if (max_bb < m_live_ranges[reg->index()].finish.basic_block)
+                continue;
+
+            if (block_id(basic_block) == max_bb) {
+                m_live_ranges[reg->index()].finish = { block_id(basic_block), i.offset() };
+            } else {
+                // The maximum size_t is equivalent to the end of the basic block.
+                m_live_ranges[reg->index()].finish = { max_bb, NumericLimits<size_t>::max() };
+            }
+        }
+    }
+}
+
+void AllocateRegisters::find_live_ranges(const BasicBlock* basic_block, size_t max_bb)
+{
+    if (m_live_range_path.contains_slow(basic_block))
+        return;
+
+    m_live_range_path.append(basic_block);
+    max_bb = max(block_id(basic_block), max_bb);
+
+    find_block_range(basic_block, max_bb);
+
+    const auto& children = m_executable->cfg.value().get(basic_block);
+    if (children.has_value()) {
+        for (auto& child : children.value()) {
+            find_live_ranges(child, max_bb);
+        }
+    }
+
+    m_live_range_path.take_last();
+}
+
+Vector<Register> AllocateRegisters::rename_registers()
+{
+    Vector<Register> rename;
+    for (size_t i = 0; i < m_executable->executable.number_of_registers; ++i) {
+        rename.append(Register(i));
+    }
+
+    Vector<size_t> active;
+    active.resize(m_executable->executable.number_of_registers);
+    for (auto& i : active) {
+        i = 0;
+    }
+
+    quick_sort(m_live_ranges, [](LiveRange a, LiveRange b) { return a.start < b.start; });
+
+    for (size_t i = 2; i < m_live_ranges.size(); ++i) {
+        auto& timestamp = m_live_ranges[i].start;
+
+        // Expire old intervals.
+        for (size_t j = 2; j < i; ++j) {
+            auto reg = rename[m_live_ranges[j].reg].index();
+            if (m_live_ranges[j].finish < timestamp && active[reg] == j) {
+                active[reg] = 0;
+            }
+        }
+
+        // Select a register.
+        for (size_t j = 2; j <= i; ++j) {
+            if (!active[j]) {
+                rename[m_live_ranges[i].reg] = Register(j);
+                active[j] = i;
+                break;
+            }
+        }
+    }
+
+    return rename;
+}
+
+void AllocateRegisters::apply_register_rename(Vector<Register> const& rename)
+{
+    for (auto& basic_block : m_executable->executable.basic_blocks) {
+        for (auto i = InstructionStreamIterator(basic_block.instruction_stream()); !i.at_end(); ++i) {
+            auto& inst = *i;
+            for (auto reg : inst.write_registers()) {
+                *reg = rename[reg->index()];
+            }
+
+            for (auto reg : inst.read_registers()) {
+                *reg = rename[reg->index()];
+            }
+        }
+    }
+
+    u32 number_of_registers = 0;
+    for (auto& reg : rename) {
+        number_of_registers = max(number_of_registers, reg.index() + 1);
+    }
+
+    m_executable->executable.number_of_registers = number_of_registers;
+}
+
+void AllocateRegisters::perform(PassPipelineExecutable& executable)
+{
+    started();
+
+    VERIFY(executable.cfg.has_value());
+    m_executable = &executable;
+
+    id_basic_blocks();
+
+    m_is_live.resize(m_executable->executable.number_of_registers);
+    m_has_been_written.resize(m_executable->executable.number_of_registers);
+    m_live_ranges.resize(m_executable->executable.number_of_registers);
+
+    for (auto& i : m_is_live) {
+        i = false;
+    }
+
+    for (auto& i : m_has_been_written) {
+        i = false;
+    }
+
+    find_live_ranges(&(m_executable->executable.basic_blocks.first()), 0);
+
+    auto rename = rename_registers();
+
+    apply_register_rename(rename);
+
+    finished();
+}
+
+}

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Bytecode/Instruction.cpp
     Bytecode/Interpreter.cpp
     Bytecode/Op.cpp
+    Bytecode/Pass/AllocateRegisters.cpp
     Bytecode/Pass/DumpCFG.cpp
     Bytecode/Pass/GenerateCFG.cpp
     Bytecode/Pass/MergeBlocks.cpp


### PR DESCRIPTION
I've implemented a linear-scan register allocator for LibJS's bytecode compiler to reduce the interpreter memory usage, based on [this paper](https://sci-hub.st/10.1145/330249.330250). 

for example [date.js](https://github.com/SerenityOS/serenity/blob/master/Base/home/anon/Source/js/date.js) uses 77 registers before register allocation, and 5 registers after.

