### PR TITLE
Kernel: Some minor cleanups

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -115,7 +115,7 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr base_pointer, bool use_ksym
     if (use_ksyms) {
         FlatPtr copied_stack_ptr[2];
         for (FlatPtr* stack_ptr = (FlatPtr*)base_pointer; stack_ptr && recognized_symbol_count < max_recognized_symbol_count; stack_ptr = (FlatPtr*)copied_stack_ptr[0]) {
-            if ((FlatPtr)stack_ptr < 0xc0000000)
+            if ((FlatPtr)stack_ptr < KERNEL_BASE)
                 break;
 
             void* fault_at;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -332,7 +332,7 @@ void create_signal_trampoline()
     g_signal_trampoline_region->remap();
 }
 
-void Process::crash(int signal, u32 eip, bool out_of_memory)
+void Process::crash(int signal, FlatPtr ip, bool out_of_memory)
 {
     VERIFY(!is_dead());
     VERIFY(Process::current() == this);
@@ -340,11 +340,11 @@ void Process::crash(int signal, u32 eip, bool out_of_memory)
     if (out_of_memory) {
         dbgln("\033[31;1mOut of memory\033[m, killing: {}", *this);
     } else {
-        if (eip >= 0xc0000000 && g_kernel_symbols_available) {
-            auto* symbol = symbolicate_kernel_address(eip);
-            dbgln("\033[31;1m{:p}  {} +{}\033[0m\n", eip, (symbol ? demangle(symbol->name) : "(k?)"), (symbol ? eip - symbol->address : 0));
+        if (ip >= 0xc0000000 && g_kernel_symbols_available) {
+            auto* symbol = symbolicate_kernel_address(ip);
+            dbgln("\033[31;1m{:p}  {} +{}\033[0m\n", ip, (symbol ? demangle(symbol->name) : "(k?)"), (symbol ? ip - symbol->address : 0));
         } else {
-            dbgln("\033[31;1m{:p}  (?)\033[0m\n", eip);
+            dbgln("\033[31;1m{:p}  (?)\033[0m\n", ip);
         }
         dump_backtrace();
     }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -340,7 +340,7 @@ void Process::crash(int signal, FlatPtr ip, bool out_of_memory)
     if (out_of_memory) {
         dbgln("\033[31;1mOut of memory\033[m, killing: {}", *this);
     } else {
-        if (ip >= 0xc0000000 && g_kernel_symbols_available) {
+        if (ip >= KERNEL_BASE && g_kernel_symbols_available) {
             auto* symbol = symbolicate_kernel_address(ip);
             dbgln("\033[31;1m{:p}  {} +{}\033[0m\n", ip, (symbol ? demangle(symbol->name) : "(k?)"), (symbol ? ip - symbol->address : 0));
         } else {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -421,7 +421,7 @@ public:
 
     static void initialize();
 
-    [[noreturn]] void crash(int signal, u32 eip, bool out_of_memory = false);
+    [[noreturn]] void crash(int signal, FlatPtr ip, bool out_of_memory = false);
     [[nodiscard]] siginfo_t wait_info();
 
     const TTY* tty() const { return m_tty; }

--- a/Kernel/Sections.h
+++ b/Kernel/Sections.h
@@ -10,3 +10,5 @@
 
 #define READONLY_AFTER_INIT __attribute__((section(".ro_after_init")))
 #define UNMAP_AFTER_INIT NEVER_INLINE __attribute__((section(".unmap_after_init")))
+
+#define KERNEL_BASE 0xC000'0000

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -717,7 +717,7 @@ RefPtr<PhysicalPage> MemoryManager::allocate_supervisor_physical_page()
         return {};
     }
 
-    fast_u32_fill((u32*)page->paddr().offset(0xc0000000).as_ptr(), 0, PAGE_SIZE / sizeof(u32));
+    fast_u32_fill((u32*)page->paddr().offset(KERNEL_BASE).as_ptr(), 0, PAGE_SIZE / sizeof(u32));
     ++m_super_physical_pages_used;
     return page;
 }

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -40,12 +40,12 @@ constexpr FlatPtr page_round_down(FlatPtr x)
 
 inline FlatPtr low_physical_to_virtual(FlatPtr physical)
 {
-    return physical + 0xc0000000;
+    return physical + KERNEL_BASE;
 }
 
 inline FlatPtr virtual_to_low_physical(FlatPtr virtual_)
 {
-    return virtual_ - 0xc0000000;
+    return virtual_ - KERNEL_BASE;
 }
 
 enum class UsedMemoryRangeType {
@@ -260,7 +260,7 @@ void VMObject::for_each_region(Callback callback)
 
 inline bool is_user_address(VirtualAddress vaddr)
 {
-    return vaddr.get() < 0xc0000000;
+    return vaddr.get() < KERNEL_BASE;
 }
 
 inline bool is_user_range(VirtualAddress vaddr, size_t size)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -22,13 +22,13 @@ namespace Kernel {
 
 constexpr bool page_round_up_would_wrap(FlatPtr x)
 {
-    return x > 0xfffff000u;
+    return x > (explode_byte(0xFF) & ~0xFFF);
 }
 
 constexpr FlatPtr page_round_up(FlatPtr x)
 {
     FlatPtr rounded = (((FlatPtr)(x)) + PAGE_SIZE - 1) & (~(PAGE_SIZE - 1));
-    // Rounding up >0xffff0000 wraps back to 0. That's never what we want.
+    // Rounding up >0xfffff000 wraps back to 0. That's never what we want.
     VERIFY(x == 0 || rounded != 0);
     return rounded;
 }

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -37,7 +37,7 @@ extern "C" PageDirectoryEntry boot_pd3[1024];
 
 UNMAP_AFTER_INIT PageDirectory::PageDirectory()
 {
-    m_range_allocator.initialize_with_range(VirtualAddress(0xc2000000), 0x2f000000);
+    m_range_allocator.initialize_with_range(VirtualAddress(KERNEL_BASE + 0x02000000), 0x2f000000);
     m_identity_range_allocator.initialize_with_range(VirtualAddress(FlatPtr(0x00000000)), 0x00200000);
 
     // Adopt the page tables already set up by boot.S
@@ -89,7 +89,7 @@ PageDirectory::PageDirectory(const RangeAllocator* parent_range_allocator)
     m_directory_pages[2] = MM.allocate_user_physical_page();
     if (!m_directory_pages[2])
         return;
-    // Share the top 1 GiB of kernel-only mappings (>=3GiB or >=0xc0000000)
+    // Share the top 1 GiB of kernel-only mappings (>=3GiB or >=KERNEL_BASE)
     m_directory_pages[3] = MM.kernel_page_directory().m_directory_pages[3];
 
 #if ARCH(X86_64)

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -13,6 +13,7 @@
 #include <Kernel/Arch/x86/PageFault.h>
 #include <Kernel/Heap/SlabAllocator.h>
 #include <Kernel/KString.h>
+#include <Kernel/Sections.h>
 #include <Kernel/VM/PageFaultResponse.h>
 #include <Kernel/VM/PurgeablePageRanges.h>
 #include <Kernel/VM/RangeAllocator.h>
@@ -87,7 +88,7 @@ public:
     void set_mmap(bool mmap) { m_mmap = mmap; }
 
     bool is_user() const { return !is_kernel(); }
-    bool is_kernel() const { return vaddr().get() < 0x00800000 || vaddr().get() >= 0xc0000000; }
+    bool is_kernel() const { return vaddr().get() < 0x00800000 || vaddr().get() >= KERNEL_BASE; }
 
     PageFaultResponse handle_fault(const PageFault&, ScopedSpinLock<RecursiveSpinLock>&);
 


### PR DESCRIPTION
**Kernel: Fix Process::crash assuming 32-bit mode**

**Kernel: Make and use KERNEL_BASE**
This is to make the 0xc0000000 less a magic number, and will make it
easier in the future to move the Kernel around


**Kernel: Fix page round wrap detection for 64-bit**
We were assuming 32-bit pointers, which will not always be the case
Also fixed an incorrect comment about wrapping
