### PR TITLE
LibWeb: Remove all usages of Native Properties

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -23,13 +23,13 @@ void LocationObject::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
     u8 attr = JS::Attribute::Writable | JS::Attribute::Enumerable;
-    define_native_property("href", href_getter, href_setter, attr);
-    define_native_property("host", host_getter, nullptr, attr);
-    define_native_property("hostname", hostname_getter, nullptr, attr);
-    define_native_property("pathname", pathname_getter, nullptr, attr);
-    define_native_property("hash", hash_getter, nullptr, attr);
-    define_native_property("search", search_getter, nullptr, attr);
-    define_native_property("protocol", protocol_getter, nullptr, attr);
+    define_native_accessor("href", href_getter, href_setter, attr);
+    define_native_accessor("host", host_getter, {}, attr);
+    define_native_accessor("hostname", hostname_getter, {}, attr);
+    define_native_accessor("pathname", pathname_getter, {}, attr);
+    define_native_accessor("hash", hash_getter, {}, attr);
+    define_native_accessor("search", search_getter, {}, attr);
+    define_native_accessor("protocol", protocol_getter, {}, attr);
 
     define_native_function("reload", reload, 0, JS::Attribute::Enumerable);
 }
@@ -38,46 +38,47 @@ LocationObject::~LocationObject()
 {
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::href_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::href_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::js_string(vm, window.impl().document().url().to_string());
 }
 
-JS_DEFINE_NATIVE_SETTER(LocationObject::href_setter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::href_setter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
-    auto new_href = value.to_string(global_object);
+    auto new_href = vm.argument(0).to_string(global_object);
     if (vm.exception())
-        return;
+        return {};
     auto href_url = window.impl().document().complete_url(new_href);
     if (!href_url.is_valid()) {
         vm.throw_exception<JS::URIError>(global_object, String::formatted("Invalid URL '{}'", new_href));
-        return;
+        return {};
     }
     window.impl().did_set_location_href({}, href_url);
+    return JS::js_undefined();
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::pathname_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::pathname_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::js_string(vm, window.impl().document().url().path());
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::hostname_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::hostname_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::js_string(vm, window.impl().document().url().host());
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::host_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::host_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     auto url = window.impl().document().url();
     return JS::js_string(vm, String::formatted("{}:{}", url.host(), url.port()));
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::hash_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::hash_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     auto fragment = window.impl().document().url().fragment();
@@ -89,7 +90,7 @@ JS_DEFINE_NATIVE_GETTER(LocationObject::hash_getter)
     return JS::js_string(vm, builder.to_string());
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::search_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::search_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     auto query = window.impl().document().url().query();
@@ -101,7 +102,7 @@ JS_DEFINE_NATIVE_GETTER(LocationObject::search_getter)
     return JS::js_string(vm, builder.to_string());
 }
 
-JS_DEFINE_NATIVE_GETTER(LocationObject::protocol_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::protocol_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     StringBuilder builder;

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.h
@@ -23,15 +23,15 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(reload);
 
-    JS_DECLARE_NATIVE_GETTER(href_getter);
-    JS_DECLARE_NATIVE_SETTER(href_setter);
+    JS_DECLARE_NATIVE_FUNCTION(href_getter);
+    JS_DECLARE_NATIVE_FUNCTION(href_setter);
 
-    JS_DECLARE_NATIVE_GETTER(host_getter);
-    JS_DECLARE_NATIVE_GETTER(hostname_getter);
-    JS_DECLARE_NATIVE_GETTER(pathname_getter);
-    JS_DECLARE_NATIVE_GETTER(hash_getter);
-    JS_DECLARE_NATIVE_GETTER(search_getter);
-    JS_DECLARE_NATIVE_GETTER(protocol_getter);
+    JS_DECLARE_NATIVE_FUNCTION(host_getter);
+    JS_DECLARE_NATIVE_FUNCTION(hostname_getter);
+    JS_DECLARE_NATIVE_FUNCTION(pathname_getter);
+    JS_DECLARE_NATIVE_FUNCTION(hash_getter);
+    JS_DECLARE_NATIVE_FUNCTION(search_getter);
+    JS_DECLARE_NATIVE_FUNCTION(protocol_getter);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/FlyString.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibWeb/Bindings/NavigatorObject.h>
@@ -24,6 +23,7 @@ void NavigatorObject::initialize(JS::GlobalObject& global_object)
     auto* languages = JS::Array::create(global_object, 0);
     languages->indexed_properties().append(js_string(heap, "en-US"));
 
+    // FIXME: All of these should be in Navigator's prototype and be native accessors
     define_property("appCodeName", js_string(heap, "Mozilla"));
     define_property("appName", js_string(heap, "Netscape"));
     define_property("appVersion", js_string(heap, "4.0"));
@@ -32,14 +32,14 @@ void NavigatorObject::initialize(JS::GlobalObject& global_object)
     define_property("platform", js_string(heap, "SerenityOS"));
     define_property("product", js_string(heap, "Gecko"));
 
-    define_native_property("userAgent", user_agent_getter, nullptr);
+    define_native_accessor("userAgent", user_agent_getter, {});
 }
 
 NavigatorObject::~NavigatorObject()
 {
 }
 
-JS_DEFINE_NATIVE_GETTER(NavigatorObject::user_agent_getter)
+JS_DEFINE_NATIVE_FUNCTION(NavigatorObject::user_agent_getter)
 {
     return JS::js_string(vm, ResourceLoader::the().user_agent());
 }

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.h
@@ -21,7 +21,7 @@ public:
     virtual ~NavigatorObject() override;
 
 private:
