### PR TITLE
LibJS: Rewrite String.raw() closer to the specification

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -150,7 +150,6 @@
     M(SpeciesConstructorDidNotCreate, "Species constructor did not create {}")                                                          \
     M(SpeciesConstructorReturned, "Species constructor returned {}")                                                                    \
     M(StringMatchAllNonGlobalRegExp, "RegExp argument is non-global")                                                                   \
-    M(StringRawCannotConvert, "Cannot convert property 'raw' to object from {}")                                                        \
     M(StringRepeatCountMustBe, "repeat count must be a {} number")                                                                      \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \
     M(ThisIsAlreadyInitialized, "|this| is already initialized")                                                                        \

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.raw.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.raw.js
@@ -27,5 +27,5 @@ test("basic functionality", () => {
 test("passing object with no 'raw' property", () => {
     expect(() => {
         String.raw({});
-    }).toThrowWithMessage(TypeError, "Cannot convert property 'raw' to object from undefined");
+    }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
 });


### PR DESCRIPTION
This includes not throwing a custom exception and using the length_of_array_like abstract operation where required.

This fixes 6 test262 test cases.