### PR TITLE
LibWeb: Improve HTML tokenization performance and reduce HTMLToken size

### DIFF
--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -14,13 +14,13 @@ using Token = Web::HTML::HTMLToken;
 
 #define BEGIN_ENUMERATION(tokens)          \
     auto current_token = (tokens).begin(); \
-    Optional<Token> last_token;
+    [[maybe_unused]] Token* last_token;
 
 #define END_ENUMERATION() \
     EXPECT(current_token.is_end());
 
-#define NEXT_TOKEN()             \
-    last_token = *current_token; \
+#define NEXT_TOKEN()              \
+    last_token = &*current_token; \
     ++current_token;
 
 #define EXPECT_START_TAG_TOKEN(_tag_name)                    \
@@ -56,11 +56,11 @@ using Token = Web::HTML::HTMLToken;
     NEXT_TOKEN();
 
 #define EXPECT_TAG_TOKEN_ATTRIBUTE(name, value) \
-    VERIFY(last_token.has_value());             \
+    VERIFY(last_token);                         \
     EXPECT_EQ(last_token->attribute(#name), #value);
 
 #define EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(count) \
-    VERIFY(last_token.has_value());             \
+    VERIFY(last_token);                         \
     EXPECT_EQ(last_token->attribute_count(), (size_t)(count));
 
 static Vector<Token> run_tokenizer(StringView const& input)

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -61,7 +61,7 @@ using Token = Web::HTML::HTMLToken;
 
 #define EXPECT_TAG_TOKEN_ATTRIBUTE_COUNT(count) \
     VERIFY(last_token.has_value());             \
-    EXPECT_EQ(last_token->attributes().size(), (size_t)count);
+    EXPECT_EQ(last_token->attribute_count(), (size_t)(count));
 
 static Vector<Token> run_tokenizer(StringView const& input)
 {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -317,7 +317,7 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.comment()));
         document().append_child(move(comment));
         return;
     }
@@ -347,7 +347,7 @@ void HTMLDocumentParser::handle_before_html(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.comment()));
         document().append_child(move(comment));
         return;
     }
@@ -520,9 +520,8 @@ AnythingElse:
 
 void HTMLDocumentParser::insert_comment(HTMLToken& token)
 {
-    auto data = token.m_comment_or_character.data;
     auto adjusted_insertion_location = find_appropriate_place_for_inserting_node();
-    adjusted_insertion_location.parent->insert_before(adopt_ref(*new DOM::Comment(document(), data)), adjusted_insertion_location.insert_before_sibling);
+    adjusted_insertion_location.parent->insert_before(adopt_ref(*new DOM::Comment(document(), token.comment())), adjusted_insertion_location.insert_before_sibling);
 }
 
 void HTMLDocumentParser::handle_in_head(HTMLToken& token)
@@ -832,9 +831,8 @@ void HTMLDocumentParser::handle_after_body(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto data = token.m_comment_or_character.data;
         auto& insertion_location = m_stack_of_open_elements.first();
-        insertion_location.append_child(adopt_ref(*new DOM::Comment(document(), data)));
+        insertion_location.append_child(adopt_ref(*new DOM::Comment(document(), token.comment())));
         return;
     }
 
@@ -870,7 +868,7 @@ void HTMLDocumentParser::handle_after_body(HTMLToken& token)
 void HTMLDocumentParser::handle_after_after_body(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.comment()));
         document().append_child(move(comment));
         return;
     }
@@ -2751,7 +2749,7 @@ void HTMLDocumentParser::handle_after_frameset(HTMLToken& token)
 void HTMLDocumentParser::handle_after_after_frameset(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = adopt_ref(*new DOM::Comment(document(), token.m_comment_or_character.data));
+        auto comment = adopt_ref(*new DOM::Comment(document(), token.comment()));
         document().append_child(move(comment));
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -1570,7 +1570,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::image) {
         // Parse error. Change the token's tag name to HTML::TagNames::img and reprocess it. (Don't ask.)
         log_parse_error();
-        token.m_tag.tag_name = "img";
+        token.set_tag_name("img");
         process_using_the_rules_for(m_insertion_mode, token);
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -2103,7 +2103,7 @@ void HTMLDocumentParser::handle_in_table_text(HTMLToken& token)
             return;
         }
 
