### PR TITLE
Kernel/FileSystem: Some changes to VFS

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -852,9 +852,9 @@ KResult VFS::validate_path_against_process_veil(StringView path, int options)
     if (path == "/usr/lib/Loader.so")
         return KSuccess;
 
-    // FIXME: Figure out a nicer way to do this.
-    if (String(path).contains("/.."))
-        return EINVAL;
+    VERIFY(path.starts_with('/'));
+    VERIFY(!path.contains("/../"sv) && !path.ends_with("/.."sv));
+    VERIFY(!path.contains("/./"sv) && !path.ends_with("/."sv));
 
     auto& unveiled_path = find_matching_unveiled_path(path);
     if (unveiled_path.permissions() == UnveilAccess::None) {

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -103,6 +103,7 @@ private:
     friend class FileDescription;
 
     UnveilNode const& find_matching_unveiled_path(StringView path);
+    KResult validate_path_against_process_veil(Custody const& path, int options);
     KResult validate_path_against_process_veil(StringView path, int options);
 
     bool is_vfs_root(InodeIdentifier) const;


### PR DESCRIPTION
This PR contains three patches:
1) Previously, every caller of `validate_path_against_process_veil` needed to provide the absolute path, which meant allocating a `KString`. This is entirely pointless if there is no veil at all. This adds an overload to that method that takes a `Custody const&` and only calls `Custody::absolute_path` if there actually is a veil and the path is actually needed. (This improves the time Assistant takes to index the file system by around 16 percent on my machine.)
2) Replace some instantiations of `LexicalPath` with the static `LexicalPath::basename` in VFS. This just cleans up the code a bit, and doesn't change anything, since the static method still creates a `LexicalPath` object (this is to be improved in the future).
3) Check paths input into `validate_path_against_process_veil` more strictly. We should only allow absolute paths without any `.` or `..` segments. This should `VERIFY` instead of returning `EINVAL` since it's the responsibility of the calling code to canonicalize the paths.