### PR TITLE
LibJS: Remove the last 2 old non-standard Object helper methods

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -177,7 +177,7 @@ JS_DEFINE_NATIVE_FUNCTION(TestRunnerGlobalObject::fuzzilli)
 void TestRunnerGlobalObject::initialize_global_object()
 {
     Base::initialize_global_object();
-    define_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global", this, JS::Attribute::Enumerable);
     define_native_function("fuzzilli", fuzzilli, 2);
 }
 

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -178,7 +178,7 @@ void TestRunnerGlobalObject::initialize_global_object()
 {
     Base::initialize_global_object();
     define_direct_property("global", this, JS::Attribute::Enumerable);
-    define_native_function("fuzzilli", fuzzilli, 2);
+    define_native_function("fuzzilli", fuzzilli, 2, JS::default_attributes);
 }
 
 int main(int, char**)

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -157,8 +157,8 @@ TESTJS_GLOBAL_FUNCTION(compare_typed_arrays, compareTypedArrays)
 void WebAssemblyModule::initialize(JS::GlobalObject& global_object)
 {
     Base::initialize(global_object);
-    define_native_function("getExport", get_export);
-    define_native_function("invoke", wasm_invoke);
+    define_native_function("getExport", get_export, 1, JS::default_attributes);
+    define_native_function("invoke", wasm_invoke, 1, JS::default_attributes);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::get_export)

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -265,8 +265,8 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::parse_cell_name)
         return JS::js_undefined();
 
     auto object = JS::Object::create(global_object, global_object.object_prototype());
-    object->put("column", JS::js_string(vm, sheet_object->m_sheet.column(position.value().column)));
-    object->put("row", JS::Value((unsigned)position.value().row));
+    object->define_direct_property("column", JS::js_string(vm, sheet_object->m_sheet.column(position.value().column)), JS::default_attributes);
+    object->define_direct_property("row", JS::Value((unsigned)position.value().row), JS::default_attributes);
 
     return object;
 }
@@ -295,8 +295,8 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::current_cell_position)
     auto position = current_cell->position();
 
     auto object = JS::Object::create(global_object, global_object.object_prototype());
-    object->put("column", JS::js_string(vm, sheet_object->m_sheet.column(position.column)));
-    object->put("row", JS::Value((unsigned)position.row));
+    object->define_direct_property("column", JS::js_string(vm, sheet_object->m_sheet.column(position.column)), JS::default_attributes);
+    object->define_direct_property("row", JS::Value((unsigned)position.row), JS::default_attributes);
 
     return object;
 }

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -139,12 +139,13 @@ bool SheetGlobalObject::internal_set(const JS::PropertyName& property_name, JS::
 void SheetGlobalObject::initialize_global_object()
 {
     Base::initialize_global_object();
-    define_native_function("get_real_cell_contents", get_real_cell_contents, 1);
-    define_native_function("set_real_cell_contents", set_real_cell_contents, 2);
-    define_native_function("parse_cell_name", parse_cell_name, 1);
-    define_native_function("current_cell_position", current_cell_position, 0);
-    define_native_function("column_arithmetic", column_arithmetic, 2);
-    define_native_function("column_index", column_index, 1);
+    u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
+    define_native_function("get_real_cell_contents", get_real_cell_contents, 1, attr);
+    define_native_function("set_real_cell_contents", set_real_cell_contents, 2, attr);
+    define_native_function("parse_cell_name", parse_cell_name, 1, attr);
+    define_native_function("current_cell_position", current_cell_position, 0, attr);
+    define_native_function("column_arithmetic", column_arithmetic, 2, attr);
+    define_native_function("column_index", column_index, 1, attr);
 }
 
 void SheetGlobalObject::visit_edges(Visitor& visitor)
@@ -389,7 +390,7 @@ WorkbookObject::~WorkbookObject()
 void WorkbookObject::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
-    define_native_function("sheet", sheet, 1);
+    define_native_function("sheet", sheet, 1, JS::default_attributes);
 }
 
 void WorkbookObject::visit_edges(Visitor& visitor)

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -42,8 +42,8 @@ Sheet::Sheet(Workbook& workbook)
     JS::DeferGC defer_gc(m_workbook.interpreter().heap());
     m_global_object = m_workbook.interpreter().heap().allocate_without_global_object<SheetGlobalObject>(*this);
     global_object().initialize_global_object();
-    global_object().put("workbook", m_workbook.workbook_object());
-    global_object().put("thisSheet", &global_object()); // Self-reference is unfortunate, but required.
+    global_object().define_direct_property("workbook", m_workbook.workbook_object(), JS::default_attributes);
+    global_object().define_direct_property("thisSheet", &global_object(), JS::default_attributes); // Self-reference is unfortunate, but required.
 
     // Sadly, these have to be evaluated once per sheet.
     auto file_or_error = Core::File::open("/res/js/Spreadsheet/runtime.js", Core::OpenMode::ReadOnly);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -38,7 +38,7 @@ Workbook::Workbook(NonnullRefPtrVector<Sheet>&& sheets)
     , m_interpreter_scope(JS::VM::InterpreterExecutionScope(interpreter()))
 {
     m_workbook_object = interpreter().heap().allocate<WorkbookObject>(global_object(), *this);
-    global_object().put("workbook", workbook_object());
+    global_object().define_direct_property("workbook", workbook_object(), JS::default_attributes);
 }
 
 bool Workbook::set_filename(const String& filename)

--- a/Userland/DevTools/HackStudio/Debugger/DebuggerGlobalJSObject.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerGlobalJSObject.cpp
@@ -89,9 +89,8 @@ Optional<JS::Value> DebuggerGlobalJSObject::debugger_to_js(const Debug::DebugInf
         auto member_value = debugger_to_js(member);
         if (!member_value.has_value())
             continue;
-        object->put(member.name, member_value.value(), {});
+        object->define_direct_property(member.name, member_value.value(), JS::default_attributes);
     }
-    object->finish_writing_properties();
 
     return JS::Value(object);
 }

--- a/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.cpp
@@ -29,11 +29,8 @@ DebuggerVariableJSObject::~DebuggerVariableJSObject()
 {
 }
 
-bool DebuggerVariableJSObject::internal_set(const JS::PropertyName& property_name, JS::Value value, JS::Value receiver)
+bool DebuggerVariableJSObject::internal_set(const JS::PropertyName& property_name, JS::Value value, JS::Value)
 {
-    if (m_is_writing_properties)
-        return Base::internal_set(property_name, value, receiver);
-
     if (!property_name.is_string()) {
         vm().throw_exception<JS::TypeError>(global_object(), String::formatted("Invalid variable name {}", property_name.to_string()));
         return false;

--- a/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.h
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.h
@@ -25,13 +25,11 @@ public:
     virtual const char* class_name() const override { return m_variable_info.type_name.characters(); }
 
     bool internal_set(JS::PropertyName const&, JS::Value value, JS::Value receiver) override;
-    void finish_writing_properties() { m_is_writing_properties = false; }
 
 private:
     DebuggerGlobalJSObject& debugger_object() const;
 
     const Debug::DebugInfo::VariableInfo& m_variable_info;
-    bool m_is_writing_properties { true };
 };
 
 }

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -896,10 +896,10 @@ Value ClassExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
         }
         auto* prototype = Object::create(global_object, super_constructor_prototype);
 
-        prototype->define_property(vm.names.constructor, class_constructor, 0);
+        prototype->define_direct_property(vm.names.constructor, class_constructor, 0);
         if (interpreter.exception())
             return {};
-        class_constructor->define_property(vm.names.prototype, prototype, Attribute::Writable);
+        class_constructor->define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
         if (interpreter.exception())
             return {};
         class_constructor->internal_set_prototype_of(super_constructor.is_null() ? global_object.function_prototype() : &super_constructor.as_object());
