### PR TITLE
WindowServer: Add basic virtual desktop support

### DIFF
--- a/Base/etc/WindowServer.ini
+++ b/Base/etc/WindowServer.ini
@@ -50,3 +50,6 @@ Mode=stretch
 [Applet]
 Order=CPUGraph,MemoryGraph,Network,ClipboardHistory,Audio
 
+[VirtualDesktops]
+Rows=2
+Columns=2

--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -6,11 +6,14 @@ serenity_component(
 
 compile_gml(MonitorSettings.gml MonitorSettingsGML.h monitor_settings_window_gml)
 compile_gml(BackgroundSettings.gml BackgroundSettingsGML.h background_settings_gml)
+compile_gml(DesktopSettings.gml DesktopSettingsGML.h desktop_settings_gml)
 compile_gml(FontSettings.gml FontSettingsGML.h font_settings_gml)
 
 set(SOURCES
     BackgroundSettingsGML.h
     BackgroundSettingsWidget.cpp
+    DesktopSettingsWidget.cpp
+    DesktopSettingsGML.h
     FontSettingsGML.h
     FontSettingsWidget.cpp
     MonitorSettingsWidget.cpp

--- a/Userland/Applications/DisplaySettings/DesktopSettings.gml
+++ b/Userland/Applications/DisplaySettings/DesktopSettings.gml
@@ -1,0 +1,75 @@
+@GUI::Widget {
+    fill_with_background_color: true
+
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8, 8, 8, 8]
+    }
+
+    @GUI::GroupBox {
+        layout: @GUI::VerticalBoxLayout {
+            margins: [16, 24, 16, 6]
+        }
+
+        title: "Virtual Desktops"
+        shrink_to_fit: true
+
+        @GUI::Widget {
+            fixed_height: 32
+
+            layout: @GUI::HorizontalBoxLayout {
+                margins: [6, 6, 6, 6]
+            }
+
+            @GUI::Label {
+                text: "Rows:"
+                text_alignment: "CenterRight"
+            }
+
+            @GUI::SpinBox {
+                name: "virtual_desktop_rows_spinbox"
+                min: 1
+                max: 16
+                orientation: "Horizontal"
+            }
+
+            @GUI::Label {
+                text: "Columns:"
+                text_alignment: "CenterRight"
+            }
+
+            @GUI::SpinBox {
+                name: "virtual_desktop_columns_spinbox"
+                min: 1
+                max: 16
+                orientation: "Horizontal"
+            }
+        }
+
+        @GUI::Widget {
+            fixed_height: 76
+
+            layout: @GUI::HorizontalBoxLayout {
+            }
+            @GUI::Label {
+                name: "light_bulb_label"
+                fixed_height: 32
+                fixed_width: 32
+            }
+            @GUI::Widget {
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [6, 6, 6, 6]
+                }
+                @GUI::Label {
+                    text: "Use the Ctrl+Alt+Arrow hotkeys to move between virtual desktops."
+                    text_alignment: "TopLeft"
+                    word_wrap: true
+                }
+                @GUI::Label {
+                    text: "Use the Ctrl+Shift+Alt+Arrow hotkeys to move between virtual desktops and move the active window."
+                    text_alignment: "TopLeft"
+                    word_wrap: true
+                }
+            }
+        }
+    }
+}

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "DesktopSettingsWidget.h"
+#include <AK/StringBuilder.h>
+#include <Applications/DisplaySettings/DesktopSettingsGML.h>
+#include <LibGUI/Application.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Desktop.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
+#include <LibGUI/SpinBox.h>
+#include <LibGUI/WindowServerConnection.h>
+
+namespace DisplaySettings {
+
+DesktopSettingsWidget::DesktopSettingsWidget()
+{
+    create_frame();
+    load_current_settings();
+}
+
+DesktopSettingsWidget::~DesktopSettingsWidget()
+{
+}
+
+void DesktopSettingsWidget::create_frame()
+{
+    load_from_gml(desktop_settings_gml);
+
+    auto& light_bulb_label = *find_descendant_of_type_named<GUI::Label>("light_bulb_label");
+    light_bulb_label.set_icon(Gfx::Bitmap::load_from_file("/res/icons/32x32/app-welcome.png"));
+
+    m_virtual_desktop_rows_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("virtual_desktop_rows_spinbox");
+    m_virtual_desktop_columns_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("virtual_desktop_columns_spinbox");
+}
+
+void DesktopSettingsWidget::load_current_settings()
+{
+    auto& desktop = GUI::Desktop::the();
+    m_virtual_desktop_rows_spinbox->set_value(desktop.virtual_desktop_rows());
+    m_virtual_desktop_columns_spinbox->set_value(desktop.virtual_desktop_columns());
+}
+
+void DesktopSettingsWidget::apply_settings()
+{
+    auto virtual_desktop_rows = (unsigned)m_virtual_desktop_rows_spinbox->value();
+    auto virtual_desktop_columns = (unsigned)m_virtual_desktop_columns_spinbox->value();
+    auto& desktop = GUI::Desktop::the();
+    if (virtual_desktop_rows != desktop.virtual_desktop_rows() || virtual_desktop_columns != desktop.virtual_desktop_columns()) {
+        if (!GUI::WindowServerConnection::the().apply_virtual_desktop_settings(virtual_desktop_rows, virtual_desktop_columns, true)) {
+            GUI::MessageBox::show(window(), String::formatted("Error applying virtual desktop settings"),
+                "Virtual desktop settings", GUI::MessageBox::Type::Error);
+        }
+    }
+}
+
+}

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Timer.h>
+#include <LibGUI/SpinBox.h>
+
+namespace DisplaySettings {
+
+class DesktopSettingsWidget : public GUI::Widget {
+    C_OBJECT(DesktopSettingsWidget);
+
+public:
+    virtual ~DesktopSettingsWidget() override;
+
+    void apply_settings();
+
+private:
+    DesktopSettingsWidget();
+
+    void create_frame();
+    void load_current_settings();
+
+    RefPtr<GUI::SpinBox> m_virtual_desktop_rows_spinbox;
+    RefPtr<GUI::SpinBox> m_virtual_desktop_columns_spinbox;
+};
+
+}

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "BackgroundSettingsWidget.h"
+#include "DesktopSettingsWidget.h"
 #include "FontSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
 #include <LibGUI/Action.h>
@@ -52,6 +53,7 @@ int main(int argc, char** argv)
     auto& background_settings_widget = tab_widget.add_tab<DisplaySettings::BackgroundSettingsWidget>("Background");
     auto& font_settings_widget = tab_widget.add_tab<DisplaySettings::FontSettingsWidget>("Fonts");
     auto& monitor_settings_widget = tab_widget.add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor");
+    auto& desktop_settings_widget = tab_widget.add_tab<DisplaySettings::DesktopSettingsWidget>("Desktop");
     tab_widget.on_change = [&](auto& widget) {
         monitor_settings_widget.show_screen_numbers(&widget == &monitor_settings_widget);
     };
@@ -67,6 +69,7 @@ int main(int argc, char** argv)
     ok_button.on_click = [&](auto) {
         background_settings_widget.apply_settings();
         monitor_settings_widget.apply_settings();
+        desktop_settings_widget.apply_settings();
         font_settings_widget.apply_settings();
         app->quit();
     };
@@ -82,6 +85,7 @@ int main(int argc, char** argv)
     apply_button.on_click = [&](auto) {
         background_settings_widget.apply_settings();
         monitor_settings_widget.apply_settings();
+        desktop_settings_widget.apply_settings();
         font_settings_widget.apply_settings();
     };
 

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -25,7 +25,7 @@ Desktop::Desktop()
 {
 }
 
