### PR TITLE
Kernel: Make VirtIO GPU buffer flipping more spec compliant

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOFrameBufferDevice.h
@@ -19,6 +19,7 @@ class VirtIOFrameBufferDevice final : public BlockDevice {
         size_t framebuffer_offset { 0 };
         u8* framebuffer_data { nullptr };
         VirtIOGPUResourceID resource_id { 0 };
+        VirtIOGPURect dirty_rect {};
     };
 
 public:

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -413,4 +413,25 @@ void Screen::flush_display(int buffer_index)
     fb_data.too_many_pending_flush_rects = false;
     fb_data.pending_flush_rects.clear_with_capacity();
 }
+
+void Screen::flush_display_front_buffer(int front_buffer_index, Gfx::IntRect& rect)
+{
+    VERIFY(m_can_device_flush_buffers);
+    auto scale_factor = this->scale_factor();
+    FBRect flush_rect {
+        x : (unsigned)(rect.x() * scale_factor),
+        y : (unsigned)(rect.y() * scale_factor),
+        width : (unsigned)(rect.width() * scale_factor),
+        height : (unsigned)(rect.height() * scale_factor)
+    };
+
+    if (fb_flush_buffers(m_framebuffer_fd, front_buffer_index, &flush_rect, 1) < 0) {
+        int err = errno;
+        if (err == ENOTSUP)
+            m_can_device_flush_buffers = false;
+        else
+            dbgln("Screen #{}: Error ({}) flushing display front buffer: {}", index(), err, strerror(err));
+    }
+}
+
 }

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -167,6 +167,7 @@ public:
     bool can_device_flush_buffers() const { return m_can_device_flush_buffers; }
     void queue_flush_display_rect(Gfx::IntRect const& rect);
     void flush_display(int buffer_index);
+    void flush_display_front_buffer(int front_buffer_index, Gfx::IntRect&);
 
 private:
     Screen(ScreenLayout::Screen&);


### PR DESCRIPTION
The spec requires a flush after setting the new buffer resource id,
which is required by QEMUs SDL backend but not the GTK backend. This
brings us in line with the spec and makes it work for the SDL backend.