### PR TITLE
 Meta: Prefer to use the QEMU binaries from the toolchain directory 

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -18,6 +18,16 @@ if [ "$(uname -s)" = "Darwin" ]; then
     export PATH="/usr/local/opt/e2fsprogs/sbin:$PATH"
 fi
 
+SCRIPT_DIR="$(dirname "${0}")"
+
+# Prepend the toolchain qemu directory so we pick up QEMU from there
+PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
+
+# Also prepend the i686 toolchain directory because that's where most
+# people will have their QEMU binaries if they built them before the
+# directory was changed to Toolchain/Local/qemu.
+PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
+
 disk_usage() {
     # shellcheck disable=SC2003
 if [ "$(uname -s)" = "Darwin" ]; then

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -25,6 +25,16 @@ if [ "$(uname)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
     fi
 fi
 
+SCRIPT_DIR="$(dirname "${0}")"
+
+# Prepend the toolchain qemu directory so we pick up QEMU from there
+PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
+
+# Also prepend the i686 toolchain directory because that's where most
+# people will have their QEMU binaries if they built them before the
+# directory was changed to Toolchain/Local/qemu.
+PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
+
 SERENITY_RUN="${SERENITY_RUN:-$1}"
 
 if [ -z "$SERENITY_QEMU_BIN" ]; then

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -59,9 +59,17 @@ fi
     fi
 }
 
+if ! command -v $SERENITY_QEMU_BIN >/dev/null 2>&1 ; then
+    die "Please install QEMU version 5.0 or newer or use the Toolchain/BuildQemu.sh script."
+fi
+
 SERENITY_QEMU_MIN_REQ_VERSION=5
 installed_major_version=$("$SERENITY_QEMU_BIN" -version | head -n 1 | sed -E 's/QEMU emulator version ([1-9][0-9]*|0).*/\1/')
-[ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ] && die "Required QEMU >= 5.0! Found $($SERENITY_QEMU_BIN -version | head -n 1)"
+if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ]; then
+    echo "Required QEMU >= 5.0! Found $($SERENITY_QEMU_BIN -version | head -n 1)"
+    echo "Please install a newer version of QEMU or use the Toolchain/BuildQemu.sh script."
+    die
+fi
 
 SERENITY_SCREENS="${SERENITY_SCREENS:-1}"
 if (uname -a | grep -iq WSL) || (uname -a | grep -iq microsoft); then

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -7,8 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "$DIR"
 
-ARCH=${ARCH:-"i686"}
-PREFIX="$DIR/Local/$ARCH"
+PREFIX="$DIR/Local/qemu"
 BUILD=$(realpath "$DIR/../Build")
 SYSROOT="$BUILD/Root"
 
@@ -46,7 +45,7 @@ pushd "$DIR/Tarballs"
 popd
 
 mkdir -p "$PREFIX"
-mkdir -p "$DIR/Build/$ARCH/qemu"
+mkdir -p "$DIR/Build/qemu"
 
 if [ -z "$MAKEJOBS" ]; then
     MAKEJOBS=$(nproc)
@@ -61,12 +60,10 @@ fi
 
 echo Using $UI_LIB based UI
 
-pushd "$DIR/Build/$ARCH"
-    pushd qemu
-        "$DIR"/Tarballs/$QEMU_VERSION/configure --prefix="$PREFIX" \
-                                                --target-list=i386-softmmu,x86_64-softmmu \
-                                                --enable-$UI_LIB || exit 1
-        make -j "$MAKEJOBS" || exit 1
-        make install || exit 1
-    popd
+pushd "$DIR/Build/qemu"
+    "$DIR"/Tarballs/$QEMU_VERSION/configure --prefix="$PREFIX" \
+                                            --target-list=i386-softmmu,x86_64-softmmu \
+                                            --enable-$UI_LIB || exit 1
+    make -j "$MAKEJOBS" || exit 1
+    make install || exit 1
 popd


### PR DESCRIPTION
**Meta: Prefer to use the QEMU binaries from the toolchain directory**

**Meta: Provide better instructions when QEMU is not installed or too old**

**Meta: Change the QEMU binary directory to Toolchain/Local/qemu**

Previously we'd place the QEMU binaries into the architecture-specific toolchain directory. This is a problem because the BuildIt.sh script clears those directories which also removes the QEMU binaries users may have built earlier. Also, the QEMU binaries are not specific to the target architecture.