### PR TITLE
Meta: Use the SDL backend for QEMU on Windows

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -92,7 +92,7 @@ if (uname -a | grep -iq WSL) || (uname -a | grep -iq microsoft); then
     # Also, when using the GTK backend we run into this problem: https://github.com/SerenityOS/serenity/issues/7657
     SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-sdl,gl=off}"
 elif [ $SERENITY_SCREENS = 1 ]; then
-    SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-gtk,gl=on}"
+    SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-gtk,gl=off}"
 elif ("${SERENITY_QEMU_BIN}" --display help | grep -iq sdl) && (ldconfig -p | grep -iq virglrenderer); then
     SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-sdl,gl=on}"
 elif "${SERENITY_QEMU_BIN}" --display help | grep -iq cocoa; then

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -87,11 +87,12 @@ if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ]; then
 fi
 
 SERENITY_SCREENS="${SERENITY_SCREENS:-1}"
-if [ $SERENITY_SCREENS = 1 ]; then
-    SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-gtk,gl=on}"
-elif (uname -a | grep -iq WSL) || (uname -a | grep -iq microsoft); then
+if (uname -a | grep -iq WSL) || (uname -a | grep -iq microsoft); then
     # QEMU for windows does not like gl=on, so detect if we are building in wsl, and if so, disable it
+    # Also, when using the GTK backend we run into this problem: https://github.com/SerenityOS/serenity/issues/7657
     SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-sdl,gl=off}"
+elif [ $SERENITY_SCREENS = 1 ]; then
+    SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-gtk,gl=on}"
 elif ("${SERENITY_QEMU_BIN}" --display help | grep -iq sdl) && (ldconfig -p | grep -iq virglrenderer); then
     SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-sdl,gl=on}"
 elif "${SERENITY_QEMU_BIN}" --display help | grep -iq cocoa; then


### PR DESCRIPTION
#8651 broke starting QEMU on Windows:

```
[0/1] cd /home/gunnar/serenity/Build/i686 && /usr/bin/cmake -E env SERENITY_ARCH=i686 /home/gunnar/serenity/Meta/run.sh
qemu-system-x86_64.exe: OpenGL support is disabled
FAILED: CMakeFiles/run
```