### PR TITLE
Kernel: Generate a unique device id for each framebuffer device

### DIFF
--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -20,6 +20,8 @@ namespace Kernel {
 class FramebufferDevice : public BlockDevice {
     AK_MAKE_ETERNAL
 public:
+    static unsigned allocate_device_id();
+
     static NonnullRefPtr<FramebufferDevice> create(const GraphicsDevice&, size_t, PhysicalAddress, size_t, size_t, size_t);
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
@@ -47,6 +49,8 @@ private:
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
 
     FramebufferDevice(const GraphicsDevice&, size_t, PhysicalAddress, size_t, size_t, size_t);
+
+    const unsigned m_device_id;
 
     PhysicalAddress m_framebuffer_address;
     size_t m_framebuffer_pitch { 0 };

--- a/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.cpp
@@ -12,6 +12,7 @@ namespace Kernel::Graphics {
 
 VirtIOFrameBufferDevice::VirtIOFrameBufferDevice(RefPtr<VirtIOGPU> virtio_gpu)
     : BlockDevice(29, GraphicsManagement::the().allocate_minor_device_number())
+    , m_device_id(FramebufferDevice::allocate_device_id())
     , m_gpu(virtio_gpu)
 {
     auto write_sink_page = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::No).release_nonnull();

--- a/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.h
@@ -33,7 +33,9 @@ private:
     virtual void start_request(AsyncBlockDeviceRequest& request) override { request.complete(AsyncDeviceRequest::Failure); }
 
     virtual mode_t required_mode() const override { return 0666; }
-    virtual String device_name() const override { return String::formatted("fb{}", minor()); }
+    virtual String device_name() const override { return String::formatted("fb{}", m_device_id); }
+
+    const unsigned m_device_id;
 
     RefPtr<VirtIOGPU> m_gpu;
     RefPtr<VMObject> m_framebuffer_sink_vmobject;


### PR DESCRIPTION
This solves the problem where creating multiple framebuffer devices
would be using the same fbX, which was dependent on the value returned
by minor().