### PR TITLE
Kernel+Userland: x86_64 support (part 7)

### DIFF
--- a/Kernel/Arch/x86/RegisterState.h
+++ b/Kernel/Arch/x86/RegisterState.h
@@ -47,11 +47,11 @@ struct [[gnu::packed]] RegisterState {
     FlatPtr r14;
     FlatPtr r15;
 #endif
+    u16 exception_code;
+    u16 isr_number;
 #if ARCH(X86_64)
     u32 padding;
 #endif
-    u16 exception_code;
-    u16 isr_number;
 #if ARCH(I386)
     FlatPtr eip;
 #else

--- a/Kernel/Arch/x86/i386/Processor.cpp
+++ b/Kernel/Arch/x86/i386/Processor.cpp
@@ -17,7 +17,6 @@ namespace Kernel {
 
 #define ENTER_THREAD_CONTEXT_ARGS_SIZE (2 * 4) //  to_thread, from_thread
 extern "C" void thread_context_first_enter(void);
-extern "C" void do_assume_context(Thread* thread, u32 flags);
 extern "C" void exit_kernel_thread(void);
 
 // clang-format off
@@ -234,21 +233,6 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
     dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 
     Processor::current().restore_in_critical(to_thread->saved_critical());
-}
-
-void Processor::assume_context(Thread& thread, FlatPtr flags)
-{
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "Assume context for thread {} {}", VirtualAddress(&thread), thread);
-
-    VERIFY_INTERRUPTS_DISABLED();
-    Scheduler::prepare_after_exec();
-    // in_critical() should be 2 here. The critical section in Process::exec
-    // and then the scheduler lock
-    VERIFY(Processor::current().in_critical() == 2);
-
-    do_assume_context(&thread, flags);
-
-    VERIFY_NOT_REACHED();
 }
 
 UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_thread)

--- a/Kernel/Arch/x86/x86_64/InterruptEntry.cpp
+++ b/Kernel/Arch/x86/x86_64/InterruptEntry.cpp
@@ -14,7 +14,11 @@ asm(
     "interrupt_common_asm_entry: \n"
     // add the padding field in RegisterState
     "    subq $4, %rsp\n"
-    "    movl $0, 0(%rsp)\n"
+    "    pushq %rax\n"
+    "    movl 12(%rsp), %eax\n"
+    "    movl $0, 12(%rsp)\n"
+    "    movl %eax, 8(%rsp)\n"
+    "    popq %rax\n"
     // save all the other registers
     "    pushq %r15\n"
     "    pushq %r14\n"

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -16,7 +16,6 @@
 namespace Kernel {
 
 extern "C" void thread_context_first_enter(void);
-extern "C" void do_assume_context(Thread* thread, u32 flags);
 extern "C" void exit_kernel_thread(void);
 
 // clang-format off
@@ -50,6 +49,8 @@ asm(
 "    movq %rax, %rsp \n" // move stack pointer to what Processor::init_context set up for us
 "    movq %r12, %rdi \n" // to_thread
 "    movq %r12, %rsi \n" // from_thread
+"    pushq %r12 \n" // to_thread (for thread_context_first_enter)
+"    pushq %r12 \n" // from_thread (for thread_context_first_enter)
 "    movabs $thread_context_first_enter, %r12 \n" // should be same as regs.rip
 "    pushq %r12 \n"
 "    jmp enter_thread_context \n"
@@ -236,22 +237,6 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
     dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 
     Processor::current().restore_in_critical(to_thread->saved_critical());
-}
-
-void Processor::assume_context(Thread& thread, FlatPtr flags)
-{
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "Assume context for thread {} {}", VirtualAddress(&thread), thread);
-
-    VERIFY_INTERRUPTS_DISABLED();
-    Scheduler::prepare_after_exec();
-    // in_critical() should be 2 here. The critical section in Process::exec
-    // and then the scheduler lock
-    VERIFY(Processor::current().in_critical() == 2);
-
-    (void)flags;
-    TODO();
-
-    VERIFY_NOT_REACHED();
 }
 
 UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_thread)

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -78,7 +78,11 @@ KResult CoreDump::write_elf_header()
     elf_file_header.e_ident[EI_MAG1] = 'E';
     elf_file_header.e_ident[EI_MAG2] = 'L';
     elf_file_header.e_ident[EI_MAG3] = 'F';
