### PR TITLE
Profiler: Configure the TimelineContainer to be shrink to fit

### DIFF
--- a/Userland/DevTools/Profiler/TimelineContainer.cpp
+++ b/Userland/DevTools/Profiler/TimelineContainer.cpp
@@ -6,12 +6,13 @@
 
 #include "TimelineContainer.h"
 #include "TimelineView.h"
-#include <LibGUI/Layout.h>
+#include <LibGUI/BoxLayout.h>
 
 namespace Profiler {
 
 TimelineContainer::TimelineContainer(GUI::Widget& header_container, TimelineView& timeline_view)
 {
+    set_layout<GUI::HorizontalBoxLayout>();
     set_should_hide_unnecessary_scrollbars(true);
     m_header_container = header_container;
     m_timeline_view = timeline_view;
@@ -21,6 +22,7 @@ TimelineContainer::TimelineContainer(GUI::Widget& header_container, TimelineView
     timeline_view.move_to_back();
     update_widget_sizes();
     update_widget_positions();
+    set_shrink_to_fit(true);
 
     m_timeline_view->on_scale_change = [this] {
         update_widget_positions();


### PR DESCRIPTION
Today the profile viewer timeline view has a static size, which is
computed as half the height of the window given it has two root widgets.

Instead the timeline view should shrink to only consume the size that
each process timeline consumes.