### PR TITLE
LibJS: Miscellaneous fixes for RegExp.prototype

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -55,6 +55,7 @@
     M(NotAFunctionNoParam, "Not a function")                                                                                            \
     M(NotAn, "Not an {} object")                                                                                                        \
     M(NotAnObject, "{} is not an object")                                                                                               \
+    M(NotAnObjectOrNull, "{} is neither an object nor null")                                                                            \
     M(NotASymbol, "{} is not a symbol")                                                                                                 \
     M(NotIterable, "{} is not iterable")                                                                                                \
     M(NotObjectCoercible, "{} cannot be converted to an object")                                                                        \

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -268,7 +268,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::exec)
 // 22.2.5.15 RegExp.prototype.test ( S ), https://tc39.es/ecma262/#sec-regexp.prototype.test
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::test)
 {
-    auto* regexp_object = regexp_object_from(vm, global_object);
+    auto* regexp_object = this_object_from(vm, global_object);
     if (!regexp_object)
         return {};
 
@@ -310,7 +310,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::to_string)
 // 22.2.5.7 RegExp.prototype [ @@match ] ( string ), https://tc39.es/ecma262/#sec-regexp.prototype-@@match
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
 {
-    auto* regexp_object = regexp_object_from(vm, global_object);
+    auto* regexp_object = this_object_from(vm, global_object);
     if (!regexp_object)
         return {};
     auto s = vm.argument(0).to_string(global_object);
@@ -380,7 +380,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
     auto string_value = vm.argument(0);
     auto replace_value = vm.argument(1);
 
-    auto* regexp_object = regexp_object_from(vm, global_object);
+    auto* regexp_object = this_object_from(vm, global_object);
     if (!regexp_object)
         return {};
     auto string = string_value.to_string(global_object);

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -27,6 +27,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(symbol_match);
     JS_DECLARE_NATIVE_FUNCTION(symbol_replace);
+    JS_DECLARE_NATIVE_FUNCTION(symbol_search);
 
 #define __JS_ENUMERATE(_, flag_name, ...) \
     JS_DECLARE_NATIVE_GETTER(flag_name);

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -19,8 +19,6 @@ public:
     virtual ~RegExpPrototype() override;
 
 private:
-    static RegexResult do_match(const Regex<ECMA262>&, const StringView&);
-
     JS_DECLARE_NATIVE_GETTER(flags);
     JS_DECLARE_NATIVE_GETTER(source);
 

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.test.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.test.js
@@ -56,3 +56,38 @@ test("flag and options", () => {
         Function("/foo/x");
     }).toThrowWithMessage(SyntaxError, "Invalid RegExp flag 'x'");
 });
+
+test("override exec with function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    let oldExec = re.exec.bind(re);
+    re.exec = function (...args) {
+        ++calls;
+        return oldExec(...args);
+    };
+
+    expect(re.test("test")).toBe(true);
+    expect(calls).toBe(1);
+});
+
+test("override exec with bad function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    re.exec = function (...args) {
+        ++calls;
+        return 4;
+    };
+
+    expect(() => {
+        re.test("test");
+    }).toThrow(TypeError);
+    expect(calls).toBe(1);
+});
+
+test("override exec with non-function", () => {
+    let re = /test/;
+    re.exec = 3;
+    expect(re.test("test")).toBe(true);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
@@ -3,6 +3,12 @@ test("basic functionality", () => {
 
     expect("hello friends".match(/hello/)).not.toBeNull();
     expect("hello friends".match(/enemies/)).toBeNull();
+
+    expect("aaa".match(/a/)).toEqual(["a"]);
+    expect("aaa".match(/a/g)).toEqual(["a", "a", "a"]);
+
+    expect("aaa".match(/b/)).toBeNull();
+    expect("aaa".match(/b/g)).toBeNull();
 });
 
 test("override exec with function", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
@@ -4,3 +4,38 @@ test("basic functionality", () => {
     expect("hello friends".match(/hello/)).not.toBeNull();
     expect("hello friends".match(/enemies/)).toBeNull();
 });
+
+test("override exec with function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    let oldExec = re.exec.bind(re);
+    re.exec = function (...args) {
+        ++calls;
+        return oldExec(...args);
+    };
+
+    expect("test".match(re)).not.toBeNull();
+    expect(calls).toBe(1);
+});
+
+test("override exec with bad function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    re.exec = function (...args) {
+        ++calls;
+        return 4;
+    };
+
+    expect(() => {
+        "test".match(re);
+    }).toThrow(TypeError);
+    expect(calls).toBe(1);
+});
+
+test("override exec with non-function", () => {
+    let re = /test/;
+    re.exec = 3;
+    expect("test".match(re)).not.toBeNull();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -197,3 +197,38 @@ test("search value is coerced to a string", () => {
     expect(newString).toBe("abc");
     expect(coerced).toBe("x");
 });
+
+test("override exec with function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    let oldExec = re.exec.bind(re);
+    re.exec = function (...args) {
+        ++calls;
+        return oldExec(...args);
+    };
+
+    expect("test".replace(re, "x")).toBe("x");
+    expect(calls).toBe(1);
+});
+
+test("override exec with bad function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    re.exec = function (...args) {
+        ++calls;
+        return 4;
+    };
+
+    expect(() => {
+        "test".replace(re, "x");
+    }).toThrow(TypeError);
+    expect(calls).toBe(1);
+});
+
+test("override exec with non-function", () => {
+    let re = /test/;
+    re.exec = 3;
+    expect("test".replace(re, "x")).toBe("x");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.search.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.search.js
@@ -1,0 +1,47 @@
+test("basic functionality", () => {
+    expect(String.prototype.search).toHaveLength(1);
+
+    expect("hello friends".search("h")).toBe(0);
+    expect("hello friends".search("e")).toBe(1);
+    expect("hello friends".search("l")).toBe(2);
+    expect("hello friends".search("o")).toBe(4);
+    expect("hello friends".search("z")).toBe(-1);
+
+    expect("abc123def".search(/\d/)).toBe(3);
+    expect("abcdef".search(/\d/)).toBe(-1);
+});
+
+test("override exec with function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    let oldExec = re.exec.bind(re);
+    re.exec = function (...args) {
+        ++calls;
+        return oldExec(...args);
+    };
+
+    expect("test".search(re)).toBe(0);
+    expect(calls).toBe(1);
+});
+
+test("override exec with bad function", () => {
+    let calls = 0;
+
+    let re = /test/;
+    re.exec = function (...args) {
+        ++calls;
+        return 4;
+    };
+
+    expect(() => {
+        "test".search(re);
+    }).toThrow(TypeError);
+    expect(calls).toBe(1);
+});
+
+test("override exec with non-function", () => {
+    let re = /test/;
+    re.exec = 3;
+    expect("test".search(re)).toBe(0);
+});


### PR DESCRIPTION
This fixes 74 test262 tests.