### PR TITLE
LibGUI: Add PasswordBox

### DIFF
--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -72,4 +72,12 @@ void TextBox::add_input_to_history(String input)
     m_history_index++;
 }
 
+PasswordBox::PasswordBox()
+    : TextBox()
+{
+    set_substitution_code_point('*');
+    undo_action().set_enabled(false);
+    redo_action().set_enabled(false);
+}
+
 }

--- a/Userland/Libraries/LibGUI/TextBox.h
+++ b/Userland/Libraries/LibGUI/TextBox.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGUI/Action.h>
 #include <LibGUI/TextEditor.h>
 
 namespace GUI {
@@ -34,6 +35,12 @@ private:
     Vector<String> m_history;
     int m_history_index { -1 };
     String m_saved_input;
+};
+
+class PasswordBox : public TextBox {
+    C_OBJECT(PasswordBox)
+public:
+    PasswordBox();
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -217,25 +217,21 @@ void TextEditor::doubleclick_event(MouseEvent& event)
     m_triple_click_timer.start();
     m_in_drag_select = false;
 
-    auto start = text_position_at(event.position());
-    auto end = start;
+    auto position = text_position_at(event.position());
 
-    if (!document().has_spans()) {
-        start = document().first_word_break_before(start, false);
-        end = document().first_word_break_after(end);
-    } else {
+    if (document().has_spans()) {
         for (auto& span : document().spans()) {
-            if (!span.range.contains(start))
-                continue;
-            start = span.range.start();
-            end = span.range.end();
-            end.set_column(end.column() + 1);
-            break;
+            if (span.range.contains(position)) {
+                m_selection = span.range;
+                break;
+            }
         }
+    } else {
+        m_selection.set_start(document().first_word_break_before(position, false));
+        m_selection.set_end(document().first_word_break_after(position));
     }
 
-    m_selection.set(start, end);
-    set_cursor(end);
+    set_cursor(m_selection.end());
     update();
     did_update_selection();
 }
@@ -254,22 +250,8 @@ void TextEditor::mousedown_event(MouseEvent& event)
 
     if (m_triple_click_timer.is_valid() && m_triple_click_timer.elapsed() < 250) {
         m_triple_click_timer = Core::ElapsedTimer();
-
-        TextPosition start;
-        TextPosition end;
-
-        if (is_multi_line()) {
-            // select *current* line
-            start = TextPosition(m_cursor.line(), 0);
-            end = TextPosition(m_cursor.line(), line(m_cursor.line()).length());
-        } else {
-            // select *whole* line
-            start = TextPosition(0, 0);
-            end = TextPosition(line_count() - 1, line(line_count() - 1).length());
-        }
-
-        m_selection.set(start, end);
-        set_cursor(end);
+        m_selection = document().range_for_entire_line(m_cursor.line());
+        set_cursor(m_selection.end());
         update();
         did_update_selection();
         return;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -219,7 +219,11 @@ void TextEditor::doubleclick_event(MouseEvent& event)
 
     auto position = text_position_at(event.position());
 
-    if (document().has_spans()) {
+    if (m_substitution_code_point) {
+        // NOTE: If we substitute the code points, we don't want double clicking to only select a single word, since
+        //       whitespace isn't visible anymore.
+        m_selection = document().range_for_entire_line(position.line());
+    } else if (document().has_spans()) {
         for (auto& span : document().spans()) {
             if (span.range.contains(position)) {
                 m_selection = span.range;
@@ -389,6 +393,16 @@ void TextEditor::paint_event(PaintEvent& event)
     painter.add_clip_rect(event.rect());
     painter.fill_rect(event.rect(), widget_background_color);
 
+    // NOTE: This lambda and TextEditor::text_width_for_font() are used to substitute all glyphs with m_substitution_code_point if necessary.
+    //       Painter::draw_text() and Gfx::Font::width() should not be called directly, but using this lambda and TextEditor::text_width_for_font().
+    auto draw_text = [&](Gfx::IntRect const& rect, auto const& raw_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Gfx::Color color) {
+        if (m_substitution_code_point) {
+            painter.draw_text(rect, substitution_code_point_view(raw_text.length()), font, alignment, color);
+        } else {
+            painter.draw_text(rect, raw_text, font, alignment, color);
+        }
+    };
+
     if (is_displayonly() && is_focused()) {
         widget_background_color = palette().selection();
         Gfx::IntRect display_rect {
@@ -431,6 +445,7 @@ void TextEditor::paint_event(PaintEvent& event)
         for (size_t i = first_visible_line; i <= last_visible_line; ++i) {
             bool is_current_line = i == m_cursor.line();
             auto ruler_line_rect = ruler_content_rect(i);
+            // NOTE: Use Painter::draw_text() directly here, as we want to always draw the line numbers in clear text.
             painter.draw_text(
                 ruler_line_rect.shrunken(2, 0).translated(0, m_line_spacing / 2),
                 String::number(i + 1),
@@ -496,14 +511,14 @@ void TextEditor::paint_event(PaintEvent& event)
 
             if (!placeholder().is_empty() && document().is_empty() && !is_focused() && line_index == 0) {
                 auto line_rect = visual_line_rect;
-                line_rect.set_width(font().width(placeholder()));
-                painter.draw_text(line_rect, placeholder(), m_text_alignment, palette().color(Gfx::ColorRole::PlaceholderText));
+                line_rect.set_width(text_width_for_font(placeholder(), font()));
+                draw_text(line_rect, placeholder(), font(), m_text_alignment, palette().color(Gfx::ColorRole::PlaceholderText));
             } else if (!document().has_spans()) {
                 // Fast-path for plain text
                 auto color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
                 if (is_displayonly() && is_focused())
                     color = palette().color(is_enabled() ? Gfx::ColorRole::SelectionText : Gfx::ColorRole::DisabledText);
-                painter.draw_text(visual_line_rect, visual_line_text, m_text_alignment, color);
+                draw_text(visual_line_rect, visual_line_text, font(), m_text_alignment, color);
             } else {
                 auto unspanned_color = palette().color(is_enabled() ? foreground_role() : Gfx::ColorRole::DisabledText);
                 if (is_displayonly() && is_focused())
@@ -522,7 +537,7 @@ void TextEditor::paint_event(PaintEvent& event)
                     if (background_color.has_value()) {
                         painter.fill_rect(span_rect, background_color.value());
                     }
-                    painter.draw_text(span_rect, text, *font, m_text_alignment, color);
+                    draw_text(span_rect, text, *font, m_text_alignment, color);
                     if (underline) {
                         painter.draw_line(span_rect.bottom_left().translated(0, 1), span_rect.bottom_right().translated(0, 1), color);
                     }
@@ -626,7 +641,7 @@ void TextEditor::paint_event(PaintEvent& event)
                     Gfx::IntRect whitespace_rect {
                         content_x_for_position({ line_index, visual_column }),
                         visual_line_rect.y(),
-                        font().width(visual_line_text.substring_view(visual_column, visual_line_text.length() - visual_column)),
+                        text_width_for_font(visual_line_text.substring_view(visual_column, visual_line_text.length() - visual_column), font()),
                         visual_line_rect.height()
                     };
                     painter.fill_rect_with_dither_pattern(whitespace_rect, Color(), Color(255, 192, 192));
@@ -641,7 +656,7 @@ void TextEditor::paint_event(PaintEvent& event)
                     Gfx::IntRect whitespace_rect {
                         content_x_for_position({ line_index, start_of_visual_line }),
                         visual_line_rect.y(),
-                        font().width(visual_line_text.substring_view(0, end_of_leading_whitespace)),
+                        text_width_for_font(visual_line_text.substring_view(0, end_of_leading_whitespace), font()),
                         visual_line_rect.height()
                     };
                     painter.fill_rect_with_dither_pattern(whitespace_rect, Color(), Color(192, 255, 192));
@@ -685,7 +700,7 @@ void TextEditor::paint_event(PaintEvent& event)
                             end_of_selection_within_visual_line - start_of_selection_within_visual_line
                         };
 
-                        painter.draw_text(selection_rect, visual_selected_text, Gfx::TextAlignment::CenterLeft, text_color);
+                        draw_text(selection_rect, visual_selected_text, font(), Gfx::TextAlignment::CenterLeft, text_color);
                     }
                 }
             }
@@ -971,7 +986,7 @@ int TextEditor::content_x_for_position(const TextPosition& position) const
                 if (offset_in_visual_line == 0) {
                     x_offset = 0;
                 } else {
-                    x_offset = font().width(visual_line_view.substring_view(0, offset_in_visual_line));
+                    x_offset = text_width_for_font(visual_line_view.substring_view(0, offset_in_visual_line), font());
                     x_offset += font().glyph_spacing();
                 }
                 return IterationDecision::Break;
@@ -986,6 +1001,26 @@ int TextEditor::content_x_for_position(const TextPosition& position) const
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+int TextEditor::text_width_for_font(auto const& text, Gfx::Font const& font) const
+{
+    if (m_substitution_code_point)
+        return font.width(substitution_code_point_view(text.length()));
+    else
+        return font.width(text);
+}
+
+Utf32View TextEditor::substitution_code_point_view(size_t length) const
+{
+    VERIFY(m_substitution_code_point);
+    if (!m_substitution_string_data)
+        m_substitution_string_data = make<Vector<u32>>();
+    if (!m_substitution_string_data->is_empty())
+        VERIFY(m_substitution_string_data->first() == m_substitution_code_point);
+    while (m_substitution_string_data->size() < length)
+        m_substitution_string_data->append(m_substitution_code_point);
+    return Utf32View { m_substitution_string_data->data(), length };
 }
 
 Gfx::IntRect TextEditor::content_rect_for_position(const TextPosition& position) const
@@ -1058,7 +1093,7 @@ Gfx::IntRect TextEditor::line_content_rect(size_t line_index) const
 {
     auto& line = this->line(line_index);
     if (is_single_line()) {
-        Gfx::IntRect line_rect = { content_x_for_position({ line_index, 0 }), 0, font().width(line.view()), font().glyph_height() + 4 };
+        Gfx::IntRect line_rect = { content_x_for_position({ line_index, 0 }), 0, text_width_for_font(line.view(), font()), font().glyph_height() + 4 };
         line_rect.center_vertically_within({ {}, frame_inner_rect().size() });
         return line_rect;
     }
@@ -1067,7 +1102,7 @@ Gfx::IntRect TextEditor::line_content_rect(size_t line_index) const
     return {
         content_x_for_position({ line_index, 0 }),
         (int)line_index * line_height(),
-        font().width(line.view()),
+        text_width_for_font(line.view(), font()),
         line_height()
     };
 }
@@ -1597,7 +1632,7 @@ void TextEditor::recompute_visual_lines(size_t line_index)
     if (is_wrapping_enabled())
         visual_data.visual_rect = { m_horizontal_content_padding, 0, available_width, static_cast<int>(visual_data.visual_line_breaks.size()) * line_height() };
     else
-        visual_data.visual_rect = { m_horizontal_content_padding, 0, font().width(line.view()), line_height() };
+        visual_data.visual_rect = { m_horizontal_content_padding, 0, text_width_for_font(line.view(), font()), line_height() };
 }
 
 template<typename Callback>
@@ -1615,7 +1650,7 @@ void TextEditor::for_each_visual_line(size_t line_index, Callback callback) cons
         Gfx::IntRect visual_line_rect {
             visual_data.visual_rect.x(),
             visual_data.visual_rect.y() + ((int)visual_line_index * line_height()),
-            font().width(visual_line_view) + font().glyph_spacing(),
+            text_width_for_font(visual_line_view, font()) + font().glyph_spacing(),
             line_height()
         };
         if (is_right_text_alignment(text_alignment()))
@@ -1863,6 +1898,14 @@ void TextEditor::set_should_autocomplete_automatically(bool value)
     remove_child(*m_autocomplete_timer);
     m_autocomplete_timer = nullptr;
 }
+
+void TextEditor::set_substitution_code_point(u32 code_point)
+{
+    VERIFY(is_unicode(code_point));
+    m_substitution_string_data.clear();
+    m_substitution_code_point = code_point;
+}
+
 int TextEditor::number_of_visible_lines() const
 {
     return visible_content_rect().height() / line_height();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -175,6 +175,9 @@ public:
     bool should_autocomplete_automatically() const { return m_autocomplete_timer; }
     void set_should_autocomplete_automatically(bool);
 
+    u32 substitution_code_point() const { return m_substitution_code_point; }
+    void set_substitution_code_point(u32 code_point);
+
     bool is_in_drag_select() const { return m_in_drag_select; }
 
     TextRange* selection() { return &m_selection; };
@@ -273,6 +276,9 @@ private:
         TextEditor& m_editor;
     };
 
+    int text_width_for_font(auto const& text_view, Gfx::Font const&) const;
+    Utf32View substitution_code_point_view(size_t length) const;
+
     Gfx::IntRect line_content_rect(size_t item_index) const;
     Gfx::IntRect line_widget_rect(size_t line_index) const;
     void delete_selection();
@@ -319,6 +325,11 @@ private:
     size_t m_soft_tab_width { 4 };
     int m_horizontal_content_padding { 3 };
     TextRange m_selection;
+
+    // NOTE: If non-zero, all glyphs will be substituted with this one.
+    u32 m_substitution_code_point { 0 };
+    mutable OwnPtr<Vector<u32>> m_substitution_string_data; // Used to avoid repeated String construction.
+
     RefPtr<Menu> m_context_menu;
     RefPtr<Action> m_undo_action;
     RefPtr<Action> m_redo_action;


### PR DESCRIPTION
This PR adds a `PasswordBox` to LibGUI. This consists of two parts:

**Part 1**  
Add `u32 m_substitution_code_point` to `GUI::TextEditor`. If non-zero, all glyphs will be substituted with this one while painting the TextEditor. There are a few helper methods and lambdas to proxy all calls to `Painter::draw_text` and `Font::width` and transparently replace the text if `m_substitution_code_point` is set.
There is also `OwnPtr<Vector<u32>> m_substitution_string_data` (so basically a `StringBuilder`, but for UTF-32) and a method `substitution_code_point_view(size_t length)` to generate `Utf32` views of the required lengths. This has two reasons: It avoids repeated String allocation in `paint_event`, and it also works with non-ASCII code points, unlike `String::repeated`.

**Part 2**
Add `GUI::PasswordBox`, which inherits from `TextBox` and thus `TextEditor`. Currently, the only things it does differently from `TextBox` is that it automatically sets the substitution code point to `*` and disables undo and redo context menu actions.

**Drive-by fix**
I found the bug where double-clicking a word in syntax-highlighted text would also select the character directly after the word. This was regressed in #7768 and has now been fixed. While doing that, I could simplify the relevant code quite a lot.