### PR TITLE
LibJS: Remove PropertyName::to_value and fix proxy traps

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -544,10 +544,19 @@ Object* create_mapped_arguments_object(GlobalObject& global_object, FunctionObje
 }
 
 // 7.1.21 CanonicalNumericIndexString ( argument ), https://tc39.es/ecma262/#sec-canonicalnumericindexstring
-Value canonical_numeric_index_string(GlobalObject& global_object, Value argument)
+Value canonical_numeric_index_string(GlobalObject& global_object, PropertyName const& property_name)
 {
+    // NOTE: If the property name is a number type (An implementation-defined optimized
+    // property key type), it can be treated as a string property that has already been
+    // converted successfully into a canonical numeric index.
+
+    VERIFY(property_name.is_string() || property_name.is_number());
+
+    if (property_name.is_number())
+        return Value(property_name.as_number());
+
     // 1. Assert: Type(argument) is String.
-    VERIFY(argument.is_string());
+    auto argument = Value(js_string(global_object.vm(), property_name.as_string()));
 
     // 2. If argument is "-0", return -0𝔽.
     if (argument.as_string().string() == "-0")

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -29,7 +29,7 @@ bool validate_and_apply_property_descriptor(Object*, PropertyName const&, bool e
 Object* get_prototype_from_constructor(GlobalObject&, FunctionObject const& constructor, Object* (GlobalObject::*intrinsic_default_prototype)());
 Object* create_unmapped_arguments_object(GlobalObject&, Vector<Value> const& arguments);
 Object* create_mapped_arguments_object(GlobalObject&, FunctionObject&, Vector<FunctionNode::Parameter> const&, Vector<Value> const& arguments, Environment&);
-Value canonical_numeric_index_string(GlobalObject&, Value);
+Value canonical_numeric_index_string(GlobalObject&, PropertyName const&);
 
 enum class CallerMode {
     Strict,

--- a/Userland/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyName.h
@@ -176,17 +176,6 @@ public:
         return StringOrSymbol(as_symbol());
     }
 
-    Value to_value(VM& vm) const
-    {
-        if (is_string())
-            return js_string(vm, m_string);
-        if (is_number())
-            return Value(m_number);
-        if (is_symbol())
-            return m_symbol;
-        return js_undefined();
-    }
-
 private:
     Type m_type { Type::Invalid };
     bool m_string_may_be_number { true };

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -31,6 +31,19 @@ ProxyObject::~ProxyObject()
 {
 }
 
+static Value property_name_to_value(VM& vm, PropertyName const& name)
+{
+    VERIFY(name.is_valid());
+    if (name.is_symbol())
+        return name.as_symbol();
+
+    if (name.is_string())
+        return js_string(vm, name.as_string());
+
+    VERIFY(name.is_number());
+    return js_string(vm, String::number(name.as_number()));
+}
+
 // 10.5.1 [[GetPrototypeOf]] ( ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
 Object* ProxyObject::internal_get_prototype_of() const
 {
@@ -287,7 +300,7 @@ Optional<PropertyDescriptor> ProxyObject::internal_get_own_property(const Proper
     }
 
     // 8. Let trapResultObj be ? Call(trap, handler, « target, P »).
-    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name.to_value(vm));
+    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name_to_value(vm, property_name));
     if (vm.exception())
         return {};
 
@@ -408,7 +421,7 @@ bool ProxyObject::internal_define_own_property(PropertyName const& property_name
     auto descriptor_object = from_property_descriptor(global_object, property_descriptor);
 
     // 9. Let booleanTrapResult be ! ToBoolean(? Call(trap, handler, « target, P, descObj »)).
-    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name.to_value(vm), descriptor_object);
+    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name_to_value(vm, property_name), descriptor_object);
     if (vm.exception())
         return {};
 
@@ -506,7 +519,7 @@ bool ProxyObject::internal_has_property(PropertyName const& property_name) const
     }
 
     // 8. Let booleanTrapResult be ! ToBoolean(? Call(trap, handler, « target, P »)).
-    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name.to_value(vm));
+    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name_to_value(vm, property_name));
     if (vm.exception())
         return {};
 
