### PR TITLE
LibJS: Fixes for array-like objects with large lengths

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -362,7 +362,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
         if (vm.exception())
             return {};
     }
-    auto new_length_value = Value((i32)new_length);
+    auto new_length_value = Value(new_length);
     this_object->set(vm.names.length, new_length_value, true);
     if (vm.exception())
         return {};
@@ -440,7 +440,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     this_object->delete_property_or_throw(index);
     if (vm.exception())
         return {};
-    this_object->set(vm.names.length, Value((i32)index), true);
+    this_object->set(vm.names.length, Value(index), true);
     if (vm.exception())
         return {};
     return element;
@@ -1713,7 +1713,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
             return {};
     }
 
-    this_object->set(vm.names.length, Value((i32)new_length), true);
+    this_object->set(vm.names.length, Value(new_length), true);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -737,14 +737,15 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::slice)
         return {};
 
     size_t index = 0;
+    size_t k = actual_start;
 
-    while (actual_start < final) {
-        bool present = this_object->has_property((u32)actual_start);
+    while (k < final) {
+        bool present = this_object->has_property(k);
         if (vm.exception())
             return {};
 
         if (present) {
-            auto value = this_object->get((u32)actual_start);
+            auto value = this_object->get(k);
             if (vm.exception())
                 return {};
 
@@ -753,7 +754,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::slice)
                 return {};
         }
 
-        ++actual_start;
+        ++k;
         ++index;
     }
 
@@ -801,18 +802,18 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::index_of)
     if (Value(n).is_negative_infinity())
         n = 0;
 
-    u32 k;
+    size_t k;
 
     // 8. If n ≥ 0, then
     if (n >= 0) {
         // a. Let k be n.
-        k = (u32)n;
+        k = (size_t)n;
     }
     // 9. Else,
     else {
         // a. Let k be len + n.
         // b. If k < 0, set k to 0.
-        k = max((i32)length + (i32)n, 0);
+        k = max(length + n, 0);
     }
 
     // 10. Repeat, while k < len,
@@ -1036,7 +1037,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reduce_right)
                 return {};
 
             // ii. Set accumulator to ? Call(callbackfn, undefined, « accumulator, kValue, 𝔽(k), O »).
-            accumulator = vm.call(callback_function.as_function(), js_undefined(), accumulator, k_value, Value((i32)k), object);
+            accumulator = vm.call(callback_function.as_function(), js_undefined(), accumulator, k_value, Value((size_t)k), object);
             if (vm.exception())
                 return {};
         }
@@ -1311,17 +1312,17 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::last_index_of)
     if (Value(n).is_negative_infinity())
         return Value(-1);
 
-    i32 k;
+    ssize_t k;
 
     // 6. If n ≥ 0, then
     if (n >= 0) {
         // a. Let k be min(n, len - 1).
-        k = min((i32)n, (i32)length - 1);
+        k = min(n, (double)length - 1);
     }
     // 7. Else,
     else {
         //  a. Let k be len + n.
-        k = (i32)length + (i32)n;
+        k = (double)length + n;
     }
 
     // 8. Repeat, while k ≥ 0,
@@ -1345,7 +1346,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::last_index_of)
 
             // iii. If same is true, return 𝔽(k).
             if (same)
-                return Value(k);
+                return Value((size_t)k);
         }
 
         // c. Set k to k - 1.
@@ -1361,7 +1362,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::includes)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return {};
-    i32 length = length_of_array_like(global_object, *this_object);
+    auto length = length_of_array_like(global_object, *this_object);
     if (vm.exception())
         return {};
     if (length == 0)

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1367,18 +1367,24 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::includes)
         return {};
     if (length == 0)
         return Value(false);