@@ -1825,7 +1825,7 @@ Value ObjectExpression::execute(Interpreter& interpreter, GlobalObject& global_o
 
                 for (auto& it : obj_to_spread.shape().property_table_ordered()) {
                     if (it.value.attributes.is_enumerable()) {
-                        object->define_property(it.key, obj_to_spread.get(it.key));
+                        object->define_direct_property(it.key, obj_to_spread.get(it.key), JS::default_attributes);
                         if (interpreter.exception())
                             return {};
                     }
@@ -1834,7 +1834,7 @@ Value ObjectExpression::execute(Interpreter& interpreter, GlobalObject& global_o
                 auto& str_to_spread = key.as_string().string();
 
                 for (size_t i = 0; i < str_to_spread.length(); i++) {
-                    object->define_property(i, js_string(interpreter.heap(), str_to_spread.substring(i, 1)));
+                    object->define_direct_property(i, js_string(interpreter.heap(), str_to_spread.substring(i, 1)), JS::default_attributes);
                     if (interpreter.exception())
                         return {};
                 }
@@ -1861,14 +1861,14 @@ Value ObjectExpression::execute(Interpreter& interpreter, GlobalObject& global_o
         switch (property.type()) {
         case ObjectProperty::Type::Getter:
             VERIFY(value.is_function());
-            object->define_accessor(PropertyName::from_value(global_object, key), &value.as_function(), nullptr, Attribute::Configurable | Attribute::Enumerable);
+            object->define_direct_accessor(PropertyName::from_value(global_object, key), &value.as_function(), nullptr, Attribute::Configurable | Attribute::Enumerable);
             break;
         case ObjectProperty::Type::Setter:
             VERIFY(value.is_function());
-            object->define_accessor(PropertyName::from_value(global_object, key), nullptr, &value.as_function(), Attribute::Configurable | Attribute::Enumerable);
+            object->define_direct_accessor(PropertyName::from_value(global_object, key), nullptr, &value.as_function(), Attribute::Configurable | Attribute::Enumerable);
             break;
         case ObjectProperty::Type::KeyValue:
-            object->define_property(PropertyName::from_value(global_object, key), value);
+            object->define_direct_property(PropertyName::from_value(global_object, key), value, JS::default_attributes);
             break;
         case ObjectProperty::Type::Spread:
         default:
@@ -2110,7 +2110,7 @@ Value TaggedTemplateLiteral::execute(Interpreter& interpreter, GlobalObject& glo
             return {};
         raw_strings->indexed_properties().append(value);
     }
-    strings->define_property(vm.names.raw, raw_strings, 0);
+    strings->define_direct_property(vm.names.raw, raw_strings, 0);
     return vm.call(tag_function, js_undefined(), move(arguments));
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -203,7 +203,7 @@ void CopyObjectExcludingProperties::execute_impl(Bytecode::Interpreter& interpre
             auto property_value = from_object->get(property_name);
             if (interpreter.vm().exception())
                 return;
-            to_object->define_property(property_name, property_value);
+            to_object->define_direct_property(property_name, property_value, JS::default_attributes);
         }
     }
 

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -110,11 +110,11 @@ void Interpreter::enter_scope(const ScopeNode& scope_node, ScopeType scope_type,
             if (is_program_node && declaration.declaration_kind() == DeclarationKind::Var) {
                 declarator.target().visit(
                     [&](const NonnullRefPtr<Identifier>& id) {
-                        global_object.put(id->string(), js_undefined());
+                        global_object.define_direct_property(id->string(), js_undefined(), JS::Attribute::Writable | JS::Attribute::Enumerable);
                     },
                     [&](const NonnullRefPtr<BindingPattern>& binding) {
                         binding->for_each_bound_name([&](const auto& name) {
-                            global_object.put(name, js_undefined());
+                            global_object.define_direct_property(name, js_undefined(), JS::Attribute::Writable | JS::Attribute::Enumerable);
                         });
                     });
                 if (exception())

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
@@ -25,9 +25,9 @@ void AggregateErrorConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 20.5.7.2.1 AggregateError.prototype, https://tc39.es/ecma262/#sec-aggregate-error.prototype
-    define_property(vm.names.prototype, global_object.aggregate_error_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.aggregate_error_prototype(), 0);
 
-    define_property(vm.names.length, Value(2), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
 
 // 20.5.7.1.1 AggregateError ( errors, message ), https://tc39.es/ecma262/#sec-aggregate-error

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
@@ -46,13 +46,11 @@ Value AggregateErrorConstructor::construct(FunctionObject& new_target)
     if (vm.exception())
         return {};
 
-    u8 attr = Attribute::Writable | Attribute::Configurable;
-
     if (!vm.argument(1).is_undefined()) {
         auto message = vm.argument(1).to_string(global_object);
         if (vm.exception())
             return {};
-        aggregate_error->define_property(vm.names.message, js_string(vm, message), attr);
+        aggregate_error->create_non_enumerable_data_property_or_throw(vm.names.message, js_string(vm, message));
     }
 
     aggregate_error->install_error_cause(vm.argument(2));
@@ -63,7 +61,7 @@ Value AggregateErrorConstructor::construct(FunctionObject& new_target)
     if (vm.exception())
         return {};
 
-    aggregate_error->define_property(vm.names.errors, Array::create_from(global_object, errors_list), attr);
+    aggregate_error->define_property_or_throw(vm.names.errors, { .value = Array::create_from(global_object, errors_list), .writable = true, .enumerable = false, .configurable = true });
 
     return aggregate_error;
 }

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
@@ -20,8 +20,8 @@ void AggregateErrorPrototype::initialize(GlobalObject& global_object)
     auto& vm = this->vm();
     Object::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_property(vm.names.name, js_string(vm, "AggregateError"), attr);
-    define_property(vm.names.message, js_string(vm, ""), attr);
+    define_direct_property(vm.names.name, js_string(vm, "AggregateError"), attr);
+    define_direct_property(vm.names.message, js_string(vm, ""), attr);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -81,14 +81,6 @@ JS_DEFINE_NATIVE_GETTER(Array::length_getter)
     if (!this_object)
         return {};
 
-    // TODO: could be incorrect if receiver/this_value is fixed or changed
-    if (!this_object->is_array()) {
-        auto value = this_object->internal_get(vm.names.length.to_string_or_symbol(), this_object);
-        if (vm.exception())
-            return {};
-        return value;
-    }
-
     return Value(this_object->indexed_properties().array_like_size());
 }
 
@@ -97,14 +89,6 @@ JS_DEFINE_NATIVE_SETTER(Array::length_setter)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return;
-
-    // TODO: could be incorrect if receiver/this_value is fixed or changed
-    if (!this_object->is_array()) {
-        this_object->define_property(vm.names.length.to_string_or_symbol(), value, default_attributes);
-        if (vm.exception())
-            return;
-        return;
-    }
 
     auto length = value.to_number(global_object);
     if (vm.exception())

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -24,9 +24,9 @@ void ArrayBufferConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 25.1.4.2 ArrayBuffer.prototype, https://tc39.es/ecma262/#sec-arraybuffer.prototype
-    define_property(vm.names.prototype, global_object.array_buffer_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.array_buffer_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.isView, is_view, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -28,7 +28,7 @@ void ArrayBufferPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.byteLength, byte_length_getter, {}, Attribute::Configurable);
 
     // 25.1.5.4 ArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-arraybuffer.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.ArrayBuffer.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.ArrayBuffer.as_string()), Attribute::Configurable);
 }
 
 ArrayBufferPrototype::~ArrayBufferPrototype()

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -31,9 +31,9 @@ void ArrayConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 23.1.2.4 Array.prototype, https://tc39.es/ecma262/#sec-array.prototype
-    define_property(vm.names.prototype, global_object.array_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.array_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.from, from, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -28,7 +28,7 @@ void ArrayIteratorPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
 
     // 23.1.5.2.2 %ArrayIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Array Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Array Iterator"), Attribute::Configurable);
 }
 
 ArrayIteratorPrototype::~ArrayIteratorPrototype()
@@ -87,10 +87,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)
     if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, value, false);
 
-    auto* entry_array = Array::create(global_object, 0);
-    entry_array->define_property(0, Value(static_cast<i32>(index)));
-    entry_array->define_property(1, value);
-    return create_iterator_result_object(global_object, entry_array, false);
+    return create_iterator_result_object(global_object, Array::create_from(global_object, { Value(static_cast<i32>(index)), value }), false);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -74,7 +74,7 @@ void ArrayPrototype::initialize(GlobalObject& global_object)
     // Object.is(Array.prototype[Symbol.iterator], Array.prototype.values)
     // evaluates to true
     // 23.1.3.33 Array.prototype [ @@iterator ] ( ), https://tc39.es/ecma262/#sec-array.prototype-@@iterator
-    define_property(*vm.well_known_symbol_iterator(), get(vm.names.values), attr);
+    define_direct_property(*vm.well_known_symbol_iterator(), get(vm.names.values), attr);
 
     // 23.1.3.34 Array.prototype [ @@unscopables ], https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
     auto* unscopable_list = Object::create(global_object, nullptr);
@@ -89,7 +89,7 @@ void ArrayPrototype::initialize(GlobalObject& global_object)
     unscopable_list->create_data_property_or_throw(vm.names.keys, Value(true));
     unscopable_list->create_data_property_or_throw(vm.names.values, Value(true));
 
-    define_property(*vm.well_known_symbol_unscopables(), unscopable_list, Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_unscopables(), unscopable_list, Attribute::Configurable);
 }
 
 ArrayPrototype::~ArrayPrototype()
@@ -364,7 +364,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
         return {};
     }
     for (size_t i = 0; i < argument_count; ++i) {
-        this_object->define_property(length + i, vm.argument(i));
+        this_object->set(length + i, vm.argument(i), true);
         if (vm.exception())
             return {};
     }
@@ -403,7 +403,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::unshift)
                 auto from_value = this_object->get(from);
                 if (vm.exception())
                     return {};
-                this_object->define_property(to, from_value);
+                this_object->set(to, from_value, true);
                 if (vm.exception())
                     return {};
             } else {
@@ -414,7 +414,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::unshift)
         }
 
         for (size_t j = 0; j < arg_count; j++) {
-            this_object->define_property(j, vm.argument(j));
+            this_object->set(j, vm.argument(j), true);
             if (vm.exception())
                 return {};
         }
@@ -487,7 +487,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
             auto from_value = this_object->get(from);
             if (vm.exception())
                 return {};
-            this_object->define_property(to, from_value);
+            this_object->set(to, from_value, true);
             if (vm.exception())
                 return {};
         } else {
@@ -1095,14 +1095,14 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reverse)
         }
 
         if (lower_exists && upper_exists) {
-            this_object->define_property(lower, upper_value);
+            this_object->set(lower, upper_value, true);
             if (vm.exception())
                 return {};
-            this_object->define_property(upper, lower_value);
+            this_object->set(upper, lower_value, true);
             if (vm.exception())
                 return {};
         } else if (!lower_exists && upper_exists) {
-            this_object->define_property(lower, upper_value);
+            this_object->set(lower, upper_value, true);
             if (vm.exception())
                 return {};
             this_object->delete_property_or_throw(upper);
@@ -1112,7 +1112,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reverse)
             this_object->delete_property_or_throw(lower);
             if (vm.exception())
                 return {};
-            this_object->define_property(upper, lower_value);
+            this_object->set(upper, lower_value, true);
             if (vm.exception())
                 return {};
         }
@@ -1688,7 +1688,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
             auto to = i + insert_count;
 
             if (!from.is_empty()) {
-                this_object->define_property(to, from);
+                this_object->set(to, from, true);
             } else {
                 this_object->delete_property_or_throw(to);
             }
@@ -1710,7 +1710,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
             auto to = i + insert_count - 1;
 
             if (!from.is_empty()) {
-                this_object->define_property(to, from);
+                this_object->set(to, from, true);
             } else {
                 this_object->delete_property_or_throw(to);
             }
@@ -1720,7 +1720,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
     }
 
     for (size_t i = 0; i < insert_count; ++i) {
-        this_object->define_property(actual_start + i, vm.argument(i + 2));
+        this_object->set(actual_start + i, vm.argument(i + 2), true);
         if (vm.exception())
             return {};
     }

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -101,7 +101,11 @@ static Object* array_species_create(GlobalObject& global_object, Object& origina
 {
     auto& vm = global_object.vm();
 
-    if (!Value(&original_array).is_array(global_object)) {
+    auto is_array = Value(&original_array).is_array(global_object);
+    if (vm.exception())
+        return {};
+
+    if (!is_array) {
         auto array = Array::create(global_object, length);
         if (vm.exception())
             return {};

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -369,7 +369,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
             return {};
     }
     auto new_length_value = Value((i32)new_length);
-    this_object->put(vm.names.length, new_length_value);
+    this_object->set(vm.names.length, new_length_value, true);
     if (vm.exception())
         return {};
     return new_length_value;
@@ -420,7 +420,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::unshift)
         }
     }
 
-    this_object->put(vm.names.length, Value(new_length));
+    this_object->set(vm.names.length, Value(new_length), true);
     if (vm.exception())
         return {};
     return Value(new_length);
@@ -442,7 +442,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     if (vm.exception())
         return {};
     if (length == 0) {
-        this_object->put(vm.names.length, Value(0));
+        this_object->set(vm.names.length, Value(0), true);
         return js_undefined();
     }
     auto index = length - 1;
@@ -452,7 +452,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     this_object->delete_property_or_throw(index);
     if (vm.exception())
         return {};
-    this_object->put(vm.names.length, Value((i32)index));
+    this_object->set(vm.names.length, Value((i32)index), true);
     if (vm.exception())
         return {};
     return element;
@@ -468,7 +468,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
     if (vm.exception())
         return {};
     if (length == 0) {
-        this_object->put(vm.names.length, Value(0));
+        this_object->set(vm.names.length, Value(0), true);
         if (vm.exception())
             return {};
         return js_undefined();
@@ -501,7 +501,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
     if (vm.exception())
         return {};
 
-    this_object->put(vm.names.length, Value(length - 1));
+    this_object->set(vm.names.length, Value(length - 1), true);
     if (vm.exception())
         return {};
     return first;
@@ -693,7 +693,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
             return {};
     }
 
-    new_array->put(vm.names.length, Value(n));
+    new_array->set(vm.names.length, Value(n), true);
     if (vm.exception())
         return {};
     return Value(new_array);
@@ -769,7 +769,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::slice)
         ++index;
     }
 
-    new_array->put(vm.names.length, Value(index));
+    new_array->set(vm.names.length, Value(index), true);
     if (vm.exception())
         return {};
 
@@ -1675,7 +1675,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
         }
     }
 
-    removed_elements->put(vm.names.length, Value(actual_delete_count));
+    removed_elements->set(vm.names.length, Value(actual_delete_count), true);
     if (vm.exception())
         return {};
 
@@ -1725,7 +1725,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
             return {};
     }
 
-    this_object->put(vm.names.length, Value((i32)new_length));
+    this_object->set(vm.names.length, Value((i32)new_length), true);
     if (vm.exception())
         return {};
 
@@ -1771,7 +1771,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::fill)
         to = min(relative_end, length);
 
     for (size_t i = from; i < to; i++) {
-        this_object->put(i, vm.argument(0));
+        this_object->set(i, vm.argument(0), true);
         if (vm.exception())
             return {};
     }
@@ -1988,7 +1988,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::copy_within)
             auto from_value = this_object->get(from_i);
             if (vm.exception())
                 return {};
