### PR TITLE
PixelPaint: Check modifier on mousemove in LineTool

### DIFF
--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -67,11 +67,11 @@ void LineTool::on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEven
     if (m_drawing_button == GUI::MouseButton::None)
         return;
 
-    if (!m_constrain_angle) {
-        m_line_end_position = layer_event.position();
-    } else {
+    if (layer_event.shift()) {
         constexpr auto ANGLE_STEP = M_PI / 8;
         m_line_end_position = constrain_line_angle(m_line_start_position, layer_event.position(), ANGLE_STEP);
+    } else {
+        m_line_end_position = layer_event.position();
     }
     m_editor->update();
 }
@@ -92,21 +92,6 @@ void LineTool::on_keydown(GUI::KeyEvent& event)
 {
     if (event.key() == Key_Escape && m_drawing_button != GUI::MouseButton::None) {
         m_drawing_button = GUI::MouseButton::None;
-        m_editor->update();
-        event.accept();
-    }
-
-    if (event.key() == Key_Shift) {
-        m_constrain_angle = true;
-        m_editor->update();
-        event.accept();
-    }
-}
-
-void LineTool::on_keyup(GUI::KeyEvent& event)
-{
-    if (event.key() == Key_Shift) {
-        m_constrain_angle = false;
         m_editor->update();
         event.accept();
     }

--- a/Userland/Applications/PixelPaint/LineTool.h
+++ b/Userland/Applications/PixelPaint/LineTool.h
@@ -23,7 +23,6 @@ public:
     virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
-    virtual void on_keyup(GUI::KeyEvent&) override;
 
 private:
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
@@ -33,7 +32,6 @@ private:
     RefPtr<GUI::Menu> m_context_menu;
     GUI::ActionGroup m_thickness_actions;
     int m_thickness { 1 };
-    bool m_constrain_angle { false };
 };
 
 }


### PR DESCRIPTION
Previously `m_constrain_angle` could end up not being reset if the keyup-event was swallowed by another window, for example when opening a dialog with Ctrl+Shift+S. Instead check the event modifiers in on_mousemove().