### PR TITLE
PixelPaint: Make sure that an Image always has an active layer

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -134,11 +134,9 @@ void LayerListWidget::mousedown_event(GUI::MouseEvent& event)
     Gfx::IntPoint translated_event_point = { 0, vertical_scrollbar().value() + event.y() };
 
     auto gadget_index = gadget_at(translated_event_point);
-    if (!gadget_index.has_value()) {
-        if (on_layer_select)
-            on_layer_select(nullptr);
+    if (!gadget_index.has_value())
         return;
-    }
+
     m_moving_gadget_index = gadget_index;
     m_selected_layer_index = gadget_index.value();
     m_moving_event_origin = translated_event_point;

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -310,12 +310,18 @@ void LayerListWidget::set_selected_layer(Layer* layer)
 {
     if (!m_image)
         return;
-    for (size_t i = 0; i < m_image->layer_count(); ++i)
-        m_image->layer(i).set_selected(layer == &m_image->layer(i));
+    for (size_t i = 0; i < m_image->layer_count(); ++i) {
+        if (layer == &m_image->layer(i)) {
+            m_image->layer(i).set_selected(true);
+            scroll_into_view(m_gadgets[i].rect, false, true);
+            m_selected_layer_index = i;
+        } else {
+            m_image->layer(i).set_selected(false);
+        }
+    }
     if (on_layer_select)
         on_layer_select(layer);
 
-    scroll_into_view(m_gadgets[m_selected_layer_index].rect, false, true);
     update();
 }
 


### PR DESCRIPTION
This PR fixes some cases where an Image would be in a state without a selected layer.

**PixelPaint/LayerListWidget: Only scroll into view when needed**
Previously we would crash when deleting the last layer `since scroll_into_view()` was still called.

**PixelPaint: Make sure that a layer is always selected**
Make the background layer the selected layer when creating a new image. Also select the layer beneath the active layer after deleting it.

**PixelPaint/LayerListWidget: Don't deselect layers**
Since no action can be made without a selected layer, let's ignore if a user tries to click outside of a layer gadget. The only time a nullptr is passed to `on_layer_select()` now is when we have deleted all layers, which is still possible.