### PR TITLE
ImageViewer: Preserve the aspect ratio on rotate

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -111,11 +111,6 @@ void ViewWidget::set_scale(int scale)
     if (m_bitmap.is_null())
         return;
 
-    if (m_scale == scale) {
-        update();
-        return;
-    }
-
     if (scale < 10)
         scale = 10;
     if (scale > 1000)

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -130,7 +130,7 @@ void ViewWidget::set_scale(int scale)
     m_bitmap_rect.set_size(new_size);
 
     if (on_scale_change)
-        on_scale_change(m_scale, m_bitmap_rect);
+        on_scale_change(m_scale);
 
     relayout();
 }

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -277,7 +277,12 @@ void ViewWidget::drop_event(GUI::DropEvent& event)
 
 void ViewWidget::resize_window()
 {
-    if (window()->is_fullscreen())
+    if (window()->is_fullscreen() || window()->is_maximized())
+        return;
+
+    auto absolute_bitmap_rect = m_bitmap_rect;
+    absolute_bitmap_rect.translate_by(window()->rect().top_left());
+    if (window()->rect().contains(absolute_bitmap_rect))
         return;
 
     if (!m_bitmap)

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -34,6 +34,7 @@ public:
     int toolbar_height() { return m_toolbar_height; }
     bool scaled_for_first_image() { return m_scaled_for_first_image; }
     void set_scaled_for_first_image(bool val) { m_scaled_for_first_image = val; }
+    void resize_window();
 
     void clear();
     void flip(Gfx::Orientation);
@@ -41,7 +42,7 @@ public:
     void navigate(Directions);
     void load_from_file(const String&);
 
-    Function<void(int, Gfx::IntRect)> on_scale_change;
+    Function<void(int)> on_scale_change;
     Function<void()> on_doubleclick;
     Function<void(const GUI::DropEvent&)> on_drop;
     Function<void(const Gfx::Bitmap*)> on_image_change;
@@ -60,7 +61,6 @@ private:
     void set_bitmap(const Gfx::Bitmap* bitmap);
 
     void relayout();
-    void resize_window();
     void reset_view();
     void animate();
 

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
     auto& main_toolbar = toolbar_container.add<GUI::Toolbar>();
 
     auto& widget = root_widget.add<ViewWidget>();
-    widget.on_scale_change = [&](int scale, Gfx::IntRect rect) {
+    widget.on_scale_change = [&](int scale) {
         if (!widget.bitmap()) {
             window->set_title("Image Viewer");
             return;
@@ -86,17 +86,9 @@ int main(int argc, char** argv)
 
         window->set_title(String::formatted("{} {} {}% - Image Viewer", widget.path(), widget.bitmap()->size().to_string(), scale));
 
-        if (window->is_fullscreen())
-            return;
-
-        if (window->is_maximized())
-            return;
-
         if (scale == 100 && !widget.scaled_for_first_image()) {
             widget.set_scaled_for_first_image(true);
-            auto w = min(GUI::Desktop::the().rect().width(), rect.width() + 4);
-            auto h = min(GUI::Desktop::the().rect().height(), rect.height() + widget.toolbar_height() + 6);
-            window->resize(w, h);
+            widget.resize_window();
         }
     };
     widget.on_drop = [&](auto& event) {


### PR DESCRIPTION
This PR fixed two bugs with ImageViewer, related to image rotations:
- The image looked shrank after rotation due to the window not being updated properly.
- The window is resized even if the image is small enough to rotate within the window.