### PR TITLE
Revert "LibJS: Don't hoist functions under certain circumstances"

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2377,9 +2377,9 @@ void ScopeNode::add_functions(NonnullRefPtrVector<FunctionDeclaration> functions
     m_functions.extend(move(functions));
 }
 
-void ScopeNode::add_hoisted_function(NonnullRefPtr<FunctionDeclaration> hoisted_function)
+void ScopeNode::add_hoisted_functions(NonnullRefPtrVector<FunctionDeclaration> hoisted_functions)
 {
-    m_hoisted_functions.append(hoisted_function);
+    m_hoisted_functions.extend(move(hoisted_functions));
 }
 
 }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -145,7 +145,7 @@ public:
 
     void add_variables(NonnullRefPtrVector<VariableDeclaration>);
     void add_functions(NonnullRefPtrVector<FunctionDeclaration>);
-    void add_hoisted_function(NonnullRefPtr<FunctionDeclaration>);
+    void add_hoisted_functions(NonnullRefPtrVector<FunctionDeclaration>);
     NonnullRefPtrVector<VariableDeclaration> const& variables() const { return m_variables; }
     NonnullRefPtrVector<FunctionDeclaration> const& functions() const { return m_functions; }
     NonnullRefPtrVector<FunctionDeclaration> const& hoisted_functions() const { return m_hoisted_functions; }

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -201,18 +201,12 @@ private:
             Function,
             Block,
         };
-        struct HoistableDeclaration {
-            NonnullRefPtr<FunctionDeclaration> declaration;
-            NonnullRefPtr<Scope> scope; // where it is actually declared
-        };
 
         Type type;
         RefPtr<Scope> parent;
 
         NonnullRefPtrVector<FunctionDeclaration> function_declarations;
-        Vector<HoistableDeclaration> hoisted_function_declarations;
-
-        HashTable<FlyString> lexical_declarations;
+        NonnullRefPtrVector<FunctionDeclaration> hoisted_function_declarations;
 
         explicit Scope(Type, RefPtr<Scope>);
         RefPtr<Scope> get_current_function_scope();


### PR DESCRIPTION
This reverts commit 3411d50.

It was causing LeakSanitizer on CI to fail, possibly due to a circular
reference.

cc @Hendi48