### PR TITLE
WindowServer+Taskbar: Add show desktop button

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -190,6 +190,7 @@ int main(int argc, char** argv)
 
     auto app = GUI::Application::construct(argc, argv);
     auto window = GUI::Window::construct();
+    window->set_minimizable(false);
 
     Assistant::AppState app_state;
     Assistant::Database db { app_state };

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -88,12 +88,23 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
 
     main_widget.add<Taskbar::ClockWidget>();
 
+    m_show_desktop_button = GUI::Button::construct();
+    m_show_desktop_button->set_tooltip("Show Desktop");
+    m_show_desktop_button->set_fixed_size(12, 21);
+    m_show_desktop_button->on_click = TaskbarWindow::show_desktop_button_clicked;
+    main_widget.add_child(*m_show_desktop_button);
+
     auto af_path = String::formatted("{}/{}", Desktop::AppFile::APP_FILES_DIRECTORY, "Assistant.af");
     m_assistant_app_file = Desktop::AppFile::open(af_path);
 }
 
 TaskbarWindow::~TaskbarWindow()
 {
+}
+
+void TaskbarWindow::show_desktop_button_clicked(unsigned)
+{
+    GUI::WindowManagerServerConnection::the().async_toggle_show_desktop();
 }
 
 void TaskbarWindow::create_quick_launch_bar()

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -21,6 +21,7 @@ public:
 
 private:
     explicit TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu);
+    static void show_desktop_button_clicked(unsigned);
     void create_quick_launch_bar();
     void on_screen_rects_change(const Vector<Gfx::IntRect, 4>&, size_t);
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
@@ -41,6 +42,7 @@ private:
     Gfx::IntSize m_applet_area_size;
     RefPtr<GUI::Frame> m_applet_area_container;
     RefPtr<GUI::Button> m_start_button;
+    RefPtr<GUI::Button> m_show_desktop_button;
 
     RefPtr<Desktop::AppFile> m_assistant_app_file;
 };

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -115,6 +115,34 @@ void WMClientConnection::set_window_minimized(i32 client_id, i32 window_id, bool
     WindowManager::the().minimize_windows(window, minimized);
 }
 
