### PR TITLE
Kernel+Userland: x86_64 support (part 10)

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -352,10 +352,16 @@ struct SC_create_thread_params {
     // a call to pthread_attr_getguardsize() specifying attr shall store in the guardsize
     // parameter the guard size specified by the previous pthread_attr_setguardsize() function call"
     // ... ok, if you say so posix. Guess we get to lie to people about guard page size
-    unsigned int m_guard_page_size = 0;          // Rounded up to PAGE_SIZE
-    unsigned int m_reported_guard_page_size = 0; // The lie we tell callers
-    unsigned int m_stack_size = 4 * MiB;         // Default PTHREAD_STACK_MIN
-    void* m_stack_location;                      // nullptr means any, o.w. process virtual address
+    unsigned int guard_page_size = 0;          // Rounded up to PAGE_SIZE
+    unsigned int reported_guard_page_size = 0; // The lie we tell callers
+    unsigned int stack_size = 4 * MiB;         // Default PTHREAD_STACK_MIN
+    void* stack_location;                      // nullptr means any, o.w. process virtual address
+#    if ARCH(X86_64)
+    FlatPtr rdi;
+    FlatPtr rsi;
+    FlatPtr rcx;
+    FlatPtr rdx;
+#    endif
 };
 
 struct SC_realpath_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -345,8 +345,8 @@ struct SC_getkeymap_params {
 };
 
 struct SC_create_thread_params {
-    unsigned int m_detach_state = 0; // JOINABLE or DETACHED
-    int m_schedule_priority = 30;    // THREAD_PRIORITY_NORMAL
+    unsigned int detach_state = 0; // JOINABLE or DETACHED
+    int schedule_priority = 30;    // THREAD_PRIORITY_NORMAL
     // FIXME: Implement guard pages in create_thread (unreadable pages at "overflow" end of stack)
     // "If an implementation rounds up the value of guardsize to a multiple of {PAGESIZE},
     // a call to pthread_attr_getguardsize() specifying attr shall store in the guardsize

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -70,6 +70,10 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
     regs.rip = (FlatPtr)entry;
     regs.rflags = 0x0202;
     regs.rsp = user_sp.value();
+    regs.rdi = params.rdi;
+    regs.rsi = params.rsi;
+    regs.rdx = params.rdx;
+    regs.rcx = params.rcx;
 #endif
     regs.cr3 = space().page_directory().cr3();
 
@@ -81,11 +85,7 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
 
     ScopedSpinLock lock(g_scheduler_lock);
     thread->set_priority(requested_thread_priority);
-#if ARCH(I386)
     thread->set_state(Thread::State::Runnable);
-#else
-    dbgln("FIXME: Not starting thread {} (because it'd crash)", *thread);
-#endif
     return thread->tid().value();
 }
 

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -24,11 +24,11 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
     if (!copy_from_user(&params, user_params))
         return EFAULT;
 
-    unsigned detach_state = params.m_detach_state;
-    int schedule_priority = params.m_schedule_priority;
-    unsigned stack_size = params.m_stack_size;
+    unsigned detach_state = params.detach_state;
+    int schedule_priority = params.schedule_priority;
+    unsigned stack_size = params.stack_size;
 
-    auto user_sp = Checked<FlatPtr>((FlatPtr)params.m_stack_location);
+    auto user_sp = Checked<FlatPtr>((FlatPtr)params.stack_location);
     user_sp += stack_size;
     if (user_sp.has_overflow())
         return EOVERFLOW;

--- a/Userland/DynamicLoader/CMakeLists.txt
+++ b/Userland/DynamicLoader/CMakeLists.txt
@@ -12,7 +12,7 @@ if ("${SERENITY_ARCH}" STREQUAL "i686")
     file(GLOB LIBC_SOURCES3 "../Libraries/LibC/arch/i386/*.S")
     set(ELF_SOURCES ${ELF_SOURCES} ../Libraries/LibELF/Arch/i386/plt_trampoline.S)
 elseif ("${SERENITY_ARCH}" STREQUAL "x86_64")
