### PR TITLE
LibC strtod: Reduce incremental error to nearly nothing.

### DIFF
--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -646,9 +646,15 @@ double strtod(const char* str, char** endptr)
 
     // TODO: If `exponent` is large, this could be made faster.
     double value = digits.number();
+    double scale = 1;
+
     if (exponent < 0) {
         exponent = -exponent;
-        for (int i = 0; i < exponent; ++i) {
+        for (int i = 0; i < min(exponent, 300); ++i) {
+            scale *= base;
+        }
+        value /= scale;
+        for (int i = 300; i < exponent; i++) {
             value /= base;
         }
         if (value == -0.0 || value == +0.0) {
@@ -656,8 +662,9 @@ double strtod(const char* str, char** endptr)
         }
     } else if (exponent > 0) {
         for (int i = 0; i < exponent; ++i) {
-            value *= base;
+            scale *= base;
         }
+        value *= scale;
         if (value == -__builtin_huge_val() || value == +__builtin_huge_val()) {
             errno = ERANGE;
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/DataView/ArrayBuffer.prototype.float64.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/DataView/ArrayBuffer.prototype.float64.js
@@ -4,5 +4,5 @@ test("basic functionality", () => {
     view.setFloat64(0, 6865415254.161212);
     expect(view.getFloat64(0)).toBe(6865415254.161212);
     view.setFloat64(0, 6865415254.161212, true);
-    expect(view.getFloat64(0)).toBe(4.2523296908380055e94);
+    expect(view.getFloat64(0)).toBe(4.2523296908380052e94);
 });


### PR DESCRIPTION
Instead of scaling by 1/10th N times, scale 10^N and then divide by
that. Avoid doing this beyond double-infinity. This decreases the
progressive error for numbers outside of integer range immensely. Not
a full 100% fix; there is still a single ULP difference detected by a
Javascript test.

This fixes all still remaining test failures on x86_64 and @BertalanD 's Clang branch, except for the single ULP Javascript bit.