### PR TITLE
Kernel+LibELF: x86_64 support (part 11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,11 +93,6 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if("${SERENITY_ARCH}" STREQUAL "x86_64")
-    # FIXME: Implement TLS support and get rid of this
-    add_compile_definitions(NO_TLS X86_64_NO_TLS)
-endif()
-
 add_compile_options(-Wno-literal-suffix)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-fconcepts)

--- a/Kernel/Arch/x86/MSR.h
+++ b/Kernel/Arch/x86/MSR.h
@@ -30,15 +30,19 @@ public:
     {
     }
 
-    void get(u32& low, u32& high)
+    [[nodiscard]] u64 get()
     {
+        u32 low, high;
         asm volatile("rdmsr"
                      : "=a"(low), "=d"(high)
                      : "c"(m_msr));
+        return ((u64)high << 32) | low;
     }
 
-    void set(u32 low, u32 high)
+    void set(u64 value)
     {
+        u32 low = value & 0xffffffff;
+        u32 high = value >> 32;
         asm volatile("wrmsr" ::"a"(low), "d"(high), "c"(m_msr));
     }
 };

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -1128,7 +1128,7 @@ UNMAP_AFTER_INIT void Processor::gdt_init()
 
 #if ARCH(X86_64)
     MSR gs_base(MSR_GS_BASE);
