### PR TITLE
Kernel: Kill user mode threads that are marked to die

### DIFF
--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -217,13 +217,6 @@ bool Scheduler::pick_next()
 
     ScopedSpinLock lock(g_scheduler_lock);
 
-    auto current_thread = Thread::current();
-    if (current_thread->should_die() && current_thread->may_die_immediately()) {
-        // Ordinarily the thread would die on syscall exit, however if the thread
-        // doesn't perform any syscalls we still need to mark it for termination here.
-        current_thread->set_state(Thread::Dying);
-    }
-
     if constexpr (SCHEDULER_RUNNABLE_DEBUG) {
         dump_thread_list();
     }

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ScopeGuard.h>
 #include <Kernel/API/Syscall.h>
 #include <Kernel/Arch/x86/Interrupts.h>
 #include <Kernel/Arch/x86/TrapFrame.h>
@@ -154,14 +153,6 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
 {
     auto& regs = *trap->regs;
     auto current_thread = Thread::current();
-    {
-        ScopedSpinLock lock(g_scheduler_lock);
-        current_thread->set_may_die_immediately(false);
-    }
-    ScopeGuard reset_may_die_immediately = [&current_thread] {
-        ScopedSpinLock lock(g_scheduler_lock);
-        current_thread->set_may_die_immediately(true);
-    };
     VERIFY(current_thread->previous_mode() == Thread::PreviousMode::UserMode);
     auto& process = current_thread->process();
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1187,8 +1187,6 @@ public:
     bool is_profiling_suppressed() const { return m_is_profiling_suppressed; }
     void set_profiling_suppressed() { m_is_profiling_suppressed = true; }
 
-    bool may_die_immediately() const { return m_may_die_immediately; }
-    void set_may_die_immediately(bool flag) { m_may_die_immediately = flag; }
     InodeIndex global_procfs_inode_index() const { return m_global_procfs_inode_index; }
 
 private:
@@ -1287,7 +1285,6 @@ private:
     Kernel::Lock* m_blocking_lock { nullptr };
     u32 m_lock_requested_count { 0 };
     IntrusiveListNode<Thread> m_blocked_threads_list_node;
-    bool m_may_die_immediately { true };
 
 #if LOCK_DEBUG
     struct HoldingLockInfo {


### PR DESCRIPTION
Threads that don't make syscalls still need to be killed, and we can
do that at any time we want so long the thread is in user mode and
not somehow blocked (e.g. page fault).

@gunnarbeutner Had to revert one of your commits which caused #8691