### PR TITLE
AK+LibM: Replace some parts of LibM with an AK internal implemenation for better inlineing and code duplication reduction

### DIFF
--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -7,10 +7,7 @@
 #pragma once
 
 #include <AK/Concepts.h>
-#if __has_include(<math.h>)
-#    define AKCOMPLEX_CAN_USE_MATH_H
-#    include <math.h>
-#endif
+#include <AK/Math.h>
 
 #ifdef __cplusplus
 #    if __cplusplus >= 201103L
@@ -45,18 +42,9 @@ public:
 
     constexpr T magnitude_squared() const COMPLEX_NOEXCEPT { return m_real * m_real + m_imag * m_imag; }
 
-#    ifdef AKCOMPLEX_CAN_USE_MATH_H
     constexpr T magnitude() const COMPLEX_NOEXCEPT
     {
-        // for numbers 32 or under bit long we don't need the extra precision of sqrt
-        // although it may return values with a considerable error if real and imag are too big?
-        if constexpr (sizeof(T) <= sizeof(float)) {
-            return sqrtf(m_real * m_real + m_imag * m_imag);
-        } else if constexpr (sizeof(T) <= sizeof(double)) {
-            return sqrt(m_real * m_real + m_imag * m_imag);
-        } else {
-            return sqrtl(m_real * m_real + m_imag * m_imag);
-        }
+        return hypot(m_real, m_imag);
     }
 
     constexpr T phase() const COMPLEX_NOEXCEPT
@@ -67,15 +55,8 @@ public:
     template<AK::Concepts::Arithmetic U, AK::Concepts::Arithmetic V>
     static constexpr Complex<T> from_polar(U magnitude, V phase)
     {
-        if constexpr (sizeof(T) <= sizeof(float)) {
-            return Complex<T>(magnitude * cosf(phase), magnitude * sinf(phase));
-        } else if constexpr (sizeof(T) <= sizeof(double)) {
-            return Complex<T>(magnitude * cos(phase), magnitude * sin(phase));
-        } else {
-            return Complex<T>(magnitude * cosl(phase), magnitude * sinl(phase));
-        }
+        return Complex<T>(magnitude * cos(phase), magnitude * sin(phase));
     }
-#    endif
 
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T>& operator=(const Complex<U>& other)
@@ -288,7 +269,6 @@ static constinit Complex<T> complex_real_unit = Complex<T>((T)1, (T)0);
 template<AK::Concepts::Arithmetic T>
 static constinit Complex<T> complex_imag_unit = Complex<T>((T)0, (T)1);
 
