### PR TITLE
LibJS: Ensure RegExpStringIterator keeps the RegExp matcher object alive

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -24,4 +24,10 @@ RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_obj
 {
 }
 
+void RegExpStringIterator::visit_edges(Cell::Visitor& visitor)
+{
+    Object::visit_edges(visitor);
+    visitor.visit(&m_regexp_object);
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -28,6 +28,8 @@ public:
     void set_done() { m_done = true; }
 
 private:
+    virtual void visit_edges(Cell::Visitor&) override;
+
     Object& m_regexp_object;
     String m_string;
     bool m_global { false };


### PR DESCRIPTION
Fixes a crash found with `test-js -g` due to this object going out of
scope.