### PR TITLE
LibGfx: Optimize font width calculation

### DIFF
--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -5,20 +5,11 @@
  */
 
 #include "BitmapFont.h"
-#include "Bitmap.h"
 #include "Emoji.h"
-#include <AK/StdLibExtras.h>
-#include <AK/StringBuilder.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
-#include <AK/Vector.h>
 #include <LibCore/FileStream.h>
 #include <LibGfx/FontDatabase.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <unistd.h>
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -248,14 +248,12 @@ int BitmapFont::glyph_or_emoji_width_for_variable_width_font(u32 code_point) con
     return emoji->size().width();
 }
 
-int BitmapFont::width(const StringView& string) const
-{
-    Utf8View utf8 { string };
-    return width(utf8);
-}
+int BitmapFont::width(StringView const& view) const { return unicode_view_width(Utf8View(view)); }
+int BitmapFont::width(Utf8View const& view) const { return unicode_view_width(view); }
+int BitmapFont::width(Utf32View const& view) const { return unicode_view_width(view); }
 
 template<typename T>
-int BitmapFont::unicode_view_width(T const& view) const
+ALWAYS_INLINE int BitmapFont::unicode_view_width(T const& view) const
 {
     if (view.is_empty())
         return 0;
@@ -278,16 +276,6 @@ int BitmapFont::unicode_view_width(T const& view) const
     }
 
     return longest_width;
-}
-
-int BitmapFont::width(const Utf8View& utf8) const
-{
-    return unicode_view_width(utf8);
-}
-
-int BitmapFont::width(const Utf32View& view) const
-{
-    return unicode_view_width(view);
 }
 
 void BitmapFont::set_type(FontTypes type)

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -264,6 +264,7 @@ ALWAYS_INLINE int BitmapFont::unicode_view_width(T const& view) const
     for (u32 code_point : view) {
         if (code_point == '\n' || code_point == '\r') {
             first = true;
+            longest_width = max(width, longest_width);
             width = 0;
             continue;
         }
@@ -271,10 +272,8 @@ ALWAYS_INLINE int BitmapFont::unicode_view_width(T const& view) const
             width += glyph_spacing();
         first = false;
         width += glyph_or_emoji_width(code_point);
-        if (width > longest_width)
-            longest_width = width;
     }
-
+    longest_width = max(width, longest_width);
     return longest_width;
 }
 

--- a/Userland/Libraries/LibGfx/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/BitmapFont.h
@@ -26,9 +26,9 @@ enum FontTypes {
     __Count
 };
 
