### PR TITLE
Utilities: Make `sort` read from file and stdin

### DIFF
--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -7,34 +7,60 @@
 #include <AK/QuickSort.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+int main(int argc, char** argv)
 {
-    if (pledge("stdio", nullptr) > 0) {
+    if (pledge("stdio rpath", nullptr) > 0) {
         perror("pledge");
         return 1;
     }
 
+    Vector<const char*> files;
     Vector<String> lines;
 
-    for (;;) {
-        char* buffer = nullptr;
-        ssize_t buflen = 0;
-        size_t n;
-        errno = 0;
-        buflen = getline(&buffer, &n, stdin);
-        if (buflen == -1 && errno != 0) {
-            perror("getline");
-            exit(1);
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(files, "File(s) to process", "file", Core::ArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
+    auto handle_file = [&](StringView filename) -> bool {
+        auto file = Core::File::construct(filename);
+        if (!file->open(Core::OpenMode::ReadOnly)) {
+            warnln("Failed to open {}: {}", filename, file->error_string());
+            return false;
         }
-        if (buflen == -1)
-            break;
-        lines.append({ buffer, AK::ShouldChomp::Chomp });
+
+        while (file->can_read_line())
+            lines.append(file->read_line());
+        return true;
+    };
+
+    if (!files.size()) {
+        for (;;) {
+            char* buffer = nullptr;
+            ssize_t buflen = 0;
+            size_t n;
+            errno = 0;
+            buflen = getline(&buffer, &n, stdin);
+            if (buflen == -1 && errno != 0) {
+                perror("getline");
+                exit(1);
+            }
+            if (buflen == -1)
+                break;
+            lines.append({ buffer, AK::ShouldChomp::Chomp });
+        }
+    } else {
+        for (auto& filename : files) {
+            if (!handle_file(filename))
+                return 1;
+        }
     }
 
     quick_sort(lines, [](auto& a, auto& b) {

--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
         return true;
     };
 
-    if (!files.size()) {
+    if (files.is_empty()) {
         for (;;) {
             char* buffer = nullptr;
             ssize_t buflen = 0;


### PR DESCRIPTION
It's now possible to directly invoke sort given filename(s) without a pipeline. Of course, sort will still work if stdin is piped into it.
