### PR TITLE
LibJS: Fix parser scoping

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2349,9 +2349,9 @@ void ScopeNode::add_functions(NonnullRefPtrVector<FunctionDeclaration> functions
     m_functions.extend(move(functions));
 }
 
-void ScopeNode::add_hoisted_functions(NonnullRefPtrVector<FunctionDeclaration> hoisted_functions)
+void ScopeNode::add_hoisted_function(NonnullRefPtr<FunctionDeclaration> hoisted_function)
 {
-    m_hoisted_functions.extend(move(hoisted_functions));
+    m_hoisted_functions.append(hoisted_function);
 }
 
 }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2349,4 +2349,9 @@ void ScopeNode::add_functions(NonnullRefPtrVector<FunctionDeclaration> functions
     m_functions.extend(move(functions));
 }
 
+void ScopeNode::add_hoisted_functions(NonnullRefPtrVector<FunctionDeclaration> hoisted_functions)
+{
+    m_hoisted_functions.extend(move(hoisted_functions));
+}
+
 }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1286,13 +1286,6 @@ void FunctionNode::dump(int indent, String const& class_name) const
                 parameter.default_value->dump(indent + 3);
         }
     }
-    if (!m_variables.is_empty()) {
-        print_indent(indent + 1);
-        outln("(Variables)");
-
-        for (auto& variable : m_variables)
-            variable.dump(indent + 2);
-    }
     print_indent(indent + 1);
     outln("(Body)");
     body().dump(indent + 2);

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -145,7 +145,7 @@ public:
 
     void add_variables(NonnullRefPtrVector<VariableDeclaration>);
     void add_functions(NonnullRefPtrVector<FunctionDeclaration>);
-    void add_hoisted_functions(NonnullRefPtrVector<FunctionDeclaration>);
+    void add_hoisted_function(NonnullRefPtr<FunctionDeclaration>);
     NonnullRefPtrVector<VariableDeclaration> const& variables() const { return m_variables; }
     NonnullRefPtrVector<FunctionDeclaration> const& functions() const { return m_functions; }
     NonnullRefPtrVector<FunctionDeclaration> const& hoisted_functions() const { return m_hoisted_functions; }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -257,11 +257,10 @@ public:
     FunctionKind kind() const { return m_kind; }
 
 protected:
-    FunctionNode(FlyString name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, FunctionKind kind, bool is_strict_mode, bool is_arrow_function)
+    FunctionNode(FlyString name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool is_arrow_function)
         : m_name(move(name))
         , m_body(move(body))
         , m_parameters(move(parameters))
-        , m_variables(move(variables))
         , m_function_length(function_length)
         , m_kind(kind)
         , m_is_strict_mode(is_strict_mode)
@@ -270,8 +269,6 @@ protected:
     }
 
     void dump(int indent, String const& class_name) const;
-
-    NonnullRefPtrVector<VariableDeclaration> const& variables() const { return m_variables; }
 
 protected:
     void set_name(FlyString name)
@@ -284,7 +281,6 @@ private:
     FlyString m_name;
     NonnullRefPtr<Statement> m_body;
     Vector<Parameter> const m_parameters;
-    NonnullRefPtrVector<VariableDeclaration> m_variables;
     const i32 m_function_length;
     FunctionKind m_kind;
     bool m_is_strict_mode;
@@ -297,9 +293,9 @@ class FunctionDeclaration final
 public:
     static bool must_have_name() { return true; }
 
-    FunctionDeclaration(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, FunctionKind kind, bool is_strict_mode = false)
+    FunctionDeclaration(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode = false)
         : Declaration(source_range)
-        , FunctionNode(name, move(body), move(parameters), function_length, move(variables), kind, is_strict_mode, false)
+        , FunctionNode(name, move(body), move(parameters), function_length, kind, is_strict_mode, false)
     {
     }
 
@@ -314,9 +310,9 @@ class FunctionExpression final
 public:
     static bool must_have_name() { return false; }
 
-    FunctionExpression(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, FunctionKind kind, bool is_strict_mode, bool is_arrow_function = false)
+    FunctionExpression(SourceRange source_range, FlyString const& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, bool is_arrow_function = false)
         : Expression(source_range)
