### PR TITLE
LibRegex: Fix some random stuff found by fuzzers

### DIFF
--- a/Userland/Libraries/LibC/regex.h
+++ b/Userland/Libraries/LibC/regex.h
@@ -15,6 +15,8 @@ typedef ssize_t regoff_t;
 
 typedef struct {
     void* __data;
+    // Number of capture groups, Dr.POSIX requires this.
+    size_t re_nsub;
 } regex_t;
 
 enum __Regex_Error {

--- a/Userland/Libraries/LibRegex/C/Regex.cpp
+++ b/Userland/Libraries/LibRegex/C/Regex.cpp
@@ -26,7 +26,6 @@ struct internal_regex_t {
     size_t re_pat_errpos;
     ReError re_pat_err;
     String re_pat;
-    size_t re_nsub;
 };
 
 static internal_regex_t* impl_from(regex_t* re)
@@ -51,7 +50,7 @@ int regcomp(regex_t* reg, const char* pattern, int cflags)
 
     // Note that subsequent uses of regcomp() without regfree() _will_ leak memory
     // This could've been prevented if libc provided a reginit() or similar, but it does not.
-    reg->__data = new internal_regex_t { 0, 0, {}, 0, ReError::REG_NOERR, {}, 0 };
+    reg->__data = new internal_regex_t { 0, 0, {}, 0, ReError::REG_NOERR, {} };
 
     auto preg = impl_from(reg);
     bool is_extended = cflags & REG_EXTENDED;
@@ -76,7 +75,7 @@ int regcomp(regex_t* reg, const char* pattern, int cflags)
         return (ReError)parser_result.error;
     }
 
-    preg->re_nsub = parser_result.capture_groups_count;
+    reg->re_nsub = parser_result.capture_groups_count;
 
     return REG_NOERR;
 }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -304,11 +304,11 @@ ALWAYS_INLINE bool AbstractPosixParser::parse_bracket_expression(Vector<CompareT
         }
     }
 
-    if (values.size())
+    if (!values.is_empty()) {
         match_length_minimum = 1;
-
-    if (values.first().type == CharacterCompareType::Inverse)
-        match_length_minimum = 0;
+        if (values.first().type == CharacterCompareType::Inverse)
+            match_length_minimum = 0;
+    }
 
     return true;
 }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -193,6 +193,9 @@ ALWAYS_INLINE bool AbstractPosixParser::parse_bracket_expression(Vector<CompareT
             } else if (values.last().type == CharacterCompareType::Char) {
                 values.append({ CharacterCompareType::RangeExpressionDummy, 0 });
 
+                if (done())
+                    return set_error(Error::MismatchingBracket);
+
                 if (match(TokenType::HyphenMinus)) {
                     consume();
                     // Valid range, add ordinary character

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -497,7 +497,8 @@ bool PosixBasicParser::parse_one_char_or_collation_element(ByteCode& bytecode, s
 
         consume(TokenType::RightBracket, Error::MismatchingBracket);
 
-        bytecode.insert_bytecode_compare_values(move(values));
+        if (!has_error())
+            bytecode.insert_bytecode_compare_values(move(values));
         match_length_minimum += bracket_minimum_length;
         return !has_error();
     }
@@ -617,7 +618,8 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_bracket_expression(ByteCode& stack
     if (!AbstractPosixParser::parse_bracket_expression(values, match_length_minimum))
         return false;
 
-    stack.insert_bytecode_compare_values(move(values));
+    if (!has_error())
+        stack.insert_bytecode_compare_values(move(values));
 
     return !has_error();
 }


### PR DESCRIPTION
Also fixes the `re_nsub` thing from #8605.