-        m_pending_table_character_tokens.append(token);
+        m_pending_table_character_tokens.append(move(token));
         return;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -258,15 +258,15 @@ void HTMLDocumentParser::process_using_the_rules_for(InsertionMode mode, HTMLTok
 
 DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_token) const
 {
-    if (doctype_token.m_doctype.force_quirks)
+    if (doctype_token.doctype_data().force_quirks)
         return DOM::QuirksMode::Yes;
 
     // NOTE: The tokenizer puts the name into lower case for us.
-    if (doctype_token.m_doctype.name != "html")
+    if (doctype_token.doctype_data().name != "html")
         return DOM::QuirksMode::Yes;
 
-    auto const& public_identifier = doctype_token.m_doctype.public_identifier;
-    auto const& system_identifier = doctype_token.m_doctype.system_identifier;
+    auto const& public_identifier = doctype_token.doctype_data().public_identifier;
+    auto const& system_identifier = doctype_token.doctype_data().system_identifier;
 
     if (public_identifier.equals_ignoring_case("-//W3O//DTD W3 HTML Strict 3.0//EN//"))
         return DOM::QuirksMode::Yes;
@@ -285,7 +285,7 @@ DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_t
             return DOM::QuirksMode::Yes;
     }
 
-    if (doctype_token.m_doctype.missing_system_identifier) {
+    if (doctype_token.doctype_data().missing_system_identifier) {
         if (public_identifier.starts_with("-//W3C//DTD HTML 4.01 Frameset//", CaseSensitivity::CaseInsensitive))
             return DOM::QuirksMode::Yes;
 
@@ -299,7 +299,7 @@ DOM::QuirksMode HTMLDocumentParser::which_quirks_mode(const HTMLToken& doctype_t
     if (public_identifier.starts_with("-//W3C//DTD XHTML 1.0 Transitional//", CaseSensitivity::CaseInsensitive))
         return DOM::QuirksMode::Limited;
 
-    if (!doctype_token.m_doctype.missing_system_identifier) {
+    if (!doctype_token.doctype_data().missing_system_identifier) {
         if (public_identifier.starts_with("-//W3C//DTD HTML 4.01 Frameset//", CaseSensitivity::CaseInsensitive))
             return DOM::QuirksMode::Limited;
 
@@ -324,9 +324,9 @@ void HTMLDocumentParser::handle_initial(HTMLToken& token)
 
     if (token.is_doctype()) {
         auto doctype = adopt_ref(*new DOM::DocumentType(document()));
-        doctype->set_name(token.m_doctype.name);
-        doctype->set_public_id(token.m_doctype.public_identifier);
-        doctype->set_system_id(token.m_doctype.system_identifier);
+        doctype->set_name(token.doctype_data().name);
+        doctype->set_public_id(token.doctype_data().public_identifier);
+        doctype->set_system_id(token.doctype_data().system_identifier);
         document().append_child(move(doctype));
         document().set_quirks_mode(which_quirks_mode(token));
         m_insertion_mode = InsertionMode::BeforeHTML;

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -16,7 +16,7 @@ String HTMLToken::to_string() const
     case HTMLToken::Type::DOCTYPE:
         builder.append("DOCTYPE");
         builder.append(" { name: '");
-        builder.append(m_doctype.name);
+        builder.append(doctype_data().name);
         builder.append("' }");
         break;
     case HTMLToken::Type::StartTag:

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -42,12 +42,13 @@ String HTMLToken::to_string() const
         builder.append(" { name: '");
         builder.append(tag_name());
         builder.append("', { ");
-        for (auto& attribute : m_tag.attributes) {
+        for_each_attribute([&](auto& attribute) {
             builder.append(attribute.local_name);
             builder.append("=\"");
             builder.append(attribute.value);
             builder.append("\" ");
-        }
+            return IterationDecision::Continue;
+        });
         builder.append("} }");
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -40,7 +40,7 @@ String HTMLToken::to_string() const
 
     if (type() == HTMLToken::Type::StartTag || type() == HTMLToken::Type::EndTag) {
         builder.append(" { name: '");
-        builder.append(m_tag.tag_name);
+        builder.append(tag_name());
         builder.append("', { ");
         for (auto& attribute : m_tag.attributes) {
             builder.append(attribute.local_name);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -52,9 +52,15 @@ String HTMLToken::to_string() const
         builder.append("} }");
     }
 
-    if (type() == HTMLToken::Type::Comment || type() == HTMLToken::Type::Character) {
+    if (is_comment()) {
         builder.append(" { data: '");
-        builder.append(m_comment_or_character.data);
+        builder.append(comment());
+        builder.append("' }");
+    }
+
+    if (is_character()) {
+        builder.append(" { data: '");
+        builder.append_code_point(code_point());
         builder.append("' }");
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -19,8 +19,6 @@ namespace Web::HTML {
 class HTMLTokenizer;
 
 class HTMLToken {
-    friend class HTMLDocumentParser;
-    friend class HTMLTokenizer;
 
 public:
     enum class Type {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -19,6 +19,7 @@ namespace Web::HTML {
 class HTMLTokenizer;
 
 class HTMLToken {
+    AK_MAKE_NONCOPYABLE(HTMLToken);
 
 public:
     enum class Type {
@@ -78,6 +79,9 @@ public:
         : m_type(type)
     {
     }
+
+    HTMLToken(HTMLToken&& other) = default;
+    HTMLToken& operator=(HTMLToken&& other) = default;
 
     bool is_doctype() const { return m_type == Type::DOCTYPE; }
     bool is_start_tag() const { return m_type == Type::StartTag; }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -62,18 +62,23 @@ public:
 
     static HTMLToken make_character(u32 code_point)
     {
-        HTMLToken token;
-        token.m_type = Type::Character;
+        HTMLToken token { Type::Character };
         token.set_code_point(code_point);
         return token;
     }
 
     static HTMLToken make_start_tag(FlyString const& tag_name)
     {
-        HTMLToken token;
-        token.m_type = Type::StartTag;
+        HTMLToken token { Type::StartTag };
         token.set_tag_name(tag_name);
         return token;
+    }
+
+    HTMLToken() = default;
+
+    HTMLToken(Type type)
+        : m_type(type)
+    {
     }
 
     bool is_doctype() const { return m_type == Type::DOCTYPE; }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -304,7 +304,7 @@ public:
         return *ptr;
     }
 
-    DoctypeData& doctype_data()
+    DoctypeData& ensure_doctype_data()
     {
         VERIFY(is_doctype());
         auto& ptr = m_data.get<OwnPtr<DoctypeData>>();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -47,6 +47,17 @@ public:
         Position value_end_position;
     };
 
+    struct DoctypeData {
+        // NOTE: "Missing" is a distinct state from the empty string.
+        String name;
+        String public_identifier;
+        String system_identifier;
+        bool missing_name { true };
+        bool missing_public_identifier { true };
+        bool missing_system_identifier { true };
+        bool force_quirks { false };
+    };
+
     static HTMLToken make_character(u32 code_point)
     {
         HTMLToken token;
@@ -252,6 +263,18 @@ public:
         });
     }
 
+    DoctypeData const& doctype_data() const
+    {
+        VERIFY(is_doctype());
+        return m_doctype;
+    }
+
+    DoctypeData& doctype_data()
+    {
+        VERIFY(is_doctype());
+        return m_doctype;
+    }
+
     Type type() const { return m_type; }
 
     String to_string() const;
@@ -263,17 +286,7 @@ private:
     Type m_type { Type::Invalid };
 
     // Type::DOCTYPE
-    struct {
-        // NOTE: "Missing" is a distinct state from the empty string.
-
-        String name;
-        bool missing_name { true };
-        String public_identifier;
-        bool missing_public_identifier { true };
-        String system_identifier;
-        bool missing_system_identifier { true };
-        bool force_quirks { false };
-    } m_doctype;
+    DoctypeData m_doctype;
 
     // Type::StartTag
     // Type::EndTag

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -97,6 +97,18 @@ public:
         }
     }
 
+    String const& comment() const
+    {
+        VERIFY(is_comment());
+        return m_comment_or_character.data;
+    }
+
+    void set_comment(String comment)
+    {
+        VERIFY(is_comment());
+        m_comment_or_character.data = move(comment);
+    }
+
     String tag_name() const
     {
         VERIFY(is_start_tag() || is_end_tag());

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -27,6 +28,22 @@ public:
         Comment,
         Character,
         EndOfFile,
+    };
+
+    struct Position {
+        size_t line { 0 };
+        size_t column { 0 };
+    };
+
+    struct AttributeBuilder {
+        String prefix;
+        String local_name;
+        String namespace_;
+        String value;
+        Position name_start_position;
+        Position value_start_position;
+        Position name_end_position;
+        Position value_end_position;
     };
 
     static HTMLToken make_character(u32 code_point)
@@ -158,32 +175,16 @@ public:
 
     String to_string() const;
 
-    auto const& start_position() const { return m_start_position; }
-    auto const& end_position() const { return m_end_position; }
+    Position const& start_position() const { return m_start_position; }
+    Position const& end_position() const { return m_end_position; }
 
-    auto const& attributes() const
+    Vector<Attribute> const& attributes() const
     {
         VERIFY(is_start_tag() || is_end_tag());
         return m_tag.attributes;
     }
 
 private:
-    struct Position {
-        size_t line { 0 };
-        size_t column { 0 };
-    };
-
-    struct AttributeBuilder {
-        String prefix;
-        String local_name;
-        String namespace_;
-        String value;
-        Position name_start_position;
-        Position value_start_position;
-        Position name_end_position;
-        Position value_end_position;
-    };
-
     Type m_type { Type::Invalid };
 
     // Type::DOCTYPE

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -35,7 +35,7 @@ public:
         size_t column { 0 };
     };
 
-    struct AttributeBuilder {
+    struct Attribute {
         String prefix;
         String local_name;
         String namespace_;
@@ -206,7 +206,7 @@ private:
         String tag_name;
         bool self_closing { false };
         bool self_closing_acknowledged { false };
-        Vector<AttributeBuilder> attributes;
+        Vector<Attribute> attributes;
     } m_tag;
 
     // Type::Comment

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -50,10 +50,7 @@ public:
     {
         HTMLToken token;
         token.m_type = Type::Character;
-        StringBuilder builder;
-        // FIXME: This narrows code_point to char, should this be append_code_point() instead?
-        builder.append(code_point);
-        token.m_comment_or_character.data = builder.to_string();
+        token.set_code_point(code_point);
         return token;
     }
 
@@ -95,6 +92,14 @@ public:
         default:
             return false;
         }
+    }
+
+    void set_code_point(u32 code_point)
+    {
+        VERIFY(is_character());
+        StringBuilder builder;
+        builder.append_code_point(code_point);
+        m_comment_or_character.data = builder.to_string();
     }
 
     String const& comment() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -58,7 +58,7 @@ public:
     {
         HTMLToken token;
         token.m_type = Type::StartTag;
-        token.m_tag.tag_name = tag_name;
+        token.set_tag_name(tag_name);
         return token;
     }
 
@@ -114,16 +114,28 @@ public:
         m_comment_or_character.data = move(comment);
     }
 
-    String tag_name() const
+    String const& tag_name() const
     {
         VERIFY(is_start_tag() || is_end_tag());
         return m_tag.tag_name;
+    }
+
+    void set_tag_name(String name)
+    {
+        VERIFY(is_start_tag() || is_end_tag());
+        m_tag.tag_name = move(name);
     }
 
     bool is_self_closing() const
     {
         VERIFY(is_start_tag() || is_end_tag());
         return m_tag.self_closing;
+    }
+
+    void set_self_closing(bool self_closing)
+    {
+        VERIFY(is_start_tag() || is_end_tag());
+        m_tag.self_closing = self_closing;
     }
 
     bool has_acknowledged_self_closing_flag() const
@@ -156,8 +168,8 @@ public:
     void adjust_tag_name(FlyString const& old_name, FlyString const& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
-        if (old_name == m_tag.tag_name)
-            m_tag.tag_name = new_name;
+        if (old_name == tag_name())
+            set_tag_name(new_name);
     }
 
     void adjust_attribute_name(FlyString const& old_name, FlyString const& new_name)

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -16,6 +16,8 @@
 
 namespace Web::HTML {
 
+class HTMLTokenizer;
+
 class HTMLToken {
     friend class HTMLDocumentParser;
     friend class HTMLTokenizer;
@@ -281,6 +283,9 @@ public:
 
     Position const& start_position() const { return m_start_position; }
     Position const& end_position() const { return m_end_position; }
+
+    void set_start_position(Badge<HTMLTokenizer>, Position start_position) { m_start_position = start_position; }
+    void set_end_position(Badge<HTMLTokenizer>, Position end_position) { m_end_position = end_position; }
 
 private:
     Type m_type { Type::Invalid };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -284,7 +284,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::Comment);
-                    m_current_token.m_start_position = nth_last_position(2);
+                    m_current_token.set_start_position({}, nth_last_position(2));
                     RECONSUME_IN(BogusComment);
                 }
                 ON_EOF
@@ -306,44 +306,44 @@ _StartOfFunction:
                 ON_WHITESPACE
                 {
                     m_current_token.set_tag_name(consume_current_builder());
-                    m_current_token.m_end_position = nth_last_position(1);
+                    m_current_token.set_end_position({}, nth_last_position(1));
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('/')
                 {
                     m_current_token.set_tag_name(consume_current_builder());
-                    m_current_token.m_end_position = nth_last_position(0);
+                    m_current_token.set_end_position({}, nth_last_position(0));
                     SWITCH_TO(SelfClosingStartTag);
                 }
                 ON('>')
                 {
                     m_current_token.set_tag_name(consume_current_builder());
-                    m_current_token.m_end_position = nth_last_position(1);
+                    m_current_token.set_end_position({}, nth_last_position(1));
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
                 {
                     m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
-                    m_current_token.m_end_position = nth_last_position(0);
+                    m_current_token.set_end_position({}, nth_last_position(0));
                     continue;
                 }
                 ON(0)
                 {
                     log_parse_error();
                     m_current_builder.append_code_point(0xFFFD);
-                    m_current_token.m_end_position = nth_last_position(0);
+                    m_current_token.set_end_position({}, nth_last_position(0));
                     continue;
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_end_position = nth_last_position(0);
+                    m_current_token.set_end_position({}, nth_last_position(0));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     m_current_builder.append_code_point(current_input_character.value());
-                    m_current_token.m_end_position = nth_last_position(0);
+                    m_current_token.set_end_position({}, nth_last_position(0));
                     continue;
                 }
             }
@@ -382,7 +382,7 @@ _StartOfFunction:
                 DONT_CONSUME_NEXT_INPUT_CHARACTER;
                 if (consume_next_if_match("--")) {
                     create_new_token(HTMLToken::Type::Comment);
-                    m_current_token.m_start_position = nth_last_position(4);
+                    m_current_token.set_start_position({}, nth_last_position(4));
                     SWITCH_TO(CommentStart);
                 }
                 if (consume_next_if_match("DOCTYPE", CaseSensitivity::CaseInsensitive)) {
@@ -2679,7 +2679,7 @@ void HTMLTokenizer::create_new_token(HTMLToken::Type type)
         break;
     }
 
-    m_current_token.m_start_position = nth_last_position(offset);
+    m_current_token.set_start_position({}, nth_last_position(offset));
 }
 
 HTMLTokenizer::HTMLTokenizer(StringView const& input, String const& encoding)
@@ -2712,7 +2712,7 @@ void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
         m_last_emitted_start_tag_name = token.tag_name();
-    token.m_end_position = nth_last_position(0);
+    token.set_end_position({}, nth_last_position(0));
 }
 
 bool HTMLTokenizer::current_end_tag_token_is_appropriate() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -305,19 +305,19 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('/')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     m_current_token.m_end_position = nth_last_position(0);
                     SWITCH_TO(SelfClosingStartTag);
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     m_current_token.m_end_position = nth_last_position(1);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
@@ -1031,7 +1031,7 @@ _StartOfFunction:
             {
                 ON('>')
                 {
-                    m_current_token.m_tag.self_closing = true;
+                    m_current_token.set_self_closing(true);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
@@ -1858,7 +1858,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1870,7 +1870,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1882,7 +1882,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1973,7 +1973,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1985,7 +1985,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -1997,7 +1997,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (!current_end_tag_token_is_appropriate()) {
                         m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                         m_queued_tokens.enqueue(HTMLToken::make_character('/'));
@@ -2188,7 +2188,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(BeforeAttributeName);
 
@@ -2203,7 +2203,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(SelfClosingStartTag);
 
@@ -2218,7 +2218,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
 
@@ -2524,7 +2524,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(BeforeAttributeName);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2537,7 +2537,7 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO(SelfClosingStartTag);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
@@ -2550,7 +2550,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.tag_name = consume_current_builder();
+                    m_current_token.set_tag_name(consume_current_builder());
                     if (current_end_tag_token_is_appropriate())
                         SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -440,7 +440,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -462,7 +462,7 @@ _StartOfFunction:
                 {
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
-                    m_current_token.doctype_data().missing_name = false;
+                    m_current_token.ensure_doctype_data().missing_name = false;
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
                 ON(0)
@@ -470,21 +470,21 @@ _StartOfFunction:
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_builder.append_code_point(0xFFFD);
-                    m_current_token.doctype_data().missing_name = false;
+                    m_current_token.ensure_doctype_data().missing_name = false;
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
                 ON('>')
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -492,7 +492,7 @@ _StartOfFunction:
                 {
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_builder.append_code_point(current_input_character.value());
-                    m_current_token.doctype_data().missing_name = false;
+                    m_current_token.ensure_doctype_data().missing_name = false;
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
             }
@@ -502,12 +502,12 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.doctype_data().name = consume_current_builder();
+                    m_current_token.ensure_doctype_data().name = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEName);
                 }
                 ON('>')
                 {
-                    m_current_token.doctype_data().name = consume_current_builder();
+                    m_current_token.ensure_doctype_data().name = consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
@@ -524,7 +524,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -549,7 +549,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -562,7 +562,7 @@ _StartOfFunction:
                         SWITCH_TO(AfterDOCTYPESystemKeyword);
                     }
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -577,32 +577,32 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().missing_public_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().missing_public_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -617,34 +617,34 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().system_identifier = {};
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().system_identifier = {};
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().system_identifier = {};
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().system_identifier = {};
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -658,31 +658,31 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.doctype_data().missing_public_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.doctype_data().missing_public_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -696,31 +696,31 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -730,7 +730,7 @@ _StartOfFunction:
             {
                 ON('"')
                 {
-                    m_current_token.doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEPublicIdentifier);
                 }
                 ON(0)
@@ -742,14 +742,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().public_identifier = consume_current_builder();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -765,7 +765,7 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
-                    m_current_token.doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEPublicIdentifier);
                 }
                 ON(0)
@@ -777,14 +777,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().public_identifier = consume_current_builder();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -800,7 +800,7 @@ _StartOfFunction:
             {
                 ON('"')
                 {
-                    m_current_token.doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPESystemIdentifier);
                 }
                 ON(0)
@@ -812,14 +812,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().public_identifier = consume_current_builder();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -835,7 +835,7 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
-                    m_current_token.doctype_data().system_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().system_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPESystemIdentifier);
                 }
                 ON(0)
@@ -847,14 +847,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().system_identifier = consume_current_builder();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().system_identifier = consume_current_builder();
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -879,26 +879,26 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -916,25 +916,25 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.doctype_data().missing_system_identifier = false;
+                    m_current_token.ensure_doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -953,7 +953,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.doctype_data().force_quirks = true;
+                    m_current_token.ensure_doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -440,7 +440,7 @@ _StartOfFunction:
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -462,7 +462,7 @@ _StartOfFunction:
                 {
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_builder.append_code_point(to_ascii_lowercase(current_input_character.value()));
-                    m_current_token.m_doctype.missing_name = false;
+                    m_current_token.doctype_data().missing_name = false;
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
                 ON(0)
@@ -470,21 +470,21 @@ _StartOfFunction:
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_builder.append_code_point(0xFFFD);
-                    m_current_token.m_doctype.missing_name = false;
+                    m_current_token.doctype_data().missing_name = false;
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
                 ON('>')
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -492,7 +492,7 @@ _StartOfFunction:
                 {
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_builder.append_code_point(current_input_character.value());
-                    m_current_token.m_doctype.missing_name = false;
+                    m_current_token.doctype_data().missing_name = false;
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(DOCTYPEName);
                 }
             }
@@ -502,12 +502,12 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_doctype.name = consume_current_builder();
+                    m_current_token.doctype_data().name = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEName);
                 }
                 ON('>')
                 {
-                    m_current_token.m_doctype.name = consume_current_builder();
+                    m_current_token.doctype_data().name = consume_current_builder();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
@@ -524,7 +524,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -549,7 +549,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -562,7 +562,7 @@ _StartOfFunction:
                         SWITCH_TO(AfterDOCTYPESystemKeyword);
                     }
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -577,32 +577,32 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.missing_public_identifier = false;
+                    m_current_token.doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.missing_public_identifier = false;
+                    m_current_token.doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -617,34 +617,34 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier = {};
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().system_identifier = {};
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier = {};
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().system_identifier = {};
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -658,31 +658,31 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.m_doctype.missing_public_identifier = false;
+                    m_current_token.doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.m_doctype.missing_public_identifier = false;
+                    m_current_token.doctype_data().missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -696,31 +696,31 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -730,7 +730,7 @@ _StartOfFunction:
             {
                 ON('"')
                 {
-                    m_current_token.m_doctype.public_identifier = consume_current_builder();
+                    m_current_token.doctype_data().public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEPublicIdentifier);
                 }
                 ON(0)
@@ -742,14 +742,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.public_identifier = consume_current_builder();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -765,7 +765,7 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
-                    m_current_token.m_doctype.public_identifier = consume_current_builder();
+                    m_current_token.doctype_data().public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPEPublicIdentifier);
                 }
                 ON(0)
