### PR TITLE
Assistant: Change to home directory when spawning applications

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -6,17 +6,24 @@
 
 #include "Providers.h"
 #include "FuzzyMatch.h"
+#include <LibCore/StandardPaths.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Lexer.h>
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <unistd.h>
 
 namespace Assistant {
 
 void AppResult::activate() const
 {
+    if (chdir(Core::StandardPaths::home_directory().characters()) < 0) {
+        perror("chdir");
+        exit(1);
+    }
+
     m_app_file->spawn();
 }
 


### PR DESCRIPTION
When launching Terminal via Taskbar we change to the users home
directory. For consistency, let's also `chdir` to `/home/anon` when
launching apps via Assistant's AppProvider.

Fixes #8369 