### PR TITLE
LibJS: Reorder and add missing name & length properties to Built-ins

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -26,13 +26,13 @@ void ArrayBufferConstructor::initialize(GlobalObject& global_object)
     // 25.1.4.2 ArrayBuffer.prototype, https://tc39.es/ecma262/#sec-arraybuffer.prototype
     define_direct_property(vm.names.prototype, global_object.array_buffer_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.isView, is_view, 1, attr);
 
     // 25.1.5.4 ArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-arraybuffer.prototype-@@tostringtag
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 ArrayBufferConstructor::~ArrayBufferConstructor()

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -33,8 +33,6 @@ void ArrayConstructor::initialize(GlobalObject& global_object)
     // 23.1.2.4 Array.prototype, https://tc39.es/ecma262/#sec-array.prototype
     define_direct_property(vm.names.prototype, global_object.array_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.from, from, 1, attr);
     define_native_function(vm.names.isArray, is_array, 1, attr);
@@ -42,6 +40,8 @@ void ArrayConstructor::initialize(GlobalObject& global_object)
 
     // 23.1.2.5 get Array [ @@species ], https://tc39.es/ecma262/#sec-get-array-@@species
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 // 23.1.1.1 Array ( ...values ), https://tc39.es/ecma262/#sec-array

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -27,12 +27,12 @@ void BigIntConstructor::initialize(GlobalObject& global_object)
     // 21.2.2.3 BigInt.prototype, https://tc39.es/ecma262/#sec-bigint.prototype
     define_direct_property(vm.names.prototype, global_object.bigint_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     // TODO: Implement these functions below and uncomment this.
     // u8 attr = Attribute::Writable | Attribute::Configurable;
     // define_native_function(vm.names.asIntN, as_int_n, 2, attr);
     // define_native_function(vm.names.asUintN, as_uint_n, 2, attr);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 BigIntConstructor::~BigIntConstructor()

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -133,12 +133,12 @@ void DateConstructor::initialize(GlobalObject& global_object)
     // 21.4.3.3 Date.prototype, https://tc39.es/ecma262/#sec-date.prototype
     define_direct_property(vm.names.prototype, global_object.date_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(7), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.now, now, 0, attr);
     define_native_function(vm.names.parse, parse, 1, attr);
     define_native_function(vm.names.UTC, utc, 1, attr);
+
+    define_direct_property(vm.names.length, Value(7), Attribute::Configurable);
 }
 
 DateConstructor::~DateConstructor()

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -26,9 +26,9 @@ void MapConstructor::initialize(GlobalObject& global_object)
     // 24.1.2.1 Map.prototype, https://tc39.es/ecma262/#sec-map.prototype
     define_direct_property(vm.names.prototype, global_object.map_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
-
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
 MapConstructor::~MapConstructor()

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -36,8 +36,6 @@ void NumberConstructor::initialize(GlobalObject& global_object)
     // 21.1.2.15 Number.prototype, https://tc39.es/ecma262/#sec-number.prototype
     define_direct_property(vm.names.prototype, global_object.number_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.isFinite, is_finite, 1, attr);
     define_native_function(vm.names.isInteger, is_integer, 1, attr);
@@ -53,6 +51,8 @@ void NumberConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.NEGATIVE_INFINITY, js_negative_infinity(), 0);
     define_direct_property(vm.names.POSITIVE_INFINITY, js_infinity(), 0);
     define_direct_property(vm.names.NaN, js_nan(), 0);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 NumberConstructor::~NumberConstructor()

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -30,8 +30,6 @@ void ObjectConstructor::initialize(GlobalObject& global_object)
     // 20.1.2.19 Object.prototype, https://tc39.es/ecma262/#sec-object.prototype
     define_direct_property(vm.names.prototype, global_object.object_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.defineProperty, define_property, 3, attr);
     define_native_function(vm.names.defineProperties, define_properties, 2, attr);
@@ -55,6 +53,8 @@ void ObjectConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.create, create, 2, attr);
     define_native_function(vm.names.hasOwn, has_own, 2, attr);
     define_native_function(vm.names.assign, assign, 2, attr);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 ObjectConstructor::~ObjectConstructor()

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -93,6 +93,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         vm.enqueue_promise_job(*job);
         return js_undefined();
     });
