### PR TITLE
Spreadsheet: Pressing Enter in the editor doesn't move to the next cell

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -315,6 +315,11 @@ void SpreadsheetView::show_event(GUI::ShowEvent&)
     }
 }
 
+void SpreadsheetView::move_cursor(GUI::AbstractView::CursorMovement direction)
+{
+    m_table_view->move_cursor(direction, GUI::AbstractView::SelectionUpdate::Set);
+}
+
 void SpreadsheetView::TableCellPainter::paint(GUI::Painter& painter, const Gfx::IntRect& rect, const Gfx::Palette& palette, const GUI::ModelIndex& index)
 {
     // Draw a border.

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -100,6 +100,8 @@ public:
     Function<void(Vector<Position>&&)> on_selection_changed;
     Function<void()> on_selection_dropped;
 
+    void move_cursor(GUI::AbstractView::CursorMovement);
+
 private:
     virtual void hide_event(GUI::HideEvent&) override;
     virtual void show_event(GUI::ShowEvent&) override;

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -53,6 +53,10 @@ SpreadsheetWidget::SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets, bool s
     cell_value_editor.set_font(Gfx::FontDatabase::default_fixed_width_font());
     cell_value_editor.set_scrollbars_enabled(false);
 
+    cell_value_editor.on_return_pressed = [this]() {
+        m_selected_view->move_cursor(GUI::AbstractView::CursorMovement::Down);
+    };
+
     cell_value_editor.set_syntax_highlighter(make<CellSyntaxHighlighter>());
     cell_value_editor.set_enabled(false);
     current_cell_label.set_enabled(false);


### PR DESCRIPTION
My solution to #8287 is to expose cursor movement functionality via new member function in `SpreadsheetView` class and call it via editors `on_return_pressed`.