### PR TITLE
LibWeb: ResourceLoader can use FileSystemAccessServer for local files

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -16,7 +16,7 @@ class RequestClient;
 }
 
 namespace Web {
-
+class FileSystemAccessClient;
 #if ARCH(I386)
 #    define CPU_STRING "x86"
 #else
@@ -54,6 +54,7 @@ private:
     int m_pending_loads { 0 };
 
     RefPtr<Protocol::RequestClient> m_protocol_client;
+    NonnullRefPtr<FileSystemAccessClient> m_file_system_access_client;
     String m_user_agent;
 };
 

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -32,6 +32,10 @@ int main(int, char**)
         perror("unveil");
         return 1;
     }
+    if (unveil("/tmp/portal/filesystemaccess", "rw") < 0) {
+        perror("unveil");
+        return 1;
+    }
     if (unveil(nullptr, nullptr) < 0) {
         perror("unveil");
         return 1;


### PR DESCRIPTION
Currently, you are not able to load local HTML files, due to them not being unveiled. This pull request changes the ResourceLoader inside LibWeb to uses the FileSystemAccessServer if it finds local files that are not unveiled yet.
It does not fully replace the old direct way of accessing files, because some files are already unveiled and do not require the FSAS. (e.g. file:///res/html/error.html).