### PR TITLE
Kernel: Don't byteswap the ISR number on interrupt entry

### DIFF
--- a/Kernel/Arch/x86/Interrupts.h
+++ b/Kernel/Arch/x86/Interrupts.h
@@ -16,6 +16,13 @@ class GenericInterruptHandeler;
 
 extern "C" void interrupt_common_asm_entry();
 
+#if ARCH(I386)
+#    define INTERRUPT_HANDLER_PUSH_PADDING
+#else
+#    define INTERRUPT_HANDLER_PUSH_PADDING "pushw $0\npushw $0\n"
+#endif
+
+// clang-format off
 #define GENERATE_GENERIC_INTERRUPT_HANDLER_ASM_ENTRY(isr_number)                  \
     extern "C" void interrupt_##isr_number##_asm_entry();                         \
     static void interrupt_##isr_number##_asm_entry_dummy() __attribute__((used)); \
@@ -23,10 +30,12 @@ extern "C" void interrupt_common_asm_entry();
     {                                                                             \
         asm(".globl interrupt_" #isr_number "_asm_entry\n"                        \
             "interrupt_" #isr_number "_asm_entry:\n"                              \
+            INTERRUPT_HANDLER_PUSH_PADDING                                        \
             "    pushw $" #isr_number "\n"                                        \
             "    pushw $0\n"                                                      \
             "    jmp interrupt_common_asm_entry\n");                              \
     }
+// clang-format on
 
 void register_interrupt_handler(u8 number, void (*handler)());
 void register_user_callable_interrupt_handler(u8 number, void (*handler)());

--- a/Kernel/Arch/x86/x86_64/InterruptEntry.cpp
+++ b/Kernel/Arch/x86/x86_64/InterruptEntry.cpp
@@ -12,13 +12,6 @@
 asm(
     ".globl interrupt_common_asm_entry\n"
     "interrupt_common_asm_entry: \n"
-    // add the padding field in RegisterState
-    "    subq $4, %rsp\n"
-    "    pushq %rax\n"
-    "    movl 12(%rsp), %eax\n"
-    "    movl $0, 12(%rsp)\n"
-    "    movl %eax, 8(%rsp)\n"
-    "    popq %rax\n"
     // save all the other registers
     "    pushq %r15\n"
     "    pushq %r14\n"


### PR DESCRIPTION
Let's just add the padding before we jump to `interrupt_common_asm_entry`.