### PR TITLE
AK+LibJS+LibRegex: Use UTF-32 views for RegEx matching when the unicode flag is set

### DIFF
--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -95,9 +95,6 @@ public:
 
     Utf32View substring_view(size_t offset, size_t length) const
     {
-        if (length == 0)
-            return {};
-        VERIFY(offset < m_length);
         VERIFY(!Checked<size_t>::addition_would_overflow(offset, length));
         VERIFY((offset + length) <= m_length);
         return Utf32View(m_code_points + offset, length);

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
@@ -80,14 +80,15 @@ test("not matching", () => {
 
 // Backreference to a group not yet parsed: #6039
 test("Future group backreference, #6039", () => {
-    let re = /(\3)(\1)(a)/;
-    let result = re.exec("cat");
-    expect(result.length).toBe(4);
-    expect(result[0]).toBe("a");
-    expect(result[1]).toBe("");
-    expect(result[2]).toBe("");
-    expect(result[3]).toBe("a");
-    expect(result.index).toBe(1);
+    [/(\3)(\1)(a)/, /(\3)(\1)(a)/u].forEach(re => {
+        let result = re.exec("cat");
+        expect(result.length).toBe(4);
+        expect(result[0]).toBe("a");
+        expect(result[1]).toBe("");
+        expect(result[2]).toBe("");
+        expect(result[3]).toBe("a");
+        expect(result.index).toBe(1);
+    });
 });
 
 // #6108

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -88,10 +88,11 @@ public:
             return new_views;
         }
 
-        // FIXME: line splitting for Utf32View needed
-        Vector<RegexStringView> views;
-        views.append(m_u32view.value());
-        return views;
+        auto views = u32view().lines(false);
+        Vector<RegexStringView> new_views;
+        for (auto& view : views)
+            new_views.append(move(view));
+        return new_views;
     }
 
     RegexStringView substring_view(size_t offset, size_t length) const


### PR DESCRIPTION
Fixes 6 `RegExp.prototype` test262 tests