### PR TITLE
Kernel: Simplify graphics initialization somewhat

### DIFF
--- a/Kernel/Bus/PCI/IDs.h
+++ b/Kernel/Bus/PCI/IDs.h
@@ -6,19 +6,22 @@
 
 #pragma once
 
-namespace Kernel {
+namespace Kernel::PCI {
 
-enum class PCIVendorID {
+enum VendorID {
     VirtIO = 0x1af4,
     Intel = 0x8086,
     WCH = 0x1c00,
     RedHat = 0x1b36,
-    Realtek = 0x10ec
+    Realtek = 0x10ec,
+    QEMUOld = 0x1234,
+    VirtualBox = 0x80ee
 };
 
-enum class PCIDeviceID {
+enum DeviceID {
     VirtIOConsole = 0x1003,
     VirtIOEntropy = 0x1005,
     VirtIOGPU = 0x1050,
 };
+
 }

--- a/Kernel/Devices/PCISerialDevice.h
+++ b/Kernel/Devices/PCISerialDevice.h
@@ -32,10 +32,10 @@ private:
     };
 
     static constexpr BoardDefinition board_definitions[4] = {
-        { { (u16)PCIVendorID::WCH, 0x3253 }, "WCH CH382 2S", 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 },
-        { { (u16)PCIVendorID::RedHat, 0x0002 }, "QEMU PCI 16550A", 1, 0, 0, 8, SerialDevice::Baud::Baud115200 },
-        { { (u16)PCIVendorID::RedHat, 0x0003 }, "QEMU PCI Dual-port 16550A", 2, 0, 0, 8, SerialDevice::Baud::Baud115200 },
-        { { (u16)PCIVendorID::RedHat, 0x0004 }, "QEMU PCI Quad-port 16550A", 4, 0, 0, 8, SerialDevice::Baud::Baud115200 }
+        { { PCI::VendorID::WCH, 0x3253 }, "WCH CH382 2S", 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 },
+        { { PCI::VendorID::RedHat, 0x0002 }, "QEMU PCI 16550A", 1, 0, 0, 8, SerialDevice::Baud::Baud115200 },
+        { { PCI::VendorID::RedHat, 0x0003 }, "QEMU PCI Dual-port 16550A", 2, 0, 0, 8, SerialDevice::Baud::Baud115200 },
+        { { PCI::VendorID::RedHat, 0x0004 }, "QEMU PCI Quad-port 16550A", 4, 0, 0, 8, SerialDevice::Baud::Baud115200 }
     };
 };
 

--- a/Kernel/Graphics/BochsGraphicsAdapter.cpp
+++ b/Kernel/Graphics/BochsGraphicsAdapter.cpp
@@ -50,8 +50,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initi
 }
 
 UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::Address pci_address)
