### PR TITLE
AK: Improve JsonObject and JsonArray

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -78,7 +78,7 @@ using OrderedHashTable = HashTable<T, TraitsForT, true>;
 template<typename K, typename V, typename KeyTraits = Traits<K>, bool IsOrdered = false>
 class HashMap;
 
-template<typename K, typename V, typename KeyTraits>
+template<typename K, typename V, typename KeyTraits = Traits<K>>
 using OrderedHashMap = HashMap<K, V, KeyTraits, true>;
 
 template<typename T>

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -48,11 +48,11 @@ public:
         return *this;
     }
 
-    size_t size() const { return m_values.size(); }
-    bool is_empty() const { return m_values.is_empty(); }
+    [[nodiscard]] size_t size() const { return m_values.size(); }
+    [[nodiscard]] bool is_empty() const { return m_values.is_empty(); }
 
-    JsonValue const& at(size_t index) const { return m_values.at(index); }
-    JsonValue const& operator[](size_t index) const { return at(index); }
+    [[nodiscard]] JsonValue const& at(size_t index) const { return m_values.at(index); }
+    [[nodiscard]] JsonValue const& operator[](size_t index) const { return at(index); }
 
     void clear() { m_values.clear(); }
     void append(JsonValue value) { m_values.append(move(value)); }
@@ -64,7 +64,7 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    String to_string() const { return serialized<StringBuilder>(); }
+    [[nodiscard]] String to_string() const { return serialized<StringBuilder>(); }
 
     template<typename Callback>
     void for_each(Callback callback) const
@@ -73,7 +73,7 @@ public:
             callback(value);
     }
 
-    Vector<JsonValue> const& values() const { return m_values; }
+    [[nodiscard]] Vector<JsonValue> const& values() const { return m_values; }
 
     void ensure_capacity(size_t capacity) { m_values.ensure_capacity(capacity); }
 

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -17,7 +17,7 @@ public:
     JsonArray() = default;
     ~JsonArray() = default;
 
-    JsonArray(const JsonArray& other)
+    JsonArray(JsonArray const& other)
         : m_values(other.m_values)
     {
     }
@@ -28,13 +28,13 @@ public:
     }
 
     template<typename T>
-    JsonArray(const Vector<T>& vector)
+    JsonArray(Vector<T> const& vector)
     {
         for (auto& value : vector)
             m_values.append(move(value));
     }
 
-    JsonArray& operator=(const JsonArray& other)
+    JsonArray& operator=(JsonArray const& other)
     {
         if (this != &other)
             m_values = other.m_values;
@@ -51,8 +51,8 @@ public:
     int size() const { return m_values.size(); }
     bool is_empty() const { return m_values.is_empty(); }
 
-    const JsonValue& at(size_t index) const { return m_values.at(index); }
-    const JsonValue& operator[](size_t index) const { return at(index); }
+    JsonValue const& at(size_t index) const { return m_values.at(index); }
+    JsonValue const& operator[](size_t index) const { return at(index); }
 
     void clear() { m_values.clear(); }
     void append(JsonValue value) { m_values.append(move(value)); }
@@ -73,7 +73,7 @@ public:
             callback(value);
     }
 
-    const Vector<JsonValue>& values() const { return m_values; }
+    Vector<JsonValue> const& values() const { return m_values; }
 
     void ensure_capacity(int capacity) { m_values.ensure_capacity(capacity); }
 

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -48,7 +48,7 @@ public:
         return *this;
     }
 
-    int size() const { return m_values.size(); }
+    size_t size() const { return m_values.size(); }
     bool is_empty() const { return m_values.is_empty(); }
 
     JsonValue const& at(size_t index) const { return m_values.at(index); }
@@ -56,7 +56,7 @@ public:
 
     void clear() { m_values.clear(); }
     void append(JsonValue value) { m_values.append(move(value)); }
-    void set(int index, JsonValue value) { m_values[index] = move(value); }
+    void set(size_t index, JsonValue value) { m_values[index] = move(value); }
 
     template<typename Builder>
     typename Builder::OutputType serialized() const;
@@ -75,7 +75,7 @@ public:
 
     Vector<JsonValue> const& values() const { return m_values; }
 
