### PR TITLE
LibJS: Mark FunctionObject::is_ordinary_function() as override

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.h
@@ -41,7 +41,7 @@ protected:
     virtual bool is_strict_mode() const final { return m_is_strict; }
 
 private:
-    virtual bool is_ordinary_function_object() const { return true; }
+    virtual bool is_ordinary_function_object() const override { return true; }
     virtual FunctionEnvironmentRecord* create_environment_record(FunctionObject&) override;
     virtual void visit_edges(Visitor&) override;
 


### PR DESCRIPTION
LibJS: Mark FunctionObject is_ordinary as override

I hope this is the only occurrence of this issue