@@ -576,7 +589,7 @@ Value ProxyObject::internal_get(PropertyName const& property_name, Value receive
     }
 
     // 8. Let trapResult be ? Call(trap, handler, « target, P, Receiver »).
-    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name.to_value(vm), receiver);
+    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name_to_value(vm, property_name), receiver);
     if (vm.exception())
         return {};
 
@@ -644,7 +657,7 @@ bool ProxyObject::internal_set(PropertyName const& property_name, Value value, V
     }
 
     // 8. Let booleanTrapResult be ! ToBoolean(? Call(trap, handler, « target, P, V, Receiver »)).
-    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name.to_value(vm), value, receiver);
+    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name_to_value(vm, property_name), value, receiver);
     if (vm.exception())
         return {};
 
@@ -713,7 +726,7 @@ bool ProxyObject::internal_delete(PropertyName const& property_name)
     }
 
     // 8. Let booleanTrapResult be ! ToBoolean(? Call(trap, handler, « target, P »)).
-    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name.to_value(vm));
+    auto trap_result = vm.call(*trap, &m_handler, &m_target, property_name_to_value(vm, property_name));
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -29,9 +29,9 @@ void Reference::put_value(GlobalObject& global_object, Value value)
         // FIXME: This is an ad-hoc hack until we support proper variable bindings.
         if (!m_base_value.is_object() && vm.in_strict_mode()) {
             if (m_base_value.is_nullish())
-                vm.throw_exception<TypeError>(global_object, ErrorType::ReferenceNullishSetProperty, m_name.to_value(vm).to_string_without_side_effects(), m_base_value.to_string_without_side_effects());
+                vm.throw_exception<TypeError>(global_object, ErrorType::ReferenceNullishSetProperty, m_name, m_base_value.to_string_without_side_effects());
             else
-                vm.throw_exception<TypeError>(global_object, ErrorType::ReferencePrimitiveSetProperty, m_name.to_value(vm).to_string_without_side_effects(), m_base_value.typeof(), m_base_value.to_string_without_side_effects());
+                vm.throw_exception<TypeError>(global_object, ErrorType::ReferencePrimitiveSetProperty, m_name, m_base_value.typeof(), m_base_value.to_string_without_side_effects());
             return;
         }
 
@@ -43,7 +43,7 @@ void Reference::put_value(GlobalObject& global_object, Value value)
         if (vm.exception())
             return;
         if (!succeeded && m_strict) {
-            vm.throw_exception<TypeError>(global_object, ErrorType::ReferenceNullishSetProperty, m_name.to_value(vm).to_string_without_side_effects(), m_base_value.to_string_without_side_effects());
+            vm.throw_exception<TypeError>(global_object, ErrorType::ReferenceNullishSetProperty, m_name, m_base_value.to_string_without_side_effects());
             return;
         }
         return;
@@ -68,7 +68,7 @@ void Reference::put_value(GlobalObject& global_object, Value value)
 
     if (!succeeded && m_strict) {
         // FIXME: This is a hack and will disappear when we support proper variable bindings.
-        vm.throw_exception<TypeError>(global_object, ErrorType::DescWriteNonWritable, m_name.to_value(vm).to_string_without_side_effects());
+        vm.throw_exception<TypeError>(global_object, ErrorType::DescWriteNonWritable, m_name);
         return;
     }
 }
