### PR TITLE
LibGfx: BitmapFont: Handle '\r' and '\n' when calculating text width

### DIFF
--- a/Userland/Libraries/LibGfx/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/BitmapFont.h
@@ -115,6 +115,9 @@ private:
 
     static RefPtr<BitmapFont> load_from_memory(const u8*);
 
+    template<typename T>
+    int unicode_view_width(T const& view) const;
+
     void update_x_height() { m_x_height = m_baseline - m_mean_line; };
     int glyph_or_emoji_width_for_variable_width_font(u32 code_point) const;
 


### PR DESCRIPTION
Previously calculating multiline text width would return invalid value,
this change makes it so that we are returning the longest line width.

Before:
![Screenshot from 2021-07-06 12-15-01](https://user-images.githubusercontent.com/6830979/124583875-dad55d00-de53-11eb-9019-d7270e31e5c8.png)

After:
![Screenshot from 2021-07-06 12-14-41](https://user-images.githubusercontent.com/6830979/124583870-d9a43000-de53-11eb-9cc9-ae47845ebfd1.png)
