### PR TITLE
Kernel: x86_64 support (part 3)

### DIFF
--- a/Kernel/Arch/x86/ASM_wrapper.h
+++ b/Kernel/Arch/x86/ASM_wrapper.h
@@ -30,6 +30,7 @@ ALWAYS_INLINE FlatPtr cpu_flags()
     return flags;
 }
 
+#if ARCH(I386)
 ALWAYS_INLINE void set_fs(u16 segment)
 {
     asm volatile(
@@ -59,6 +60,7 @@ ALWAYS_INLINE u16 get_gs()
         : "=a"(gs));
     return gs;
 }
+#endif
 
 ALWAYS_INLINE u32 read_fs_u32(u32 offset)
 {

--- a/Kernel/Arch/x86/CPUID.h
+++ b/Kernel/Arch/x86/CPUID.h
@@ -53,6 +53,7 @@ enum class CPUFeature : u32 {
     XSAVE = (1 << 21),
     AVX = (1 << 22),
     FXSR = (1 << 23),
+    LM = (1 << 24),
 };
 
 }

--- a/Kernel/Arch/x86/DescriptorTable.h
+++ b/Kernel/Arch/x86/DescriptorTable.h
@@ -132,14 +132,14 @@ struct [[gnu::packed]] IDTEntry
 #endif
 
     IDTEntry() = default;
-    IDTEntry(FlatPtr callback, u16 selector_, IDTEntryType type, u8 storage_segment, u8 privilige_level)
+    IDTEntry(FlatPtr callback, u16 selector_, IDTEntryType type, u8 storage_segment, u8 privilege_level)
         : offset_1 { (u16)((FlatPtr)callback & 0xFFFF) }
         , selector { selector_ }
         , zero { 0 }
         , type_attr {
             .gate_type = (u8)type,
             .storage_segment = storage_segment,
-            .descriptor_privilege_level = (u8)(privilige_level & 0b11),
+            .descriptor_privilege_level = (u8)(privilege_level & 0b11),
             .present = 1,
         }
         , offset_2 { (u16)((FlatPtr)callback >> 16) }

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -19,6 +19,11 @@
 
 namespace Kernel {
 
+#if ARCH(X86_64)
+#    define MSR_FS_BASE 0xc0000100
+#    define MSR_GS_BASE 0xc0000102
+#endif
+
 class Thread;
 class SchedulerPerProcessorData;
 struct MemoryManagerData;
@@ -241,7 +246,11 @@ public:
 
     ALWAYS_INLINE static bool is_initialized()
     {
-        return get_fs() == GDT_SELECTOR_PROC && read_fs_u32(__builtin_offsetof(Processor, m_self)) != 0;
+        return
+#if ARCH(I386)
+            get_fs() == GDT_SELECTOR_PROC &&
+#endif
+            read_fs_u32(__builtin_offsetof(Processor, m_self)) != 0;
     }
 
     ALWAYS_INLINE void set_scheduler_data(SchedulerPerProcessorData& scheduler_data)

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -109,6 +109,8 @@ UNMAP_AFTER_INIT void Processor::cpu_detect()
             set_feature(CPUFeature::NX);
         if (extended_processor_info.edx() & (1 << 27))
             set_feature(CPUFeature::RDTSCP);
+        if (extended_processor_info.edx() & (1 << 29))
+            set_feature(CPUFeature::LM);
         if (extended_processor_info.edx() & (1 << 11)) {
             // Only available in 64 bit mode
             set_feature(CPUFeature::SYSCALL);
@@ -260,6 +262,8 @@ String Processor::features_string() const
             return "xsave";
         case CPUFeature::AVX:
             return "avx";
+        case CPUFeature::LM:
+            return "lm";
             // no default statement here intentionally so that we get
             // a warning if a new feature is forgotten to be added here
         }

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -355,7 +355,7 @@ void Processor::write_raw_gdt_entry(u16 selector, u32 low, u32 high)
     u16 i = (selector & 0xfffc) >> 3;
     u32 prev_gdt_length = m_gdt_length;
 
-    if (i > m_gdt_length) {
+    if (i >= m_gdt_length) {
         m_gdt_length = i + 1;
         VERIFY(m_gdt_length <= sizeof(m_gdt) / sizeof(m_gdt[0]));
         m_gdtr.limit = (m_gdt_length + 1) * 8 - 1;

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -1074,7 +1074,7 @@ UNMAP_AFTER_INIT void Processor::gdt_init()
 
     Descriptor fs_descriptor {};
     fs_descriptor.set_base(VirtualAddress { this });
-    fs_descriptor.set_limit(sizeof(Processor));
+    fs_descriptor.set_limit(sizeof(Processor) - 1);
     fs_descriptor.dpl = 0;
     fs_descriptor.segment_present = 1;
     fs_descriptor.granularity = 0;
@@ -1086,7 +1086,7 @@ UNMAP_AFTER_INIT void Processor::gdt_init()
 
     Descriptor tss_descriptor {};
     tss_descriptor.set_base(VirtualAddress { &m_tss });
-    tss_descriptor.set_limit(sizeof(TSS32));
+    tss_descriptor.set_limit(sizeof(TSS32) - 1);
     tss_descriptor.dpl = 0;
     tss_descriptor.segment_present = 1;
     tss_descriptor.granularity = 0;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -348,7 +348,7 @@ set(SOURCES
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -Wvla -Wnull-dereference")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -fPIE -fno-rtti -ffreestanding -fbuiltin")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -ffreestanding -fbuiltin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-80387 -mno-mmx -mno-sse -mno-sse2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-asynchronous-unwind-tables")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong")
@@ -357,7 +357,9 @@ if (NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
 endif()
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=large -mno-red-zone -z max-page-size=0x1000")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=large -fno-pic -mno-red-zone -z max-page-size=0x1000")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -fPIE")
 endif()
 
 # Kernel Undefined Behavior Sanitizer (KUBSAN)

--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -20,6 +20,10 @@ class Heap {
 
     struct AllocationHeader {
         size_t allocation_size_in_chunks;
+#if ARCH(X86_64)
+        // FIXME: Get rid of this somehow
+        size_t alignment_dummy;
+#endif
         u8 data[0];
     };
 

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -110,6 +110,7 @@ static SlabAllocator<16> s_slab_allocator_16;
 static SlabAllocator<32> s_slab_allocator_32;
 static SlabAllocator<64> s_slab_allocator_64;
 static SlabAllocator<128> s_slab_allocator_128;
+static SlabAllocator<256> s_slab_allocator_256;
 
 #if ARCH(I386)
 static_assert(sizeof(Region) <= s_slab_allocator_128.slab_size());
@@ -122,6 +123,7 @@ void for_each_allocator(Callback callback)
     callback(s_slab_allocator_32);
     callback(s_slab_allocator_64);
     callback(s_slab_allocator_128);
+    callback(s_slab_allocator_256);
 }
 
 UNMAP_AFTER_INIT void slab_alloc_init()
@@ -130,6 +132,7 @@ UNMAP_AFTER_INIT void slab_alloc_init()
     s_slab_allocator_32.init(128 * KiB);
     s_slab_allocator_64.init(512 * KiB);
     s_slab_allocator_128.init(512 * KiB);
+    s_slab_allocator_256.init(128 * KiB);
 }
 
 void* slab_alloc(size_t slab_size)
@@ -142,6 +145,8 @@ void* slab_alloc(size_t slab_size)
         return s_slab_allocator_64.alloc();
     if (slab_size <= 128)
         return s_slab_allocator_128.alloc();
+    if (slab_size <= 256)
+        return s_slab_allocator_256.alloc();
     VERIFY_NOT_REACHED();
 }
 
