### PR TITLE
Kernel: Add KLexicalPath and use some more KString

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -304,7 +304,6 @@ set(AK_SOURCES
     ../AK/FlyString.cpp
     ../AK/GenericLexer.cpp
     ../AK/Hex.cpp
-    ../AK/LexicalPath.cpp
     ../AK/String.cpp
     ../AK/StringBuilder.cpp
     ../AK/StringImpl.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -128,6 +128,7 @@ set(KERNEL_SOURCES
     Interrupts/SpuriousInterruptHandler.cpp
     Interrupts/UnhandledInterruptHandler.cpp
     KBufferBuilder.cpp
+    KLexicalPath.cpp
     KString.cpp
     KSyms.cpp
     Lock.cpp

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -13,6 +13,7 @@
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
+#include <Kernel/KLexicalPath.h>
 #include <Kernel/Process.h>
 #include <Kernel/RTC.h>
 #include <Kernel/SpinLock.h>
@@ -44,8 +45,7 @@ CoreDump::CoreDump(NonnullRefPtr<Process> process, NonnullRefPtr<FileDescription
 
 RefPtr<FileDescription> CoreDump::create_target_file(const Process& process, const String& output_path)
 {
-    LexicalPath lexical_path(output_path);
-    const auto& output_directory = lexical_path.dirname();
+    auto output_directory = KLexicalPath::dirname(output_path);
     auto dump_directory = VFS::the().open_directory(output_directory, VFS::the().root_custody());
     if (dump_directory.is_error()) {
         dbgln("Can't find directory '{}' for core dump", output_directory);
@@ -57,7 +57,7 @@ RefPtr<FileDescription> CoreDump::create_target_file(const Process& process, con
         return nullptr;
     }
     auto fd_or_error = VFS::the().open(
-        lexical_path.basename(),
+        KLexicalPath::basename(output_path),
         O_CREAT | O_WRONLY | O_EXCL,
         S_IFREG, // We will enable reading from userspace when we finish generating the coredump file
         *dump_directory.value(),

--- a/Kernel/CoreDump.h
+++ b/Kernel/CoreDump.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/OwnPtr.h>
 #include <Kernel/Forward.h>

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -30,6 +30,7 @@ public:
     Inode& inode() { return *m_inode; }
     const Inode& inode() const { return *m_inode; }
     StringView name() const { return m_name->view(); }
+    OwnPtr<KString> try_create_absolute_path() const;
     String absolute_path() const;
 
     int mount_flags() const { return m_mount_flags; }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -361,7 +361,10 @@ KResult VFS::mknod(StringView path, mode_t mode, dev_t dev, Custody& base)
 KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> owner)
 {
     auto basename = KLexicalPath::basename(path);
-    if (auto result = validate_path_against_process_veil(String::formatted("{}/{}", parent_custody.absolute_path(), basename), options); result.is_error())
+    auto full_path = KLexicalPath::try_join(parent_custody.absolute_path(), basename);
+    if (!full_path)
+        return ENOMEM;
+    if (auto result = validate_path_against_process_veil(full_path->view(), options); result.is_error())
         return result;
 
     if (!is_socket(mode) && !is_fifo(mode) && !is_block_device(mode) && !is_character_device(mode)) {

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
 #include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/Debug.h>
@@ -14,6 +13,7 @@
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
+#include <Kernel/KLexicalPath.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Process.h>
 #include <Kernel/Sections.h>
@@ -353,14 +353,14 @@ KResult VFS::mknod(StringView path, mode_t mode, dev_t dev, Custody& base)
     if (parent_custody->is_readonly())
         return EROFS;
 
-    auto basename = LexicalPath::basename(path);
+    auto basename = KLexicalPath::basename(path);
     dbgln("VFS::mknod: '{}' mode={} dev={} in {}", basename, mode, dev, parent_inode.identifier());
     return parent_inode.create_child(basename, mode, dev, current_process->euid(), current_process->egid()).result();
 }
 
 KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> owner)
 {
-    auto basename = LexicalPath::basename(path);
+    auto basename = KLexicalPath::basename(path);
     if (auto result = validate_path_against_process_veil(String::formatted("{}/{}", parent_custody.absolute_path(), basename), options); result.is_error())
         return result;
 
@@ -418,7 +418,7 @@ KResult VFS::mkdir(StringView path, mode_t mode, Custody& base)
     if (parent_custody->is_readonly())
         return EROFS;
 
-    auto basename = LexicalPath::basename(path);
+    auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VFS::mkdir: '{}' in {}", basename, parent_inode.identifier());
     return parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process->euid(), current_process->egid()).result();
 }
@@ -533,7 +533,7 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
     if (old_parent_custody->is_readonly() || new_parent_custody->is_readonly())
         return EROFS;
 
-    auto new_basename = LexicalPath::basename(new_path);
+    auto new_basename = KLexicalPath::basename(new_path);
 
     if (!new_custody_or_error.is_error()) {
         auto& new_custody = *new_custody_or_error.value();
@@ -554,7 +554,7 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
     if (auto result = new_parent_inode.add_child(old_inode, new_basename, old_inode.mode()); result.is_error())
         return result;
 
-    if (auto result = old_parent_inode.remove_child(LexicalPath::basename(old_path)); result.is_error())
+    if (auto result = old_parent_inode.remove_child(KLexicalPath::basename(old_path)); result.is_error())
         return result;
 
     return KSuccess;
@@ -656,7 +656,7 @@ KResult VFS::link(StringView old_path, StringView new_path, Custody& base)
     if (!hard_link_allowed(old_inode))
         return EPERM;
 
-    return parent_inode.add_child(old_inode, LexicalPath::basename(new_path), old_inode.mode());
+    return parent_inode.add_child(old_inode, KLexicalPath::basename(new_path), old_inode.mode());
 }
 
 KResult VFS::unlink(StringView path, Custody& base)
@@ -689,7 +689,7 @@ KResult VFS::unlink(StringView path, Custody& base)
     if (parent_custody->is_readonly())
         return EROFS;
 
-    if (auto result = parent_inode.remove_child(LexicalPath::basename(path)); result.is_error())
+    if (auto result = parent_inode.remove_child(KLexicalPath::basename(path)); result.is_error())
         return result;
 
     return KSuccess;
@@ -712,7 +712,7 @@ KResult VFS::symlink(StringView target, StringView linkpath, Custody& base)
     if (parent_custody->is_readonly())
         return EROFS;
 
-    auto basename = LexicalPath::basename(linkpath);
+    auto basename = KLexicalPath::basename(linkpath);
     dbgln_if(VFS_DEBUG, "VFS::symlink: '{}' (-> '{}') in {}", basename, target, parent_inode.identifier());
     auto inode_or_error = parent_inode.create_child(basename, S_IFLNK | 0644, 0, current_process->euid(), current_process->egid());
     if (inode_or_error.is_error())
@@ -771,7 +771,7 @@ KResult VFS::rmdir(StringView path, Custody& base)
     if (auto result = inode.remove_child(".."); result.is_error())
         return result;
 
-    return parent_inode.remove_child(LexicalPath::basename(path));
+    return parent_inode.remove_child(KLexicalPath::basename(path));
 }
 
 VFS::Mount::Mount(FS& guest_fs, Custody* host_custody, int flags)
@@ -833,8 +833,7 @@ UnveilNode const& VFS::find_matching_unveiled_path(StringView path)
     VERIFY(Process::current()->veil_state() != VeilState::None);
     auto& unveil_root = Process::current()->unveiled_paths();
 
-    LexicalPath lexical_path { path };
-    auto& path_parts = lexical_path.parts_view();
+    auto path_parts = KLexicalPath::parts(path);
     return unveil_root.traverse_until_last_accessible_node(path_parts.begin(), path_parts.end());
 }
 

--- a/Kernel/KLexicalPath.cpp
+++ b/Kernel/KLexicalPath.cpp
@@ -55,4 +55,32 @@ Vector<StringView> parts(StringView const& path)
     return path.split_view('/');
 }
 
+OwnPtr<KString> try_join(StringView const& first, StringView const& second)
+{
+    VERIFY(is_canonical(first));
+    VERIFY(is_canonical(second));
+    VERIFY(!is_absolute(second));
+
+    if (first == "/"sv) {
+        char* buffer;
+        auto string = KString::try_create_uninitialized(1 + second.length(), buffer);
+        if (!string)
+            return {};
+        buffer[0] = '/';
+        __builtin_memcpy(buffer + 1, second.characters_without_null_termination(), second.length());
+        buffer[string->length()] = 0;
+        return string;
+    } else {
+        char* buffer;
+        auto string = KString::try_create_uninitialized(first.length() + 1 + second.length(), buffer);
+        if (!string)
+            return string;
+        __builtin_memcpy(buffer, first.characters_without_null_termination(), first.length());
+        buffer[first.length()] = '/';
+        __builtin_memcpy(buffer + first.length() + 1, second.characters_without_null_termination(), second.length());
+        buffer[string->length()] = 0;
+        return string;
+    }
+}
+
 }

