### PR TITLE
LibGfx/BMPWriter + PixelPaint: Add DIB v3 & v4 with support for saving image with alpha channel

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -192,9 +192,9 @@ Result<void, String> Image::write_to_file(const String& file_path) const
     return {};
 }
 
-RefPtr<Gfx::Bitmap> Image::try_compose_bitmap() const
+RefPtr<Gfx::Bitmap> Image::try_compose_bitmap(Gfx::BitmapFormat format) const
 {
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, m_size);
+    auto bitmap = Gfx::Bitmap::create(format, m_size);
     if (!bitmap)
         return nullptr;
     GUI::Painter painter(*bitmap);
@@ -202,13 +202,14 @@ RefPtr<Gfx::Bitmap> Image::try_compose_bitmap() const
     return bitmap;
 }
 
-Result<void, String> Image::export_bmp_to_file(String const& file_path)
+Result<void, String> Image::export_bmp_to_file(String const& file_path, bool preserve_alpha_channel)
 {
     auto file_or_error = Core::File::open(file_path, (Core::OpenMode)(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate));
     if (file_or_error.is_error())
         return file_or_error.error();
 
-    auto bitmap = try_compose_bitmap();
+    auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
+    auto bitmap = try_compose_bitmap(bitmap_format);
     if (!bitmap)
         return String { "Failed to allocate bitmap for encoding"sv };
 
@@ -222,13 +223,14 @@ Result<void, String> Image::export_bmp_to_file(String const& file_path)
     return {};
 }
 
-Result<void, String> Image::export_png_to_file(String const& file_path)
+Result<void, String> Image::export_png_to_file(String const& file_path, bool preserve_alpha_channel)
 {
     auto file_or_error = Core::File::open(file_path, (Core::OpenMode)(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate));
     if (file_or_error.is_error())
         return file_or_error.error();
 
-    auto bitmap = try_compose_bitmap();
+    auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
+    auto bitmap = try_compose_bitmap(bitmap_format);
     if (!bitmap)
         return String { "Failed to allocate bitmap for encoding"sv };
 

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -43,7 +43,7 @@ public:
     static RefPtr<Image> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
-    RefPtr<Gfx::Bitmap> try_compose_bitmap() const;
+    RefPtr<Gfx::Bitmap> try_compose_bitmap(Gfx::BitmapFormat format) const;
 
     size_t layer_count() const { return m_layers.size(); }
     Layer const& layer(size_t index) const { return m_layers.at(index); }
@@ -58,8 +58,8 @@ public:
 
     void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
     Result<void, String> write_to_file(String const& file_path) const;
-    Result<void, String> export_bmp_to_file(String const& file_path);
-    Result<void, String> export_png_to_file(String const& file_path);
+    Result<void, String> export_bmp_to_file(String const& file_path, bool preserve_alpha_channel);
+    Result<void, String> export_png_to_file(String const& file_path, bool preserve_alpha_channel);
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -157,7 +157,8 @@ int main(int argc, char** argv)
                 auto save_path = GUI::FilePicker::get_save_filepath(window, "untitled", "bmp");
                 if (!save_path.has_value())
                     return;
-                auto result = editor->image().export_bmp_to_file(save_path.value());
+                auto preserve_alpha_channel = GUI::MessageBox::show(window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
+                auto result = editor->image().export_bmp_to_file(save_path.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
                 if (result.is_error())
                     GUI::MessageBox::show_error(window, String::formatted("Export to BMP failed: {}", result.error()));
             },
@@ -169,7 +170,8 @@ int main(int argc, char** argv)
                 auto save_path = GUI::FilePicker::get_save_filepath(window, "untitled", "png");
                 if (!save_path.has_value())
                     return;
-                auto result = editor->image().export_bmp_to_file(save_path.value());
+                auto preserve_alpha_channel = GUI::MessageBox::show(window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
+                auto result = editor->image().export_png_to_file(save_path.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
                 if (result.is_error())
                     GUI::MessageBox::show_error(window, String::formatted("Export to PNG failed: {}", result.error()));
             },

--- a/Userland/Libraries/LibGfx/BMPWriter.h
+++ b/Userland/Libraries/LibGfx/BMPWriter.h
@@ -16,16 +16,25 @@ class BMPWriter {
 public:
     BMPWriter() = default;
 
-    ByteBuffer dump(const RefPtr<Bitmap>);
-
     enum class Compression : u32 {
-        RGB = 0,
+        BI_RGB = 0,
+        BI_BITFIELDS = 3,
     };
+
+    enum class DibHeader : u32 {
+        Info = 40,
+        V3 = 56,
+        V4 = 108,
+    };
+
+    ByteBuffer dump(const RefPtr<Bitmap>, DibHeader dib_header = DibHeader::V4);
 
     inline void set_compression(Compression compression) { m_compression = compression; }
 
 private:
-    Compression m_compression { Compression::RGB };
+    Compression m_compression { Compression::BI_BITFIELDS };
+    int m_bytes_per_pixel { 4 };
+    bool m_include_alpha_channel { true };
 };
 
 }


### PR DESCRIPTION
This PR extends `BMPWriter` with very basic support for `BITMAPV3INFOHEADER` and `BITMAPV4HEADER`. This enables us to save BMP files with the alpha channel preserved, in for example .pp files or when exporting to BMP.

No color space or gamma information is stored but can be implemented in the future if needed.