### PR TITLE
Kernel: Add aligned `operator new`

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -59,6 +59,15 @@
 #endif
 #define NAKED __attribute__((naked))
 
+#ifdef DISALLOW
+#    undef DISALLOW
+#endif
+#ifdef __clang__
+#    define DISALLOW(message) __attribute__((diagnose_if(1, message, "error")))
+#else
+#    define DISALLOW(message) __attribute__((error(message)))
+#endif
+
 // GCC doesn't have __has_feature but clang does
 #ifndef __has_feature
 #    define __has_feature(...) 0

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -356,8 +356,10 @@ endif()
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=large -fno-pic -mno-red-zone")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new=8")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -fPIE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new=4")
 endif()
 
 # Kernel Undefined Behavior Sanitizer (KUBSAN)

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -64,14 +64,15 @@ inline void* operator new[](size_t, void* p) { return p; }
 [[nodiscard]] void* operator new(size_t size, std::align_val_t);
 [[nodiscard]] void* operator new(size_t size, std::align_val_t, const std::nothrow_t&) noexcept;
 
-void operator delete(void* ptr) noexcept;
+void operator delete(void* ptr) noexcept DISALLOW("All deletes in the kernel should have a known size.");
 void operator delete(void* ptr, size_t) noexcept;
+void operator delete(void* ptr, std::align_val_t) noexcept DISALLOW("All deletes in the kernel should have a known size.");
 void operator delete(void* ptr, size_t, std::align_val_t) noexcept;
 
 [[nodiscard]] void* operator new[](size_t size);
 [[nodiscard]] void* operator new[](size_t size, const std::nothrow_t&) noexcept;
 
-void operator delete[](void* ptrs) noexcept;
+void operator delete[](void* ptrs) noexcept DISALLOW("All deletes in the kernel should have a known size.");
 void operator delete[](void* ptr, size_t) noexcept;
 
 [[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] void* kmalloc(size_t);

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -34,6 +34,8 @@ struct nothrow_t {
 };
 
 extern const nothrow_t nothrow;
+
+enum class align_val_t : size_t {};
 };
 
 void kmalloc_init();
@@ -59,10 +61,16 @@ inline void* operator new[](size_t, void* p) { return p; }
 
 [[nodiscard]] void* operator new(size_t size);
 [[nodiscard]] void* operator new(size_t size, const std::nothrow_t&) noexcept;
+[[nodiscard]] void* operator new(size_t size, std::align_val_t);
+[[nodiscard]] void* operator new(size_t size, std::align_val_t, const std::nothrow_t&) noexcept;
+
 void operator delete(void* ptr) noexcept;
 void operator delete(void* ptr, size_t) noexcept;
+void operator delete(void* ptr, size_t, std::align_val_t) noexcept;
+
 [[nodiscard]] void* operator new[](size_t size);
 [[nodiscard]] void* operator new[](size_t size, const std::nothrow_t&) noexcept;
+
 void operator delete[](void* ptrs) noexcept;
 void operator delete[](void* ptr, size_t) noexcept;
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -38,11 +38,9 @@ UNMAP_AFTER_INIT void Thread::initialize()
 
 KResultOr<NonnullRefPtr<Thread>> Thread::try_create(NonnullRefPtr<Process> process)
 {
-    // FIXME: Once we have aligned + nothrow operator new, we can avoid the manual kfree.
-    FPUState* fpu_state = (FPUState*)kmalloc_aligned<16>(sizeof(FPUState));
+    auto fpu_state = try_make<FPUState>();
     if (!fpu_state)
         return ENOMEM;
-    ArmedScopeGuard fpu_guard([fpu_state]() { kfree_aligned(fpu_state); });
 
     auto kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, {}, Region::Access::Read | Region::Access::Write, AllocationStrategy::AllocateNow);
     if (!kernel_stack_region)
@@ -53,18 +51,17 @@ KResultOr<NonnullRefPtr<Thread>> Thread::try_create(NonnullRefPtr<Process> proce
     if (!block_timer)
         return ENOMEM;
 
-    auto thread = adopt_ref_if_nonnull(new (nothrow) Thread(move(process), kernel_stack_region.release_nonnull(), block_timer.release_nonnull(), fpu_state));
+    auto thread = adopt_ref_if_nonnull(new (nothrow) Thread(move(process), kernel_stack_region.release_nonnull(), block_timer.release_nonnull(), fpu_state.release_nonnull()));
     if (!thread)
         return ENOMEM;
-    fpu_guard.disarm();
 
     return thread.release_nonnull();
 }
 
-Thread::Thread(NonnullRefPtr<Process> process, NonnullOwnPtr<Region> kernel_stack_region, NonnullRefPtr<Timer> block_timer, FPUState* fpu_state)
+Thread::Thread(NonnullRefPtr<Process> process, NonnullOwnPtr<Region> kernel_stack_region, NonnullRefPtr<Timer> block_timer, NonnullOwnPtr<FPUState> fpu_state)
     : m_process(move(process))
     , m_kernel_stack_region(move(kernel_stack_region))
-    , m_fpu_state(fpu_state)
+    , m_fpu_state(move(fpu_state))
     , m_name(m_process->name())
     , m_block_timer(block_timer)
     , m_global_procfs_inode_index(ProcFSComponentRegistry::the().allocate_inode_index())
@@ -525,7 +522,6 @@ void Thread::finalize()
     if (m_dump_backtrace_on_finalization)
         dbgln("{}", backtrace());
 
-    kfree_aligned(m_fpu_state);
     drop_thread_count(false);
 }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1190,7 +1190,7 @@ public:
     InodeIndex global_procfs_inode_index() const { return m_global_procfs_inode_index; }
 
 private:
-    Thread(NonnullRefPtr<Process>, NonnullOwnPtr<Region>, NonnullRefPtr<Timer>, FPUState*);
+    Thread(NonnullRefPtr<Process>, NonnullOwnPtr<Region>, NonnullRefPtr<Timer>, NonnullOwnPtr<FPUState>);
 
     IntrusiveListNode<Thread> m_process_thread_list_node;
     int m_runnable_priority { -1 };
@@ -1317,7 +1317,7 @@ private:
     unsigned m_ipv4_socket_read_bytes { 0 };
     unsigned m_ipv4_socket_write_bytes { 0 };
 
-    FPUState* m_fpu_state { nullptr };
+    OwnPtr<FPUState> m_fpu_state;
     State m_state { Invalid };
     String m_name;
     u32 m_priority { THREAD_PRIORITY_NORMAL };


### PR DESCRIPTION
This fixes a `FIXME` in the kernel by allowing over-aligned objects to be allocated by `new`, in turn making it possible to use them with smart pointer factories.

We now also get nicer errors if the non-sized deallocation functions were used for some reason.

This is how the error looks with Clang (with sized deallocations turned off):
```
../.././AK/Function.h:156:13: error: All deletes in the kernel should have a known size.
            delete this;
```

GCC emits a similar message, too.

If the compiler detects that a type requires an alignment larger than what we guarantee in normal `new`, the aligned functions will be called automatically instead.