### PR TITLE
Kernel: Move new process registration out of Space spinlock scope

### DIFF
--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -108,9 +108,9 @@ KResultOr<FlatPtr> Process::sys$fork(RegisterState& regs)
             if (region == m_master_tls_region.unsafe_ptr())
                 child->m_master_tls_region = child_region;
         }
-
-        Process::register_new(*child);
     }
+
+    Process::register_new(*child);
 
     PerformanceManager::add_process_created_event(*child);
 


### PR DESCRIPTION
There appears to be no reason why the process registration needs
to happen under the space spin lock. As the first thread is not started
yet it should be completely uncontested, but it's still bad practice.