+void WMClientConnection::toggle_show_desktop()
+{
+    bool should_hide = false;
+    WindowServer::ClientConnection::for_each_client([&should_hide](auto& client) {
+        client.for_each_window([&should_hide](Window& window) {
+            if (window.type() == WindowType::Normal && window.is_minimizable()) {
+                if (!window.is_hidden() && !window.is_minimized()) {
+                    should_hide = true;
+                    return IterationDecision::Break;
+                }
+            }
+            return IterationDecision::Continue;
+        });
+    });
+
+    WindowServer::ClientConnection::for_each_client([should_hide](auto& client) {
+        client.for_each_window([should_hide](Window& window) {
+            if (window.type() == WindowType::Normal && window.is_minimizable()) {
+                auto state = window.minimized_state();
+                if (state == WindowMinimizedState::None || state == WindowMinimizedState::Hidden) {
+                    WindowManager::the().hide_windows(window, should_hide);
+                }
+            }
+            return IterationDecision::Continue;
+        });
+    });
+}
+
 void WMClientConnection::set_event_mask(u32 event_mask)
 {
     m_event_mask = event_mask;

--- a/Userland/Services/WindowServer/WMClientConnection.h
+++ b/Userland/Services/WindowServer/WMClientConnection.h
@@ -23,6 +23,7 @@ public:
 
     virtual void set_active_window(i32, i32) override;
     virtual void set_window_minimized(i32, i32, bool) override;
+    virtual void toggle_show_desktop() override;
     virtual void start_window_resize(i32, i32) override;
     virtual void popup_window_menu(i32, i32, Gfx::IntPoint const&) override;
     virtual void set_window_taskbar_rect(i32, i32, Gfx::IntRect const&) override;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -267,28 +267,45 @@ void Window::update_window_menu_items()
     if (!m_window_menu)
         return;
 
-    m_window_menu_minimize_item->set_text(m_minimized ? "&Unminimize" : "Mi&nimize");
+    m_window_menu_minimize_item->set_text(m_minimized_state != WindowMinimizedState::None ? "&Unminimize" : "Mi&nimize");
     m_window_menu_minimize_item->set_enabled(m_minimizable);
 
     m_window_menu_maximize_item->set_text(m_maximized ? "&Restore" : "Ma&ximize");
     m_window_menu_maximize_item->set_enabled(m_resizable);
 
-    m_window_menu_move_item->set_enabled(!m_minimized && !m_maximized && !m_fullscreen);
+    m_window_menu_move_item->set_enabled(m_minimized_state == WindowMinimizedState::None && !m_maximized && !m_fullscreen);
 }
 
 void Window::set_minimized(bool minimized)
 {
-    if (m_minimized == minimized)
+    if ((m_minimized_state != WindowMinimizedState::None) == minimized)
         return;
     if (minimized && !m_minimizable)
         return;
-    m_minimized = minimized;
+    m_minimized_state = minimized ? WindowMinimizedState::Minimized : WindowMinimizedState::None;
     update_window_menu_items();
     Compositor::the().invalidate_occlusions();
     Compositor::the().invalidate_screen(frame().render_rect());
     if (!blocking_modal_window())
         start_minimize_animation();
     if (!minimized)
+        request_update({ {}, size() });
+    WindowManager::the().notify_minimization_state_changed(*this);
+}
+
+void Window::set_hidden(bool hidden)
+{
+    if ((m_minimized_state != WindowMinimizedState::None) == hidden)
+        return;
+    if (hidden && !m_minimizable)
+        return;
+    m_minimized_state = hidden ? WindowMinimizedState::Hidden : WindowMinimizedState::None;
+    update_window_menu_items();
+    Compositor::the().invalidate_occlusions();
+    Compositor::the().invalidate_screen(frame().render_rect());
+    if (!blocking_modal_window())
+        start_minimize_animation();
+    if (!hidden)
         request_update({ {}, size() });
     WindowManager::the().notify_minimization_state_changed(*this);
 }
@@ -747,8 +764,8 @@ void Window::handle_window_menu_action(WindowMenuAction action)
 {
     switch (action) {
     case WindowMenuAction::MinimizeOrUnminimize:
-        WindowManager::the().minimize_windows(*this, !m_minimized);
-        if (!m_minimized)
+        WindowManager::the().minimize_windows(*this, m_minimized_state == WindowMinimizedState::None);
+        if (m_minimized_state == WindowMinimizedState::None)
             WindowManager::the().move_to_front_and_make_active(*this);
         break;
     case WindowMenuAction::MaximizeOrRestore:
@@ -788,7 +805,7 @@ void Window::popup_window_menu(const Gfx::IntPoint& position, WindowMenuDefaultA
             default_action = WindowMenuDefaultAction::Minimize;
     }
     m_window_menu_minimize_item->set_default(default_action == WindowMenuDefaultAction::Minimize || default_action == WindowMenuDefaultAction::Unminimize);
-    m_window_menu_minimize_item->set_icon(m_minimized ? nullptr : &minimize_icon());
+    m_window_menu_minimize_item->set_icon(m_minimized_state != WindowMinimizedState::None ? nullptr : &minimize_icon());
     m_window_menu_maximize_item->set_default(default_action == WindowMenuDefaultAction::Maximize || default_action == WindowMenuDefaultAction::Restore);
     m_window_menu_maximize_item->set_icon(m_maximized ? &restore_icon() : &maximize_icon());
     m_window_menu_close_item->set_default(default_action == WindowMenuDefaultAction::Close);

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -67,6 +67,12 @@ enum class WindowMenuDefaultAction {
     Restore
 };
 
+enum class WindowMinimizedState : u32 {
+    None = 0,
+    Minimized,
+    Hidden,
+};
+
 class Window final : public Core::Object {
     C_OBJECT(Window);
 
@@ -81,8 +87,11 @@ public:
     void window_menu_activate_default();
     void request_close();
 
-    bool is_minimized() const { return m_minimized; }
+    bool is_minimized() const { return m_minimized_state != WindowMinimizedState::None; }
     void set_minimized(bool);
+    bool is_hidden() const { return m_minimized_state == WindowMinimizedState::Hidden; }
+    void set_hidden(bool);
+    WindowMinimizedState minimized_state() const { return m_minimized_state; }
 
     bool is_minimizable() const { return m_type == WindowType::Normal && m_minimizable; }
     void set_minimizable(bool);
@@ -370,7 +379,7 @@ private:
     bool m_frameless { false };
     bool m_resizable { false };
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};
-    bool m_minimized { false };
+    WindowMinimizedState m_minimized_state { WindowMinimizedState::None };
     bool m_maximized { false };
     bool m_fullscreen { false };
     bool m_accessory { false };

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1618,6 +1618,18 @@ void WindowManager::minimize_windows(Window& window, bool minimized)
     });
 }
 