--- a/Kernel/KLexicalPath.cpp
+++ b/Kernel/KLexicalPath.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/KLexicalPath.h>
+
+namespace Kernel::KLexicalPath {
+
+bool is_absolute(StringView const& path)
+{
+    return !path.is_empty() && path[0] == '/';
+}
+
+bool is_canonical(StringView const& path)
+{
+    // FIXME: This can probably be done more efficiently.
+    if (path.is_empty())
+        return false;
+    if (path.ends_with('/') && path.length() != 1)
+        return false;
+    if (path.starts_with("./"sv) || path.contains("/./"sv) || path.ends_with("/."sv))
+        return false;
+    if (path.starts_with("../"sv) || path.contains("/../"sv) || path.ends_with("/.."))
+        return false;
+    if (path.contains("//"sv))
+        return false;
+    return true;
+}
+
+StringView basename(StringView const& path)
+{
+    auto slash_index = path.find_last('/');
+    if (!slash_index.has_value()) {
+        VERIFY(!path.is_empty());
+        return path;
+    }
+    auto basename = path.substring_view(*slash_index + 1);
+    VERIFY(!basename.is_empty() && basename != "."sv && basename != ".."sv);
+    return basename;
+}
+
+StringView dirname(StringView const& path)
+{
+    VERIFY(is_canonical(path));
+    auto slash_index = path.find_last('/');
+    VERIFY(slash_index.has_value());
+    return path.substring_view(0, *slash_index);
+}
+
+Vector<StringView> parts(StringView const& path)
+{
+    VERIFY(is_canonical(path));
+    return path.split_view('/');
+}
+
+}

