### PR TITLE
Bound Icon View Rubber Banding + Tiny refactor of Point.constrain

### DIFF
--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -246,9 +246,9 @@ void IconView::mouseup_event(MouseEvent& event)
     AbstractView::mouseup_event(event);
 }
 
-bool IconView::update_rubber_banding(const Gfx::IntPoint& position)
+bool IconView::update_rubber_banding(const Gfx::IntPoint& input_position)
 {
-    auto adjusted_position = to_content_position(position);
+    auto adjusted_position = to_content_position(input_position.constrained(widget_inner_rect()));
     if (m_rubber_band_current != adjusted_position) {
         auto prev_rect = Gfx::IntRect::from_two_points(m_rubber_band_origin, m_rubber_band_current);
         auto prev_rubber_band_fill_rect = prev_rect.shrunken(1, 1);

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -15,17 +15,8 @@ namespace Gfx {
 template<typename T>
 void Point<T>::constrain(Rect<T> const& rect)
 {
-    if (x() < rect.left()) {
-        set_x(rect.left());
-    } else if (x() > rect.right()) {
-        set_x(rect.right());
-    }
-
-    if (y() < rect.top()) {
-        set_y(rect.top());
-    } else if (y() > rect.bottom()) {
-        set_y(rect.bottom());
-    }
+    m_x = AK::clamp<T>(x(), rect.left(), rect.right());
+    m_y = AK::clamp<T>(y(), rect.top(), rect.bottom());
 }
 
 template<>


### PR DESCRIPTION
This bounds/clamps the rubber banding selection to the actually visible
portion of the AbstractScrollableWidget, and adds a utility function to
the LibGfx Rect that clamps a Point.

With this change the selection rubber band will not go outside the
visible area, and instead stop at the Border of the visible area.

This works fine in the File Manager, but on the desktop it
 * A: does not respect the Task Bar, and -- basically no one cares
 * ~B: behaves as if the decoration borders of the widget were there (stops just shy of the actual screen border)~ -- fixed on master

This also makes it impossible to see a bug i discovered while testing where, when you have a scroll bar in the File Manager in Icon Mode, and if the Rubber Band selection border is dragged through the dithered pattern on the scroll bar (underneath), the dithering pattern is redrawn wrong.