### PR TITLE
LibGUI: Pass path to FileSystemModel when creating FilePicker

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -64,7 +64,7 @@ Optional<String> FilePicker::get_save_filepath(Window* parent_window, const Stri
 
 FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filename, const StringView& path)
     : Dialog(parent_window)
-    , m_model(FileSystemModel::create())
+    , m_model(FileSystemModel::create(path))
     , m_mode(mode)
 {
     switch (m_mode) {
@@ -232,7 +232,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
         m_common_location_buttons.append({ path, button });
     }
 
-    set_path(path);
+    m_location_textbox->set_icon(FileIconProvider::icon_for_path(path).bitmap_for_size(16));
 }
 
 FilePicker::~FilePicker()


### PR DESCRIPTION
FileSystemModel defaults to `/` if no path is passed to the constructor. This causes a few unnecessary lstat lookups when a FilePicker is created since it calls set_path() after the  FSM constructor. Passing the path to the constructor also cleans up lstat warnings if `/` is not unveiled, like in WidgetGallery