### PR TITLE
WidgetGallery: Pledge thread

### DIFF
--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -21,7 +21,6 @@
 #include <LibGUI/InputBox.h>
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/MessageBox.h>
-#include <LibGUI/SeparatorWidget.h>
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TabWidget.h>

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -15,14 +15,14 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd rpath unix", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath unix thread", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath thread", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
Previously, opening the FilePicker in WidgetGallery would cause a crash since thread was not pledged.