### PR TITLE
LibDebug: Implement symbolication for x86_64

### DIFF
--- a/Userland/Libraries/LibC/elf.h
+++ b/Userland/Libraries/LibC/elf.h
@@ -38,7 +38,7 @@
 #    include <AK/Types.h>
 #endif
 
-#ifdef __LP64__
+#ifdef __x86_64__
 #    define ElfW(type) Elf64_##type
 #else
 #    define ElfW(type) Elf32_##type

--- a/Userland/Libraries/LibC/inttypes.h
+++ b/Userland/Libraries/LibC/inttypes.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Platform.h>
 #include <bits/stdint.h>
 #include <sys/cdefs.h>
 
@@ -18,7 +19,7 @@ __BEGIN_DECLS
 #define PRIi8 "d"
 #define PRIi16 "d"
 #define PRIi32 "d"
-#ifndef __LP64__
+#if ARCH(I386)
 #    define PRIi64 "lld"
 #else
 #    define PRIi64 "ld"
@@ -27,14 +28,14 @@ __BEGIN_DECLS
 #define PRIo8 "o"
 #define PRIo16 "o"
 #define PRIo32 "o"
-#ifndef __LP64__
+#if ARCH(I386)
 #    define PRIo64 "llo"
 #else
 #    define PRIo64 "lo"
 #endif
 #define PRIu16 "u"
 #define PRIu32 "u"
-#ifndef __LP64__
+#if ARCH(I386)
 #    define PRIu64 "llu"
 #    define PRIuPTR "x"
 #else
@@ -47,7 +48,7 @@ __BEGIN_DECLS
 #define PRIX16 "hX"
 #define PRIx32 "x"
 #define PRIX32 "X"
-#ifndef __LP64__
+#if ARCH(I386)
 #    define PRIx64 "llx"
 #    define PRIX64 "llX"
 #    define PRIxPTR "x"

--- a/Userland/Libraries/LibC/link.h
+++ b/Userland/Libraries/LibC/link.h
@@ -16,12 +16,6 @@
 
 __BEGIN_DECLS
 
