### PR TITLE
Tests: Fix two benchmarks and clean up some test runner pet peeves

### DIFF
--- a/Base/home/anon/.config/Tests.ini
+++ b/Base/home/anon/.config/Tests.ini
@@ -1,6 +1,6 @@
 [Global]
 SkipDirectories=Kernel/Legacy UserEmulator
-SkipTests=stack-smash test-web
+SkipTests=test-web
 NotTestsPattern=.txt|.frm|.inc
 
 [test-js]

--- a/Base/home/anon/tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/tests/run-tests-and-shutdown.sh
@@ -3,7 +3,7 @@
 echo
 echo "==== Running Tests on SerenityOS ===="
 
-run-tests
+run-tests --show-progress=false
 fail_count=$?
 
 echo "Failed: $fail_count" > ./test-results.log

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCDirEnt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCInodeWatcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCString.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TestStackSmash.cpp
 )
 
 file(GLOB CMD_SOURCES  CONFIGURE_DEPENDS "*.cpp")

--- a/Tests/LibC/TestStackSmash.cpp
+++ b/Tests/LibC/TestStackSmash.cpp
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <cstdio>
+#include <AK/Format.h>
+#include <LibTest/TestCase.h>
 
 // Note: Needs to be 'noline' so stack canary isn't optimized out.
 static void __attribute__((noinline)) smasher(char* string)
@@ -24,11 +25,12 @@ static void __attribute__((noinline)) stack_to_smash()
     smasher(string);
 }
 
-int main()
+TEST_CASE(stack_smash)
 {
-    puts("[+] Starting the stack smash...");
-    stack_to_smash();
-    puts("[+] Stack smash wasn't detected!");
-
-    return 0;
+    EXPECT_CRASH("Smash the stack and trigger __stack_chk_fail", [] {
+        outln("[+] Starting the stack smash...");
+        stack_to_smash();
+        outln("[+] Stack smash wasn't detected!");
+        return Test::Crash::Failure::DidNotCrash;
+    });
 }

--- a/Tests/LibGfx/BenchmarkGfxPainter.cpp
+++ b/Tests/LibGfx/BenchmarkGfxPainter.cpp
@@ -7,8 +7,18 @@
 #include <LibTest/TestCase.h>
 
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/FontDatabase.h>
 #include <LibGfx/Painter.h>
 #include <stdio.h>
+
+// Make sure that no matter what order tests are run in, we've got some
+// default fonts for the application to use without talking to WindowServer
+static struct FontDatabaseSpoofer {
+    FontDatabaseSpoofer()
+    {
+        Gfx::FontDatabase::the().set_default_font_query("Katica 10 400"sv);
+    }
+} g_spoof;
 
 BENCHMARK_CASE(diagonal_lines)
 {

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -6,9 +6,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Platform.h>
 #include <LibTest/CrashTest.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#ifndef AK_OS_MACOS
+#    include <sys/prctl.h>
+#endif
 
 namespace Test {
 
@@ -49,6 +54,10 @@ bool Crash::run(RunType run_type)
             perror("fork");
             VERIFY_NOT_REACHED();
         } else if (pid == 0) {
+#ifndef AK_OS_MACOS
+            if (prctl(PR_SET_DUMPABLE, 0, 0) < 0)
+                perror("prctl(PR_SET_DUMPABLE)");
+#endif
             run_crash_and_print_if_error();
             exit(0);
         }


### PR DESCRIPTION
Few small fixes here:

1) Fix the graphics benchmark painter which has been broken for months
2) Fix the CSV reader benchmark that never had its associated input file
3) Don't print OSC 9 when running via the run tests script
4) Don't generate a core dump for crash test crashy children
5) convert stack-smash to be LibTest based so we don't have to skip it anymore