-    file(GLOB LIBC_SOURCES3 "../Libraries/LibC/arch/x86_64/*.S") # FIXME: this does not exist at this point!
+    file(GLOB LIBC_SOURCES3 "../Libraries/LibC/arch/x86_64/*.S")
     set(ELF_SOURCES ${ELF_SOURCES} ../Libraries/LibELF/Arch/x86_64/plt_trampoline.S)
 endif()
 

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -71,10 +71,17 @@ static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argumen
     while (((uintptr_t)stack - 16) % 16 != 0)
         push_on_stack(nullptr);
 
+#if ARCH(I386)
     push_on_stack((void*)(uintptr_t)thread_params->stack_size);
     push_on_stack(thread_params->stack_location);
     push_on_stack(argument);
     push_on_stack((void*)entry);
+#else
+    thread_params->rdi = (FlatPtr)entry;
+    thread_params->rsi = (FlatPtr)argument;
+    thread_params->rdx = (FlatPtr)thread_params->stack_location;
+    thread_params->rcx = thread_params->stack_size;
+#endif
     VERIFY((uintptr_t)stack % 16 == 0);
 
     // Push a fake return address

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -57,12 +57,12 @@ static void* pthread_create_helper(void* (*routine)(void*), void* argument, void
 
 static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argument, PthreadAttrImpl* thread_params)
 {
-    void** stack = (void**)((uintptr_t)thread_params->m_stack_location + thread_params->m_stack_size);
+    void** stack = (void**)((uintptr_t)thread_params->stack_location + thread_params->stack_size);
 
     auto push_on_stack = [&](void* data) {
         stack--;
         *stack = data;
-        thread_params->m_stack_size -= sizeof(void*);
+        thread_params->stack_size -= sizeof(void*);
     };
 
     // We set up the stack for pthread_create_helper.
@@ -71,8 +71,8 @@ static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argumen
     while (((uintptr_t)stack - 16) % 16 != 0)
         push_on_stack(nullptr);
 
-    push_on_stack((void*)(uintptr_t)thread_params->m_stack_size);
-    push_on_stack(thread_params->m_stack_location);
+    push_on_stack((void*)(uintptr_t)thread_params->stack_size);
+    push_on_stack(thread_params->stack_location);
     push_on_stack(argument);
     push_on_stack((void*)entry);
     VERIFY((uintptr_t)stack % 16 == 0);
@@ -108,23 +108,23 @@ int pthread_create(pthread_t* thread, pthread_attr_t* attributes, void* (*start_
 
     PthreadAttrImpl* used_attributes = arg_attributes ? *arg_attributes : &default_attributes;
 
-    if (!used_attributes->m_stack_location) {
+    if (!used_attributes->stack_location) {
         // adjust stack size, user might have called setstacksize, which has no restrictions on size/alignment
-        if (0 != (used_attributes->m_stack_size % required_stack_alignment))
-            used_attributes->m_stack_size += required_stack_alignment - (used_attributes->m_stack_size % required_stack_alignment);
+        if (0 != (used_attributes->stack_size % required_stack_alignment))
+            used_attributes->stack_size += required_stack_alignment - (used_attributes->stack_size % required_stack_alignment);
 
-        used_attributes->m_stack_location = mmap_with_name(nullptr, used_attributes->m_stack_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, 0, 0, "Thread stack");
-        if (!used_attributes->m_stack_location)
+        used_attributes->stack_location = mmap_with_name(nullptr, used_attributes->stack_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, 0, 0, "Thread stack");
+        if (!used_attributes->stack_location)
             return -1;
     }
 
     dbgln_if(PTHREAD_DEBUG, "pthread_create: Creating thread with attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         used_attributes,
-        (PTHREAD_CREATE_JOINABLE == used_attributes->m_detach_state) ? "joinable" : "detached",
-        used_attributes->m_schedule_priority,
-        used_attributes->m_guard_page_size,
-        used_attributes->m_stack_size,
-        used_attributes->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == used_attributes->detach_state) ? "joinable" : "detached",
+        used_attributes->schedule_priority,
+        used_attributes->guard_page_size,
+        used_attributes->stack_size,
+        used_attributes->stack_location);
 
     return create_thread(thread, start_routine, argument_to_start_routine, used_attributes);
 }
@@ -222,11 +222,11 @@ int pthread_attr_init(pthread_attr_t* attributes)
 
     dbgln_if(PTHREAD_DEBUG, "pthread_attr_init: New thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         impl,
-        (PTHREAD_CREATE_JOINABLE == impl->m_detach_state) ? "joinable" : "detached",
-        impl->m_schedule_priority,
-        impl->m_guard_page_size,
-        impl->m_stack_size,
-        impl->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == impl->detach_state) ? "joinable" : "detached",
+        impl->schedule_priority,
+        impl->guard_page_size,
+        impl->stack_size,
+        impl->stack_location);
 
     return 0;
 }
