### PR TITLE
AK: Refresh of LexicalPath

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,7 +16,6 @@ LexicalPath::LexicalPath(String s)
     : m_string(move(s))
 {
     canonicalize();
-    m_is_valid = true;
 }
 
 void LexicalPath::canonicalize()

--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -93,7 +93,7 @@ void LexicalPath::canonicalize()
     m_string = builder.to_string();
 }
 
-bool LexicalPath::has_extension(const StringView& extension) const
+bool LexicalPath::has_extension(StringView const& extension) const
 {
     return m_string.ends_with(extension, CaseSensitivity::CaseInsensitive);
 }
@@ -103,7 +103,7 @@ String LexicalPath::canonicalized_path(String path)
     return LexicalPath(move(path)).string();
 }
 
-String LexicalPath::relative_path(String absolute_path, const String& prefix)
+String LexicalPath::relative_path(String absolute_path, String const& prefix)
 {
     if (!LexicalPath { absolute_path }.is_absolute() || !LexicalPath { prefix }.is_absolute())
         return {};

--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -137,15 +137,14 @@ String LexicalPath::relative_path(String absolute_path, String const& prefix)
     return absolute_path.substring(prefix_length);
 }
 
-void LexicalPath::append(String const& component)
+LexicalPath LexicalPath::append(StringView const& value) const
 {
-    StringBuilder builder;
-    builder.append(m_string);
-    builder.append('/');
-    builder.append(component);
+    return LexicalPath::join(m_string, value);
+}
 
-    m_string = builder.to_string();
-    canonicalize();
+LexicalPath LexicalPath::parent() const
+{
+    return append("..");
 }
 
 }

