### PR TITLE
Kernel: pledge promises accessible via /proc/PID/pledge

### DIFF
--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -142,6 +142,7 @@ class ProcFSProcessFolder final
     friend class ProcFSComponentsRegistrar;
     friend class ProcFSRootFolder;
     friend class ProcFSProcessInformation;
+    friend class ProcFSProcessPledge;
     friend class ProcFSProcessUnveil;
     friend class ProcFSProcessPerformanceEvents;
     friend class ProcFSProcessFileDescription;


### PR DESCRIPTION
The promises set by pledge(2) can now be read as a string.