### PR TITLE
LibWeb: Fix assertion failure in HTMLTokenizer

### DIFF
--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -193,5 +193,5 @@ TEST_CASE(regression)
     auto file_contents = file.value()->read_all();
     auto tokens = run_tokenizer(file_contents);
     u32 hash = hash_tokens(tokens);
-    EXPECT_EQ(hash, 1328591125u);
+    EXPECT_EQ(hash, 2891738465u);
 }

--- a/Tests/LibWeb/tokenizer-test.html
+++ b/Tests/LibWeb/tokenizer-test.html
@@ -7,5 +7,8 @@
 <body>
     <p>This is the first paragraph.</p>
     <p foo="bar">The second paragraph has an attribute!</p>
+    <!-- This is a standard HTML comment. -->
+    <!----- This comment has a few too many dashes. ----->
+    <!----> <!-- <= There is an empty comment over there. -->
 </body>
 </html>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -59,6 +59,7 @@ namespace Web::HTML {
 
 #define SWITCH_TO_AND_EMIT_CURRENT_TOKEN(new_state)     \
     do {                                                \
+        VERIFY(m_current_builder.is_empty());           \
         will_switch_to(State::new_state);               \
         m_state = State::new_state;                     \
         will_emit(m_current_token);                     \
@@ -135,6 +136,7 @@ namespace Web::HTML {
 
 #define EMIT_CURRENT_TOKEN                              \
     do {                                                \
+        VERIFY(m_current_builder.is_empty());           \
         will_emit(m_current_token);                     \
         m_queued_tokens.enqueue(move(m_current_token)); \
         return m_queued_tokens.dequeue();               \

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1351,18 +1351,17 @@ _StartOfFunction:
             {
                 ON('-')
                 {
-                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentEnd);
+                    SWITCH_TO(CommentEnd);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(move(m_current_token));
+                    EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1393,7 +1392,8 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(move(m_current_token));
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1413,7 +1413,7 @@ _StartOfFunction:
                 }
                 ON('!')
                 {
-                    SWITCH_TO(CommentEndBang);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentEndBang);
                 }
                 ON('-')
                 {
@@ -1423,7 +1423,8 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(move(m_current_token));
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1439,17 +1440,19 @@ _StartOfFunction:
                 ON('-')
                 {
                     m_current_builder.append("--!");
-                    SWITCH_TO(CommentEndDash);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentEndDash);
                 }
                 ON('>')
                 {
                     log_parse_error();
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(move(m_current_token));
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1469,7 +1472,8 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_queued_tokens.enqueue(move(m_current_token));
+                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1503,7 +1507,7 @@ _StartOfFunction:
             {
                 ON('-')
                 {
-                    SWITCH_TO(CommentLessThanSignBangDash);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentLessThanSignBangDash);
                 }
                 ANYTHING_ELSE
                 {
@@ -1516,7 +1520,7 @@ _StartOfFunction:
             {
                 ON('-')
                 {
-                    SWITCH_TO(CommentLessThanSignBangDashDash);
+                    SWITCH_TO_WITH_UNCLEAN_BUILDER(CommentLessThanSignBangDashDash);
                 }
                 ANYTHING_ELSE
                 {


### PR DESCRIPTION
This fixes #8757, adds some more `VERIFY` to hopefully catch this behavior earlier in the future, and adds comments to the `HTMLTokenizer` regression test.