### PR TITLE
ELF-DynamicLinker: Evaluate symbols in library insertion order

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -34,7 +34,7 @@ namespace ELF {
 
 static HashMap<String, NonnullRefPtr<ELF::DynamicLoader>> s_loaders;
 static String s_main_program_name;
-static HashMap<String, NonnullRefPtr<ELF::DynamicObject>> s_global_objects;
+static OrderedHashMap<String, NonnullRefPtr<ELF::DynamicObject>> s_global_objects;
 
 using EntryPointFunction = int (*)(int, char**, char**);
 using LibCExitFunction = void (*)(int);


### PR DESCRIPTION
When loading libraries, it is required that each library uses the same instance of each symbol, and that they use the one from the executable if any. This is barely noticeable if done incorrectly; except that it completely breaks RTTI on Clang. This switches the hashmap to be ordered; tested to work for Clang by @Bertaland