-        , FunctionNode(name, move(body), move(parameters), function_length, move(variables), kind, is_strict_mode, is_arrow_function)
+        , FunctionNode(name, move(body), move(parameters), function_length, kind, is_strict_mode, is_arrow_function)
     {
     }
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -145,8 +145,10 @@ public:
 
     void add_variables(NonnullRefPtrVector<VariableDeclaration>);
     void add_functions(NonnullRefPtrVector<FunctionDeclaration>);
+    void add_hoisted_functions(NonnullRefPtrVector<FunctionDeclaration>);
     NonnullRefPtrVector<VariableDeclaration> const& variables() const { return m_variables; }
     NonnullRefPtrVector<FunctionDeclaration> const& functions() const { return m_functions; }
+    NonnullRefPtrVector<FunctionDeclaration> const& hoisted_functions() const { return m_hoisted_functions; }
 
 protected:
     explicit ScopeNode(SourceRange source_range)
@@ -160,6 +162,7 @@ private:
     NonnullRefPtrVector<Statement> m_children;
     NonnullRefPtrVector<VariableDeclaration> m_variables;
     NonnullRefPtrVector<FunctionDeclaration> m_functions;
+    NonnullRefPtrVector<FunctionDeclaration> m_hoisted_functions;
 };
 
 class Program final : public ScopeNode {

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -84,6 +84,9 @@ const GlobalObject& Interpreter::global_object() const
 void Interpreter::enter_scope(const ScopeNode& scope_node, ScopeType scope_type, GlobalObject& global_object)
 {
     ScopeGuard guard([&] {
+        for (auto& declaration : scope_node.hoisted_functions()) {
+            lexical_environment()->put_into_environment(declaration.name(), { js_undefined(), DeclarationKind::Var });
+        }
         for (auto& declaration : scope_node.functions()) {
             auto* function = OrdinaryFunctionObject::create(global_object, declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), lexical_environment(), declaration.kind(), declaration.is_strict_mode());
             vm().set_variable(declaration.name(), function, global_object);

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -64,7 +64,24 @@ public:
             scope_node->add_variables(m_parser.m_state.let_scopes.last());
 
         scope_node->add_functions(m_parser.m_state.current_scope->function_declarations);
-        scope_node->add_hoisted_functions(m_parser.m_state.current_scope->hoisted_function_declarations);
+
+        for (auto& hoistable_function : m_parser.m_state.current_scope->hoisted_function_declarations) {
+            if (is_hoistable(hoistable_function)) {
+                scope_node->add_hoisted_function(hoistable_function.declaration);
+            }
+        }
+    }
+
+    static bool is_hoistable(Parser::Scope::HoistableDeclaration& declaration)
+    {
+        auto& name = declaration.declaration->name();
+        // See if we find any conflicting lexical declaration on the way up
+        for (RefPtr<Parser::Scope> scope = declaration.scope; !scope.is_null(); scope = scope->parent) {
+            if (scope->lexical_declarations.contains(name)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     Parser& m_parser;
@@ -304,7 +321,8 @@ NonnullRefPtr<Declaration> Parser::parse_declaration()
     case TokenType::Function: {
         auto declaration = parse_function_node<FunctionDeclaration>();
         m_state.current_scope->function_declarations.append(declaration);
-        m_state.current_scope->get_current_function_scope()->hoisted_function_declarations.append(declaration);
+        auto hoisting_target = m_state.current_scope->get_current_function_scope();
+        hoisting_target->hoisted_function_declarations.append({ declaration, *m_state.current_scope });
         return declaration;
     }
     case TokenType::Let:
@@ -1760,10 +1778,23 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
         consume_or_insert_semicolon();
 
     auto declaration = create_ast_node<VariableDeclaration>({ m_state.current_token.filename(), rule_start.position(), position() }, declaration_kind, move(declarations));
-    if (declaration_kind == DeclarationKind::Var)
+    if (declaration_kind == DeclarationKind::Var) {
         m_state.var_scopes.last().append(declaration);
-    else
+    } else {
         m_state.let_scopes.last().append(declaration);
+
+        for (auto& declarator : declaration->declarations()) {
+            declarator.target().visit(
+                [&](const NonnullRefPtr<Identifier>& id) {
+                    m_state.current_scope->lexical_declarations.set(id->string());
+                },
+                [&](const NonnullRefPtr<BindingPattern>& binding) {
+                    binding->for_each_bound_name([&](const auto& name) {
+                        m_state.current_scope->lexical_declarations.set(name);
+                    });
+                });
+        }
+    }
     return declaration;
 }
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -2033,6 +2033,11 @@ NonnullRefPtr<Statement> Parser::parse_for_statement()
     consume(TokenType::ParenOpen);
 
     bool in_scope = false;
+    ScopeGuard guard([&]() {
+        if (in_scope)
+            m_state.let_scopes.take_last();
+    });
+
     RefPtr<ASTNode> init;
     if (!match(TokenType::Semicolon)) {
         if (match_expression()) {
@@ -2074,10 +2079,6 @@ NonnullRefPtr<Statement> Parser::parse_for_statement()
     TemporaryChange break_change(m_state.in_break_context, true);
     TemporaryChange continue_change(m_state.in_continue_context, true);
     auto body = parse_statement();
-
-    if (in_scope) {
-        m_state.let_scopes.take_last();
-    }
 
     return create_ast_node<ForStatement>({ m_state.current_token.filename(), rule_start.position(), position() }, move(init), move(test), move(update), move(body));
 }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -348,7 +348,6 @@ NonnullRefPtr<Statement> Parser::parse_statement()
 RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expect_parens)
 {
     save_state();
-    m_state.var_scopes.append(NonnullRefPtrVector<VariableDeclaration>());
     auto rule_start = push_start();
 
     ArmedScopeGuard state_rollback_guard = [&] {
@@ -426,7 +425,7 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
         auto body = function_body_result.release_nonnull();
         return create_ast_node<FunctionExpression>(
             { m_state.current_token.filename(), rule_start.position(), position() }, "", move(body),
-            move(parameters), function_length, m_state.var_scopes.take_last(), FunctionKind::Regular, is_strict, true);
+            move(parameters), function_length, FunctionKind::Regular, is_strict, true);
     }
 
     return nullptr;
@@ -623,11 +622,11 @@ NonnullRefPtr<ClassExpression> Parser::parse_class_expression(bool expect_class_
 
             constructor = create_ast_node<FunctionExpression>(
                 { m_state.current_token.filename(), rule_start.position(), position() }, class_name, move(constructor_body),
-                Vector { FunctionNode::Parameter { FlyString { "args" }, nullptr, true } }, 0, NonnullRefPtrVector<VariableDeclaration>(), FunctionKind::Regular, true);
+                Vector { FunctionNode::Parameter { FlyString { "args" }, nullptr, true } }, 0, FunctionKind::Regular, true);
         } else {
             constructor = create_ast_node<FunctionExpression>(
                 { m_state.current_token.filename(), rule_start.position(), position() }, class_name, move(constructor_body),
-                Vector<FunctionNode::Parameter> {}, 0, NonnullRefPtrVector<VariableDeclaration>(), FunctionKind::Regular, true);
+                Vector<FunctionNode::Parameter> {}, 0, FunctionKind::Regular, true);
         }
     }
 
@@ -1465,7 +1464,7 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u8 parse_options)
     body->add_functions(m_state.function_scopes.last());
     return create_ast_node<FunctionNodeType>(
         { m_state.current_token.filename(), rule_start.position(), position() },
-        name, move(body), move(parameters), function_length, NonnullRefPtrVector<VariableDeclaration>(),
+        name, move(body), move(parameters), function_length,
         is_generator ? FunctionKind::Generator : FunctionKind::Regular, is_strict);
 }
 

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -201,12 +201,18 @@ private:
             Function,
             Block,
         };