--- a/Kernel/KLexicalPath.h
+++ b/Kernel/KLexicalPath.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace Kernel::KLexicalPath {
+
+bool is_absolute(StringView const&);
+bool is_canonical(StringView const&);
+StringView basename(StringView const&);
+StringView dirname(StringView const&);
+Vector<StringView> parts(StringView const&);
+
+}

--- a/Kernel/KLexicalPath.h
+++ b/Kernel/KLexicalPath.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StringView.h>
+#include <Kernel/KString.h>
 
 namespace Kernel::KLexicalPath {
 
@@ -15,5 +16,7 @@ bool is_canonical(StringView const&);
 StringView basename(StringView const&);
 StringView dirname(StringView const&);
 Vector<StringView> parts(StringView const&);
+
+OwnPtr<KString> try_join(StringView const&, StringView const&);
 
 }

--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -48,7 +48,18 @@ template<>
 struct Formatter<Kernel::KString> : Formatter<StringView> {
     void format(FormatBuilder& builder, Kernel::KString const& value)
     {
-        Formatter<StringView>::format(builder, value.characters());
+        Formatter<StringView>::format(builder, value.view());
+    }
+};
+
+template<>
+struct Formatter<OwnPtr<Kernel::KString>> : Formatter<StringView> {
+    void format(FormatBuilder& builder, OwnPtr<Kernel::KString> const& value)
+    {
+        if (value)
+            Formatter<StringView>::format(builder, value->view());
+        else
+            Formatter<StringView>::format(builder, "[out of memory]"sv);
     }
 };
 

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -48,7 +48,10 @@ KResultOr<FlatPtr> Process::sys$getcwd(Userspace<char*> buffer, size_t size)
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
 
-    auto path = current_directory().absolute_path();
+    auto maybe_path = current_directory().try_create_absolute_path();
+    if (!maybe_path)
+        return ENOMEM;
+    auto& path = *maybe_path;
 
     size_t ideal_size = path.length() + 1;
     auto size_to_copy = min(ideal_size, size);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/TemporaryChange.h>
 #include <AK/WeakPtr.h>


### PR DESCRIPTION
This PR adds `KLexicalPath` and removes all usage of `AK::LexicalPath` from the Kernel. It also turned into a bit of a `String` => `KString` yak shave (by adding `Custody::try_create_absolute_path`).

`KLexicalPath` is currently very restrictive in what paths it is able to operate on (absolute, no ".", no "..", no "//"), but it will `VERIFY` that this is the case, so any bugs that are introduced by this will not go unnoticed.

I'm happy to hear some opinions, especially about the formatter function for `OwnPtr<KString>` (see the commit message for my rationale).