### PR TITLE
LibCore: Add method to leak fd from File

### DIFF
--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -92,6 +92,12 @@ bool File::open_impl(OpenMode mode, mode_t permissions)
     return true;
 }
 
+int File::leak_fd()
+{
+    m_should_close_file_descriptor = ShouldCloseFileDescriptor::No;
+    return fd();
+}
+
 bool File::is_device() const
 {
     struct stat stat;

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -74,6 +74,7 @@ public:
         Yes
     };
     bool open(int fd, OpenMode, ShouldCloseFileDescriptor);
+    [[nodiscard]] int leak_fd();
 
     static NonnullRefPtr<File> standard_input();
     static NonnullRefPtr<File> standard_output();


### PR DESCRIPTION
This will let other code use the fd while making sure the fd isn't
automatically closed by Core::File's destructor