@@ -777,14 +777,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.public_identifier = consume_current_builder();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -800,7 +800,7 @@ _StartOfFunction:
             {
                 ON('"')
                 {
-                    m_current_token.m_doctype.public_identifier = consume_current_builder();
+                    m_current_token.doctype_data().public_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPESystemIdentifier);
                 }
                 ON(0)
@@ -812,14 +812,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.public_identifier = consume_current_builder();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().public_identifier = consume_current_builder();
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -835,7 +835,7 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
-                    m_current_token.m_doctype.system_identifier = consume_current_builder();
+                    m_current_token.doctype_data().system_identifier = consume_current_builder();
                     SWITCH_TO(AfterDOCTYPESystemIdentifier);
                 }
                 ON(0)
@@ -847,14 +847,14 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.system_identifier = consume_current_builder();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().system_identifier = consume_current_builder();
+                    m_current_token.doctype_data().force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
@@ -879,26 +879,26 @@ _StartOfFunction:
                 ON('"')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -916,25 +916,25 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    m_current_token.m_doctype.missing_system_identifier = false;
+                    m_current_token.doctype_data().missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -953,7 +953,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_doctype.force_quirks = true;
+                    m_current_token.doctype_data().force_quirks = true;
                     m_queued_tokens.enqueue(move(m_current_token));
                     EMIT_EOF;
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -996,8 +996,8 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    if (!m_current_token.m_tag.attributes.is_empty())
-                        m_current_token.m_tag.attributes.last().name_end_position = nth_last_position(1);
+                    if (m_current_token.has_attributes())
+                        m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('>')
@@ -1014,14 +1014,14 @@ _StartOfFunction:
                     HTMLToken::Attribute new_attribute;
                     new_attribute.name_start_position = nth_last_position(1);
                     m_current_builder.append_code_point(current_input_character.value());
