### PR TITLE
AK+Kernel+Tests: Change EnumBits has_flag() to check all flags in mask are present

### DIFF
--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -78,4 +78,10 @@
     {                                                                      \
         using Type = UnderlyingType<Enum>;                                 \
         return static_cast<Type>(value & mask) == static_cast<Type>(mask); \
+    }                                                                      \
+                                                                           \
+    Prefix constexpr bool has_any_flag(Enum value, Enum mask)              \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        return static_cast<Type>(value & mask) != 0;                       \
     }

--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -20,62 +20,62 @@
 #define AK_ENUM_BITWISE_FRIEND_OPERATORS(Enum) \
     _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, friend)
 
-#define _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, Prefix)             \
-                                                                      \
-    [[nodiscard]] Prefix constexpr Enum operator|(Enum lhs, Enum rhs) \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        return static_cast<Enum>(                                     \
-            static_cast<Type>(lhs) | static_cast<Type>(rhs));         \
-    }                                                                 \
-                                                                      \
-    [[nodiscard]] Prefix constexpr Enum operator&(Enum lhs, Enum rhs) \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        return static_cast<Enum>(                                     \
-            static_cast<Type>(lhs) & static_cast<Type>(rhs));         \
-    }                                                                 \
-                                                                      \
-    [[nodiscard]] Prefix constexpr Enum operator^(Enum lhs, Enum rhs) \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        return static_cast<Enum>(                                     \
-            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));         \
-    }                                                                 \
-                                                                      \
-    [[nodiscard]] Prefix constexpr Enum operator~(Enum rhs)           \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        return static_cast<Enum>(                                     \
-            ~static_cast<Type>(rhs));                                 \
-    }                                                                 \
-                                                                      \
-    Prefix constexpr Enum& operator|=(Enum& lhs, Enum rhs)            \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        lhs = static_cast<Enum>(                                      \
-            static_cast<Type>(lhs) | static_cast<Type>(rhs));         \
-        return lhs;                                                   \
-    }                                                                 \
-                                                                      \
-    Prefix constexpr Enum& operator&=(Enum& lhs, Enum rhs)            \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        lhs = static_cast<Enum>(                                      \
-            static_cast<Type>(lhs) & static_cast<Type>(rhs));         \
-        return lhs;                                                   \
-    }                                                                 \
-                                                                      \
-    Prefix constexpr Enum& operator^=(Enum& lhs, Enum rhs)            \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        lhs = static_cast<Enum>(                                      \
-            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));         \
-        return lhs;                                                   \
-    }                                                                 \
-                                                                      \
-    Prefix constexpr bool has_flag(Enum value, Enum mask)             \
-    {                                                                 \
-        using Type = UnderlyingType<Enum>;                            \
-        return static_cast<Type>(value & mask) != 0;                  \
+#define _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, Prefix)                  \
+                                                                           \
+    [[nodiscard]] Prefix constexpr Enum operator|(Enum lhs, Enum rhs)      \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        return static_cast<Enum>(                                          \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));              \
+    }                                                                      \
+                                                                           \
+    [[nodiscard]] Prefix constexpr Enum operator&(Enum lhs, Enum rhs)      \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        return static_cast<Enum>(                                          \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));              \
+    }                                                                      \
+                                                                           \
+    [[nodiscard]] Prefix constexpr Enum operator^(Enum lhs, Enum rhs)      \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        return static_cast<Enum>(                                          \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));              \
+    }                                                                      \
+                                                                           \
+    [[nodiscard]] Prefix constexpr Enum operator~(Enum rhs)                \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        return static_cast<Enum>(                                          \
+            ~static_cast<Type>(rhs));                                      \
+    }                                                                      \
+                                                                           \
+    Prefix constexpr Enum& operator|=(Enum& lhs, Enum rhs)                 \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        lhs = static_cast<Enum>(                                           \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));              \
+        return lhs;                                                        \
+    }                                                                      \
+                                                                           \
+    Prefix constexpr Enum& operator&=(Enum& lhs, Enum rhs)                 \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        lhs = static_cast<Enum>(                                           \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));              \
+        return lhs;                                                        \
+    }                                                                      \
+                                                                           \
+    Prefix constexpr Enum& operator^=(Enum& lhs, Enum rhs)                 \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        lhs = static_cast<Enum>(                                           \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));              \
+        return lhs;                                                        \
+    }                                                                      \
+                                                                           \
+    Prefix constexpr bool has_flag(Enum value, Enum mask)                  \
+    {                                                                      \
+        using Type = UnderlyingType<Enum>;                                 \
+        return static_cast<Type>(value & mask) == static_cast<Type>(mask); \
     }

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -96,7 +96,7 @@ Thread::FileBlocker::BlockFlags FileDescription::should_unblock(Thread::FileBloc
         unblock_flags |= BlockFlags::Write;
     // TODO: Implement Thread::FileBlocker::BlockFlags::Exception
 
-    if (has_flag(block_flags, BlockFlags::SocketFlags)) {
+    if (has_any_flag(block_flags, BlockFlags::SocketFlags)) {
         auto* sock = socket();
         VERIFY(sock);
         if (has_flag(block_flags, BlockFlags::Accept) && sock->can_accept())

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -112,7 +112,7 @@ KResultOr<FlatPtr> Process::sys$select(Userspace<const Syscall::SC_select_params
             FD_SET(selected_fds[i], &fds_write);
             marked_fd_count++;
         }
-        if (params.exceptfds && has_flag(fd_entry.unblocked_flags, BlockFlags::Exception)) {
+        if (params.exceptfds && has_any_flag(fd_entry.unblocked_flags, BlockFlags::Exception)) {
             FD_SET(selected_fds[i], &fds_except);
             marked_fd_count++;
         }
@@ -207,7 +207,7 @@ KResultOr<FlatPtr> Process::sys$poll(Userspace<const Syscall::SC_poll_params*> u
         if (fds_entry.unblocked_flags == BlockFlags::None)
             continue;
 
-        if (has_flag(fds_entry.unblocked_flags, BlockFlags::Exception)) {
+        if (has_any_flag(fds_entry.unblocked_flags, BlockFlags::Exception)) {
             if (has_flag(fds_entry.unblocked_flags, BlockFlags::ReadHangUp))
                 pfd.revents |= POLLRDHUP;
             if (has_flag(fds_entry.unblocked_flags, BlockFlags::WriteError))

--- a/Tests/AK/TestEnumBits.cpp
+++ b/Tests/AK/TestEnumBits.cpp
@@ -66,4 +66,5 @@ TEST_CASE(has_flag)
     auto intro = VideoIntro::Hello | VideoIntro::Friends;
     EXPECT(has_flag(intro, VideoIntro::Friends));
     EXPECT(!has_flag(intro, VideoIntro::Well));
+    EXPECT(!has_flag(intro, VideoIntro::CompleteIntro));
 }

--- a/Tests/AK/TestEnumBits.cpp
+++ b/Tests/AK/TestEnumBits.cpp
@@ -68,3 +68,11 @@ TEST_CASE(has_flag)
     EXPECT(!has_flag(intro, VideoIntro::Well));
     EXPECT(!has_flag(intro, VideoIntro::CompleteIntro));
 }
+
+TEST_CASE(has_any_flag)
+{
+    auto intro = VideoIntro::Hello | VideoIntro::Friends;
+    EXPECT(has_any_flag(intro, VideoIntro::Friends));
+    EXPECT(!has_any_flag(intro, VideoIntro::Well));
+    EXPECT(has_any_flag(intro, VideoIntro::CompleteIntro));
+}


### PR DESCRIPTION
I noticed this when I saw `has_flags(Core::OpenMode::ReadOnly, Core::OpenMode::ReadOnly | Core::OpenMode::WriteOnly)` was returning true.

My expectation would be that this fails.