### PR TITLE
LibGUI+DisplaySettings: Make FontSettings font previews use theme colors

### DIFF
--- a/Userland/Applications/DisplaySettings/FontSettings.gml
+++ b/Userland/Applications/DisplaySettings/FontSettings.gml
@@ -20,7 +20,7 @@
         }
 
         @GUI::Frame {
-            background_color: "white"
+            background_role: "Base"
             fill_with_background_color: true
 
             layout: @GUI::VerticalBoxLayout {
@@ -53,7 +53,7 @@
         }
 
         @GUI::Frame {
-            background_color: "white"
+            background_role: "Base"
             fill_with_background_color: true
 
             layout: @GUI::VerticalBoxLayout {

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -21,6 +21,7 @@
 #include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
+#include <LibGfx/SystemTheme.h>
 #include <unistd.h>
 
 REGISTER_CORE_OBJECT(GUI, Widget)
@@ -134,6 +135,50 @@ Widget::Widget()
                 set_palette(_palette);
                 return true;
             }
+            return false;
+        });
+
+    register_property(
+        "foreground_role", [this]() -> JsonValue { return Gfx::to_string(foreground_role()); },
+        [this](auto& value) {
+            if (!value.is_string())
+                return false;
+            auto str = value.as_string();
+            if (str == "NoRole") {
+                set_foreground_role(Gfx::ColorRole::NoRole);
+                return true;
+            }
+#undef __ENUMERATE_COLOR_ROLE
+#define __ENUMERATE_COLOR_ROLE(role)               \
+    else if (str == #role)                         \
+    {                                              \
+        set_foreground_role(Gfx::ColorRole::role); \
+        return true;                               \
+    }
+            ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
+#undef __ENUMERATE_COLOR_ROLE
+            return false;
+        });
+
+    register_property(
+        "background_role", [this]() -> JsonValue { return Gfx::to_string(background_role()); },
+        [this](auto& value) {
+            if (!value.is_string())
+                return false;
+            auto str = value.as_string();
+            if (str == "NoRole") {
+                set_background_role(Gfx::ColorRole::NoRole);
+                return true;
+            }
+#undef __ENUMERATE_COLOR_ROLE
+#define __ENUMERATE_COLOR_ROLE(role)               \
+    else if (str == #role)                         \
+    {                                              \
+        set_background_role(Gfx::ColorRole::role); \
+        return true;                               \
+    }
+            ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
+#undef __ENUMERATE_COLOR_ROLE
             return false;
         });
 }


### PR DESCRIPTION
The Font Settings currently force the font preview box to have a white background. This not only looks inconsistent on some themes but also makes the text completely unreadable with themes like "Dark" or "Basalt" that use white text.

This PR adds two properties to `GUI::Widget` that allow specifying of `Gfx::ColorRole`s instead of colors in GML files and changes `FontSettings.gml` to make use of this new feature.

This is what the result looks like:
![font_settings_fix](https://user-images.githubusercontent.com/43982164/123633703-0d0a0d80-d809-11eb-8fb8-84225c2ea6be.png)
