### PR TITLE
LibJS: Replace the boolean argument of Object::set with an enum class 

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -234,7 +234,7 @@ void GetById::execute_impl(Bytecode::Interpreter& interpreter) const
 void PutById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     if (auto* object = interpreter.reg(m_base).to_object(interpreter.global_object()))
-        object->set(interpreter.current_executable().get_string(m_property), interpreter.accumulator(), true);
+        object->set(interpreter.current_executable().get_string(m_property), interpreter.accumulator(), Object::ShouldThrowExceptions::Yes);
 }
 
 void Jump::execute_impl(Bytecode::Interpreter& interpreter) const
@@ -427,7 +427,7 @@ void PutByValue::execute_impl(Bytecode::Interpreter& interpreter) const
         auto property_key = interpreter.reg(m_property).to_property_key(interpreter.global_object());
         if (interpreter.vm().exception())
             return;
-        object->set(property_key, interpreter.accumulator(), true);
+        object->set(property_key, interpreter.accumulator(), Object::ShouldThrowExceptions::Yes);
     }
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -70,7 +70,7 @@ bool ArgumentsObject::internal_set(PropertyName const& property_name, Value valu
     // 3. If isMapped is true, then
     if (is_mapped) {
         // a. Let setStatus be Set(map, P, V, false).
-        auto set_status = m_parameter_map->set(property_name, value, false);
+        auto set_status = m_parameter_map->set(property_name, value, Object::ShouldThrowExceptions::No);
         // b. Assert: setStatus is true because formal parameters mapped by argument objects are always writable.
         VERIFY(set_status);
     }
@@ -163,7 +163,7 @@ bool ArgumentsObject::internal_define_own_property(PropertyName const& property_
             // i. If Desc.[[Value]] is present, then
             if (descriptor.value.has_value()) {
                 // 1. Let setStatus be Set(map, P, Desc.[[Value]], false).
-                bool set_status = map.set(property_name, descriptor.value.value(), false);
+                bool set_status = map.set(property_name, descriptor.value.value(), Object::ShouldThrowExceptions::No);
                 // 2. Assert: setStatus is true because formal parameters mapped by argument objects are always writable.
                 VERIFY(set_status);
             }

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -76,7 +76,9 @@ Value ArrayConstructor::construct(FunctionObject& new_target)
                 return {};
             }
         }
-        array->set(vm.names.length, Value(int_length), true);
+        array->set(vm.names.length, Value(int_length), Object::ShouldThrowExceptions::Yes);
+        if (vm.exception())
+            return {};
         return array;
     }
 
@@ -139,7 +141,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
                 return {};
 
             if (!next) {
-                array_object.set(vm.names.length, Value(k), true);
+                array_object.set(vm.names.length, Value(k), Object::ShouldThrowExceptions::Yes);
                 if (vm.exception())
                     return {};
                 return array;
@@ -204,7 +206,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
         array_object.create_data_property_or_throw(k, mapped_value);
     }
 
-    array_object.set(vm.names.length, Value(length), true);
+    array_object.set(vm.names.length, Value(length), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
 
@@ -240,7 +242,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::of)
         if (vm.exception())
             return {};
     }
-    array_object.set(vm.names.length, Value(vm.argument_count()), true);
+    array_object.set(vm.names.length, Value(vm.argument_count()), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return array;

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -358,12 +358,12 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
         return {};
     }
     for (size_t i = 0; i < argument_count; ++i) {
-        this_object->set(length + i, vm.argument(i), true);
+        this_object->set(length + i, vm.argument(i), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
     auto new_length_value = Value(new_length);
-    this_object->set(vm.names.length, new_length_value, true);
+    this_object->set(vm.names.length, new_length_value, Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return new_length_value;
@@ -397,7 +397,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::unshift)
                 auto from_value = this_object->get(from);
                 if (vm.exception())
                     return {};
-                this_object->set(to, from_value, true);
+                this_object->set(to, from_value, Object::ShouldThrowExceptions::Yes);
                 if (vm.exception())
                     return {};
             } else {
@@ -408,13 +408,13 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::unshift)
         }
 
         for (size_t j = 0; j < arg_count; j++) {
-            this_object->set(j, vm.argument(j), true);
+            this_object->set(j, vm.argument(j), Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         }
     }
 