+void WindowManager::hide_windows(Window& window, bool hidden)
+{
+    for_each_window_in_modal_stack(window, [&](auto& w, bool) {
+        w.set_hidden(hidden);
+
+        if (!hidden)
+            pick_new_active_window(&window);
+
+        return IterationDecision::Continue;
+    });
+}
+
 void WindowManager::maximize_windows(Window& window, bool maximized)
 {
     for_each_window_in_modal_stack(window, [&](auto& w, bool stack_top) {

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -193,6 +193,7 @@ public:
     bool is_menu_doubleclick(Window& window, MouseEvent const& event) const;
 
     void minimize_windows(Window&, bool);
+    void hide_windows(Window&, bool);
     void maximize_windows(Window&, bool);
 
     template<typename Function>

--- a/Userland/Services/WindowServer/WindowManagerServer.ipc
+++ b/Userland/Services/WindowServer/WindowManagerServer.ipc
@@ -5,6 +5,7 @@ endpoint WindowManagerServer
 
     set_active_window(i32 client_id, i32 window_id) =|
     set_window_minimized(i32 client_id, i32 window_id, bool minimized) =|
+    toggle_show_desktop() =|
     start_window_resize(i32 client_id, i32 window_id) =|
     popup_window_menu(i32 client_id, i32 window_id, Gfx::IntPoint screen_position) =|
     set_window_taskbar_rect(i32 client_id, i32 window_id, Gfx::IntRect rect) =|


### PR DESCRIPTION
Adds a non-blocking IPC call to WindowManagerServer to toggle whether or not all windows are minimized, a button to Taskbar to trigger it, and a small change to Assistant to prevent it from being minimized.

I'm not very happy about the implementation of `WMClientConnection::toggle_all_windows_minimized`. I would much rather be able to break out of both of the first nested loops. Having these iteration APIs use callbacks is quite unfortunate and I'm assuming there's some reason for that over a `for` in range loop which I'm missing due to my rather minimal C++ experience.

The Taskbar button is inspired by the "Show Desktop" button in Windows 7 and onward. Its call to `toggle_all_windows_minimized` sits in a private method which is assigned to `m_show_desktop_button->on_click` because that seemed nicer than having a lambda sitting there inline.

Ideally one would be able to fling their mouse cursor at the corner of the screen and click to activate the show desktop button. However with the way that the Taskbar is currently layed out that is not possible for this, the start button, or the bottom of any other button on the Taskbar. I believe that this should be resolved at some point but this is not the right patch to do so, especially with my own inexperience with LibGUI.

I err-ed on the side of caution with the commit size and scope. Please let me know if this would be better off as two or one commit(s) instead.