### PR TITLE
LibHTTP: Finish the request up on TLS connection finish

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpsJob.cpp
@@ -38,6 +38,10 @@ void HttpsJob::start()
             });
         }
     };
+    m_socket->on_tls_finished = [this] {
+        if (!m_has_scheduled_finish)
+            finish_up();
+    };
     m_socket->on_tls_certificate_request = [this](auto&) {
         if (on_certificate_requested)
             on_certificate_requested(*this);


### PR DESCRIPTION
...unless it has already been done.
Otherwise we'd be spinning in RequestServer waiting for more read
events.