-                    m_current_token.m_tag.attributes.append(new_attribute);
+                    m_current_token.add_attribute(move(new_attribute));
                     SWITCH_TO_WITH_UNCLEAN_BUILDER(AttributeName);
                 }
                 ANYTHING_ELSE
                 {
                     HTMLToken::Attribute new_attribute;
                     new_attribute.name_start_position = nth_last_position(1);
-                    m_current_token.m_tag.attributes.append(move(new_attribute));
+                    m_current_token.add_attribute(move(new_attribute));
                     RECONSUME_IN(AttributeName);
                 }
             }
@@ -1051,28 +1051,28 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('/')
                 {
-                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON_EOF
                 {
-                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('=')
                 {
-                    m_current_token.m_tag.attributes.last().name_end_position = nth_last_position(1);
-                    m_current_token.m_tag.attributes.last().local_name = consume_current_builder();
+                    m_current_token.last_attribute().name_end_position = nth_last_position(1);
+                    m_current_token.last_attribute().local_name = consume_current_builder();
                     SWITCH_TO(BeforeAttributeValue);
                 }
                 ON_ASCII_UPPER_ALPHA
@@ -1122,7 +1122,7 @@ _StartOfFunction:
                 }
                 ON('=')
                 {
-                    m_current_token.m_tag.attributes.last().name_end_position = nth_last_position(1);
+                    m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeValue);
                 }
                 ON('>')
