### PR TITLE
LibWeb: CSS Selector class improvements

### DIFF
--- a/Base/res/html/misc/not-selector.html
+++ b/Base/res/html/misc/not-selector.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+<title>:only-child test</title>
+<style>
+div {
+    background: yellow;
+}
+
+div:not(div div) {
+    background: lime;
+}
+</style>
+</head>
+<body>
+  <div>I am not a descendant and should be green.</div>
+  <div>
+    <div>I am a descendant and should be yellow.</div>
+  </div>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -109,6 +109,7 @@
         <li><a href="nth-last-child.html">:nth-last-child</a></li>
         <li><a href="empty.html">:empty</a></li>
         <li><a href="root.html">:root</a></li>
+        <li><a href="not-selector.html">:not</a></li>
         <li><a href="form.html">form</a></li>
         <li><a href="borders.html">borders</a></li>
         <li><a href="css.html">css</a></li>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::CSS {
 
-CSSStyleRule::CSSStyleRule(Vector<Selector>&& selectors, NonnullRefPtr<CSSStyleDeclaration>&& declaration)
+CSSStyleRule::CSSStyleRule(NonnullRefPtrVector<Selector>&& selectors, NonnullRefPtr<CSSStyleDeclaration>&& declaration)
     : m_selectors(move(selectors))
     , m_declaration(move(declaration))
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/NonnullRefPtr.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
@@ -19,23 +20,23 @@ class CSSStyleRule : public CSSRule {
     AK_MAKE_NONMOVABLE(CSSStyleRule);
 
 public:
-    static NonnullRefPtr<CSSStyleRule> create(Vector<Selector>&& selectors, NonnullRefPtr<CSSStyleDeclaration>&& declaration)
+    static NonnullRefPtr<CSSStyleRule> create(NonnullRefPtrVector<Selector>&& selectors, NonnullRefPtr<CSSStyleDeclaration>&& declaration)
     {
         return adopt_ref(*new CSSStyleRule(move(selectors), move(declaration)));
     }
 
     ~CSSStyleRule();
 
-    const Vector<Selector>& selectors() const { return m_selectors; }
+    const NonnullRefPtrVector<Selector>& selectors() const { return m_selectors; }
     const CSSStyleDeclaration& declaration() const { return m_declaration; }
 
     virtual StringView class_name() const { return "CSSStyleRule"; };
     virtual Type type() const { return Type::Style; };
 
 private:
-    CSSStyleRule(Vector<Selector>&&, NonnullRefPtr<CSSStyleDeclaration>&&);
+    CSSStyleRule(NonnullRefPtrVector<Selector>&&, NonnullRefPtr<CSSStyleDeclaration>&&);
 
-    Vector<Selector> m_selectors;
+    NonnullRefPtrVector<Selector> m_selectors;
     NonnullRefPtr<CSSStyleDeclaration> m_declaration;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -683,10 +683,10 @@ public:
             return;
         complex_selectors.first().relation = CSS::Selector::ComplexSelector::Relation::None;
 
-        current_rule.selectors.append(CSS::Selector(move(complex_selectors)));
+        current_rule.selectors.append(CSS::Selector::create(move(complex_selectors)));
     }
 
-    Optional<CSS::Selector> parse_individual_selector()
+    RefPtr<CSS::Selector> parse_individual_selector()
     {
         parse_selector();
         if (current_rule.selectors.is_empty())
@@ -1037,7 +1037,7 @@ private:
     NonnullRefPtrVector<CSS::CSSRule> rules;
 
     struct CurrentRule {
-        Vector<CSS::Selector> selectors;
+        NonnullRefPtrVector<CSS::Selector> selectors;
         Vector<CSS::StyleProperty> properties;
         HashMap<String, CSS::StyleProperty> custom_properties;
     };
@@ -1050,7 +1050,7 @@ private:
     StringView css;
 };
 
-Optional<CSS::Selector> parse_selector(const CSS::DeprecatedParsingContext& context, const StringView& selector_text)
+RefPtr<CSS::Selector> parse_selector(const CSS::DeprecatedParsingContext& context, const StringView& selector_text)
 {
     CSSParser parser(context, selector_text);
     return parser.parse_individual_selector();

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -442,12 +442,15 @@ public:
             simple_selector.type = CSS::Selector::SimpleSelector::Type::TagName;
         } else if (peek() == '[') {
             simple_selector.type = CSS::Selector::SimpleSelector::Type::Attribute;
+        } else if (peek() == ':') {
+            simple_selector.type = CSS::Selector::SimpleSelector::Type::PseudoClass;
         } else {
             simple_selector.type = CSS::Selector::SimpleSelector::Type::Universal;
         }
 
         if ((simple_selector.type != CSS::Selector::SimpleSelector::Type::Universal)
-            && (simple_selector.type != CSS::Selector::SimpleSelector::Type::Attribute)) {
+            && (simple_selector.type != CSS::Selector::SimpleSelector::Type::Attribute)
+            && (simple_selector.type != CSS::Selector::SimpleSelector::Type::PseudoClass)) {
 
             while (is_valid_selector_char(peek()))
                 buffer.append(consume_one());
@@ -515,7 +518,7 @@ public:
                 return {};
         }
 
-        if (peek() == ':') {
+        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass) {
             // FIXME: Implement pseudo elements.
             [[maybe_unused]] bool is_pseudo_element = false;
             consume_one();
@@ -559,49 +562,51 @@ public:
             if (is_pseudo_element)
                 return {};
 
+            auto& pseudo_class = simple_selector.pseudo_class;
+
             if (pseudo_name.equals_ignoring_case("link")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Link;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Link;
             } else if (pseudo_name.equals_ignoring_case("visited")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Visited;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Visited;
             } else if (pseudo_name.equals_ignoring_case("active")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Active;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Active;
             } else if (pseudo_name.equals_ignoring_case("hover")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Hover;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Hover;
             } else if (pseudo_name.equals_ignoring_case("focus")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Focus;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Focus;
             } else if (pseudo_name.equals_ignoring_case("first-child")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::FirstChild;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::FirstChild;
             } else if (pseudo_name.equals_ignoring_case("last-child")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::LastChild;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::LastChild;
             } else if (pseudo_name.equals_ignoring_case("only-child")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::OnlyChild;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::OnlyChild;
             } else if (pseudo_name.equals_ignoring_case("empty")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Empty;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Empty;
             } else if (pseudo_name.equals_ignoring_case("root")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Root;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Root;
             } else if (pseudo_name.equals_ignoring_case("first-of-type")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::FirstOfType;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::FirstOfType;
             } else if (pseudo_name.equals_ignoring_case("last-of-type")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::LastOfType;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::LastOfType;
             } else if (pseudo_name.starts_with("nth-child", CaseSensitivity::CaseInsensitive)) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::NthChild;
-                simple_selector.nth_child_pattern = CSS::Selector::SimpleSelector::NthChildPattern::parse(capture_selector_args(pseudo_name));
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild;
+                pseudo_class.nth_child_pattern = CSS::Selector::SimpleSelector::NthChildPattern::parse(capture_selector_args(pseudo_name));
             } else if (pseudo_name.starts_with("nth-last-child", CaseSensitivity::CaseInsensitive)) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::NthLastChild;
-                simple_selector.nth_child_pattern = CSS::Selector::SimpleSelector::NthChildPattern::parse(capture_selector_args(pseudo_name));
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild;
+                pseudo_class.nth_child_pattern = CSS::Selector::SimpleSelector::NthChildPattern::parse(capture_selector_args(pseudo_name));
             } else if (pseudo_name.equals_ignoring_case("before")) {
                 simple_selector.pseudo_element = CSS::Selector::SimpleSelector::PseudoElement::Before;
             } else if (pseudo_name.equals_ignoring_case("after")) {
                 simple_selector.pseudo_element = CSS::Selector::SimpleSelector::PseudoElement::After;
             } else if (pseudo_name.equals_ignoring_case("disabled")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Disabled;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Disabled;
             } else if (pseudo_name.equals_ignoring_case("enabled")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Enabled;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Enabled;
             } else if (pseudo_name.equals_ignoring_case("checked")) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Checked;
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Checked;
             } else if (pseudo_name.starts_with("not", CaseSensitivity::CaseInsensitive)) {
-                simple_selector.pseudo_class = CSS::Selector::SimpleSelector::PseudoClass::Not;
-                simple_selector.not_selector = capture_selector_args(pseudo_name);
+                pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Not;
+                pseudo_class.not_selector = capture_selector_args(pseudo_name);
             } else {
                 dbgln("Unknown pseudo class: '{}'", pseudo_name);
                 return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -606,7 +606,11 @@ public:
                 pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Checked;
             } else if (pseudo_name.starts_with("not", CaseSensitivity::CaseInsensitive)) {
                 pseudo_class.type = CSS::Selector::SimpleSelector::PseudoClass::Type::Not;
-                pseudo_class.not_selector = capture_selector_args(pseudo_name);
+                auto not_selector = Web::parse_selector(m_context, capture_selector_args(pseudo_name));
+                if (not_selector) {
+                    pseudo_class.not_selector.clear();
+                    pseudo_class.not_selector.append(not_selector.release_nonnull());
+                }
             } else {
                 dbgln("Unknown pseudo class: '{}'", pseudo_name);
                 return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.h
@@ -31,7 +31,7 @@ namespace Web {
 RefPtr<CSS::CSSStyleSheet> parse_css(const CSS::DeprecatedParsingContext&, const StringView&);
 RefPtr<CSS::CSSStyleDeclaration> parse_css_declaration(const CSS::DeprecatedParsingContext&, const StringView&);
 RefPtr<CSS::StyleValue> parse_css_value(const CSS::DeprecatedParsingContext&, const StringView&, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
-Optional<CSS::Selector> parse_selector(const CSS::DeprecatedParsingContext&, const StringView&);
+RefPtr<CSS::Selector> parse_selector(const CSS::DeprecatedParsingContext&, const StringView&);
 
 RefPtr<CSS::LengthStyleValue> parse_line_width(const CSS::DeprecatedParsingContext&, const StringView&);
 RefPtr<CSS::ColorStyleValue> parse_color(const CSS::DeprecatedParsingContext&, const StringView&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -363,10 +363,24 @@ Optional<Selector> Parser::parse_single_selector(TokenStream<T>& tokens, bool is
                     return {};
             }
 
-            // Ignore for now, otherwise we produce a "false positive" selector
-            // and apply styles to the element itself, not its pseudo element
-            if (is_pseudo)
-                return {};
+            if (is_pseudo) {
+                auto pseudo_name = ((Token)current_value).ident();
+                simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
+
+                if (pseudo_name.equals_ignoring_case("before")) {
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::Before;
+                } else if (pseudo_name.equals_ignoring_case("after")) {
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::After;
+                } else if (pseudo_name.equals_ignoring_case("first-line")) {
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLine;
+                } else if (pseudo_name.equals_ignoring_case("first-letter")) {
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLetter;
+                } else {
+                    return {};
+                }
+
+                return simple_selector;
+            }
 
             auto& pseudo_class = simple_selector.pseudo_class;
 
@@ -411,6 +425,22 @@ Optional<Selector> Parser::parse_single_selector(TokenStream<T>& tokens, bool is
                     pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Enabled;
                 } else if (pseudo_name.equals_ignoring_case("checked")) {
                     pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Checked;
+                } else if (pseudo_name.equals_ignoring_case("before")) {
+                    // Single-colon syntax allowed for compatibility. https://www.w3.org/TR/selectors/#pseudo-element-syntax
+                    simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::Before;
+                } else if (pseudo_name.equals_ignoring_case("after")) {
+                    // See :before
+                    simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::After;
+                } else if (pseudo_name.equals_ignoring_case("first-line")) {
+                    // See :before
+                    simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLine;
+                } else if (pseudo_name.equals_ignoring_case("first-letter")) {
+                    // See :before
+                    simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
+                    simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLetter;
                 } else {
                     dbgln("Unknown pseudo class: '{}'", pseudo_name);
                     return simple_selector;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -469,7 +469,8 @@ RefPtr<Selector> Parser::parse_single_selector(TokenStream<T>& tokens, bool is_r
                     }
                 } else if (pseudo_function.name().equals_ignoring_case("not")) {
                     pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Not;
-                    pseudo_class.not_selector = pseudo_function.values_as_string();
+                    auto function_token_stream = TokenStream(pseudo_function.values());
+                    pseudo_class.not_selector = parse_a_selector(function_token_stream);
                 } else {
                     dbgln("Unknown pseudo class: '{}'()", pseudo_function.name());
                     return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <AK/NonnullOwnPtrVector.h>
+#include <AK/NonnullRefPtrVector.h>
+#include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
@@ -110,19 +112,19 @@ public:
     Vector<Vector<StyleComponentValueRule>> parse_as_comma_separated_list_of_component_values(TokenStream<T>&);
 
     template<typename T>
-    Optional<Selector> parse_single_selector(TokenStream<T>&, bool is_relative = false);
+    RefPtr<Selector> parse_single_selector(TokenStream<T>&, bool is_relative = false);
 
     Optional<Selector::SimpleSelector::NthChildPattern> parse_nth_child_pattern(TokenStream<StyleComponentValueRule>&);
 
     // FIXME: https://www.w3.org/TR/selectors-4/
     // Contrary to the name, these parse a comma-separated list of selectors, according to the spec.
-    Vector<Selector> parse_a_selector();
+    NonnullRefPtrVector<Selector> parse_a_selector();
     template<typename T>
-    Vector<Selector> parse_a_selector(TokenStream<T>&);
+    NonnullRefPtrVector<Selector> parse_a_selector(TokenStream<T>&);
 
-    Vector<Selector> parse_a_relative_selector();
+    NonnullRefPtrVector<Selector> parse_a_relative_selector();
     template<typename T>
-    Vector<Selector> parse_a_relative_selector(TokenStream<T>&);
+    NonnullRefPtrVector<Selector> parse_a_relative_selector(TokenStream<T>&);
 
     RefPtr<StyleValue> parse_css_value(PropertyID, TokenStream<StyleComponentValueRule>&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleFunctionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleFunctionRule.h
@@ -24,11 +24,6 @@ public:
 
     String const& name() const { return m_name; }
     Vector<StyleComponentValueRule> const& values() const { return m_values; }
-    // FIXME: This method is a temporary hack while much of the parser still expects a string, rather than tokens.
-    String values_as_string() const
-    {
-        return "";
-    }
 
     String to_string() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -49,6 +49,8 @@ u32 Selector::specificity() const
 
 Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPattern::parse(StringView const& args)
 {
+    // FIXME: Remove this when the DeprecatedCSSParser is gone.
+    // The new Parser::parse_nth_child_pattern() does the same as this, using Tokens.
     CSS::Selector::SimpleSelector::NthChildPattern pattern;
     if (args.equals_ignoring_case("odd")) {
         pattern.step_size = 2;

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -47,7 +47,7 @@ u32 Selector::specificity() const
     return ids * 0x10000 + classes * 0x100 + tag_names;
 }
 
-Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPattern::parse(const StringView& args)
+Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPattern::parse(StringView const& args)
 {
     CSS::Selector::SimpleSelector::NthChildPattern pattern;
     if (args.equals_ignoring_case("odd")) {
@@ -56,7 +56,7 @@ Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPatt
     } else if (args.equals_ignoring_case("even")) {
         pattern.step_size = 2;
     } else {
-        const auto consume_int = [](GenericLexer& lexer) -> Optional<int> {
+        auto const consume_int = [](GenericLexer& lexer) -> Optional<int> {
             return AK::StringUtils::convert_to_int(lexer.consume_while([](char c) -> bool {
                 return isdigit(c) || c == '+' || c == '-';
             }));
@@ -81,7 +81,7 @@ Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPatt
             step_size_or_offset = -1;
             lexer.retreat();
         } else {
-            const auto value = consume_int(lexer);
+            auto const value = consume_int(lexer);
             if (!value.has_value())
                 return {};
             step_size_or_offset = value.value();
@@ -90,12 +90,12 @@ Selector::SimpleSelector::NthChildPattern Selector::SimpleSelector::NthChildPatt
         if (lexer.consume_specific("n")) {
             lexer.ignore_while(isspace);
             if (lexer.next_is('+') || lexer.next_is('-')) {
-                const auto sign = lexer.next_is('+') ? 1 : -1;
+                auto const sign = lexer.next_is('+') ? 1 : -1;
                 lexer.ignore();
                 lexer.ignore_while(isspace);
 
                 // "An+B" pattern
-                const auto offset = consume_int(lexer);
+                auto const offset = consume_int(lexer);
                 if (!offset.has_value())
                     return {};
                 pattern.step_size = step_size_or_offset;

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,6 +22,7 @@ public:
             TagName,
             Id,
             Class,
+            Attribute,
         };
         Type type { Type::Invalid };
 
@@ -56,20 +58,22 @@ public:
 
         FlyString value;
 
-        enum class AttributeMatchType {
-            None,
-            HasAttribute,
-            ExactValueMatch,
-            ContainsWord,      // [att~=val]
-            ContainsString,    // [att*=val]
-            StartsWithSegment, // [att|=val]
-            StartsWithString,  // [att^=val]
-            EndsWithString,    // [att$=val]
+        struct Attribute {
+            enum class MatchType {
+                None,
+                HasAttribute,
+                ExactValueMatch,
+                ContainsWord,      // [att~=val]
+                ContainsString,    // [att*=val]
+                StartsWithSegment, // [att|=val]
+                StartsWithString,  // [att^=val]
+                EndsWithString,    // [att$=val]
+            };
+            MatchType match_type { MatchType::None };
+            FlyString name;
+            String value;
         };
-
-        AttributeMatchType attribute_match_type { AttributeMatchType::None };
-        FlyString attribute_name;
-        String attribute_value;
+        Attribute attribute;
 
         struct NthChildPattern {
             int step_size = 0;

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -75,7 +75,7 @@ public:
             int step_size = 0;
             int offset = 0;
 
-            static NthChildPattern parse(const StringView& args);
+            static NthChildPattern parse(StringView const& args);
         };
 
         // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
@@ -103,7 +103,7 @@ public:
     explicit Selector(Vector<ComplexSelector>&&);
     ~Selector();
 
-    const Vector<ComplexSelector>& complex_selectors() const { return m_complex_selectors; }
+    Vector<ComplexSelector> const& complex_selectors() const { return m_complex_selectors; }
 
     u32 specificity() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -23,31 +23,49 @@ public:
             Id,
             Class,
             Attribute,
+            PseudoClass,
         };
         Type type { Type::Invalid };
 
-        enum class PseudoClass {
-            None,
-            Link,
-            Visited,
-            Hover,
-            Focus,
-            FirstChild,
-            LastChild,
-            OnlyChild,
-            Empty,
-            Root,
-            FirstOfType,
-            LastOfType,
-            NthChild,
-            NthLastChild,
-            Disabled,
-            Enabled,
-            Checked,
-            Not,
-            Active,
+        struct NthChildPattern {
+            int step_size = 0;
+            int offset = 0;
+
+            static NthChildPattern parse(StringView const& args);
         };
-        PseudoClass pseudo_class { PseudoClass::None };
+
+        struct PseudoClass {
+            enum class Type {
+                None,
+                Link,
+                Visited,
+                Hover,
+                Focus,
+                FirstChild,
+                LastChild,
+                OnlyChild,
+                Empty,
+                Root,
+                FirstOfType,
+                LastOfType,
+                NthChild,
+                NthLastChild,
+                Disabled,
+                Enabled,
+                Checked,
+                Not,
+                Active,
+            };
+            Type type { Type::None };
+
+            // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
+            // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
+            NthChildPattern nth_child_pattern;
+
+            // FIXME: This wants to be a Selector, rather than parsing it each time it is used.
+            String not_selector {};
+        };
+        PseudoClass pseudo_class;
 
         enum class PseudoElement {
             None,
@@ -74,19 +92,6 @@ public:
             String value;
         };
         Attribute attribute;
-
-        struct NthChildPattern {
-            int step_size = 0;
-            int offset = 0;
-
-            static NthChildPattern parse(StringView const& args);
-        };
-
-        // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
-        // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
-        NthChildPattern nth_child_pattern;
-        // FIXME: This wants to be a Selector, rather than parsing it each time it is used.
-        String not_selector {};
     };
 
     struct ComplexSelector {

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -8,12 +8,13 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace Web::CSS {
 
-class Selector {
+class Selector : public RefCounted<Selector> {
 public:
     struct SimpleSelector {
         enum class Type {
@@ -112,7 +113,11 @@ public:
         CompoundSelector compound_selector;
     };
 
-    explicit Selector(Vector<ComplexSelector>&&);
+    static NonnullRefPtr<Selector> create(Vector<ComplexSelector>&& complex_selectors)
+    {
+        return adopt_ref(*new Selector(move(complex_selectors)));
+    }
+
     ~Selector();
 
     Vector<ComplexSelector> const& complex_selectors() const { return m_complex_selectors; }
@@ -120,6 +125,8 @@ public:
     u32 specificity() const;
 
 private:
+    explicit Selector(Vector<ComplexSelector>&&);
+
     Vector<ComplexSelector> m_complex_selectors;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -24,6 +24,7 @@ public:
             Class,
             Attribute,
             PseudoClass,
+            PseudoElement,
         };
         Type type { Type::Invalid };
 
@@ -71,6 +72,8 @@ public:
             None,
             Before,
             After,
+            FirstLine,
+            FirstLetter,
         };
         PseudoElement pseudo_element { PseudoElement::None };
 

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/NonnullRefPtrVector.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -64,8 +65,7 @@ public:
             // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
             NthChildPattern nth_child_pattern;
 
-            // FIXME: This wants to be a Selector, rather than parsing it each time it is used.
-            String not_selector {};
+            NonnullRefPtrVector<Selector> not_selector {};
         };
         PseudoClass pseudo_class;
 

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -14,7 +14,7 @@
 
 namespace Web::SelectorEngine {
 
-static bool matches_hover_pseudo_class(const DOM::Element& element)
+static bool matches_hover_pseudo_class(DOM::Element const& element)
 {
     auto* hovered_node = element.document().hovered_node();
     if (!hovered_node)
@@ -24,7 +24,7 @@ static bool matches_hover_pseudo_class(const DOM::Element& element)
     return element.is_ancestor_of(*hovered_node);
 }
 
-static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::Element& element)
+static bool matches(CSS::Selector::SimpleSelector const& component, DOM::Element const& element)
 {
     switch (component.pseudo_element) {
     case CSS::Selector::SimpleSelector::PseudoElement::None:
@@ -119,12 +119,12 @@ static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::E
     }
     case CSS::Selector::SimpleSelector::PseudoClass::NthChild:
     case CSS::Selector::SimpleSelector::PseudoClass::NthLastChild:
-        const auto step_size = component.nth_child_pattern.step_size;
-        const auto offset = component.nth_child_pattern.offset;
+        auto const step_size = component.nth_child_pattern.step_size;
+        auto const offset = component.nth_child_pattern.offset;
         if (step_size == 0 && offset == 0)
             return false; // "If both a and b are equal to zero, the pseudo-class represents no element in the document tree."
 
-        const auto* parent = element.parent_element();
+        auto const* parent = element.parent_element();
         if (!parent)
             return false;
 
@@ -152,7 +152,7 @@ static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::E
         }
 
         // Like "a % b", but handles negative integers correctly.
-        const auto canonical_modulo = [](int a, int b) -> int {
+        auto const canonical_modulo = [](int a, int b) -> int {
             int c = a % b;
             if ((c < 0 && b > 0) || (c > 0 && b < 0)) {
                 c += b;
@@ -218,7 +218,7 @@ static bool matches(const CSS::Selector::SimpleSelector& component, const DOM::E
     }
 }
 
-static bool matches(const CSS::Selector& selector, int component_list_index, const DOM::Element& element)
+static bool matches(CSS::Selector const& selector, int component_list_index, DOM::Element const& element)
 {
     auto& component_list = selector.complex_selectors()[component_list_index];
     for (auto& component : component_list.compound_selector) {
@@ -260,7 +260,7 @@ static bool matches(const CSS::Selector& selector, int component_list_index, con
     VERIFY_NOT_REACHED();
 }
 
-bool matches(const CSS::Selector& selector, const DOM::Element& element)
+bool matches(CSS::Selector const& selector, DOM::Element const& element)
 {
     VERIFY(!selector.complex_selectors().is_empty());
     return matches(selector, selector.complex_selectors().size() - 1, element);

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -117,9 +117,9 @@ static bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClass cons
         if (pseudo_class.not_selector.is_empty())
             return false;
         auto not_selector = Web::parse_selector(CSS::DeprecatedParsingContext(element), pseudo_class.not_selector);
-        if (!not_selector.has_value())
+        if (!not_selector)
             return false;
-        auto not_matches = matches(not_selector.value(), element);
+        auto not_matches = matches(not_selector.release_nonnull(), element);
         return !not_matches;
     }
     case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild:

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -113,15 +113,12 @@ static bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClass cons
         if (!element.has_attribute("checked"))
             return false;
         return true;
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Not: {
-        if (pseudo_class.not_selector.is_empty())
-            return false;
-        auto not_selector = Web::parse_selector(CSS::DeprecatedParsingContext(element), pseudo_class.not_selector);
-        if (!not_selector)
-            return false;
-        auto not_matches = matches(not_selector.release_nonnull(), element);
-        return !not_matches;
-    }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
+        for (auto& selector : pseudo_class.not_selector) {
+            if (matches(selector, element))
+                return false;
+        }
+        return true;
     case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild:
     case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
         auto const step_size = pseudo_class.nth_child_pattern.step_size;

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -175,14 +175,6 @@ static bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClass cons
 
 static bool matches(CSS::Selector::SimpleSelector const& component, DOM::Element const& element)
 {
-    switch (component.pseudo_element) {
-    case CSS::Selector::SimpleSelector::PseudoElement::None:
-        break;
-    default:
-        // FIXME: Implement pseudo-elements.
-        return false;
-    }
-
     switch (component.type) {
     case CSS::Selector::SimpleSelector::Type::Universal:
         return true;
@@ -196,6 +188,9 @@ static bool matches(CSS::Selector::SimpleSelector const& component, DOM::Element
         return matches_attribute(component.attribute, element);
     case CSS::Selector::SimpleSelector::Type::PseudoClass:
         return matches_pseudo_class(component.pseudo_class, element);
+    case CSS::Selector::SimpleSelector::Type::PseudoElement:
+        // FIXME: Implement pseudo-elements.
+        return false;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -11,6 +11,6 @@
 
 namespace Web::SelectorEngine {
 
-bool matches(const CSS::Selector&, const DOM::Element&);
+bool matches(CSS::Selector const&, DOM::Element const&);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -14,14 +14,14 @@ namespace Web::DOM {
 RefPtr<Element> ParentNode::query_selector(const StringView& selector_text)
 {
     auto selector = parse_selector(CSS::DeprecatedParsingContext(*this), selector_text);
-    if (!selector.has_value())
+    if (!selector)
         return {};
 
-    dump_selector(selector.value());
+    dump_selector(selector.release_nonnull());
 
     RefPtr<Element> result;
     for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-        if (SelectorEngine::matches(selector.value(), element)) {
+        if (SelectorEngine::matches(selector.release_nonnull(), element)) {
             result = element;
             return IterationDecision::Break;
         }
@@ -34,14 +34,14 @@ RefPtr<Element> ParentNode::query_selector(const StringView& selector_text)
 NonnullRefPtrVector<Element> ParentNode::query_selector_all(const StringView& selector_text)
 {
     auto selector = parse_selector(CSS::DeprecatedParsingContext(*this), selector_text);
-    if (!selector.has_value())
+    if (!selector)
         return {};
 
-    dump_selector(selector.value());
+    dump_selector(selector.release_nonnull());
 
     NonnullRefPtrVector<Element> elements;
     for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-        if (SelectorEngine::matches(selector.value(), element)) {
+        if (SelectorEngine::matches(selector.release_nonnull(), element)) {
             elements.append(element);
         }
         return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -314,31 +314,8 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             case CSS::Selector::SimpleSelector::Type::TagName:
                 type_description = "TagName";
                 break;
-            }
-            const char* attribute_match_type_description = "";
-            switch (simple_selector.attribute_match_type) {
-            case CSS::Selector::SimpleSelector::AttributeMatchType::None:
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::HasAttribute:
-                attribute_match_type_description = "HasAttribute";
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::ExactValueMatch:
-                attribute_match_type_description = "ExactValueMatch";
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::ContainsWord:
-                attribute_match_type_description = "ContainsWord";
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::ContainsString:
-                attribute_match_type_description = "ContainsString";
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithSegment:
-                attribute_match_type_description = "StartsWithSegment";
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::StartsWithString:
-                attribute_match_type_description = "StartsWithString";
-                break;
-            case CSS::Selector::SimpleSelector::AttributeMatchType::EndsWithString:
-                attribute_match_type_description = "EndsWithString";
+            case CSS::Selector::SimpleSelector::Type::Attribute:
+                type_description = "Attribute";
                 break;
             }
 
@@ -406,8 +383,38 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             builder.appendff("{}:{}", type_description, simple_selector.value);
             if (simple_selector.pseudo_class != CSS::Selector::SimpleSelector::PseudoClass::None)
                 builder.appendff(" pseudo_class={}", pseudo_class_description);
-            if (simple_selector.attribute_match_type != CSS::Selector::SimpleSelector::AttributeMatchType::None) {
-                builder.appendff(" [{}, name='{}', value='{}']", attribute_match_type_description, simple_selector.attribute_name, simple_selector.attribute_value);
+
+            if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Attribute) {
+                char const* attribute_match_type_description = "";
+
+                switch (simple_selector.attribute.match_type) {
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::None:
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::HasAttribute:
+                    type_description = "HasAttribute";
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch:
+                    type_description = "ExactValueMatch";
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsWord:
+                    type_description = "ContainsWord";
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsString:
+                    type_description = "ContainsString";
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::StartsWithSegment:
+                    type_description = "StartsWithSegment";
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::StartsWithString:
+                    type_description = "StartsWithString";
+                    break;
+                case CSS::Selector::SimpleSelector::Attribute::MatchType::EndsWithString:
+                    type_description = "EndsWithString";
+                    break;
+                }
+                break;
+
+                builder.appendff(" [{}, name='{}', value='{}']", attribute_match_type_description, simple_selector.attribute.name, simple_selector.attribute.value);
             }
 
             if (i != complex_selector.compound_selector.size() - 1)

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -393,7 +393,10 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);
                 if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not) {
-                    builder.appendff("({})", pseudo_class.not_selector);
+                    builder.append("(");
+                    for (auto& selector : pseudo_class.not_selector)
+                        dump_selector(builder, selector);
+                    builder.append(")");
                 } else if ((pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild)
                     || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild)) {
                     builder.appendff("(step={}, offset={})", pseudo_class.nth_child_pattern.step_size, pseudo_class.nth_child_pattern.offset);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -320,6 +320,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             case CSS::Selector::SimpleSelector::Type::PseudoClass:
                 type_description = "PseudoClass";
                 break;
+            case CSS::Selector::SimpleSelector::Type::PseudoElement:
+                type_description = "PseudoElement";
+                break;
             }
 
             builder.appendff("{}:{}", type_description, simple_selector.value);
@@ -395,6 +398,29 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                     || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild)) {
                     builder.appendff("(step={}, offset={})", pseudo_class.nth_child_pattern.step_size, pseudo_class.nth_child_pattern.offset);
                 }
+            }
+
+            if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoElement) {
+                char const* pseudo_element_description = "";
+                switch (simple_selector.pseudo_element) {
+                case CSS::Selector::SimpleSelector::PseudoElement::None:
+                    pseudo_element_description = "None";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoElement::Before:
+                    pseudo_element_description = "before";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoElement::After:
+                    pseudo_element_description = "after";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoElement::FirstLine:
+                    pseudo_element_description = "first-line";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoElement::FirstLetter:
+                    pseudo_element_description = "first-letter";
+                    break;
+                }
+
+                builder.appendff(" pseudo_element={}", pseudo_element_description);
             }
 
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Attribute) {

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -317,72 +317,85 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             case CSS::Selector::SimpleSelector::Type::Attribute:
                 type_description = "Attribute";
                 break;
-            }
-
-            char const* pseudo_class_description = "";
-            switch (simple_selector.pseudo_class) {
-            case CSS::Selector::SimpleSelector::PseudoClass::Link:
-                pseudo_class_description = "Link";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Visited:
-                pseudo_class_description = "Visited";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Active:
-                pseudo_class_description = "Active";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::None:
-                pseudo_class_description = "None";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Root:
-                pseudo_class_description = "Root";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::FirstOfType:
-                pseudo_class_description = "FirstOfType";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::LastOfType:
-                pseudo_class_description = "LastOfType";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::NthChild:
-                pseudo_class_description = "NthChild";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::NthLastChild:
-                pseudo_class_description = "NthLastChild";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Focus:
-                pseudo_class_description = "Focus";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Empty:
-                pseudo_class_description = "Empty";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Hover:
-                pseudo_class_description = "Hover";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::LastChild:
-                pseudo_class_description = "LastChild";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::FirstChild:
-                pseudo_class_description = "FirstChild";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::OnlyChild:
-                pseudo_class_description = "OnlyChild";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Disabled:
-                pseudo_class_description = "Disabled";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Enabled:
-                pseudo_class_description = "Enabled";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Checked:
-                pseudo_class_description = "Checked";
-                break;
-            case CSS::Selector::SimpleSelector::PseudoClass::Not:
-                pseudo_class_description = "Not";
+            case CSS::Selector::SimpleSelector::Type::PseudoClass:
+                type_description = "PseudoClass";
                 break;
             }
 
             builder.appendff("{}:{}", type_description, simple_selector.value);
-            if (simple_selector.pseudo_class != CSS::Selector::SimpleSelector::PseudoClass::None)
+
+            if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass) {
+                auto const& pseudo_class = simple_selector.pseudo_class;
+
+                char const* pseudo_class_description = "";
+                switch (pseudo_class.type) {
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Link:
+                    pseudo_class_description = "Link";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Visited:
+                    pseudo_class_description = "Visited";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Active:
+                    pseudo_class_description = "Active";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::None:
+                    pseudo_class_description = "None";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Root:
+                    pseudo_class_description = "Root";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstOfType:
+                    pseudo_class_description = "FirstOfType";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::LastOfType:
+                    pseudo_class_description = "LastOfType";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild:
+                    pseudo_class_description = "NthChild";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
+                    pseudo_class_description = "NthLastChild";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
+                    pseudo_class_description = "Focus";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Empty:
+                    pseudo_class_description = "Empty";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Hover:
+                    pseudo_class_description = "Hover";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::LastChild:
+                    pseudo_class_description = "LastChild";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstChild:
+                    pseudo_class_description = "FirstChild";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::OnlyChild:
+                    pseudo_class_description = "OnlyChild";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Disabled:
+                    pseudo_class_description = "Disabled";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Enabled:
+                    pseudo_class_description = "Enabled";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Checked:
+                    pseudo_class_description = "Checked";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
+                    pseudo_class_description = "Not";
+                    break;
+                }
+
                 builder.appendff(" pseudo_class={}", pseudo_class_description);
+                if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not) {
+                    builder.appendff("({})", pseudo_class.not_selector);
+                } else if ((pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild)
+                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild)) {
+                    builder.appendff("(step={}, offset={})", pseudo_class.nth_child_pattern.step_size, pseudo_class.nth_child_pattern.offset);
+                }
+            }
 
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Attribute) {
                 char const* attribute_match_type_description = "";

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -27,14 +27,14 @@
 
 namespace Web {
 
-void dump_tree(const DOM::Node& node)
+void dump_tree(DOM::Node const& node)
 {
     StringBuilder builder;
     dump_tree(builder, node);
     dbgln("{}", builder.string_view());
 }
 
-void dump_tree(StringBuilder& builder, const DOM::Node& node)
+void dump_tree(StringBuilder& builder, DOM::Node const& node)
 {
     static int indent = 0;
     for (int i = 0; i < indent; ++i)
@@ -56,7 +56,7 @@ void dump_tree(StringBuilder& builder, const DOM::Node& node)
     }
     if (is<DOM::ParentNode>(node)) {
         if (!is<HTML::HTMLTemplateElement>(node)) {
-            static_cast<const DOM::ParentNode&>(node).for_each_child([](auto& child) {
+            static_cast<DOM::ParentNode const&>(node).for_each_child([](auto& child) {
                 dump_tree(child);
             });
         } else {
@@ -67,14 +67,14 @@ void dump_tree(StringBuilder& builder, const DOM::Node& node)
     --indent;
 }
 
-void dump_tree(const Layout::Node& layout_node, bool show_box_model, bool show_specified_style)
+void dump_tree(Layout::Node const& layout_node, bool show_box_model, bool show_specified_style)
 {
     StringBuilder builder;
     dump_tree(builder, layout_node, show_box_model, show_specified_style, true);
     dbgln("{}", builder.string_view());
 }
 
-void dump_tree(StringBuilder& builder, const Layout::Node& layout_node, bool show_box_model, bool show_specified_style, bool interactive)
+void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool show_box_model, bool show_specified_style, bool interactive)
 {
     static size_t indent = 0;
     for (size_t i = 0; i < indent; ++i)
@@ -104,15 +104,15 @@ void dump_tree(StringBuilder& builder, const Layout::Node& layout_node, bool sho
         identifier = builder.to_string();
     }
 
-    const char* nonbox_color_on = "";
-    const char* box_color_on = "";
-    const char* positioned_color_on = "";
-    const char* floating_color_on = "";
-    const char* inline_block_color_on = "";
-    const char* line_box_color_on = "";
-    const char* fragment_color_on = "";
-    const char* flex_color_on = "";
-    const char* color_off = "";
+    char const* nonbox_color_on = "";
+    char const* box_color_on = "";
+    char const* positioned_color_on = "";
+    char const* floating_color_on = "";
+    char const* inline_block_color_on = "";
+    char const* line_box_color_on = "";
+    char const* fragment_color_on = "";
+    char const* flex_color_on = "";
+    char const* color_off = "";
 
     if (interactive) {
         nonbox_color_on = "\033[33m";
@@ -194,8 +194,8 @@ void dump_tree(StringBuilder& builder, const Layout::Node& layout_node, bool sho
         builder.append("\n");
     }
 
-    if (is<Layout::BlockBox>(layout_node) && static_cast<const Layout::BlockBox&>(layout_node).children_are_inline()) {
-        auto& block = static_cast<const Layout::BlockBox&>(layout_node);
+    if (is<Layout::BlockBox>(layout_node) && static_cast<Layout::BlockBox const&>(layout_node).children_are_inline()) {
+        auto& block = static_cast<Layout::BlockBox const&>(layout_node);
         for (size_t line_box_index = 0; line_box_index < block.line_boxes().size(); ++line_box_index) {
             auto& line_box = block.line_boxes()[line_box_index];
             for (size_t i = 0; i < indent; ++i)
@@ -223,7 +223,7 @@ void dump_tree(StringBuilder& builder, const Layout::Node& layout_node, bool sho
                 if (is<Layout::TextNode>(fragment.layout_node())) {
                     for (size_t i = 0; i < indent; ++i)
                         builder.append("  ");
-                    auto& layout_text = static_cast<const Layout::TextNode&>(fragment.layout_node());
+                    auto& layout_text = static_cast<Layout::TextNode const&>(fragment.layout_node());
                     auto fragment_text = layout_text.text_for_rendering().substring(fragment.start(), fragment.length());
                     builder.appendff("      \"{}\"\n", fragment_text);
                 }
@@ -256,21 +256,21 @@ void dump_tree(StringBuilder& builder, const Layout::Node& layout_node, bool sho
     --indent;
 }
 
-void dump_selector(const CSS::Selector& selector)
+void dump_selector(CSS::Selector const& selector)
 {
     StringBuilder builder;
     dump_selector(builder, selector);
     dbgln("{}", builder.string_view());
 }
 
-void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
+void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
 {
     builder.append("  CSS::Selector:\n");
 
     for (auto& complex_selector : selector.complex_selectors()) {
         builder.append("    ");
 
-        const char* relation_description = "";
+        char const* relation_description = "";
         switch (complex_selector.relation) {
         case CSS::Selector::ComplexSelector::Relation::None:
             relation_description = "None";
@@ -297,7 +297,7 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
 
         for (size_t i = 0; i < complex_selector.compound_selector.size(); ++i) {
             auto& simple_selector = complex_selector.compound_selector[i];
-            const char* type_description = "Unknown";
+            char const* type_description = "Unknown";
             switch (simple_selector.type) {
             case CSS::Selector::SimpleSelector::Type::Invalid:
                 type_description = "Invalid";
@@ -342,7 +342,7 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
                 break;
             }
 
-            const char* pseudo_class_description = "";
+            char const* pseudo_class_description = "";
             switch (simple_selector.pseudo_class) {
             case CSS::Selector::SimpleSelector::PseudoClass::Link:
                 pseudo_class_description = "Link";
@@ -417,34 +417,34 @@ void dump_selector(StringBuilder& builder, const CSS::Selector& selector)
     }
 }
 
-void dump_rule(const CSS::CSSRule& rule)
+void dump_rule(CSS::CSSRule const& rule)
 {
     StringBuilder builder;
     dump_rule(builder, rule);
     dbgln("{}", builder.string_view());
 }
 
-void dump_rule(StringBuilder& builder, const CSS::CSSRule& rule)
+void dump_rule(StringBuilder& builder, CSS::CSSRule const& rule)
 {
     builder.appendff("{}:\n", rule.class_name());
     switch (rule.type()) {
     case CSS::CSSRule::Type::Style:
-        dump_style_rule(builder, verify_cast<const CSS::CSSStyleRule>(rule));
+        dump_style_rule(builder, verify_cast<CSS::CSSStyleRule const>(rule));
         break;
     case CSS::CSSRule::Type::Import:
-        dump_import_rule(builder, verify_cast<const CSS::CSSImportRule>(rule));
+        dump_import_rule(builder, verify_cast<CSS::CSSImportRule const>(rule));
         break;
     default:
         VERIFY_NOT_REACHED();
     }
 }
 
-void dump_import_rule(StringBuilder& builder, const CSS::CSSImportRule& rule)
+void dump_import_rule(StringBuilder& builder, CSS::CSSImportRule const& rule)
 {
     builder.appendff("  Document URL: {}\n", rule.url());
 }
 
-void dump_style_rule(StringBuilder& builder, const CSS::CSSStyleRule& rule)
+void dump_style_rule(StringBuilder& builder, CSS::CSSStyleRule const& rule)
 {
     for (auto& selector : rule.selectors()) {
         dump_selector(builder, selector);
@@ -455,7 +455,7 @@ void dump_style_rule(StringBuilder& builder, const CSS::CSSStyleRule& rule)
     }
 }
 
-void dump_sheet(const CSS::StyleSheet& sheet)
+void dump_sheet(CSS::StyleSheet const& sheet)
 {
     StringBuilder builder;
     dump_sheet(builder, sheet);

--- a/Userland/Libraries/LibWeb/Dump.h
+++ b/Userland/Libraries/LibWeb/Dump.h
@@ -12,17 +12,17 @@
 
 namespace Web {
 
-void dump_tree(StringBuilder&, const DOM::Node&);
-void dump_tree(const DOM::Node&);
-void dump_tree(StringBuilder&, const Layout::Node&, bool show_box_model = false, bool show_specified_style = false, bool colorize = false);
-void dump_tree(const Layout::Node&, bool show_box_model = false, bool show_specified_style = false);
-void dump_sheet(StringBuilder&, const CSS::StyleSheet&);
-void dump_sheet(const CSS::StyleSheet&);
-void dump_rule(StringBuilder&, const CSS::CSSRule&);
-void dump_rule(const CSS::CSSRule&);
-void dump_style_rule(StringBuilder&, const CSS::CSSStyleRule&);
-void dump_import_rule(StringBuilder&, const CSS::CSSImportRule&);
-void dump_selector(StringBuilder&, const CSS::Selector&);
-void dump_selector(const CSS::Selector&);
+void dump_tree(StringBuilder&, DOM::Node const&);
+void dump_tree(DOM::Node const&);
+void dump_tree(StringBuilder&, Layout::Node const&, bool show_box_model = false, bool show_specified_style = false, bool colorize = false);
+void dump_tree(Layout::Node const&, bool show_box_model = false, bool show_specified_style = false);
+void dump_sheet(StringBuilder&, CSS::StyleSheet const&);
+void dump_sheet(CSS::StyleSheet const&);
+void dump_rule(StringBuilder&, CSS::CSSRule const&);
+void dump_rule(CSS::CSSRule const&);
+void dump_style_rule(StringBuilder&, CSS::CSSStyleRule const&);
+void dump_import_rule(StringBuilder&, CSS::CSSImportRule const&);
+void dump_selector(StringBuilder&, CSS::Selector const&);
+void dump_selector(CSS::Selector const&);
 
 }


### PR DESCRIPTION
This covers three related changes:

1. Adapting SimpleSelector to only contain one selector at a time.
2. Changing Selector into a reference type.
3. Making the `not_selector` be a list of Selectors instead of a String.

1: Previously, the Selector::SimpleSelector struct used its `Type` for some kinds of selectors, but attributes and pseudo-elements could apply to any of those types. This made parsing them more difficult than it needs to be, and also deviated from the spec, which expects a SimpleSelector to only select one thing. In this PR I've expanded the `Type` to include Attribute, PseudoClass and PseudoElement selectors, so that a SimpleSelector can only contain one thing at a time.

As a bonus, selectors for the two pseudo-elements that are required by CSS2.2 are now detected (`:first-line` and `:first-letter`), and all of those work in the new parser with either `::` or `:` syntax for compatibility. (Though the SelectorEngine still rejects all of them as not matching.)

This means that SimpleSelector is now essentially just a Variant. In the future we could use a real Variant in order to reduce the memory footprint.

3: Using a Selector for the value in a `:not()` selector means we no longer have to re-parse it every time we want to test against it. Also, the new parser has no mechanism (yet?) for producing a string representation of its data, so this means `:not()` now works there. Additionally, it is a list of selectors instead of only 1, as required by _Selectors Level 4_.

We did not have a test page for `:not()` as far as I could tell, so I have added one.

2 was a necessary consequence of 3, which makes Selector contain Selectors. But as Selectors are quite bulky now with them containing Vectors of Vectors, it should help performance to not need to copy them around all the time.