-#    ifdef AKCOMPLEX_CAN_USE_MATH_H
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
 static constexpr bool approx_eq(const Complex<T>& a, const Complex<U>& b, const double margin = 0.000001)
 {
@@ -300,23 +280,15 @@ static constexpr bool approx_eq(const Complex<T>& a, const Complex<U>& b, const 
 template<AK::Concepts::Arithmetic T>
 static constexpr Complex<T> cexp(const Complex<T>& a)
 {
-    // FIXME: this can probably be faster and not use so many expensive trigonometric functions
-    if constexpr (sizeof(T) <= sizeof(float)) {
-        return expf(a.real()) * Complex<T>(cosf(a.imag()), sinf(a.imag()));
-    } else if constexpr (sizeof(T) <= sizeof(double)) {
-        return exp(a.real()) * Complex<T>(cos(a.imag()), sin(a.imag()));
-    } else {
-        return expl(a.real()) * Complex<T>(cosl(a.imag()), sinl(a.imag()));
-    }
+    // FIXME: this can probably be faster and not use so many "expensive" trigonometric functions
+    return exp(a.real()) * Complex<T>(cos(a.imag()), sin(a.imag()));
 }
 }
-#    endif
 
+using AK::approx_eq;
+using AK::cexp;
 using AK::Complex;
 using AK::complex_imag_unit;
 using AK::complex_real_unit;
-#    ifdef AKCOMPLEX_CAN_USE_MATH_H
-using AK::approx_eq;
-using AK::cexp;
-#    endif
+
 #endif

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<FloatingPoint T>
+constexpr T NaN = __builtin_nan("");
+template<FloatingPoint T>
+constexpr T Pi = 3.141592653589793238462643383279502884L;
+template<FloatingPoint T>
+constexpr T E = 2.718281828459045235360287471352662498L;
+
+namespace Details {
+template<size_t>
+constexpr size_t product_even();
+template<>
+constexpr size_t product_even<2>() { return 2; }
+template<size_t value>
+constexpr size_t product_even() { return value * product_even<value - 2>(); }
+
+template<size_t>
+constexpr size_t product_odd();
+template<>
+constexpr size_t product_odd<1>() { return 1; }
+template<size_t value>
+constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
+}
+
+#define CONSTEXPR_STATE(function, args...)        \
+    if (is_constant_evaluated()) {                \
+        if (IsSame<T, long double>)               \
+            return __builtin_##function##l(args); \
+        if (IsSame<T, double>)                    \
+            return __builtin_##function(args);    \
+        if (IsSame<T, float>)                     \
+            return __builtin_##function##f(args); \
+    }
+
+#define INTEGER_BUILTIN(name)                         \
+    template<Integral T>                              \
+    constexpr T name(T x)                             \
+    {                                                 \
+        if constexpr (sizeof(T) == sizeof(long long)) \
+            return __builtin_##name##ll(x);           \
+        if constexpr (sizeof(T) == sizeof(long))      \
+            return __builtin_##name##l(x);            \
+        return __builtin_##name(x);                   \
+    }
+
+INTEGER_BUILTIN(clz);
+INTEGER_BUILTIN(ctz);
+INTEGER_BUILTIN(popcnt);
+
+namespace Division {
+template<FloatingPoint T>
+constexpr T fmod(T x, T y)
+{
+    CONSTEXPR_STATE(fmod, x, y);
+    T res;
+    asm(
+        "fprem"
+        : "=t"(res)
+        : "0"(x), "u"(y));
+    return res;
+}
+template<FloatingPoint T>
+constexpr T remainder(T x, T y)
+{
+    CONSTEXPR_STATE(remainder, x, y);
+    T res;
+    asm(
+        "fprem1"
+        : "=t"(res)
+        : "0"(x), "u"(y));
+    return res;
+}
+}
+
+using Division::fmod;
+using Division::remainder;
+
+template<FloatingPoint T>
+constexpr T sqrt(T x)
+{
+    CONSTEXPR_STATE(sqrt, x);
+    T res;
+    asm("fsqrt"
+        : "=t"(res)
+        : "0"(x));
+    return res;
+}
+
+template<FloatingPoint T>
+constexpr T cbrt(T x)
+{
+    CONSTEXPR_STATE(cbrt, x);
+    if (__builtin_isinf(x) || x == 0)
+        return x;
+    if (x < 0)
+        return -cbrt(-x);
+
+    T r = x;
+    T ex = 0;
+
+    while (r < 0.125l) {
+        r *= 8;
+        ex--;
+    }
+    while (r > 1.0l) {
+        r *= 0.125l;
+        ex++;
+    }
+
+    r = (-0.46946116l * r + 1.072302l) * r + 0.3812513l;
+
+    while (ex < 0) {
+        r *= 0.5l;
+        ex++;
+    }
+    while (ex > 0) {
+        r *= 2.0l;
+        ex--;
+    }
+
+    r = (2.0l / 3.0l) * r + (1.0l / 3.0l) * x / (r * r);
+    r = (2.0l / 3.0l) * r + (1.0l / 3.0l) * x / (r * r);
+    r = (2.0l / 3.0l) * r + (1.0l / 3.0l) * x / (r * r);
+    r = (2.0l / 3.0l) * r + (1.0l / 3.0l) * x / (r * r);
+
+    return r;
+}
+
+template<FloatingPoint T>
+constexpr T fabs(T x)
+{
+    if (is_constant_evaluated())
+        return x < 0 ? -x : x;
+    asm(
+        "fabs"
+        : "+t"(x));
+    return x;
+}
+
+namespace Trigonometry {
+
+template<FloatingPoint T>
+constexpr T hypot(T x, T y)
+{
+    return sqrt(x * x + y * y);
+}
+
+template<FloatingPoint T>
+constexpr T sin(T angle)
+{
+    CONSTEXPR_STATE(sin, angle);
+    T ret;
+    asm(
+        "fsin"
+        : "=t"(ret)
+        : "0"(angle));
+    return ret;
+}
+
+template<FloatingPoint T>
+constexpr T cos(T angle)
+{
+    CONSTEXPR_STATE(cos, angle);
+    T ret;
+    asm(
+        "fcos"
+        : "=t"(ret)
+        : "0"(angle));
+    return ret;
+}
+
+template<FloatingPoint T>
+constexpr T tan(T angle)
+{
+    CONSTEXPR_STATE(tan, angle);
+    double ret, one;
+    asm(
+        "fptan"
+        : "=t"(one), "=u"(ret)
+        : "0"(angle));
+
+    return ret;
+}
+
+template<FloatingPoint T>
+constexpr T atan(T value)
+{
+    CONSTEXPR_STATE(atan, value);
+
+    T ret;
+    asm(
+        "fld1\n"
+        "fpatan\n"
+        : "=t"(ret)
+        : "0"(value));
+    return ret;
+}
+
+template<FloatingPoint T>
+constexpr T asin(T x)
+{
+    CONSTEXPR_STATE(asin, x);
+    if (x > 1 || x < -1)
+        return NaN<T>;
+    if (x > (T)0.5 || x < (T)-0.5)
+        return 2 * atan<T>(x / (1 + sqrt<T>(1 - x * x)));
+    T squared = x * x;
+    T value = x;
+    T i = x * squared;
+    value += i * Details::product_odd<1>() / Details::product_even<2>() / 3;
+    i *= squared;
+    value += i * Details::product_odd<3>() / Details::product_even<4>() / 5;
+    i *= squared;
+    value += i * Details::product_odd<5>() / Details::product_even<6>() / 7;
+    i *= squared;
+    value += i * Details::product_odd<7>() / Details::product_even<8>() / 9;
+    i *= squared;
+    value += i * Details::product_odd<9>() / Details::product_even<10>() / 11;
+    i *= squared;
+    value += i * Details::product_odd<11>() / Details::product_even<12>() / 13;
+    i *= squared;
+    value += i * Details::product_odd<13>() / Details::product_even<14>() / 15;
+    i *= squared;
+    value += i * Details::product_odd<15>() / Details::product_even<16>() / 17;
+    return value;
+}
+
+template<FloatingPoint T>
+constexpr T acos(T value)
+{
+    CONSTEXPR_STATE(acos, value);
+
+    // FIXME: I am naive
+    return Pi<T> + asin(value);
+}
+
+template<FloatingPoint T>
+constexpr T atan2(T y, T x)
+{
+    CONSTEXPR_STATE(atan2, y, x);
+
+    T ret;
+    asm("fpatan"
+        : "=t"(ret)
+        : "0"(x), "u"(y)
+        : "st(1)");
+    return ret;
+}
+
+}
+
+using Trigonometry::acos;
+using Trigonometry::asin;
+using Trigonometry::atan;
+using Trigonometry::atan2;
+using Trigonometry::cos;
+using Trigonometry::hypot;
+using Trigonometry::sin;
+using Trigonometry::tan;
+
+namespace Exponentials {
+
+template<FloatingPoint T>
+constexpr T log(T x)
+{
+    CONSTEXPR_STATE(log, x);
+
+    T ret;
+    asm(
+        "fldln2\n"
+        "fxch %%st(1)\n"
+        "fyl2x\n"
+        : "=t"(ret)
+        : "0"(x));
+    return ret;
+}
+
+template<FloatingPoint T>
+constexpr T log2(T x)
+{
+    CONSTEXPR_STATE(log2, x);
+
+    T ret;
+    asm(
+        "fld1\n"
+        "fxch %%st(1)\n"
+        "fyl2x\n"
+        : "=t"(ret)
+        : "0"(x));
+    return ret;
+}
+
+template<Integral T>
+constexpr T log2(T x)
+{
+    return x ? 8 * sizeof(T) - clz(x) : 0;
+}
+
+template<FloatingPoint T>
+constexpr T log10(T x)
+{
+    CONSTEXPR_STATE(log10, x);
+
+    T ret;
+    asm(
+        "fldlg2\n"
+        "fxch %%st(1)\n"
+        "fyl2x\n"
+        : "=t"(ret)
+        : "0"(x));
+    return ret;
+}
+
+template<FloatingPoint T>
+constexpr T exp(T exponent)
+{
+    CONSTEXPR_STATE(exp, exponent);
+
+    T res;
+    asm("fldl2e\n"
+        "fmulp\n"
+        "fld1\n"
+        "fld %%st(1)\n"
+        "fprem\n"
+        "f2xm1\n"
+        "faddp\n"
+        "fscale\n"
+        "fstp %%st(1)"
+        : "=t"(res)
+        : "0"(exponent));
+    return res;
+}
+
+template<FloatingPoint T>
+constexpr T exp2(T exponent)
+{
+    CONSTEXPR_STATE(exp2, exponent);
+
+    T res;
+    asm("fld1\n"
+        "fld %%st(1)\n"
+        "fprem\n"
+        "f2xm1\n"
+        "faddp\n"
+        "fscale\n"
+        "fstp %%st(1)"
+        : "=t"(res)
+        : "0"(exponent));
+    return res;
+}
+template<Integral T>
+constexpr T exp2(T exponent)
+{
+    return 1u << exponent;
+}
+}
+
+using Exponentials::exp;
+using Exponentials::exp2;
+using Exponentials::log;
+using Exponentials::log10;
+using Exponentials::log2;
+
+namespace Hyperbolic {
+
+template<FloatingPoint T>
+constexpr T sinh(T x)
+{
+    T exponentiated = exp<T>(x);
+    if (x > 0)
+        return (exponentiated * exponentiated - 1) / 2 / exponentiated;
+    return (exponentiated - 1 / exponentiated) / 2;
+}
+
+template<FloatingPoint T>
+constexpr T cosh(T x)
+{
+    CONSTEXPR_STATE(cosh, x);
+
+    T exponentiated = exp(-x);
+    if (x < 0)
+        return (1 + exponentiated * exponentiated) / 2 / exponentiated;
+    return (1 / exponentiated + exponentiated) / 2;
+}
+
+template<FloatingPoint T>
+constexpr T tanh(T x)
+{
+    if (x > 0) {
+        T exponentiated = exp<T>(2 * x);
+        return (exponentiated - 1) / (exponentiated + 1);
+    }
+    T plusX = exp<T>(x);
+    T minusX = 1 / plusX;
+    return (plusX - minusX) / (plusX + minusX);
+}
+
+template<FloatingPoint T>
+constexpr T asinh(T x)
+{
+    return log<T>(x + sqrt<T>(x * x + 1));
+}
+
+template<FloatingPoint T>
+constexpr T acosh(T x)
+{
+    return log<T>(x + sqrt<T>(x * x - 1));
+}
+
+template<FloatingPoint T>
+constexpr T atanh(T x)
+{
+    return log<T>((1 + x) / (1 - x)) / (T)2.0l;
+}
+
+}
+
+using Hyperbolic::acosh;
+using Hyperbolic::asinh;
+using Hyperbolic::atanh;
+using Hyperbolic::cosh;
+using Hyperbolic::sinh;
+using Hyperbolic::tanh;
+
+template<FloatingPoint T>
+constexpr T pow(T x, T y)
+{
+    CONSTEXPR_STATE(pow, x, y);
+    // fixme I am naive
+    if (__builtin_isnan(y))
+        return y;
+    if (y == 0)
+        return 1;
+    if (x == 0)
+        return 0;
+    if (y == 1)
+        return x;
+    int y_as_int = (int)y;
+    if (y == (T)y_as_int) {
+        T result = x;
+        for (int i = 0; i < fabs<T>(y) - 1; ++i)
+            result *= x;
+        if (y < 0)
+            result = 1.0l / result;
+        return result;
+    }
+
+    return exp2<T>(y * log2<T>(x));
+}
+
+#undef CONSTEXPR_STATE
+#undef INTEGER_BUILTIN
+
+}

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -22,7 +22,6 @@
 #include <LibGUI/Window.h>
 #include <LibProtocol/RequestClient.h>
 #include <LibWeb/Loader/ResourceLoader.h>
