### PR TITLE
AK+LibRegex+LibJS: Make LibRegex support unicode strings a bit better

### DIFF
--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -81,6 +81,14 @@ public:
         return { end_ptr(), 0 };
     }
 
+    u32 at(size_t index) const
+    {
+        VERIFY(index < m_length);
+        return m_code_points[index];
+    }
+
+    u32 operator[](size_t index) const { return at(index); }
+
     const u32* code_points() const { return m_code_points; }
     bool is_empty() const { return m_length == 0; }
     bool is_null() const { return !m_code_points; }

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -83,6 +83,7 @@ public:
 
     const u32* code_points() const { return m_code_points; }
     bool is_empty() const { return m_length == 0; }
+    bool is_null() const { return !m_code_points; }
     size_t length() const { return m_length; }
 
     size_t iterator_offset(const Utf32CodePointIterator& it) const

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -94,9 +94,7 @@ public:
 
     Utf32View substring_view(size_t offset, size_t length) const
     {
-        if (length == 0)
-            return {};
-        VERIFY(offset < m_length);
+        VERIFY(offset <= m_length);
         VERIFY(!Checked<size_t>::addition_would_overflow(offset, length));
         VERIFY((offset + length) <= m_length);
         return Utf32View(m_code_points + offset, length);

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -74,6 +74,7 @@ public:
     Utf8View unicode_substring_view(size_t code_point_offset) const { return unicode_substring_view(code_point_offset, length() - code_point_offset); }
 
     bool is_empty() const { return m_string.is_empty(); }
+    bool is_null() const { return m_string.is_null(); }
     bool starts_with(const Utf8View&) const;
     bool contains(u32) const;
 

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -458,10 +458,12 @@ TEST_CASE(a_star)
     String haystack = "[Window]\nOpacity=255\nAudibleBeep=0\n";
     EXPECT_EQ(re.search(haystack.view(), result, PosixFlags::Multiline), true);
     EXPECT_EQ(result.count, 32u);
-    EXPECT_EQ(result.matches.at(0).view.length(), 0u);
-    EXPECT_EQ(result.matches.at(10).view.length(), 1u);
-    EXPECT_EQ(result.matches.at(10).view, "a");
-    EXPECT_EQ(result.matches.at(31).view.length(), 0u);
+    if (result.count == 32u) {
+        EXPECT_EQ(result.matches.at(0).view.length(), 0u);
+        EXPECT_EQ(result.matches.at(10).view.length(), 1u);
+        EXPECT_EQ(result.matches.at(10).view, "a");
+        EXPECT_EQ(result.matches.at(31).view.length(), 0u);
+    }
 }
 
 TEST_CASE(simple_period_end_benchmark)
@@ -624,5 +626,7 @@ TEST_CASE(case_insensitive_match)
     auto result = re.match("AEKFCD");
 
     EXPECT_EQ(result.success, true);
-    EXPECT_EQ(result.matches.at(0).column, 4ul);
+    if (result.success) {
+        EXPECT_EQ(result.matches.at(0).column, 4ul);
+    }
 }

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -249,7 +249,7 @@ TEST_CASE(char_utf8)
     Regex<PosixExtended> re("😀");
     RegexResult result;
 
-    EXPECT_EQ((result = match("Привет, мир! 😀 γειά σου κόσμος 😀 こんにちは世界", re, PosixFlags::Global)).success, true);
+    EXPECT_EQ((result = match(Utf8View { "Привет, мир! 😀 γειά σου κόσμος 😀 こんにちは世界" }, re, PosixFlags::Global)).success, true);
     EXPECT_EQ(result.count, 2u);
 }
 
@@ -312,7 +312,6 @@ TEST_CASE(match_all_character_class)
     EXPECT_EQ(result.matches.at(0).view, "W");
     EXPECT_EQ(result.matches.at(1).view, "i");
     EXPECT_EQ(result.matches.at(2).view, "n");
