### PR TITLE
Kernel: Fix misuses of nothrow new

### DIFF
--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -37,10 +37,19 @@ inline size_t malloc_good_size(size_t size) { return size; }
 #endif
 
 #ifdef KERNEL
-#    define AK_MAKE_ETERNAL                                               \
-    public:                                                               \
-        void* operator new(size_t size) { return kmalloc_eternal(size); } \
-                                                                          \
+#    define AK_MAKE_ETERNAL                                                           \
+    public:                                                                           \
+        [[nodiscard]] void* operator new(size_t size)                                 \
+        {                                                                             \
+            void* ptr = kmalloc_eternal(size);                                        \
+            VERIFY(ptr);                                                              \
+            return ptr;                                                               \
+        }                                                                             \
+        [[nodiscard]] void* operator new(size_t size, const std::nothrow_t&) noexcept \
+        {                                                                             \
+            return kmalloc_eternal(size);                                             \
+        }                                                                             \
+                                                                                      \
     private:
 #else
 #    define AK_MAKE_ETERNAL

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -28,7 +28,7 @@ Parser* Parser::the()
 
 UNMAP_AFTER_INIT NonnullRefPtr<ACPISysFSComponent> ACPISysFSComponent::create(String name, PhysicalAddress paddr, size_t table_size)
 {
-    return adopt_ref(*new (nothrow) ACPISysFSComponent(name, paddr, table_size));
+    return adopt_ref(*new ACPISysFSComponent(name, paddr, table_size));
 }
 
 KResultOr<size_t> ACPISysFSComponent::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, FileDescription*) const
