### PR TITLE
AK+LibJS: Fix some handling of byte length vs. code point length

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -185,24 +185,24 @@ bool Utf8View::contains(u32 needle) const
 Utf8View Utf8View::trim(const Utf8View& characters, TrimMode mode) const
 {
     size_t substring_start = 0;
-    size_t substring_length = length();
+    size_t substring_length = byte_length();
 
     if (mode == TrimMode::Left || mode == TrimMode::Both) {
-        for (auto code_point : *this) {
+        for (auto code_point = begin(); code_point != end(); ++code_point) {
             if (substring_length == 0)
                 return {};
-            if (!characters.contains(code_point))
+            if (!characters.contains(*code_point))
                 break;
-            ++substring_start;
-            --substring_length;
+            substring_start += code_point.underlying_code_point_length_in_bytes();
+            substring_length -= code_point.underlying_code_point_length_in_bytes();
         }
     }
 
     if (mode == TrimMode::Right || mode == TrimMode::Both) {
         size_t seen_whitespace_length = 0;
-        for (auto code_point : *this) {
-            if (characters.contains(code_point))
-                seen_whitespace_length++;
+        for (auto code_point = begin(); code_point != end(); ++code_point) {
+            if (characters.contains(*code_point))
+                seen_whitespace_length += code_point.underlying_code_point_length_in_bytes();
             else
                 seen_whitespace_length = 0;
         }

--- a/Tests/AK/TestUtf8.cpp
+++ b/Tests/AK/TestUtf8.cpp
@@ -182,3 +182,38 @@ TEST_CASE(decode_invalid_ut8)
         VERIFY(i == expected_size);
     }
 }
+
+TEST_CASE(trim)
+{
+    Utf8View whitespace { " " };
+    {
+        Utf8View view { "word" };
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Both).as_string(), "word");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Left).as_string(), "word");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Right).as_string(), "word");
+    }
+    {
+        Utf8View view { "   word" };
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Both).as_string(), "word");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Left).as_string(), "word");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Right).as_string(), "   word");
+    }
+    {
+        Utf8View view { "word   " };
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Both).as_string(), "word");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Left).as_string(), "word   ");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Right).as_string(), "word");
+    }
+    {
+        Utf8View view { "   word   " };
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Both).as_string(), "word");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Left).as_string(), "word   ");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Right).as_string(), "   word");
+    }
+    {
+        Utf8View view { "\u180E" };
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Both).as_string(), "\u180E");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Left).as_string(), "\u180E");
+        EXPECT_EQ(view.trim(whitespace, TrimMode::Right).as_string(), "\u180E");
+    }
+}

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Utf8View.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
@@ -33,7 +34,7 @@ void StringObject::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Object::initialize(global_object);
-    define_direct_property(vm.names.length, Value(m_string.string().length()), 0);
+    define_direct_property(vm.names.length, Value(Utf8View(m_string.string()).length()), 0);
 }
 
 void StringObject::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.js
@@ -7,3 +7,10 @@ test("typeof", () => {
     expect(typeof String()).toBe("string");
     expect(typeof new String()).toBe("object");
 });
+
+test("length", () => {
+    expect(new String().length).toBe(0);
+    expect(new String("a").length).toBe(1);
+    expect(new String("\u180E").length).toBe(1);
+    expect(new String("\uDBFF\uDFFF").length).toBe(2);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.trim.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.trim.js
@@ -56,3 +56,9 @@ test("trimEnd", () => {
     expect("\r\nhello friends".trimEnd()).toBe("\r\nhello friends");
     expect("\rhello friends\r\n".trimEnd()).toBe("\rhello friends");
 });
+
+test("multi-byte code point", () => {
+    expect("_\u180E".trim()).toBe("_\u180E");
+    expect("\u180E".trim()).toBe("\u180E");
+    expect("\u180E_".trim()).toBe("\u180E_");
+});


### PR DESCRIPTION
Fixes ~~[some number of]~~ 20 test262 tests ~~(my local test262 was behind, so I don't have an accurate number yet)~~