-    EXPECT(&result.matches.at(0).view.characters_without_null_termination()[0] != &str.view().characters_without_null_termination()[1]);
 }
 
 TEST_CASE(match_character_class_with_assertion)

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -359,7 +359,7 @@ String CppComprehensionEngine::document_path_from_include_path(const StringView&
         if (!library_include.search(include_path, result))
             return {};
 
-        auto path = result.capture_group_matches.at(0).at(0).view.u8view();
+        auto path = result.capture_group_matches.at(0).at(0).view.string_view();
         return String::formatted("/usr/include/{}", path);
     };
 
@@ -368,7 +368,7 @@ String CppComprehensionEngine::document_path_from_include_path(const StringView&
         if (!user_defined_include.search(include_path, result))
             return {};
 
-        return result.capture_group_matches.at(0).at(0).view.u8view();
+        return result.capture_group_matches.at(0).at(0).view.string_view();
     };
 
     auto result = document_path_for_library_include(include_path);

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -422,7 +422,7 @@ void DebugSession::update_loaded_libs()
         auto rc = re.search(vm_name, result);
         if (!rc)
             return {};
-        auto lib_name = result.capture_group_matches.at(0).at(0).view.u8view().to_string();
+        auto lib_name = result.capture_group_matches.at(0).at(0).view.string_view().to_string();
         if (lib_name.starts_with("/"))
             return lib_name;
         return String::formatted("/usr/lib/{}", lib_name);

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -240,7 +240,12 @@ static Value regexp_builtin_exec(GlobalObject& global_object, RegExpObject& rege
         }
 
         regex.start_offset = last_index;
