### PR TITLE
Kernel: Fix some Lock problems and VERIFY statements

### DIFF
--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -11,7 +11,7 @@ namespace Kernel {
 KResultOr<FlatPtr> Process::sys$yield()
 {
     REQUIRE_PROMISE(stdio);
-    Thread::current()->yield_without_holding_big_lock();
+    Thread::current()->yield_and_release_relock_big_lock();
     return 0;
 }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -819,7 +819,7 @@ public:
         while (state() == Thread::Stopped) {
             lock.unlock();
             // We shouldn't be holding the big lock here
-            yield_while_not_holding_big_lock();
+            yield_assuming_not_holding_big_lock();
             lock.lock();
         }
     }
@@ -905,7 +905,7 @@ public:
             // Yield to the scheduler, and wait for us to resume unblocked.
             VERIFY(!g_scheduler_lock.own_lock());
             VERIFY(Processor::current().in_critical());
-            yield_while_not_holding_big_lock();
+            yield_assuming_not_holding_big_lock();
             VERIFY(Processor::current().in_critical());
 
             ScopedSpinLock block_lock2(m_block_lock);
@@ -1341,8 +1341,8 @@ private:
 
     bool m_is_profiling_suppressed { false };
 
-    void yield_without_holding_big_lock();
-    void yield_while_not_holding_big_lock();
+    void yield_and_release_relock_big_lock();
+    void yield_assuming_not_holding_big_lock();
     void drop_thread_count(bool);
 };
 


### PR DESCRIPTION
When a Lock blocks (e.g. due to a mode mismatch or because someone
else holds it) the lock mode will be updated to what was requested.

There were also some cases where restoring locks may have not worked
as intended as it may have been held already by the same thread.

Fixes #8787

@Lubrsi does this make any difference?