### PR TITLE
LibJS: Extend class 'extends' RHS expression parsing

### DIFF
--- a/Userland/Libraries/LibJS/Tests/classes/class-inheritance.js
+++ b/Userland/Libraries/LibJS/Tests/classes/class-inheritance.js
@@ -132,6 +132,24 @@ test("super constructor call from child class with argument", () => {
     expect(c.x).toBe(10);
 });
 
+test("advanced 'extends' RHS", () => {
+    const foo = {
+        bar() {
+            return {
+                baz() {
+                    return function () {
+                        return function () {
+                            return { quux: Number };
+                        };
+                    };
+                },
+            };
+        },
+    };
+    class Foo extends foo.bar()["baz"]()`qux`().quux {}
+    expect(new Foo()).toBeInstanceOf(Number);
+});
+
 test("issue #7045, super constructor call from child class in catch {}", () => {
     class Parent {
         constructor(x) {


### PR DESCRIPTION
Fixes parsing of the [newly added `temporalHelpers.js` test262 harness file](https://github.com/tc39/test262/blob/main/harness/temporalHelpers.js) and quite possibly a bunch of test262 class tests.