### PR TITLE
HackStudio+CppLanguageServer: "Parameters hint" tooltip

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -62,6 +62,7 @@ private:
     virtual void drop_event(GUI::DropEvent&) override;
     virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
 
     void show_documentation_tooltip_if_available(const String&, const Gfx::IntPoint& screen_location);
     void navigate_to_include_if_available(String);
@@ -94,11 +95,14 @@ private:
     void flush_file_content_to_langauge_server();
     void set_syntax_highlighter_for(const CodeDocument&);
     void set_language_client_for(const CodeDocument&);
+    void handle_function_parameters_hint_request();
 
     explicit Editor();
 
     RefPtr<GUI::Window> m_documentation_tooltip_window;
+    RefPtr<GUI::Window> m_parameters_hint_tooltip_window;
     RefPtr<Web::OutOfProcessWebView> m_documentation_page_view;
+    RefPtr<Web::OutOfProcessWebView> m_parameter_hint_page_view;
     String m_last_parsed_token;
     GUI::TextPosition m_previous_text_position { 0, 0 };
     bool m_hovering_editor { false };
@@ -108,6 +112,8 @@ private:
     RefPtr<GUI::Action> m_move_execution_to_line_action;
 
     OwnPtr<LanguageClient> m_language_client;
+    void initialize_documentation_tooltip();
+    void initialize_parameters_hint_tooltip();
 };
 
 }

--- a/Userland/DevTools/HackStudio/LanguageClient.h
+++ b/Userland/DevTools/HackStudio/LanguageClient.h
@@ -48,6 +48,7 @@ protected:
     virtual void declaration_location(GUI::AutocompleteProvider::ProjectLocation const&) override;
     virtual void declarations_in_document(String const&, Vector<GUI::AutocompleteProvider::Declaration> const&) override;
     virtual void todo_entries_in_document(String const&, Vector<Cpp::Parser::TodoEntry> const&) override;
+    virtual void parameters_hint_result(Vector<String> const&, int index) override;
     void set_wrapper(ServerConnectionWrapper& wrapper) { m_wrapper = &wrapper; }
 
     String m_project_path;
@@ -129,12 +130,16 @@ public:
     virtual void remove_text(const String& path, size_t from_line, size_t from_column, size_t to_line, size_t to_column);
     virtual void request_autocomplete(const String& path, size_t cursor_line, size_t cursor_column);
     virtual void search_declaration(const String& path, size_t line, size_t column);
+    virtual void get_parameters_hint(const String& path, size_t line, size_t column);
 
     void provide_autocomplete_suggestions(const Vector<GUI::AutocompleteProvider::Entry>&) const;
     void declaration_found(const String& file, size_t line, size_t column) const;
+    void parameters_hint_result(Vector<String> const& params, size_t argument_index) const;
 
+    // Callbacks that get called when the result of a language server query is ready
     Function<void(Vector<GUI::AutocompleteProvider::Entry>)> on_autocomplete_suggestions;
     Function<void(const String&, size_t, size_t)> on_declaration_found;
+    Function<void(Vector<String> const&, size_t)> on_function_parameters_hint_result;
 
 private:
     ServerConnectionWrapper& m_connection_wrapper;

--- a/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.cpp
@@ -118,4 +118,29 @@ void ClientConnection::find_declaration(GUI::AutocompleteProvider::ProjectLocati
     async_declaration_location(GUI::AutocompleteProvider::ProjectLocation { decl_location.value().file, decl_location.value().line, decl_location.value().column });
 }
 
