### PR TITLE
LibJS: Implement RegExp.prototype.hasIndices proposal (and related RegExp.flags/source fixes) 

### DIFF
--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -108,13 +108,13 @@
     __JS_ENUMERATE(toPrimitive, to_primitive)                \
     __JS_ENUMERATE(toStringTag, to_string_tag)
 
-#define JS_ENUMERATE_REGEXP_FLAGS                           \
-    __JS_ENUMERATE(global, global, g, Global)               \
-    __JS_ENUMERATE(ignoreCase, ignore_case, i, Insensitive) \
-    __JS_ENUMERATE(multiline, multiline, m, Multiline)      \
-    __JS_ENUMERATE(dotAll, dot_all, s, SingleLine)          \
-    __JS_ENUMERATE(unicode, unicode, u, Unicode)            \
-    __JS_ENUMERATE(sticky, sticky, y, Sticky)
+#define JS_ENUMERATE_REGEXP_FLAGS              \
+    __JS_ENUMERATE(global, global, g)          \
+    __JS_ENUMERATE(ignoreCase, ignore_case, i) \
+    __JS_ENUMERATE(multiline, multiline, m)    \
+    __JS_ENUMERATE(dotAll, dot_all, s)         \
+    __JS_ENUMERATE(unicode, unicode, u)        \
+    __JS_ENUMERATE(sticky, sticky, y)
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -109,6 +109,7 @@
     __JS_ENUMERATE(toStringTag, to_string_tag)
 
 #define JS_ENUMERATE_REGEXP_FLAGS              \
