### PR TITLE
Userland: Keep ImageViewer window size the same while zooming in

### DIFF
--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -92,9 +92,11 @@ int main(int argc, char** argv)
         if (window->is_maximized())
             return;
 
-        auto w = max(window->width(), rect.width() + 4);
-        auto h = max(window->height(), rect.height() + widget.toolbar_height() + 6);
-        window->resize(w, h);
+        if (scale == 100) {
+            auto w = min(GUI::Desktop::the().rect().width(), rect.width() + 4);
+            auto h = min(GUI::Desktop::the().rect().height(), rect.height() + widget.toolbar_height() + 6);
+            window->resize(w, h);
+        }
     };
     widget.on_drop = [&](auto& event) {
         window->move_to_front();


### PR DESCRIPTION
ImageViewer window kept growing while zooming in, which causes out of
memory error and crashes the application. Now, only the image content is
rescaled and the window size is preserved.

We also open the display window as the same size as the image, which may
cause a similar issue for very large image files. This is prevented by
limiting the maximum window size to be the screen size.