+void ClientConnection::get_parameters_hint(GUI::AutocompleteProvider::ProjectLocation const& location)
+{
+    dbgln_if(LANGUAGE_SERVER_DEBUG, "GetFunctionParams: {} {}:{}", location.file, location.line, location.column);
+    auto document = m_filedb.get(location.file);
+    if (!document) {
+        dbgln("file {} has not been opened", location.file);
+        return;
+    }
+
+    GUI::TextPosition identifier_position = { (size_t)location.line, (size_t)location.column };
+    auto params = m_autocomplete_engine->get_function_params_hint(location.file, identifier_position);
+    if (!params.has_value()) {
+        dbgln("could not get parameters hint");
+        return;
+    }
+
+    dbgln_if(LANGUAGE_SERVER_DEBUG, "parameters hint:");
+    for (auto& param : params->params) {
+        dbgln_if(LANGUAGE_SERVER_DEBUG, "{}", param);
+    }
+    dbgln_if(LANGUAGE_SERVER_DEBUG, "Parameter index: {}", params->current_index);
+
+    async_parameters_hint_result(params->params, params->current_index);
+}
+
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.h
@@ -33,6 +33,7 @@ protected:
     virtual void set_file_content(String const&, String const&) override;
     virtual void auto_complete_suggestions(GUI::AutocompleteProvider::ProjectLocation const&) override;
     virtual void find_declaration(GUI::AutocompleteProvider::ProjectLocation const&) override;
+    virtual void get_parameters_hint(GUI::AutocompleteProvider::ProjectLocation const&) override;
 
     FileDB m_filedb;
     OwnPtr<CodeComprehensionEngine> m_autocomplete_engine;

--- a/Userland/DevTools/HackStudio/LanguageServers/CodeComprehensionEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/CodeComprehensionEngine.h
@@ -26,7 +26,13 @@ public:
     virtual void on_edit([[maybe_unused]] const String& file) {};
     virtual void file_opened([[maybe_unused]] const String& file) {};
 
-    virtual Optional<GUI::AutocompleteProvider::ProjectLocation> find_declaration_of(const String&, const GUI::TextPosition&) { return {}; };
+    virtual Optional<GUI::AutocompleteProvider::ProjectLocation> find_declaration_of(const String&, const GUI::TextPosition&) { return {}; }
+
+    struct FunctionParamsHint {
+        Vector<String> params;
+        size_t current_index { 0 };
+    };
+    virtual Optional<FunctionParamsHint> get_function_params_hint(const String&, const GUI::TextPosition&) { return {}; }
 
 public:
     Function<void(const String&, Vector<GUI::AutocompleteProvider::Declaration>&&)> set_declarations_of_document_callback;

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
@@ -29,6 +29,7 @@ public:
     virtual void on_edit(const String& file) override;
     virtual void file_opened([[maybe_unused]] const String& file) override;
     virtual Optional<GUI::AutocompleteProvider::ProjectLocation> find_declaration_of(const String& filename, const GUI::TextPosition& identifier_position) override;
+    virtual Optional<FunctionParamsHint> get_function_params_hint(const String&, const GUI::TextPosition&) override;
 
 private:
     struct SymbolName {
@@ -130,6 +131,7 @@ private:
     Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_name(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
     Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_include(const DocumentData&, Token include_path_token);
     static bool is_symbol_available(const Symbol&, const Vector<StringView>& current_scope, const Vector<StringView>& reference_scope);
+    Optional<FunctionParamsHint> get_function_params_hint(DocumentData const&, FunctionCall&, size_t argument_index);
 
     template<typename Func>
     void for_each_available_symbol(const DocumentData&, Func) const;
@@ -171,7 +173,6 @@ void CppComprehensionEngine::for_each_included_document_recursive(const Document
             continue;
     }
 }
-
 }
 
 namespace AK {

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests.cpp
@@ -42,6 +42,7 @@ static void test_complete_local_vars();
 static void test_complete_type();
 static void test_find_variable_definition();
 static void test_complete_includes();
+static void test_parameters_hint();
 
 int run_tests()
 {
@@ -50,6 +51,7 @@ int run_tests()
     test_complete_type();
     test_find_variable_definition();
     test_complete_includes();
+    test_parameters_hint();
     return s_some_test_failed ? 1 : 0;
 }
 
@@ -122,6 +124,7 @@ void test_find_variable_definition()
         PASS;
     FAIL("wrong declaration location");
 }
