### PR TITLE
HeaderView: Fix horizonal section size miscalculation

### DIFF
--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -93,6 +93,8 @@ HeaderView::VisibleSectionRange HeaderView::visible_section_range() const
     for (; range.end < section_count; ++range.end) {
         auto& section = section_data(range.end);
         int section_size = section.size;
+        if (orientation() == Gfx::Orientation::Horizontal)
+            section_size += m_table_view.horizontal_padding() * 2;
         if (offset + section_size < start) {
             if (section.visibility)
                 offset += section_size;


### PR DESCRIPTION
When calculating the horizonal size of a section in
`HeaderView::visible_section_range()`, the horizonal padding is now
correctly taken into account.

This fixes header missalignment issues in Spreadsheet, SystemMonitor
and maybe also the playlist tab of SoundPlayer

closes #8268