### PR TITLE
PixelPaint: Don't crash when opening a .pp file with layer properties set

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -125,12 +125,12 @@ Result<NonnullRefPtr<Image>, String> Image::try_create_from_pixel_paint_file(Str
         if (width != layer->size().width() || height != layer->size().height())
             return String { "Decoded layer bitmap has wrong size"sv };
 
+        image->add_layer(*layer);
+
         layer->set_location({ layer_object.get("locationx").to_i32(), layer_object.get("locationy").to_i32() });
         layer->set_opacity_percent(layer_object.get("opacity_percent").to_i32());
         layer->set_visible(layer_object.get("visible").as_bool());
         layer->set_selected(layer_object.get("selected").as_bool());
-
-        image->add_layer(*layer);
     }
 
     image->set_path(file_path);

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -553,6 +553,12 @@ int main(int argc, char** argv)
 
     tab_widget.on_tab_close_click = [&](auto& widget) {
         auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
+
+        if (tab_widget.children().size() == 1) {
+            layer_list_widget.set_image(nullptr);
+            layer_properties_widget.set_layer(nullptr);
+        }
+
         tab_widget.deferred_invoke([&](auto&) {
             tab_widget.remove_tab(image_editor);
         });


### PR DESCRIPTION
This PR fixes a bug where PixelPaint would crash when opening a .pp file with layer options, like visibility, set.

Also clear LayerListWidget and LayerPropertiesWidget when closing the last tab.