### PR TITLE
Vim editing improvements

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -241,34 +241,42 @@ void EditingEngine::move_to_next_span(const KeyEvent& event)
     }
 }
 
-void EditingEngine::move_to_line_beginning()
+void EditingEngine::move_to_logical_line_beginning()
 {
     TextPosition new_cursor;
-    if (m_editor->is_wrapping_enabled()) {
-        // FIXME: Replicate the first_nonspace_column behavior in wrapping mode.
-        auto home_position = m_editor->cursor_content_rect().location().translated(-m_editor->width(), 0);
-        new_cursor = m_editor->text_position_at_content_position(home_position);
+    size_t first_nonspace_column = m_editor->current_line().first_non_whitespace_column();
+    if (m_editor->cursor().column() == first_nonspace_column) {
+        new_cursor = { m_editor->cursor().line(), 0 };
     } else {
-        size_t first_nonspace_column = m_editor->current_line().first_non_whitespace_column();
-        if (m_editor->cursor().column() == first_nonspace_column) {
-            new_cursor = { m_editor->cursor().line(), 0 };
-        } else {
-            new_cursor = { m_editor->cursor().line(), first_nonspace_column };
-        }
+        new_cursor = { m_editor->cursor().line(), first_nonspace_column };
     }
     m_editor->set_cursor(new_cursor);
 }
 
+void EditingEngine::move_to_line_beginning()
+{
+    if (m_editor->is_wrapping_enabled()) {
+        // FIXME: Replicate the first_nonspace_column behavior in wrapping mode.
+        auto home_position = m_editor->cursor_content_rect().location().translated(-m_editor->width(), 0);
+        m_editor->set_cursor(m_editor->text_position_at_content_position(home_position));
+    } else {
+        move_to_logical_line_beginning();
+    }
+}
+
 void EditingEngine::move_to_line_end()
 {
-    TextPosition new_cursor;
     if (m_editor->is_wrapping_enabled()) {
         auto end_position = m_editor->cursor_content_rect().location().translated(m_editor->width(), 0);
-        new_cursor = m_editor->text_position_at_content_position(end_position);
+        m_editor->set_cursor(m_editor->text_position_at_content_position(end_position));
     } else {
-        new_cursor = { m_editor->cursor().line(), m_editor->current_line().length() };
+        move_to_logical_line_end();
     }
-    m_editor->set_cursor(new_cursor);
+}
+
+void EditingEngine::move_to_logical_line_end()
+{
+    m_editor->set_cursor({ m_editor->cursor().line(), m_editor->current_line().length() });
 }
 
 void EditingEngine::move_one_up(const KeyEvent& event)

--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -48,6 +48,8 @@ protected:
     void move_one_down(const KeyEvent& event);
     void move_to_previous_span();
     void move_to_next_span(const KeyEvent& event);
+    void move_to_logical_line_beginning();
+    void move_to_logical_line_end();
     void move_to_line_beginning();
     void move_to_line_end();
     void move_page_up();

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -926,6 +926,8 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 move_one_left();
                 return true;
             }
+            case (KeyCode::Key_P):
+                put_before();
             default:
                 break;
             }
@@ -986,7 +988,7 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 m_previous_key = event.key();
                 return true;
             case (KeyCode::Key_P):
-                put();
+                put_after();
                 return true;
             case (KeyCode::Key_PageUp):
                 move_page_up();
@@ -1237,7 +1239,22 @@ void VimEditingEngine::yank(TextRange range)
     m_yank_buffer = m_editor->document().text_in_range(range);
 }
 
