### PR TITLE
LibCore: Add File methods for determining absolute path and current working directory

### DIFF
--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -106,7 +106,7 @@ bool File::is_device() const
     return S_ISBLK(stat.st_mode) || S_ISCHR(stat.st_mode);
 }
 
-bool File::is_device(const String& filename)
+bool File::is_device(String const& filename)
 {
     struct stat st;
     if (stat(filename.characters(), &st) < 0)
@@ -122,7 +122,7 @@ bool File::is_directory() const
     return S_ISDIR(stat.st_mode);
 }
 
-bool File::is_directory(const String& filename)
+bool File::is_directory(String const& filename)
 {
     struct stat st;
     if (stat(filename.characters(), &st) < 0)
@@ -138,7 +138,7 @@ bool File::is_link() const
     return S_ISLNK(stat.st_mode);
 }
 
-bool File::is_link(const String& filename)
+bool File::is_link(String const& filename)
 {
     struct stat st;
     if (lstat(filename.characters(), &st) < 0)
@@ -146,13 +146,13 @@ bool File::is_link(const String& filename)
     return S_ISLNK(st.st_mode);
 }
 
-bool File::exists(const String& filename)
+bool File::exists(String const& filename)
 {
     struct stat st;
     return stat(filename.characters(), &st) == 0;
 }
 
-String File::real_path_for(const String& filename)
+String File::real_path_for(String const& filename)
 {
     if (filename.is_null())
         return {};
@@ -162,7 +162,7 @@ String File::real_path_for(const String& filename)
     return real_path;
 }
 
-bool File::ensure_parent_directories(const String& path)
+bool File::ensure_parent_directories(String const& path)
 {
     VERIFY(path.starts_with("/"));
 
@@ -172,7 +172,7 @@ bool File::ensure_parent_directories(const String& path)
     char* parent_buffer = strdup(path.characters());
     ScopeGuard free_buffer = [parent_buffer] { free(parent_buffer); };
 
-    const char* parent = dirname(parent_buffer);
+    char const* parent = dirname(parent_buffer);
 
     int rc = mkdir(parent, 0755);
     saved_errno = errno;
@@ -313,7 +313,7 @@ NonnullRefPtr<File> File::standard_error()
     return *stderr_file;
 }
 
