### PR TITLE
Documentation: Add a package manager section to the FAQ

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -25,3 +25,11 @@ If you can't figure out what to do, ask in the `#build-problems` channel on Disc
 ## Why don't you use `$LIBRARY` instead of implementing `$FEATURE` yourself?
 
 The SerenityOS project tries to maximize hackability, accountability, and fun(!) by implementing everything ourselves.
+
+## Does SerenityOS have a package manager?
+
+No, SerenityOS does not have a package manager. The project uses a monorepo approach, meaning that all software is built in the same style and using the same tools. There is no reason to have something like a package manager because of this.
+
+*However* there are ports which can be found in the [Ports directory](../Ports). A port is a piece of software that can optionally be installed, might have not been built by us but supports running on SerenityOS. They act quite similar to packages, coming with an install script each.
+
+Currently when running the system in a virtual machine, ports need to be cross compiled on the host and added to the file system image before booting. Then its also possible to configure the build system to [in- or exclude components](./BuildInstructions.md#component-configuration) from a build.


### PR DESCRIPTION
People are commonly asking about a package manager in
serenity. This patch adds an answer the FAQ, explaining
why there is no need for packages as well as different
possible ways to add or remove software installed on the
system.
