### PR TITLE
LibJS: Add a [[Realm]] getter to FunctionObject and use it where needed

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -110,9 +110,8 @@ GlobalObject* get_function_realm(GlobalObject& global_object, FunctionObject con
 {
     auto& vm = global_object.vm();
 
-    // FIXME: not sure how to do this currently.
-    // 2. If obj has a [[Realm]] internal slot, then
-    //     a. Return obj.[[Realm]].
+    if (function.realm())
+        return function.realm();
     if (is<BoundFunction>(function)) {
         auto& bound_function = static_cast<BoundFunction const&>(function);
         auto& target = bound_function.target_function();

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -159,11 +159,12 @@ static Object* array_species_create(GlobalObject& global_object, Object& origina
         return {};
     if (constructor.is_constructor()) {
         auto& constructor_function = constructor.as_function();
-        if (&constructor_function.global_object() != &global_object) {
-            auto* array_constructor = constructor_function.global_object().array_constructor();
-            if (&constructor_function == array_constructor) {
+        auto* constructor_realm = get_function_realm(global_object, constructor_function);
+        if (vm.exception())
+            return {};
+        if (constructor_realm != &global_object) {
+            if (&constructor_function == constructor_realm->array_constructor())
                 constructor = js_undefined();
-            }
         }
     }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -47,6 +47,9 @@ public:
     // Used as the outer environment when evaluating the code of the function.
     virtual EnvironmentRecord* environment() { return nullptr; }
 
+    // [[Realm]]
+    virtual GlobalObject* realm() const { return nullptr; }
+
     enum class ThisMode : u8 {
         Lexical,
         Strict,

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -29,6 +29,8 @@ public:
 
     virtual bool is_strict_mode() const override;
 
+    GlobalObject* realm() const override { return &global_object(); }
+
 protected:
     NativeFunction(FlyString name, Object& prototype);
     explicit NativeFunction(Object& prototype);

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
@@ -56,6 +56,7 @@ OrdinaryFunctionObject::OrdinaryFunctionObject(GlobalObject& global_object, cons
     , m_body(body)
     , m_parameters(move(parameters))
     , m_environment(parent_scope)
+    , m_realm(&global_object)
     , m_function_length(function_length)
     , m_kind(kind)
     , m_is_strict(is_strict)

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.h
@@ -37,6 +37,8 @@ public:
 
     virtual EnvironmentRecord* environment() override { return m_environment; }
 
+    GlobalObject* realm() const override { return m_realm; }
+
 protected:
     virtual bool is_strict_mode() const final { return m_is_strict; }
 
@@ -55,6 +57,7 @@ private:
     const Vector<FunctionNode::Parameter> m_parameters;
     Optional<Bytecode::Executable> m_bytecode_executable;
     EnvironmentRecord* m_environment { nullptr };
+    GlobalObject* m_realm { nullptr };
     i32 m_function_length { 0 };
     FunctionKind m_kind { FunctionKind::Regular };
     bool m_is_strict { false };

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -54,16 +54,21 @@ Value StringConstructor::call()
 }
 
 // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
-Value StringConstructor::construct(FunctionObject&)
+Value StringConstructor::construct(FunctionObject& new_target)
 {
-    PrimitiveString* primitive_string = nullptr;
-    if (!vm().argument_count())
-        primitive_string = js_string(vm(), "");
+    auto& vm = global_object().vm();
+
+    PrimitiveString* primitive_string;
+    if (!vm.argument_count())
+        primitive_string = js_string(vm, "");
     else
-        primitive_string = vm().argument(0).to_primitive_string(global_object());
+        primitive_string = vm.argument(0).to_primitive_string(global_object());
     if (!primitive_string)
         return {};
-    return StringObject::create(global_object(), *primitive_string);
+    auto* prototype = get_prototype_from_constructor(global_object(), new_target, &GlobalObject::string_prototype);
+    if (vm.exception())
+        return {};
+    return StringObject::create(global_object(), *primitive_string, *prototype);
 }
 
 // 22.1.2.4 String.raw ( template, ...substitutions ), https://tc39.es/ecma262/#sec-string.raw

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -11,9 +11,10 @@
 
 namespace JS {
 
-StringObject* StringObject::create(GlobalObject& global_object, PrimitiveString& primitive_string)
+// 10.4.3.4 StringCreate ( value, prototype ), https://tc39.es/ecma262/#sec-stringcreate
+StringObject* StringObject::create(GlobalObject& global_object, PrimitiveString& primitive_string, Object& prototype)
 {
-    return global_object.heap().allocate<StringObject>(global_object, primitive_string, *global_object.string_prototype());
+    return global_object.heap().allocate<StringObject>(global_object, primitive_string, prototype);
 }
 
 StringObject::StringObject(PrimitiveString& string, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -14,7 +14,7 @@ class StringObject : public Object {
     JS_OBJECT(StringObject, Object);
 
 public:
-    static StringObject* create(GlobalObject&, PrimitiveString&);
+    static StringObject* create(GlobalObject&, PrimitiveString&, Object& prototype);
 
     StringObject(PrimitiveString&, Object& prototype);
     virtual void initialize(GlobalObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -449,7 +449,7 @@ Object* Value::to_object(GlobalObject& global_object) const
     case Type::Double:
         return NumberObject::create(global_object, as_double());
     case Type::String:
-        return StringObject::create(global_object, *m_value.as_string);
+        return StringObject::create(global_object, *m_value.as_string, *global_object.string_prototype());
     case Type::Symbol:
         return SymbolObject::create(global_object, *m_value.as_symbol);
     case Type::BigInt:


### PR DESCRIPTION
Defined by https://tc39.es/ecma262/#sec-ordinaryfunctioncreate step #17 and by https://tc39.es/ecma262/#sec-createbuiltinfunction step #6.

(Also includes a small fix to String's constructor to make it use this underlying behaviour)

Fixes 30 test262 test cases.