### PR TITLE
LibC: Replace use of do/while in assert() with the ternary operator

### DIFF
--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -14,11 +14,11 @@ __BEGIN_DECLS
 __attribute__((noreturn)) void __assertion_failed(const char* msg);
 #    define __stringify_helper(x) #    x
 #    define __stringify(x) __stringify_helper(x)
-#    define assert(expr)                                                           \
-        do {                                                                       \
-            if (__builtin_expect(!(expr), 0))                                      \
-                __assertion_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)); \
-        } while (0)
+#    define assert(expr)                                                            \
+        (__builtin_expect(!(expr), 0)                                               \
+                ? __assertion_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)) \
+                : void(0))
+
 #else
 #    define assert(expr) ((void)(0))
 #    define VERIFY_NOT_REACHED() _abort()


### PR DESCRIPTION
It's a single expression, no do/while needed. This makes assert() work
with the comma operator (assert(foo), assert(bar), assert(baz)).
Found because exactly this is being used somewhere in the guts of LLVM.