-#ifdef __LP64__
-#    define ElfW(type) Elf64_##type
-#else
-#    define ElfW(type) Elf32_##type
-#endif
-
 struct dl_phdr_info {
     ElfW(Addr) dlpi_addr;
     const char* dlpi_name;

--- a/Userland/Libraries/LibCoreDump/Backtrace.h
+++ b/Userland/Libraries/LibCoreDump/Backtrace.h
@@ -42,7 +42,7 @@ public:
     const Vector<Entry> entries() const { return m_entries; }
 
 private:
-    void add_entry(const Reader&, FlatPtr eip);
+    void add_entry(const Reader&, FlatPtr ip);
     ELFObjectInfo const* object_info_for_region(ELF::Core::MemoryRegionInfo const&);
 
     ELF::Core::ThreadInfo m_thread_info;

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -226,7 +226,7 @@ static void parse_variable_location(Dwarf::DIE const& variable_die, DebugInfo::V
         auto value = Dwarf::Expression::evaluate(expression_bytes, regs);
 
         if (value.type != Dwarf::Expression::Type::None) {
-            VERIFY(value.type == Dwarf::Expression::Type::UnsignedIntetger);
+            VERIFY(value.type == Dwarf::Expression::Type::UnsignedInteger);
             variable_info.location_type = DebugInfo::VariableInfo::LocationType::Address;
             variable_info.location_data.address = value.data.as_u32;
         }

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -31,7 +31,7 @@ public:
     struct SourcePosition {
         FlyString file_path;
         size_t line_number { 0 };
-        Optional<u32> address_of_first_statement;
+        Optional<FlatPtr> address_of_first_statement;
 
         SourcePosition()
             : SourcePosition(String::empty(), 0)
@@ -42,7 +42,7 @@ public:
             , line_number(line_number)
         {
         }
-        SourcePosition(String file_path, size_t line_number, u32 address_of_first_statement)
+        SourcePosition(String file_path, size_t line_number, FlatPtr address_of_first_statement)
             : file_path(file_path)
             , line_number(line_number)
             , address_of_first_statement(address_of_first_statement)
@@ -65,7 +65,7 @@ public:
         String type_name;
         LocationType location_type { LocationType::None };
         union {
-            u32 address;
+            FlatPtr address;
         } location_data { 0 };
 
         union {
@@ -86,20 +86,20 @@ public:
     struct VariablesScope {
         bool is_function { false };
         String name;
-        u32 address_low { 0 };
-        u32 address_high { 0 }; // Non-inclusive - the lowest address after address_low that's not in this scope
+        FlatPtr address_low { 0 };
+        FlatPtr address_high { 0 }; // Non-inclusive - the lowest address after address_low that's not in this scope
         Vector<Dwarf::DIE> dies_of_variables;
     };
 
     NonnullOwnPtrVector<VariableInfo> get_variables_in_current_scope(PtraceRegisters const&) const;
 
-    Optional<SourcePosition> get_source_position(u32 address) const;
+    Optional<SourcePosition> get_source_position(FlatPtr address) const;
 
     struct SourcePositionWithInlines {
         Optional<SourcePosition> source_position;
         Vector<SourcePosition> inline_chain;
     };
-    SourcePositionWithInlines get_source_position_with_inlines(u32 address) const;
+    SourcePositionWithInlines get_source_position_with_inlines(FlatPtr address) const;
 
     struct SourcePositionAndAddress {
         String file;
@@ -109,9 +109,9 @@ public:
 
     Optional<SourcePositionAndAddress> get_address_from_source_position(const String& file, size_t line) const;
 
-    String name_of_containing_function(u32 address) const;
+    String name_of_containing_function(FlatPtr address) const;
     Vector<SourcePosition> source_lines_in_scope(const VariablesScope&) const;
-    Optional<VariablesScope> get_containing_function(u32 address) const;
+    Optional<VariablesScope> get_containing_function(FlatPtr address) const;
 
 private:
     void prepare_variable_scopes();

--- a/Userland/Libraries/LibDebug/Dwarf/AttributeValue.h
+++ b/Userland/Libraries/LibDebug/Dwarf/AttributeValue.h
@@ -25,6 +25,7 @@ struct AttributeValue {
     } type;
 
     union {
+        FlatPtr as_addr;
         u32 as_u32;
         i32 as_i32;
         u64 as_u64;

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -47,7 +47,7 @@ void DwarfInfo::populate_compilation_units()
 
         debug_info_stream >> compilation_unit_header;
         VERIFY(compilation_unit_header.common.version <= 5);
-        VERIFY(compilation_unit_header.address_size() == sizeof(u32));
+        VERIFY(compilation_unit_header.address_size() == sizeof(FlatPtr));
 
         u32 length_after_header = compilation_unit_header.length() - (compilation_unit_header.header_size() - offsetof(CompilationUnitHeader, common.version));
 
@@ -102,11 +102,11 @@ AttributeValue DwarfInfo::get_attribute_value(AttributeDataForm form, ssize_t im
         break;
     }
     case AttributeDataForm::Addr: {
-        u32 address;
+        FlatPtr address;
         debug_info_stream >> address;
         VERIFY(!debug_info_stream.has_any_error());
         value.type = AttributeValue::Type::UnsignedNumber;
-        value.data.as_u32 = address;
+        value.data.as_addr = address;
         break;
     }
     case AttributeDataForm::SData: {
@@ -250,7 +250,6 @@ void DwarfInfo::build_cached_dies() const
         if (!start.has_value() || !end.has_value())
             return {};
 
-        VERIFY(sizeof(FlatPtr) == sizeof(u32));
         VERIFY(start->type == Dwarf::AttributeValue::Type::UnsignedNumber);
 
         // DW_AT_high_pc attribute can have different meanings depending on the attribute form.
@@ -258,7 +257,7 @@ void DwarfInfo::build_cached_dies() const
 
         uint32_t range_end = 0;
         if (end->form == Dwarf::AttributeDataForm::Addr)
-            range_end = end->data.as_u32;
+            range_end = end->data.as_addr;
         else
             range_end = start->data.as_u32 + end->data.as_u32;
 

--- a/Userland/Libraries/LibDebug/Dwarf/Expression.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/Expression.cpp
@@ -25,13 +25,13 @@ Value evaluate(ReadonlyBytes bytes, [[maybe_unused]] PtraceRegisters const& regs
         case Operations::RegEbp: {
             ssize_t offset = 0;
             stream.read_LEB128_signed(offset);
-            return Value { Type::UnsignedIntetger, { regs.ebp + offset } };
+            return Value { Type::UnsignedInteger, { regs.ebp + offset } };
         }
 
         case Operations::FbReg: {
             ssize_t offset = 0;
             stream.read_LEB128_signed(offset);
-            return Value { Type::UnsignedIntetger, { regs.ebp + 2 * sizeof(size_t) + offset } };
+            return Value { Type::UnsignedInteger, { regs.ebp + 2 * sizeof(size_t) + offset } };
         }
 #endif
 

--- a/Userland/Libraries/LibDebug/Dwarf/Expression.h
+++ b/Userland/Libraries/LibDebug/Dwarf/Expression.h
@@ -15,7 +15,7 @@ namespace Debug::Dwarf::Expression {
 
 enum class Type {
     None,
-    UnsignedIntetger,
+    UnsignedInteger,
     Register,
 };
 

--- a/Userland/Libraries/LibDebug/Dwarf/Expression.h
+++ b/Userland/Libraries/LibDebug/Dwarf/Expression.h
@@ -22,6 +22,7 @@ enum class Type {
 struct Value {
     Type type;
     union {
+        FlatPtr as_addr;
         u32 as_u32;
     } data { 0 };
 };

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -174,7 +174,7 @@ void LineProgram::handle_extended_opcode()
         break;
     }
     default:
-        dbgln_if(DWARF_DEBUG, "offset: {:p}", m_stream.offset());
+        dbgln("Encountered unknown sub opcode {} at stream offset {:p}", sub_opcode, m_stream.offset());
         VERIFY_NOT_REACHED();
     }
 }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -109,7 +109,7 @@ public:
     explicit LineProgram(DwarfInfo& dwarf_info, InputMemoryStream& stream);
 
     struct LineInfo {
-        u32 address { 0 };
+        FlatPtr address { 0 };
         FlyString file;
         size_t line { 0 };
     };
@@ -176,7 +176,7 @@ private:
     Vector<FileEntry> m_source_files;
 
     // The registers of the "line program" virtual machine
-    u32 m_address { 0 };
+    FlatPtr m_address { 0 };
     size_t m_line { 0 };
     size_t m_file_index { 0 };
     bool m_is_statement { false };

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -398,7 +398,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         patch_ptr = (FlatPtr*)(FlatPtr)relocation.offset();
 
     switch (relocation.type()) {
-#ifndef __LP64__
+#if ARCH(I386)
     case R_386_NONE:
 #else
     case R_X86_64_NONE:
@@ -406,7 +406,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         // Apparently most loaders will just skip these?
         // Seems if the 'link editor' generates one something is funky with your code
         break;
-#ifndef __LP64__
+#if ARCH(I386)
     case R_386_32: {
 #else
     case R_X86_64_64: {
@@ -426,7 +426,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
             *patch_ptr += symbol_address.get();
         break;
     }
-#ifndef __LP64__
+#if ARCH(I386)
     case R_386_PC32: {
         auto symbol = relocation.symbol();
         auto result = lookup_symbol(symbol);
@@ -459,7 +459,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         *patch_ptr = symbol_location.get();
         break;
     }
-#ifndef __LP64__
+#if ARCH(I386)
     case R_386_RELATIVE: {
 #else
     case R_X86_64_RELATIVE: {
@@ -473,7 +473,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
             *patch_ptr += (FlatPtr)m_dynamic_object->base_address().as_ptr();
         break;
     }
-#ifndef __LP64__
+#if ARCH(I386)
     case R_386_TLS_TPOFF32:
     case R_386_TLS_TPOFF: {
 #else
@@ -497,7 +497,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         *patch_ptr = negative_offset_from_tls_block_end(dynamic_object_of_symbol->tls_offset().value(), symbol_value + addend);
         break;
     }
-#ifndef __LP64__
+#if ARCH(I386)
     case R_386_JMP_SLOT: {
 #else
     case R_X86_64_JUMP_SLOT: {

--- a/Userland/Utilities/crash.cpp
+++ b/Userland/Utilities/crash.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
                 return Crash::Failure::UnexpectedError;
 
             u8* bad_esp = bad_stack + 2048;
-#ifndef __LP64__
+#if ARCH(I386)
             asm volatile("mov %%eax, %%esp" ::"a"(bad_esp));
             asm volatile("pushl $0");
 #else


### PR DESCRIPTION
**Userland: Prefer using ARCH() over __LP64__**

**LibDebug: Fix spelling mistake**

**LibDebug: Implement symbolication for x86_64**

There's a fairly good chance that I missed some as_32 vs. as_addr fixes, but it works well enough to symbolicate stacktrackes for `crash`.