### PR TITLE
Kernel: Avoid unnecessary context switch when no other thread is ready

### DIFF
--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -44,6 +44,7 @@ public:
     static void invoke_async();
     static void notify_finalizer();
     static Thread& pull_next_runnable_thread();
+    static Thread* peek_next_runnable_thread();
     static bool dequeue_runnable_thread(Thread&, bool = false);
     static void queue_runnable_thread(Thread&);
     static void dump_scheduler_state();


### PR DESCRIPTION
If no other thread is ready to be run we don't need to switch to the
idle thread and wait for the next timer interrupt. We can just give
the thread another timeslice and keep it running.