### PR TITLE
LibJS+LibRegex: Miscellaneous fixes for `String.prototype.replace` family

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -422,6 +422,27 @@ TEST_CASE(named_capture_group)
     EXPECT_EQ(result.named_capture_group_matches.at(1).ensure("Test").view, "0");
 }
 
+TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
+{
+    Regex<ECMA262> re("[a-zA-Z]*=(?<$Test$>[0-9]*)");
+    RegexResult result;
+
+    if constexpr (REGEX_DEBUG) {
+        RegexDebug regex_dbg(stderr);
+        regex_dbg.print_raw_bytecode(re);
+        regex_dbg.print_header();
+        regex_dbg.print_bytecode(re);
+    }
+
+    String haystack = "[Window]\nOpacity=255\nAudibleBeep=0\n";
+    EXPECT_EQ(re.search(haystack, result, ECMAScriptFlags::Multiline), true);
+    EXPECT_EQ(result.count, 2u);
+    EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
+    EXPECT_EQ(result.named_capture_group_matches.at(0).ensure("$Test$").view, "255");
+    EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
+    EXPECT_EQ(result.named_capture_group_matches.at(1).ensure("$Test$").view, "0");
+}
+
 TEST_CASE(a_star)
 {
     Regex<PosixExtended> re("a*");

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -286,6 +286,16 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
     if (vm.exception())
         return {};
 
+    if (!replace_value.is_function()) {
+        auto replace_string = replace_value.to_string(global_object);
+        if (vm.exception())
+            return {};
+
+        replace_value = js_string(vm, move(replace_string));
+        if (vm.exception())
+            return {};
+    }
+
     auto global_value = rx->get(vm.names.global);
     if (vm.exception())
         return {};

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -800,6 +800,17 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace)
     auto search_string = search_value.to_string(global_object);
     if (vm.exception())
         return {};
+
+    if (!replace_value.is_function()) {
+        auto replace_string = replace_value.to_string(global_object);
+        if (vm.exception())
+            return {};
+
+        replace_value = js_string(vm, move(replace_string));
+        if (vm.exception())
+            return {};
+    }
+
     Optional<size_t> position = string.find(search_string);
     if (!position.has_value())
         return js_string(vm, string);
@@ -876,6 +887,16 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
     auto search_string = search_value.to_string(global_object);
     if (vm.exception())
         return {};
+
+    if (!replace_value.is_function()) {
+        auto replace_string = replace_value.to_string(global_object);
+        if (vm.exception())
+            return {};
+
+        replace_value = js_string(vm, move(replace_string));
+        if (vm.exception())
+            return {};
+    }
 
     Vector<size_t> match_positions;
     size_t advance_by = max(1u, search_string.length());

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -819,7 +819,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace)
     String replacement;
 
     if (replace_value.is_function()) {
-        auto result = vm.call(replace_value.as_function(), js_undefined(), search_value, Value(position.value()), js_string(vm, string));
+        auto result = vm.call(replace_value.as_function(), js_undefined(), js_string(vm, search_string), Value(position.value()), js_string(vm, string));
         if (vm.exception())
             return {};
 
@@ -915,7 +915,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
         String replacement;
 
         if (replace_value.is_function()) {
-            auto result = vm.call(replace_value.as_function(), js_undefined(), search_value, Value(position), js_string(vm, string));
+            auto result = vm.call(replace_value.as_function(), js_undefined(), js_string(vm, search_string), Value(position), js_string(vm, string));
             if (vm.exception())
                 return {};
 

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -158,3 +158,21 @@ test("replacement with substitution and 'groups' coerced to an object", () => {
 
     expect(r[Symbol.replace]("ab", "[$<length>]")).toBe("a[3]");
 });
+
+test("replacement value is evaluated before searching the source string", () => {
+    var calls = 0;
+    var replaceValue = {
+        toString: function () {
+            calls += 1;
+            return "b";
+        },
+    };
+
+    var newString = "".replace("a", replaceValue);
+    expect(newString).toBe("");
+    expect(calls).toBe(1);
+
+    newString = "".replace(/a/g, replaceValue);
+    expect(newString).toBe("");
+    expect(calls).toBe(2);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -138,6 +138,9 @@ test("replacement with substitution", () => {
     expect("abc".replace(/(?<val1>a)b(?<val2>c)/, "$<val1>")).toBe("a");
     expect("abc".replace(/(?<val1>a)b(?<val2>c)/, "$<val2>")).toBe("c");
     expect("abc".replace(/(?<val1>a)b(?<val2>c)/, "$<val2>b$<val1>")).toBe("cba");
+
+    expect(/(?<𝒜>b)/u[Symbol.replace]("abc", "d$<𝒜>$`")).toBe("adbac");
+    expect(/(?<$𐒤>b)/gu[Symbol.replace]("abc", "$'$<$𐒤>d")).toBe("acbdc");
 });
 
 test("replacement with substitution and 'groups' coerced to an object", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -176,3 +176,24 @@ test("replacement value is evaluated before searching the source string", () => 
     expect(newString).toBe("");
     expect(calls).toBe(2);
 });
+
+test("search value is coerced to a string", () => {
+    var calls = 0;
+    var coerced;
+
+    var searchValue = {
+        toString: function () {
+            calls += 1;
+            return "x";
+        },
+    };
+
+    var replaceValue = function (matched) {
+        coerced = matched;
+        return "abc";
+    };
+
+    var newString = "x".replace(searchValue, replaceValue);
+    expect(newString).toBe("abc");
+    expect(coerced).toBe("x");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
@@ -122,3 +122,24 @@ test("replacement value is evaluated before searching the source string", () => 
     expect(newString).toBe("");
     expect(calls).toBe(2);
 });
+
+test("search value is coerced to a string", () => {
+    var calls = 0;
+    var coerced;
+
+    var searchValue = {
+        toString: function () {
+            calls += 1;
+            return "x";
+        },
+    };
+
+    var replaceValue = function (matched) {
+        coerced = matched;
+        return "abc";
+    };
+
+    var newString = "x".replaceAll(searchValue, replaceValue);
+    expect(newString).toBe("abc");
+    expect(coerced).toBe("x");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
@@ -104,3 +104,21 @@ test("functional regex replacement", () => {
         })
     ).toBe("xd");
 });
+
+test("replacement value is evaluated before searching the source string", () => {
+    var calls = 0;
+    var replaceValue = {
+        toString: function () {
+            calls += 1;
+            return "b";
+        },
+    };
+
+    var newString = "".replaceAll("a", replaceValue);
+    expect(newString).toBe("");
+    expect(calls).toBe(1);
+
+    newString = "".replaceAll(/a/g, replaceValue);
+    expect(newString).toBe("");
+    expect(calls).toBe(2);
+});

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1625,7 +1625,7 @@ StringView ECMA262Parser::read_capture_group_specifier(bool take_starting_angle_
 
     auto start_token = m_parser_state.current_token;
     size_t offset = 0;
-    while (match(TokenType::Char)) {
+    while (match(TokenType::Char) || match(TokenType::Dollar)) {
         auto c = m_parser_state.current_token.value();
         if (c == ">")
             break;


### PR DESCRIPTION
Fixes 6 test262 tests.