### PR TITLE
WindowServer: Close submenus when hovering over separators

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -558,11 +558,8 @@ int Menu::item_index_at(const Gfx::IntPoint& position)
 {
     int i = 0;
     for (auto& item : m_items) {
-        if (item.rect().contains(position)) {
-            if (item.type() == MenuItem::Type::Separator)
-                return -1;
+        if (item.rect().contains(position))
             return i;
-        }
         ++i;
     }
     return -1;
@@ -661,13 +658,13 @@ void Menu::set_hovered_index(int index, bool make_input)
     if (m_hovered_item_index == index)
         return;
     if (auto* old_hovered_item = hovered_item()) {
-        if (client())
+        if (client() && old_hovered_item->type() != MenuItem::Type::Separator)
             client()->async_menu_item_left(m_menu_id, old_hovered_item->identifier());
     }
     m_hovered_item_index = index;
     update_for_new_hovered_item(make_input);
     if (auto* new_hovered_item = hovered_item()) {
-        if (client())
+        if (client() && new_hovered_item->type() != MenuItem::Type::Separator)
             client()->async_menu_item_entered(m_menu_id, new_hovered_item->identifier());
     }
 }


### PR DESCRIPTION
ec6debb changed item_index_at to return -1 when hovering over a
separator. The intent was to not send the separator to clients for
MenuItemEntered.

However, this had the unintented consequence of not closing the submenu
when you hover over a separator. Submenus ignore when the item index is
-1 in order to leave the menu open when you move the mouse outside. This
ends up leaving the submenu open without the highlight to show what menu
item the submenu belongs to.

A slightly less severe consequence is that pressing the up or down arrow
key in such a situation would now go the top or bottom of the menu
rather than the item above or below the separator.

We now push the special casing of separators into set_hovered_index so
that the rest of the code behaves as it did before ec6debb.