### PR TITLE
Kernel: Optionally dump scheduler state with stack traces

### DIFF
--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -32,10 +32,10 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         return;
     }
 
-    if (m_modifiers == (Mod_Alt | Mod_Shift) && byte == 0x58) {
+    if ((m_modifiers == (Mod_Alt | Mod_Shift) || m_modifiers == (Mod_Ctrl | Mod_Alt | Mod_Shift)) && byte == 0x58) {
         // Alt+Shift+F12 pressed, dump some kernel state to the debug console.
         ConsoleManagement::the().switch_to_debug();
-        Scheduler::dump_scheduler_state();
+        Scheduler::dump_scheduler_state(m_modifiers == (Mod_Ctrl | Mod_Alt | Mod_Shift));
     }
 
     dbgln_if(KEYBOARD_DEBUG, "Keyboard::irq_handle_byte_read: {:#02x} {}", ch, (pressed ? "down" : "up"));

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -53,7 +53,7 @@ static SpinLock<u8> g_ready_queues_lock;
 static u32 g_ready_queues_mask;
 static constexpr u32 g_ready_queue_buckets = sizeof(g_ready_queues_mask) * 8;
 READONLY_AFTER_INIT static ThreadReadyQueue* g_ready_queues; // g_ready_queue_buckets entries
-static void dump_thread_list();
+static void dump_thread_list(bool = false);
 
 static inline u32 thread_priority_to_priority_index(u32 thread_priority)
 {
@@ -526,9 +526,9 @@ void Scheduler::idle_loop(void*)
     }
 }
 
-void Scheduler::dump_scheduler_state()
+void Scheduler::dump_scheduler_state(bool with_stack_traces)
 {
-    dump_thread_list();
+    dump_thread_list(with_stack_traces);
 }
 
 bool Scheduler::is_initialized()
@@ -537,7 +537,7 @@ bool Scheduler::is_initialized()
     return Processor::idle_thread() != nullptr;
 }
 
-void dump_thread_list()
+void dump_thread_list(bool with_stack_traces)
 {
     dbgln("Scheduler thread list for processor {}:", Processor::id());
 
@@ -580,6 +580,8 @@ void dump_thread_list()
                 thread.times_scheduled());
             break;
         }
+        if (with_stack_traces)
+            dbgln("{}", thread.backtrace());
     });
 }
 

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -47,7 +47,7 @@ public:
     static Thread* peek_next_runnable_thread();
     static bool dequeue_runnable_thread(Thread&, bool = false);
     static void queue_runnable_thread(Thread&);
-    static void dump_scheduler_state();
+    static void dump_scheduler_state(bool = false);
     static bool is_initialized();
 };
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1189,6 +1189,8 @@ public:
 
     InodeIndex global_procfs_inode_index() const { return m_global_procfs_inode_index; }
 
+    String backtrace();
+
 private:
     Thread(NonnullRefPtr<Process>, NonnullOwnPtr<Region>, NonnullRefPtr<Timer>, FPUState*);
 
@@ -1255,7 +1257,6 @@ private:
 
     LockMode unlock_process_if_locked(u32&);
     void relock_process(LockMode, u32);
-    String backtrace();
     void reset_fpu_state();
 
     mutable RecursiveSpinLock m_lock;


### PR DESCRIPTION
This will dump stack traces of all threads when pressing
Ctrl+Shift+Alt+F12