### PR TITLE
LibJS: Bag of parser fixes

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1455,6 +1455,10 @@ void BindingPattern::for_each_bound_name(C&& callback) const
             callback(alias.get<NonnullRefPtr<Identifier>>()->string());
         } else if (alias.has<NonnullRefPtr<BindingPattern>>()) {
             alias.get<NonnullRefPtr<BindingPattern>>()->for_each_bound_name(forward<C>(callback));
+        } else {
+            auto& name = entry.name;
+            if (name.has<NonnullRefPtr<Identifier>>())
+                callback(name.get<NonnullRefPtr<Identifier>>()->string());
         }
     }
 }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1134,9 +1134,10 @@ private:
 
 class ObjectExpression final : public Expression {
 public:
-    explicit ObjectExpression(SourceRange source_range, NonnullRefPtrVector<ObjectProperty> properties = {})
+    explicit ObjectExpression(SourceRange source_range, NonnullRefPtrVector<ObjectProperty> properties = {}, Optional<SourceRange> first_invalid_property_range = {})
         : Expression(source_range)
         , m_properties(move(properties))
+        , m_first_invalid_property_range(move(first_invalid_property_range))
     {
     }
 
@@ -1144,8 +1145,11 @@ public:
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
+    Optional<SourceRange> const& invalid_property_range() const { return m_first_invalid_property_range; }
+
 private:
     NonnullRefPtrVector<ObjectProperty> m_properties;
+    Optional<SourceRange> m_first_invalid_property_range;
 };
 
 class ArrayExpression final : public Expression {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -998,13 +998,21 @@ public:
     {
     }
 
+    AssignmentExpression(SourceRange source_range, AssignmentOp op, NonnullRefPtr<BindingPattern> lhs, NonnullRefPtr<Expression> rhs)
+        : Expression(source_range)
+        , m_op(op)
+        , m_lhs(move(lhs))
+        , m_rhs(move(rhs))
+    {
+    }
+
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     AssignmentOp m_op;
-    NonnullRefPtr<Expression> m_lhs;
+    Variant<NonnullRefPtr<Expression>, NonnullRefPtr<BindingPattern>> m_lhs;
     NonnullRefPtr<Expression> m_rhs;
 };
 

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1303,14 +1303,21 @@ public:
     {
     }
 
-    FlyString const& parameter() const { return m_parameter; }
+    CatchClause(SourceRange source_range, NonnullRefPtr<BindingPattern> parameter, NonnullRefPtr<BlockStatement> body)
+        : ASTNode(source_range)
+        , m_parameter(move(parameter))
+        , m_body(move(body))
+    {
+    }
+
+    auto& parameter() const { return m_parameter; }
     BlockStatement const& body() const { return m_body; }
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&, GlobalObject&) const override;
 
 private:
-    FlyString m_parameter;
+    Variant<FlyString, NonnullRefPtr<BindingPattern>> m_parameter;
     NonnullRefPtr<BlockStatement> m_body;
 };
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -272,8 +272,10 @@ void Identifier::generate_bytecode(Bytecode::Generator& generator) const
 
 void AssignmentExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
