### PR TITLE
LibC: Add struct keyword to FBRects.rects to make it C compiler safe

### DIFF
--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -32,7 +32,7 @@ struct FBRect {
 
 struct FBRects {
     unsigned count;
-    FBRect const* rects;
+    struct FBRect const* rects;
 };
 
 __END_DECLS


### PR DESCRIPTION
This was found by trying to compile the neofetch/bash5.0 port.

Related error found:
```
/home/xxx/proj/serenity/Build/i686/Root/usr/include/sys/ioctl_numbers.h:35:5: error: expected specifier-qualifier-list before 'FBRect'
   35 |     FBRect const* rects;
      |     ^~~~~~
```