-void Desktop::did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index)
+void Desktop::did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index, unsigned virtual_desktop_rows, unsigned virtual_desktop_columns)
 {
     m_main_screen_index = main_screen_index;
     m_rects = rects;
@@ -36,6 +36,9 @@ void Desktop::did_receive_screen_rects(Badge<WindowServerConnection>, const Vect
     } else {
         m_bounding_rect = {};
     }
+
+    m_virtual_desktop_rows = virtual_desktop_rows;
+    m_virtual_desktop_columns = virtual_desktop_columns;
 }
 
 void Desktop::set_background_color(const StringView& background_color)

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -36,14 +36,19 @@ public:
     const Vector<Gfx::IntRect, 4>& rects() const { return m_rects; }
     size_t main_screen_index() const { return m_main_screen_index; }
 
+    unsigned virtual_desktop_rows() const { return m_virtual_desktop_rows; }
+    unsigned virtual_desktop_columns() const { return m_virtual_desktop_columns; }
+
     int taskbar_height() const { return TaskbarWindow::taskbar_height(); }
 
-    void did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>&, size_t);
+    void did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>&, size_t, unsigned, unsigned);
 
 private:
     Vector<Gfx::IntRect, default_screen_rect_count> m_rects;
     size_t m_main_screen_index { 0 };
     Gfx::IntRect m_bounding_rect;
+    unsigned m_virtual_desktop_rows { 1 };
+    unsigned m_virtual_desktop_columns { 1 };
 };
 
 }

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -64,6 +64,7 @@ public:
         WM_AppletAreaSizeChanged,
         WM_SuperKeyPressed,
         WM_SuperSpaceKeyPressed,
+        WM_VirtualDesktopChanged,
         __End_WM_Events,
     };
 
@@ -135,13 +136,15 @@ public:
 
 class WMWindowStateChangedEvent : public WMEvent {
 public:
-    WMWindowStateChangedEvent(int client_id, int window_id, int parent_client_id, int parent_window_id, const StringView& title, const Gfx::IntRect& rect, bool is_active, bool is_modal, WindowType window_type, bool is_minimized, bool is_frameless, Optional<int> progress)
+    WMWindowStateChangedEvent(int client_id, int window_id, int parent_client_id, int parent_window_id, const StringView& title, const Gfx::IntRect& rect, unsigned virtual_desktop_row, unsigned virtual_desktop_column, bool is_active, bool is_modal, WindowType window_type, bool is_minimized, bool is_frameless, Optional<int> progress)
         : WMEvent(Event::Type::WM_WindowStateChanged, client_id, window_id)
         , m_parent_client_id(parent_client_id)
         , m_parent_window_id(parent_window_id)
         , m_title(title)
         , m_rect(rect)
         , m_window_type(window_type)
+        , m_virtual_desktop_row(virtual_desktop_row)
+        , m_virtual_desktop_column(virtual_desktop_column)
         , m_active(is_active)
         , m_modal(is_modal)
         , m_minimized(is_minimized)
@@ -160,6 +163,8 @@ public:
     bool is_minimized() const { return m_minimized; }
     bool is_frameless() const { return m_frameless; }
     Optional<int> progress() const { return m_progress; }
+    unsigned virtual_desktop_row() const { return m_virtual_desktop_row; }
+    unsigned virtual_desktop_column() const { return m_virtual_desktop_column; }
 
 private:
     int m_parent_client_id;
@@ -167,6 +172,8 @@ private:
     String m_title;
     Gfx::IntRect m_rect;
     WindowType m_window_type;
+    unsigned m_virtual_desktop_row;
+    unsigned m_virtual_desktop_column;
     bool m_active;
     bool m_modal;
     bool m_minimized;
@@ -200,6 +207,23 @@ public:
 
 private:
     RefPtr<Gfx::Bitmap> m_bitmap;
+};
+
+class WMVirtualDesktopChangedEvent : public WMEvent {
+public:
+    explicit WMVirtualDesktopChangedEvent(int client_id, unsigned current_row, unsigned current_column)
+        : WMEvent(Event::Type::WM_VirtualDesktopChanged, client_id, 0)
+        , m_current_row(current_row)
+        , m_current_column(current_column)
+    {
+    }
+
+    unsigned current_row() const { return m_current_row; }
+    unsigned current_column() const { return m_current_column; }
+
+private:
+    const unsigned m_current_row;
+    const unsigned m_current_column;
 };
 
 class MultiPaintEvent final : public Event {

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
@@ -20,11 +20,12 @@ WindowManagerServerConnection& WindowManagerServerConnection::the()
 }
 
 void WindowManagerServerConnection::window_state_changed(i32 wm_id, i32 client_id, i32 window_id,
-    i32 parent_client_id, i32 parent_window_id, bool is_active, bool is_minimized, bool is_modal,
-    bool is_frameless, i32 window_type, String const& title, Gfx::IntRect const& rect, Optional<i32> const& progress)
+    i32 parent_client_id, i32 parent_window_id, u32 virtual_desktop_row, u32 virtual_desktop_column,
+    bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type,
+    String const& title, Gfx::IntRect const& rect, Optional<i32> const& progress)
 {
     if (auto* window = Window::from_window_id(wm_id))
-        Core::EventLoop::current().post_event(*window, make<WMWindowStateChangedEvent>(client_id, window_id, parent_client_id, parent_window_id, title, rect, is_active, is_modal, static_cast<WindowType>(window_type), is_minimized, is_frameless, progress));
+        Core::EventLoop::current().post_event(*window, make<WMWindowStateChangedEvent>(client_id, window_id, parent_client_id, parent_window_id, title, rect, virtual_desktop_row, virtual_desktop_column, is_active, is_modal, static_cast<WindowType>(window_type), is_minimized, is_frameless, progress));
 }
 
 void WindowManagerServerConnection::applet_area_size_changed(i32 wm_id, const Gfx::IntSize& size)
@@ -63,4 +64,11 @@ void WindowManagerServerConnection::super_space_key_pressed(i32 wm_id)
     if (auto* window = Window::from_window_id(wm_id))
         Core::EventLoop::current().post_event(*window, make<WMSuperSpaceKeyPressedEvent>(wm_id));
 }
+
+void WindowManagerServerConnection::virtual_desktop_changed(i32 wm_id, u32 row, u32 column)
+{
+    if (auto* window = Window::from_window_id(wm_id))
+        Core::EventLoop::current().post_event(*window, make<WMVirtualDesktopChangedEvent>(wm_id, row, column));
+}
+
 }

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
@@ -27,12 +27,13 @@ public:
 
 private:
     virtual void window_removed(i32, i32, i32) override;
-    virtual void window_state_changed(i32, i32, i32, i32, i32, bool, bool, bool, bool, i32, String const&, Gfx::IntRect const&, Optional<i32> const&) override;
+    virtual void window_state_changed(i32, i32, i32, i32, i32, u32, u32, bool, bool, bool, bool, i32, String const&, Gfx::IntRect const&, Optional<i32> const&) override;
     virtual void window_icon_bitmap_changed(i32, i32, i32, Gfx::ShareableBitmap const&) override;
     virtual void window_rect_changed(i32, i32, i32, Gfx::IntRect const&) override;
     virtual void applet_area_size_changed(i32, Gfx::IntSize const&) override;
     virtual void super_key_pressed(i32) override;
     virtual void super_space_key_pressed(i32) override;