@@ -155,6 +160,8 @@ void slab_dealloc(void* ptr, size_t slab_size)
         return s_slab_allocator_64.dealloc(ptr);
     if (slab_size <= 128)
         return s_slab_allocator_128.dealloc(ptr);
+    if (slab_size <= 256)
+        return s_slab_allocator_256.dealloc(ptr);
     VERIFY_NOT_REACHED();
 }
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -315,8 +315,8 @@ void signal_trampoline_dummy()
 #endif
 }
 
-extern "C" void asm_signal_trampoline(void) __attribute__((used));
-extern "C" void asm_signal_trampoline_end(void);
+extern "C" char const asm_signal_trampoline[];
+extern "C" char const asm_signal_trampoline_end[];
 
 void create_signal_trampoline()
 {
@@ -324,12 +324,10 @@ void create_signal_trampoline()
     g_signal_trampoline_region = MM.allocate_kernel_region(PAGE_SIZE, "Signal trampolines", Region::Access::Read | Region::Access::Write).leak_ptr();
     g_signal_trampoline_region->set_syscall_region(true);
 
-    u8* trampoline = (u8*)asm_signal_trampoline;
-    u8* trampoline_end = (u8*)asm_signal_trampoline_end;
-    size_t trampoline_size = trampoline_end - trampoline;
+    size_t trampoline_size = asm_signal_trampoline_end - asm_signal_trampoline;
 
     u8* code_ptr = (u8*)g_signal_trampoline_region->vaddr().as_ptr();
-    memcpy(code_ptr, trampoline, trampoline_size);
+    memcpy(code_ptr, asm_signal_trampoline, trampoline_size);
 
     g_signal_trampoline_region->set_writable(false);
     g_signal_trampoline_region->remap();

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -109,7 +109,10 @@ protected:
 
 class ProcessBase : public ProtectedProcessBase {
 protected:
-    u8 m_process_base_padding[PAGE_SIZE - sizeof(ProtectedProcessBase)];
+    // Without the alignas specifier here the compiler places this class into
+    // the parent class' padding which then causes the members for the RefCounted
+    // class to be placed within the first page of the Process class.
+    alignas(ProtectedProcessBase) u8 m_process_base_padding[PAGE_SIZE - sizeof(ProtectedProcessBase)];
 };
 
 static_assert(sizeof(ProcessBase) == PAGE_SIZE);

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -243,11 +243,19 @@ void* memcpy(void* dest_ptr, const void* src_ptr, size_t n)
     // FIXME: Support starting at an unaligned address.
     if (!(dest & 0x3) && !(src & 0x3) && n >= 12) {
         size_t size_ts = n / sizeof(size_t);
+#if ARCH(I386)
         asm volatile(
             "rep movsl\n"
             : "=S"(src), "=D"(dest)
             : "S"(src), "D"(dest), "c"(size_ts)
             : "memory");
+#else
+        asm volatile(
+            "rep movsq\n"
+            : "=S"(src), "=D"(dest)
+            : "S"(src), "D"(dest), "c"(size_ts)
+            : "memory");
+#endif
         n -= size_ts * sizeof(size_t);
         if (n == 0)
             return dest_ptr;
@@ -296,11 +304,19 @@ void* memset(void* dest_ptr, int c, size_t n)
     if (!(dest & 0x3) && n >= 12) {
         size_t size_ts = n / sizeof(size_t);
         size_t expanded_c = explode_byte((u8)c);
+#if ARCH(I386)
         asm volatile(
             "rep stosl\n"
             : "=D"(dest)
             : "D"(dest), "c"(size_ts), "a"(expanded_c)
             : "memory");
+#else
+        asm volatile(
+            "rep stosq\n"
+            : "=D"(dest)
+            : "D"(dest), "c"(size_ts), "a"(expanded_c)
+            : "memory");
+#endif
         n -= size_ts * sizeof(size_t);
         if (n == 0)
             return dest_ptr;

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -607,9 +607,13 @@ KResultOr<FlatPtr> Process::sys$allocate_tls(Userspace<const char*> initial_data
     if (tsr_result.is_error())
         return EFAULT;
 
+#if ARCH(I386)
     auto& tls_descriptor = Processor::current().get_gdt_entry(GDT_SELECTOR_TLS);
     tls_descriptor.set_base(main_thread->thread_specific_data());
     tls_descriptor.set_limit(main_thread->thread_specific_region_size());
+#else
+    TODO();
+#endif
 
     return m_master_tls_region.unsafe_ptr()->vaddr().get();
 }

--- a/Kernel/VM/PageDirectory.h
+++ b/Kernel/VM/PageDirectory.h
@@ -32,7 +32,14 @@ public:
 
     ~PageDirectory();
 
-    u32 cr3() const { return m_directory_table->paddr().get(); }
+    u32 cr3() const
+    {
+#if ARCH(X86_64)
+        return m_pml4t->paddr().get();
+#else
+        return m_directory_table->paddr().get();
+#endif
+    }
 
     RangeAllocator& range_allocator() { return m_range_allocator; }
     const RangeAllocator& range_allocator() const { return m_range_allocator; }
@@ -55,6 +62,9 @@ private:
     Space* m_space { nullptr };
     RangeAllocator m_range_allocator;
     RangeAllocator m_identity_range_allocator;
+#if ARCH(X86_64)
+    RefPtr<PhysicalPage> m_pml4t;
+#endif
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[4];
     HashMap<u32, RefPtr<PhysicalPage>> m_page_tables;


### PR DESCRIPTION
**Kernel: Fix GDT limits**

The GDT limits are inclusive, so for correctness we should subtract one from the structs' size.

**Kernel: Add support for setting up a x86_64 GDT once in C++ land**

**Kernel: Fix off-by-one error in Processor::write_raw_gdt_entry**

**Kernel: Add slab allocator for 256 bytes**

Our types are getting a tiny bit larger for x86_64 so we need another slab allocator to deal with that.

**Kernel: Fix memcpy and memset for x86_64**

Those size_ts sure are growing up fast.

**Kernel: Add PML4T support for the PageDirectory class**

**Kernel: Make addresses returned by kmalloc() properly aligned for x86_64**

**Kernel: Correct spelling mistake**

**Kernel: Ensure that the ProcessBase class is properly laid out on x86_64**

Without this the ProcessBase class is placed into the padding for the ProtectedProcessBase class which then causes the members of the RefCounted class to end up without the first 4096 bytes of the Process
class:

```
BP 1, Kernel::Process::protect_data (this=this@entry=0xc063b000)
205     {
(gdb) p &m_ref_count
$1 = (AK::Atomic<unsigned int, (AK::MemoryOrder)5> *) 0xc063bffc
```

Note how the difference between 'this' and &m_ref_count is less than 4096.

**Kernel: Add CPUID flag for long mode**

This isn't particularly useful because by the time we've entered init() the CPU had better support x86_64 anyway. However this shows the CPU flag in System Monitor - even in 32-bit mode.

**Kernel: Clean up create_signal_trampoline a bit**

The types for asm_signal_trampoline and asm_signal_trampoline_end were incorrect. They both point into the text segment but they're not really functions.

**Kernel: Specify -fno-pic when using -mcmodel=large**

According to the gcc man page these are mutually exclusive and did in fact cause problems when trying to get the address for asm labels on x86_64.