### PR TITLE
Piano+LibAudio: Make Piano use AudioServer instead of /dev/audio

### DIFF
--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -23,7 +23,7 @@ struct Sample {
     i16 right;
 };
 
-constexpr int sample_count = 1024;
+constexpr int sample_count = 1 << 9;
 
 constexpr int buffer_size = sample_count * sizeof(Sample);
 

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -14,7 +14,7 @@ ClientConnection::ClientConnection()
 {
 }
 
-void ClientConnection::enqueue(const Buffer& buffer)
+void ClientConnection::enqueue(Buffer const& buffer)
 {
     for (;;) {
         auto success = enqueue_buffer(buffer.anonymous_buffer(), buffer.id(), buffer.sample_count());
@@ -26,7 +26,12 @@ void ClientConnection::enqueue(const Buffer& buffer)
     }
 }
 
-bool ClientConnection::try_enqueue(const Buffer& buffer)
+void ClientConnection::async_enqueue(Buffer const& buffer)
+{
+    async_enqueue_buffer(buffer.anonymous_buffer(), buffer.id(), buffer.sample_count());
+}
+
+bool ClientConnection::try_enqueue(Buffer const& buffer)
 {
     return enqueue_buffer(buffer.anonymous_buffer(), buffer.id(), buffer.sample_count());
 }

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -20,7 +20,9 @@ void ClientConnection::enqueue(const Buffer& buffer)
         auto success = enqueue_buffer(buffer.anonymous_buffer(), buffer.id(), buffer.sample_count());
         if (success)
             break;
-        usleep(100000);
+        // FIXME: We don't know what is a good value for this.
+        // For now, decrease it to enable better real-time audio.
+        usleep(10000);
     }
 }
 

--- a/Userland/Libraries/LibAudio/ClientConnection.h
+++ b/Userland/Libraries/LibAudio/ClientConnection.h
@@ -21,8 +21,9 @@ class ClientConnection final
 public:
     ClientConnection();
 
-    void enqueue(const Buffer&);
-    bool try_enqueue(const Buffer&);
+    void enqueue(Buffer const&);
+    bool try_enqueue(Buffer const&);
+    void async_enqueue(Buffer const&);
 
     Function<void(i32 buffer_id)> on_finish_playing_buffer;
     Function<void(bool muted)> on_muted_state_change;


### PR DESCRIPTION
These three commits fix long-standing issues with the way that Piano handled audio playback: As a very old application, it would talk directly to `/dev/audio`, bypassing the AudioServer stack. This PR makes Piano talk to AudioServer and adds the required LibAudio backend. Audio performance is greatly improved and you can now mute Piano from the system tray! :^)