### PR TITLE
Kernel: Make PAGE_MASK architecture independent

### DIFF
--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -15,7 +15,7 @@
 /* Map IRQ0-15 @ ISR 0x50-0x5F */
 #define IRQ_VECTOR_BASE 0x50
 #define GENERIC_INTERRUPT_HANDLERS_COUNT (256 - IRQ_VECTOR_BASE)
-#define PAGE_MASK ((FlatPtr)0xfffff000u)
+#define PAGE_MASK (~(FlatPtr)0xfffu)
 
 namespace Kernel {
 


### PR DESCRIPTION
Due to us still only handing out 32-bit pointer this did not bite us yet, but it may have been difficult to debug going forward.