### PR TITLE
AK+Everywhere: Add and use the RemoveCVReference<T> type trait

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -196,6 +196,9 @@ template<typename T>
 using RemoveReference = typename __RemoveReference<T>::Type;
 
 template<typename T>
+using RemoveCVReference = RemoveCV<RemoveReference<T>>;
+
+template<typename T>
 struct __MakeUnsigned {
     using Type = void;
 };
@@ -478,6 +481,7 @@ using AK::Detail::MakeSigned;
 using AK::Detail::MakeUnsigned;
 using AK::Detail::RemoveConst;
 using AK::Detail::RemoveCV;
+using AK::Detail::RemoveCVReference;
 using AK::Detail::RemovePointer;
 using AK::Detail::RemoveReference;
 using AK::Detail::RemoveVolatile;

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -251,7 +251,7 @@ public:
 
     using Detail::MergeAndDeduplicatePacks<Detail::VariantConstructors<Ts, Variant<Ts...>>...>::MergeAndDeduplicatePacks;
 
-    template<typename T, typename StrippedT = RemoveCV<RemoveReference<T>>>
+    template<typename T, typename StrippedT = RemoveCVReference<T>>
     void set(T&& t) requires(can_contain<StrippedT>())
     {
         constexpr auto new_index = index_of<StrippedT>();
@@ -260,7 +260,7 @@ public:
         m_index = new_index;
     }
 
-    template<typename T, typename StrippedT = RemoveCV<RemoveReference<T>>>
+    template<typename T, typename StrippedT = RemoveCVReference<T>>
     void set(T&& t, Detail::VariantNoClearTag) requires(can_contain<StrippedT>())
     {
         constexpr auto new_index = index_of<StrippedT>();
@@ -323,7 +323,7 @@ public:
     {
         Variant<NewTs...> instance { Variant<NewTs...>::invalid_index, Detail::VariantConstructTag {} };
         visit([&](auto& value) {
-            if constexpr (Variant<NewTs...>::template can_contain<RemoveCV<RemoveReference<decltype(value)>>>())
+            if constexpr (Variant<NewTs...>::template can_contain<RemoveCVReference<decltype(value)>>())
                 instance.set(move(value), Detail::VariantNoClearTag {});
         });
         VERIFY(instance.m_index != instance.invalid_index);
@@ -335,7 +335,7 @@ public:
     {
         Variant<NewTs...> instance { Variant<NewTs...>::invalid_index, Detail::VariantConstructTag {} };
         visit([&](const auto& value) {
-            if constexpr (Variant<NewTs...>::template can_contain<RemoveCV<RemoveReference<decltype(value)>>>())
+            if constexpr (Variant<NewTs...>::template can_contain<RemoveCVReference<decltype(value)>>())
                 instance.set(value, Detail::VariantNoClearTag {});
         });
         VERIFY(instance.m_index != instance.invalid_index);

--- a/Tests/AK/TestTypeTraits.cpp
+++ b/Tests/AK/TestTypeTraits.cpp
@@ -105,3 +105,11 @@ TEST_CASE(UnderlyingType)
 
     STATIC_EXPECT_EQ(Type, u8);
 }
+
+TEST_CASE(RemoveCVReference)
+{
+    using TestTypeList = TypeList<int, int&, int const&, int volatile&, int const volatile&, int&&, int const&&, int volatile&&, int const volatile&&>;
+    using ResultTypeList = TypeList<int, int, int, int, int, int, int, int, int>;
+
+    EXPECT_EQ_WITH_TRAIT(RemoveCVReference, TestTypeList, ResultTypeList);
+}


### PR DESCRIPTION
C++20 added this, and it was nice, and we used it in a few places, so I added it for extra niceness.
This isn't a functional change.