### PR TITLE
LibGUI: Use wrapped text rect for paint invalidation

### DIFF
--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -404,6 +404,14 @@ Gfx::IntRect IconView::editing_rect(ModelIndex const& index) const
     return item_data.text_rect.inflated(4, 4);
 }
 
+Gfx::IntRect IconView::paint_invalidation_rect(const ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return {};
+    auto& item_data = get_item_data(index.row());
+    return item_data.rect(true);
+}
+
 void IconView::did_change_hovered_index(const ModelIndex& old_index, const ModelIndex& new_index)
 {
     AbstractView::did_change_hovered_index(old_index, new_index);
@@ -462,6 +470,7 @@ void IconView::get_item_rects(int item_index, ItemData& item_data, const Gfx::Fo
         item_data.text_rect.intersect(item_rect);
         item_data.text_rect.set_height(font.glyph_height() * item_data.wrapped_text_lines.size());
         item_data.text_rect.inflate(6, 4);
+        item_data.text_rect_wrapped = item_data.text_rect;
     } else {
         item_data.text_rect.set_width(unwrapped_text_width);
         item_data.text_rect.inflate(6, 4);

--- a/Userland/Libraries/LibGUI/IconView.h
+++ b/Userland/Libraries/LibGUI/IconView.h
@@ -41,6 +41,7 @@ public:
     virtual ModelIndex index_at_event_position(const Gfx::IntPoint&) const override;
     virtual Gfx::IntRect content_rect(const ModelIndex&) const override;
     virtual Gfx::IntRect editing_rect(ModelIndex const&) const override;
+    virtual Gfx::IntRect paint_invalidation_rect(ModelIndex const&) const override;
 
     virtual void select_all() override;
 
@@ -61,6 +62,7 @@ private:
 
     struct ItemData {
         Gfx::IntRect text_rect;
+        Optional<Gfx::IntRect> text_rect_wrapped;
         Gfx::IntRect icon_rect;
         int icon_offset_y;
         int text_offset_y;
@@ -90,8 +92,10 @@ private:
             return icon_rect.contains(point) || text_rect.contains(point);
         }
 
-        Gfx::IntRect rect() const
+        Gfx::IntRect rect(bool wrapped = false) const
         {
+            if (wrapped && text_rect_wrapped.has_value())
+                return text_rect_wrapped->united(icon_rect);
             return text_rect.united(icon_rect);
         }
     };


### PR DESCRIPTION
This fixes an issue where after anything past first line would not get
invalidated after unhovering an icon.