### PR TITLE
HackStudio: Disable Delete action on insufficient permissions

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -796,7 +796,13 @@ void HackStudioWidget::configure_project_tree_view()
 
     m_project_tree_view->on_selection_change = [this] {
         m_open_selected_action->set_enabled(!m_project_tree_view->selection().is_empty());
-        m_delete_action->set_enabled(!m_project_tree_view->selection().is_empty());
+
+        auto selections = m_project_tree_view->selection().indices();
+        auto it = selections.find_if([&](auto selected_file) {
+            return access(m_project->model().full_path(selected_file.parent()).characters(), W_OK) == 0;
+        });
+        bool has_permissions = it != selections.end();
+        m_delete_action->set_enabled(!m_project_tree_view->selection().is_empty() && has_permissions);
     };
 
     m_project_tree_view->on_activation = [this](auto& index) {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -469,7 +469,6 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()
                         "Removal failed",
                         GUI::MessageBox::Type::Error);
                 }
-                break;
             }
         }
     });


### PR DESCRIPTION
Hack Studio will now disable the action when any parent of selected files do not have write permission.