### PR TITLE
LibC: Fix grp.h includes

### DIFF
--- a/Userland/Libraries/LibC/grp.h
+++ b/Userland/Libraries/LibC/grp.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <bits/FILE.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
That header file uses FILE*, which is defined in bits/FILE.h.