### PR TITLE
Kernel+LibELF: x86_64 support (part 9)

### DIFF
--- a/Kernel/Arch/x86/x86_64/Boot/boot.S
+++ b/Kernel/Arch/x86/x86_64/Boot/boot.S
@@ -354,6 +354,12 @@ apic_ap_start32:
     movl (ap_cpu_init_cr3 - apic_ap_start)(%ebp), %eax
     movl %eax, %cr3
 
+    /* Enter Long-mode! ref(https://wiki.osdev.org/Setting_Up_Long_Mode)*/
+    mov $0xC0000080, %ecx           /* Set the C-register to 0xC0000080, which is the EFER MSR.*/
+    rdmsr                           /* Read from the model-specific register.*/
+    or $(1 << 8), %eax              /* Set the LM-bit which is the 9th bit (bit 8).*/
+    wrmsr                           /* Write to the model-specific register.*/
+
     /* enable PAE + PSE */
     movl %cr4, %eax
     orl $0x60, %eax
@@ -364,39 +370,48 @@ apic_ap_start32:
     orl $0x80000000, %eax
     movl %eax, %cr0
 
-    /* load a second temporary gdt that points above 3GB */
-    lgdt (ap_cpu_gdtr_initial2 - apic_ap_start + 0xc0008000)
+    /* load the temporary 64-bit gdt from boot that points above 3GB */
+    lgdt gdt64ptr
 
     /* jump above 3GB into our identity mapped area now */
-    ljmp $8, $(apic_ap_start32_2 - apic_ap_start + 0xc0008000)
-apic_ap_start32_2:
+    ljmpl $code64_sel, $(apic_ap_start64 - apic_ap_start + 0xc0008000)
+.code64
+apic_ap_start64:
+    mov $0, %ax
+    mov %ax, %ss
+    mov %ax, %ds
+    mov %ax, %es
+    mov %ax, %fs
+    mov %ax, %gs
+
     /* flush the TLB */
-    movl %cr3, %eax
-    movl %eax, %cr3
+    movq %cr3, %rax
+    movq %rax, %cr3
 
     movl $0xc0008000, %ebp
 
     /* now load the final gdt and idt from the identity mapped area */
-    movl (ap_cpu_gdtr - apic_ap_start)(%ebp), %eax
-    lgdt (%eax)
-    movl (ap_cpu_idtr - apic_ap_start)(%ebp), %eax
-    lidt (%eax)
+    movq (ap_cpu_gdtr - apic_ap_start)(%rbp), %rax
+    lgdt (%rax)
+    movq (ap_cpu_idtr - apic_ap_start)(%rbp), %rax
+    lidt (%rax)
 
     /* set same cr0 and cr4 values as the BSP */
-    movl (ap_cpu_init_cr0 - apic_ap_start)(%ebp), %eax
-    movl %eax, %cr0
-    movl (ap_cpu_init_cr4 - apic_ap_start)(%ebp), %eax
-    movl %eax, %cr4
+    movq (ap_cpu_init_cr0 - apic_ap_start)(%rbp), %rax
+    movq %rax, %cr0
+    movq (ap_cpu_init_cr4 - apic_ap_start)(%rbp), %rax
+    movq %rax, %cr4
 
     /* push the Processor pointer this CPU is going to use */
