### PR TITLE
AK: Allow instantiation of Vector<T, 0> even when T is incomplete

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -775,10 +775,26 @@ private:
     StorageType& raw_first() { return raw_at(0); }
     StorageType& raw_at(size_t index) { return *slot(index); }
 
+    constexpr static size_t inline_storage_size()
+    {
+        if constexpr (inline_capacity == 0)
+            return 0;
+        else
+            return inline_capacity * sizeof(StorageType);
+    }
+
+    constexpr static size_t inline_storage_align()
+    {
+        if constexpr (inline_capacity == 0)
+            return 1;
+        else
+            return alignof(StorageType);
+    }
+
     size_t m_size { 0 };
     size_t m_capacity { 0 };
 
-    alignas(StorageType) unsigned char m_inline_buffer_storage[sizeof(StorageType) * inline_capacity];
+    alignas(inline_storage_align()) unsigned char m_inline_buffer_storage[inline_storage_size()];
     StorageType* m_outline_buffer { nullptr };
 };
 

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -510,3 +510,13 @@ TEST_CASE(reference_deletion_should_not_affect_object)
     }
     EXPECT_EQ(times_deleted, 1u);
 }
+
+TEST_CASE(allows_incomplete_types_with_zero_inline_storage)
+{
+    struct IncompleteStruct;
+    Vector<IncompleteStruct> vector_of_incomplete_type;
+
+    struct IncompleteStruct {
+    };
+    vector_of_incomplete_type.append({});
+}


### PR DESCRIPTION
This simply moves the resolution of alignof(T)/sizeof(T) into a
constexpr function and makes it dependent on the inline size being
nonzero.