### PR TITLE
WindowServer: Fix menu location on screens other than main screen

### DIFF
--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -75,7 +75,7 @@ public:
     void set_rect_in_window_menubar(const Gfx::IntRect& rect) { m_rect_in_window_menubar = rect; }
 
     Window* menu_window() { return m_menu_window.ptr(); }
-    Window& ensure_menu_window();
+    Window& ensure_menu_window(Gfx::IntPoint const&);
 
     Window* window_menu_of() { return m_window_menu_of; }
     void set_window_menu_of(Window& window) { m_window_menu_of = window; }

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -101,7 +101,7 @@ void MenuManager::event(Core::Event& event)
                     else {
                         auto* target_menu = previous_menu(m_current_menu);
                         if (target_menu) {
-                            target_menu->ensure_menu_window().move_to(target_menu->rect_in_window_menubar().bottom_left().translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
+                            target_menu->ensure_menu_window(target_menu->rect_in_window_menubar().bottom_left().translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
                             open_menu(*target_menu);
                             wm.window_with_active_menu()->invalidate_menubar();
                         }
@@ -118,7 +118,7 @@ void MenuManager::event(Core::Event& event)
                 else if (m_open_menu_stack.size() <= 1 && wm.window_with_active_menu()) {
                     auto* target_menu = next_menu(m_current_menu);
                     if (target_menu) {
-                        target_menu->ensure_menu_window().move_to(target_menu->rect_in_window_menubar().bottom_left().translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
+                        target_menu->ensure_menu_window(target_menu->rect_in_window_menubar().bottom_left().translated(wm.window_with_active_menu()->frame().rect().location()).translated(wm.window_with_active_menu()->frame().menubar_rect().location()));
                         open_menu(*target_menu);
                         wm.window_with_active_menu()->invalidate_menubar();
                         close_everyone_not_in_lineage(*target_menu);
@@ -300,9 +300,9 @@ void MenuManager::open_menu(Menu& menu, bool as_current_menu)
 
     if (!menu.is_empty()) {
         menu.redraw_if_theme_changed();
-        if (!menu.menu_window())
-            menu.ensure_menu_window();
-        menu.set_visible(true);
+        auto* window = menu.menu_window();
+        VERIFY(window);
+        window->set_visible(true);
     }
 
     if (m_open_menu_stack.find_if([&menu](auto& other) { return &menu == other.ptr(); }).is_end())

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -845,7 +845,7 @@ void WindowFrame::open_menubar_menu(Menu& menu)
 {
     auto menubar_rect = this->menubar_rect();
     MenuManager::the().close_everyone();
-    menu.ensure_menu_window().move_to(menu.rect_in_window_menubar().bottom_left().translated(rect().location()).translated(menubar_rect.location()));
+    menu.ensure_menu_window(menu.rect_in_window_menubar().bottom_left().translated(rect().location()).translated(menubar_rect.location()));
     MenuManager::the().open_menu(menu);
     WindowManager::the().set_window_with_active_menu(&m_window);
     invalidate(menubar_rect);


### PR DESCRIPTION
The menus always thought they were being outside of the main screen,
which caused them to be left and/or top aligned. This also fixes the
calculation of the available space by using the screen rectangle where
it will be displayed.