### PR TITLE
Kernel: Try to find a good filename for dumping perfcore

### DIFF
--- a/Base/res/apps/Profiler.af
+++ b/Base/res/apps/Profiler.af
@@ -2,3 +2,6 @@
 Name=Profiler
 Executable=/bin/Profiler
 Category=Development
+
+[Launcher]
+FileTypes=profile


### PR DESCRIPTION
Currently, if the Kernel tries to dump a perfcore to disk and a file with that name already exists, it will just ignore the error, meaning
the performance events will just be lost.

This patch changes the behvaior of `Process::dump_perfcore()` so it appends a dot and a digit after the filename if the "main" filename is already taken. This also adds some more error logging to `dump_perfcore()`.

This annoyed me for too long, and I finally got around to fixing it. :^)