### PR TITLE
LibGUI: Make tooltip height line count aware

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -28,12 +28,13 @@ public:
     {
         m_label->set_text(Gfx::parse_ampersand_string(tooltip));
         int tooltip_width = m_label->min_width() + 10;
+        int tooltip_height = m_label->font().glyph_height() * max(1, m_label->text().count("\n")) + 8;
 
         Gfx::IntRect desktop_rect = Desktop::the().rect();
         if (tooltip_width > desktop_rect.width())
             tooltip_width = desktop_rect.width();
 
-        set_rect(rect().x(), rect().y(), tooltip_width, m_label->font().glyph_height() + 8);
+        set_rect(rect().x(), rect().y(), tooltip_width, tooltip_height);
     }
 
 private:


### PR DESCRIPTION
Previously multiline was not handled properly thus in case of the
Network applet the tooltip would be drawn improperly.

Before: 
![Screenshot from 2021-07-04 10-44-03](https://user-images.githubusercontent.com/6830979/124379066-1be33b00-dcb5-11eb-9fdb-14337459e25c.png)

After:
![Screenshot from 2021-07-04 10-44-52](https://user-images.githubusercontent.com/6830979/124379069-1e459500-dcb5-11eb-928f-e71487515364.png)
