### PR TITLE
Browser + LibGUI: Add URL autocomplete when ctrl+return pressed

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -144,6 +144,16 @@ Tab::Tab(BrowserWindow& window, Type type)
     m_location_box = toolbar.add<GUI::TextBox>();
     m_location_box->set_placeholder("Address");
 
+    m_location_box->on_control_return_pressed = [this] {
+        StringBuilder pre_url;
+        pre_url.append("www.");
+        pre_url.append(m_location_box->text());
+        pre_url.append(".com");
+        auto url = url_from_user_input(pre_url.to_string());
+        load(url);
+        view().set_focus(true);
+    };    
+
     m_location_box->on_return_pressed = [this] {
         auto url = url_from_user_input(m_location_box->text());
         load(url);

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -761,12 +761,17 @@ void TextEditor::keydown_event(KeyEvent& event)
                 on_shift_return_pressed();
             return;
         }
-
+        if (event.modifiers() == KeyModifier::Mod_Ctrl && event.key() == KeyCode::Key_Return) {
+            if (on_control_return_pressed)
+                on_control_return_pressed();    
+            return;
+        }
         if (event.key() == KeyCode::Key_Return) {
             if (on_return_pressed)
                 on_return_pressed();
             return;
         }
+
 
         if (event.key() == KeyCode::Key_Up) {
             if (on_up_pressed)

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -142,6 +142,7 @@ public:
     Function<void(bool modified)> on_modified_change;
     Function<void()> on_mousedown;
     Function<void()> on_return_pressed;
+    Function<void()> on_control_return_pressed;
     Function<void()> on_shift_return_pressed;
     Function<void()> on_escape_pressed;
     Function<void()> on_up_pressed;


### PR DESCRIPTION
I like to use the control + return shortcut to autocomplete the URL for ".com" domains
when using Firefox. So I wanted Serenity Browser to have the same behavior.

Added a new event (on_control_return_pressed) in TextEditor.cpp when Control key 
modifies the behavior of Return key.

In browser side, add a new event that use a StringBuilder to complete the url to be 
loaded for tab window.