+    __JS_ENUMERATE(hasIndices, has_indices, d) \
     __JS_ENUMERATE(global, global, g)          \
     __JS_ENUMERATE(ignoreCase, ignore_case, i) \
     __JS_ENUMERATE(multiline, multiline, m)    \

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -789,7 +789,7 @@ NonnullRefPtr<RegExpLiteral> Parser::parse_regexp_literal()
         HashTable<char> seen_flags;
         for (size_t i = 0; i < flags.length(); ++i) {
             auto flag = flags.substring_view(i, 1);
-            if (!flag.is_one_of("g", "i", "m", "s", "u", "y"))
+            if (!flag.is_one_of("d", "g", "i", "m", "s", "u", "y"))
                 syntax_error(String::formatted("Invalid RegExp flag '{}'", flag), Position { flags_start.line, flags_start.column + i });
             if (seen_flags.contains(*flag.characters_without_null_termination()))
                 syntax_error(String::formatted("Repeated RegExp flag '{}'", flag), Position { flags_start.line, flags_start.column + i });

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -198,6 +198,7 @@ namespace JS {
     P(includes)                              \
     P(index)                                 \
     P(indexOf)                               \
+    P(indices)                               \
     P(info)                                  \
     P(input)                                 \
     P(instant)                               \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -188,6 +188,7 @@ namespace JS {
     P(globalThis)                            \
     P(groups)                                \
     P(has)                                   \
+    P(hasIndices)                            \
     P(hasOwn)                                \
     P(hasOwnProperty)                        \
     P(hypot)                                 \

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -16,7 +16,7 @@ namespace JS {
 static Flags options_from(GlobalObject& global_object, const String& flags)
 {
     auto& vm = global_object.vm();
-    bool g = false, i = false, m = false, s = false, u = false, y = false;
+    bool d = false, g = false, i = false, m = false, s = false, u = false, y = false;
     Flags options {
         // JS regexps are all 'global' by default as per our definition, but the "global" flag enables "stateful".
         // FIXME: Enable 'BrowserExtended' only if in a browser context.
@@ -26,6 +26,11 @@ static Flags options_from(GlobalObject& global_object, const String& flags)
 
     for (auto ch : flags) {
         switch (ch) {
+        case 'd':
+            if (d)
+                vm.throw_exception<SyntaxError>(global_object, ErrorType::RegExpObjectRepeatedFlag, ch);
+            d = true;
+            break;
         case 'g':
             if (g)
                 vm.throw_exception<SyntaxError>(global_object, ErrorType::RegExpObjectRepeatedFlag, ch);

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -39,7 +39,7 @@ void RegExpPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.flags, flags, {}, Attribute::Configurable);
     define_native_accessor(vm.names.source, source, {}, Attribute::Configurable);
 
-#define __JS_ENUMERATE(flagName, flag_name, flag_char, ECMAScriptFlagName) \
+#define __JS_ENUMERATE(flagName, flag_name, flag_char) \
     define_native_accessor(vm.names.flagName, flag_name, {}, Attribute::Configurable);
     JS_ENUMERATE_REGEXP_FLAGS
 #undef __JS_ENUMERATE
@@ -230,7 +230,7 @@ static Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Str
 // 22.2.5.9 get RegExp.prototype.multiline, https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline
 // 22.2.5.14 get RegExp.prototype.sticky, https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky
 // 22.2.5.17 get RegExp.prototype.unicode, https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode
-#define __JS_ENUMERATE(flagName, flag_name, flag_char, ECMAScriptFlagName)           \
+#define __JS_ENUMERATE(flagName, flag_name, flag_char)                               \
     JS_DEFINE_NATIVE_GETTER(RegExpPrototype::flag_name)                              \
     {                                                                                \
         auto* regexp_object = this_object_from(vm, global_object);                   \
@@ -244,8 +244,8 @@ static Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Str
             return {};                                                               \
         }                                                                            \
                                                                                      \
-        auto flags = static_cast<RegExpObject*>(regexp_object)->declared_options();  \
-        return Value(flags.has_flag_set(ECMAScriptFlags::ECMAScriptFlagName));       \
+        auto const& flags = static_cast<RegExpObject*>(regexp_object)->flags();      \
+        return Value(flags.contains(#flag_char##sv));                                \
     }
 JS_ENUMERATE_REGEXP_FLAGS
 #undef __JS_ENUMERATE
@@ -259,11 +259,11 @@ JS_DEFINE_NATIVE_GETTER(RegExpPrototype::flags)
 
     StringBuilder builder(8);
 
-#define __JS_ENUMERATE(flagName, flag_name, flag_char, ECMAScriptFlagName) \
-    auto flag_##flag_name = this_object->get(vm.names.flagName);           \
-    if (vm.exception())                                                    \
-        return {};                                                         \
-    if (flag_##flag_name.to_boolean())                                     \
+#define __JS_ENUMERATE(flagName, flag_name, flag_char)           \
+    auto flag_##flag_name = this_object->get(vm.names.flagName); \
+    if (vm.exception())                                          \
+        return {};                                               \
+    if (flag_##flag_name.to_boolean())                           \
         builder.append(#flag_char);
     JS_ENUMERATE_REGEXP_FLAGS
 #undef __JS_ENUMERATE

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -224,6 +224,7 @@ static Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Str
     return regexp_builtin_exec(global_object, static_cast<RegExpObject&>(regexp_object), string);
 }
 
+// 1.1.4.3 get RegExp.prototype.hasIndices, https://tc39.es/proposal-regexp-match-indices/#sec-get-regexp.prototype.hasIndices
 // 22.2.5.3 get RegExp.prototype.dotAll, https://tc39.es/ecma262/#sec-get-regexp.prototype.dotAll
 // 22.2.5.5 get RegExp.prototype.global, https://tc39.es/ecma262/#sec-get-regexp.prototype.global
 // 22.2.5.6 get RegExp.prototype.ignoreCase, https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -274,19 +274,18 @@ JS_DEFINE_NATIVE_GETTER(RegExpPrototype::flags)
 // 22.2.5.12 get RegExp.prototype.source, https://tc39.es/ecma262/#sec-get-regexp.prototype.source
 JS_DEFINE_NATIVE_GETTER(RegExpPrototype::source)
 {
-    auto this_object = this_object_from(vm, global_object);
-    if (!this_object)
-        return {};
-
-    auto* regexp_prototype = global_object.regexp_prototype();
-    if (this_object == regexp_prototype)
-        return js_string(vm, "(?:)");
-
-    auto regexp_object = regexp_object_from(vm, global_object);
+    auto* regexp_object = this_object_from(vm, global_object);
     if (!regexp_object)
         return {};
 
-    return js_string(vm, escape_regexp_pattern(*regexp_object));
+    if (!is<RegExpObject>(regexp_object)) {
+        if (same_value(regexp_object, global_object.regexp_prototype()))
+            return js_string(vm, "(?:)");
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "RegExp");
+        return {};
+    }
+
+    return js_string(vm, escape_regexp_pattern(static_cast<RegExpObject&>(*regexp_object)));
 }
 
 // 22.2.5.2 RegExp.prototype.exec ( string ), https://tc39.es/ecma262/#sec-regexp.prototype.exec

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.flags.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.flags.js
@@ -1,5 +1,6 @@
 test("basic functionality", () => {
     expect(/foo/.flags).toBe("");
+    expect(/foo/d.flags).toBe("d");
     expect(/foo/g.flags).toBe("g");
     expect(/foo/i.flags).toBe("i");
     expect(/foo/m.flags).toBe("m");
@@ -7,5 +8,5 @@ test("basic functionality", () => {
     expect(/foo/u.flags).toBe("u");
     expect(/foo/y.flags).toBe("y");
     // prettier-ignore
-    expect(/foo/sgimyu.flags).toBe("gimsuy");
+    expect(/foo/dsgimyu.flags).toBe("dgimsuy");
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.hasIndices.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.hasIndices.js
@@ -1,0 +1,53 @@
+test("basic functionality", () => {
+    const str = "foo bar foo";
+
+    var regex = new RegExp("bar");
+    expect(regex.hasIndices).toBeFalse();
+    expect(regex.exec(str).indices).toBeUndefined();
+
+    regex = new RegExp("foo", "gd");
+    expect(regex.hasIndices).toBeTrue();
+    expect(regex.exec(str).indices[0]).toEqual([0, 3]);
+    expect(regex.exec(str).indices[0]).toEqual([8, 11]);
+
+    regex = new RegExp("(foo)", "gd");
+    expect(regex.hasIndices).toBeTrue();
+    {
+        var result = regex.exec(str).indices;
+        expect(result.length).toBe(2);
+        expect(result[0]).toEqual([0, 3]);
+        expect(result[1]).toEqual([0, 3]);
+        expect(result.groups).toBeUndefined();
+    }
+    {
+        var result = regex.exec(str).indices;
+        expect(result.length).toBe(2);
+        expect(result[0]).toEqual([8, 11]);
+        expect(result[1]).toEqual([8, 11]);
+        expect(result.groups).toBeUndefined();
+    }
+
+    regex = new RegExp("(?<group_name>foo)", "gd");
+    expect(regex.hasIndices).toBeTrue();
+    {
+        var result = regex.exec(str).indices;
+        expect(result.length).toBe(2);
+        expect(result[0]).toEqual([0, 3]);
+        expect(result[1]).toEqual([0, 3]);
+        expect(result.groups).toEqual({ group_name: [0, 3] });
+    }
+    {
+        var result = regex.exec(str).indices;
+        expect(result.length).toBe(2);
+        expect(result[0]).toEqual([8, 11]);
+        expect(result[1]).toEqual([8, 11]);
+        expect(result.groups).toEqual({ group_name: [8, 11] });
+    }
+
+    regex = /(?<keyword>let|const|var)\s+(?<id>[a-zA-Z_$][0-9a-zA-Z_$]*)/d;
+    expect(regex.hasIndices).toBeTrue();
+    {
+        var result = regex.exec("let foo").indices;
+        expect(result.groups).toEqual({ keyword: [0, 3], id: [4, 7] });
+    }
+});


### PR DESCRIPTION
Fixes 20 test262 tests.