### PR TITLE
PixelPaint: Make layer widget scrollable + tweaks

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -30,6 +30,8 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize const& suggested_size, G
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
     m_name_textbox = main_widget.add<GUI::TextBox>();
+    m_name_textbox->set_text("Layer");
+    m_name_textbox->select_all();
     m_name_textbox->on_change = [this] {
         m_layer_name = m_name_textbox->text();
     };
@@ -63,6 +65,10 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize const& suggested_size, G
 
     height_spinbox.on_change = [this](int value) {
         m_layer_size.set_height(value);
+    };
+
+    m_name_textbox->on_return_pressed = [this] {
+        done(ExecOK);
     };
 
     width_spinbox.set_range(1, 16384);

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -86,17 +86,22 @@ void LayerListWidget::paint_event(GUI::PaintEvent& event)
             painter.fill_rect(adjusted_rect, palette().selection());
         }
 
-        painter.draw_rect(adjusted_rect, Color::Black);
+        painter.draw_rect(adjusted_rect, palette().color(ColorRole::BaseText));
 
         Gfx::IntRect thumbnail_rect { adjusted_rect.x(), adjusted_rect.y(), adjusted_rect.height(), adjusted_rect.height() };
         thumbnail_rect.shrink(8, 8);
         painter.draw_scaled_bitmap(thumbnail_rect, layer.bitmap(), layer.bitmap().rect());
-        painter.draw_rect(thumbnail_rect, Color::Black);
 
         Gfx::IntRect text_rect { thumbnail_rect.right() + 10, adjusted_rect.y(), adjusted_rect.width(), adjusted_rect.height() };
         text_rect.intersect(adjusted_rect);
 
-        painter.draw_text(text_rect, layer.name(), Gfx::TextAlignment::CenterLeft, layer.is_selected() ? palette().selection_text() : palette().button_text());
+        if (layer.is_visible()) {
+            painter.draw_text(text_rect, layer.name(), Gfx::TextAlignment::CenterLeft, layer.is_selected() ? palette().selection_text() : palette().button_text());
+            painter.draw_rect(thumbnail_rect, palette().color(ColorRole::BaseText));
+        } else {
+            painter.draw_text(text_rect, layer.name(), Gfx::TextAlignment::CenterLeft, palette().color(ColorRole::DisabledText));
+            painter.draw_rect(thumbnail_rect, palette().color(ColorRole::DisabledText));
+        }
     };
 
     for (auto& gadget : m_gadgets) {

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -183,6 +183,20 @@ void LayerListWidget::mouseup_event(GUI::MouseEvent& event)
     m_image->change_layer_index(old_index, new_index);
 }
 
+void LayerListWidget::context_menu_event(GUI::ContextMenuEvent& event)
+{
+    Gfx::IntPoint translated_event_point = { 0, vertical_scrollbar().value() + event.position().y() };
+
+    auto gadget_index = gadget_at(translated_event_point);
+    if (gadget_index.has_value()) {
+        auto& layer = m_image->layer(gadget_index.value());
+        set_selected_layer(&layer);
+    }
+
+    if (on_context_menu_request)
+        on_context_menu_request(event);
+}
+
 void LayerListWidget::image_did_add_layer(size_t layer_index)
 {
     if (m_moving_gadget_index.has_value()) {

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -23,6 +23,7 @@ public:
 
     void set_selected_layer(Layer*);
     Function<void(Layer*)> on_layer_select;
+    Function<void(GUI::ContextMenuEvent&)> on_context_menu_request;
 
     void select_bottom_layer();
     void select_top_layer();
@@ -35,6 +36,7 @@ private:
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
+    virtual void context_menu_event(GUI::ContextMenuEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
 
     virtual void image_did_add_layer(size_t) override;

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -7,12 +7,12 @@
 #pragma once
 
 #include "Image.h"
-#include <LibGUI/Widget.h>
+#include <LibGUI/AbstractScrollableWidget.h>
 
 namespace PixelPaint {
 
 class LayerListWidget final
-    : public GUI::Widget
+    : public GUI::AbstractScrollableWidget
     , ImageClient {
     C_OBJECT(LayerListWidget);
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -27,7 +27,7 @@ public:
 
     void select_bottom_layer();
     void select_top_layer();
-    void move_selection(int delta);
+    void cycle_through_selection(int delta);
 
 private:
     explicit LayerListWidget();
@@ -66,6 +66,8 @@ private:
 
     Optional<size_t> m_moving_gadget_index;
     Gfx::IntPoint m_moving_event_origin;
+
+    size_t m_selected_layer_index { 0 };
 };
 
 }

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -51,7 +51,7 @@
             @GUI::GroupBox {
                 title: "Layers"
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [4, 16, 4, 8]
+                    margins: [6, 16, 6, 6]
                 }
 
                 @PixelPaint::LayerListWidget {

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -348,12 +348,12 @@ int main(int argc, char** argv)
     layer_menu.add_separator();
     layer_menu.add_action(GUI::Action::create(
         "Select &Previous Layer", { 0, Key_PageUp }, [&](auto&) {
-            layer_list_widget.move_selection(1);
+            layer_list_widget.cycle_through_selection(1);
         },
         window));
     layer_menu.add_action(GUI::Action::create(
         "Select &Next Layer", { 0, Key_PageDown }, [&](auto&) {
-            layer_list_widget.move_selection(-1);
+            layer_list_widget.cycle_through_selection(-1);
         },
         window));
     layer_menu.add_action(GUI::Action::create(

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -403,6 +403,10 @@ int main(int argc, char** argv)
         },
         window));
 
+    layer_list_widget.on_context_menu_request = [&](auto& event) {
+        layer_menu.popup(event.screen_position());
+    };
+
     auto& filter_menu = menubar->add_menu("&Filter");
     auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");
 


### PR DESCRIPTION
![Screenshot_20210701_164130](https://user-images.githubusercontent.com/69970419/124143319-52d60880-da8b-11eb-8396-13dbf84b2a1e.png)

**PixelPaint: Make LayerListWidget scrollable**

Previously only a couple of layers would fit in the layer widget, this makes it scrollable and also tweaks some sizes and coordinates.

**PixelPaint: Use layer menu as context menu in LayerListWidget**

This enables the layer menu as a context menu in LayerListWidget. In the future it would be nice to make the context menu aware of which layer you're clicking and base it's actions on that, but for now it sets the clicked layer as active and shows the main layer menu. I'll look into rewriting the layer actions but there are a couple of bugs I'll need to sort out first regarding what layer is active.

**PixelPaint: Make move_selection() cycle through layers**

Previously move_selection() did not work as expected. Instead store the selected layer index in a member variable and continue to cycle through the layers when you come to the start/end. Also use it to scroll into view. Lastly rename the function to cycle_through_selection() to make it clearer what it does.