+    virtual void virtual_desktop_changed(i32, u32, u32) override;
 };
 
 }

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -48,12 +48,12 @@ WindowServerConnection::WindowServerConnection()
     //       All we have to do is wait for it to arrive. This avoids a round-trip during application startup.
     auto message = wait_for_specific_message<Messages::WindowClient::FastGreet>();
     set_system_theme_from_anonymous_buffer(message->theme_buffer());
-    Desktop::the().did_receive_screen_rects({}, message->screen_rects(), message->main_screen_index());
+    Desktop::the().did_receive_screen_rects({}, message->screen_rects(), message->main_screen_index(), message->virtual_desktop_rows(), message->virtual_desktop_columns());
     Gfx::FontDatabase::set_default_font_query(message->default_font_query());
     Gfx::FontDatabase::set_fixed_width_font_query(message->fixed_width_font_query());
 }
 
-void WindowServerConnection::fast_greet(Vector<Gfx::IntRect> const&, u32, Core::AnonymousBuffer const&, String const&, String const&)
+void WindowServerConnection::fast_greet(Vector<Gfx::IntRect> const&, u32, u32, u32, Core::AnonymousBuffer const&, String const&, String const&)
 {
     // NOTE: This message is handled in the constructor.
 }
@@ -311,9 +311,9 @@ void WindowServerConnection::menu_item_left(i32 menu_id, u32 identifier)
     Core::EventLoop::current().post_event(*app, make<ActionEvent>(GUI::Event::ActionLeave, *action));
 }
 
-void WindowServerConnection::screen_rects_changed(Vector<Gfx::IntRect> const& rects, u32 main_screen_index)
+void WindowServerConnection::screen_rects_changed(Vector<Gfx::IntRect> const& rects, u32 main_screen_index, u32 virtual_desktop_rows, u32 virtual_desktop_columns)
 {
-    Desktop::the().did_receive_screen_rects({}, rects, main_screen_index);
+    Desktop::the().did_receive_screen_rects({}, rects, main_screen_index, virtual_desktop_rows, virtual_desktop_columns);
     Window::for_each_window({}, [&](auto& window) {
         Core::EventLoop::current().post_event(window, make<ScreenRectsChangeEvent>(rects, main_screen_index));
     });

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -23,7 +23,7 @@ public:
 private:
     WindowServerConnection();
 
-    virtual void fast_greet(Vector<Gfx::IntRect> const&, u32, Core::AnonymousBuffer const&, String const&, String const&) override;
+    virtual void fast_greet(Vector<Gfx::IntRect> const&, u32, u32, u32, Core::AnonymousBuffer const&, String const&, String const&) override;
     virtual void paint(i32, Gfx::IntSize const&, Vector<Gfx::IntRect> const&) override;
     virtual void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, bool, Vector<String> const&) override;
     virtual void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32) override;
@@ -44,7 +44,7 @@ private:
     virtual void menu_item_entered(i32, u32) override;
     virtual void menu_item_left(i32, u32) override;
     virtual void menu_visibility_did_change(i32, bool) override;
-    virtual void screen_rects_changed(Vector<Gfx::IntRect> const&, u32) override;
+    virtual void screen_rects_changed(Vector<Gfx::IntRect> const&, u32, u32, u32) override;
     virtual void set_wallpaper_finished(bool) override;
     virtual void drag_dropped(i32, Gfx::IntPoint const&, String const&, HashMap<String, ByteBuffer> const&) override;
     virtual void drag_accepted() override;

--- a/Userland/Libraries/LibGfx/DisjointRectSet.h
+++ b/Userland/Libraries/LibGfx/DisjointRectSet.h
@@ -129,6 +129,17 @@ public:
     const Vector<IntRect, 32>& rects() const { return m_rects; }
     Vector<IntRect, 32> take_rects() { return move(m_rects); }
 
+    void translate_by(int dx, int dy)
+    {
+        for (auto& rect : m_rects)
+            rect.translate_by(dx, dy);
+    }
+    void translate_by(Gfx::IntPoint const& delta)
+    {
+        for (auto& rect : m_rects)
+            rect.translate_by(delta);
+    }
+
 private:
     bool add_no_shatter(const IntRect&);
     void shatter();

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -34,6 +34,9 @@ private:
 
     void update_applet_area();
 
+    bool is_window_on_current_virtual_desktop(::Window&) const;
+    void virtual_desktop_change_event(unsigned, unsigned);
+
     NonnullRefPtr<GUI::Menu> m_start_menu;
     RefPtr<GUI::Widget> m_task_button_container;
     RefPtr<Gfx::Bitmap> m_default_icon;
@@ -43,4 +46,7 @@ private:
     RefPtr<GUI::Button> m_start_button;
 
     RefPtr<Desktop::AppFile> m_assistant_app_file;
+
+    unsigned m_current_virtual_desktop_row { 0 };
+    unsigned m_current_virtual_desktop_column { 0 };
 };

--- a/Userland/Services/Taskbar/WindowList.h
+++ b/Userland/Services/Taskbar/WindowList.h
@@ -48,6 +48,14 @@ public:
     void set_modal(bool modal) { m_modal = modal; }
     bool is_modal() const { return m_modal; }
 
+    void set_virtual_desktop(unsigned row, unsigned column)
+    {
+        m_virtual_desktop_row = row;
+        m_virtual_desktop_column = column;
+    }
+    unsigned virtual_desktop_row() const { return m_virtual_desktop_row; }
+    unsigned virtual_desktop_column() const { return m_virtual_desktop_column; }
+
     void set_progress(Optional<int> progress)
     {
         if (m_progress == progress)
@@ -68,6 +76,8 @@ private:
     Gfx::IntRect m_rect;
     RefPtr<GUI::Button> m_button;
     RefPtr<Gfx::Bitmap> m_icon;
+    unsigned m_virtual_desktop_row { 0 };
+    unsigned m_virtual_desktop_column { 0 };
     bool m_active { false };
     bool m_minimized { false };
     bool m_modal { false };

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -60,7 +60,8 @@ int main(int argc, char** argv)
     window->make_window_manager(
         WindowServer::WMEventMask::WindowStateChanges
         | WindowServer::WMEventMask::WindowRemovals
-        | WindowServer::WMEventMask::WindowIconChanges);
+        | WindowServer::WMEventMask::WindowIconChanges
+        | WindowServer::WMEventMask::VirtualDesktopChanges);
 
     return app->exec();
 }

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -42,7 +42,7 @@ public:
     static ClientConnection* from_client_id(int client_id);
     static void for_each_client(Function<void(ClientConnection&)>);
 
-    void notify_about_new_screen_rects(const Vector<Gfx::IntRect, 4>&, size_t);
+    void notify_about_new_screen_rects();
     void post_paint_message(Window&, bool ignore_occlusion = false);
 
     Menu* find_menu_by_id(int menu_id)
@@ -130,6 +130,8 @@ private:
     virtual Messages::WindowServer::SetScreenLayoutResponse set_screen_layout(ScreenLayout const&, bool) override;
     virtual Messages::WindowServer::GetScreenLayoutResponse get_screen_layout() override;
     virtual Messages::WindowServer::SaveScreenLayoutResponse save_screen_layout() override;
