### PR TITLE
HackStudio: Remove old form editing logic

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -268,11 +268,7 @@ bool HackStudioWidget::open_file(const String& full_filename)
     current_editor().vertical_scrollbar().set_value(new_project_file->vertical_scroll_value());
     current_editor().set_editing_engine(make<GUI::RegularEditingEngine>());
 
-    if (filename.ends_with(".frm")) {
-        set_edit_mode(EditMode::Form);
-    } else {
-        set_edit_mode(EditMode::Text);
-    }
+    set_edit_mode(EditMode::Text);
 
     String relative_file_path = filename;
     if (filename.starts_with(m_project->root_path()))
@@ -302,8 +298,6 @@ void HackStudioWidget::set_edit_mode(EditMode mode)
 {
     if (mode == EditMode::Text) {
         m_right_hand_stack->set_active_widget(m_editors_splitter);
-    } else if (mode == EditMode::Form) {
-        m_right_hand_stack->set_active_widget(m_form_inner_container);
     } else if (mode == EditMode::Diff) {
         m_right_hand_stack->set_active_widget(m_diff_viewer);
     } else {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -65,7 +65,6 @@ private:
 
     enum class EditMode {
         Text,
-        Form,
         Diff,
     };
 
@@ -133,8 +132,6 @@ private:
     RefPtr<GUI::VerticalSplitter> m_right_hand_splitter;
     RefPtr<GUI::StackWidget> m_right_hand_stack;
     RefPtr<GUI::Splitter> m_editors_splitter;
-    RefPtr<GUI::Widget> m_form_inner_container;
-    RefPtr<GUI::TreeView> m_form_widget_tree_view;
     RefPtr<DiffViewer> m_diff_viewer;
     RefPtr<GitWidget> m_git_widget;
     RefPtr<ClassViewWidget> m_class_view;


### PR DESCRIPTION
In the past Hack Studio had the ability to design GUI widgets via `.frm`
files. We now use the GML playground for this purpose, and the old code
can be removed. `.frm` files are now treated as plain text files.

This commit also fixes a crash when opening `.frm` files.
`m_form_inner_container` was never instantiated, and caused a null
pointer dereference.