### PR TITLE
Toolchain: Allow containerized work with Serenity via Docker

### DIFF
--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -23,7 +23,12 @@ RUN apt-get update -y \
         tzdata \
         unzip \
         wget
+RUN apt install gcc-10 g++-10; \
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+
+RUN git clone --depth 1 https://github.com/SerenityOS/serenity.git /serenity/serenity-git
+RUN cd /serenity/serenity-git/Toolchain; \
+        ./BuildIt.sh
 
 WORKDIR /serenity
-
-RUN /bin/bash
+VOLUME /serenity/out


### PR DESCRIPTION
Docker is a nice way of doing build automation, or just containerizing builds for increased safety and isolating unstable packages. The old Dockerfile in the toolchain did not satisfy these needs. The new Dockerfile is known to run successfully on Docker version 20.10.7. It clones the SerenityOS repo and builds the toolchain. In this way, it is intended to be a starting point for other Docker images that can e.g. run builds. For example, one can simply run this docker image as-is, exec a shell in it and run a build there.