### PR TITLE
Base: Remove www. from link to project website in welcome page

### DIFF
--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -126,7 +126,7 @@
         <li><a href="afrag.html">links with fragments</a></li>
         <li><a href="bmfw.html">better mother fricken website</a></li>
         <li><a href="http://bettermotherfuckingwebsite.com/">bettermotherfuckingwebsite</a></li>
-        <li><a href="http://www.serenityos.org/">www.serenityos.org</a></li>
+        <li><a href="http://serenityos.org/">serenityos.org</a></li>
         <li><a href="pbmsuite.html">PBM test suite</a></li>
         <li><a href="pgmsuite.html">PGM test suite</a></li>
         <li><a href="ppmsuite.html">PPM test suite</a></li>


### PR DESCRIPTION
The www subdomain does not allow http and as LibTLS currently
has no cipher suite in common the request fails.