-    i32 from_index = 0;
+    u64 from_index = 0;
     if (vm.argument_count() >= 2) {
-        from_index = vm.argument(1).to_i32(global_object);
+        auto from_argument = vm.argument(1).to_integer_or_infinity(global_object);
         if (vm.exception())
             return {};
-        if (from_index >= length)
+        if (Value(from_argument).is_positive_infinity() || from_argument >= length)
             return Value(false);
-        if (from_index < 0)
-            from_index = max(length + from_index, 0);
+
+        if (Value(from_argument).is_negative_infinity())
+            from_argument = 0;
+
+        if (from_argument < 0)
+            from_index = max(length + from_argument, 0);
+        else
+            from_index = from_argument;
     }
     auto value_to_find = vm.argument(0);
-    for (i32 i = from_index; i < length; ++i) {
+    for (u64 i = from_index; i < length; ++i) {
         auto element = this_object->get(i);
         if (vm.exception())
             return {};

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -348,14 +348,6 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return {};
-    if (is<Array>(this_object)) {
-        auto* array = static_cast<Array*>(this_object);
-        if (array->length_is_writable()) {
-            for (size_t i = 0; i < vm.argument_count(); ++i)
-                array->indexed_properties().append(vm.argument(i));
-            return Value(static_cast<i32>(array->indexed_properties().array_like_size()));
-        }
-    }
     auto length = length_of_array_like(global_object, *this_object);
     if (vm.exception())
         return {};
@@ -434,14 +426,6 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return {};
-    if (is<Array>(this_object)) {
-        auto* array = static_cast<Array*>(this_object);
-        if (array->length_is_writable()) {
-            if (array->indexed_properties().is_empty())
-                return js_undefined();
-            return array->indexed_properties().take_last(array).value.value_or(js_undefined());
-        }
-    }
     auto length = length_of_array_like(global_object, *this_object);
     if (vm.exception())
         return {};

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1845,10 +1845,10 @@ static size_t flatten_into_array(GlobalObject& global_object, Object& new_array,
         }
 
         if (depth > 0 && value.is_array(global_object)) {
-            auto length = length_of_array_like(global_object, value.as_array());
+            auto length = length_of_array_like(global_object, value.as_object());
             if (vm.exception())
                 return {};
-            target_index = flatten_into_array(global_object, new_array, value.as_array(), length, target_index, depth - 1);
+            target_index = flatten_into_array(global_object, new_array, value.as_object(), length, target_index, depth - 1);
             if (vm.exception())
                 return {};
             continue;

--- a/Userland/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyName.h
@@ -43,14 +43,21 @@ public:
 
     template<Integral T>
     PropertyName(T index)
-        : m_type(Type::Number)
-        , m_number(index)
     {
         // FIXME: Replace this with requires(IsUnsigned<T>)?
         //        Needs changes in various places using `int` (but not actually being in the negative range)
         VERIFY(index >= 0);
-        if constexpr (NumericLimits<T>::max() >= NumericLimits<u32>::max())
-            VERIFY(index < NumericLimits<u32>::max());
+        if constexpr (NumericLimits<T>::max() >= NumericLimits<u32>::max()) {
+            if (index >= NumericLimits<u32>::max()) {
+                m_string = String::number(index);
+                m_type = Type::String;
+                m_string_may_be_number = false;
+                return;
+            }
+        }
+
+        m_type = Type::Number;
+        m_number = index;
     }
 
     PropertyName(char const* chars)

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.pop.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.pop.js
@@ -26,4 +26,19 @@ describe("normal behavior", () => {
         expect(a.pop()).toBeUndefined();
         expect(a).toEqual([]);
     });
+
+    test("array with prototype indexed value", () => {
+        Array.prototype[1] = 1;
+
+        var a = [0];
+        a.length = 2;
+        expect(a[1]).toEqual(1);
+        expect(a.pop()).toEqual(1);
+
+        expect(a.length).toEqual(1);
+        expect(a).toEqual([0]);
+        expect(a[1]).toEqual(1);
+
+        delete Array.prototype[1];
+    });
 });


### PR DESCRIPTION
This leaves array with:
```
test/built-ins/Array  2745/2763  ( 99.35%) [ ✅ 2745  ❌ 17💥️ 1]
```
but those are mostly this value problems.

This also removed the fast array paths in `push` and `pop` since these run into issues if `Array.prototype` is modified
We need to find some way of making these fast paths possible since this is much slower