### PR TITLE
AK: Fix possible UB caused by inlined `new` and `delete` operators

### DIFF
--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#if defined(__serenity__) && !defined(KERNEL)
+
+#    include <AK/Assertions.h>
+#    include <AK/kmalloc.h>
+
+// However deceptively simple these functions look, they must not be inlined.
+// Memory allocated in one translation unit has to be deallocatable in another
+// translation unit, so these functions must be the same everywhere.
+// By making these functions global, this invariant is enforced.
+
+void* operator new(size_t size)
+{
+    void* ptr = malloc(size);
+    VERIFY(ptr);
+    return ptr;
+}
+
+void* operator new(size_t size, const std::nothrow_t&) noexcept
+{
+    return malloc(size);
+}
+
+void operator delete(void* ptr) noexcept
+{
+    return free(ptr);
+}
+
+void operator delete(void* ptr, size_t) noexcept
+{
+    return free(ptr);
+}
+
+void* operator new[](size_t size)
+{
+    void* ptr = malloc(size);
+    VERIFY(ptr);
+    return ptr;
+}
+
+void* operator new[](size_t size, const std::nothrow_t&) noexcept
+{
+    return malloc(size);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+    return free(ptr);
+}
+
+void operator delete[](void* ptr, size_t) noexcept
+{
+    return free(ptr);
+}
+
+#endif

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -1,13 +1,27 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#ifndef __serenity__
+#if defined(KERNEL)
+#    include <Kernel/Heap/kmalloc.h>
+#else
 #    include <new>
+#    include <stdlib.h>
+
+#    define kcalloc calloc
+#    define kmalloc malloc
+#    define kmalloc_good_size malloc_good_size
+#    define kfree free
+#    define krealloc realloc
+#endif
+
+#ifndef __serenity__
+#    include <AK/Types.h>
 
 #    ifndef AK_OS_MACOS
 extern "C" {
@@ -26,70 +40,6 @@ inline size_t malloc_good_size(size_t size) { return size; }
     private:
 #else
 #    define AK_MAKE_ETERNAL
-#endif
-
-#if defined(KERNEL)
-#    include <Kernel/Heap/kmalloc.h>
-#else
-#    include <stdlib.h>
-
-#    define kcalloc calloc
-#    define kmalloc malloc
-#    define kmalloc_good_size malloc_good_size
-#    define kfree free
-#    define krealloc realloc
-
-#    ifdef __serenity__
-
-#        include <AK/Assertions.h>
-#        include <new>
-
-inline void* operator new(size_t size)
-{
-    void* ptr = kmalloc(size);
-    VERIFY(ptr);
-    return ptr;
-}
-
-inline void* operator new(size_t size, const std::nothrow_t&) noexcept
-{
-    return kmalloc(size);
-}
-
-inline void operator delete(void* ptr) noexcept
-{
-    return kfree(ptr);
-}
-
-inline void operator delete(void* ptr, size_t) noexcept
-{
-    return kfree(ptr);
-}
-
-inline void* operator new[](size_t size)
-{
-    void* ptr = kmalloc(size);
-    VERIFY(ptr);
-    return ptr;
-}
-
-inline void* operator new[](size_t size, const std::nothrow_t&) noexcept
-{
-    return kmalloc(size);
-}
-
-inline void operator delete[](void* ptr) noexcept
-{
-    return kfree(ptr);
-}
-
-inline void operator delete[](void* ptr, size_t) noexcept
-{
-    return kfree(ptr);
-}
-
-#    endif
-
 #endif
 
 using std::nothrow;


### PR DESCRIPTION
This fixes a build issue introduced in 23d66fe, where the compiler
statically detected that that mismatching new and delete operators were
used.

Clang generates a warning for this, for the reasons described in the
comment in `AK/kmalloc.cpp`, but GCC does not.

Besides moving the allocator functions into a `.cpp` file, declarations
in `AK/kmalloc.cpp` were reordered to have imports at the top, in order
to make the code more readable.

However deceptively simple these functions look, they must not be inlined.
Memory allocated in one translation unit has to be deallocatable in another
translation unit, so these functions must be the same everywhere.
By making these functions global, this invariant is enforced.

cc @gunnarbeutner
Thank you for notifying me