### PR TITLE
AK: Make JsonParser correctly parse unsigned values larger than u32

### DIFF
--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -263,9 +263,13 @@ Optional<JsonValue> JsonParser::parse_number()
         value = JsonValue((double)whole + ((double)fraction / divider));
     } else {
 #endif
-        auto to_unsigned_result = number_string.to_uint();
+        auto to_unsigned_result = number_string.to_uint<u64>();
         if (to_unsigned_result.has_value()) {
-            value = JsonValue(to_unsigned_result.value());
+            auto number = *to_unsigned_result;
+            if (number <= NumericLimits<u32>::max())
+                value = JsonValue((u32)number);
+            else
+                value = JsonValue(number);
         } else {
             auto number = number_string.to_int<i64>();
             if (!number.has_value())

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -105,3 +105,12 @@ TEST_CASE(json_duplicate_keys)
     json.set("test", "baz");
     EXPECT_EQ(json.to_string(), "{\"test\":\"baz\"}");
 }
+
+TEST_CASE(json_u64_roundtrip)
+{
+    auto big_value = 0xffffffffffffffffull;
+    auto json = JsonValue(big_value).to_string();
+    auto value = JsonValue::from_string(json);
+    EXPECT_EQ_FORCE(value.has_value(), true);
+    EXPECT_EQ(value->as_u64(), big_value);
+}


### PR DESCRIPTION
Prior to this, it'd try to stuff them into an i64, which could fail and
give us nothing.
Even though this is an extension we've made to JSON, the parser should
be able to correctly round-trip from whatever our serialiser has
generated.