### PR TITLE
LibGUI: Don't clear textbox on save mode in FilePicker

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -165,7 +165,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
         auto should_open_folder = m_mode == Mode::OpenFolder;
         if (should_open_folder == node.is_directory()) {
             m_filename_textbox->set_text(node.name);
-        } else {
+        } else if (m_mode != Mode::Save) {
             m_filename_textbox->clear();
         }
     };


### PR DESCRIPTION
This fixes a rather frustrating issue during saving a file, when clicking on a folder (to change the path of saved file) caused the filename to disappear from the text box.