### PR TITLE
LibWasm: Some tiny correctness changes and test generator tweaks

### DIFF
--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -188,8 +188,10 @@ def generate(ast):
         elif len(entry) >= 2 and entry[0][0] == 'invoke':
             # toplevel invoke :shrug:
             arg, name, module = 0, None, None
-            if isinstance(entry[1][1], str):
+            if not isinstance(entry[1], str) and isinstance(entry[1][1], str):
                 name = entry[1][1]
+            elif isinstance(entry[1], str):
+                name = entry[1]
             else:
                 name = entry[1][2]
                 module = named_modules[entry[1][1][0]]

--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -295,8 +295,8 @@ def genresult(ident, entry):
 
     if entry['kind'] == 'return':
         return (
-            f'let {ident}_result = {expectation};\n    '
-            f'expect({ident}_result).toBe({genarg(entry["result"])})\n    ' if entry["result"] is not None else ''
+            f'let {ident}_result = {expectation};\n    ' +
+            (f'expect({ident}_result).toBe({genarg(entry["result"])})\n    ' if entry["result"] is not None else '')
         )
 
     if entry['kind'] == 'trap':

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -350,6 +350,9 @@ public:
         if (size_to_grow == 0)
             return true;
         auto new_size = m_data.size() + size_to_grow;
+        // Can't grow past 2^16 pages.
+        if (new_size >= Constants::page_size * 65536)
+            return false;
         if (auto max = m_type.limits().max(); max.has_value()) {
             if (max.value() * Constants::page_size < new_size)
                 return false;

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -350,8 +350,10 @@ public:
         if (size_to_grow == 0)
             return true;
         auto new_size = m_data.size() + size_to_grow;
-        if (m_type.limits().max().value_or(new_size) < new_size)
-            return false;
+        if (auto max = m_type.limits().max(); max.has_value()) {
+            if (max.value() * Constants::page_size < new_size)
+                return false;
+        }
         auto previous_size = m_size;
         m_data.resize(new_size);
         m_size = new_size;

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -617,10 +617,11 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         TRAP_IF_NOT(entry.has<Value>());
         auto maybe_i = entry.get<Value>().to<i32>();
         TRAP_IF_NOT(maybe_i.has_value());
-        TRAP_IF_NOT(maybe_i.value() >= 0);
-        size_t i = *maybe_i;
-        if (i < arguments.labels.size())
-            return branch_to_label(configuration, arguments.labels[i]);
+        if (0 <= *maybe_i) {
+            size_t i = *maybe_i;
+            if (i < arguments.labels.size())
+                return branch_to_label(configuration, arguments.labels[i]);
+        }
         return branch_to_label(configuration, arguments.default_);
     }
     case Instructions::call.value(): {

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -916,11 +916,11 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::i64_popcnt.value():
         UNARY_NUMERIC_OPERATION(i64, __builtin_popcountll);
     case Instructions::i64_add.value():
-        OVF_CHECKED_BINARY_NUMERIC_OPERATION(i64, +, i64);
+        BINARY_NUMERIC_OPERATION(i64, +, i64);
     case Instructions::i64_sub.value():
-        OVF_CHECKED_BINARY_NUMERIC_OPERATION(i64, -, i64);
+        BINARY_NUMERIC_OPERATION(i64, -, i64);
     case Instructions::i64_mul.value():
-        OVF_CHECKED_BINARY_NUMERIC_OPERATION(i64, *, i64);
+        BINARY_NUMERIC_OPERATION(i64, *, i64);
     case Instructions::i64_divs.value():
         OVF_CHECKED_BINARY_NUMERIC_OPERATION(i64, /, i64, TRAP_IF_NOT(rhs.value() != 0));
     case Instructions::i64_divu.value():

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -17,7 +17,7 @@ namespace Wasm {
 
 #define TRAP_IF_NOT(x)                                                                         \
     do {                                                                                       \
-        if (trap_if_not(x, #x)) {                                                              \
+        if (trap_if_not(x, #x##sv)) {                                                          \
             dbgln_if(WASM_TRACE_DEBUG, "Trapped because {} failed, at line {}", #x, __LINE__); \
             return;                                                                            \
         }                                                                                      \
@@ -25,7 +25,7 @@ namespace Wasm {
 
 #define TRAP_IF_NOT_NORETURN(x)                                                                \
     do {                                                                                       \
-        if (trap_if_not(x, #x)) {                                                              \
+        if (trap_if_not(x, #x##sv)) {                                                          \
             dbgln_if(WASM_TRACE_DEBUG, "Trapped because {} failed, at line {}", #x, __LINE__); \
         }                                                                                      \
     } while (false)

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -49,10 +49,10 @@ protected:
     T read_value(ReadonlyBytes data);
 
     Vector<Value> pop_values(Configuration& configuration, size_t count);
-    bool trap_if_not(bool value, String reason)
+    bool trap_if_not(bool value, StringView reason)
     {
         if (!value)
-            m_trap = Trap { move(reason) };
+            m_trap = Trap { reason };
         return m_trap.has_value();
     }
 

--- a/Userland/Libraries/LibWasm/Constants.h
+++ b/Userland/Libraries/LibWasm/Constants.h
@@ -36,8 +36,9 @@ static constexpr auto extern_global_tag = 0x03;
 
 static constexpr auto page_size = 64 * KiB;
 
-// Limits
-static constexpr auto max_allowed_call_stack_depth = 1000;
-static constexpr auto max_allowed_executed_instructions_per_call = 1024 * 1024 * 1024;
+// Implementation-defined limits
+// These are not concretely defined by the spec, so the values are only defined by us.
+static constexpr auto max_allowed_call_stack_depth = 512;
+static constexpr auto max_allowed_executed_instructions_per_call = 256 * 1024 * 1024;
 
 }

--- a/Userland/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Userland/Libraries/LibWasm/Printer/Printer.cpp
@@ -435,7 +435,12 @@ void Printer::print(Wasm::Instruction const& instruction)
             [&](Instruction::IndirectCallArgs const& args) { print("(indirect (type index {}) (table index {}))", args.type.value(), args.table.value()); },
             [&](Instruction::MemoryArgument const& args) { print("(memory (align {}) (offset {}))", args.align, args.offset); },
             [&](Instruction::StructuredInstructionArgs const& args) { print("(structured (else {}) (end {}))", args.else_ip.has_value() ? String::number(args.else_ip->value()) : "(none)", args.end_ip.value()); },
-            [&](Instruction::TableBranchArgs const&) { print("(table_branch ...)"); },
+            [&](Instruction::TableBranchArgs const& args) {
+                print("(table_branch");
+                for (auto& label : args.labels)
+                    print(" (label {})", label.value());
+                print(" (label {}))", args.default_.value());
+            },
             [&](Instruction::TableElementArgs const& args) { print("(table_element (table index {}) (element index {}))", args.table_index.value(), args.element_index.value()); },
             [&](Instruction::TableTableArgs const& args) { print("(table_table (table index {}) (table index {}))", args.lhs.value(), args.rhs.value()); },
             [&](ValueType const& type) { print(type); },


### PR DESCRIPTION
This should
- Fix instantiating modules with data sections
- Not blow up when some bad module tries to access the stack wrong
- Make memory.grow work for bounded memory types
- Run more tests :P