### PR TITLE
Trying to rename a file on the desktop using F2 does not prevent illegal filenames an thus may crash the OS.

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -525,7 +525,13 @@ KResult VirtualFileSystem::rename(StringView old_path, StringView new_path, Cust
     if (old_parent_custody->is_readonly() || new_parent_custody->is_readonly())
         return EROFS;
 
+    auto old_basename = KLexicalPath::basename(old_path);
+    if (old_basename.is_empty() || old_basename == "."sv || old_basename == ".."sv)
+        return EINVAL;
+
     auto new_basename = KLexicalPath::basename(new_path);
+    if (new_basename.is_empty() || new_basename == "."sv || new_basename == ".."sv)
+        return EINVAL;
 
     if (!new_custody_or_error.is_error()) {
         auto& new_custody = *new_custody_or_error.value();
@@ -546,7 +552,7 @@ KResult VirtualFileSystem::rename(StringView old_path, StringView new_path, Cust
     if (auto result = new_parent_inode.add_child(old_inode, new_basename, old_inode.mode()); result.is_error())
         return result;
 
-    if (auto result = old_parent_inode.remove_child(KLexicalPath::basename(old_path)); result.is_error())
+    if (auto result = old_parent_inode.remove_child(old_basename); result.is_error())
         return result;
 
     return KSuccess;

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -214,7 +214,7 @@ const GUI::FileSystemModel::Node& DirectoryView::node(const GUI::ModelIndex& ind
 
 void DirectoryView::setup_model()
 {
-    m_model->on_error = [this](int, const char* error_string) {
+    m_model->on_directory_change_error = [this](int, const char* error_string) {
         auto failed_path = m_model->root_path();
         auto error_message = String::formatted("Could not read {}:\n{}", failed_path, error_string);
         m_error_label->set_text(error_message);
@@ -227,6 +227,10 @@ void DirectoryView::setup_model()
 
         if (on_path_change)
             on_path_change(failed_path, false, false);
+    };
+
+    m_model->on_rename_error = [this](int, const char* error_string) {
+        GUI::MessageBox::show_error(window(), String::formatted("Unable to rename file: {}", error_string));
     };
 
     m_model->on_complete = [this] {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -367,8 +367,8 @@ void FileSystemModel::set_root_path(String root_path)
     update();
 
     if (m_root->has_error()) {
-        if (on_error)
-            on_error(m_root->error(), m_root->error_string());
+        if (on_directory_change_error)
+            on_directory_change_error(m_root->error(), m_root->error_string());
     } else if (on_complete) {
         on_complete();
     }
@@ -676,8 +676,8 @@ void FileSystemModel::set_data(const ModelIndex& index, const Variant& data)
     auto new_full_path = String::formatted("{}/{}", dirname, data.to_string());
     int rc = rename(node.full_path().characters(), new_full_path.characters());
     if (rc < 0) {
-        if (on_error)
-            on_error(errno, strerror(errno));
+        if (on_rename_error)
+            on_rename_error(errno, strerror(errno));
     }
 }
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -114,7 +114,8 @@ public:
 
     Function<void(int done, int total)> on_thumbnail_progress;
     Function<void()> on_complete;
-    Function<void(int error, const char* error_string)> on_error;
+    Function<void(int error, const char* error_string)> on_directory_change_error;
+    Function<void(int error, const char* error_string)> on_rename_error;
 
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(const ModelIndex& = ModelIndex()) const override;


### PR DESCRIPTION
Trying to rename a file on the desktop using F2 does not prevent illegal filenames an thus may crash the OS.

How to reproduce:

1. Select a File on the Desktop
2. Press F2
3. Delete all the Content (or type '.' or '..')
4.  Press Enter

![image](https://user-images.githubusercontent.com/8739722/125175545-38a7d300-e1cd-11eb-9716-e8ae1084bff6.png)

```
[FileManager (Desktop)(12:12)]: ASSERTION FAILED: !basename.is_empty() && basename != "."sv && basename != ".."sv
[FileManager (Desktop)(12:12)]: ../../Kernel/KLexicalPath.cpp:40 in AK::StringView Kernel::KLexicalPath::basename(const AK::StringView&)
[#0 FileManager (Desktop)(12:12)]: 0xc0723b51  abort +0x17e
[#0 FileManager (Desktop)(12:12)]: 0xc07239b3  _abort +0x0
[#0 FileManager (Desktop)(12:12)]: 0xc04348a1  Kernel::KLexicalPath::basename(AK::StringView const&) +0x18b
[#0 FileManager (Desktop)(12:12)]: 0xc040f148  Kernel::VFS::rename(AK::StringView, AK::StringView, Kernel::Custody&) +0x870
[#0 FileManager (Desktop)(12:12)]: 0xc05ce559  Kernel::Process::sys$rename(AK::Userspace<Kernel::Syscall::SC_rename_params const*>) +0xd89
[#0 FileManager (Desktop)(12:12)]: 0xc052e2a3  syscall_handler +0x1df2
[#0 FileManager (Desktop)(12:12)]: 0xc052c4a7  syscall_asm_entry +0x31
```