### PR TITLE
LibJS: Small string fixes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -284,7 +284,14 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::index_of)
     auto needle = vm.argument(0).to_string(global_object);
     if (vm.exception())
         return {};
-    return Value((i32)string->find(needle).value_or(-1));
+    size_t from = 0;
+    if (vm.argument_count() > 1) {
+        double from_argument = vm.argument(1).to_integer_or_infinity(global_object);
+        if (vm.exception())
+            return {};
+        from = clamp(from_argument, static_cast<double>(0), static_cast<double>(string->length()));
+    }
+    return Value((i32)string->find(needle, from).value_or(-1));
 }
 
 // 22.1.3.26 String.prototype.toLowerCase ( ), https://tc39.es/ecma262/#sec-string.prototype.tolowercase

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.indexOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.indexOf.js
@@ -5,4 +5,19 @@ test("basic functionality", () => {
 
     expect(s.indexOf("friends")).toBe(6);
     expect(s.indexOf("enemies")).toBe(-1);
+
+    expect(s.indexOf("friends", 0)).toBe(6);
+    expect(s.indexOf("enemies", 0)).toBe(-1);
+
+    expect(s.indexOf("friends", 4)).toBe(6);
+    expect(s.indexOf("friends", 6)).toBe(6);
+    expect(s.indexOf("friends", 7)).toBe(-1);
+    expect(s.indexOf("friends", 8)).toBe(-1);
+
+    expect(s.indexOf("enemies", 2)).toBe(-1);
+    expect(s.indexOf("enemies", 7)).toBe(-1);
+
+    expect(s.indexOf("e")).toBe(1);
+    expect(s.indexOf("e", 0)).toBe(1);
+    expect(s.indexOf("e", 2)).toBe(9);
 });


### PR DESCRIPTION
Should fix one of the timeouts of test262

There are also some methods which simply did not exists but since their implementation is usually very Unicode heavy I left those for someone else.
If you want easy test fixes implement the methods and lengths and stuff