### PR TITLE
ThemeEditor: Disable focus for demo widgets

### DIFF
--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -49,6 +49,11 @@ private:
         m_statusbar->set_text("Status bar");
         m_editor = add<GUI::TextEditor>();
         m_editor->set_text("Text editor\nwith multiple\nlines.");
+
+        for_each_child_widget([](auto& child) {
+            child.set_focus_policy(GUI::FocusPolicy::NoFocus);
+            return IterationDecision::Continue;
+        });
     }
 
     virtual void resize_event(GUI::ResizeEvent&) override


### PR DESCRIPTION
Pressing tab would previously shift focus to the demo widgets instead of switching between the combo box and color input field, instead disable focus for all the widgets.

Fixes #8803 