### PR TITLE
Meta: Only try to use SDL when there are multiple displays

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -87,7 +87,9 @@ if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ]; then
 fi
 
 SERENITY_SCREENS="${SERENITY_SCREENS:-1}"
-if (uname -a | grep -iq WSL) || (uname -a | grep -iq microsoft); then
+if [ $SERENITY_SCREENS = 1 ]; then
+    SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-gtk,gl=on}"
+elif (uname -a | grep -iq WSL) || (uname -a | grep -iq microsoft); then
     # QEMU for windows does not like gl=on, so detect if we are building in wsl, and if so, disable it
     SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-sdl,gl=off}"
 elif ("${SERENITY_QEMU_BIN}" --display help | grep -iq sdl) && (ldconfig -p | grep -iq virglrenderer); then


### PR DESCRIPTION
SDL brings with it an annoying issue whereby trying to resize the window
before Serenity starts up prevents it from automatically resizing to fit
the screen.

This patch makes the previous behavior (i.e using the GTK backend) the
default unless SERENITY_SCREENS is greater than 1.