### PR TITLE
DisplaySettings: Add ComboBox to allow selecting other screens

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.cpp
@@ -73,6 +73,14 @@ void FrameBufferDevice::create_buffer(Buffer& buffer, size_t framebuffer_offset,
     if (&buffer == m_current_buffer)
         flush_displayed_image(info.rect, buffer);
 
+    // Make sure we constrain the existing dirty rect (if any)
+    if (buffer.dirty_rect.width != 0 || buffer.dirty_rect.height != 0) {
+        auto dirty_right = buffer.dirty_rect.x + buffer.dirty_rect.width;
+        auto dirty_bottom = buffer.dirty_rect.y + buffer.dirty_rect.height;
+        buffer.dirty_rect.width = min(dirty_right, info.rect.x + info.rect.width) - buffer.dirty_rect.x;
+        buffer.dirty_rect.height = min(dirty_bottom, info.rect.y + info.rect.height) - buffer.dirty_rect.y;
+    }
+
     info.enabled = 1;
 }
 

--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -15,6 +15,23 @@
         fixed_height: 20
     }
 
+    @GUI::Widget {
+        shrink_to_fit: true
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [16, 8, 8, 6]
+        }
+
+        @GUI::Label {
+            text: "Screen:"
+            text_alignment: "CenterLeft"
+            fixed_width: 95
+        }
+
+        @GUI::ComboBox {
+            name: "screen_combo"
+        }
+    }
+
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 24, 16, 6]

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -34,11 +34,16 @@ private:
     void create_frame();
     void create_resolution_list();
     void load_current_settings();
+    void selected_screen_index_changed();
+
+    size_t m_selected_screen_index { 0 };
 
     WindowServer::ScreenLayout m_screen_layout;
+    Vector<String> m_screens;
     Vector<Gfx::IntSize> m_resolutions;
 
     RefPtr<DisplaySettings::MonitorWidget> m_monitor_widget;
+    RefPtr<GUI::ComboBox> m_screen_combo;
     RefPtr<GUI::ComboBox> m_resolution_combo;
     RefPtr<GUI::RadioButton> m_display_scale_radio_1x;
     RefPtr<GUI::RadioButton> m_display_scale_radio_2x;

--- a/Userland/Services/WindowServer/ScreenLayout.h
+++ b/Userland/Services/WindowServer/ScreenLayout.h
@@ -35,7 +35,7 @@ public:
     unsigned main_screen_index { 0 };
 
     bool is_valid(String* error_msg = nullptr) const;
-    void normalize();
+    bool normalize();
     bool load_config(const Core::ConfigFile& config_file, String* error_msg = nullptr);
     bool save_config(Core::ConfigFile& config_file, bool sync = true) const;
     bool try_auto_add_framebuffer(String const&);


### PR DESCRIPTION
This enables changing monitor settings for each monitor individually.

In the event that changing a resolution causes screens to overlap we
now try to disperse the screens, although the algorithm currently
implemented may result in some rather unexpected layouts in certain
cases. We can still improve this logic, and eventually we're going to
have a widget where the screens can be arranged as desired.

https://user-images.githubusercontent.com/10320822/126075104-5dbb5d8e-9668-4238-8120-d90188128629.mp4