### PR TITLE
Kernel: Implement buffer flipping for VirtIOGPU framebuffers

### DIFF
--- a/Kernel/API/FB.h
+++ b/Kernel/API/FB.h
@@ -28,6 +28,16 @@ ALWAYS_INLINE int fb_set_resolution(int fd, FBResolution* info)
     return ioctl(fd, FB_IOCTL_SET_RESOLUTION, info);
 }
 
+ALWAYS_INLINE int fb_get_buffer_offset(int fd, int index, unsigned* offset)
+{
+    FBBufferOffset fb_buffer_offset;
+    fb_buffer_offset.buffer_index = index;
+    int result = ioctl(fd, FB_IOCTL_GET_BUFFER_OFFSET, &fb_buffer_offset);
+    if (result == 0)
+        *offset = fb_buffer_offset.offset;
+    return result;
+}
+
 ALWAYS_INLINE int fb_get_buffer(int fd, int* index)
 {
     return ioctl(fd, FB_IOCTL_GET_BUFFER, index);

--- a/Kernel/API/FB.h
+++ b/Kernel/API/FB.h
@@ -38,12 +38,13 @@ ALWAYS_INLINE int fb_set_buffer(int fd, int index)
     return ioctl(fd, FB_IOCTL_SET_BUFFER, index);
 }
 
-ALWAYS_INLINE int fb_flush_buffers(int fd, FBRect const* rects, unsigned count)
+ALWAYS_INLINE int fb_flush_buffers(int fd, int index, FBRect const* rects, unsigned count)
 {
-    FBRects fb_rects;
-    fb_rects.count = count;
-    fb_rects.rects = rects;
-    return ioctl(fd, FB_IOCTL_FLUSH_BUFFERS, &fb_rects);
+    FBFlushRects fb_flush_rects;
+    fb_flush_rects.buffer_index = index;
+    fb_flush_rects.count = count;
+    fb_flush_rects.rects = rects;
+    return ioctl(fd, FB_IOCTL_FLUSH_BUFFERS, &fb_flush_rects);
 }
 
 __END_DECLS

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -215,6 +215,17 @@ int FramebufferDevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
             return -EFAULT;
         return 0;
     }
+    case FB_IOCTL_GET_BUFFER_OFFSET: {
+        FBBufferOffset buffer_offset;
+        if (!copy_from_user(&buffer_offset, (FBBufferOffset*)arg))
+            return -EFAULT;
+        if (buffer_offset.buffer_index != 0 && buffer_offset.buffer_index != 1)
+            return -EINVAL;
+        buffer_offset.offset = (size_t)buffer_offset.buffer_index * m_framebuffer_pitch * m_framebuffer_height;
+        if (!copy_to_user((FBBufferOffset*)arg, &buffer_offset))
+            return -EFAULT;
+        return 0;
+    }
     case FB_IOCTL_FLUSH_BUFFERS:
         return -ENOTSUP;
     default:

--- a/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.h
@@ -14,6 +14,13 @@
 namespace Kernel::Graphics {
 
 class VirtIOFrameBufferDevice final : public BlockDevice {
+    friend class VirtIOGPUConsole;
+    struct Buffer {
+        size_t framebuffer_offset { 0 };
+        u8* framebuffer_data { nullptr };
+        VirtIOGPUResourceID resource_id { 0 };
+    };
+
 public:
     VirtIOFrameBufferDevice(VirtIOGPU& virtio_gpu, VirtIOGPUScanoutID);
     virtual ~VirtIOFrameBufferDevice() override;
@@ -22,23 +29,23 @@ public:
     virtual void activate_writes();
 
     bool try_to_set_resolution(size_t width, size_t height);
-    void clear_to_black();
+    void clear_to_black(Buffer&);
 
     size_t width() const { return display_info().rect.width; }
     size_t height() const { return display_info().rect.height; }
     size_t pitch() const { return display_info().rect.width * 4; }
 
-    size_t size_in_bytes() const;
     static size_t calculate_framebuffer_size(size_t width, size_t height)
     {
-        return sizeof(u32) * width * height;
+        // VirtIO resources can only map on page boundaries!
+        return page_round_up(sizeof(u32) * width * height);
     }
 
-    void flush_dirty_window(VirtIOGPURect const&);
-    void transfer_framebuffer_data_to_host(VirtIOGPURect const&);
-    void flush_displayed_image(VirtIOGPURect const&);
+    void flush_dirty_window(VirtIOGPURect const&, Buffer&);
+    void transfer_framebuffer_data_to_host(VirtIOGPURect const&, Buffer&);
+    void flush_displayed_image(VirtIOGPURect const&, Buffer&);
 
-    void draw_ntsc_test_pattern();
+    void draw_ntsc_test_pattern(Buffer&);
 
     u8* framebuffer_data();
 
@@ -49,6 +56,8 @@ private:
     VirtIOGPURespDisplayInfo::VirtIOGPUDisplayOne& display_info();
 
     void create_framebuffer();
+    void create_buffer(Buffer&, size_t, size_t);
+    void set_buffer(int);
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
@@ -61,11 +70,26 @@ private:
     virtual mode_t required_mode() const override { return 0666; }
     virtual String device_name() const override { return String::formatted("fb{}", minor()); }
 
+    static bool is_valid_buffer_index(int buffer_index)
+    {
+        return buffer_index == 0 || buffer_index == 1;
+    }
+
+    Buffer& buffer_from_index(int buffer_index)
+    {
+        return buffer_index == 0 ? m_main_buffer : m_back_buffer;
+    }
+    Buffer& current_buffer() const { return *m_current_buffer; }
+
     VirtIOGPU& m_gpu;
     const VirtIOGPUScanoutID m_scanout;
-    VirtIOGPUResourceID m_resource_id { 0 };
+    Buffer* m_current_buffer { nullptr };
+    Atomic<int, AK::memory_order_relaxed> m_last_set_buffer_index { 0 };
+    Buffer m_main_buffer;
+    Buffer m_back_buffer;
     OwnPtr<Region> m_framebuffer;
     RefPtr<VMObject> m_framebuffer_sink_vmobject;
+    size_t m_buffer_size { 0 };
     bool m_are_writes_active { true };
     // FIXME: This needs to be cleaned up if the WindowServer exits while we are in a tty
     WeakPtr<Region> m_userspace_mmap_region;

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGPU.h
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGPU.h
@@ -220,7 +220,7 @@ private:
     void query_display_information();
     VirtIOGPUResourceID create_2d_resource(VirtIOGPURect rect);
     void delete_resource(VirtIOGPUResourceID resource_id);
-    void ensure_backing_storage(Region& region, size_t buffer_length, VirtIOGPUResourceID resource_id);
+    void ensure_backing_storage(Region& region, size_t buffer_offset, size_t buffer_length, VirtIOGPUResourceID resource_id);
     void detach_backing_storage(VirtIOGPUResourceID resource_id);
     void set_scanout_resource(VirtIOGPUScanoutID scanout, VirtIOGPUResourceID resource_id, VirtIOGPURect rect);
     void transfer_framebuffer_data_to_host(VirtIOGPUScanoutID scanout, VirtIOGPURect const& rect, VirtIOGPUResourceID resource_id);

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGPUConsole.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGPUConsole.cpp
@@ -66,7 +66,7 @@ void VirtIOGPUConsole::enqueue_refresh_timer()
                 .height = (u32)rect.height(),
             };
             g_io_work->queue([this, dirty_rect]() {
-                m_framebuffer_device->flush_dirty_window(dirty_rect);
+                m_framebuffer_device->flush_dirty_window(dirty_rect, m_framebuffer_device->current_buffer());
                 m_dirty_rect.clear();
             });
         }

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGraphicsAdapter.cpp
@@ -40,7 +40,6 @@ void VirtIOGraphicsAdapter::enable_consoles()
     dbgln_if(VIRTIO_DEBUG, "VirtIOGPU: Enabling consoles");
     m_gpu_device->for_each_framebuffer([&](auto& framebuffer, auto& console) {
         framebuffer.deactivate_writes();
-        framebuffer.clear_to_black();
         console.enable();
         return IterationDecision::Continue;
     });

--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -30,6 +30,11 @@ struct FBRect {
     unsigned height;
 };
 
