### PR TITLE
AK: Un-confuse Traits<T>

### DIFF
--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -36,13 +36,9 @@ requires(IsIntegral<T>) struct Traits<T> : public GenericTraits<T> {
 };
 
 template<typename T>
-struct Traits<T*> : public GenericTraits<T*> {
-    static unsigned hash(const T* p)
-    {
-        return int_hash((unsigned)(__PTRDIFF_TYPE__)p);
-    }
+requires(IsPointer<T>) struct Traits<T> : public GenericTraits<T> {
+    static unsigned hash(T p) { return ptr_hash((FlatPtr)p); }
     static constexpr bool is_trivial() { return true; }
-    static bool equals(const T* a, const T* b) { return a == b; }
 };
 
 }

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -23,52 +23,16 @@ template<typename T>
 struct Traits : public GenericTraits<T> {
 };
 
-template<>
-struct Traits<int> : public GenericTraits<int> {
+template<typename T>
+requires(IsIntegral<T>) struct Traits<T> : public GenericTraits<T> {
     static constexpr bool is_trivial() { return true; }
-    static unsigned hash(int i) { return int_hash(i); }
-};
-
-template<>
-struct Traits<char> : public GenericTraits<char> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(char c) { return int_hash(c); }
-};
-
-template<>
-struct Traits<i16> : public GenericTraits<i16> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(i16 i) { return int_hash(i); }
-};
-
-template<>
-struct Traits<i64> : public GenericTraits<i64> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(i64 i) { return u64_hash(i); }
-};
-
-template<>
-struct Traits<unsigned> : public GenericTraits<unsigned> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(unsigned u) { return int_hash(u); }
-};
-
-template<>
-struct Traits<u8> : public GenericTraits<u8> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(u8 u) { return int_hash(u); }
-};
-
-template<>
-struct Traits<u16> : public GenericTraits<u16> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(u16 u) { return int_hash(u); }
-};
-
-template<>
-struct Traits<u64> : public GenericTraits<u64> {
-    static constexpr bool is_trivial() { return true; }
-    static unsigned hash(u64 u) { return u64_hash(u); }
+    static constexpr unsigned hash(T value)
+    {
+        if constexpr (sizeof(T) < 8)
+            return int_hash(value);
+        else
+            return u64_hash(value);
+    }
 };
 
 template<typename T>


### PR DESCRIPTION
This commit un-confuses the many specialisations of AK::Traits, and makes it work correctly for all integral types.
Prior to this, `AK::Traits<size_t>` would've been instantiating the base Traits implementation, not `Traits<u32>` or `Traits<u64>`.
Also fixes a silly T* == 32-bit assumption in Traits<T*>.