### PR TITLE
LibCpp: Performance improvements

### DIFF
--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -894,6 +894,10 @@ Vector<Token> Parser::tokens_in_range(Position start, Position end) const
 void Parser::error(StringView message)
 {
     LOG_SCOPE();
+
+    if (!m_saved_states.is_empty())
+        return;
+    
     if (message.is_null() || message.is_empty())
         message = "<empty>";
     String formatted_message;
@@ -907,7 +911,7 @@ void Parser::error(StringView message)
             m_tokens[m_state.token_index].start().column);
     }
 
-    m_state.errors.append(formatted_message);
+    m_errors.append(formatted_message);
 }
 
 bool Parser::match_expression()

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -33,7 +33,7 @@ public:
     String text_of_node(const ASTNode&) const;
     StringView text_of_token(const Cpp::Token& token) const;
     void print_tokens() const;
-    const Vector<String>& errors() const { return m_state.errors; }
+    const Vector<String>& errors() const { return m_errors; }
     const Preprocessor::Definitions& preprocessor_definitions() const { return m_preprocessor_definitions; }
 
     struct TodoEntry {
@@ -147,7 +147,6 @@ private:
 
     struct State {
         size_t token_index { 0 };
-        Vector<String> errors;
         NonnullRefPtrVector<ASTNode> nodes;
     };
 
@@ -200,6 +199,7 @@ private:
     State m_state;
     Vector<State> m_saved_states;
     RefPtr<TranslationUnit> m_root_node;
+    Vector<String> m_errors;
 
     Vector<TokenAndPreprocessorDefinition> m_replaced_preprocessor_tokens;
 };

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -24,7 +24,6 @@ public:
     NonnullRefPtr<TranslationUnit> parse();
     bool eof() const;
 
-    RefPtr<ASTNode> eof_node() const;
     RefPtr<ASTNode> node_at(Position) const;
     Optional<size_t> index_of_node_at(Position) const;
     Optional<Token> token_at(Position) const;
@@ -147,7 +146,7 @@ private:
 
     struct State {
         size_t token_index { 0 };
-        NonnullRefPtrVector<ASTNode> nodes;
+        NonnullRefPtrVector<ASTNode> state_nodes;
     };
 
     void error(StringView message = {});
@@ -157,9 +156,13 @@ private:
     create_ast_node(ASTNode& parent, const Position& start, Optional<Position> end, Args&&... args)
     {
         auto node = adopt_ref(*new T(&parent, start, end, m_filename, forward<Args>(args)...));
-        if (!parent.is_dummy_node()) {
-            m_state.nodes.append(node);
+
+        if (m_saved_states.is_empty()) {
+            m_nodes.append(node);
+        } else {
+            m_state.state_nodes.append(node);
         }
+
         return node;
     }
 
@@ -167,7 +170,7 @@ private:
     create_root_ast_node(const Position& start, Position end)
     {
         auto node = adopt_ref(*new TranslationUnit(nullptr, start, end, m_filename));
-        m_state.nodes.append(node);
+        m_nodes.append(node);
         m_root_node = node;
         return node;
     }
@@ -200,6 +203,7 @@ private:
     Vector<State> m_saved_states;
     RefPtr<TranslationUnit> m_root_node;
     Vector<String> m_errors;
+    NonnullRefPtrVector<ASTNode> m_nodes;
 
     Vector<TokenAndPreprocessorDefinition> m_replaced_preprocessor_tokens;
 };


### PR DESCRIPTION
This reduces what we store in each parser state, and reduces the work we do when storing and loading states.

These improvements reduce the time it takes on my machine for the c++ language server to handle this file:
```c++
#include <LibGUI/Widget.h>
```
from ~14sec to ~0.7sec.