-#include <math.h>
 
 namespace Browser {
 

--- a/Userland/Applications/Calculator/Calculator.cpp
+++ b/Userland/Applications/Calculator/Calculator.cpp
@@ -6,7 +6,7 @@
 
 #include "Calculator.h"
 #include <AK/Assertions.h>
-#include <math.h>
+#include <AK/Math.h>
 
 Calculator::Calculator()
 {
@@ -37,7 +37,7 @@ double Calculator::begin_operation(Operation operation, double argument)
             m_has_error = true;
             return argument;
         }
-        res = sqrt(argument);
+        res = AK::sqrt(argument);
         clear_operation();
         break;
     case Operation::Inverse:

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -8,11 +8,11 @@
 
 #include "RollWidget.h"
 #include "TrackManager.h"
+#include <AK/Math.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
-#include <math.h>
 
 constexpr int note_height = 20;
 constexpr int max_note_width = note_height * 2;
@@ -47,7 +47,7 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
     if (m_num_notes < time_signature_notes)
         m_num_notes = time_signature_notes;
     else
-        m_num_notes = time_signature_notes * pow(2, static_cast<int>(log2(m_num_notes / time_signature_notes)));
+        m_num_notes = time_signature_notes * AK::exp2(AK::log2(m_num_notes / time_signature_notes));
     m_note_width = static_cast<double>(m_roll_width) / m_num_notes;
 
     // This calculates the minimum number of rows needed. We account for a
@@ -62,9 +62,9 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
     int key_pattern_index = (notes_per_octave - 1) - (note_offset % notes_per_octave);
 
     int x_offset = horizontal_scrollbar().value();
-    int horizontal_note_offset_remainder = fmod(x_offset, m_note_width);
+    int horizontal_note_offset_remainder = static_cast<int>(AK::fmod((double)x_offset, m_note_width));
     int horizontal_paint_area = widget_inner_rect().width() + horizontal_note_offset_remainder;
-    if (fmod(horizontal_paint_area, m_note_width) != 0)
+    if (AK::fmod((double)horizontal_paint_area, m_note_width) != 0.)
         horizontal_paint_area += m_note_width;
     int horizontal_notes_to_paint = horizontal_paint_area / m_note_width;
 

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "Track.h"
+#include <AK/Math.h>
 #include <AK/NumericLimits.h>
 #include <LibAudio/Loader.h>
 #include <math.h>
@@ -176,7 +177,7 @@ Audio::Frame Track::square(size_t note)
 {
     double pos = note_frequencies[note] / sample_rate;
     double square_step = pos * 2 * M_PI;
-    double w = sin(m_pos[note]) >= 0 ? 1 : -1;
+    double w = AK::sin(m_pos[note]) >= 0 ? 1 : -1;
     m_pos[note] += square_step;
     return w;
 }
@@ -185,7 +186,7 @@ Audio::Frame Track::triangle(size_t note)
 {
     double triangle_step = note_frequencies[note] / sample_rate;
     double t = m_pos[note];
-    double w = fabs(fmod((4 * t) + 1, 4) - 2) - 1;
+    double w = AK::fabs(AK::fmod((4 * t) + 1, 4.) - 2) - 1.;
     m_pos[note] += triangle_step;
     return w;
 }

--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Rect.h>
-#include <math.h>
 
 namespace PixelPaint {
 

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -7,24 +7,24 @@
 #include "LineTool.h"
 #include "ImageEditor.h"
 #include "Layer.h"
+#include <AK/Math.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
-#include <math.h>
 
 namespace PixelPaint {
 
 static Gfx::IntPoint constrain_line_angle(Gfx::IntPoint const& start_pos, Gfx::IntPoint const& end_pos, float angle_increment)
 {
-    float current_angle = atan2f(end_pos.y() - start_pos.y(), end_pos.x() - start_pos.x()) + float { M_PI * 2 };
+    float current_angle = AK::atan2<float>(end_pos.y() - start_pos.y(), end_pos.x() - start_pos.x()) + float { M_PI * 2 };
 
     float constrained_angle = ((int)((current_angle + angle_increment / 2) / angle_increment)) * angle_increment;
 
     auto diff = end_pos - start_pos;
-    float line_length = sqrt(diff.x() * diff.x() + diff.y() * diff.y());
+    float line_length = AK::hypot<float>(diff.x(), diff.y());
 
-    return { start_pos.x() + (int)(cosf(constrained_angle) * line_length),
-        start_pos.y() + (int)(sinf(constrained_angle) * line_length) };
+    return { start_pos.x() + (int)(AK::cos(constrained_angle) * line_length),
+        start_pos.y() + (int)(AK::sin(constrained_angle) * line_length) };
 }
 
 LineTool::LineTool()

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Rect.h>
-#include <math.h>
 
 namespace PixelPaint {
 

--- a/Userland/Applications/PixelPaint/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/SprayTool.cpp
@@ -7,6 +7,7 @@
 #include "SprayTool.h"
 #include "ImageEditor.h"
 #include "Layer.h"
+#include <AK/Math.h>
 #include <AK/Queue.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
@@ -15,7 +16,6 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Slider.h>
 #include <LibGfx/Bitmap.h>
-#include <math.h>
 #include <stdio.h>
 
 namespace PixelPaint {
@@ -52,8 +52,8 @@ void SprayTool::paint_it()
     for (int i = 0; i < M_PI * base_radius * base_radius * (m_density / 100.0); i++) {
         double radius = base_radius * nrand();
         double angle = 2 * M_PI * nrand();
-        const int xpos = m_last_pos.x() + radius * cos(angle);
-        const int ypos = m_last_pos.y() - radius * sin(angle);
+        const int xpos = m_last_pos.x() + radius * AK::cos(angle);
+        const int ypos = m_last_pos.y() - radius * AK::sin(angle);
         if (xpos < 0 || xpos >= bitmap.width())
             continue;
         if (ypos < 0 || ypos >= bitmap.height())

--- a/Userland/Applications/SoundPlayer/AudioAlgorithms.cpp
+++ b/Userland/Applications/SoundPlayer/AudioAlgorithms.cpp
@@ -6,7 +6,7 @@
 
 #include "AudioAlgorithms.h"
 #include <AK/Complex.h>
-#include <math.h>
+#include <AK/Math.h>
 
 // This function uses the input vector as output too. therefore, if you wish to
 // leave it intact, pass a copy to this function
@@ -38,8 +38,8 @@ void fft(Vector<Complex<double>>& sample_data, bool invert)
     }
 
     for (int len = 2; len <= n; len <<= 1) {
-        double ang = 2 * M_PI / len * (invert ? -1 : 1);
-        Complex<double> wlen(cos(ang), sin(ang));
+        double ang = 2 * AK::Pi<double> / len * (invert ? -1 : 1);
+        Complex<double> wlen(AK::cos(ang), AK::sin(ang));
         for (int i = 0; i < n; i += len) {
             Complex<double> w = { 1., 0. };
             for (int j = 0; j < len / 2; j++) {

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -7,11 +7,11 @@
 #include "BarsVisualizationWidget.h"
 #include "AudioAlgorithms.h"
 #include <AK/Complex.h>
+#include <AK/Math.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
-#include <math.h>
 
 u32 round_previous_power_of_2(u32 x);
 
@@ -27,7 +27,7 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
         return;
 
     fft(m_sample_buffer, false);
-    double max = sqrt(m_sample_count * 2);
+    double max = AK::sqrt(m_sample_count * 2.);
 
     double freq_bin = m_samplerate / m_sample_count;
 
@@ -45,10 +45,10 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     int bins_per_group = ceil_div((m_sample_count - 1) / 2, group_count) * freq_bin;
 
     for (int i = 1; i < m_sample_count / 2; i++) {
-        groups[(i * freq_bin) / bins_per_group] += fabs(m_sample_buffer.data()[i].real());
+        groups[(i * freq_bin) / bins_per_group] += AK::fabs(m_sample_buffer.data()[i].real());
     }
     for (int i = 0; i < group_count; i++)
-        groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(pow(M_E, (double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);
+        groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(AK::pow(AK::E<double>, (double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);
 
     const int horizontal_margin = 30;
     const int top_vertical_margin = 15;
@@ -102,7 +102,7 @@ void BarsVisualizationWidget::set_buffer(RefPtr<Audio::Buffer> buffer, int sampl
     m_sample_count = round_previous_power_of_2(samples_to_use);
     m_sample_buffer.resize(m_sample_count);
     for (int i = 0; i < m_sample_count; i++) {
-        m_sample_buffer.data()[i] = (fabs(buffer->samples()[i].left) + fabs(buffer->samples()[i].right)) / 2.;
+        m_sample_buffer.data()[i] = (AK::fabs(buffer->samples()[i].left) + AK::fabs(buffer->samples()[i].right)) / 2.;
     }
 
     update();

--- a/Userland/Applications/SoundPlayer/SampleWidget.cpp
+++ b/Userland/Applications/SoundPlayer/SampleWidget.cpp
@@ -5,9 +5,9 @@
  */
 
 #include "SampleWidget.h"
+#include <AK/Math.h>
 #include <LibAudio/Buffer.h>
 #include <LibGUI/Painter.h>
-#include <math.h>
 
 SampleWidget::SampleWidget()
 {
@@ -34,7 +34,7 @@ void SampleWidget::paint_event(GUI::PaintEvent& event)
     if (m_buffer) {
         int samples_per_pixel = m_buffer->sample_count() / frame_inner_rect().width();
         for (int sample_index = 0; sample_index < m_buffer->sample_count() && (x - x_offset) < frame_inner_rect().width(); ++sample_index) {
-            float sample = fabsf((float)m_buffer->samples()[sample_index].left);
+            float sample = AK::fabs((float)m_buffer->samples()[sample_index].left);
 
             sample_max = max(sample, sample_max);
             ++count;

--- a/Userland/Demos/CatDog/CatDog.h
+++ b/Userland/Demos/CatDog/CatDog.h
@@ -7,7 +7,6 @@
 #include <LibCore/ElapsedTimer.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Widget.h>
-#include <math.h>
 #include <unistd.h>
 
 #pragma once

--- a/Userland/Demos/Eyes/EyesWidget.cpp
+++ b/Userland/Demos/Eyes/EyesWidget.cpp
@@ -5,12 +5,12 @@
  */
 
 #include "EyesWidget.h"
+#include <AK/Math.h>
 #include <AK/StdLibExtraDetails.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Palette.h>
-#include <math.h>
 
 EyesWidget::~EyesWidget()
 {
@@ -79,7 +79,7 @@ Gfx::IntPoint EyesWidget::pupil_center(Gfx::IntRect& eyeball_bounds) const
     auto mouse_vector = m_mouse_position - eyeball_bounds.center();
     double dx = mouse_vector.x();
     double dy = mouse_vector.y();
-    double mouse_distance = sqrt(dx * dx + dy * dy);
+    double mouse_distance = AK::hypot(dx, dy);
 
     if (mouse_distance == 0.0)
         return eyeball_bounds.center();
@@ -93,14 +93,14 @@ Gfx::IntPoint EyesWidget::pupil_center(Gfx::IntRect& eyeball_bounds) const
     if (dx != 0 && AK::abs(dx) >= AK::abs(dy)) {
         double slope = dy / dx;
         double slope_squared = slope * slope;
-        max_distance_along_this_direction = 0.25 * sqrt(
+        max_distance_along_this_direction = 0.25 * AK::sqrt(
             (slope_squared + 1) /
             (1 / width_squared + slope_squared / height_squared)
         );
     } else if (dy != 0 && AK::abs(dy) >= AK::abs(dx)) {
         double slope = dx / dy;
         double slope_squared = slope * slope;
-        max_distance_along_this_direction = 0.25 * sqrt(
+        max_distance_along_this_direction = 0.25 * AK::sqrt(
             (slope_squared + 1) /
             (slope_squared / width_squared + 1 / height_squared)
         );

--- a/Userland/Demos/Mouse/main.cpp
+++ b/Userland/Demos/Mouse/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -17,8 +18,6 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Path.h>
 #include <unistd.h>
-
-#include <math.h>
 
 class MainFrame final : public GUI::Frame {
     C_OBJECT(MainFrame);
@@ -100,17 +99,17 @@ public:
             Gfx::IntPoint p3;
             Gfx::IntPoint p4;
 
-            p1.set_x(radius * cos(M_PI * m_wheel_delta_acc / 18) + off_x);
-            p1.set_y(radius * sin(M_PI * m_wheel_delta_acc / 18) + off_y);
+            p1.set_x(radius * AK::cos(AK::Pi<double> * m_wheel_delta_acc / 18.) + off_x);
+            p1.set_y(radius * AK::sin(AK::Pi<double> * m_wheel_delta_acc / 18.) + off_y);
 
-            p2.set_x(radius * cos(M_PI * (m_wheel_delta_acc + 18) / 18) + off_x);
-            p2.set_y(radius * sin(M_PI * (m_wheel_delta_acc + 18) / 18) + off_y);
+            p2.set_x(radius * AK::cos(AK::Pi<double> * (m_wheel_delta_acc + 18) / 18.) + off_x);
+            p2.set_y(radius * AK::sin(AK::Pi<double> * (m_wheel_delta_acc + 18) / 18.) + off_y);
 
-            p3.set_x(radius * cos(M_PI * (m_wheel_delta_acc + 9) / 18) + off_x);
-            p3.set_y(radius * sin(M_PI * (m_wheel_delta_acc + 9) / 18) + off_y);
+            p3.set_x(radius * AK::cos(AK::Pi<double> * (m_wheel_delta_acc + 9) / 18.) + off_x);
+            p3.set_y(radius * AK::sin(AK::Pi<double> * (m_wheel_delta_acc + 9) / 18.) + off_y);
 
-            p4.set_x(radius * cos(M_PI * (m_wheel_delta_acc + 27) / 18) + off_x);
-            p4.set_y(radius * sin(M_PI * (m_wheel_delta_acc + 27) / 18) + off_y);
+            p4.set_x(radius * AK::cos(AK::Pi<double> * (m_wheel_delta_acc + 27) / 18.) + off_x);
+            p4.set_y(radius * AK::sin(AK::Pi<double> * (m_wheel_delta_acc + 27) / 18.) + off_y);
 
             painter.draw_line(p1, p2, Color::Red, 2);
             painter.draw_line(p3, p4, Color::Red, 2);

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -6,17 +6,17 @@
 
 #include "GameSizeDialog.h"
 #include "Game.h"
+#include <AK/Math.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/SpinBox.h>
-#include <math.h>
 
 GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t target, bool evil_ai)
     : GUI::Dialog(parent)
     , m_board_size(board_size)
-    , m_target_tile_power(log2(target))
+    , m_target_tile_power(AK::log2(target))
     , m_evil_ai(evil_ai)
 {
     set_rect({ 0, 0, 250, 150 });

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -10,12 +10,12 @@
 #include <AK/Debug.h>
 #include <AK/FlyString.h>
 #include <AK/Format.h>
+#include <AK/Math.h>
 #include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
 #include <LibCore/FileStream.h>
-#include <math.h>
 
 namespace Audio {
 
@@ -417,9 +417,9 @@ u32 FlacLoaderPlugin::convert_sample_count_code(u8 sample_count_code)
         return FLAC_BLOCKSIZE_AT_END_OF_HEADER_16;
     }
     if (sample_count_code >= 2 && sample_count_code <= 5) {
-        return 576 * pow(2, (sample_count_code - 2));
+        return 576 * AK::exp2(sample_count_code - 2);
     }
-    return 256 * pow(2, (sample_count_code - 8));
+    return 256 * AK::exp2(sample_count_code - 8);
 }
 
 u32 FlacLoaderPlugin::convert_sample_rate_code(u8 sample_rate_code)
@@ -797,7 +797,7 @@ u64 read_utf8_char(InputStream& input)
     while (((start_byte << length) & 0b10000000) == 0b10000000)
         ++length;
     u8 bits_from_start_byte = 8 - (length + 1);
-    u8 start_byte_bitmask = pow(2, bits_from_start_byte) - 1;
+    u8 start_byte_bitmask = AK::exp2(bits_from_start_byte) - 1;
     character = start_byte_bitmask & start_byte;
     for (u8 i = length; i > 0; --i) {
         input.read(single_byte_buffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -18,7 +18,6 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Vector4.h>
-#include <math.h>
 
 using AK::dbgln;
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -28,7 +28,6 @@
 #include <LibGfx/Palette.h>
 #include <LibSyntax/Highlighter.h>
 #include <fcntl.h>
-#include <math.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -9,11 +9,11 @@
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
+#include <AK/Math.h>
 #include <AK/Memory.h>
 #include <AK/MemoryStream.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <LibGfx/GIFLoader.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -138,7 +138,7 @@ public:
         : m_lzw_bytes(lzw_bytes)
         , m_code_size(min_code_size)
         , m_original_code_size(min_code_size)
-        , m_table_capacity(pow(2, min_code_size))
+        , m_table_capacity(AK::exp2<u32>(min_code_size))
     {
         init_code_table();
     }
@@ -162,7 +162,7 @@ public:
         m_code_table.clear();
         m_code_table.extend(m_original_code_table);
         m_code_size = m_original_code_size;
-        m_table_capacity = pow(2, m_code_size);
+        m_table_capacity = AK::exp2<u32>(m_code_size);
         m_output.clear();
     }
 
@@ -563,7 +563,7 @@ static bool load_gif_frame_descriptors(GIFLoadingContext& context)
             image.interlaced = (packed_fields & 0x40) != 0;
 
             if (!image.use_global_color_map) {
-                size_t local_color_table_size = pow(2, (packed_fields & 7) + 1);
+                size_t local_color_table_size = AK::exp2<size_t>((packed_fields & 7) + 1);
 
                 for (size_t i = 0; i < local_color_table_size; ++i) {
                     u8 r = 0;

--- a/Userland/Libraries/LibGfx/Gamma.h
+++ b/Userland/Libraries/LibGfx/Gamma.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "Color.h"
-#include <math.h>
+#include <AK/Math.h>
 #include <xmmintrin.h>
 
 #include <AK/SIMD.h>
@@ -58,7 +58,7 @@ inline f32x4 linear_to_gamma4(f32x4 x)
     // Source for approximation: https://mimosa-pudica.net/fast-gamma/
     constexpr float a = 0.00279491f;
     constexpr float b = 1.15907984f;
-    float c = (b / sqrtf(1.0f + a)) - 1;
+    float c = (b / AK::sqrt(1.0f + a)) - 1;
     return ((b * __builtin_ia32_rsqrtps(x + a)) - c) * x;
 }
 
@@ -85,8 +85,8 @@ inline float linear_to_gamma(float x)
     // Source for approximation: https://mimosa-pudica.net/fast-gamma/
     constexpr float a = 0.00279491;
     constexpr float b = 1.15907984;
-    float c = (b / sqrtf(1 + a)) - 1;
-    return ((b / __builtin_sqrtf(x + a)) - c) * x;
+    float c = (b / AK::sqrt(1 + a)) - 1;
+    return ((b / AK::sqrt(x + a)) - c) * x;
 }
 
 // Linearize v1 and v2, lerp them by mix factor, then convert back.

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -13,7 +13,6 @@
 #include <AK/Types.h>
 #include <LibGfx/ICOLoader.h>
 #include <LibGfx/PNGLoader.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -10,12 +10,12 @@
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
+#include <AK/Math.h>
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/JPGLoader.h>
-#include <math.h>
 
 #define JPG_INVALID 0X0000
 
@@ -864,20 +864,20 @@ static void dequantize(JPGLoadingContext& context, Vector<Macroblock>& macrobloc
 
 static void inverse_dct(const JPGLoadingContext& context, Vector<Macroblock>& macroblocks)
 {
-    static const float m0 = 2.0 * cos(1.0 / 16.0 * 2.0 * M_PI);
-    static const float m1 = 2.0 * cos(2.0 / 16.0 * 2.0 * M_PI);
-    static const float m3 = 2.0 * cos(2.0 / 16.0 * 2.0 * M_PI);
-    static const float m5 = 2.0 * cos(3.0 / 16.0 * 2.0 * M_PI);
+    static const float m0 = 2.0 * AK::cos(1.0 / 16.0 * 2.0 * AK::Pi<double>);
+    static const float m1 = 2.0 * AK::cos(2.0 / 16.0 * 2.0 * AK::Pi<double>);
+    static const float m3 = 2.0 * AK::cos(2.0 / 16.0 * 2.0 * AK::Pi<double>);
+    static const float m5 = 2.0 * AK::cos(3.0 / 16.0 * 2.0 * AK::Pi<double>);
     static const float m2 = m0 - m5;
     static const float m4 = m0 + m5;
-    static const float s0 = cos(0.0 / 16.0 * M_PI) / sqrt(8);
-    static const float s1 = cos(1.0 / 16.0 * M_PI) / 2.0;
-    static const float s2 = cos(2.0 / 16.0 * M_PI) / 2.0;
-    static const float s3 = cos(3.0 / 16.0 * M_PI) / 2.0;
-    static const float s4 = cos(4.0 / 16.0 * M_PI) / 2.0;
-    static const float s5 = cos(5.0 / 16.0 * M_PI) / 2.0;
-    static const float s6 = cos(6.0 / 16.0 * M_PI) / 2.0;
-    static const float s7 = cos(7.0 / 16.0 * M_PI) / 2.0;
+    static const float s0 = AK::cos(0.0 / 16.0 * AK::Pi<double>) / sqrt(8);
+    static const float s1 = AK::cos(1.0 / 16.0 * AK::Pi<double>) / 2.0;
+    static const float s2 = AK::cos(2.0 / 16.0 * AK::Pi<double>) / 2.0;
+    static const float s3 = AK::cos(3.0 / 16.0 * AK::Pi<double>) / 2.0;
+    static const float s4 = AK::cos(4.0 / 16.0 * AK::Pi<double>) / 2.0;
+    static const float s5 = AK::cos(5.0 / 16.0 * AK::Pi<double>) / 2.0;
+    static const float s6 = AK::cos(6.0 / 16.0 * AK::Pi<double>) / 2.0;
+    static const float s7 = AK::cos(7.0 / 16.0 * AK::Pi<double>) / 2.0;
 
     for (u32 vcursor = 0; vcursor < context.mblock_meta.vcount; vcursor += context.vsample_factor) {
         for (u32 hcursor = 0; hcursor < context.mblock_meta.hcount; hcursor += context.hsample_factor) {

--- a/Userland/Libraries/LibGfx/Line.h
+++ b/Userland/Libraries/LibGfx/Line.h
@@ -11,7 +11,6 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
-#include <math.h>
 #include <stdlib.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/Matrix4x4.h
+++ b/Userland/Libraries/LibGfx/Matrix4x4.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/Math.h>
 #include <LibGfx/Matrix.h>
 #include <LibGfx/Vector3.h>
 #include <LibGfx/Vector4.h>
-#include <math.h>
 
 namespace Gfx {
 
@@ -70,8 +70,8 @@ constexpr static Matrix4x4<T> scale_matrix(const Vector3<T>& s)
 template<typename T>
 constexpr static Matrix4x4<T> rotation_matrix(const Vector3<T>& axis, T angle)
 {
-    T c = cos(angle);
-    T s = sin(angle);
+    T c = AK::cos(angle);
+    T s = AK::sin(angle);
     T t = 1 - c;
     T x = axis.x();
     T y = axis.y();

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -11,7 +11,6 @@
 #include <LibCompress/Zlib.h>
 #include <LibGfx/PNGLoader.h>
 #include <fcntl.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -14,6 +14,7 @@
 #include <AK/Assertions.h>
 #include <AK/Debug.h>
 #include <AK/Function.h>
+#include <AK/Math.h>
 #include <AK/Memory.h>
 #include <AK/Queue.h>
 #include <AK/QuickSort.h>
@@ -25,7 +26,6 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/TextDirection.h>
-#include <math.h>
 #include <stdio.h>
 
 #if defined(__GNUC__) && !defined(__clang__)
@@ -492,11 +492,11 @@ void Painter::draw_ellipse_intersecting(const IntRect& rect, Color color, int th
     double increment = M_PI / number_samples;
 
     auto ellipse_x = [&](double theta) -> int {
-        return (cos(theta) * rect.width() / sqrt(2)) + rect.center().x();
+        return (AK::cos(theta) * rect.width() / AK::sqrt(2.)) + rect.center().x();
     };
 
     auto ellipse_y = [&](double theta) -> int {
-        return (sin(theta) * rect.height() / sqrt(2)) + rect.center().y();
+        return (AK::sin(theta) * rect.height() / AK::sqrt(2.)) + rect.center().y();
     };
 
     for (auto theta = 0.0; theta < 2 * M_PI; theta += increment) {
@@ -1920,8 +1920,8 @@ void Painter::for_each_line_segment_on_elliptical_arc(const FloatPoint& p1, cons
     FloatPoint current_point = relative_start;
     FloatPoint next_point = { 0, 0 };
 
-    auto sin_x_axis = sinf(x_axis_rotation);
-    auto cos_x_axis = cosf(x_axis_rotation);
+    auto sin_x_axis = AK::sin(x_axis_rotation);
+    auto cos_x_axis = AK::cos(x_axis_rotation);
     auto rotate_point = [sin_x_axis, cos_x_axis](FloatPoint& p) {
         auto original_x = p.x();
         auto original_y = p.y();
@@ -1931,8 +1931,8 @@ void Painter::for_each_line_segment_on_elliptical_arc(const FloatPoint& p1, cons
     };
 
     for (double theta = theta_1; theta <= ((double)theta_1 + (double)theta_delta); theta += theta_step) {
-        next_point.set_x(a * cosf(theta));
-        next_point.set_y(b * sinf(theta));
+        next_point.set_x(a * AK::cos<float>(theta));
+        next_point.set_y(b * AK::sin<float>(theta));
         rotate_point(next_point);
 
         callback(current_point + center, next_point + center);

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -6,11 +6,11 @@
 
 #include <AK/Function.h>
 #include <AK/HashTable.h>
+#include <AK/Math.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
-#include <math.h>
 
 namespace Gfx {
 
@@ -21,8 +21,8 @@ void Path::elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, d
     double rx = radii.x();
     double ry = radii.y();
 
-    double x_axis_rotation_c = cos(x_axis_rotation);
-    double x_axis_rotation_s = sin(x_axis_rotation);
+    double x_axis_rotation_c = AK::cos(x_axis_rotation);
+    double x_axis_rotation_s = AK::sin(x_axis_rotation);
 
     // Find the last point
     FloatPoint last_point { 0, 0 };
@@ -61,24 +61,24 @@ void Path::elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, d
     auto y1p = -x_axis_rotation_s * x_avg + x_axis_rotation_c * y_avg;
 
     // Step 2: Compute (cx', cy')
-    double x1p_sq = pow(x1p, 2.0);
-    double y1p_sq = pow(y1p, 2.0);
-    double rx_sq = pow(rx, 2.0);
-    double ry_sq = pow(ry, 2.0);
+    double x1p_sq = x1p * x1p;
+    double y1p_sq = y1p * y1p;
+    double rx_sq = rx * rx;
+    double ry_sq = ry * ry;
 
     // Step 3 of out-of-range radii correction
     double lambda = x1p_sq / rx_sq + y1p_sq / ry_sq;
     double multiplier;
 
     if (lambda > 1.0) {
-        auto lambda_sqrt = sqrt(lambda);
+        auto lambda_sqrt = AK::sqrt(lambda);
         rx *= lambda_sqrt;
         ry *= lambda_sqrt;
         multiplier = 0.0;
     } else {
         double numerator = rx_sq * ry_sq - rx_sq * y1p_sq - ry_sq * x1p_sq;
         double denominator = rx_sq * y1p_sq + ry_sq * x1p_sq;
-        multiplier = sqrt(numerator / denominator);
+        multiplier = AK::sqrt(numerator / denominator);
     }
 
     if (large_arc == sweep)
@@ -93,8 +93,8 @@ void Path::elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, d
     double cx = x_axis_rotation_c * cxp - x_axis_rotation_s * cyp + x_avg;
     double cy = x_axis_rotation_s * cxp + x_axis_rotation_c * cyp + y_avg;
 
-    double theta_1 = atan2((y1p - cyp) / ry, (x1p - cxp) / rx);
-    double theta_2 = atan2((-y1p - cyp) / ry, (-x1p - cxp) / rx);
+    double theta_1 = AK::atan2((y1p - cyp) / ry, (x1p - cxp) / rx);
+    double theta_2 = AK::atan2((-y1p - cyp) / ry, (-x1p - cxp) / rx);
 
     auto theta_delta = theta_2 - theta_1;
 

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -7,12 +7,12 @@
 #pragma once
 
 #include <AK/Format.h>
+#include <AK/Math.h>
 #include <AK/StdLibExtras.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Orientation.h>
 #include <LibIPC/Forward.h>
-#include <math.h>
 
 namespace Gfx {
 
@@ -223,7 +223,7 @@ public:
     {
         if (*this == other)
             return 0;
-        return sqrtf(powf(m_x - other.m_x, 2.0f) + powf(m_y - other.m_y, 2.0f));
+        return AK::hypot<float>(m_x - other.m_x, m_y - other.m_y);
     }
 
     [[nodiscard]] Point absolute_relative_distance_to(Point const& other) const

--- a/Userland/Libraries/LibGfx/Vector2.h
+++ b/Userland/Libraries/LibGfx/Vector2.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <AK/Math.h>
 #include <AK/String.h>
-#include <math.h>
 
 namespace Gfx {
 template<typename T>
@@ -105,7 +105,7 @@ public:
 
     constexpr T length() const
     {
-        return sqrt(m_x * m_x + m_y * m_y);
+        return AK::hypot(m_x, m_y);
     }
 
     String to_string() const

--- a/Userland/Libraries/LibGfx/Vector3.h
+++ b/Userland/Libraries/LibGfx/Vector3.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <AK/Math.h>
 #include <AK/String.h>
-#include <math.h>
 
 namespace Gfx {
 template<typename T>
@@ -121,7 +121,7 @@ public:
 
     constexpr T length() const
     {
-        return sqrt(m_x * m_x + m_y * m_y + m_z * m_z);
+        return AK::sqrt(m_x * m_x + m_y * m_y + m_z * m_z);
     }
 
     String to_string() const

--- a/Userland/Libraries/LibGfx/Vector4.h
+++ b/Userland/Libraries/LibGfx/Vector4.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <AK/Math.h>
 #include <AK/String.h>
-#include <math.h>
 
 namespace Gfx {
 template<typename T>
@@ -121,7 +121,7 @@ public:
 
     constexpr T length() const
     {
-        return sqrt(m_x * m_x + m_y * m_y + m_z * m_z + m_w * m_w);
+        return AK::sqrt(m_x * m_x + m_y * m_y + m_z * m_z + m_w * m_w);
     }
 
     String to_string() const

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NumberConstructor.h>
 #include <LibJS/Runtime/NumberObject.h>
-#include <math.h>
 
 #ifdef __clang__
-#    define EPSILON_VALUE pow(2, -52)
-#    define MAX_SAFE_INTEGER_VALUE pow(2, 53) - 1
-#    define MIN_SAFE_INTEGER_VALUE -(pow(2, 53) - 1)
+#    define EPSILON_VALUE AK::exp2(-52.)
+#    define MAX_SAFE_INTEGER_VALUE AK::exp2(53.) - 1
+#    define MIN_SAFE_INTEGER_VALUE -(AK::exp2(53.) - 1)
 #else
-constexpr const double EPSILON_VALUE { __builtin_pow(2, -52) };
-constexpr const double MAX_SAFE_INTEGER_VALUE { __builtin_pow(2, 53) - 1 };
-constexpr const double MIN_SAFE_INTEGER_VALUE { -(__builtin_pow(2, 53) - 1) };
+constexpr const double EPSILON_VALUE { __builtin_exp2(-52) };
+constexpr const double MAX_SAFE_INTEGER_VALUE { __builtin_exp2(53) - 1 };
+constexpr const double MIN_SAFE_INTEGER_VALUE { -(__builtin_exp2(53) - 1) };
 #endif
 
 namespace JS {

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -14,7 +14,6 @@
 #include <LibPDF/Parser.h>
 #include <LibTextCodec/Decoder.h>
 #include <ctype.h>
-#include <math.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -9,6 +9,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/CheckedFormatString.h>
+#include <AK/Math.h>
 #include <LibTest/CrashTest.h>
 
 namespace AK {
@@ -89,7 +90,7 @@ void current_test_case_did_fail();
         auto expect_close_lhs = a;                                                                              \
         auto expect_close_rhs = b;                                                                              \
         auto expect_close_diff = static_cast<double>(expect_close_lhs) - static_cast<double>(expect_close_rhs); \
-        if (fabs(expect_close_diff) > 0.0000005) {                                                              \
+        if (AK::fabs(expect_close_diff) > 0.0000005) {                                                          \
             ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_APPROXIMATE({}, {})"                             \
                          " failed with lhs={}, rhs={}, (lhs-rhs)={}",                                           \
                 __FILE__, __LINE__, #a, #b, expect_close_lhs, expect_close_rhs, expect_close_diff);             \

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -31,7 +31,6 @@
 #include <LibGfx/StylePainter.h>
 #include <ctype.h>
 #include <errno.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/Userland/Libraries/LibVideo/MatroskaReader.h
+++ b/Userland/Libraries/LibVideo/MatroskaReader.h
@@ -8,10 +8,10 @@
 
 #include "MatroskaDocument.h"
 #include <AK/Debug.h>
+#include <AK/Math.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
-#include <math.h>
 
 namespace Video {
 
@@ -122,7 +122,7 @@ private:
                 u8 next_octet = read_octet();
                 result = (result << 8u) | next_octet;
             }
-            result -= pow(2, length * 7 - 1) - 1;
+            result -= AK::exp2<i64>(length * 7 - 1) - 1;
             return result;
         }
 

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -17,7 +17,6 @@
 #include <LibCore/Object.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -17,7 +17,6 @@
 #include <LibELF/Image.h>
 #include <LibX86/Disassembler.h>
 #include <LibX86/Instruction.h>
-#include <math.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/Userland/Utilities/ntpquery.cpp
+++ b/Userland/Utilities/ntpquery.cpp
@@ -292,7 +292,7 @@ int main(int argc, char** argv)
     NtpTimestamp T3 = transmit_timestamp;
     NtpTimestamp T4 = destination_timestamp;
     auto timestamp_difference_in_seconds = [](NtpTimestamp from, NtpTimestamp to) {
-        return static_cast<int64_t>(to - from) / pow(2.0, 32);
+        return static_cast<i64>(to - from) >> 32;
     };
 
     // The network round-trip time of the request.


### PR DESCRIPTION
~The commits might be a bit too atomic, tell me if I should squash them~

~fmod and remainder might be the next thing to do~

This moves a lot of code from math.cpp into AK
sadly we cant move all the rounding without taking the helper functions with them, because they would require changing the FPU environment, which isn't really the thing we should do all the time we call them