### PR TITLE
LibGUI: Select radio buttons with keyboard

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -161,7 +161,9 @@ void AbstractButton::keydown_event(KeyEvent& event)
 
 void AbstractButton::keyup_event(KeyEvent& event)
 {
-    if (m_being_pressed && (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Space)) {
+    bool was_being_pressed = m_being_pressed;
+    m_being_pressed = false;
+    if (was_being_pressed && (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Space)) {
         click(event.modifiers());
         event.accept();
         return;


### PR DESCRIPTION
As @gunnarbeutner mentioned in issue #8702, it was only possible to select radio buttons via mouse, not keyboard, because `m_being_pressed` was not reset during a `keyup_event`. With this fix, radio buttons can be selected with by space bar or return key as intended.