+struct FBBufferOffset {
+    int buffer_index;
+    unsigned offset;
+};
+
 struct FBFlushRects {
     int buffer_index;
     unsigned count;
@@ -55,6 +60,7 @@ enum IOCtlNumber {
     FB_IOCTL_GET_RESOLUTION,
     FB_IOCTL_SET_RESOLUTION,
     FB_IOCTL_GET_BUFFER,
+    FB_IOCTL_GET_BUFFER_OFFSET,
     FB_IOCTL_SET_BUFFER,
     FB_IOCTL_FLUSH_BUFFERS,
     SIOCSIFADDR,
@@ -88,6 +94,7 @@ enum IOCtlNumber {
 #define FB_IOCTL_GET_RESOLUTION FB_IOCTL_GET_RESOLUTION
 #define FB_IOCTL_SET_RESOLUTION FB_IOCTL_SET_RESOLUTION
 #define FB_IOCTL_GET_BUFFER FB_IOCTL_GET_BUFFER
+#define FB_IOCTL_GET_BUFFER_OFFSET FB_IOCTL_GET_BUFFER_OFFSET
 #define FB_IOCTL_SET_BUFFER FB_IOCTL_SET_BUFFER
 #define FB_IOCTL_FLUSH_BUFFERS FB_IOCTL_FLUSH_BUFFERS
 #define SIOCSIFADDR SIOCSIFADDR

--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -30,7 +30,8 @@ struct FBRect {
     unsigned height;
 };
 
-struct FBRects {
+struct FBFlushRects {
+    int buffer_index;
     unsigned count;
     struct FBRect const* rects;
 };

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -87,12 +87,12 @@ void Compositor::ScreenData::init_bitmaps(Compositor& compositor, Screen& screen
 
     auto size = screen.size();
 
-    m_front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor(), screen.pitch(), screen.scanline(0));
+    m_front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor(), screen.pitch(), screen.scanline(0, 0));
     m_front_painter = make<Gfx::Painter>(*m_front_bitmap);
     m_front_painter->translate(-screen.rect().location());
 
     if (m_screen_can_set_buffer)
-        m_back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor(), screen.pitch(), screen.scanline(screen.physical_height()));
+        m_back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor(), screen.pitch(), screen.scanline(1, 0));
     else
         m_back_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, size, screen.scale_factor());
     m_back_painter = make<Gfx::Painter>(*m_back_bitmap);

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -171,7 +171,9 @@ private:
         OwnPtr<WindowStackSwitchOverlay> m_window_stack_switch_overlay;
         bool m_buffers_are_flipped { false };
         bool m_screen_can_set_buffer { false };
+        bool m_has_flipped { false };
         bool m_cursor_back_is_valid { false };
+        bool m_have_flush_rects { false };
 
         Gfx::DisjointRectSet m_flush_rects;
         Gfx::DisjointRectSet m_flush_transparent_rects;

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -364,7 +364,7 @@ void Screen::queue_flush_display_rect(Gfx::IntRect const& flush_region)
     }
 }
 
-void Screen::flush_display()
+void Screen::flush_display(int buffer_index)
 {
     VERIFY(m_can_device_flush_buffers);
     auto& fb_data = *m_framebuffer_data;
@@ -380,7 +380,7 @@ void Screen::flush_display()
         flush_rect.height *= scale_factor;
     }
 
-    if (fb_flush_buffers(m_framebuffer_fd, fb_data.pending_flush_rects.data(), (unsigned)fb_data.pending_flush_rects.size()) < 0) {
+    if (fb_flush_buffers(m_framebuffer_fd, buffer_index, fb_data.pending_flush_rects.data(), (unsigned)fb_data.pending_flush_rects.size()) < 0) {
         int err = errno;
         if (err == ENOTSUP)
             m_can_device_flush_buffers = false;

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -147,6 +147,7 @@ public:
 
     bool can_set_buffer() { return m_can_set_buffer; }
     void set_buffer(int index);
+    size_t buffer_offset(int index) const;
 
     int physical_width() const { return width() * scale_factor(); }
     int physical_height() const { return height() * scale_factor(); }
@@ -156,7 +157,7 @@ public:
     int height() const { return m_virtual_rect.height(); }
     int scale_factor() const { return m_info.scale_factor; }
 
-    Gfx::RGBA32* scanline(int y);
+    Gfx::RGBA32* scanline(int buffer_index, int y);
 
     Gfx::IntSize physical_size() const { return { physical_width(), physical_height() }; }
 
@@ -190,7 +191,8 @@ private:
     static Vector<int, default_scale_factors_in_use_count> s_scale_factors_in_use;
     size_t m_index { 0 };
 
-    size_t m_size_in_bytes;
+    size_t m_size_in_bytes { 0 };
+    size_t m_back_buffer_offset { 0 };
 
     Gfx::RGBA32* m_framebuffer { nullptr };
     bool m_can_set_buffer { false };
@@ -204,9 +206,9 @@ private:
     ScreenLayout::Screen& m_info;
 };
 
-inline Gfx::RGBA32* Screen::scanline(int y)
+inline Gfx::RGBA32* Screen::scanline(int buffer_index, int y)
 {
-    return reinterpret_cast<Gfx::RGBA32*>(((u8*)m_framebuffer) + (y * m_pitch));
+    return reinterpret_cast<Gfx::RGBA32*>(((u8*)m_framebuffer) + buffer_offset(buffer_index) + (y * m_pitch));
 }
 
 }

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -165,7 +165,7 @@ public:
 
     bool can_device_flush_buffers() const { return m_can_device_flush_buffers; }
     void queue_flush_display_rect(Gfx::IntRect const& rect);
-    void flush_display();
+    void flush_display(int buffer_index);
 
 private:
     Screen(ScreenLayout::Screen&);


### PR DESCRIPTION
This solves tearing issues and improves performance when updating the
VirtIOGPU framebuffers.

@ccapitalK 