### PR TITLE
HackStudio: Fix crash on "goto definition"

### DIFF
--- a/AK/Function.h
+++ b/AK/Function.h
@@ -189,6 +189,7 @@ private:
     void clear(bool may_defer = true)
     {
         bool called_from_inside_function = m_call_nesting_level > 0;
+        // NOTE: This VERIFY could fail because a Function is destroyed from within itself.
         VERIFY(may_defer || !called_from_inside_function);
         if (called_from_inside_function && may_defer) {
             m_deferred_clear = true;

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -92,6 +92,8 @@ private:
     Optional<AutoCompleteRequestData> get_autocomplete_request_data();
 
     void flush_file_content_to_langauge_server();
+    void set_syntax_highlighter_for(const CodeDocument&);
+    void set_language_client_for(const CodeDocument&);
 
     explicit Editor();
 

--- a/Userland/DevTools/HackStudio/LanguageClient.h
+++ b/Userland/DevTools/HackStudio/LanguageClient.h
@@ -65,6 +65,7 @@ public:
     template<typename LanguageServerType>
     static ServerConnectionWrapper& get_or_create(const String& project_path);
 
+    Language language() const { return m_language; }
     ServerConnection* connection();
     void on_crash();
     void try_respawn_connection();
@@ -120,6 +121,7 @@ public:
             m_connection_wrapper.set_active_client(*m_previous_client);
     }
 
+    Language language() const { return m_connection_wrapper.language(); }
     void set_active_client();
     virtual void open_file(const String& path, int fd);
     virtual void set_file_content(const String& path, const String& content);

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -49,6 +49,7 @@ public:
 
     const TextDocument& document() const { return *m_document; }
     TextDocument& document() { return *m_document; }
+    bool has_document() const { return !!m_document; }
 
     virtual void set_document(TextDocument&);
 


### PR DESCRIPTION
This fixes an issue where HackStudio crashed when you tried to ctrl+click a definition.
The crash occurred because we tried to destruct an `AK::Function` object while executing inside it.