### PR TITLE
Kernel: Give Devices without a custody a less fake absoulte_path

### DIFF
--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -52,7 +52,8 @@ Device::~Device()
 
 String Device::absolute_path() const
 {
-    return String::formatted("device:{},{} ({})", m_major, m_minor, class_name());
+    // FIXME: Don't assume mount point for DevFs
+    return String::formatted("/dev/{}", device_name());
 }
 
 String Device::absolute_path(const FileDescription&) const


### PR DESCRIPTION
This hack allows self-test mode run-tests-and-shutdown.sh to give
TestProcFs a stat(2)-able /proc/self/fd/0. For some reason, when
stdin is a SerialDevice, /proc/self/fd/0 will be a symlink to the device
as expected, but, calling realpath or stat on /proc/self/fd/0 will error
out. realpath will give the string from Device::absolute_path() which
would be something like "device:4,64 (SerialDevice)". When VFS is trying
to resolve_path so that we can stat the file, it would bail out on this
fake-y path.

Change the fake path (that doesn't show up when you ls a device, nor
when checking the devices tab in SystemMonitor) from the major/minor
device number and class_name() to /dev/device_name(). There's probably
a very hairy yak standing behind this issue that was only discovered due
to the ProcFS rework.