### PR TITLE
WindowServer: Fix animations not triggering rendering

### DIFF
--- a/Userland/Services/WindowServer/Animation.cpp
+++ b/Userland/Services/WindowServer/Animation.cpp
@@ -29,6 +29,7 @@ void Animation::start()
 {
     m_running = true;
     m_timer.start();
+    Compositor::the().animation_started({});
 }
 
 void Animation::stop()

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -71,6 +71,7 @@ public:
         invalidate_screen();
     }
 
+    void animation_started(Badge<Animation>);
     void invalidate_occlusions() { m_occlusions_dirty = true; }
     void overlay_rects_changed();
 


### PR DESCRIPTION
When starting the first animation and while animations are ongoing we
need to make sure we trigger rendering.