+    virtual Messages::WindowServer::ApplyVirtualDesktopSettingsResponse apply_virtual_desktop_settings(u32, u32, bool) override;
+    virtual Messages::WindowServer::GetVirtualDesktopSettingsResponse get_virtual_desktop_settings() override;
     virtual void show_screen_numbers(bool) override;
     virtual void set_window_cursor(i32, i32) override;
     virtual void set_window_custom_cursor(i32, Gfx::ShareableBitmap const&) override;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -1001,7 +1001,19 @@ void Compositor::recompute_occlusions()
     auto& wm = WindowManager::the();
     bool is_switcher_visible = wm.m_switcher.is_visible();
     wm.for_each_window_stack([&](WindowStack& window_stack) {
-        window_stack.set_all_occluded(!is_switcher_visible);
+        if (is_switcher_visible) {
+            switch (wm.m_switcher.mode()) {
+            case WindowSwitcher::Mode::ShowCurrentDesktop:
+                window_stack.set_all_occluded(!(&window_stack == m_current_window_stack || &window_stack == m_transitioning_to_window_stack));
+                break;
+            case WindowSwitcher::Mode::ShowAllWindows:
+                window_stack.set_all_occluded(false);
+                break;
+            }
+        } else {
+            window_stack.set_all_occluded(!(&window_stack == m_current_window_stack || &window_stack == m_transitioning_to_window_stack));
+        }
+
         return IterationDecision::Continue;
     });
     if (!is_switcher_visible) {

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -142,7 +142,7 @@ Gfx::IntPoint Compositor::window_transition_offset(Window& window)
     if (window.is_moving_to_another_stack())
         return {};
 
-    return window.outer_stack()->transition_offset();
+    return window.window_stack().transition_offset();
 }
 
 void Compositor::compose()
@@ -1152,7 +1152,7 @@ void Compositor::recompute_occlusions()
             // This window should not be occluded while the window switcher is interested in it (depending
             // on the mode it's in). If it isn't then determine occlusions based on whether the window
             // rect has any visible areas at all.
-            w.set_occluded(never_occlude(*w.outer_stack()) ? false : visible_window_rects.is_empty());
+            w.set_occluded(never_occlude(w.window_stack()) ? false : visible_window_rects.is_empty());
 
             if (!m_overlay_rects.is_empty() && m_overlay_rects.intersects(visible_opaque)) {
                 // In order to render overlays flicker-free we need to force these area into the

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -22,6 +22,7 @@ class Cursor;
 class MultiScaleBitmaps;
 class Window;
 class WindowManager;
+class WindowStack;
 
 enum class WallpaperMode {
     Tile,
@@ -92,6 +93,27 @@ public:
         return IterationDecision::Continue;
     }
 
+    template<typename F>
+    IterationDecision for_each_rendering_window_stack(F f)
+    {
+        VERIFY(m_current_window_stack);
+        IterationDecision decision = f(*m_current_window_stack);
+        if (decision != IterationDecision::Continue)
+            return decision;
+        if (m_transitioning_to_window_stack)
+            decision = f(*m_transitioning_to_window_stack);
+        return decision;
+    }
+
+    [[nodiscard]] WindowStack& get_rendering_window_stacks(WindowStack*& transitioning_window_stack)
+    {
+        transitioning_window_stack = m_transitioning_to_window_stack;
+        return *m_current_window_stack;
+    }
+
+    bool is_switching_window_stacks() const { return m_transitioning_to_window_stack != nullptr; }
+    void switch_to_window_stack(WindowStack&);
+
     void did_construct_window_manager(Badge<WindowManager>);
 
     const Gfx::Bitmap* cursor_bitmap_for_screenshot(Badge<ClientConnection>, Screen&) const;
@@ -114,10 +136,14 @@ private:
     void start_compose_async_timer();
     void recompute_overlay_rects();
     void recompute_occlusions();
-    bool any_opaque_window_above_this_one_contains_rect(const Window&, const Gfx::IntRect&);
+    bool any_opaque_window_above_this_one_contains_rect(Window&, const Gfx::IntRect&);
     void change_cursor(const Cursor*);
     void flush(Screen&);
+    Gfx::IntPoint window_transition_offset(Window&);
     void update_animations(Screen&, Gfx::DisjointRectSet& flush_rects);
+    void create_window_stack_switch_overlay(WindowStack&);
+    void start_window_stack_switch_overlay_timer();
+    void finish_window_stack_switch();
 
     RefPtr<Core::Timer> m_compose_timer;
     RefPtr<Core::Timer> m_immediate_compose_timer;
@@ -139,6 +165,7 @@ private:
         OwnPtr<Gfx::Painter> m_cursor_back_painter;
         Gfx::IntRect m_last_cursor_rect;
         OwnPtr<ScreenNumberOverlay> m_screen_number_overlay;
+        OwnPtr<WindowStackSwitchOverlay> m_window_stack_switch_overlay;
         bool m_buffers_are_flipped { false };
         bool m_screen_can_set_buffer { false };
         bool m_cursor_back_is_valid { false };
@@ -196,6 +223,12 @@ private:
 
     RefPtr<Core::Timer> m_display_link_notify_timer;
     size_t m_display_link_count { 0 };
+
+    WindowStack* m_current_window_stack { nullptr };
+    WindowStack* m_transitioning_to_window_stack { nullptr };
+    RefPtr<Animation> m_window_stack_transition_animation;
+    OwnPtr<WindowStackSwitchOverlay> m_stack_switch_overlay;
+    RefPtr<Core::Timer> m_stack_switch_overlay_timer;
 
     size_t m_show_screen_number_count { 0 };
     Optional<Gfx::Color> m_custom_background_color;

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -138,7 +138,6 @@ private:
     void start_compose_async_timer();
     void recompute_overlay_rects();
     void recompute_occlusions();
-    bool any_opaque_window_above_this_one_contains_rect(Window&, const Gfx::IntRect&);
     void change_cursor(const Cursor*);
     void flush(Screen&);
     Gfx::IntPoint window_transition_offset(Window&);

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -112,7 +112,9 @@ public:
     }
 
     bool is_switching_window_stacks() const { return m_transitioning_to_window_stack != nullptr; }
-    void switch_to_window_stack(WindowStack&);
+    void switch_to_window_stack(WindowStack&, bool);
+    void set_current_window_stack_no_transition(WindowStack&);
+    void invalidate_for_window_stack_merge_or_change();
 
     void did_construct_window_manager(Badge<WindowManager>);
 
@@ -142,6 +144,8 @@ private:
     Gfx::IntPoint window_transition_offset(Window&);
     void update_animations(Screen&, Gfx::DisjointRectSet& flush_rects);
     void create_window_stack_switch_overlay(WindowStack&);
+    void remove_window_stack_switch_overlays();
+    void stop_window_stack_switch_overlay_timer();
     void start_window_stack_switch_overlay_timer();
     void finish_window_stack_switch();
 
@@ -227,7 +231,6 @@ private:
     WindowStack* m_current_window_stack { nullptr };
     WindowStack* m_transitioning_to_window_stack { nullptr };
     RefPtr<Animation> m_window_stack_transition_animation;
-    OwnPtr<WindowStackSwitchOverlay> m_stack_switch_overlay;
     RefPtr<Core::Timer> m_stack_switch_overlay_timer;
 
     size_t m_show_screen_number_count { 0 };

--- a/Userland/Services/WindowServer/Overlays.cpp
+++ b/Userland/Services/WindowServer/Overlays.cpp
@@ -311,4 +311,40 @@ RefPtr<Gfx::Bitmap> DndOverlay::create_bitmap(int scale_factor)
     return new_bitmap;
 }
 
