### PR TITLE
LibJS: Bring %TypedArray%.prototype.set slightly closer to spec

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -35,8 +35,11 @@ public:
 
     virtual size_t element_size() const = 0;
     virtual String element_name() const = 0;
-    virtual bool put_by_index(u32 property_index, Value value) override = 0;
-    virtual Value get_by_index(u32 property_index, AllowSideEffects = AllowSideEffects::Yes) const override = 0;
+
+    // 25.1.2.10 GetValueFromBuffer ( arrayBuffer, byteIndex, type, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getvaluefrombuffer
+    virtual Value get_value_from_buffer(size_t byte_index, ArrayBuffer::Order, bool is_little_endian = true) const = 0;
+    // 25.1.2.12 SetValueInBuffer ( arrayBuffer, byteIndex, type, value, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-setvalueinbuffer
+    virtual void set_value_in_buffer(size_t byte_index, Value, ArrayBuffer::Order, bool is_little_endian = true) = 0;
 
 protected:
     explicit TypedArrayBase(Object& prototype)
@@ -139,6 +142,9 @@ public:
     }
 
     virtual size_t element_size() const override { return sizeof(UnderlyingBufferDataType); };
+
+    Value get_value_from_buffer(size_t byte_index, ArrayBuffer::Order order, bool is_little_endian = true) const override { return viewed_array_buffer()->template get_value<T>(byte_index, true, order, is_little_endian); }
+    void set_value_in_buffer(size_t byte_index, Value value, ArrayBuffer::Order order, bool is_little_endian = true) override { viewed_array_buffer()->template set_value<T>(byte_index, value, true, order, is_little_endian); }
 
 protected:
     TypedArray(u32 array_length, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -343,7 +343,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
         // 23.2.3.23.1 SetTypedArrayFromTypedArray ( target, targetOffset, source ), https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray
         auto target_buffer = typed_array->viewed_array_buffer();
         if (target_buffer->is_detached()) {
-            vm.throw_exception<JS::TypeError>(global_object, "Target array is detached");
+            vm.throw_exception<JS::TypeError>(global_object, ErrorType::DetachedArrayBuffer);
             return {};
         }
         auto target_length = typed_array->array_length();
@@ -351,7 +351,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
 
         auto source_buffer = source_typed_array.viewed_array_buffer();
         if (source_buffer->is_detached()) {
-            vm.throw_exception<JS::TypeError>(global_object, "Source array is detached");
+            vm.throw_exception<JS::TypeError>(global_object, ErrorType::DetachedArrayBuffer);
             return {};
         }
         auto source_length = source_typed_array.array_length();
@@ -407,8 +407,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
             target_buffer->buffer().overwrite(target_byte_index, source_buffer->buffer().data(), limit - target_byte_index);
         } else {
             while (target_byte_index < limit) {
-                auto value = source_typed_array.get_by_index(source_byte_index);
-                typed_array->put_by_index(target_byte_index, value);
+                auto value = source_typed_array.get_value_from_buffer(source_byte_index, ArrayBuffer::Unordered);
+                typed_array->set_value_in_buffer(target_byte_index, value, ArrayBuffer::Unordered);
                 source_byte_index += source_typed_array.element_size();
                 target_byte_index += typed_array->element_size();
             }
@@ -417,7 +417,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
         // 23.2.3.23.2 SetTypedArrayFromArrayLike ( target, targetOffset, source ), https://tc39.es/ecma262/#sec-settypedarrayfromarraylike
         auto target_buffer = typed_array->viewed_array_buffer();
         if (target_buffer->is_detached()) {
-            vm.throw_exception<JS::TypeError>(global_object, "Target array is detached");
+            vm.throw_exception<JS::TypeError>(global_object, ErrorType::DetachedArrayBuffer);
             return {};
         }
         auto target_length = typed_array->array_length();
@@ -474,11 +474,11 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
                 return {};
 
             if (target_buffer->is_detached()) {
-                vm.throw_exception<JS::TypeError>(global_object, "Target array is detached");
+                vm.throw_exception<JS::TypeError>(global_object, ErrorType::DetachedArrayBuffer);
                 return {};
             }
 
-            typed_array->put_by_index(target_byte_index, value);
+            typed_array->set_value_in_buffer(target_byte_index, value, ArrayBuffer::Unordered);
             ++k;
             target_byte_index += typed_array->element_size();
         }


### PR DESCRIPTION
Specifically, instead of using the internal {get, put}_by_index methods we now use the GetValueFromBuffer and SetValueInBuffer abstract operations, as required by the specification. (A nice side-effect of this change is that it should now just seemlessly work™ with the Object rewrite :)

While i was here i also replaced a couple custom detached array buffer error messages with the existing ErrorType::DetachedArrayBuffer.