### PR TITLE
AK: Harmonize the String and StringView APIs

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -29,7 +29,7 @@ LexicalPath::LexicalPath(String path)
 
     m_parts = m_string.split_view('/');
 
-    auto last_slash_index = m_string.view().find_last_of('/');
+    auto last_slash_index = m_string.view().find_last('/');
     if (!last_slash_index.has_value()) {
         // The path contains a single part and is not absolute. m_dirname = "."sv
         m_dirname = { &s_single_dot, 1 };
@@ -47,7 +47,7 @@ LexicalPath::LexicalPath(String path)
         m_basename = m_parts.last();
     }
 
-    auto last_dot_index = m_basename.find_last_of('.');
+    auto last_dot_index = m_basename.find_last('.');
     // NOTE: if the dot index is 0, this means we have ".foo", it's not an extension, as the title would then be "".
     if (last_dot_index.has_value() && *last_dot_index != 0) {
         m_title = m_basename.substring_view(0, *last_dot_index);

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -459,14 +459,4 @@ String String::vformatted(StringView fmtstr, TypeErasedFormatParams params)
     return builder.to_string();
 }
 
-Optional<size_t> String::find(char c, size_t start) const
-{
-    return find(StringView { &c, 1 }, start);
-}
-
-Optional<size_t> String::find(StringView const& view, size_t start) const
-{
-    return StringUtils::find(*this, view, start);
-}
-
 }

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -293,23 +293,6 @@ bool String::equals_ignoring_case(const StringView& other) const
     return StringUtils::equals_ignoring_case(view(), other);
 }
 
-Vector<size_t> String::find_all(const String& needle) const
-{
-    Vector<size_t> positions;
-    size_t start = 0, pos;
-    for (;;) {
-        const char* ptr = strstr(characters() + start, needle.characters());
-        if (!ptr)
-            break;
-
-        pos = ptr - characters();
-        positions.append(pos);
-
-        start = pos + 1;
-    }
-    return positions;
-}
-
 int String::replace(const String& needle, const String& replacement, bool all_occurrences)
 {
     if (is_empty())

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -91,6 +91,16 @@ String String::isolated_copy() const
     return String(move(*impl));
 }
 
+String String::substring(size_t start, size_t length) const
+{
+    if (!length)
+        return String::empty();
+    VERIFY(m_impl);
+    VERIFY(!Checked<size_t>::addition_would_overflow(start, length));
+    VERIFY(start + length <= m_impl->length());
+    return { characters() + start, length };
+}
+
 String String::substring(size_t start) const
 {
     VERIFY(m_impl);
@@ -98,21 +108,11 @@ String String::substring(size_t start) const
     return { characters() + start, length() - start };
 }
 
-String String::substring(size_t start, size_t length) const
-{
-    if (!length)
-        return "";
-    VERIFY(m_impl);
-    VERIFY(start + length <= m_impl->length());
-    // FIXME: This needs some input bounds checking.
-    return { characters() + start, length };
-}
-
 StringView String::substring_view(size_t start, size_t length) const
 {
     VERIFY(m_impl);
+    VERIFY(!Checked<size_t>::addition_would_overflow(start, length));
     VERIFY(start + length <= m_impl->length());
-    // FIXME: This needs some input bounds checking.
     return { characters() + start, length };
 }
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -483,10 +483,7 @@ Optional<size_t> String::find(char c, size_t start) const
 
 Optional<size_t> String::find(StringView const& view, size_t start) const
 {
-    auto index = StringUtils::find(substring_view(start), view);
-    if (!index.has_value())
-        return {};
-    return index.value() + start;
+    return StringUtils::find(*this, view, start);
 }
 
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -141,8 +141,10 @@ public:
     [[nodiscard]] Vector<String> split_limit(char separator, size_t limit, bool keep_empty = false) const;
     [[nodiscard]] Vector<String> split(char separator, bool keep_empty = false) const;
 
