### PR TITLE
AK: Optimize `Optional`/`Variant` ctors and dtors

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -25,6 +25,10 @@
 
 #define ARCH(arch) (defined(AK_ARCH_##arch) && AK_ARCH_##arch)
 
+#if !defined(__clang__)
+#    define AK_HAS_CONDITIONALLY_TRIVIAL
+#endif
+
 #ifdef ALWAYS_INLINE
 #    undef ALWAYS_INLINE
 #endif

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -266,6 +266,9 @@ public:
         requires(!(IsTriviallyCopyConstructible<Ts> && ...) || !(IsTriviallyDestructible<Ts> && ...))
 #endif
     {
+        if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {
+            Helper::delete_(m_index, m_data);
+        }
         m_index = other.m_index;
         Helper::copy_(other.m_index, other.m_data, m_data);
         return *this;
@@ -276,6 +279,9 @@ public:
         requires(!(IsTriviallyMoveConstructible<Ts> && ...) || !(IsTriviallyDestructible<Ts> && ...))
 #endif
     {
+        if constexpr (!(IsTriviallyDestructible<Ts> && ...)) {
+            Helper::delete_(m_index, m_data);
+        }
         m_index = other.m_index;
         Helper::move_(other.m_index, other.m_data, m_data);
         return *this;

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -95,4 +96,96 @@ TEST_CASE(comparison_with_numeric_types)
     EXPECT_EQ(opt1, 7.0);
     EXPECT_EQ(opt1, 7u);
     EXPECT_NE(opt1, -2);
+}
+
+TEST_CASE(test_copy_ctor_and_dtor_called)
+{
+#ifdef AK_HAVE_CONDITIONALLY_TRIVIAL
+    static_assert(IsTriviallyDestructible<Optional<u8>>);
+    static_assert(IsTriviallyCopyable<Optional<u8>>);
+    static_assert(IsTriviallyCopyConstructible<Optional<u8>>);
+    static_assert(IsTriviallyCopyAssignable<Optional<u8>>);
+    // These can't be trivial as we have to clear the original object.
+    static_assert(!IsTriviallyMoveConstructible<Optional<u8>>);
+    static_assert(!IsTriviallyMoveAssignable<Optional<u8>>);
+#endif
+
+    struct DestructionChecker {
+        explicit DestructionChecker(bool& was_destroyed)
+            : m_was_destroyed(was_destroyed)
+        {
+        }
+
+        ~DestructionChecker()
+        {
+            m_was_destroyed = true;
+        }
+        bool& m_was_destroyed;
+    };
+
+    static_assert(!IsTriviallyDestructible<Optional<DestructionChecker>>);
+
+    bool was_destroyed = false;
+    {
+        Optional<DestructionChecker> test_optional = DestructionChecker { was_destroyed };
+    }
+    EXPECT(was_destroyed);
+
+    struct CopyChecker {
+        explicit CopyChecker(bool& was_copy_constructed)
+            : m_was_copy_constructed(was_copy_constructed)
+        {
+        }
+
+        CopyChecker(const CopyChecker& other)
+            : m_was_copy_constructed(other.m_was_copy_constructed)
+        {
+            m_was_copy_constructed = true;
+        }
+
+        bool& m_was_copy_constructed;
+    };
+
+    static_assert(IsCopyConstructible<Optional<CopyChecker>>);
+    static_assert(!IsTriviallyCopyConstructible<Optional<CopyChecker>>);
+
+    bool was_copy_constructed = false;
+    Optional<CopyChecker> copy1 = CopyChecker { was_copy_constructed };
+    Optional<CopyChecker> copy2 = copy1;
+    EXPECT(was_copy_constructed);
+
+    struct MoveChecker {
+        explicit MoveChecker(bool& was_move_constructed)
+            : m_was_move_constructed(was_move_constructed)
+        {
+        }
+
+        MoveChecker(const MoveChecker& other)
+            : m_was_move_constructed(other.m_was_move_constructed)
+        {
+            EXPECT(false);
+        };
+
+        MoveChecker(MoveChecker&& other)
+            : m_was_move_constructed(other.m_was_move_constructed)
+        {
+            m_was_move_constructed = true;
+        };
+
+        bool& m_was_move_constructed;
+    };
+    static_assert(IsMoveConstructible<Optional<MoveChecker>>);
+    static_assert(!IsTriviallyMoveConstructible<Optional<MoveChecker>>);
+
+    bool was_moved = false;
+    Optional<MoveChecker> move1 = MoveChecker { was_moved };
+    Optional<MoveChecker> move2 = move(move1);
+    EXPECT(was_moved);
+
+#ifdef AK_HAVE_CONDITIONALLY_TRIVIAL
+    struct NonDestructible {
+        ~NonDestructible() = delete;
+    };
+    static_assert(!IsDestructible<Optional<NonDestructible>>);
+#endif
 }

--- a/Tests/AK/TestTypeTraits.cpp
+++ b/Tests/AK/TestTypeTraits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -32,6 +32,12 @@
     for_each_type_zipped<ListA, ListB>([]<typename A, typename B>(TypeWrapper<A>, TypeWrapper<B>) { \
         STATIC_EXPECT_EQ(trait<A>, B);                                                              \
     })
+
+#define EXPECT_VARIADIC_TRAIT_TRUE(trait, ...) \
+    static_assert(trait<__VA_ARGS__>)
+
+#define EXPECT_VARIADIC_TRAIT_FALSE(trait, ...) \
+    static_assert(!trait<__VA_ARGS__>)
 
 struct Empty {
 };
@@ -112,4 +118,131 @@ TEST_CASE(RemoveCVReference)
     using ResultTypeList = TypeList<int, int, int, int, int, int, int, int, int>;
 
     EXPECT_EQ_WITH_TRAIT(RemoveCVReference, TestTypeList, ResultTypeList);
+}
+
+TEST_CASE(AddReference)
+{
+    STATIC_EXPECT_EQ(AddLvalueReference<int>, int&);
+    STATIC_EXPECT_EQ(AddLvalueReference<int&>, int&);
+    STATIC_EXPECT_EQ(AddLvalueReference<int&&>, int&);
+
+    STATIC_EXPECT_EQ(AddRvalueReference<int>, int&&);
+    STATIC_EXPECT_EQ(AddRvalueReference<int&>, int&);
+    STATIC_EXPECT_EQ(AddRvalueReference<int&&>, int&&);
+
+    STATIC_EXPECT_EQ(AddLvalueReference<void>, void);
+}
+
+TEST_CASE(IsConvertible)
+{
+    struct A {
+    };
+    struct B {
+        B(A);
+    };
+    struct C {
+        A a;
+        operator A() { return a; };
+    };
+    struct D {
+    };
+
+    EXPECT_VARIADIC_TRAIT_TRUE(IsConvertible, A, B);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsConvertible, B, A);
+    EXPECT_VARIADIC_TRAIT_TRUE(IsConvertible, C, A);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsConvertible, A, C);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsConvertible, D, A);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsConvertible, A, D);
+}
+
+TEST_CASE(IsAssignable)
+{
+    EXPECT_VARIADIC_TRAIT_FALSE(IsAssignable, int, int);
+    EXPECT_VARIADIC_TRAIT_TRUE(IsAssignable, int&, int);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsAssignable, int, void);
+
+    struct A {
+    };
+    EXPECT_TRAIT_TRUE(IsCopyAssignable, A);
+    EXPECT_TRAIT_TRUE(IsTriviallyCopyAssignable, A);
+    EXPECT_TRAIT_TRUE(IsMoveAssignable, A);
+    EXPECT_TRAIT_TRUE(IsTriviallyMoveAssignable, A);
+
+    struct B {
+        B& operator=(const B&) { return *this; }
+        B& operator=(B&&) { return *this; }
+    };
+    EXPECT_TRAIT_TRUE(IsCopyAssignable, B);
+    EXPECT_TRAIT_FALSE(IsTriviallyCopyAssignable, B);
+    EXPECT_TRAIT_TRUE(IsMoveAssignable, B);
+    EXPECT_TRAIT_FALSE(IsTriviallyMoveAssignable, B);
+
+    struct C {
+        C& operator=(const C&) = delete;
+        C& operator=(C&&) = delete;
+    };
+    EXPECT_TRAIT_FALSE(IsCopyAssignable, C);
+    EXPECT_TRAIT_FALSE(IsTriviallyCopyAssignable, C);
+    EXPECT_TRAIT_FALSE(IsMoveAssignable, C);
+    EXPECT_TRAIT_FALSE(IsTriviallyMoveAssignable, C);
+}
+
+TEST_CASE(IsConstructible)
+{
+    struct A {
+    };
+    EXPECT_TRAIT_TRUE(IsCopyConstructible, A);
+    EXPECT_TRAIT_TRUE(IsTriviallyCopyConstructible, A);
+    EXPECT_TRAIT_TRUE(IsMoveConstructible, A);
+    EXPECT_TRAIT_TRUE(IsTriviallyMoveConstructible, A);
+
+    struct B {
+        B(const B&)
+        {
+        }
+        B(B&&)
+        {
+        }
+    };
+    EXPECT_TRAIT_TRUE(IsCopyConstructible, B);
+    EXPECT_TRAIT_FALSE(IsTriviallyCopyConstructible, B);
+    EXPECT_TRAIT_TRUE(IsMoveConstructible, B);
+    EXPECT_TRAIT_FALSE(IsTriviallyMoveConstructible, B);
+
+    struct C {
+        C(const C&) = delete;
+        C(C&&) = delete;
+    };
+    EXPECT_TRAIT_FALSE(IsCopyConstructible, C);
+    EXPECT_TRAIT_FALSE(IsTriviallyCopyConstructible, C);
+    EXPECT_TRAIT_FALSE(IsMoveConstructible, C);
+    EXPECT_TRAIT_FALSE(IsTriviallyMoveConstructible, C);
+
+    struct D {
+        D(int);
+    };
+    EXPECT_VARIADIC_TRAIT_TRUE(IsConstructible, D, int);
+    EXPECT_VARIADIC_TRAIT_TRUE(IsConstructible, D, char);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsConstructible, D, const char*);
+    EXPECT_VARIADIC_TRAIT_FALSE(IsConstructible, D, void);
+}
+
+TEST_CASE(IsDestructible)
+{
+    struct A {
+    };
+    EXPECT_TRAIT_TRUE(IsDestructible, A);
+    EXPECT_TRAIT_TRUE(IsTriviallyDestructible, A);
+    struct B {
+        ~B()
+        {
+        }
+    };
+    EXPECT_TRAIT_TRUE(IsDestructible, B);
+    EXPECT_TRAIT_FALSE(IsTriviallyDestructible, B);
+    struct C {
+        ~C() = delete;
+    };
+    EXPECT_TRAIT_FALSE(IsDestructible, C);
+    EXPECT_TRAIT_FALSE(IsTriviallyDestructible, C);
 }

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -57,6 +57,12 @@ TEST_CASE(destructor)
         Variant<DestructionChecker> test_variant { DestructionChecker { was_destroyed } };
     }
     EXPECT(was_destroyed);
