### PR TITLE
Fix wcast align

### DIFF
--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -63,7 +63,7 @@ public:
 
         for (size_t idx = 0; idx < nread; ++idx) {
             const auto index = (m_total_written - seekback + idx) % Capacity;
-            bytes[idx] = m_queue.m_storage[index];
+            bytes[idx] = ((u8*)&m_queue.m_storage)[index];
         }
 
         return nread;
@@ -105,7 +105,7 @@ public:
     {
         VERIFY(count <= remaining_contigous_space());
 
-        Bytes bytes { m_queue.m_storage + (m_queue.head_index() + m_queue.size()) % Capacity, count };
+        Bytes bytes { (u8*)&m_queue.m_storage + (m_queue.head_index() + m_queue.size()) % Capacity, count };
 
         m_queue.m_size += count;
         m_total_written += count;

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -100,11 +100,11 @@ public:
     size_t head_index() const { return m_head; }
 
 protected:
-    T* elements() { return reinterpret_cast<T*>(m_storage); }
-    const T* elements() const { return reinterpret_cast<const T*>(m_storage); }
+    T* elements() { return reinterpret_cast<T*>(&m_storage); }
+    const T* elements() const { return reinterpret_cast<const T*>(&m_storage); }
 
     friend class ConstIterator;
-    alignas(T) u8 m_storage[sizeof(T) * Capacity];
+    AlignedStorage<sizeof(T) * Capacity, alignof(T)> m_storage;
     size_t m_size { 0 };
     size_t m_head { 0 };
 };

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -87,10 +87,10 @@ class HashTable {
         bool used;
         bool deleted;
         bool end;
-        alignas(T) u8 storage[sizeof(T)];
+        TypeAlignedStorage<T> storage;
 
-        T* slot() { return reinterpret_cast<T*>(storage); }
-        const T* slot() const { return reinterpret_cast<const T*>(storage); }
+        T* slot() { return reinterpret_cast<T*>(&storage); }
+        const T* slot() const { return reinterpret_cast<const T*>(&storage); }
     };
 
     struct OrderedBucket {
@@ -98,9 +98,9 @@ class HashTable {
         OrderedBucket* next;
         bool used;
         bool deleted;
-        alignas(T) u8 storage[sizeof(T)];
-        T* slot() { return reinterpret_cast<T*>(storage); }
-        const T* slot() const { return reinterpret_cast<const T*>(storage); }
+        TypeAlignedStorage<T> storage;
+        T* slot() { return reinterpret_cast<T*>(&storage); }
+        const T* slot() const { return reinterpret_cast<const T*>(&storage); }
     };
 
     using BucketType = Conditional<IsOrdered, OrderedBucket, Bucket>;

--- a/AK/NeverDestroyed.h
+++ b/AK/NeverDestroyed.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK {
@@ -20,7 +21,7 @@ public:
     template<typename... Args>
     NeverDestroyed(Args&&... args)
     {
-        new (storage) T(forward<Args>(args)...);
+        new (&storage) T(forward<Args>(args)...);
     }
 
     ~NeverDestroyed() = default;
@@ -35,7 +36,7 @@ public:
     const T& get() const { return reinterpret_cast<T&>(storage); }
 
 private:
-    alignas(T) u8 storage[sizeof(T)];
+    TypeAlignedStorage<T> storage;
 };
 
 }

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -162,7 +162,7 @@ public:
     ALWAYS_INLINE T* operator->() { return &value(); }
 
 private:
-    alignas(T) u8 m_storage[sizeof(T)];
+    TypeAlignedStorage<T> m_storage;
     bool m_has_value { false };
 };
 }

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -511,6 +511,15 @@ inline constexpr bool IsMoveAssignable = IsAssignable<AddLvalueReference<T>, Add
 
 template<typename T>
 inline constexpr bool IsTriviallyMoveAssignable = IsTriviallyAssignable<AddLvalueReference<T>, AddRvalueReference<T>>;
+
+template<unsigned long size, unsigned long align>
+struct AlignedStorage {
+    struct alignas(align) Storage {
+        char buffer[size];
+    };
+    using Type = Storage;
+};
+
 }
 using AK::Detail::AddConst;
 using AK::Detail::AddLvalueReference;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -125,6 +125,12 @@ constexpr bool is_constant_evaluated()
 #endif
 }
 