+void WindowStackSwitchOverlay::render_overlay_bitmap(Gfx::Painter& painter)
+{
+    // We should come up with a more elegant way to get the content rectangle
+    Gfx::IntRect content_rect({}, m_content_size);
+    content_rect.center_within({ {}, rect().size() });
+    auto active_color = WindowManager::the().palette().active_window_border1();
+    auto inactive_color = WindowManager::the().palette().inactive_window_border1();
+    for (int y = 0; y < m_rows; y++) {
+        for (int x = 0; x < m_columns; x++) {
+            Gfx::IntRect rect {
+                content_rect.left() + x * (default_screen_rect_width + default_screen_rect_padding),
+                content_rect.top() + y * (default_screen_rect_height + default_screen_rect_padding),
+                default_screen_rect_width,
+                default_screen_rect_height
+            };
+            bool is_target = y == m_target_row && x == m_target_column;
+            painter.fill_rect(rect, is_target ? active_color : inactive_color);
+        }
+    }
+}
+
+WindowStackSwitchOverlay::WindowStackSwitchOverlay(Screen& screen, WindowStack& target_window_stack)
+    : m_rows((int)WindowManager::the().window_stack_rows())
+    , m_columns((int)WindowManager::the().window_stack_columns())
+    , m_target_row((int)target_window_stack.row())
+    , m_target_column((int)target_window_stack.column())
+{
+    m_content_size = {
+        m_columns * (default_screen_rect_width + default_screen_rect_padding) - default_screen_rect_padding,
+        m_rows * (default_screen_rect_height + default_screen_rect_padding) - default_screen_rect_padding,
+    };
+    auto rect = calculate_frame_rect(Gfx::IntRect({}, m_content_size).inflated(2 * default_screen_rect_margin, 2 * default_screen_rect_margin));
+    rect.center_within(screen.rect());
+    set_rect(rect);
+}
+
 }

--- a/Userland/Services/WindowServer/Overlays.h
+++ b/Userland/Services/WindowServer/Overlays.h
@@ -17,6 +17,7 @@ namespace WindowServer {
 
 class Screen;
 class Window;
+class WindowStack;
 
 class Overlay {
     friend class Compositor;
@@ -27,6 +28,7 @@ public:
     enum class ZOrder {
         WindowGeometry,
         Dnd,
+        WindowStackSwitch,
         ScreenNumber,
     };
     [[nodiscard]] virtual ZOrder zorder() const = 0;
@@ -166,6 +168,26 @@ private:
     RefPtr<Gfx::Bitmap> m_bitmap;
     String m_text;
     Gfx::IntRect m_label_rect;
+};
+
+class WindowStackSwitchOverlay : public RectangularOverlay {
+public:
+    static constexpr int default_screen_rect_width = 40;
+    static constexpr int default_screen_rect_height = 30;
+    static constexpr int default_screen_rect_margin = 16;
+    static constexpr int default_screen_rect_padding = 8;
+
+    WindowStackSwitchOverlay(Screen&, WindowStack&);
+
+    virtual ZOrder zorder() const override { return ZOrder::WindowStackSwitch; }
+    virtual void render_overlay_bitmap(Gfx::Painter&) override;
+
+private:
+    Gfx::IntSize m_content_size;
+    const int m_rows;
+    const int m_columns;
+    const int m_target_row;
+    const int m_target_column;
 };
 
 }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -1204,4 +1204,5 @@ String Window::computed_title() const
         return String::formatted("{} (Not responding)", title);
     return title;
 }
+
 }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -664,9 +664,12 @@ void Window::clear_dirty_rects()
 
 bool Window::is_active() const
 {
-    if (!outer_stack())
+    if (!m_window_stack) {
+        // This may be called while destroying a window as part of
+        // determining what the render rectangle is!
         return false;
-    return outer_stack()->active_window() == this;
+    }
+    return m_window_stack->active_window() == this;
 }
 
 Window* Window::blocking_modal_window()

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -319,9 +319,18 @@ public:
     const Menubar* menubar() const { return m_menubar; }
     void set_menubar(Menubar*);
 
-    WindowStack* outer_stack() { return m_outer_stack; }
-    WindowStack const* outer_stack() const { return m_outer_stack; }
-    void set_outer_stack(Badge<WindowStack>, WindowStack* stack) { m_outer_stack = stack; }
+    WindowStack& window_stack()
+    {
+        VERIFY(m_window_stack);
+        return *m_window_stack;
+    }
+    WindowStack const& window_stack() const
+    {
+        VERIFY(m_window_stack);
+        return *m_window_stack;
+    }
+    bool is_on_any_window_stack(Badge<WindowStack>) const { return m_window_stack != nullptr; }
+    void set_window_stack(Badge<WindowStack>, WindowStack* stack) { m_window_stack = stack; }
 
     const Vector<Screen*, default_screen_count>& screens() const { return m_screens; }
     Vector<Screen*, default_screen_count>& screens() { return m_screens; }
@@ -416,7 +425,7 @@ private:
     MenuItem* m_window_menu_menubar_visibility_item { nullptr };
     Optional<int> m_progress;
     bool m_should_show_menubar { true };
-    WindowStack* m_outer_stack { nullptr };
+    WindowStack* m_window_stack { nullptr };
     RefPtr<Animation> m_animation;
 
 public:

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -330,6 +330,9 @@ public:
         frame().window_was_constructed({});
     }
 
+    void set_moving_to_another_stack(bool value) { m_moving_to_another_stack = value; }
+    bool is_moving_to_another_stack() const { return m_moving_to_another_stack; }
+
 private:
     Window(ClientConnection&, WindowType, int window_id, bool modal, bool minimizable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window = nullptr);
     Window(Core::Object&, WindowType);
@@ -382,6 +385,7 @@ private:
     bool m_invalidated_frame { true };
     bool m_hit_testing_enabled { true };
     bool m_modified { false };
