### PR TITLE
Taskbar: Make clicks at the edges and corners work as expected

### DIFF
--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -30,6 +30,7 @@ private:
     void update_window_button(::Window&, bool);
     ::Window* find_window_owner(::Window&) const;
 
+    virtual void event(Core::Event&) override;
     virtual void wm_event(GUI::WMEvent&) override;
     virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
 


### PR DESCRIPTION
This makes it easy for the user to just throw the mouse at the corner
of the screen and obtain the desired outcome (eg. opening the start
menu), without having to precisely position the cursor over one of the
buttons.