### PR TITLE
Kernel: Fix race causing modifying a Process to fail with a panic

### DIFF
--- a/Kernel/AtomicEdgeAction.h
+++ b/Kernel/AtomicEdgeAction.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <Kernel/Arch/x86/Processor.h>
+
+namespace Kernel {
+
+template<typename AtomicRefCountType>
+class AtomicEdgeAction {
+public:
+    template<typename FirstRefAction>
+    bool ref(FirstRefAction first_ref_action)
+    {
+        AtomicRefCountType expected = 0;
+        AtomicRefCountType desired = (1 << 1) | 1;
+        // Least significant bit indicates we're busy protecting/unprotecting
+        for (;;) {
+            if (m_atomic_ref_count.compare_exchange_strong(expected, desired, AK::memory_order_relaxed))
+                break;
+
+            Processor::wait_check();
+
+            expected &= ~1;
+            desired = expected + (1 << 1);
+            VERIFY(desired > expected);
+            if (expected == 0)
+                desired |= 1;
+        }
+
+        atomic_thread_fence(AK::memory_order_acquire);
+
+        if (expected == 0) {
+            first_ref_action();
+
+            // drop the busy flag
+            m_atomic_ref_count.store(desired & ~1, AK::memory_order_release);
+            return true;
+        }
+        return false;
+    }
+
+    template<typename LastRefAction>
+    bool unref(LastRefAction last_ref_action)
+    {
+        AtomicRefCountType expected = 1 << 1;
+        AtomicRefCountType desired = (1 << 1) | 1;
+        // Least significant bit indicates we're busy protecting/unprotecting
+        for (;;) {
+            if (m_atomic_ref_count.compare_exchange_strong(expected, desired, AK::memory_order_relaxed))
+                break;
+
+            Processor::wait_check();
+
+            expected &= ~1;
+            VERIFY(expected != 0); // Someone should always have at least one reference
+
+            if (expected == 1 << 1) {
+                desired = (1 << 1) | 1;
+            } else {
+                desired = expected - (1 << 1);
+                VERIFY(desired < expected);
+            }
+        }
+
+        AK::atomic_thread_fence(AK::memory_order_release);
+
+        if (expected == 1 << 1) {
+            last_ref_action();
+
+            // drop the busy flag and release reference
+            m_atomic_ref_count.store(0, AK::memory_order_release);
+            return true;
+        }
+        return false;
+    }
+
+private:
+    Atomic<AtomicRefCountType> m_atomic_ref_count { 0 };
+};
+
+}

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -205,12 +205,16 @@ RefPtr<Process> Process::create_kernel_process(RefPtr<Thread>& first_thread, Str
 
 void Process::protect_data()
 {
-    MM.set_page_writable_direct(VirtualAddress { this }, false);
+    m_protected_data_refs.unref([&]() {
+        MM.set_page_writable_direct(VirtualAddress { this }, false);
+    });
 }
 
 void Process::unprotect_data()
 {
-    MM.set_page_writable_direct(VirtualAddress { this }, true);
+    m_protected_data_refs.ref([&]() {
+        MM.set_page_writable_direct(VirtualAddress { this }, true);
+    });
 }
 
 RefPtr<Process> Process::create(RefPtr<Thread>& first_thread, const String& name, uid_t uid, gid_t gid, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd, RefPtr<Custody> executable, TTY* tty, Process* fork_parent)

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -17,6 +17,7 @@
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <Kernel/API/Syscall.h>
+#include <Kernel/AtomicEdgeAction.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/InodeMetadata.h>
 #include <Kernel/Forward.h>
@@ -569,6 +570,7 @@ private:
 
     RefPtr<ProcessGroup> m_pg;
 
+    AtomicEdgeAction<u32> m_protected_data_refs;
     void protect_data();
     void unprotect_data();
 


### PR DESCRIPTION
The ProtectedDataMutationScope cannot blindly assume that there is only
exactly one thread at a time that may want to unprotect the Process.
Most of the time the big lock guaranteed this, but there are some cases
such as finalization (among others) where this is not necessarily
guaranteed.

This fixes random panics due to access violations when the
ProtectedDataMutationScope protects the Process instance while another
is still modifying it.

Fixes #8512