### PR TITLE
LibVT: Always check intermediate bytes in CSI sequences

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -226,7 +226,8 @@ protected:
 
     void emit_string(const StringView&);
 
-    void alter_mode(bool should_set, Parameters, Intermediates);
+    void alter_ansi_mode(bool should_set, Parameters);
+    void alter_private_mode(bool should_set, Parameters);
 
     // CUU – Cursor Up
     void CUU(Parameters);
@@ -274,10 +275,16 @@ protected:
     void DECSTBM(Parameters);
 
     // RM – Reset Mode
-    void RM(Parameters, Intermediates);
+    void RM(Parameters);
+
+    // DECRST - DEC Private Mode Reset
+    void DECRST(Parameters);
 
     // SM – Set Mode
-    void SM(Parameters, Intermediates);
+    void SM(Parameters);
+
+    // DECSET - Dec Private Mode Set
+    void DECSET(Parameters);
 
     // DA - Device Attributes
     void DA(Parameters);


### PR DESCRIPTION
Previously, we only checked the intermediate bytes for those escape
sequences that performed different operations based on their
intermediate bytes. This lead to a crash when `CSI ?1001 r` was
incorrectly parsed as `CSI Pt ; Pb r` (note the missing question mark),
as seen in #8559.