+        struct HoistableDeclaration {
+            NonnullRefPtr<FunctionDeclaration> declaration;
+            NonnullRefPtr<Scope> scope; // where it is actually declared
+        };
 
         Type type;
         RefPtr<Scope> parent;
 
         NonnullRefPtrVector<FunctionDeclaration> function_declarations;
-        NonnullRefPtrVector<FunctionDeclaration> hoisted_function_declarations;
+        Vector<HoistableDeclaration> hoisted_function_declarations;
+
+        HashTable<FlyString> lexical_declarations;
 
         explicit Scope(Type, RefPtr<Scope>);
         RefPtr<Scope> get_current_function_scope();

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -196,13 +196,29 @@ private:
 
     [[nodiscard]] RulePosition push_start() { return { *this, position() }; }
 
+    struct Scope : public RefCounted<Scope> {
+        enum Type {
+            Function,
+            Block,
+        };
+
+        Type type;
+        RefPtr<Scope> parent;
+
+        NonnullRefPtrVector<FunctionDeclaration> function_declarations;
+        NonnullRefPtrVector<FunctionDeclaration> hoisted_function_declarations;
+
+        explicit Scope(Type, RefPtr<Scope>);
+        RefPtr<Scope> get_current_function_scope();
+    };
+
     struct ParserState {
         Lexer lexer;
         Token current_token;
         Vector<Error> errors;
         Vector<NonnullRefPtrVector<VariableDeclaration>> var_scopes;
         Vector<NonnullRefPtrVector<VariableDeclaration>> let_scopes;
-        Vector<NonnullRefPtrVector<FunctionDeclaration>> function_scopes;
+        RefPtr<Scope> current_scope;
 
         Vector<Vector<FunctionNode::Parameter>&> function_parameters;
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.every.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.every.js
@@ -46,7 +46,7 @@ describe("normal behavior", () => {
         var array = [1, 2, 3, 4, 5];
 
         expect(
-            arrayTwo.every((value, index, arr) => {
+            array.every((value, index, arr) => {
                 arr.push(6);
                 return value <= 5;
             })

--- a/Userland/Libraries/LibJS/Tests/functions/function-hoisting.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-hoisting.js
@@ -8,7 +8,7 @@ test("basic functionality", () => {
 });
 
 // First two calls produce a ReferenceError, but the declarations should be hoisted
-test.skip("functions are hoisted across non-lexical scopes", () => {
+test("functions are hoisted across non-lexical scopes", () => {
     expect(scopedHoisted).toBeUndefined();
     expect(callScopedHoisted).toBeUndefined();
     {

--- a/Userland/Libraries/LibJS/Tests/operators/assignment-operators.js
+++ b/Userland/Libraries/LibJS/Tests/operators/assignment-operators.js
@@ -127,7 +127,7 @@ test("evaluation order", () => {
         b.hasBeenCalled = false;
         c.hasBeenCalled = false;
         expect(() => {
-            new Function(`a[b()] ${op} c()`)();
+            new Function("a", "b", "c", "op", `a[b()] ${op} c()`)(a, b, c, op);
         }).toThrow(Error);
         expect(b.hasBeenCalled).toBeTrue();
         expect(c.hasBeenCalled).toBeFalse();

--- a/Userland/Libraries/LibJS/Tests/test-common.js
+++ b/Userland/Libraries/LibJS/Tests/test-common.js
@@ -1,10 +1,10 @@
-let describe;
-let test;
-let expect;
+var describe;
+var test;
+var expect;
 
 // Stores the results of each test and suite. Has a terrible
 // name to avoid name collision.
-let __TestResults__ = {};
+var __TestResults__ = {};
 
 // So test names like "toString" don't automatically produce an error
 Object.setPrototypeOf(__TestResults__, null);
@@ -12,7 +12,7 @@ Object.setPrototypeOf(__TestResults__, null);
 // This array is used to communicate with the C++ program. It treats
 // each message in this array as a separate message. Has a terrible
 // name to avoid name collision.
-let __UserOutput__ = [];
+var __UserOutput__ = [];
 
 // We also rebind console.log here to use the array above
 console.log = (...args) => {


### PR DESCRIPTION
This pull request improves function hoisting so that there's no more `skip` in the `function-hoisting` test.

As a side effect, it also does some general improvements w.r.t to scoping, especially when it comes to arrow functions. This caused scoping bugs in two other tests to show up, which have also been fixed.

~~The PR is currently in draft status because it breaks 67 annexB tests in test262.~~ Outside of annexB, it doesn't cause any regressions and even allows two more tests to pass successfully.

Closes #8299 .