+#if ARCH(I386)
     elf_file_header.e_ident[EI_CLASS] = ELFCLASS32;
+#else
+    elf_file_header.e_ident[EI_CLASS] = ELFCLASS64;
+#endif
     elf_file_header.e_ident[EI_DATA] = ELFDATA2LSB;
     elf_file_header.e_ident[EI_VERSION] = EV_CURRENT;
     elf_file_header.e_ident[EI_OSABI] = 0; // ELFOSABI_NONE
@@ -90,7 +94,11 @@ KResult CoreDump::write_elf_header()
     elf_file_header.e_ident[EI_PAD + 5] = 0;
     elf_file_header.e_ident[EI_PAD + 6] = 0;
     elf_file_header.e_type = ET_CORE;
+#if ARCH(I386)
     elf_file_header.e_machine = EM_386;
+#else
+    elf_file_header.e_machine = EM_X86_64;
+#endif
     elf_file_header.e_version = 1;
     elf_file_header.e_entry = 0;
     elf_file_header.e_phoff = sizeof(ElfW(Ehdr));

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -144,8 +144,8 @@ static KResultOr<FlatPtr> make_userspace_context_for_main_thread([[maybe_unused]
     push_on_new_stack(argv);
     push_on_new_stack(argv_entries.size());
 #else
-    regs.rdi = argv;
-    regs.rsi = argv_entries.size();
+    regs.rdi = argv_entries.size();
+    regs.rsi = argv;
     regs.rdx = envp;
 #endif
     push_on_new_stack(0); // return address

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -66,8 +66,29 @@ KResultOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:04x}:{:08x} with stack {:04x}:{:08x}, kstack {:04x}:{:08x}",
         child_regs.cs, child_regs.eip, child_regs.ss, child_regs.esp, child_regs.ss0, child_regs.esp0);
 #else
