### PR TITLE
Kernel: Remove double RedBlackTree lookup in VM/Space region removal

### DIFF
--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -334,7 +334,6 @@ KResultOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int
         // Remove the old region from our regions tree, since were going to add another region
         // with the exact same start address, but dont deallocate it yet
         auto region = space().take_region(*old_region);
-        VERIFY(region);
 
         // Unmap the old region here, specifying that we *don't* want the VM deallocated.
         region->unmap(Region::ShouldDeallocateVirtualMemoryRange::No);
@@ -398,7 +397,6 @@ KResultOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int
             // Remove the old region from our regions tree, since were going to add another region
             // with the exact same start address, but dont deallocate it yet
             auto region = space().take_region(*old_region);
-            VERIFY(region);
 
             // Unmap the old region here, specifying that we *don't* want the VM deallocated.
             region->unmap(Region::ShouldDeallocateVirtualMemoryRange::No);
@@ -564,8 +562,7 @@ KResultOr<FlatPtr> Process::sys$mremap(Userspace<const Syscall::SC_mremap_params
 
         // Unmap without deallocating the VM range since we're going to reuse it.
         old_region->unmap(Region::ShouldDeallocateVirtualMemoryRange::No);
-        bool success = space().deallocate_region(*old_region);
-        VERIFY(success);
+        space().deallocate_region(*old_region);
 
         auto new_region_or_error = space().allocate_region_with_vmobject(range, new_vmobject.release_nonnull(), old_offset, old_name->view(), old_prot, false);
         if (new_region_or_error.is_error())

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -404,9 +404,7 @@ void Thread::exit(void* exit_value)
     [[maybe_unused]] auto rc = unlock_process_if_locked(unlock_count);
     if (m_thread_specific_range.has_value()) {
         auto* region = process().space().find_region_from_range(m_thread_specific_range.value());
-        VERIFY(region);
-        if (!process().space().deallocate_region(*region))
-            dbgln("Failed to unmap TLS range, exiting thread anyway.");
+        process().space().deallocate_region(*region);
     }
     die_if_needed();
 }

--- a/Kernel/VM/Space.h
+++ b/Kernel/VM/Space.h
@@ -39,8 +39,8 @@ public:
 
     KResultOr<Region*> allocate_region_with_vmobject(const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, StringView name, int prot, bool shared);
     KResultOr<Region*> allocate_region(const Range&, StringView name, int prot = PROT_READ | PROT_WRITE, AllocationStrategy strategy = AllocationStrategy::Reserve);
-    bool deallocate_region(Region& region);
-    OwnPtr<Region> take_region(Region& region);
+    void deallocate_region(Region& region);
+    NonnullOwnPtr<Region> take_region(Region& region);
 
     KResultOr<Region*> try_allocate_split_region(Region const& source_region, Range const&, size_t offset_in_vmobject);
     KResultOr<Vector<Region*, 2>> try_split_region_around_range(Region const& source_region, Range const&);


### PR DESCRIPTION
We should never request a regions removal that we don't currently
own. We currently assert this everywhere else by all callers.

Instead lets just push the assert down into the RedBlackTree removal
and assume that we will always successfully remove the region.