-            this_object->put(to_i, from_value);
+            this_object->set(to_i, from_value, true);
             if (vm.exception())
                 return {};
         } else {

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -25,9 +25,9 @@ void BigIntConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 21.2.2.3 BigInt.prototype, https://tc39.es/ecma262/#sec-bigint.prototype
-    define_property(vm.names.prototype, global_object.bigint_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.bigint_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     // TODO: Implement these functions below and uncomment this.
     // u8 attr = Attribute::Writable | Attribute::Configurable;

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
@@ -27,7 +27,7 @@ void BigIntPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 
     // 21.2.3.5 BigInt.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-bigint.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.BigInt.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.BigInt.as_string()), Attribute::Configurable);
 }
 
 BigIntPrototype::~BigIntPrototype()

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -22,9 +22,9 @@ void BooleanConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 20.3.2.1 Boolean.prototype, https://tc39.es/ecma262/#sec-boolean.prototype
-    define_property(vm.names.prototype, global_object.boolean_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.boolean_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 BooleanConstructor::~BooleanConstructor()

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -22,7 +22,7 @@ void BoundFunction::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Base::initialize(global_object);
-    define_property(vm.names.length, Value(m_length), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(m_length), Attribute::Configurable);
 }
 
 BoundFunction::~BoundFunction()

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -21,16 +21,17 @@ void ConsoleObject::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Object::initialize(global_object);
-    define_native_function(vm.names.log, log);
-    define_native_function(vm.names.debug, debug);
-    define_native_function(vm.names.info, info);
-    define_native_function(vm.names.warn, warn);
-    define_native_function(vm.names.error, error);
-    define_native_function(vm.names.trace, trace);
-    define_native_function(vm.names.count, count);
-    define_native_function(vm.names.countReset, count_reset);
-    define_native_function(vm.names.clear, clear);
-    define_native_function(vm.names.assert, assert_);
+    u8 attr = Attribute::Writable | Attribute::Enumerable | Attribute::Configurable;
+    define_native_function(vm.names.log, log, 0, attr);
+    define_native_function(vm.names.debug, debug, 0, attr);
+    define_native_function(vm.names.info, info, 0, attr);
+    define_native_function(vm.names.warn, warn, 0, attr);
+    define_native_function(vm.names.error, error, 0, attr);
+    define_native_function(vm.names.trace, trace, 0, attr);
+    define_native_function(vm.names.count, count, 0, attr);
+    define_native_function(vm.names.countReset, count_reset, 0, attr);
+    define_native_function(vm.names.clear, clear, 0, attr);
+    define_native_function(vm.names.assert, assert_, 0, attr);
 }
 
 ConsoleObject::~ConsoleObject()

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -23,9 +23,9 @@ void DataViewConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 25.3.3.1 DataView.prototype, https://tc39.es/ecma262/#sec-dataview.prototype
-    define_property(vm.names.prototype, global_object.data_view_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.data_view_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 DataViewConstructor::~DataViewConstructor()

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -45,7 +45,7 @@ void DataViewPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.byteOffset, byte_offset_getter, {}, Attribute::Configurable);
 
     // 25.3.4.25 DataView.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-dataview.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.DataView.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.DataView.as_string()), Attribute::Configurable);
 }
 
 DataViewPrototype::~DataViewPrototype()

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -131,9 +131,9 @@ void DateConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 21.4.3.3 Date.prototype, https://tc39.es/ecma262/#sec-date.prototype
-    define_property(vm.names.prototype, global_object.date_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.date_prototype(), 0);
 
-    define_property(vm.names.length, Value(7), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(7), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.now, now, 0, attr);

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -93,7 +93,7 @@ void DatePrototype::initialize(GlobalObject& global_object)
     // B.2.4.3 Date.prototype.toGMTString ( ), https://tc39.es/ecma262/#sec-date.prototype.togmtstring
     // The function object that is the initial value of Date.prototype.toGMTString
     // is the same function object that is the initial value of Date.prototype.toUTCString.
-    define_property(vm.names.toGMTString, get(vm.names.toUTCString), attr);
+    define_direct_property(vm.names.toGMTString, get(vm.names.toUTCString), attr);
 }
 
 DatePrototype::~DatePrototype()

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -41,7 +41,7 @@ void Error::install_error_cause(Value options)
     auto cause = options_object.get(vm.names.cause);
     if (vm.exception())
         return;
-    define_property(vm.names.cause, cause, Attribute::Writable | Attribute::Configurable);
+    create_non_enumerable_data_property_or_throw(vm.names.cause, cause);
 }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                         \

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -20,7 +20,7 @@ Error* Error::create(GlobalObject& global_object, String const& message)
     auto& vm = global_object.vm();
     auto* error = Error::create(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    error->define_property(vm.names.message, js_string(vm, message), attr);
+    error->define_direct_property(vm.names.message, js_string(vm, message), attr);
     return error;
 }
 
@@ -55,7 +55,7 @@ void Error::install_error_cause(Value options)
         auto& vm = global_object.vm();                                                                           \
         auto* error = ClassName::create(global_object);                                                          \
         u8 attr = Attribute::Writable | Attribute::Configurable;                                                 \
-        error->define_property(vm.names.message, js_string(vm, message), attr);                                  \
+        error->define_direct_property(vm.names.message, js_string(vm, message), attr);                           \
         return error;                                                                                            \
     }                                                                                                            \
                                                                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -43,13 +43,11 @@ Value ErrorConstructor::construct(FunctionObject& new_target)
     if (vm.exception())
         return {};
 
-    u8 attr = Attribute::Writable | Attribute::Configurable;
-
     if (!vm.argument(0).is_undefined()) {
         auto message = vm.argument(0).to_string(global_object);
         if (vm.exception())
             return {};
-        error->define_property(vm.names.message, js_string(vm, message), attr);
+        error->create_non_enumerable_data_property_or_throw(vm.names.message, js_string(vm, message));
     }
 
     error->install_error_cause(vm.argument(1));
@@ -59,57 +57,55 @@ Value ErrorConstructor::construct(FunctionObject& new_target)
     return error;
 }
 
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
-    ConstructorName::ConstructorName(GlobalObject& global_object)                        \
-        : NativeFunction(*static_cast<Object*>(global_object.error_constructor()))       \
-    {                                                                                    \
-    }                                                                                    \
-                                                                                         \
-    void ConstructorName::initialize(GlobalObject& global_object)                        \
-    {                                                                                    \
-        auto& vm = this->vm();                                                           \
-        NativeFunction::initialize(global_object);                                       \
-                                                                                         \
-        /* 20.5.6.2.1 NativeError.prototype,                                             \
-           https://tc39.es/ecma262/#sec-nativeerror.prototype */                         \
-        define_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);  \
-                                                                                         \
-        define_property(vm.names.length, Value(1), Attribute::Configurable);             \
-    }                                                                                    \
-                                                                                         \
-    ConstructorName::~ConstructorName() { }                                              \
-                                                                                         \
-    /* 20.5.6.1.1 NativeError ( message ), https://tc39.es/ecma262/#sec-nativeerror */   \
-    Value ConstructorName::call()                                                        \
-    {                                                                                    \
-        return construct(*this);                                                         \
-    }                                                                                    \
-                                                                                         \
-    /* 20.5.6.1.1 NativeError ( message ), https://tc39.es/ecma262/#sec-nativeerror */   \
-    Value ConstructorName::construct(FunctionObject& new_target)                         \
-    {                                                                                    \
-        auto& vm = this->vm();                                                           \
-        auto& global_object = this->global_object();                                     \
-                                                                                         \
-        auto* error = ordinary_create_from_constructor<ClassName>(                       \
-            global_object, new_target, &GlobalObject::snake_name##_prototype);           \
-        if (vm.exception())                                                              \
-            return {};                                                                   \
-                                                                                         \
-        u8 attr = Attribute::Writable | Attribute::Configurable;                         \
-                                                                                         \
-        if (!vm.argument(0).is_undefined()) {                                            \
-            auto message = vm.argument(0).to_string(global_object);                      \
-            if (vm.exception())                                                          \
-                return {};                                                               \
-            error->define_property(vm.names.message, js_string(vm, message), attr);      \
-        }                                                                                \
-                                                                                         \
-        error->install_error_cause(vm.argument(1));                                      \
-        if (vm.exception())                                                              \
-            return {};                                                                   \
-                                                                                         \
-        return error;                                                                    \
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                   \
+    ConstructorName::ConstructorName(GlobalObject& global_object)                                          \
+        : NativeFunction(*static_cast<Object*>(global_object.error_constructor()))                         \
+    {                                                                                                      \
+    }                                                                                                      \
+                                                                                                           \
+    void ConstructorName::initialize(GlobalObject& global_object)                                          \
+    {                                                                                                      \
+        auto& vm = this->vm();                                                                             \
+        NativeFunction::initialize(global_object);                                                         \
+                                                                                                           \
+        /* 20.5.6.2.1 NativeError.prototype,                                                               \
+           https://tc39.es/ecma262/#sec-nativeerror.prototype */                                           \
+        define_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);                    \
+                                                                                                           \
+        define_property(vm.names.length, Value(1), Attribute::Configurable);                               \
+    }                                                                                                      \
+                                                                                                           \
+    ConstructorName::~ConstructorName() { }                                                                \
+                                                                                                           \
+    /* 20.5.6.1.1 NativeError ( message ), https://tc39.es/ecma262/#sec-nativeerror */                     \
+    Value ConstructorName::call()                                                                          \
+    {                                                                                                      \
+        return construct(*this);                                                                           \
+    }                                                                                                      \
+                                                                                                           \
+    /* 20.5.6.1.1 NativeError ( message ), https://tc39.es/ecma262/#sec-nativeerror */                     \
+    Value ConstructorName::construct(FunctionObject& new_target)                                           \
+    {                                                                                                      \
+        auto& vm = this->vm();                                                                             \
+        auto& global_object = this->global_object();                                                       \
+                                                                                                           \
+        auto* error = ordinary_create_from_constructor<ClassName>(                                         \
+            global_object, new_target, &GlobalObject::snake_name##_prototype);                             \
+        if (vm.exception())                                                                                \
+            return {};                                                                                     \
+                                                                                                           \
+        if (!vm.argument(0).is_undefined()) {                                                              \
+            auto message = vm.argument(0).to_string(global_object);                                        \
+            if (vm.exception())                                                                            \
+                return {};                                                                                 \
+            error->create_non_enumerable_data_property_or_throw(vm.names.message, js_string(vm, message)); \
+        }                                                                                                  \
+                                                                                                           \
+        error->install_error_cause(vm.argument(1));                                                        \
+        if (vm.exception())                                                                                \
+            return {};                                                                                     \
+                                                                                                           \
+        return error;                                                                                      \
     }
 
 JS_ENUMERATE_NATIVE_ERRORS

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -22,9 +22,9 @@ void ErrorConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 20.5.2.1 Error.prototype, https://tc39.es/ecma262/#sec-error.prototype
-    define_property(vm.names.prototype, global_object.error_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.error_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 // 20.5.1.1 Error ( message ), https://tc39.es/ecma262/#sec-error-message
@@ -70,9 +70,9 @@ Value ErrorConstructor::construct(FunctionObject& new_target)
                                                                                                            \
         /* 20.5.6.2.1 NativeError.prototype,                                                               \
            https://tc39.es/ecma262/#sec-nativeerror.prototype */                                           \
-        define_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);                    \
+        define_direct_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);             \
                                                                                                            \
-        define_property(vm.names.length, Value(1), Attribute::Configurable);                               \
+        define_direct_property(vm.names.length, Value(1), Attribute::Configurable);                        \
     }                                                                                                      \
                                                                                                            \
     ConstructorName::~ConstructorName() { }                                                                \

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -24,8 +24,8 @@ void ErrorPrototype::initialize(GlobalObject& global_object)
     auto& vm = this->vm();
     Object::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_property(vm.names.name, js_string(vm, "Error"), attr);
