### PR TITLE
Toolchain: Build the x86_64 target in addition to i386 in BuildQemu.sh

### DIFF
--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -64,7 +64,7 @@ echo Using $UI_LIB based UI
 pushd "$DIR/Build/$ARCH"
     pushd qemu
         "$DIR"/Tarballs/$QEMU_VERSION/configure --prefix="$PREFIX" \
-                                                --target-list=i386-softmmu \
+                                                --target-list=i386-softmmu,x86_64-softmmu \
                                                 --enable-$UI_LIB || exit 1
         make -j "$MAKEJOBS" || exit 1
         make install || exit 1


### PR DESCRIPTION
This helps with testing the current work on increasing x64 support on machines with old qemu distro packages.