### PR TITLE
Kernel: Use timer source for randomness only after it was initialized

### DIFF
--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -48,7 +48,7 @@ UNMAP_AFTER_INIT KernelRng::KernelRng()
 
             this->resource().add_random_event(value, i % 32);
         }
-    } else if (TimeManagement::the().can_query_precise_time()) {
+    } else if (TimeManagement::initialized() && TimeManagement::the().can_query_precise_time()) {
         // Add HPET as entropy source if we don't have anything better.
         dmesgln("KernelRng: Using HPET as entropy source");
 

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -131,6 +131,11 @@ u64 TimeManagement::uptime_ms() const
     return ms;
 }
 
+bool TimeManagement::initialized()
+{
+    return s_the.is_initialized();
+}
+
 UNMAP_AFTER_INIT void TimeManagement::initialize(u32 cpu)
 {
     if (cpu == 0) {


### PR DESCRIPTION
Fixes #8710