### PR TITLE
LibWasm: Use AK::StackInfo to track stack size

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -286,6 +286,8 @@ InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<Ex
                         };
                         return;
                     }
+                    if (data.init.is_empty())
+                        return;
                     auto address = main_module_instance.memories()[data.index.value()];
                     if (auto instance = m_store.get(address)) {
                         if (auto max = instance->type().limits().max(); max.has_value()) {

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -32,6 +32,7 @@ namespace Wasm {
 
 void BytecodeInterpreter::interpret(Configuration& configuration)
 {
+    m_stack_info = {};
     m_trap.clear();
     auto& instructions = configuration.frame().expression().instructions();
     auto max_ip_value = InstructionPointer { instructions.size() };
@@ -129,7 +130,7 @@ void BytecodeInterpreter::store_to_memory(Configuration& configuration, Instruct
 
 void BytecodeInterpreter::call_address(Configuration& configuration, FunctionAddress address)
 {
-    TRAP_IF_NOT(configuration.depth() <= Constants::max_allowed_call_stack_depth);
+    TRAP_IF_NOT(m_stack_info.size_free() >= Constants::minimum_stack_space_to_keep_free);
 
     auto instance = configuration.store().get(address);
     TRAP_IF_NOT(instance);

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StackInfo.h>
 #include <LibWasm/AbstractMachine/Configuration.h>
 #include <LibWasm/AbstractMachine/Interpreter.h>
 
@@ -57,6 +58,7 @@ protected:
     }
 
     Optional<Trap> m_trap;
+    StackInfo m_stack_info;
 };
 
 struct DebuggerBytecodeInterpreter : public BytecodeInterpreter {

--- a/Userland/Libraries/LibWasm/Constants.h
+++ b/Userland/Libraries/LibWasm/Constants.h
@@ -38,7 +38,7 @@ static constexpr auto page_size = 64 * KiB;
 
 // Implementation-defined limits
 // These are not concretely defined by the spec, so the values are only defined by us.
-static constexpr auto max_allowed_call_stack_depth = 512;
+static constexpr auto minimum_stack_space_to_keep_free = 32 * KiB; // Note: Value copied from LibJS/VM.h
 static constexpr auto max_allowed_executed_instructions_per_call = 256 * 1024 * 1024;
 
 }


### PR DESCRIPTION
This way, we can make sure that it doesn't overflow when ASAN is
enabled.

Resolves (part of) #8629.

cc @ADKaster: could you give me the modules generated for `custom`? they should be in `Userland/Libraries/LibWasm/Tests/Fixtures/SpecTests/custom_*.wasm`