### PR TITLE
LibJS: Fix crashes related to the `String.prototype.replace` family

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -399,7 +399,14 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
             if (vm.exception())
                 return {};
         } else {
-            replacement = get_substitution(global_object, matched, string, position, captures, named_captures, replace_value);
+            auto named_captures_object = js_undefined();
+            if (!named_captures.is_undefined()) {
+                named_captures_object = named_captures.to_object(global_object);
+                if (vm.exception())
+                    return {};
+            }
+
+            replacement = get_substitution(global_object, matched, string, position, captures, named_captures_object, replace_value);
             if (vm.exception())
                 return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -883,9 +883,16 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
     if (vm.exception())
         return {};
 
-    Vector<size_t> match_positions = string.find_all(search_string);
-    size_t end_of_last_match = 0;
+    Vector<size_t> match_positions;
+    size_t advance_by = max(1u, search_string.length());
+    auto position = string.find(search_string);
 
+    while (position.has_value()) {
+        match_positions.append(*position);
+        position = string.find(search_string, *position + advance_by);
+    }
+
+    size_t end_of_last_match = 0;
     StringBuilder result;
 
     for (auto position : match_positions) {

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -139,3 +139,19 @@ test("replacement with substitution", () => {
     expect("abc".replace(/(?<val1>a)b(?<val2>c)/, "$<val2>")).toBe("c");
     expect("abc".replace(/(?<val1>a)b(?<val2>c)/, "$<val2>b$<val1>")).toBe("cba");
 });
+
+test("replacement with substitution and 'groups' coerced to an object", () => {
+    var r = /./;
+    var coercibleValue = {
+        length: 1,
+        0: "b",
+        index: 1,
+        groups: "123",
+    };
+
+    r.exec = function () {
+        return coercibleValue;
+    };
+
+    expect(r[Symbol.replace]("ab", "[$<length>]")).toBe("a[3]");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
@@ -59,6 +59,11 @@ test("basic regex replacement", () => {
 
     expect("abc123def".replaceAll(/\D/g, "*")).toBe("***123***");
     expect("123abc456".replaceAll(/\D/g, "*")).toBe("123***456");
+
+    expect("aaab a a aac".replaceAll("aa", "z")).toBe("zab a a zc");
+    expect("aaab a a aac".replaceAll("aa", "a")).toBe("aab a a ac");
+    expect("aaab a a aac".replaceAll("a", "a")).toBe("aaab a a aac");
+    expect("aaab a a aac".replaceAll("a", "z")).toBe("zzzb z z zzc");
 });
 
 test("functional regex replacement", () => {


### PR DESCRIPTION
Fixes 2 crashes found by test262.