-    if (is<Identifier>(*m_lhs)) {
-        auto& identifier = static_cast<Identifier const&>(*m_lhs);
+    // FIXME: Implement this for BindingPatterns too.
+    auto& lhs = m_lhs.get<NonnullRefPtr<Expression>>();
+    if (is<Identifier>(*lhs)) {
+        auto& identifier = static_cast<Identifier const&>(*lhs);
 
         if (m_op == AssignmentOp::Assignment) {
             m_rhs->generate_bytecode(generator);
@@ -281,7 +283,7 @@ void AssignmentExpression::generate_bytecode(Bytecode::Generator& generator) con
             return;
         }
 
-        m_lhs->generate_bytecode(generator);
+        lhs->generate_bytecode(generator);
 
         Bytecode::BasicBlock* rhs_block_ptr { nullptr };
         Bytecode::BasicBlock* end_block_ptr { nullptr };
@@ -377,8 +379,8 @@ void AssignmentExpression::generate_bytecode(Bytecode::Generator& generator) con
         return;
     }
 
-    if (is<MemberExpression>(*m_lhs)) {
-        auto& expression = static_cast<MemberExpression const&>(*m_lhs);
+    if (is<MemberExpression>(*lhs)) {
+        auto& expression = static_cast<MemberExpression const&>(*lhs);
         expression.object().generate_bytecode(generator);
         auto object_reg = generator.allocate_register();
         generator.emit<Bytecode::Op::Store>(object_reg);

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -20,7 +20,7 @@ HashMap<char, TokenType> Lexer::s_single_char_tokens;
 
 Lexer::Lexer(StringView source, StringView filename, size_t line_number, size_t line_column)
     : m_source(source)
-    , m_current_token(TokenType::Eof, {}, StringView(nullptr), StringView(nullptr), filename, 0, 0)
+    , m_current_token(TokenType::Eof, {}, StringView(nullptr), StringView(nullptr), filename, 0, 0, 0)
     , m_filename(filename)
     , m_line_number(line_number)
     , m_line_column(line_column)
@@ -659,7 +659,8 @@ Token Lexer::next()
         m_source.substring_view(value_start - 1, m_position - value_start),
         m_filename,
         value_start_line_number,
-        value_start_column_number);
+        value_start_column_number,
+        m_position);
 
     if constexpr (LEXER_DEBUG) {
         dbgln("------------------------------");

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1570,6 +1570,7 @@ Vector<FunctionNode::Parameter> Parser::parse_formal_parameters(int& function_le
         RefPtr<Expression> default_value;
         if (match(TokenType::Equals)) {
             consume();
+            TemporaryChange change(m_state.in_function_context, true);
             has_default_parameter = true;
             function_length = parameters.size();
             default_value = parse_expression(2);

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1635,7 +1635,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
             } else if (match(TokenType::BracketOpen)) {
                 consume();
                 name = parse_expression(0);
-                consume(TokenType::BracketOpen);
+                consume(TokenType::BracketClose);
             } else {
                 syntax_error("Expected identifier or computed property name");
                 return {};

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -934,7 +934,7 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
 
         if (property_type == ObjectProperty::Type::Getter || property_type == ObjectProperty::Type::Setter) {
             if (!match(TokenType::ParenOpen)) {
-                syntax_error("Expected '(' for object getter or setter property");
+                expected("'(' for object getter or setter property");
                 skip_to_next_property();
                 continue;
             }
@@ -959,7 +959,7 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
             properties.append(create_ast_node<ObjectProperty>({ m_state.current_token.filename(), rule_start.position(), position() }, *property_name, function, property_type, true));
         } else if (match(TokenType::Colon)) {
             if (!property_name) {
-                syntax_error("Expected a property name");
+                expected("a property name");
                 skip_to_next_property();
                 continue;
             }
@@ -968,7 +968,7 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
         } else if (property_name && property_value) {
             properties.append(create_ast_node<ObjectProperty>({ m_state.current_token.filename(), rule_start.position(), position() }, *property_name, *property_value, property_type, false));
         } else {
-            syntax_error("Expected a property");
+            expected("a property");
             skip_to_next_property();
             continue;
         }
@@ -1706,7 +1706,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
                 name = parse_expression(0);
                 consume(TokenType::BracketClose);
             } else {
-                syntax_error("Expected identifier or computed property name");
+                expected("identifier or computed property name");
                 return {};
             }
 
@@ -1722,7 +1722,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
                         { m_state.current_token.filename(), rule_start.position(), position() },
                         consume().value());
                 } else {
-                    syntax_error("Expected identifier or binding pattern");
+                    expected("identifier or binding pattern");
                     return {};
                 }
             }
@@ -1735,12 +1735,12 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
             } else if (match(TokenType::BracketOpen) || match(TokenType::CurlyOpen)) {
                 auto pattern = parse_binding_pattern();
                 if (!pattern) {
-                    syntax_error("Expected binding pattern");
+                    expected("binding pattern");
                     return {};
                 }
                 alias = pattern.release_nonnull();
             } else {
-                syntax_error("Expected identifier or binding pattern");
+                expected("identifier or binding pattern");
                 return {};
             }
         }
@@ -1755,7 +1755,7 @@ RefPtr<BindingPattern> Parser::parse_binding_pattern()
 
             initializer = parse_expression(2);
             if (!initializer) {
-                syntax_error("Expected initialization expression");
+                expected("initialization expression");
                 return {};
             }
         }
