### PR TITLE
Kernel: Ignore subsequent calls to Process::die

### DIFF
--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -155,6 +155,12 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     auto current_thread = Thread::current();
     VERIFY(current_thread->previous_mode() == Thread::PreviousMode::UserMode);
     auto& process = current_thread->process();
+    if (process.is_dying()) {
+        // It's possible this thread is just about to make a syscall while another is
+        // is killing our process.
+        current_thread->die_if_needed();
+        return;
+    }
 
     if (auto tracer = process.tracer(); tracer && tracer->is_tracing_syscalls()) {
         tracer->set_trace_syscalls(false);


### PR DESCRIPTION
It's possible that another thread might try to exit the process just
about the same time another thread does the same, or a crash happens.
Also, we may not be able to kill all other threads instantly as they
may be blocked in the kernel (though in this case they would get killed
before ever returning back to user mode. So keep track of whether
Process::die was already called and ignore it on subsequent calls.

Fixes #8485