@@ -1136,8 +1136,8 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_tag.attributes.append({});
-                    m_current_token.m_tag.attributes.last().name_start_position = m_source_positions.last();
+                    m_current_token.add_attribute({});
+                    m_current_token.last_attribute().name_start_position = m_source_positions.last();
                     RECONSUME_IN(AttributeName);
                 }
             }
@@ -1145,7 +1145,7 @@ _StartOfFunction:
 
             BEGIN_STATE(BeforeAttributeValue)
             {
-                m_current_token.m_tag.attributes.last().value_start_position = nth_last_position(1);
+                m_current_token.last_attribute().value_start_position = nth_last_position(1);
                 ON_WHITESPACE
                 {
                     continue;
@@ -1174,12 +1174,12 @@ _StartOfFunction:
             {
                 ON('"')
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
+                    m_current_token.last_attribute().value = consume_current_builder();
                     SWITCH_TO(AfterAttributeValueQuoted);
                 }
                 ON('&')
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
+                    m_current_token.last_attribute().value = consume_current_builder();
                     m_return_state = State::AttributeValueDoubleQuoted;
                     SWITCH_TO(CharacterReference);
                 }
@@ -1206,12 +1206,12 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
+                    m_current_token.last_attribute().value = consume_current_builder();
                     SWITCH_TO(AfterAttributeValueQuoted);
                 }
                 ON('&')
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
+                    m_current_token.last_attribute().value = consume_current_builder();
                     m_return_state = State::AttributeValueSingleQuoted;
                     SWITCH_TO(CharacterReference);
                 }
