### PR TITLE
LibJS: Stop using a native property for Array lengths 

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -162,7 +162,7 @@ bool is_compatible_property_descriptor(bool extensible, PropertyDescriptor const
     return validate_and_apply_property_descriptor(nullptr, {}, extensible, descriptor, current);
 }
 
-// 10.1.6.3 ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current ),
+// 10.1.6.3 ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current ), https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
 bool validate_and_apply_property_descriptor(Object* object, PropertyName const& property_name, bool extensible, PropertyDescriptor const& descriptor, Optional<PropertyDescriptor> const& current)
 {
     // 1. Assert: If O is not undefined, then IsPropertyKey(P) is true.

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -18,14 +18,19 @@ public:
     static Array* create_from(GlobalObject&, Vector<Value> const&);
 
     explicit Array(Object& prototype);
-    virtual void initialize(GlobalObject&) override;
     virtual ~Array() override;
 
-    static Array* typed_this(VM&, GlobalObject&);
+    virtual Optional<PropertyDescriptor> internal_get_own_property(PropertyName const&) const override;
+    virtual bool internal_define_own_property(PropertyName const&, PropertyDescriptor const&) override;
+    virtual bool internal_delete(PropertyName const&) override;
+    virtual MarkedValueList internal_own_property_keys() const override;
+
+    [[nodiscard]] bool length_is_writable() const { return m_length_writable; };
 
 private:
-    JS_DECLARE_NATIVE_GETTER(length_getter);
-    JS_DECLARE_NATIVE_SETTER(length_setter);
+    bool set_length(PropertyDescriptor const&);
+
+    bool m_length_writable { true };
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -350,9 +350,11 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
         return {};
     if (is<Array>(this_object)) {
         auto* array = static_cast<Array*>(this_object);
-        for (size_t i = 0; i < vm.argument_count(); ++i)
-            array->indexed_properties().append(vm.argument(i));
-        return Value(static_cast<i32>(array->indexed_properties().array_like_size()));
+        if (array->length_is_writable()) {
+            for (size_t i = 0; i < vm.argument_count(); ++i)
+                array->indexed_properties().append(vm.argument(i));
+            return Value(static_cast<i32>(array->indexed_properties().array_like_size()));
+        }
     }
     auto length = length_of_array_like(global_object, *this_object);
     if (vm.exception())
@@ -434,9 +436,11 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
         return {};
     if (is<Array>(this_object)) {
         auto* array = static_cast<Array*>(this_object);
-        if (array->indexed_properties().is_empty())
-            return js_undefined();
-        return array->indexed_properties().take_last(array).value.value_or(js_undefined());
+        if (array->length_is_writable()) {
+            if (array->indexed_properties().is_empty())
+                return js_undefined();
+            return array->indexed_properties().take_last(array).value.value_or(js_undefined());
+        }
     }
     auto length = length_of_array_like(global_object, *this_object);
     if (vm.exception())

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -35,7 +35,7 @@ public:
 
     virtual size_t size() const = 0;
     virtual size_t array_like_size() const = 0;
-    virtual void set_array_like_size(size_t new_size) = 0;
+    virtual bool set_array_like_size(size_t new_size) = 0;
 
     virtual bool is_simple_storage() const { return false; }
 };
@@ -55,7 +55,7 @@ public:
 
     virtual size_t size() const override { return m_packed_elements.size(); }
     virtual size_t array_like_size() const override { return m_array_size; }
-    virtual void set_array_like_size(size_t new_size) override;
+    virtual bool set_array_like_size(size_t new_size) override;
 
     virtual bool is_simple_storage() const override { return true; }
     const Vector<Value>& elements() const { return m_packed_elements; }
@@ -83,7 +83,7 @@ public:
 
     virtual size_t size() const override { return m_sparse_elements.size(); }
     virtual size_t array_like_size() const override { return m_array_size; }
-    virtual void set_array_like_size(size_t new_size) override;
+    virtual bool set_array_like_size(size_t new_size) override;
 
     const HashMap<u32, ValueAndAttributes>& sparse_elements() const { return m_sparse_elements; }
 
@@ -134,7 +134,9 @@ public:
 
     bool is_empty() const { return array_like_size() == 0; }
     size_t array_like_size() const { return m_storage->array_like_size(); }
-    void set_array_like_size(size_t);
+    bool set_array_like_size(size_t);
+
+    size_t real_size() const;
 
     Vector<u32> indices() const;
 


### PR DESCRIPTION
Specifically, replace it with a specification-based implementation that overrides the internal methods that interact with the length property instead. (The implementation is not a one to one match with the specification text, as i had to work around the optimized indexed properties storage we use for Arrays while matching the required spec behaviour)

As an extra bonus this fixes 29 test262 test cases.