### PR TITLE
Hackstudio: Disable debugging context menu entries

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -43,18 +43,12 @@ Editor::Editor()
     initialize_documentation_tooltip();
     initialize_parameters_hint_tooltip();
     m_evaluate_expression_action = GUI::Action::create("Evaluate expression", { Mod_Ctrl, Key_E }, [this](auto&) {
-        if (!execution_position().has_value()) {
-            GUI::MessageBox::show(window(), "Program is not running", "Error", GUI::MessageBox::Type::Error);
-            return;
-        }
+        VERIFY(is_program_running());
         auto dialog = EvaluateExpressionDialog::construct(window());
         dialog->exec();
     });
     m_move_execution_to_line_action = GUI::Action::create("Set execution point to line", [this](auto&) {
-        if (!execution_position().has_value()) {
-            GUI::MessageBox::show(window(), "Program must be paused", "Error", GUI::MessageBox::Type::Error);
-            return;
-        }
+        VERIFY(is_program_running());
         auto success = Debugger::the().set_execution_position(currently_open_file(), cursor().line());
         if (success) {
             set_execution_position(cursor().line());
@@ -62,6 +56,9 @@ Editor::Editor()
             GUI::MessageBox::show(window(), "Failed to set execution position", "Error", GUI::MessageBox::Type::Error);
         }
     });
+
+    set_debug_mode(false);
+
     add_custom_context_menu_action(*m_evaluate_expression_action);
     add_custom_context_menu_action(*m_move_execution_to_line_action);
 
@@ -670,6 +667,12 @@ void Editor::handle_function_parameters_hint_request()
         code_document().file_path(),
         cursor().line(),
         cursor().column());
+}
+
+void Editor::set_debug_mode(bool enabled)
+{
+    m_evaluate_expression_action->set_enabled(enabled);
+    m_move_execution_to_line_action->set_enabled(enabled);
 }
 
 }

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -34,8 +34,10 @@ public:
     const Vector<size_t>& breakpoint_lines() const { return code_document().breakpoint_lines(); }
     Vector<size_t>& breakpoint_lines() { return code_document().breakpoint_lines(); }
     Optional<size_t> execution_position() const { return code_document().execution_position(); }
+    bool is_program_running() const { return execution_position().has_value(); }
     void set_execution_position(size_t line_number);
     void clear_execution_position();
+    void set_debug_mode(bool);
 
     const CodeDocument& code_document() const;
     CodeDocument& code_document();

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -137,4 +137,9 @@ void EditorWrapper::update_title()
     m_filename_label->set_text(title.to_string());
 }
 
+void EditorWrapper::set_debug_mode(bool enabled)
+{
+    m_editor->set_debug_mode(enabled);
+}
+
 }

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -39,6 +39,7 @@ public:
 
     void set_mode_displayable();
     void set_mode_non_displayable();
+    void set_debug_mode(bool);
     void set_filename(const String&);
     const String& filename() const { return m_filename; }
     bool document_dirty() const { return m_document_dirty; }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -638,6 +638,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_debug_action()
         m_debugger_thread = Threading::Thread::construct(Debugger::start_static);
         m_debugger_thread->start();
         m_stop_action->set_enabled(true);
+        m_run_action->set_enabled(false);
     });
 }
 
@@ -687,6 +688,7 @@ void HackStudioWidget::initialize_debugger()
                 m_debug_info_widget->program_stopped();
                 m_disassembly_widget->program_stopped();
                 m_stop_action->set_enabled(false);
+                m_run_action->set_enabled(true);
                 m_debugger_thread.clear();
                 HackStudioWidget::hide_action_tabs();
                 GUI::MessageBox::show(window(), "Program Exited", "Debugger", GUI::MessageBox::Type::Information);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -639,6 +639,10 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_debug_action()
         m_debugger_thread->start();
         m_stop_action->set_enabled(true);
         m_run_action->set_enabled(false);
+
+        for (auto& editor_wrapper : m_all_editor_wrappers) {
+            editor_wrapper.set_debug_mode(true);
+        }
     });
 }
 
@@ -690,6 +694,11 @@ void HackStudioWidget::initialize_debugger()
                 m_stop_action->set_enabled(false);
                 m_run_action->set_enabled(true);
                 m_debugger_thread.clear();
+
+                for (auto& editor_wrapper : m_all_editor_wrappers) {
+                    editor_wrapper.set_debug_mode(false);
+                }
+
                 HackStudioWidget::hide_action_tabs();
                 GUI::MessageBox::show(window(), "Program Exited", "Debugger", GUI::MessageBox::Type::Information);
             }));


### PR DESCRIPTION
This PR fixes #7164.

The context menu entries "Evaluate expression" and "Set execution point to line" are now only enabled when a debug session is active.

Other than that, it was possible to run the program while a debug session is active. After the program finishes, the stop button gets disabled. This makes it impossible to exit the debug mode. I have disabled the run button while the debug mode is active.

This is my first PR to an open-source project, so please let me know if I did something wrong :)