### PR TITLE
Everywhere: Improve CPU usage calculation

### DIFF
--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -469,8 +469,8 @@ private:
                 thread_object.add("tid", thread.tid().value());
                 thread_object.add("name", thread.name());
                 thread_object.add("times_scheduled", thread.times_scheduled());
-                thread_object.add("ticks_user", thread.ticks_in_user());
-                thread_object.add("ticks_kernel", thread.ticks_in_kernel());
+                thread_object.add("time_user", thread.time_in_user());
+                thread_object.add("time_kernel", thread.time_in_kernel());
                 thread_object.add("state", thread.state_string());
                 thread_object.add("cpu", thread.cpu());
                 thread_object.add("priority", thread.priority());
@@ -497,9 +497,9 @@ private:
                     build_process(array, process);
             }
 
-            auto total_ticks_scheduled = Scheduler::get_total_ticks_scheduled();
-            json.add("total_ticks", total_ticks_scheduled.total);
-            json.add("total_ticks_kernel", total_ticks_scheduled.total_kernel);
+            auto total_time_scheduled = Scheduler::get_total_time_scheduled();
+            json.add("total_time", total_time_scheduled.total);
+            json.add("total_time_kernel", total_time_scheduled.total_kernel);
         }
         return true;
     }

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -24,6 +24,11 @@ extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
 extern RecursiveSpinLock g_scheduler_lock;
 
+struct TotalTicksScheduled {
+    u64 total { 0 };
+    u64 total_kernel { 0 };
+};
+
 class Scheduler {
 public:
     static void initialize();
@@ -49,6 +54,7 @@ public:
     static void queue_runnable_thread(Thread&);
     static void dump_scheduler_state(bool = false);
     static bool is_initialized();
+    static TotalTicksScheduled get_total_ticks_scheduled();
 };
 
 }

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -24,7 +24,7 @@ extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
 extern RecursiveSpinLock g_scheduler_lock;
 
-struct TotalTicksScheduled {
+struct TotalTimeScheduled {
     u64 total { 0 };
     u64 total_kernel { 0 };
 };
@@ -54,7 +54,9 @@ public:
     static void queue_runnable_thread(Thread&);
     static void dump_scheduler_state(bool = false);
     static bool is_initialized();
-    static TotalTicksScheduled get_total_ticks_scheduled();
+    static TotalTimeScheduled get_total_time_scheduled();
+    static void add_time_scheduled(u64, bool);
+    static u64 (*current_time)();
 };
 
 }

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -80,6 +80,8 @@ private:
     void set_system_timer(HardwareTimerBase&);
     static void system_timer_tick(const RegisterState&);
 
+    static u64 scheduling_current_time(bool);
+
     // Variables between m_update1 and m_update2 are synchronized
     Atomic<u32> m_update1 { 0 };
     u32 m_ticks_this_second { 0 };
@@ -91,6 +93,7 @@ private:
 
     u32 m_time_ticks_per_second { 0 }; // may be different from interrupts/second (e.g. hpet)
     bool m_can_query_precise_time { false };
+    bool m_updating_time { false }; // may only be accessed from the BSP!
 
     RefPtr<HardwareTimerBase> m_system_timer;
     RefPtr<HardwareTimerBase> m_time_keeper_timer;

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -129,15 +129,15 @@ private:
             return false;
 
         if (m_last_total_sum.has_value())
-            scheduled_diff = all_processes->total_ticks_scheduled - m_last_total_sum.value();
-        m_last_total_sum = all_processes->total_ticks_scheduled;
+            scheduled_diff = all_processes->total_time_scheduled - m_last_total_sum.value();
+        m_last_total_sum = all_processes->total_time_scheduled;
 
         for (auto& it : all_processes.value().processes) {
             for (auto& jt : it.threads) {
                 if (it.pid == 0)
-                    idle += jt.ticks_user + jt.ticks_kernel;
+                    idle += jt.time_user + jt.time_kernel;
                 else
-                    busy += jt.ticks_user + jt.ticks_kernel;
+                    busy += jt.time_user + jt.time_kernel;
             }
         }
         return true;

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -129,4 +129,7 @@ private:
     Vector<int> m_tids;
     RefPtr<Core::File> m_proc_all;
     GUI::Icon m_kernel_process_icon;
+    u64 m_total_ticks_scheduled { 0 };
+    u64 m_total_ticks_scheduled_kernel { 0 };
+    bool m_has_total_ticks { false };
 };

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -88,8 +88,8 @@ private:
         pid_t ppid;
         pid_t pgid;
         pid_t sid;
-        unsigned ticks_user;
-        unsigned ticks_kernel;
+        u64 time_user;
+        u64 time_kernel;
         bool kernel;
         String executable;
         String name;
