### PR TITLE
LibGUI: Ignore drop events by default

### DIFF
--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -554,6 +554,7 @@ void Widget::drag_leave_event(Event&)
 void Widget::drop_event(DropEvent& event)
 {
     dbgln("{} {:p} DROP @ {}, '{}'", class_name(), this, event.position(), event.text());
+    event.ignore();
 }
 
 void Widget::theme_change_event(ThemeChangeEvent&)


### PR DESCRIPTION
Before this change, parent widgets such as Buttons or Labels were stealing drop events their parents.

I noticed it during drag-n-dropping files into visualization widgets in Sound Player (which takes practically the entire application size and gave impression that drop events weren't supported in the app at all).