-void VimEditingEngine::put()
+void VimEditingEngine::put_before()
+{
+    if (m_yank_type == YankType::Line) {
+        move_to_logical_line_beginning();
+        StringBuilder sb = StringBuilder(m_yank_buffer.length() + 1);
+        sb.append(m_yank_buffer);
+        sb.append_code_point(0x0A);
+        m_editor->insert_at_cursor_or_replace_selection(sb.to_string());
+        m_editor->set_cursor({ m_editor->cursor().line(), m_editor->current_line().first_non_whitespace_column() });
+    } else {
+        m_editor->insert_at_cursor_or_replace_selection(m_yank_buffer);
+        move_one_left();
+    }
+}
+
+void VimEditingEngine::put_after()
 {
     if (m_yank_type == YankType::Line) {
         move_to_logical_line_end();

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -916,6 +916,16 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
             case (KeyCode::Key_RightBrace):
                 move_to_next_empty_lines_block();
                 return true;
+            case (KeyCode::Key_J): {
+                if (m_editor->cursor().line() + 1 >= m_editor->line_count())
+                    return true;
+                move_to_logical_line_end();
+                m_editor->add_code_point(' ');
+                TextPosition next_line = { m_editor->cursor().line() + 1, 0 };
+                m_editor->delete_text_range({ m_editor->cursor(), next_line });
+                move_one_left();
+                return true;
+            }
             default:
                 break;
             }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -963,13 +963,18 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 move_to_next_empty_lines_block();
                 return true;
             case (KeyCode::Key_J): {
-                if (m_editor->cursor().line() + 1 >= m_editor->line_count())
-                    return true;
-                move_to_logical_line_end();
-                m_editor->add_code_point(' ');
-                TextPosition next_line = { m_editor->cursor().line() + 1, 0 };
-                m_editor->delete_text_range({ m_editor->cursor(), next_line });
-                move_one_left();
+                // Looks a bit strange, but join without a repeat, with 1 as the repeat or 2 as the repeat all join the current and next lines
+                auto amount = (m_motion.amount() > 2) ? (m_motion.amount() - 1) : 1;
+                m_motion.reset();
+                for (int i = 0; i < amount; i++) {
+                    if (m_editor->cursor().line() + 1 >= m_editor->line_count())
+                        return true;
+                    move_to_logical_line_end();
+                    m_editor->add_code_point(' ');
+                    TextPosition next_line = { m_editor->cursor().line() + 1, 0 };
+                    m_editor->delete_text_range({ m_editor->cursor(), next_line });
+                    move_one_left();
+                }
                 return true;
             }
             case (KeyCode::Key_P):

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -834,10 +834,10 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
             delete_line();
             if (was_second_last_line || (m_editor->cursor().line() != 0 && m_editor->cursor().line() != m_editor->line_count() - 1)) {
                 move_one_up(event);
-                move_to_line_end();
+                move_to_logical_line_end();
                 m_editor->add_code_point(0x0A);
             } else if (m_editor->cursor().line() == 0) {
-                move_to_line_beginning();
+                move_to_logical_line_beginning();
                 m_editor->add_code_point(0x0A);
                 move_one_up(event);
             } else if (m_editor->cursor().line() == m_editor->line_count() - 1) {
@@ -896,15 +896,15 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
         if (event.shift() && !event.ctrl() && !event.alt()) {
             switch (event.key()) {
             case (KeyCode::Key_A):
-                move_to_line_end();
+                move_to_logical_line_end();
                 switch_to_insert_mode();
                 return true;
             case (KeyCode::Key_I):
-                move_to_line_beginning();
+                move_to_logical_line_beginning();
                 switch_to_insert_mode();
                 return true;
             case (KeyCode::Key_O):
-                move_to_line_beginning();
+                move_to_logical_line_beginning();
                 m_editor->add_code_point(0x0A);
                 move_one_up(event);
                 switch_to_insert_mode();
@@ -958,7 +958,7 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 switch_to_insert_mode();
                 return true;
             case (KeyCode::Key_O):
-                move_to_line_end();
+                move_to_logical_line_end();
                 m_editor->add_code_point(0x0A);
                 switch_to_insert_mode();
                 return true;
@@ -1043,11 +1043,11 @@ bool VimEditingEngine::on_key_in_visual_mode(const KeyEvent& event)
     if (event.shift() && !event.ctrl() && !event.alt()) {
         switch (event.key()) {
         case (KeyCode::Key_A):
-            move_to_line_end();
+            move_to_logical_line_end();
             switch_to_insert_mode();
             return true;
         case (KeyCode::Key_I):
-            move_to_line_beginning();
+            move_to_logical_line_beginning();
             switch_to_insert_mode();
             return true;
         default:
@@ -1230,7 +1230,7 @@ void VimEditingEngine::yank(TextRange range)
 void VimEditingEngine::put()
 {
     if (m_yank_type == YankType::Line) {
-        move_to_line_end();
+        move_to_logical_line_end();
         StringBuilder sb = StringBuilder(m_yank_buffer.length() + 1);
         sb.append_code_point(0x0A);
         sb.append(m_yank_buffer);

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -166,7 +166,8 @@ private:
     String m_yank_buffer {};
     void yank(YankType);
     void yank(TextRange);
-    void put();
+    void put_before();
+    void put_after();
 
     TextPosition m_selection_start_position = {};
     void update_selection_on_cursor_move();

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -101,6 +101,7 @@ public:
 
     void add_key_code(KeyCode key, bool ctrl, bool shift, bool alt);
     Optional<TextRange> get_range(class VimEditingEngine& engine, bool normalize_for_position = false);
+    Optional<TextRange> get_repeat_range(class VimEditingEngine& engine, Unit, bool normalize_for_position = false);
     Optional<TextPosition> get_position(VimEditingEngine& engine, bool in_visual_mode = false);
     void reset();
 
@@ -165,7 +166,7 @@ private:
     YankType m_yank_type {};
     String m_yank_buffer {};
     void yank(YankType);
-    void yank(TextRange);
+    void yank(TextRange, YankType yank_type);
     void put_before();
     void put_after();
 


### PR DESCRIPTION
A few improvements to the vim editing mode in TextEditor:
1. I noticed that it seemed to be operating on visual lines rather than logical ones. That is if you turn line wrapping on then commands like I, A and so on were looking at the wrapped line rather than the real one
2. Added J to join the current line and the next one
3. Added P to put before the cursor position

The first one is probably the most interesting one. I've added two new methods to the EditingEngine: move_to_logical_line_beginning/end, and move_to_line_beginning/end now piggyback off this when line wrapping is turned off.

Apologies if I should have split these up! 