### PR TITLE
Base: Fix typo in the man page for `file`

### DIFF
--- a/Base/usr/share/man/man1/file.md
+++ b/Base/usr/share/man/man1/file.md
@@ -30,6 +30,6 @@ First, an attempt is made to identify a given file based on predetermined binary
 $ file Buggie.png
 Buggie.png: PNG image data, 64 x 138
 # Identify all files in the current directory, and show only the mime type.
-$ file -I *
+$ file -I *
 ```
 


### PR DESCRIPTION
On macOS with a Finnish keyboard layout, `$` is typed with `Option+4`. While
writing this manpage, I made the mistake of holding `Option` down a little
too long, as I often do, resulting in the keystroke `Option+space`. This,
instead of typing a space, types `U+00A0` (non-breaking space), which
looks identical on my host terminal. Luckily the Serenity terminal
called me out on it, printing out a question mark instead.

Before:
![image](https://user-images.githubusercontent.com/20117975/125368130-43f02f80-e382-11eb-9dd9-7e96292fd913.png)
After:
![image](https://user-images.githubusercontent.com/20117975/125368144-4ce10100-e382-11eb-8eb8-eb41489b9b38.png)