-    define_property(vm.names.message, js_string(vm, ""), attr);
+    define_direct_property(vm.names.name, js_string(vm, "Error"), attr);
+    define_direct_property(vm.names.message, js_string(vm, ""), attr);
     define_native_function(vm.names.toString, to_string, 0, attr);
 }
 
@@ -77,8 +77,8 @@ JS_DEFINE_NATIVE_FUNCTION(ErrorPrototype::to_string)
         auto& vm = this->vm();                                                           \
         Object::initialize(global_object);                                               \
         u8 attr = Attribute::Writable | Attribute::Configurable;                         \
-        define_property(vm.names.name, js_string(vm, #ClassName), attr);                 \
-        define_property(vm.names.message, js_string(vm, ""), attr);                      \
+        define_direct_property(vm.names.name, js_string(vm, #ClassName), attr);          \
+        define_direct_property(vm.names.message, js_string(vm, ""), attr);               \
     }
 
 JS_ENUMERATE_NATIVE_ERRORS

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
@@ -23,9 +23,9 @@ void FinalizationRegistryConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 26.2.2.1 FinalizationRegistry.prototype, https://tc39.es/ecma262/#sec-finalization-registry.prototype
-    define_property(vm.names.prototype, global_object.finalization_registry_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.finalization_registry_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 FinalizationRegistryConstructor::~FinalizationRegistryConstructor()

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -24,7 +24,7 @@ void FinalizationRegistryPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.unregister, unregister, 1, attr);
 
     // 26.2.3.4 FinalizationRegistry.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-finalization-registry.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.FinalizationRegistry.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.FinalizationRegistry.as_string()), Attribute::Configurable);
 }
 
 FinalizationRegistryPrototype::~FinalizationRegistryPrototype()

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -26,9 +26,9 @@ void FunctionConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 20.2.2.2 Function.prototype, https://tc39.es/ecma262/#sec-function.prototype
-    define_property(vm.names.prototype, global_object.function_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.function_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 FunctionConstructor::~FunctionConstructor()

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -35,8 +35,8 @@ void FunctionPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.call, call, 1, attr);
     define_native_function(vm.names.toString, to_string, 0, attr);
     define_native_function(*vm.well_known_symbol_has_instance(), symbol_has_instance, 1, 0);
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
-    define_property(vm.names.name, js_string(heap(), ""), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.name, js_string(heap(), ""), Attribute::Configurable);
 }
 
 FunctionPrototype::~FunctionPrototype()

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
@@ -27,9 +27,9 @@ void GeneratorFunctionConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 27.3.2.1 GeneratorFunction.length, https://tc39.es/ecma262/#sec-generatorfunction.length
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
     // 27.3.2.2 GeneratorFunction.prototype, https://tc39.es/ecma262/#sec-generatorfunction.length
-    define_property(vm.names.prototype, global_object.generator_function_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.generator_function_prototype(), 0);
 }
 
 GeneratorFunctionConstructor::~GeneratorFunctionConstructor()

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
@@ -21,9 +21,9 @@ void GeneratorFunctionPrototype::initialize(GlobalObject& global_object)
     Object::initialize(global_object);
 
     // 27.3.3.2 %GeneratorFunction.prototype% prototype, https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype
-    define_property(vm.names.prototype, global_object.generator_object_prototype(), Attribute::Configurable);
+    define_direct_property(vm.names.prototype, global_object.generator_object_prototype(), Attribute::Configurable);
     // 27.3.3.3 %GeneratorFunction.prototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-generatorfunction.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "GeneratorFunction"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "GeneratorFunction"), Attribute::Configurable);
 }
 
 GeneratorFunctionPrototype::~GeneratorFunctionPrototype()

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -73,10 +73,10 @@ Value GeneratorObject::next_impl(VM& vm, GlobalObject& global_object, Optional<V
         return {};
 
     auto result = Object::create(global_object, global_object.object_prototype());
-    result->put("value", previous_generated_value);
+    result->define_direct_property("value", previous_generated_value, JS::default_attributes);
 
     if (m_done) {
-        result->put("done", Value(true));
+        result->define_direct_property("done", Value(true), JS::default_attributes);
         return result;
     }
 
@@ -88,7 +88,7 @@ Value GeneratorObject::next_impl(VM& vm, GlobalObject& global_object, Optional<V
     if (!next_block) {
         // The generator has terminated, now we can simply return done=true.
         m_done = true;
-        result->put("done", Value(true));
+        result->define_direct_property("done", Value(true), JS::default_attributes);
         return result;
     }
 
@@ -115,8 +115,8 @@ Value GeneratorObject::next_impl(VM& vm, GlobalObject& global_object, Optional<V
 
     m_done = generated_continuation(m_previous_value) == nullptr;
 
-    result->put("value", generated_value(m_previous_value));
-    result->put("done", Value(m_done));
+    result->define_direct_property("value", generated_value(m_previous_value), JS::default_attributes);
+    result->define_direct_property("done", Value(m_done), JS::default_attributes);
 
     if (vm.exception())
         return {};

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.cpp
@@ -37,7 +37,7 @@ void GeneratorObjectPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.throw_, throw_, 1, attr);
 
     // 27.5.1.5 Generator.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-generator.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Generator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Generator"), Attribute::Configurable);
 }
 
 GeneratorObjectPrototype::~GeneratorObjectPrototype()

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -126,7 +126,7 @@ void GlobalObject::initialize_global_object()
     // %GeneratorFunction.prototype.prototype% must be initialized separately as it has no
     // companion constructor
     m_generator_object_prototype = heap().allocate<GeneratorObjectPrototype>(*this, *this);
-    m_generator_object_prototype->define_property(vm.names.constructor, m_generator_function_constructor, Attribute::Configurable);
+    m_generator_object_prototype->define_direct_property(vm.names.constructor, m_generator_function_constructor, Attribute::Configurable);
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     if (!m_##snake_name##_prototype)                                                     \
@@ -148,13 +148,13 @@ void GlobalObject::initialize_global_object()
         vm.throw_exception<TypeError>(global_object, ErrorType::RestrictedFunctionPropertiesAccess);
         return Value();
     });
-    m_throw_type_error_function->define_property_without_transition(vm.names.length, Value(0), 0, false);
-    m_throw_type_error_function->define_property_without_transition(vm.names.name, js_string(vm, ""), 0, false);
+    m_throw_type_error_function->define_direct_property(vm.names.length, Value(0), 0);
+    m_throw_type_error_function->define_direct_property(vm.names.name, js_string(vm, ""), 0);
     m_throw_type_error_function->internal_prevent_extensions();
 
     // 10.2.4 AddRestrictedFunctionProperties ( F, realm ), https://tc39.es/ecma262/#sec-addrestrictedfunctionproperties
-    m_function_prototype->define_accessor(vm.names.caller, throw_type_error_function(), throw_type_error_function(), Attribute::Configurable);
-    m_function_prototype->define_accessor(vm.names.arguments, throw_type_error_function(), throw_type_error_function(), Attribute::Configurable);
+    m_function_prototype->define_direct_accessor(vm.names.caller, throw_type_error_function(), throw_type_error_function(), Attribute::Configurable);
+    m_function_prototype->define_direct_accessor(vm.names.arguments, throw_type_error_function(), throw_type_error_function(), Attribute::Configurable);
 
     define_native_function(vm.names.encodeURI, encode_uri, 1, attr);
     define_native_function(vm.names.decodeURI, decode_uri, 1, attr);
@@ -163,15 +163,15 @@ void GlobalObject::initialize_global_object()
     define_native_function(vm.names.escape, escape, 1, attr);
     define_native_function(vm.names.unescape, unescape, 1, attr);
 
-    define_property(vm.names.NaN, js_nan(), 0);
-    define_property(vm.names.Infinity, js_infinity(), 0);
-    define_property(vm.names.undefined, js_undefined(), 0);
+    define_direct_property(vm.names.NaN, js_nan(), 0);
+    define_direct_property(vm.names.Infinity, js_infinity(), 0);
+    define_direct_property(vm.names.undefined, js_undefined(), 0);
 
-    define_property(vm.names.globalThis, this, attr);
-    define_property(vm.names.console, heap().allocate<ConsoleObject>(*this, *this), attr);
-    define_property(vm.names.Math, heap().allocate<MathObject>(*this, *this), attr);
-    define_property(vm.names.JSON, heap().allocate<JSONObject>(*this, *this), attr);
-    define_property(vm.names.Reflect, heap().allocate<ReflectObject>(*this, *this), attr);
+    define_direct_property(vm.names.globalThis, this, attr);
+    define_direct_property(vm.names.console, heap().allocate<ConsoleObject>(*this, *this), attr);
+    define_direct_property(vm.names.Math, heap().allocate<MathObject>(*this, *this), attr);
+    define_direct_property(vm.names.JSON, heap().allocate<JSONObject>(*this, *this), attr);
+    define_direct_property(vm.names.Reflect, heap().allocate<ReflectObject>(*this, *this), attr);
 
     // This must be initialized before allocating AggregateErrorConstructor, which uses ErrorConstructor as its prototype.
     initialize_constructor(vm.names.Error, m_error_constructor, m_error_prototype);
@@ -210,7 +210,7 @@ void GlobalObject::initialize_global_object()
     // The generator constructor cannot be initialized with add_constructor as it has no global binding
     m_generator_function_constructor = heap().allocate<GeneratorFunctionConstructor>(*this, *this);
     // 27.3.3.1 GeneratorFunction.prototype.constructor, https://tc39.es/ecma262/#sec-generatorfunction.prototype.constructor
