### PR TITLE
Userland: POSIX compliance improvements

### DIFF
--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -27,6 +27,7 @@ struct spwd {
 
 class Account {
 public:
+    static Account self();
     static Result<Account, String> from_name(const char* username);
     static Result<Account, String> from_uid(uid_t uid);
 

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -27,9 +27,14 @@ struct spwd {
 
 class Account {
 public:
-    static Account self();
-    static Result<Account, String> from_name(const char* username);
-    static Result<Account, String> from_uid(uid_t uid);
+    enum class Read {
+        All,
+        PasswdOnly
+    };
+
+    static Account self(Read options = Read::All);
+    static Result<Account, String> from_name(const char* username, Read options = Read::All);
+    static Result<Account, String> from_uid(uid_t uid, Read options = Read::All);
 
     bool authenticate(const char* password) const;
     bool login() const;

--- a/Userland/Utilities/expr.cpp
+++ b/Userland/Utilities/expr.cpp
@@ -31,7 +31,7 @@ template<typename Fmt, typename... Args>
     warn("ERROR: \e[31m");
     warnln(StringView { fmt }, args...);
     warn("\e[0m");
-    exit(1);
+    exit(2);
 }
 
 class Expression {
@@ -569,12 +569,12 @@ int main(int argc, char** argv)
 {
     if (pledge("stdio", nullptr) < 0) {
         perror("pledge");
-        return 1;
+        return 3;
     }
 
     if (unveil(nullptr, nullptr) < 0) {
         perror("unveil");
-        return 1;
+        return 3;
     }
 
     if ((argc == 2 && "--help"sv == argv[1]) || argc == 1)
@@ -596,5 +596,5 @@ int main(int argc, char** argv)
         outln("{}", expression->string());
         break;
     }
-    return 0;
+    return expression->truth() ? 0 : 1;
 }

--- a/Userland/Utilities/id.cpp
+++ b/Userland/Utilities/id.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
 #include <alloca.h>
 #include <grp.h>
@@ -11,7 +12,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static int print_id_objects();
+static int print_id_objects(Core::Account const&);
 
 static bool flag_print_uid = false;
 static bool flag_print_gid = false;
@@ -57,100 +58,82 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    int status = print_id_objects();
-    return status;
+    auto account = Core::Account::self(Core::Account::Read::PasswdOnly);
+    return print_id_objects(account);
 }
 
-static bool print_uid_object(uid_t uid)
+static bool print_uid_object(Core::Account const& account)
 {
-    if (flag_print_name) {
-        struct passwd* pw = getpwuid(uid);
-        out("{}", pw ? pw->pw_name : "n/a");
-    } else
-        out("{}", uid);
+    if (flag_print_name)
+        out("{}", account.username());
+    else
+        out("{}", account.uid());
 
     return true;
 }
 
-static bool print_gid_object(gid_t gid)
+static bool print_gid_object(Core::Account const& account)
 {
     if (flag_print_name) {
-        struct group* gr = getgrgid(gid);
+        struct group* gr = getgrgid(account.gid());
         out("{}", gr ? gr->gr_name : "n/a");
     } else
-        out("{}", gid);
+        out("{}", account.gid());
+
     return true;
 }
 
-static bool print_gid_list()
+static bool print_gid_list(Core::Account const& account)
 {
-    int extra_gid_count = getgroups(0, nullptr);
-    if (extra_gid_count) {
-        auto* extra_gids = (gid_t*)alloca(extra_gid_count * sizeof(gid_t));
-        int rc = getgroups(extra_gid_count, extra_gids);
-
-        if (rc < 0) {
-            perror("\ngetgroups");
-            return false;
-        }
-
-        for (int g = 0; g < extra_gid_count; ++g) {
-            auto* gr = getgrgid(extra_gids[g]);
-            if (flag_print_name && gr)
-                out("{}", gr->gr_name);
-            else
-                out("{}", extra_gids[g]);
-            if (g != extra_gid_count - 1)
-                out(" ");
-        }
+    auto& extra_gids = account.extra_gids();
+    auto extra_gid_count = extra_gids.size();
+    for (size_t g = 0; g < extra_gid_count; ++g) {
+        auto gid = extra_gids[g];
+        auto* gr = getgrgid(gid);
+        if (flag_print_name && gr)
+            out("{}", gr->gr_name);
+        else
+            out("{}", gid);
+        if (g != extra_gid_count - 1)
+            out(" ");
     }
+
     return true;
 }
 
-static bool print_full_id_list()
+static bool print_full_id_list(Core::Account const& account)
 {
-    uid_t uid = getuid();
-    gid_t gid = getgid();
+    auto uid = account.uid();
+    auto gid = account.gid();
     struct passwd* pw = getpwuid(uid);
     struct group* gr = getgrgid(gid);
 
     out("uid={}({}) gid={}({})", uid, pw ? pw->pw_name : "n/a", gid, gr ? gr->gr_name : "n/a");
 
-    int extra_gid_count = getgroups(0, nullptr);
-    if (extra_gid_count) {
-        auto* extra_gids = (gid_t*)alloca(extra_gid_count * sizeof(gid_t));
-        int rc = getgroups(extra_gid_count, extra_gids);
-        if (rc < 0) {
-            perror("\ngetgroups");
-            return false;
-        }
-        out(" groups=");
-        for (int g = 0; g < extra_gid_count; ++g) {
-            auto* gr = getgrgid(extra_gids[g]);
-            if (gr)
-                out("{}({})", extra_gids[g], gr->gr_name);
-            else
-                out("{}", extra_gids[g]);
-            if (g != extra_gid_count - 1)
-                out(",");
-        }
+    for (auto extra_gid : account.extra_gids()) {
+        auto* gr = getgrgid(gid);
+        if (gr)
+            out(" {}({})", extra_gid, gr->gr_name);
+        else
+            out(" {}", extra_gid);
     }
+
     return true;
 }
 
-static int print_id_objects()
+static int print_id_objects(Core::Account const& account)
 {
     if (flag_print_uid) {
-        if (!print_uid_object(getuid()))
+        if (!print_uid_object(account))
             return 1;
     } else if (flag_print_gid) {
-        if (!print_gid_object(getgid()))
+        if (!print_gid_object(account))
             return 1;
     } else if (flag_print_gid_all) {
-        if (!print_gid_list())
+        if (!print_gid_list(account))
             return 1;
     } else {
-        if (!print_full_id_list())
+        if (!print_full_id_list(account))
             return 1;
     }
 

--- a/Userland/Utilities/pwd.cpp
+++ b/Userland/Utilities/pwd.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int, char**)
+{
+    char* cwd = getcwd(nullptr, 0);
+    puts(cwd);
+    free(cwd);
+    return 0;
+}

--- a/Userland/Utilities/tr.cpp
+++ b/Userland/Utilities/tr.cpp
@@ -12,26 +12,45 @@
 
 int main(int argc, char** argv)
 {
+    bool delete_flag = false;
     const char* from_chars = nullptr;
     const char* to_chars = nullptr;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(delete_flag, "Delete characters instead of replacing", nullptr, 'd');
     args_parser.add_positional_argument(from_chars, "Character to translate from", "from");
-    args_parser.add_positional_argument(to_chars, "Character to translate to", "to");
+    args_parser.add_positional_argument(to_chars, "Character to translate to", "to", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
-    // TODO: Support multiple characters to translate from and to
-    auto from = from_chars[0];
-    auto to = to_chars[0];
+    if (!to_chars && !delete_flag) {
+        args_parser.print_usage(stderr, argv[0]);
+        return 1;
+    }
 
-    for (;;) {
-        char ch = fgetc(stdin);
-        if (feof(stdin))
-            break;
-        if (ch == from)
-            putchar(to);
-        else
-            putchar(ch);
+    if (delete_flag) {
+        auto from_str = AK::StringView(from_chars);
+
+        for (;;) {
+            char ch = fgetc(stdin);
+            if (feof(stdin))
+                break;
+            if (!from_str.contains(ch))
+                putchar(ch);
+        }
+    } else {
+        // TODO: Support multiple characters to translate from and to
+        auto from = from_chars[0];
+        auto to = to_chars[0];
+
+        for (;;) {
+            char ch = fgetc(stdin);
+            if (feof(stdin))
+                break;
+            if (ch == from)
+                putchar(to);
+            else
+                putchar(ch);
+        }
     }
 
     return 0;


### PR DESCRIPTION
Fix various stuff I've encountered while attempting to bootstrap pkgsrc on SerenityOS. It's not working yet, at the very least `expr` still needs a POSIX basic regular expression engine for compliance (#8506).