-    void ensure_capacity(int capacity) { m_values.ensure_capacity(capacity); }
+    void ensure_capacity(size_t capacity) { m_values.ensure_capacity(capacity); }
 
 private:
     Vector<JsonValue> m_values;

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -21,32 +21,26 @@ public:
     ~JsonObject() = default;
 
     JsonObject(JsonObject const& other)
-        : m_order(other.m_order)
-        , m_members(other.m_members)
+        : m_members(other.m_members)
     {
     }
 
     JsonObject(JsonObject&& other)
-        : m_order(move(other.m_order))
-        , m_members(move(other.m_members))
+        : m_members(move(other.m_members))
     {
     }
 
     JsonObject& operator=(JsonObject const& other)
     {
-        if (this != &other) {
+        if (this != &other)
             m_members = other.m_members;
-            m_order = other.m_order;
-        }
         return *this;
     }
 
     JsonObject& operator=(JsonObject&& other)
     {
-        if (this != &other) {
+        if (this != &other)
             m_members = move(other.m_members);
-            m_order = move(other.m_order);
-        }
         return *this;
     }
 
@@ -80,27 +74,19 @@ public:
 
     void set(String const& key, JsonValue value)
     {
-        if (m_members.set(key, move(value)) == HashSetResult::ReplacedExistingEntry)
-            m_order.remove(m_order.find_first_index(key).value());
-        m_order.append(key);
+        m_members.set(key, move(value));
     }
 
     template<typename Callback>
     void for_each_member(Callback callback) const
     {
-        for (size_t i = 0; i < m_order.size(); ++i) {
-            auto property = m_order[i];
-            callback(property, m_members.get(property).value());
-        }
+        for (auto& member : m_members)
+            callback(member.key, member.value);
     }
 
     bool remove(String const& key)
     {
-        if (m_members.remove(key)) {
-            m_order.remove(m_order.find_first_index(key).value());
-            return true;
-        }
-        return false;
+        return m_members.remove(key);
     }
 
     template<typename Builder>
@@ -112,8 +98,7 @@ public:
     String to_string() const { return serialized<StringBuilder>(); }
 
 private:
-    Vector<String> m_order;
-    HashMap<String, JsonValue> m_members;
+    OrderedHashMap<String, JsonValue> m_members;
 };
 
 template<typename Builder>

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -78,6 +78,64 @@ public:
         return m_members.contains(key);
     }
 
+    bool has_null(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_null();
+    }
+    bool has_bool(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_bool();
+    }
+    bool has_string(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_string();
+    }
+    bool has_i32(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_i32();
+    }
+    bool has_u32(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_u32();
+    }
+    bool has_i64(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_i64();
+    }
+    bool has_u64(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_u64();
+    }
+    bool has_number(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_number();
+    }
+    bool has_array(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_array();
+    }
+    bool has_object(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_object();
+    }
+#ifndef KERNEL
+    bool has_double(String const& key) const
+    {
+        auto* value = get_ptr(key);
+        return value && value->is_double();
+    }
+#endif
+
     void set(String const& key, JsonValue value)
     {
         m_members.set(key, move(value));

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -44,7 +44,7 @@ public:
         return *this;
     }
 
-    int size() const { return m_members.size(); }
+    size_t size() const { return m_members.size(); }
     bool is_empty() const { return m_members.is_empty(); }
 
     JsonValue const& get(String const& key) const

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,7 +20,7 @@ public:
     JsonObject() = default;
     ~JsonObject() = default;
 