-        result = regex.match(string);
+        // FIXME: JavaScript strings are UTF-16, update this if the backing storage
+        //        encoding changes for spec compliance reasons.
+        if (unicode)
+            result = regex.match(Utf8View { string });
+        else
+            result = regex.match(string);
 
         if (result.success)
             break;

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -682,7 +682,7 @@ public:
 
 private:
     ALWAYS_INLINE static void compare_char(const MatchInput& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static bool compare_string(const MatchInput& input, MatchState& state, const char* str, size_t length, bool& had_zero_length_match);
+    ALWAYS_INLINE static bool compare_string(const MatchInput& input, MatchState& state, RegexStringView const& str, bool& had_zero_length_match);
     ALWAYS_INLINE static void compare_character_class(const MatchInput& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
     ALWAYS_INLINE static void compare_character_range(const MatchInput& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
 };

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -82,7 +82,7 @@ public:
             builder.appendff(", next ip: {}", state.instruction_position + opcode.size());
         }
 
-        out(m_file, " | {:20}", builder.to_string());
+        outln(m_file, " | {:20}", builder.to_string());
 
         if (is<OpCode_Compare>(opcode)) {
             for (auto& line : to<OpCode_Compare>(opcode).variable_arguments_to_string(input)) {

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -8,14 +8,14 @@
 
 #include "RegexOptions.h"
 
-#include "AK/FlyString.h"
-#include "AK/HashMap.h"
-#include "AK/MemMem.h"
-#include "AK/String.h"
-#include "AK/StringBuilder.h"
-#include "AK/StringView.h"
-#include "AK/Utf32View.h"
-#include "AK/Vector.h"
+#include <AK/FlyString.h>
+#include <AK/HashMap.h>
+#include <AK/MemMem.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <AK/StringView.h>
+#include <AK/Utf32View.h>
+#include <AK/Vector.h>
 
 namespace regex {
 

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -15,6 +15,8 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Utf32View.h>
+#include <AK/Utf8View.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 
 namespace regex {
@@ -22,124 +24,172 @@ namespace regex {
 class RegexStringView {
 public:
     RegexStringView(const char* chars)
-        : m_u8view(chars)
+        : m_view(StringView { chars })
     {
     }
 
     RegexStringView(const String& string)
-        : m_u8view(string)
+        : m_view(string.view())
     {
     }
 
     RegexStringView(const StringView view)
-        : m_u8view(view)
-    {
-    }
-    RegexStringView(const Utf32View view)
-        : m_u32view(view)
+        : m_view(view)
     {
     }
 
-    bool is_u8_view() const { return m_u8view.has_value(); }
-    bool is_u32_view() const { return m_u32view.has_value(); }
-
-    const StringView& u8view() const
+    RegexStringView(Utf32View view)
+        : m_view(view)
     {
-        VERIFY(m_u8view.has_value());
-        return m_u8view.value();
-    };
+    }
 
-    const Utf32View& u32view() const
+    RegexStringView(Utf8View view)
+        : m_view(view)
     {
-        VERIFY(m_u32view.has_value());
-        return m_u32view.value();
-    };
+    }
+
+    const StringView& string_view() const
+    {
+        return m_view.get<StringView>();
+    }
+
+    const Utf32View& u32_view() const
+    {
+        return m_view.get<Utf32View>();
+    }
+
+    const Utf8View& u8_view() const
+    {
+        return m_view.get<Utf8View>();
+    }
 
     bool is_empty() const
     {
-        if (is_u8_view())
-            return m_u8view.value().is_empty();
-        else
-            return m_u32view.value().is_empty();
+        return m_view.visit([](auto& view) { return view.is_empty(); });
     }
 
     bool is_null() const
     {
-        if (is_u8_view())
-            return m_u8view.value().is_null();
-        else
-            return m_u32view.value().code_points() == nullptr;
+        return m_view.visit([](auto& view) { return view.is_null(); });
     }
 
     size_t length() const
     {
-        if (is_u8_view())
-            return m_u8view.value().length();
-        else
-            return m_u32view.value().length();
+        return m_view.visit([](auto& view) { return view.length(); });
+    }
+
+    RegexStringView construct_as_same(Span<u32> data, Optional<String>& optional_string_storage) const
+    {
+        return m_view.visit(
+            [&]<typename T>(T const&) {
+                StringBuilder builder;
+                for (auto ch : data)
+                    builder.append(ch); // Note: The type conversion is intentional.
+                optional_string_storage = builder.build();
+                return RegexStringView { T { *optional_string_storage } };
+            },
+            [&](Utf32View) {
+                return RegexStringView { Utf32View { data.data(), data.size() } };
+            });
     }
 
     Vector<RegexStringView> lines() const
     {
-        if (is_u8_view()) {
-            auto views = u8view().lines(false);
-            Vector<RegexStringView> new_views;
-            for (auto& view : views)
-                new_views.append(move(view));
-            return new_views;
-        }
-
-        Vector<RegexStringView> views;
-        auto view = u32view();
-        u32 newline = '\n';
-        while (!view.is_empty()) {
-            auto position = AK::memmem_optional(view.code_points(), view.length() * sizeof(u32), &newline, sizeof(u32));
-            if (!position.has_value())
-                break;
-            auto offset = position.value() / sizeof(u32);
-            views.append(view.substring_view(0, offset));
-            view = view.substring_view(offset + 1, view.length() - offset - 1);
-        }
-        if (!view.is_empty())
-            views.append(view);
-        return views;
+        return m_view.visit(
+            [](StringView view) {
+                auto views = view.lines(false);
+                Vector<RegexStringView> new_views;
+                for (auto& view : views)
+                    new_views.empend(view);
+                return new_views;
+            },
+            [](Utf32View view) {
+                Vector<RegexStringView> views;
+                u32 newline = '\n';
+                while (!view.is_empty()) {
+                    auto position = AK::memmem_optional(view.code_points(), view.length() * sizeof(u32), &newline, sizeof(u32));
+                    if (!position.has_value())
+                        break;
+                    auto offset = position.value() / sizeof(u32);
+                    views.empend(view.substring_view(0, offset));
+                    view = view.substring_view(offset + 1, view.length() - offset - 1);
+                }
+                if (!view.is_empty())
+                    views.empend(view);
+                return views;
+            },
+            [](Utf8View& view) {
+                Vector<RegexStringView> views;
+                auto it = view.begin();
+                auto previous_newline_position_it = it;
+                for (;;) {
+                    if (*it == '\n') {
+                        auto previous_offset = view.byte_offset_of(previous_newline_position_it);
+                        auto new_offset = view.byte_offset_of(it);
+                        auto slice = view.substring_view(previous_offset, new_offset - previous_offset);
+                        views.empend(slice);
+                        ++it;
+                        previous_newline_position_it = it;
+                    }
+                    if (it.done())
+                        break;
+                    ++it;
+                }
+                if (it != previous_newline_position_it) {
+                    auto previous_offset = view.byte_offset_of(previous_newline_position_it);
+                    auto new_offset = view.byte_offset_of(it);
+                    auto slice = view.substring_view(previous_offset, new_offset - previous_offset);
+                    views.empend(slice);
+                }
+                return views;
+            });
     }
 
     RegexStringView substring_view(size_t offset, size_t length) const
     {
-        if (is_u8_view()) {
-            return u8view().substring_view(offset, length);
-        }
-        return u32view().substring_view(offset, length);
+        return m_view.visit(
+            [&](auto view) { return RegexStringView { view.substring_view(offset, length) }; },
+            [&](Utf8View const& view) { return RegexStringView { view.unicode_substring_view(offset, length) }; });
     }
 
     String to_string() const
     {
-        if (is_u8_view()) {
-            return u8view().to_string();
-        }
-
-        StringBuilder builder;
-        builder.append(u32view());
-        return builder.to_string();
+        return m_view.visit(
+            [](StringView view) { return view.to_string(); },
+            [](auto& view) {
+                StringBuilder builder;
+                for (auto it = view.begin(); it != view.end(); ++it)
+                    builder.append_code_point(*it);
+                return builder.to_string();
+            });
     }
 
     u32 operator[](size_t index) const
     {
-        if (is_u8_view()) {
-            i8 ch = u8view()[index];
-            u8 value = *reinterpret_cast<u8*>(&ch);
-            return static_cast<u32>(value);
-        }
-        return u32view().code_points()[index];
+        return m_view.visit(
+            [&](StringView view) -> u32 {
+                auto ch = view[index];
+                if (ch < 0)
+                    return 256u + ch;
+                return ch;
+            },
+            [&](auto view) -> u32 { return view[index]; },
+            [&](Utf8View& view) -> u32 {
+                size_t i = index;
+                for (auto it = view.begin(); it != view.end(); ++it, --i) {
+                    if (i == 0)
+                        return *it;
+                }
+                VERIFY_NOT_REACHED();
+            });
     }
 
     bool operator==(const char* cstring) const
     {
-        if (is_u8_view())
-            return u8view() == cstring;
-
-        return to_string() == cstring;
+        return m_view.visit(
+            [&](Utf32View) { return to_string() == cstring; },
+            [&](Utf8View const& view) { return view.as_string() == cstring; },
+            [&](StringView view) { return view == cstring; });
     }
 
     bool operator!=(const char* cstring) const
@@ -149,18 +199,18 @@ public:
 
     bool operator==(const String& string) const
     {
-        if (is_u8_view())
-            return u8view() == string;
-
-        return to_string() == string;
+        return m_view.visit(
+            [&](Utf32View) { return to_string() == string; },
+            [&](Utf8View const& view) { return view.as_string() == string; },
+            [&](StringView view) { return view == string; });
     }
 
-    bool operator==(const StringView& other) const
+    bool operator==(const StringView& string) const
     {
-        if (is_u8_view())
-            return u8view() == other;
-
-        return false;
+        return m_view.visit(
+            [&](Utf32View) { return to_string() == string; },
+            [&](Utf8View const& view) { return view.as_string() == string; },
+            [&](StringView view) { return view == string; });
     }
 
     bool operator!=(const StringView& other) const
@@ -170,13 +220,12 @@ public:
 
     bool operator==(const Utf32View& other) const
     {
-        if (is_u32_view()) {
-            StringBuilder builder;
-            builder.append(other);
-            return to_string() == builder.to_string();
-        }
-
-        return false;
+        return m_view.visit(
+            [&](Utf32View view) {
+                return view.length() == other.length() && __builtin_memcmp(view.code_points(), other.code_points(), view.length() * sizeof(u32)) == 0;
+            },
+            [&](Utf8View const& view) { return view.as_string() == RegexStringView { other }.to_string(); },
+            [&](StringView view) { return view == RegexStringView { other }.to_string(); });
     }
 
     bool operator!=(const Utf32View& other) const
@@ -184,34 +233,78 @@ public:
         return !(*this == other);
     }
 
-    const char* characters_without_null_termination() const
+    bool operator==(const Utf8View& other) const
     {
-        if (is_u8_view())
-            return u8view().characters_without_null_termination();
+        return m_view.visit(
+            [&](Utf32View) {
+                return to_string() == other.as_string();
+            },
+            [&](Utf8View const& view) { return view.as_string() == other.as_string(); },
+            [&](StringView view) { return other.as_string() == view; });
+    }
 
-        return to_string().characters(); // FIXME: it contains the null termination, does that actually matter?
+    bool operator!=(const Utf8View& other) const
+    {
+        return !(*this == other);
+    }
+
+    bool equals(const RegexStringView& other) const
+    {
+        return other.m_view.visit([&](auto const& view) { return operator==(view); });
+    }
+
+    bool equals_ignoring_case(const RegexStringView& other) const
+    {
+        // FIXME: Implement equals_ignoring_case() for unicode.
+        return m_view.visit(
+            [&](StringView view) {
+                return other.m_view.visit(
+                    [&](StringView other_view) { return view.equals_ignoring_case(other_view); },
+                    [](auto&) -> bool { TODO(); });
+            },
+            [](auto&) -> bool { TODO(); });
     }
 
     bool starts_with(const StringView& str) const
     {
-        if (is_u32_view())
-            return false;
-        return u8view().starts_with(str);
+        return m_view.visit(
+            [&](Utf32View) -> bool {
+                TODO();
+            },
+            [&](Utf8View const& view) { return view.as_string().starts_with(str); },
+            [&](StringView view) { return view.starts_with(str); });
     }
 
     bool starts_with(const Utf32View& str) const
     {
-        if (is_u8_view())
-            return false;
-
-        StringBuilder builder;
-        builder.append(str);
-        return to_string().starts_with(builder.to_string());
+        return m_view.visit(
+            [&](Utf32View view) -> bool {
+                if (str.length() > view.length())
+                    return false;
+                if (str.length() == view.length())
+                    return operator==(str);
+                for (size_t i = 0; i < str.length(); ++i) {
+                    if (str.at(i) != view.at(i))
+                        return false;
+                }
+                return true;
+            },
+            [&](Utf8View const& view) {
+                auto it = view.begin();
+                for (auto code_point : str) {
+                    if (it.done())
+                        return false;
+                    if (code_point != *it)
+                        return false;
+                    ++it;
+                }
+                return true;
+            },
+            [&](StringView) -> bool { TODO(); });
     }
 
 private:
-    Optional<StringView> m_u8view;
-    Optional<Utf32View> m_u32view;
+    Variant<StringView, Utf8View, Utf32View> m_view;
 };
 
 class Match final {
@@ -271,6 +364,9 @@ struct MatchState {
     size_t string_position { 0 };
     size_t instruction_position { 0 };
     size_t fork_at_position { 0 };
+    Vector<Match> matches;
+    Vector<Vector<Match>> capture_group_matches;
+    Vector<HashMap<String, Match>> named_capture_group_matches;
 };
 
 struct MatchOutput {
@@ -288,6 +384,7 @@ template<>
 struct AK::Formatter<regex::RegexStringView> : Formatter<StringView> {
     void format(FormatBuilder& builder, const regex::RegexStringView& value)
     {
-        return Formatter<StringView>::format(builder, { value.characters_without_null_termination(), value.length() });
+        auto string = value.to_string();
+        return Formatter<StringView>::format(builder, string);
     }
 };

--- a/Userland/Utilities/expr.cpp
+++ b/Userland/Utilities/expr.cpp
@@ -417,7 +417,7 @@ private:
 
                 StringBuilder result;
                 for (auto& e : match.capture_group_matches[0])
-                    result.append(e.view.u8view());
+                    result.append(e.view.string_view());
 
                 return result.build();
             }


### PR DESCRIPTION
This does a complete overhaul of `RegexStringView`, making it capable of handling raw strings, utf-8 encoded strings, or raw unicode code points, and shuffles around quite a few bits of LibRegex to make it properly handle unicode.

This PR should:
- **not** make any previously correct regex incorrect
- Make the libjs regular expressions handle unicode a bit better
- Make it possible to match on `Utf8View`s with correct unicode semantics

(technically) supersedes #8840.
cc @trflynn89 - please tell me if I forgot to co-author you on any related commit.