### PR TITLE
CI: Run the commit linter for Draft Pull Requests

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -5,7 +5,7 @@ on: [pull_request_target]
 jobs:
   lint_commits:
     runs-on: ubuntu-20.04
-    if: always() && github.repository == 'SerenityOS/serenity' && !github.event.pull_request.draft
+    if: always() && github.repository == 'SerenityOS/serenity'
 
     steps:
       - name: Get PR Commits
@@ -54,7 +54,7 @@ jobs:
           error: 'Commit title ends in a period'
 
       - name: Comment on PR
-        if: ${{ failure() }}
+        if: ${{ failure() && !github.event.pull_request.draft }}
         uses: IdanHo/comment-on-pr@5f51df338210754f519f721f8320d8f72525a4d0
         env:
           GITHUB_TOKEN: ${{ secrets.BUGGIEBOT }}


### PR DESCRIPTION
The commit linter will now run for draft pull requests as well, but BuggieBot will not post a message on failing draft PRs.