### PR TITLE
LibC: Make sure crt0 and crt0_shared are built before LibC

### DIFF
--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -118,6 +118,7 @@ set_property(
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
 serenity_libc(LibC c)
+add_dependencies(LibC crt0 crt0_shared)
 target_link_libraries(LibC ssp system)
 
 # We mark LibCStatic as a dependency of LibC because this triggers the build of the LibCStatic target


### PR DESCRIPTION
We need these two object files in order for ld to work.