### PR TITLE
SpiceAgent: Add Clipboard as a build dependency

### DIFF
--- a/Userland/Services/SpiceAgent/CMakeLists.txt
+++ b/Userland/Services/SpiceAgent/CMakeLists.txt
@@ -11,3 +11,4 @@ set(SOURCES
 
 serenity_bin(SpiceAgent)
 target_link_libraries(SpiceAgent LibGfx LibCore LibIPC)
+add_dependencies(SpiceAgent Clipboard)


### PR DESCRIPTION
SpiceAgent depends on header files built as part of the Clipboard target:

```
[873/3940] Building CXX object Userland/Services/SpiceAgent/CMakeFiles/SpiceAgent.dir/main.cpp.o
FAILED: Userland/Services/SpiceAgent/CMakeFiles/SpiceAgent.dir/main.cpp.o 
/usr/bin/ccache /home/runner/work/serenity/serenity/Toolchain/Local/x86_64//bin/x86_64-pc-serenity-g++ -DENABLE_COMPILETIME_FORMAT_CHECK -DSANITIZE_PTRS -I../Userland/Libraries -I../. -I. -I../Userland/Libraries/LibC -I../Userland/Libraries/LibCrypt -I../Userland/Libraries/LibM -I../Userland/Libraries/LibPthread -I../Userland/Libraries/LibSystem -I../Userland/Services -I../Userland -IUserland/Services -IUserland/Libraries -IUserland -fsanitize=undefined -pie -fpic -fno-sanitize=vptr -Wno-literal-suffix -Wformat=2 -fdiagnostics-color=always -Werror -Wall -Wextra -Wno-address-of-packed-member -Wcast-align -Wcast-qual -Wno-deprecated-copy -Wduplicated-cond -Wdouble-promotion -Wno-expansion-to-defined -Wimplicit-fallthrough -Wlogical-op -Wmisleading-indentation -Wmissing-declarations -Wno-nonnull-compare -Wnon-virtual-dtor -Wno-unknown-warning-option -Wundef -Wunused -Wwrite-strings -Wno-maybe-uninitialized -ffile-prefix-map=/home/runner/work/serenity/serenity=. -fno-exceptions -fstack-protector-strong -g1 -fstack-clash-protection -O2 -std=c++2a -MD -MT Userland/Services/SpiceAgent/CMakeFiles/SpiceAgent.dir/main.cpp.o -MF Userland/Services/SpiceAgent/CMakeFiles/SpiceAgent.dir/main.cpp.o.d -o Userland/Services/SpiceAgent/CMakeFiles/SpiceAgent.dir/main.cpp.o -c ../Userland/Services/SpiceAgent/main.cpp
In file included from ../Userland/Services/SpiceAgent/SpiceAgent.h:7,
                 from ../Userland/Services/SpiceAgent/main.cpp:7:
../Userland/Services/SpiceAgent/ClipboardServerConnection.h:8:10: fatal error: Clipboard/ClipboardClientEndpoint.h: No such file or directory
    8 | #include <Clipboard/ClipboardClientEndpoint.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```