### PR TITLE
IPCCompiler: Add include parsing for endpoints

### DIFF
--- a/Userland/DevTools/IPCCompiler/main.cpp
+++ b/Userland/DevTools/IPCCompiler/main.cpp
@@ -276,12 +276,7 @@ int main(int argc, char** argv)
     generator.append(R"~~~(#include <AK/MemoryStream.h>
 #include <AK/OwnPtr.h>
 #include <AK/Result.h>
-#include <AK/URL.h>
 #include <AK/Utf8View.h>
-#include <LibCore/AnonymousBuffer.h>
-#include <LibGfx/Color.h>
-#include <LibGfx/Rect.h>
-#include <LibGfx/ShareableBitmap.h>
 #include <LibIPC/Connection.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Dictionary.h>

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -8,6 +8,7 @@
 #include <Clipboard/ClipboardClientEndpoint.h>
 #include <Clipboard/ClipboardServerEndpoint.h>
 #include <LibGUI/Clipboard.h>
+#include <LibGfx/Bitmap.h>
 #include <LibIPC/ServerConnection.h>
 
 namespace GUI {

--- a/Userland/Services/AudioServer/AudioClient.ipc
+++ b/Userland/Services/AudioServer/AudioClient.ipc
@@ -1,3 +1,5 @@
+#include <LibCore/AnonymousBuffer.h>
+
 endpoint AudioClient
 {
     finished_playing_buffer(i32 buffer_id) =|

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -1,3 +1,5 @@
+#include <LibCore/AnonymousBuffer.h>
+
 endpoint AudioServer
 {
     // Mixer functions

--- a/Userland/Services/Clipboard/ClipboardClient.ipc
+++ b/Userland/Services/Clipboard/ClipboardClient.ipc
@@ -1,3 +1,5 @@
+#include <LibCore/AnonymousBuffer.h>
+
 endpoint ClipboardClient
 {
     clipboard_data_changed([UTF8] String mime_type) =|

--- a/Userland/Services/Clipboard/ClipboardServer.ipc
+++ b/Userland/Services/Clipboard/ClipboardServer.ipc
@@ -1,3 +1,5 @@
+#include <LibCore/AnonymousBuffer.h>
+
 endpoint ClipboardServer
 {
     get_clipboard_data() => (Core::AnonymousBuffer data, [UTF8] String mime_type, IPC::Dictionary metadata)

--- a/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
@@ -1,3 +1,6 @@
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint ImageDecoderClient
 {
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -1,3 +1,6 @@
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint ImageDecoderServer
 {
     decode_image(Core::AnonymousBuffer data) => (bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations)

--- a/Userland/Services/LaunchServer/LaunchClient.ipc
+++ b/Userland/Services/LaunchServer/LaunchClient.ipc
@@ -1,3 +1,5 @@
+#include <AK/URL.h>
+
 endpoint LaunchClient
 {
 }

--- a/Userland/Services/LaunchServer/LaunchServer.ipc
+++ b/Userland/Services/LaunchServer/LaunchServer.ipc
@@ -1,3 +1,5 @@
+#include <AK/URL.h>
+
 endpoint LaunchServer
 {
     open_url(URL url, String handler_name) => (bool response)

--- a/Userland/Services/NotificationServer/NotificationClient.ipc
+++ b/Userland/Services/NotificationServer/NotificationClient.ipc
@@ -1,3 +1,5 @@
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint NotificationClient
 {
 }

--- a/Userland/Services/NotificationServer/NotificationServer.ipc
+++ b/Userland/Services/NotificationServer/NotificationServer.ipc
@@ -1,3 +1,5 @@
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint NotificationServer
 {
     show_notification([UTF8] String text, [UTF8] String title, Gfx::ShareableBitmap icon) => ()

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -1,3 +1,5 @@
+#include <AK/URL.h>
+
 endpoint RequestClient
 {
     request_progress(i32 request_id, Optional<u32> total_size, u32 downloaded_size) =|

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -1,3 +1,5 @@
+#include <AK/URL.h>
+
 endpoint RequestServer
 {
     // Test if a specific protocol is supported, e.g "http"

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -1,3 +1,7 @@
+#include <AK/URL.h>
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint WebContentClient
 {
     did_start_loading(URL url) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -1,3 +1,7 @@
+#include <AK/URL.h>
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint WebContentServer
 {
     update_system_theme(Core::AnonymousBuffer theme_buffer) =|

--- a/Userland/Services/WebSocket/WebSocketClient.ipc
+++ b/Userland/Services/WebSocket/WebSocketClient.ipc
@@ -1,3 +1,5 @@
+#include <AK/URL.h>
+
 endpoint WebSocketClient
 {
     // Connection API

--- a/Userland/Services/WebSocket/WebSocketServer.ipc
+++ b/Userland/Services/WebSocket/WebSocketServer.ipc
@@ -1,3 +1,5 @@
+#include <AK/URL.h>
+
 endpoint WebSocketServer
 {
     // Connection API

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -1,3 +1,6 @@
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint WindowClient
 {
     fast_greet(Vector<Gfx::IntRect> screen_rects, u32 main_screen_index, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query) =|

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -1,3 +1,5 @@
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint WindowManagerClient
 {
     window_removed(i32 wm_id, i32 client_id, i32 window_id) =|

--- a/Userland/Services/WindowServer/WindowManagerServer.ipc
+++ b/Userland/Services/WindowServer/WindowManagerServer.ipc
@@ -1,3 +1,5 @@
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint WindowManagerServer
 {
     set_event_mask(u32 event_mask) =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -1,3 +1,6 @@
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/ShareableBitmap.h>
+
 endpoint WindowServer
 {
     create_menubar(i32 menubar_id) =|


### PR DESCRIPTION
Removed the following as default includes and included them only where necessary:
```
#include <AK/URL.h>
#include <LibCore/AnonymousBuffer.h>
#include <LibGfx/Color.h>
#include <LibGfx/Rect.h>
#include <LibGfx/ShareableBitmap.h>
```

Clipboard was relying on the default include of `LibGfx/ShareableBitmap.h` to provide `Bitmap`, so we now include that specifically.