### PR TITLE
Tests: Print out a list of which tests failed after a run-tests run

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -442,7 +442,7 @@ void FormatBuilder::put_hexdump(ReadonlyBytes bytes, size_t width, char fill)
         if (width > 0) {
             if (i % width == 0 && i) {
                 put_char_view(i);
-                put_literal("\n");
+                put_literal("\n"sv);
             }
         }
         put_u64(bytes[i], 16, false, false, true, Align::Right, 2);

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -354,8 +354,10 @@ requires(HasFormatter<T>) struct Formatter<Vector<T>> : StandardFormatter {
         builder.put_literal("[ "sv);
         bool first = true;
         for (auto& content : value) {
-            if (!first)
+            if (!first) {
                 builder.put_literal(", "sv);
+                content_fmt = Formatter<T> {};
+            }
             first = false;
             content_fmt.format(builder, content);
         }

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -351,15 +351,15 @@ requires(HasFormatter<T>) struct Formatter<Vector<T>> : StandardFormatter {
         m_precision = m_precision.value_or(NumericLimits<size_t>::max());
 
         Formatter<T> content_fmt;
-        builder.put_literal("[ ");
+        builder.put_literal("[ "sv);
         bool first = true;
         for (auto& content : value) {
             if (!first)
-                builder.put_literal(", ");
+                builder.put_literal(", "sv);
             first = false;
             content_fmt.format(builder, content);
         }
-        builder.put_literal(" ]");
+        builder.put_literal(" ]"sv);
     }
 };
 

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/Vector.h>
 
 TEST_CASE(is_integral_works_properly)
 {
@@ -305,4 +306,20 @@ TEST_CASE(hex_dump)
     EXPECT_EQ(String::formatted("{:>4hex-dump}", "0000"), "30303030    0000");
     EXPECT_EQ(String::formatted("{:>2hex-dump}", "0000"), "3030    00\n3030    00");
     EXPECT_EQ(String::formatted("{:*>4hex-dump}", "0000"), "30303030****0000");
+}
+
+TEST_CASE(vector_format)
+{
+    {
+        Vector<int> v { 1, 2, 3, 4 };
+        EXPECT_EQ(String::formatted("{}", v), "[ 1, 2, 3, 4 ]");
+    }
+    {
+        Vector<StringView> v { "1"sv, "2"sv, "3"sv, "4"sv };
+        EXPECT_EQ(String::formatted("{}", v), "[ 1, 2, 3, 4 ]");
+    }
+    {
+        Vector<Vector<String>> v { { "1"sv, "2"sv }, { "3"sv, "4"sv } };
+        EXPECT_EQ(String::formatted("{}", v), "[ [ 1, 2 ], [ 3, 4 ] ]");
+    }
 }

--- a/Userland/Libraries/LibTest/TestRunner.h
+++ b/Userland/Libraries/LibTest/TestRunner.h
@@ -55,6 +55,7 @@ protected:
 
     virtual Vector<String> get_test_paths() const = 0;
     virtual void do_run_single_test(const String&) = 0;
+    virtual const Vector<String>* get_failed_test_names() const { return nullptr; }
 
     String m_test_root;
     bool m_print_times;
@@ -213,6 +214,9 @@ inline void TestRunner::print_test_results() const
         outln("{}ms", static_cast<int>(m_total_elapsed_time_in_ms));
     } else {
         outln("{:>.3}s", m_total_elapsed_time_in_ms / 1000.0);
+    }
+    if (auto* failed_tests = get_failed_test_names(); failed_tests && !failed_tests->is_empty()) {
+        outln("Failed tests: {}", *failed_tests);
     }
     outln();
 }

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -48,6 +48,7 @@ public:
 protected:
     virtual void do_run_single_test(const String& test_path) override;
     virtual Vector<String> get_test_paths() const override;
+    virtual const Vector<String>* get_failed_test_names() const override { return &m_failed_test_names; }
 
     virtual FileResult run_test_file(const String& test_path);
 
@@ -57,6 +58,7 @@ protected:
     NonnullRefPtr<Core::ConfigFile> m_config;
     Vector<String> m_skip_directories;
     Vector<String> m_skip_files;
+    Vector<String> m_failed_test_names;
     Regex<PosixExtended> m_skip_regex;
     bool m_print_all_output { false };
 };
@@ -120,6 +122,7 @@ void TestRunner::do_run_single_test(const String& test_path)
     bool crashed_or_failed = test_result.result == Test::Result::Fail || test_result.result == Test::Result::Crashed;
     bool print_stdout_stderr = crashed_or_failed || m_print_all_output;
     if (crashed_or_failed) {
+        m_failed_test_names.append(test_path);
         print_modifiers({ Test::BG_RED, Test::FG_BLACK, Test::FG_BOLD });
         out("{}", test_result.result == Test::Result::Fail ? " FAIL  " : "CRASHED");
         print_modifiers({ Test::CLEAR });


### PR DESCRIPTION
Two AK Format fixes before this actually works though.

- Use `sv` StringView literals when applicable in AK/Format.[h, cpp]
- Fix Formatter<Vector<T>> so that it actually works when T is String, StringView, and Vector<T> (add tests too)

LibTest/run-tests: Print out the list of failed tests when at least one test has failed.