### PR TITLE
WindowServer: Make descending into submenu make the submenu current

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -322,7 +322,7 @@ void Menu::descend_into_submenu_at_hovered_item()
     VERIFY(hovered_item());
     auto submenu = hovered_item()->submenu();
     VERIFY(submenu);
-    MenuManager::the().open_menu(*submenu, false);
+    MenuManager::the().open_menu(*submenu, true);
     submenu->set_hovered_index(0);
     VERIFY(submenu->hovered_item()->type() != MenuItem::Separator);
 }


### PR DESCRIPTION
This fixes a bug with menu keyboard navigation. If you pressed the right
arrow to enter a submenu, then the left arrow to exit the submenu, then
right and left again it would leave no menu item selected.

Because descending into the submenu wasn't making it the current menu,
when you press the left arrow it couldn't find the "current menu" in the
stack, so didn't know what menu to pop back to.

It was an accident that it worked the first time you navigated into the
menu. Selecting the parent item also opened the submenu, and opening
an already open menu sets it as the current menu. After closing the
submenu with the left arrow, it is no longer already open, so it wasn't
getting set as the current menu.