### PR TITLE
TextEditor: Avoid calling realpath()

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -260,7 +260,7 @@ MainWidget::MainWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto fd_response = m_file_system_access_client->prompt_open_file(Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
+        auto fd_response = m_file_system_access_client->prompt_open_file(Core::StandardPaths::home_directory(), Core::OpenMode::ReadOnly);
 
         if (fd_response.error() != 0)
             return;

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Menubar.h>
+#include <LibGUI/MessageBox.h>
 
 using namespace TextEditor;
 
@@ -109,8 +110,10 @@ int main(int argc, char** argv)
         FileArgument parsed_argument(file_to_edit);
         auto file = Core::File::open(file_to_edit_full_path, Core::OpenMode::ReadOnly);
 
-        if (file.is_error())
+        if (file.is_error()) {
+            GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", file_to_edit_full_path, file.error()));
             return 1;
+        }
 
         if (!text_widget.read_file_and_close(file.value()->leak_fd(), file_to_edit_full_path))
             return 1;

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -30,11 +30,14 @@ int main(int argc, char** argv)
 
     parser.parse(argc, argv);
 
+    String file_to_edit_full_path;
+
     if (file_to_edit) {
         FileArgument parsed_argument(file_to_edit);
 
-        auto path_to_unveil = Core::File::real_path_for(parsed_argument.filename());
-        if (unveil(path_to_unveil.characters(), "rwc") < 0) {
+        file_to_edit_full_path = Core::File::real_path_for(parsed_argument.filename());
+        dbgln("unveil for: {}", file_to_edit_full_path);
+        if (unveil(file_to_edit_full_path.characters(), "rwc") < 0) {
             perror("unveil");
             return 1;
         }
@@ -104,13 +107,12 @@ int main(int argc, char** argv)
     if (file_to_edit) {
         // A file name was passed, parse any possible line and column numbers included.
         FileArgument parsed_argument(file_to_edit);
-        auto absolute_path = Core::File::real_path_for(parsed_argument.filename());
-        auto file = Core::File::open(absolute_path, Core::OpenMode::ReadWrite);
+        auto file = Core::File::open(file_to_edit_full_path, Core::OpenMode::ReadWrite);
 
         if (file.is_error())
             return 1;
 
-        if (!text_widget.read_file_and_close(file.value()->leak_fd(), absolute_path))
+        if (!text_widget.read_file_and_close(file.value()->leak_fd(), file_to_edit_full_path))
             return 1;
 
         text_widget.editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
     if (file_to_edit) {
         // A file name was passed, parse any possible line and column numbers included.
         FileArgument parsed_argument(file_to_edit);
-        auto file = Core::File::open(file_to_edit_full_path, Core::OpenMode::ReadWrite);
+        auto file = Core::File::open(file_to_edit_full_path, Core::OpenMode::ReadOnly);
 
         if (file.is_error())
             return 1;


### PR DESCRIPTION
We can't use realpath() at that point because we've already called unveil(nullptr, nullptr).

Also, we should only open the file for reading because the user might not have write permissions for all files.

cc @timmot