### PR TITLE
LibJS: Add missing has_constructor override to Generator Functions

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
@@ -21,6 +21,9 @@ public:
 
     virtual Value call() override;
     virtual Value construct(FunctionObject& new_target) override;
+
+private:
+    bool has_constructor() const override { return true; }
 };
 
 }


### PR DESCRIPTION
Fixes 1 test262 test case