### PR TITLE
FileManager: Add Rename action to context and application menu

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -538,9 +538,10 @@ void DirectoryView::handle_selection_change()
 {
     update_statusbar();
 
-    bool can_delete = !current_view().selection().is_empty() && access(path().characters(), W_OK) == 0;
-    m_delete_action->set_enabled(can_delete);
-    m_force_delete_action->set_enabled(can_delete);
+    bool can_modify = !current_view().selection().is_empty() && access(path().characters(), W_OK) == 0;
+    m_delete_action->set_enabled(can_modify);
+    m_force_delete_action->set_enabled(can_modify);
+    m_rename_action->set_enabled(can_modify);
 
     if (on_selection_change)
         on_selection_change(current_view());
@@ -591,6 +592,10 @@ void DirectoryView::setup_actions()
     });
 
     m_delete_action = GUI::CommonActions::make_delete_action([this](auto&) { do_delete(true); }, window());
+    m_rename_action = GUI::CommonActions::make_rename_action([this](auto&) {
+        current_view().begin_editing(current_view().cursor_index());
+    },
+        window());
 
     m_force_delete_action = GUI::Action::create(
         "Delete Without Confirmation", { Mod_Shift, Key_Delete },

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -123,6 +123,7 @@ public:
     GUI::Action& open_terminal_action() { return *m_open_terminal_action; }
     GUI::Action& delete_action() { return *m_delete_action; }
     GUI::Action& force_delete_action() { return *m_force_delete_action; }
+    GUI::Action& rename_action() { return *m_rename_action; }
 
 private:
     explicit DirectoryView(Mode);
@@ -168,6 +169,7 @@ private:
     RefPtr<GUI::Action> m_open_terminal_action;
     RefPtr<GUI::Action> m_delete_action;
     RefPtr<GUI::Action> m_force_delete_action;
+    RefPtr<GUI::Action> m_rename_action;
 };
 
 }

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -375,6 +375,7 @@ int run_in_desktop_mode([[maybe_unused]] RefPtr<Core::ConfigFile> config)
     desktop_context_menu->add_action(cut_action);
     desktop_context_menu->add_action(paste_action);
     desktop_context_menu->add_action(directory_view.delete_action());
+    desktop_context_menu->add_action(directory_view.rename_action());
     desktop_context_menu->add_separator();
     desktop_context_menu->add_action(properties_action);
 
@@ -393,6 +394,7 @@ int run_in_desktop_mode([[maybe_unused]] RefPtr<Core::ConfigFile> config)
                 file_context_menu->add_action(cut_action);
                 file_context_menu->add_action(paste_action);
                 file_context_menu->add_action(directory_view.delete_action());
+                file_context_menu->add_action(directory_view.rename_action());
                 file_context_menu->add_separator();
 
                 if (node.full_path().ends_with(".zip", AK::CaseSensitivity::CaseInsensitive)) {
@@ -846,6 +848,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     file_menu.add_action(mkdir_action);
     file_menu.add_action(touch_action);
     file_menu.add_action(focus_dependent_delete_action);
+    file_menu.add_action(directory_view.rename_action());
     file_menu.add_separator();
     file_menu.add_action(properties_action);
     file_menu.add_separator();
@@ -1040,6 +1043,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     directory_context_menu->add_action(cut_action);
     directory_context_menu->add_action(folder_specific_paste_action);
     directory_context_menu->add_action(directory_view.delete_action());
+    directory_context_menu->add_action(directory_view.rename_action());
     directory_context_menu->add_action(shortcut_action);
     directory_context_menu->add_separator();
     directory_context_menu->add_action(properties_action);
@@ -1059,6 +1063,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     tree_view_directory_context_menu->add_action(cut_action);
     tree_view_directory_context_menu->add_action(paste_action);
     tree_view_directory_context_menu->add_action(tree_view_delete_action);
+    tree_view_directory_context_menu->add_action(directory_view.rename_action());
     tree_view_directory_context_menu->add_separator();
     tree_view_directory_context_menu->add_action(properties_action);
     tree_view_directory_context_menu->add_separator();
@@ -1083,6 +1088,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 file_context_menu->add_action(cut_action);
                 file_context_menu->add_action(paste_action);
                 file_context_menu->add_action(directory_view.delete_action());
+                file_context_menu->add_action(directory_view.rename_action());
                 file_context_menu->add_action(shortcut_action);
                 file_context_menu->add_separator();
 

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -149,6 +149,11 @@ NonnullRefPtr<Action> make_select_all_action(Function<void(Action&)> callback, C
     return Action::create("Select &All", { Mod_Ctrl, Key_A }, Gfx::Bitmap::load_from_file("/res/icons/16x16/select-all.png"), move(callback), parent);
 }
 
+NonnullRefPtr<Action> make_rename_action(Function<void(Action&)> callback, Core::Object* parent)
+{
+    return Action::create("Re&name", Key_F2, move(callback), parent);
+}
+
 NonnullRefPtr<Action> make_properties_action(Function<void(Action&)> callback, Core::Object* parent)
 {
     return Action::create("P&roperties", { Mod_Alt, Key_Return }, Gfx::Bitmap::load_from_file("/res/icons/16x16/properties.png"), move(callback), parent);

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -42,6 +42,7 @@ NonnullRefPtr<Action> make_go_forward_action(Function<void(Action&)>, Core::Obje
 NonnullRefPtr<Action> make_go_home_action(Function<void(Action&)> callback, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_reload_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_select_all_action(Function<void(Action&)>, Core::Object* parent = nullptr);
+NonnullRefPtr<Action> make_rename_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_properties_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_zoom_in_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_zoom_out_action(Function<void(Action&)>, Core::Object* parent = nullptr);


### PR DESCRIPTION
Prior to this change, the only way to rename a file was to press F2 on keyboard.

![context menu preview (4,2K)](https://user-images.githubusercontent.com/16520278/125368678-19e73f00-e37b-11eb-8b88-b8e15d14cdbf.png) ![app menu preview (6,0K)](https://user-images.githubusercontent.com/16520278/125368692-223f7a00-e37b-11eb-8e82-33319e3c358b.png)
---

Some notes:
- an icon would be nice
- I suppose this check below isn’t needed anymore. Don’t know if I should remove it though. https://github.com/SerenityOS/serenity/blob/8922049507ebc2df1ddd8f1a964a86ad1703b8d8/Userland/Libraries/LibGUI/AbstractView.cpp#L500-L506