-    m_generator_function_prototype->define_property(vm.names.constructor, m_generator_function_constructor, Attribute::Configurable);
+    m_generator_function_prototype->define_direct_property(vm.names.constructor, m_generator_function_constructor, Attribute::Configurable);
 }
 
 GlobalObject::~GlobalObject()

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -109,11 +109,11 @@ inline void GlobalObject::initialize_constructor(PropertyName const& property_na
 {
     auto& vm = this->vm();
     constructor = heap().allocate<ConstructorType>(*this, *this);
-    constructor->define_property(vm.names.name, js_string(heap(), property_name.as_string()), Attribute::Configurable);
+    constructor->define_direct_property(vm.names.name, js_string(heap(), property_name.as_string()), Attribute::Configurable);
     if (vm.exception())
         return;
     if (prototype) {
-        prototype->define_property(vm.names.constructor, constructor, Attribute::Writable | Attribute::Configurable);
+        prototype->define_direct_property(vm.names.constructor, constructor, Attribute::Writable | Attribute::Configurable);
         if (vm.exception())
             return;
     }
@@ -125,7 +125,7 @@ inline void GlobalObject::add_constructor(PropertyName const& property_name, Con
     // Some constructors are pre-initialized separately.
     if (!constructor)
         initialize_constructor(property_name, constructor, prototype);
-    define_property(property_name, constructor, Attribute::Writable | Attribute::Configurable);
+    define_direct_property(property_name, constructor, Attribute::Writable | Attribute::Configurable);
 }
 
 inline GlobalObject* Shape::global_object() const

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -149,8 +149,8 @@ Value create_iterator_result_object(GlobalObject& global_object, Value value, bo
 {
     auto& vm = global_object.vm();
     auto* object = Object::create(global_object, global_object.object_prototype());
-    object->define_property(vm.names.value, value);
-    object->define_property(vm.names.done, Value(done));
+    object->create_data_property_or_throw(vm.names.value, value);
+    object->create_data_property_or_throw(vm.names.done, Value(done));
     return object;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -37,7 +37,7 @@ void JSONObject::initialize(GlobalObject& global_object)
     define_native_function(vm.names.parse, parse, 2, attr);
 
     // 25.5.3 JSON [ @@toStringTag ], https://tc39.es/ecma262/#sec-json-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "JSON"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "JSON"), Attribute::Configurable);
 }
 
 JSONObject::~JSONObject()
@@ -460,7 +460,7 @@ Object* JSONObject::parse_json_object(GlobalObject& global_object, const JsonObj
 {
     auto* object = Object::create(global_object, global_object.object_prototype());
     json_object.for_each_member([&](auto& key, auto& value) {
-        object->define_property(key, parse_json_value(global_object, value));
+        object->define_direct_property(key, parse_json_value(global_object, value), JS::default_attributes);
     });
     return object;
 }
@@ -470,7 +470,7 @@ Array* JSONObject::parse_json_array(GlobalObject& global_object, const JsonArray
     auto* array = Array::create(global_object, 0);
     size_t index = 0;
     json_array.for_each([&](auto& value) {
-        array->define_property(index++, parse_json_value(global_object, value));
+        array->define_direct_property(index++, parse_json_value(global_object, value), JS::default_attributes);
     });
     return array;
 }

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -24,9 +24,9 @@ void MapConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 24.1.2.1 Map.prototype, https://tc39.es/ecma262/#sec-map.prototype
-    define_property(vm.names.prototype, global_object.map_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.map_prototype(), 0);
 
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -24,7 +24,7 @@ void MapIteratorPrototype::initialize(GlobalObject& global_object)
     Object::initialize(global_object);
 
     define_native_function(vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Map Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Map Iterator"), Attribute::Configurable);
 }
 
 MapIteratorPrototype::~MapIteratorPrototype()
@@ -59,10 +59,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapIteratorPrototype::next)
     else if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, entry.value, false);
 
-    auto* entry_array = Array::create(global_object, 0);
-    entry_array->define_property(0, entry.key);
-    entry_array->define_property(1, entry.value);
-    return create_iterator_result_object(global_object, entry_array, false);
+    return create_iterator_result_object(global_object, Array::create_from(global_object, { entry.key, entry.value }), false);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
@@ -33,8 +33,8 @@ void MapPrototype::initialize(GlobalObject& global_object)
 
     define_native_accessor(vm.names.size, size_getter, {}, Attribute::Configurable);
 
-    define_property(*vm.well_known_symbol_iterator(), Object::get(vm.names.entries), attr);
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.Map.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_iterator(), Object::get(vm.names.entries), attr);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.Map.as_string()), Attribute::Configurable);
 }
 
 MapPrototype::~MapPrototype()

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -61,17 +61,17 @@ void MathObject::initialize(GlobalObject& global_object)
     define_native_function(vm.names.tanh, tanh, 1, attr);
 
     // 21.3.1 Value Properties of the Math Object, https://tc39.es/ecma262/#sec-value-properties-of-the-math-object
-    define_property(vm.names.E, Value(M_E), 0);
-    define_property(vm.names.LN2, Value(M_LN2), 0);
-    define_property(vm.names.LN10, Value(M_LN10), 0);
-    define_property(vm.names.LOG2E, Value(::log2(M_E)), 0);
-    define_property(vm.names.LOG10E, Value(::log10(M_E)), 0);
-    define_property(vm.names.PI, Value(M_PI), 0);
-    define_property(vm.names.SQRT1_2, Value(M_SQRT1_2), 0);
-    define_property(vm.names.SQRT2, Value(M_SQRT2), 0);
+    define_direct_property(vm.names.E, Value(M_E), 0);
+    define_direct_property(vm.names.LN2, Value(M_LN2), 0);
+    define_direct_property(vm.names.LN10, Value(M_LN10), 0);
+    define_direct_property(vm.names.LOG2E, Value(::log2(M_E)), 0);
+    define_direct_property(vm.names.LOG10E, Value(::log10(M_E)), 0);
+    define_direct_property(vm.names.PI, Value(M_PI), 0);
+    define_direct_property(vm.names.SQRT1_2, Value(M_SQRT1_2), 0);
+    define_direct_property(vm.names.SQRT2, Value(M_SQRT2), 0);
 
     // 21.3.1.9 Math [ @@toStringTag ], https://tc39.es/ecma262/#sec-math-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Math.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Math.as_string()), Attribute::Configurable);
 }
 
 MathObject::~MathObject()

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -34,25 +34,25 @@ void NumberConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 21.1.2.15 Number.prototype, https://tc39.es/ecma262/#sec-number.prototype
-    define_property(vm.names.prototype, global_object.number_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.number_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.isFinite, is_finite, 1, attr);
     define_native_function(vm.names.isInteger, is_integer, 1, attr);
     define_native_function(vm.names.isNaN, is_nan, 1, attr);
     define_native_function(vm.names.isSafeInteger, is_safe_integer, 1, attr);
-    define_property(vm.names.parseInt, global_object.get(vm.names.parseInt), attr);
-    define_property(vm.names.parseFloat, global_object.get(vm.names.parseFloat), attr);
-    define_property(vm.names.EPSILON, Value(EPSILON_VALUE), 0);
-    define_property(vm.names.MAX_VALUE, Value(NumericLimits<double>::max()), 0);
-    define_property(vm.names.MIN_VALUE, Value(NumericLimits<double>::min()), 0);
-    define_property(vm.names.MAX_SAFE_INTEGER, Value(MAX_SAFE_INTEGER_VALUE), 0);
-    define_property(vm.names.MIN_SAFE_INTEGER, Value(MIN_SAFE_INTEGER_VALUE), 0);
-    define_property(vm.names.NEGATIVE_INFINITY, js_negative_infinity(), 0);
-    define_property(vm.names.POSITIVE_INFINITY, js_infinity(), 0);
-    define_property(vm.names.NaN, js_nan(), 0);
+    define_direct_property(vm.names.parseInt, global_object.get(vm.names.parseInt), attr);
+    define_direct_property(vm.names.parseFloat, global_object.get(vm.names.parseFloat), attr);
+    define_direct_property(vm.names.EPSILON, Value(EPSILON_VALUE), 0);
+    define_direct_property(vm.names.MAX_VALUE, Value(NumericLimits<double>::max()), 0);
+    define_direct_property(vm.names.MIN_VALUE, Value(NumericLimits<double>::min()), 0);
+    define_direct_property(vm.names.MAX_SAFE_INTEGER, Value(MAX_SAFE_INTEGER_VALUE), 0);
+    define_direct_property(vm.names.MIN_SAFE_INTEGER, Value(MIN_SAFE_INTEGER_VALUE), 0);
+    define_direct_property(vm.names.NEGATIVE_INFINITY, js_negative_infinity(), 0);
+    define_direct_property(vm.names.POSITIVE_INFINITY, js_infinity(), 0);
+    define_direct_property(vm.names.NaN, js_nan(), 0);
 }
 
 NumberConstructor::~NumberConstructor()

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -190,6 +190,19 @@ bool Object::create_data_property_or_throw(PropertyName const& property_name, Va
     return success;
 }
 
