### PR TITLE
Meta: Add a note about commit hooks to the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,16 @@ In theory, the best person to speak with is whoever wrote most code adjacent to 
 ### Is Discord the place to ask for review help, or is Github preferred?
 
 It's definitely better to ask on Discord. Due to the volume of GitHub notifications, many of us turn them off and rely on Discord for learning about review requests.
+
+## Commit Hooks
+
+The repository contains a file called `.pre-commit-config.yaml` that defines several 'commit hooks' that can be run automatically just before and after creating a new commit. These hooks lint your commit message, and the changes it contains to ensure they will pass the automated CI for pull requests.
+To enable these hooks firstly follow the installation instructions available at https://pre-commit.com/#install and then enable one or both of the following hooks:
+ - pre-commit hook - Runs Meta/lint-ci.sh and Meta/lint-ports.py to ensure changes to the code will pass linting:
+   ```console
+   pre-commit install
+   ```
+ - post-commit hook - Lints the commit message to ensure it will pass the commit linting:
+   ```console
+   pre-commit install --hook-type commit-msg
+   ```


### PR DESCRIPTION
These are pretty useful but are not documented anywhere, so this should fix that :^)