@@ -61,7 +61,7 @@ UNMAP_AFTER_INIT ACPISysFSComponent::ACPISysFSComponent(String name, PhysicalAdd
 
 UNMAP_AFTER_INIT void ACPISysFSDirectory::initialize()
 {
-    auto acpi_directory = adopt_ref(*new (nothrow) ACPISysFSDirectory());
+    auto acpi_directory = adopt_ref(*new ACPISysFSDirectory());
     SysFSComponentRegistry::the().register_new_component(acpi_directory);
 }
 

--- a/Kernel/Arch/PC/BIOS.cpp
+++ b/Kernel/Arch/PC/BIOS.cpp
@@ -21,7 +21,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<DMIEntryPointExposedBlob> DMIEntryPointExposedBlob::create(PhysicalAddress dmi_entry_point, size_t blob_size)
 {
-    return adopt_ref(*new (nothrow) DMIEntryPointExposedBlob(dmi_entry_point, blob_size));
+    return adopt_ref(*new DMIEntryPointExposedBlob(dmi_entry_point, blob_size));
 }
 
 UNMAP_AFTER_INIT BIOSSysFSComponent::BIOSSysFSComponent(String name)
@@ -59,7 +59,7 @@ OwnPtr<KBuffer> DMIEntryPointExposedBlob::try_to_generate_buffer() const
 
 UNMAP_AFTER_INIT NonnullRefPtr<SMBIOSExposedTable> SMBIOSExposedTable::create(PhysicalAddress smbios_structure_table, size_t smbios_structure_table_length)
 {
-    return adopt_ref(*new (nothrow) SMBIOSExposedTable(smbios_structure_table, smbios_structure_table_length));
+    return adopt_ref(*new SMBIOSExposedTable(smbios_structure_table, smbios_structure_table_length));
 }
 
 UNMAP_AFTER_INIT SMBIOSExposedTable::SMBIOSExposedTable(PhysicalAddress smbios_structure_table, size_t smbios_structure_table_length)
@@ -95,7 +95,7 @@ UNMAP_AFTER_INIT void BIOSSysFSDirectory::set_dmi_32_bit_entry_initialization_va
 
 UNMAP_AFTER_INIT void BIOSSysFSDirectory::initialize()
 {
-    auto bios_directory = adopt_ref(*new (nothrow) BIOSSysFSDirectory());
+    auto bios_directory = adopt_ref(*new BIOSSysFSDirectory());
     SysFSComponentRegistry::the().register_new_component(bios_directory);
     bios_directory->create_components();
 }

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -370,7 +370,7 @@ void Capability::write32(u32 field, u32 value)
 
 UNMAP_AFTER_INIT NonnullRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(const SysFSDirectory& parent_directory, Address address)
 {
-    return adopt_ref(*new (nothrow) PCIDeviceSysFSDirectory(parent_directory, address));
+    return adopt_ref(*new PCIDeviceSysFSDirectory(parent_directory, address));
 }
 
 UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(const SysFSDirectory& parent_directory, Address address)
@@ -388,7 +388,7 @@ UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(const SysFSDir
 
 UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
 {
-    auto pci_directory = adopt_ref(*new (nothrow) PCIBusSysFSDirectory());
+    auto pci_directory = adopt_ref(*new PCIBusSysFSDirectory());
     SysFSComponentRegistry::the().register_new_component(pci_directory);
 }
 
@@ -403,7 +403,7 @@ UNMAP_AFTER_INIT PCIBusSysFSDirectory::PCIBusSysFSDirectory()
 
 NonnullRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(String name, const PCIDeviceSysFSDirectory& device, size_t offset, size_t field_bytes_width)
 {
-    return adopt_ref(*new (nothrow) PCIDeviceAttributeSysFSComponent(name, device, offset, field_bytes_width));
+    return adopt_ref(*new PCIDeviceAttributeSysFSComponent(name, device, offset, field_bytes_width));
 }
 
 PCIDeviceAttributeSysFSComponent::PCIDeviceAttributeSysFSComponent(String name, const PCIDeviceSysFSDirectory& device, size_t offset, size_t field_bytes_width)

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -71,7 +71,7 @@ Inode& ProcFS::root_inode()
 
 NonnullRefPtr<ProcFSInode> ProcFSInode::create(const ProcFS& fs, const ProcFSExposedComponent& component)
 {
-    return adopt_ref(*new (nothrow) ProcFSInode(fs, component));
+    return adopt_ref(*new ProcFSInode(fs, component));
 }
 
 ProcFSInode::ProcFSInode(const ProcFS& fs, const ProcFSExposedComponent& component)
@@ -179,7 +179,7 @@ KResult ProcFSInode::truncate(u64)
 
 NonnullRefPtr<ProcFSDirectoryInode> ProcFSDirectoryInode::create(const ProcFS& procfs, const ProcFSExposedComponent& component)
 {
-    return adopt_ref(*new (nothrow) ProcFSDirectoryInode(procfs, component));
+    return adopt_ref(*new ProcFSDirectoryInode(procfs, component));
 }
 
 ProcFSDirectoryInode::ProcFSDirectoryInode(const ProcFS& fs, const ProcFSExposedComponent& component)
@@ -219,7 +219,7 @@ RefPtr<Inode> ProcFSDirectoryInode::lookup(StringView name)
 
 NonnullRefPtr<ProcFSLinkInode> ProcFSLinkInode::create(const ProcFS& procfs, const ProcFSExposedComponent& component)
 {
-    return adopt_ref(*new (nothrow) ProcFSLinkInode(procfs, component));
+    return adopt_ref(*new ProcFSLinkInode(procfs, component));
 }
 
 ProcFSLinkInode::ProcFSLinkInode(const ProcFS& fs, const ProcFSExposedComponent& component)

--- a/Kernel/FileSystem/SysFS.cpp
+++ b/Kernel/FileSystem/SysFS.cpp
@@ -37,7 +37,7 @@ UNMAP_AFTER_INIT void SysFSComponentRegistry::register_new_component(SysFSCompon
 
 NonnullRefPtr<SysFSRootDirectory> SysFSRootDirectory::create()
 {
-    return adopt_ref(*new (nothrow) SysFSRootDirectory);
+    return adopt_ref(*new SysFSRootDirectory);
 }
 
 KResult SysFSRootDirectory::traverse_as_directory(unsigned fsid, Function<bool(FileSystem::DirectoryEntryView const&)> callback) const
@@ -63,7 +63,7 @@ SysFSRootDirectory::SysFSRootDirectory()
 
 NonnullRefPtr<SysFS> SysFS::create()
 {
-    return adopt_ref(*new (nothrow) SysFS);
+    return adopt_ref(*new SysFS);
 }
 
 SysFS::SysFS()
@@ -87,7 +87,7 @@ Inode& SysFS::root_inode()
 
 NonnullRefPtr<SysFSInode> SysFSInode::create(SysFS const& fs, SysFSComponent const& component)
 {
-    return adopt_ref(*new (nothrow) SysFSInode(fs, component));
+    return adopt_ref(*new SysFSInode(fs, component));
 }
 
 SysFSInode::SysFSInode(SysFS const& fs, SysFSComponent const& component)
@@ -165,7 +165,7 @@ KResult SysFSInode::truncate(u64)
 
 NonnullRefPtr<SysFSDirectoryInode> SysFSDirectoryInode::create(SysFS const& sysfs, SysFSComponent const& component)
 {
-    return adopt_ref(*new (nothrow) SysFSDirectoryInode(sysfs, component));
+    return adopt_ref(*new SysFSDirectoryInode(sysfs, component));
 }
 
 SysFSDirectoryInode::SysFSDirectoryInode(SysFS const& fs, SysFSComponent const& component)
@@ -217,7 +217,7 @@ void SysFSComponentRegistry::register_new_bus_directory(SysFSDirectory& new_bus_
 
 UNMAP_AFTER_INIT NonnullRefPtr<SysFSBusDirectory> SysFSBusDirectory::must_create(SysFSRootDirectory const& parent_directory)
 {
-    auto directory = adopt_ref(*new (nothrow) SysFSBusDirectory(parent_directory));
+    auto directory = adopt_ref(*new SysFSBusDirectory(parent_directory));
     return directory;
 }
 

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -197,7 +197,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<ProcFSUDP> ProcFSUDP::must_create()
 
 UNMAP_AFTER_INIT NonnullRefPtr<ProcFSNetworkDirectory> ProcFSNetworkDirectory::must_create(const ProcFSRootDirectory& parent_directory)
 {
-    auto directory = adopt_ref(*new (nothrow) ProcFSNetworkDirectory(parent_directory));
+    auto directory = adopt_ref(*new ProcFSNetworkDirectory(parent_directory));
     directory->m_components.append(ProcFSAdapters::must_create());
     directory->m_components.append(ProcFSARP::must_create());
     directory->m_components.append(ProcFSTCP::must_create());
@@ -815,7 +815,7 @@ UNMAP_AFTER_INIT ProcFSProfile::ProcFSProfile()
 
 UNMAP_AFTER_INIT NonnullRefPtr<ProcFSSystemDirectory> ProcFSSystemDirectory::must_create(const ProcFSRootDirectory& parent_directory)
 {
-    auto directory = adopt_ref(*new (nothrow) ProcFSSystemDirectory(parent_directory));
+    auto directory = adopt_ref(*new ProcFSSystemDirectory(parent_directory));
     directory->m_components.append(ProcFSDumpKmallocStacks::must_create(directory));
     directory->m_components.append(ProcFSUBSanDeadly::must_create(directory));
     directory->m_components.append(ProcFSCapsLockRemap::must_create(directory));
@@ -829,7 +829,7 @@ UNMAP_AFTER_INIT ProcFSSystemDirectory::ProcFSSystemDirectory(const ProcFSRootDi
 
 UNMAP_AFTER_INIT NonnullRefPtr<ProcFSRootDirectory> ProcFSRootDirectory::must_create()
 {
-    auto directory = adopt_ref(*new (nothrow) ProcFSRootDirectory);
+    auto directory = adopt_ref(*new ProcFSRootDirectory);
     directory->m_components.append(ProcFSSelfProcessDirectory::must_create());
     directory->m_components.append(ProcFSDiskUsage::must_create());
     directory->m_components.append(ProcFSMemoryStatus::must_create());

--- a/Kernel/Net/LoopbackAdapter.cpp
+++ b/Kernel/Net/LoopbackAdapter.cpp
@@ -13,7 +13,7 @@ static bool s_loopback_initialized = false;
 
 RefPtr<LoopbackAdapter> LoopbackAdapter::try_create()
 {
-    return adopt_ref_if_nonnull(new LoopbackAdapter());
+    return adopt_ref_if_nonnull(new (nothrow) LoopbackAdapter());
 }
 
 LoopbackAdapter::LoopbackAdapter()

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -22,7 +22,7 @@ public:
     // Note: We pass const ProcFSProcessStacks& to enforce creation with this type of directory
     static NonnullRefPtr<ProcFSThreadStack> create(const ProcFSProcessDirectory& process_directory, const ProcFSProcessStacks&, const Thread& thread)
     {
-        return adopt_ref(*new (nothrow) ProcFSThreadStack(process_directory, thread));
+        return adopt_ref(*new ProcFSThreadStack(process_directory, thread));
     }
 
 private:
@@ -66,7 +66,7 @@ public:
 
     static NonnullRefPtr<ProcFSProcessStacks> create(const ProcFSProcessDirectory& parent_directory)
     {
-        auto directory = adopt_ref(*new (nothrow) ProcFSProcessStacks(parent_directory));
+        auto directory = adopt_ref(*new ProcFSProcessStacks(parent_directory));
         return directory;
     }
 
@@ -132,7 +132,7 @@ public:
     // Note: we pass const ProcFSProcessFileDescriptions& just to enforce creation of this in the correct directory.
     static NonnullRefPtr<ProcFSProcessFileDescription> create(unsigned fd_number, const FileDescription& fd, InodeIndex preallocated_index, const ProcFSProcessFileDescriptions&)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessFileDescription(fd_number, fd, preallocated_index));
+        return adopt_ref(*new ProcFSProcessFileDescription(fd_number, fd, preallocated_index));
     }
 
 private:
@@ -163,7 +163,7 @@ public:
 
     static NonnullRefPtr<ProcFSProcessFileDescriptions> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessFileDescriptions(parent_directory));
+        return adopt_ref(*new ProcFSProcessFileDescriptions(parent_directory));
     }
 
     virtual void prepare_for_deletion() override
@@ -235,7 +235,7 @@ class ProcFSProcessPledge final : public ProcFSProcessInformation {
 public:
     static NonnullRefPtr<ProcFSProcessPledge> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessPledge(parent_directory));
+        return adopt_ref(*new ProcFSProcessPledge(parent_directory));
     }
 
 private:
@@ -273,7 +273,7 @@ class ProcFSProcessUnveil final : public ProcFSProcessInformation {
 public:
     static NonnullRefPtr<ProcFSProcessUnveil> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessUnveil(parent_directory));
+        return adopt_ref(*new ProcFSProcessUnveil(parent_directory));
     }
 
 private:
@@ -317,7 +317,7 @@ class ProcFSProcessPerformanceEvents final : public ProcFSProcessInformation {
 public:
     static NonnullRefPtr<ProcFSProcessPerformanceEvents> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessPerformanceEvents(parent_directory));
+        return adopt_ref(*new ProcFSProcessPerformanceEvents(parent_directory));
     }
 
 private:
@@ -346,7 +346,7 @@ class ProcFSProcessOverallFileDescriptions final : public ProcFSProcessInformati
 public:
     static NonnullRefPtr<ProcFSProcessOverallFileDescriptions> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessOverallFileDescriptions(parent_directory));
