### PR TITLE
AK + Kernel: Minor improvements to RedBlackTree / InclusiveRedBlackTree / IntrusiveList

### DIFF
--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -9,6 +9,7 @@
 #include <AK/Assertions.h>
 #include <AK/BitCast.h>
 #include <AK/Forward.h>
+#include <AK/Noncopyable.h>
 #include <AK/StdLibExtras.h>
 
 namespace AK {
@@ -45,6 +46,9 @@ private:
 
 template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
 class IntrusiveList {
+    AK_MAKE_NONCOPYABLE(IntrusiveList);
+    AK_MAKE_NONMOVABLE(IntrusiveList);
+
 public:
     IntrusiveList() = default;
     ~IntrusiveList();

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -83,6 +83,7 @@ public:
         }
         [[nodiscard]] bool is_end() const { return !m_node; }
         [[nodiscard]] bool is_begin() const { return !m_prev; }
+        [[nodiscard]] auto key() const { return m_node->key; }
 
     private:
         friend class IntrusiveRedBlackTree;
@@ -159,7 +160,7 @@ public:
         VERIFY(!is_in_tree());
     }
 
-    bool is_in_tree()
+    [[nodiscard]] bool is_in_tree() const
     {
         return m_in_tree;
     }

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -14,7 +14,8 @@ template<Integral K>
 class IntrusiveRedBlackTreeNode;
 
 template<Integral K, typename V, IntrusiveRedBlackTreeNode<K> V::*member>
-class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
+class IntrusiveRedBlackTree final : public BaseRedBlackTree<K> {
+
 public:
     IntrusiveRedBlackTree() = default;
     virtual ~IntrusiveRedBlackTree() override

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -406,7 +406,7 @@ public:
     [[nodiscard]] bool is_end() const { return !m_node; }
     [[nodiscard]] bool is_begin() const { return !m_prev; }
 
-    auto key() const { return m_node->key; }
+    [[nodiscard]] auto key() const { return m_node->key; }
 
 private:
     friend TreeType;

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -420,7 +420,7 @@ private:
 };
 
 template<Integral K, typename V>
-class RedBlackTree : public BaseRedBlackTree<K> {
+class RedBlackTree final : public BaseRedBlackTree<K> {
 public:
     RedBlackTree() = default;
     virtual ~RedBlackTree() override

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -430,7 +430,7 @@ public:
 
     using BaseTree = BaseRedBlackTree<K>;
 
-    V* find(K key)
+    [[nodiscard]] V* find(K key)
     {
         auto* node = static_cast<Node*>(BaseTree::find(this->m_root, key));
         if (!node)
@@ -438,7 +438,7 @@ public:
         return &node->value;
     }
 
-    V* find_largest_not_above(K key)
+    [[nodiscard]] V* find_largest_not_above(K key)
     {
         auto* node = static_cast<Node*>(BaseTree::find_largest_not_above(this->m_root, key));
         if (!node)

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -33,10 +33,6 @@ void RangeAllocator::initialize_from_parent(RangeAllocator const& parent_allocat
     }
 }
 
-RangeAllocator::~RangeAllocator()
-{
-}
-
 void RangeAllocator::dump() const
 {
     VERIFY(m_lock.is_locked());

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/BinarySearch.h>
 #include <AK/Checked.h>
 #include <Kernel/Random.h>
 #include <Kernel/VM/RangeAllocator.h>

--- a/Kernel/VM/RangeAllocator.h
+++ b/Kernel/VM/RangeAllocator.h
@@ -16,7 +16,7 @@ namespace Kernel {
 class RangeAllocator {
 public:
     RangeAllocator();
-    ~RangeAllocator();
+    ~RangeAllocator() = default;
 
     void initialize_with_range(VirtualAddress, size_t);
     void initialize_from_parent(RangeAllocator const&);


### PR DESCRIPTION
A small collection of improvements to AK RedBlackTree / InclusiveRedBlackTree / IntrusiveList, and two minor Kernel changes:

 -  **Kernel: Declare VM/RangeAllocator trivial destructor as default**

    This is a clang tidy recommendation.

 - **Kernel: Remove stale include from VM/RangeAllocator.cpp**

   This was left over after the latest big refactor of the VM subsystem.

 - **AK: Mark RedBlackTree functions as [[nodiscard]]**

 - **AK: Mark AK::IntrusiveRedBlackTree as final**

 - **AK: Mark AK::IntrusiveList Non copyable and movable**

 - **AK: Mark RedBlackTree as final**

 - **AK: Mark RedBlackTree find APIs as [[nodiscard]]**