### PR TITLE
LibRegex: Correctly parse BRE bracket expressions

### DIFF
--- a/Tests/LibRegex/RegexLibC.cpp
+++ b/Tests/LibRegex/RegexLibC.cpp
@@ -1149,4 +1149,10 @@ TEST_CASE(bre_basic)
     EXPECT_EQ(regcomp(&regex, "15{1,2}", REG_NOSUB | REG_ICASE), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "15{1,2}", 0, NULL, 0), REG_NOERR);
     regfree(&regex);
+
+    EXPECT_EQ(regcomp(&regex, "1[56]", REG_NOSUB | REG_ICASE), REG_NOERR);
+    EXPECT_EQ(regexec(&regex, "15", 0, NULL, 0), REG_NOERR);
+    EXPECT_EQ(regexec(&regex, "16", 0, NULL, 0), REG_NOERR);
+    EXPECT_EQ(regexec(&regex, "17", 0, NULL, 0), REG_NOMATCH);
+    regfree(&regex);
 }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -481,12 +481,20 @@ bool PosixBasicParser::parse_one_char_or_collation_element(ByteCode& bytecode, s
 
     Vector<CompareTypeAndValuePair> values;
     size_t bracket_minimum_length = 0;
-    if (!AbstractPosixParser::parse_bracket_expression(values, bracket_minimum_length))
-        return false;
 
-    bytecode.insert_bytecode_compare_values(move(values));
-    match_length_minimum += bracket_minimum_length;
-    return !has_error();
+    if (match(TokenType::LeftBracket)) {
+        consume();
+        if (!AbstractPosixParser::parse_bracket_expression(values, bracket_minimum_length))
+            return false;
+
+        consume(TokenType::RightBracket, Error::MismatchingBracket);
+
+        bytecode.insert_bytecode_compare_values(move(values));
+        match_length_minimum += bracket_minimum_length;
+        return !has_error();
+    }
+
+    return set_error(Error::InvalidPattern);
 }
 
 // =============================


### PR DESCRIPTION
Commonly, bracket expressions are in fact, enclosed in brackets.