### PR TITLE
LibJS: Make FunctionObject's m_home_object an Object*, not Value

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
@@ -33,9 +33,9 @@ Value FunctionEnvironment::get_super_base() const
 {
     VERIFY(m_function_object);
     auto home_object = m_function_object->home_object();
-    if (home_object.is_undefined())
+    if (!home_object)
         return js_undefined();
-    return home_object.as_object().internal_get_prototype_of();
+    return home_object->internal_get_prototype_of();
 }
 
 // 9.1.1.3.2 HasThisBinding ( ), https://tc39.es/ecma262/#sec-function-environment-records-hasthisbinding
@@ -51,7 +51,7 @@ bool FunctionEnvironment::has_super_binding() const
 {
     if (this_binding_status() == ThisBindingStatus::Lexical)
         return false;
-    if (function_object().home_object().is_undefined())
+    if (!function_object().home_object())
         return false;
     return true;
 }

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -34,8 +34,8 @@ public:
 
     const Vector<Value>& bound_arguments() const { return m_bound_arguments; }
 
-    Value home_object() const { return m_home_object; }
-    void set_home_object(Value home_object) { m_home_object = home_object; }
+    Object* home_object() const { return m_home_object; }
+    void set_home_object(Object* home_object) { m_home_object = home_object; }
 
     ConstructorKind constructor_kind() const { return m_constructor_kind; };
     void set_constructor_kind(ConstructorKind constructor_kind) { m_constructor_kind = constructor_kind; }
@@ -75,7 +75,7 @@ private:
     virtual bool is_function() const override { return true; }
     Value m_bound_this;
     Vector<Value> m_bound_arguments;
-    Value m_home_object;
+    Object* m_home_object { nullptr };
     ConstructorKind m_constructor_kind = ConstructorKind::Base;
     ThisMode m_this_mode { ThisMode::Global };
     bool m_has_simple_parameter_list { false };


### PR DESCRIPTION
As the name implies (and the spec confirms), this is only ever going to
be an object or "nothing", or "undefined" in the spec. By taking this
literally and updating a check to check for `is_undefined()`, we
introduced a bug - the value was still initialized as an empty value.
Instead, use a pointer to an Object - either we have one, or we don't.

Fixes #8448.