-    (void)regs;
-    PANIC("Process::sys$fork() not implemented.");
+    auto& child_regs = child_first_thread->m_regs;
+    child_regs.rax = 0; // fork() returns 0 in the child :^)
+    child_regs.rbx = regs.rbx;
+    child_regs.rcx = regs.rcx;
+    child_regs.rdx = regs.rdx;
+    child_regs.rbp = regs.rbp;
+    child_regs.rsp = regs.userspace_rsp;
+    child_regs.rsi = regs.rsi;
+    child_regs.rdi = regs.rdi;
+    child_regs.r8 = regs.r8;
+    child_regs.r9 = regs.r9;
+    child_regs.r10 = regs.r10;
+    child_regs.r11 = regs.r11;
+    child_regs.r12 = regs.r12;
+    child_regs.r13 = regs.r13;
+    child_regs.r14 = regs.r14;
+    child_regs.r15 = regs.r15;
+    child_regs.rflags = regs.rflags;
+    child_regs.rip = regs.rip;
+    child_regs.cs = regs.cs;
+
+    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:04x}:{:16x} with stack {:08x}, kstack {:08x}",
+        child_regs.cs, child_regs.rip, child_regs.rsp, child_regs.rsp0);
 #endif
 
     {

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -28,12 +28,12 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
     int schedule_priority = params.m_schedule_priority;
     unsigned stack_size = params.m_stack_size;
 
-    auto user_esp = Checked<FlatPtr>((FlatPtr)params.m_stack_location);
-    user_esp += stack_size;
-    if (user_esp.has_overflow())
+    auto user_sp = Checked<FlatPtr>((FlatPtr)params.m_stack_location);
+    user_sp += stack_size;
+    if (user_sp.has_overflow())
         return EOVERFLOW;
 
-    if (!MM.validate_user_stack(*this, VirtualAddress(user_esp.value() - 4)))
+    if (!MM.validate_user_stack(*this, VirtualAddress(user_sp.value() - 4)))
         return EFAULT;
 
     // FIXME: return EAGAIN if Thread::all_threads().size() is greater than PTHREAD_THREADS_MAX
@@ -65,11 +65,11 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
 #if ARCH(I386)
     regs.eip = (FlatPtr)entry;
     regs.eflags = 0x0202;
-    regs.esp = user_esp.value();
+    regs.esp = user_sp.value();
 #else
     regs.rip = (FlatPtr)entry;
     regs.rflags = 0x0202;
-    regs.rsp = user_esp.value();
+    regs.rsp = user_sp.value();
 #endif
     regs.cr3 = space().page_directory().cr3();
 

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -23,7 +23,12 @@ KResultOr<FlatPtr> Process::sys$uname(Userspace<utsname*> user_buf)
     memcpy(buf.sysname, "SerenityOS", 11);
     memcpy(buf.release, "1.0-dev", 8);
     memcpy(buf.version, "FIXME", 6);
+#if ARCH(I386)
     memcpy(buf.machine, "i686", 5);
+#else
+    memcpy(buf.machine, "x86_64", 7);
+#endif
+
     memcpy(buf.nodename, g_hostname->characters(), g_hostname->length() + 1);
 
     if (!copy_to_user(user_buf, &buf))

--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -21,4 +21,6 @@ exec $SERENITY_KERNEL_DEBUGGER \
     -ex "set arch $gdb_arch" \
     -ex 'target remote localhost:1234' \
     -ex "source $(dirname "$0")/serenity_gdb.py" \
+    -ex "layout asm" \
+    -ex "fs next" \
     "$@"

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -49,11 +49,13 @@ static void perform_self_relocations(auxv_t* auxvp)
     auto dynamic_object = ELF::DynamicObject::create({}, (VirtualAddress(base_address)), (VirtualAddress(dynamic_section_addr)));
 
     dynamic_object->relocation_section().for_each_relocation([base_address](auto& reloc) {
-        if (reloc.type() != R_386_RELATIVE)
-            return IterationDecision::Continue;
+#if ARCH(I386)
+        VERIFY(reloc.type() == R_386_RELATIVE);
+#else
+        VERIFY(reloc.type() == R_X86_64_RELATIVE);
+#endif
 
-        *(u32*)reloc.address().as_ptr() += base_address;
-        return IterationDecision::Continue;
+        *(FlatPtr*)reloc.address().as_ptr() += base_address;
     });
 }
 

--- a/Userland/Libraries/LibC/dirent.cpp
+++ b/Userland/Libraries/LibC/dirent.cpp
@@ -57,11 +57,11 @@ void rewinddir(DIR* dirp)
 struct [[gnu::packed]] sys_dirent {
     ino_t ino;
     u8 file_type;
-    size_t namelen;
+    u32 namelen;
     char name[];
     size_t total_size()
     {
-        return sizeof(ino_t) + sizeof(u8) + sizeof(size_t) + sizeof(char) * namelen;
+        return sizeof(ino_t) + sizeof(u8) + sizeof(u32) + sizeof(char) * namelen;
     }
 };
 

--- a/Userland/Libraries/LibC/elf.h
+++ b/Userland/Libraries/LibC/elf.h
@@ -803,3 +803,4 @@ struct elf_args {
 #define R_X86_64_GLOB_DAT 6
 #define R_X86_64_JUMP_SLOT 7
 #define R_X86_64_RELATIVE 8
+#define R_X86_64_TPOFF64 18

--- a/Userland/Libraries/LibCoreDump/Reader.cpp
+++ b/Userland/Libraries/LibCoreDump/Reader.cpp
@@ -106,7 +106,7 @@ bool Reader::NotesEntryIterator::at_end() const
     return type() == ELF::Core::NotesEntryHeader::Type::Null;
 }
 
