### PR TITLE
Kernel: Don't truncate physical address in ACPI table to 32 bits

### DIFF
--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -408,8 +408,8 @@ UNMAP_AFTER_INIT static PhysicalAddress search_table_in_xsdt(PhysicalAddress xsd
     auto xsdt = map_typed<Structures::XSDT>(xsdt_address);
 
     for (size_t i = 0; i < ((xsdt->h.length - sizeof(Structures::SDTHeader)) / sizeof(u64)); ++i) {
-        if (match_table_signature(PhysicalAddress((FlatPtr)xsdt->table_ptrs[i]), signature))
-            return PhysicalAddress((FlatPtr)xsdt->table_ptrs[i]);
+        if (match_table_signature(PhysicalAddress((PhysicalPtr)xsdt->table_ptrs[i]), signature))
+            return PhysicalAddress((PhysicalPtr)xsdt->table_ptrs[i]);
     }
     return {};
 }
@@ -431,8 +431,8 @@ UNMAP_AFTER_INIT static PhysicalAddress search_table_in_rsdt(PhysicalAddress rsd
     auto rsdt = map_typed<Structures::RSDT>(rsdt_address);
 
     for (u32 i = 0; i < ((rsdt->h.length - sizeof(Structures::SDTHeader)) / sizeof(u32)); i++) {
-        if (match_table_signature(PhysicalAddress((FlatPtr)rsdt->table_ptrs[i]), signature))
-            return PhysicalAddress((FlatPtr)rsdt->table_ptrs[i]);
+        if (match_table_signature(PhysicalAddress((PhysicalPtr)rsdt->table_ptrs[i]), signature))
+            return PhysicalAddress((PhysicalPtr)rsdt->table_ptrs[i]);
     }
     return {};
 }


### PR DESCRIPTION
We need to cast physical addresses to PhysicalPtr instead of FlatPtr,
which is currently always 64 bits. However, if one day we were to
support 32 bit non-pae mode then it would also truncate appropriately.