### PR TITLE
LibThreading: Fix BackgroundAction result use-after-free

### DIFF
--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -66,8 +66,8 @@ private:
         enqueue_work([this] {
             m_result = m_action(*this);
             if (m_on_complete) {
-                Core::EventLoop::current().post_event(*this, make<Core::DeferredInvocationEvent>([this](auto&) {
-                    m_on_complete(m_result.release_value());
+                Core::EventLoop::current().post_event(*this, make<Core::DeferredInvocationEvent>([this, result = m_result.release_value()](auto&) {
+                    m_on_complete(result);
                     this->remove_from_parent();
                 }));
                 Core::EventLoop::wake();


### PR DESCRIPTION
We need to move the result out of the BackgroundAction object before
posting the completion callback as there is a chance the
BackgroundAction instance gets freed before the event loop runs our
callback.

Fixes #7641

@gunnarbeutner 