### PR TITLE
KeyboardSettings+Kernel: Setting to enable Num Lock on login

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -143,6 +143,7 @@ namespace Kernel {
     S(getrandom)                  \
     S(getkeymap)                  \
     S(setkeymap)                  \
+    S(set_num_lock)               \
     S(clock_gettime)              \
     S(clock_settime)              \
     S(clock_nanosleep)            \

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -191,6 +191,7 @@ set(KERNEL_SOURCES
     Syscalls/mmap.cpp
     Syscalls/module.cpp
     Syscalls/mount.cpp
+    Syscalls/num_lock.cpp
     Syscalls/open.cpp
     Syscalls/perf_event.cpp
     Syscalls/pipe.cpp

--- a/Kernel/Devices/HID/HIDManagement.cpp
+++ b/Kernel/Devices/HID/HIDManagement.cpp
@@ -98,6 +98,11 @@ void HIDManagement::set_maps(const Keyboard::CharacterMapData& character_map_dat
     dbgln("New Character map '{}' passed in by client.", character_map_name);
 }
 
+void HIDManagement::set_num_lock(bool on)
+{
+    m_i8042_controller->keyboard()->set_num_lock(on);
+}
+
 UNMAP_AFTER_INIT void HIDManagement::enumerate()
 {
     // FIXME: When we have USB HID support, we should ensure that we disable

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -45,6 +45,7 @@ public:
     const Keyboard::CharacterMap& character_map() const { return m_character_map; }
     void set_client(KeyboardClient* client) { m_client = client; }
     void set_maps(const Keyboard::CharacterMapData& character_map, const String& character_map_name);
+    void set_num_lock(bool on);
 
 private:
     size_t generate_minor_device_number_for_mouse();

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -45,6 +45,8 @@ public:
             m_modifiers &= ~modifier;
     }
 
+    void set_num_lock(bool on) { m_num_lock_on = on; }
+
 protected:
     KeyboardDevice();
     mutable SpinLock<u8> m_queue_lock;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -291,6 +291,7 @@ public:
     KResultOr<FlatPtr> sys$getresuid(Userspace<uid_t*>, Userspace<uid_t*>, Userspace<uid_t*>);
     KResultOr<FlatPtr> sys$getresgid(Userspace<gid_t*>, Userspace<gid_t*>, Userspace<gid_t*>);
     KResultOr<FlatPtr> sys$umask(mode_t);
+    KResultOr<FlatPtr> sys$set_num_lock(bool);
     KResultOr<FlatPtr> sys$open(Userspace<const Syscall::SC_open_params*>);
     KResultOr<FlatPtr> sys$close(int fd);
     KResultOr<FlatPtr> sys$read(int fd, Userspace<u8*>, size_t);

--- a/Kernel/Syscalls/num_lock.cpp
+++ b/Kernel/Syscalls/num_lock.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Devices/HID/HIDManagement.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+KResultOr<FlatPtr> Process::sys$set_num_lock(bool on)
+{
+    HIDManagement::the().set_num_lock(on);
+    return 0;
+}
+
+}

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -137,6 +137,11 @@ int getkeymap(char* name_buffer, size_t name_buffer_size, u32* map, u32* shift_m
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+void set_num_lock(bool on)
+{
+    syscall(SC_set_num_lock, on);
+}
+
 u16 internet_checksum(const void* ptr, size_t count)
 {
     u32 checksum = 0;

--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -105,6 +105,8 @@ int serenity_readlink(const char* path, size_t path_length, char* buffer, size_t
 int getkeymap(char* name_buffer, size_t name_buffer_size, uint32_t* map, uint32_t* shift_map, uint32_t* alt_map, uint32_t* altgr_map, uint32_t* shift_altgr_map);
 int setkeymap(const char* name, const uint32_t* map, uint32_t* const shift_map, const uint32_t* alt_map, const uint32_t* altgr_map, const uint32_t* shift_altgr_map);
 
+void set_num_lock(bool on);
+
 uint16_t internet_checksum(const void* ptr, size_t count);
 
 __END_DECLS

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -6,6 +6,7 @@
 
 #include <LibCore/ConfigFile.h>
 #include <errno.h>
+#include <serenity.h>
 #include <spawn.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -16,6 +17,8 @@ int main()
         perror("pledge");
         return 1;
     }
+
+    auto keyboard_settings_config = Core::ConfigFile::get_for_app("KeyboardSettings");
 
     if (unveil("/bin/keymap", "x") < 0) {
         perror("unveil /bin/keymap");
@@ -41,4 +44,7 @@ int main()
         perror("posix_spawn");
         exit(1);
     }
+
+    bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
+    set_num_lock(enable_num_lock);
 }


### PR DESCRIPTION
It was bothering me having to enable the Num Lock on every boot in order to use the number pad to input numerals so this is intended to address that :^)

Adds a new setting to KeyboardSettings which toggles whether or not the Num Lock is enabled on login. By default it is set to true and the number pad will input numerals. This config file is stored per-user in the user's `.config` directory under the KeyboardSettings' app name.

I'm not entirely happy with this having its own dedicated syscall to modify the Num Lock status but I'm not sure if there is another way for a userland application to ask the KeyboardDevice to change the status. One alternative may be to move the on-login logic into the kernel?