### PR TITLE
AK: Make StringView::operator==() constexpr

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -158,7 +158,7 @@ public:
     [[nodiscard]] StringView substring_view_starting_from_substring(const StringView& substring) const;
     [[nodiscard]] StringView substring_view_starting_after_substring(const StringView& substring) const;
 
-    bool operator==(const char* cstring) const
+    constexpr bool operator==(char const* cstring) const
     {
         if (is_null())
             return !cstring;


### PR DESCRIPTION
PR'ing to see if clang on CI is fine with this. It likely is, there's no magic (`__builtin_*`) involved.