### PR TITLE
CI: Cancel duplicate workflow runs for pull requests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,6 +8,10 @@ env:
   # github.workspace = /home/runner/work/serenity/serenity
   SERENITY_SOURCE_DIR: ${{ github.workspace }}
 
+concurrency:
+  group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test_serenity:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
These are created when a pull request is force-pushed to, which results in the unneeded waste of action runners on the obsolete CI run.