@@ -1238,20 +1238,20 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
-                    m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(2);
+                    m_current_token.last_attribute().value = consume_current_builder();
+                    m_current_token.last_attribute().value_end_position = nth_last_position(2);
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('&')
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
+                    m_current_token.last_attribute().value = consume_current_builder();
                     m_return_state = State::AttributeValueUnquoted;
                     SWITCH_TO(CharacterReference);
                 }
                 ON('>')
                 {
-                    m_current_token.m_tag.attributes.last().value = consume_current_builder();
-                    m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(1);
+                    m_current_token.last_attribute().value = consume_current_builder();
+                    m_current_token.last_attribute().value_end_position = nth_last_position(1);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON(0)
@@ -1301,7 +1301,7 @@ _StartOfFunction:
 
             BEGIN_STATE(AfterAttributeValueQuoted)
             {
-                m_current_token.m_tag.attributes.last().value_end_position = nth_last_position(1);
+                m_current_token.last_attribute().value_end_position = nth_last_position(1);
                 ON_WHITESPACE
                 {
                     SWITCH_TO(BeforeAttributeName);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -406,7 +406,7 @@ _StartOfFunction:
             {
                 ON('>')
                 {
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
@@ -1392,7 +1392,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
@@ -1408,7 +1408,7 @@ _StartOfFunction:
             {
                 ON('>')
                 {
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON('!')
@@ -1423,7 +1423,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
@@ -1445,13 +1445,13 @@ _StartOfFunction:
                 ON('>')
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }
@@ -1472,7 +1472,7 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.m_comment_or_character.data = consume_current_builder();
+                    m_current_token.set_comment(consume_current_builder());
                     EMIT_CURRENT_TOKEN;
                     EMIT_EOF;
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -75,18 +75,17 @@ namespace Web::HTML {
         goto new_state;                                                 \
     } while (0)
 
-#define FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE                               \
-    do {                                                                                 \
-        for (auto code_point : m_temporary_buffer) {                                     \
-            if (consumed_as_part_of_an_attribute()) {                                    \
-                m_current_builder.append_code_point(code_point);                         \
-            } else {                                                                     \
-                create_new_token(HTMLToken::Type::Character);                            \
-                m_current_builder.append_code_point(code_point);                         \
-                m_current_token.m_comment_or_character.data = consume_current_builder(); \
-                m_queued_tokens.enqueue(move(m_current_token));                          \
-            }                                                                            \
-        }                                                                                \
+#define FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE       \
+    do {                                                         \
+        for (auto code_point : m_temporary_buffer) {             \
+            if (consumed_as_part_of_an_attribute()) {            \
+                m_current_builder.append_code_point(code_point); \
+            } else {                                             \
+                create_new_token(HTMLToken::Type::Character);    \
+                m_current_token.set_code_point(code_point);      \
+                m_queued_tokens.enqueue(move(m_current_token));  \
+            }                                                    \
+        }                                                        \
     } while (0)
 
 #define DONT_CONSUME_NEXT_INPUT_CHARACTER \
@@ -142,13 +141,12 @@ namespace Web::HTML {
         return m_queued_tokens.dequeue();               \
     } while (0)
 
-#define EMIT_CHARACTER(code_point)                                               \
-    do {                                                                         \
-        create_new_token(HTMLToken::Type::Character);                            \
-        m_current_builder.append_code_point(code_point);                         \
-        m_current_token.m_comment_or_character.data = consume_current_builder(); \
-        m_queued_tokens.enqueue(move(m_current_token));                          \
-        return m_queued_tokens.dequeue();                                        \
+#define EMIT_CHARACTER(code_point)                      \
+    do {                                                \
+        create_new_token(HTMLToken::Type::Character);   \
+        m_current_token.set_code_point(code_point);     \
+        m_queued_tokens.enqueue(move(m_current_token)); \
+        return m_queued_tokens.dequeue();               \
     } while (0)
 
 #define EMIT_CURRENT_CHARACTER \

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1013,7 +1013,7 @@ _StartOfFunction:
                 ON('=')
                 {
                     log_parse_error();
-                    auto new_attribute = HTMLToken::AttributeBuilder();
+                    HTMLToken::Attribute new_attribute;
                     new_attribute.name_start_position = nth_last_position(1);
                     m_current_builder.append_code_point(current_input_character.value());
                     m_current_token.m_tag.attributes.append(new_attribute);
@@ -1021,7 +1021,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    auto new_attribute = HTMLToken::AttributeBuilder();
+                    HTMLToken::Attribute new_attribute;
                     new_attribute.name_start_position = nth_last_position(1);
                     m_current_token.m_tag.attributes.append(move(new_attribute));
                     RECONSUME_IN(AttributeName);
@@ -1138,7 +1138,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_tag.attributes.append(HTMLToken::AttributeBuilder());
+                    m_current_token.m_tag.attributes.append({});
                     m_current_token.m_tag.attributes.last().name_start_position = m_source_positions.last();
                     RECONSUME_IN(AttributeName);
                 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2665,8 +2665,7 @@ bool HTMLTokenizer::consume_next_if_match(StringView const& string, CaseSensitiv
 
 void HTMLTokenizer::create_new_token(HTMLToken::Type type)
 {
-    m_current_token = {};
-    m_current_token.m_type = type;
+    m_current_token = { type };
     size_t offset = 0;
     switch (type) {
     case HTMLToken::Type::StartTag:

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -132,7 +132,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
                 { palette.syntax_keyword(), {}, false, true },
                 token->is_start_tag() ? AugmentedTokenKind::OpenTag : AugmentedTokenKind::CloseTag);
 
-            for (auto& attribute : token->attributes()) {
+            token->for_each_attribute([&](auto& attribute) {
                 highlight(
                     attribute.name_start_position.line,
                     attribute.name_start_position.column + token_start_offset,
@@ -147,7 +147,8 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
                     attribute.value_end_position.column + token_start_offset,
                     { palette.syntax_string(), {} },
                     AugmentedTokenKind::AttributeValue);
-            }
+                return IterationDecision::Continue;
+            });
         } else if (token->is_doctype()) {
             highlight(
                 token->start_position().line,


### PR DESCRIPTION
This PR aims to make HTML tokenization faster and more memory efficient. While #8687 has brought `sizeof(HTMLToken)` from almost a KB down to 68 bytes, this reduces it further, down to 32 bytes. Also, there is a 20-50% decrease in tokenization time and a 4-20% improvment in document parsing time (which includes tokenization).

The PR has two distinct parts:
In the first part, all direct access of `HTMLToken`s members is replaced with getters and setters, which allows removal of the `friend class` declarations.

In the second part, the internal storage mechanism of `HMTLToken` is optimized. This means that there isn't space reserved for data of all token types. Rather, there are a few fixed members, as well as a `union`, which contains either the code point (for Character tokens), or a pointer (for Tag and DOCTYPE tokens).

Even though this PR leads to some additional heap allocations by using pointers, performance increases and memory consumption decreases considerably. This is because the allocations only happen for DOCTYPE tokens (1 per document) and for Tag tokens (but only those with attributes). In sum, around 5 percent of all tokens emitted need to heap-allocate. This is negligible, especially considering that Strings (of which there are many) are also heap-allocated.