### PR TITLE
AK: Explicitly require Checked types to be Integral 

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Concepts.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtras.h>
 
@@ -109,17 +110,17 @@ template<typename Destination, typename Source>
     return TypeBoundsChecker<Destination, Source>::is_within_range(value);
 }
 
-template<typename T>
+template<Integral T>
 class Checked {
 public:
     constexpr Checked() = default;
 
-    constexpr Checked(T value)
+    explicit constexpr Checked(T value)
         : m_value(value)
     {
     }
 
-    template<typename U>
+    template<Integral U>
     constexpr Checked(U value)
     {
         m_overflow = !is_within_range<T>(value);

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -131,42 +131,42 @@ template<typename T>
 [[nodiscard]] inline bool copy_n_from_user(T* dest, const T* src, size_t count)
 {
     static_assert(IsTriviallyCopyable<T>);
-    Checked size = sizeof(T);
+    Checked<size_t> size = sizeof(T);
     size *= count;
     if (size.has_overflow())
         return false;
-    return copy_from_user(dest, src, sizeof(T) * count);
+    return copy_from_user(dest, src, size.value());
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_n_to_user(T* dest, const T* src, size_t count)
 {
     static_assert(IsTriviallyCopyable<T>);
-    Checked size = sizeof(T);
+    Checked<size_t> size = sizeof(T);
     size *= count;
     if (size.has_overflow())
         return false;
-    return copy_to_user(dest, src, sizeof(T) * count);
+    return copy_to_user(dest, src, size.value());
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_n_from_user(T* dest, Userspace<const T*> src, size_t count)
 {
     static_assert(IsTriviallyCopyable<T>);
-    Checked size = sizeof(T);
+    Checked<size_t> size = sizeof(T);
     size *= count;
     if (size.has_overflow())
         return false;
-    return copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T) * count);
+    return copy_from_user(dest, src.unsafe_userspace_ptr(), size.value());
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_n_to_user(Userspace<T*> dest, const T* src, size_t count)
 {
     static_assert(IsTriviallyCopyable<T>);
-    Checked size = sizeof(T);
+    Checked<size_t> size = sizeof(T);
     size *= count;
     if (size.has_overflow())
         return false;
-    return copy_to_user(dest.unsafe_userspace_ptr(), src, sizeof(T) * count);
+    return copy_to_user(dest.unsafe_userspace_ptr(), src, size.value());
 }

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -942,14 +942,14 @@ KResultOr<FlatPtr> Process::sys$execve(Userspace<const Syscall::SC_execve_params
     auto copy_user_strings = [](const auto& list, auto& output) {
         if (!list.length)
             return true;
-        Checked size = sizeof(*list.strings);
+        Checked<size_t> size = sizeof(*list.strings);
         size *= list.length;
         if (size.has_overflow())
             return false;
         Vector<Syscall::StringArgument, 32> strings;
         if (!strings.try_resize(list.length))
             return false;
-        if (!copy_from_user(strings.data(), list.strings, list.length * sizeof(*list.strings)))
+        if (!copy_from_user(strings.data(), list.strings, size.value()))
             return false;
         for (size_t i = 0; i < list.length; ++i) {
             auto string = copy_string_from_user(strings[i]);

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -152,7 +152,7 @@ KResultOr<FlatPtr> Process::sys$poll(Userspace<const Syscall::SC_poll_params*> u
 
     Vector<pollfd, FD_SETSIZE> fds_copy;
     if (params.nfds > 0) {
-        Checked nfds_checked = sizeof(pollfd);
+        Checked<size_t> nfds_checked = sizeof(pollfd);
         nfds_checked *= params.nfds;
         if (nfds_checked.has_overflow())
             return EFAULT;

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-enum LengthModifier {
+enum class LengthModifier {
     None,
     Default,
     Char,
@@ -27,7 +27,7 @@ enum LengthModifier {
     LongDouble,
 };
 
-enum ConversionSpecifier {
+enum class ConversionSpecifier {
     Unspecified,
     Decimal,
     Integer,
@@ -254,15 +254,15 @@ struct ReadElement {
     {
         switch (length_modifier) {
         default:
-        case None:
+        case LengthModifier::None:
             VERIFY_NOT_REACHED();
-        case Default:
+        case LengthModifier::Default:
             return ReadElementConcrete<T, T, kind> {}(input_lexer, ap);
-        case Char:
+        case LengthModifier::Char:
             return ReadElementConcrete<T, char, kind> {}(input_lexer, ap);
-        case Short:
+        case LengthModifier::Short:
             return ReadElementConcrete<T, short, kind> {}(input_lexer, ap);
-        case Long:
+        case LengthModifier::Long:
             if constexpr (IsSame<T, int>)
                 return ReadElementConcrete<T, long, kind> {}(input_lexer, ap);
             if constexpr (IsSame<T, unsigned>)
@@ -270,7 +270,7 @@ struct ReadElement {
             if constexpr (IsSame<T, float>)
                 return ReadElementConcrete<int, double, kind> {}(input_lexer, ap);
             return false;
-        case LongLong:
+        case LengthModifier::LongLong:
             if constexpr (IsSame<T, int>)
                 return ReadElementConcrete<long long, long long, kind> {}(input_lexer, ap);
             if constexpr (IsSame<T, unsigned>)
@@ -278,13 +278,13 @@ struct ReadElement {
             if constexpr (IsSame<T, float>)
                 return ReadElementConcrete<long long, double, kind> {}(input_lexer, ap);
             return false;
-        case IntMax:
+        case LengthModifier::IntMax:
             return ReadElementConcrete<T, intmax_t, kind> {}(input_lexer, ap);
-        case Size:
+        case LengthModifier::Size:
             return ReadElementConcrete<T, size_t, kind> {}(input_lexer, ap);
-        case PtrDiff:
+        case LengthModifier::PtrDiff:
             return ReadElementConcrete<T, ptrdiff_t, kind> {}(input_lexer, ap);
-        case LongDouble:
+        case LengthModifier::LongDouble:
             return ReadElementConcrete<T, long double, kind> {}(input_lexer, ap);
         }
     }
@@ -420,84 +420,84 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
 
         bool invert_scanlist = false;
         StringView scanlist;
-        LengthModifier length_modifier { None };
-        ConversionSpecifier conversion_specifier { Unspecified };
+        LengthModifier length_modifier { LengthModifier::None };
+        ConversionSpecifier conversion_specifier { ConversionSpecifier::Unspecified };
     reread_lookahead:;
         auto format_lookahead = format_lexer.peek();
-        if (length_modifier == None) {
+        if (length_modifier == LengthModifier::None) {
             switch (format_lookahead) {
             case 'h':
                 if (format_lexer.peek(1) == 'h') {
                     format_lexer.consume(2);
-                    length_modifier = Char;
+                    length_modifier = LengthModifier::Char;
                 } else {
                     format_lexer.consume(1);
-                    length_modifier = Short;
+                    length_modifier = LengthModifier::Short;
                 }
                 break;
             case 'l':
                 if (format_lexer.peek(1) == 'l') {
                     format_lexer.consume(2);
-                    length_modifier = LongLong;
+                    length_modifier = LengthModifier::LongLong;
                 } else {
                     format_lexer.consume(1);
-                    length_modifier = Long;
+                    length_modifier = LengthModifier::Long;
                 }
                 break;
             case 'j':
                 format_lexer.consume();
-                length_modifier = IntMax;
+                length_modifier = LengthModifier::IntMax;
                 break;
             case 'z':
                 format_lexer.consume();
-                length_modifier = Size;
+                length_modifier = LengthModifier::Size;
                 break;
             case 't':
                 format_lexer.consume();
-                length_modifier = PtrDiff;
+                length_modifier = LengthModifier::PtrDiff;
                 break;
             case 'L':
                 format_lexer.consume();
-                length_modifier = LongDouble;
+                length_modifier = LengthModifier::LongDouble;
                 break;
             default:
-                length_modifier = Default;
+                length_modifier = LengthModifier::Default;
                 break;
             }
             goto reread_lookahead;
         }
-        if (conversion_specifier == Unspecified) {
+        if (conversion_specifier == ConversionSpecifier::Unspecified) {
             switch (format_lookahead) {
             case 'd':
                 format_lexer.consume();
-                conversion_specifier = Decimal;
+                conversion_specifier = ConversionSpecifier::Decimal;
                 break;
             case 'i':
                 format_lexer.consume();
-                conversion_specifier = Integer;
+                conversion_specifier = ConversionSpecifier::Integer;
                 break;
             case 'o':
                 format_lexer.consume();
-                conversion_specifier = Octal;
+                conversion_specifier = ConversionSpecifier::Octal;
                 break;
             case 'u':
                 format_lexer.consume();
-                conversion_specifier = Unsigned;
+                conversion_specifier = ConversionSpecifier::Unsigned;
                 break;
             case 'x':
                 format_lexer.consume();
-                conversion_specifier = Hex;
+                conversion_specifier = ConversionSpecifier::Hex;
                 break;
             case 'a':
             case 'e':
             case 'f':
             case 'g':
                 format_lexer.consume();
-                conversion_specifier = Floating;
+                conversion_specifier = ConversionSpecifier::Floating;
                 break;
             case 's':
                 format_lexer.consume();
-                conversion_specifier = String;
+                conversion_specifier = ConversionSpecifier::String;
                 break;
             case '[':
                 format_lexer.consume();
@@ -506,33 +506,33 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
                     scanlist = scanlist.substring_view(1);
                     invert_scanlist = true;
                 }
-                conversion_specifier = UseScanList;
+                conversion_specifier = ConversionSpecifier::UseScanList;
                 break;
             case 'c':
                 format_lexer.consume();
-                conversion_specifier = Character;
+                conversion_specifier = ConversionSpecifier::Character;
                 break;
             case 'p':
                 format_lexer.consume();
-                conversion_specifier = Pointer;
+                conversion_specifier = ConversionSpecifier::Pointer;
                 break;
             case 'n':
                 format_lexer.consume();
-                conversion_specifier = OutputNumberOfBytes;
+                conversion_specifier = ConversionSpecifier::OutputNumberOfBytes;
                 break;
             case 'C':
                 format_lexer.consume();
-                length_modifier = Long;
-                conversion_specifier = Character;
+                length_modifier = LengthModifier::Long;
+                conversion_specifier = ConversionSpecifier::Character;
                 break;
             case 'S':
                 format_lexer.consume();
-                length_modifier = Long;
-                conversion_specifier = String;
+                length_modifier = LengthModifier::Long;
+                conversion_specifier = ConversionSpecifier::String;
                 break;
             default:
                 format_lexer.consume();
-                conversion_specifier = Invalid;
+                conversion_specifier = ConversionSpecifier::Invalid;
                 break;
             }
         }
@@ -541,73 +541,73 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
 
         // Now try to read.
         switch (conversion_specifier) {
-        case Invalid:
-        case Unspecified:
+        case ConversionSpecifier::Invalid:
+        case ConversionSpecifier::Unspecified:
         default:
             // "undefined behaviour", let's be nice and crash.
             dbgln("Invalid conversion specifier {} in scanf!", (int)conversion_specifier);
             VERIFY_NOT_REACHED();
-        case Decimal:
+        case ConversionSpecifier::Decimal:
             if (!ReadElement<int, ReadKind::Normal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Integer:
+        case ConversionSpecifier::Integer:
             if (!ReadElement<int, ReadKind::Infer> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Octal:
+        case ConversionSpecifier::Octal:
             if (!ReadElement<unsigned, ReadKind::Octal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Unsigned:
+        case ConversionSpecifier::Unsigned:
             if (!ReadElement<unsigned, ReadKind::Normal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Hex:
+        case ConversionSpecifier::Hex:
             if (!ReadElement<unsigned, ReadKind::Hex> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Floating:
+        case ConversionSpecifier::Floating:
             if (!ReadElement<float, ReadKind::Normal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case String:
+        case ConversionSpecifier::String:
             if (!ReadElement<char*, ReadKind::Normal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case UseScanList:
+        case ConversionSpecifier::UseScanList:
             if (!ReadElement<char*, ReadKind::Normal> { scanlist, invert_scanlist }(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Character:
+        case ConversionSpecifier::Character:
             if (!ReadElement<char, ReadKind::Normal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case Pointer:
+        case ConversionSpecifier::Pointer:
             if (!ReadElement<void*, ReadKind::Normal> {}(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
             else
                 ++elements_matched;
             break;
-        case OutputNumberOfBytes: {
+        case ConversionSpecifier::OutputNumberOfBytes: {
             if (!suppress_assignment) {
                 auto* ptr = va_arg(ap, int*);
                 *ptr = input_lexer.tell();

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -97,7 +97,8 @@ static void initialize_typed_array_from_typed_array(GlobalObject& global_object,
 
     auto element_length = src_array.array_length();
     auto element_size = dest_array.element_size();
-    Checked byte_length = element_size * element_length;
+    Checked<size_t> byte_length = element_size;
+    byte_length *= element_length;
     if (byte_length.has_overflow()) {
         vm.throw_exception<RangeError>(global_object, ErrorType::InvalidLength, "typed array");
         return;

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -362,7 +362,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
             return {};
         }
 
-        Checked checked { source_length };
+        Checked<size_t> checked = source_length;
         checked += static_cast<u32>(target_offset);
         if (checked.has_overflow() || checked.value() > target_length) {
             vm.throw_exception<JS::RangeError>(global_object, "Overflow or out of bounds in target length");
@@ -436,7 +436,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
             return {};
         }
 
-        Checked checked { source_length };
+        Checked<size_t> checked = source_length;
         checked += static_cast<u32>(target_offset);
         if (checked.has_overflow() || checked.value() > target_length) {
             vm.throw_exception<JS::RangeError>(global_object, "Overflow or out of bounds in target length");

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -191,7 +191,7 @@ void BytecodeInterpreter::call_address(Configuration& configuration, FunctionAdd
         TRAP_IF_NOT(rhs.has_value());                                                              \
         dbgln_if(WASM_TRACE_DEBUG, "{} {} {} = ??", ulhs.value(), #operator, rhs.value());         \
         __VA_ARGS__;                                                                               \
-        Checked lhs = ulhs.value();                                                                \
+        Checked<type> lhs = ulhs.value();                                                          \
         lhs operator##= rhs.value();                                                               \
         TRAP_IF_NOT(!lhs.has_overflow());                                                          \
         auto result = lhs.value();                                                                 \


### PR DESCRIPTION
These were already implicitly required to be integral via the usage of the is_within_range templated function, but making them explicit should produce nicer error messages when building, and make the IDE highlight the incorrect usage.