### PR TITLE
LibGfx: Speed up PNGWriter by avoiding some memory copies and allocations

### DIFF
--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -18,6 +18,7 @@ public:
     explicit PNGChunk(String);
     auto const& data() const { return m_data; };
     String const& type() const { return m_type; };
+    void reserve(size_t bytes) { m_data.ensure_capacity(bytes); }
 
     template<typename T>
     void add_as_big_endian(T);
@@ -166,6 +167,7 @@ void PNGWriter::add_IEND_chunk()
 void PNGWriter::add_IDAT_chunk(Gfx::Bitmap const& bitmap)
 {
     PNGChunk png_chunk { "IDAT" };
+    png_chunk.reserve(bitmap.size_in_bytes());
 
     u16 CMF_FLG = 0x81d;
     png_chunk.add_as_big_endian(CMF_FLG);

--- a/Userland/Libraries/LibGfx/PNGWriter.h
+++ b/Userland/Libraries/LibGfx/PNGWriter.h
@@ -22,7 +22,7 @@ private:
     PNGWriter() { }
 
     Vector<u8> m_data;
-    void add_chunk(PNGChunk const&);
+    void add_chunk(PNGChunk&);
     void add_png_header();
     void add_IHDR_chunk(u32 width, u32 height, u8 bit_depth, u8 color_type, u8 compression_method, u8 filter_method, u8 interlace_method);
     void add_IDAT_chunk(Gfx::Bitmap const&);


### PR DESCRIPTION
Results on my PC, for 1920x1080 resolution:
- Before: 635 ms
- After: 306 ms