### PR TITLE
LibCore+shot: Fail on negative delay values

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -322,6 +322,23 @@ void ArgsParser::add_option(int& value, const char* help_string, const char* lon
     add_option(move(option));
 }
 
+void ArgsParser::add_option(unsigned& value, const char* help_string, const char* long_name, char short_name, const char* value_name)
+{
+    Option option {
+        true,
+        help_string,
+        long_name,
+        short_name,
+        value_name,
+        [&value](const char* s) {
+            auto opt = StringView(s).to_uint();
+            value = opt.value_or(0);
+            return opt.has_value();
+        }
+    };
+    add_option(move(option));
+}
+
 void ArgsParser::add_option(double& value, const char* help_string, const char* long_name, char short_name, const char* value_name)
 {
     Option option {
@@ -398,6 +415,22 @@ void ArgsParser::add_positional_argument(int& value, const char* help_string, co
         1,
         [&value](const char* s) {
             auto opt = StringView(s).to_int();
+            value = opt.value_or(0);
+            return opt.has_value();
+        }
+    };
+    add_positional_argument(move(arg));
+}
+
+void ArgsParser::add_positional_argument(unsigned& value, const char* help_string, const char* name, Required required)
+{
+    Arg arg {
+        help_string,
+        name,
+        required == Required::Yes ? 1 : 0,
+        1,
+        [&value](const char* s) {
+            auto opt = StringView(s).to_uint();
             value = opt.value_or(0);
             return opt.has_value();
         }

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -65,6 +65,7 @@ public:
     void add_option(String& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
     void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name);
     void add_option(int& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
+    void add_option(unsigned& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
     void add_option(double& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
 
     void add_positional_argument(Arg&&);
@@ -72,6 +73,7 @@ public:
     void add_positional_argument(String& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(StringView& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(int& value, const char* help_string, const char* name, Required required = Required::Yes);
+    void add_positional_argument(unsigned& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(double& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(Vector<const char*>& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(Vector<String>& value, const char* help_string, const char* name, Required required = Required::Yes);

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
 
     String output_path;
     bool output_to_clipboard = false;
-    int delay = 0;
+    unsigned delay = 0;
     int screen = -1;
 
     args_parser.add_positional_argument(output_path, "Output filename", "output", Core::ArgsParser::Required::No);


### PR DESCRIPTION
Return an error on a negative delay option instead of underflowing.