@@ -153,7 +153,7 @@ bool Reference::delete_(GlobalObject& global_object)
 
         // e. If deleteStatus is false and ref.[[Strict]] is true, throw a TypeError exception.
         if (!delete_status && m_strict) {
-            vm.throw_exception<TypeError>(global_object, ErrorType::ReferenceNullishDeleteProperty, m_name.to_value(vm).to_string_without_side_effects(), m_base_value.to_string_without_side_effects());
+            vm.throw_exception<TypeError>(global_object, ErrorType::ReferenceNullishDeleteProperty, m_name, m_base_value.to_string_without_side_effects());
             return {};
         }
 

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -45,8 +45,6 @@ void StringObject::visit_edges(Cell::Visitor& visitor)
 // 10.4.3.5 StringGetOwnProperty ( S, P ),https://tc39.es/ecma262/#sec-stringgetownproperty
 static Optional<PropertyDescriptor> string_get_own_property(GlobalObject& global_object, StringObject const& string, PropertyName const& property_name)
 {
-    auto& vm = global_object.vm();
-
     // 1. Assert: S is an Object that has a [[StringData]] internal slot.
     // 2. Assert: IsPropertyKey(P) is true.
     VERIFY(property_name.is_valid());
@@ -58,14 +56,7 @@ static Optional<PropertyDescriptor> string_get_own_property(GlobalObject& global
         return {};
 
     // 4. Let index be ! CanonicalNumericIndexString(P).
-    // NOTE: If the property name is a number type (An implementation-defined optimized
-    // property key type), it can be treated as a string property that has already been
-    // converted successfully into a canonical numeric index.
-    Value index;
-    if (property_name.is_string())
-        index = canonical_numeric_index_string(global_object, property_name.to_value(vm));
-    else
-        index = Value(property_name.as_number());
+    auto index = canonical_numeric_index_string(global_object, property_name);
     // 5. If index is undefined, return undefined.
     if (index.is_undefined())
         return {};

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -185,19 +185,14 @@ public:
         // 2. Assert: O is an Integer-Indexed exotic object.
 
         // NOTE: If the property name is a number type (An implementation-defined optimized
-        // property key type), it can be treated as a string property that has already been
-        // converted successfully into a canonical numeric index.
+        // property key type), it can be treated as a string property that will transparently be
+        // converted into a canonical numeric index.
 
         // 3. If Type(P) is String, then
         // NOTE: This includes an implementation-defined optimization, see note above!
         if (property_name.is_string() || property_name.is_number()) {
             // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-            // NOTE: This includes an implementation-defined optimization, see note above!
-            Value numeric_index;
-            if (property_name.is_string())
-                numeric_index = canonical_numeric_index_string(global_object(), property_name.to_value(vm()));
-            else
-                numeric_index = Value(property_name.as_number());
+            auto numeric_index = canonical_numeric_index_string(global_object(), property_name);
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
                 // i. Let value be ! IntegerIndexedElementGet(O, numericIndex).
@@ -230,19 +225,14 @@ public:
         // 2. Assert: O is an Integer-Indexed exotic object.
 
         // NOTE: If the property name is a number type (An implementation-defined optimized
-        // property key type), it can be treated as a string property that has already been
-        // converted successfully into a canonical numeric index.
+        // property key type), it can be treated as a string property that will transparently be
+        // converted into a canonical numeric index.
 
         // 3. If Type(P) is String, then
         // NOTE: This includes an implementation-defined optimization, see note above!
         if (property_name.is_string() || property_name.is_number()) {
             // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-            // NOTE: This includes an implementation-defined optimization, see note above!
-            Value numeric_index;
-            if (property_name.is_string())
-                numeric_index = canonical_numeric_index_string(global_object(), property_name.to_value(vm()));
-            else
-                numeric_index = Value(property_name.as_number());
+            auto numeric_index = canonical_numeric_index_string(global_object(), property_name);
             // b. If numericIndex is not undefined, return ! IsValidIntegerIndex(O, numericIndex).
             if (!numeric_index.is_undefined())
                 return is_valid_integer_index(*this, numeric_index);
@@ -261,19 +251,14 @@ public:
         // 2. Assert: O is an Integer-Indexed exotic object.
 
         // NOTE: If the property name is a number type (An implementation-defined optimized
-        // property key type), it can be treated as a string property that has already been
-        // converted successfully into a canonical numeric index.
+        // property key type), it can be treated as a string property that will transparently be
+        // converted into a canonical numeric index.
 
         // 3. If Type(P) is String, then
         // NOTE: This includes an implementation-defined optimization, see note above!
         if (property_name.is_string() || property_name.is_number()) {
             // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-            // NOTE: This includes an implementation-defined optimization, see note above!
-            Value numeric_index;
-            if (property_name.is_string())
-                numeric_index = canonical_numeric_index_string(global_object(), property_name.to_value(vm()));
-            else
-                numeric_index = Value(property_name.as_number());
+            auto numeric_index = canonical_numeric_index_string(global_object(), property_name);
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
                 // i. If ! IsValidIntegerIndex(O, numericIndex) is false, return false.
@@ -319,21 +304,15 @@ public:
 
         // 1. Assert: IsPropertyKey(P) is true.
         VERIFY(property_name.is_valid());
-
         // NOTE: If the property name is a number type (An implementation-defined optimized
-        // property key type), it can be treated as a string property that has already been
-        // converted successfully into a canonical numeric index.
+        // property key type), it can be treated as a string property that will transparently be
+        // converted into a canonical numeric index.
 
         // 2. If Type(P) is String, then
         // NOTE: This includes an implementation-defined optimization, see note above!
         if (property_name.is_string() || property_name.is_number()) {
             // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-            // NOTE: This includes an implementation-defined optimization, see note above!
-            Value numeric_index;
-            if (property_name.is_string())
-                numeric_index = canonical_numeric_index_string(global_object(), property_name.to_value(vm()));
-            else
-                numeric_index = Value(property_name.as_number());
+            auto numeric_index = canonical_numeric_index_string(global_object(), property_name);
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
                 // i. Return ! IntegerIndexedElementGet(O, numericIndex).
@@ -353,21 +332,15 @@ public:
 
         // 1. Assert: IsPropertyKey(P) is true.
         VERIFY(property_name.is_valid());
-
         // NOTE: If the property name is a number type (An implementation-defined optimized
-        // property key type), it can be treated as a string property that has already been
-        // converted successfully into a canonical numeric index.
+        // property key type), it can be treated as a string property that will transparently be
+        // converted into a canonical numeric index.
 
         // 2. If Type(P) is String, then
         // NOTE: This includes an implementation-defined optimization, see note above!
         if (property_name.is_string() || property_name.is_number()) {
             // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-            // NOTE: This includes an implementation-defined optimization, see note above!
-            Value numeric_index;
-            if (property_name.is_string())
-                numeric_index = canonical_numeric_index_string(global_object(), property_name.to_value(vm()));
-            else
-                numeric_index = Value(property_name.as_number());
+            auto numeric_index = canonical_numeric_index_string(global_object(), property_name);
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
                 // i. Perform ? IntegerIndexedElementSet(O, numericIndex, V).
@@ -391,21 +364,15 @@ public:
         VERIFY(property_name.is_valid());
 
         // 2. Assert: O is an Integer-Indexed exotic object.
-
         // NOTE: If the property name is a number type (An implementation-defined optimized
-        // property key type), it can be treated as a string property that has already been
-        // converted successfully into a canonical numeric index.
+        // property key type), it can be treated as a string property that will transparently be
+        // converted into a canonical numeric index.
 
         // 3. If Type(P) is String, then
         // NOTE: This includes an implementation-defined optimization, see note above!
         if (property_name.is_string() || property_name.is_number()) {
             // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-            // NOTE: This includes an implementation-defined optimization, see note above!
-            Value numeric_index;
-            if (property_name.is_string())
-                numeric_index = canonical_numeric_index_string(global_object(), property_name.to_value(vm()));
-            else
-                numeric_index = Value(property_name.as_number());
+            auto numeric_index = canonical_numeric_index_string(global_object(), property_name);
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
                 // i. If ! IsValidIntegerIndex(O, numericIndex) is false, return true; else return false.

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-defineProperty.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-defineProperty.js
@@ -27,6 +27,25 @@ describe("[[DefineProperty]] trap normal behavior", () => {
         Object.defineProperty(p, "foo", { configurable: true, writable: true, value: 10 });
     });
 
+    test("correct arguments passed to trap even for number", () => {
+        let o = {};
+        p = new Proxy(o, {
+            defineProperty(target, name, descriptor) {
+                expect(target).toBe(o);
+                expect(name).toBe("1");
+                expect(descriptor.configurable).toBeTrue();
+                expect(descriptor.enumerable).toBeUndefined();
+                expect(descriptor.writable).toBeTrue();
+                expect(descriptor.value).toBe(10);
+                expect(descriptor.get).toBeUndefined();
+                expect(descriptor.set).toBeUndefined();
+                return true;
+            },
+        });
+
+        Object.defineProperty(p, 1, { configurable: true, writable: true, value: 10 });
+    });
+
     test("optionally ignoring the define call", () => {
         let o = {};
         let p = new Proxy(o, {

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-deleteProperty.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-deleteProperty.js
@@ -18,6 +18,19 @@ describe("[[Delete]] trap normal behavior", () => {
         delete p.foo;
     });
 
+    test("correct arguments passed to trap even for number", () => {
+        let o = {};
+        let p = new Proxy(o, {
+            deleteProperty(target, property) {
+                expect(target).toBe(o);
+                expect(property).toBe("1");
+                return true;
+            },
+        });
+
+        delete p[1];
+    });
+
     test("conditional deletion", () => {
         o = { foo: 1, bar: 2 };
         p = new Proxy(o, {

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
@@ -18,6 +18,19 @@ describe("[[Get]] trap normal behavior", () => {
         p.foo;
     });
 
+    test("correct arguments passed to trap even for number", () => {
+        let o = {};
+        let p = new Proxy(o, {
+            get(target, property, receiver) {
+                expect(target).toBe(o);
+                expect(property).toBe("1");
+                expect(receiver).toBe(p);
+            },
+        });
+
+        p[1];
+    });
+
     test("conditional return", () => {
         let o = { foo: 1 };
         let p = new Proxy(o, {

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-getOwnPropertyDescriptor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-getOwnPropertyDescriptor.js
@@ -24,6 +24,18 @@ describe("[Call][GetOwnProperty]] trap normal behavior", () => {
         Object.getOwnPropertyDescriptor(p, "foo");
     });
 
+    test("correct arguments passed to trap even for number", () => {
+        let o = {};
+        let p = new Proxy(o, {
+            getOwnPropertyDescriptor(target, property) {
+                expect(target).toBe(o);
+                expect(property).toBe("1");
+            },
+        });
+
+        Object.getOwnPropertyDescriptor(p, 1);
+    });
+
     test("conditional returned descriptor", () => {
         let o = { foo: "bar" };
         Object.defineProperty(o, "baz", {

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-has.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-has.js
@@ -18,6 +18,19 @@ describe("[[Has]] trap normal behavior", () => {
         "foo" in p;
     });
 
+    test("correct arguments passed to trap even for number", () => {
+        let o = {};
+        let p = new Proxy(o, {
+            has(target, prop) {
+                expect(target).toBe(o);
+                expect(prop).toBe("1");
+                return true;
+            },
+        });
+
+        1 in p;
+    });
+
     test("conditional return", () => {
         let o = {};
         let p = new Proxy(o, {

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
@@ -20,6 +20,21 @@ describe("[[Set]] trap normal behavior", () => {
         p.foo = 10;
     });
 
+    test("correct arguments passed to trap even for number", () => {
+        let o = {};
+        let p = new Proxy(o, {
+            set(target, prop, value, receiver) {
+                expect(target).toBe(o);
+                expect(prop).toBe("1");
+                expect(value).toBe(10);
+                expect(receiver).toBe(p);
+                return true;
+            },
+        });
+
+        p[1] = 10;
+    });
+
     test("conditional return value", () => {
         let p = new Proxy(
             {},


### PR DESCRIPTION
Removed PropertyName::to_value, the only usage were:
- To build an error message (Reference.cpp) -> Switched to using the supplied formatter
- To call `CanonicalNumericIndexString(P)` -> replaced with a method on PropertyName
- To supply the value for traps in Proxy which gave the wrong type -> extra method added in ProxyObject

I'm not completely happy with this solution but it is good enough and allows us to "hide" the number optimization

Another option is adding an overload for the CanonicalNumericIndexString abstract operation with PropertyName
(Also it fixes at least one test262 test if I remember correctly and probably more since proxy is used in more places)