### PR TITLE
LibJS: Add and use the %ThrowTypeError% intrinsic

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -210,7 +210,6 @@ Value perform_eval(Value x, GlobalObject& caller_realm, CallerMode strict_caller
 Object* create_unmapped_arguments_object(GlobalObject& global_object, Vector<Value> const& arguments)
 {
     auto& vm = global_object.vm();
-    // FIXME: This should use OrdinaryObjectCreate
     auto* object = Object::create(global_object, global_object.object_prototype());
     if (vm.exception())
         return nullptr;
@@ -226,12 +225,8 @@ Object* create_unmapped_arguments_object(GlobalObject& global_object, Vector<Val
     for (auto& argument : arguments)
         object->indexed_properties().append(argument);
 
-    // FIXME: 8. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false }).
-    PropertyAttributes attributes;
-    attributes.set_has_configurable();
-    attributes.set_has_enumerable();
-
-    object->define_property(vm.names.callee, js_undefined(), attributes);
+    // 8. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false }).
+    object->define_accessor(vm.names.callee, global_object.throw_type_error_function(), global_object.throw_type_error_function(), 0);
     if (vm.exception())
         return nullptr;
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 ArrayBufferConstructor::ArrayBufferConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.ArrayBuffer, *global_object.function_prototype())
+    : NativeFunction(vm().names.ArrayBuffer.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -17,7 +17,7 @@
 namespace JS {
 
 ArrayConstructor::ArrayConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Array, *global_object.function_prototype())
+    : NativeFunction(vm().names.Array.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -15,7 +15,7 @@
 namespace JS {
 
 BigIntConstructor::BigIntConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.BigInt, *global_object.function_prototype())
+    : NativeFunction(vm().names.BigInt.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 BooleanConstructor::BooleanConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Boolean, *global_object.function_prototype())
+    : NativeFunction(vm().names.Boolean.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -76,6 +76,7 @@ namespace JS {
     P(byteOffset)                            \
     P(call)                                  \
     P(callee)                                \
+    P(caller)                                \
     P(cause)                                 \
     P(cbrt)                                  \
     P(ceil)                                  \

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 DataViewConstructor::DataViewConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.DataView, *global_object.function_prototype())
+    : NativeFunction(vm().names.DataView.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -121,7 +121,7 @@ static Value parse_simplified_iso8601(const String& iso_8601)
 }
 
 DateConstructor::DateConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Date, *global_object.function_prototype())
+    : NativeFunction(vm().names.Date.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 ErrorConstructor::ErrorConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Error, *global_object.function_prototype())
+    : NativeFunction(vm().names.Error.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -145,6 +145,8 @@
     M(RegExpCompileError, "RegExp compile error: {}")                                                                                   \
     M(RegExpObjectBadFlag, "Invalid RegExp flag '{}'")                                                                                  \
     M(RegExpObjectRepeatedFlag, "Repeated RegExp flag '{}'")                                                                            \
+    M(RestrictedFunctionPropertiesAccess, "Restricted function properties like 'callee', 'caller' and 'arguments' may "                 \
+                                          "not be accessed in strict mode")                                                             \
     M(SpeciesConstructorDidNotCreate, "Species constructor did not create {}")                                                          \
     M(SpeciesConstructorReturned, "Species constructor returned {}")                                                                    \
     M(StringMatchAllNonGlobalRegExp, "RegExp argument is non-global")                                                                   \

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 FinalizationRegistryConstructor::FinalizationRegistryConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.FinalizationRegistry, *global_object.function_prototype())
+    : NativeFunction(vm().names.FinalizationRegistry.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -16,7 +16,7 @@
 namespace JS {
 
 FunctionConstructor::FunctionConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Function, *global_object.function_prototype())
+    : NativeFunction(vm().names.Function.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -38,6 +38,8 @@ public:
 
     FunctionObject* eval_function() const { return m_eval_function; }
 
+    FunctionObject* throw_type_error_function() const { return m_throw_type_error_function; }
+
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* snake_name##_constructor() { return m_##snake_name##_constructor; } \
     Object* snake_name##_prototype() { return m_##snake_name##_prototype; }
@@ -99,6 +101,7 @@ private:
 #undef __JS_ENUMERATE
 
     FunctionObject* m_eval_function;
+    FunctionObject* m_throw_type_error_function;
 };
 
 template<typename ConstructorType>

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 MapConstructor::MapConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Map, *global_object.function_prototype())
+    : NativeFunction(vm().names.Map.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -20,16 +20,16 @@ NativeFunction::NativeFunction(Object& prototype)
 {
 }
 
-NativeFunction::NativeFunction(PropertyName const& name, Function<Value(VM&, GlobalObject&)> native_function, Object& prototype)
+NativeFunction::NativeFunction(FlyString name, Function<Value(VM&, GlobalObject&)> native_function, Object& prototype)
     : FunctionObject(prototype)
-    , m_name(name.as_string())
+    , m_name(move(name))
     , m_native_function(move(native_function))
 {
 }
 
-NativeFunction::NativeFunction(PropertyName const& name, Object& prototype)
+NativeFunction::NativeFunction(FlyString name, Object& prototype)
     : FunctionObject(prototype)
-    , m_name(name.as_string())
+    , m_name(move(name))
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -17,7 +17,7 @@ class NativeFunction : public FunctionObject {
 public:
     static NativeFunction* create(GlobalObject&, const FlyString& name, Function<Value(VM&, GlobalObject&)>);
 
-    explicit NativeFunction(PropertyName const& name, Function<Value(VM&, GlobalObject&)>, Object& prototype);
+    explicit NativeFunction(FlyString name, Function<Value(VM&, GlobalObject&)>, Object& prototype);
     virtual void initialize(GlobalObject&) override { }
     virtual ~NativeFunction() override;
 
@@ -30,7 +30,7 @@ public:
     virtual bool is_strict_mode() const override;
 
 protected:
-    NativeFunction(PropertyName const& name, Object& prototype);
+    NativeFunction(FlyString name, Object& prototype);
     explicit NativeFunction(Object& prototype);
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -24,7 +24,7 @@ constexpr const double MIN_SAFE_INTEGER_VALUE { -(__builtin_pow(2, 53) - 1) };
 namespace JS {
 
 NumberConstructor::NumberConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Number, *global_object.function_prototype())
+    : NativeFunction(vm().names.Number.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -18,7 +18,7 @@
 namespace JS {
 
 ObjectConstructor::ObjectConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Object, *global_object.function_prototype())
+    : NativeFunction(vm().names.Object.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -16,7 +16,7 @@
 namespace JS {
 
 PromiseConstructor::PromiseConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Promise, *global_object.function_prototype())
+    : NativeFunction(vm().names.Promise.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -29,7 +29,7 @@ static ProxyObject* proxy_create(GlobalObject& global_object, Value target, Valu
 }
 
 ProxyConstructor::ProxyConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Proxy, *global_object.function_prototype())
+    : NativeFunction(vm().names.Proxy.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 RegExpConstructor::RegExpConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.RegExp, *global_object.function_prototype())
+    : NativeFunction(vm().names.RegExp.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 SetConstructor::SetConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Set, *global_object.function_prototype())
+    : NativeFunction(vm().names.Set.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -15,7 +15,7 @@
 namespace JS {
 
 StringConstructor::StringConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.String, *global_object.function_prototype())
+    : NativeFunction(vm().names.String.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 SymbolConstructor::SymbolConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.Symbol, *global_object.function_prototype())
+    : NativeFunction(vm().names.Symbol.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -16,7 +16,7 @@ TypedArrayConstructor::TypedArrayConstructor(const FlyString& name, Object& prot
 }
 
 TypedArrayConstructor::TypedArrayConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.TypedArray, *global_object.function_prototype())
+    : NativeFunction(vm().names.TypedArray.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 WeakMapConstructor::WeakMapConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.WeakMap, *global_object.function_prototype())
+    : NativeFunction(vm().names.WeakMap.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 WeakRefConstructor::WeakRefConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.WeakRef, *global_object.function_prototype())
+    : NativeFunction(vm().names.WeakRef.as_string(), *global_object.function_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
@@ -14,7 +14,7 @@
 namespace JS {
 
 WeakSetConstructor::WeakSetConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.WeakSet, *global_object.function_prototype())
+    : NativeFunction(vm().names.WeakSet.as_string(), *global_object.function_prototype())
 {
 }
 


### PR DESCRIPTION
This includes a small fix to NativeFunction's constructor as well.