### PR TITLE
LibJS: NewClass bytecode instruction

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -851,6 +851,7 @@ public:
     }
 
     StringView name() const { return m_name; }
+    RefPtr<FunctionExpression> constructor() const { return m_constructor; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -872,6 +873,7 @@ public:
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<ClassExpression> m_class_expression;

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1300,4 +1300,10 @@ void SwitchStatement::generate_bytecode(Bytecode::Generator& generator) const
     generator.switch_to_basic_block(end_block);
 }
 
+void ClassDeclaration::generate_bytecode(Bytecode::Generator& generator) const
+{
+    generator.emit<Bytecode::Op::NewClass>(m_class_expression);
+    generator.emit<Bytecode::Op::SetVariable>(generator.intern_string(m_class_expression.ptr()->name()));
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -72,7 +72,8 @@
     O(GetIterator)                   \
     O(IteratorNext)                  \
     O(IteratorResultDone)            \
-    O(IteratorResultValue)
+    O(IteratorResultValue)           \
+    O(NewClass)
 
 namespace JS::Bytecode {
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -452,6 +452,11 @@ void IteratorResultValue::execute_impl(Bytecode::Interpreter& interpreter) const
         interpreter.accumulator() = iterator_value(interpreter.global_object(), *iterator_result);
 }
 
+void NewClass::execute_impl(Bytecode::Interpreter&) const
+{
+    TODO();
+}
+
 String Load::to_string_impl(Bytecode::Executable const&) const
 {
     return String::formatted("Load {}", m_src);
@@ -596,6 +601,11 @@ String Call::to_string_impl(Bytecode::Executable const&) const
 String NewFunction::to_string_impl(Bytecode::Executable const&) const
 {
     return "NewFunction";
+}
+
+String NewClass::to_string_impl(Bytecode::Executable const&) const
+{
+    return "NewClass";
 }
 
 String Return::to_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -484,6 +484,22 @@ private:
     Register m_arguments[];
 };
 
+class NewClass final : public Instruction {
+public:
+    explicit NewClass(ClassExpression const& class_expression)
+        : Instruction(Type::NewClass)
+        , m_class_expression(class_expression)
+    {
+    }
+
+    void execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
+    ClassExpression const& m_class_expression;
+};
+
 class NewFunction final : public Instruction {
 public:
     explicit NewFunction(FunctionNode const& function_node)

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -119,6 +119,7 @@ class BigInt;
 class BoundFunction;
 class Cell;
 class CellAllocator;
+class ClassExpression;
 class Console;
 class DeclarativeEnvironment;
 class DeferGC;


### PR DESCRIPTION
This adds a the NewClass bytecode instruction, enough of it
is implemented for it to show it in the bytecode (js -d).