@@ -1831,7 +1831,7 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
         }
 
         if (target.has<Empty>()) {
-            syntax_error("Expected an identifier or a binding pattern");
+            expected("identifier or a binding pattern");
             if (match(TokenType::Comma)) {
                 consume();
                 continue;
@@ -2108,7 +2108,7 @@ NonnullRefPtr<CatchClause> Parser::parse_catch_clause()
     }
 
     if (should_expect_parameter && parameter.is_empty() && !pattern_parameter)
-        syntax_error("Expected an identifier or a binding pattern");
+        expected("an identifier or a binding pattern");
 
     if (pattern_parameter)
         pattern_parameter->for_each_bound_name([this](auto& name) { check_identifier_name_for_assignment_validity(name); });

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -150,6 +150,7 @@ private:
     bool match_statement() const;
     bool match_declaration() const;
     bool match_variable_declaration() const;
+    bool match_identifier() const;
     bool match_identifier_name() const;
     bool match_property_key() const;
     bool match(TokenType type) const;
@@ -157,6 +158,8 @@ private:
     void expected(const char* what);
     void syntax_error(const String& message, Optional<Position> = {});
     Token consume();
+    Token consume_identifier();
+    Token consume_identifier_reference();
     Token consume(TokenType type);
     Token consume_and_validate_numeric_literal();
     void consume_or_insert_semicolon();
@@ -164,6 +167,8 @@ private:
     void load_state();
     void discard_saved_state();
     Position position() const;
+
+    void check_identifier_name_for_assignment_validity(StringView);
 
     bool try_parse_arrow_function_expression_failed_at_position(const Position&) const;
     void set_try_parse_arrow_function_expression_failed_at_position(const Position&, bool);

--- a/Userland/Libraries/LibJS/SourceRange.h
+++ b/Userland/Libraries/LibJS/SourceRange.h
@@ -13,9 +13,12 @@ namespace JS {
 struct Position {
     size_t line { 0 };
     size_t column { 0 };
+    size_t offset { 0 };
 };
 
 struct SourceRange {
+    [[nodiscard]] bool contains(Position const& position) const { return position.offset <= end.offset && position.offset >= start.offset; }
+
     StringView filename;
     Position start;
     Position end;

--- a/Userland/Libraries/LibJS/Token.h
+++ b/Userland/Libraries/LibJS/Token.h
@@ -161,7 +161,7 @@ enum class TokenCategory {
 
 class Token {
 public:
-    Token(TokenType type, String message, StringView trivia, StringView value, StringView filename, size_t line_number, size_t line_column)
+    Token(TokenType type, String message, StringView trivia, StringView value, StringView filename, size_t line_number, size_t line_column, size_t offset)
         : m_type(type)
         , m_message(message)
         , m_trivia(trivia)
@@ -169,6 +169,7 @@ public:
         , m_filename(filename)
         , m_line_number(line_number)
         , m_line_column(line_column)
+        , m_offset(offset)
     {
     }
 
@@ -184,6 +185,7 @@ public:
     const StringView& filename() const { return m_filename; }
     size_t line_number() const { return m_line_number; }
     size_t line_column() const { return m_line_column; }
+    size_t offset() const { return m_offset; }
     double double_value() const;
     bool bool_value() const;
 
@@ -207,6 +209,7 @@ private:
     StringView m_filename;
     size_t m_line_number;
     size_t m_line_column;
+    size_t m_offset;
 };
 
 }


### PR DESCRIPTION
- LibJS: Treat default parameter values as being in function context
- LibJS: Fix computed property ending token in binding pattern parsing
- LibJS: Allow 'name = value' in object literals as the spec does
    This is admittedly a bit of a hack, but it's no uglier than the spec, as it's literally what the spec does.
- LibJS: Implement parsing and evaluation for AssignmentPatterns
- LibJS: Add support for binding patterns in catch clauses
- LibJS: Consume identifier names where they are expected
    Consuming just `TokenType::Identifier` is not sufficient in these cases, add a `consume_identifier_name()` function to help lazy people like myself not slap `consume(TokenType::Identifier)` in there.