### PR TITLE
LibJS: Add %TypedArray%.prototype.{map,filter}

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -202,6 +202,33 @@ static void initialize_typed_array_from_list(GlobalObject& global_object, TypedA
     }
 }
 
+// 23.2.4.2 TypedArrayCreate ( constructor, argumentList ), https://tc39.es/ecma262/#typedarray-create
+TypedArrayBase* typed_array_create(GlobalObject& global_object, FunctionObject& constructor, MarkedValueList arguments)
+{
+    auto& vm = global_object.vm();
+
+    auto argument_count = arguments.size();
+    auto first_argument = argument_count > 0 ? arguments[0] : js_undefined();
+
+    auto new_typed_array = vm.construct(constructor, constructor, move(arguments));
+    if (vm.exception())
+        return nullptr;
+    if (!new_typed_array.is_object() || !new_typed_array.as_object().is_typed_array()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "TypedArray");
+        return nullptr;
+    }
+    auto& typed_array = static_cast<TypedArrayBase&>(new_typed_array.as_object());
+    if (typed_array.viewed_array_buffer()->is_detached()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
+        return nullptr;
+    }
+    if (argument_count == 1 && first_argument.is_number() && typed_array.array_length() < first_argument.as_double()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::InvalidLength, "typed array");
+        return nullptr;
+    }
+    return &typed_array;
+}
+
 void TypedArrayBase::visit_edges(Visitor& visitor)
 {
     Object::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -455,6 +455,8 @@ private:
     virtual bool is_typed_array() const final { return true; }
 };
 
+TypedArrayBase* typed_array_create(GlobalObject& global_object, FunctionObject& constructor, MarkedValueList arguments);
+
 #define JS_DECLARE_TYPED_ARRAY(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     class ClassName : public TypedArray<Type> {                                             \
         JS_OBJECT(ClassName, TypedArray);                                                   \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -55,33 +55,6 @@ Value TypedArrayConstructor::construct(FunctionObject&)
     return {};
 }
 
