### PR TITLE
Documentation: Add git to the list of self-hosted runner requirements

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -13,6 +13,11 @@ jobs:
     concurrency: libjs-test262
 
     steps:
+      - name: Cleanup
+        run: |
+          echo "Cleaning up previous run"
+          rm -rf "${{ github.workspace }}/*"
+
       - name: Checkout SerenityOS/serenity
         uses: actions/checkout@v2
 

--- a/Documentation/SelfHostedRunners.md
+++ b/Documentation/SelfHostedRunners.md
@@ -20,7 +20,7 @@ These instructions assume the OS installed is Ubuntu 20.04 (Focal), so they migh
 ```shell
 add-apt-repository ppa:canonical-server/server-backports
 apt update
-apt install build-essential make cmake clang-format-11 gcc-10 g++-10 libstdc++-10-dev libgmp-dev ccache libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 wabt
+apt install git build-essential make cmake clang-format-11 gcc-10 g++-10 libstdc++-10-dev libgmp-dev ccache libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 wabt
 ```
 ### Force usage of GCC 10
 ```shell


### PR DESCRIPTION
Github-hosted runners have this pre-installed, so our actions scripts do not install it themselves. 

Fixes the failing test262 workflow :sweat_smile: 