+    bool m_moving_to_another_stack { false };
     WindowTileType m_tiled { WindowTileType::None };
     Gfx::IntRect m_untiled_rect;
     bool m_occluded { false };

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -35,6 +35,7 @@ enum WMEventMask {
     WindowStateChanges = 1 << 1,
     WindowIconChanges = 1 << 2,
     WindowRemovals = 1 << 3,
+    VirtualDesktopChanges = 1 << 4,
 };
 
 enum class WindowTileType {

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -1,6 +1,6 @@
 endpoint WindowClient
 {
-    fast_greet(Vector<Gfx::IntRect> screen_rects, u32 main_screen_index, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query) =|
+    fast_greet(Vector<Gfx::IntRect> screen_rects, u32 main_screen_index, u32 virtual_desktop_rows, u32 virtual_desktop_columns, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query) =|
 
     paint(i32 window_id, Gfx::IntSize window_size, Vector<Gfx::IntRect> rects) =|
     mouse_move(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta, bool is_drag, Vector<String> mime_types) =|
@@ -25,7 +25,7 @@ endpoint WindowClient
     menu_item_left(i32 menu_id, u32 identifier) =|
     menu_visibility_did_change(i32 menu_id, bool visible) =|
 
-    screen_rects_changed(Vector<Gfx::IntRect> rects, u32 main_screen_index) =|
+    screen_rects_changed(Vector<Gfx::IntRect> rects, u32 main_screen_index, u32 virtual_desktop_rows, u32 virtual_desktop_columns) =|
 
     set_wallpaper_finished(bool success) =|
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1567,8 +1567,12 @@ void WindowManager::process_key_event(KeyEvent& event)
         return;
     }
 
-    if (event.type() == Event::KeyDown && ((event.modifiers() == Mod_Super && event.key() == Key_Tab) || (event.modifiers() == (Mod_Super | Mod_Shift) && event.key() == Key_Tab)))
-        m_switcher.show();
+    if (event.type() == Event::KeyDown) {
+        if ((event.modifiers() == Mod_Super && event.key() == Key_Tab) || (event.modifiers() == (Mod_Super | Mod_Shift) && event.key() == Key_Tab))
+            m_switcher.show(WindowSwitcher::Mode::ShowAllWindows);
+        else if ((event.modifiers() == Mod_Alt && event.key() == Key_Tab) || (event.modifiers() == (Mod_Alt | Mod_Shift) && event.key() == Key_Tab))
+            m_switcher.show(WindowSwitcher::Mode::ShowCurrentDesktop);
+    }
     if (m_switcher.is_visible()) {
         m_switcher.on_key_event(event);
         return;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -90,17 +90,36 @@ public:
     void start_dnd_drag(ClientConnection&, String const& text, Gfx::Bitmap const*, Core::MimeData const&);
     void end_dnd_drag();
 
-    Window* active_window() { return m_window_stack.active_window(); }
-    Window const* active_window() const { return m_window_stack.active_window(); }
-    Window* active_input_window() { return m_active_input_window.ptr(); }
-    Window const* active_input_window() const { return m_active_input_window.ptr(); }
+    Window* active_window()
+    {
+        VERIFY(m_current_window_stack);
+        return m_current_window_stack->active_window();
+    }
+    Window const* active_window() const
+    {
+        VERIFY(m_current_window_stack);
+        return m_current_window_stack->active_window();
+    }
+
+    Window* active_input_window()
+    {
+        VERIFY(m_current_window_stack);
+        return m_current_window_stack->active_input_window();
+    }
+    Window const* active_input_window() const
+    {
+        VERIFY(m_current_window_stack);
+        return m_current_window_stack->active_input_window();
+    }
+
     ClientConnection const* active_client() const;
 
     Window* window_with_active_menu() { return m_window_with_active_menu; }
     Window const* window_with_active_menu() const { return m_window_with_active_menu; }
     void set_window_with_active_menu(Window*);
 
-    Window const* highlight_window() const { return m_window_stack.highlight_window(); }
+    Window* highlight_window() { return m_highlight_window; }
+    Window const* highlight_window() const { return m_highlight_window; }
     void set_highlight_window(Window*);
 
     void move_to_front_and_make_active(Window&);
@@ -223,6 +242,7 @@ public:
             return f(window, true);
         }
     }
+    bool is_window_in_modal_stack(Window& window_in_modal_stack, Window& other_window);
 
     Gfx::IntPoint get_recommended_window_position(Gfx::IntPoint const& desired);
 
@@ -231,12 +251,60 @@ public:
     void reevaluate_hovered_window(Window* = nullptr);
     Window* hovered_window() const { return m_hovered_window.ptr(); }
 
-    WindowStack& window_stack() { return m_window_stack; }
+    void switch_to_window_stack(WindowStack&, Window* = nullptr);
+
+    size_t window_stack_rows() const { return m_window_stacks.size(); }
+    size_t window_stack_columns() const { return m_window_stacks[0].size(); }
+
+    WindowStack& current_window_stack()
+    {
+        VERIFY(m_current_window_stack);
+        return *m_current_window_stack;
+    }
+
+    template<typename F>
+    IterationDecision for_each_window_stack(F f)
+    {
+        for (auto& row : m_window_stacks) {
+            for (auto& stack : row) {
+                IterationDecision decision = f(stack);
+                if (decision != IterationDecision::Continue)
+                    return decision;
+            }
+        }
+        return IterationDecision::Continue;
+    }
+
+    WindowStack& window_stack_for_window(Window&);
+
+    static constexpr bool is_stationary_window_type(WindowType window_type)
+    {
+        switch (window_type) {
+        case WindowType::Normal:
+        case WindowType::ToolWindow:
+        case WindowType::Tooltip:
+            return false;
+        default:
+            return true;
+        }
+    }
+
+    void did_switch_window_stack(Badge<Compositor>, WindowStack&, WindowStack&);
+
+    template<typename Callback>
+    IterationDecision for_each_visible_window_from_back_to_front(Callback, WindowStack* = nullptr);
+    template<typename Callback>
+    IterationDecision for_each_visible_window_from_front_to_back(Callback, WindowStack* = nullptr);
 
     MultiScaleBitmaps const* overlay_rect_shadow() const { return m_overlay_rect_shadow.ptr(); }
 
 private:
     RefPtr<Cursor> get_cursor(String const& name);
+
+    void notify_new_active_window(Window&);
+    void notify_new_active_input_window(Window&);
+    void notify_previous_active_window(Window&);
+    void notify_previous_active_input_window(Window&);
 
     void process_mouse_event(MouseEvent&);
     void process_event_for_doubleclick(Window& window, MouseEvent& event);
@@ -260,6 +328,8 @@ private:
 
     void do_move_to_front(Window&, bool, bool);
 
+    [[nodiscard]] static WindowStack& get_rendering_window_stacks(WindowStack*&);
+
     RefPtr<Cursor> m_hidden_cursor;
     RefPtr<Cursor> m_arrow_cursor;
     RefPtr<Cursor> m_hand_cursor;
@@ -279,7 +349,9 @@ private:
 
     RefPtr<MultiScaleBitmaps> m_overlay_rect_shadow;
 