+// 7.3.6 CreateNonEnumerableDataPropertyOrThrow ( O, P, V ), https://tc39.es/proposal-error-cause/#sec-createnonenumerabledatapropertyorthrow
+bool Object::create_non_enumerable_data_property_or_throw(PropertyName const& property_name, Value value)
+{
+    VERIFY(!value.is_empty());
+    VERIFY(property_name.is_valid());
+
+    // 1. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+    auto new_description = PropertyDescriptor { .value = value, .writable = true, .enumerable = false, .configurable = true };
+
+    // 2. Return ? DefinePropertyOrThrow(O, P, newDesc).
+    return define_property_or_throw(property_name, new_description);
+}
+
 // 7.3.8 DefinePropertyOrThrow ( O, P, desc ), https://tc39.es/ecma262/#sec-definepropertyorthrow
 bool Object::define_property_or_throw(PropertyName const& property_name, PropertyDescriptor const& property_descriptor)
 {

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -123,9 +123,6 @@ public:
 
     // Non-standard methods
 
-    // - Helpers using old, non-standard names but wrapping the standard methods.
-    //   FIXME: Update all the code relying on these and remove them.
-    bool put(PropertyName const& property_name, Value value, Value receiver = {}) { return internal_set(property_name, value, receiver.value_or(this)); }
     Value get_without_side_effects(const PropertyName&) const;
 
     void define_direct_property(PropertyName const& property_name, Value value, PropertyAttributes attributes) { storage_set(property_name, { value, attributes }); };

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -131,9 +131,9 @@ public:
     void define_direct_property(PropertyName const& property_name, Value value, PropertyAttributes attributes) { storage_set(property_name, { value, attributes }); };
     void define_direct_accessor(PropertyName const&, FunctionObject* getter, FunctionObject* setter, PropertyAttributes attributes);
 
-    void define_native_function(PropertyName const&, Function<Value(VM&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
-    void define_native_property(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<void(VM&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);
-    void define_native_accessor(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<Value(VM&, GlobalObject&)> setter, PropertyAttributes attributes = default_attributes);
+    void define_native_function(PropertyName const&, Function<Value(VM&, GlobalObject&)>, i32 length, PropertyAttributes attributes);
+    void define_native_property(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<void(VM&, GlobalObject&, Value)> setter, PropertyAttributes attributes);
+    void define_native_accessor(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<Value(VM&, GlobalObject&)> setter, PropertyAttributes attributes);
 
     virtual bool is_array() const { return false; }
     virtual bool is_function() const { return false; }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -126,19 +126,14 @@ public:
     // - Helpers using old, non-standard names but wrapping the standard methods.
     //   FIXME: Update all the code relying on these and remove them.
     bool put(PropertyName const& property_name, Value value, Value receiver = {}) { return internal_set(property_name, value, receiver.value_or(this)); }
-    bool define_property(PropertyName const& property_name, Value value, PropertyAttributes attributes = default_attributes, bool = true)
-    {
-        return internal_define_own_property(property_name, { .value = value, .writable = attributes.is_writable(), .enumerable = attributes.is_enumerable(), .configurable = attributes.is_configurable() });
-    };
-
     Value get_without_side_effects(const PropertyName&) const;
 
-    bool define_property_without_transition(const PropertyName&, Value value, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
-    bool define_accessor(const PropertyName&, FunctionObject* getter, FunctionObject* setter, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
+    void define_direct_property(PropertyName const& property_name, Value value, PropertyAttributes attributes) { storage_set(property_name, { value, attributes }); };
+    void define_direct_accessor(PropertyName const&, FunctionObject* getter, FunctionObject* setter, PropertyAttributes attributes);
 
-    bool define_native_function(PropertyName const&, Function<Value(VM&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
-    bool define_native_property(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<void(VM&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);
-    bool define_native_accessor(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<Value(VM&, GlobalObject&)> setter, PropertyAttributes attributes = default_attributes);
+    void define_native_function(PropertyName const&, Function<Value(VM&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
+    void define_native_property(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<void(VM&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);
+    void define_native_accessor(PropertyName const&, Function<Value(VM&, GlobalObject&)> getter, Function<Value(VM&, GlobalObject&)> setter, PropertyAttributes attributes = default_attributes);
 
     virtual bool is_array() const { return false; }
     virtual bool is_function() const { return false; }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -78,6 +78,7 @@ public:
     bool create_data_property(PropertyName const&, Value);
     bool create_method_property(PropertyName const&, Value);
     bool create_data_property_or_throw(PropertyName const&, Value);
+    bool create_non_enumerable_data_property_or_throw(PropertyName const&, Value);
     bool define_property_or_throw(PropertyName const&, PropertyDescriptor const&);
     bool delete_property_or_throw(PropertyName const&);
     bool has_property(PropertyName const&) const;

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -28,9 +28,9 @@ void ObjectConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 20.1.2.19 Object.prototype, https://tc39.es/ecma262/#sec-object.prototype
-    define_property(vm.names.prototype, global_object.object_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.object_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.defineProperty, define_property_, 3, attr);
@@ -263,7 +263,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::from_entries)
         auto property_key = key.to_property_key(global_object);
         if (vm.exception())
             return IterationDecision::Break;
-        object->define_property(property_key, value);
+        object->create_data_property_or_throw(property_key, value);
         if (vm.exception())
             return IterationDecision::Break;
         return IterationDecision::Continue;

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -34,7 +34,7 @@ Optional<Variable> ObjectEnvironment::get_from_environment(FlyString const& name
 
 bool ObjectEnvironment::put_into_environment(FlyString const& name, Variable variable)
 {
-    return m_binding_object.put(name, variable.value);
+    return m_binding_object.set(name, variable.value, false);
 }
 
 bool ObjectEnvironment::delete_from_environment(FlyString const& name)

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
@@ -78,14 +78,14 @@ void OrdinaryFunctionObject::initialize(GlobalObject& global_object)
         auto* prototype = vm.heap().allocate<Object>(global_object, *global_object.new_ordinary_function_prototype_object_shape());
         switch (m_kind) {
         case FunctionKind::Regular:
-            prototype->define_property(vm.names.constructor, this, Attribute::Writable | Attribute::Configurable);
+            prototype->define_property_or_throw(vm.names.constructor, { .value = this, .writable = true, .enumerable = false, .configurable = true });
             break;
         case FunctionKind::Generator:
             // prototype is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
             prototype->internal_set_prototype_of(global_object.generator_object_prototype());
             break;
         }
-        define_property(vm.names.prototype, prototype, Attribute::Writable);
+        define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
     }
     define_property_or_throw(vm.names.length, { .value = Value(m_function_length), .writable = false, .enumerable = false, .configurable = true });
     define_property_or_throw(vm.names.name, { .value = js_string(vm, m_name.is_null() ? "" : m_name), .writable = false, .enumerable = false, .configurable = true });

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -26,9 +26,9 @@ void PromiseConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 27.2.4.4 Promise.prototype, https://tc39.es/ecma262/#sec-promise.prototype
-    define_property(vm.names.prototype, global_object.promise_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.promise_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     // TODO: Implement these functions below and uncomment this.

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -32,7 +32,7 @@ void PromisePrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.finally, finally, 1, attr);
 
     // 27.2.5.5 Promise.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-promise.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Promise.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Promise.as_string()), Attribute::Configurable);
 }
 
 static Promise* promise_from(VM& vm, GlobalObject& global_object)
@@ -106,7 +106,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
             });
             return promise->invoke(vm.names.then.as_string(), value_thunk);
         });
-        then_finally_function->define_property(vm.names.length, Value(1), Attribute::Configurable);
+        then_finally_function->define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
         // 27.2.5.3.2 Catch Finally Functions, https://tc39.es/ecma262/#sec-catchfinallyfunctions
         auto* catch_finally_function = NativeFunction::create(global_object, "", [constructor_handle = make_handle(constructor), on_finally_handle = make_handle(&on_finally.as_function())](auto& vm, auto& global_object) -> Value {
@@ -125,7 +125,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
             });
             return promise->invoke(vm.names.then.as_string(), thrower);
         });
-        catch_finally_function->define_property(vm.names.length, Value(1), Attribute::Configurable);
+        catch_finally_function->define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
         then_finally = Value(then_finally_function);
         catch_finally = Value(catch_finally_function);

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
@@ -42,7 +42,7 @@ PromiseCapability new_promise_capability(GlobalObject& global_object, Value cons
         promise_capability_functions.reject = reject;
         return js_undefined();
     });
-    executor->define_property(vm.names.length, Value(2), Attribute::Configurable);
+    executor->define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 
     MarkedValueList arguments(vm.heap());
     arguments.append(executor);

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -27,7 +27,7 @@ PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, AlreadyReso
 void PromiseResolvingFunction::initialize(GlobalObject& global_object)
 {
     Base::initialize(global_object);
-    define_property(vm().names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm().names.length, Value(1), Attribute::Configurable);
 }
 
 Value PromiseResolvingFunction::call()

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -37,7 +37,7 @@ void ProxyConstructor::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     NativeFunction::initialize(global_object);
-    define_property(vm.names.length, Value(2), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.revocable, revocable, 2, attr);
 }
@@ -79,7 +79,7 @@ JS_DEFINE_NATIVE_FUNCTION(ProxyConstructor::revocable)
         proxy.revoke();
         return js_undefined();
     });
-    revoker->define_property(vm.names.length, Value(0), Attribute::Configurable);
+    revoker->define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
     auto* result = Object::create(global_object, global_object.object_prototype());
     result->create_data_property_or_throw(vm.names.proxy, proxy);

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -40,7 +40,7 @@ void ReflectObject::initialize(GlobalObject& global_object)
     define_native_function(vm.names.setPrototypeOf, set_prototype_of, 2, attr);
 
     // 28.1.14 Reflect [ @@toStringTag ], https://tc39.es/ecma262/#sec-reflect-@@tostringtag
-    Object::define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Reflect.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Reflect.as_string()), Attribute::Configurable);
 }
 
 ReflectObject::~ReflectObject()

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -22,9 +22,9 @@ void RegExpConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 22.2.4.1 RegExp.prototype, https://tc39.es/ecma262/#sec-regexp.prototype
-    define_property(vm.names.prototype, global_object.regexp_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.regexp_prototype(), 0);
 
-    define_property(vm.names.length, Value(2), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -24,9 +24,9 @@ void SetConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 24.2.2.1 Set.prototype, https://tc39.es/ecma262/#sec-set.prototype
-    define_property(vm.names.prototype, global_object.set_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.set_prototype(), 0);
 
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 }

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -27,7 +27,7 @@ void SetIteratorPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
 
     // 24.2.5.2.2 %SetIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%setiteratorprototype%-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Set Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Set Iterator"), Attribute::Configurable);
 }
 
 SetIteratorPrototype::~SetIteratorPrototype()
@@ -61,10 +61,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetIteratorPrototype::next)
     if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, value, false);
 
-    auto* entry_array = Array::create(global_object, 0);
-    entry_array->define_property(0, value);
-    entry_array->define_property(1, value);
-    return create_iterator_result_object(global_object, entry_array, false);
+    return create_iterator_result_object(global_object, Array::create_from(global_object, { value, value }), false);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -30,13 +30,13 @@ void SetPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.values, values, 0, attr);
     define_native_accessor(vm.names.size, size_getter, {}, Attribute::Configurable);
 
-    define_property(vm.names.keys, get(vm.names.values), attr);
+    define_direct_property(vm.names.keys, get(vm.names.values), attr);
 
     // 24.2.3.11 Set.prototype [ @@iterator ] ( ), https://tc39.es/ecma262/#sec-set.prototype-@@iterator
-    define_property(*vm.well_known_symbol_iterator(), get(vm.names.values), attr);
+    define_direct_property(*vm.well_known_symbol_iterator(), get(vm.names.values), attr);
 
     // 24.2.3.12 Set.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-set.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Set.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.Set.as_string()), Attribute::Configurable);
 }
 
 SetPrototype::~SetPrototype()

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -26,9 +26,9 @@ void StringConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 22.1.2.3 String.prototype, https://tc39.es/ecma262/#sec-string.prototype
-    define_property(vm.names.prototype, global_object.string_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.string_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.raw, raw, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -25,7 +25,7 @@ void StringIteratorPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.next, next, 0, Attribute::Configurable | Attribute::Writable);
 
     // 22.1.5.1.2 %StringIteratorPrototype% [ @@toStringTag ], https://tc39.es/ecma262/#sec-%stringiteratorprototype%-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "String Iterator"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "String Iterator"), Attribute::Configurable);
 }
 
 StringIteratorPrototype::~StringIteratorPrototype()

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -33,7 +33,7 @@ void StringObject::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Object::initialize(global_object);
-    define_property(vm.names.length, Value(m_string.string().length()), 0);
+    define_direct_property(vm.names.length, Value(m_string.string().length()), 0);
 }
 
 void StringObject::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -68,9 +68,9 @@ void StringPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.padEnd, pad_end, 1, attr);
     define_native_function(vm.names.trim, trim, 0, attr);
     define_native_function(vm.names.trimStart, trim_start, 0, attr);
-    define_property(vm.names.trimLeft, get_without_side_effects(vm.names.trimStart), attr);
+    define_direct_property(vm.names.trimLeft, get_without_side_effects(vm.names.trimStart), attr);
     define_native_function(vm.names.trimEnd, trim_end, 0, attr);
-    define_property(vm.names.trimRight, get_without_side_effects(vm.names.trimEnd), attr);
+    define_direct_property(vm.names.trimRight, get_without_side_effects(vm.names.trimEnd), attr);
     define_native_function(vm.names.concat, concat, 1, attr);
     define_native_function(vm.names.substr, substr, 2, attr);
     define_native_function(vm.names.substring, substring, 2, attr);

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -21,16 +21,16 @@ void SymbolConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 20.4.2.9 Symbol.prototype, https://tc39.es/ecma262/#sec-symbol.prototype
-    define_property(vm.names.prototype, global_object.symbol_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.symbol_prototype(), 0);
 
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.for_, for_, 1, attr);
     define_native_function(vm.names.keyFor, key_for, 1, attr);
 
 #define __JS_ENUMERATE(SymbolName, snake_name) \
-    define_property(vm.names.SymbolName, vm.well_known_symbol_##snake_name(), 0);
+    define_direct_property(vm.names.SymbolName, vm.well_known_symbol_##snake_name(), 0);
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
 }

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -33,7 +33,7 @@ void SymbolPrototype::initialize(GlobalObject& global_object)
     define_native_function(*vm.well_known_symbol_to_primitive(), symbol_to_primitive, 1, Attribute::Configurable);
 
     // 20.4.3.6 Symbol.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-symbol.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Symbol"), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Symbol"), Attribute::Configurable);
 }
 
 SymbolPrototype::~SymbolPrototype()

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -236,11 +236,16 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
     PrototypeName::PrototypeName(GlobalObject& global_object)                                                                          \
         : Object(*global_object.typed_array_prototype())                                                                               \
     {                                                                                                                                  \
-        auto& vm = this->vm();                                                                                                         \
-        define_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                                      \
     }                                                                                                                                  \
                                                                                                                                        \
     PrototypeName::~PrototypeName() { }                                                                                                \
+                                                                                                                                       \
+    void PrototypeName::initialize(GlobalObject& global_object)                                                                        \
+    {                                                                                                                                  \
+        auto& vm = this->vm();                                                                                                         \
+        Object::initialize(global_object);                                                                                             \
+        define_direct_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                               \
+    }                                                                                                                                  \
                                                                                                                                        \
     ConstructorName::ConstructorName(GlobalObject& global_object)                                                                      \
         : TypedArrayConstructor(vm().names.ClassName.as_string(), *global_object.typed_array_constructor())                            \
@@ -255,12 +260,12 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         NativeFunction::initialize(global_object);                                                                                     \
                                                                                                                                        \
         /* 23.2.6.2 TypedArray.prototype, https://tc39.es/ecma262/#sec-typedarray.prototype */                                         \
