### PR TITLE
AK: Some minor oddities

### DIFF
--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -61,7 +61,13 @@ public:
 
     constexpr T phase() const COMPLEX_NOEXCEPT
     {
-        return atan2(m_imag, m_real);
+        if constexpr (sizeof(T) <= sizeof(float)) {
+            return atan2f(m_imag, m_real);
+        } else if constexpr (sizeof(T) <= sizeof(double)) {
+            return atan2(m_imag, m_real);
+        } else {
+            return atan2l(m_imag, m_real);
+        }
     }
 
     template<AK::Concepts::Arithmetic U, AK::Concepts::Arithmetic V>

--- a/AK/SIMD.h
+++ b/AK/SIMD.h
@@ -21,6 +21,14 @@ using i16x4 = i16 __attribute__((vector_size(8)));
 using i16x8 = i16 __attribute__((vector_size(16)));
 using i16x16 = i16 __attribute__((vector_size(32)));
 
+// the asm intrinsics demand chars as  the 8-bit type, and do not allow
+// (un-)signed ones to be used
+using c8x2 = char __attribute__((vector_size(2)));
+using c8x4 = char __attribute__((vector_size(4)));
+using c8x8 = char __attribute__((vector_size(8)));
+using c8x16 = char __attribute__((vector_size(16)));
+using c8x32 = char __attribute__((vector_size(32)));
+
 using i32x2 = i32 __attribute__((vector_size(8)));
 using i32x4 = i32 __attribute__((vector_size(16)));
 using i32x8 = i32 __attribute__((vector_size(32)));


### PR DESCRIPTION
AK: Bring Complex:phase inline to other functions
The phase functions was the only one not differentiating types

AK: Add char SIMD types
These are used in intrinsics, which do not recognize any signed version
if the char type

