### PR TITLE
LibJS: Make Array.of(...items) generic

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -242,7 +242,9 @@ bool Value::is_constructor() const
         return false;
     if (is<NativeFunction>(as_object()))
         return static_cast<const NativeFunction&>(as_object()).has_constructor();
-    // OrdinaryFunctionObject or BoundFunction
+    if (is<BoundFunction>(as_object()))
+        return Value(&static_cast<const BoundFunction&>(as_object()).target_function()).is_constructor();
+    // OrdinaryFunctionObject
     return true;
 }
 


### PR DESCRIPTION
This fixes 6 test262 test cases.

(This PR also includes a fix to our Value::is_constructor abstract operation that was required for one of the Array.of tests)