-Optional<uint32_t> Reader::peek_memory(FlatPtr address) const
+Optional<FlatPtr> Reader::peek_memory(FlatPtr address) const
 {
     const auto* region = region_containing(address);
     if (!region)
@@ -114,7 +114,7 @@ Optional<uint32_t> Reader::peek_memory(FlatPtr address) const
 
     FlatPtr offset_in_region = address - region->region_start;
     const char* region_data = image().program_header(region->program_header_index).raw_data();
-    return *(const uint32_t*)(&region_data[offset_in_region]);
+    return *(const FlatPtr*)(&region_data[offset_in_region]);
 }
 
 const JsonObject Reader::process_info() const

--- a/Userland/Libraries/LibCoreDump/Reader.h
+++ b/Userland/Libraries/LibCoreDump/Reader.h
@@ -31,7 +31,7 @@ public:
 
     const ELF::Image& image() const { return m_coredump_image; }
 
-    Optional<uint32_t> peek_memory(FlatPtr address) const;
+    Optional<FlatPtr> peek_memory(FlatPtr address) const;
     const ELF::Core::MemoryRegionInfo* region_containing(FlatPtr address) const;
 
     struct LibraryData {

--- a/Userland/Libraries/LibELF/Arch/x86_64/plt_trampoline.S
+++ b/Userland/Libraries/LibELF/Arch/x86_64/plt_trampoline.S
@@ -8,5 +8,42 @@
     .globl _plt_trampoline
     .hidden _plt_trampoline
     .type _plt_trampoline,@function
-_plt_trampoline:
-    int3
+_plt_trampoline: # (object, relocation_index)
+     # save flags/registers (https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call)
+    pushfq
+    pushq %rax
+    pushq %rcx
+    pushq %rdx
+    pushq %rsi
+    pushq %rdi
+    pushq %r8
+    pushq %r9
+    pushq %r10
+    pushq %r11
+
+    movq 80(%rsp), %rdi # object
+    movq 88(%rsp), %rsi # relocation_index
+
+    # offset = index * sizeof(Elf64_Rela)
+    shlq $3, %rsi
+    leaq (%rsi, %rsi, 2), %rsi
+
+    call _fixup_plt_entry@PLT
+
+    movq %rax, 88(%rsp) # replace object argument with symbol address
+
+     # restore flags/registers
+    popq %r11
+    popq %r10
+    popq %r9
+    popq %r8
+    popq %rdi
+    popq %rsi
+    popq %rdx
+    popq %rcx
+    popq %rax
+    popfq
+
+    addq $8, %rsp # remove relocation_index argument
+
+    retq

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -506,7 +506,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
             u8* relocation_address = relocation.address().as_ptr();
 
             if (m_elf_image.is_dynamic())
-                *(u32*)relocation_address += (FlatPtr)m_dynamic_object->base_address().as_ptr();
+                *(FlatPtr*)relocation_address += (FlatPtr)m_dynamic_object->base_address().as_ptr();
         }
         break;
     }

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -320,7 +320,7 @@ void DynamicLoader::load_program_headers()
 
     for (auto& text_region : text_regions) {
         FlatPtr ph_text_base = text_region.desired_load_address().page_base().get();
-        FlatPtr ph_text_end = round_up_to_power_of_two(text_region.desired_load_address().offset(text_region.size_in_memory()).get(), PAGE_SIZE);
+        FlatPtr ph_text_end = ph_text_base + round_up_to_power_of_two(text_region.size_in_memory() + (size_t)(text_region.desired_load_address().as_ptr() - ph_text_base), PAGE_SIZE);
         size_t text_segment_size = ph_text_end - ph_text_base;
 
         auto text_segment_offset = ph_text_base - ph_load_base;
@@ -358,7 +358,7 @@ void DynamicLoader::load_program_headers()
 
     for (auto& data_region : data_regions) {
         FlatPtr ph_data_base = data_region.desired_load_address().page_base().get();
-        FlatPtr ph_data_end = round_up_to_power_of_two(data_region.desired_load_address().offset(data_region.size_in_memory()).get(), PAGE_SIZE);
+        FlatPtr ph_data_end = ph_data_base + round_up_to_power_of_two(data_region.size_in_memory() + (size_t)(data_region.desired_load_address().as_ptr() - ph_data_base), PAGE_SIZE);
         size_t data_segment_size = ph_data_end - ph_data_base;
 
         auto data_segment_offset = ph_data_base - ph_load_base;
@@ -384,6 +384,8 @@ void DynamicLoader::load_program_headers()
             data_segment_start = VirtualAddress { (u8*)reservation + data_region.desired_load_address().get() };
         else
             data_segment_start = data_region.desired_load_address();
+
+        VERIFY(data_segment_start.as_ptr() + data_region.size_in_memory() <= data_segment + data_segment_size);
 
         memcpy(data_segment_start.as_ptr(), (u8*)m_file_data + data_region.offset(), data_region.size_in_image());
     }

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -486,6 +486,13 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         *patch_ptr = negative_offset_from_tls_block_end(res.value().value, dynamic_object_of_symbol->tls_offset().value(), res.value().size);
         break;
     }
