### PR TITLE
Follow-up to 8455

### DIFF
--- a/Userland/Libraries/LibPthread/pthread_cond.cpp
+++ b/Userland/Libraries/LibPthread/pthread_cond.cpp
@@ -128,6 +128,6 @@ int pthread_cond_broadcast(pthread_cond_t* cond)
     VERIFY(mutex);
 
     int rc = futex(&cond->value, FUTEX_REQUEUE, 1, nullptr, &mutex->lock, INT_MAX);
-    VERIFY(rc == 0);
+    VERIFY(rc >= 0);
     return 0;
 }

--- a/Userland/Libraries/LibPthread/semaphore.cpp
+++ b/Userland/Libraries/LibPthread/semaphore.cpp
@@ -77,7 +77,7 @@ int sem_post(sem_t* sem)
     if (!(value & POST_WAKES)) [[likely]]
         return 0;
     int rc = futex_wake(&sem->value, 1);
-    VERIFY(rc == 0);
+    VERIFY(rc >= 0);
     return 0;
 }
 

--- a/Userland/Utilities/test-pthread.cpp
+++ b/Userland/Utilities/test-pthread.cpp
@@ -7,7 +7,9 @@
 #include <AK/Assertions.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <LibThreading/Thread.h>
+#include <errno.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include <unistd.h>
 
 static void test_once()
@@ -34,8 +36,112 @@ static void test_once()
     VERIFY(v.size() == 1);
 }
 
+static void test_semaphore_as_lock()
+{
+    constexpr size_t threads_count = 10;
+    constexpr size_t num_times = 100;
+
+    Vector<int> v;
+    NonnullRefPtrVector<Threading::Thread, threads_count> threads;
+    sem_t semaphore;
+    sem_init(&semaphore, 0, 1);
+
+    for (size_t i = 0; i < threads_count; i++) {
+        threads.append(Threading::Thread::construct([&] {
+            for (size_t j = 0; j < num_times; j++) {
+                sem_wait(&semaphore);
+                v.append(35);
+                sched_yield();
+                sem_post(&semaphore);
+                sched_yield();
+            }
+            return 0;
+        }));
+        threads.last().start();
+    }
+    for (auto& thread : threads)
+        [[maybe_unused]] auto res = thread.join();
+
+    VERIFY(v.size() == threads_count * num_times);
+    VERIFY(sem_trywait(&semaphore) == 0);
+    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+}
+
+static void test_semaphore_as_event()
+{
+    Vector<int> v;
+    sem_t semaphore;
+    sem_init(&semaphore, 0, 0);
+
+    auto reader = Threading::Thread::construct([&] {
+        sem_wait(&semaphore);
+        VERIFY(v.size() == 1);
+        return 0;
+    });
+    reader->start();
+
+    auto writer = Threading::Thread::construct([&] {
+        sched_yield();
+        v.append(35);
+        sem_post(&semaphore);
+        return 0;
+    });
+    writer->start();
+
+    [[maybe_unused]] auto r1 = reader->join();
+    [[maybe_unused]] auto r2 = writer->join();
+
+    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+}
+
+static void test_semaphore_nonbinary()
+{
+    constexpr size_t num = 5;
+    constexpr size_t threads_count = 10;
+    constexpr size_t num_times = 100;
+
+    NonnullRefPtrVector<Threading::Thread, threads_count> threads;
+    sem_t semaphore;
+    sem_init(&semaphore, 0, num);
+
+    Atomic<u32, AK::memory_order_relaxed> value = 0;
+    Atomic<bool, AK::memory_order_relaxed> seen_more_than_two = false;
+
+    for (size_t i = 0; i < threads_count; i++) {
+        threads.append(Threading::Thread::construct([&] {
+            for (size_t j = 0; j < num_times; j++) {
+                sem_wait(&semaphore);
+                u32 v = 1 + value.fetch_add(1);
+                VERIFY(v <= num);
+                if (v > 2)
+                    seen_more_than_two.store(true);
+                sched_yield();
+                value.fetch_sub(1);
+                sem_post(&semaphore);
+            }
+            return 0;
+        }));
+        threads.last().start();
+    }
+
+    for (auto& thread : threads)
+        [[maybe_unused]] auto res = thread.join();
+
+    VERIFY(value.load() == 0);
+    VERIFY(seen_more_than_two.load());
+    for (size_t i = 0; i < num; i++) {
+        VERIFY(sem_trywait(&semaphore) == 0);
+    }
+    VERIFY(sem_trywait(&semaphore) == EAGAIN);
+}
+
 int main()
 {
     test_once();
+
+    test_semaphore_as_lock();
+    test_semaphore_as_event();
+    test_semaphore_nonbinary();
+
     return 0;
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/SerenityOS/serenity/pull/8455

* Fix a few things
* Let's try not setting `owner` for non-recursive mutexes, perhaps it's faster. (Although `gettid()` should be fast anyway.)
* Port LWSP semaphore tests

Now, about those tests. LWSP uses 100 threads (NPTL is very scalable — 100 threads is nothing). I turned that down to 10 threads for us (dunno how scalable our threading is, but 10 sounds reasonable); the downside is there's obviously less contention, so less chances to reproduce the potentially problematic patterns.

But even with that, the test sometimes passes, and sometimes hangs (on `test_semaphore_as_lock()`, even). Which is, uh, unexpected, but also good, it means we caught a bug that we can fix and make things better. That being said, I don't know where the bug _is_; given that LWSP test works on Linux each time, could this bug a race in Kernel-side futex implementation?

cc @tomuta, @supercomputer7, @gunnarbeutner