### PR TITLE
LibTLS+LibHTTP: Ensure finish_up() is not called more than once

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpsJob.cpp
@@ -38,9 +38,6 @@ void HttpsJob::start()
             });
         }
     };
-    m_socket->on_tls_finished = [&] {
-        finish_up();
-    };
     m_socket->on_tls_certificate_request = [this](auto&) {
         if (on_certificate_requested)
             on_certificate_requested(*this);

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -360,6 +360,7 @@ void Job::timer_event(Core::TimerEvent& event)
 
 void Job::finish_up()
 {
+    VERIFY(m_state != State::Finished);
     m_state = State::Finished;
     if (!m_can_stream_response) {
         auto flattened_buffer = ByteBuffer::create_uninitialized(m_received_size);

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -195,7 +195,7 @@ bool TLSv12::check_connection_state(bool read)
         return false;
     }
     if (((read && m_context.application_buffer.size() == 0) || !read) && m_context.connection_finished) {
-        if (m_context.application_buffer.size() == 0) {
+        if (m_context.application_buffer.size() == 0 && m_context.connection_status != ConnectionStatus::Disconnected) {
             if (on_tls_finished)
                 on_tls_finished();
         }


### PR DESCRIPTION
There's no reason to manually call it on TLS close, the HTTP reading
logic is smart enough to handle connection closes transparently.
Fixes #8211.
Also closes #8213.