### PR TITLE
LibGUI: Make ComboBox use WindowType::Menu window type

### DIFF
--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -85,6 +85,7 @@ ComboBox::ComboBox()
     };
 
     m_list_window = add<Window>(window());
+    m_list_window->set_window_type(WindowType::Menu);
     m_list_window->set_frameless(true);
     m_list_window->set_accessory(true);
     m_list_window->on_active_input_change = [this](bool is_active_input) {


### PR DESCRIPTION
This change addresses an issue where ComboBox list window was being drawn behind a tool window.