### PR TITLE
Kernel: Remove stale forward declaration of BochsFramebufferDevice

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -17,14 +17,12 @@
 
 namespace Kernel {
 
-class BochsFramebufferDevice;
 class GraphicsManagement;
 struct BochsDisplayMMIORegisters;
 
 class BochsGraphicsAdapter final : public GraphicsDevice
     , public PCI::DeviceController {
     AK_MAKE_ETERNAL
-    friend class BochsFramebufferDevice;
     friend class GraphicsManagement;
 
 public:


### PR DESCRIPTION
When @awesomekling showed the graphics subsystem in the Kernel in the livestream,
I noticed that there's a stale forward declaration I forgot about when I removed special framebuffer devices.