### PR TITLE
LibAudio: Set variable type for decoding fixed subframes in FLAC

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -684,27 +684,27 @@ Vector<i32> FlacLoaderPlugin::decode_fixed_lpc(FlacSubframeHeader& subframe, Inp
     switch (subframe.order) {
     case 0:
         // s_0(t) = 0
-        for (auto i = subframe.order; i < m_current_frame->sample_count; ++i)
+        for (u32 i = subframe.order; i < m_current_frame->sample_count; ++i)
             decoded[i] += 0;
         break;
     case 1:
         // s_1(t) = s(t-1)
-        for (auto i = subframe.order; i < m_current_frame->sample_count; ++i)
+        for (u32 i = subframe.order; i < m_current_frame->sample_count; ++i)
             decoded[i] += decoded[i - 1];
         break;
     case 2:
         // s_2(t) = 2s(t-1) - s(t-2)
-        for (auto i = subframe.order; i < m_current_frame->sample_count; ++i)
+        for (u32 i = subframe.order; i < m_current_frame->sample_count; ++i)
             decoded[i] += 2 * decoded[i - 1] - decoded[i - 2];
         break;
     case 3:
         // s_3(t) = 3s(t-1) - 3s(t-2) + s(t-3)
-        for (auto i = subframe.order; i < m_current_frame->sample_count; ++i)
+        for (u32 i = subframe.order; i < m_current_frame->sample_count; ++i)
             decoded[i] += 3 * decoded[i - 1] - 3 * decoded[i - 2] + decoded[i - 3];
         break;
     case 4:
         // s_4(t) = 4s(t-1) - 6s(t-2) + 4s(t-3) - s(t-4)
-        for (auto i = subframe.order; i < m_current_frame->sample_count; ++i)
+        for (u32 i = subframe.order; i < m_current_frame->sample_count; ++i)
             decoded[i] += 4 * decoded[i - 1] - 6 * decoded[i - 2] + 4 * decoded[i - 3] - decoded[i - 4];
         break;
     default:


### PR DESCRIPTION
This fixes an crash caused by using the type from `FlacSubframeHeader::order` (unsigned 8-bit), which after overflowing
the integer, converting it back to u32, and decrementing by one resulted in accessing an array waaay out of bounds.