-class BitmapFont : public Font {
+class BitmapFont final : public Font {
 public:
-    NonnullRefPtr<Font> clone() const;
+    NonnullRefPtr<Font> clone() const override;
     static NonnullRefPtr<BitmapFont> create(u8 glyph_height, u8 glyph_width, bool fixed, FontTypes type);
 
     static RefPtr<BitmapFont> load_from_file(String const& path);
@@ -36,56 +36,56 @@ public:
 
     ~BitmapFont();
 
-    u8 presentation_size() const { return m_presentation_size; }
+    u8 presentation_size() const override { return m_presentation_size; }
     void set_presentation_size(u8 size) { m_presentation_size = size; }
 
-    u16 weight() const { return m_weight; }
+    u16 weight() const override { return m_weight; }
     void set_weight(u16 weight) { m_weight = weight; }
 
-    Glyph glyph(u32 code_point) const;
-    bool contains_glyph(u32 code_point) const { return code_point < (u32)glyph_count() && m_glyph_widths[code_point] > 0; }
+    Glyph glyph(u32 code_point) const override;
+    bool contains_glyph(u32 code_point) const override { return code_point < (u32)glyph_count() && m_glyph_widths[code_point] > 0; }
 
-    u8 glyph_width(size_t ch) const { return m_fixed_width ? m_glyph_width : m_glyph_widths[ch]; }
-    ALWAYS_INLINE int glyph_or_emoji_width(u32 code_point) const
+    u8 glyph_width(size_t ch) const override { return m_fixed_width ? m_glyph_width : m_glyph_widths[ch]; }
+    ALWAYS_INLINE int glyph_or_emoji_width(u32 code_point) const override
     {
         if (m_fixed_width)
             return m_glyph_width;
         return glyph_or_emoji_width_for_variable_width_font(code_point);
     }
-    u8 glyph_height() const { return m_glyph_height; }
-    int x_height() const { return m_x_height; }
+    u8 glyph_height() const override { return m_glyph_height; }
+    int x_height() const override { return m_x_height; }
 
     u8 raw_glyph_width(size_t ch) const { return m_glyph_widths[ch]; }
 
-    u8 min_glyph_width() const { return m_min_glyph_width; }
-    u8 max_glyph_width() const { return m_max_glyph_width; }
-    u8 glyph_fixed_width() const { return m_glyph_width; }
+    u8 min_glyph_width() const override { return m_min_glyph_width; }
+    u8 max_glyph_width() const override { return m_max_glyph_width; }
+    u8 glyph_fixed_width() const override { return m_glyph_width; }
 
-    u8 baseline() const { return m_baseline; }
+    u8 baseline() const override { return m_baseline; }
     void set_baseline(u8 baseline)
     {
         m_baseline = baseline;
         update_x_height();
     }
 
-    u8 mean_line() const { return m_mean_line; }
+    u8 mean_line() const override { return m_mean_line; }
     void set_mean_line(u8 mean_line)
     {
         m_mean_line = mean_line;
         update_x_height();
     }
 
-    int width(const StringView&) const;
-    int width(const Utf8View&) const;
-    int width(const Utf32View&) const;
+    int width(StringView const&) const override;
+    int width(Utf8View const&) const override;
+    int width(Utf32View const&) const override;
 
-    String name() const { return m_name; }
+    String name() const override { return m_name; }
     void set_name(String name) { m_name = move(name); }
 
-    bool is_fixed_width() const { return m_fixed_width; }
+    bool is_fixed_width() const override { return m_fixed_width; }
     void set_fixed_width(bool b) { m_fixed_width = b; }
 
-    u8 glyph_spacing() const { return m_glyph_spacing; }
+    u8 glyph_spacing() const override { return m_glyph_spacing; }
     void set_glyph_spacing(u8 spacing) { m_glyph_spacing = spacing; }
 
     void set_glyph_width(size_t ch, u8 width)
@@ -94,18 +94,18 @@ public:
         m_glyph_widths[ch] = width;
     }
 
-    size_t glyph_count() const { return m_glyph_count; }
+    size_t glyph_count() const override { return m_glyph_count; }
 
     FontTypes type() { return m_type; }
     void set_type(FontTypes type);
 
-    String family() const { return m_family; }
+    String family() const override { return m_family; }
     void set_family(String family) { m_family = move(family); }
-    String variant() const { return String::formatted("{}", weight()); }
+    String variant() const override { return String::number(weight()); }
 
-    String qualified_name() const;
+    String qualified_name() const override;
 
-    const Font& bold_variant() const;
+    Font const& bold_variant() const override;
 
     static size_t glyph_count_by_type(FontTypes type);
     static String type_name_by_type(FontTypes type);
@@ -113,7 +113,7 @@ public:
 private:
     BitmapFont(String name, String family, unsigned* rows, u8* widths, bool is_fixed_width, u8 glyph_width, u8 glyph_height, u8 glyph_spacing, FontTypes type, u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, bool owns_arrays = false);
 
-    static RefPtr<BitmapFont> load_from_memory(const u8*);
+    static RefPtr<BitmapFont> load_from_memory(u8 const*);
 
     template<typename T>
     int unicode_view_width(T const& view) const;


### PR DESCRIPTION
This PR aims to optimize performance of `BitmapFont::width()` calculations. In some synthetic tests, I managed to get a speed-up of between 7 and 15 percent depending on how long the input string was. It's quite hard to test this with real workloads, sadly.

This works towards #8553, although there seems to be another problem there, so let's keep the issue open.