### PR TITLE
LibJS: Some parser yak shaves

### DIFF
--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -360,7 +360,6 @@ bool Lexer::slash_means_division() const
     return type == TokenType::BigIntLiteral
         || type == TokenType::BoolLiteral
         || type == TokenType::BracketClose
-        || type == TokenType::CurlyClose
         || type == TokenType::Identifier
         || type == TokenType::NullLiteral
         || type == TokenType::NumericLiteral

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -645,7 +645,9 @@ Parser::PrimaryExpressionParseResult Parser::parse_primary_expression()
     case TokenType::ParenOpen: {
         auto paren_position = position();
         consume(TokenType::ParenOpen);
-        if ((match(TokenType::ParenClose) || match(TokenType::Identifier) || match(TokenType::TripleDot)) && !try_parse_arrow_function_expression_failed_at_position(paren_position)) {
+        if ((match(TokenType::ParenClose) || match(TokenType::Identifier) || match(TokenType::TripleDot) || match(TokenType::CurlyOpen) || match(TokenType::BracketOpen))
+            && !try_parse_arrow_function_expression_failed_at_position(paren_position)) {
+
             auto arrow_function_result = try_parse_arrow_function_expression(true);
             if (!arrow_function_result.is_null())
                 return { arrow_function_result.release_nonnull() };

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1417,6 +1417,7 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u8 parse_options)
 
     ScopePusher scope(*this, ScopePusher::Var | ScopePusher::Function);
 
+    constexpr auto is_function_expression = IsSame<FunctionNodeType, FunctionExpression>;
     auto is_generator = (parse_options & FunctionNodeParseOptions::IsGeneratorFunction) != 0;
     String name;
     if (parse_options & FunctionNodeParseOptions::CheckForFunctionAndName) {
@@ -1431,6 +1432,8 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u8 parse_options)
 
         if (FunctionNodeType::must_have_name() || match(TokenType::Identifier))
             name = consume(TokenType::Identifier).value();
+        else if (is_function_expression && (match(TokenType::Yield) || match(TokenType::Await)))
+            name = consume().value();
     }
     consume(TokenType::ParenOpen);
     i32 function_length = -1;

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1701,7 +1701,7 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
             init = parse_expression(2);
         } else if (!for_loop_variable_declaration && declaration_kind == DeclarationKind::Const) {
             syntax_error("Missing initializer in 'const' variable declaration");
-        } else if (target.has<NonnullRefPtr<BindingPattern>>()) {
+        } else if (!for_loop_variable_declaration && target.has<NonnullRefPtr<BindingPattern>>()) {
             syntax_error("Missing initializer in destructuring assignment");
         }
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1680,6 +1680,10 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
                 consume(TokenType::Identifier).value());
         } else if (auto pattern = parse_binding_pattern()) {
             target = pattern.release_nonnull();
+        } else if (!m_state.in_generator_function_context && match(TokenType::Yield)) {
+            target = create_ast_node<Identifier>(
+                { m_state.current_token.filename(), rule_start.position(), position() },
+                consume().value());
         }
 
         if (target.has<Empty>()) {

--- a/Userland/Libraries/LibJS/Tests/functions/arrow-functions.js
+++ b/Userland/Libraries/LibJS/Tests/functions/arrow-functions.js
@@ -162,3 +162,10 @@ test("syntax errors", () => {
     expect("(a = 1 = 2) => {}").not.toEval();
     expect("()\n=> {}").not.toEval();
 });
+
+test("destructuring parameters", () => {
+    expect(`({ a }) => {}`).toEval();
+    expect(`([ a ]) => {}`).toEval();
+    expect(`{ a } => {}`).not.toEval();
+    expect(`[ a ] => {}`).not.toEval();
+});

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -49,3 +49,7 @@ test("use already-declared variable", () => {
     for (property in "abc");
     expect(property).toBe("2");
 });
+
+test("allow binding patterns", () => {
+    expect(`for (let [a, b] in foo) {}`).toEval();
+});

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -98,3 +98,7 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "[object Object] is not iterable");
     });
 });
+
+test("allow binding patterns", () => {
+    expect(`for (let [a, b] of foo) {}`).toEval();
+});

--- a/Userland/Libraries/LibJS/Tests/syntax/generators.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/generators.js
@@ -39,3 +39,13 @@ describe("parsing object literal generator functions", () => {
                 foo() { yield (yield); } }`).toEval();
     });
 });
+
+describe("parsing classes with generator methods", () => {
+    test("simple", () => {
+        expect(`class Foo { *foo() {} }`).toEval();
+        expect(`class Foo { static *foo() {} }`).toEval();
+        expect(`class Foo { *foo() { yield; } }`).toEval();
+        expect(`class Foo { *foo() { yield 42; } }`).toEval();
+        expect(`class Foo { *constructor() { yield 42; } }`).not.toEval();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/syntax/generators.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/generators.js
@@ -49,3 +49,8 @@ describe("parsing classes with generator methods", () => {
         expect(`class Foo { *constructor() { yield 42; } }`).not.toEval();
     });
 });
+
+test("function expression names equal to 'yield'", () => {
+    expect(`function *foo() { (function yield() {}); }`).toEval();
+    expect(`function *foo() { function yield() {} }`).not.toEval();
+});

--- a/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
@@ -1,0 +1,6 @@
+test("slash token resolution in lexer", () => {
+    expect(`{ blah.blah; }\n/foo/`).toEval();
+    expect("``/foo/").not.toEval();
+    expect("1/foo/").not.toEval();
+    expect("1/foo").toEval();
+});


### PR DESCRIPTION
I swear this only started as "oh, class expressions can have generator functions too"
One thing lead to another and I ended up fixing some random stuff.