### PR TITLE
Tests: Run on target tests with deadly UBSAN

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -169,7 +169,7 @@ User=anon
 [TestRunner@ttyS0]
 Executable=/home/anon/tests/run-tests-and-shutdown.sh
 StdIO=/dev/ttyS0
-Environment=DO_SHUTDOWN_AFTER_TESTS=1 TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin TESTS_ONLY=1
+Environment=DO_SHUTDOWN_AFTER_TESTS=1 TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin TESTS_ONLY=1 UBSAN_OPTIONS=halt_on_error=1
 User=anon
 WorkingDirectory=/home/anon
 BootModes=self-test

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.h
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteReader.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <LibCrypto/Hash/HashFunction.h>
@@ -35,8 +36,10 @@ public:
 
     explicit GHash(const ReadonlyBytes& key)
     {
-        for (size_t i = 0; i < 16; i += 4)
-            m_key[i / 4] = AK::convert_between_host_and_big_endian(*(const u32*)(key.offset(i)));
+        VERIFY(key.size() >= 16);
+        for (size_t i = 0; i < 16; i += 4) {
+            m_key[i / 4] = AK::convert_between_host_and_big_endian(ByteReader::load32(key.offset(i)));
+        }
     }
 
     constexpr static size_t digest_size() { return TagType::Size; }

--- a/Userland/Libraries/LibSanitizer/UBSanitizer.cpp
+++ b/Userland/Libraries/LibSanitizer/UBSanitizer.cpp
@@ -10,7 +10,7 @@
 using namespace AK::UBSanitizer;
 
 // FIXME: Parse option from UBSAN_OPTIONS: halt_on_error=0 or 1
-bool AK::UBSanitizer::g_ubsan_is_deadly { false }; // FIXME: Make true!!
+bool AK::UBSanitizer::g_ubsan_is_deadly { false };
 
 #define WARNLN_AND_DBGLN(fmt, ...) \
     warnln(fmt, ##__VA_ARGS__);    \
@@ -28,6 +28,15 @@ static void print_location(const SourceLocation& location)
     // FIXME: Dump backtrace of this process (with symbols? without symbols?) in case the user wants non-deadly UBSAN
     //    Should probably go through the kernel for SC_dump_backtrace, then access the loader's symbol tables rather than
     //    going through the symbolizer service?
+
+    static bool checked_env_for_deadly = false;
+    if (!checked_env_for_deadly) {
+        checked_env_for_deadly = true;
+        StringView options = getenv("UBSAN_OPTIONS");
+        // FIXME: Parse more options and complain about invalid options
+        if (!options.is_null() && options.contains("halt_on_error=1"))
+            g_ubsan_is_deadly = true;
+    }
     if (g_ubsan_is_deadly) {
         WARNLN_AND_DBGLN("UB is configured to be deadly");
         VERIFY_NOT_REACHED();


### PR DESCRIPTION
Set UBSAN to deadly for running tests only.

Fix a LibCrypto unaligned read along the way.

There still might be UBSAN violations getting shouted into the void by daemon services, like with #7447, but this will keep our on-target tests from going off the rails and adding UB.

