### PR TITLE
LibJS: ArrayConstructor Specification Compliance Fixes

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1992,7 +1992,7 @@ Value ArrayExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
 {
     InterpreterNodeScope node_scope { interpreter, *this };
 
-    auto* array = Array::create(global_object);
+    auto* array = Array::create(global_object, 0);
     for (auto& element : m_elements) {
         auto value = Value();
         if (element) {
@@ -2066,7 +2066,7 @@ Value TaggedTemplateLiteral::execute(Interpreter& interpreter, GlobalObject& glo
     }
     auto& tag_function = tag.as_function();
     auto& expressions = m_template_literal->expressions();
-    auto* strings = Array::create(global_object);
+    auto* strings = Array::create(global_object, 0);
     MarkedValueList arguments(vm.heap());
     arguments.append(strings);
     for (size_t i = 0; i < expressions.size(); ++i) {
@@ -2082,7 +2082,7 @@ Value TaggedTemplateLiteral::execute(Interpreter& interpreter, GlobalObject& glo
         }
     }
 
-    auto* raw_strings = Array::create(global_object);
+    auto* raw_strings = Array::create(global_object, 0);
     for (auto& raw_string : m_template_literal->raw_strings()) {
         auto value = raw_string.execute(interpreter, global_object);
         if (vm.exception())

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -134,7 +134,7 @@ void IteratorToArray::execute_impl(Bytecode::Interpreter& interpreter) const
     if (vm.exception())
         return;
 
-    auto array = Array::create(global_object);
+    auto array = Array::create(global_object, 0);
     size_t index = 0;
 
     while (true) {

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -13,23 +13,24 @@
 namespace JS {
 
 // 10.4.2.2 ArrayCreate ( length [ , proto ] ), https://tc39.es/ecma262/#sec-arraycreate
-Array* Array::create(GlobalObject& global_object, size_t length)
+Array* Array::create(GlobalObject& global_object, size_t length, Object* prototype)
 {
-    // FIXME: Support proto parameter
+    auto& vm = global_object.vm();
     if (length > NumericLimits<u32>::max()) {
-        auto& vm = global_object.vm();
         vm.throw_exception<RangeError>(global_object, ErrorType::InvalidLength, "array");
         return nullptr;
     }
-    auto* array = global_object.heap().allocate<Array>(global_object, *global_object.array_prototype());
-    array->indexed_properties().set_array_like_size(length);
+    if (!prototype)
+        prototype = global_object.array_prototype();
+    auto* array = global_object.heap().allocate<Array>(global_object, *prototype);
+    array->put(vm.names.length, Value(length));
     return array;
 }
 
 // 7.3.17 CreateArrayFromList ( elements ), https://tc39.es/ecma262/#sec-createarrayfromlist
 Array* Array::create_from(GlobalObject& global_object, const Vector<Value>& elements)
 {
-    auto* array = Array::create(global_object);
+    auto* array = Array::create(global_object, 0);
     for (size_t i = 0; i < elements.size(); ++i)
         array->define_property(i, elements[i]);
     return array;

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -14,7 +14,7 @@ class Array : public Object {
     JS_OBJECT(Array, Object);
 
 public:
-    static Array* create(GlobalObject&, size_t length = 0);
+    static Array* create(GlobalObject&, size_t length, Object* prototype = nullptr);
     static Array* create_from(GlobalObject&, const Vector<Value>&);
 
     explicit Array(Object& prototype);

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -87,7 +87,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)
     if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, value, false);
 
-    auto* entry_array = Array::create(global_object);
+    auto* entry_array = Array::create(global_object, 0);
     entry_array->define_property(0, Value(static_cast<i32>(index)));
     entry_array->define_property(1, value);
     return create_iterator_result_object(global_object, entry_array, false);

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -151,8 +151,12 @@ static Object* array_species_create(GlobalObject& global_object, Object& origina
 {
     auto& vm = global_object.vm();
 
-    if (!Value(&original_array).is_array(global_object))
-        return Array::create(global_object, length);
+    if (!Value(&original_array).is_array(global_object)) {
+        auto array = Array::create(global_object, length);
+        if (vm.exception())
+            return {};
+        return array;
+    }
 
     auto constructor = original_array.get(vm.names.constructor).value_or(js_undefined());
     if (vm.exception())
@@ -176,8 +180,12 @@ static Object* array_species_create(GlobalObject& global_object, Object& origina
             constructor = js_undefined();
     }
 
-    if (constructor.is_undefined())
-        return Array::create(global_object, length);
+    if (constructor.is_undefined()) {
+        auto array = Array::create(global_object, length);
+        if (vm.exception())
+            return {};
+        return array;
+    }
 
     if (!constructor.is_constructor()) {
         vm.throw_exception<TypeError>(global_object, ErrorType::NotAConstructor, constructor.to_string_without_side_effects());

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -73,13 +73,40 @@ Object* iterator_next(Object& iterator, Value value)
 // 7.4.3 IteratorComplete ( iterResult ), https://tc39.es/ecma262/#sec-iteratorcomplete
 bool iterator_complete(GlobalObject& global_object, Object& iterator_result)
 {
-    return iterator_result.get(global_object.vm().names.done).value_or(Value(false)).to_boolean();
+    auto& vm = global_object.vm();
+    auto done = iterator_result.get(vm.names.done).value_or(js_undefined());
+    if (vm.exception())
+        return {};
+    return done.to_boolean();
 }
 
 // 7.4.4 IteratorValue ( iterResult ), https://tc39.es/ecma262/#sec-iteratorvalue
 Value iterator_value(GlobalObject& global_object, Object& iterator_result)
 {
-    return iterator_result.get(global_object.vm().names.value).value_or(js_undefined());
+    auto& vm = global_object.vm();
+    auto value = iterator_result.get(vm.names.value).value_or(js_undefined());
+    if (vm.exception())
+        return {};
+    return value;
+}
+
+// 7.4.5 IteratorStep ( iteratorRecord ), https://tc39.es/ecma262/#sec-iteratorstep
+Object* iterator_step(GlobalObject& global_object, Object& iterator)
+{
+    auto& vm = global_object.vm();
+
+    auto result = iterator_next(iterator);
+    if (vm.exception())
+        return {};
+
+    auto done = iterator_complete(global_object, *result);
+    if (vm.exception())
+        return {};
+
+    if (done)
+        return nullptr;
+
+    return result;
 }
 
 // 7.4.6 IteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-iteratorclose

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.h
@@ -20,6 +20,7 @@ enum class IteratorHint {
 
 Object* get_iterator(GlobalObject&, Value value, IteratorHint hint = IteratorHint::Sync, Value method = {});
 Object* iterator_next(Object& iterator, Value value = {});
+Object* iterator_step(GlobalObject&, Object& iterator);
 bool iterator_complete(GlobalObject&, Object& iterator_result);
 Value iterator_value(GlobalObject&, Object& iterator_result);
 void iterator_close(Object& iterator);

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -467,7 +467,7 @@ Object* JSONObject::parse_json_object(GlobalObject& global_object, const JsonObj
 
 Array* JSONObject::parse_json_array(GlobalObject& global_object, const JsonArray& json_array)
 {
-    auto* array = Array::create(global_object);
+    auto* array = Array::create(global_object, 0);
     size_t index = 0;
     json_array.for_each([&](auto& value) {
         array->define_property(index++, parse_json_value(global_object, value));

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -59,7 +59,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapIteratorPrototype::next)
     else if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, entry.value, false);
 
-    auto* entry_array = Array::create(global_object);
+    auto* entry_array = Array::create(global_object, 0);
     entry_array->define_property(0, entry.key);
     entry_array->define_property(1, entry.value);
     return create_iterator_result_object(global_object, entry_array, false);

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -297,7 +297,7 @@ MarkedValueList Object::get_own_properties(PropertyKind kind, bool only_enumerab
             } else if (kind == PropertyKind::Value) {
                 properties.append(js_string(vm(), String::formatted("{:c}", str[i])));
             } else {
-                auto* entry_array = Array::create(global_object());
+                auto* entry_array = Array::create(global_object(), 0);
                 entry_array->define_property(0, js_string(vm(), String::number(i)));
                 entry_array->define_property(1, js_string(vm(), String::formatted("{:c}", str[i])));
                 properties.append(entry_array);
@@ -318,7 +318,7 @@ MarkedValueList Object::get_own_properties(PropertyKind kind, bool only_enumerab
             } else if (kind == PropertyKind::Value) {
                 properties.append(value_and_attributes.value);
             } else {
-                auto* entry_array = Array::create(global_object());
+                auto* entry_array = Array::create(global_object(), 0);
                 entry_array->define_property(0, js_string(vm(), String::number(entry.index())));
                 entry_array->define_property(1, value_and_attributes.value);
                 properties.append(entry_array);
@@ -341,7 +341,7 @@ MarkedValueList Object::get_own_properties(PropertyKind kind, bool only_enumerab
             if (val.is_empty())
                 return;
 
-            auto* entry_array = Array::create(global_object());
+            auto* entry_array = Array::create(global_object(), 0);
             entry_array->define_property(0, property.key.to_value(vm()));
             entry_array->define_property(1, val);
             properties.append(entry_array);

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
@@ -166,7 +166,7 @@ Value OrdinaryFunctionObject::execute_function_body()
                 [&](const auto& param) {
                     Value argument_value;
                     if (parameter.is_rest) {
-                        auto* array = Array::create(global_object());
+                        auto* array = Array::create(global_object(), 0);
                         for (size_t rest_index = i; rest_index < execution_context_arguments.size(); ++rest_index)
                             array->indexed_properties().append(execution_context_arguments[rest_index]);
                         argument_value = move(array);

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -431,7 +431,7 @@ Value ProxyObject::call()
     arguments.append(Value(&m_target));
     arguments.append(Value(&m_handler));
     // FIXME: Pass global object
-    auto arguments_array = Array::create(global_object());
+    auto arguments_array = Array::create(global_object(), 0);
     vm.for_each_argument([&](auto& argument) {
         arguments_array->indexed_properties().append(argument);
     });
@@ -458,7 +458,7 @@ Value ProxyObject::construct(FunctionObject& new_target)
         return static_cast<FunctionObject&>(m_target).construct(new_target);
     MarkedValueList arguments(vm.heap());
     arguments.append(Value(&m_target));
-    auto arguments_array = Array::create(global_object());
+    auto arguments_array = Array::create(global_object(), 0);
     vm.for_each_argument([&](auto& argument) {
         arguments_array->indexed_properties().append(argument);
     });

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -61,7 +61,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetIteratorPrototype::next)
     if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, value, false);
 
-    auto* entry_array = Array::create(global_object);
+    auto* entry_array = Array::create(global_object, 0);
     entry_array->define_property(0, value);
     entry_array->define_property(1, value);
     return create_iterator_result_object(global_object, entry_array, false);

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -592,7 +592,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::split)
 
     auto string = this_value.to_string(global_object);
 
-    auto* result = Array::create(global_object);
+    auto* result = Array::create(global_object, 0);
     size_t result_len = 0;
 
     auto limit = NumericLimits<u32>::max();

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -218,7 +218,7 @@ void VM::assign(const NonnullRefPtr<BindingPattern>& target, Value value, Global
             if (entry.is_rest) {
                 VERIFY(i == binding.entries.size() - 1);
 
-                auto* array = Array::create(global_object);
+                auto* array = Array::create(global_object, 0);
                 for (;;) {
                     auto next_object = iterator_next(*iterator);
                     if (!next_object)

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -21,7 +21,7 @@ NavigatorObject::NavigatorObject(JS::GlobalObject& global_object)
 void NavigatorObject::initialize(JS::GlobalObject& global_object)
 {
     auto& heap = this->heap();
-    auto* languages = JS::Array::create(global_object);
+    auto* languages = JS::Array::create(global_object, 0);
     languages->indexed_properties().append(js_string(heap, "en-US"));
 
     define_property("appCodeName", js_string(heap, "Mozilla"));

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -1401,7 +1401,7 @@ static @fully_qualified_name@* impl_from(JS::VM& vm, JS::GlobalObject& global_ob
             // FIXME: Remove this fake type hack once it's no longer needed.
             //        Basically once we have NodeList we can throw this out.
             scoped_generator.append(R"~~~(
-    auto* new_array = JS::Array::create(global_object);
+    auto* new_array = JS::Array::create(global_object, 0);
     for (auto& element : retval)
         new_array->indexed_properties().append(wrap(global_object, element));
 


### PR DESCRIPTION
This fixes 7 test262 test cases.

Note for @linusg: This patch [array.patch.zip](https://github.com/SerenityOS/serenity/files/6759142/array.patch.zip) has all of the rebase fixes for the Object rewrite for this PR (It also fixes 2 regressions)