+
+    bool was_destroyed_when_assigned_to = false;
+    Variant<DestructionChecker, int> original { DestructionChecker { was_destroyed_when_assigned_to } };
+    Variant<DestructionChecker, int> other { 42 };
+    original = other;
+    EXPECT(was_destroyed_when_assigned_to);
 }
 
 TEST_CASE(move_moves)

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -94,7 +94,7 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
     auto properties = Vector<PropertyValuePair>();
     properties.append({ "Type:", get_description(m_mode) });
     auto parent_link = URL::create_with_file_protocol(m_parent_path, m_name);
-    properties.append(PropertyValuePair { "Location:", path, Optional(parent_link) });
+    properties.append(PropertyValuePair { "Location:", path, parent_link });
 
     if (S_ISLNK(m_mode)) {
         auto link_destination = Core::File::read_link(path);
@@ -103,7 +103,7 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
         } else {
             auto link_directory = LexicalPath(link_destination);
             auto link_parent = URL::create_with_file_protocol(link_directory.dirname(), link_directory.basename());
-            properties.append({ "Link target:", link_destination, Optional(link_parent) });
+            properties.append({ "Link target:", link_destination, link_parent });
         }
     }
 


### PR DESCRIPTION
This PR makes use of the C++20 conditionally trivial special member functions. This means that we can make it so that if `T` is trivially copyable, `Optional<T>` will be too.  The same applies to the other special member functions.

GCC supports this, but Clang's support table shows that it's not yet implemented. This might result in a build failure with the AppleClang toolchain, we'll have to see.

cc @alimpfard
I hope this doesn't mess up Variant