### PR TITLE
WindowServer: Add a new IPC to set the cursor position

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -894,6 +894,18 @@ void ClientConnection::pong()
     set_unresponsive(false);
 }
 
+void ClientConnection::set_global_cursor_position(Gfx::IntPoint const& position)
+{
+    if (!Screen::main().rect().contains(position)) {
+        did_misbehave("SetGlobalCursorPosition with bad position");
+        return;
+    }
+    if (position != ScreenInput::the().cursor_location()) {
+        ScreenInput::the().set_cursor_location(position);
+        Compositor::the().invalidate_cursor();
+    }
+}
+
 Messages::WindowServer::GetGlobalCursorPositionResponse ClientConnection::get_global_cursor_position()
 {
     return ScreenInput::the().cursor_location();

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -150,6 +150,7 @@ private:
     virtual void set_window_progress(i32, Optional<i32> const&) override;
     virtual void refresh_system_theme() override;
     virtual void pong() override;
+    virtual void set_global_cursor_position(Gfx::IntPoint const&) override;
     virtual Messages::WindowServer::GetGlobalCursorPositionResponse get_global_cursor_position() override;
     virtual void set_mouse_acceleration(float) override;
     virtual Messages::WindowServer::GetMouseAccelerationResponse get_mouse_acceleration() override;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -127,6 +127,7 @@ endpoint WindowServer
     enable_display_link() =|
     disable_display_link() =|
 
+    set_global_cursor_position(Gfx::IntPoint position) =|
     get_global_cursor_position() => (Gfx::IntPoint position)
 
     set_mouse_acceleration(float factor) =|


### PR DESCRIPTION
This can be useful, for example, for porting games that continually re-center the cursor in order to be provide effectively boundless mouse movements.