+template<unsigned long size, unsigned long align>
+using AlignedStorage = typename Detail::AlignedStorage<size, align>::Type;
+
+template<typename T>
+using TypeAlignedStorage = typename Detail::AlignedStorage<sizeof(T), alignof(T)>::Type;
+
 // These can't be exported into the global namespace as they would clash with the C standard library.
 
 #define __DEFINE_GENERIC_ABS(type, zero, intrinsic) \
@@ -147,6 +153,7 @@ __DEFINE_GENERIC_ABS(long double, 0.0l, fabsl);
 
 }
 
+using AK::AlignedStorage;
 using AK::array_size;
 using AK::ceil_div;
 using AK::clamp;
@@ -158,3 +165,4 @@ using AK::min;
 using AK::RawPtr;
 using AK::swap;
 using AK::to_underlying;
+using AK::TypeAlignedStorage;

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -763,12 +763,12 @@ private:
     StorageType* inline_buffer()
     {
         static_assert(inline_capacity > 0);
-        return reinterpret_cast<StorageType*>(m_inline_buffer_storage);
+        return reinterpret_cast<StorageType*>(&m_inline_buffer_storage);
     }
     StorageType const* inline_buffer() const
     {
         static_assert(inline_capacity > 0);
-        return reinterpret_cast<StorageType const*>(m_inline_buffer_storage);
+        return reinterpret_cast<StorageType const*>(&m_inline_buffer_storage);
     }
 
     StorageType& raw_last() { return raw_at(size() - 1); }
@@ -778,7 +778,7 @@ private:
     size_t m_size { 0 };
     size_t m_capacity { 0 };
 
-    alignas(StorageType) unsigned char m_inline_buffer_storage[sizeof(StorageType) * inline_capacity];
+    AlignedStorage<sizeof(StorageType) * inline_capacity, alignof(StorageType)> m_inline_buffer_storage;
     StorageType* m_outline_buffer { nullptr };
 };
 