+        return adopt_ref(*new ProcFSProcessOverallFileDescriptions(parent_directory));
     }
 
 private:
@@ -398,7 +398,7 @@ class ProcFSProcessRoot final : public ProcFSExposedLink {
 public:
     static NonnullRefPtr<ProcFSProcessRoot> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessRoot(parent_directory));
+        return adopt_ref(*new ProcFSProcessRoot(parent_directory));
     }
 
 private:
@@ -425,7 +425,7 @@ class ProcFSProcessVirtualMemory final : public ProcFSProcessInformation {
 public:
     static NonnullRefPtr<ProcFSProcessRoot> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessVirtualMemory(parent_directory));
+        return adopt_ref(*new ProcFSProcessVirtualMemory(parent_directory));
     }
 
 private:
@@ -489,7 +489,7 @@ class ProcFSProcessCurrentWorkDirectory final : public ProcFSExposedLink {
 public:
     static NonnullRefPtr<ProcFSProcessCurrentWorkDirectory> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessCurrentWorkDirectory(parent_directory));
+        return adopt_ref(*new ProcFSProcessCurrentWorkDirectory(parent_directory));
     }
 
 private:
@@ -517,7 +517,7 @@ class ProcFSProcessBinary final : public ProcFSExposedLink {
 public:
     static NonnullRefPtr<ProcFSProcessBinary> create(const ProcFSProcessDirectory& parent_directory)
     {
-        return adopt_ref(*new (nothrow) ProcFSProcessBinary(parent_directory));
+        return adopt_ref(*new ProcFSProcessBinary(parent_directory));
     }
 
     virtual mode_t required_mode() const override

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -20,7 +20,7 @@ class PhysicalRegion {
 public:
     static OwnPtr<PhysicalRegion> try_create(PhysicalAddress lower, PhysicalAddress upper)
     {
-        return adopt_own_if_nonnull(new PhysicalRegion { lower, upper });
+        return adopt_own_if_nonnull(new (nothrow) PhysicalRegion { lower, upper });
     }
 
     ~PhysicalRegion();


### PR DESCRIPTION
Dereferencing a pointer returned from `new (nothrow)` without first
checking whether it's null will cause undefined behavior if the
allocation fails.