-        define_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);                                                \
+        define_direct_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);                                         \
                                                                                                                                        \
-        define_property(vm.names.length, Value(3), Attribute::Configurable);                                                           \
+        define_direct_property(vm.names.length, Value(3), Attribute::Configurable);                                                    \
                                                                                                                                        \
         /* 23.2.6.1 TypedArray.BYTES_PER_ELEMENT, https://tc39.es/ecma262/#sec-typedarray.bytes_per_element */                         \
-        define_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                                      \
+        define_direct_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                               \
     }                                                                                                                                  \
                                                                                                                                        \
     /* 23.2.5.1 TypedArray ( ...args ), https://tc39.es/ecma262/#sec-typedarray */                                                     \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -471,6 +471,7 @@ private:
                                                                                             \
     public:                                                                                 \
         PrototypeName(GlobalObject&);                                                       \
+        virtual void initialize(GlobalObject&) override;                                    \
         virtual ~PrototypeName() override;                                                  \
     };                                                                                      \
     class ConstructorName final : public TypedArrayConstructor {                            \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -27,9 +27,9 @@ void TypedArrayConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 23.2.2.3 %TypedArray%.prototype, https://tc39.es/ecma262/#sec-%typedarray%.prototype
-    define_property(vm.names.prototype, global_object.typed_array_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.typed_array_prototype(), 0);
 
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.from, from, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -180,7 +180,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayConstructor::of)
     if (vm.exception())
         return {};
     for (size_t k = 0; k < length; ++k) {
-        auto success = new_object->put(k, vm.argument(k));
+        auto success = new_object->set(k, vm.argument(k), true);
         if (vm.exception())
             return {};
         if (!success) {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -43,7 +43,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_native_accessor(*vm.well_known_symbol_to_string_tag(), to_string_tag_getter, nullptr, Attribute::Configurable);
 
     // 23.2.3.29 %TypedArray%.prototype.toString ( ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.tostring
-    define_property(vm.names.toString, global_object().array_prototype()->get_without_side_effects(vm.names.toString), attr);
+    define_direct_property(vm.names.toString, global_object().array_prototype()->get_without_side_effects(vm.names.toString), attr);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -160,7 +160,7 @@ void VM::set_variable(const FlyString& name, Value value, GlobalObject& global_o
         return;
     }
 
-    global_object.put(name, value);
+    global_object.set(name, value, true);
 }
 
 bool VM::delete_variable(FlyString const& name)
@@ -298,7 +298,7 @@ void VM::assign(const NonnullRefPtr<BindingPattern>& target, Value value, Global
                         continue;
                     if (seen_names.contains(object_property.key.to_display_string()))
                         continue;
-                    rest_object->put(object_property.key, object->get(object_property.key));
+                    rest_object->set(object_property.key, object->get(object_property.key), true);
                     if (exception())
                         return;
                 }

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
@@ -24,9 +24,9 @@ void WeakMapConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 24.3.2.1 WeakMap.prototype, https://tc39.es/ecma262/#sec-weakmap.prototype
-    define_property(vm.names.prototype, global_object.weak_map_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.weak_map_prototype(), 0);
 
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
 WeakMapConstructor::~WeakMapConstructor()

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
@@ -26,7 +26,7 @@ void WeakMapPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.set, set, 2, attr);
 
     // 24.3.3.6 WeakMap.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-weakmap.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.WeakMap.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.WeakMap.as_string()), Attribute::Configurable);
 }
 
 WeakMapPrototype::~WeakMapPrototype()

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
@@ -23,9 +23,9 @@ void WeakRefConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 26.1.2.1 WeakRef.prototype, https://tc39.es/ecma262/#sec-weak-ref.prototype
-    define_property(vm.names.prototype, global_object.weak_ref_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.weak_ref_prototype(), 0);
 
-    define_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 WeakRefConstructor::~WeakRefConstructor()

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -20,7 +20,7 @@ void WeakRefPrototype::initialize(GlobalObject& global_object)
 
     define_native_function(vm.names.deref, deref, 0, Attribute::Writable | Attribute::Configurable);
 
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.WeakRef.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), vm.names.WeakRef.as_string()), Attribute::Configurable);
 }
 
 WeakRefPrototype::~WeakRefPrototype()

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
@@ -24,9 +24,9 @@ void WeakSetConstructor::initialize(GlobalObject& global_object)
     NativeFunction::initialize(global_object);
 
     // 24.4.2.1 WeakSet.prototype, https://tc39.es/ecma262/#sec-weakset.prototype
-    define_property(vm.names.prototype, global_object.weak_set_prototype(), 0);
+    define_direct_property(vm.names.prototype, global_object.weak_set_prototype(), 0);
 
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
 WeakSetConstructor::~WeakSetConstructor()

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -25,7 +25,7 @@ void WeakSetPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.has, has, 1, attr);
 
     // 24.4.3.5 WeakSet.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-weakset.prototype-@@tostringtag
