### PR TITLE
Kernel/VFS: Make the mkdir syscall respect process veils

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -874,8 +874,11 @@ KResultOr<NonnullRefPtr<Custody>> VirtualFileSystem::resolve_path(StringView pat
         return custody_or_error.error();
 
     auto& custody = custody_or_error.value();
-    if (auto result = validate_path_against_process_veil(*custody, options); result.is_error())
+    if (auto result = validate_path_against_process_veil(*custody, options); result.is_error()) {
+        if (out_parent)
+            out_parent->clear();
         return result;
+    }
 
     return custody;
 }

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestStackSmash.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestIo.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCMkdir.cpp
 )
 
 file(GLOB CMD_SOURCES  CONFIGURE_DEPENDS "*.cpp")

--- a/Tests/LibC/TestLibCMkdir.cpp
+++ b/Tests/LibC/TestLibCMkdir.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <errno.h>
+#include <errno_numbers.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static String random_dirname()
+{
+    auto string = String::formatted("/tmp/test_mkdir_{:8x}", (u32)rand());
+    dbgln("{}", string);
+    return string;
+}
+
+TEST_CASE(basic)
+{
+    auto dirname = random_dirname();
+    int res = mkdir(dirname.characters(), 0755);
+    EXPECT(res == 0);
+
+    res = mkdir(dirname.characters(), 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, EEXIST);
+}
+
+TEST_CASE(insufficient_permissions)
+{
+    VERIFY(getuid() != 0);
+    int res = mkdir("/root/foo", 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, EACCES);
+}
+
+TEST_CASE(nonexistent_parent)
+{
+    auto parent = random_dirname();
+    auto child = String::formatted("{}/foo", parent);
+    int res = mkdir(child.characters(), 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, ENOENT);
+}
+
+TEST_CASE(parent_is_file)
+{
+    int res = mkdir("/etc/passwd/foo", 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, ENOTDIR);
+}
+
+TEST_CASE(pledge)
+{
+    int res = pledge("stdio cpath", nullptr);
+    EXPECT(res == 0);
+
+    auto dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    EXPECT(res == 0);
+    // FIXME: Somehow also check that mkdir() stops working when removing the cpath promise. This is currently
+    //        not possible because this would prevent the unveil test case from properly working.
+}
+
+TEST_CASE(unveil)
+{
+    int res = unveil("/tmp", "rwc");
+    EXPECT(res == 0);
+
+    auto dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    EXPECT(res == 0);
+
+    res = unveil("/tmp", "rw");
+    EXPECT(res == 0);
+
+    dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, EACCES);
+
+    res = unveil("/tmp", "");
+    EXPECT(res == 0);
+
+    dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, ENOENT);
+}


### PR DESCRIPTION
This fixes a bug where the `mkdir` syscall would not respect the process veil at all.

It also changes `resolve_path` to return a null `out_parent` if it fails because a path wasn't unveiled. This seems sensible because relying on `out_parent` for veiled paths is dangerous, as the parent and child could be unveiled/veiled differently, and it thus makes more sense to use `resolve_path_without_veil` and check the veil manually.