### PR TITLE
Kernel+Userland: x86_64 support (part 8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if("${SERENITY_ARCH}" STREQUAL "x86_64")
+    # FIXME: Implement TLS support and get rid of this
+    add_compile_definitions(NO_TLS X86_64_NO_TLS)
+endif()
+
 add_compile_options(-Wno-literal-suffix)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-fconcepts)

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -152,13 +152,11 @@ asm(                                                \
         "    pushq %rdi\n"                          \
         "    pushq %rsp \n" /* set TrapFrame::regs */ \
         "    subq $" __STRINGIFY(TRAP_FRAME_SIZE - 8) ", %rsp \n" \
-        "    subq $0x8, %rsp\n" /* align stack */   \
-        "    lea 0x8(%rsp), %rdi \n"                \
+        "    movq %rsp, %rdi \n"                    \
         "    cld\n"                                 \
         "    call enter_trap_no_irq \n"             \
-        "    lea 0x8(%rsp), %rdi \n"                \
+        "    movq %rsp, %rdi \n"                    \
         "    call " #title "_handler\n"             \
-        "    addq $0x8, %rsp\n" /* undo alignment */\
         "    jmp common_trap_exit \n");
 #endif
 

--- a/Kernel/Arch/x86/x86_64/InterruptEntry.cpp
+++ b/Kernel/Arch/x86/x86_64/InterruptEntry.cpp
@@ -38,13 +38,11 @@ asm(
     "    pushq %rdi\n"
     "    pushq %rsp \n" /* set TrapFrame::regs */
     "    subq $" __STRINGIFY(TRAP_FRAME_SIZE - 8) ", %rsp \n"
-    "    subq $0x8, %rsp\n" /* align stack */
-    "    lea 0x8(%rsp), %rdi \n"
+    "    movq %rsp, %rdi \n"
     "    cld\n"
     "    call enter_trap \n"
-    "    lea 0x8(%rsp), %rdi \n"
+    "    movq %rsp, %rdi \n"
     "    call handle_interrupt \n"
-    "    addq $0x8, %rsp\n" /* undo alignment */
     ".globl common_trap_exit \n"
     "common_trap_exit: \n"
     // another thread may have handled this trap at this point, so don't

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -109,6 +109,14 @@ FlatPtr Processor::init_context(Thread& thread, bool leave_crit)
     iretframe.rdx = regs.rdx;
     iretframe.rcx = regs.rcx;
     iretframe.rax = regs.rax;
+    iretframe.r8 = regs.r8;
+    iretframe.r9 = regs.r9;
+    iretframe.r10 = regs.r10;
+    iretframe.r11 = regs.r11;
+    iretframe.r12 = regs.r12;
+    iretframe.r13 = regs.r13;
+    iretframe.r14 = regs.r14;
+    iretframe.r15 = regs.r15;
     iretframe.rflags = regs.rflags;
     iretframe.rip = regs.rip;
     iretframe.cs = regs.cs;

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -74,13 +74,11 @@ NEVER_INLINE void syscall_asm_entry_dummy()
         "    pushq %rdi\n"
         "    pushq %rsp \n" /* set TrapFrame::regs */
         "    subq $" __STRINGIFY(TRAP_FRAME_SIZE - 8) ", %rsp \n"
-        "    subq $0x8, %rsp\n" /* align stack */
-        "    lea 0x8(%rsp), %rdi \n"
+        "    movq %rsp, %rdi \n"
         "    cld\n"
         "    call enter_trap_no_irq \n"
-        "    lea 0x8(%rsp), %rdi \n"
+        "    movq %rsp, %rdi \n"
         "    call syscall_handler\n"
-        "    addq $0x8, %rsp\n" /* undo alignment */
         "    jmp common_trap_exit \n");
 #endif
     // clang-format on

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -612,7 +612,7 @@ KResultOr<FlatPtr> Process::sys$allocate_tls(Userspace<const char*> initial_data
     tls_descriptor.set_base(main_thread->thread_specific_data());
     tls_descriptor.set_limit(main_thread->thread_specific_region_size());
 #else
-    TODO();
+    dbgln("FIXME: Not setting FS_BASE for process.");
 #endif
 
     return m_master_tls_region.unsafe_ptr()->vaddr().get();

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -81,7 +81,11 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
 
     ScopedSpinLock lock(g_scheduler_lock);
     thread->set_priority(requested_thread_priority);
+#if ARCH(I386)
     thread->set_state(Thread::State::Runnable);
+#else
+    dbgln("FIXME: Not starting thread {} (because it'd crash)", *thread);
+#endif
     return thread->tid().value();
 }
 

