### PR TITLE
Kernel: Give devices their own WorkQueue

### DIFF
--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -18,8 +18,6 @@ namespace Kernel {
 
 class Device;
 
-extern WorkQueue* g_io_work;
-
 class AsyncDeviceRequest : public RefCounted<AsyncDeviceRequest> {
     AK_MAKE_NONCOPYABLE(AsyncDeviceRequest);
     AK_MAKE_NONMOVABLE(AsyncDeviceRequest);

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -69,7 +69,7 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         break;
     default:
         if ((m_modifiers & Mod_Alt) != 0 && ch >= 2 && ch <= ConsoleManagement::s_max_virtual_consoles + 1) {
-            g_io_work->queue([ch]() {
+            m_io_work_queue->queue([ch]() {
                 ConsoleManagement::the().switch_to(ch - 0x02);
             });
         }
@@ -107,6 +107,7 @@ UNMAP_AFTER_INIT PS2KeyboardDevice::PS2KeyboardDevice(const I8042Controller& ps2
     : IRQHandler(IRQ_KEYBOARD)
     , KeyboardDevice()
     , I8042Device(ps2_controller)
+    , m_io_work_queue(adopt_own_if_nonnull(new WorkQueue("PS2KeyboardDevice WorkQueue")).release_nonnull())
 {
 }
 

--- a/Kernel/Devices/HID/PS2KeyboardDevice.h
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.h
@@ -43,6 +43,8 @@ private:
 
     // ^CharacterDevice
     virtual const char* class_name() const override { return "KeyboardDevice"; }
+
+    NonnullOwnPtr<WorkQueue> m_io_work_queue;
 };
 
 }

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGPUConsole.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGPUConsole.cpp
@@ -65,7 +65,7 @@ void VirtIOGPUConsole::enqueue_refresh_timer()
                 .width = (u32)rect.width(),
                 .height = (u32)rect.height(),
             };
-            g_io_work->queue([this, dirty_rect]() {
+            Processor::deferred_call_queue([this, dirty_rect]() {
                 m_framebuffer_device->flush_dirty_window(dirty_rect, m_framebuffer_device->current_buffer());
                 m_dirty_rect.clear();
             });

--- a/Kernel/Storage/AHCIController.cpp
+++ b/Kernel/Storage/AHCIController.cpp
@@ -12,6 +12,7 @@
 #include <Kernel/Storage/AHCIController.h>
 #include <Kernel/Storage/SATADiskDevice.h>
 #include <Kernel/VM/MemoryManager.h>
+#include <Kernel/WorkQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -36,6 +36,7 @@ class AHCIPort : public RefCounted<AHCIPort> {
 
 public:
     UNMAP_AFTER_INIT static NonnullRefPtr<AHCIPort> create(const AHCIPortHandler&, volatile AHCI::PortRegisters&, u32 port_index);
+    ~AHCIPort();
 
     u32 port_index() const { return m_port_index; }
     u32 representative_port_index() const { return port_index() + 1; }
@@ -121,6 +122,7 @@ private:
     AHCI::PortInterruptEnableBitField m_interrupt_enable;
 
     RefPtr<ScatterGatherList> m_current_scatter_list;
+    NonnullOwnPtr<WorkQueue> m_io_work_queue;
     bool m_disabled_by_firmware { false };
 };
 }

--- a/Kernel/Storage/BMIDEChannel.h
+++ b/Kernel/Storage/BMIDEChannel.h
@@ -27,7 +27,7 @@ class BMIDEChannel final : public IDEChannel {
 public:
     static NonnullRefPtr<BMIDEChannel> create(const IDEController&, IDEChannel::IOAddressGroup, IDEChannel::ChannelType type);
     static NonnullRefPtr<BMIDEChannel> create(const IDEController&, u8 irq, IDEChannel::IOAddressGroup, IDEChannel::ChannelType type);
-    virtual ~BMIDEChannel() override {};
+    virtual ~BMIDEChannel() override;
 
     virtual bool is_dma_enabled() const override { return true; };
 
@@ -51,5 +51,6 @@ private:
     OwnPtr<Region> m_dma_buffer_region;
     RefPtr<PhysicalPage> m_prdt_page;
     RefPtr<PhysicalPage> m_dma_buffer_page;
+    NonnullOwnPtr<WorkQueue> m_io_work_queue;
 };
 }

--- a/Kernel/Storage/IDEChannel.h
+++ b/Kernel/Storage/IDEChannel.h
@@ -162,5 +162,6 @@ protected:
 
     IOAddressGroup m_io_group;
     NonnullRefPtr<IDEController> m_parent_controller;
+    NonnullOwnPtr<WorkQueue> m_io_work_queue;
 };
 }

