### PR TITLE
RunWindow: Don't center FilePicker within the window

### DIFF
--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -62,7 +62,7 @@ RunWindow::RunWindow()
 
     m_browse_button = *find_descendant_of_type_named<GUI::Button>("browse_button");
     m_browse_button->on_click = [this](auto) {
-        Optional<String> path = GUI::FilePicker::get_open_filepath(this);
+        Optional<String> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::Center);
         if (path.has_value())
             m_path_combo_box->set_text(path.value().view());
     };

--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -5,13 +5,15 @@
  */
 
 #include <LibCore/EventLoop.h>
+#include <LibGUI/Desktop.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Event.h>
 
 namespace GUI {
 
-Dialog::Dialog(Window* parent_window)
+Dialog::Dialog(Window* parent_window, ScreenPosition screen_position)
     : Window(parent_window)
+    , m_screen_position(screen_position)
 {
     set_modal(true);
     set_minimizable(false);
@@ -25,16 +27,64 @@ int Dialog::exec()
 {
     VERIFY(!m_event_loop);
     m_event_loop = make<Core::EventLoop>();
-    if (parent() && is<Window>(parent())) {
-        auto& parent_window = *static_cast<Window*>(parent());
-        if (parent_window.is_visible()) {
-            center_within(parent_window);
-        } else {
-            center_on_screen();
+
+    auto desktop_rect = Desktop::the().rect();
+    auto window_rect = rect();
+
+    auto top_align = [](Gfx::Rect<int>& rect) { rect.set_y(32); };
+    auto bottom_align = [this, desktop_rect](Gfx::Rect<int>& rect) { rect.set_y(desktop_rect.height() - Desktop::the().taskbar_height() - height() - 12); };
+
+    auto left_align = [](Gfx::Rect<int>& rect) { rect.set_x(12); };
+    auto right_align = [this, desktop_rect](Gfx::Rect<int>& rect) { rect.set_x(desktop_rect.width() - width() - 12); };
+
+    switch (m_screen_position) {
+    case CenterWithinParent:
+        if (parent() && is<Window>(parent())) {
+            auto& parent_window = *static_cast<Window*>(parent());
+            if (parent_window.is_visible()) {
+                window_rect.center_within(parent_window.rect());
+                break;
+            }
         }
-    } else {
-        center_on_screen();
+        [[fallthrough]]; // Fall back to `Center` if parent window is invalid or not visible
+    case Center:
+        window_rect.center_within(desktop_rect);
+        break;
+    case CenterLeft:
+        left_align(window_rect);
+        window_rect.center_vertically_within(desktop_rect);
+        break;
+    case CenterRight:
+        right_align(window_rect);
+        window_rect.center_vertically_within(desktop_rect);
+        break;
+    case TopLeft:
+        left_align(window_rect);
+        top_align(window_rect);
+        break;
+    case TopCenter:
+        window_rect.center_horizontally_within(desktop_rect);
+        top_align(window_rect);
+        break;
+    case TopRight:
+        right_align(window_rect);
+        top_align(window_rect);
+        break;
+    case BottomLeft:
+        left_align(window_rect);
+        bottom_align(window_rect);
+        break;
+    case BottomCenter:
+        window_rect.center_horizontally_within(desktop_rect);
+        bottom_align(window_rect);
+        break;
+    case BottomRight:
+        right_align(window_rect);
+        bottom_align(window_rect);
+        break;
     }
+
+    set_rect(window_rect);
     show();
     auto result = m_event_loop->exec();
     m_event_loop = nullptr;

--- a/Userland/Libraries/LibGUI/Dialog.h
+++ b/Userland/Libraries/LibGUI/Dialog.h
@@ -20,6 +20,21 @@ public:
         ExecYes = 3,
         ExecNo = 4,
     };
+    enum ScreenPosition {
+        CenterWithinParent = 0,
+
+        Center = 1,
+        CenterLeft = 2,
+        CenterRight = 3,
+
+        TopLeft = 4,
+        TopCenter = 5,
+        TopRight = 6,
+
+        BottomLeft = 7,
+        BottomCenter = 8,
+        BottomRight = 9,
+    };
 
     virtual ~Dialog() override;
 
@@ -33,11 +48,12 @@ public:
     virtual void close() override;
 
 protected:
-    explicit Dialog(Window* parent_window);
+    explicit Dialog(Window* parent_window, ScreenPosition screen_position = CenterWithinParent);
 
 private:
     OwnPtr<Core::EventLoop> m_event_loop;
     int m_result { ExecAborted };
+    int m_screen_position { CenterWithinParent };
 };
 
 }

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -29,9 +29,9 @@
 
 namespace GUI {
 
-Optional<String> FilePicker::get_open_filepath(Window* parent_window, const String& window_title, const StringView& path, bool folder)
+Optional<String> FilePicker::get_open_filepath(Window* parent_window, const String& window_title, const StringView& path, bool folder, ScreenPosition screen_position)
 {
-    auto picker = FilePicker::construct(parent_window, folder ? Mode::OpenFolder : Mode::Open, "", path);
+    auto picker = FilePicker::construct(parent_window, folder ? Mode::OpenFolder : Mode::Open, "", path, screen_position);
 
     if (!window_title.is_null())
         picker->set_title(window_title);
@@ -47,9 +47,9 @@ Optional<String> FilePicker::get_open_filepath(Window* parent_window, const Stri
     return {};
 }
 
-Optional<String> FilePicker::get_save_filepath(Window* parent_window, const String& title, const String& extension, const StringView& path)
+Optional<String> FilePicker::get_save_filepath(Window* parent_window, const String& title, const String& extension, const StringView& path, ScreenPosition screen_position)
 {
-    auto picker = FilePicker::construct(parent_window, Mode::Save, String::formatted("{}.{}", title, extension), path);
+    auto picker = FilePicker::construct(parent_window, Mode::Save, String::formatted("{}.{}", title, extension), path, screen_position);
 
     if (picker->exec() == Dialog::ExecOK) {
         String file_path = picker->selected_file();
@@ -62,8 +62,8 @@ Optional<String> FilePicker::get_save_filepath(Window* parent_window, const Stri
     return {};
 }
 
-FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filename, const StringView& path)
-    : Dialog(parent_window)
+FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filename, const StringView& path, ScreenPosition screen_position)
+    : Dialog(parent_window, screen_position)
     , m_model(FileSystemModel::create(path))
     , m_mode(mode)
 {

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -28,8 +28,8 @@ public:
         Save
     };
 
-    static Optional<String> get_open_filepath(Window* parent_window, const String& window_title = {}, const StringView& path = Core::StandardPaths::home_directory(), bool folder = false);
-    static Optional<String> get_save_filepath(Window* parent_window, const String& title, const String& extension, const StringView& path = Core::StandardPaths::home_directory());
+    static Optional<String> get_open_filepath(Window* parent_window, const String& window_title = {}, const StringView& path = Core::StandardPaths::home_directory(), bool folder = false, ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
+    static Optional<String> get_save_filepath(Window* parent_window, const String& title, const String& extension, const StringView& path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
 
     virtual ~FilePicker() override;
 
@@ -43,7 +43,7 @@ private:
     // ^GUI::ModelClient
     virtual void model_did_update(unsigned) override;
 
-    FilePicker(Window* parent_window, Mode type = Mode::Open, const StringView& filename = "Untitled", const StringView& path = Core::StandardPaths::home_directory());
+    FilePicker(Window* parent_window, Mode type = Mode::Open, const StringView& filename = "Untitled", const StringView& path = Core::StandardPaths::home_directory(), ScreenPosition screen_position = Dialog::ScreenPosition::CenterWithinParent);
 
     static String ok_button_name(Mode mode)
     {


### PR DESCRIPTION
It doesn't make much sense since run window is created in the bottom
left corner of the screen.