### PR TITLE
Kernel/PCI: Don't unmap determine_memory_mapped_bus_region after init

### DIFF
--- a/Kernel/PCI/MMIOAccess.cpp
+++ b/Kernel/PCI/MMIOAccess.cpp
@@ -36,7 +36,7 @@ u8 MMIOAccess::segment_end_bus(u32 seg) const
     return segment.value().get_end_bus();
 }
 
-UNMAP_AFTER_INIT PhysicalAddress MMIOAccess::determine_memory_mapped_bus_region(u32 segment, u8 bus) const
+PhysicalAddress MMIOAccess::determine_memory_mapped_bus_region(u32 segment, u8 bus) const
 {
     VERIFY(bus >= segment_start_bus(segment) && bus <= segment_end_bus(segment));
     auto seg = m_segments.get(segment);


### PR DESCRIPTION
This can be accessed after init via lspci.