-    this_object->set(vm.names.length, Value(new_length), true);
+    this_object->set(vm.names.length, Value(new_length), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return Value(new_length);
@@ -430,7 +430,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     if (vm.exception())
         return {};
     if (length == 0) {
-        this_object->set(vm.names.length, Value(0), true);
+        this_object->set(vm.names.length, Value(0), Object::ShouldThrowExceptions::Yes);
         return js_undefined();
     }
     auto index = length - 1;
@@ -440,7 +440,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::pop)
     this_object->delete_property_or_throw(index);
     if (vm.exception())
         return {};
-    this_object->set(vm.names.length, Value(index), true);
+    this_object->set(vm.names.length, Value(index), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return element;
@@ -456,7 +456,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
     if (vm.exception())
         return {};
     if (length == 0) {
-        this_object->set(vm.names.length, Value(0), true);
+        this_object->set(vm.names.length, Value(0), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
         return js_undefined();
@@ -475,7 +475,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
             auto from_value = this_object->get(from);
             if (vm.exception())
                 return {};
-            this_object->set(to, from_value, true);
+            this_object->set(to, from_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         } else {
@@ -489,7 +489,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::shift)
     if (vm.exception())
         return {};
 
-    this_object->set(vm.names.length, Value(length - 1), true);
+    this_object->set(vm.names.length, Value(length - 1), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return first;
@@ -681,7 +681,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::concat)
             return {};
     }
 
-    new_array->set(vm.names.length, Value(n), true);
+    new_array->set(vm.names.length, Value(n), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return Value(new_array);
@@ -758,7 +758,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::slice)
         ++index;
     }
 
-    new_array->set(vm.names.length, Value(index), true);
+    new_array->set(vm.names.length, Value(index), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
 
@@ -1084,14 +1084,14 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reverse)
         }
 
         if (lower_exists && upper_exists) {
-            this_object->set(lower, upper_value, true);
+            this_object->set(lower, upper_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
-            this_object->set(upper, lower_value, true);
+            this_object->set(upper, lower_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         } else if (!lower_exists && upper_exists) {
-            this_object->set(lower, upper_value, true);
+            this_object->set(lower, upper_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
             this_object->delete_property_or_throw(upper);
@@ -1101,7 +1101,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reverse)
             this_object->delete_property_or_throw(lower);
             if (vm.exception())
                 return {};
-            this_object->set(upper, lower_value, true);
+            this_object->set(upper, lower_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         }
@@ -1260,7 +1260,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::sort)
         return {};
 
     for (size_t j = 0; j < items.size(); ++j) {
-        object->set(j, items[j], true);
+        object->set(j, items[j], Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -1673,7 +1673,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
         }
     }
 
-    removed_elements->set(vm.names.length, Value(actual_delete_count), true);
+    removed_elements->set(vm.names.length, Value(actual_delete_count), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
 
@@ -1691,7 +1691,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
                 if (vm.exception())
                     return {};
 
-                this_object->set(to, from_value, true);
+                this_object->set(to, from_value, Object::ShouldThrowExceptions::Yes);
             } else {
                 this_object->delete_property_or_throw(to);
             }
@@ -1717,7 +1717,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
                 auto from_value = this_object->get(from_index);
                 if (vm.exception())
                     return {};
-                this_object->set(to, from_value, true);
+                this_object->set(to, from_value, Object::ShouldThrowExceptions::Yes);
             } else {
                 this_object->delete_property_or_throw(to);
             }
@@ -1727,12 +1727,12 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
     }
 
     for (u64 i = 0; i < insert_count; ++i) {
-        this_object->set(actual_start + i, vm.argument(i + 2), true);
+        this_object->set(actual_start + i, vm.argument(i + 2), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
 
-    this_object->set(vm.names.length, Value(new_length), true);
+    this_object->set(vm.names.length, Value(new_length), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
 
@@ -1783,7 +1783,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::fill)
         to = min(relative_end, length);
 
     for (u64 i = from; i < to; i++) {
-        this_object->set(i, vm.argument(0), true);
+        this_object->set(i, vm.argument(0), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -2000,7 +2000,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::copy_within)
             auto from_value = this_object->get(from_i);
             if (vm.exception())
                 return {};
-            this_object->set(to_i, from_value, true);
+            this_object->set(to_i, from_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         } else {

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
@@ -225,7 +225,7 @@ void GlobalEnvironment::create_global_function_binding(FlyString const& name, Va
     global_object.define_property_or_throw(name, desc);
     if (vm.exception())
         return;
-    global_object.set(name, value, false);
+    global_object.set(name, value, Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return;
     if (!m_var_names.contains_slow(name))

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -92,7 +92,7 @@ Value Object::get(PropertyName const& property_name) const
 // 7.3.3 GetV ( V, P ) is defined as Value::get().
 
 // 7.3.4 Set ( O, P, V, Throw ), https://tc39.es/ecma262/#sec-set-o-p-v-throw
-bool Object::set(PropertyName const& property_name, Value value, bool throw_exceptions)
+bool Object::set(PropertyName const& property_name, Value value, ShouldThrowExceptions throw_exceptions)
 {
     VERIFY(!value.is_empty());
     auto& vm = this->vm();
@@ -110,7 +110,7 @@ bool Object::set(PropertyName const& property_name, Value value, bool throw_exce
         return {};
 
     // 5. If success is false and Throw is true, throw a TypeError exception.
-    if (!success && throw_exceptions) {
+    if (!success && throw_exceptions == ShouldThrowExceptions::Yes) {
         // FIXME: Improve/contextualize error message
         vm.throw_exception<TypeError>(global_object(), ErrorType::ObjectSetReturnedFalse);
         return {};

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -41,11 +41,6 @@ public:
         KeyAndValue,
     };
 
-    enum class PutOwnPropertyMode {
-        Put,
-        DefineProperty,
-    };
-
     enum class IntegrityLevel {
         Sealed,
         Frozen,

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -46,6 +46,11 @@ public:
         Frozen,
     };
 
+    enum class ShouldThrowExceptions {
+        No,
+        Yes,
+    };
+
     // Please DO NOT make up your own non-standard methods unless you
     // have a very good reason to do so. If any object abstract
     // operation from the spec is missing, add it instead.
@@ -69,7 +74,7 @@ public:
     // 7.3 Operations on Objects, https://tc39.es/ecma262/#sec-operations-on-objects
 
     Value get(PropertyName const&) const;
-    bool set(PropertyName const&, Value, bool throw_exceptions);
+    bool set(PropertyName const&, Value, ShouldThrowExceptions);
     bool create_data_property(PropertyName const&, Value);
     bool create_method_property(PropertyName const&, Value);
     bool create_data_property_or_throw(PropertyName const&, Value);

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -506,7 +506,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::assign)
                 return {};
 
             // b. Perform ? Set(to, nextKey, propValue, true).
-            to->set(property_name, prop_value, true);
+            to->set(property_name, prop_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -34,7 +34,7 @@ Optional<Variable> ObjectEnvironment::get_from_environment(FlyString const& name
 
 bool ObjectEnvironment::put_into_environment(FlyString const& name, Variable variable)
 {
-    return m_binding_object.set(name, variable.value, false);
+    return m_binding_object.set(name, variable.value, Object::ShouldThrowExceptions::No);
 }
 
 bool ObjectEnvironment::delete_from_environment(FlyString const& name)
@@ -98,7 +98,7 @@ void ObjectEnvironment::set_mutable_binding(GlobalObject& global_object, FlyStri
         global_object.vm().throw_exception<ReferenceError>(global_object, ErrorType::UnknownIdentifier, name);
         return;
     }
-    m_binding_object.set(name, value, strict);
+    m_binding_object.set(name, value, strict ? Object::ShouldThrowExceptions::Yes : Object::ShouldThrowExceptions::No);
 }
 
 // 9.1.1.2.6 GetBindingValue ( N, S ), https://tc39.es/ecma262/#sec-object-environment-records-getbindingvalue-n-s

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -21,7 +21,7 @@ void Reference::put_value(GlobalObject& global_object, Value value)
             throw_reference_error(global_object);
             return;
         }
-        global_object.set(m_name, value, false);
+        global_object.set(m_name, value, Object::ShouldThrowExceptions::No);
         return;
     }
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -137,7 +137,7 @@ RegExpObject* regexp_create(GlobalObject& global_object, Value pattern, Value fl
             return {};
     }
     auto* object = RegExpObject::create(global_object, move(p), move(f));
-    object->set(vm.names.lastIndex, Value(0), true);
+    object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
     return object;

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -128,7 +128,7 @@ static void increment_last_index(GlobalObject& global_object, Object& regexp_obj
         return;
 
     last_index = advance_string_index(string, last_index, unicode);
-    regexp_object.set(vm.names.lastIndex, Value(last_index), true);
+    regexp_object.set(vm.names.lastIndex, Value(last_index), Object::ShouldThrowExceptions::Yes);
 }
 
 // 1.1.2.1 Match Records, https://tc39.es/proposal-regexp-match-indices/#sec-match-records
@@ -231,7 +231,7 @@ static Value regexp_builtin_exec(GlobalObject& global_object, RegExpObject& rege
     while (true) {
         if (last_index > string.length()) {
             if (global || sticky) {
-                regexp_object.set(vm.names.lastIndex, Value(0), true);
+                regexp_object.set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
                 if (vm.exception())
                     return {};
             }
@@ -246,7 +246,7 @@ static Value regexp_builtin_exec(GlobalObject& global_object, RegExpObject& rege
             break;
 
         if (sticky) {
-            regexp_object.set(vm.names.lastIndex, Value(0), true);
+            regexp_object.set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
 
@@ -265,7 +265,7 @@ static Value regexp_builtin_exec(GlobalObject& global_object, RegExpObject& rege
     // FIXME: Do code point index correction if the Unicode flag is set.
 
     if (global || sticky) {
-        regexp_object.set(vm.names.lastIndex, Value(end_index), true);
+        regexp_object.set(vm.names.lastIndex, Value(end_index), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -490,7 +490,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
         return result;
     }
 
-    regexp_object->set(vm.names.lastIndex, Value(0), true);
+    regexp_object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
 
@@ -582,7 +582,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
     if (vm.exception())
         return {};
 
-    matcher->set(vm.names.lastIndex, Value(last_index), true);
+    matcher->set(vm.names.lastIndex, Value(last_index), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
 
@@ -625,7 +625,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
             return {};
         unicode = unicode_value.to_boolean();
 
-        regexp_object->set(vm.names.lastIndex, Value(0), true);
+        regexp_object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -779,7 +779,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_search)
     if (vm.exception())
         return {};
     if (!same_value(previous_last_index, Value(0))) {
-        regexp_object->set(vm.names.lastIndex, Value(0), true);
+        regexp_object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -792,7 +792,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_search)
     if (vm.exception())
         return {};
     if (!same_value(current_last_index, previous_last_index)) {
-        regexp_object->set(vm.names.lastIndex, previous_last_index, true);
+        regexp_object->set(vm.names.lastIndex, previous_last_index, Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -871,7 +871,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
     size_t next_search_from = 0; // 'q' in the spec.
 
     while (next_search_from < string.length()) {
-        splitter->set(vm.names.lastIndex, Value(next_search_from), true);
+        splitter->set(vm.names.lastIndex, Value(next_search_from), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -77,7 +77,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpStringIteratorPrototype::next)
 
         last_index = advance_string_index(iterator.string(), last_index, iterator.unicode());
 
-        iterator.regexp_object().set(vm.names.lastIndex, Value(last_index), true);
+        iterator.regexp_object().set(vm.names.lastIndex, Value(last_index), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -191,7 +191,7 @@ static void initialize_typed_array_from_array_like(GlobalObject& global_object, 
         auto value = array_like.get(k);
         if (vm.exception())
             return;
-        typed_array.set(k, value, true);
+        typed_array.set(k, value, Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return;
     }
@@ -222,7 +222,7 @@ static void initialize_typed_array_from_list(GlobalObject& global_object, TypedA
 
     for (size_t k = 0; k < list.size(); k++) {
         auto value = list[k];
-        typed_array.set(k, value, true);
+        typed_array.set(k, value, Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return;
     }

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -101,7 +101,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayConstructor::from)
             } else {
                 mapped_value = k_value;
             }
-            target_object->set(k, mapped_value, true);
+            target_object->set(k, mapped_value, Object::ShouldThrowExceptions::Yes);
             if (vm.exception())
                 return {};
         }
@@ -130,7 +130,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayConstructor::from)
         } else {
             mapped_value = k_value;
         }
-        target_object->set(k, mapped_value, true);
+        target_object->set(k, mapped_value, Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -153,7 +153,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayConstructor::of)
     if (vm.exception())
         return {};
     for (size_t k = 0; k < length; ++k) {
-        auto success = new_object->set(k, vm.argument(k), true);
+        auto success = new_object->set(k, vm.argument(k), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
         if (!success) {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -267,7 +267,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::fill)
     }
 
     for (; k < final; ++k) {
-        typed_array->set(k, value, true);
+        typed_array->set(k, value, Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -868,7 +868,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
         if (typed_array->element_name() != new_array->element_name()) {
             for (i32 n = 0; k < final; ++k, ++n) {
                 auto k_value = typed_array->get(k);
-                new_array->set(n, k_value, true);
+                new_array->set(n, k_value, Object::ShouldThrowExceptions::Yes);
             }
         } else {
             auto element_size = typed_array->element_size();
@@ -1033,7 +1033,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::sort)
 
     u32 j;
     for (j = 0; j < items.size(); ++j) {
-        typed_array->set(j, items[j], true);
+        typed_array->set(j, items[j], Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
     }
@@ -1132,10 +1132,10 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reverse)
         auto upper_value = typed_array->get(upper);
 
         // f. Perform ! Set(O, lowerP, upperValue, true).
-        typed_array->set(lower, upper_value, true);
+        typed_array->set(lower, upper_value, Object::ShouldThrowExceptions::Yes);
 
         // g. Perform ! Set(O, upperP, lowerValue, true).
-        typed_array->set(upper, lower_value, true);
+        typed_array->set(upper, lower_value, Object::ShouldThrowExceptions::Yes);
 
         // h. Set lower to lower + 1.
     }
@@ -1385,7 +1385,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::filter)
     // 11. For each element e of kept, do
     for (auto& value : kept) {
         // a. Perform ! Set(A, ! ToString(𝔽(n)), e, true).
-        filter_array->set(index, value, true);
+        filter_array->set(index, value, Object::ShouldThrowExceptions::Yes);
 
         // b. Set n to n + 1.
         ++index;
@@ -1434,7 +1434,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::map)
             return {};
 
         // d. Perform ? Set(A, Pk, mappedValue, true).
-        return_array->set(i, mapped_value, true);
+        return_array->set(i, mapped_value, Object::ShouldThrowExceptions::Yes);
         if (vm.exception())
             return {};
 

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -160,7 +160,7 @@ void VM::set_variable(const FlyString& name, Value value, GlobalObject& global_o
         return;
     }
 
-    global_object.set(name, value, true);
+    global_object.set(name, value, Object::ShouldThrowExceptions::Yes);
 }
 
 bool VM::delete_variable(FlyString const& name)
@@ -298,7 +298,7 @@ void VM::assign(const NonnullRefPtr<BindingPattern>& target, Value value, Global
                         continue;
                     if (seen_names.contains(object_property.key.to_display_string()))
                         continue;
-                    rest_object->set(object_property.key, object->get(object_property.key), true);
+                    rest_object->set(object_property.key, object->get(object_property.key), Object::ShouldThrowExceptions::Yes);
                     if (exception())
                         return;
                 }


### PR DESCRIPTION
This is more serenity-esque and also makes pointing out missing exception checks during reviews much easier. (Just remembered we decided on doing this after the Object rewrite was merged in, cc @alimpfard)

~~This will be draft until #8775 is merged so i can fix up those `set()`s as well :)~~