### PR TITLE
Follow-up to 8495

### DIFF
--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -82,14 +82,14 @@ static ALWAYS_INLINE int futex_wait(uint32_t* userspace_address, uint32_t value,
         if (clockid == CLOCK_REALTIME || clockid == CLOCK_REALTIME_COARSE)
             op |= FUTEX_CLOCK_REALTIME;
     } else {
-        op = FUTEX_WAIT;
+        op = FUTEX_WAIT | FUTEX_PRIVATE_FLAG;
     }
     return futex(userspace_address, op, value, abstime, nullptr, FUTEX_BITSET_MATCH_ANY);
 }
 
 static ALWAYS_INLINE int futex_wake(uint32_t* userspace_address, uint32_t count)
 {
-    return futex(userspace_address, FUTEX_WAKE, count, NULL, NULL, 0);
+    return futex(userspace_address, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, count, NULL, NULL, 0);
 }
 
 #define PURGE_ALL_VOLATILE 0x1

--- a/Userland/Libraries/LibPthread/pthread_cond.cpp
+++ b/Userland/Libraries/LibPthread/pthread_cond.cpp
@@ -127,7 +127,7 @@ int pthread_cond_broadcast(pthread_cond_t* cond)
     pthread_mutex_t* mutex = AK::atomic_load(&cond->mutex, AK::memory_order_relaxed);
     VERIFY(mutex);
 
-    int rc = futex(&cond->value, FUTEX_REQUEUE, 1, nullptr, &mutex->lock, INT_MAX);
+    int rc = futex(&cond->value, FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG, 1, nullptr, &mutex->lock, INT_MAX);
     VERIFY(rc >= 0);
     return 0;
 }

--- a/Userland/Libraries/LibPthread/pthread_once.cpp
+++ b/Userland/Libraries/LibPthread/pthread_once.cpp
@@ -45,7 +45,7 @@ int pthread_once(pthread_once_t* self, void (*callback)(void))
             // anyone.
             break;
         case State::PERFORMING_WITH_WAITERS:
-            futex(self, FUTEX_WAKE, INT_MAX, nullptr, nullptr, 0);
+            futex_wake(self, INT_MAX);
             break;
         }
 
@@ -75,7 +75,7 @@ int pthread_once(pthread_once_t* self, void (*callback)(void))
             [[fallthrough]];
         case State::PERFORMING_WITH_WAITERS:
             // Let's wait for it.
-            futex(self, FUTEX_WAIT, state2, nullptr, nullptr, 0);
+            futex_wait(self, state2, nullptr, 0);
             // We have been woken up, but that might have been due to a signal
             // or something, so we have to reevaluate. We need acquire ordering
             // here for the same reason as above. Hopefully we'll just see


### PR DESCRIPTION
This is a follow-up to #8495

* Use `FUTEX_PRIVATE_FLAG` in more places
    * This was intended to be in #8455, @tomuta spotted in #8495 that I forgot most of the places
* Add a mutex test
    * It hangs in the exact same way the `test_semaphore_as_lock()` test hangs, which means the problem is unlikely to be in userspace