--- a/Userland/Libraries/LibC/pthread_tls.cpp
+++ b/Userland/Libraries/LibC/pthread_tls.cpp
@@ -26,7 +26,10 @@ struct SpecificTable {
 
 static KeyTable s_keys;
 
-__thread SpecificTable t_specifics;
+#    ifndef X86_64_NO_TLS
+__thread
+#    endif
+    SpecificTable t_specifics;
 
 int __pthread_key_create(pthread_key_t* key, KeyDestructor destructor)
 {

--- a/Userland/Libraries/LibDl/dlfcn.cpp
+++ b/Userland/Libraries/LibDl/dlfcn.cpp
@@ -11,8 +11,16 @@
 #include <string.h>
 
 // FIXME: use thread_local and a String once TLS works
-__thread char* s_dlerror_text = NULL;
-__thread bool s_dlerror_retrieved = false;
+#ifndef X86_64_NO_TLS
+__thread
+#endif
+    char* s_dlerror_text
+    = NULL;
+#ifndef X86_64_NO_TLS
+__thread
+#endif
+    bool s_dlerror_retrieved
+    = false;
 
 static void store_error(const String& error)
 {

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -33,8 +33,14 @@ static constexpr size_t required_stack_alignment = 4 * MiB;
 static constexpr size_t highest_reasonable_guard_size = 32 * PAGE_SIZE;
 static constexpr size_t highest_reasonable_stack_size = 8 * MiB; // That's the default in Ubuntu?
 
-__thread void* s_stack_location;
-__thread size_t s_stack_size;
+#ifndef X86_64_NO_TLS
+__thread
+#endif
+    void* s_stack_location;
+#ifndef X86_64_NO_TLS
+__thread
+#endif
+    size_t s_stack_size;
 
 #define __RETURN_PTHREAD_ERROR(rc) \
     return ((rc) < 0 ? -(rc) : 0)

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -47,7 +47,6 @@ static void* pthread_create_helper(void* (*routine)(void*), void* argument, void
     s_stack_size = stack_size;
     void* ret_val = routine(argument);
     pthread_exit(ret_val);
-    return nullptr;
 }
 
 static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argument, PthreadAttrImpl* thread_params)


### PR DESCRIPTION
Known issues:

* `__thread` and dynamic TLS don't work but they're disabled for now so at least text mode boots properly.
* `dynamic_cast` in userspace doesn't work. Somehow `__do_upcast` ends up with a null `this` pointer.
* Usermode threads crash after being started. I've disabled starting them for now.

Apart from the fix for `fork()` clobbering `r8-r15` this is mostly a cleaned up version of my `workarounds` branch from the last PR.

**Kernel: Don't start usermode threads on x86_64 for now**

Starting usermode threads doesn't currently work on x86_64. With this stubbed out we can get text mode to boot though.

**Kernel: Properly initialize r8-r15 for new threads on x86_64**

**Kernel: Fix stack alignment on x86_64**

These were already properly aligned (as far as I can tell).

**LibPthread: Remove redundant return statement**

The pthread_exit() function doesn't return and is marked as such.

**Kernel: Disable __thread and TLS on x86_64 for now**

They're not yet properly supported.