### PR TITLE
LibWeb: Remove StringBuilders from the HTMLToken class

### DIFF
--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -46,6 +46,13 @@ public:
             m_index_into_first = 0;
         }
         --m_size;
+        if (m_size == 0 && !m_segments.is_empty()) {
+            // This is not necessary for correctness but avoids faulting in
+            // all the pages for the underlying Vector in the case where
+            // the caller repeatedly enqueues and then dequeues a single item.
+            m_index_into_first = 0;
+            m_segments.last()->data.clear_with_capacity();
+        }
         return value;
     }
 

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,2 +1,12 @@
+set(
+    TEST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/TestHTMLTokenizer.cpp
+)
+
+foreach(source ${TEST_SOURCES})
+    serenity_test(${source} LibWeb LIBS LibWeb)
+endforeach()
+
 serenity_testjs_test(test-web.cpp test-web LIBS LibWeb)
 install(TARGETS test-web RUNTIME DESTINATION bin OPTIONAL)
+install(FILES tokenizer-test.html DESTINATION usr/Tests/LibWeb)

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibCore/File.h>
+#include <LibWeb/HTML/Parser/HTMLTokenizer.h>
+
+using Tokenizer = Web::HTML::HTMLTokenizer;
+using Token = Web::HTML::HTMLToken;
+
+#define BEGIN_ENUMERATION(tokens)          \
+    auto current_token = (tokens).begin(); \
+    Optional<Token> last_token;
+
+#define END_ENUMERATION() \
+    EXPECT(current_token.is_end());
+
+#define NEXT_TOKEN()             \
+    last_token = *current_token; \
+    ++current_token;
+
+#define EXPECT_START_TAG_TOKEN(_tag_name)                    \
+    EXPECT_EQ(current_token->type(), Token::Type::StartTag); \
+    EXPECT_EQ(current_token->tag_name(), #_tag_name);        \
+    NEXT_TOKEN();
+
+#define EXPECT_END_TAG_TOKEN(_tag_name)                    \
+    EXPECT_EQ(current_token->type(), Token::Type::EndTag); \
+    EXPECT_EQ(current_token->tag_name(), #_tag_name);      \
+    NEXT_TOKEN();
+
+#define EXPECT_END_OF_FILE_TOKEN()                            \
+    EXPECT_EQ(current_token->type(), Token::Type::EndOfFile); \
+    NEXT_TOKEN();
+
+#define EXPECT_CHARACTER_TOKEN(character)                     \
+    EXPECT_EQ(current_token->type(), Token::Type::Character); \
+    EXPECT_EQ(current_token->code_point(), (u32)(character)); \
+    NEXT_TOKEN();
+
+#define EXPECT_CHARACTER_TOKENS(string)  \
+    for (auto c : StringView(#string)) { \
+        EXPECT_CHARACTER_TOKEN(c);       \
+    }
+
+#define EXPECT_COMMENT_TOKEN()                              \
+    EXPECT_EQ(current_token->type(), Token::Type::Comment); \
+    NEXT_TOKEN();
+
+#define EXPECT_DOCTYPE_TOKEN()                              \
+    EXPECT_EQ(current_token->type(), Token::Type::DOCTYPE); \
+    NEXT_TOKEN();
+
+#define EXPECT_TAG_TOKEN_ATTRIBUTE(name, value) \
+    VERIFY(last_token.has_value());             \
+    EXPECT_EQ(last_token->attribute(#name), #value);
+
+#define EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(count) \
+    VERIFY(last_token.has_value());             \
+    EXPECT_EQ(last_token->attributes().size(), (size_t)count);
+
+static Vector<Token> run_tokenizer(StringView const& input)
+{
+    Vector<Token> tokens;
+    Tokenizer tokenizer { input, "UTF-8"sv };
+    while (true) {
+        auto maybe_token = tokenizer.next_token();
+        if (!maybe_token.has_value())
+            break;
+        tokens.append(maybe_token.release_value());
+    }
+    return tokens;
+}
+
+// FIXME: It's not very nice to rely on the format of HTMLToken::to_string() to stay the same.
+static u32 hash_tokens(Vector<Token> const& tokens)
+{
+    StringBuilder builder;
+    for (auto& token : tokens)
+        builder.append(token.to_string());
+    return (u32)builder.string_view().hash();
+}
+
+TEST_CASE(empty)
+{
+    auto tokens = run_tokenizer("");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(basic)
+{
+    auto tokens = run_tokenizer("<html><head></head><body></body></html>");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(html);
+    EXPECT_START_TAG_TOKEN(head);
+    EXPECT_END_TAG_TOKEN(head);
+    EXPECT_START_TAG_TOKEN(body);
+    EXPECT_END_TAG_TOKEN(body);
+    EXPECT_END_TAG_TOKEN(html);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(basic_with_text)
+{
+    auto tokens = run_tokenizer("<p>This is some text.</p>");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(p);
+    EXPECT_CHARACTER_TOKENS(This is some text.);
+    EXPECT_END_TAG_TOKEN(p);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(unquoted_attributes)
+{
+    auto tokens = run_tokenizer("<p foo=bar>");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(p);
+    EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(1);
+    EXPECT_TAG_TOKEN_ATTRIBUTE(foo, bar);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(single_quoted_attributes)
+{
+    auto tokens = run_tokenizer("<p foo='bar'>");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(p);
+    EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(1);
+    EXPECT_TAG_TOKEN_ATTRIBUTE(foo, bar);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(double_quoted_attributes)
+{
+    auto tokens = run_tokenizer("<p foo=\"bar\">");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(p);
+    EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(1);
+    EXPECT_TAG_TOKEN_ATTRIBUTE(foo, bar);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(multiple_attributes)
+{
+    auto tokens = run_tokenizer("<p foo=\"bar\" baz=foobar foo2=\"bar2\">");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(p);
+    EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(3);
+    EXPECT_TAG_TOKEN_ATTRIBUTE(foo, bar);
+    EXPECT_TAG_TOKEN_ATTRIBUTE(baz, foobar);
+    EXPECT_TAG_TOKEN_ATTRIBUTE(foo2, bar2);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(comment)
+{
+    auto tokens = run_tokenizer("<p><!-- This is a comment --></p>");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_START_TAG_TOKEN(p);
+    EXPECT_COMMENT_TOKEN();
+    EXPECT_END_TAG_TOKEN(p);
+    EXPECT_END_OF_FILE_TOKEN();
+    END_ENUMERATION();
+}
+
+TEST_CASE(doctype)
+{
+    auto tokens = run_tokenizer("<!DOCTYPE html><html></html>");
+    BEGIN_ENUMERATION(tokens);
+    EXPECT_DOCTYPE_TOKEN();
+    EXPECT_START_TAG_TOKEN(html);
+    EXPECT_END_TAG_TOKEN(html);
+}
+
+// NOTE: This relies on the format of HTMLToken::to_string() staying the same.
+//       If that changes, or something is added to the test HTML, the hash needs to be adjusted.
+TEST_CASE(regression)
+{
+    auto file = Core::File::open("/usr/Tests/LibWeb/tokenizer-test.html", Core::OpenMode::ReadOnly);
+    VERIFY(!file.is_error());
+    auto file_contents = file.value()->read_all();
+    auto tokens = run_tokenizer(file_contents);
+    u32 hash = hash_tokens(tokens);
+    EXPECT_EQ(hash, 1328591125u);
+}

--- a/Tests/LibWeb/tokenizer-test.html
+++ b/Tests/LibWeb/tokenizer-test.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>This is a test page :^)</title>
+</head>
+<body>
+    <p>This is the first paragraph.</p>
+    <p foo="bar">The second paragraph has an attribute!</p>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -437,7 +437,7 @@ NonnullRefPtr<DOM::Element> HTMLDocumentParser::create_element_for(const HTMLTok
 {
     auto element = create_element(document(), token.tag_name(), namespace_);
     for (auto& attribute : token.m_tag.attributes) {
-        element->set_attribute(attribute.local_name_builder.to_string(), attribute.value_builder.to_string());
+        element->set_attribute(attribute.local_name, attribute.value);
     }
     return element;
 }
@@ -1120,9 +1120,9 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         if (m_stack_of_open_elements.contains(HTML::TagNames::template_))
             return;
         for (auto& attribute : token.m_tag.attributes) {
-            if (current_node().has_attribute(attribute.local_name_builder.string_view()))
+            if (current_node().has_attribute(attribute.local_name))
                 continue;
-            current_node().set_attribute(attribute.local_name_builder.to_string(), attribute.value_builder.to_string());
+            current_node().set_attribute(attribute.local_name, attribute.value);
         }
         return;
     }
@@ -1147,9 +1147,9 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         m_frameset_ok = false;
         auto& body_element = m_stack_of_open_elements.elements().at(1);
         for (auto& attribute : token.m_tag.attributes) {
-            if (body_element.has_attribute(attribute.local_name_builder.string_view()))
+            if (body_element.has_attribute(attribute.local_name))
                 continue;
-            body_element.set_attribute(attribute.local_name_builder.to_string(), attribute.value_builder.to_string());
+            body_element.set_attribute(attribute.local_name, attribute.value);
         }
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -262,11 +262,11 @@ DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_t
         return DOM::QuirksMode::Yes;
 
     // NOTE: The tokenizer puts the name into lower case for us.
-    if (doctype_token.m_doctype.name.to_string() != "html")
+    if (doctype_token.m_doctype.name != "html")
         return DOM::QuirksMode::Yes;
 
-    auto public_identifier = doctype_token.m_doctype.public_identifier.to_string();
-    auto system_identifier = doctype_token.m_doctype.system_identifier.to_string();
+    auto const& public_identifier = doctype_token.m_doctype.public_identifier;
+    auto const& system_identifier = doctype_token.m_doctype.system_identifier;
 
     if (public_identifier.equals_ignoring_case("-//W3O//DTD W3 HTML Strict 3.0//EN//"))
         return DOM::QuirksMode::Yes;
@@ -324,9 +324,9 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
 
     if (token.is_doctype()) {
         auto doctype = adopt_ref(*new DOM::DocumentType(document()));
-        doctype->set_name(token.m_doctype.name.to_string());
-        doctype->set_public_id(token.m_doctype.public_identifier.to_string());
-        doctype->set_system_id(token.m_doctype.system_identifier.to_string());
+        doctype->set_name(token.m_doctype.name);
+        doctype->set_public_id(token.m_doctype.public_identifier);
+        doctype->set_system_id(token.m_doctype.system_identifier);
         document().append_child(move(doctype));
         document().set_quirks_mode(which_quirks_mode(token));
         m_insertion_mode = InsertionMode::BeforeHTML;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -1572,8 +1572,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::image) {
         // Parse error. Change the token's tag name to HTML::TagNames::img and reprocess it. (Don't ask.)
         log_parse_error();
-        token.m_tag.tag_name.clear();
-        token.m_tag.tag_name.append(HTML::TagNames::img);
+        token.m_tag.tag_name = "img";
         process_using_the_rules_for(m_insertion_mode, token);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -317,7 +317,7 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }
@@ -347,7 +347,7 @@ void HTMLDocumentParser::handle_before_html(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }
@@ -520,7 +520,7 @@ AnythingElse:
 
 void HTMLDocumentParser::insert_comment(HTMLToken& token)
 {
-    auto data = token.m_comment_or_character.data.to_string();
+    auto data = token.m_comment_or_character.data;
     auto adjusted_insertion_location = find_appropriate_place_for_inserting_node();
     adjusted_insertion_location.parent->insert_before(adopt_ref(*new DOM::Comment(document(), data)), adjusted_insertion_location.insert_before_sibling);
 }
@@ -832,7 +832,7 @@ void HTMLDocumentParser::handle_after_body(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto data = token.m_comment_or_character.data.to_string();
+        auto data = token.m_comment_or_character.data;
         auto& insertion_location = m_stack_of_open_elements.first();
         insertion_location.append_child(adopt_ref(*new DOM::Comment(document(), data)));
         return;
@@ -870,7 +870,7 @@ void HTMLDocumentParser::handle_after_body(HTMLToken& token)
 void HTMLDocumentParser::handle_after_after_body(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }
@@ -2751,7 +2751,7 @@ void HTMLDocumentParser::handle_after_frameset(HTMLToken& token)
 void HTMLDocumentParser::handle_after_after_frameset(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data.to_string()));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
         document().append_child(move(comment));
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -16,7 +16,7 @@ String HTMLToken::to_string() const
     case HTMLToken::Type::DOCTYPE:
         builder.append("DOCTYPE");
         builder.append(" { name: '");
-        builder.append(m_doctype.name.to_string());
+        builder.append(m_doctype.name);
         builder.append("' }");
         break;
     case HTMLToken::Type::StartTag:

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -43,9 +43,9 @@ String HTMLToken::to_string() const
         builder.append(m_tag.tag_name.to_string());
         builder.append("', { ");
         for (auto& attribute : m_tag.attributes) {
-            builder.append(attribute.local_name_builder.to_string());
+            builder.append(attribute.local_name);
             builder.append("=\"");
-            builder.append(attribute.value_builder.to_string());
+            builder.append(attribute.value);
             builder.append("\" ");
         }
         builder.append("} }");

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -40,7 +40,7 @@ String HTMLToken::to_string() const
 
     if (type() == HTMLToken::Type::StartTag || type() == HTMLToken::Type::EndTag) {
         builder.append(" { name: '");
-        builder.append(m_tag.tag_name.to_string());
+        builder.append(m_tag.tag_name);
         builder.append("', { ");
         for (auto& attribute : m_tag.attributes) {
             builder.append(attribute.local_name);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -53,7 +53,7 @@ String HTMLToken::to_string() const
 
     if (type() == HTMLToken::Type::Comment || type() == HTMLToken::Type::Character) {
         builder.append(" { data: '");
-        builder.append(m_comment_or_character.data.to_string());
+        builder.append(m_comment_or_character.data);
         builder.append("' }");
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -42,7 +42,7 @@ public:
     {
         HTMLToken token;
         token.m_type = Type::StartTag;
-        token.m_tag.tag_name.append(tag_name);
+        token.m_tag.tag_name = tag_name;
         return token;
     }
 
@@ -81,7 +81,7 @@ public:
     String tag_name() const
     {
         VERIFY(is_start_tag() || is_end_tag());
-        return m_tag.tag_name.to_string();
+        return m_tag.tag_name;
     }
 
     bool is_self_closing() const
@@ -120,10 +120,8 @@ public:
     void adjust_tag_name(const FlyString& old_name, const FlyString& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
-        if (old_name == m_tag.tag_name.string_view()) {
-            m_tag.tag_name.clear();
-            m_tag.tag_name.append(new_name);
-        }
+        if (old_name == m_tag.tag_name)
+            m_tag.tag_name = new_name;
     }
 
     void adjust_attribute_name(const FlyString& old_name, const FlyString& new_name)
@@ -202,7 +200,7 @@ private:
     // Type::StartTag
     // Type::EndTag
     struct {
-        StringBuilder tag_name;
+        String tag_name;
         bool self_closing { false };
         bool self_closing_acknowledged { false };
         Vector<AttributeBuilder> attributes;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -40,7 +40,7 @@ public:
         return token;
     }
 
-    static HTMLToken make_start_tag(const FlyString& tag_name)
+    static HTMLToken make_start_tag(FlyString const& tag_name)
     {
         HTMLToken token;
         token.m_type = Type::StartTag;
@@ -104,7 +104,7 @@ public:
             m_tag.self_closing_acknowledged = true;
     }
 
-    StringView attribute(const FlyString& attribute_name)
+    StringView attribute(FlyString const& attribute_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
@@ -114,19 +114,19 @@ public:
         return {};
     }
 
-    bool has_attribute(const FlyString& attribute_name)
+    bool has_attribute(FlyString const& attribute_name)
     {
         return !attribute(attribute_name).is_null();
     }
 
-    void adjust_tag_name(const FlyString& old_name, const FlyString& new_name)
+    void adjust_tag_name(FlyString const& old_name, FlyString const& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
         if (old_name == m_tag.tag_name)
             m_tag.tag_name = new_name;
     }
 
-    void adjust_attribute_name(const FlyString& old_name, const FlyString& new_name)
+    void adjust_attribute_name(FlyString const& old_name, FlyString const& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
@@ -136,7 +136,7 @@ public:
         }
     }
 
-    void adjust_foreign_attribute(const FlyString& old_name, const FlyString& prefix, const FlyString& local_name, const FlyString& namespace_)
+    void adjust_foreign_attribute(FlyString const& old_name, FlyString const& prefix, FlyString const& local_name, FlyString const& namespace_)
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
@@ -158,10 +158,10 @@ public:
 
     String to_string() const;
 
-    const auto& start_position() const { return m_start_position; }
-    const auto& end_position() const { return m_end_position; }
+    auto const& start_position() const { return m_start_position; }
+    auto const& end_position() const { return m_end_position; }
 
-    const auto& attributes() const
+    auto const& attributes() const
     {
         VERIFY(is_start_tag() || is_end_tag());
         return m_tag.attributes;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -106,8 +106,8 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (attribute_name == attribute.local_name_builder.string_view())
-                return attribute.value_builder.string_view();
+            if (attribute_name == attribute.local_name)
+                return attribute.value;
         }
         return {};
     }
@@ -130,9 +130,8 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (old_name == attribute.local_name_builder.string_view()) {
-                attribute.local_name_builder.clear();
-                attribute.local_name_builder.append(new_name);
+            if (old_name == attribute.local_name) {
+                attribute.local_name = new_name;
             }
         }
     }
@@ -141,12 +140,9 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (old_name == attribute.local_name_builder.string_view()) {
+            if (old_name == attribute.local_name) {
                 attribute.prefix = prefix;
-
-                attribute.local_name_builder.clear();
-                attribute.local_name_builder.append(local_name);
-
+                attribute.local_name = local_name;
                 attribute.namespace_ = namespace_;
             }
         }
@@ -179,9 +175,9 @@ private:
 
     struct AttributeBuilder {
         String prefix;
-        StringBuilder local_name_builder;
+        String local_name;
         String namespace_;
-        StringBuilder value_builder;
+        String value;
         Position name_start_position;
         Position value_start_position;
         Position name_end_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -8,7 +8,6 @@
 
 #include <AK/FlyString.h>
 #include <AK/String.h>
-#include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
@@ -34,7 +33,10 @@ public:
     {
         HTMLToken token;
         token.m_type = Type::Character;
-        token.m_comment_or_character.data.append(code_point);
+        StringBuilder builder;
+        // FIXME: This narrows code_point to char, should this be append_code_point() instead?
+        builder.append(code_point);
+        token.m_comment_or_character.data = builder.to_string();
         return token;
     }
 
@@ -56,7 +58,7 @@ public:
     u32 code_point() const
     {
         VERIFY(is_character());
-        Utf8View view(m_comment_or_character.data.string_view());
+        Utf8View view(m_comment_or_character.data);
         VERIFY(view.length() == 1);
         return *view.begin();
     }
@@ -209,7 +211,7 @@ private:
     // Type::Comment
     // Type::Character
     struct {
-        StringBuilder data;
+        String data;
     } m_comment_or_character;
 
     Position m_start_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -142,14 +142,12 @@ public:
         VERIFY(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
             if (old_name == attribute.local_name_builder.string_view()) {
-                attribute.prefix_builder.clear();
-                attribute.prefix_builder.append(prefix);
+                attribute.prefix = prefix;
 
                 attribute.local_name_builder.clear();
                 attribute.local_name_builder.append(local_name);
 
-                attribute.namespace_builder.clear();
-                attribute.namespace_builder.append(namespace_);
+                attribute.namespace_ = namespace_;
             }
         }
     }
@@ -180,9 +178,9 @@ private:
     };
 
     struct AttributeBuilder {
-        StringBuilder prefix_builder;
+        String prefix;
         StringBuilder local_name_builder;
-        StringBuilder namespace_builder;
+        String namespace_;
         StringBuilder value_builder;
         Position name_start_position;
         Position value_start_position;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -194,11 +194,11 @@ private:
     struct {
         // NOTE: "Missing" is a distinct state from the empty string.
 
-        StringBuilder name;
+        String name;
         bool missing_name { true };
-        StringBuilder public_identifier;
+        String public_identifier;
         bool missing_public_identifier { true };
-        StringBuilder system_identifier;
+        String system_identifier;
         bool missing_system_identifier { true };
         bool force_quirks { false };
     } m_doctype;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2649,16 +2649,16 @@ void HTMLTokenizer::switch_to(Badge<HTMLDocumentParser>, State new_state)
 void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
-        m_last_emitted_start_tag = token;
+        m_last_emitted_start_tag_name = token.tag_name();
     token.m_end_position = nth_last_position(0);
 }
 
 bool HTMLTokenizer::current_end_tag_token_is_appropriate() const
 {
     VERIFY(m_current_token.is_end_tag());
-    if (!m_last_emitted_start_tag.is_start_tag())
+    if (!m_last_emitted_start_tag_name.has_value())
         return false;
-    return m_current_token.tag_name() == m_last_emitted_start_tag.tag_name();
+    return m_current_token.tag_name() == m_last_emitted_start_tag_name.value();
 }
 
 bool HTMLTokenizer::consumed_as_part_of_an_attribute() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -303,29 +303,32 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     m_current_token.m_end_position = nth_last_position(0);
                     SWITCH_TO(SelfClosingStartTag);
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(to_ascii_lowercase(current_input_character.value()));
+                    m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
                     m_current_token.m_end_position = nth_last_position(0);
                     continue;
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_tag.tag_name.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     m_current_token.m_end_position = nth_last_position(0);
                     continue;
                 }
@@ -337,7 +340,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_tag.tag_name.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     m_current_token.m_end_position = nth_last_position(0);
                     continue;
                 }
@@ -1846,6 +1849,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1857,6 +1861,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1868,6 +1873,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1879,13 +1885,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(to_ascii_lowercase(current_input_character.value()));
+                    m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
@@ -1956,6 +1962,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1967,6 +1974,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1978,6 +1986,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1989,13 +1998,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(to_ascii_lowercase(current_input_character.value()));
+                    m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(current_input_character.value());
+                    m_current_builder.append(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
@@ -2166,6 +2175,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(BeforeAttributeName);
 
@@ -2178,6 +2188,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(SelfClosingStartTag);
 
@@ -2190,6 +2201,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
 
@@ -2202,13 +2214,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(to_ascii_lowercase(current_input_character.value()));
+                    m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(current_input_character.value());
+                    m_current_builder.append(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
@@ -2491,6 +2503,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(BeforeAttributeName);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2501,6 +2514,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(SelfClosingStartTag);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2511,6 +2525,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
+                    m_current_token.m_tag.tag_name = consume_current_builder();
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2521,13 +2536,13 @@ _StartOfFunction:
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(to_ascii_lowercase(current_input_character.value()));
+                    m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }
                 ON_ASCII_LOWER_ALPHA
                 {
-                    m_current_token.m_tag.tag_name.append(current_input_character.value());
+                    m_current_builder.append(current_input_character.value());
                     m_temporary_buffer.append(current_input_character.value());
                     continue;
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -74,17 +74,18 @@ namespace Web::HTML {
         goto new_state;                                                 \
     } while (0)
 
-#define FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE                                           \
-    do {                                                                                             \
-        for (auto code_point : m_temporary_buffer) {                                                 \
-            if (consumed_as_part_of_an_attribute()) {                                                \
-                m_current_builder.append_code_point(code_point);                                     \
-            } else {                                                                                 \
-                create_new_token(HTMLToken::Type::Character);                                        \
-                m_current_token.m_comment_or_character.data.append_code_point(code_point);           \
-                m_queued_tokens.enqueue(m_current_token);                                            \
-            }                                                                                        \
-        }                                                                                            \
+#define FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE                               \
+    do {                                                                                 \
+        for (auto code_point : m_temporary_buffer) {                                     \
+            if (consumed_as_part_of_an_attribute()) {                                    \
+                m_current_builder.append_code_point(code_point);                         \
+            } else {                                                                     \
+                create_new_token(HTMLToken::Type::Character);                            \
+                m_current_builder.append_code_point(code_point);                         \
+                m_current_token.m_comment_or_character.data = consume_current_builder(); \
+                m_queued_tokens.enqueue(m_current_token);                                \
+            }                                                                            \
+        }                                                                                \
     } while (0)
 
 #define DONT_CONSUME_NEXT_INPUT_CHARACTER \
@@ -139,12 +140,13 @@ namespace Web::HTML {
         return m_queued_tokens.dequeue();         \
     } while (0)
 
-#define EMIT_CHARACTER(code_point)                                                 \
-    do {                                                                           \
-        create_new_token(HTMLToken::Type::Character);                              \
-        m_current_token.m_comment_or_character.data.append_code_point(code_point); \
-        m_queued_tokens.enqueue(m_current_token);                                  \
-        return m_queued_tokens.dequeue();                                          \
+#define EMIT_CHARACTER(code_point)                                               \
+    do {                                                                         \
+        create_new_token(HTMLToken::Type::Character);                            \
+        m_current_builder.append_code_point(code_point);                         \
+        m_current_token.m_comment_or_character.data = consume_current_builder(); \
+        m_queued_tokens.enqueue(m_current_token);                                \
+        return m_queued_tokens.dequeue();                                        \
     } while (0)
 
 #define EMIT_CURRENT_CHARACTER \
@@ -402,6 +404,7 @@ _StartOfFunction:
             {
                 ON('>')
                 {
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
@@ -412,12 +415,12 @@ _StartOfFunction:
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_comment_or_character.data.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
             }
@@ -1346,11 +1349,12 @@ _StartOfFunction:
             {
                 ON('-')
                 {
-                    SWITCH_TO(CommentEnd);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentEnd);
                 }
                 ON('>')
                 {
                     log_parse_error();
+                    consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
@@ -1361,7 +1365,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_comment_or_character.data.append('-');
+                    m_current_builder.append('-');
                     RECONSUME_IN(Comment);
                 }
             }
@@ -1371,17 +1375,17 @@ _StartOfFunction:
             {
                 ON('<')
                 {
-                    m_current_token.m_comment_or_character.data.append_code_point(current_input_character.value());
-                    SWITCH_TO(CommentLessThanSign);
+                    m_current_builder.append_code_point(current_input_character.value());
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentLessThanSign);
                 }
                 ON('-')
                 {
-                    SWITCH_TO(CommentEndDash);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentEndDash);
                 }
                 ON(0)
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data.append_code_point(0xFFFD);
+                    m_current_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
@@ -1392,7 +1396,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_comment_or_character.data.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
             }
@@ -1402,6 +1406,7 @@ _StartOfFunction:
             {
                 ON('>')
                 {
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON('!')
@@ -1410,7 +1415,7 @@ _StartOfFunction:
                 }
                 ON('-')
                 {
-                    m_current_token.m_comment_or_character.data.append('-');
+                    m_current_builder.append('-');
                     continue;
                 }
                 ON_EOF
@@ -1421,7 +1426,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_comment_or_character.data.append('-');
+                    m_current_builder.append('-');
                     RECONSUME_IN(Comment);
                 }
             }
@@ -1431,7 +1436,7 @@ _StartOfFunction:
             {
                 ON('-')
                 {
-                    m_current_token.m_comment_or_character.data.append("--!");
+                    m_current_builder.append("--!");
                     SWITCH_TO(CommentEndDash);
                 }
                 ON('>')
@@ -1447,7 +1452,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_comment_or_character.data.append("--!");
+                    m_current_builder.append("--!");
                     RECONSUME_IN(Comment);
                 }
             }
@@ -1457,7 +1462,7 @@ _StartOfFunction:
             {
                 ON('-')
                 {
-                    SWITCH_TO(CommentEnd);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentEnd);
                 }
                 ON_EOF
                 {
@@ -1467,7 +1472,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_comment_or_character.data.append('-');
+                    m_current_builder.append('-');
                     RECONSUME_IN(Comment);
                 }
             }
@@ -1477,12 +1482,12 @@ _StartOfFunction:
             {
                 ON('!')
                 {
-                    m_current_token.m_comment_or_character.data.append_code_point(current_input_character.value());
-                    SWITCH_TO(CommentLessThanSignBang);
+                    m_current_builder.append_code_point(current_input_character.value());
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentLessThanSignBang);
                 }
                 ON('<')
                 {
-                    m_current_token.m_comment_or_character.data.append_code_point(current_input_character.value());
+                    m_current_builder.append_code_point(current_input_character.value());
                     continue;
                 }
                 ANYTHING_ELSE

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -57,13 +57,13 @@ namespace Web::HTML {
         goto _StartOfFunction;                   \
     } while (0)
 
-#define SWITCH_TO_AND_EMIT_CURRENT_TOKEN(new_state) \
-    do {                                            \
-        will_switch_to(State::new_state);           \
-        m_state = State::new_state;                 \
-        will_emit(m_current_token);                 \
-        m_queued_tokens.enqueue(m_current_token);   \
-        return m_queued_tokens.dequeue();           \
+#define SWITCH_TO_AND_EMIT_CURRENT_TOKEN(new_state)     \
+    do {                                                \
+        will_switch_to(State::new_state);               \
+        m_state = State::new_state;                     \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
 #define EMIT_CHARACTER_AND_RECONSUME_IN(code_point, new_state)          \
@@ -83,7 +83,7 @@ namespace Web::HTML {
                 create_new_token(HTMLToken::Type::Character);                            \
                 m_current_builder.append_code_point(code_point);                         \
                 m_current_token.m_comment_or_character.data = consume_current_builder(); \
-                m_queued_tokens.enqueue(m_current_token);                                \
+                m_queued_tokens.enqueue(move(m_current_token));                          \
             }                                                                            \
         }                                                                                \
     } while (0)
@@ -122,22 +122,22 @@ namespace Web::HTML {
 
 #define ANYTHING_ELSE if (1)
 
-#define EMIT_EOF                                      \
-    do {                                              \
-        if (m_has_emitted_eof)                        \
-            return {};                                \
-        m_has_emitted_eof = true;                     \
-        create_new_token(HTMLToken::Type::EndOfFile); \
-        will_emit(m_current_token);                   \
-        m_queued_tokens.enqueue(m_current_token);     \
-        return m_queued_tokens.dequeue();             \
+#define EMIT_EOF                                        \
+    do {                                                \
+        if (m_has_emitted_eof)                          \
+            return {};                                  \
+        m_has_emitted_eof = true;                       \
+        create_new_token(HTMLToken::Type::EndOfFile);   \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
-#define EMIT_CURRENT_TOKEN                        \
-    do {                                          \
-        will_emit(m_current_token);               \
-        m_queued_tokens.enqueue(m_current_token); \
-        return m_queued_tokens.dequeue();         \
+#define EMIT_CURRENT_TOKEN                              \
+    do {                                                \
+        will_emit(m_current_token);                     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
 #define EMIT_CHARACTER(code_point)                                               \
@@ -145,7 +145,7 @@ namespace Web::HTML {
         create_new_token(HTMLToken::Type::Character);                            \
         m_current_builder.append_code_point(code_point);                         \
         m_current_token.m_comment_or_character.data = consume_current_builder(); \
-        m_queued_tokens.enqueue(m_current_token);                                \
+        m_queued_tokens.enqueue(move(m_current_token));                          \
         return m_queued_tokens.dequeue();                                        \
     } while (0)
 
@@ -409,7 +409,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ON(0)
@@ -441,7 +441,7 @@ _StartOfFunction:
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -485,7 +485,7 @@ _StartOfFunction:
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -525,7 +525,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -550,7 +550,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -596,7 +596,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -638,7 +638,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -676,7 +676,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -714,7 +714,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -750,7 +750,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -785,7 +785,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -820,7 +820,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -855,7 +855,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -892,7 +892,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -928,7 +928,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -954,7 +954,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -978,7 +978,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1360,7 +1360,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1391,7 +1391,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1421,7 +1421,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1447,7 +1447,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1467,7 +1467,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(m_current_token);
+                    m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -175,7 +175,7 @@ namespace Web::HTML {
     }                     \
     }
 
-static inline void log_parse_error(const SourceLocation& location = SourceLocation::current())
+static inline void log_parse_error(SourceLocation const& location = SourceLocation::current())
 {
     dbgln_if(TOKENIZER_TRACE_DEBUG, "Parse error (tokenization) {}", location);
 }
@@ -2618,7 +2618,7 @@ _StartOfFunction:
     }
 }
 
-bool HTMLTokenizer::consume_next_if_match(const StringView& string, CaseSensitivity case_sensitivity)
+bool HTMLTokenizer::consume_next_if_match(StringView const& string, CaseSensitivity case_sensitivity)
 {
     for (size_t i = 0; i < string.length(); ++i) {
         auto code_point = peek_code_point(i);
@@ -2658,7 +2658,7 @@ void HTMLTokenizer::create_new_token(HTMLToken::Type type)
     m_current_token.m_start_position = nth_last_position(offset);
 }
 
-HTMLTokenizer::HTMLTokenizer(const StringView& input, const String& encoding)
+HTMLTokenizer::HTMLTokenizer(StringView const& input, String const& encoding)
 {
     auto* decoder = TextCodec::decoder_for(encoding);
     VERIFY(decoder);
@@ -2704,7 +2704,7 @@ bool HTMLTokenizer::consumed_as_part_of_an_attribute() const
     return m_return_state == State::AttributeValueUnquoted || m_return_state == State::AttributeValueSingleQuoted || m_return_state == State::AttributeValueDoubleQuoted;
 }
 
-void HTMLTokenizer::restore_to(const Utf8CodePointIterator& new_iterator)
+void HTMLTokenizer::restore_to(Utf8CodePointIterator const& new_iterator)
 {
     if (new_iterator != m_prev_utf8_iterator) {
         auto diff = m_prev_utf8_iterator - new_iterator;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -100,7 +100,7 @@ namespace Web::HTML {
 
 class HTMLTokenizer {
 public:
-    explicit HTMLTokenizer(const StringView& input, const String& encoding);
+    explicit HTMLTokenizer(StringView const& input, String const& encoding);
 
     enum class State {
 #define __ENUMERATE_TOKENIZER_STATE(state) state,
@@ -125,12 +125,12 @@ private:
     void skip(size_t count);
     Optional<u32> next_code_point();
     Optional<u32> peek_code_point(size_t offset) const;
-    bool consume_next_if_match(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive);
+    bool consume_next_if_match(StringView const&, CaseSensitivity = CaseSensitivity::CaseSensitive);
     void create_new_token(HTMLToken::Type);
     bool current_end_tag_token_is_appropriate() const;
     String consume_current_builder();
 
-    static const char* state_name(State state)
+    static char const* state_name(State state)
     {
         switch (state) {
 #define __ENUMERATE_TOKENIZER_STATE(state) \
@@ -148,7 +148,7 @@ private:
 
     bool consumed_as_part_of_an_attribute() const;
 
-    void restore_to(const Utf8CodePointIterator& new_iterator);
+    void restore_to(Utf8CodePointIterator const& new_iterator);
     HTMLToken::Position nth_last_position(size_t n = 0);
 
     State m_state { State::Data };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -127,6 +127,7 @@ private:
     bool consume_next_if_match(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive);
     void create_new_token(HTMLToken::Type);
     bool current_end_tag_token_is_appropriate() const;
+    String consume_current_builder();
 
     static const char* state_name(State state)
     {
@@ -163,6 +164,7 @@ private:
     Utf8CodePointIterator m_prev_utf8_iterator;
 
     HTMLToken m_current_token;
+    StringBuilder m_current_builder;
 
     Optional<String> m_last_emitted_start_tag_name;
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -158,8 +158,6 @@ private:
 
     String m_decoded_input;
 
-    StringView m_input;
-
     Utf8View m_utf8_view;
     Utf8CodePointIterator m_utf8_iterator;
     Utf8CodePointIterator m_prev_utf8_iterator;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Queue.h>
+#include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Utf8View.h>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -164,7 +164,7 @@ private:
 
     HTMLToken m_current_token;
 
-    HTMLToken m_last_emitted_start_tag;
+    Optional<String> m_last_emitted_start_tag_name;
 
     bool m_has_emitted_eof { false };
 


### PR DESCRIPTION
This PR is a continuation of #7391 (by @gunnarbeutner). Most of the functionality comes from that PR. I also included a few style changes (east const) and added a basic test suite for HTMLTokenizer, since the Tokenizer now has some more complex state (and is thus easier to break).

When timing raw tokenizing (without interaction with an HTMLDocumentParser), the time needed to tokenize e.g. the WHATWG bookmark has decreased by around 60 to 75 percent. :^)