### PR TITLE
Kernel: Stop booting and print if PAE is not supported by the processor

### DIFF
--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -12,3 +12,8 @@ You might want to revert latest changes in tree to see if that solves the proble
 ### "Your computer does not support long mode (64-bit mode). Halting!"
 
 Either your machine (if you try to boot on bare metal) is very old, thus it's not supporting x86_64 extensions, or you try to use VirtualBox without using a x64 virtualization mode or you try to use `qemu-system-i386` which doesn't support x86_64 extensions too.
+
+### "Your computer does not support PAE. Halting!"
+- If booting on bare metal, your CPU is too old to boot Serenity.
+- If you're using VirtualBox, you need to enable PAE/NX. Check the instructions [here.](VirtualBox.md)
+- If you're using QEMU, the [CPU model configuration](https://qemu-project.gitlab.io/qemu/system/qemu-cpu-models.html) is not exposing PAE.

--- a/Documentation/VirtualBox.md
+++ b/Documentation/VirtualBox.md
@@ -61,6 +61,12 @@ Please note that at the time of writing, audio and networking do not work in Vir
 
 That is all you need to boot Serenity in VirtualBox! Read on for additional configuration you may want to use.
 
+## Blinking cursor after GRUB menu
+If you only see a blinking cursor after selecting an option in the GRUB menu, it is very likely you have encountered one of the errors listed in the [troubleshooting document.](Troubleshooting.md)
+
+- Check that you have enabled PAE/NX in the **Settings** > **System** > **Processor** tab.
+- If you are using a 64-bit disk image, check that **Version** is set to **Other/Unknown (64-bit)** instead of **Other/Unknown** in **Settings** > **General**.
+
 ## Additional configuration (optional)
 For serial debugging, go to **Serial Ports** and enable port 1. Feel free to set the **Port Mode** to anything if you know what you're doing. The recommended mode is **Raw File**. Set **Path/Address** to where you want to store the file. This must also include the file name.
 

--- a/Kernel/Arch/x86/common/Boot/boot.S
+++ b/Kernel/Arch/x86/common/Boot/boot.S
@@ -118,6 +118,16 @@ start:
 */
 print_and_halt:
 
+/*  from now on, we don't really care about booting because we are missing required CPU features such as PAE or long mode.
+    the flow from now is like so:
+    1. Copy all necessary parts to low memory section in RAM
+    2. Jump to that section
+    3. In that section we do:
+        a. exit protected mode to pure 16 bit real mode
+        b. load the "<missing feature> is not supported" String, call the BIOS print to screen service
+        c. halt
+*/
+
 .equ COPIED_STRING_LOCATION, 0x400
 .equ GDT_REAL_MODE_LOCATION, 0x45000
 .equ EXITING_PROTECTED_MODE_CODE_LOCATION, 0x10000
@@ -214,6 +224,9 @@ gdt_table_real_mode_end:
 no_long_mode_string:
     .asciz "Your computer does not support long mode (64-bit mode). Halting!"
 
+no_pae_string:
+    .asciz "Your computer does not support PAE. Halting!"
+
 kernel_image_too_big_string:
     .asciz "Error: Kernel Image too big for memory slot. Halting!"
 
@@ -307,28 +320,32 @@ real_start:
     hlt
 
 kernel_not_too_large:
-
-
-#if ARCH(X86_64)
-    /* test for long mode presence, save the most important registers from corruption */
+    /* test for PAE presence, save the most important registers from corruption */
     pushl %eax
     pushl %edx
     pushl %ebx
 
+    movl $0x1, %eax       /* PAE presence is in CPUID input 0x1 */
+    cpuid
+    testl $(1 << 6), %edx /* Test if the PAE-bit, which is bit 6, is set in the edx register. */
+    jnz pae_supported     /* If the bit is not set, there is no PAE capability. */
+
+    /* Since there is no PAE capability, halt with an error message */
+    movl $(no_pae_string - KERNEL_BASE), %esi
+    pushl %esi
+    call print_and_halt
+    /* We should not return, but just in case, halt */
+    hlt
+
+
+#if ARCH(X86_64)
+pae_supported:
     movl $0x80000001, %eax
     cpuid
     testl $(1 << 29), %edx   /* Test if the LM-bit, which is bit 29, is set in the edx register. */
     jnz long_mode_supported             /* If LM-bit is not enabled, there is no long mode. */
 
-    /*  from now on, we don't really care about booting because we don't have long mode supported.
-         the flow from now is like so:
-         1. Copy all necessary parts to low memory section in RAM
-         2. Jump to that section
-         3. In that section we do:
-            a. exit protected mode to pure 16 bit real mode
-            b. load the "Long mode is not supported" String, call the BIOS print to screen service
-            c. halt
-    */
+    /* Since there is no long mode, halt with an error message */
     movl $(no_long_mode_string - KERNEL_BASE), %esi
     pushl %esi
     call print_and_halt
@@ -336,10 +353,17 @@ kernel_not_too_large:
     hlt
 
 
-/* If long mode is supported, continue with booting the system */
+/* If both PAE and long mode is supported, continue with booting the system */
 
-.code32
 long_mode_supported:
+    /* restore the pushed registers and continue with booting */
+    popl %ebx
+    popl %edx
+    popl %eax
+#else
+/* If PAE is supported, continue with booting the system */
+
+pae_supported:
     /* restore the pushed registers and continue with booting */
     popl %ebx
     popl %edx
@@ -545,4 +569,3 @@ long_mode_supported:
 loop:
     hlt
     jmp loop
-


### PR DESCRIPTION
We currently require PAE and not having it causes us to crash.
This turns that crash into an error message.

(Please let CI finish because I have only tested i686 locally)