### PR TITLE
Assistant: Compare two chars instead of StringViews of length 1

### DIFF
--- a/Userland/Applications/Assistant/FuzzyMatch.cpp
+++ b/Userland/Applications/Assistant/FuzzyMatch.cpp
@@ -42,7 +42,7 @@ static FuzzyMatchResult fuzzy_match_recursive(String const& needle, String const
     bool first_match = true;
     while (needle_idx < needle.length() && haystack_idx < haystack.length()) {
 
-        if (needle.substring_view(needle_idx, 1).equals_ignoring_case(haystack.substring_view(haystack_idx, 1))) {
+        if (to_ascii_lowercase(needle[needle_idx]) == to_ascii_lowercase(haystack[haystack_idx])) {
             if (next_match >= MAX_MATCHES)
                 return { false, out_score };
 


### PR DESCRIPTION
This patch should optimize Assistant by a bit, by comparing chars, instead of StringViews of size 1.
I noticed it while watching Andreas' last optimization video.