--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -12,85 +12,102 @@
 
 namespace AK {
 
+char s_single_dot = '.';
+
 LexicalPath::LexicalPath(String s)
     : m_string(move(s))
 {
     canonicalize();
 }
 
+Vector<String> LexicalPath::parts() const
+{
+    Vector<String> vector;
+    vector.ensure_capacity(m_parts.size());
+    for (auto& part : m_parts)
+        vector.unchecked_append(part);
+    return vector;
+}
+
 void LexicalPath::canonicalize()
 {
+    // NOTE: We never allow an empty m_string, if it's empty, we just set it to '.'.
     if (m_string.is_empty()) {
+        m_string = ".";
+        m_dirname = m_string;
+        m_basename = {};
+        m_title = {};
+        m_extension = {};
         m_parts.clear();
         return;
     }
 
-    m_is_absolute = m_string[0] == '/';
-    auto parts = m_string.split_view('/');
+    // NOTE: If there are no dots, no '//' and the path doesn't end with a slash, it is already canonical.
+    if (m_string.contains("."sv) || m_string.contains("//"sv) || m_string.ends_with('/')) {
+        auto parts = m_string.split_view('/');
+        size_t approximate_canonical_length = 0;
+        Vector<String> canonical_parts;
 
-    size_t approximate_canonical_length = 0;
-    Vector<String> canonical_parts;
-
-    for (size_t i = 0; i < parts.size(); ++i) {
-        auto& part = parts[i];
-        if (part == ".")
-            continue;
-        if (part == "..") {
-            if (canonical_parts.is_empty()) {
-                if (m_is_absolute) {
-                    // At the root, .. does nothing.
-                    continue;
-                }
-            } else {
-                if (canonical_parts.last() != "..") {
-                    // A .. and a previous non-.. part cancel each other.
-                    canonical_parts.take_last();
-                    continue;
+        for (auto& part : parts) {
+            if (part == ".")
+                continue;
+            if (part == "..") {
+                if (canonical_parts.is_empty()) {
+                    if (is_absolute()) {
+                        // At the root, .. does nothing.
+                        continue;
+                    }
+                } else {
+                    if (canonical_parts.last() != "..") {
+                        // A .. and a previous non-.. part cancel each other.
+                        canonical_parts.take_last();
+                        continue;
+                    }
                 }
             }
-        }
-        if (!part.is_empty()) {
             approximate_canonical_length += part.length() + 1;
             canonical_parts.append(part);
         }
-    }
-    if (canonical_parts.is_empty()) {
-        m_string = m_basename = m_dirname = m_is_absolute ? "/" : ".";
-        return;
-    }
 
-    StringBuilder dirname_builder(approximate_canonical_length);
-    for (size_t i = 0; i < canonical_parts.size() - 1; ++i) {
-        auto& canonical_part = canonical_parts[i];
-        if (m_is_absolute || i != 0)
-            dirname_builder.append('/');
-        dirname_builder.append(canonical_part);
-    }
-    m_dirname = dirname_builder.to_string();
+        if (canonical_parts.is_empty() && !is_absolute())
+            canonical_parts.append(".");
 
-    if (m_dirname.is_empty()) {
-        m_dirname = m_is_absolute ? "/" : ".";
+        StringBuilder builder(approximate_canonical_length);
+        if (is_absolute())
+            builder.append('/');
+        builder.join('/', canonical_parts);
+        m_string = builder.to_string();
     }
 
-    m_basename = canonical_parts.last();
+    m_parts = m_string.split_view('/');
 
-    Optional<size_t> last_dot = StringView(m_basename).find_last_of('.');
-    if (last_dot.has_value()) {
-        m_title = m_basename.substring(0, last_dot.value());
-        m_extension = m_basename.substring(last_dot.value() + 1, m_basename.length() - last_dot.value() - 1);
+    auto last_slash_index = m_string.view().find_last_of('/');
+    if (!last_slash_index.has_value()) {
+        // The path contains a single part and is not absolute. m_dirname = "."sv
+        m_dirname = { &s_single_dot, 1 };
+    } else if (*last_slash_index == 0) {
+        // The path contains a single part and is absolute. m_dirname = "/"sv
+        m_dirname = m_string.substring_view(0, 1);
+    } else {
+        m_dirname = m_string.substring_view(0, *last_slash_index);
+    }
+
+    if (m_string == "/")
+        m_basename = m_string;
+    else {
+        VERIFY(m_parts.size() > 0);
+        m_basename = m_parts.last();
+    }
+
+    auto last_dot_index = m_basename.find_last_of('.');
+    // NOTE: if the dot index is 0, this means we have ".foo", it's not an extension, as the title would then be "".
+    if (last_dot_index.has_value() && *last_dot_index != 0) {
+        m_title = m_basename.substring_view(0, *last_dot_index);
+        m_extension = m_basename.substring_view(*last_dot_index + 1);
     } else {
         m_title = m_basename;
+        m_extension = {};
     }
-
-    StringBuilder builder(approximate_canonical_length);
-    for (size_t i = 0; i < canonical_parts.size(); ++i) {
-        auto& canonical_part = canonical_parts[i];
-        if (m_is_absolute || i != 0)
-            builder.append('/');
-        builder.append(canonical_part);
-    }
-    m_parts = move(canonical_parts);
-    m_string = builder.to_string();
 }
 
 bool LexicalPath::has_extension(StringView const& extension) const

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -44,6 +44,30 @@ public:
         return LexicalPath { builder.to_string() };
     }
 
+    static String dirname(String path)
+    {
+        auto lexical_path = LexicalPath(move(path));
+        return lexical_path.dirname();
+    }
+
+    static String basename(String path)
+    {
+        auto lexical_path = LexicalPath(move(path));
+        return lexical_path.basename();
+    }
+
+    static String title(String path)
+    {
+        auto lexical_path = LexicalPath(move(path));
+        return lexical_path.title();
+    }
+
+    static String extension(String path)
+    {
+        auto lexical_path = LexicalPath(move(path));
+        return lexical_path.extension();
+    }
+
 private:
     void canonicalize();
 

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -33,7 +33,7 @@ public:
     [[nodiscard]] LexicalPath parent() const;
 
     [[nodiscard]] static String canonicalized_path(String);
-    [[nodiscard]] static String relative_path(String absolute_path, String const& prefix);
+    [[nodiscard]] static String relative_path(StringView const& absolute_path, StringView const& prefix);
 
     template<typename... S>
     [[nodiscard]] static LexicalPath join(String const& first, S&&... rest)

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -25,18 +25,18 @@ public:
     StringView const& extension() const { return m_extension; }
 
     Vector<StringView> const& parts_view() const { return m_parts; }
-    Vector<String> parts() const;
+    [[nodiscard]] Vector<String> parts() const;
 
     bool has_extension(StringView const&) const;
 
     [[nodiscard]] LexicalPath append(StringView const&) const;
     [[nodiscard]] LexicalPath parent() const;
 
-    static String canonicalized_path(String);
-    static String relative_path(String absolute_path, String const& prefix);
+    [[nodiscard]] static String canonicalized_path(String);
+    [[nodiscard]] static String relative_path(String absolute_path, String const& prefix);
 
     template<typename... S>
-    static LexicalPath join(String const& first, S&&... rest)
+    [[nodiscard]] static LexicalPath join(String const& first, S&&... rest)
     {
         StringBuilder builder;
         builder.append(first);
@@ -45,25 +45,25 @@ public:
         return LexicalPath { builder.to_string() };
     }
 
-    static String dirname(String path)
+    [[nodiscard]] static String dirname(String path)
     {
         auto lexical_path = LexicalPath(move(path));
         return lexical_path.dirname();
     }
 
-    static String basename(String path)
+    [[nodiscard]] static String basename(String path)
     {
         auto lexical_path = LexicalPath(move(path));
         return lexical_path.basename();
     }
 
-    static String title(String path)
+    [[nodiscard]] static String title(String path)
     {
         auto lexical_path = LexicalPath(move(path));
         return lexical_path.title();
     }
 
-    static String extension(String path)
+    [[nodiscard]] static String extension(String path)
     {
         auto lexical_path = LexicalPath(move(path));
         return lexical_path.extension();

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -14,7 +14,6 @@ namespace AK {
 
 class LexicalPath {
 public:
-    LexicalPath() = default;
     explicit LexicalPath(String);
 
     bool is_absolute() const { return !m_string.is_empty() && m_string[0] == '/'; }

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -18,16 +18,16 @@ public:
 
     bool is_valid() const { return m_is_valid; }
     bool is_absolute() const { return m_is_absolute; }
-    const String& string() const { return m_string; }
+    String const& string() const { return m_string; }
 
-    const String& dirname() const { return m_dirname; }
-    const String& basename() const { return m_basename; }
-    const String& title() const { return m_title; }
-    const String& extension() const { return m_extension; }
+    String const& dirname() const { return m_dirname; }
+    String const& basename() const { return m_basename; }
+    String const& title() const { return m_title; }
+    String const& extension() const { return m_extension; }
 
-    const Vector<String>& parts() const { return m_parts; }
+    Vector<String> const& parts() const { return m_parts; }
 
-    bool has_extension(const StringView&) const;
+    bool has_extension(StringView const&) const;
 
     void append(String const& component);
 
@@ -59,7 +59,7 @@ private:
 
 template<>
 struct Formatter<LexicalPath> : Formatter<StringView> {
-    void format(FormatBuilder& builder, const LexicalPath& value)
+    void format(FormatBuilder& builder, LexicalPath const& value)
     {
         Formatter<StringView>::format(builder, value.string());
     }

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -30,7 +30,8 @@ public:
 
     bool has_extension(StringView const&) const;
 
-    void append(String const& component);
+    [[nodiscard]] LexicalPath append(StringView const&) const;
+    [[nodiscard]] LexicalPath parent() const;
 
     static String canonicalized_path(String);
     static String relative_path(String absolute_path, String const& prefix);

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,7 +17,6 @@ public:
     LexicalPath() = default;
     explicit LexicalPath(String);
 
-    bool is_valid() const { return m_is_valid; }
     bool is_absolute() const { return m_is_absolute; }
     String const& string() const { return m_string; }
 
@@ -53,7 +53,6 @@ private:
     String m_basename;
     String m_title;
     String m_extension;
-    bool m_is_valid { false };
     bool m_is_absolute { false };
 };
 

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -17,15 +17,16 @@ public:
     LexicalPath() = default;
     explicit LexicalPath(String);
 
-    bool is_absolute() const { return m_is_absolute; }
+    bool is_absolute() const { return !m_string.is_empty() && m_string[0] == '/'; }
     String const& string() const { return m_string; }
 
-    String const& dirname() const { return m_dirname; }
-    String const& basename() const { return m_basename; }
-    String const& title() const { return m_title; }
-    String const& extension() const { return m_extension; }
+    StringView const& dirname() const { return m_dirname; }
+    StringView const& basename() const { return m_basename; }
+    StringView const& title() const { return m_title; }
+    StringView const& extension() const { return m_extension; }
 
-    Vector<String> const& parts() const { return m_parts; }
+    Vector<StringView> const& parts_view() const { return m_parts; }
+    Vector<String> parts() const;
 
     bool has_extension(StringView const&) const;
 
@@ -71,13 +72,12 @@ public:
 private:
     void canonicalize();
 
-    Vector<String> m_parts;
+    Vector<StringView> m_parts;
     String m_string;
-    String m_dirname;
-    String m_basename;
-    String m_title;
-    String m_extension;
-    bool m_is_absolute { false };
+    StringView m_dirname;
+    StringView m_basename;
+    StringView m_title;
+    StringView m_extension;
 };
 
 template<>

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -70,8 +70,6 @@ public:
     }
 
 private:
-    void canonicalize();
-
     Vector<StringView> m_parts;
     String m_string;
     StringView m_dirname;

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -162,7 +162,7 @@ u16 URL::default_port_for_scheme(StringView const& scheme)
 URL URL::create_with_file_scheme(String const& path, String const& fragment, String const& hostname)
 {
     LexicalPath lexical_path(path);
-    if (!lexical_path.is_valid() || !lexical_path.is_absolute())
+    if (!lexical_path.is_absolute())
         return {};
 
     URL url;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -533,7 +533,7 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
     if (old_parent_custody->is_readonly() || new_parent_custody->is_readonly())
         return EROFS;
 
-    auto new_basename = LexicalPath(new_path).basename();
+    auto new_basename = LexicalPath::basename(new_path);
 
     if (!new_custody_or_error.is_error()) {
         auto& new_custody = *new_custody_or_error.value();
@@ -554,7 +554,7 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
     if (auto result = new_parent_inode.add_child(old_inode, new_basename, old_inode.mode()); result.is_error())
         return result;
 
-    if (auto result = old_parent_inode.remove_child(LexicalPath(old_path).basename()); result.is_error())
+    if (auto result = old_parent_inode.remove_child(LexicalPath::basename(old_path)); result.is_error())
         return result;
 
     return KSuccess;
@@ -656,7 +656,7 @@ KResult VFS::link(StringView old_path, StringView new_path, Custody& base)
     if (!hard_link_allowed(old_inode))
         return EPERM;
 
-    return parent_inode.add_child(old_inode, LexicalPath(new_path).basename(), old_inode.mode());
+    return parent_inode.add_child(old_inode, LexicalPath::basename(new_path), old_inode.mode());
 }
 
 KResult VFS::unlink(StringView path, Custody& base)
@@ -689,7 +689,7 @@ KResult VFS::unlink(StringView path, Custody& base)
     if (parent_custody->is_readonly())
         return EROFS;
 
-    if (auto result = parent_inode.remove_child(LexicalPath(path).basename()); result.is_error())
+    if (auto result = parent_inode.remove_child(LexicalPath::basename(path)); result.is_error())
         return result;
 
     return KSuccess;
@@ -771,7 +771,7 @@ KResult VFS::rmdir(StringView path, Custody& base)
     if (auto result = inode.remove_child(".."); result.is_error())
         return result;
 
-    return parent_inode.remove_child(LexicalPath(path).basename());
+    return parent_inode.remove_child(LexicalPath::basename(path));
 }
 
 VFS::Mount::Mount(FS& guest_fs, Custody* host_custody, int flags)

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -834,7 +834,7 @@ UnveilNode const& VFS::find_matching_unveiled_path(StringView path)
     auto& unveil_root = Process::current()->unveiled_paths();
 
     LexicalPath lexical_path { path };
-    auto& path_parts = lexical_path.parts();
+    auto& path_parts = lexical_path.parts_view();
     return unveil_root.traverse_until_last_accessible_node(path_parts.begin(), path_parts.end());
 }
 

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -91,7 +91,7 @@ KResultOr<int> Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> u
     if (!custody_or_error.is_error()) {
         new_unveiled_path = custody_or_error.value()->absolute_path();
     } else if (custody_or_error.error() == -ENOENT && parent_custody && (new_permissions & UnveilAccess::CreateOrRemove)) {
-        String basename = LexicalPath(path.view()).basename();
+        String basename = LexicalPath::basename(path.view());
         new_unveiled_path = String::formatted("{}/{}", parent_custody->absolute_path(), basename);
     } else {
         // FIXME Should this be EINVAL?

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -99,8 +99,8 @@ KResultOr<int> Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> u
     }
 
     LexicalPath lexical_path(new_unveiled_path);
-    auto it = lexical_path.parts().begin();
-    auto& matching_node = m_unveiled_paths.traverse_until_last_accessible_node(it, lexical_path.parts().end());
+    auto it = lexical_path.parts_view().begin();
+    auto& matching_node = m_unveiled_paths.traverse_until_last_accessible_node(it, lexical_path.parts_view().end());
     if (it.is_end()) {
         // If the path has already been explicitly unveiled, do not allow elevating its permissions.
         if (matching_node.was_explicitly_unveiled()) {
@@ -122,7 +122,7 @@ KResultOr<int> Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> u
 
     matching_node.insert(
         it,
-        lexical_path.parts().end(),
+        lexical_path.parts_view().end(),
         { new_unveiled_path, (UnveilAccess)new_permissions, true },
         [](auto& parent, auto& it) -> Optional<UnveilMetadata> {
             auto path = LexicalPath::join(parent.path(), *it).string();

--- a/Tests/AK/TestLexicalPath.cpp
+++ b/Tests/AK/TestLexicalPath.cpp
@@ -165,11 +165,38 @@ TEST_CASE(join)
     EXPECT_EQ(LexicalPath::join("anon", "foo.txt").string(), "anon/foo.txt");
     EXPECT_EQ(LexicalPath::join("/home", "anon/foo.txt").string(), "/home/anon/foo.txt");
     EXPECT_EQ(LexicalPath::join("/", "foo.txt").string(), "/foo.txt");
+    EXPECT_EQ(LexicalPath::join("/home", "anon", "foo.txt").string(), "/home/anon/foo.txt");
 }
 
 TEST_CASE(append)
 {
-    LexicalPath path("/home/anon");
-    path.append("foo.txt");
-    EXPECT_EQ(path.string(), "/home/anon/foo.txt");
+    LexicalPath path("/home/anon/");
+    auto new_path = path.append("foo.txt");
+    EXPECT_EQ(new_path.string(), "/home/anon/foo.txt");
+}
+
+TEST_CASE(parent)
+{
+    {
+        LexicalPath path("/home/anon/foo.txt");
+        auto parent = path.parent();
+        EXPECT_EQ(parent.string(), "/home/anon");
+    }
+    {
+        LexicalPath path("anon/foo.txt");
+        auto parent = path.parent();
+        EXPECT_EQ(parent.string(), "anon");
+    }
+    {
+        LexicalPath path("foo.txt");
+        auto parent = path.parent();
+        EXPECT_EQ(parent.string(), ".");
+        auto parent_of_parent = parent.parent();
+        EXPECT_EQ(parent_of_parent.string(), "..");
+    }
+    {
+        LexicalPath path("/");
+        auto parent = path.parent();
+        EXPECT_EQ(parent.string(), "/");
+    }
 }

--- a/Tests/AK/TestLexicalPath.cpp
+++ b/Tests/AK/TestLexicalPath.cpp
@@ -9,15 +9,9 @@
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
 
-TEST_CASE(construct)
-{
-    EXPECT_EQ(LexicalPath().is_valid(), false);
-}
-
 TEST_CASE(basic)
 {
     LexicalPath path("/abc/def/ghi.txt");
-    EXPECT_EQ(path.is_valid(), true);
     EXPECT_EQ(path.basename(), "ghi.txt");
     EXPECT_EQ(path.title(), "ghi");
     EXPECT_EQ(path.extension(), "txt");

--- a/Tests/AK/TestLexicalPath.cpp
+++ b/Tests/AK/TestLexicalPath.cpp
@@ -150,11 +150,6 @@ TEST_CASE(has_extension)
     }
 
     {
-        LexicalPath path;
-        EXPECT_EQ(path.has_extension(".png"), false);
-    }
-
-    {
         LexicalPath path("png");
         EXPECT_EQ(path.has_extension(".png"), false);
     }

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -204,7 +204,7 @@ int main(int argc, char** argv)
     auto& icon_image_widget = *widget.find_descendant_of_type_named<GUI::ImageWidget>("icon");
     icon_image_widget.set_bitmap(GUI::FileIconProvider::icon_for_executable(executable_path).bitmap_for_size(32));
 
-    auto app_name = LexicalPath(executable_path).basename();
+    auto app_name = LexicalPath::basename(executable_path);
     auto af = Desktop::AppFile::get_for_app(app_name);
     if (af->is_valid())
         app_name = af->name();

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -55,7 +55,7 @@ static void run_file_operation([[maybe_unused]] FileOperation operation, const S
             perror("dup2");
             _exit(1);
         }
-        if (execlp("/bin/FileOperation", "/bin/FileOperation", "Copy", source.characters(), LexicalPath(destination).dirname().characters(), nullptr) < 0) {
+        if (execlp("/bin/FileOperation", "/bin/FileOperation", "Copy", source.characters(), LexicalPath::dirname(destination).characters(), nullptr) < 0) {
             perror("execlp");
             _exit(1);
         }
@@ -609,7 +609,7 @@ void DirectoryView::handle_drop(const GUI::ModelIndex& index, const GUI::DropEve
     for (auto& url_to_copy : urls) {
         if (!url_to_copy.is_valid() || url_to_copy.path() == target_node.full_path())
             continue;
-        auto new_path = String::formatted("{}/{}", target_node.full_path(), LexicalPath(url_to_copy.path()).basename());
+        auto new_path = String::formatted("{}/{}", target_node.full_path(), LexicalPath::basename(url_to_copy.path()));
         if (url_to_copy.path() == new_path)
             continue;
 

--- a/Userland/Applications/FileManager/FileUtils.cpp
+++ b/Userland/Applications/FileManager/FileUtils.cpp
@@ -47,7 +47,7 @@ void delete_paths(const Vector<String>& paths, bool should_confirm, GUI::Window*
 {
     String message;
     if (paths.size() == 1) {
-        message = String::formatted("Really delete {}?", LexicalPath(paths[0]).basename());
+        message = String::formatted("Really delete {}?", LexicalPath::basename(paths[0]));
     } else {
         message = String::formatted("Really delete {} files?", paths.size());
     }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -28,7 +28,6 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
     : Window(parent_window)
 {
     auto lexical_path = LexicalPath(path);
-    VERIFY(lexical_path.is_valid());
 
     auto& main_widget = set_main_widget<GUI::Widget>();
     main_widget.set_layout<GUI::VerticalBoxLayout>();
@@ -103,7 +102,6 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
             perror("readlink");
         } else {
             auto link_directory = LexicalPath(link_destination);
-            VERIFY(link_directory.is_valid());
             auto link_parent = URL::create_with_file_protocol(link_directory.dirname(), link_directory.basename());
             properties.append({ "Link target:", link_destination, Optional(link_parent) });
         }

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -187,7 +187,7 @@ void do_paste(const String& target_directory, GUI::Window* window)
 void do_create_link(const Vector<String>& selected_file_paths, GUI::Window* window)
 {
     auto path = selected_file_paths.first();
-    auto destination = String::formatted("{}/{}", Core::StandardPaths::desktop_directory(), LexicalPath { path }.basename());
+    auto destination = String::formatted("{}/{}", Core::StandardPaths::desktop_directory(), LexicalPath::basename(path));
     if (auto result = Core::File::link_file(destination, path); result.is_error()) {
         GUI::MessageBox::show(window, String::formatted("Could not create desktop shortcut:\n{}", result.error()), "File Manager",
             GUI::MessageBox::Type::Error);
@@ -736,7 +736,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 selected = directory_view.selected_file_paths();
             } else {
                 path = directories_model->full_path(tree_view.selection().first());
-                container_dir_path = LexicalPath(path).basename();
+                container_dir_path = LexicalPath::basename(path);
                 selected = tree_view_selected_file_paths();
             }
 
@@ -1115,7 +1115,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
         for (auto& url_to_copy : urls) {
             if (!url_to_copy.is_valid() || url_to_copy.path() == directory)
                 continue;
-            auto new_path = String::formatted("{}/{}", directory, LexicalPath(url_to_copy.path()).basename());
+            auto new_path = String::formatted("{}/{}", directory, LexicalPath::basename(url_to_copy.path()));
             if (url_to_copy.path() == new_path)
                 continue;
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -78,7 +78,7 @@ HexEditorWidget::HexEditorWidget()
             if (file_size.has_value() && file_size.value() > 0) {
                 m_document_dirty = false;
                 m_editor->set_buffer(ByteBuffer::create_zeroed(file_size.value()));
-                set_path(LexicalPath());
+                set_path({});
                 update_title();
             } else {
                 GUI::MessageBox::show(window(), "Invalid file size entered.", "Error", GUI::MessageBox::Type::Error);
@@ -130,7 +130,7 @@ HexEditorWidget::HexEditorWidget()
         }
 
         m_document_dirty = false;
-        set_path(LexicalPath(save_path.value()));
+        set_path(save_path.value());
         dbgln("Wrote document to {}", save_path.value());
     });
 
@@ -311,11 +311,18 @@ void HexEditorWidget::initialize_menubar(GUI::Menubar& menubar)
     help_menu.add_action(GUI::CommonActions::make_about_action("Hex Editor", GUI::Icon::default_icon("app-hex-editor"), window()));
 }
 
-void HexEditorWidget::set_path(const LexicalPath& lexical_path)
+void HexEditorWidget::set_path(StringView const& path)
 {
-    m_path = lexical_path.string();
-    m_name = lexical_path.title();
-    m_extension = lexical_path.extension();
+    if (path.is_empty()) {
+        m_path = {};
+        m_name = {};
+        m_extension = {};
+    } else {
+        auto lexical_path = LexicalPath(path);
+        m_path = lexical_path.string();
+        m_name = lexical_path.title();
+        m_extension = lexical_path.extension();
+    }
     update_title();
 }
 
@@ -342,7 +349,7 @@ void HexEditorWidget::open_file(const String& path)
 
     m_document_dirty = false;
     m_editor->set_buffer(file->read_all()); // FIXME: On really huge files, this is never going to work. Should really create a framework to fetch data from the file on-demand.
-    set_path(LexicalPath(path));
+    set_path(path);
 }
 
 bool HexEditorWidget::request_close()

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -27,7 +27,7 @@ public:
 
 private:
     HexEditorWidget();
-    void set_path(const LexicalPath& file);
+    void set_path(StringView const&);
     void update_title();
     void set_search_results_visible(bool visible);
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -432,7 +432,7 @@ void Image::set_title(String title)
 void Image::set_path(String path)
 {
     m_path = move(path);
-    set_title(LexicalPath(m_path).basename());
+    set_title(LexicalPath::basename(m_path));
 }
 
 }

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -36,7 +36,7 @@ GUI::Variant PlaylistModel::data(const GUI::ModelIndex& index, GUI::ModelRole ro
     if (role == GUI::ModelRole::Display) {
         switch (index.column()) {
         case 0:
-            return m_playlist_items[index.row()].extended_info->track_display_title.value_or(LexicalPath(m_playlist_items[index.row()].path).title());
+            return m_playlist_items[index.row()].extended_info->track_display_title.value_or(LexicalPath::title(m_playlist_items[index.row()].path));
         case 1:
             return format_duration(m_playlist_items[index.row()].extended_info->track_length_in_seconds.value_or(0));
         case 2:

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -300,7 +300,7 @@ void SoundPlayerWidgetAdvancedView::try_fill_missing_info(Vector<M3UEntry>& entr
         }
 
         if (!entry.extended_info->track_display_title.has_value())
-            entry.extended_info->track_display_title = LexicalPath(entry.path).title();
+            entry.extended_info->track_display_title = LexicalPath::title(entry.path);
         if (!entry.extended_info->track_length_in_seconds.has_value()) {
             if (entry_path.has_extension("wav")) {
                 auto wav_reader = Audio::Loader::create(entry.path);

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -300,7 +300,7 @@ Result<void, String> ExportDialog::make_and_run_for(StringView mime, Core::File&
     } else {
         auto page = GUI::WizardPage::construct(
             "Export File Format",
-            String::formatted("Select the format you wish to export to '{}' as", LexicalPath { file.filename() }.basename()));
+            String::formatted("Select the format you wish to export to '{}' as", LexicalPath::basename(file.filename())));
 
         page->on_next_page = [] { return nullptr; };
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -82,7 +82,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     m_webview->on_link_click = [this](auto& url, auto&, auto&&) {
         VERIFY(url.protocol() == "spreadsheet");
         if (url.host() == "example") {
-            auto entry = LexicalPath(url.path()).basename();
+            auto entry = LexicalPath::basename(url.path());
             auto doc_option = m_docs.get(entry);
             if (!doc_option.is_object()) {
                 GUI::MessageBox::show_error(this, String::formatted("No documentation entry found for '{}'", url.path()));
@@ -120,7 +120,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             widget.add_sheet(sheet.release_nonnull());
             window->show();
         } else if (url.host() == "doc") {
-            auto entry = LexicalPath(url.path()).basename();
+            auto entry = LexicalPath::basename(url.path());
             m_webview->load(URL::create_with_data("text/html", render(entry)));
         } else {
             dbgln("Invalid spreadsheet action domain '{}'", url.host());

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -252,7 +252,7 @@ Result<NonnullRefPtrVector<Sheet>, String> ImportDialog::make_and_run_for(String
     } else {
         auto page = GUI::WizardPage::construct(
             "Import File Format",
-            String::formatted("Select the format you wish to import '{}' as", LexicalPath { file.filename() }.basename()));
+            String::formatted("Select the format you wish to import '{}' as", LexicalPath::basename(file.filename())));
 
         page->on_next_page = [] { return nullptr; };
 

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -254,7 +254,7 @@ MainWidget::MainWidget()
         }
 
         m_editor->set_text(StringView());
-        set_path(LexicalPath());
+        set_path({});
         update_title();
     });
 
@@ -287,7 +287,7 @@ MainWidget::MainWidget()
         // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
         window()->set_modified(false);
 
-        set_path(LexicalPath(save_path.value()));
+        set_path(save_path.value());
         dbgln("Wrote document to {}", save_path.value());
     });
 
@@ -595,11 +595,18 @@ void MainWidget::initialize_menubar(GUI::Menubar& menubar)
     help_menu.add_action(GUI::CommonActions::make_about_action("Text Editor", GUI::Icon::default_icon("app-text-editor"), window()));
 }
 
-void MainWidget::set_path(const LexicalPath& lexical_path)
+void MainWidget::set_path(StringView const& path)
 {
-    m_path = lexical_path.string();
-    m_name = lexical_path.title();
-    m_extension = lexical_path.extension();
+    if (path.is_empty()) {
+        m_path = {};
+        m_name = {};
+        m_extension = {};
+    } else {
+        auto lexical_path = LexicalPath(path);
+        m_path = lexical_path.string();
+        m_name = lexical_path.title();
+        m_extension = lexical_path.extension();
+    }
 
     if (m_extension == "c" || m_extension == "cc" || m_extension == "cxx" || m_extension == "cpp" || m_extension == "h") {
         m_cpp_highlight->activate();
@@ -660,7 +667,7 @@ bool MainWidget::open_file(const String& path)
 
     m_editor->set_text(file->read_all());
 
-    set_path(LexicalPath(path));
+    set_path(path);
 
     m_editor->set_focus(true);
 

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -42,7 +42,7 @@ public:
 
 private:
     MainWidget();
-    void set_path(const LexicalPath& file);
+    void set_path(StringView const&);
     void update_preview();
     void update_markdown_preview();
     void update_html_preview();

--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -22,7 +22,7 @@ CodeDocument::CodeDocument(const String& file_path, Client* client)
     : TextDocument(client)
     , m_file_path(file_path)
 {
-    m_language = language_from_file_extension(LexicalPath { file_path }.extension());
+    m_language = language_from_file_extension(LexicalPath::extension(file_path));
 }
 
 CodeDocument::CodeDocument(Client* client)

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -182,18 +182,10 @@ Optional<String> NewProjectDialog::get_project_full_path()
     auto create_in = m_create_in_input->text();
     auto maybe_project_name = get_available_project_name();
 
-    if (!maybe_project_name.has_value()) {
-        return {};
-    }
-
-    auto project_name = maybe_project_name.value();
-    auto full_path = LexicalPath(String::formatted("{}/{}", create_in, project_name));
-
-    // Do not permit otherwise invalid paths.
-    if (!full_path.is_valid())
+    if (!maybe_project_name.has_value())
         return {};
 
-    return full_path.string();
+    return LexicalPath::join(create_in, *maybe_project_name).string();
 }
 
 void NewProjectDialog::do_create_project()

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -169,7 +169,7 @@ static HashMap<String, String>& man_paths()
         Core::DirIterator it("/usr/share/man/man2", Core::DirIterator::Flags::SkipDots);
         while (it.has_next()) {
             auto path = it.next_full_path();
-            auto title = LexicalPath(path).title();
+            auto title = LexicalPath::title(path);
             paths.set(title, path);
         }
     }

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -113,8 +113,7 @@ void EditorWrapper::update_diff()
 void EditorWrapper::set_project_root(LexicalPath const& project_root)
 {
     m_project_root = project_root;
-
-    auto result = GitRepo::try_to_create(m_project_root);
+    auto result = GitRepo::try_to_create(*m_project_root);
     switch (result.type) {
     case GitRepo::CreateResult::Type::Success:
         m_git_repo = result.repo;

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -43,7 +43,7 @@ public:
     const String& filename() const { return m_filename; }
     bool document_dirty() const { return m_document_dirty; }
 
-    LexicalPath const& project_root() const { return m_project_root; }
+    Optional<LexicalPath> const& project_root() const { return m_project_root; }
     void set_project_root(LexicalPath const& project_root);
 
     GitRepo const* git_repo() const { return m_git_repo; }
@@ -62,7 +62,7 @@ private:
     RefPtr<Editor> m_editor;
     bool m_document_dirty { false };
 
-    LexicalPath m_project_root;
+    Optional<LexicalPath> m_project_root;
     RefPtr<GitRepo> m_git_repo;
     Vector<Diff::Hunk> m_hunks;
 };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -733,7 +733,7 @@ String HackStudioWidget::get_project_executable_path() const
     // FIXME: Dumb heuristic ahead!
     // e.g /my/project => /my/project/project
     // TODO: Perhaps a Makefile rule for getting the value of $(PROGRAM) would be better?
-    return String::formatted("{}/{}", m_project->root_path(), LexicalPath(m_project->root_path()).basename());
+    return String::formatted("{}/{}", m_project->root_path(), LexicalPath::basename(m_project->root_path()));
 }
 
 void HackStudioWidget::build(TerminalWrapper& wrapper)

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -23,7 +23,7 @@ public:
 
     GUI::FileSystemModel& model() { return *m_model; }
     const GUI::FileSystemModel& model() const { return *m_model; }
-    String name() const { return LexicalPath(m_root_path).basename(); }
+    String name() const { return LexicalPath::basename(m_root_path); }
     String root_path() const { return m_root_path; }
 
     NonnullRefPtr<ProjectFile> get_file(const String& path) const;

--- a/Userland/DevTools/HackStudio/ProjectTemplate.cpp
+++ b/Userland/DevTools/HackStudio/ProjectTemplate.cpp
@@ -38,7 +38,7 @@ RefPtr<ProjectTemplate> ProjectTemplate::load_from_manifest(const String& manife
         || !config->has_key("HackStudioTemplate", "IconName32x"))
         return {};
 
-    auto id = LexicalPath(manifest_path).title();
+    auto id = LexicalPath::title(manifest_path);
     auto name = config->read_entry("HackStudioTemplate", "Name");
     auto description = config->read_entry("HackStudioTemplate", "Description");
     int priority = config->read_num_entry("HackStudioTemplate", "Priority", 0);

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -255,7 +255,7 @@ Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const St
             auto sampled_process = adopt_own(*new Process {
                 .pid = event.pid,
                 .executable = event.executable,
-                .basename = LexicalPath(event.executable).basename(),
+                .basename = LexicalPath::basename(event.executable),
                 .start_valid = event.serial,
                 .end_valid = {},
             });
@@ -274,7 +274,7 @@ Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const St
             auto sampled_process = adopt_own(*new Process {
                 .pid = event.pid,
                 .executable = event.executable,
-                .basename = LexicalPath(event.executable).basename(),
+                .basename = LexicalPath::basename(event.executable),
                 .start_valid = event.serial,
                 .end_valid = {},
             });
@@ -498,7 +498,7 @@ ProfileNode::ProfileNode(Process const& process, const String& object_name, Stri
     } else {
         object = object_name;
     }
-    m_object_name = LexicalPath(object).basename();
+    m_object_name = LexicalPath::basename(object);
 }
 
 }

--- a/Userland/DevTools/Profiler/TimelineHeader.cpp
+++ b/Userland/DevTools/Profiler/TimelineHeader.cpp
@@ -26,7 +26,7 @@ TimelineHeader::TimelineHeader(Profile& profile, Process const& process)
     update_selection();
 
     m_icon = GUI::FileIconProvider::icon_for_executable(m_process.executable).bitmap_for_size(32);
-    m_text = String::formatted("{} ({})", LexicalPath(m_process.executable).basename(), m_process.pid);
+    m_text = String::formatted("{} ({})", LexicalPath::basename(m_process.executable), m_process.pid);
 }
 
 TimelineHeader::~TimelineHeader()

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -426,7 +426,7 @@ String Emulator::create_backtrace_line(FlatPtr address)
 
     auto source_position = it->value.debug_info->get_source_position(address - region->base());
     if (source_position.has_value())
-        return String::formatted("=={{{}}}==    {:p}  [{}]: {} (\e[34;1m{}\e[0m:{})", getpid(), (void*)address, lib_name, symbol, LexicalPath(source_position.value().file_path).basename(), source_position.value().line_number);
+        return String::formatted("=={{{}}}==    {:p}  [{}]: {} (\e[34;1m{}\e[0m:{})", getpid(), (void*)address, lib_name, symbol, LexicalPath::basename(source_position.value().file_path), source_position.value().line_number);
 
     return line_without_source_info;
 }
@@ -464,7 +464,7 @@ String Emulator::create_instruction_line(FlatPtr address, X86::Instruction insn)
     if (!source_position.has_value())
         return minimal;
 
-    return String::formatted("{:p}: {} \e[34;1m{}\e[0m:{}", (void*)address, insn.to_string(address), LexicalPath(source_position.value().file_path).basename(), source_position.value().line_number);
+    return String::formatted("{:p}: {} \e[34;1m{}\e[0m:{}", (void*)address, insn.to_string(address), LexicalPath::basename(source_position.value().file_path), source_position.value().line_number);
 }
 
 static void emulator_signal_handler(int signum)

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv, char** env)
 
     StringBuilder builder;
     builder.append("(UE) ");
-    builder.append(LexicalPath(arguments[0]).basename());
+    builder.append(LexicalPath::basename(arguments[0]));
     if (set_process_name(builder.string_view().characters_without_null_termination(), builder.string_view().length()) < 0) {
         perror("set_process_name");
         return 1;

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -332,7 +332,7 @@ Result<void, File::CopyError> File::copy_file(const String& dst_path, const stru
         if (errno != EISDIR)
             return CopyError { OSError(errno), false };
 
-        auto dst_dir_path = String::formatted("{}/{}", dst_path, LexicalPath(source.filename()).basename());
+        auto dst_dir_path = String::formatted("{}/{}", dst_path, LexicalPath::basename(source.filename()));
         dst_fd = creat(dst_dir_path.characters(), 0666);
         if (dst_fd < 0)
             return CopyError { OSError(errno), false };

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -271,16 +271,17 @@ static String get_duplicate_name(const String& path, int duplicate_count)
     LexicalPath lexical_path(path);
     StringBuilder duplicated_name;
     duplicated_name.append('/');
-    for (size_t i = 0; i < lexical_path.parts().size() - 1; ++i) {
-        duplicated_name.appendff("{}/", lexical_path.parts()[i]);
+    auto& parts = lexical_path.parts_view();
+    for (size_t i = 0; i < parts.size() - 1; ++i) {
+        duplicated_name.appendff("{}/", parts[i]);
     }
     auto prev_duplicate_tag = String::formatted("({})", duplicate_count);
     auto title = lexical_path.title();
     if (title.ends_with(prev_duplicate_tag)) {
         // remove the previous duplicate tag "(n)" so we can add a new tag.
-        title = title.substring(0, title.length() - prev_duplicate_tag.length());
+        title = title.substring_view(0, title.length() - prev_duplicate_tag.length());
     }
-    duplicated_name.appendff("{} ({})", lexical_path.title(), duplicate_count);
+    duplicated_name.appendff("{} ({})", title, duplicate_count);
     if (!lexical_path.extension().is_empty()) {
         duplicated_name.appendff(".{}", lexical_path.extension());
     }

--- a/Userland/Libraries/LibCore/FileWatcher.cpp
+++ b/Userland/Libraries/LibCore/FileWatcher.cpp
@@ -74,13 +74,7 @@ static Optional<FileWatcherEvent> get_event_from_fd(int fd, HashMap<unsigned, St
     // We trust that the kernel only sends the name when appropriate.
     if (event->name_length > 0) {
         String child_name { event->name, event->name_length - 1 };
-        auto lexical_path = LexicalPath::join(path, child_name);
-        if (!lexical_path.is_valid()) {
-            dbgln_if(FILE_WATCHER_DEBUG, "get_event_from_fd: Reading from wd {}: Invalid child name '{}'", fd, child_name);
-            return {};
-        }
-
-        result.event_path = lexical_path.string();
+        result.event_path = LexicalPath::join(path, child_name).string();
     } else {
         result.event_path = path;
     }
@@ -98,11 +92,6 @@ Result<bool, String> FileWatcherBase::add_watch(String path, FileWatcherEvent::T
         char* buf = getcwd(nullptr, 0);
         lexical_path = LexicalPath::join(String(buf), path);
         free(buf);
-    }
-
-    if (!lexical_path.is_valid()) {
-        dbgln_if(FILE_WATCHER_DEBUG, "add_watch: path '{}' invalid", path);
-        return false;
     }
 
     auto const& canonical_path = lexical_path.string();
@@ -143,11 +132,6 @@ Result<bool, String> FileWatcherBase::remove_watch(String path)
         char* buf = getcwd(nullptr, 0);
         lexical_path = LexicalPath::join(String(buf), path);
         free(buf);
-    }
-
-    if (!lexical_path.is_valid()) {
-        dbgln_if(FILE_WATCHER_DEBUG, "remove_watch: path '{}' invalid", path);
-        return false;
     }
 
     auto const& canonical_path = lexical_path.string();

--- a/Userland/Libraries/LibCoreDump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoreDump/Backtrace.cpp
@@ -127,7 +127,7 @@ String Backtrace::Entry::to_string(bool color) const
     for (size_t i = 0; i < source_positions.size(); ++i) {
         auto& position = source_positions[i];
         auto fmt = color ? "\033[34;1m{}\033[0m:{}" : "{}:{}";
-        builder.appendff(fmt, LexicalPath(position.file_path).basename(), position.line_number);
+        builder.appendff(fmt, LexicalPath::basename(position.file_path), position.line_number);
         if (i != source_positions.size() - 1) {
             builder.append(" => ");
         }

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -438,7 +438,7 @@ void DebugSession::update_loaded_libs()
 
         String lib_name = object_path.value();
         if (lib_name.ends_with(".so"))
-            lib_name = LexicalPath(object_path.value()).basename();
+            lib_name = LexicalPath::basename(object_path.value());
 
         // FIXME: DebugInfo currently cannot parse the debug information of libgcc_s.so
         if (lib_name == "libgcc_s.so")

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -77,7 +77,7 @@ Optional<DynamicObject::SymbolLookupResult> DynamicLinker::lookup_global_symbol(
 
 static String get_library_name(String path)
 {
-    return LexicalPath(move(path)).basename();
+    return LexicalPath::basename(move(path));
 }
 
 static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> map_library(const String& filename, int fd)

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -26,10 +26,10 @@ static Vector<u32> supported_emoji_code_points()
         auto lexical_path = LexicalPath(filename);
         if (lexical_path.extension() != "png")
             continue;
-        auto basename = lexical_path.basename();
+        auto& basename = lexical_path.basename();
         if (!basename.starts_with("U+"))
             continue;
-        u32 code_point = strtoul(basename.characters() + 2, nullptr, 16);
+        u32 code_point = strtoul(basename.to_string().characters() + 2, nullptr, 16);
         code_points.append(code_point);
     }
     return code_points;

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -222,7 +222,7 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
         if (raw_symlink_target.starts_with('/')) {
             target_path = raw_symlink_target;
         } else {
-            target_path = Core::File::real_path_for(String::formatted("{}/{}", LexicalPath(path).dirname(), raw_symlink_target));
+            target_path = Core::File::real_path_for(String::formatted("{}/{}", LexicalPath::dirname(path), raw_symlink_target));
         }
         auto target_icon = icon_for_path(target_path);
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -202,15 +202,16 @@ FileSystemModel::Node const* FileSystemModel::node_for_path(String const& path) 
     if (lexical_path.string() == "/")
         return node;
 
-    for (size_t i = 0; i < lexical_path.parts().size(); ++i) {
-        auto& part = lexical_path.parts()[i];
+    auto& parts = lexical_path.parts_view();
+    for (size_t i = 0; i < parts.size(); ++i) {
+        auto& part = parts[i];
         bool found = false;
         for (auto& child : node->children) {
             if (child.name == part) {
                 const_cast<Node&>(child).reify_if_needed();
                 node = &child;
                 found = true;
-                if (i == lexical_path.parts().size() - 1)
+                if (i == parts.size() - 1)
                     return node;
                 break;
             }

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -653,7 +653,7 @@ void FileSystemModel::set_data(const ModelIndex& index, const Variant& data)
 {
     VERIFY(is_editable(index));
     Node& node = const_cast<Node&>(this->node(index));
-    auto dirname = LexicalPath(node.full_path()).dirname();
+    auto dirname = LexicalPath::dirname(node.full_path());
     auto new_full_path = String::formatted("{}/{}", dirname, data.to_string());
     int rc = rename(node.full_path().characters(), new_full_path.characters());
     if (rc < 0) {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -189,14 +189,14 @@ ModelIndex FileSystemModel::index(String path, int column) const
 
 FileSystemModel::Node const* FileSystemModel::node_for_path(String const& path) const
 {
-    LexicalPath lexical_path;
-    if (path == m_root_path) {
-        lexical_path = LexicalPath { "/" };
-    } else if (!m_root_path.is_empty() && path.starts_with(m_root_path)) {
-        lexical_path = LexicalPath { LexicalPath::relative_path(path, m_root_path) };
-    } else {
-        lexical_path = LexicalPath { move(path) };
-    }
+    String resolved_path;
+    if (path == m_root_path)
+        resolved_path = "/";
+    else if (!m_root_path.is_empty() && path.starts_with(m_root_path))
+        resolved_path = LexicalPath::relative_path(path, m_root_path);
+    else
+        resolved_path = path;
+    LexicalPath lexical_path(resolved_path);
 
     const Node* node = m_root->m_parent_of_root ? &m_root->children.first() : m_root;
     if (lexical_path.string() == "/")

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
 {
     g_test_argc = argc;
     g_test_argv = argv;
-    auto program_name = LexicalPath { argv[0] }.basename();
+    auto program_name = LexicalPath::basename(argv[0]);
     g_program_name = program_name;
 
     struct sigaction act;

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1064,7 +1064,7 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
         // Then add them to the context menu.
         // FIXME: Adapt this code when we actually support calling LaunchServer with a specific handler in mind.
         for (auto& handler : handlers) {
-            auto af = Desktop::AppFile::get_for_app(LexicalPath(handler).basename());
+            auto af = Desktop::AppFile::get_for_app(LexicalPath::basename(handler));
             if (!af->is_valid())
                 continue;
             auto action = GUI::Action::create(String::formatted("&Open in {}", af->name()), af->icon().bitmap_for_size(16), [this, handler](auto&) {
@@ -1084,7 +1084,7 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
             // file://courage/home/anon/something -> /home/anon/something
             auto path = URL(m_context_menu_href).path();
             // /home/anon/something -> something
-            auto name = LexicalPath(path).basename();
+            auto name = LexicalPath::basename(path);
             GUI::Clipboard::the().set_plain_text(name);
         }));
         m_context_menu_for_hyperlink->add_separator();

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -402,7 +402,7 @@ int main(int argc, char** argv)
     }
 
     LexicalPath lexical_path(path);
-    auto namespace_ = lexical_path.parts().at(lexical_path.parts().size() - 2);
+    auto& namespace_ = lexical_path.parts_view().at(lexical_path.parts_view().size() - 2);
 
     auto data = file_or_error.value()->read_all();
     auto interface = IDL::parse_interface(path, data);

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -81,7 +81,7 @@ static bool build_image_document(DOM::Document& document, const ByteBuffer& data
     auto title_element = document.create_element("title");
     head_element->append_child(title_element);
 
-    auto basename = LexicalPath(document.url().path()).basename();
+    auto basename = LexicalPath::basename(document.url().path());
     auto title_text = adopt_ref(*new DOM::Text(document, String::formatted("{} [{}x{}]", basename, bitmap->width(), bitmap->height())));
     title_element->append_child(title_text);
 

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -70,7 +70,7 @@ static bool collect_work_items(const String& source, const String& destination, 
         items.append(WorkItem {
             .type = WorkItem::Type::CopyFile,
             .source = source,
-            .destination = String::formatted("{}/{}", destination, LexicalPath(source).basename()),
+            .destination = String::formatted("{}/{}", destination, LexicalPath::basename(source)),
             .size = st.st_size,
         });
         return true;
@@ -80,7 +80,7 @@ static bool collect_work_items(const String& source, const String& destination, 
     items.append(WorkItem {
         .type = WorkItem::Type::CreateDirectory,
         .source = {},
-        .destination = String::formatted("{}/{}", destination, LexicalPath(source).basename()),
+        .destination = String::formatted("{}/{}", destination, LexicalPath::basename(source)),
         .size = 0,
     });
 
@@ -89,7 +89,7 @@ static bool collect_work_items(const String& source, const String& destination, 
         auto name = dt.next_path();
         if (!collect_work_items(
                 String::formatted("{}/{}", source, name),
-                String::formatted("{}/{}", destination, LexicalPath(source).basename()),
+                String::formatted("{}/{}", destination, LexicalPath::basename(source)),
                 items)) {
             return false;
         }

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -269,7 +269,7 @@ void Launcher::for_each_handler_for_path(const String& path, Function<bool(const
     if ((st.st_mode & S_IFMT) == S_IFREG && (st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)))
         f(get_handler_for_executable(Handler::Type::Application, path));
 
-    auto extension = LexicalPath(path).extension().to_lowercase();
+    auto extension = LexicalPath::extension(path).to_lowercase();
 
     for_each_handler(extension, m_file_handlers, [&](const auto& handler) -> bool {
         if (handler.handler_type != Handler::Type::Default || handler.file_types.contains(extension))

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -198,7 +198,7 @@ NonnullRefPtr<GUI::Menu> build_system_menu()
         while (dt.has_next()) {
             auto theme_name = dt.next_path();
             auto theme_path = String::formatted("/res/themes/{}", theme_name);
-            g_themes.append({ LexicalPath(theme_name).title(), theme_path });
+            g_themes.append({ LexicalPath::title(theme_name), theme_path });
         }
         quick_sort(g_themes, [](auto& a, auto& b) { return a.name < b.name; });
     }

--- a/Userland/Services/WindowServer/Cursor.cpp
+++ b/Userland/Services/WindowServer/Cursor.cpp
@@ -14,10 +14,6 @@ namespace WindowServer {
 CursorParams CursorParams::parse_from_filename(const StringView& cursor_path, const Gfx::IntPoint& default_hotspot)
 {
     LexicalPath path(cursor_path);
-    if (!path.is_valid()) {
-        dbgln("Cannot parse invalid cursor path, use default cursor params");
-        return { default_hotspot };
-    }
     auto file_title = path.title();
     auto last_dot_in_title = StringView(file_title).find_last_of('.');
     if (!last_dot_in_title.has_value() || last_dot_in_title.value() == 0) {

--- a/Userland/Utilities/basename.cpp
+++ b/Userland/Utilities/basename.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(suffix, "Suffix to strip from name", "suffix", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
-    auto result = LexicalPath(path).basename();
+    auto result = LexicalPath::basename(path);
 
     if (!suffix.is_null() && result.length() != suffix.length() && result.ends_with(suffix))
         result = result.substring(0, result.length() - suffix.length());

--- a/Userland/Utilities/basename.cpp
+++ b/Userland/Utilities/basename.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
     auto result = LexicalPath::basename(path);
 
     if (!suffix.is_null() && result.length() != suffix.length() && result.ends_with(suffix))
-        result = result.substring(0, result.length() - suffix.length());
+        result = result.substring_view(0, result.length() - suffix.length());
 
     outln("{}", result);
     return 0;

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
                         out("\033]8;;{}\033\\", url.serialize());
                     }
 
-                    out("\033[34;1m{}:{}\033[0m", LexicalPath(source_position.file_path).basename(), source_position.line_number);
+                    out("\033[34;1m{}:{}\033[0m", LexicalPath::basename(source_position.file_path), source_position.line_number);
 
                     if (linked)
                         out("\033]8;;\033\\");

--- a/Userland/Utilities/cp.cpp
+++ b/Userland/Utilities/cp.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
 
     for (auto& source : sources) {
         auto destination_path = destination_is_existing_dir
-            ? String::formatted("{}/{}", destination, LexicalPath(source).basename())
+            ? String::formatted("{}/{}", destination, LexicalPath::basename(source))
             : destination;
 
         auto result = Core::File::copy_file_or_directory(

--- a/Userland/Utilities/dirname.cpp
+++ b/Userland/Utilities/dirname.cpp
@@ -14,6 +14,6 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(path, "Path", "path");
     args_parser.parse(argc, argv);
 
-    outln("{}", LexicalPath(path).dirname());
+    outln("{}", LexicalPath::dirname(path));
     return 0;
 }

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -151,7 +151,7 @@ int print_space_usage(const String& path, const DuOption& du_option, int max_dep
         }
     }
 
-    const auto basename = LexicalPath(path).basename();
+    const auto basename = LexicalPath::basename(path);
     for (const auto& pattern : du_option.excluded_patterns) {
         if (basename.matches(pattern, CaseSensitivity::CaseSensitive))
             return 0;

--- a/Userland/Utilities/ln.cpp
+++ b/Userland/Utilities/ln.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
 
     String path_buffer;
     if (!path) {
-        path_buffer = LexicalPath(target).basename();
+        path_buffer = LexicalPath::basename(target);
         path = path_buffer.characters();
     }
 

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
         StringBuilder path_builder;
         if (lexical_path.is_absolute())
             path_builder.append("/");
-        for (auto& part : lexical_path.parts()) {
+        for (auto& part : lexical_path.parts_view()) {
             path_builder.append(part);
             auto path = path_builder.build();
             struct stat st;

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -97,20 +97,15 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    LexicalPath target_path(String::formatted("{}/{}", target_directory, file_template));
-    if (!target_path.is_valid()) {
-        if (!quiet)
-            warnln("Invalid template path {}", target_path.string().characters());
-        return 1;
-    }
+    auto target_path = LexicalPath::join(target_directory, file_template).string();
 
-    char* final_path = make_temp(target_path.string().characters(), create_directory, dry_run);
+    char* final_path = make_temp(target_path.characters(), create_directory, dry_run);
     if (!final_path) {
         if (!quiet) {
             if (create_directory)
-                warnln("Failed to create directory via template {}", target_path.string().characters());
+                warnln("Failed to create directory via template {}", target_path.characters());
             else
-                warnln("Failed to create file via template {}", target_path.string().characters());
+                warnln("Failed to create file via template {}", target_path.characters());
         }
         return 1;
     }

--- a/Userland/Utilities/mv.cpp
+++ b/Userland/Utilities/mv.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
         String combined_new_path;
         const char* new_path = original_new_path;
         if (S_ISDIR(st.st_mode)) {
-            auto old_basename = LexicalPath(old_path).basename();
+            auto old_basename = LexicalPath::basename(old_path);
             combined_new_path = String::formatted("{}/{}", original_new_path, old_basename);
             new_path = combined_new_path.characters();
         }

--- a/Userland/Utilities/test.cpp
+++ b/Userland/Utilities/test.cpp
@@ -498,7 +498,7 @@ int main(int argc, char* argv[])
         return 126;
     }
 
-    if (LexicalPath { argv[0] }.basename() == "[") {
+    if (LexicalPath::basename(argv[0]) == "[") {
         --argc;
         if (StringView { argv[argc] } != "]")
             fatal_error("test invoked as '[' requires a closing bracket ']'");

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -36,7 +36,7 @@ static void print_directory_tree(const String& root_path, int depth, const Strin
         out("{}|-- ", root_indent_string);
     }
 
-    String root_dir_name = LexicalPath(root_path).basename();
+    String root_dir_name = LexicalPath::basename(root_path);
     out("\033[34;1m{}\033[0m\n", root_dir_name);
 
     if (depth >= max_depth) {


### PR DESCRIPTION
This PR reworks `AK::LexicalPath`.

* Removed `LexicalPath::is_valid()` API.
* Replaced most `String`s with `StringView`s, and have added a few static methods to return `String`s (to be used when the `LexicalPath` object constructed) would only be temporary. 
* The "null state" of `LexicalPath` (and with it the default constructor) have been removed.
* `LexicalPath` is now immutable.
* Added `LexicalPath::append(StringView const&)` and `LexicalPath::parent()`.
* More tests.
* Various smaller changes.