### PR TITLE
Documentation+AK: Update smart pointer documentation and make small improvements

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -98,17 +98,26 @@ public:
         return exchange(m_ptr, nullptr);
     }
 
-    T* ptr() { return m_ptr; }
-    const T* ptr() const { return m_ptr; }
+    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
+    {
+        VERIFY(m_ptr);
+        return m_ptr;
+    }
 
-    T* operator->() { return m_ptr; }
-    const T* operator->() const { return m_ptr; }
+    ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
+    {
+        VERIFY(m_ptr);
+        return m_ptr;
+    }
 
-    T& operator*() { return *m_ptr; }
-    const T& operator*() const { return *m_ptr; }
+    ALWAYS_INLINE RETURNS_NONNULL T* operator->() { return ptr(); }
+    ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const { return ptr(); }
 
-    operator const T*() const { return m_ptr; }
-    operator T*() { return m_ptr; }
+    ALWAYS_INLINE T& operator*() { return *ptr(); }
+    ALWAYS_INLINE const T& operator*() const { return *ptr(); }
+
+    ALWAYS_INLINE RETURNS_NONNULL operator const T*() const { return ptr(); }
+    ALWAYS_INLINE RETURNS_NONNULL operator T*() { return ptr(); }
 
     operator bool() const = delete;
     bool operator!() const = delete;

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -156,20 +156,20 @@ public:
         return *ptr;
     }
 
-    ALWAYS_INLINE T* ptr()
+    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE const T* ptr() const
+    ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T* operator->()
+    ALWAYS_INLINE RETURNS_NONNULL T* operator->()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE const T* operator->() const
+    ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const
     {
         return as_nonnull_ptr();
     }
@@ -183,11 +183,11 @@ public:
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator T*()
+    ALWAYS_INLINE RETURNS_NONNULL operator T*()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE operator const T*() const
+    ALWAYS_INLINE RETURNS_NONNULL operator const T*() const
     {
         return as_nonnull_ptr();
     }
@@ -232,7 +232,7 @@ private:
         return (T*)(m_bits.load(AK::MemoryOrder::memory_order_relaxed) & ~(FlatPtr)1);
     }
 
