### PR TITLE
WindowServer: Toggling desktop should only toggle current desktop

### DIFF
--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -118,28 +118,25 @@ void WMClientConnection::set_window_minimized(i32 client_id, i32 window_id, bool
 void WMClientConnection::toggle_show_desktop()
 {
     bool should_hide = false;
-    WindowServer::ClientConnection::for_each_client([&should_hide](auto& client) {
-        client.for_each_window([&should_hide](Window& window) {
-            if (window.type() == WindowType::Normal && window.is_minimizable()) {
-                if (!window.is_hidden() && !window.is_minimized()) {
-                    should_hide = true;
-                    return IterationDecision::Break;
-                }
+    auto& current_window_stack = WindowManager::the().current_window_stack();
+    current_window_stack.for_each_window([&](auto& window) {
+        if (window.type() == WindowType::Normal && window.is_minimizable()) {
+            if (!window.is_hidden() && !window.is_minimized()) {
+                should_hide = true;
+                return IterationDecision::Break;
             }
-            return IterationDecision::Continue;
-        });
+        }
+        return IterationDecision::Continue;
     });
 
-    WindowServer::ClientConnection::for_each_client([should_hide](auto& client) {
-        client.for_each_window([should_hide](Window& window) {
-            if (window.type() == WindowType::Normal && window.is_minimizable()) {
-                auto state = window.minimized_state();
-                if (state == WindowMinimizedState::None || state == WindowMinimizedState::Hidden) {
-                    WindowManager::the().hide_windows(window, should_hide);
-                }
+    current_window_stack.for_each_window([&](auto& window) {
+        if (window.type() == WindowType::Normal && window.is_minimizable()) {
+            auto state = window.minimized_state();
+            if (state == WindowMinimizedState::None || state == WindowMinimizedState::Hidden) {
+                WindowManager::the().hide_windows(window, should_hide);
             }
-            return IterationDecision::Continue;
-        });
+        }
+        return IterationDecision::Continue;
     });
 }
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -342,6 +342,8 @@ static Gfx::IntRect interpolate_rect(Gfx::IntRect const& from_rect, Gfx::IntRect
 
 void Window::start_minimize_animation()
 {
+    if (&window_stack() != &WindowManager::the().current_window_stack())
+        return;
     if (!m_have_taskbar_rect) {
         // If this is a modal window, it may not have its own taskbar
         // button, so there is no rectangle. In that case, walk the
@@ -385,6 +387,9 @@ void Window::start_minimize_animation()
 
 void Window::start_launch_animation(Gfx::IntRect const& launch_origin_rect)
 {
+    if (&window_stack() != &WindowManager::the().current_window_stack())
+        return;
+
     m_animation = Animation::create();
     m_animation->set_duration(150);
     m_animation->on_update = [this, launch_origin_rect](float progress, Gfx::Painter& painter, Screen& screen, Gfx::DisjointRectSet& flush_rects) {


### PR DESCRIPTION
We should only show/hide the windows on the current virtual desktop.