-    define_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakSet.as_string()), Attribute::Configurable);
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakSet.as_string()), Attribute::Configurable);
 }
 
 WeakSetPrototype::~WeakSetPrototype()

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.shift.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.shift.js
@@ -26,7 +26,7 @@ test("Issue #5884, GenericIndexedPropertyStorage::take_first() loses elements", 
     const a = [];
     for (let i = 0; i < 300; i++) {
         // NOTE: We use defineProperty to prevent the array from using SimpleIndexedPropertyStorage
-        Object.defineProperty(a, i, { value: i, configurable: true });
+        Object.defineProperty(a, i, { value: i, configurable: true, writable: true });
     }
     expect(a.length).toBe(300);
     for (let i = 0; i < 300; i++) {

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -180,13 +180,13 @@ public:
 inline void TestRunnerGlobalObject::initialize_global_object()
 {
     Base::initialize_global_object();
-    define_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global", this, JS::Attribute::Enumerable);
     for (auto& entry : s_exposed_global_functions) {
         define_native_function(
             entry.key, [fn = entry.value.function](auto& vm, auto& global_object) {
                 return fn(vm, global_object);
             },
-            entry.value.length);
+            entry.value.length, JS::default_attributes);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -25,8 +25,8 @@ void ImageConstructor::initialize(JS::GlobalObject& global_object)
     auto& window = static_cast<WindowObject&>(global_object);
     NativeFunction::initialize(global_object);
 
-    define_property(vm.names.prototype, &window.ensure_web_prototype<HTMLImageElementPrototype>("HTMLImageElement"), 0);
-    define_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<HTMLImageElementPrototype>("HTMLImageElement"), 0);
+    define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 
 ImageConstructor::~ImageConstructor()

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -33,7 +33,7 @@ void NavigatorObject::initialize(JS::GlobalObject& global_object)
     define_direct_property("platform", js_string(heap, "SerenityOS"), attr);
     define_direct_property("product", js_string(heap, "Gecko"), attr);
 
-    define_native_accessor("userAgent", user_agent_getter, {});
+    define_native_accessor("userAgent", user_agent_getter, {}, JS::Attribute::Configurable | JS::Attribute::Enumerable);
 }
 
 NavigatorObject::~NavigatorObject()

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -24,13 +24,14 @@ void NavigatorObject::initialize(JS::GlobalObject& global_object)
     languages->indexed_properties().append(js_string(heap, "en-US"));
 
     // FIXME: All of these should be in Navigator's prototype and be native accessors
-    define_property("appCodeName", js_string(heap, "Mozilla"));
-    define_property("appName", js_string(heap, "Netscape"));
-    define_property("appVersion", js_string(heap, "4.0"));
-    define_property("language", languages->get(0));
-    define_property("languages", languages);
-    define_property("platform", js_string(heap, "SerenityOS"));
-    define_property("product", js_string(heap, "Gecko"));
+    u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
+    define_direct_property("appCodeName", js_string(heap, "Mozilla"), attr);
+    define_direct_property("appName", js_string(heap, "Netscape"), attr);
+    define_direct_property("appVersion", js_string(heap, "4.0"), attr);
+    define_direct_property("language", languages->get(0), attr);
+    define_direct_property("languages", languages, attr);
+    define_direct_property("platform", js_string(heap, "SerenityOS"), attr);
+    define_direct_property("product", js_string(heap, "Gecko"), attr);
 
     define_native_accessor("userAgent", user_agent_getter, {});
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -47,9 +47,9 @@ void WindowObject::initialize_global_object()
     VERIFY(success);
 
     // FIXME: These should be native accessors, not properties
-    define_property("window", this, JS::Attribute::Enumerable);
-    define_property("frames", this, JS::Attribute::Enumerable);
-    define_property("self", this, JS::Attribute::Enumerable);
+    define_direct_property("window", this, JS::Attribute::Enumerable);
+    define_direct_property("frames", this, JS::Attribute::Enumerable);
+    define_direct_property("self", this, JS::Attribute::Enumerable);
     define_native_accessor("top", top_getter, nullptr, JS::Attribute::Enumerable);
     define_native_accessor("parent", parent_getter, {}, JS::Attribute::Enumerable);
     define_native_accessor("document", document_getter, {}, JS::Attribute::Enumerable);
@@ -72,11 +72,11 @@ void WindowObject::initialize_global_object()
     // Legacy
     define_native_accessor("event", event_getter, {}, JS::Attribute::Enumerable);
 
-    define_property("navigator", heap().allocate<NavigatorObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_property("location", heap().allocate<LocationObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_direct_property("navigator", heap().allocate<NavigatorObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_direct_property("location", heap().allocate<LocationObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     // WebAssembly "namespace"
-    define_property("WebAssembly", heap().allocate<WebAssemblyObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_direct_property("WebAssembly", heap().allocate<WebAssemblyObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     ADD_WINDOW_OBJECT_INTERFACES;
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -57,17 +57,18 @@ void WindowObject::initialize_global_object()
     define_native_accessor("screen", screen_getter, {}, JS::Attribute::Enumerable);
     define_native_accessor("innerWidth", inner_width_getter, {}, JS::Attribute::Enumerable);
     define_native_accessor("innerHeight", inner_height_getter, {}, JS::Attribute::Enumerable);
-    define_native_function("alert", alert);
-    define_native_function("confirm", confirm);
-    define_native_function("prompt", prompt);
-    define_native_function("setInterval", set_interval, 1);
-    define_native_function("setTimeout", set_timeout, 1);
-    define_native_function("clearInterval", clear_interval, 1);
-    define_native_function("clearTimeout", clear_timeout, 1);
-    define_native_function("requestAnimationFrame", request_animation_frame, 1);
-    define_native_function("cancelAnimationFrame", cancel_animation_frame, 1);
-    define_native_function("atob", atob, 1);
-    define_native_function("btoa", btoa, 1);
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Enumerable | JS::Attribute::Configurable;
+    define_native_function("alert", alert, 0, attr);
+    define_native_function("confirm", confirm, 0, attr);
+    define_native_function("prompt", prompt, 0, attr);
+    define_native_function("setInterval", set_interval, 1, attr);
+    define_native_function("setTimeout", set_timeout, 1, attr);
+    define_native_function("clearInterval", clear_interval, 1, attr);
+    define_native_function("clearTimeout", clear_timeout, 1, attr);
+    define_native_function("requestAnimationFrame", request_animation_frame, 1, attr);
+    define_native_function("cancelAnimationFrame", cancel_animation_frame, 1, attr);
+    define_native_function("atob", atob, 1, attr);
+    define_native_function("btoa", btoa, 1, attr);
 
     // Legacy
     define_native_accessor("event", event_getter, {}, JS::Attribute::Enumerable);

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -51,7 +51,7 @@ public:
             return *it->value;
         auto* constructor = heap().allocate<T>(*this, *this);
         m_constructors.set(class_name, constructor);
-        define_property(class_name, JS::Value(constructor), JS::Attribute::Writable | JS::Attribute::Configurable);
+        define_direct_property(class_name, JS::Value(constructor), JS::Attribute::Writable | JS::Attribute::Configurable);
         return *constructor;
     }
 

--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -226,12 +226,12 @@
 #include <LibWeb/Bindings/XMLHttpRequestEventTargetPrototype.h>
 #include <LibWeb/Bindings/XMLHttpRequestPrototype.h>
 
-#define ADD_WINDOW_OBJECT_CONSTRUCTOR_AND_PROTOTYPE(interface_name, constructor_name, prototype_name)                         \
-    {                                                                                                                         \
-        auto& constructor = ensure_web_constructor<constructor_name>(#interface_name);                                        \
-        constructor.define_property(vm.names.name, js_string(vm, #interface_name), JS::Attribute::Configurable);              \
-        auto& prototype = ensure_web_prototype<prototype_name>(#interface_name);                                              \
-        prototype.define_property(vm.names.constructor, &constructor, JS::Attribute::Writable | JS::Attribute::Configurable); \
+#define ADD_WINDOW_OBJECT_CONSTRUCTOR_AND_PROTOTYPE(interface_name, constructor_name, prototype_name)                                \
+    {                                                                                                                                \
+        auto& constructor = ensure_web_constructor<constructor_name>(#interface_name);                                               \
+        constructor.define_direct_property(vm.names.name, js_string(vm, #interface_name), JS::Attribute::Configurable);              \
+        auto& prototype = ensure_web_prototype<prototype_name>(#interface_name);                                                     \
+        prototype.define_direct_property(vm.names.constructor, &constructor, JS::Attribute::Writable | JS::Attribute::Configurable); \
     }
 
 #define ADD_WINDOW_OBJECT_INTERFACE(interface_name) \

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -1113,8 +1113,8 @@ void @constructor_class@::initialize(JS::GlobalObject& global_object)
     [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable;
 
     NativeFunction::initialize(global_object);
-    define_property(vm.names.prototype, &window.ensure_web_prototype<@prototype_class@>("@name@"), 0);
-    define_property(vm.names.length, JS::Value(@constructor.length@), JS::Attribute::Configurable);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<@prototype_class@>("@name@"), 0);
+    define_direct_property(vm.names.length, JS::Value(@constructor.length@), JS::Attribute::Configurable);
 
 )~~~");
 
@@ -1124,7 +1124,7 @@ void @constructor_class@::initialize(JS::GlobalObject& global_object)
         constant_generator.set("constant.value", constant.value);
 
         constant_generator.append(R"~~~(
-define_property("@constant.name@", JS::Value((i32)@constant.value@), JS::Attribute::Enumerable);
+define_direct_property("@constant.name@", JS::Value((i32)@constant.value@), JS::Attribute::Enumerable);
 )~~~");
     }
 
@@ -1336,7 +1336,7 @@ void @prototype_class@::initialize(JS::GlobalObject& global_object)
         constant_generator.set("constant.value", constant.value);
 
         constant_generator.append(R"~~~(
-    define_property("@constant.name@", JS::Value((i32)@constant.value@), JS::Attribute::Enumerable);
+    define_direct_property("@constant.name@", JS::Value((i32)@constant.value@), JS::Attribute::Enumerable);
 )~~~");
     }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceConstructor.cpp
@@ -59,8 +59,8 @@ void WebAssemblyInstanceConstructor::initialize(JS::GlobalObject& global_object)
     auto& window = static_cast<WindowObject&>(global_object);
 
     NativeFunction::initialize(global_object);
-    define_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyInstancePrototype>("WebAssemblyInstancePrototype"));
-    define_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyInstancePrototype>("WebAssemblyInstancePrototype"), 0);
+    define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
@@ -39,7 +39,7 @@ void WebAssemblyInstanceObject::initialize(JS::GlobalObject& global_object)
                     object = create_native_function(address, export_.name(), global_object);
                     cache.function_instances.set(address, *object);
                 }
-                m_exports_object->define_property(export_.name(), *object);
+                m_exports_object->define_direct_property(export_.name(), *object, JS::default_attributes);
             },
             [&](const Wasm::MemoryAddress& address) {
                 auto object = cache.memory_instances.get(address);
@@ -47,7 +47,7 @@ void WebAssemblyInstanceObject::initialize(JS::GlobalObject& global_object)
                     object = heap().allocate<Web::Bindings::WebAssemblyMemoryObject>(global_object, global_object, address);
                     cache.memory_instances.set(address, *object);
                 }
-                m_exports_object->define_property(export_.name(), *object);
+                m_exports_object->define_direct_property(export_.name(), *object, JS::default_attributes);
             },
             [&](const auto&) {
                 // FIXME: Implement other exports!

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObjectPrototype.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObjectPrototype.cpp
@@ -12,7 +12,7 @@ namespace Web::Bindings {
 void WebAssemblyInstancePrototype::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
-    define_native_accessor("exports", exports_getter, {});
+    define_native_accessor("exports", exports_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(WebAssemblyInstancePrototype::exports_getter)

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
@@ -72,8 +72,8 @@ void WebAssemblyMemoryConstructor::initialize(JS::GlobalObject& global_object)
     auto& window = static_cast<WindowObject&>(global_object);
 
     NativeFunction::initialize(global_object);
-    define_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssemblyMemoryPrototype"));
-    define_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssemblyMemoryPrototype"), 0);
+    define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryPrototype.cpp
@@ -13,8 +13,8 @@ namespace Web::Bindings {
 void WebAssemblyMemoryPrototype::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
-    define_native_accessor("buffer", buffer_getter, {});
-    define_native_function("grow", grow);
+    define_native_accessor("buffer", buffer_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_function("grow", grow, 1, JS::Attribute::Writable | JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(WebAssemblyMemoryPrototype::grow)

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleConstructor.cpp
@@ -54,8 +54,8 @@ void WebAssemblyModuleConstructor::initialize(JS::GlobalObject& global_object)
     auto& window = static_cast<WindowObject&>(global_object);
 
     NativeFunction::initialize(global_object);
-    define_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyModulePrototype>("WebAssemblyModulePrototype"));
-    define_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WebAssemblyModulePrototype>("WebAssemblyModulePrototype"), 0);
+    define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -329,8 +329,8 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyObject::instantiate)
         auto instance_object = vm.heap().allocate<WebAssemblyInstanceObject>(global_object, global_object, result.value());
         if (should_return_module) {
             auto object = JS::Object::create(global_object, nullptr);
-            object->put("module", vm.heap().allocate<WebAssemblyModuleObject>(global_object, global_object, s_compiled_modules.size() - 1));
-            object->put("instance", instance_object);
+            object->define_direct_property("module", vm.heap().allocate<WebAssemblyModuleObject>(global_object, global_object, s_compiled_modules.size() - 1), JS::default_attributes);
+            object->define_direct_property("instance", instance_object, JS::default_attributes);
             promise->fulfill(object);
         } else {
             promise->fulfill(instance_object);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -31,30 +31,31 @@ void WebAssemblyObject::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
 
-    define_native_function("validate", validate, 1);
-    define_native_function("compile", compile, 1);
-    define_native_function("instantiate", instantiate, 1);
+    u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
+    define_native_function("validate", validate, 1, attr);
+    define_native_function("compile", compile, 1, attr);
+    define_native_function("instantiate", instantiate, 1, attr);
 
     auto& vm = global_object.vm();
 
     auto& window = static_cast<WindowObject&>(global_object);
     auto& memory_constructor = window.ensure_web_constructor<WebAssemblyMemoryConstructor>("WebAssembly.Memory");
-    memory_constructor.define_property(vm.names.name, js_string(vm, "WebAssembly.Memory"), JS::Attribute::Configurable);
+    memory_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Memory"), JS::Attribute::Configurable);
     auto& memory_prototype = window.ensure_web_prototype<WebAssemblyMemoryPrototype>("WebAssemblyMemoryPrototype");
-    memory_prototype.define_property(vm.names.constructor, &memory_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
-    define_property("Memory", &memory_constructor);
+    memory_prototype.define_direct_property(vm.names.constructor, &memory_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
+    define_direct_property("Memory", &memory_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 
     auto& instance_constructor = window.ensure_web_constructor<WebAssemblyInstanceConstructor>("WebAssembly.Instance");
-    instance_constructor.define_property(vm.names.name, js_string(vm, "WebAssembly.Instance"), JS::Attribute::Configurable);
+    instance_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Instance"), JS::Attribute::Configurable);
     auto& instance_prototype = window.ensure_web_prototype<WebAssemblyInstancePrototype>("WebAssemblyInstancePrototype");
-    instance_prototype.define_property(vm.names.constructor, &instance_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
-    define_property("Instance", &instance_constructor);
+    instance_prototype.define_direct_property(vm.names.constructor, &instance_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
+    define_direct_property("Instance", &instance_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 
     auto& module_constructor = window.ensure_web_constructor<WebAssemblyModuleConstructor>("WebAssembly.Module");
-    module_constructor.define_property(vm.names.name, js_string(vm, "WebAssembly.Module"), JS::Attribute::Configurable);
+    module_constructor.define_direct_property(vm.names.name, js_string(vm, "WebAssembly.Module"), JS::Attribute::Configurable);
     auto& module_prototype = window.ensure_web_prototype<WebAssemblyModulePrototype>("WebAssemblyModulePrototype");
-    module_prototype.define_property(vm.names.constructor, &module_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
-    define_property("Module", &module_constructor);
+    module_prototype.define_direct_property(vm.names.constructor, &module_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
+    define_direct_property("Module", &module_constructor, JS::Attribute::Writable | JS::Attribute::Configurable);
 }
 
 NonnullOwnPtrVector<WebAssemblyObject::CompiledWebAssemblyModule> WebAssemblyObject::s_compiled_modules;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -653,7 +653,7 @@ static JS::Value load_file_impl(JS::VM& vm, JS::GlobalObject& global_object)
 void ReplObject::initialize_global_object()
 {
     Base::initialize_global_object();
-    define_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global", this, JS::Attribute::Enumerable);
     define_native_function("exit", exit_interpreter);
     define_native_function("help", repl_help);
     define_native_function("load", load_file, 1);
@@ -700,7 +700,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReplObject::load_file)
 void ScriptObject::initialize_global_object()
 {
     Base::initialize_global_object();
-    define_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global", this, JS::Attribute::Enumerable);
     define_native_function("load", load_file, 1);
 }
 

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -654,10 +654,11 @@ void ReplObject::initialize_global_object()
 {
     Base::initialize_global_object();
     define_direct_property("global", this, JS::Attribute::Enumerable);
-    define_native_function("exit", exit_interpreter);
-    define_native_function("help", repl_help);
-    define_native_function("load", load_file, 1);
-    define_native_function("save", save_to_file, 1);
+    u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
+    define_native_function("exit", exit_interpreter, 0, attr);
+    define_native_function("help", repl_help, 0, attr);
+    define_native_function("load", load_file, 1, attr);
+    define_native_function("save", save_to_file, 1, attr);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ReplObject::save_to_file)
@@ -701,7 +702,8 @@ void ScriptObject::initialize_global_object()
 {
     Base::initialize_global_object();
     define_direct_property("global", this, JS::Attribute::Enumerable);
-    define_native_function("load", load_file, 1);
+    u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
+    define_native_function("load", load_file, 1, attr);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ScriptObject::load_file)


### PR DESCRIPTION
Also fixes 17 test262 test cases as an extra bonus :^)

(The first 2 commits are issues in the implementations that were uncovered after using the correct object helpers)