@@ -129,7 +129,7 @@ private:
     Vector<int> m_tids;
     RefPtr<Core::File> m_proc_all;
     GUI::Icon m_kernel_process_icon;
-    u64 m_total_ticks_scheduled { 0 };
-    u64 m_total_ticks_scheduled_kernel { 0 };
-    bool m_has_total_ticks { false };
+    u64 m_total_time_scheduled { 0 };
+    u64 m_total_time_scheduled_kernel { 0 };
+    bool m_has_total_scheduled_time { false };
 };

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -273,7 +273,8 @@ bool generate_profile(pid_t& pid)
 
     auto all_processes = Core::ProcessStatisticsReader::get_all();
     if (all_processes.has_value()) {
-        if (auto it = all_processes.value().find_if([&](auto& entry) { return entry.pid == pid; }); it != all_processes.value().end())
+        auto& processes = all_processes->processes;
+        if (auto it = processes.find_if([&](auto& entry) { return entry.pid == pid; }); it != processes.end())
             process_name = it->name;
         else
             process_name = "(unknown)";

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -37,6 +37,7 @@ Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::F
     auto json = JsonValue::from_string(file_contents);
     if (!json.has_value())
         return {};
+
     auto& json_obj = json.value().as_object();
     json_obj.get("processes").as_array().for_each([&](auto& value) {
         const JsonObject& process_object = value.as_object();
@@ -74,8 +75,8 @@ Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::F
             thread.times_scheduled = thread_object.get("times_scheduled").to_u32();
             thread.name = thread_object.get("name").to_string();
             thread.state = thread_object.get("state").to_string();
-            thread.ticks_user = thread_object.get("ticks_user").to_u32();
-            thread.ticks_kernel = thread_object.get("ticks_kernel").to_u32();
+            thread.time_user = thread_object.get("time_user").to_u64();
+            thread.time_kernel = thread_object.get("time_kernel").to_u64();
             thread.cpu = thread_object.get("cpu").to_u32();
             thread.priority = thread_object.get("priority").to_u32();
             thread.syscall_count = thread_object.get("syscall_count").to_u32();
@@ -96,8 +97,8 @@ Optional<AllProcessesStatistics> ProcessStatisticsReader::get_all(RefPtr<Core::F
         all_processes_statistics.processes.append(move(process));
     });
 
-    all_processes_statistics.total_ticks_scheduled = json_obj.get("total_ticks").to_u64();
-    all_processes_statistics.total_ticks_scheduled_kernel = json_obj.get("total_ticks_kernel").to_u64();
+    all_processes_statistics.total_time_scheduled = json_obj.get("total_time").to_u64();
+    all_processes_statistics.total_time_scheduled_kernel = json_obj.get("total_time_kernel").to_u64();
     return all_processes_statistics;
 }
 

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -15,8 +15,8 @@ namespace Core {
 struct ThreadStatistics {
     pid_t tid;
     unsigned times_scheduled;
-    unsigned ticks_user;
-    unsigned ticks_kernel;
+    u64 time_user;
+    u64 time_kernel;
     unsigned syscall_count;
     unsigned inode_faults;
     unsigned zero_faults;
@@ -66,8 +66,8 @@ struct ProcessStatistics {
 
 struct AllProcessesStatistics {
     Vector<ProcessStatistics> processes;
-    u64 total_ticks_scheduled;
-    u64 total_ticks_scheduled_kernel;
+    u64 total_time_scheduled;
+    u64 total_time_scheduled_kernel;
 };
 
 class ProcessStatisticsReader {

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.h
@@ -64,10 +64,16 @@ struct ProcessStatistics {
     String username;
 };
 
+struct AllProcessesStatistics {
+    Vector<ProcessStatistics> processes;
+    u64 total_ticks_scheduled;
+    u64 total_ticks_scheduled_kernel;
+};
+
 class ProcessStatisticsReader {
 public:
-    static Optional<Vector<Core::ProcessStatistics>> get_all(RefPtr<Core::File>&);
-    static Optional<Vector<Core::ProcessStatistics>> get_all();
+    static Optional<AllProcessesStatistics> get_all(RefPtr<Core::File>&);
+    static Optional<AllProcessesStatistics> get_all();
 
 private:
     static String username_from_uid(uid_t);

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
@@ -27,9 +27,9 @@ void RunningProcessesModel::update()
 {
     m_processes.clear();
 
-    auto processes = Core::ProcessStatisticsReader::get_all();
-    if (processes.has_value()) {
-        for (auto& it : processes.value()) {
+    auto all_processes = Core::ProcessStatisticsReader::get_all();
+    if (all_processes.has_value()) {
+        for (auto& it : all_processes.value().processes) {
             Process process;
             process.pid = it.pid;
             process.uid = it.uid;

--- a/Userland/Utilities/killall.cpp
+++ b/Userland/Utilities/killall.cpp
@@ -19,11 +19,11 @@ static void print_usage_and_exit()
 
 static int kill_all(const String& process_name, const unsigned signum)
 {
-    auto processes = Core::ProcessStatisticsReader::get_all();
-    if (!processes.has_value())
+    auto all_processes = Core::ProcessStatisticsReader::get_all();
+    if (!all_processes.has_value())
         return 1;
 
-    for (auto& process : processes.value()) {
+    for (auto& process : all_processes.value().processes) {
         if (process.name == process_name) {
             int ret = kill(process.pid, signum);
             if (ret < 0)

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -146,11 +146,11 @@ int main(int argc, char* argv[])
     }
 
     outln("{:28} {:>4} {:>4} {:10} {:>4} {}", "COMMAND", "PID", "PGID", "USER", "FD", "NAME");
-    auto processes = Core::ProcessStatisticsReader::get_all();
-    if (!processes.has_value())
+    auto all_processes = Core::ProcessStatisticsReader::get_all();
+    if (!all_processes.has_value())
         return 1;
     if (arg_pid == -1) {
-        for (auto& process : processes.value()) {
+        for (auto& process : all_processes.value().processes) {
             if (process.pid == 0)
                 continue;
             auto open_files = get_open_files_by_pid(process.pid);
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
             return 0;
 
         for (auto& file : open_files) {
-            display_entry(file, *processes->find_if([&](auto& entry) { return entry.pid == arg_pid; }));
+            display_entry(file, *all_processes->processes.find_if([&](auto& entry) { return entry.pid == arg_pid; }));
         }
     }
 

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -36,12 +36,12 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto processes = Core::ProcessStatisticsReader::get_all();
-    if (!processes.has_value())
+    auto all_processes = Core::ProcessStatisticsReader::get_all();
+    if (!all_processes.has_value())
         return 1;
 
     Vector<pid_t> matches;
-    for (auto& it : processes.value()) {
+    for (auto& it : all_processes.value().processes) {
         auto result = re.match(it.name, PosixFlags::Global);
         if (result.success ^ invert_match) {
             matches.append(it.pid);

--- a/Userland/Utilities/pidof.cpp
+++ b/Userland/Utilities/pidof.cpp
@@ -16,11 +16,11 @@ static int pid_of(const String& process_name, bool single_shot, bool omit_pid, p
 {
     bool displayed_at_least_one = false;
 
-    auto processes = Core::ProcessStatisticsReader::get_all();
-    if (!processes.has_value())
+    auto all_processes = Core::ProcessStatisticsReader::get_all();
+    if (!all_processes.has_value())
         return 1;
 
-    for (auto& it : processes.value()) {
+    for (auto& it : all_processes.value().processes) {
         if (it.name == process_name) {
             if (!omit_pid || it.pid != pid) {
                 out(displayed_at_least_one ? " {}" : "{}", it.pid);

--- a/Userland/Utilities/ps.cpp
+++ b/Userland/Utilities/ps.cpp
@@ -83,14 +83,15 @@ int main(int argc, char** argv)
         cmd_column = add_column("CMD", Alignment::Left);
     }
 
-    auto processes = Core::ProcessStatisticsReader::get_all();
-    if (!processes.has_value())
+    auto all_processes = Core::ProcessStatisticsReader::get_all();
+    if (!all_processes.has_value())
         return 1;
 
-    quick_sort(processes.value(), [](auto& a, auto& b) { return a.pid < b.pid; });
+    auto& processes = all_processes.value().processes;
+    quick_sort(processes, [](auto& a, auto& b) { return a.pid < b.pid; });
 
     Vector<Vector<String>> rows;
-    rows.ensure_capacity(1 + processes.value().size());
+    rows.ensure_capacity(1 + processes.size());
 
     Vector<String> header;
     header.ensure_capacity(columns.size());
@@ -98,7 +99,7 @@ int main(int argc, char** argv)
         header.append(column.title);
     rows.append(move(header));
 
-    for (auto const& process : processes.value()) {
+    for (auto const& process : processes) {
         auto tty = process.tty;
 
         if (!every_process_flag && tty != this_tty)

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -93,7 +93,7 @@ int main()
 
         String what = "n/a";
 
-        for (auto& process : process_statistics.value()) {
+        for (auto& process : process_statistics.value().processes) {
             if (process.tty == tty && process.pid == process.pgid)
                 what = process.name;
         }


### PR DESCRIPTION
As threads come and go, we can't simply account for how many time
slices the threads at any given point may have been using. We need to
also account for threads that have since disappeared. This means we
also need to track how many time slices we have expired globally.

However, because this doesn't account for context switches outside of
the system timer tick values may still be under-reported. To solve this
we will need to track more accurate time information on each context
switch.

This also fixes top's cpu usage calculation which was still based on
the number of context switches.

Fixes #6473