### PR TITLE
LibJS: Fix Promise constructor reject function argument

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -68,11 +68,11 @@ Value PromiseConstructor::construct(FunctionObject& new_target)
 
     auto [resolve_function, reject_function] = promise->create_resolving_functions();
 
-    auto completion_value = vm.call(executor.as_function(), js_undefined(), &resolve_function, &reject_function);
-    if (vm.exception()) {
+    (void)vm.call(executor.as_function(), js_undefined(), &resolve_function, &reject_function);
+    if (auto* exception = vm.exception()) {
         vm.clear_exception();
         vm.stop_unwind();
-        [[maybe_unused]] auto result = vm.call(reject_function, js_undefined(), completion_value);
+        (void)vm.call(reject_function, js_undefined(), exception->value());
     }
     return promise;
 }


### PR DESCRIPTION
If calling the executor function throws an exception, the return value
of `vm.call()` will be an empty value, which we then passed as an
argument to the reject function, which is incorrect - what it actually
needs is the exception value. This stems from a misunderstanding of the
spec I had at the time of implementing this - in their case, the
exception value is part of the completion record returned by Call().

This error was previously masked as we would use a fallback
(`value_or(js_undefined())` for the empty value argument, but that was
removed in 57f7e6e.

Fixes #8447.