### PR TITLE
Kernel: Some fixes for the prekernel

### DIFF
--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -22,8 +22,8 @@
 #include <Kernel/VM/PhysicalRegion.h>
 #include <Kernel/VM/SharedInodeVMObject.h>
 
-extern u8* start_of_bootloader_image;
-extern u8* end_of_bootloader_image;
+extern u8* start_of_prekernel_image;
+extern u8* end_of_prekernel_image;
 extern u8* start_of_kernel_image;
 extern u8* end_of_kernel_image;
 extern FlatPtr start_of_kernel_text;
@@ -201,7 +201,7 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map()
     // Register used memory regions that we know of.
     m_used_memory_ranges.ensure_capacity(4);
     m_used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::LowMemory, PhysicalAddress(0x00000000), PhysicalAddress(1 * MiB) });
-    m_used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::Bootloader, PhysicalAddress(virtual_to_low_physical(FlatPtr(start_of_bootloader_image))), PhysicalAddress(page_round_up(virtual_to_low_physical(FlatPtr(end_of_bootloader_image)))) });
+    m_used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::Prekernel, PhysicalAddress(virtual_to_low_physical(FlatPtr(start_of_prekernel_image))), PhysicalAddress(page_round_up(virtual_to_low_physical(FlatPtr(end_of_prekernel_image)))) });
     m_used_memory_ranges.append(UsedMemoryRange { UsedMemoryRangeType::Kernel, PhysicalAddress(virtual_to_low_physical(FlatPtr(&start_of_kernel_image))), PhysicalAddress(page_round_up(virtual_to_low_physical(FlatPtr(&end_of_kernel_image)))) });
 
     if (multiboot_info_ptr->flags & 0x4) {

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -53,7 +53,7 @@ inline FlatPtr virtual_to_low_physical(FlatPtr virtual_)
 
 enum class UsedMemoryRangeType {
     LowMemory = 0,
-    Bootloader,
+    Prekernel,
     Kernel,
     BootModule,
     PhysicalPages,
@@ -61,7 +61,7 @@ enum class UsedMemoryRangeType {
 
 static constexpr StringView UserMemoryRangeTypeNames[] {
     "Low memory",
-    "Bootloader",
+    "Prekernel",
     "Kernel",
     "Boot module",
     "Physical Pages"

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -106,8 +106,8 @@ static Processor s_bsp_processor; // global but let's keep it "private"
 // init_stage2() function. Initialization continues there.
 
 extern "C" {
-u8 const* start_of_bootloader_image;
-u8 const* end_of_bootloader_image;
+u8 const* start_of_prekernel_image;
+u8 const* end_of_prekernel_image;
 __attribute__((section(".boot_bss"))) FlatPtr kernel_base;
 #if ARCH(X86_64)
 extern "C" u32 gdt64ptr;
@@ -127,8 +127,8 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     setup_serial_debug();
 
     multiboot_info_ptr = boot_info.multiboot_info_ptr;
-    start_of_bootloader_image = boot_info.start_of_prekernel_image;
-    end_of_bootloader_image = boot_info.end_of_prekernel_image;
+    start_of_prekernel_image = boot_info.start_of_prekernel_image;
+    end_of_prekernel_image = boot_info.end_of_prekernel_image;
     kernel_base = boot_info.kernel_base;
 #if ARCH(X86_64)
     gdt64ptr = boot_info.gdt64ptr;

--- a/Meta/grub-ebr.cfg
+++ b/Meta/grub-ebr.cfg
@@ -2,25 +2,25 @@ timeout=1
 
 menuentry 'SerenityOS (normal)' {
   root=hd0,5
-  multiboot /boot/Bootloader root=/dev/hda4
+  multiboot /boot/Prekernel root=/dev/hda4
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (text mode)' {
   root=hd0,5
-  multiboot /boot/Bootloader boot_mode=no-fbdev root=/dev/hda4
+  multiboot /boot/Prekernel boot_mode=no-fbdev root=/dev/hda4
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (No ACPI)' {
   root=hd0,5
-  multiboot /boot/Bootloader root=/dev/hda4 acpi=off
+  multiboot /boot/Prekernel root=/dev/hda4 acpi=off
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (with serial debug)' {
   root=hd0,5
-  multiboot /boot/Bootloader serial_debug root=/dev/hda4
+  multiboot /boot/Prekernel serial_debug root=/dev/hda4
   module /boot/Kernel
 }
 

--- a/Meta/grub-gpt.cfg
+++ b/Meta/grub-gpt.cfg
@@ -2,24 +2,24 @@ timeout=1
 
 menuentry 'SerenityOS (normal)' {
   root=hd0,2
-  multiboot /boot/Bootloader root=/dev/hda2
+  multiboot /boot/Prekernel root=/dev/hda2
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (text mode)' {
   root=hd0,2
-  multiboot /boot/Bootloader boot_mode=no-fbdev root=/dev/hda2
+  multiboot /boot/Prekernel boot_mode=no-fbdev root=/dev/hda2
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (No ACPI)' {
   root=hd0,2
-  multiboot /boot/Bootloader root=/dev/hda2 acpi=off
+  multiboot /boot/Prekernel root=/dev/hda2 acpi=off
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (with serial debug)' {
   root=hd0,2
-  multiboot /boot/Bootloader serial_debug root=/dev/hda2
+  multiboot /boot/Prekernel serial_debug root=/dev/hda2
   module /boot/Kernel
 }

--- a/Meta/grub-mbr.cfg
+++ b/Meta/grub-mbr.cfg
@@ -2,24 +2,24 @@ timeout=1
 
 menuentry 'SerenityOS (normal)' {
   root=hd0,1
-  multiboot /boot/Bootloader root=/dev/hda1
+  multiboot /boot/Prekernel root=/dev/hda1
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (text mode)' {
   root=hd0,1
-  multiboot /boot/Bootloader boot_mode=no-fbdev root=/dev/hda1
+  multiboot /boot/Prekernel boot_mode=no-fbdev root=/dev/hda1
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (No ACPI)' {
   root=hd0,1
-  multiboot /boot/Bootloader root=/dev/hda1 acpi=off
+  multiboot /boot/Prekernel root=/dev/hda1 acpi=off
   module /boot/Kernel
 }
 
 menuentry 'SerenityOS (with serial debug)' {
   root=hd0,1
-  multiboot /boot/Bootloader serial_debug root=/dev/hda1
+  multiboot /boot/Prekernel serial_debug root=/dev/hda1
   module /boot/Kernel
 }

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -240,19 +240,6 @@ elif [ "$SERENITY_RUN" = "q35" ]; then
         -kernel Kernel/Prekernel/Prekernel \
         -initrd Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
-elif [ "$SERENITY_RUN" = "bootloader_test" ]; then
-    # Meta/run.sh q35: qemu (q35 chipset) with SerenityOS
-    echo "Starting SerenityOS with QEMU Q35 machine, Commandline: ${SERENITY_KERNEL_CMDLINE}"
-    "$SERENITY_QEMU_BIN" \
-        $SERENITY_COMMON_QEMU_Q35_ARGS \
-        $SERENITY_VIRT_TECH_ARG \
-        -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
-        -device e1000,netdev=breh \
-        -kernel Kernel/Prekernel/Prekernel \
-        -initrd Kernel/Kernel \
-        -append "${SERENITY_KERNEL_CMDLINE}" \
-        -no-reboot \
-        -no-shutdown
 elif [ "$SERENITY_RUN" = "ci" ]; then
     # Meta/run.sh ci: qemu in text mode
     echo "Running QEMU in CI"


### PR DESCRIPTION
**Kernel: Rename bootloader to prekernel**

There are a few occurrences of the old name that slipped through.

**Kernel: Fix GRUB config by specifying the correct file name**

**Meta: Remove unused bootloader_test target**

Due to other changes this is now just a copy of the q35 target.