### PR TITLE
LibJS: Add Uint8ClampedArray to typed array tests and fixup some typed array tests

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.BYTES_PER_ELEMENT.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.BYTES_PER_ELEMENT.js
@@ -1,5 +1,6 @@
 test("basic functionality", () => {
     expect(Uint8Array.BYTES_PER_ELEMENT).toBe(1);
+    expect(Uint8ClampedArray.BYTES_PER_ELEMENT).toBe(1);
     expect(Uint16Array.BYTES_PER_ELEMENT).toBe(2);
     expect(Uint32Array.BYTES_PER_ELEMENT).toBe(4);
     expect(BigUint64Array.BYTES_PER_ELEMENT).toBe(8);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.from.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,
@@ -176,6 +177,7 @@ test("typed array from TypedArray element cast", () => {
 
     const u32Expected = [
         [0, 0xff],
+        [0xff, 0xff],
         [0x100, 0xff],
         [0x100, 0xff],
         [0, -1],
@@ -184,7 +186,7 @@ test("typed array from TypedArray element cast", () => {
         [0x100, 0xff],
         [0x100, 0xff],
     ];
-    const u8Expected = [0xff, 0xff, 0xff, -1, 0xff, 0xff, 0xff, 0xff];
+    const u8Expected = [0xff, 0xff, 0xff, 0xff, -1, 0xff, 0xff, 0xff, 0xff];
 
     TYPED_ARRAYS.forEach((T, i) => {
         const newArrFromU32 = new T(u32Array);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.of.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.of.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.BYTES_PER_ELEMENT.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.BYTES_PER_ELEMENT.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     { array: Uint8Array, expected: 1 },
+    { array: Uint8ClampedArray, expected: 1 },
     { array: Uint16Array, expected: 2 },
     { array: Uint32Array, expected: 4 },
     { array: BigUint64Array, expected: 8 },

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.at.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.at.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.buffer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.buffer.js
@@ -20,7 +20,7 @@ test("basic functionality", () => {
         if (!isBigIntArray) typedArray = new T([1, 2, 3]);
         else typedArray = new T([1n, 2n, 3n]);
 
-        expect(Object.hasOwn(typedArray, "byteOffset")).toBeFalse();
+        expect(Object.hasOwn(typedArray, "buffer")).toBeFalse();
 
         const buffer = typedArray.buffer;
         expect(buffer).toBeInstanceOf(ArrayBuffer);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.buffer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.buffer.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     BigUint64Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
@@ -20,7 +20,7 @@ test("basic functionality", () => {
         if (!isBigIntArray) typedArray = new T.array([1, 2, 3]);
         else typedArray = new T.array([1n, 2n, 3n]);
 
-        expect(Object.hasOwn(typedArray, "byteOffset")).toBeFalse();
+        expect(Object.hasOwn(typedArray, "byteLength")).toBeFalse();
         expect(typedArray.byteLength).toBe(T.expected);
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     { array: Uint8Array, expected: 3 },
+    { array: Uint8ClampedArray, expected: 3 },
     { array: Uint16Array, expected: 6 },
     { array: Uint32Array, expected: 12 },
     { array: BigUint64Array, expected: 24 },

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteOffset.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteOffset.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     BigUint64Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.entries.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.entries.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.find.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.find.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findIndex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findIndex.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
@@ -95,7 +95,7 @@ describe("normal behaviour", () => {
             const typedArray = new T([1n, 2n, 3n]);
             typedArray.forEach((value, index) => {
                 expect(value).toBe(typedArray[index]);
-                expect(index).toBe(parseInt(typedArray[index] - 1n));
+                expect(index).toBe(Number(typedArray[index] - 1n));
             });
         });
     });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.keys.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.keys.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.length.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.length.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     BigUint64Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.values.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.values.js
@@ -1,5 +1,6 @@
 const TYPED_ARRAYS = [
     Uint8Array,
+    Uint8ClampedArray,
     Uint16Array,
     Uint32Array,
     Int8Array,


### PR DESCRIPTION
LibJS: Add Uint8ClampedArray to TypedArray tests

-----

LibJS: Use Number instead of parseInt in TypedArray forEach BigInt tests

The Number constructor previously didn't support converting BigInts to
regular numbers, so I used parseInt as a workaround.

Since it now supports this, this workaround is no longer needed.

-----

LibJS: Fix byteOffset copy-paste error in TypedArray byteLength test

-----

LibJS: Fix byteOffset copy-paste error in TypedArray buffer test