### PR TITLE
Assistant: Add new URLProvider to open URL's in the browser

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -41,6 +41,11 @@ void FileResult::activate() const
     Desktop::Launcher::open(URL::create_with_file_protocol(title()));
 }
 
+void URLResult::activate() const
+{
+    Desktop::Launcher::open(URL::create_with_url_or_path(title()));
+}
+
 void AppProvider::query(String const& query, Function<void(Vector<NonnullRefPtr<Result>>)> on_complete)
 {
     if (query.starts_with("="))
@@ -149,6 +154,25 @@ void FileProvider::build_filesystem_cache()
         }
 
         return 0; }, [this](auto) { m_building_cache = false; });
+}
+
+void URLProvider::query(String const& query, Function<void(Vector<NonnullRefPtr<Result>>)> on_complete)
+{
+    URL url = URL(query);
+
+    if (url.scheme().is_empty())
+        url.set_scheme("http");
+    if (url.host().is_empty())
+        url.set_host(query);
+    if (url.paths().is_empty())
+        url.set_paths({ "" });
+
+    if (!url.is_valid())
+        return;
+
+    Vector<NonnullRefPtr<Result>> results;
+    results.append(adopt_ref(*new URLResult(url)));
+    on_complete(results);
 }
 
 }

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -8,6 +8,7 @@
 
 #include <AK/Queue.h>
 #include <AK/String.h>
+#include <AK/URL.h>
 #include <LibDesktop/AppFile.h>
 #include <LibGUI/Desktop.h>
 #include <LibJS/Interpreter.h>
@@ -84,6 +85,16 @@ public:
     void activate() const override;
 };
 
+class URLResult : public Result {
+public:
+    explicit URLResult(const URL& url)
+        : Result(GUI::Icon::default_icon("app-browser").bitmap_for_size(16), url.to_string(), "'Enter' will open this URL in the browser"sv, 50)
+    {
+    }
+    ~URLResult() override = default;
+    void activate() const override;
+};
+
 class Provider {
 public:
     virtual ~Provider() = default;
@@ -111,6 +122,11 @@ private:
     bool m_building_cache { false };
     Vector<String> m_full_path_cache;
     Queue<String> m_work_queue;
+};
+
+class URLProvider : public Provider {
+public:
+    void query(String const& query, Function<void(Vector<NonnullRefPtr<Result>>)> on_complete) override;
 };
 
 }

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -138,6 +138,10 @@ public:
         m_calculator_provider.query(query, [=, this](auto results) {
             recv_results(query, results);
         });
+
+        m_url_provider.query(query, [=, this](auto results) {
+            recv_results(query, results);
+        });
     }
 
 private:
@@ -178,6 +182,7 @@ private:
     AppProvider m_app_provider;
     CalculatorProvider m_calculator_provider;
     FileProvider m_file_provider;
+    URLProvider m_url_provider;
 
     Threading::Lock m_lock;
     HashMap<String, Vector<NonnullRefPtr<Result>>> m_result_cache;


### PR DESCRIPTION
Tries to parse the Assistant input to an URL, which you can then open with the Browser.

![2021-07-02_23:44:02](https://user-images.githubusercontent.com/6866019/124331453-8306cf80-db8f-11eb-85f3-784a27e9d56b.png)