+    resolve_function->define_direct_property(vm.names.name, js_string(vm, vm.names.resolve.as_string()), Attribute::Configurable);
 
     // 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
     auto* reject_function = PromiseResolvingFunction::create(global_object(), *this, *already_resolved, [](auto& vm, auto&, auto& promise, auto& already_resolved) {
@@ -103,6 +104,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         auto reason = vm.argument(0);
         return promise.reject(reason);
     });
+    reject_function->define_direct_property(vm.names.name, js_string(vm, vm.names.reject.as_string()), Attribute::Configurable);
 
     return { *resolve_function, *reject_function };
 }

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -28,8 +28,6 @@ void PromiseConstructor::initialize(GlobalObject& global_object)
     // 27.2.4.4 Promise.prototype, https://tc39.es/ecma262/#sec-promise.prototype
     define_direct_property(vm.names.prototype, global_object.promise_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     // TODO: Implement these functions below and uncomment this.
     // define_native_function(vm.names.all, all, 1, attr);
@@ -40,6 +38,8 @@ void PromiseConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.resolve, resolve, 1, attr);
 
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 // 27.2.3.1 Promise ( executor ), https://tc39.es/ecma262/#sec-promise-executor

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -37,9 +37,10 @@ void ProxyConstructor::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     NativeFunction::initialize(global_object);
-    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.revocable, revocable, 2, attr);
+
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
 
 ProxyConstructor::~ProxyConstructor()

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -24,9 +24,9 @@ void RegExpConstructor::initialize(GlobalObject& global_object)
     // 22.2.4.1 RegExp.prototype, https://tc39.es/ecma262/#sec-regexp.prototype
     define_direct_property(vm.names.prototype, global_object.regexp_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
-
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
 
 RegExpConstructor::~RegExpConstructor()

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -26,9 +26,9 @@ void SetConstructor::initialize(GlobalObject& global_object)
     // 24.2.2.1 Set.prototype, https://tc39.es/ecma262/#sec-set.prototype
     define_direct_property(vm.names.prototype, global_object.set_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
-
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
 SetConstructor::~SetConstructor()

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -28,12 +28,12 @@ void StringConstructor::initialize(GlobalObject& global_object)
     // 22.1.2.3 String.prototype, https://tc39.es/ecma262/#sec-string.prototype
     define_direct_property(vm.names.prototype, global_object.string_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.raw, raw, 1, attr);
     define_native_function(vm.names.fromCharCode, from_char_code, 1, attr);
     define_native_function(vm.names.fromCodePoint, from_code_point, 1, attr);
+
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
 StringConstructor::~StringConstructor()

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -23,8 +23,6 @@ void SymbolConstructor::initialize(GlobalObject& global_object)
     // 20.4.2.9 Symbol.prototype, https://tc39.es/ecma262/#sec-symbol.prototype
     define_direct_property(vm.names.prototype, global_object.symbol_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.for_, for_, 1, attr);
     define_native_function(vm.names.keyFor, key_for, 1, attr);
@@ -33,6 +31,8 @@ void SymbolConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.SymbolName, vm.well_known_symbol_##snake_name(), 0);
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
+
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
 SymbolConstructor::~SymbolConstructor()

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -262,10 +262,10 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         /* 23.2.6.2 TypedArray.prototype, https://tc39.es/ecma262/#sec-typedarray.prototype */                                         \
         define_direct_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);                                         \
                                                                                                                                        \
-        define_direct_property(vm.names.length, Value(3), Attribute::Configurable);                                                    \
-                                                                                                                                       \
         /* 23.2.6.1 TypedArray.BYTES_PER_ELEMENT, https://tc39.es/ecma262/#sec-typedarray.bytes_per_element */                         \
         define_direct_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                               \
+                                                                                                                                       \
+        define_direct_property(vm.names.length, Value(3), Attribute::Configurable);                                                    \
     }                                                                                                                                  \
                                                                                                                                        \
     /* 23.2.5.1 TypedArray ( ...args ), https://tc39.es/ecma262/#sec-typedarray */                                                     \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -29,13 +29,13 @@ void TypedArrayConstructor::initialize(GlobalObject& global_object)
     // 23.2.2.3 %TypedArray%.prototype, https://tc39.es/ecma262/#sec-%typedarray%.prototype
     define_direct_property(vm.names.prototype, global_object.typed_array_prototype(), 0);
 
-    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.from, from, 1, attr);
     define_native_function(vm.names.of, of, 0, attr);
 
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
+
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
 TypedArrayConstructor::~TypedArrayConstructor()


### PR DESCRIPTION
The specification dicatates that each built-in will have a length and name property. (defined in that order)

Fixes 4 test262 test cases.