### PR TITLE
Meta: Make serenity.sh pass the SERENITY_ARCH cmake argument for x86_64

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -95,6 +95,10 @@ is_valid_target() {
         CMAKE_ARGS+=("-DBUILD_LAGOM=ON")
         return 0
     fi
+    if [ "$TARGET" = "x86_64" ]; then
+        CMAKE_ARGS+=("-DSERENITY_ARCH=x86_64")
+        return 0
+    fi
     [[ "$TARGET" =~ ^(i686|x86_64|lagom)$ ]] || return 1
 }
 


### PR DESCRIPTION
This is required as our CMake config defaults to i686 if not overriden manually via the SERENITY_ARCH argument.