### PR TITLE
LibCoreDump: Change Backtrace debug info cache to member variable

### DIFF
--- a/Userland/Libraries/LibCoreDump/Backtrace.h
+++ b/Userland/Libraries/LibCoreDump/Backtrace.h
@@ -43,9 +43,11 @@ public:
 
 private:
     void add_entry(const Reader&, FlatPtr eip);
+    ELFObjectInfo const* object_info_for_region(ELF::Core::MemoryRegionInfo const&);
 
     ELF::Core::ThreadInfo m_thread_info;
     Vector<Entry> m_entries;
+    HashMap<String, NonnullOwnPtr<ELFObjectInfo>> m_debug_info_cache;
 };
 
 }


### PR DESCRIPTION
This changes the previously static `s_debug_info_cache` to a member variable. This is required so the cache is not kept alive if the `Backtrace` object is destroyed.

Previously, the cache object would keep alive `MappedFile` objects and other data, resulting in `CrashReporter` and `CrashDaemon` using more than 100 MB of memory even after the `Backtrace` objects have been destroyed (and the data is thus no longer needed). This was especially the case when handling crashes from Browser (due to `libweb.so` and `libjs.so`).

Due to this change, `object_info_for_region` has been promoted to a instance method. It has also been cleaned up somewhat.