-    movl (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %eax
-    addl $0xc0000000, %eax
-    movl 0(%eax, %esi, 4), %eax
-    push %eax
+    movq (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %rax
+    movq $0xc0000000, %r8
+    addq %r8, %rax
+    movq 0(%rax, %rsi, 4), %rax
+    push %rax
 
     /* push the cpu id, 0 representing the bsp and call into c++ */
-    incl %esi
-    push %esi
+    incq %rsi
+    push %rsi
 
     xor %ebp, %ebp
     cld
@@ -404,8 +419,10 @@ apic_ap_start32_2:
     /* We are in identity mapped P0x8000 and the BSP will unload this code
        once all APs are initialized, so call init_ap but return to our
        infinite loop */
-    push $loop
-    ljmp $8, $init_ap
+    movabs $loop, %rax
+    pushq %rax
+    movabs $init_ap, %rax
+    jmp *(%rax)
 
 .align 4
 .global apic_ap_start_size
@@ -427,27 +444,24 @@ ap_cpu_gdt_end:
 ap_cpu_gdtr_initial:
     .2byte ap_cpu_gdt_end - ap_cpu_gdt - 1
     .4byte (ap_cpu_gdt - apic_ap_start) + 0x8000
-ap_cpu_gdtr_initial2:
-    .2byte ap_cpu_gdt_end - ap_cpu_gdt - 1
-    .4byte (ap_cpu_gdt - apic_ap_start) + 0xc0008000
 .global ap_cpu_gdtr
 ap_cpu_gdtr:
-    .4byte 0x0 /* will be set at runtime */
+    .8byte 0x0 /* will be set at runtime */
 .global ap_cpu_idtr
 ap_cpu_idtr:
-    .4byte 0x0 /* will be set at runtime */
+    .8byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_cr0
 ap_cpu_init_cr0:
-    .4byte 0x0 /* will be set at runtime */
+    .8byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_cr3
 ap_cpu_init_cr3:
-    .4byte 0x0 /* will be set at runtime */
+    .8byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_cr4
 ap_cpu_init_cr4:
-    .4byte 0x0 /* will be set at runtime */
+    .8byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_processor_info_array
 ap_cpu_init_processor_info_array:
-    .4byte 0x0 /* will be set at runtime */
+    .8byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_stacks
 ap_cpu_init_stacks:
     /* array of allocated stack pointers */

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -88,7 +88,7 @@ static void setup_serial_debug();
 // boot.S expects these functions to exactly have the following signatures.
 // We declare them here to ensure their signatures don't accidentally change.
 extern "C" void init_finished(u32 cpu) __attribute__((used));
-extern "C" [[noreturn]] void init_ap(u32 cpu, Processor* processor_info);
+extern "C" [[noreturn]] void init_ap(FlatPtr cpu, Processor* processor_info);
 extern "C" [[noreturn]] void init();
 
 READONLY_AFTER_INIT VirtualConsole* tty0;
@@ -194,7 +194,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init()
 //
 // The purpose of init_ap() is to initialize APs for multi-tasking.
 //
-extern "C" [[noreturn]] UNMAP_AFTER_INIT void init_ap(u32 cpu, Processor* processor_info)
+extern "C" [[noreturn]] UNMAP_AFTER_INIT void init_ap(FlatPtr cpu, Processor* processor_info)
 {
     processor_info->early_initialize(cpu);
 

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -321,10 +321,9 @@ void DynamicLoader::load_program_headers()
     for (auto& text_region : text_regions) {
         FlatPtr ph_text_base = text_region.desired_load_address().page_base().get();
         FlatPtr ph_text_end = ph_text_base + round_up_to_power_of_two(text_region.size_in_memory() + (size_t)(text_region.desired_load_address().as_ptr() - ph_text_base), PAGE_SIZE);
-        size_t text_segment_size = ph_text_end - ph_text_base;
 
-        auto text_segment_offset = ph_text_base - ph_load_base;
-        auto* text_segment_address = (u8*)reservation + text_segment_offset;
+        auto* text_segment_address = (u8*)reservation + ph_text_base;
+        size_t text_segment_size = ph_text_end - ph_text_base;
 
         // Now we can map the text segment at the reserved address.
         auto* text_segment_begin = (u8*)mmap_with_name(
@@ -359,10 +358,9 @@ void DynamicLoader::load_program_headers()
     for (auto& data_region : data_regions) {
         FlatPtr ph_data_base = data_region.desired_load_address().page_base().get();
         FlatPtr ph_data_end = ph_data_base + round_up_to_power_of_two(data_region.size_in_memory() + (size_t)(data_region.desired_load_address().as_ptr() - ph_data_base), PAGE_SIZE);
-        size_t data_segment_size = ph_data_end - ph_data_base;
 
-        auto data_segment_offset = ph_data_base - ph_load_base;
-        auto* data_segment_address = (u8*)reservation + data_segment_offset;
+        auto* data_segment_address = (u8*)reservation + ph_data_base;
+        size_t data_segment_size = ph_data_end - ph_data_base;
 
         // Finally, we make an anonymous mapping for the data segment. Contents are then copied from the file.
         auto* data_segment = (u8*)mmap_with_name(

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -422,7 +422,10 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
             return RelocationResult::Failed;
         }
         auto symbol_address = res.value().address;
-        *patch_ptr += symbol_address.get();
+        if (relocation.addend_used())
+            *patch_ptr = symbol_address.get() + relocation.addend();
+        else
+            *patch_ptr += symbol_address.get();
         break;
     }
 #ifndef __LP64__
@@ -466,7 +469,10 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         // FIXME: According to the spec, R_386_relative ones must be done first.
         //     We could explicitly do them first using m_number_of_relocations from DT_RELCOUNT
         //     However, our compiler is nice enough to put them at the front of the relocations for us :)
-        *patch_ptr += (FlatPtr)m_dynamic_object->base_address().as_ptr(); // + addend for RelA (addend for Rel is stored at addr)
+        if (relocation.addend_used())
+            *patch_ptr = (FlatPtr)m_dynamic_object->base_address().as_ptr() + relocation.addend();
+        else
+            *patch_ptr += (FlatPtr)m_dynamic_object->base_address().as_ptr();
         break;
     }
 #ifndef __LP64__

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -215,7 +215,7 @@ Result<NonnullRefPtr<DynamicObject>, DlErrorMessage> DynamicLoader::load_stage_3
 
     if (m_relro_segment_size) {
         if (mprotect(m_relro_segment_address.as_ptr(), m_relro_segment_size, PROT_READ) < 0) {
-            return DlErrorMessage { String::formatted("mprotect .text: PROT_READ: {}", strerror(errno)) };
+            return DlErrorMessage { String::formatted("mprotect .relro: PROT_READ: {}", strerror(errno)) };
         }
 
 #if __serenity__


### PR DESCRIPTION
Known issues:

* `__thread` and dynamic TLS don't work but they're disabled for now so at least text mode boots properly.
* Usermode threads crash after being started. Starting them is disabled for now.

Other than that I'll just let this screenshot speak for itself:

![x86_64](https://user-images.githubusercontent.com/388571/124047379-609c7700-da14-11eb-89c5-ba6aff0b934d.png)

**Kernel: Support starting up secondary processors on x86_64**

**LibELF: Fix incorrect error message**

**LibELF: Simplify ELF load address calculations**

These were unnecessarily complicated.

**LibELF: Implement support for RELA relocations**