-    : GraphicsDevice(pci_address)
-    , PCI::DeviceController(pci_address)
+    : PCI::DeviceController(pci_address)
     , m_mmio_registers(PCI::get_BAR2(pci_address) & 0xfffffff0)
 {
     // We assume safe resolutio is 1024x768x32

--- a/Kernel/Graphics/BochsGraphicsAdapter.cpp
+++ b/Kernel/Graphics/BochsGraphicsAdapter.cpp
@@ -46,6 +46,8 @@ struct [[gnu::packed]] BochsDisplayMMIORegisters {
 
 UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initialize(PCI::Address address)
 {
+    PCI::ID id = PCI::get_id(address);
+    VERIFY((id.vendor_id == 0x1234 && id.device_id == 0x1111) || (id.vendor_id == 0x80ee && id.device_id == 0xbeef));
     return adopt_ref(*new BochsGraphicsAdapter(address));
 }
 

--- a/Kernel/Graphics/BochsGraphicsAdapter.cpp
+++ b/Kernel/Graphics/BochsGraphicsAdapter.cpp
@@ -8,6 +8,7 @@
 #include <AK/Checked.h>
 #include <AK/Singleton.h>
 #include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Graphics/Bochs.h>
 #include <Kernel/Graphics/BochsGraphicsAdapter.h>
@@ -47,7 +48,7 @@ struct [[gnu::packed]] BochsDisplayMMIORegisters {
 UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initialize(PCI::Address address)
 {
     PCI::ID id = PCI::get_id(address);
-    VERIFY((id.vendor_id == 0x1234 && id.device_id == 0x1111) || (id.vendor_id == 0x80ee && id.device_id == 0xbeef));
+    VERIFY((id.vendor_id == PCI::VendorID::QEMUOld && id.device_id == 0x1111) || (id.vendor_id == PCI::VendorID::VirtualBox && id.device_id == 0xbeef));
     return adopt_ref(*new BochsGraphicsAdapter(address));
 }
 

--- a/Kernel/Graphics/BochsGraphicsAdapter.h
+++ b/Kernel/Graphics/BochsGraphicsAdapter.h
@@ -46,6 +46,7 @@ private:
     explicit BochsGraphicsAdapter(PCI::Address);
 
     void set_safe_resolution();
+    void unblank();
 
     bool validate_setup_resolution(size_t width, size_t height);
     u32 find_framebuffer_address();

--- a/Kernel/Graphics/GraphicsDevice.h
+++ b/Kernel/Graphics/GraphicsDevice.h
@@ -24,7 +24,6 @@ public:
     virtual ~GraphicsDevice() = default;
     virtual void initialize_framebuffer_devices() = 0;
     virtual Type type() const = 0;
-    PCI::Address device_pci_address() const { return m_pci_address; }
     virtual void enable_consoles() = 0;
     virtual void disable_consoles() = 0;
     bool consoles_enabled() const { return m_consoles_enabled; }
@@ -37,12 +36,8 @@ public:
     virtual bool set_y_offset(size_t output_port_index, size_t y) = 0;
 
 protected:
-    GraphicsDevice(PCI::Address pci_address)
-        : m_pci_address(pci_address)
-    {
-    }
+    GraphicsDevice() = default;
 
-    const PCI::Address m_pci_address;
     bool m_consoles_enabled { false };
 };
 

--- a/Kernel/Graphics/GraphicsManagement.cpp
+++ b/Kernel/Graphics/GraphicsManagement.cpp
@@ -82,18 +82,18 @@ UNMAP_AFTER_INIT bool GraphicsManagement::determine_and_initialize_graphics_devi
 
     RefPtr<GraphicsDevice> adapter;
     switch (id.vendor_id) {
-    case 0x1234:
+    case PCI::VendorID::QEMUOld:
         if (id.device_id == 0x1111)
             adapter = BochsGraphicsAdapter::initialize(address);
         break;
-    case 0x80ee:
+    case PCI::VendorID::VirtualBox:
         if (id.device_id == 0xbeef)
             adapter = BochsGraphicsAdapter::initialize(address);
         break;
-    case 0x8086:
+    case PCI::VendorID::Intel:
         adapter = IntelNativeGraphicsAdapter::initialize(address);
         break;
-    case static_cast<u16>(PCIVendorID::VirtIO):
+    case PCI::VendorID::VirtIO:
         dmesgln("Graphics: Using VirtIO console");
         adapter = Graphics::VirtIOGraphicsAdapter::initialize(address);
         break;

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -47,6 +47,7 @@ public:
     void activate_graphical_mode();
 
 private:
+    bool determine_and_initialize_graphics_device(const PCI::Address& address, PCI::ID id);
     NonnullRefPtrVector<GraphicsDevice> m_graphics_devices;
     NonnullOwnPtr<Region> m_vga_font_region;
     RefPtr<Graphics::Console> m_console;

--- a/Kernel/Graphics/VGACompatibleAdapter.cpp
+++ b/Kernel/Graphics/VGACompatibleAdapter.cpp
@@ -37,8 +37,7 @@ UNMAP_AFTER_INIT void VGACompatibleAdapter::initialize_framebuffer_devices()
 }
 
 UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address)
-    : GraphicsDevice(address)
-    , PCI::DeviceController(address)
+    : PCI::DeviceController(address)
 {
     m_framebuffer_console = Graphics::TextModeConsole::initialize(*this);
     // FIXME: This is a very wrong way to do this...
@@ -46,8 +45,7 @@ UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address
 }
 
 UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address, PhysicalAddress framebuffer_address, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch)
