### PR TITLE
LibJS: Bring Reflect.construct() closer to the specification

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -138,6 +138,7 @@
     M(ReferenceNullishSetProperty, "Cannot set property '{}' of {}")                                                                    \
     M(ReferencePrimitiveSetProperty, "Cannot set property '{}' of {} '{}'")                                                             \
     M(ReferenceUnresolvable, "Unresolvable reference")                                                                                  \
+    M(ReflectArgumentMustBeAConstructor, "First argument of Reflect.{}() must be a constructor")                                        \
     M(ReflectArgumentMustBeAFunction, "First argument of Reflect.{}() must be a function")                                              \
     M(ReflectArgumentMustBeAnObject, "First argument of Reflect.{}() must be an object")                                                \
     M(ReflectBadNewTarget, "Optional third argument of Reflect.construct() must be a constructor")                                      \

--- a/Userland/Libraries/LibJS/Tests/builtins/Reflect/Reflect.construct.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Reflect/Reflect.construct.js
@@ -9,7 +9,7 @@ describe("errors", () => {
                 Reflect.construct(value);
             }).toThrowWithMessage(
                 TypeError,
-                "First argument of Reflect.construct() must be a function"
+                "First argument of Reflect.construct() must be a constructor"
             );
         });
     });


### PR DESCRIPTION
This includes checking that the target is a constructor, not just a function, as well as switching the order of the list creation and argument validation to match the specification, to ensure correct exception throwing order.

This fixes 1 test262 test case :^)