### PR TITLE
LibC: Use 64-bit stack smash value for 64-bit mode

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -64,8 +64,8 @@ extern ctor_func_t end_heap_ctors;
 extern ctor_func_t start_ctors;
 extern ctor_func_t end_ctors;
 
-extern u32 __stack_chk_guard;
-u32 __stack_chk_guard;
+extern size_t __stack_chk_guard;
+size_t __stack_chk_guard;
 
 extern "C" u8* start_of_safemem_text;
 extern "C" u8* end_of_safemem_text;
@@ -147,7 +147,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init()
     // Initialize TimeManagement before using randomness!
     TimeManagement::initialize(0);
 
-    __stack_chk_guard = get_fast_random<u32>();
+    __stack_chk_guard = get_fast_random<size_t>();
 
     ProcFSComponentRegistry::initialize();
     Thread::initialize();

--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -14,7 +14,7 @@
 #ifndef _DYNAMIC_LOADER
 extern "C" {
 
-extern u32 __stack_chk_guard;
+extern size_t __stack_chk_guard;
 
 int main(int, char**, char**);
 
@@ -31,7 +31,7 @@ NAKED void _start(int, char**, char**)
 
 int _entry(int argc, char** argv, char** env)
 {
-    u32 original_stack_chk = __stack_chk_guard;
+    size_t original_stack_chk = __stack_chk_guard;
     arc4random_buf(&__stack_chk_guard, sizeof(__stack_chk_guard));
 
     if (__stack_chk_guard == 0)

--- a/Userland/Libraries/LibC/ssp.cpp
+++ b/Userland/Libraries/LibC/ssp.cpp
@@ -17,8 +17,8 @@
 
 extern "C" {
 
-extern u32 __stack_chk_guard;
-u32 __stack_chk_guard = (u32)0xc6c7c8c9;
+extern size_t __stack_chk_guard;
+size_t __stack_chk_guard = (size_t)0xc6c7c8c9;
 
 __attribute__((noreturn)) void __stack_chk_fail()
 {


### PR DESCRIPTION
Otherwise it'll use the first 32 bits that happen to come after,
leading to very weird bugs. Fixes #8601