### PR TITLE
AK: Expose RedBlackTree allocation failures via try_insert

### DIFF
--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -446,10 +446,19 @@ public:
         insert(key, V(value));
     }
 
+    [[nodiscard]] bool try_insert(K key, V&& value)
+    {
+        auto* node = new (nothrow) Node(key, move(value));
+        if (!node)
+            return false;
+        BaseTree::insert(node);
+        return true;
+    }
+
     void insert(K key, V&& value)
     {
-        auto* node = new Node(key, move(value));
-        BaseTree::insert(node);
+        auto success = try_insert(key, move(value));
+        VERIFY(success);
     }
 
     using Iterator = RedBlackTreeIterator<RedBlackTree, V>;

--- a/Kernel/VM/Space.h
+++ b/Kernel/VM/Space.h
@@ -24,7 +24,7 @@ public:
     PageDirectory& page_directory() { return *m_page_directory; }
     const PageDirectory& page_directory() const { return *m_page_directory; }
 
-    Region& add_region(NonnullOwnPtr<Region>);
+    Region* add_region(NonnullOwnPtr<Region>);
 
     size_t region_count() const { return m_regions.size(); }
 


### PR DESCRIPTION
This should help with using the RedBlackTree in a more OOM-safe way in the kernel.