### PR TITLE
Toolchain: Fix building toolchain on arm64 equipped macs

### DIFF
--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -6317,3 +6317,17 @@ diff -Naur gcc-11.1.0/libstdc++-v3/configure gcc-11.1.0.serenity/libstdc++-v3/co
  if test x$gcc_no_link = xyes; then
    # Setting cross_compile will disable run tests; it will
    # also disable AC_CHECK_FILE but that's generally
+diff -Naur gcc-11.1.0/gcc/config/host-darwin.c gcc-11.1.0.serenity/gcc/config/host-darwin.c
+--- gcc-11.1.0/gcc/config/host-darwin.c	2021-04-27 03:00:13.000000000 -0700
++++ gcc-11.1.0.serenity/gcc/config/host-darwin.c	2021-06-11 14:49:13.754000000 -0700
+@@ -22,6 +22,10 @@
+ #include "coretypes.h"
+ #include "diagnostic-core.h"
+ #include "config/host-darwin.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+ 
+ /* Yes, this is really supposed to work.  */
+ /* This allows for a pagesize of 16384, which we have on Darwin20, but should

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -6317,3 +6317,17 @@ diff -Naur gcc-11.1.0/libstdc++-v3/configure gcc-11.1.0.serenity/libstdc++-v3/co
  if test x$gcc_no_link = xyes; then
    # Setting cross_compile will disable run tests; it will
    # also disable AC_CHECK_FILE but that's generally
+diff -Naur gcc-11.1.0/gcc/config/host-darwin.c gcc-11.1.0.serenity/gcc/config/host-darwin.c
+--- gcc-11.1.0/gcc/config/host-darwin.c	2021-04-27 03:00:13.000000000 -0700
++++ gcc-11.1.0.serenity/gcc/config/host-darwin.c	2021-06-11 14:49:13.754000000 -0700
+@@ -22,6 +22,10 @@
+ #include "coretypes.h"
+ #include "diagnostic-core.h"
+ #include "config/host-darwin.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+ 
+ /* Yes, this is really supposed to work.  */
+ /* This allows for a pagesize of 16384, which we have on Darwin20, but should


### PR DESCRIPTION
This GCC patch fixes building the toolchain on arm64 equipped macs, it has also been tested on an Intel based Mac. This does not support building serenity for aarch64, but is a helpful step towards that goal.

![Screenshot 2021-07-08 at 09 29 30](https://user-images.githubusercontent.com/4324090/124902164-99bb8500-dfda-11eb-8c38-3062872aab7d.png)
![Screenshot 2021-07-08 at 10 38 06](https://user-images.githubusercontent.com/4324090/124902171-9c1ddf00-dfda-11eb-8521-87cbbc9125f9.png)
 

This patch is based off: https://github.com/osx-cross/homebrew-avr/pull/248 and https://github.com/riscv/riscv-gnu-toolchain/issues/800#issuecomment-808722775

This fixes: https://github.com/SerenityOS/serenity/issues/4541

This stuff is all quite new to me so please let me know if there is anything that I can improve on. Many thanks!