--- a/Kernel/Storage/SATADiskDevice.cpp
+++ b/Kernel/Storage/SATADiskDevice.cpp
@@ -10,6 +10,7 @@
 #include <Kernel/Storage/AHCIController.h>
 #include <Kernel/Storage/IDEChannel.h>
 #include <Kernel/Storage/SATADiskDevice.h>
+#include <Kernel/WorkQueue.h>
 
 namespace Kernel {
 
@@ -21,6 +22,7 @@ NonnullRefPtr<SATADiskDevice> SATADiskDevice::create(const AHCIController& contr
 SATADiskDevice::SATADiskDevice(const AHCIController& controller, const AHCIPort& port, size_t sector_size, u64 max_addressable_block)
     : StorageDevice(controller, sector_size, max_addressable_block)
     , m_port(port)
+    , m_io_queue(adopt_own_if_nonnull(new WorkQueue(String::formatted("SATADiskDevice {} WorkQueue", device_name()))).release_nonnull())
 {
 }
 

--- a/Kernel/Storage/SATADiskDevice.h
+++ b/Kernel/Storage/SATADiskDevice.h
@@ -38,6 +38,7 @@ private:
     // ^DiskDevice
     virtual const char* class_name() const override;
     NonnullRefPtr<AHCIPort> m_port;
+    NonnullOwnPtr<WorkQueue> m_io_queue;
 };
 
 }

--- a/Kernel/WorkQueue.h
+++ b/Kernel/WorkQueue.h
@@ -11,16 +11,13 @@
 
 namespace Kernel {
 
-extern WorkQueue* g_io_work;
-
 class WorkQueue {
     AK_MAKE_NONCOPYABLE(WorkQueue);
     AK_MAKE_NONMOVABLE(WorkQueue);
 
 public:
-    static void initialize();
-
-    WorkQueue(const char*);
+    WorkQueue(String&&);
+    ~WorkQueue();
 
     void queue(void (*function)(void*), void* data = nullptr, void (*free_data)(void*) = nullptr)
     {
@@ -53,6 +50,7 @@ private:
     WaitQueue m_wait_queue;
     IntrusiveList<WorkItem, RawPtr<WorkItem>, &WorkItem::m_node> m_items;
     SpinLock<u8> m_lock;
+    bool m_destroying { false };
 };
 
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -163,14 +163,12 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init()
     (void)SerialDevice::must_create(2).leak_ref();
     (void)SerialDevice::must_create(3).leak_ref();
 
-    VMWareBackdoor::the(); // don't wait until first mouse packet
-    HIDManagement::initialize();
-
     Thread::initialize();
     Process::initialize();
     Scheduler::initialize();
 
-    WorkQueue::initialize();
+    VMWareBackdoor::the(); // don't wait until first mouse packet
+    HIDManagement::initialize();
 
     {
         RefPtr<Thread> init_stage2_thread;


### PR DESCRIPTION
This creates a WorkQueue for each device that needs one. This solves
the problem where a function may block on the device, leading to
everything else using the same global WorkQueue to be blocked as well.