-static String get_duplicate_name(const String& path, int duplicate_count)
+static String get_duplicate_name(String const& path, int duplicate_count)
 {
     if (duplicate_count == 0) {
         return path;
@@ -338,7 +338,7 @@ static String get_duplicate_name(const String& path, int duplicate_count)
     return duplicated_name.build();
 }
 
-Result<void, File::CopyError> File::copy_file_or_directory(const String& dst_path, const String& src_path, RecursionMode recursion_mode, LinkMode link_mode, AddDuplicateFileMarker add_duplicate_file_marker)
+Result<void, File::CopyError> File::copy_file_or_directory(String const& dst_path, String const& src_path, RecursionMode recursion_mode, LinkMode link_mode, AddDuplicateFileMarker add_duplicate_file_marker)
 {
     if (add_duplicate_file_marker == AddDuplicateFileMarker::Yes) {
         int duplicate_count = 0;
@@ -376,7 +376,7 @@ Result<void, File::CopyError> File::copy_file_or_directory(const String& dst_pat
     return copy_file(dst_path, src_stat, source);
 }
 
-Result<void, File::CopyError> File::copy_file(const String& dst_path, const struct stat& src_stat, File& source)
+Result<void, File::CopyError> File::copy_file(String const& dst_path, struct stat const& src_stat, File& source)
 {
     int dst_fd = creat(dst_path.characters(), 0666);
     if (dst_fd < 0) {
@@ -426,7 +426,7 @@ Result<void, File::CopyError> File::copy_file(const String& dst_path, const stru
     return {};
 }
 
-Result<void, File::CopyError> File::copy_directory(const String& dst_path, const String& src_path, const struct stat& src_stat, LinkMode link)
+Result<void, File::CopyError> File::copy_directory(String const& dst_path, String const& src_path, struct stat const& src_stat, LinkMode link)
 {
     if (mkdir(dst_path.characters(), 0755) < 0)
         return CopyError { OSError(errno), false };
@@ -461,7 +461,7 @@ Result<void, File::CopyError> File::copy_directory(const String& dst_path, const
     return {};
 }
 
-Result<void, OSError> File::link_file(const String& dst_path, const String& src_path)
+Result<void, OSError> File::link_file(String const& dst_path, String const& src_path)
 {
     int duplicate_count = 0;
     while (access(get_duplicate_name(dst_path, duplicate_count).characters(), F_OK) == 0) {
@@ -478,7 +478,7 @@ Result<void, OSError> File::link_file(const String& dst_path, const String& src_
     return {};
 }
 
-Result<void, File::RemoveError> File::remove(const String& path, RecursionMode mode, bool force)
+Result<void, File::RemoveError> File::remove(String const& path, RecursionMode mode, bool force)
 {
     struct stat path_stat;
     if (lstat(path.characters(), &path_stat) < 0) {

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -193,6 +193,20 @@ bool File::ensure_parent_directories(const String& path)
     return rc == 0;
 }
 
+String File::current_working_directory()
+{
+    char* cwd = getcwd(nullptr, 0);
+    if (!cwd) {
+        perror("getcwd");
+        return {};
+    }
+
+    auto cwd_as_string = String(cwd);
+    free(cwd);
+
+    return cwd_as_string;
+}
+
 #ifdef __serenity__
 
 String File::read_link(String const& link_path)

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -207,6 +207,20 @@ String File::current_working_directory()
     return cwd_as_string;
 }
 
+String File::absolute_path(String const& path)
+{
+    if (File::exists(path))
+        return File::real_path_for(path);
+
+    if (path.starts_with("/"sv))
+        return LexicalPath::canonicalized_path(path);
+
+    auto working_directory = File::current_working_directory();
+    auto full_path = LexicalPath::join(working_directory, path);
+
+    return LexicalPath::canonicalized_path(full_path.string());
+}
+
 #ifdef __serenity__
 
 String File::read_link(String const& link_path)

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -35,6 +35,7 @@ public:
 
     static bool exists(const String& filename);
     static bool ensure_parent_directories(const String& path);
+    static String current_working_directory();
 
     enum class RecursionMode {
         Allowed,

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -36,6 +36,7 @@ public:
     static bool exists(const String& filename);
     static bool ensure_parent_directories(const String& path);
     static String current_working_directory();
+    static String absolute_path(String const& path);
 
     enum class RecursionMode {
         Allowed,

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -25,16 +25,16 @@ public:
     void set_filename(const String filename) { m_filename = move(filename); }
 
     bool is_directory() const;
-    static bool is_directory(const String& filename);
+    static bool is_directory(String const& filename);
 
     bool is_device() const;
-    static bool is_device(const String& filename);
+    static bool is_device(String const& filename);
 
     bool is_link() const;
-    static bool is_link(const String& filename);
+    static bool is_link(String const& filename);
 
-    static bool exists(const String& filename);
-    static bool ensure_parent_directories(const String& path);
+    static bool exists(String const& filename);
+    static bool ensure_parent_directories(String const& path);
     static String current_working_directory();
     static String absolute_path(String const& path);
 
@@ -58,19 +58,19 @@ public:
         bool tried_recursing;
     };
 
-    static Result<void, CopyError> copy_file(const String& dst_path, const struct stat& src_stat, File& source);
-    static Result<void, CopyError> copy_directory(const String& dst_path, const String& src_path, const struct stat& src_stat, LinkMode = LinkMode::Disallowed);
-    static Result<void, CopyError> copy_file_or_directory(const String& dst_path, const String& src_path, RecursionMode = RecursionMode::Allowed, LinkMode = LinkMode::Disallowed, AddDuplicateFileMarker = AddDuplicateFileMarker::Yes);
+    static Result<void, CopyError> copy_file(String const& dst_path, struct stat const& src_stat, File& source);
+    static Result<void, CopyError> copy_directory(String const& dst_path, String const& src_path, struct stat const& src_stat, LinkMode = LinkMode::Disallowed);
+    static Result<void, CopyError> copy_file_or_directory(String const& dst_path, String const& src_path, RecursionMode = RecursionMode::Allowed, LinkMode = LinkMode::Disallowed, AddDuplicateFileMarker = AddDuplicateFileMarker::Yes);
 
-    static String real_path_for(const String& filename);
+    static String real_path_for(String const& filename);
     static String read_link(String const& link_path);
-    static Result<void, OSError> link_file(const String& dst_path, const String& src_path);
+    static Result<void, OSError> link_file(String const& dst_path, String const& src_path);
 
     struct RemoveError {
         String file;
         OSError error_code;
     };
-    static Result<void, RemoveError> remove(const String& path, RecursionMode, bool force);
+    static Result<void, RemoveError> remove(String const& path, RecursionMode, bool force);
 
     virtual bool open(OpenMode) override;
 


### PR DESCRIPTION
The motivation for this is to generate absolute paths for non-existent files in unveil calls, as `realpath` will not work if the file does not exist.