### PR TITLE
Spider: Automatically reveal top cards

### DIFF
--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -114,6 +114,18 @@ void Game::draw_cards()
     update();
 }
 
+void Game::ensure_top_card_is_visible(NonnullRefPtr<CardStack> stack)
+{
+    if (stack->is_empty())
+        return;
+
+    auto& top_card = stack->peek();
+    if (top_card.is_upside_down()) {
+        top_card.set_upside_down(false);
+        update(top_card.rect());
+    }
+}
+
 void Game::detect_full_stacks()
 {
     auto& completed_stack = stack(Completed);
@@ -142,6 +154,8 @@ void Game::detect_full_stacks()
                 for (size_t j = 0; j < Card::card_count; j++) {
                     completed_stack.push(current_pile.pop());
                 }
+
+                ensure_top_card_is_visible(current_pile);
 
                 update_score(101);
             }
@@ -300,6 +314,8 @@ void Game::mouseup_event(GUI::MouseEvent& event)
                     update_score(-1);
 
                     detect_full_stacks();
+
+                    ensure_top_card_is_visible(*m_focused_stack);
 
                     rebound = false;
                     break;

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -67,6 +67,7 @@ private:
     void start_timer_if_necessary();
     void update_score(int delta);
     void draw_cards();
+    void ensure_top_card_is_visible(NonnullRefPtr<CardStack> stack);
     void detect_full_stacks();
     void detect_victory();
 


### PR DESCRIPTION
This matches basically all other Spider implementations I've played,
and makes playing much easier :)

I have left click-to-reveal in place, but mostly incase there is a
condition I've forgotten about.


https://user-images.githubusercontent.com/5103549/125820392-d23ea47e-b7a3-4d0c-b2f9-b008e3951766.mp4

