### PR TITLE
WindowServer: Un-tile window if resizing warrants it

### DIFF
--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -100,6 +100,8 @@ public:
 
     WindowTileType tiled() const { return m_tiled; }
     void set_tiled(Screen*, WindowTileType);
+    WindowTileType tile_type_based_on_rect(Gfx::IntRect const&) const;
+    void check_untile_due_to_resize(Gfx::IntRect const&);
     bool set_untiled(Optional<Gfx::IntPoint> fixed_point = {});
 
     bool is_occluded() const { return m_occluded; }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -715,6 +715,7 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
     // First, size the new rect.
     new_rect.set_width(new_rect.width() + change_w);
     new_rect.set_height(new_rect.height() + change_h);
+
     m_resize_window->apply_minimum_size(new_rect);
 
     if (!m_resize_window->size_increment().is_null()) {
@@ -762,6 +763,14 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
     if (m_resize_window->rect() == new_rect)
         return true;
 
+    if (m_resize_window->tiled() != WindowTileType::None) {
+        // Check if we should be un-tiling the window. This should happen when one side touching
+        // the screen border changes. We need to un-tile because while it is tiled, rendering is
+        // constrained to the screen where it's tiled on, and if one of these sides move we should
+        // no longer constrain rendering to that screen. Changing the sides not touching a screen
+        // border however is fine as long as the screen contains the entire window.
+        m_resize_window->check_untile_due_to_resize(new_rect);
+    }
     dbgln_if(RESIZE_DEBUG, "[WM] Resizing, original: {}, now: {}", m_resize_window_original_rect, new_rect);
 
     m_resize_window->set_rect(new_rect);


### PR DESCRIPTION
Since being tiled means we restrict rendering a window to the screen it
is on (so that we don't "bleed" into an adjacent screen), we need to
untile it if the window either can't fit into the screen, or it is
detached from the screen edges.