### PR TITLE
LibGUI+Browser: Show an example url placeholder in the search engine InputBox

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -313,7 +314,7 @@ void BrowserWindow::build_menus()
 
     auto custom_search_engine_action = GUI::Action::create_checkable("Custom", [&](auto& action) {
         String search_engine;
-        if (GUI::InputBox::show(this, search_engine, "Enter URL template:", "Custom Search Engine") != GUI::InputBox::ExecOK || search_engine.is_empty()) {
+        if (GUI::InputBox::show(this, search_engine, "Enter URL template:", "Custom Search Engine", "https://host/search?q={}") != GUI::InputBox::ExecOK || search_engine.is_empty()) {
             m_disable_search_engine_action->activate();
             return;
         }

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -15,7 +15,7 @@
 
 namespace GUI {
 
-InputBox::InputBox(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder)
+InputBox::InputBox(Window* parent_window, String& text_value, StringView const& prompt, StringView const& title, StringView const& placeholder)
     : Dialog(parent_window)
     , m_text_value(text_value)
     , m_prompt(prompt)
@@ -29,7 +29,7 @@ InputBox::~InputBox()
 {
 }
 
-int InputBox::show(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder)
+int InputBox::show(Window* parent_window, String& text_value, StringView const& prompt, StringView const& title, StringView const& placeholder)
 {
     auto box = InputBox::construct(parent_window, text_value, prompt, title, placeholder);
     box->set_resizable(false);

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,10 +15,11 @@
 
 namespace GUI {
 
-InputBox::InputBox(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title)
+InputBox::InputBox(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder)
     : Dialog(parent_window)
     , m_text_value(text_value)
     , m_prompt(prompt)
+    , m_placeholder(placeholder)
 {
     set_title(title);
     build();
@@ -27,9 +29,9 @@ InputBox::~InputBox()
 {
 }
 
-int InputBox::show(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title)
+int InputBox::show(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder)
 {
-    auto box = InputBox::construct(parent_window, text_value, prompt, title);
+    auto box = InputBox::construct(parent_window, text_value, prompt, title, placeholder);
     box->set_resizable(false);
     if (parent_window)
         box->set_icon(parent_window->icon());
@@ -63,6 +65,9 @@ void InputBox::build()
     m_text_editor = label_editor_container.add<TextBox>();
     m_text_editor->set_fixed_height(19);
     m_text_editor->set_text(m_text_value);
+
+    if (!m_placeholder.is_null())
+        m_text_editor->set_placeholder(m_placeholder);
 
     auto& button_container_outer = widget.add<Widget>();
     button_container_outer.set_fixed_height(20);

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -16,10 +16,10 @@ class InputBox : public Dialog {
 public:
     virtual ~InputBox() override;
 
-    static int show(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder = {});
+    static int show(Window* parent_window, String& text_value, StringView const& prompt, StringView const& title, StringView const& placeholder = {});
 
 private:
-    explicit InputBox(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder);
+    explicit InputBox(Window* parent_window, String& text_value, StringView const& prompt, StringView const& title, StringView const& placeholder);
 
     String text_value() const { return m_text_value; }
 

--- a/Userland/Libraries/LibGUI/InputBox.h
+++ b/Userland/Libraries/LibGUI/InputBox.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,16 +16,17 @@ class InputBox : public Dialog {
 public:
     virtual ~InputBox() override;
 
-    static int show(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title);
+    static int show(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder = {});
 
 private:
-    explicit InputBox(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title);
+    explicit InputBox(Window* parent_window, String& text_value, const StringView& prompt, const StringView& title, const StringView& placeholder);
 
     String text_value() const { return m_text_value; }
 
     void build();
     String m_text_value;
     String m_prompt;
+    String m_placeholder;
 
     RefPtr<Button> m_ok_button;
     RefPtr<Button> m_cancel_button;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -510,7 +511,7 @@ void TextEditor::paint_event(PaintEvent& event)
             if constexpr (TEXTEDITOR_DEBUG)
                 painter.draw_rect(visual_line_rect, Color::Cyan);
 
-            if (!placeholder().is_empty() && document().is_empty() && !is_focused() && line_index == 0) {
+            if (!placeholder().is_empty() && document().is_empty() && line_index == 0) {
                 auto line_rect = visual_line_rect;
                 line_rect.set_width(text_width_for_font(placeholder(), font()));
                 draw_text(line_rect, placeholder(), font(), m_text_alignment, palette().color(Gfx::ColorRole::PlaceholderText));


### PR DESCRIPTION
Previously there was no indicator for how the url format for a search engine should look, besides an error if entered incorrectly. This pull requests adds a placeholder example url to the InputBox as well as the nessesarry functionality to LibGUI.