### PR TITLE
CI: Increase the on-target tests timeout to 60 minutes from 30 minutes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -163,7 +163,7 @@ jobs:
           exit 1
         fi
         echo "::endgroup::"
-      timeout-minutes: 30
+      timeout-minutes: 60
 
     - name: Print Target Logs
       # Extremely useful if Serenity hangs trying to run one of the tests


### PR DESCRIPTION
This should help reduce the random test failures due to timeouts on slower github actions runners.