### PR TITLE
Kernel: Logic fix in the pledge syscall

### DIFF
--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -53,7 +53,7 @@ KResultOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params
         u32 new_promises = 0;
         if (!parse_pledge(promises, new_promises))
             return EINVAL;
-        if (m_promises && (!new_promises || new_promises & ~m_promises))
+        if (m_has_promises && (new_promises & ~m_promises))
             return EPERM;
 
         m_has_promises = true;
@@ -64,7 +64,7 @@ KResultOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params
         u32 new_execpromises = 0;
         if (!parse_pledge(execpromises, new_execpromises))
             return EINVAL;
-        if (m_execpromises && (!new_execpromises || new_execpromises & ~m_execpromises))
+        if (m_has_execpromises && (new_execpromises & ~m_execpromises))
             return EPERM;
         m_has_execpromises = true;
         m_execpromises = new_execpromises;


### PR DESCRIPTION
Pledge should check m_has_promises. Calling pledge("", nullptr)
does not fail on an already pledged process anymore.