### PR TITLE
LibGfx: Fix classic theme frame transparency check

### DIFF
--- a/Userland/Libraries/LibGfx/ClassicWindowTheme.h
+++ b/Userland/Libraries/LibGfx/ClassicWindowTheme.h
@@ -47,7 +47,10 @@ private:
 
         bool uses_alpha() const
         {
-            return title_color.alpha() != 0xff || border_color.alpha() != 0xff || border_color2.alpha() != 0xff || title_stripes_color.alpha() != 0xff || title_shadow_color.alpha() != 0xff;
+            // We don't care about the title_stripes_color or title_shadow_color alpha channels because they are
+            // effectively rendered on top of the borders and don't mean whether the frame itself atually has
+            // any alpha channels that would require the entire frame to be rendered as transparency.
+            return title_color.alpha() != 0xff || border_color.alpha() != 0xff || border_color2.alpha() != 0xff;
         }
     };
 


### PR DESCRIPTION
We shouldn't use the title stripe or title shadow colors to determine
whether the frame itself is going to have alpha channels or not. This
caused e.g. the classic theme's window frame to be rendered as
transparency just because the stripe color had an alpha channel of 0.