### PR TITLE
LibGUI: Don't allocate a scope-local MouseEvent on the heap

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -354,15 +354,15 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (m_global_cursor_tracking_widget) {
         auto window_relative_rect = m_global_cursor_tracking_widget->window_relative_rect();
         Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
-        auto local_event = make<MouseEvent>((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
-        m_global_cursor_tracking_widget->dispatch_event(*local_event, this);
+        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+        m_global_cursor_tracking_widget->dispatch_event(local_event, this);
         return;
     }
     if (m_automatic_cursor_tracking_widget) {
         auto window_relative_rect = m_automatic_cursor_tracking_widget->window_relative_rect();
         Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
-        auto local_event = make<MouseEvent>((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
-        m_automatic_cursor_tracking_widget->dispatch_event(*local_event, this);
+        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+        m_automatic_cursor_tracking_widget->dispatch_event(local_event, this);
         if (event.buttons() == 0)
             m_automatic_cursor_tracking_widget = nullptr;
         return;
@@ -370,13 +370,13 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (!m_main_widget)
         return;
     auto result = m_main_widget->hit_test(event.position());
-    auto local_event = make<MouseEvent>((Event::Type)event.type(), result.local_position, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+    auto local_event = MouseEvent((Event::Type)event.type(), result.local_position, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
     VERIFY(result.widget);
     set_hovered_widget(result.widget);
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)
         m_automatic_cursor_tracking_widget = *result.widget;
     if (result.widget != m_global_cursor_tracking_widget.ptr())
-        result.widget->dispatch_event(*local_event, this);
+        result.widget->dispatch_event(local_event, this);
 
     if (!m_pending_paint_event_rects.is_empty()) {
         MultiPaintEvent paint_event(move(m_pending_paint_event_rects), size());


### PR DESCRIPTION
This fixes the build by hiding the problem from the compiler, but it's
a useful change in and of itself anyway.
A malloc/free per every mouse event is pretty annoying, especially when
we can actually avoid it.