### PR TITLE
PixelPaint: More layer actions and brush tool tweak

### DIFF
--- a/Userland/Applications/PixelPaint/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/BrushTool.cpp
@@ -25,11 +25,17 @@ BrushTool::~BrushTool()
 {
 }
 
-void BrushTool::on_mousedown(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
+void BrushTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
     if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
         return;
 
+    const int first_draw_opacity = 10;
+
+    for (int i = 0; i < first_draw_opacity; ++i)
+        draw_point(layer.bitmap(), m_editor->color_for(event), event.position());
+
+    layer.did_modify_bitmap();
     m_last_position = event.position();
 }
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -366,6 +366,24 @@ void Image::remove_layer(Layer& layer)
     did_modify_layer_stack();
 }
 
+void Image::flatten_all_layers()
+{
+    if (m_layers.size() < 2)
+        return;
+
+    auto& bottom_layer = m_layers.at(0);
+
+    GUI::Painter painter(bottom_layer.bitmap());
+    paint_into(painter, { 0, 0, m_size.width(), m_size.height() });
+
+    for (size_t index = m_layers.size() - 1; index > 0; index--) {
+        auto& layer = m_layers.at(index);
+        remove_layer(layer);
+    }
+    bottom_layer.set_name("Background");
+    select_layer(&bottom_layer);
+}
+
 void Image::select_layer(Layer* layer)
 {
     for (auto* client : m_clients)

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -384,6 +384,34 @@ void Image::flatten_all_layers()
     select_layer(&bottom_layer);
 }
 
+void Image::merge_visible_layers()
+{
+    if (m_layers.size() < 2)
+        return;
+
+    size_t index = 0;
+
+    while (index < m_layers.size()) {
+        if (m_layers.at(index).is_visible()) {
+            auto& bottom_layer = m_layers.at(index);
+            GUI::Painter painter(bottom_layer.bitmap());
+            paint_into(painter, { 0, 0, m_size.width(), m_size.height() });
+            select_layer(&bottom_layer);
+            index++;
+            break;
+        }
+        index++;
+    }
+    while (index < m_layers.size()) {
+        if (m_layers.at(index).is_visible()) {
+            auto& layer = m_layers.at(index);
+            remove_layer(layer);
+        } else {
+            index++;
+        }
+    }
+}
+
 void Image::select_layer(Layer* layer)
 {
     for (auto* client : m_clients)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -68,6 +68,7 @@ public:
     void change_layer_index(size_t old_index, size_t new_index);
     void remove_layer(Layer&);
     void select_layer(Layer*);
+    void flatten_all_layers();
 
     void add_client(ImageClient&);
     void remove_client(ImageClient&);

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -69,6 +69,7 @@ public:
     void remove_layer(Layer&);
     void select_layer(Layer*);
     void flatten_all_layers();
+    void merge_visible_layers();
 
     void add_client(ImageClient&);
     void remove_client(ImageClient&);

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -163,6 +163,11 @@ void LayerListWidget::mousemove_event(GUI::MouseEvent& event)
     auto& gadget = m_gadgets[m_moving_gadget_index.value()];
     VERIFY(gadget.is_moving);
     gadget.movement_delta = delta;
+
+    auto adjusted_rect = gadget.rect;
+    adjusted_rect.translate_by(gadget.movement_delta);
+    scroll_into_view(adjusted_rect, false, true);
+
     relayout_gadgets();
 }
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -217,6 +217,7 @@ void LayerListWidget::image_did_remove_layer(size_t layer_index)
         m_moving_gadget_index = {};
     }
     m_gadgets.remove(layer_index);
+    m_selected_layer_index = 0;
     relayout_gadgets();
 }
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -419,6 +419,16 @@ int main(int argc, char** argv)
         },
         window));
 
+    layer_menu.add_action(GUI::Action::create(
+        "&Merge Visible", { Mod_Ctrl, Key_M }, [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            editor->image().merge_visible_layers();
+            editor->did_complete_action();
+        },
+        window));
+
     auto& filter_menu = menubar->add_menu("&Filter");
     auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -408,6 +408,16 @@ int main(int argc, char** argv)
     layer_list_widget.on_context_menu_request = [&](auto& event) {
         layer_menu.popup(event.screen_position());
     };
+    layer_menu.add_separator();
+    layer_menu.add_action(GUI::Action::create(
+        "&Flatten Image", { Mod_Ctrl, Key_F }, [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            editor->image().flatten_all_layers();
+            editor->did_complete_action();
+        },
+        window));
 
     auto& filter_menu = menubar->add_menu("&Filter");
     auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");


### PR DESCRIPTION
**PixelPaint: Add method to merge visible layers
PixelPaint: Add method to flatten image layers**
Some more layer actions. Flatten image merges all visible layers into the bottom layer and discards the invisible ones, like when exporting to bmp or png. Merge visible does almost the same thing, but keeps the invisible layers.

**PixelPaint: Scroll into view when reordering layers**
Also make the LayerListWidget scroll into view when dragging and reordering the layer gadgets.

**PixelPaint: Make brush draw on mousedown**
In Gimp the brush tool paints on mousedown, so I implemented it to our brush as well. Sometimes you just want to paint a "dot". It feels a bit hackish iterating over draw_point() 10 times but It felt better than duplicating and adjusting the logic for such a small one-off event.
