### PR TITLE
Assistant: Keep the Terminal window open after the command has run

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -50,7 +50,7 @@ void FileResult::activate() const
 void TerminalResult::activate() const
 {
     pid_t pid;
-    char const* argv[] = { "Terminal", "-e", title().characters(), nullptr };
+    char const* argv[] = { "Terminal", "-k", "-e", title().characters(), nullptr };
 
     if ((errno = posix_spawn(&pid, "/bin/Terminal", nullptr, nullptr, const_cast<char**>(argv), environ))) {
         perror("posix_spawn");

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -80,7 +80,7 @@ static void utmp_update(const char* tty, pid_t pid, bool create)
     }
 }
 
-static void run_command(String command)
+static void run_command(String command, bool keep_open)
 {
     String shell = "/bin/Shell";
     auto* pw = getpwuid(getuid());
@@ -89,10 +89,13 @@ static void run_command(String command)
     }
     endpwent();
 
-    const char* args[4] = { shell.characters(), nullptr, nullptr, nullptr };
+    const char* args[5] = { shell.characters(), nullptr, nullptr, nullptr, nullptr };
     if (!command.is_empty()) {
-        args[1] = "-c";
-        args[2] = command.characters();
+        int arg_index = 1;
+        if (keep_open)
+            args[arg_index++] = "--keep-open";
+        args[arg_index++] = "-c";
+        args[arg_index++] = command.characters();
     }
     const char* envs[] = { "TERM=xterm", "PAGER=more", "PATH=/bin:/usr/bin:/usr/local/bin", nullptr };
     int rc = execve(shell.characters(), const_cast<char**>(args), const_cast<char**>(envs));
@@ -275,11 +278,18 @@ int main(int argc, char** argv)
     }
 
     const char* command_to_execute = nullptr;
+    bool keep_open = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(command_to_execute, "Execute this command inside the terminal", nullptr, 'e', "command");
+    args_parser.add_option(keep_open, "Keep the terminal open after the command has finished executing", nullptr, 'k');
 
     args_parser.parse(argc, argv);
+
+    if (keep_open && !command_to_execute) {
+        warnln("Option -k can only be used in combination with -e.");
+        return 1;
+    }
 
     RefPtr<Core::ConfigFile> config = Core::ConfigFile::get_for_app("Terminal");
     Core::File::ensure_parent_directories(config->filename());
@@ -293,9 +303,9 @@ int main(int argc, char** argv)
     if (shell_pid == 0) {
         close(ptm_fd);
         if (command_to_execute)
-            run_command(command_to_execute);
+            run_command(command_to_execute, keep_open);
         else
-            run_command(config->read_entry("Startup", "Command", ""));
+            run_command(config->read_entry("Startup", "Command", ""), false);
         VERIFY_NOT_REACHED();
     }
 

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -93,12 +93,14 @@ int main(int argc, char** argv)
     bool skip_rc_files = false;
     const char* format = nullptr;
     bool should_format_live = false;
+    bool keep_open = false;
 
     Core::ArgsParser parser;
     parser.add_option(command_to_run, "String to read commands from", "command-string", 'c', "command-string");
     parser.add_option(skip_rc_files, "Skip running shellrc files", "skip-shellrc", 0);
     parser.add_option(format, "Format the given file into stdout and exit", "format", 0, "file");
     parser.add_option(should_format_live, "Enable live formatting", "live-formatting", 'f');
+    parser.add_option(keep_open, "Keep the shell open after running the specified command or file", "keep-open", 0);
     parser.add_positional_argument(file_to_read_from, "File to read commands from", "file", Core::ArgsParser::Required::No);
     parser.add_positional_argument(script_args, "Extra arguments to pass to the script (via $* and co)", "argument", Core::ArgsParser::Required::No);
 
@@ -141,6 +143,11 @@ int main(int argc, char** argv)
     auto execute_file = file_to_read_from && StringView { "-" } != file_to_read_from;
     attempt_interactive = !execute_file;
 
+    if (keep_open && !command_to_run && !execute_file) {
+        warnln("Option --keep-open can only be used in combination with -c or when specifying a file to execute.");
+        return 1;
+    }
+
     initialize();
 
     shell->set_live_formatting(should_format_live);
@@ -168,13 +175,18 @@ int main(int argc, char** argv)
 
     if (command_to_run) {
         dbgln("sh -c '{}'\n", command_to_run);
-        return shell->run_command(command_to_run);
+        auto result = shell->run_command(command_to_run);
+        if (!keep_open)
+            return result;
     }
 
     if (execute_file) {
-        if (shell->run_file(file_to_read_from))
-            return 0;
-        return 1;
+        auto result = shell->run_file(file_to_read_from);
+        if (!keep_open) {
+            if (result)
+                return 0;
+            return 1;
+        }
     }
 
     shell->add_child(*editor);


### PR DESCRIPTION
In its current form it's not quite ideal: The command that's being run isn't shown in the terminal (i.e. as if the user had typed it themselves).