### PR TITLE
SoundPlayer: Show the context menu right under the cursor

### DIFF
--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -117,12 +117,9 @@ void BarsVisualizationWidget::set_buffer(RefPtr<Audio::Buffer> buffer)
     set_buffer(buffer, buffer->sample_count());
 }
 
-void BarsVisualizationWidget::mousedown_event(GUI::MouseEvent& event)
+void BarsVisualizationWidget::context_menu_event(GUI::ContextMenuEvent& event)
 {
-    Widget::mousedown_event(event);
-    if (event.button() == GUI::Right) {
-        m_context_menu->popup(event.position());
-    }
+    m_context_menu->popup(event.screen_position());
 }
 
 void BarsVisualizationWidget::set_samplerate(int samplerate)

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
@@ -25,7 +25,7 @@ private:
     void set_buffer(RefPtr<Audio::Buffer> buffer, int samples_to_use);
 
     void paint_event(GUI::PaintEvent&) override;
-    void mousedown_event(GUI::MouseEvent& event) override;
+    void context_menu_event(GUI::ContextMenuEvent& event) override;
 
     Vector<Complex<double>> m_sample_buffer;
     Vector<int> m_gfx_falling_bars;


### PR DESCRIPTION
The context menu used the mouse position by window, which resulted in a pop-up menu in the upper left corner of the screen.