### PR TITLE
Kernel: Convert RangeAllocator VERIFY to proper error handling

### DIFF
--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -143,7 +143,9 @@ Optional<Range> RangeAllocator::allocate_specific(VirtualAddress base, size_t si
     VERIFY((size % PAGE_SIZE) == 0);
 
     Range const allocated_range(base, size);
-    VERIFY(m_total_range.contains(allocated_range));
+    if (!m_total_range.contains(allocated_range)) {
+        return {};
+    }
 
     ScopedSpinLock lock(m_lock);
     for (auto it = m_available_ranges.begin(); !it.is_end(); ++it) {


### PR DESCRIPTION
If a user allocates above 0x0 and below the allowable usermode
virtual address space, we need to return error instead of asserting.

Fixes: #8484