-    [[nodiscard]] Optional<size_t> find(char, size_t start = 0) const;
-    [[nodiscard]] Optional<size_t> find(StringView const&, size_t start = 0) const;
+    [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
+    [[nodiscard]] Optional<size_t> find(StringView const& needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
+    [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
+    // FIXME: Implement find_last(StringView const&) for API symmetry.
     [[nodiscard]] Vector<size_t> find_all(StringView const& needle) const { return StringUtils::find_all(*this, needle); }
 
     [[nodiscard]] String substring(size_t start) const;

--- a/AK/String.h
+++ b/AK/String.h
@@ -140,6 +140,7 @@ public:
 
     [[nodiscard]] Vector<String> split_limit(char separator, size_t limit, bool keep_empty = false) const;
     [[nodiscard]] Vector<String> split(char separator, bool keep_empty = false) const;
+    [[nodiscard]] Vector<StringView> split_view(char separator, bool keep_empty = false) const;
 
     [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find(StringView const& needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
@@ -147,10 +148,8 @@ public:
     // FIXME: Implement find_last(StringView const&) for API symmetry.
     [[nodiscard]] Vector<size_t> find_all(StringView const& needle) const { return StringUtils::find_all(*this, needle); }
 
-    [[nodiscard]] String substring(size_t start) const;
     [[nodiscard]] String substring(size_t start, size_t length) const;
-
-    [[nodiscard]] Vector<StringView> split_view(char separator, bool keep_empty = false) const;
+    [[nodiscard]] String substring(size_t start) const;
     [[nodiscard]] StringView substring_view(size_t start, size_t length) const;
     [[nodiscard]] StringView substring_view(size_t start) const;
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -147,6 +147,8 @@ public:
     [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
     // FIXME: Implement find_last(StringView const&) for API symmetry.
     [[nodiscard]] Vector<size_t> find_all(StringView const& needle) const { return StringUtils::find_all(*this, needle); }
+    using SearchDirection = StringUtils::SearchDirection;
+    [[nodiscard]] Optional<size_t> find_any_of(StringView const& needles, SearchDirection direction) const { return StringUtils::find_any_of(*this, needles, direction); }
 
     [[nodiscard]] String substring(size_t start, size_t length) const;
     [[nodiscard]] String substring(size_t start) const;

--- a/AK/String.h
+++ b/AK/String.h
@@ -143,6 +143,7 @@ public:
 
     [[nodiscard]] Optional<size_t> find(char, size_t start = 0) const;
     [[nodiscard]] Optional<size_t> find(StringView const&, size_t start = 0) const;
+    [[nodiscard]] Vector<size_t> find_all(StringView const& needle) const { return StringUtils::find_all(*this, needle); }
 
     [[nodiscard]] String substring(size_t start) const;
     [[nodiscard]] String substring(size_t start, size_t length) const;
@@ -279,7 +280,6 @@ public:
 
     int replace(const String& needle, const String& replacement, bool all_occurrences = false);
     size_t count(const String& needle) const;
-    Vector<size_t> find_all(const String& needle) const;
     [[nodiscard]] String reverse() const;
 
     template<typename... Ts>

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -26,6 +26,9 @@ public:
     static RefPtr<StringImpl> create(const char* cstring, ShouldChomp = NoChomp);
     static RefPtr<StringImpl> create(const char* cstring, size_t length, ShouldChomp = NoChomp);
     static RefPtr<StringImpl> create(ReadonlyBytes, ShouldChomp = NoChomp);
+    static RefPtr<StringImpl> create_lowercased(char const* cstring, size_t length);
+    static RefPtr<StringImpl> create_uppercased(char const* cstring, size_t length);
+
     NonnullRefPtr<StringImpl> to_lowercase() const;
     NonnullRefPtr<StringImpl> to_uppercase() const;
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -362,6 +362,22 @@ Optional<size_t> find_last(StringView const& haystack, char needle)
     return {};
 }
 
+Vector<size_t> find_all(StringView const& haystack, StringView const& needle)
+{
+    Vector<size_t> positions;
+    size_t current_position = 0;
+    while (current_position <= haystack.length()) {
+        auto maybe_position = AK::memmem_optional(
+            haystack.characters_without_null_termination() + current_position, haystack.length() - current_position,
+            needle.characters_without_null_termination(), needle.length());
+        if (!maybe_position.has_value())
+            break;
+        positions.append(current_position + *maybe_position);
+        current_position += *maybe_position + 1;
+    }
+    return positions;
+}
+
 String to_snakecase(const StringView& str)
 {
     auto should_insert_underscore = [&](auto i, auto current_char) {

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -332,11 +332,34 @@ StringView trim_whitespace(const StringView& str, TrimMode mode)
     return trim(str, " \n\t\v\f\r", mode);
 }
 
-Optional<size_t> find(const StringView& haystack, const StringView& needle)
+Optional<size_t> find(StringView const& haystack, char needle, size_t start)
 {
-    return AK::memmem_optional(
-        haystack.characters_without_null_termination(), haystack.length(),
+    if (start >= haystack.length())
+        return {};
+    for (size_t i = start; i < haystack.length(); ++i) {
+        if (haystack[i] == needle)
+            return i;
+    }
+    return {};
+}
+
+Optional<size_t> find(StringView const& haystack, StringView const& needle, size_t start)
+{
+    if (start > haystack.length())
+        return {};
+    auto index = AK::memmem_optional(
+        haystack.characters_without_null_termination() + start, haystack.length() - start,
         needle.characters_without_null_termination(), needle.length());
+    return index.has_value() ? (*index + start) : index;
+}
+
+Optional<size_t> find_last(StringView const& haystack, char needle)
+{
+    for (size_t i = haystack.length(); i > 0; --i) {
+        if (haystack[i - 1] == needle)
+            return i - 1;
+    }
+    return {};
 }
 
 String to_snakecase(const StringView& str)

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -378,6 +378,24 @@ Vector<size_t> find_all(StringView const& haystack, StringView const& needle)
     return positions;
 }
 
+Optional<size_t> find_any_of(StringView const& haystack, StringView const& needles, SearchDirection direction)
+{
+    if (haystack.is_empty() || needles.is_empty())
+        return {};
+    if (direction == SearchDirection::Forward) {
+        for (size_t i = 0; i < haystack.length(); ++i) {
+            if (needles.contains(haystack[i]))
+                return i;
+        }
+    } else if (direction == SearchDirection::Backward) {
+        for (size_t i = haystack.length(); i > 0; --i) {
+            if (needles.contains(haystack[i - 1]))
+                return i - 1;
+        }
+    }
+    return {};
+}
+
 String to_snakecase(const StringView& str)
 {
     auto should_insert_underscore = [&](auto i, auto current_char) {

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -62,6 +62,11 @@ Optional<size_t> find(StringView const& haystack, char needle, size_t start = 0)
 Optional<size_t> find(StringView const& haystack, StringView const& needle, size_t start = 0);
 Optional<size_t> find_last(StringView const& haystack, char needle);
 Vector<size_t> find_all(StringView const& haystack, StringView const& needle);
+enum class SearchDirection {
+    Forward,
+    Backward
+};
+Optional<size_t> find_any_of(StringView const& haystack, StringView const& needles, SearchDirection);
 
 String to_snakecase(const StringView&);
 

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -57,7 +57,12 @@ bool contains(const StringView&, const StringView&, CaseSensitivity);
 bool is_whitespace(const StringView&);
 StringView trim(const StringView& string, const StringView& characters, TrimMode mode);
 StringView trim_whitespace(const StringView& string, TrimMode mode);
-Optional<size_t> find(const StringView& haystack, const StringView& needle);
+
+Optional<size_t> find(StringView const& haystack, char needle, size_t start = 0);
+Optional<size_t> find(StringView const& haystack, StringView const& needle, size_t start = 0);
+Optional<size_t> find_last(StringView const& haystack, char needle);
+Vector<size_t> find_all(StringView const& haystack, StringView const& needle);
+
 String to_snakecase(const StringView&);
 
 }

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -238,14 +238,6 @@ bool StringView::operator==(const String& string) const
     return !__builtin_memcmp(m_characters, string.characters(), m_length);
 }
 
-Optional<size_t> StringView::find_first_of(char c) const
-{
-    if (const auto location = AK::find(begin(), end(), c); location != end()) {
-        return location.index();
-    }
-    return {};
-}
-
 Optional<size_t> StringView::find_first_of(const StringView& view) const
 {
     if (const auto location = AK::find_if(begin(), end(),
@@ -257,15 +249,6 @@ Optional<size_t> StringView::find_first_of(const StringView& view) const
             });
         location != end()) {
         return location.index();
-    }
-    return {};
-}
-
-Optional<size_t> StringView::find_last_of(char c) const
-{
-    for (size_t pos = m_length; pos != 0; --pos) {
-        if (m_characters[pos - 1] == c)
-            return pos - 1;
     }
     return {};
 }

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -173,6 +173,16 @@ bool StringView::equals_ignoring_case(const StringView& other) const
     return StringUtils::equals_ignoring_case(*this, other);
 }
 
+String StringView::to_lowercase_string() const
+{
+    return StringImpl::create_lowercased(characters_without_null_termination(), length());
+}
+
+String StringView::to_uppercase_string() const
+{
+    return StringImpl::create_uppercased(characters_without_null_termination(), length());
+}
+
 StringView StringView::substring_view_starting_from_substring(const StringView& substring) const
 {
     const char* remaining_characters = substring.characters_without_null_termination();

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -282,16 +282,6 @@ Optional<size_t> StringView::find_last_of(const StringView& view) const
     return {};
 }
 
-Optional<size_t> StringView::find(char c) const
-{
-    return find(StringView { &c, 1 });
-}
-
-Optional<size_t> StringView::find(const StringView& view) const
-{
-    return StringUtils::find(*this, view);
-}
-
 String StringView::to_string() const { return String { *this }; }
 
 }

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -238,33 +238,6 @@ bool StringView::operator==(const String& string) const
     return !__builtin_memcmp(m_characters, string.characters(), m_length);
 }
 
-Optional<size_t> StringView::find_first_of(const StringView& view) const
-{
-    if (const auto location = AK::find_if(begin(), end(),
-            [&](const auto c) {
-                return any_of(view.begin(), view.end(),
-                    [&](const auto view_char) {
-                        return c == view_char;
-                    });
-            });
-        location != end()) {
-        return location.index();
-    }
-    return {};
-}
-
-Optional<size_t> StringView::find_last_of(const StringView& view) const
-{
-    for (size_t pos = m_length; pos != 0; --pos) {
-        char c = m_characters[pos - 1];
-        for (char view_char : view) {
-            if (c == view_char)
-                return pos - 1;
-        }
-    }
-    return {};
-}
-
 String StringView::to_string() const { return String { *this }; }
 
 }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -86,16 +86,13 @@ public:
     [[nodiscard]] String to_lowercase_string() const;
     [[nodiscard]] String to_uppercase_string() const;
 
-    Optional<size_t> find_first_of(char) const;
-    Optional<size_t> find_first_of(const StringView&) const;
-
-    Optional<size_t> find_last_of(char) const;
-    Optional<size_t> find_last_of(const StringView&) const;
-
     [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find(StringView const& needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
     [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
     // FIXME: Implement find_last(StringView const&) for API symmetry.
+
+    [[nodiscard]] Optional<size_t> find_first_of(StringView const&) const;
+    [[nodiscard]] Optional<size_t> find_last_of(StringView const&) const;
 
     [[nodiscard]] constexpr StringView substring_view(size_t start, size_t length) const
     {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -93,8 +93,8 @@ public:
 
     [[nodiscard]] Vector<size_t> find_all(StringView const& needle) const { return StringUtils::find_all(*this, needle); }
 
-    [[nodiscard]] Optional<size_t> find_first_of(StringView const&) const;
-    [[nodiscard]] Optional<size_t> find_last_of(StringView const&) const;
+    using SearchDirection = StringUtils::SearchDirection;
+    [[nodiscard]] Optional<size_t> find_any_of(StringView const& needles, SearchDirection direction = SearchDirection::Forward) { return StringUtils::find_any_of(*this, needles, direction); }
 
     [[nodiscard]] constexpr StringView substring_view(size_t start, size_t length) const
     {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -91,6 +91,8 @@ public:
     [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
     // FIXME: Implement find_last(StringView const&) for API symmetry.
 
+    [[nodiscard]] Vector<size_t> find_all(StringView const& needle) const { return StringUtils::find_all(*this, needle); }
+
     [[nodiscard]] Optional<size_t> find_first_of(StringView const&) const;
     [[nodiscard]] Optional<size_t> find_last_of(StringView const&) const;
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -83,6 +83,9 @@ public:
     [[nodiscard]] StringView trim(const StringView& characters, TrimMode mode = TrimMode::Both) const { return StringUtils::trim(*this, characters, mode); }
     [[nodiscard]] StringView trim_whitespace(TrimMode mode = TrimMode::Both) const { return StringUtils::trim_whitespace(*this, mode); }
 
+    [[nodiscard]] String to_lowercase_string() const;
+    [[nodiscard]] String to_uppercase_string() const;
+
     Optional<size_t> find_first_of(char) const;
     Optional<size_t> find_first_of(const StringView&) const;
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -92,8 +92,10 @@ public:
     Optional<size_t> find_last_of(char) const;
     Optional<size_t> find_last_of(const StringView&) const;
 
-    Optional<size_t> find(const StringView&) const;
-    Optional<size_t> find(char c) const;
+    [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
+    [[nodiscard]] Optional<size_t> find(StringView const& needle, size_t start = 0) const { return StringUtils::find(*this, needle, start); }
+    [[nodiscard]] Optional<size_t> find_last(char needle) const { return StringUtils::find_last(*this, needle); }
+    // FIXME: Implement find_last(StringView const&) for API symmetry.
 
     [[nodiscard]] constexpr StringView substring_view(size_t start, size_t length) const
     {

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -271,3 +271,14 @@ TEST_CASE(find)
     EXPECT_EQ(a.find('b', 4), Optional<size_t> { 6 });
     EXPECT_EQ(a.find('b', 9), Optional<size_t> {});
 }
+
+TEST_CASE(find_with_empty_needle)
+{
+    String string = "";
+    EXPECT_EQ(string.find(""sv), 0u);
+    EXPECT_EQ(string.find_all(""sv), (Vector<size_t> { 0u }));
+
+    string = "abc";
+    EXPECT_EQ(string.find(""sv), 0u);
+    EXPECT_EQ(string.find_all(""sv), (Vector<size_t> { 0u, 1u, 2u, 3u }));
+}

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -123,26 +123,19 @@ TEST_CASE(find_last)
     EXPECT_EQ(test_string_view.find_last('/'), 0U);
 }
 
-TEST_CASE(find_first_of)
+TEST_CASE(find_any_of)
 {
     auto test_string_view = "aabbcc_xy_ccbbaa"sv;
-    EXPECT_EQ(test_string_view.find_first_of("bc"), 2U);
-    EXPECT_EQ(test_string_view.find_first_of("yx"), 7U);
-    EXPECT_EQ(test_string_view.find_first_of("defg").has_value(), false);
+    EXPECT_EQ(test_string_view.find_any_of("bc", StringView::SearchDirection::Forward), 2U);
+    EXPECT_EQ(test_string_view.find_any_of("yx", StringView::SearchDirection::Forward), 7U);
+    EXPECT_EQ(test_string_view.find_any_of("defg", StringView::SearchDirection::Forward).has_value(), false);
+    EXPECT_EQ(test_string_view.find_any_of("bc", StringView::SearchDirection::Backward), 13U);
+    EXPECT_EQ(test_string_view.find_any_of("yx", StringView::SearchDirection::Backward), 8U);
+    EXPECT_EQ(test_string_view.find_any_of("fghi", StringView::SearchDirection::Backward).has_value(), false);
 
     test_string_view = "/"sv;
-    EXPECT_EQ(test_string_view.find_first_of("/"), 0U);
-}
-
-TEST_CASE(find_last_of)
-{
-    auto test_string_view = "aabbcc_xy_ccbbaa"sv;
-    EXPECT_EQ(test_string_view.find_last_of("bc"), 13U);
-    EXPECT_EQ(test_string_view.find_last_of("yx"), 8U);
-    EXPECT_EQ(test_string_view.find_last_of("fghi").has_value(), false);
-
-    test_string_view = "/"sv;
-    EXPECT_EQ(test_string_view.find_last_of("/"), 0U);
+    EXPECT_EQ(test_string_view.find_any_of("/", StringView::SearchDirection::Forward), 0U);
+    EXPECT_EQ(test_string_view.find_any_of("/", StringView::SearchDirection::Backward), 0U);
 }
 
 TEST_CASE(split_view)

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -104,52 +104,45 @@ TEST_CASE(lines)
     EXPECT_EQ(test_string_vector.at(2).is_empty(), true);
 }
 
+TEST_CASE(find)
+{
+    auto test_string_view = "aabbcc_xy_ccbbaa"sv;
+    EXPECT_EQ(test_string_view.find('b'), 2U);
+    EXPECT_EQ(test_string_view.find('_'), 6U);
+    EXPECT_EQ(test_string_view.find('n').has_value(), false);
+}
+
+TEST_CASE(find_last)
+{
+    auto test_string_view = "aabbcc_xy_ccbbaa"sv;
+    EXPECT_EQ(test_string_view.find_last('b'), 13U);
+    EXPECT_EQ(test_string_view.find_last('_'), 9U);
+    EXPECT_EQ(test_string_view.find_last('3').has_value(), false);
+
+    test_string_view = "/"sv;
+    EXPECT_EQ(test_string_view.find_last('/'), 0U);
+}
+
 TEST_CASE(find_first_of)
 {
-    String test_string = "aabbcc_xy_ccbbaa";
-    StringView test_string_view = test_string.view();
-
-    EXPECT_EQ(test_string_view.find_first_of('b').has_value(), true);
-    EXPECT_EQ(test_string_view.find_first_of('b').value(), 2U);
-
-    EXPECT_EQ(test_string_view.find_first_of('_').has_value(), true);
-    EXPECT_EQ(test_string_view.find_first_of('_').value(), 6U);
-
-    EXPECT_EQ(test_string_view.find_first_of("bc").has_value(), true);
-    EXPECT_EQ(test_string_view.find_first_of("bc").value(), 2U);
-
-    EXPECT_EQ(test_string_view.find_first_of("yx").has_value(), true);
-    EXPECT_EQ(test_string_view.find_first_of("yx").value(), 7U);
-
-    EXPECT_EQ(test_string_view.find_first_of('n').has_value(), false);
+    auto test_string_view = "aabbcc_xy_ccbbaa"sv;
+    EXPECT_EQ(test_string_view.find_first_of("bc"), 2U);
+    EXPECT_EQ(test_string_view.find_first_of("yx"), 7U);
     EXPECT_EQ(test_string_view.find_first_of("defg").has_value(), false);
+
+    test_string_view = "/"sv;
+    EXPECT_EQ(test_string_view.find_first_of("/"), 0U);
 }
 
 TEST_CASE(find_last_of)
 {
-    String test_string = "aabbcc_xy_ccbbaa";
-    StringView test_string_view = test_string.view();
-
-    EXPECT_EQ(test_string_view.find_last_of('b').has_value(), true);
-    EXPECT_EQ(test_string_view.find_last_of('b').value(), 13U);
-
-    EXPECT_EQ(test_string_view.find_last_of('_').has_value(), true);
-    EXPECT_EQ(test_string_view.find_last_of('_').value(), 9U);
-
-    EXPECT_EQ(test_string_view.find_last_of("bc").has_value(), true);
-    EXPECT_EQ(test_string_view.find_last_of("bc").value(), 13U);
-
-    EXPECT_EQ(test_string_view.find_last_of("yx").has_value(), true);
-    EXPECT_EQ(test_string_view.find_last_of("yx").value(), 8U);
-
-    EXPECT_EQ(test_string_view.find_last_of('3').has_value(), false);
+    auto test_string_view = "aabbcc_xy_ccbbaa"sv;
+    EXPECT_EQ(test_string_view.find_last_of("bc"), 13U);
+    EXPECT_EQ(test_string_view.find_last_of("yx"), 8U);
     EXPECT_EQ(test_string_view.find_last_of("fghi").has_value(), false);
 
-    test_string_view = "/";
-    EXPECT_EQ(test_string_view.find_last_of('/').has_value(), true);
-    EXPECT_EQ(test_string_view.find_last_of('/').value(), 0U);
-    EXPECT_EQ(test_string_view.find_last_of("/").has_value(), true);
-    EXPECT_EQ(test_string_view.find_last_of("/").value(), 0U);
+    test_string_view = "/"sv;
+    EXPECT_EQ(test_string_view.find_last_of("/"), 0U);
 }
 
 TEST_CASE(split_view)

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -142,7 +142,7 @@ String CookieJar::default_path(const URL& url)
         return "/";
 
     StringView uri_path_view = uri_path;
-    std::size_t last_separator = uri_path_view.find_last_of('/').value();
+    size_t last_separator = uri_path_view.find_last('/').value();
 
     // 3. If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
     if (last_separator == 0)

--- a/Userland/Applications/SoundPlayer/M3UParser.cpp
+++ b/Userland/Applications/SoundPlayer/M3UParser.cpp
@@ -64,7 +64,7 @@ NonnullOwnPtr<Vector<M3UEntry>> M3UParser::parse(bool include_extended_info)
             if (line.starts_with('#') && has_exteded_info_tag) {
                 if (line.starts_with("#EXTINF")) {
                     auto data = line.substring_view(8);
-                    auto separator = data.find_first_of(',');
+                    auto separator = data.find(',');
                     VERIFY(separator.has_value());
                     auto seconds = data.substring_view(0, separator.value());
                     VERIFY(!seconds.is_whitespace() && !seconds.is_null() && !seconds.is_empty());

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -91,7 +91,7 @@ static size_t convert_from_string(StringView str, unsigned base = 26, StringView
 
     size_t value = 0;
     for (size_t i = str.length(); i > 0; --i) {
-        auto digit_value = map.find_first_of(str[i - 1]).value_or(0);
+        auto digit_value = map.find(str[i - 1]).value_or(0);
         // NOTE: Refer to the note in `String::bijective_base_from()'.
         if (i == str.length() && str.length() > 1)
             ++digit_value;

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -637,7 +637,7 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_a
     } else
         return {};
 
-    auto last_slash = partial_include.find_last_of("/");
+    auto last_slash = partial_include.find_last('/');
     auto include_dir = String::empty();
     auto partial_basename = partial_include.substring_view((last_slash.has_value() ? last_slash.value() : 0) + 1);
     if (last_slash.has_value()) {

--- a/Userland/DevTools/Profiler/Process.cpp
+++ b/Userland/DevTools/Profiler/Process.cpp
@@ -74,7 +74,7 @@ void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, const String& name)
     else if (!name.contains(":"))
         return;
     else
-        path = name.substring(0, name.view().find_first_of(":").value());
+        path = name.substring(0, name.view().find(':').value());
 
     String full_path;
     if (name.contains(".so"))

--- a/Userland/Libraries/LibELF/CoreDump.h
+++ b/Userland/Libraries/LibELF/CoreDump.h
@@ -60,9 +60,10 @@ struct [[gnu::packed]] MemoryRegionInfo {
         StringView memory_region_name { region_name };
         if (memory_region_name.contains("Loader.so"))
             return "Loader.so";
-        if (!memory_region_name.contains(":"))
+        auto maybe_colon_index = memory_region_name.find(':');
+        if (!maybe_colon_index.has_value())
             return {};
-        return memory_region_name.substring_view(0, memory_region_name.find_first_of(":").value()).to_string();
+        return memory_region_name.substring_view(0, *maybe_colon_index).to_string();
     }
 };
 

--- a/Userland/Libraries/LibGemini/Line.cpp
+++ b/Userland/Libraries/LibGemini/Line.cpp
@@ -73,7 +73,7 @@ Link::Link(String text, const Document& document)
     while (index < m_text.length() && (m_text[index] == ' ' || m_text[index] == '\t'))
         ++index;
     auto url_string = m_text.substring_view(index, m_text.length() - index);
-    auto space_offset = url_string.find_first_of(" \t");
+    auto space_offset = url_string.find_any_of(" \t");
     String url = url_string;
     if (space_offset.has_value()) {
         url = url_string.substring_view(0, space_offset.value());

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -252,7 +252,7 @@ bool Editor::load_history(const String& path)
     auto data = history_file->read_all();
     auto hist = StringView { data.data(), data.size() };
     for (auto& str : hist.split_view("\n\n")) {
-        auto it = str.find_first_of("::").value_or(0);
+        auto it = str.find("::").value_or(0);
         auto time = str.substring_view(0, it).to_uint<time_t>().value_or(0);
         auto string = str.substring_view(it == 0 ? it : it + 2);
         m_history.append({ string, time });

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -222,7 +222,7 @@ static StringView parse_custom_property_name(const StringView& value)
     if (!value.starts_with("var(") || !value.ends_with(")"))
         return {};
     // FIXME: Allow for fallback
-    auto first_comma_index = value.find_first_of(",");
+    auto first_comma_index = value.find(',');
     auto length = value.length();
 
     auto substring_length = first_comma_index.has_value() ? first_comma_index.value() - 4 - 1 : length - 4 - 1;

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -26,7 +26,7 @@ static bool spawn(String executable, const Vector<String>& arguments);
 
 String Handler::name_from_executable(const StringView& executable)
 {
-    auto separator = executable.find_last_of('/');
+    auto separator = executable.find_last('/');
     if (separator.has_value()) {
         auto start = separator.value() + 1;
         return executable.substring_view(start, executable.length() - start);

--- a/Userland/Services/WindowServer/Cursor.cpp
+++ b/Userland/Services/WindowServer/Cursor.cpp
@@ -15,7 +15,7 @@ CursorParams CursorParams::parse_from_filename(const StringView& cursor_path, co
 {
     LexicalPath path(cursor_path);
     auto file_title = path.title();
-    auto last_dot_in_title = StringView(file_title).find_last_of('.');
+    auto last_dot_in_title = file_title.find_last('.');
     if (!last_dot_in_title.has_value() || last_dot_in_title.value() == 0) {
         // No encoded params in filename. Not an error, we'll just use defaults
         return { default_hotspot };

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
         .value_name = "header-value",
         .accept_value = [&](auto* s) {
             StringView header { s };
-            auto split = header.find_first_of(':');
+            auto split = header.find(':');
             if (!split.has_value())
                 return false;
             request_headers.set(header.substring_view(0, split.value()), header.substring_view(split.value() + 1));


### PR DESCRIPTION
This PR (and possibly further PRs) aim to harmonize the APIs of `String` and `StringView` as far as possible (and sensible). The main work done in this PR is moving all `find*` functions into `StringUtils`. `String and `StringView` now have the same `find*` functions:
```cpp
Optional<size_t> find(char, size_t start = 0);
Optional<size_t> find(StringView const&, size_t start = 0);
Optional<size_t> find_last(char);
Vector<size_t> find_all(StringView const&);
Optional<size_t> find_any_of(StringView const&);
```

The selection is somewhat arbitrary, but at least it's uniform now (e.g. `find_last(StringView const&)` is missing), meaning all methods on `String` should yield the exact same result as when first calling `view()` on the `String`.

Furthermore, a few small fixes have been applied to `String::substring` and `String::substring_view()`