### PR TITLE
WindowServer: Change animation time to duration

### DIFF
--- a/Userland/Services/WindowServer/Animation.cpp
+++ b/Userland/Services/WindowServer/Animation.cpp
@@ -20,9 +20,9 @@ Animation::~Animation()
     Compositor::the().unregister_animation({}, *this);
 }
 
-void Animation::set_length(int length_in_ms)
+void Animation::set_duration(int duration_in_ms)
 {
-    m_length = length_in_ms;
+    m_duration = duration_in_ms;
 }
 
 void Animation::start()
@@ -41,7 +41,7 @@ void Animation::stop()
 void Animation::update(Badge<Compositor>, Gfx::Painter& painter, Screen& screen, Gfx::DisjointRectSet& flush_rects)
 {
     int elapsed_ms = m_timer.elapsed();
-    float progress = min((float)elapsed_ms / (float)m_length, 1.0f);
+    float progress = min((float)elapsed_ms / (float)m_duration, 1.0f);
 
     if (on_update)
         on_update(progress, painter, screen, flush_rects);

--- a/Userland/Services/WindowServer/Animation.h
+++ b/Userland/Services/WindowServer/Animation.h
@@ -29,8 +29,8 @@ public:
     void start();
     void stop();
 
-    void set_length(int length_in_ms);
-    int length() const { return m_length; }
+    void set_duration(int duration_in_ms);
+    int duration() const { return m_duration; }
 
     void update(Badge<Compositor>, Gfx::Painter&, Screen&, Gfx::DisjointRectSet& flush_rects);
 
@@ -41,7 +41,7 @@ private:
     Animation();
 
     Core::ElapsedTimer m_timer;
-    int m_length { 0 };
+    int m_duration { 0 };
     bool m_running { false };
 };
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -346,7 +346,7 @@ void Window::start_minimize_animation()
     }
 
     m_animation = Animation::create();
-    m_animation->set_length(150);
+    m_animation->set_duration(150);
     m_animation->on_update = [this](float progress, Gfx::Painter& painter, Screen& screen, Gfx::DisjointRectSet& flush_rects) {
         Gfx::PainterStateSaver saver(painter);
         painter.set_draw_op(Gfx::Painter::DrawOp::Invert);
@@ -369,7 +369,7 @@ void Window::start_minimize_animation()
 void Window::start_launch_animation(Gfx::IntRect const& launch_origin_rect)
 {
     m_animation = Animation::create();
-    m_animation->set_length(150);
+    m_animation->set_duration(150);
     m_animation->on_update = [this, launch_origin_rect](float progress, Gfx::Painter& painter, Screen& screen, Gfx::DisjointRectSet& flush_rects) {
         Gfx::PainterStateSaver saver(painter);
         painter.set_draw_op(Gfx::Painter::DrawOp::Invert);


### PR DESCRIPTION
The time interval for animations is most often described as `duration` in animation contexts and the `WindowServer::Animation` class should reflect that.

This closes https://github.com/SerenityOS/serenity/issues/8292.