### PR TITLE
Typographical: Change a miss-spelled word

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ I'm also on [Patreon](https://www.patreon.com/serenityos) and [GitHub Sponsors](
 * Filesystem notifications
 * CPU and memory profiling
 * SoundBlaster 16 driver
-* VMWare/QEMU mouse integration
+* VMware/QEMU mouse integration
 
 ## System services
 


### PR DESCRIPTION
Change "VMWare" to "VMware" in the README.md 
Source: [https://en.wikipedia.org/wiki/VMware](https://en.wikipedia.org/wiki/VMware)