### PR TITLE
Kernel+AK+LibC: Make the kernel build with Clang

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -163,9 +163,16 @@ inline NonnullOwnPtr<T> adopt_own(T& object)
 #endif
 
 template<class T, class... Args>
-inline NonnullOwnPtr<T> make(Args&&... args)
+requires(IsConstructible<T, Args...>) inline NonnullOwnPtr<T> make(Args&&... args)
 {
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T(forward<Args>(args)...));
+}
+
+// FIXME: Remove once P0960R3 is available in Clang.
+template<class T, class... Args>
+inline NonnullOwnPtr<T> make(Args&&... args)
+{
+    return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T { forward<Args>(args)... });
 }
 
 template<typename T>

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -33,7 +33,7 @@ public:
         : m_ptr(&ptr)
     {
         static_assert(
-            requires { requires typename T::AllowOwnPtr()(); } || !requires(T obj) { requires !typename T::AllowOwnPtr()(); obj.ref(); obj.unref(); },
+            requires { requires typename T::AllowOwnPtr()(); } || !requires { requires !typename T::AllowOwnPtr()(); declval<T>().ref(); declval<T>().unref(); },
             "Use NonnullRefPtr<> for RefCounted types");
     }
     NonnullOwnPtr(NonnullOwnPtr&& other)

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -336,11 +336,17 @@ inline void swap(NonnullRefPtr<T>& a, NonnullRefPtr<U>& b)
 }
 
 template<typename T, class... Args>
-inline NonnullRefPtr<T> create(Args&&... args)
+requires(IsConstructible<T, Args...>) inline NonnullRefPtr<T> create(Args&&... args)
 {
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T(forward<Args>(args)...));
 }
 
+// FIXME: Remove once P0960R3 is available in Clang.
+template<typename T, class... Args>
+inline NonnullRefPtr<T> create(Args&&... args)
+{
+    return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T { forward<Args>(args)... });
+}
 }
 
 template<typename T>

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -14,7 +14,7 @@
 namespace AK {
 
 template<typename T>
-class alignas(T) [[nodiscard]] Optional {
+class [[nodiscard]] Optional {
 public:
     using ValueType = T;
 
@@ -132,13 +132,13 @@ public:
     [[nodiscard]] ALWAYS_INLINE T& value()
     {
         VERIFY(m_has_value);
-        return *reinterpret_cast<T*>(&m_storage);
+        return *__builtin_launder(reinterpret_cast<T*>(&m_storage));
     }
 
     [[nodiscard]] ALWAYS_INLINE const T& value() const
     {
         VERIFY(m_has_value);
-        return *reinterpret_cast<const T*>(&m_storage);
+        return *__builtin_launder(reinterpret_cast<const T*>(&m_storage));
     }
 
     [[nodiscard]] T release_value()
@@ -164,7 +164,7 @@ public:
     ALWAYS_INLINE T* operator->() { return &value(); }
 
 private:
-    u8 m_storage[sizeof(T)] { 0 };
+    alignas(T) u8 m_storage[sizeof(T)];
     bool m_has_value { false };
 };
 

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -184,8 +184,7 @@ protected:
         : m_ptr(ptr)
     {
         static_assert(
-            requires { requires typename T::AllowOwnPtr()(); } || !requires(T obj) { requires !typename T::AllowOwnPtr()(); obj.ref(); obj.unref(); },
-            "Use RefPtr<> for RefCounted types");
+            requires { requires typename T::AllowOwnPtr()(); } || !requires { requires !typename T::AllowOwnPtr()(); declval<T>().ref(); declval<T>().unref(); }, "Use RefPtr<> for RefCounted types");
     }
 
 private:

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -206,9 +206,17 @@ inline OwnPtr<T> adopt_own_if_nonnull(T* object)
 }
 
 template<typename T, class... Args>
-inline OwnPtr<T> try_make(Args&&... args)
+requires(IsConstructible<T, Args...>) inline OwnPtr<T> try_make(Args&&... args)
 {
     return adopt_own_if_nonnull(new (nothrow) T(forward<Args>(args)...));
+}
+
+// FIXME: Remove once P0960R3 is available in Clang.
+template<typename T, class... Args>
+inline OwnPtr<T> try_make(Args&&... args)
+
+{
+    return adopt_own_if_nonnull(new (nothrow) T { forward<Args>(args)... });
 }
 
 template<typename T>

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -486,9 +486,16 @@ inline RefPtr<T> adopt_ref_if_nonnull(T* object)
 }
 
 template<typename T, class... Args>