-    WindowStack m_window_stack;
+    // Setup 2 rows 1 column by default
+    NonnullOwnPtrVector<NonnullOwnPtrVector<WindowStack, 3>, 2> m_window_stacks;
+    WindowStack* m_current_window_stack { nullptr };
 
     struct DoubleClickInfo {
         struct ClickMetadata {
@@ -317,8 +389,7 @@ private:
     bool m_previous_event_was_super_keydown { false };
 
     WeakPtr<Window> m_hovered_window;
-    WeakPtr<Window> m_active_input_window;
-    WeakPtr<Window> m_active_input_tracking_window;
+    WeakPtr<Window> m_highlight_window;
     WeakPtr<Window> m_window_with_active_menu;
 
     OwnPtr<WindowGeometryOverlay> m_geometry_overlay;
@@ -349,7 +420,84 @@ private:
     String m_dnd_text;
 
     RefPtr<Core::MimeData> m_dnd_mime_data;
+
+    WindowStack* m_switching_to_window_stack { nullptr };
+    Vector<WeakPtr<Window>, 4> m_carry_window_to_new_stack;
 };
+
+template<typename Callback>
+inline IterationDecision WindowManager::for_each_visible_window_from_back_to_front(Callback callback, WindowStack* specific_stack)
+{
+    auto* window_stack = specific_stack;
+    WindowStack* transitioning_to_window_stack = nullptr;
+    if (!window_stack)
+        window_stack = &get_rendering_window_stacks(transitioning_to_window_stack);
+    auto for_each_window = [&]<WindowType window_type>() {
+        if constexpr (is_stationary_window_type(window_type)) {
+            auto& stationary_stack = window_stack->stationary_window_stack();
+            return stationary_stack.for_each_visible_window_of_type_from_back_to_front(window_type, callback);
+        } else {
+            auto decision = window_stack->for_each_visible_window_of_type_from_back_to_front(window_type, callback);
+            if (decision == IterationDecision::Continue && transitioning_to_window_stack)
+                decision = transitioning_to_window_stack->for_each_visible_window_of_type_from_back_to_front(window_type, callback);
+            return decision;
+        }
+    };
+    if (for_each_window.template operator()<WindowType::Desktop>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Normal>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::ToolWindow>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Taskbar>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::AppletArea>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Notification>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Tooltip>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Menu>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    return for_each_window.template operator()<WindowType::WindowSwitcher>();
+}
+
+template<typename Callback>
+inline IterationDecision WindowManager::for_each_visible_window_from_front_to_back(Callback callback, WindowStack* specific_stack)
+{
+    auto* window_stack = specific_stack;
+    WindowStack* transitioning_to_window_stack = nullptr;
+    if (!window_stack)
+        window_stack = &get_rendering_window_stacks(transitioning_to_window_stack);
+    auto for_each_window = [&]<WindowType window_type>() {
+        if constexpr (is_stationary_window_type(window_type)) {
+            auto& stationary_stack = window_stack->stationary_window_stack();
+            return stationary_stack.for_each_visible_window_of_type_from_front_to_back(window_type, callback);
+        } else {
+            auto decision = window_stack->for_each_visible_window_of_type_from_front_to_back(window_type, callback);
+            if (decision == IterationDecision::Continue && transitioning_to_window_stack)
+                decision = transitioning_to_window_stack->for_each_visible_window_of_type_from_front_to_back(window_type, callback);
+            return decision;
+        }
+    };
+    if (for_each_window.template operator()<WindowType::WindowSwitcher>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Menu>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Tooltip>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Notification>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::AppletArea>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Taskbar>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::ToolWindow>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    if (for_each_window.template operator()<WindowType::Normal>() == IterationDecision::Break)
+        return IterationDecision::Break;
+    return for_each_window.template operator()<WindowType::Desktop>();
+}
 
 template<typename Callback>
 void WindowManager::for_each_window_manager(Callback callback)

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -1,10 +1,11 @@
 endpoint WindowManagerClient
 {
     window_removed(i32 wm_id, i32 client_id, i32 window_id) =|
-    window_state_changed(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, Optional<i32> progress) =|
+    window_state_changed(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, u32 virtual_desktop_row, u32 virtual_desktop_column, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, Optional<i32> progress) =|
     window_icon_bitmap_changed(i32 wm_id, i32 client_id, i32 window_id, Gfx::ShareableBitmap bitmap) =|
     window_rect_changed(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
     applet_area_size_changed(i32 wm_id, Gfx::IntSize size) =|
     super_key_pressed(i32 wm_id) =|
     super_space_key_pressed(i32 wm_id) =|
+    virtual_desktop_changed(i32 wm_id, u32 row, u32 column) =|
 }

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -99,6 +99,9 @@ endpoint WindowServer
     save_screen_layout() => (bool success, String error_msg)
     show_screen_numbers(bool show) =|
 
+    apply_virtual_desktop_settings(u32 rows, u32 columns, bool save) => (bool success)
+    get_virtual_desktop_settings() => (u32 rows, u32 columns, u32 max_rows, u32 max_columns)
+
     set_window_icon_bitmap(i32 window_id, Gfx::ShareableBitmap icon) =|
 
     get_wallpaper() => (String path)

--- a/Userland/Services/WindowServer/WindowStack.cpp
+++ b/Userland/Services/WindowServer/WindowStack.cpp
@@ -26,6 +26,13 @@ void WindowStack::add(Window& window)
     window.set_outer_stack({}, this);
 }
 
+void WindowStack::add_to_back(Window& window)
+{
+    VERIFY(window.outer_stack() == nullptr);
+    m_windows.prepend(window);
+    window.set_outer_stack({}, this);
+}
+
 void WindowStack::remove(Window& window)
 {
     VERIFY(window.outer_stack() == this);
@@ -45,6 +52,27 @@ void WindowStack::move_to_front(Window& window)
         window.invalidate();
     m_windows.remove(window);
     m_windows.append(window);
+}
+
+void WindowStack::move_all_windows(WindowStack& new_window_stack, Vector<Window*, 32>& windows_moved, MoveAllWindowsTo move_to)
+{
+    VERIFY(this != &new_window_stack);
+    if (move_to == MoveAllWindowsTo::Front) {
+        while (auto* window = m_windows.take_first()) {
+            window->set_outer_stack({}, nullptr);
+            new_window_stack.add(*window);
+            windows_moved.append(window);
+        }
+    } else {
+        while (auto* window = m_windows.take_last()) {
+            window->set_outer_stack({}, nullptr);
+            new_window_stack.add_to_back(*window);
+            windows_moved.append(window);
+        }
+    }
+    m_active_window = nullptr;
+    m_active_input_window = nullptr;
+    m_active_input_tracking_window = nullptr;
 }
 
 Window* WindowStack::window_at(Gfx::IntPoint const& position, IncludeWindowFrame include_window_frame) const

--- a/Userland/Services/WindowServer/WindowStack.cpp
+++ b/Userland/Services/WindowServer/WindowStack.cpp
@@ -21,23 +21,23 @@ WindowStack::~WindowStack()
 
 void WindowStack::add(Window& window)
 {
-    VERIFY(window.outer_stack() == nullptr);
+    VERIFY(!window.is_on_any_window_stack({}));
     m_windows.append(window);
-    window.set_outer_stack({}, this);
+    window.set_window_stack({}, this);
 }
 
 void WindowStack::add_to_back(Window& window)
 {
-    VERIFY(window.outer_stack() == nullptr);
+    VERIFY(!window.is_on_any_window_stack({}));
     m_windows.prepend(window);
-    window.set_outer_stack({}, this);
+    window.set_window_stack({}, this);
 }
 
 void WindowStack::remove(Window& window)
 {
-    VERIFY(window.outer_stack() == this);
+    VERIFY(&window.window_stack() == this);
     m_windows.remove(window);
-    window.set_outer_stack({}, nullptr);
+    window.set_window_stack({}, nullptr);
     if (m_active_window == &window)
         m_active_window = nullptr;
     if (m_active_input_window == &window)
@@ -59,13 +59,13 @@ void WindowStack::move_all_windows(WindowStack& new_window_stack, Vector<Window*
     VERIFY(this != &new_window_stack);
     if (move_to == MoveAllWindowsTo::Front) {
         while (auto* window = m_windows.take_first()) {
-            window->set_outer_stack({}, nullptr);
+            window->set_window_stack({}, nullptr);
             new_window_stack.add(*window);
             windows_moved.append(window);
         }
     } else {
         while (auto* window = m_windows.take_last()) {
-            window->set_outer_stack({}, nullptr);
+            window->set_window_stack({}, nullptr);
             new_window_stack.add_to_back(*window);
             windows_moved.append(window);
         }
@@ -87,7 +87,7 @@ Window* WindowStack::window_at(Gfx::IntPoint const& position, IncludeWindowFrame
 
 Window* WindowStack::highlight_window() const
 {
-    if (auto* window = WindowManager::the().highlight_window(); window && window->outer_stack() == this)
+    if (auto* window = WindowManager::the().highlight_window(); window && &window->window_stack() == this)
         return window;
     return nullptr;
 }

--- a/Userland/Services/WindowServer/WindowStack.h
+++ b/Userland/Services/WindowServer/WindowStack.h
@@ -19,8 +19,15 @@ public:
 
     bool is_empty() const { return m_windows.is_empty(); }
     void add(Window&);
+    void add_to_back(Window&);
     void remove(Window&);
     void move_to_front(Window&);
+
+    enum class MoveAllWindowsTo {
+        Front,
+        Back
+    };
+    void move_all_windows(WindowStack&, Vector<Window*, 32>&, MoveAllWindowsTo);
 
     enum class IncludeWindowFrame {
         Yes,
@@ -38,6 +45,8 @@ public:
 
     template<typename Callback>
     void for_each_window(Callback);
+    template<typename Callback>
+    IterationDecision for_each_window_from_back_to_front(Callback);
 
     Window::List& windows() { return m_windows; }
 
@@ -143,6 +152,17 @@ inline void WindowStack::for_each_window(Callback callback)
         if (callback(window) == IterationDecision::Break)
             return;
     }
+}
+
+template<typename Callback>
+inline IterationDecision WindowStack::for_each_window_from_back_to_front(Callback callback)
+{
+    for (auto& window : m_windows) {
+        IterationDecision decision = callback(window);
+        if (decision != IterationDecision::Break)
+            return decision;
+    }
+    return IterationDecision::Continue;
 }
 
 template<typename Callback>

--- a/Userland/Services/WindowServer/WindowSwitcher.cpp
+++ b/Userland/Services/WindowServer/WindowSwitcher.cpp
@@ -137,8 +137,8 @@ void WindowSwitcher::select_window_at_index(int index)
     VERIFY(highlight_window);
     auto& wm = WindowManager::the();
     if (m_mode == Mode::ShowAllWindows) {
-        if (auto* window_stack = highlight_window->outer_stack(); window_stack != &wm.current_window_stack())
-            wm.switch_to_window_stack(*window_stack, nullptr, false);
+        if (auto& window_stack = highlight_window->window_stack(); &window_stack != &wm.current_window_stack())
+            wm.switch_to_window_stack(window_stack, nullptr, false);
     }
     wm.set_highlight_window(highlight_window);
     redraw();
@@ -191,7 +191,7 @@ void WindowSwitcher::draw()
         painter.fill_rect(icon_rect, palette.window());
         painter.blit(icon_rect.location(), window.icon(), window.icon().rect());
         painter.draw_text(item_rect.translated(thumbnail_width() + 12, 0), window.computed_title(), WindowManager::the().window_title_font(), Gfx::TextAlignment::CenterLeft, text_color);
-        auto window_details = m_windows_on_multiple_stacks ? String::formatted("{} on {}:{}", window.rect().to_string(), window.outer_stack()->row() + 1, window.outer_stack()->column() + 1) : window.rect().to_string();
+        auto window_details = m_windows_on_multiple_stacks ? String::formatted("{} on {}:{}", window.rect().to_string(), window.window_stack().row() + 1, window.window_stack().column() + 1) : window.rect().to_string();
         painter.draw_text(item_rect, window_details, Gfx::TextAlignment::CenterRight, rect_text_color);
     }
 }
@@ -221,10 +221,11 @@ void WindowSwitcher::refresh()
                 if (selected_window == &window)
                     m_selected_index = m_windows.size();
                 m_windows.append(window);
+                auto& window_stack = window.window_stack();
                 if (!last_added_on_window_stack) {
-                    last_added_on_window_stack = window.outer_stack();
-                } else if (last_added_on_window_stack != window.outer_stack()) {
-                    last_added_on_window_stack = window.outer_stack();
+                    last_added_on_window_stack = &window_stack;
+                } else if (last_added_on_window_stack != &window_stack) {
+                    last_added_on_window_stack = &window_stack;
                     m_windows_on_multiple_stacks = true;
                 }
                 return IterationDecision::Continue;

--- a/Userland/Services/WindowServer/WindowSwitcher.cpp
+++ b/Userland/Services/WindowServer/WindowSwitcher.cpp
@@ -202,18 +202,21 @@ void WindowSwitcher::refresh()
     m_selected_index = 0;
     int window_count = 0;
     int longest_title_width = 0;
-    wm.window_stack().for_each_window_of_type_from_front_to_back(
-        WindowType::Normal, [&](Window& window) {
-            if (window.is_frameless())
+    wm.for_each_window_stack([&](auto& window_stack) {
+        window_stack.for_each_window_of_type_from_front_to_back(
+            WindowType::Normal, [&](Window& window) {
+                if (window.is_frameless())
+                    return IterationDecision::Continue;
+                ++window_count;
+                longest_title_width = max(longest_title_width, wm.font().width(window.computed_title()));
+                if (selected_window == &window)
+                    m_selected_index = m_windows.size();
+                m_windows.append(window);
                 return IterationDecision::Continue;
-            ++window_count;
-            longest_title_width = max(longest_title_width, wm.font().width(window.computed_title()));
-            if (selected_window == &window)
-                m_selected_index = m_windows.size();
-            m_windows.append(window);
-            return IterationDecision::Continue;
-        },
-        true);
+            },
+            true);
+        return IterationDecision::Continue;
+    });
     if (m_windows.is_empty()) {
         hide();
         return;

--- a/Userland/Services/WindowServer/WindowSwitcher.h
+++ b/Userland/Services/WindowServer/WindowSwitcher.h
@@ -67,6 +67,7 @@ private:
     Mode m_mode { Mode::ShowCurrentDesktop };
     Gfx::IntRect m_rect;
     bool m_visible { false };
+    bool m_windows_on_multiple_stacks { false };
     Vector<WeakPtr<Window>> m_windows;
     int m_selected_index { 0 };
     int m_hovered_index { -1 };

--- a/Userland/Services/WindowServer/WindowSwitcher.h
+++ b/Userland/Services/WindowServer/WindowSwitcher.h
@@ -20,6 +20,10 @@ class Window;
 class WindowSwitcher final : public Core::Object {
     C_OBJECT(WindowSwitcher)
 public:
+    enum class Mode {
+        ShowAllWindows,
+        ShowCurrentDesktop
+    };
     static WindowSwitcher& the();
 
     WindowSwitcher();
@@ -28,7 +32,11 @@ public:
     bool is_visible() const { return m_visible; }
     void set_visible(bool);
 
-    void show() { set_visible(true); }
+    void show(Mode mode)
+    {
+        m_mode = mode;
+        set_visible(true);
+    }
     void hide() { set_visible(false); }
 
     void on_key_event(const KeyEvent&);
@@ -37,6 +45,8 @@ public:
     void refresh_if_needed();
 
     void select_window(Window&);
+
+    Mode mode() const { return m_mode; }
 
 private:
     int thumbnail_width() const { return 40; }
@@ -54,6 +64,7 @@ private:
     virtual void event(Core::Event&) override;
 
     RefPtr<Window> m_switcher_window;
+    Mode m_mode { Mode::ShowCurrentDesktop };
     Gfx::IntRect m_rect;
     bool m_visible { false };
     Vector<WeakPtr<Window>> m_windows;


### PR DESCRIPTION
Ctrl+Alt+(Left|Up|Right|Down) moves to the appropriate neighboring window stack
Ctrl+Shift+Alt+(Left|Up|Right|Down takes the active window along with it

https://user-images.githubusercontent.com/10320822/123734276-461e9e00-d85a-11eb-8948-ae27841ac6ae.mp4

![Screenshot from 2021-07-01 09-25-19](https://user-images.githubusercontent.com/10320822/124196421-a0ea0c80-da89-11eb-8611-950313683ece.png)

Known issues:
- Reducing the number of virtual desktops has sub-optimal merging algorithm. Could use more smarts (FIXME enclosed)
