### PR TITLE
LibJS: Add missing exception check in internalize_json_property

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -509,6 +509,8 @@ Value JSONObject::internalize_json_property(GlobalObject& global_object, Object*
             }
         } else {
             auto property_list = value_object.enumerable_own_property_names(Object::PropertyKind::Key);
+            if (vm.exception())
+                return {};
             for (auto& property_name : property_list) {
                 process_property(property_name.as_string().string());
                 if (vm.exception())


### PR DESCRIPTION
The call to enumerable_own_property_names in the non-array case was
missing an exception check.

Fixes 1 test262 case (JSON/parse/reviver-object-own-keys-err.js)