### PR TITLE
Kernel: Fix safe_memset not setting the last few bytes in some cases

### DIFF
--- a/Kernel/Arch/x86/common/SafeMem.cpp
+++ b/Kernel/Arch/x86/common/SafeMem.cpp
@@ -148,7 +148,7 @@ NEVER_INLINE bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
         if (remainder != 0)
             return false; // fault_at is already set!
         n -= size_ts * sizeof(size_t);
-        if (remainder == 0) {
+        if (n == 0) {
             fault_at = nullptr;
             return true;
         }


### PR DESCRIPTION
Because the remainder variable will always be 0 unless a fault happened
we should not use it to decide if we have nothing left to memset when
finishing the fast path. This caused not all bytes to be zeroed
if the size was not an exact multiple of sizeof(size_t).

Fixes #8352

@ADKaster I think this should fix your problem.