### PR TITLE
Documentation: Remove '$' character from build instruction commands

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -71,7 +71,7 @@ There is also documentation for installing the build prerequisites for some less
 In order to build SerenityOS you will first need to build the toolchain by running the following command:
 
 ```console
-$ Meta/serenity.sh rebuild-toolchain
+Meta/serenity.sh rebuild-toolchain
 ```
 
 Later on, when you use `git pull` to get the latest changes, there's (usually) no need to rebuild the toolchain.
@@ -79,7 +79,7 @@ Later on, when you use `git pull` to get the latest changes, there's (usually) n
 Run the following command to build and run SerenityOS:
 
 ```console
-$ Meta/serenity.sh run
+Meta/serenity.sh run
 ```
 
 This will compile all of SerenityOS and install the built files into the `Build/i686/Root` directory inside your Git

--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -86,12 +86,12 @@ apk add cmake e2fsprogs grub-bios samurai mpc1-dev mpfr-dev gmp-dev ccache rsync
 ## OpenBSD prerequisites
 
 ```console
-$ doas pkg_add bash cmake g++ gcc git gmake gmp ninja ccache rsync coreutils qemu sudo
+doas pkg_add bash cmake g++ gcc git gmake gmp ninja ccache rsync coreutils qemu sudo
 ```
 
 ## FreeBSD prerequisites
 
 ```console
-$ pkg install bash coreutils git gmake ninja sudo gmp mpc mpfr ccache rsync
+pkg install bash coreutils git gmake ninja sudo gmp mpc mpfr ccache rsync
 ```
 


### PR DESCRIPTION
This removes the '$' character so that it is easier to copy commands
directly from the build instructions and then executing them without
first having to remove the '$' character.