-// 23.2.4.2 TypedArrayCreate ( constructor, argumentList ), https://tc39.es/ecma262/#typedarray-create
-static TypedArrayBase* typed_array_create(GlobalObject& global_object, FunctionObject& constructor, MarkedValueList arguments)
-{
-    auto& vm = global_object.vm();
-
-    auto argument_count = arguments.size();
-    auto first_argument = argument_count > 0 ? arguments[0] : js_undefined();
-
-    auto new_typed_array = vm.construct(constructor, constructor, move(arguments));
-    if (vm.exception())
-        return nullptr;
-    if (!new_typed_array.is_object() || !new_typed_array.as_object().is_typed_array()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "TypedArray");
-        return nullptr;
-    }
-    auto& typed_array = static_cast<TypedArrayBase&>(new_typed_array.as_object());
-    if (typed_array.viewed_array_buffer()->is_detached()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
-        return nullptr;
-    }
-    if (argument_count == 1 && first_argument.is_number() && typed_array.array_length() < first_argument.as_double()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::InvalidLength, "typed array");
-        return nullptr;
-    }
-    return &typed_array;
-}
-
 // 23.2.2.1 %TypedArray%.from ( source [ , mapfn [ , thisArg ] ] ), https://tc39.es/ecma262/#sec-%typedarray%.from
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayConstructor::from)
 {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -45,6 +45,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(reverse);
     JS_DECLARE_NATIVE_FUNCTION(copy_within);
     JS_DECLARE_NATIVE_FUNCTION(filter);
+    JS_DECLARE_NATIVE_FUNCTION(map);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -44,6 +44,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(set);
     JS_DECLARE_NATIVE_FUNCTION(reverse);
     JS_DECLARE_NATIVE_FUNCTION(copy_within);
+    JS_DECLARE_NATIVE_FUNCTION(filter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.filter.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.filter.js
@@ -1,0 +1,217 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint8ClampedArray,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.filter).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.filter).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function argumentErrorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().filter();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.filter() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().filter(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => argumentErrorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => argumentErrorTests(T));
+
+    test("Symbol.species returns a typed array with a different content type", () => {
+        TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return BigUint64Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().filter(() => {});
+            }).toThrowWithMessage(TypeError, `Can't create BigUint64Array from ${T.name}`);
+
+            expect(result).toBeUndefined();
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Uint32Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().filter(() => {});
+            }).toThrowWithMessage(TypeError, `Can't create Uint32Array from ${T.name}`);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    test("Symbol.species doesn't return a typed array", () => {
+        TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().filter(() => {});
+            }).toThrowWithMessage(TypeError, "Not a TypedArray object");
+
+            expect(result).toBeUndefined();
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().filter(() => {});
+            }).toThrowWithMessage(TypeError, "Not a TypedArray object");
+
+            expect(result).toBeUndefined();
+        });
+    });
+});
+
+describe("normal behaviour", () => {
+    test("never calls callback with empty array", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([]).filter(() => {
+                    callbackCalled++;
+                })
+            ).toHaveLength(0);
+            expect(callbackCalled).toBe(0);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([]).filter(() => {
+                    callbackCalled++;
+                })
+            ).toHaveLength(0);
+            expect(callbackCalled).toBe(0);
+        });
+    });
+
+    test("calls callback once for every item", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([1, 2, 3]).filter(() => {
+                    callbackCalled++;
+                })
+            ).toHaveLength(0);
+            expect(callbackCalled).toBe(3);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([1n, 2n, 3n]).filter(() => {
+                    callbackCalled++;
+                })
+            ).toHaveLength(0);
+            expect(callbackCalled).toBe(3);
+        });
+    });
+
+    test("can filter based on callback return value", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const evenNumbers = new T([0, 1, 2, 3, 4, 5, 6, 7]).filter(x => x % 2 === 0);
+            expect(evenNumbers).toHaveLength(4);
+            expect(evenNumbers[0]).toBe(0);
+            expect(evenNumbers[1]).toBe(2);
+            expect(evenNumbers[2]).toBe(4);
+            expect(evenNumbers[3]).toBe(6);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const evenNumbers = new T([0n, 1n, 2n, 3n, 4n, 5n, 6n, 7n]).filter(x => x % 2n === 0n);
+            expect(evenNumbers).toHaveLength(4);
+            expect(evenNumbers[0]).toBe(0n);
+            expect(evenNumbers[1]).toBe(2n);
+            expect(evenNumbers[2]).toBe(4n);
+            expect(evenNumbers[3]).toBe(6n);
+        });
+    });
+
+    test("Symbol.species returns a typed array with a matching content type", () => {
+        TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Uint32Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray([1, 2, 3]).filter(value => value % 2 === 0);
+            }).not.toThrowWithMessage(TypeError, `Can't create Uint32Array from ${T.name}`);
+
+            expect(result).toBeInstanceOf(Uint32Array);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(2);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return BigUint64Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray([1n, 2n, 3n]).filter(value => value % 2n === 0n);
+            }).not.toThrowWithMessage(TypeError, `Can't create BigUint64Array from ${T.name}`);
+
+            expect(result).toBeInstanceOf(BigUint64Array);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(2n);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.map.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.map.js
@@ -1,0 +1,259 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint8ClampedArray,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.map).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.map).toHaveLength(1);
+    });
+});
+
+describe("errors", () => {
+    function argumentErrorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().map();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray.prototype.map() requires at least one argument"
+            );
+        });
+
+        test(`callback must be a function (${T.name})`, () => {
+            expect(() => {
+                new T().map(undefined);
+            }).toThrowWithMessage(TypeError, "undefined is not a function");
+        });
+    }
+
+    TYPED_ARRAYS.forEach(T => argumentErrorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(T => argumentErrorTests(T));
+
+    test("throws if mappedValue is not the same type of the typed array", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            let result;
+
+            expect(() => {
+                result = new T([1, 2, 3]).map((value, index) => {
+                    callbackCalled++;
+                    return index % 2 === 0 ? 1n : 1;
+                });
+            }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+
+            expect(callbackCalled).toBe(1);
+            expect(result).toBeUndefined();
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            let result;
+
+            expect(() => {
+                result = new T([1n, 2n, 3n]).map((value, index) => {
+                    callbackCalled++;
+                    return index % 2 === 0 ? 1 : 1n;
+                });
+            }).toThrowWithMessage(TypeError, "Cannot convert number to BigInt");
+
+            expect(callbackCalled).toBe(1);
+            expect(result).toBeUndefined();
+        });
+    });
+
+    test("Symbol.species returns a typed array with a different content type", () => {
+        TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return BigUint64Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().map(() => {});
+            }).toThrowWithMessage(TypeError, `Can't create BigUint64Array from ${T.name}`);
+
+            expect(result).toBeUndefined();
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Uint32Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().map(() => {});
+            }).toThrowWithMessage(TypeError, `Can't create Uint32Array from ${T.name}`);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    test("Symbol.species doesn't return a typed array", () => {
+        TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().map(() => {});
+            }).toThrowWithMessage(TypeError, "Not a TypedArray object");
+
+            expect(result).toBeUndefined();
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray().map(() => {});
+            }).toThrowWithMessage(TypeError, "Not a TypedArray object");
+
+            expect(result).toBeUndefined();
+        });
+    });
+});
+
+describe("normal behaviour", () => {
+    test("never calls callback with empty array", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([]).map(() => {
+                    callbackCalled++;
+                })
+            ).toHaveLength(0);
+            expect(callbackCalled).toBe(0);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([]).map(() => {
+                    callbackCalled++;
+                })
+            ).toHaveLength(0);
+            expect(callbackCalled).toBe(0);
+        });
+    });
+
+    test("calls callback once for every item", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([1, 2, 3]).map(value => {
+                    callbackCalled++;
+                    // NOTE: This is just to prevent a conversion exception.
+                    return value;
+                })
+            ).toHaveLength(3);
+            expect(callbackCalled).toBe(3);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            let callbackCalled = 0;
+            expect(
+                new T([1n, 2n, 3n]).map(value => {
+                    callbackCalled++;
+                    // NOTE: This is just to prevent a conversion exception.
+                    return value;
+                })
+            ).toHaveLength(3);
+            expect(callbackCalled).toBe(3);
+        });
+    });
+
+    test("can map based on callback return value", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const squaredNumbers = new T([0, 1, 2, 3, 4]).map(x => x ** 2);
+            expect(squaredNumbers).toHaveLength(5);
+            expect(squaredNumbers[0]).toBe(0);
+            expect(squaredNumbers[1]).toBe(1);
+            expect(squaredNumbers[2]).toBe(4);
+            expect(squaredNumbers[3]).toBe(9);
+            expect(squaredNumbers[4]).toBe(16);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const squaredNumbers = new T([0n, 1n, 2n, 3n, 4n]).map(x => x ** 2n);
+            expect(squaredNumbers).toHaveLength(5);
+            expect(squaredNumbers[0]).toBe(0n);
+            expect(squaredNumbers[1]).toBe(1n);
+            expect(squaredNumbers[2]).toBe(4n);
+            expect(squaredNumbers[3]).toBe(9n);
+            expect(squaredNumbers[4]).toBe(16n);
+        });
+    });
+
+    test("Symbol.species returns a typed array with a matching content type", () => {
+        TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return Uint32Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray([1, 2, 3]).map(value => value + 2);
+            }).not.toThrowWithMessage(TypeError, `Can't create Uint32Array from ${T.name}`);
+
+            expect(result).toBeInstanceOf(Uint32Array);
+            expect(result).toHaveLength(3);
+            expect(result[0]).toBe(3);
+            expect(result[1]).toBe(4);
+            expect(result[2]).toBe(5);
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            class TypedArray extends T {
+                static get [Symbol.species]() {
+                    return BigUint64Array;
+                }
+            }
+
+            let result;
+
+            expect(() => {
+                result = new TypedArray([1n, 2n, 3n]).map(value => value + 2n);
+            }).not.toThrowWithMessage(TypeError, `Can't create BigUint64Array from ${T.name}`);
+
+            expect(result).toBeInstanceOf(BigUint64Array);
+            expect(result).toHaveLength(3);
+            expect(result[0]).toBe(3n);
+            expect(result[1]).toBe(4n);
+            expect(result[2]).toBe(5n);
+        });
+    });
+});


### PR DESCRIPTION
This fixes 114 test262 cases.

I'm not too happy with how I get the default constructor in
typed_array_species_create, but it works for now.

As a side note, test262 does not test the content type exception in TypedArraySpeciesCreate.
Plus, v8 and SpiderMonkey do not do this content type check (but JSC does).
Should we file issue(s) for this?