### PR TITLE
Assistant: Add a new FileProvider for searching the file system

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -6,7 +6,11 @@
 
 #include "Providers.h"
 #include "FuzzyMatch.h"
+#include <AK/URL.h>
+#include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibJS/Interpreter.h>
@@ -30,6 +34,11 @@ void AppResult::activate() const
 void CalculatorResult::activate() const
 {
     GUI::Clipboard::the().set_plain_text(title());
+}
+
+void FileResult::activate() const
+{
+    Desktop::Launcher::open(URL::create_with_file_protocol(title()));
 }
 
 void AppProvider::query(String const& query, Function<void(Vector<NonnullRefPtr<Result>>)> on_complete)
@@ -80,6 +89,66 @@ void CalculatorProvider::query(String const& query, Function<void(Vector<Nonnull
     Vector<NonnullRefPtr<Result>> results;
     results.append(adopt_ref(*new CalculatorResult(calculation)));
     on_complete(results);
+}
+
+void FileProvider::query(const String& query, Function<void(Vector<NonnullRefPtr<Result>>)> on_complete)
+{
+    build_filesystem_cache();
+
+    if (m_fuzzy_match_work)
+        m_fuzzy_match_work->cancel();
+
+    m_fuzzy_match_work = Threading::BackgroundAction<Vector<NonnullRefPtr<Result>>>::create([this, query](auto& task) {
+        Vector<NonnullRefPtr<Result>> results;
+
+        for (auto& path : m_full_path_cache) {
+            if (task.is_cancelled())
+                return results;
+
+            auto match_result = fuzzy_match(query, path);
+            if (!match_result.matched)
+                continue;
+            if (match_result.score < 0)
+                continue;
+
+            results.append(adopt_ref(*new FileResult(path, match_result.score)));
+        }
+        return results; }, [on_complete = move(on_complete)](auto results) { on_complete(results); });
+}
+
+void FileProvider::build_filesystem_cache()
+{
+    if (m_full_path_cache.size() > 0 || m_building_cache)
+        return;
+
+    m_building_cache = true;
+    m_work_queue.enqueue("/");
+
+    Threading::BackgroundAction<int>::create([this](auto&) {
+        while (!m_work_queue.is_empty()) {
+            auto start = m_work_queue.dequeue();
+            Core::DirIterator di(start, Core::DirIterator::SkipDots);
+
+            while (di.has_next()) {
+                auto path = di.next_full_path();
+                struct stat st = {};
+                if (lstat(path.characters(), &st) < 0) {
+                    perror("stat");
+                    continue;
+                }
+
+                if (S_ISLNK(st.st_mode))
+                    continue;
+
+                m_full_path_cache.append(path);
+
+                if (S_ISDIR(st.st_mode)) {
+                    m_work_queue.enqueue(path);
+                }
+            }
+        }
+
+        return 0; }, [this](auto) { m_building_cache = false; });
 }
 
 }

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -11,17 +11,12 @@
 #include <LibGUI/Desktop.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/VM.h>
