### PR TITLE
VimEditingEngine: Add 3 Vim bindings to insert mode

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -106,6 +106,8 @@ public:
     TextPosition first_word_break_before(const TextPosition&, bool start_at_column_before) const;
     TextPosition first_word_break_after(const TextPosition&) const;
 
+    TextPosition first_word_before(const TextPosition&, bool start_at_column_before) const;
+
     void add_to_undo_stack(NonnullOwnPtr<TextDocumentUndoCommand>);
 
     bool can_undo() const { return m_undo_stack.can_undo(); }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -912,6 +912,23 @@ void TextEditor::delete_current_line()
     execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
 }
 
+void TextEditor::delete_previous_char()
+{
+    if (!is_editable())
+        return;
+
+    if (has_selection())
+        return delete_selection();
+
+    TextRange to_erase({ m_cursor.line(), m_cursor.column() - 1 }, m_cursor);
+    if (m_cursor.column() == 0 && m_cursor.line() != 0) {
+        size_t prev_line_len = line(m_cursor.line() - 1).length();
+        to_erase.set_start({ m_cursor.line() - 1, prev_line_len });
+    }
+
+    execute<RemoveTextCommand>(document().text_in_range(to_erase), to_erase);
+}
+
 void TextEditor::do_delete()
 {
     if (!is_editable())

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -884,6 +884,12 @@ void TextEditor::keydown_event(KeyEvent& event)
     event.ignore();
 }
 
+void TextEditor::delete_previous_word()
+{
+    TextRange to_erase(document().first_word_before(m_cursor, true), m_cursor);
+    execute<RemoveTextCommand>(document().text_in_range(to_erase), to_erase);
+}
+
 void TextEditor::delete_current_line()
 {
     if (has_selection())

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -929,6 +929,13 @@ void TextEditor::delete_previous_char()
     execute<RemoveTextCommand>(document().text_in_range(to_erase), to_erase);
 }
 
+void TextEditor::delete_from_line_start_to_cursor()
+{
+    TextPosition start(m_cursor.line(), current_line().first_non_whitespace_column());
+    TextRange to_erase(start, m_cursor);
+    execute<RemoveTextCommand>(document().text_in_range(to_erase), to_erase);
+}
+
 void TextEditor::do_delete()
 {
     if (!is_editable())

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -135,6 +135,7 @@ public:
     void paste();
     void do_delete();
     void delete_current_line();
+    void delete_previous_word();
     void select_all();
     virtual void undo();
     virtual void redo();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -136,6 +136,7 @@ public:
     void do_delete();
     void delete_current_line();
     void delete_previous_word();
+    void delete_previous_char();
     void select_all();
     virtual void undo();
     virtual void redo();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -137,6 +137,7 @@ public:
     void delete_current_line();
     void delete_previous_word();
     void delete_previous_char();
+    void delete_from_line_start_to_cursor();
     void select_all();
     virtual void undo();
     virtual void redo();

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -766,6 +766,9 @@ bool VimEditingEngine::on_key_in_insert_mode(const KeyEvent& event)
         case KeyCode::Key_W:
             m_editor->delete_previous_word();
             return true;
+        case KeyCode::Key_H:
+            m_editor->delete_previous_char();
+            return true;
         default:
             break;
         }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -769,6 +769,9 @@ bool VimEditingEngine::on_key_in_insert_mode(const KeyEvent& event)
         case KeyCode::Key_H:
             m_editor->delete_previous_char();
             return true;
+        case KeyCode::Key_U:
+            m_editor->delete_from_line_start_to_cursor();
+            return true;
         default:
             break;
         }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -761,6 +761,16 @@ bool VimEditingEngine::on_key_in_insert_mode(const KeyEvent& event)
     if (EditingEngine::on_key(event))
         return true;
 
+    if (event.ctrl()) {
+        switch (event.key()) {
+        case KeyCode::Key_W:
+            m_editor->delete_previous_word();
+            return true;
+        default:
+            break;
+        }
+    }
+
     if (event.key() == KeyCode::Key_Escape || (event.ctrl() && event.key() == KeyCode::Key_LeftBracket) || (event.ctrl() && event.key() == KeyCode::Key_C)) {
         if (m_editor->cursor().column() > 0)
             move_one_left();


### PR DESCRIPTION
Add CTRL-W, CTRL-H, and CTRL-U in insert mode to Vim emulation. These key combinations revolve around deletion in insert mode.

- CTRL-W deletes the previous word
- CTRL-H deletes the previous character
- CTRL-U deletes the characters from the beginning of the line to the cursor