### PR TITLE
Meta: Force relative mouse coordinates with multiple screens

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -57,6 +57,10 @@ SERENITY_SCREENS="${SERENITY_SCREENS:-1}"
 SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-sdl,gl=on}"
 if [ "$SERENITY_SCREENS" -gt 1 ]; then
     SERENITY_QEMU_DISPLAY_DEVICE="virtio-gpu,max_outputs=$SERENITY_SCREENS "
+    # QEMU appears to always relay absolute mouse coordinates relative to the screen that the mouse is
+    # pointed to, without any way for us to know what screen it was. So, when dealing with multiple
+    # displays force using relative coordinates only
+    SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE vmmouse=off"
 else
     SERENITY_QEMU_DISPLAY_DEVICE="VGA,vgamem_mb=64 "
 fi


### PR DESCRIPTION
QEMU appears to always relay absolute mouse coordinates relative to the
screen that the mouse is pointed to, without any way for us to know
what screen it was. So, when dealing with multiple displays force using
relative coordinates only.