+#else
+    case R_X86_64_TPOFF64:
+        dbgln("FIXME: Patched R_X86_64_TPOFF64 relocation with invalid ptr.");
+        *patch_ptr = 0xaaaaaaaaaaaaaaaa;
+        break;
+#endif
+#ifndef __LP64__
     case R_386_JMP_SLOT: {
 #else
     case R_X86_64_JUMP_SLOT: {

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -449,7 +449,11 @@ NonnullRefPtr<DynamicObject> DynamicObject::create(const String& filename, Virtu
 VirtualAddress DynamicObject::patch_plt_entry(u32 relocation_offset)
 {
     auto relocation = plt_relocation_section().relocation_at_offset(relocation_offset);
+#if ARCH(I386)
     VERIFY(relocation.type() == R_386_JMP_SLOT);
+#else
+    VERIFY(relocation.type() == R_X86_64_JUMP_SLOT);
+#endif
     auto symbol = relocation.symbol();
     u8* relocation_address = relocation.address().as_ptr();
 

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -63,10 +63,24 @@ public:
         unsigned value() const { return m_sym.st_value; }
         unsigned size() const { return m_sym.st_size; }
         unsigned index() const { return m_index; }
-        unsigned type() const { return ELF32_ST_TYPE(m_sym.st_info); }
+#if ARCH(I386)
+        unsigned type() const
+        {
+            return ELF32_ST_TYPE(m_sym.st_info);
+        }
         unsigned bind() const { return ELF32_ST_BIND(m_sym.st_info); }
+#else
+        unsigned type() const
+        {
+            return ELF64_ST_TYPE(m_sym.st_info);
+        }
+        unsigned bind() const { return ELF64_ST_BIND(m_sym.st_info); }
+#endif
 
-        bool is_undefined() const { return section_index() == 0; }
+        bool is_undefined() const
+        {
+            return section_index() == 0;
+        }
 
         VirtualAddress address() const
         {
@@ -146,9 +160,23 @@ public:
 
         unsigned offset_in_section() const { return m_offset_in_section; }
         unsigned offset() const { return m_rel.r_offset; }
-        unsigned type() const { return ELF32_R_TYPE(m_rel.r_info); }
+#if ARCH(I386)
+        unsigned type() const
+        {
+            return ELF32_R_TYPE(m_rel.r_info);
+        }
         unsigned symbol_index() const { return ELF32_R_SYM(m_rel.r_info); }
-        Symbol symbol() const { return m_dynamic.symbol(symbol_index()); }
+#else
+        unsigned type() const
+        {
+            return ELF64_R_TYPE(m_rel.r_info);
+        }
+        unsigned symbol_index() const { return ELF64_R_SYM(m_rel.r_info); }
+#endif
+        Symbol symbol() const
+        {
+            return m_dynamic.symbol(symbol_index());
+        }
         VirtualAddress address() const
         {
             if (m_dynamic.elf_is_dynamic())

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -54,9 +54,23 @@ public:
         unsigned value() const { return m_sym.st_value; }
         unsigned size() const { return m_sym.st_size; }
         unsigned index() const { return m_index; }
-        unsigned type() const { return ELF32_ST_TYPE(m_sym.st_info); }
+#if ARCH(I386)
+        unsigned type() const
+        {
+            return ELF32_ST_TYPE(m_sym.st_info);
+        }
         unsigned bind() const { return ELF32_ST_BIND(m_sym.st_info); }
-        Section section() const { return m_image.section(section_index()); }
+#else
+        unsigned type() const
+        {
+            return ELF64_ST_TYPE(m_sym.st_info);
+        }
+        unsigned bind() const { return ELF64_ST_BIND(m_sym.st_info); }
+#endif
+        Section section() const
+        {
+            return m_image.section(section_index());
+        }
         bool is_undefined() const { return section_index() == 0; }
         StringView raw_data() const;
 
@@ -151,9 +165,23 @@ public:
         ~Relocation() { }
 
         unsigned offset() const { return m_rel.r_offset; }
-        unsigned type() const { return ELF32_R_TYPE(m_rel.r_info); }
+#if ARCH(I386)
+        unsigned type() const
+        {
+            return ELF32_R_TYPE(m_rel.r_info);
+        }
         unsigned symbol_index() const { return ELF32_R_SYM(m_rel.r_info); }
-        Symbol symbol() const { return m_image.symbol(symbol_index()); }
+#else
+        unsigned type() const
+        {
+            return ELF64_R_TYPE(m_rel.r_info);
+        }
+        unsigned symbol_index() const { return ELF64_R_SYM(m_rel.r_info); }
+#endif
+        Symbol symbol() const
+        {
+            return m_image.symbol(symbol_index());
+        }
 
     private:
         const Image& m_image;


### PR DESCRIPTION
Known issues:

* `__thread` and dynamic TLS don't work
* Syscalls trash some registers (in particular `r12`, `r13`, `r14`, `r15` and `rbx`).
* `dynamic_cast` in userspace doesn't work. Somehow `__do_upcast` ends up with a null `this` pointer.
* Usermode threads crash after being started.

https://github.com/gunnarbeutner/serenity/commits/x86_64-workarounds has a couple of workarounds to get around those issues.

![image](https://user-images.githubusercontent.com/388571/123840812-1b425180-d90f-11eb-964d-f0895f9aadbd.png)

https://user-images.githubusercontent.com/388571/123840823-20070580-d90f-11eb-81bc-72ef3b662e52.mp4

**DynamicLoader: Implement self relocations for x86_64**

**LibELF: Implement GNU hash section lookups for x86_64**

**LibELF: Use correct accessor macros on x86_64 for some ELF fields**

**LibELF: Make sure the mmap() regions are large enough**

Sometimes we'd end up requesting a smaller range for .text and .data than was actually necessary.

**Kernel: Add x86_64 support for fork()**

**LibELF: Add stub for R_X86_64_TPOFF64**

**Kernel: Fix struct layout for interrupt entries on x86_64**

**Kernel: Implement signal handling for x86_64**

**Kernel: Implement capturing stack traces on x86_64**

**Meta: Change default GDB layout**

This adds a TUI window that displays disassembly/source code which I've found quite useful.

**Kernel: Fix correct argument order for userspace entry point**

**LibC: Fix struct layout for sys_dirent on x86_64**

**LibELF: Implement PLT relocations for x86_64**

**Kernel+LibCoreDump: Implement more x86_64 coredump functionality**

**Kernel: Rename some variables to arch-independent names**

**Kernel: Report correct architecture for uname()**