-    JsonObject(const JsonObject& other)
+    JsonObject(JsonObject const& other)
         : m_order(other.m_order)
         , m_members(other.m_members)
     {
@@ -31,7 +32,7 @@ public:
     {
     }
 
-    JsonObject& operator=(const JsonObject& other)
+    JsonObject& operator=(JsonObject const& other)
     {
         if (this != &other) {
             m_members = other.m_members;
@@ -52,19 +53,19 @@ public:
     int size() const { return m_members.size(); }
     bool is_empty() const { return m_members.is_empty(); }
 
-    JsonValue get(const String& key) const
+    JsonValue get(String const& key) const
     {
         auto* value = get_ptr(key);
         return value ? *value : JsonValue(JsonValue::Type::Null);
     }
 
-    JsonValue get_or(const String& key, const JsonValue& alternative) const
+    JsonValue get_or(String const& key, JsonValue const& alternative) const
     {
         auto* value = get_ptr(key);
         return value ? *value : alternative;
     }
 
-    const JsonValue* get_ptr(const String& key) const
+    JsonValue const* get_ptr(String const& key) const
     {
         auto it = m_members.find(key);
         if (it == m_members.end())
@@ -72,12 +73,12 @@ public:
         return &(*it).value;
     }
 
-    bool has(const String& key) const
+    bool has(String const& key) const
     {
         return m_members.contains(key);
     }
 
-    void set(const String& key, JsonValue value)
+    void set(String const& key, JsonValue value)
     {
         if (m_members.set(key, move(value)) == HashSetResult::ReplacedExistingEntry)
             m_order.remove(m_order.find_first_index(key).value());
@@ -93,7 +94,7 @@ public:
         }
     }
 
-    bool remove(const String& key)
+    bool remove(String const& key)
     {
         if (m_members.remove(key)) {
             m_order.remove(m_order.find_first_index(key).value());

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -59,12 +59,6 @@ public:
         return *value;
     }
 
-    JsonValue get_or(String const& key, JsonValue const& alternative) const
-    {
-        auto* value = get_ptr(key);
-        return value ? *value : alternative;
-    }
-
     JsonValue const* get_ptr(String const& key) const
     {
         auto it = m_members.find(key);

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -44,10 +44,10 @@ public:
         return *this;
     }
 
-    size_t size() const { return m_members.size(); }
-    bool is_empty() const { return m_members.is_empty(); }
+    [[nodiscard]] size_t size() const { return m_members.size(); }
+    [[nodiscard]] bool is_empty() const { return m_members.is_empty(); }
 
-    JsonValue const& get(String const& key) const
+    [[nodiscard]] JsonValue const& get(String const& key) const
     {
         auto* value = get_ptr(key);
         static JsonValue* s_null_value { nullptr };
@@ -59,7 +59,7 @@ public:
         return *value;
     }
 
-    JsonValue const* get_ptr(String const& key) const
+    [[nodiscard]] JsonValue const* get_ptr(String const& key) const
     {
         auto it = m_members.find(key);
         if (it == m_members.end())
@@ -67,63 +67,63 @@ public:
         return &(*it).value;
     }
 
-    bool has(String const& key) const
+    [[nodiscard]] [[nodiscard]] bool has(String const& key) const
     {
         return m_members.contains(key);
     }
 
-    bool has_null(String const& key) const
+    [[nodiscard]] bool has_null(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_null();
     }
-    bool has_bool(String const& key) const
+    [[nodiscard]] bool has_bool(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_bool();
     }
-    bool has_string(String const& key) const
+    [[nodiscard]] bool has_string(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_string();
     }
-    bool has_i32(String const& key) const
+    [[nodiscard]] bool has_i32(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_i32();
     }
-    bool has_u32(String const& key) const
+    [[nodiscard]] bool has_u32(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_u32();
     }
-    bool has_i64(String const& key) const
+    [[nodiscard]] bool has_i64(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_i64();
     }
-    bool has_u64(String const& key) const
+    [[nodiscard]] bool has_u64(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_u64();
     }
-    bool has_number(String const& key) const
+    [[nodiscard]] bool has_number(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_number();
     }
-    bool has_array(String const& key) const
+    [[nodiscard]] bool has_array(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_array();
     }
-    bool has_object(String const& key) const
+    [[nodiscard]] bool has_object(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_object();
     }
 #ifndef KERNEL
-    bool has_double(String const& key) const
+    [[nodiscard]] [[nodiscard]] bool has_double(String const& key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_double();
@@ -153,7 +153,7 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    String to_string() const { return serialized<StringBuilder>(); }
+    [[nodiscard]] String to_string() const { return serialized<StringBuilder>(); }
 
 private:
     OrderedHashMap<String, JsonValue> m_members;

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -47,10 +47,16 @@ public:
     int size() const { return m_members.size(); }
     bool is_empty() const { return m_members.is_empty(); }
 
-    JsonValue get(String const& key) const
+    JsonValue const& get(String const& key) const
     {
         auto* value = get_ptr(key);
-        return value ? *value : JsonValue(JsonValue::Type::Null);
+        static JsonValue* s_null_value { nullptr };
+        if (!value) {
+            if (!s_null_value)
+                s_null_value = new JsonValue;
+            return *s_null_value;
+        }
+        return *value;
     }
 
     JsonValue get_or(String const& key, JsonValue const& alternative) const

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -90,7 +90,7 @@ bool JsonValue::equals(const JsonValue& other) const
 
     if (is_array() && other.is_array() && as_array().size() == other.as_array().size()) {
         bool result = true;
-        for (int i = 0; i < as_array().size(); ++i) {
+        for (size_t i = 0; i < as_array().size(); ++i) {
             result &= as_array().at(i).equals(other.as_array().at(i));
         }
         return result;

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -69,7 +69,7 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    String as_string_or(const String& alternative)
+    String as_string_or(String const& alternative) const
     {
         if (is_string())
             return as_string();

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -376,7 +376,7 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
             format.background_color = Color::from_string(value.as_string());
     };
 
-    cells.for_each_member([&](auto& name, JsonValue& value) {
+    cells.for_each_member([&](auto& name, JsonValue const& value) {
         auto position_option = sheet->parse_cell_name(name);
         if (!position_option.has_value())
             return IterationDecision::Continue;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -343,10 +343,8 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
     auto rows = object.get("rows").to_u32(default_row_count);
     auto columns = object.get("columns");
     auto name = object.get("name").as_string_or("Sheet");
-    auto cells_value = object.get_or("cells", JsonObject {});
-    if (!cells_value.is_object())
-        return nullptr;
-    auto& cells = cells_value.as_object();
+    if (object.has("cells") && !object.has_object("cells"))
+        return {};
 
     sheet->set_name(name);
 
@@ -376,77 +374,79 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
             format.background_color = Color::from_string(value.as_string());
     };
 
-    cells.for_each_member([&](auto& name, JsonValue const& value) {
-        auto position_option = sheet->parse_cell_name(name);
-        if (!position_option.has_value())
-            return IterationDecision::Continue;
-
-        auto position = position_option.value();
-        auto& obj = value.as_object();
-        auto kind = obj.get("kind").as_string_or("LiteralString") == "LiteralString" ? Cell::LiteralString : Cell::Formula;
-
-        OwnPtr<Cell> cell;
-        switch (kind) {
-        case Cell::LiteralString:
-            cell = make<Cell>(obj.get("value").to_string(), position, *sheet);
-            break;
-        case Cell::Formula: {
-            auto& interpreter = sheet->interpreter();
-            auto value = interpreter.vm().call(parse_function, json, JS::js_string(interpreter.heap(), obj.get("value").as_string()));
-            cell = make<Cell>(obj.get("source").to_string(), move(value), position, *sheet);
-            break;
-        }
-        }
-
-        auto type_name = obj.get_or("type", "Numeric").to_string();
-        cell->set_type(type_name);
-
-        auto type_meta = obj.get("type_metadata");
-        if (type_meta.is_object()) {
-            auto& meta_obj = type_meta.as_object();
-            auto meta = cell->type_metadata();
-            if (auto value = meta_obj.get("length"); value.is_number())
-                meta.length = value.to_i32();
-            if (auto value = meta_obj.get("format"); value.is_string())
-                meta.format = value.as_string();
-            read_format(meta.static_format, meta_obj);
-
-            cell->set_type_metadata(move(meta));
-        }
-
-        auto conditional_formats = obj.get("conditional_formats");
-        auto cformats = cell->conditional_formats();
-        if (conditional_formats.is_array()) {
-            conditional_formats.as_array().for_each([&](const auto& fmt_val) {
-                if (!fmt_val.is_object())
-                    return IterationDecision::Continue;
-
-                auto& fmt_obj = fmt_val.as_object();
-                auto fmt_cond = fmt_obj.get("condition").to_string();
-                if (fmt_cond.is_empty())
-                    return IterationDecision::Continue;
-
-                ConditionalFormat fmt;
-                fmt.condition = move(fmt_cond);
-                read_format(fmt, fmt_obj);
-                cformats.append(move(fmt));
-
+    if (object.has_object("cells")) {
+        object.get("cells").as_object().for_each_member([&](auto& name, JsonValue const& value) {
+            auto position_option = sheet->parse_cell_name(name);
+            if (!position_option.has_value())
                 return IterationDecision::Continue;
-            });
-            cell->set_conditional_formats(move(cformats));
-        }
 
-        auto evaluated_format = obj.get("evaluated_formats");
-        if (evaluated_format.is_object()) {
-            auto& evaluated_format_obj = evaluated_format.as_object();
-            auto& evaluated_fmts = cell->evaluated_formats();
+            auto position = position_option.value();
+            auto& obj = value.as_object();
+            auto kind = obj.get("kind").as_string_or("LiteralString") == "LiteralString" ? Cell::LiteralString : Cell::Formula;
 
-            read_format(evaluated_fmts, evaluated_format_obj);
-        }
+            OwnPtr<Cell> cell;
+            switch (kind) {
+            case Cell::LiteralString:
+                cell = make<Cell>(obj.get("value").to_string(), position, *sheet);
+                break;
+            case Cell::Formula: {
+                auto& interpreter = sheet->interpreter();
+                auto value = interpreter.vm().call(parse_function, json, JS::js_string(interpreter.heap(), obj.get("value").as_string()));
+                cell = make<Cell>(obj.get("source").to_string(), move(value), position, *sheet);
+                break;
+            }
+            }
 
-        sheet->m_cells.set(position, cell.release_nonnull());
-        return IterationDecision::Continue;
-    });
+            auto type_name = obj.has("type") ? obj.get("type").to_string() : "Numeric";
+            cell->set_type(type_name);
+
+            auto type_meta = obj.get("type_metadata");
+            if (type_meta.is_object()) {
+                auto& meta_obj = type_meta.as_object();
+                auto meta = cell->type_metadata();
+                if (auto value = meta_obj.get("length"); value.is_number())
+                    meta.length = value.to_i32();
+                if (auto value = meta_obj.get("format"); value.is_string())
+                    meta.format = value.as_string();
+                read_format(meta.static_format, meta_obj);
+
+                cell->set_type_metadata(move(meta));
+            }
+
+            auto conditional_formats = obj.get("conditional_formats");
+            auto cformats = cell->conditional_formats();
+            if (conditional_formats.is_array()) {
+                conditional_formats.as_array().for_each([&](const auto& fmt_val) {
+                    if (!fmt_val.is_object())
+                        return IterationDecision::Continue;
+
+                    auto& fmt_obj = fmt_val.as_object();
+                    auto fmt_cond = fmt_obj.get("condition").to_string();
+                    if (fmt_cond.is_empty())
+                        return IterationDecision::Continue;
+
+                    ConditionalFormat fmt;
+                    fmt.condition = move(fmt_cond);
+                    read_format(fmt, fmt_obj);
+                    cformats.append(move(fmt));
+
+                    return IterationDecision::Continue;
+                });
+                cell->set_conditional_formats(move(cformats));
+            }
+
+            auto evaluated_format = obj.get("evaluated_formats");
+            if (evaluated_format.is_object()) {
+                auto& evaluated_format_obj = evaluated_format.as_object();
+                auto& evaluated_fmts = cell->evaluated_formats();
+
+                read_format(evaluated_fmts, evaluated_format_obj);
+            }
+
+            sheet->m_cells.set(position, cell.release_nonnull());
+            return IterationDecision::Continue;
+        });
+    }
 
     return sheet;
 }

--- a/Userland/DevTools/Inspector/RemoteObjectPropertyModel.cpp
+++ b/Userland/DevTools/Inspector/RemoteObjectPropertyModel.cpp
@@ -22,7 +22,7 @@ int RemoteObjectPropertyModel::row_count(const GUI::ModelIndex& index) const
             return value.as_array().size();
         else if (value.is_object())
             return value.as_object().size();
-        return 0;
+        return (size_t)0;
     };
 
     if (index.is_valid()) {

--- a/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
+++ b/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
@@ -58,7 +58,7 @@ void CommonLocationsProvider::load_from_json(const String& json_path)
 
     s_common_locations.clear();
     auto contents = json.value().as_array();
-    for (auto i = 0; i < contents.size(); ++i) {
+    for (size_t i = 0; i < contents.size(); ++i) {
         auto entry_value = contents.at(i);
         if (!entry_value.is_object())
             continue;

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -59,7 +59,7 @@ bool JsonArrayModel::set(int row, Vector<JsonValue>&& values)
 {
     VERIFY(values.size() == m_fields.size());
 
-    if (row >= m_array.size())
+    if ((size_t)row >= m_array.size())
         return false;
 
     JsonObject obj;
@@ -76,12 +76,12 @@ bool JsonArrayModel::set(int row, Vector<JsonValue>&& values)
 
 bool JsonArrayModel::remove(int row)
 {
-    if (row >= m_array.size())
+    if ((size_t)row >= m_array.size())
         return false;
 
     JsonArray new_array;
-    for (int i = 0; i < m_array.size(); ++i)
-        if (i != row)
+    for (size_t i = 0; i < m_array.size(); ++i)
+        if (i != (size_t)row)
             new_array.append(m_array.at(i));
 
     m_array = new_array;

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -74,7 +74,7 @@ Vector<u32> CharacterMapFile::read_map(const JsonObject& json, const String& nam
     buffer.resize(CHAR_MAP_SIZE);
 
     auto map_arr = json.get(name).as_array();
-    for (int i = 0; i < map_arr.size(); i++) {
+    for (size_t i = 0; i < map_arr.size(); i++) {
         auto key_value = map_arr.at(i).as_string();
         if (key_value.length() == 0) {
             buffer[i] = 0;

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
@@ -100,10 +100,14 @@ bool is_pseudo_property(PropertyID property_id)
     json.value().as_object().for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
 
-        auto pseudo = value.as_object().get_or("pseudo", false);
-        VERIFY(pseudo.is_bool());
+        bool pseudo = false;
+        if (value.as_object().has("pseudo")) {
+            auto& pseudo_value = value.as_object().get("pseudo");
+            VERIFY(pseudo_value.is_bool());
+            pseudo = pseudo_value.as_bool();
+        }
 
-        if (pseudo.as_bool()) {
+        if (pseudo) {
             auto member_generator = generator.fork();
             member_generator.set("name:titlecase", title_casify(name));
             member_generator.append(R"~~~(

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -59,7 +59,7 @@ private:
 static Vector<Quote> parse_all(const JsonArray& array)
 {
     Vector<Quote> quotes;
-    for (int i = 0; i < array.size(); ++i) {
+    for (size_t i = 0; i < array.size(); ++i) {
         Optional<Quote> q = Quote::try_parse(array[i]);
         if (!q.has_value()) {
             warnln("WARNING: Could not parse quote #{}!", i);

--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -112,7 +112,7 @@ static void print(const String& name, const JsonValue& value, Vector<String>& tr
     if (value.is_array()) {
         outln("{}[]{};", color_brace, color_off);
         trail.append(String::formatted("{}{}{}", color_name, name, color_off));
-        for (int i = 0; i < value.as_array().size(); ++i) {
+        for (size_t i = 0; i < value.as_array().size(); ++i) {
             auto element_name = String::formatted("{}{}[{}{}{}{}{}]{}", color_off, color_brace, color_off, color_index, i, color_off, color_brace, color_off);
             print(element_name, value.as_array()[i], trail);
         }


### PR DESCRIPTION
This PR aims to improve the APIs and performance of `JsonObject` and `JsonArray`.

* Use east const style.
* Use `OrderedHashMap` instead of a `Vector` and regular `HashMap` for `JsonObject`.
* Return a `JsonValue const&` from `JsonObject::get(String const& key)` instead of copying the value.
* `int` => `size_t` where applicable.
* Add `bool JsonObject::has_{array,object,string,...}(String const& key)` methods to simplify validation of correct JSON structure.
* Remove `JsonValue JsonObject::get_or(String const& key, JsonValue const& default)` method, as it's not easily possible to avoid copy-construction there, and some callers used it in a way that possibly large `JsonObject`s were copied.
* Use `[[nodiscard]]` where applicable.