-    ALWAYS_INLINE T* as_nonnull_ptr() const
+    ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
     {
         T* ptr = (T*)(m_bits.load(AK::MemoryOrder::memory_order_relaxed) & ~(FlatPtr)1);
         VERIFY(ptr);

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -40,6 +40,11 @@
 #endif
 #define FLATTEN __attribute__((flatten))
 
+#ifdef RETURNS_NONNULL
+#    undef RETURNS_NONNULL
+#endif
+#define RETURNS_NONNULL __attribute__((returns_nonnull))
+
 #ifdef NO_SANITIZE_ADDRESS
 #    undef NO_SANITIZE_ADDRESS
 #endif

--- a/Documentation/SmartPointers.md
+++ b/Documentation/SmartPointers.md
@@ -15,9 +15,15 @@ The reason for using these pointers is to make it explicit through code who owns
 
 This means that the `OwnPtr` is responsible for deleting the pointee when the `OwnPtr` goes out of scope.
 
+These pointers cannot be copied. Transferring ownership is done by moving the pointer.
+
 `NonnullOwnPtr` is a special variant of `OwnPtr` with one additional property: it cannot be null. `NonnullOwnPtr` is suitable as a return type from functions that are guaranteed to never return null, and as an argument type where ownership is transferred, and the argument may not be null. In other words, if `OwnPtr` is "\*", then `NonnullOwnPtr` is "&".
 
-There is a `make<T>()` helper that creates a new object and returns it wrapped in an `NonnullOwnPtr`.
+Note: A `NonnullOwnPtr` can be assigned to an `OwnPtr` but not vice versa. To transform an known-non-null `OwnPtr` into a `NonnullOwnPtr`, use `OwnPtr::release_nonnull()`.
+
+### Construction using helper functions
+
+There is a `make<T>()` helper that constructs a new object and returns it wrapped in a `NonnullOwnPtr`. All arguments passed to it are forwarded to `T`'s constructor. If it fails to allocate heap memory for the object, it terminates the program.
 
 ```cpp
 {
@@ -27,7 +33,39 @@ There is a `make<T>()` helper that creates a new object and returns it wrapped i
 }
 ```
 
-Note: A `NonnullOwnPtr` can be assigned to an `OwnPtr` but not vice versa. To transform an known-non-null `OwnPtr` into a `NonnullOwnPtr`, use `OwnPtr::release_nonnull()`.
+The `try_make<T>()` helper attempts to construct a new object wrapped in an `OwnPtr`. All arguments passed to it are forwarded to `T`'s constructor. In case of allocation failure, a null pointer is returned. This allows the calling code to handle allocation failure as it wishes.
+
+```cpp
+OwnPtr<Foo> my_object = try_make<Foo>();
+if (!my_object) {
+    // handle allocation failure...
+}
+my_object->do_stuff();
+```
+
+Note: Objects constructed using `try_make<T>()` should only be dereferenced after a null check.
+
+### Manual construction
+
+The helper functions cannot access private constructors, so in some cases, smart pointers need to be created manually. This is done by "adopting" a raw pointer, which moves its ownership to the smart pointer. Dereferencing the raw pointer or calling its destructor afterwards can cause undefined behavior.
+
+Known non-null pointers can be turned into a `NonnullOwnPtr` by the global `adopt_own()` function.
+
+```cpp
+NonnullOwnPtr<Foo> my_object = adopt_own(*new Foo);
+```
+
+It is safe to immediately dereference this raw pointer, as the normal `new` expression cannot return a null pointer.
+
+Any (possibly null) pointer to `T` can be turned into an `OwnPtr<T>` by the global `adopt_own_if_nonnull()` function.
+
+```cpp
+OwnPtr<Foo> my_object = adopt_own_if_nonnull(new (nothrow) Foo);
+```
+
+In this case, the *non-throwing* `new` should be used to construct the raw pointer, which returns null if the allocation fails, instead of aborting the program.
+
+**Note:** Always prefer the helper functions to manual construction.
 
 ----
 ## RefPtr<T> and NonnullRefPtr<T>
@@ -42,20 +80,56 @@ Objects can only be held by `RefPtr` if they meet certain criteria. Specifically
 
 To make a class `T` reference-counted, you can simply make it inherit from `RefCounted<T>`. This will add all the necessary pieces to `T`.
 
-**Note:** When constructing an object that derives from `RefCounted`, the reference count starts out at 1 (since 0 would mean that the object has no owners and should be deleted.) The object must therefore be "adopted" by someone who takes responsibility of that 1. This is done through the global `adopt_ref()` function:
-
 ```cpp
 class Bar : public RefCounted<Bar> {
     ...
 };
+```
 
-RefPtr<Bar> our_object = adopt_ref(*new Bar);
+Note: A `NonnullRefPtr` can be assigned to a `RefPtr` but not vice versa. To transform an known-non-null `RefPtr` into a `NonnullRefPtr`, either use `RefPtr::release_nonnull()` or simply dereference the `RefPtr` using its `operator*`.
+
+### Construction using helper functions
+
+There is a `create<T>()` global helper function that constructs a new object and returns it wrapped in a `NonnullRefPtr`. All arguments passed to it are forwarded to `T`'s constructor. If memory cannot be allocated for the object, the program is terminated.
+
+```cpp
+NonnullRefPtr<Bar> our_object = create<Bar>();
+NonnullRefPtr<Bar> another_owner = our_object;
+```
+
+
+The `try_create<T>()` function constructs an object wrapped in `RefPtr<T>` which may be null if the allocation does not succeed. This allows the calling code to handle allocation failure as it wishes. All arguments passed to it are forwarded to `T`'s constructor.
+
+```cpp
+RefPtr<Bar> our_object = try_create<Bar>();
+if (!our_object) {
+    // handle allocation failure...
+}
 RefPtr<Bar> another_owner = our_object;
 ```
 
-In the above example, the Bar object will only be deleted once both `our_object` and `another_owner` are gone.
+In the above examples, the Bar object will only be deleted once both `our_object` and `another_owner` are gone.
 
-Note: A `NonnullRefPtr` can be assigned to a `RefPtr` but not vice versa. To transform an known-non-null `RefPtr` into a `NonnullRefPtr`, either use `RefPtr::release_nonnull()` or simply dereference the `RefPtr` using its `operator*`.
+### Manual construction
+
+The helper functions cannot access private constructors, so in some cases, objects need to be manually wrapped into smart pointers. When constructing an object that derives from `RefCounted`, the reference count starts out at 1 (since 0 would mean that the object has no owners and should be deleted). The object must therefore be "adopted" by someone who takes responsibility of that 1. The raw pointer must not be used after its ownership is transferred to the smart pointer.
+
+A known non-null raw pointer can be turned into a `NonnullRefPtr` by the global `adopt_ref()` function.
+
+```cpp
+NonnullRefPtr<Bar> our_object = adopt_ref(*new Bar);
+```
+
+Note: It is safe to immediately dereference this raw pointer, as the normal `new` expression cannot return a null pointer.
+
+Any (possibly null) pointer to a reference-counted object can can be turned into a `RefPtr` by the global `adopt_ref_if_nonnull()` function.
+
+```cpp
+RefPtr<Bar> our_object = adopt_ref_if_nonnull(new (nothrow) Bar);
+```
+In this case, the *non-throwing* `new` should be used to construct the raw pointer, which returns null if the allocation fails, instead of aborting the program.
+
+**Note:** Always prefer the helper functions to manual construction.
 
 ----
 ## WeakPtr<T>
@@ -73,7 +147,7 @@ class Baz : public Weakable<Baz> {
 
 WeakPtr<Baz> a_baz;
 {
-    OwnPtr<Baz> my_baz = make<Baz>();
+    NonnullOwnPtr<Baz> my_baz = make<Baz>();
     a_baz = my_baz->make_weak_ptr();
     // a_baz now points to my_baz
 }

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -10,7 +10,12 @@
 #define __STRINGIFY(x) __STRINGIFY_HELPER(x)
 
 [[noreturn]] void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func);
-#define VERIFY(expr) (static_cast<bool>(expr) ? void(0) : __assertion_failed(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#define VERIFY(expr)                                                            \
+    do {                                                                        \
+        if (!static_cast<bool>(expr)) [[unlikely]]                              \
+            __assertion_failed(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__); \
+    } while (0)
+
 #define VERIFY_NOT_REACHED() VERIFY(false)
 
 extern "C" {

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<FullDevice> FullDevice::must_create()
 {
-    return adopt_ref_if_nonnull(new FullDevice).release_nonnull();
+    return adopt_ref(*new FullDevice);
 }
 
 UNMAP_AFTER_INIT FullDevice::FullDevice()
@@ -45,5 +45,4 @@ KResultOr<size_t> FullDevice::write(FileDescription&, u64, const UserOrKernelBuf
         return 0;
     return ENOSPC;
 }
-
 }

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -17,7 +17,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<MemoryDevice> MemoryDevice::must_create()
 {
-    return adopt_ref_if_nonnull(new MemoryDevice).release_nonnull();
+    return adopt_ref(*new MemoryDevice);
 }
 
 UNMAP_AFTER_INIT MemoryDevice::MemoryDevice()

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -13,7 +13,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<RandomDevice> RandomDevice::must_create()
 {
-    return adopt_ref_if_nonnull(new RandomDevice).release_nonnull();
+    return adopt_ref(*new RandomDevice);
 }
 
 UNMAP_AFTER_INIT RandomDevice::RandomDevice()

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -14,7 +14,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<ZeroDevice> ZeroDevice::must_create()
 {
-    return adopt_ref_if_nonnull(new ZeroDevice).release_nonnull();
+    return adopt_ref(*new ZeroDevice);
 }
 
 UNMAP_AFTER_INIT ZeroDevice::ZeroDevice()

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1775,7 +1775,7 @@ RefPtr<Value> IfCond::run(RefPtr<Shell> shell)
 {
     auto cond = m_condition->run(shell)->resolve_without_cast(shell);
     // The condition could be a builtin, in which case it has already run and exited.
-    if (cond && cond->is_job()) {
+    if (cond->is_job()) {
         auto cond_job_value = static_cast<const JobValue*>(cond.ptr());
         auto cond_job = cond_job_value->job();
 


### PR DESCRIPTION
This PR documents the changes to memory allocation and updates to smart pointers introduced in #8150.

Also, dereference operators of smart pointers have been marked RETURNS_NONNULL, so that compilers can avoid null checks.

`VERIFY()` was changed in the kernel to mark the failure case as unlikely. This will reduce the cost of using `Nonnull{Own,Ref}Ptr` even with all checks enabled.

Construction of `NonnullRefPtr<T>` has been tidied up in a couple of places in the kernel.