### PR TITLE
CI: Fix some macOS test failures

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -209,9 +209,14 @@ jobs:
       run: |
         sudo apt-get purge -y clang-11
         sudo apt-get update
-        sudo apt-get install ninja-build wabt
+        sudo apt-get install ninja-build
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100
+        # Install wabt tools from github packages
+        wget https://github.com/WebAssembly/wabt/releases/download/1.0.23/wabt-1.0.23-ubuntu.tar.gz
+        tar -xzf ./wabt-1.0.23-ubuntu.tar.gz
+        rm ./wabt-1.0.23-ubuntu.tar.gz
+        echo "$PWD/wabt-1.0.23/bin" >> $GITHUB_PATH
       if: ${{ runner.os == 'Linux' }}
     - name: Install macOS dependencies
       run: brew install ninja wabt

--- a/AK/ByteReader.h
+++ b/AK/ByteReader.h
@@ -49,6 +49,27 @@ struct ByteReader {
         value = v._32;
     }
 
+    static void load(const u8* address, u64& value)
+    {
+        union {
+            u64 _64;
+            u8 _8[8];
+        } v { ._64 = 0 };
+        __builtin_memcpy(&v._8, address, 8);
+        value = v._64;
+    }
+
+    template<typename T>
+    static T* load_pointer(const u8* address)
+    {
+        if constexpr (sizeof(T*) == 4) {
+            return reinterpret_cast<T*>(load32(address));
+        } else {
+            static_assert(sizeof(T*) == 8, "sizeof(T*) must be either 4 or 8");
+            return reinterpret_cast<T*>(load64(address));
+        }
+    }
+
     static u16 load16(const u8* address)
     {
         u16 value;
@@ -59,6 +80,13 @@ struct ByteReader {
     static u32 load32(const u8* address)
     {
         u32 value;
+        load(address, value);
+        return value;
+    }
+
+    static u64 load64(const u8* address)
+    {
+        u64 value;
         load(address, value);
         return value;
     }

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -34,7 +34,7 @@ There are some optional features that can be enabled during compilation that are
 - `BUILD_LAGOM`: builds [Lagom](../Meta/Lagom/ReadMe.md), which makes various SerenityOS libraries and programs available on the host system.
 - `PRECOMPILE_COMMON_HEADERS`: precompiles some common headers to speedup compilation.
 - `ENABLE_KERNEL_LTO`: builds the kernel with link-time optimization.
-- `INCLUDE_WASM_SPEC_TESTS`: downloads and includes the WebAssembly spec testsuite tests
+- `INCLUDE_WASM_SPEC_TESTS`: downloads and includes the WebAssembly spec testsuite tests. In order to use this option, you will need to install `prettier` and `wabt`. wabt version 1.0.23 or higher is required to pre-process the WebAssembly spec testsuite.
 - `BUILD_<component>`: builds the specified component, e.g. `BUILD_HEARTS` (note: must be all caps). Check the components.ini file in your build directory for a list of available components. Make sure to run `ninja clean` and `rm -rf Build/i686/Root` after disabling components. These options can be easily configured by using the `ConfigureComponents` utility. See the [Component Configuration](#component-configuration) section below.
 - `BUILD_EVERYTHING`: builds all optional components, overrides other `BUILD_<component>` flags when enabled
 

--- a/Meta/CMake/wasm_spec_tests.cmake
+++ b/Meta/CMake/wasm_spec_tests.cmake
@@ -30,6 +30,11 @@ if(INCLUDE_WASM_SPEC_TESTS)
         foreach(PATH ${WASM_TESTS})
             get_filename_component(NAME ${PATH} NAME_WLE)
             message(STATUS "Generating test cases for WebAssembly test ${NAME}...")
+            # FIXME: GH 8668. loop_0.wasm causes CI timeout
+            if (NAME STREQUAL "loop")
+                message(STATUS "Skipping generation of ${NAME} test due to timeouts")
+                continue()
+            endif()
             execute_process(
                 COMMAND env SKIP_PRETTIER=${SKIP_PRETTIER} bash ${SOURCE_DIR}/Meta/generate-libwasm-spec-test.sh "${PATH}" "${SOURCE_DIR}/Userland/Libraries/LibWasm/Tests/Spec" "${NAME}" "${WASM_SPEC_TEST_PATH}")
         endforeach()

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -286,6 +286,8 @@ InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<Ex
                         };
                         return;
                     }
+                    if (data.init.is_empty())
+                        return;
                     auto address = main_module_instance.memories()[data.index.value()];
                     if (auto instance = m_store.get(address)) {
                         if (auto max = instance->type().limits().max(); max.has_value()) {

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -32,6 +32,7 @@ namespace Wasm {
 
 void BytecodeInterpreter::interpret(Configuration& configuration)
 {
+    m_stack_info = {};
     m_trap.clear();
     auto& instructions = configuration.frame().expression().instructions();
     auto max_ip_value = InstructionPointer { instructions.size() };
@@ -129,7 +130,7 @@ void BytecodeInterpreter::store_to_memory(Configuration& configuration, Instruct
 
 void BytecodeInterpreter::call_address(Configuration& configuration, FunctionAddress address)
 {
-    TRAP_IF_NOT(configuration.depth() <= Constants::max_allowed_call_stack_depth);
+    TRAP_IF_NOT(m_stack_info.size_free() >= Constants::minimum_stack_space_to_keep_free);
 
     auto instance = configuration.store().get(address);
     TRAP_IF_NOT(instance);

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StackInfo.h>
 #include <LibWasm/AbstractMachine/Configuration.h>
 #include <LibWasm/AbstractMachine/Interpreter.h>
 
@@ -57,6 +58,7 @@ protected:
     }
 
     Optional<Trap> m_trap;
+    StackInfo m_stack_info;
 };
 
 struct DebuggerBytecodeInterpreter : public BytecodeInterpreter {

--- a/Userland/Libraries/LibWasm/Constants.h
+++ b/Userland/Libraries/LibWasm/Constants.h
@@ -38,7 +38,7 @@ static constexpr auto page_size = 64 * KiB;
 
 // Implementation-defined limits
 // These are not concretely defined by the spec, so the values are only defined by us.
-static constexpr auto max_allowed_call_stack_depth = 512;
+static constexpr auto minimum_stack_space_to_keep_free = 256 * KiB; // Note: Value is arbitrary and chosen by testing with ASAN
 static constexpr auto max_allowed_executed_instructions_per_call = 256 * 1024 * 1024;
 
 }


### PR DESCRIPTION
1) struct hostent contains misaligned pointers on macOS Mojave. Use ByteReader to ensure we only read from aligned const char* pointers. Fixes #7158

2) homebrew was installing wabt version 1.0.23 which parses more of the master WASM parser tests than version 1.0.13 that Ubuntu 20.04 ships. Make sure (for now) that we have version parity on these tools.

3) Fixup LibWasm ASAN/UBSAN errors with wat2wasm 1.0.23 generated test files. Fixes #8629 (Thanks Ali!)

With these fixes, #4651 is the only remaining macOS CI failure before we can stop allowing failure for lagom tests. Which would be a first since macOS CI was originally enabled :).