### PR TITLE
LibGUI: Add ScopedPaintEventDisable class to disable paint events

### DIFF
--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -85,11 +85,12 @@ void TabWidget::set_active_widget(Widget* widget)
         m_active_widget->set_visible(false);
     m_active_widget = widget;
     if (m_active_widget) {
+        GUI::ScopedPaintEventDisable disable_paint_events(*widget);
         m_active_widget->set_relative_rect(child_rect_for_size(size()));
         if (active_widget_had_focus)
             m_active_widget->set_focus(true);
         m_active_widget->set_visible(true);
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this, disable_paint_events = move(disable_paint_events)](auto&) {
             if (on_change)
                 on_change(*m_active_widget);
         });

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -619,6 +619,13 @@ void Window::force_update()
     WindowServerConnection::the().async_invalidate_rect(m_window_id, { { 0, 0, rect.width(), rect.height() } }, true);
 }
 
+void Window::force_update(Badge<Widget>, Vector<Gfx::IntRect> const& rects)
+{
+    if (!is_visible())
+        return;
+    WindowServerConnection::the().async_invalidate_rect(m_window_id, rects, true);
+}
+
 void Window::update(const Gfx::IntRect& a_rect)
 {
     if (!is_visible())

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -202,6 +202,8 @@ public:
 
     void set_menubar(RefPtr<Menubar>);
 
+    void force_update(Badge<Widget>, Vector<Gfx::IntRect> const&);
+
 protected:
     Window(Core::Object* parent = nullptr);
     virtual void wm_event(WMEvent&);


### PR DESCRIPTION
This class can temporarily disable the delivery of paint events. This
may be useful to disable painting for a while when we don't want to
trigger too many paint events that can lead to e.g. a popcorn effect.