### PR TITLE
KeyboardPreferenceLoader: Use correct default Num Lock config value

### DIFF
--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -52,7 +52,7 @@ int main()
         exit(1);
     }
 
-    bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", false);
+    bool enable_num_lock = keyboard_settings_config->read_bool_entry("StartupEnable", "NumLock", true);
 
     auto keyboard_device_or_error = Core::File::open("/dev/keyboard0", Core::OpenMode::ReadOnly);
     if (keyboard_device_or_error.is_error()) {


### PR DESCRIPTION
The original goal of this setting was to enable the num lock by default on login while still allowing the user to change that behavior, but a refactoring to use a different mechanism for setting the num lock status inadvertently changed the default value that is read here. This of course meant that it wouldn't be enabled on startup by default and also caused KeyboardSettings to lie about num lock being enabled when it wasn't.