### PR TITLE
LibJS: Ensure shift values in left_shift are modded by 32

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -993,7 +993,7 @@ Value left_shift(GlobalObject& global_object, Value lhs, Value rhs)
             return lhs_numeric;
         // Ok, so this performs toNumber() again but that "can't" throw
         auto lhs_i32 = lhs_numeric.to_i32(global_object);
-        auto rhs_u32 = rhs_numeric.to_u32(global_object);
+        auto rhs_u32 = rhs_numeric.to_u32(global_object) % 32;
         return Value(lhs_i32 << rhs_u32);
     }
     if (both_bigint(lhs_numeric, rhs_numeric)) {


### PR DESCRIPTION
This is equivalent to 58d6a2d0192b7860ecb2edb4aa5d36b389213a15 but for the left shift operation.

This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35691.