### PR TITLE
WindowServer: Improve screen invalidation on window state changes

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -655,6 +655,18 @@ void Compositor::invalidate_screen(const Gfx::IntRect& screen_rect)
     start_compose_async_timer();
 }
 
+void Compositor::invalidate_screen(Gfx::DisjointRectSet const& rects)
+{
+    m_dirty_screen_rects.add(rects.intersected(Screen::bounding_rect()));
+
+    if (m_invalidated_any)
+        return;
+
+    m_invalidated_any = true;
+    m_invalidated_window = true;
+    start_compose_async_timer();
+}
+
 void Compositor::invalidate_window()
 {
     if (m_invalidated_window)
@@ -1042,14 +1054,31 @@ void Compositor::recompute_occlusions()
         visible_rects.add_many(Screen::rects());
         bool have_transparent = false;
         wm.for_each_visible_window_from_front_to_back([&](Window& w) {
+            VERIFY(!w.is_minimized());
             w.transparency_wallpaper_rects().clear();
+            auto previous_visible_opaque = move(w.opaque_rects());
+            auto previous_visible_transparency = move(w.transparency_rects());
+
+            auto invalidate_previous_render_rects = [&](Gfx::IntRect const& new_render_rect) {
+                if (!previous_visible_opaque.is_empty()) {
+                    if (new_render_rect.is_empty())
+                        invalidate_screen(previous_visible_opaque);
+                    else
+                        invalidate_screen(previous_visible_opaque.shatter(new_render_rect));
+                }
+                if (!previous_visible_transparency.is_empty()) {
+                    if (new_render_rect.is_empty())
+                        invalidate_screen(previous_visible_transparency);
+                    else
+                        invalidate_screen(previous_visible_transparency.shatter(new_render_rect));
+                }
+            };
+
             auto& visible_opaque = w.opaque_rects();
-            visible_opaque.clear();
             auto& transparency_rects = w.transparency_rects();
-            transparency_rects.clear();
+            bool should_invalidate_old = w.should_invalidate_last_rendered_screen_rects();
+
             w.screens().clear_with_capacity();
-            if (w.is_minimized())
-                return IterationDecision::Continue;
 
             auto transition_offset = window_transition_offset(w);
             auto transparent_frame_render_rects = w.frame().transparent_render_rects();
@@ -1057,6 +1086,12 @@ void Compositor::recompute_occlusions()
             if (window_stack_transition_in_progress) {
                 transparent_frame_render_rects.translate_by(transition_offset);
                 opaque_frame_render_rects.translate_by(transition_offset);
+            }
+            if (should_invalidate_old) {
+                for (auto& rect : opaque_frame_render_rects.rects())
+                    invalidate_previous_render_rects(rect);
+                for (auto& rect : transparent_frame_render_rects.rects())
+                    invalidate_previous_render_rects(rect);
             }
             Gfx::DisjointRectSet visible_opaque_rects;
             Screen::for_each([&](auto& screen) {
@@ -1091,8 +1126,7 @@ void Compositor::recompute_occlusions()
                     return IterationDecision::Continue;
                 }
 
-                if (w2.is_minimized())
-                    return IterationDecision::Continue;
+                VERIFY(!w2.is_minimized());
 
                 auto w2_render_rect = w2.frame().render_rect();
                 auto w2_render_rect_on_screen = w2_render_rect;
@@ -1198,10 +1232,8 @@ void Compositor::recompute_occlusions()
             // Determine what transparent window areas need to render the wallpaper first
             wm.for_each_visible_window_from_back_to_front([&](Window& w) {
                 auto& transparency_wallpaper_rects = w.transparency_wallpaper_rects();
-                if (w.is_minimized()) {
-                    transparency_wallpaper_rects.clear();
-                    return IterationDecision::Continue;
-                }
+                VERIFY(!w.is_minimized());
+
                 Gfx::DisjointRectSet& transparency_rects = w.transparency_rects();
                 if (transparency_rects.is_empty()) {
                     transparency_wallpaper_rects.clear();

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -42,6 +42,7 @@ public:
     void invalidate_window();
     void invalidate_screen();
     void invalidate_screen(const Gfx::IntRect&);
+    void invalidate_screen(Gfx::DisjointRectSet const&);
 
     void screen_resolution_changed();
 

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -201,6 +201,9 @@ public:
     void invalidate(const Gfx::IntRect&, bool with_frame = false);
     void invalidate_menubar();
     bool invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame = false);
+    void invalidate_last_rendered_screen_rects();
+    void invalidate_last_rendered_screen_rects_now();
+    [[nodiscard]] bool should_invalidate_last_rendered_screen_rects() { return exchange(m_invalidate_last_render_rects, false); }
 
     void refresh_client_size();
 
@@ -409,6 +412,7 @@ private:
     bool m_hit_testing_enabled { true };
     bool m_modified { false };
     bool m_moving_to_another_stack { false };
+    bool m_invalidate_last_render_rects { false };
     WindowTileType m_tiled { WindowTileType::None };
     Gfx::IntRect m_untiled_rect;
     bool m_occluded { false };

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -598,25 +598,7 @@ void WindowFrame::window_rect_changed(const Gfx::IntRect& old_rect, const Gfx::I
 {
     layout_buttons();
 
-    auto new_frame_rect = constrained_render_rect_to_screen(frame_rect_for_window(m_window, new_rect));
     set_dirty(true);
-    auto& compositor = Compositor::the();
-
-    {
-        // Invalidate the areas outside of the new rect. Use the last computed occlusions for this purpose
-        // as we can't reliably calculate the previous frame rect anymore. The window state (e.g. maximized
-        // or tiled) may affect the calculations and it may have already been changed by the time we get
-        // called here.
-        auto invalidate_opaque = m_window.opaque_rects().shatter(new_frame_rect);
-        for (auto& rect : invalidate_opaque.rects())
-            compositor.invalidate_screen(rect);
-        auto invalidate_transparent = m_window.transparency_rects().shatter(new_frame_rect);
-        for (auto& rect : invalidate_transparent.rects())
-            compositor.invalidate_screen(rect);
-    }
-
-    compositor.invalidate_occlusions();
-
     WindowManager::the().notify_rect_changed(m_window, old_rect, new_rect);
 }
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -399,7 +399,7 @@ void WindowManager::remove_window(Window& window)
     if (active == &window || active_input == &window || (active && window.is_descendant_of(*active)) || (active_input && active_input != active && window.is_descendant_of(*active_input)))
         pick_new_active_window(&window);
 
-    Compositor::the().invalidate_screen(window.frame().render_rect());
+    window.invalidate_last_rendered_screen_rects_now();
 
     if (m_switcher.is_visible() && window.type() != WindowType::WindowSwitcher)
         m_switcher.refresh();


### PR DESCRIPTION
Because window states and various flags can affect the windows'
rendered areas it's safer to use the last computed occlusion rectangles
to invalidate areas on the screen that may have to be re-rendered due
to e.g. a window size change.

Fixes #6723