### PR TITLE
LibJS: Make FunctionExpression more spec-compliant

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -327,16 +327,20 @@ public:
         if (m_cannot_auto_rename)
             return;
         m_cannot_auto_rename = true;
-        if (name().is_empty())
+        if (name().is_empty()) {
             set_name(move(new_name));
+            m_is_auto_renamed = true;
+        }
     }
     bool cannot_auto_rename() const { return m_cannot_auto_rename; }
+    bool is_auto_renamed() const { return m_is_auto_renamed; }
     void set_cannot_auto_rename() { m_cannot_auto_rename = true; }
 
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     bool m_cannot_auto_rename { false };
+    bool m_is_auto_renamed { false };
 };
 
 class ErrorExpression final : public Expression {

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -384,6 +384,8 @@ Value VM::get_variable(const FlyString& name, GlobalObject& global_object)
                 return {};
             if (possible_match.has_value())
                 return possible_match.value().value;
+            if (environment->has_binding(name))
+                return environment->get_binding_value(global_object, name, false);
         }
     }
 


### PR DESCRIPTION
This PR allows functions declared as an expression to reference themselves (e.g., for recursive calls). This didn't work before because their identifier is not supposed to be added to their outer lexical environment, it's only available inside the function itself.

This means we can now support hilarious constructs such as this (S14_A2.js):
```js
if (function f(arg){
	if (arg===0)
	   return 1;
	else
	   return f(arg-1)*arg;
}(3)!==6) {
     $ERROR()
};
```

---

Placing `get_binding_value` in `get_variable` is probably a bit of an ad-hoc fix. I assume `get_variable` will be changed up a bit in the future or changed for something more compliant entirely. So far nothing was calling `get_binding_value` yet, so I had to add it there.

---

`23266/41267 ( 56.38%) [ ✅ 23266 ❌ 15185 ⚙️ 124   💀 7     💥️ 2685  ]`
->
`23284/41267 ( 56.42%) [ ✅ 23284 ❌ 15167 ⚙️ 124   💀 7     💥️ 2685  ]`