### PR TITLE
LibRegex+expr: Make Match expressions comply with POSIX 

### DIFF
--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -411,7 +411,7 @@ bool PosixBasicParser::parse_nonduplicating_re(ByteCode& bytecode, size_t& match
     if (try_skip("\\(")) {
         ByteCode capture_bytecode;
         size_t capture_length_minimum = 0;
-        auto capture_group_index = ++m_capture_group;
+        auto capture_group_index = ++m_parser_state.capture_groups_count;
 
         if (!parse_re_expression(capture_bytecode, capture_length_minimum))
             return false;

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -155,7 +155,6 @@ private:
     bool parse_nonduplicating_re(ByteCode&, size_t&);
     bool parse_one_char_or_collation_element(ByteCode&, size_t&);
 
-    size_t m_capture_group { 0 };
     constexpr static size_t number_of_addressable_capture_groups = 9;
     size_t m_capture_group_minimum_lengths[number_of_addressable_capture_groups] { 0 };
     bool m_capture_group_seen[number_of_addressable_capture_groups] { false };

--- a/Userland/Utilities/expr.cpp
+++ b/Userland/Utilities/expr.cpp
@@ -359,7 +359,12 @@ public:
     }
 
 private:
-    virtual bool truth() const override { return integer() != 0; }
+    virtual bool truth() const override
+    {
+        if (type() == Expression::Type::String)
+            return !string().is_empty();
+        return integer() != 0;
+    }
     virtual int integer() const override
     {
         if (m_op == StringOperation::Substring || m_op == StringOperation::Match) {
@@ -411,10 +416,8 @@ private:
                     return "";
 
                 StringBuilder result;
-                for (auto& m : match.capture_group_matches) {
-                    for (auto& e : m)
-                        result.append(e.view.to_string());
-                }
+                for (auto& e : match.capture_group_matches[0])
+                    result.append(e.view.u8view());
 
                 return result.build();
             }


### PR DESCRIPTION
(hopefully) final patches fixing the behaviour of `expr`.