### PR TITLE
AK+LibIPC: Make all enums codable

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -26,6 +26,9 @@ concept Signed = IsSigned<T>;
 template<typename T>
 concept Unsigned = IsUnsigned<T>;
 
+template<typename T>
+concept Enum = IsEnum<T>;
+
 template<typename T, typename U>
 concept SameAs = IsSame<T, U>;
 
@@ -52,6 +55,7 @@ concept IteratorFunction = requires(Func func, Args... args)
 }
 
 using AK::Concepts::Arithmetic;
+using AK::Concepts::Enum;
 using AK::Concepts::FloatingPoint;
 using AK::Concepts::Integral;
 using AK::Concepts::IteratorFunction;

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Forward.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtras.h>
@@ -63,6 +64,17 @@ public:
 
             hashmap.set(move(key), move(value));
         }
+        return true;
+    }
+
+    template<Enum T>
+    bool decode(T& enum_value)
+    {
+        UnderlyingType<T> inner_value;
+        if (!decode(inner_value))
+            return false;
+
+        enum_value = T(inner_value);
         return true;
     }
 

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
+#include <AK/StdLibExtras.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
 
@@ -59,6 +61,13 @@ public:
         *this << (u64)vector.size();
         for (auto& value : vector)
             *this << value;
+        return *this;
+    }
+
+    template<Enum T>
+    Encoder& operator<<(T const& enum_value)
+    {
+        *this << AK::to_underlying(enum_value);
         return *this;
     }
 


### PR DESCRIPTION
If an enum has a supported underlying type we can provide encoding and decoding for the enum as well.