### PR TITLE
LibC+Kernel: Error handling in readdir fix

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -242,7 +242,7 @@ KResultOr<size_t> FileDescription::get_dir_entries(UserOrKernelBuffer& output_bu
         if (stream.size() == 0)
             return true;
         if (remaining < stream.size()) {
-            error = EINVAL;
+            error = EFAULT;
             return false;
         } else if (!output_buffer.write(stream.bytes())) {
             error = EFAULT;

--- a/Userland/Libraries/LibC/dirent.cpp
+++ b/Userland/Libraries/LibC/dirent.cpp
@@ -103,7 +103,7 @@ static int allocate_dirp_buffer(DIR* dirp)
     for (;;) {
         ssize_t nread = syscall(SC_get_dir_entries, dirp->fd, dirp->buffer, size_to_allocate);
         if (nread < 0) {
-            if (nread == -EINVAL) {
+            if (nread == -EFAULT) {
                 size_to_allocate *= 2;
                 char* new_buffer = (char*)realloc(dirp->buffer, size_to_allocate);
                 if (new_buffer) {


### PR DESCRIPTION
As mentioned in Kernel/FileSystem/FileDescription.cpp, the error
code EFAULT should be used to signal readdir to increase its
buffer size. With this change readdir sets errno correctly if
some filesystem returns EINVAL in 'traverse_as_directory'.