+#include <typeinfo>
 
 namespace Assistant {
 
 class Result : public RefCounted<Result> {
 public:
-    enum class Kind {
-        Unknown,
-        App,
-        Calculator,
-    };
-
     virtual ~Result() = default;
 
     virtual void activate() const = 0;
@@ -29,22 +24,20 @@ public:
     RefPtr<Gfx::Bitmap> bitmap() { return m_bitmap; }
     String const& title() const { return m_title; }
     String const& subtitle() const { return m_subtitle; }
-    Kind kind() const { return m_kind; }
     int score() const { return m_score; }
     bool equals(Result const& other) const
     {
-        return kind() == other.kind()
+        return typeid(this) == typeid(&other)
             && title() == other.title()
             && subtitle() == other.subtitle();
     }
 
 protected:
-    Result(RefPtr<Gfx::Bitmap> bitmap, String title, String subtitle, int score = 0, Kind kind = Kind::Unknown)
+    Result(RefPtr<Gfx::Bitmap> bitmap, String title, String subtitle, int score = 0)
         : m_bitmap(move(bitmap))
         , m_title(move(title))
         , m_subtitle(move(subtitle))
         , m_score(score)
-        , m_kind(kind)
     {
     }
 
@@ -53,13 +46,12 @@ private:
     String m_title;
     String m_subtitle;
     int m_score { 0 };
-    Kind m_kind;
 };
 
 class AppResult : public Result {
 public:
     AppResult(RefPtr<Gfx::Bitmap> bitmap, String title, String subtitle, NonnullRefPtr<Desktop::AppFile> af, int score)
-        : Result(move(bitmap), move(title), move(subtitle), score, Kind::App)
+        : Result(move(bitmap), move(title), move(subtitle), score)
         , m_app_file(move(af))
     {
     }
@@ -73,7 +65,7 @@ private:
 class CalculatorResult : public Result {
 public:
     explicit CalculatorResult(String title)
-        : Result(GUI::Icon::default_icon("app-calculator").bitmap_for_size(16), move(title), "'Enter' will copy to clipboard"sv, 100, Kind::Calculator)
+        : Result(GUI::Icon::default_icon("app-calculator").bitmap_for_size(16), move(title), "'Enter' will copy to clipboard"sv, 100)
     {
     }
     ~CalculatorResult() override = default;

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -61,7 +61,7 @@ private:
 void ThreadStackWidget::refresh()
 {
     Threading::BackgroundAction<Vector<Symbolication::Symbol>>::create(
-        [pid = m_pid, tid = m_tid] {
+        [pid = m_pid, tid = m_tid](auto&) {
             return Symbolication::symbolicate_thread(pid, tid);
         },
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -587,7 +587,7 @@ bool FileSystemModel::fetch_thumbnail_for(const Node& node)
     auto weak_this = make_weak_ptr();
 
     Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::create(
-        [path] {
+        [path](auto&) {
             return render_thumbnail(path);
         },
 

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -39,16 +39,26 @@ class BackgroundAction final : public Core::Object
 
 public:
     static NonnullRefPtr<BackgroundAction<Result>> create(
-        Function<Result()> action,
+        Function<Result(BackgroundAction&)> action,
         Function<void(Result)> on_complete = nullptr)
     {
         return adopt_ref(*new BackgroundAction(move(action), move(on_complete)));
     }
 
+    void cancel()
+    {
+        m_cancelled = true;
+    }
+
+    bool is_cancelled() const
+    {
+        return m_cancelled;
+    }
+
     virtual ~BackgroundAction() { }
 
 private:
-    BackgroundAction(Function<Result()> action, Function<void(Result)> on_complete)
+    BackgroundAction(Function<Result(BackgroundAction&)> action, Function<void(Result)> on_complete)
         : Core::Object(&background_thread())
         , m_action(move(action))
         , m_on_complete(move(on_complete))
@@ -56,7 +66,7 @@ private:
         Locker locker(all_actions().lock());
 
         all_actions().resource().enqueue([this] {
-            m_result = m_action();
+            m_result = m_action(*this);
             if (m_on_complete) {
                 Core::EventLoop::current().post_event(*this, make<Core::DeferredInvocationEvent>([this](auto&) {
                     m_on_complete(m_result.release_value());
@@ -69,7 +79,8 @@ private:
         });
     }
 
-    Function<Result()> m_action;
+    bool m_cancelled { false };
+    Function<Result(BackgroundAction&)> m_action;
     Function<void(Result)> m_on_complete;
     Optional<Result> m_result;
 };

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -689,7 +689,7 @@ bool Compositor::set_wallpaper_mode(const String& mode)
 bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callback)
 {
     Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::create(
-        [path] {
+        [path](auto&) {
             return Gfx::Bitmap::load_from_file(path);
         },
 


### PR DESCRIPTION
Now when searching via the Assistant it will index the whole file system and surface interesting results to select. When you activate a result, it will use the default handlers via the `Desktop::Launcher` to open the file or directory.