### PR TITLE
LibCore+LibIMAP: Move Promise to LibCore

### DIFF
--- a/Userland/Libraries/LibCore/Promise.h
+++ b/Userland/Libraries/LibCore/Promise.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Kyle Pereira <hey@xylepereira.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/EventLoop.h>
+#include <LibCore/Object.h>
+
+namespace Core {
+template<typename Result>
+class Promise : public Object {
+    C_OBJECT(Promise);
+
+private:
+    Optional<Result> m_pending;
+
+public:
+    Function<void(Result&)> on_resolved;
+
+    void resolve(Result&& result)
+    {
+        m_pending = move(result);
+        if (on_resolved)
+            on_resolved(m_pending.value());
+    }
+
+    bool is_resolved()
+    {
+        return m_pending.has_value();
+    };
+
+    Result await()
+    {
+        while (!is_resolved()) {
+            Core::EventLoop::current().pump();
+        }
+        return m_pending.release_value();
+    }
+
+    // Converts a Promise<A> to a Promise<B> using a function func: A -> B
+    template<typename T>
+    RefPtr<Promise<T>> map(T func(Result&))
+    {
+        RefPtr<Promise<T>> new_promise = Promise<T>::construct();
+        on_resolved = [new_promise, func](Result& result) mutable {
+            auto t = func(result);
+            new_promise->resolve(move(t));
+        };
+        return new_promise;
+    }
+};
+}

--- a/Userland/Libraries/LibIMAP/Client.h
+++ b/Userland/Libraries/LibIMAP/Client.h
@@ -7,10 +7,14 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <LibCore/Promise.h>
 #include <LibIMAP/Parser.h>
 #include <LibTLS/TLSv12.h>
 
 namespace IMAP {
+template<typename T>
+using Promise = Core::Promise<T>;
+
 class Client {
     friend class Parser;
 


### PR DESCRIPTION
This makes Promise available without having to link LibIMAP.

cc: @Lubrsi