### PR TITLE
Assistant: Skip URL provider if query is empty or provider specific

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -200,6 +200,9 @@ void TerminalProvider::query(String const& query, Function<void(NonnullRefPtrVec
 
 void URLProvider::query(String const& query, Function<void(NonnullRefPtrVector<Result>)> on_complete)
 {
+    if (query.is_empty() || query.starts_with('=') || query.starts_with('$'))
+        return;
+
     URL url = URL(query);
 
     if (url.scheme().is_empty())


### PR DESCRIPTION
Before the URL provider was also triggered for the calculator and terminal queries, which looked kinda weird: 
![2021-07-03_21:34:59](https://user-images.githubusercontent.com/6866019/124365181-a2acff00-dc46-11eb-94cb-3a4059bc21bb.png)