+
 void test_complete_includes()
 {
     I_TEST(Complete Type)
@@ -144,6 +147,35 @@ void test_complete_includes()
 
     if (suggestions[0].completion != "cdefs.h")
         FAIL("global include - wrong results");
+
+    PASS;
+}
+
+void test_parameters_hint()
+{
+    I_TEST(Function Parameters hint)
+    FileDB filedb;
+    filedb.set_project_root(TESTS_ROOT_DIR);
+    add_file(filedb, "parameters_hint1.cpp");
+    CppComprehensionEngine engine(filedb);
+
+    auto result = engine.get_function_params_hint("parameters_hint1.cpp", { 4, 9 });
+    if (!result.has_value())
+        FAIL("failed to get parameters hint (1)");
+    if (result->params != Vector<String> { "int x", "char y" } || result->current_index != 0)
+        FAIL("bad result (1)");
+
+    result = engine.get_function_params_hint("parameters_hint1.cpp", { 5, 15 });
+    if (!result.has_value())
+        FAIL("failed to get parameters hint (2)");
+    if (result->params != Vector<String> { "int x", "char y" } || result->current_index != 1)
+        FAIL("bad result (2)");
+
+    result = engine.get_function_params_hint("parameters_hint1.cpp", { 6, 8 });
+    if (!result.has_value())
+        FAIL("failed to get parameters hint (3)");
+    if (result->params != Vector<String> { "int x", "char y" } || result->current_index != 0)
+        FAIL("bad result (3)");
 
     PASS;
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/parameters_hint1.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/parameters_hint1.cpp
@@ -1,0 +1,8 @@
+void foo(int x, char y);
+
+void bar()
+{
+    foo();
+    foo(123, 'b');
+    foo(
+}

--- a/Userland/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
+++ b/Userland/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
@@ -4,4 +4,5 @@ endpoint LanguageClient
     declaration_location(GUI::AutocompleteProvider::ProjectLocation location) =|
     declarations_in_document(String filename, Vector<GUI::AutocompleteProvider::Declaration> declarations) =|
     todo_entries_in_document(String filename, Vector<Cpp::Parser::TodoEntry> todo_entries) =|
+    parameters_hint_result(Vector<String> params, int current_index) =|
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
+++ b/Userland/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
@@ -9,4 +9,5 @@ endpoint LanguageServer
 
     auto_complete_suggestions(GUI::AutocompleteProvider::ProjectLocation location) =|
     find_declaration(GUI::AutocompleteProvider::ProjectLocation location) =|
+    get_parameters_hint(GUI::AutocompleteProvider::ProjectLocation location) =|
 }

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -182,14 +182,13 @@ public:
     virtual ~Parameter() override = default;
     virtual const char* class_name() const override { return "Parameter"; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
+    virtual bool is_parameter() const override { return true; }
 
     Parameter(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename, StringView name)
         : VariableOrParameterDeclaration(parent, start, end, filename)
     {
         m_name = name;
     }
-
-    virtual bool is_parameter() const override { return true; }
 
     bool m_is_ellipsis { false };
 };

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1189,7 +1189,7 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
     while (!eof() && peek().type() == Token::Type::Asterisk) {
         type->set_end(position());
         auto asterisk = consume();
-        auto ptr = create_ast_node<Pointer>(parent, asterisk.start(), asterisk.end());
+        auto ptr = create_ast_node<Pointer>(parent, type->start(), asterisk.end());
         type->set_parent(*ptr);
         ptr->m_pointee = type;
         ptr->set_end(position());

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -743,11 +743,12 @@ Optional<NonnullRefPtrVector<Parameter>> Parser::parse_parameter_list(ASTNode& p
     NonnullRefPtrVector<Parameter> parameters;
     while (peek().type() != Token::Type::RightParen && !eof()) {
         if (match_ellipsis()) {
-            auto last_dot = consume();
-            while (peek().type() == Token::Type::Dot)
-                last_dot = consume();
-            auto param = create_ast_node<Parameter>(parent, position(), last_dot.end(), StringView {});
+            auto param = create_ast_node<Parameter>(parent, position(), {}, StringView {});
+            consume(Token::Type::Dot);
+            consume(Token::Type::Dot);
+            auto last_dot = consume(Token::Type::Dot);
             param->m_is_ellipsis = true;
+            param->set_end(last_dot.end());
             parameters.append(move(param));
         } else {
             auto type = parse_type(parent);
@@ -1305,7 +1306,7 @@ bool Parser::match_ellipsis()
 {
     if (m_state.token_index > m_tokens.size() - 3)
         return false;
-    return peek().type() == Token::Type::Dot && peek().type() == Token::Type::Dot && peek().type() == Token::Type::Dot;
+    return peek().type() == Token::Type::Dot && peek(1).type() == Token::Type::Dot && peek(2).type() == Token::Type::Dot;
 }
 void Parser::add_tokens_for_preprocessor(Token& replaced_token, Preprocessor::DefinedValue& definition)
 {

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -870,15 +870,25 @@ String Parser::text_of_node(const ASTNode& node) const
 
 String Parser::text_in_range(Position start, Position end) const
 {
+    StringBuilder builder;
+    for (auto token : tokens_in_range(start, end)) {
+        builder.append(token.text());
+    }
+    return builder.to_string();
+}
+
+Vector<Token> Parser::tokens_in_range(Position start, Position end) const
+{
     auto start_token_index = index_of_token_at(start);
     auto end_node_index = index_of_token_at(end);
     VERIFY(start_token_index.has_value());
     VERIFY(end_node_index.has_value());
-    StringBuilder text;
+
+    Vector<Token> tokens;
     for (size_t i = start_token_index.value(); i <= end_node_index.value(); ++i) {
-        text.append(m_tokens[i].text());
+        tokens.append(m_tokens[i]);
     }
-    return text.build();
+    return tokens;
 }
 
 void Parser::error(StringView message)

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -49,6 +49,7 @@ public:
         Preprocessor::DefinedValue preprocessor_value;
     };
     const Vector<TokenAndPreprocessorDefinition>& replaced_preprocessor_tokens() const { return m_replaced_preprocessor_tokens; }
+    Vector<Token> tokens_in_range(Position start, Position end) const;
 
 private:
     enum class DeclarationType {

--- a/Userland/Libraries/LibCpp/Tests/strace.ast
+++ b/Userland/Libraries/LibCpp/Tests/strace.ast
@@ -67,10 +67,10 @@ TranslationUnit[0:0->144:0]
     argc
       NamedType[12:9->12:13]
         int
-    Parameter[12:24->12:29]
+    Parameter[12:19->12:29]
     argv
-      Pointer[12:24->12:26]
-        Pointer[12:23->12:24]
+      Pointer[12:19->12:26]
+        Pointer[12:19->12:24]
           NamedType[12:19->12:23]
             char
     )
@@ -103,7 +103,7 @@ TranslationUnit[0:0->144:0]
           Vector<[const] char*>
         child_argv
       VariableDeclaration[21:4->21:41]
-        Pointer[21:14->21:16]
+        Pointer[21:4->21:16]
           NamedType[21:4->21:14]
             [const] char
         output_filename
@@ -382,8 +382,8 @@ TranslationUnit[0:0->144:0]
                   CppCastExpression[66:48->66:85]
                   const_cast
                     <
-                    Pointer[66:64->66:65]
-                      Pointer[66:63->66:64]
+                    Pointer[66:59->66:65]
+                      Pointer[66:59->66:64]
                         NamedType[66:59->66:63]
                           char
                     >

--- a/Userland/Libraries/LibCpp/Tests/struct.ast
+++ b/Userland/Libraries/LibCpp/Tests/struct.ast
@@ -6,7 +6,7 @@ TranslationUnit[1:0->12:0]
         int
       x
     VariableDeclaration[4:4->5:0]
-      Pointer[4:12->4:14]
+      Pointer[4:4->4:14]
         NamedType[4:4->4:12]
           s
       next


### PR DESCRIPTION
The C++ language server can now retrieve info about the parameters of a function given a call site.

HackStudio displays this information in a tooltip window when you press Ctrl+P and the cursor is inside a parameter list.

Screenshot:
![params-hint2](https://user-images.githubusercontent.com/9247514/124350058-0c072080-dbfb-11eb-862c-badf64c0bca2.png)