-    gs_base.set((size_t)this & 0xffffffff, (size_t)this >> 32);
+    gs_base.set((u64)this);
 #else
     asm volatile(
         "mov %%ax, %%ds\n"

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -1214,6 +1214,9 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
     auto& tls_descriptor = processor.get_gdt_entry(GDT_SELECTOR_TLS);
     tls_descriptor.set_base(to_thread->thread_specific_data());
     tls_descriptor.set_limit(to_thread->thread_specific_region_size());
+#else
+    MSR fs_base_msr(MSR_FS_BASE);
+    fs_base_msr.set(to_thread->thread_specific_data().get());
 #endif
 
     if (from_regs.cr3 != to_regs.cr3)

--- a/Kernel/Arch/x86/i386/Boot/boot.S
+++ b/Kernel/Arch/x86/i386/Boot/boot.S
@@ -1,3 +1,5 @@
+.set KERNEL_VIRTUAL_BASE, 0xc0000000
+
 .section .stack, "aw", @nobits
 stack_bottom:
 .skip 32768
@@ -93,55 +95,55 @@ start:
     addl $16, %esi
     movl (%esi), %esi
     movl $1024, %ecx
-    movl $(kernel_cmdline - 0xc0000000), %edi
+    movl $(kernel_cmdline - KERNEL_VIRTUAL_BASE), %edi
     rep movsl
 
     /* clear pdpt */
-    movl $(boot_pdpt - 0xc0000000), %edi
+    movl $(boot_pdpt - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* set up pdpt[0] and pdpt[3] */
-    movl $(boot_pdpt - 0xc0000000), %edi
-    movl $((boot_pd0 - 0xc0000000) + 1), 0(%edi)
-    movl $((boot_pd3 - 0xc0000000) + 1), 24(%edi)
+    movl $(boot_pdpt - KERNEL_VIRTUAL_BASE), %edi
+    movl $((boot_pd0 - KERNEL_VIRTUAL_BASE) + 1), 0(%edi)
+    movl $((boot_pd3 - KERNEL_VIRTUAL_BASE) + 1), 24(%edi)
 
     /* clear pd0 */
-    movl $(boot_pd0 - 0xc0000000), %edi
+    movl $(boot_pd0 - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* clear pd3 */
-    movl $(boot_pd3 - 0xc0000000), %edi
+    movl $(boot_pd3 - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* clear pd0's pt's */
-    movl $(boot_pd0_pt0 - 0xc0000000), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %edi
     movl $(1024 * 4), %ecx
     xorl %eax, %eax
     rep stosl
 
     /* clear pd3's pt's */
-    movl $(boot_pd3_pts - 0xc0000000), %edi
+    movl $(boot_pd3_pts - KERNEL_VIRTUAL_BASE), %edi
     movl $(1024 * 17), %ecx
     xorl %eax, %eax
     rep stosl
 
     /* add boot_pd0_pt0 to boot_pd0 */
-    movl $(boot_pd0 - 0xc0000000), %edi
-    movl $(boot_pd0_pt0 - 0xc0000000), %eax
+    movl $(boot_pd0 - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %eax
     movl %eax, 0(%edi)
     /* R/W + Present */
     orl $0x3, 0(%edi)
 
     /* add boot_pd3_pts to boot_pd3 */
     movl $16, %ecx
-    movl $(boot_pd3 - 0xc0000000), %edi
-    movl $(boot_pd3_pts - 0xc0000000), %eax
+    movl $(boot_pd3 - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pd3_pts - KERNEL_VIRTUAL_BASE), %eax
 
 1:
     movl %eax, 0(%edi)
@@ -153,7 +155,7 @@ start:
 
     /* identity map the 0 to 2MB range */
     movl $512, %ecx
-    movl $(boot_pd0_pt0 - 0xc0000000), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %edi
     xorl %eax, %eax
 
 1:
@@ -166,7 +168,7 @@ start:
 
     /* pseudo identity map the 3072-3102MB range */
     movl $(512 * 16), %ecx
-    movl $(boot_pd3_pts - 0xc0000000), %edi
+    movl $(boot_pd3_pts - KERNEL_VIRTUAL_BASE), %edi
     xorl %eax, %eax
 
 1:
@@ -178,13 +180,13 @@ start:
     loop 1b
 
     /* create an empty page table for the top 2MB at the 4GB mark */
-    movl $(boot_pd3 - 0xc0000000), %edi
-    movl $(boot_pd3_pt1023 - 0xc0000000), 4088(%edi)
+    movl $(boot_pd3 - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pd3_pt1023 - KERNEL_VIRTUAL_BASE), 4088(%edi)
     orl $0x3, 4088(%edi)
     movl $0, 4092(%edi)
 
     /* point CR3 to PDPT */
-    movl $(boot_pdpt - 0xc0000000), %eax
+    movl $(boot_pdpt - KERNEL_VIRTUAL_BASE), %eax
     movl %eax, %cr3
 
     /* enable PAE + PSE */
@@ -210,7 +212,7 @@ start:
 
     /* unmap the 0-1MB range, which isn't used after jmp-ing up here */
     movl $256, %ecx
-    movl $(boot_pd0_pt0 - 0xc0000000), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %edi
     xorl %eax, %eax
 
 1:
@@ -219,7 +221,7 @@ start:
     loop 1b
 
     /* jump into C++ land */
-    addl $0xc0000000, %ebx
+    addl $KERNEL_VIRTUAL_BASE, %ebx
     movl %ebx, multiboot_info_ptr
 
     call init
@@ -339,7 +341,7 @@ apic_ap_start32_2:
 
     /* push the Processor pointer this CPU is going to use */
     movl (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %eax
-    addl $0xc0000000, %eax
+    addl $KERNEL_VIRTUAL_BASE, %eax
     movl 0(%eax, %esi, 4), %eax
     push %eax
 

--- a/Kernel/Arch/x86/x86_64/Boot/boot.S
+++ b/Kernel/Arch/x86/x86_64/Boot/boot.S
@@ -1,4 +1,6 @@
 .code32
+.set KERNEL_VIRTUAL_BASE, 0xc0000000
+
 .section .stack, "aw", @nobits
 stack_bottom:
 .skip 32768
@@ -128,67 +130,67 @@ continue:
     addl $16, %esi
     movl (%esi), %esi
     movl $1024, %ecx
-    movl $(kernel_cmdline - 0xc0000000), %edi
+    movl $(kernel_cmdline - KERNEL_VIRTUAL_BASE), %edi
     rep movsl
 
     /* clear pml4t */
-    movl $(boot_pml4t - 0xc0000000), %edi
+    movl $(boot_pml4t - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* set up pml4t[0] */
-    movl $(boot_pml4t - 0xc0000000), %edi
-    movl $(boot_pdpt - 0xc0000000), 0(%edi)
+    movl $(boot_pml4t - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pdpt - KERNEL_VIRTUAL_BASE), 0(%edi)
     /* R/W + Present */
     orl $0x3, 0(%edi)
 
     /* clear pdpt */
-    movl $(boot_pdpt - 0xc0000000), %edi
+    movl $(boot_pdpt - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* set up pdpt[0] and pdpt[3] */
-    movl $(boot_pdpt - 0xc0000000), %edi
-    movl $((boot_pd0 - 0xc0000000) + 3), 0(%edi)
-    movl $((boot_pd3 - 0xc0000000) + 3), 24(%edi)
+    movl $(boot_pdpt - KERNEL_VIRTUAL_BASE), %edi
+    movl $((boot_pd0 - KERNEL_VIRTUAL_BASE) + 3), 0(%edi)
+    movl $((boot_pd3 - KERNEL_VIRTUAL_BASE) + 3), 24(%edi)
 
     /* clear pd0 */
-    movl $(boot_pd0 - 0xc0000000), %edi
+    movl $(boot_pd0 - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* clear pd3 */
-    movl $(boot_pd3 - 0xc0000000), %edi
+    movl $(boot_pd3 - KERNEL_VIRTUAL_BASE), %edi
     movl $1024, %ecx
     xorl %eax, %eax
     rep stosl
 
     /* clear pd0's pt's */
-    movl $(boot_pd0_pt0 - 0xc0000000), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %edi
     movl $(1024 * 4), %ecx
     xorl %eax, %eax
     rep stosl
 
     /* clear pd3's pt's */
-    movl $(boot_pd3_pts - 0xc0000000), %edi
+    movl $(boot_pd3_pts - KERNEL_VIRTUAL_BASE), %edi
     movl $(1024 * 17), %ecx
     xorl %eax, %eax
     rep stosl
 
     /* add boot_pd0_pt0 to boot_pd0 */
-    movl $(boot_pd0 - 0xc0000000), %edi
-    movl $(boot_pd0_pt0 - 0xc0000000), %eax
+    movl $(boot_pd0 - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %eax
     movl %eax, 0(%edi)
     /* R/W + Present */
     orl $0x3, 0(%edi)
 
     /* add boot_pd3_pts to boot_pd3 */
     movl $16, %ecx
-    movl $(boot_pd3 - 0xc0000000), %edi
-    movl $(boot_pd3_pts - 0xc0000000), %eax
+    movl $(boot_pd3 - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pd3_pts - KERNEL_VIRTUAL_BASE), %eax
 
 1:
     movl %eax, 0(%edi)
@@ -200,7 +202,7 @@ continue:
 
     /* identity map the 0 to 2MB range */
     movl $512, %ecx
-    movl $(boot_pd0_pt0 - 0xc0000000), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %edi
     xorl %eax, %eax
 
 1:
@@ -213,7 +215,7 @@ continue:
 
     /* pseudo identity map the 3072-3102MB range */
     movl $(512 * 16), %ecx
-    movl $(boot_pd3_pts - 0xc0000000), %edi
+    movl $(boot_pd3_pts - KERNEL_VIRTUAL_BASE), %edi
     xorl %eax, %eax
 
 1:
@@ -225,13 +227,13 @@ continue:
     loop 1b
 
     /* create an empty page table for the top 2MB at the 4GB mark */
-    movl $(boot_pd3 - 0xc0000000), %edi
-    movl $(boot_pd3_pt1023 - 0xc0000000), 4088(%edi)
+    movl $(boot_pd3 - KERNEL_VIRTUAL_BASE), %edi
+    movl $(boot_pd3_pt1023 - KERNEL_VIRTUAL_BASE), 4088(%edi)
     orl $0x3, 4088(%edi)
     movl $0, 4092(%edi)
 
     /* point CR3 to PML4T */
-    movl $(boot_pml4t - 0xc0000000), %eax
+    movl $(boot_pml4t - KERNEL_VIRTUAL_BASE), %eax
     movl %eax, %cr3
 
     /* enable PAE + PSE */
@@ -265,7 +267,7 @@ continue:
 
     /* unmap the 0-1MB range, which isn't used after jmp-ing up here */
     movl $256, %ecx
-    movl $(boot_pd0_pt0 - 0xc0000000), %edi
+    movl $(boot_pd0_pt0 - KERNEL_VIRTUAL_BASE), %edi
     xorl %eax, %eax
 
 1:
@@ -274,7 +276,7 @@ continue:
     loop 1b
 
     /* jump into C++ land */
-    addl $0xc0000000, %ebx
+    addl $KERNEL_VIRTUAL_BASE, %ebx
     movl %ebx, multiboot_info_ptr
 
     lgdt gdt64ptr
@@ -421,7 +423,7 @@ apic_ap_start64:
 
     /* push the Processor pointer this CPU is going to use */
     movq (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %rax
-    movq $0xc0000000, %r8
+    movq $KERNEL_VIRTUAL_BASE, %r8
     addq %r8, %rax
     movq 0(%rax, %rsi, 4), %rax
     push %rax

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -136,18 +136,15 @@ UNMAP_AFTER_INIT void APIC::initialize()
 
 PhysicalAddress APIC::get_base()
 {
-    u32 lo, hi;
     MSR msr(APIC_BASE_MSR);
-    msr.get(lo, hi);
-    return PhysicalAddress(lo & 0xfffff000);
+    auto base = msr.get();
+    return PhysicalAddress(base & 0xfffff000);
 }
 
 void APIC::set_base(const PhysicalAddress& base)
 {
-    u32 hi = 0;
-    u32 lo = base.get() | 0x800;
     MSR msr(APIC_BASE_MSR);
-    msr.set(lo, hi);
+    msr.set(base.get() | 0x800);
 }
 
 void APIC::write_register(u32 offset, u32 value)

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <Kernel/Arch/x86/InterruptDisabler.h>
+#include <Kernel/Arch/x86/MSR.h>
 #include <Kernel/Arch/x86/SmapDisabler.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/PerformanceEventBuffer.h>
@@ -618,7 +619,8 @@ KResultOr<FlatPtr> Process::sys$allocate_tls(Userspace<const char*> initial_data
     tls_descriptor.set_base(main_thread->thread_specific_data());
     tls_descriptor.set_limit(main_thread->thread_specific_region_size());
 #else
-    dbgln("FIXME: Not setting FS_BASE for process.");
+    MSR fs_base_msr(MSR_FS_BASE);
+    fs_base_msr.set(main_thread->thread_specific_data().get());
 #endif
 
     return m_master_tls_region.unsafe_ptr()->vaddr().get();

--- a/Userland/Libraries/LibC/pthread_tls.cpp
+++ b/Userland/Libraries/LibC/pthread_tls.cpp
@@ -26,10 +26,7 @@ struct SpecificTable {
 
 static KeyTable s_keys;
 
-#    ifndef X86_64_NO_TLS
-__thread
-#    endif
-    SpecificTable t_specifics;
+__thread SpecificTable t_specifics;
 
 int __pthread_key_create(pthread_key_t* key, KeyDestructor destructor)
 {

--- a/Userland/Libraries/LibDl/dlfcn.cpp
+++ b/Userland/Libraries/LibDl/dlfcn.cpp
@@ -11,16 +11,8 @@
 #include <string.h>
 
 // FIXME: use thread_local and a String once TLS works
-#ifndef X86_64_NO_TLS
-__thread
-#endif
-    char* s_dlerror_text
-    = NULL;
-#ifndef X86_64_NO_TLS
-__thread
-#endif
-    bool s_dlerror_retrieved
-    = false;
+__thread char* s_dlerror_text = NULL;
+__thread bool s_dlerror_retrieved = false;
 
 static void store_error(const String& error)
 {

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -91,8 +91,8 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> map_library(const St
 
     s_loaders.set(get_library_name(filename), *loader);
 
+    s_current_tls_offset -= loader->tls_size_of_current_object();
     loader->set_tls_offset(s_current_tls_offset);
-    s_current_tls_offset += loader->tls_size_of_current_object();
 
     return loader;
 }

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -478,6 +478,9 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
 #ifndef __LP64__
     case R_386_TLS_TPOFF32:
     case R_386_TLS_TPOFF: {
+#else
+    case R_X86_64_TPOFF64: {
+#endif
         auto symbol = relocation.symbol();
         // For some reason, LibC has a R_386_TLS_TPOFF that refers to the undefined symbol.. huh
         if (relocation.symbol_index() == 0)
@@ -490,12 +493,6 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         *patch_ptr = negative_offset_from_tls_block_end(res.value().value, dynamic_object_of_symbol->tls_offset().value(), res.value().size);
         break;
     }
-#else
-    case R_X86_64_TPOFF64:
-        dbgln("FIXME: Patched R_X86_64_TPOFF64 relocation with invalid ptr.");
-        *patch_ptr = 0xaaaaaaaaaaaaaaaa;
-        break;
-#endif
 #ifndef __LP64__
     case R_386_JMP_SLOT: {
 #else

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -131,7 +131,7 @@ private:
     };
     RelocationResult do_relocation(const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
     size_t calculate_tls_size() const;
-    ssize_t negative_offset_from_tls_block_end(size_t value_of_symbol, ssize_t tls_offset) const;
+    ssize_t negative_offset_from_tls_block_end(ssize_t tls_offset, size_t value_of_symbol) const;
 
     String m_filename;
     String m_program_interpreter;

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -131,7 +131,7 @@ private:
     };
     RelocationResult do_relocation(const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
     size_t calculate_tls_size() const;
-    ssize_t negative_offset_from_tls_block_end(size_t value_of_symbol, size_t tls_offset, size_t symbol_size) const;
+    ssize_t negative_offset_from_tls_block_end(size_t value_of_symbol, ssize_t tls_offset) const;
 
     String m_filename;
     String m_program_interpreter;
@@ -151,7 +151,7 @@ private:
 
     VirtualAddress m_dynamic_section_address;
 
-    size_t m_tls_offset { 0 };
+    ssize_t m_tls_offset { 0 };
     size_t m_tls_size_of_current_object { 0 };
 
     Vector<DynamicObject::Relocation> m_unresolved_relocations;

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -195,6 +195,7 @@ public:
                 return m_dynamic.base_address().offset(offset());
             return VirtualAddress { offset() };
         }
+        [[nodiscard]] DynamicObject const& dynamic_object() const { return m_dynamic; }
 
     private:
         const DynamicObject& m_dynamic;

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -33,14 +33,8 @@ static constexpr size_t required_stack_alignment = 4 * MiB;
 static constexpr size_t highest_reasonable_guard_size = 32 * PAGE_SIZE;
 static constexpr size_t highest_reasonable_stack_size = 8 * MiB; // That's the default in Ubuntu?
 
-#ifndef X86_64_NO_TLS
-__thread
-#endif
-    void* s_stack_location;
-#ifndef X86_64_NO_TLS
-__thread
-#endif
-    size_t s_stack_size;
+__thread void* s_stack_location;
+__thread size_t s_stack_size;
 
 #define __RETURN_PTHREAD_ERROR(rc) \
     return ((rc) < 0 ? -(rc) : 0)


### PR DESCRIPTION
**Kernel: Replace some hard-coded memory addresses with macros**

**Kernel: Don't allow allocate_tls() if the process has multiple threads**

We can't safely update the other threads' FS selector. This shouldn't be a problem in practice because allocate_tls() is only used by the loader.

**Kernel: Hide the implementation detail that MSRs use two registers**

When retrieving and setting x86 MSRs two registers are required. The existing setter and getter for the MSR class made this implementation detail visible to the caller. This changes the setter and getter to use u64 instead.

**Kernel: Implement TLS support for x86_64**

**LibELF: Implement TLS relocation support for x86_64**

**LibELF: Save the negative TLS offset in m_tls_offset**

This makes it unnecessary to track the symbol size which just isn't available for unexported symbols (e.g. for 'static __thread').

**LibELF: Fix relocation support for 'static __thread' variables**

**LibELF: Swap the arguments for negative_offset_from_tls_block_end**

Now that m_tls_offset points to the start of the TLS block the argument order makes more sense this way.

**Toolchain+Userland: Enable TLS for x86_64**

This is not technically a toolchain change, but it does require rebuilding the toolchain for x86_64 (and just that).