### PR TITLE
LibC: Don't include AK headers in system headers

### DIFF
--- a/Userland/Libraries/LibC/inttypes.h
+++ b/Userland/Libraries/LibC/inttypes.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Platform.h>
 #include <bits/stdint.h>
 #include <sys/cdefs.h>
 
@@ -19,7 +18,7 @@ __BEGIN_DECLS
 #define PRIi8 "d"
 #define PRIi16 "d"
 #define PRIi32 "d"
-#if ARCH(I386)
+#ifndef __x86_64__
 #    define PRIi64 "lld"
 #else
 #    define PRIi64 "ld"
@@ -28,14 +27,14 @@ __BEGIN_DECLS
 #define PRIo8 "o"
 #define PRIo16 "o"
 #define PRIo32 "o"
-#if ARCH(I386)
+#ifndef __x86_64__
 #    define PRIo64 "llo"
 #else
 #    define PRIo64 "lo"
 #endif
 #define PRIu16 "u"
 #define PRIu32 "u"
-#if ARCH(I386)
+#ifndef __x86_64__
 #    define PRIu64 "llu"
 #    define PRIuPTR "x"
 #else
@@ -48,7 +47,7 @@ __BEGIN_DECLS
 #define PRIX16 "hX"
 #define PRIx32 "x"
 #define PRIX32 "X"
-#if ARCH(I386)
+#ifndef __x86_64__
 #    define PRIx64 "llx"
 #    define PRIX64 "llX"
 #    define PRIxPTR "x"


### PR DESCRIPTION
AK/Platform.h might not be available when building the toolchain.