### PR TITLE
LibJS: Bring the Array constructor slightly closer to the specification

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -51,13 +51,14 @@ Value ArrayConstructor::call()
         return Array::create(global_object());
 
     if (vm().argument_count() == 1 && vm().argument(0).is_number()) {
-        auto array_length_value = vm().argument(0);
-        if (!array_length_value.is_integral_number() || array_length_value.as_i32() < 0) {
+        auto length = vm().argument(0);
+        auto int_length = length.to_u32(global_object());
+        if (int_length != length.as_double()) {
             vm().throw_exception<RangeError>(global_object(), ErrorType::InvalidLength, "array");
             return {};
         }
         auto* array = Array::create(global_object());
-        array->indexed_properties().set_array_like_size(array_length_value.as_i32());
+        array->indexed_properties().set_array_like_size(int_length);
         return array;
     }
 


### PR DESCRIPTION
Specifically, we now cast to a u32 instead of an i32, as well as use the validity check required by the specification. The current
constructor is still quite far from the specification, as we directly set the indexed properties' length instead of going through the Array's overriden DefineOwnProperty. (and as a result the checks imposed by the ArraySetLength abstract operation)

NOTE: i chose to hold off on making this completely spec compliant because linus' Object rewrite PR changes the way overriding stuff like DefineOwnProperty works by quite a bit.

This fixes 1 test262 test case.