### PR TITLE
PixelPaint: Fix crash when copying empty selection

### DIFF
--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -92,6 +92,9 @@ void Layer::set_name(String name)
 
 RefPtr<Gfx::Bitmap> Layer::try_copy_bitmap(Selection const& selection) const
 {
+    if (selection.is_empty()) {
+        return {};
+    }
     auto selection_rect = selection.bounding_rect();
 
     auto result = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, selection_rect.size());


### PR DESCRIPTION
Previously, trying to copy when there is no selection would crash, trying to call mmap with a size of 0. Now it just leaves the clipboard as it is.