### PR TITLE
Kernel+LibELF: Make the userland load correctly when linked with LLD

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -387,7 +387,10 @@ static KResultOr<LoadResult> load_elf_object(NonnullOwnPtr<Space> new_space, Fil
             prot |= PROT_WRITE;
         if (program_header.is_executable())
             prot |= PROT_EXEC;
-        auto range = new_space->allocate_range(program_header.vaddr().offset(load_offset), program_header.size_in_memory());
+
+        auto range_base = VirtualAddress { page_round_down(program_header.vaddr().offset(load_offset).get()) };
+        auto range_end = VirtualAddress { page_round_up(program_header.vaddr().offset(load_offset).offset(program_header.size_in_memory()).get()) };
+        auto range = new_space->allocate_range(range_base, range_end.get() - range_base.get());
         if (!range.has_value()) {
             ph_load_result = ENOMEM;
             return IterationDecision::Break;

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -301,8 +301,11 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> load_main_library(co
         auto& object = result.value();
 
         if (loader.filename() == "libsystem.so"sv) {
-            if (syscall(SC_msyscall, object->base_address().as_ptr())) {
-                VERIFY_NOT_REACHED();
+            VERIFY(!loader.text_segments().is_empty());
+            for (const auto& segment : loader.text_segments()) {
+                if (syscall(SC_msyscall, segment.address().get())) {
+                    VERIFY_NOT_REACHED();
+                }
             }
         }
 


### PR DESCRIPTION
Our code previously relied on some assumptions about object files that aren't true when they are linked with `ld.lld`.

### LibELF: Fix syscall regions for .text segments with a non-zero offset

Previously, we assumed that the `.text` segment was loaded at vaddr 0 in all dynamic libraries, so we used the dynamic object's base address with  `msyscall`. This did not work with the LLVM toolchain, as it likes to shuffle these segments around.

This now also handles the case when there are multiple text segments for some reason correctly.

### Kernel: Map non-page-aligned text segments correctly

`.text` segments with non-aligned offsets had their lengths applied to the first page's base address. This meant that in some cases the last PAGE_SIZE - 1 bytes weren't mapped. Previously, it did not cause any problems as the GNU ld insists on aligning everything; but that's not the case with the LLVM toolchain.

cc @gunnarbeutner 