-    JS_DECLARE_NATIVE_GETTER(user_agent_getter);
+    JS_DECLARE_NATIVE_FUNCTION(user_agent_getter);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -46,16 +46,17 @@ void WindowObject::initialize_global_object()
     auto success = Object::internal_set_prototype_of(&ensure_web_prototype<EventTargetPrototype>("EventTarget"));
     VERIFY(success);
 
+    // FIXME: These should be native accessors, not properties
     define_property("window", this, JS::Attribute::Enumerable);
     define_property("frames", this, JS::Attribute::Enumerable);
     define_property("self", this, JS::Attribute::Enumerable);
-    define_native_property("top", top_getter, nullptr, JS::Attribute::Enumerable);
-    define_native_property("parent", parent_getter, nullptr, JS::Attribute::Enumerable);
-    define_native_property("document", document_getter, nullptr, JS::Attribute::Enumerable);
-    define_native_property("performance", performance_getter, nullptr, JS::Attribute::Enumerable);
-    define_native_property("screen", screen_getter, nullptr, JS::Attribute::Enumerable);
-    define_native_property("innerWidth", inner_width_getter, nullptr, JS::Attribute::Enumerable);
-    define_native_property("innerHeight", inner_height_getter, nullptr, JS::Attribute::Enumerable);
+    define_native_accessor("top", top_getter, nullptr, JS::Attribute::Enumerable);
+    define_native_accessor("parent", parent_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("document", document_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("performance", performance_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("screen", screen_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("innerWidth", inner_width_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("innerHeight", inner_height_getter, {}, JS::Attribute::Enumerable);
     define_native_function("alert", alert);
     define_native_function("confirm", confirm);
     define_native_function("prompt", prompt);
@@ -69,7 +70,7 @@ void WindowObject::initialize_global_object()
     define_native_function("btoa", btoa, 1);
 
     // Legacy
-    define_native_property("event", event_getter, nullptr, JS::Attribute::Enumerable);
+    define_native_accessor("event", event_getter, {}, JS::Attribute::Enumerable);
 
     define_property("navigator", heap().allocate<NavigatorObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
     define_property("location", heap().allocate<LocationObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
@@ -341,7 +342,7 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::btoa)
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#dom-top
-JS_DEFINE_NATIVE_GETTER(WindowObject::top_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::top_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -357,7 +358,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::top_getter)
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#dom-parent
-JS_DEFINE_NATIVE_GETTER(WindowObject::parent_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::parent_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -376,7 +377,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::parent_getter)
     return impl->wrapper();
 }
 
-JS_DEFINE_NATIVE_GETTER(WindowObject::document_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::document_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -384,7 +385,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::document_getter)
     return wrap(global_object, impl->document());
 }
 
-JS_DEFINE_NATIVE_GETTER(WindowObject::performance_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::performance_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -392,7 +393,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::performance_getter)
     return wrap(global_object, impl->performance());
 }
 
-JS_DEFINE_NATIVE_GETTER(WindowObject::screen_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -400,7 +401,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::screen_getter)
     return wrap(global_object, impl->screen());
 }
 
-JS_DEFINE_NATIVE_GETTER(WindowObject::event_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::event_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -410,7 +411,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::event_getter)
     return wrap(global_object, const_cast<DOM::Event&>(*impl->current_event()));
 }
 
-JS_DEFINE_NATIVE_GETTER(WindowObject::inner_width_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::inner_width_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)
@@ -418,7 +419,7 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::inner_width_getter)
     return JS::Value(impl->inner_width());
 }
 
-JS_DEFINE_NATIVE_GETTER(WindowObject::inner_height_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::inner_height_getter)
 {
     auto* impl = impl_from(vm, global_object);
     if (!impl)

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -58,19 +58,19 @@ public:
 private:
     virtual void visit_edges(Visitor&) override;
 
-    JS_DECLARE_NATIVE_GETTER(top_getter);
+    JS_DECLARE_NATIVE_FUNCTION(top_getter);
 
-    JS_DECLARE_NATIVE_GETTER(document_getter);
+    JS_DECLARE_NATIVE_FUNCTION(document_getter);
 
-    JS_DECLARE_NATIVE_GETTER(performance_getter);
-    JS_DECLARE_NATIVE_GETTER(screen_getter);
+    JS_DECLARE_NATIVE_FUNCTION(performance_getter);
+    JS_DECLARE_NATIVE_FUNCTION(screen_getter);
 
-    JS_DECLARE_NATIVE_GETTER(event_getter);
+    JS_DECLARE_NATIVE_FUNCTION(event_getter);
 
-    JS_DECLARE_NATIVE_GETTER(inner_width_getter);
-    JS_DECLARE_NATIVE_GETTER(inner_height_getter);
+    JS_DECLARE_NATIVE_FUNCTION(inner_width_getter);
+    JS_DECLARE_NATIVE_FUNCTION(inner_height_getter);
 
-    JS_DECLARE_NATIVE_GETTER(parent_getter);
+    JS_DECLARE_NATIVE_FUNCTION(parent_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(alert);
     JS_DECLARE_NATIVE_FUNCTION(confirm);


### PR DESCRIPTION
This is required by the WebIDL specification, and as a result removes all non-LibJS usages of native properties.