### PR TITLE
Kernel: Fix futex race that could lead to thread waiting forever

### DIFF
--- a/Kernel/FutexQueue.h
+++ b/Kernel/FutexQueue.h
@@ -33,6 +33,17 @@ public:
 
     virtual void vmobject_deleted(VMObject&) override;
 
+    bool queue_imminent_wait();
+    void did_remove();
+    bool try_remove();
+
+    bool is_empty_and_no_imminent_waits()
+    {
+        ScopedSpinLock lock(m_lock);
+        return is_empty_and_no_imminent_waits_locked();
+    }
+    bool is_empty_and_no_imminent_waits_locked();
+
 protected:
     virtual bool should_add_blocker(Thread::Blocker& b, void* data) override;
 
@@ -42,6 +53,8 @@ private:
     const FlatPtr m_user_address_or_offset;
     WeakPtr<VMObject> m_vmobject;
     const bool m_is_global;
+    size_t m_imminent_waits { 1 }; // We only create this object if we're going to be waiting, so start out with 1
+    bool m_was_removed { false };
 };
 
 }


### PR DESCRIPTION
There is a race condition where we would remove a FutexQueue from
our futex map and in the meanwhile another thread started to queue
itself into that very same futex, leading to that thread to wait
forever as no other wake operation could discover that removed
FutexQueue.

This fixes the problem by:
* Tracking imminent waits, which prevents a new FutexQueue from being
  deleted that a thread will wait on momentarily
* Atomically marking a FutexQueue as removed, which prevents a thread
  from waiting on it before it is actually removed from the futex map.

@bugaevc This should fix the futex issues you discovered.

This should solve threads waiting forever as it can sometimes be observed by running `test-pthread` (in a loop may help)