### PR TITLE
LibWeb: Add remaining CSS AttributeMatchTypes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -478,7 +478,7 @@ public:
                         attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::ExactValueMatch;
                     } else if (ch == '~') {
                         consume_one();
-                        attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::Contains;
+                        attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::ContainsWord;
                     }
                     attribute_name = String::copy(buffer);
                     buffer.clear();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -155,12 +155,12 @@ Vector<CSS::Selector::ComplexSelector> Parser::parse_selectors(Vector<String> pa
             }
 
             if (attribute_parts.at(attribute_index) == " ~") {
-                simple_selector.attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::Contains;
+                simple_selector.attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::ContainsWord;
                 attribute_index += 2;
             }
 
             if (attribute_parts.at(attribute_index) == " |") {
-                simple_selector.attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::StartsWith;
+                simple_selector.attribute_match_type = CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithSegment;
                 attribute_index += 2;
             }
 

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -60,8 +60,11 @@ public:
             None,
             HasAttribute,
             ExactValueMatch,
-            Contains,
-            StartsWith,
+            ContainsWord,      // [att~=val]
+            ContainsString,    // [att*=val]
+            StartsWithSegment, // [att|=val]
+            StartsWithString,  // [att^=val]
+            EndsWithString,    // [att$=val]
         };
 
         AttributeMatchType attribute_match_type { AttributeMatchType::None };

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -180,8 +180,24 @@ static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::E
         if (element.attribute(component.attribute_name) != component.attribute_value)
             return false;
         break;
-    case CSS::Selector::SimpleSelector::AttributeMatchType::Contains:
+    case CSS::Selector::SimpleSelector::AttributeMatchType::ContainsWord:
         if (!element.attribute(component.attribute_name).split(' ').contains_slow(component.attribute_value))
+            return false;
+        break;
+    case CSS::Selector::SimpleSelector::AttributeMatchType::ContainsString:
+        if (!element.attribute(component.attribute_name).contains(component.attribute_value))
+            return false;
+        break;
+    case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithSegment:
+        if (element.attribute(component.attribute_name).split('-').first() != component.attribute_value)
+            return false;
+        break;
+    case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithString:
+        if (!element.attribute(component.attribute_name).starts_with(component.attribute_value))
+            return false;
+        break;
+    case CSS::Selector::SimpleSelector::AttributeMatchType::EndsWithString:
+        if (!element.attribute(component.attribute_name).ends_with(component.attribute_value))
             return false;
         break;
     default:

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -325,11 +325,20 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
             case CSS::Selector::SimpleSelector::AttributeMatchType::ExactValueMatch:
                 attribute_match_type_description = "ExactValueMatch";
                 break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::Contains:
-                attribute_match_type_description = "Contains";
+            case CSS::Selector::SimpleSelector::AttributeMatchType::ContainsWord:
+                attribute_match_type_description = "ContainsWord";
                 break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWith:
-                attribute_match_type_description = "StartsWith";
+            case CSS::Selector::SimpleSelector::AttributeMatchType::ContainsString:
+                attribute_match_type_description = "ContainsString";
+                break;
+            case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithSegment:
+                attribute_match_type_description = "StartsWithSegment";
+                break;
+            case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithString:
+                attribute_match_type_description = "StartsWithString";
+                break;
+            case CSS::Selector::SimpleSelector::AttributeMatchType::EndsWithString:
+                attribute_match_type_description = "EndsWithString";
                 break;
             }
 


### PR DESCRIPTION
A drive-by change while I was working on #8341.

This adds:
- ContainsString     [att*=val]
- StartsWithSegment  [att|=val]
- StartsWithString   [att^=val]
- EndsWithString     [att$=val]

Renamed AttributeMatchType::Contains to ::ContainsWord for clarity.

I'm not 100% sure on the naming here, so bikeshed away!

Disclaimer: We don't actually detect these (and the existing ContainsWord doesn't work correctly either) in DeprecatedCSSParser. But assuming I manage to get the non-deprecated parser working, that won't matter so much.