@@ -245,7 +245,7 @@ int pthread_attr_getdetachstate(const pthread_attr_t* attributes, int* p_detach_
     if (!attributes_impl || !p_detach_state)
         return EINVAL;
 
-    *p_detach_state = attributes_impl->m_detach_state;
+    *p_detach_state = attributes_impl->detach_state;
     return 0;
 }
 
@@ -259,15 +259,15 @@ int pthread_attr_setdetachstate(pthread_attr_t* attributes, int detach_state)
     if (detach_state != PTHREAD_CREATE_JOINABLE && detach_state != PTHREAD_CREATE_DETACHED)
         return EINVAL;
 
-    attributes_impl->m_detach_state = detach_state;
+    attributes_impl->detach_state = detach_state;
 
     dbgln_if(PTHREAD_DEBUG, "pthread_attr_setdetachstate: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
-        (PTHREAD_CREATE_JOINABLE == attributes_impl->m_detach_state) ? "joinable" : "detached",
-        attributes_impl->m_schedule_priority,
-        attributes_impl->m_guard_page_size,
-        attributes_impl->m_stack_size,
-        attributes_impl->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
+        attributes_impl->schedule_priority,
+        attributes_impl->guard_page_size,
+        attributes_impl->stack_size,
+        attributes_impl->stack_location);
 
     return 0;
 }
@@ -279,7 +279,7 @@ int pthread_attr_getguardsize(const pthread_attr_t* attributes, size_t* p_guard_
     if (!attributes_impl || !p_guard_size)
         return EINVAL;
 
-    *p_guard_size = attributes_impl->m_reported_guard_page_size;
+    *p_guard_size = attributes_impl->reported_guard_page_size;
     return 0;
 }
 
@@ -300,16 +300,16 @@ int pthread_attr_setguardsize(pthread_attr_t* attributes, size_t guard_size)
         return EINVAL;
     }
 
-    attributes_impl->m_guard_page_size = actual_guard_size;
-    attributes_impl->m_reported_guard_page_size = guard_size; // POSIX, why?
+    attributes_impl->guard_page_size = actual_guard_size;
+    attributes_impl->reported_guard_page_size = guard_size; // POSIX, why?
 
     dbgln_if(PTHREAD_DEBUG, "pthread_attr_setguardsize: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
-        (PTHREAD_CREATE_JOINABLE == attributes_impl->m_detach_state) ? "joinable" : "detached",
-        attributes_impl->m_schedule_priority,
-        attributes_impl->m_guard_page_size,
-        attributes_impl->m_stack_size,
-        attributes_impl->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
+        attributes_impl->schedule_priority,
+        attributes_impl->guard_page_size,
+        attributes_impl->stack_size,
+        attributes_impl->stack_location);
 
     return 0;
 }
@@ -321,7 +321,7 @@ int pthread_attr_getschedparam(const pthread_attr_t* attributes, struct sched_pa
     if (!attributes_impl || !p_sched_param)
         return EINVAL;
 
-    p_sched_param->sched_priority = attributes_impl->m_schedule_priority;
+    p_sched_param->sched_priority = attributes_impl->schedule_priority;
     return 0;
 }
 
@@ -334,15 +334,15 @@ int pthread_attr_setschedparam(pthread_attr_t* attributes, const struct sched_pa
     if (p_sched_param->sched_priority < THREAD_PRIORITY_MIN || p_sched_param->sched_priority > THREAD_PRIORITY_MAX)
         return ENOTSUP;
 
-    attributes_impl->m_schedule_priority = p_sched_param->sched_priority;
+    attributes_impl->schedule_priority = p_sched_param->sched_priority;
 
     dbgln_if(PTHREAD_DEBUG, "pthread_attr_setschedparam: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
-        (PTHREAD_CREATE_JOINABLE == attributes_impl->m_detach_state) ? "joinable" : "detached",
-        attributes_impl->m_schedule_priority,
-        attributes_impl->m_guard_page_size,
-        attributes_impl->m_stack_size,
-        attributes_impl->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
+        attributes_impl->schedule_priority,
+        attributes_impl->guard_page_size,
+        attributes_impl->stack_size,
+        attributes_impl->stack_location);
 
     return 0;
 }
@@ -354,8 +354,8 @@ int pthread_attr_getstack(const pthread_attr_t* attributes, void** p_stack_ptr, 
     if (!attributes_impl || !p_stack_ptr || !p_stack_size)
         return EINVAL;
 
-    *p_stack_ptr = attributes_impl->m_stack_location;
-    *p_stack_size = attributes_impl->m_stack_size;
+    *p_stack_ptr = attributes_impl->stack_location;
+    *p_stack_size = attributes_impl->stack_size;
 
     return 0;
 }
@@ -376,16 +376,16 @@ int pthread_attr_setstack(pthread_attr_t* attributes, void* p_stack, size_t stac
     // FIXME: "[EACCES] The stack page(s) described by stackaddr and stacksize are not both readable and writable by the thread."
     // Have to check that the whole range is mapped to this process/thread? Can we defer this to create_thread?
 
-    attributes_impl->m_stack_size = stack_size;
-    attributes_impl->m_stack_location = p_stack;
+    attributes_impl->stack_size = stack_size;
+    attributes_impl->stack_location = p_stack;
 
     dbgln_if(PTHREAD_DEBUG, "pthread_attr_setstack: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
-        (PTHREAD_CREATE_JOINABLE == attributes_impl->m_detach_state) ? "joinable" : "detached",
-        attributes_impl->m_schedule_priority,
-        attributes_impl->m_guard_page_size,
-        attributes_impl->m_stack_size,
-        attributes_impl->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
+        attributes_impl->schedule_priority,
+        attributes_impl->guard_page_size,
+        attributes_impl->stack_size,
+        attributes_impl->stack_location);
 
     return 0;
 }
@@ -397,7 +397,7 @@ int pthread_attr_getstacksize(const pthread_attr_t* attributes, size_t* p_stack_
     if (!attributes_impl || !p_stack_size)
         return EINVAL;
 
-    *p_stack_size = attributes_impl->m_stack_size;
+    *p_stack_size = attributes_impl->stack_size;
     return 0;
 }
 
@@ -411,15 +411,15 @@ int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
     if ((stack_size < PTHREAD_STACK_MIN) || stack_size > highest_reasonable_stack_size)
         return EINVAL;
 
-    attributes_impl->m_stack_size = stack_size;
+    attributes_impl->stack_size = stack_size;
 
     dbgln_if(PTHREAD_DEBUG, "pthread_attr_setstacksize: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
-        (PTHREAD_CREATE_JOINABLE == attributes_impl->m_detach_state) ? "joinable" : "detached",
-        attributes_impl->m_schedule_priority,
-        attributes_impl->m_guard_page_size,
-        attributes_impl->m_stack_size,
-        attributes_impl->m_stack_location);
+        (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
+        attributes_impl->schedule_priority,
+        attributes_impl->guard_page_size,
+        attributes_impl->stack_size,
+        attributes_impl->stack_location);
 
     return 0;
 }


### PR DESCRIPTION
Known issues:

* `__thread` and dynamic TLS don't work but they're disabled for now.

**Kernel+LibPthread: Remove m_ prefix for public members**

**Kernel+LibPthread: Add support for usermode threads on x86_64**

**DynamicLoader: Remove obsolete comment**