### PR TITLE
AK: Add Vector formatter

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -639,15 +639,7 @@ Vector<i32> FlacLoaderPlugin::decode_custom_lpc(FlacSubframeHeader& subframe, In
         coefficients.unchecked_append(coefficient);
     }
 
-    if constexpr (AFLACLOADER_DEBUG) {
-        StringBuilder coefficients_formatted;
-        coefficients_formatted.append("[ ");
-        for (auto coeff : coefficients) {
-            coefficients_formatted.append(String::formatted("{}, ", coeff));
-        }
-        coefficients_formatted.append("]");
-        dbgln("{}-bit {} shift coefficients: {}", lpc_precision, lpc_shift, coefficients_formatted.to_string());
-    }
+    dbgln_if(AFLACLOADER_DEBUG, "{}-bit {} shift coefficients: {}", lpc_precision, lpc_shift, coefficients);
 
     // decode residual
     // FIXME: This order may be incorrect, the LPC is applied to the residual, probably leading to incorrect results.


### PR DESCRIPTION
For debugging purposes, it is very useful to look at a Vector in a
simple list representation. Therefore, the new Formatter for Vector
provides a string representation of the following form:

```
[ 1, 2, 3, 4, 5 ]
```

This requires the content type of Vector to be formattable with default
arguments.

The current implementation ignores width and precision, which may be
accounted for later or passed down to the content formatter.