### PR TITLE
LibHTTP: Relax the finish_up() "must be called once" limitation a bit

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -360,7 +360,7 @@ void Job::timer_event(Core::TimerEvent& event)
 
 void Job::finish_up()
 {
-    VERIFY(m_state != State::Finished);
+    VERIFY(!m_has_scheduled_finish);
     m_state = State::Finished;
     if (!m_can_stream_response) {
         auto flattened_buffer = ByteBuffer::create_uninitialized(m_received_size);
@@ -395,9 +395,10 @@ void Job::finish_up()
         return;
     }
 
+    m_has_scheduled_finish = true;
     auto response = HttpResponse::create(m_code, move(m_headers));
-    deferred_invoke([this, response](auto&) {
-        did_finish(move(response));
+    deferred_invoke([this, response = move(response)](auto&) {
+        did_finish(response);
     });
 }
 }

--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -64,6 +64,7 @@ protected:
     Optional<size_t> m_current_chunk_total_size;
     bool m_can_stream_response { true };
     bool m_should_read_chunk_ending_line { false };
+    bool m_has_scheduled_finish { false };
 };
 
 }


### PR DESCRIPTION
It's alright for this function to be called multiple times, as it quits
early when a partial flush doesn't empty the download buffer.
Relax the assertion to having scheduled "did_finish()" only once.

Also do a drive-by fix of copying a refptr twice :shrug: