### PR TITLE
Documentation: Updates for the Windows build instructions

### DIFF
--- a/Documentation/BuildInstructionsWindows.md
+++ b/Documentation/BuildInstructionsWindows.md
@@ -25,9 +25,7 @@ In practice, this means cloning and building the project to somewhere such as `/
 
 ## Setting up build tools
 
-Please see the general build instructions for a list of tools you need to install in your WSL Linux environment. As a
-special exception you should _not_ install QEMU in the Linux environment and instead use the instructions from the next
-section to set up QEMU on your host system.
+Please see the general build instructions for a list of tools you need to install in your WSL Linux environment.
 
 ## Setting up QEMU
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -51,7 +51,7 @@ fi
 
 if command -v wslpath >/dev/null; then
     case "$SERENITY_QEMU_BIN" in
-        /mnt/c/*)
+        /mnt/?/*)
             [ -z "$SERENITY_QEMU_CPU" ] && SERENITY_QEMU_CPU="max,vmx=off"
             SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE disable_virtio"
     esac
@@ -67,7 +67,7 @@ fi
     fi
     if command -v wslpath >/dev/null; then
         case "$SERENITY_QEMU_BIN" in
-            /mnt/c/*)
+            /mnt/?/*)
                 SERENITY_DISK_IMAGE=$(wslpath -w "$SERENITY_DISK_IMAGE")
                 ;;
         esac


### PR DESCRIPTION
**Documentation: Make sure Windows have QEMU tools in their WSL2 system**

They don't need QEMU to run the VM but they do at least need the QEMU
tools to build the image.

**Meta: Fix QEMU detection for WSL2 if QEMU isn't installed on the C drive** 