-inline RefPtr<T> try_create(Args&&... args)
+requires(IsConstructible<T, Args...>) inline RefPtr<T> try_create(Args&&... args)
 {
     return adopt_ref_if_nonnull(new (nothrow) T(forward<Args>(args)...));
+}
+
+// FIXME: Remove once P0960R3 is available in Clang.
+template<typename T, class... Args>
+inline RefPtr<T> try_create(Args&&... args)
+{
+    return adopt_ref_if_nonnull(new (nothrow) T { forward<Args>(args)... });
 }
 
 }

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -443,6 +443,10 @@ auto declval() -> T;
 
 template<typename T, typename... Args>
 inline constexpr bool IsCallableWithArguments = requires(T t) { t(declval<Args>()...); };
+
+template<typename T, typename... Args>
+inline constexpr bool IsConstructible = requires { ::new T(declval<Args>()...); };
+
 }
 using AK::Detail::AddConst;
 using AK::Detail::Conditional;
@@ -459,6 +463,7 @@ using AK::Detail::IsBaseOf;
 using AK::Detail::IsCallableWithArguments;
 using AK::Detail::IsClass;
 using AK::Detail::IsConst;
+using AK::Detail::IsConstructible;
 using AK::Detail::IsEnum;
 using AK::Detail::IsFloatingPoint;
 using AK::Detail::IsFunction;

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -18,7 +18,7 @@
 
 namespace Kernel {
 
-class RegisterState;
+struct RegisterState;
 class GenericInterruptHandler;
 
 static constexpr u32 safe_eflags_mask = 0xdff;

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -30,7 +30,7 @@ public:
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     // ^HIDDevice
-    virtual Type instrument_type() const { return Type::Keyboard; }
+    virtual Type instrument_type() const override { return Type::Keyboard; }
 
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }

--- a/Kernel/Devices/HID/MouseDevice.h
+++ b/Kernel/Devices/HID/MouseDevice.h
@@ -29,7 +29,7 @@ public:
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     // ^HIDDevice
-    virtual Type instrument_type() const { return Type::Mouse; }
+    virtual Type instrument_type() const override { return Type::Mouse; }
 
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -69,7 +69,7 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         break;
     default:
         if ((m_modifiers & Mod_Alt) != 0 && ch >= 2 && ch <= ConsoleManagement::s_max_virtual_consoles + 1) {
-            g_io_work->queue([this, ch]() {
+            g_io_work->queue([ch]() {
                 ConsoleManagement::the().switch_to(ch - 0x02);
             });
         }

--- a/Kernel/Devices/MemoryDevice.h
+++ b/Kernel/Devices/MemoryDevice.h
@@ -30,7 +30,7 @@ private:
     virtual const char* class_name() const override { return "MemoryDevice"; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return false; }
-    virtual bool is_seekable() const { return true; }
+    virtual bool is_seekable() const override { return true; }
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
 

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -32,8 +32,11 @@ public:
     KResultOr<NonnullRefPtr<FileDescription>> open_direction(Direction);
     KResultOr<NonnullRefPtr<FileDescription>> open_direction_blocking(Direction);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
     void attach(Direction);
     void detach(Direction);
+#pragma GCC diagnostic pop
 
 private:
     // ^File

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -237,7 +237,7 @@ KResultOr<size_t> FileDescription::get_dir_entries(UserOrKernelBuffer& output_bu
         return true;
     };
 
-    KResult result = VFS::the().traverse_directory_inode(*m_inode, [&flush_stream_to_output_buffer, &error, &remaining, &output_buffer, &stream, this](auto& entry) {
+    KResult result = VFS::the().traverse_directory_inode(*m_inode, [&flush_stream_to_output_buffer, &stream, this](auto& entry) {
         size_t serialized_size = sizeof(ino_t) + sizeof(u8) + sizeof(size_t) + sizeof(char) * entry.name.length();
         if (serialized_size > stream.remaining()) {
             if (!flush_stream_to_output_buffer()) {

--- a/Kernel/Graphics/IntelNativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/IntelNativeGraphicsAdapter.cpp
@@ -26,7 +26,7 @@ static constexpr IntelNativeGraphicsAdapter::PLLMaxSettings G35Limits {
 };
 
 static constexpr u16 supported_models[] {
-    { 0x29c2 }, // Intel G35 Adapter
+    0x29c2, // Intel G35 Adapter
 };
 
 static bool is_supported_model(u16 device_id)

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -185,7 +185,7 @@ struct KmallocGlobalHeap {
 };
 
 READONLY_AFTER_INIT static KmallocGlobalHeap* g_kmalloc_global;
-static u8 g_kmalloc_global_heap[sizeof(KmallocGlobalHeap)];
+alignas(KmallocGlobalHeap) static u8 g_kmalloc_global_heap[sizeof(KmallocGlobalHeap)];
 
 // Treat the heap as logically separate from .bss
 __attribute__((section(".heap"))) static u8 kmalloc_eternal_heap[ETERNAL_RANGE_SIZE];

--- a/Kernel/Interrupts/IOAPIC.h
+++ b/Kernel/Interrupts/IOAPIC.h
@@ -50,7 +50,7 @@ public:
     virtual u16 get_isr() const override;
     virtual u16 get_irr() const override;
     virtual u32 gsi_base() const override { return m_gsi_base; }
-    virtual size_t interrupt_vectors_count() const { return m_redirection_entries_count; }
+    virtual size_t interrupt_vectors_count() const override { return m_redirection_entries_count; }
     virtual const char* model() const override { return "IOAPIC"; };
     virtual IRQControllerType type() const override { return IRQControllerType::i82093AA; }
 

--- a/Kernel/Interrupts/IRQHandler.h
+++ b/Kernel/Interrupts/IRQHandler.h
@@ -18,7 +18,7 @@ class IRQHandler : public GenericInterruptHandler {
 public:
     virtual ~IRQHandler();
 
-    virtual bool handle_interrupt(const RegisterState& regs) { return handle_irq(regs); }
+    virtual bool handle_interrupt(const RegisterState& regs) override { return handle_irq(regs); }
     virtual bool handle_irq(const RegisterState&) = 0;
 
     void enable_irq();

--- a/Kernel/Interrupts/PIC.h
+++ b/Kernel/Interrupts/PIC.h
@@ -23,7 +23,7 @@ public:
     virtual u16 get_isr() const override;
     virtual u16 get_irr() const override;
     virtual u32 gsi_base() const override { return 0; }
-    virtual size_t interrupt_vectors_count() const { return 16; }
+    virtual size_t interrupt_vectors_count() const override { return 16; }
     virtual const char* model() const override { return "Dual i8259"; }
     virtual IRQControllerType type() const override { return IRQControllerType::i8259; }
 

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -64,7 +64,7 @@ public:
         auto new_region = MM.allocate_kernel_region(page_round_up(new_capacity), m_region->name(), m_region->access(), m_allocation_strategy);
         if (!new_region)
             return false;
-        if (m_region && m_size > 0)
+        if (m_size > 0)
             memcpy(new_region->vaddr().as_ptr(), data(), min(m_region->size(), m_size));
         m_region = new_region.release_nonnull();
         return true;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -460,7 +460,7 @@ Process* Scheduler::colonel()
 
 UNMAP_AFTER_INIT void Scheduler::initialize()
 {
-    VERIFY(&Processor::current() != nullptr); // sanity check
+    VERIFY(Processor::is_initialized()); // sanity check
 
     RefPtr<Thread> idle_thread;
     g_finalizer_wait_queue = new WaitQueue;

--- a/Kernel/Storage/BMIDEChannel.h
+++ b/Kernel/Storage/BMIDEChannel.h
@@ -42,9 +42,9 @@ private:
     virtual bool handle_irq(const RegisterState&) override;
 
     //* IDEChannel
-    virtual void send_ata_io_command(LBAMode lba_mode, Direction direction) const;
-    virtual void ata_read_sectors(bool, u16);
-    virtual void ata_write_sectors(bool, u16);
+    virtual void send_ata_io_command(LBAMode lba_mode, Direction direction) const override;
+    virtual void ata_read_sectors(bool, u16) override;
+    virtual void ata_write_sectors(bool, u16) override;
 
     PhysicalRegionDescriptor& prdt() { return *reinterpret_cast<PhysicalRegionDescriptor*>(m_prdt_region->vaddr().as_ptr()); }
     OwnPtr<Region> m_prdt_region;

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -119,10 +119,10 @@ KResultOr<FlatPtr> Process::sys$accept4(Userspace<const Syscall::SC_accept4_para
     VERIFY(accepted_socket);
 
     if (user_address) {
-        u8 address_buffer[sizeof(sockaddr_un)];
+        sockaddr_un address_buffer;
         address_size = min(sizeof(sockaddr_un), static_cast<size_t>(address_size));
-        accepted_socket->get_peer_address((sockaddr*)address_buffer, &address_size);
-        if (!copy_to_user(user_address, address_buffer, address_size))
+        accepted_socket->get_peer_address((sockaddr*)&address_buffer, &address_size);
+        if (!copy_to_user(user_address, &address_buffer, address_size))
             return EFAULT;
         if (!copy_to_user(user_address_size, &address_size))
             return EFAULT;
@@ -311,13 +311,13 @@ int Process::get_sock_or_peer_name(const Params& params)
     auto& socket = *description->socket();
     REQUIRE_PROMISE_FOR_SOCKET_DOMAIN(socket.domain());
 
-    u8 address_buffer[sizeof(sockaddr_un)];
+    sockaddr_un address_buffer;
     addrlen_value = min(sizeof(sockaddr_un), static_cast<size_t>(addrlen_value));
     if constexpr (sockname)
-        socket.get_local_address((sockaddr*)address_buffer, &addrlen_value);
+        socket.get_local_address((sockaddr*)&address_buffer, &addrlen_value);
     else
-        socket.get_peer_address((sockaddr*)address_buffer, &addrlen_value);
-    if (!copy_to_user(params.addr, address_buffer, addrlen_value))
+        socket.get_peer_address((sockaddr*)&address_buffer, &addrlen_value);
+    if (!copy_to_user(params.addr, &address_buffer, addrlen_value))
         return EFAULT;
     if (!copy_to_user(params.addrlen, &addrlen_value))
         return EFAULT;

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -48,7 +48,6 @@ KResultOr<size_t> TTY::read(FileDescription&, u64, UserOrKernelBuffer& buffer, s
         [[maybe_unused]] auto rc = Process::current()->send_signal(SIGTTIN, nullptr);
         return EINTR;
     }
-
     if (m_input_buffer.size() < static_cast<size_t>(size))
         size = m_input_buffer.size();
 
@@ -93,7 +92,7 @@ KResultOr<size_t> TTY::write(FileDescription&, u64, const UserOrKernelBuffer& bu
         u8 modified_data[num_chars * 2];
         size_t modified_data_size = 0;
         for (size_t i = 0; i < buffer_bytes; ++i) {
-            process_output(data[i], [this, &modified_data, &modified_data_size](u8 out_ch) {
+            process_output(data[i], [&modified_data, &modified_data_size](u8 out_ch) {
                 modified_data[modified_data_size++] = out_ch;
             });
         }

--- a/Kernel/Time/APICTimer.h
+++ b/Kernel/Time/APICTimer.h
@@ -31,7 +31,7 @@ public:
     virtual bool is_capable_of_frequency(size_t frequency) const override;
     virtual size_t calculate_nearest_possible_frequency(size_t frequency) const override;
 
-    void will_be_destroyed() { HardwareTimer<GenericInterruptHandler>::will_be_destroyed(); }
+    void will_be_destroyed() override { HardwareTimer<GenericInterruptHandler>::will_be_destroyed(); }
     void enable_local_timer();
     void disable_local_timer();
 

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -132,7 +132,7 @@ public:
 
     virtual size_t sharing_devices_count() const override { return 0; }
     virtual bool is_shared_handler() const override { return false; }
-    virtual bool is_sharing_with_others() const { return false; }
+    virtual bool is_sharing_with_others() const override { return false; }
     virtual HandlerType type() const override { return HandlerType::IRQHandler; }
     virtual const char* controller() const override { return nullptr; }
     virtual bool eoi() override;

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -11,7 +11,7 @@
 __BEGIN_DECLS
 
 #ifdef DEBUG
-[[noreturn]] void __assertion_failed(const char* msg);
+__attribute__((noreturn)) void __assertion_failed(const char* msg);
 #    define __stringify_helper(x) #    x
 #    define __stringify(x) __stringify_helper(x)
 #    define assert(expr)                                                           \
@@ -24,7 +24,7 @@ __BEGIN_DECLS
 #    define VERIFY_NOT_REACHED() _abort()
 #endif
 
-[[noreturn]] void _abort();
+__attribute__((noreturn)) void _abort();
 
 #ifndef __cplusplus
 #    define static_assert _Static_assert

--- a/Userland/Libraries/LibC/cxxabi.cpp
+++ b/Userland/Libraries/LibC/cxxabi.cpp
@@ -104,7 +104,7 @@ void __cxa_finalize(void* dso_handle)
     __pthread_mutex_unlock(&atexit_mutex);
 }
 
-[[noreturn]] void __cxa_pure_virtual()
+__attribute__((noreturn)) void __cxa_pure_virtual()
 {
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -26,8 +26,8 @@
 
 static Threading::Lock& malloc_lock()
 {
-    static u32 lock_storage[sizeof(Threading::Lock) / sizeof(u32)];
-    return *reinterpret_cast<Threading::Lock*>(&lock_storage);
+    alignas(Threading::Lock) static u8 lock_storage[sizeof(Threading::Lock)];
+    return *reinterpret_cast<Threading::Lock*>(lock_storage);
 }
 
 constexpr size_t number_of_hot_chunked_blocks_to_keep_around = 16;
@@ -111,8 +111,8 @@ struct BigAllocator {
 // are run. Similarly, we can not allow global destructors to destruct
 // them. We could have used AK::NeverDestoyed to prevent the latter,
 // but it would have not helped with the former.
-static u8 g_allocators_storage[sizeof(Allocator) * num_size_classes];
-static u8 g_big_allocators_storage[sizeof(BigAllocator)];
+alignas(Allocator) static u8 g_allocators_storage[sizeof(Allocator) * num_size_classes];
+alignas(BigAllocator) static u8 g_big_allocators_storage[sizeof(BigAllocator)];
 
 static inline Allocator (&allocators())[num_size_classes]
 {

--- a/Userland/Libraries/LibC/ssp.cpp
+++ b/Userland/Libraries/LibC/ssp.cpp
@@ -20,7 +20,7 @@ extern "C" {
 extern u32 __stack_chk_guard;
 u32 __stack_chk_guard = (u32)0xc6c7c8c9;
 
-[[noreturn]] void __stack_chk_fail()
+__attribute__((noreturn)) void __stack_chk_fail()
 {
     dbgln("Error: USERSPACE({}) Stack protector failure, stack smashing detected!", getpid());
     if (__stdio_is_initialized)
@@ -28,7 +28,7 @@ u32 __stack_chk_guard = (u32)0xc6c7c8c9;
     abort();
 }
 
-[[noreturn]] void __stack_chk_fail_local()
+__attribute__((noreturn)) void __stack_chk_fail_local()
 {
     __stack_chk_fail();
 }

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -614,7 +614,7 @@ private:
 
 extern "C" {
 
-static u8 default_streams[3][sizeof(FILE)];
+alignas(FILE) static u8 default_streams[3][sizeof(FILE)];
 FILE* stdin = reinterpret_cast<FILE*>(&default_streams[0]);
 FILE* stdout = reinterpret_cast<FILE*>(&default_streams[1]);
 FILE* stderr = reinterpret_cast<FILE*>(&default_streams[2]);

--- a/Userland/Libraries/LibC/sys/internals.h
+++ b/Userland/Libraries/LibC/sys/internals.h
@@ -21,8 +21,8 @@ extern bool __stdio_is_initialized;
 
 int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle);
 void __cxa_finalize(void* dso_handle);
-[[noreturn]] void __cxa_pure_virtual() __attribute__((weak));
-[[noreturn]] void __stack_chk_fail();
-[[noreturn]] void __stack_chk_fail_local();
+__attribute__((noreturn)) void __cxa_pure_virtual() __attribute__((weak));
+__attribute__((noreturn)) void __stack_chk_fail();
+__attribute__((noreturn)) void __stack_chk_fail_local();
 
 __END_DECLS


### PR DESCRIPTION
This PR fixes the small things that made the kernel not build with Clang.

Note that some warnings (like `cast-align`) still have to be turned off manually, as fixing all issues related to it would take an unreasonably large effort. See #8329, which describes why GCC does not catch these bugs.