-    : GraphicsDevice(address)
-    , PCI::DeviceController(address)
+    : PCI::DeviceController(address)
     , m_framebuffer_address(framebuffer_address)
     , m_framebuffer_width(framebuffer_width)
     , m_framebuffer_height(framebuffer_height)

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
@@ -14,7 +14,7 @@ namespace Kernel::Graphics {
 
 NonnullRefPtr<VirtIOGraphicsAdapter> VirtIOGraphicsAdapter::initialize(PCI::Address base_address)
 {
-    VERIFY(PCI::get_id(base_address).vendor_id == static_cast<u16>(PCIVendorID::VirtIO));
+    VERIFY(PCI::get_id(base_address).vendor_id == PCI::VendorID::VirtIO);
     return adopt_ref(*new VirtIOGraphicsAdapter(base_address));
 }
 

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
@@ -17,7 +17,7 @@ NonnullRefPtr<VirtIOGraphicsAdapter> VirtIOGraphicsAdapter::initialize(PCI::Addr
 }
 
 VirtIOGraphicsAdapter::VirtIOGraphicsAdapter(PCI::Address base_address)
-    : GraphicsDevice(base_address)
+    : PCI::DeviceController(base_address)
 {
     m_gpu_device = adopt_ref(*new VirtIOGPU(base_address)).leak_ref();
 }

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 #include <Kernel/Graphics/VirtIOGPU/VirtIOGPU.h>
@@ -13,6 +14,7 @@ namespace Kernel::Graphics {
 
 NonnullRefPtr<VirtIOGraphicsAdapter> VirtIOGraphicsAdapter::initialize(PCI::Address base_address)
 {
+    VERIFY(PCI::get_id(base_address).vendor_id == static_cast<u16>(PCIVendorID::VirtIO));
     return adopt_ref(*new VirtIOGraphicsAdapter(base_address));
 }
 

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.h
@@ -12,7 +12,9 @@
 
 namespace Kernel::Graphics {
 
-class VirtIOGraphicsAdapter final : public GraphicsDevice {
+class VirtIOGraphicsAdapter final
+    : public GraphicsDevice
+    , public PCI::DeviceController {
     AK_MAKE_ETERNAL
 
 public:

--- a/Kernel/Net/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/E1000ENetworkAdapter.cpp
@@ -183,7 +183,7 @@ static bool is_valid_device_id(u16 device_id)
 UNMAP_AFTER_INIT RefPtr<E1000ENetworkAdapter> E1000ENetworkAdapter::try_to_initialize(PCI::Address address)
 {
     auto id = PCI::get_id(address);
-    if (id.vendor_id != (u16)PCIVendorID::Intel)
+    if (id.vendor_id != PCI::VendorID::Intel)
         return {};
     if (!is_valid_device_id(id.device_id))
         return {};

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -160,7 +160,7 @@ UNMAP_AFTER_INIT static bool is_valid_device_id(u16 device_id)
 UNMAP_AFTER_INIT RefPtr<E1000NetworkAdapter> E1000NetworkAdapter::try_to_initialize(PCI::Address address)
 {
     auto id = PCI::get_id(address);
-    if (id.vendor_id != (u16)PCIVendorID::Intel)
+    if (id.vendor_id != PCI::VendorID::Intel)
         return {};
     if (!is_valid_device_id(id.device_id))
         return {};

--- a/Kernel/Net/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8168NetworkAdapter.cpp
@@ -179,7 +179,7 @@ namespace Kernel {
 UNMAP_AFTER_INIT RefPtr<RTL8168NetworkAdapter> RTL8168NetworkAdapter::try_to_initialize(PCI::Address address)
 {
     auto id = PCI::get_id(address);
-    if (id.vendor_id != (u16)PCIVendorID::Realtek)
+    if (id.vendor_id != PCI::VendorID::Realtek)
         return {};
     if (id.device_id != 0x8168)
         return {};

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -21,18 +21,18 @@ UNMAP_AFTER_INIT void VirtIO::detect()
         if (address.is_null() || id.is_null())
             return;
         // TODO: We should also be checking that the device_id is in between 0x1000 - 0x107F inclusive
-        if (id.vendor_id != (u16)PCIVendorID::VirtIO)
+        if (id.vendor_id != PCI::VendorID::VirtIO)
             return;
         switch (id.device_id) {
-        case (u16)PCIDeviceID::VirtIOConsole: {
+        case PCI::DeviceID::VirtIOConsole: {
             [[maybe_unused]] auto& unused = adopt_ref(*new VirtIOConsole(address)).leak_ref();
             break;
         }
-        case (u16)PCIDeviceID::VirtIOEntropy: {
+        case PCI::DeviceID::VirtIOEntropy: {
             [[maybe_unused]] auto& unused = adopt_ref(*new VirtIORNG(address)).leak_ref();
             break;
         }
-        case (u16)PCIDeviceID::VirtIOGPU: {
+        case PCI::DeviceID::VirtIOGPU: {
             // This should have been initialized by the graphics subsystem
             break;
         }

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -130,6 +130,9 @@ $SERENITY_EXTRA_QEMU_ARGS
 -smp 2
 -display $SERENITY_QEMU_DISPLAY_BACKEND
 -device $SERENITY_QEMU_DISPLAY_DEVICE
+-device secondary-vga
+-device bochs-display
+-device VGA,vgamem_mb=64
 -device piix3-ide
 -drive file=${SERENITY_DISK_IMAGE},id=disk,if=none
 -device ahci,id=ahci


### PR DESCRIPTION
We use a switch-case statements to ensure we try to find the best
suitable driver for a specific graphics card. In case we don't find
such, we use the default statement to initialize the graphics card
as a generic VGA adapter, if the adapter is VGA compatible.

If we couldn't initialize the driver, we don't touch this adapter
anymore.

Also, GraphicsDevice should not be tied to a PCI::Address member,
as it can be theortically be used with other buses (e.g. ISA cards).