### PR TITLE
WindowServer: Fix compositor overdraw issues related to transparency

### DIFF
--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1135,7 +1135,7 @@ bool Widget::has_pending_drop() const
 
 bool Widget::is_visible_for_timer_purposes() const
 {
-    return is_visible();
+    return is_visible() && Object::is_visible_for_timer_purposes();
 }
 
 }

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -904,6 +904,7 @@ void Compositor::remove_overlay(Overlay& overlay)
     if (!current_render_rect.is_empty())
         invalidate_screen(current_render_rect);
     m_overlay_list.remove(overlay);
+    overlay_rects_changed();
 }
 
 void Compositor::ScreenData::draw_cursor(Screen& screen, const Gfx::IntRect& cursor_rect)

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -486,6 +486,7 @@ void Window::set_pinned(bool pinned)
     update_window_menu_items();
 
     window_stack().move_pinned_windows_to_front();
+    Compositor::the().invalidate_occlusions();
 }
 void Window::set_vertically_maximized()
 {

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -333,6 +333,10 @@ public:
     Gfx::DisjointRectSet& opaque_rects() { return m_opaque_rects; }
     Gfx::DisjointRectSet& transparency_rects() { return m_transparency_rects; }
     Gfx::DisjointRectSet& transparency_wallpaper_rects() { return m_transparency_wallpaper_rects; }
+    // The affected transparency rects are the rectangles of other windows (above or below)
+    // that also need to be marked dirty whenever a window's dirty rect in a transparency
+    // area needs to be rendered
+    auto& affected_transparency_rects() { return m_affected_transparency_rects; }
 
     Menubar* menubar() { return m_menubar; }
     const Menubar* menubar() const { return m_menubar; }
@@ -402,6 +406,7 @@ private:
     Gfx::DisjointRectSet m_opaque_rects;
     Gfx::DisjointRectSet m_transparency_rects;
     Gfx::DisjointRectSet m_transparency_wallpaper_rects;
+    HashMap<Window*, Gfx::DisjointRectSet> m_affected_transparency_rects;
     WindowType m_type { WindowType::Normal };
     bool m_global_cursor_tracking_enabled { false };
     bool m_automatic_cursor_tracking_enabled { false };


### PR DESCRIPTION
We were re-rendering areas that were considered transparency areas even
though they weren't transparency areas or were occluded by opaque
areas.

In order to fix this, we need to be a bit smarter about what is above
and below any given window. Even though a window may have transparent
areas, if those are occluded by opaque window areas on top they are
not actually any areas that should be rendered at all. And the opposite
also applies, opaque window areas for windows below that are occluded
by transparent areas, do need to be rendered as transparency. This
solves the problem of unnecessary transparency areas.

The other problem is that we need to know what areas of a window's
dirty rectangles affect other windows, and where. Basically any
opaque area that is somehow below a transparent area that isn't
otherwise occluded, and any transparent area above any other window
area (transparent or opaque) needs to be marked dirty prior to
composing. This makes sure that all affected windows render these
areas in the correct order. To track these, we now have a map of
affected windows and the rectangles that are affected (because not all
of that window's transparency areas may be affected).

Before:

https://user-images.githubusercontent.com/10320822/126054703-10878767-e5b3-48d7-b15c-7355d4bfc92d.mp4

After:

https://user-images.githubusercontent.com/10320822/126054707-2b6242f3-4e3e-4406-bd3f-ae313985cd4a.mp4
