### PR TITLE
LibWeb: Add extracting character encoding from a meta content attribute

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -15,6 +15,7 @@ namespace Web::HTML {
 bool prescan_should_abort(const ByteBuffer& input, const size_t& position);
 bool prescan_is_whitespace_or_slash(const u8& byte);
 bool prescan_skip_whitespace_and_slashes(const ByteBuffer& input, size_t& position);
+Optional<String> extract_character_encoding_from_meta_element(String const&);
 Optional<Attribute> prescan_get_attribute(const ByteBuffer& input, size_t& position);
 Optional<String> run_prescan_byte_stream_algorithm(const ByteBuffer& input);
 String run_encoding_sniffing_algorithm(const ByteBuffer& input);


### PR DESCRIPTION
Some Gmail emails contain this.