--- a/Kernel/Arch/x86/common/ProcessorInfo.cpp
+++ b/Kernel/Arch/x86/common/ProcessorInfo.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteReader.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/x86/CPUID.h>
@@ -56,14 +57,16 @@ ProcessorInfo::ProcessorInfo(Processor& processor)
     u32 max_extended_leaf = CPUID(0x80000000).eax();
 
     if (max_extended_leaf >= 0x80000004) {
-        alignas(u32) char buffer[48];
-        u32* bufptr = reinterpret_cast<u32*>(buffer);
+        char buffer[49];
+        buffer[48] = '\0';
+        char* bufptr = buffer;
         auto copy_brand_string_part_to_buffer = [&](u32 i) {
             CPUID cpuid(0x80000002 + i);
-            *bufptr++ = cpuid.eax();
-            *bufptr++ = cpuid.ebx();
-            *bufptr++ = cpuid.ecx();
-            *bufptr++ = cpuid.edx();
+            ByteReader::store((u8*)bufptr + 0, cpuid.eax());
+            ByteReader::store((u8*)bufptr + 4, cpuid.ebx());
+            ByteReader::store((u8*)bufptr + 8, cpuid.ecx());
+            ByteReader::store((u8*)bufptr + 12, cpuid.edx());
+            bufptr += 16;
         };
         copy_brand_string_part_to_buffer(0);
         copy_brand_string_part_to_buffer(1);

--- a/Kernel/Bus/USB/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCIController.cpp
@@ -423,7 +423,7 @@ UNMAP_AFTER_INIT void UHCIController::setup_schedule()
     m_dummy_qh->terminate_with_stray_descriptor(piix4_td_hack);
     m_dummy_qh->terminate_element_link_ptr();
 
-    u32* framelist = reinterpret_cast<u32*>(m_framelist->vaddr().as_ptr());
+    u32* framelist = m_framelist->vaddr().as_ptr<u32>();
     for (int frame = 0; frame < UHCI_NUMBER_OF_FRAMES; frame++) {
         // Each frame pointer points to iso_td % NUM_ISO_TDS
         framelist[frame] = m_iso_td_list.at(frame % UHCI_NUMBER_OF_ISOCHRONOUS_TDS)->paddr();

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -37,7 +37,7 @@ void Transfer::set_setup_packet(const USBRequestData& request)
     // of handing out physical pointers that we can directly write to,
     // we set the address of the setup packet to be the first 8 bytes of
     // the data buffer, which we then set to the physical address.
-    auto* request_data = reinterpret_cast<USBRequestData*>(buffer().as_ptr());
+    auto* request_data = buffer().as_ptr<USBRequestData>();
 
     request_data->request_type = request.request_type;
     request_data->request = request.request;

--- a/Kernel/Graphics/Console/TextModeConsole.h
+++ b/Kernel/Graphics/Console/TextModeConsole.h
@@ -42,7 +42,7 @@ private:
     mutable SpinLock<u8> m_vga_lock;
     u16 m_vga_start_row { 0 };
     u16 m_current_vga_start_address { 0 };
-    u8* m_current_vga_window { nullptr };
+    u16* m_current_vga_window { nullptr };
     u16 m_cursor_x { 0 };
     u16 m_cursor_y { 0 };
 };

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -279,7 +279,7 @@ void IntelNativeGraphicsAdapter::write_to_register(IntelGraphics::RegisterIndex 
     VERIFY(m_registers_region);
     ScopedSpinLock lock(m_registers_lock);
     dbgln_if(INTEL_GRAPHICS_DEBUG, "Intel Graphics {}: Write to {} value of {:x}", pci_address(), convert_register_index_to_string(index), value);
-    auto* reg = (volatile u32*)m_registers_region->vaddr().offset(index).as_ptr();
+    auto* reg = m_registers_region->vaddr().offset(index).as_ptr<volatile u32>();
     *reg = value;
 }
 u32 IntelNativeGraphicsAdapter::read_from_register(IntelGraphics::RegisterIndex index) const
@@ -287,7 +287,7 @@ u32 IntelNativeGraphicsAdapter::read_from_register(IntelGraphics::RegisterIndex 
     VERIFY(m_control_lock.is_locked());
     VERIFY(m_registers_region);
     ScopedSpinLock lock(m_registers_lock);
-    auto* reg = (volatile u32*)m_registers_region->vaddr().offset(index).as_ptr();
+    auto* reg = m_registers_region->vaddr().offset(index).as_ptr<volatile u32>();
     u32 value = *reg;
     dbgln_if(INTEL_GRAPHICS_DEBUG, "Intel Graphics {}: Read from {} value of {:x}", pci_address(), convert_register_index_to_string(index), value);
     return value;

--- a/Kernel/Graphics/VirtIOGPU/VirtIOGPU.cpp
+++ b/Kernel/Graphics/VirtIOGPU/VirtIOGPU.cpp
@@ -88,8 +88,8 @@ void VirtIOGPU::clear_pending_events(u32 event_bitmask)
 void VirtIOGPU::query_display_information()
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtIOGPUCtrlHeader*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPURespDisplayInfo*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUCtrlHeader>());
+    auto& response = *(m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPURespDisplayInfo>());
 
     populate_virtio_gpu_request_header(request, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_GET_DISPLAY_INFO, VIRTIO_GPU_FLAG_FENCE);
 
@@ -108,8 +108,8 @@ void VirtIOGPU::query_display_information()
 VirtIOGPUResourceID VirtIOGPU::create_2d_resource(VirtIOGPURect rect)
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtIOGPUResourceCreate2D*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUResourceCreate2D>());
+    auto& response = *((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_RESOURCE_CREATE_2D, VIRTIO_GPU_FLAG_FENCE);
 
@@ -136,9 +136,9 @@ void VirtIOGPU::ensure_backing_storage(Region const& region, size_t buffer_offse
     size_t num_mem_regions = buffer_length / PAGE_SIZE;
 
     // Send request
-    auto& request = *reinterpret_cast<VirtIOGPUResourceAttachBacking*>(m_scratch_space->vaddr().as_ptr());
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUResourceAttachBacking>());
     const size_t header_block_size = sizeof(request) + num_mem_regions * sizeof(VirtIOGPUMemEntry);
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(header_block_size).as_ptr()));
+    auto& response = *((m_scratch_space->vaddr().offset(header_block_size).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_RESOURCE_ATTACH_BACKING, VIRTIO_GPU_FLAG_FENCE);
     request.resource_id = resource_id.value();
@@ -157,8 +157,8 @@ void VirtIOGPU::ensure_backing_storage(Region const& region, size_t buffer_offse
 void VirtIOGPU::detach_backing_storage(VirtIOGPUResourceID resource_id)
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtIOGPUResourceDetachBacking*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUResourceDetachBacking>());
+    auto& response = *((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_RESOURCE_DETACH_BACKING, VIRTIO_GPU_FLAG_FENCE);
     request.resource_id = resource_id.value();
@@ -172,8 +172,8 @@ void VirtIOGPU::detach_backing_storage(VirtIOGPUResourceID resource_id)
 void VirtIOGPU::set_scanout_resource(VirtIOGPUScanoutID scanout, VirtIOGPUResourceID resource_id, VirtIOGPURect rect)
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtIOGPUSetScanOut*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUSetScanOut>());
+    auto& response = *((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_SET_SCANOUT, VIRTIO_GPU_FLAG_FENCE);
     request.resource_id = resource_id.value();
@@ -189,8 +189,8 @@ void VirtIOGPU::set_scanout_resource(VirtIOGPUScanoutID scanout, VirtIOGPUResour
 void VirtIOGPU::transfer_framebuffer_data_to_host(VirtIOGPUScanoutID scanout, VirtIOGPURect const& dirty_rect, VirtIOGPUResourceID resource_id)
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtIOGPUTransferToHost2D*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUTransferToHost2D>());
+    auto& response = *((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D, VIRTIO_GPU_FLAG_FENCE);
     request.offset = (dirty_rect.x + (dirty_rect.y * m_scanouts[scanout.value()].display_info.rect.width)) * sizeof(u32);
@@ -205,8 +205,8 @@ void VirtIOGPU::transfer_framebuffer_data_to_host(VirtIOGPUScanoutID scanout, Vi
 void VirtIOGPU::flush_displayed_image(VirtIOGPURect const& dirty_rect, VirtIOGPUResourceID resource_id)
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtIOGPUResourceFlush*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtIOGPUResourceFlush>());
+    auto& response = *((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_RESOURCE_FLUSH, VIRTIO_GPU_FLAG_FENCE);
     request.resource_id = resource_id.value();
@@ -259,8 +259,8 @@ VirtIOGPUResourceID VirtIOGPU::allocate_resource_id()
 void VirtIOGPU::delete_resource(VirtIOGPUResourceID resource_id)
 {
     VERIFY(m_operation_lock.is_locked());
-    auto& request = *reinterpret_cast<VirtioGPUResourceUnref*>(m_scratch_space->vaddr().as_ptr());
-    auto& response = *reinterpret_cast<VirtIOGPUCtrlHeader*>((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr()));
+    auto& request = *(m_scratch_space->vaddr().as_ptr<VirtioGPUResourceUnref>());
+    auto& response = *((m_scratch_space->vaddr().offset(sizeof(request)).as_ptr<VirtIOGPUCtrlHeader>()));
 
     populate_virtio_gpu_request_header(request.header, VirtIOGPUCtrlType::VIRTIO_GPU_CMD_RESOURCE_UNREF, VIRTIO_GPU_FLAG_FENCE);
     request.resource_id = resource_id.value();

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -157,7 +157,7 @@ public:
 
 private:
     union {
-        alignas(T) char m_storage[sizeof(T)];
+        TypeAlignedStorage<T> m_storage;
         KResult m_error;
     };
     bool m_is_error { false };

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -374,14 +374,14 @@ void VirtualConsole::echo(u8 ch)
 
 VirtualConsole::Cell& VirtualConsole::cell_at(size_t x, size_t y)
 {
-    auto* ptr = (VirtualConsole::Cell*)(m_cells->vaddr().as_ptr());
+    auto* ptr = m_cells->vaddr().as_ptr<Cell>();
     ptr += (y * columns()) + x;
     return *ptr;
 }
 
 void VirtualConsole::clear()
 {
-    auto* cell = (Cell*)m_cells->vaddr().as_ptr();
+    auto* cell = m_cells->vaddr().as_ptr<Cell>();
     for (size_t y = 0; y < rows(); y++) {
         m_lines[y].dirty = true;
         for (size_t x = 0; x < columns(); x++) {

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1209,8 +1209,8 @@ KResult Thread::make_thread_specific_region(Badge<Process>)
     m_thread_specific_range = range.value();
 
     SmapDisabler disabler;
-    auto* thread_specific_data = (ThreadSpecificData*)region_or_error.value()->vaddr().offset(align_up_to(process().m_master_tls_size, thread_specific_region_alignment())).as_ptr();
-    auto* thread_local_storage = (u8*)((u8*)thread_specific_data) - align_up_to(process().m_master_tls_size, process().m_master_tls_alignment);
+    auto* thread_specific_data = region_or_error.value()->vaddr().offset(align_up_to(process().m_master_tls_size, thread_specific_region_alignment())).as_ptr<ThreadSpecificData>();
+    auto* thread_local_storage = (u8*)thread_specific_data - align_up_to(process().m_master_tls_size, process().m_master_tls_alignment);
     m_thread_specific_data = VirtualAddress(thread_specific_data);
     thread_specific_data->self = thread_specific_data;
 

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -541,7 +541,7 @@ struct ucred {
     gid_t gid;
 };
 
-struct sockaddr {
+struct alignas(4) sockaddr {
     u16 sa_family;
     char sa_data[14];
 };
@@ -549,7 +549,7 @@ struct sockaddr {
 #define S_IFSOCK 0140000
 #define UNIX_PATH_MAX 108
 
-struct sockaddr_un {
+struct alignas(4) sockaddr_un {
     u16 sun_family;
     char sun_path[UNIX_PATH_MAX];
 };

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -549,7 +549,7 @@ struct alignas(4) sockaddr {
 #define S_IFSOCK 0140000
 #define UNIX_PATH_MAX 108
 
-struct alignas(4) sockaddr_un {
+struct sockaddr_un {
     u16 sun_family;
     char sun_path[UNIX_PATH_MAX];
 };

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -864,7 +864,7 @@ NonnullRefPtrVector<PhysicalPage> MemoryManager::allocate_contiguous_supervisor_
     }
 
     auto cleanup_region = MM.allocate_kernel_region(physical_pages[0].paddr(), PAGE_SIZE * count, "MemoryManager Allocation Sanitization", Region::Access::Read | Region::Access::Write);
-    fast_u32_fill((u32*)cleanup_region->vaddr().as_ptr(), 0, (PAGE_SIZE * count) / sizeof(u32));
+    fast_u32_fill(cleanup_region->vaddr().as_ptr<u32>(), 0, (PAGE_SIZE * count) / sizeof(u32));
     m_system_memory_info.super_physical_pages_used += count;
     return physical_pages;
 }

--- a/Kernel/VM/TypedMapping.h
+++ b/Kernel/VM/TypedMapping.h
@@ -13,8 +13,8 @@ namespace Kernel {
 
 template<typename T>
 struct TypedMapping {
-    const T* ptr() const { return reinterpret_cast<const T*>(region->vaddr().offset(offset).as_ptr()); }
-    T* ptr() { return reinterpret_cast<T*>(region->vaddr().offset(offset).as_ptr()); }
+    const T* ptr() const { return region->vaddr().offset(offset).as_ptr<const T>(); }
+    T* ptr() { return region->vaddr().offset(offset).as_ptr<T>(); }
     const T* operator->() const { return ptr(); }
     T* operator->() { return ptr(); }
     const T& operator*() const { return *ptr(); }

--- a/Kernel/VirtualAddress.h
+++ b/Kernel/VirtualAddress.h
@@ -37,8 +37,10 @@ public:
     bool operator==(const VirtualAddress& other) const { return m_address == other.m_address; }
     bool operator!=(const VirtualAddress& other) const { return m_address != other.m_address; }
 
-    [[nodiscard]] u8* as_ptr() { return reinterpret_cast<u8*>(m_address); }
-    [[nodiscard]] const u8* as_ptr() const { return reinterpret_cast<const u8*>(m_address); }
+    template<typename T = u8>
+    [[nodiscard]] T* as_ptr() { return reinterpret_cast<T*>(m_address); }
+    template<typename T = u8>
+    [[nodiscard]] const T* as_ptr() const { return reinterpret_cast<const T*>(m_address); }
 
     [[nodiscard]] VirtualAddress page_base() const { return VirtualAddress(m_address & 0xfffff000); }
 

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -614,7 +614,7 @@ private:
 
 extern "C" {
 
-alignas(FILE) static u8 default_streams[3][sizeof(FILE)];
+static TypeAlignedStorage<FILE> default_streams[3];
 FILE* stdin = reinterpret_cast<FILE*>(&default_streams[0]);
 FILE* stdout = reinterpret_cast<FILE*>(&default_streams[1]);
 FILE* stderr = reinterpret_cast<FILE*>(&default_streams[2]);

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -214,40 +214,40 @@ static void initialize_libc(DynamicObject& libc)
     // because it uses getenv() internally, so `environ` has to be initialized before we call `__libc_init`.
     auto res = libc.lookup_symbol("environ"sv);
     VERIFY(res.has_value());
-    *((char***)res.value().address.as_ptr()) = s_envp;
+    *(res.value().address.as_ptr<char**>()) = s_envp;
 
     res = libc.lookup_symbol("__environ_is_malloced"sv);
     VERIFY(res.has_value());
-    *((bool*)res.value().address.as_ptr()) = false;
+    *(res.value().address.as_ptr<bool>()) = false;
 
     res = libc.lookup_symbol("exit"sv);
     VERIFY(res.has_value());
-    s_libc_exit = (LibCExitFunction)res.value().address.as_ptr();
+    s_libc_exit = *res.value().address.as_ptr<LibCExitFunction>();
 
     res = libc.lookup_symbol("__dl_iterate_phdr"sv);
     VERIFY(res.has_value());
-    *((DlIteratePhdrFunction*)res.value().address.as_ptr()) = __dl_iterate_phdr;
+    *res.value().address.as_ptr<DlIteratePhdrFunction>() = __dl_iterate_phdr;
 
     res = libc.lookup_symbol("__dlclose"sv);
     VERIFY(res.has_value());
-    *((DlCloseFunction*)res.value().address.as_ptr()) = __dlclose;
+    *res.value().address.as_ptr<DlCloseFunction>() = __dlclose;
 
     res = libc.lookup_symbol("__dlopen"sv);
     VERIFY(res.has_value());
-    *((DlOpenFunction*)res.value().address.as_ptr()) = __dlopen;
+    *res.value().address.as_ptr<DlOpenFunction>() = __dlopen;
 
     res = libc.lookup_symbol("__dlsym"sv);
     VERIFY(res.has_value());
-    *((DlSymFunction*)res.value().address.as_ptr()) = __dlsym;
+    *res.value().address.as_ptr<DlSymFunction>() = __dlsym;
 
     res = libc.lookup_symbol("__dladdr"sv);
     VERIFY(res.has_value());
-    *((DlAddrFunction*)res.value().address.as_ptr()) = __dladdr;
+    *res.value().address.as_ptr<DlAddrFunction>() = __dladdr;
 
     res = libc.lookup_symbol("__libc_init"sv);
     VERIFY(res.has_value());
     typedef void libc_init_func();
-    ((libc_init_func*)res.value().address.as_ptr())();
+    res.value().address.as_ptr<libc_init_func>()();
 }
 
 template<typename Callback>

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -422,7 +422,7 @@ inline void DynamicObject::for_each_symbol(F func) const
 template<IteratorFunction<DynamicObject::DynamicEntry&> F>
 inline void DynamicObject::for_each_dynamic_entry(F func) const
 {
-    auto* dyns = reinterpret_cast<const ElfW(Dyn)*>(m_dynamic_address.as_ptr());
+    auto* dyns = m_dynamic_address.as_ptr<const ElfW(Dyn)>();
     for (unsigned i = 0;; ++i) {
         auto&& dyn = DynamicEntry(dyns[i]);
         if (dyn.tag() == DT_NULL)
@@ -448,7 +448,7 @@ inline void DynamicObject::for_each_needed_library(F func) const
         if (entry.tag() != DT_NEEDED)
             return;
         ElfW(Word) offset = entry.val();
-        StringView name { (const char*)(m_base_address.offset(m_string_table_offset).offset(offset)).as_ptr() };
+        StringView name { m_base_address.offset(m_string_table_offset).offset(offset).as_ptr<const char>() };
         func(name);
     });
 }


### PR DESCRIPTION
This is a start with fixing errors that pop up when enabling the -Wcast-align=strict warning on GCC. There are still about 40 files with errors remaining, so the warning is not yet turned on, but this seems to have a minor general improvement on the code itself too so I figured I'd try to drop before the change grows too much.

In particular, Range now has a as_ptr template that allows leaving the typecast within Range, removing many uses of reinterpret_cast.

This should have zero functional difference. If you see or notice any difference let me know; that is unintentional.