### PR TITLE
Kernel: Make kernel symbols available much earlier in the boot process

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -414,16 +414,13 @@ add_dependencies(${KERNEL_TARGET} kernel_heap)
 add_custom_command(
     TARGET ${KERNEL_TARGET} POST_BUILD
     COMMAND ${TOOLCHAIN_PREFIX}objcopy -O elf32-i386 ${CMAKE_CURRENT_BINARY_DIR}/${KERNEL_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/Kernel
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel
+    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
 )
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
-
-add_custom_command(
-    TARGET ${KERNEL_TARGET} POST_BUILD
-    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kernel.map DESTINATION res)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kernel.map" DESTINATION res)
 
 serenity_install_headers(Kernel)
 serenity_install_sources(Kernel)

--- a/Kernel/embedmap.sh
+++ b/Kernel/embedmap.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+tmp=$(mktemp)
+(cat kernel.map; printf '%b' '\0') > "$tmp"
+objcopy --update-section .ksyms="$tmp" Kernel
+rm -f "$tmp"

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -123,6 +123,8 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init()
     kmalloc_init();
     slab_alloc_init();
 
+    load_kernel_symbol_table();
+
     ConsoleDevice::initialize();
     s_bsp_processor.initialize(0);
 
@@ -263,8 +265,6 @@ void init_stage2(void*)
     }
 
     Process::current()->set_root_directory(VirtualFileSystem::the().root_custody());
-
-    load_kernel_symbol_table();
 
     // Switch out of early boot mode.
     g_in_early_boot = false;

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -9,6 +9,7 @@ PHDRS
   text PT_LOAD ;
   data PT_LOAD ;
   bss PT_LOAD ;
+  ksyms PT_LOAD ;
 }
 
 SECTIONS
@@ -93,4 +94,9 @@ SECTIONS
     } :bss
 
     end_of_kernel_image = .;
+
+    .ksyms ALIGN(4K) : AT (ADDR(.ksyms) - KERNEL_VIRTUAL_BASE)
+    {
+        *(.kernel_symbols)
+    } :ksyms
 }


### PR DESCRIPTION
This adds a new section .ksyms at the end of the linker map, reserves 5MiB for it (which are after end_of_kernel_image so they get re-used once MemoryManager is initialized) and then embeds the symbol map into the kernel binary with objcopy. This also shrinks the .ksyms section to the real size of the symbol file (around 900KiB at the moment).

By doing this we can make the symbol map available much earlier in the boot process, i.e. even before VFS is available.