### PR TITLE
Kernel: Start breaking up the big process lock 

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -43,7 +43,7 @@ enum class NeedsBigProcessLock {
 //   - VERIFY_NO_PROCESS_BIG_LOCK(this)
 //
 #define ENUMERATE_SYSCALLS(S)                               \
-    S(yield, NeedsBigProcessLock::Yes)                      \
+    S(yield, NeedsBigProcessLock::No)                       \
     S(open, NeedsBigProcessLock::Yes)                       \
     S(close, NeedsBigProcessLock::Yes)                      \
     S(read, NeedsBigProcessLock::Yes)                       \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -67,7 +67,7 @@ enum class NeedsBigProcessLock {
     S(gethostname, NeedsBigProcessLock::No)                 \
     S(sethostname, NeedsBigProcessLock::No)                 \
     S(chdir, NeedsBigProcessLock::Yes)                      \
-    S(uname, NeedsBigProcessLock::Yes)                      \
+    S(uname, NeedsBigProcessLock::No)                       \
     S(set_mmap_name, NeedsBigProcessLock::Yes)              \
     S(readlink, NeedsBigProcessLock::Yes)                   \
     S(write, NeedsBigProcessLock::Yes)                      \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -126,7 +126,7 @@ enum class NeedsBigProcessLock {
     S(getsockopt, NeedsBigProcessLock::Yes)                 \
     S(setsockopt, NeedsBigProcessLock::Yes)                 \
     S(create_thread, NeedsBigProcessLock::Yes)              \
-    S(gettid, NeedsBigProcessLock::Yes)                     \
+    S(gettid, NeedsBigProcessLock::No)                      \
     S(rename, NeedsBigProcessLock::Yes)                     \
     S(ftruncate, NeedsBigProcessLock::Yes)                  \
     S(exit_thread, NeedsBigProcessLock::Yes)                \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -33,6 +33,15 @@ enum class NeedsBigProcessLock {
     No
 };
 
+// Declare all syscalls and associated  metadata.
+//
+// NOTE: When declaring a new syscall or modifying an existing, please
+// ensure that the proper assert is present at the top of the syscall
+// implementation to both verify and document to any readers if the
+// syscall aquires the big process lock or not. The asserts are:
+//   - VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+//   - VERIFY_NO_PROCESS_BIG_LOCK(this)
+//
 #define ENUMERATE_SYSCALLS(S)                               \
     S(yield, NeedsBigProcessLock::Yes)                      \
     S(open, NeedsBigProcessLock::Yes)                       \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -64,8 +64,8 @@ enum class NeedsBigProcessLock {
     S(get_dir_entries, NeedsBigProcessLock::Yes)            \
     S(getcwd, NeedsBigProcessLock::Yes)                     \
     S(gettimeofday, NeedsBigProcessLock::Yes)               \
-    S(gethostname, NeedsBigProcessLock::Yes)                \
-    S(sethostname, NeedsBigProcessLock::Yes)                \
+    S(gethostname, NeedsBigProcessLock::No)                 \
+    S(sethostname, NeedsBigProcessLock::No)                 \
     S(chdir, NeedsBigProcessLock::Yes)                      \
     S(uname, NeedsBigProcessLock::Yes)                      \
     S(set_mmap_name, NeedsBigProcessLock::Yes)              \

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -28,165 +28,170 @@ typedef u32 socklen_t;
 
 namespace Kernel {
 
-#define ENUMERATE_SYSCALLS(S)     \
-    S(yield)                      \
-    S(open)                       \
-    S(close)                      \
-    S(read)                       \
-    S(lseek)                      \
-    S(kill)                       \
-    S(getuid)                     \
-    S(exit)                       \
-    S(geteuid)                    \
-    S(getegid)                    \
-    S(getgid)                     \
-    S(getpid)                     \
-    S(getppid)                    \
-    S(getresuid)                  \
-    S(getresgid)                  \
-    S(waitid)                     \
-    S(mmap)                       \
-    S(munmap)                     \
-    S(get_dir_entries)            \
-    S(getcwd)                     \
-    S(gettimeofday)               \
-    S(gethostname)                \
-    S(sethostname)                \
-    S(chdir)                      \
-    S(uname)                      \
-    S(set_mmap_name)              \
-    S(readlink)                   \
-    S(write)                      \
-    S(ttyname)                    \
-    S(stat)                       \
-    S(getsid)                     \
-    S(setsid)                     \
-    S(getpgid)                    \
-    S(setpgid)                    \
-    S(getpgrp)                    \
-    S(fork)                       \
-    S(execve)                     \
-    S(dup2)                       \
-    S(sigaction)                  \
-    S(umask)                      \
-    S(getgroups)                  \
-    S(setgroups)                  \
-    S(sigreturn)                  \
-    S(sigprocmask)                \
-    S(sigpending)                 \
-    S(pipe)                       \
-    S(killpg)                     \
-    S(seteuid)                    \
-    S(setegid)                    \
-    S(setuid)                     \
-    S(setgid)                     \
-    S(setreuid)                   \
-    S(setresuid)                  \
-    S(setresgid)                  \
-    S(alarm)                      \
-    S(fstat)                      \
-    S(access)                     \
-    S(fcntl)                      \
-    S(ioctl)                      \
-    S(mkdir)                      \
-    S(times)                      \
-    S(utime)                      \
-    S(sync)                       \
-    S(ptsname)                    \
-    S(select)                     \
-    S(unlink)                     \
-    S(poll)                       \
-    S(rmdir)                      \
-    S(chmod)                      \
-    S(socket)                     \
-    S(bind)                       \
-    S(accept4)                    \
-    S(listen)                     \
-    S(connect)                    \
-    S(link)                       \
-    S(chown)                      \
-    S(fchmod)                     \
-    S(symlink)                    \
-    S(sendmsg)                    \
-    S(recvmsg)                    \
-    S(getsockopt)                 \
-    S(setsockopt)                 \
-    S(create_thread)              \
-    S(gettid)                     \
-    S(rename)                     \
-    S(ftruncate)                  \
-    S(exit_thread)                \
-    S(mknod)                      \
-    S(writev)                     \
-    S(beep)                       \
-    S(getsockname)                \
-    S(getpeername)                \
-    S(socketpair)                 \
-    S(sched_setparam)             \
-    S(sched_getparam)             \
-    S(fchown)                     \
-    S(halt)                       \
-    S(reboot)                     \
-    S(mount)                      \
-    S(umount)                     \
-    S(dump_backtrace)             \
-    S(dbgputch)                   \
-    S(dbgputstr)                  \
-    S(create_inode_watcher)       \
-    S(inode_watcher_add_watch)    \
-    S(inode_watcher_remove_watch) \
-    S(mprotect)                   \
-    S(realpath)                   \
-    S(get_process_name)           \
-    S(fchdir)                     \
-    S(getrandom)                  \
-    S(getkeymap)                  \
-    S(setkeymap)                  \
-    S(clock_gettime)              \
-    S(clock_settime)              \
-    S(clock_nanosleep)            \
-    S(join_thread)                \
-    S(module_load)                \
-    S(module_unload)              \
-    S(detach_thread)              \
-    S(set_thread_name)            \
-    S(get_thread_name)            \
-    S(madvise)                    \
-    S(purge)                      \
-    S(profiling_enable)           \
-    S(profiling_disable)          \
-    S(profiling_free_buffer)      \
-    S(futex)                      \
-    S(chroot)                     \
-    S(pledge)                     \
-    S(unveil)                     \
-    S(perf_event)                 \
-    S(shutdown)                   \
-    S(get_stack_bounds)           \
-    S(ptrace)                     \
-    S(sendfd)                     \
-    S(recvfd)                     \
-    S(sysconf)                    \
-    S(set_process_name)           \
-    S(disown)                     \
-    S(adjtime)                    \
-    S(allocate_tls)               \
-    S(prctl)                      \
-    S(mremap)                     \
-    S(set_coredump_metadata)      \
-    S(anon_create)                \
-    S(msyscall)                   \
-    S(readv)                      \
-    S(emuctl)                     \
-    S(statvfs)                    \
-    S(fstatvfs)                   \
-    S(kill_thread)
+enum class NeedsBigProcessLock {
+    Yes,
+    No
+};
+
+#define ENUMERATE_SYSCALLS(S)                               \
+    S(yield, NeedsBigProcessLock::Yes)                      \
+    S(open, NeedsBigProcessLock::Yes)                       \
+    S(close, NeedsBigProcessLock::Yes)                      \
+    S(read, NeedsBigProcessLock::Yes)                       \
+    S(lseek, NeedsBigProcessLock::Yes)                      \
+    S(kill, NeedsBigProcessLock::Yes)                       \
+    S(getuid, NeedsBigProcessLock::Yes)                     \
+    S(exit, NeedsBigProcessLock::Yes)                       \
+    S(geteuid, NeedsBigProcessLock::Yes)                    \
+    S(getegid, NeedsBigProcessLock::Yes)                    \
+    S(getgid, NeedsBigProcessLock::Yes)                     \
+    S(getpid, NeedsBigProcessLock::Yes)                     \
+    S(getppid, NeedsBigProcessLock::Yes)                    \
+    S(getresuid, NeedsBigProcessLock::Yes)                  \
+    S(getresgid, NeedsBigProcessLock::Yes)                  \
+    S(waitid, NeedsBigProcessLock::Yes)                     \
+    S(mmap, NeedsBigProcessLock::Yes)                       \
+    S(munmap, NeedsBigProcessLock::Yes)                     \
+    S(get_dir_entries, NeedsBigProcessLock::Yes)            \
+    S(getcwd, NeedsBigProcessLock::Yes)                     \
+    S(gettimeofday, NeedsBigProcessLock::Yes)               \
+    S(gethostname, NeedsBigProcessLock::Yes)                \
+    S(sethostname, NeedsBigProcessLock::Yes)                \
+    S(chdir, NeedsBigProcessLock::Yes)                      \
+    S(uname, NeedsBigProcessLock::Yes)                      \
+    S(set_mmap_name, NeedsBigProcessLock::Yes)              \
+    S(readlink, NeedsBigProcessLock::Yes)                   \
+    S(write, NeedsBigProcessLock::Yes)                      \
+    S(ttyname, NeedsBigProcessLock::Yes)                    \
+    S(stat, NeedsBigProcessLock::Yes)                       \
+    S(getsid, NeedsBigProcessLock::Yes)                     \
+    S(setsid, NeedsBigProcessLock::Yes)                     \
+    S(getpgid, NeedsBigProcessLock::Yes)                    \
+    S(setpgid, NeedsBigProcessLock::Yes)                    \
+    S(getpgrp, NeedsBigProcessLock::Yes)                    \
+    S(fork, NeedsBigProcessLock::Yes)                       \
+    S(execve, NeedsBigProcessLock::Yes)                     \
+    S(dup2, NeedsBigProcessLock::Yes)                       \
+    S(sigaction, NeedsBigProcessLock::Yes)                  \
+    S(umask, NeedsBigProcessLock::Yes)                      \
+    S(getgroups, NeedsBigProcessLock::Yes)                  \
+    S(setgroups, NeedsBigProcessLock::Yes)                  \
+    S(sigreturn, NeedsBigProcessLock::Yes)                  \
+    S(sigprocmask, NeedsBigProcessLock::Yes)                \
+    S(sigpending, NeedsBigProcessLock::Yes)                 \
+    S(pipe, NeedsBigProcessLock::Yes)                       \
+    S(killpg, NeedsBigProcessLock::Yes)                     \
+    S(seteuid, NeedsBigProcessLock::Yes)                    \
+    S(setegid, NeedsBigProcessLock::Yes)                    \
+    S(setuid, NeedsBigProcessLock::Yes)                     \
+    S(setgid, NeedsBigProcessLock::Yes)                     \
+    S(setreuid, NeedsBigProcessLock::Yes)                   \
+    S(setresuid, NeedsBigProcessLock::Yes)                  \
+    S(setresgid, NeedsBigProcessLock::Yes)                  \
+    S(alarm, NeedsBigProcessLock::Yes)                      \
+    S(fstat, NeedsBigProcessLock::Yes)                      \
+    S(access, NeedsBigProcessLock::Yes)                     \
+    S(fcntl, NeedsBigProcessLock::Yes)                      \
+    S(ioctl, NeedsBigProcessLock::Yes)                      \
+    S(mkdir, NeedsBigProcessLock::Yes)                      \
+    S(times, NeedsBigProcessLock::Yes)                      \
+    S(utime, NeedsBigProcessLock::Yes)                      \
+    S(sync, NeedsBigProcessLock::Yes)                       \
+    S(ptsname, NeedsBigProcessLock::Yes)                    \
+    S(select, NeedsBigProcessLock::Yes)                     \
+    S(unlink, NeedsBigProcessLock::Yes)                     \
+    S(poll, NeedsBigProcessLock::Yes)                       \
+    S(rmdir, NeedsBigProcessLock::Yes)                      \
+    S(chmod, NeedsBigProcessLock::Yes)                      \
+    S(socket, NeedsBigProcessLock::Yes)                     \
+    S(bind, NeedsBigProcessLock::Yes)                       \
+    S(accept4, NeedsBigProcessLock::Yes)                    \
+    S(listen, NeedsBigProcessLock::Yes)                     \
+    S(connect, NeedsBigProcessLock::Yes)                    \
+    S(link, NeedsBigProcessLock::Yes)                       \
+    S(chown, NeedsBigProcessLock::Yes)                      \
+    S(fchmod, NeedsBigProcessLock::Yes)                     \
+    S(symlink, NeedsBigProcessLock::Yes)                    \
+    S(sendmsg, NeedsBigProcessLock::Yes)                    \
+    S(recvmsg, NeedsBigProcessLock::Yes)                    \
+    S(getsockopt, NeedsBigProcessLock::Yes)                 \
+    S(setsockopt, NeedsBigProcessLock::Yes)                 \
+    S(create_thread, NeedsBigProcessLock::Yes)              \
+    S(gettid, NeedsBigProcessLock::Yes)                     \
+    S(rename, NeedsBigProcessLock::Yes)                     \
+    S(ftruncate, NeedsBigProcessLock::Yes)                  \
+    S(exit_thread, NeedsBigProcessLock::Yes)                \
+    S(mknod, NeedsBigProcessLock::Yes)                      \
+    S(writev, NeedsBigProcessLock::Yes)                     \
+    S(beep, NeedsBigProcessLock::Yes)                       \
+    S(getsockname, NeedsBigProcessLock::Yes)                \
+    S(getpeername, NeedsBigProcessLock::Yes)                \
+    S(socketpair, NeedsBigProcessLock::Yes)                 \
+    S(sched_setparam, NeedsBigProcessLock::Yes)             \
+    S(sched_getparam, NeedsBigProcessLock::Yes)             \
+    S(fchown, NeedsBigProcessLock::Yes)                     \
+    S(halt, NeedsBigProcessLock::Yes)                       \
+    S(reboot, NeedsBigProcessLock::Yes)                     \
+    S(mount, NeedsBigProcessLock::Yes)                      \
+    S(umount, NeedsBigProcessLock::Yes)                     \
+    S(dump_backtrace, NeedsBigProcessLock::Yes)             \
+    S(dbgputch, NeedsBigProcessLock::Yes)                   \
+    S(dbgputstr, NeedsBigProcessLock::Yes)                  \
+    S(create_inode_watcher, NeedsBigProcessLock::Yes)       \
+    S(inode_watcher_add_watch, NeedsBigProcessLock::Yes)    \
+    S(inode_watcher_remove_watch, NeedsBigProcessLock::Yes) \
+    S(mprotect, NeedsBigProcessLock::Yes)                   \
+    S(realpath, NeedsBigProcessLock::Yes)                   \
+    S(get_process_name, NeedsBigProcessLock::Yes)           \
+    S(fchdir, NeedsBigProcessLock::Yes)                     \
+    S(getrandom, NeedsBigProcessLock::Yes)                  \
+    S(getkeymap, NeedsBigProcessLock::Yes)                  \
+    S(setkeymap, NeedsBigProcessLock::Yes)                  \
+    S(clock_gettime, NeedsBigProcessLock::Yes)              \
+    S(clock_settime, NeedsBigProcessLock::Yes)              \
+    S(clock_nanosleep, NeedsBigProcessLock::Yes)            \
+    S(join_thread, NeedsBigProcessLock::Yes)                \
+    S(module_load, NeedsBigProcessLock::Yes)                \
+    S(module_unload, NeedsBigProcessLock::Yes)              \
+    S(detach_thread, NeedsBigProcessLock::Yes)              \
+    S(set_thread_name, NeedsBigProcessLock::Yes)            \
+    S(get_thread_name, NeedsBigProcessLock::Yes)            \
+    S(madvise, NeedsBigProcessLock::Yes)                    \
+    S(purge, NeedsBigProcessLock::Yes)                      \
+    S(profiling_enable, NeedsBigProcessLock::Yes)           \
+    S(profiling_disable, NeedsBigProcessLock::Yes)          \
+    S(profiling_free_buffer, NeedsBigProcessLock::Yes)      \
+    S(futex, NeedsBigProcessLock::Yes)                      \
+    S(chroot, NeedsBigProcessLock::Yes)                     \
+    S(pledge, NeedsBigProcessLock::Yes)                     \
+    S(unveil, NeedsBigProcessLock::Yes)                     \
+    S(perf_event, NeedsBigProcessLock::Yes)                 \
+    S(shutdown, NeedsBigProcessLock::Yes)                   \
+    S(get_stack_bounds, NeedsBigProcessLock::Yes)           \
+    S(ptrace, NeedsBigProcessLock::Yes)                     \
+    S(sendfd, NeedsBigProcessLock::Yes)                     \
+    S(recvfd, NeedsBigProcessLock::Yes)                     \
+    S(sysconf, NeedsBigProcessLock::Yes)                    \
+    S(set_process_name, NeedsBigProcessLock::Yes)           \
+    S(disown, NeedsBigProcessLock::Yes)                     \
+    S(adjtime, NeedsBigProcessLock::Yes)                    \
+    S(allocate_tls, NeedsBigProcessLock::Yes)               \
+    S(prctl, NeedsBigProcessLock::Yes)                      \
+    S(mremap, NeedsBigProcessLock::Yes)                     \
+    S(set_coredump_metadata, NeedsBigProcessLock::Yes)      \
+    S(anon_create, NeedsBigProcessLock::Yes)                \
+    S(msyscall, NeedsBigProcessLock::Yes)                   \
+    S(readv, NeedsBigProcessLock::Yes)                      \
+    S(emuctl, NeedsBigProcessLock::Yes)                     \
+    S(statvfs, NeedsBigProcessLock::Yes)                    \
+    S(fstatvfs, NeedsBigProcessLock::Yes)                   \
+    S(kill_thread, NeedsBigProcessLock::Yes)
 
 namespace Syscall {
 
 enum Function {
 #undef __ENUMERATE_SYSCALL
-#define __ENUMERATE_SYSCALL(x) SC_##x,
+#define __ENUMERATE_SYSCALL(sys_call, needs_lock) SC_##sys_call,
     ENUMERATE_SYSCALLS(__ENUMERATE_SYSCALL)
 #undef __ENUMERATE_SYSCALL
         __Count
@@ -196,9 +201,9 @@ constexpr const char* to_string(Function function)
 {
     switch (function) {
 #undef __ENUMERATE_SYSCALL
-#define __ENUMERATE_SYSCALL(x) \
-    case SC_##x:               \
-        return #x;
+#define __ENUMERATE_SYSCALL(sys_call, needs_lock) \
+    case SC_##sys_call:                           \
+        return #sys_call;
         ENUMERATE_SYSCALLS(__ENUMERATE_SYSCALL)
 #undef __ENUMERATE_SYSCALL
     default:
@@ -522,7 +527,7 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
 }
 
 #undef __ENUMERATE_SYSCALL
-#define __ENUMERATE_SYSCALL(x) using Syscall::SC_##x;
+#define __ENUMERATE_SYSCALL(sys_call, needs_lock) using Syscall::SC_##sys_call;
 ENUMERATE_SYSCALLS(__ENUMERATE_SYSCALL)
 #undef __ENUMERATE_SYSCALL
 

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -54,7 +54,7 @@ enum class NeedsBigProcessLock {
     S(geteuid, NeedsBigProcessLock::Yes)                    \
     S(getegid, NeedsBigProcessLock::Yes)                    \
     S(getgid, NeedsBigProcessLock::Yes)                     \
-    S(getpid, NeedsBigProcessLock::Yes)                     \
+    S(getpid, NeedsBigProcessLock::No)                      \
     S(getppid, NeedsBigProcessLock::Yes)                    \
     S(getresuid, NeedsBigProcessLock::Yes)                  \
     S(getresgid, NeedsBigProcessLock::Yes)                  \

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -33,7 +33,7 @@ inline u32 get_iopl_from_eflags(u32 eflags)
 const DescriptorTablePointer& get_gdtr();
 const DescriptorTablePointer& get_idtr();
 
-[[noreturn]] void handle_crash(RegisterState&, const char* description, int signal, bool out_of_memory = false);
+[[noreturn]] void handle_crash(RegisterState const&, char const* description, int signal, bool out_of_memory = false);
 
 #define LSW(x) ((u32)(x)&0xFFFF)
 #define MSW(x) (((u32)(x) >> 16) & 0xFFFF)

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -311,7 +311,7 @@ void page_fault_handler(TrapFrame* trap)
     };
 
     VirtualAddress userspace_sp = VirtualAddress { regs.userspace_sp() };
-    if (!faulted_in_kernel && !MM.validate_user_stack(current_thread->process(), userspace_sp)) {
+    if (!faulted_in_kernel && !MM.validate_user_stack(current_thread->process().space(), userspace_sp)) {
         dbgln("Invalid stack pointer: {}", userspace_sp);
         handle_crash(regs, "Bad stack on page fault", SIGSTKFLT);
     }

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -210,7 +210,7 @@ static void dump(const RegisterState& regs)
 #endif
 }
 
-void handle_crash(RegisterState& regs, const char* description, int signal, bool out_of_memory)
+void handle_crash(RegisterState const& regs, char const* description, int signal, bool out_of_memory)
 {
     auto process = Process::current();
     if (!process) {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -882,6 +882,12 @@ inline ProcessID Thread::pid() const
     } while (0)
 }
 
+#define VERIFY_PROCESS_BIG_LOCK_ACQUIRED(process) \
+    VERIFY(process->big_lock().own_lock());
+
+#define VERIFY_NO_PROCESS_BIG_LOCK(process) \
+    VERIFY(!process->big_lock().own_lock());
+
 inline static String copy_string_from_user(const Kernel::Syscall::StringArgument& string)
 {
     return copy_string_from_user(string.characters, string.length);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -200,7 +200,7 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
 #else
     userspace_sp = VirtualAddress { regs.userspace_rsp };
 #endif
-    if (!MM.validate_user_stack(process, userspace_sp)) {
+    if (!MM.validate_user_stack(process.space(), userspace_sp)) {
         dbgln("Invalid stack pointer: {:p}", userspace_sp);
         handle_crash(regs, "Bad stack on syscall entry", SIGSTKFLT);
     }

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -196,9 +196,6 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
         PANIC("Syscall from process with IOPL != 0");
     }
 
-    // NOTE: We take the big process lock before inspecting memory regions.
-    process.big_lock().lock();
-
     MM.validate_syscall_preconditions(process.space(), regs);
 
     FlatPtr function;
@@ -206,6 +203,9 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     FlatPtr arg2;
     FlatPtr arg3;
     regs.capture_syscall_params(function, arg1, arg2, arg3);
+
+    process.big_lock().lock();
+
 
     auto result = Syscall::handle(regs, function, arg1, arg2, arg3);
     if (result.is_error()) {

--- a/Kernel/Syscalls/access.cpp
+++ b/Kernel/Syscalls/access.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$access(Userspace<const char*> user_path, size_t path_length, int mode)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(rpath);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$alarm(unsigned seconds)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     unsigned previous_alarm_remaining = 0;
     if (m_alarm_timer) {

--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
 
     if (!size)

--- a/Kernel/Syscalls/beep.cpp
+++ b/Kernel/Syscalls/beep.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$beep()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     PCSpeaker::tone_on(440);
     auto result = Thread::current()->sleep(Time::from_nanoseconds(200'000'000));
     PCSpeaker::tone_off();

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$chdir(Userspace<const char*> user_path, size_t path_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(rpath);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())
@@ -26,6 +27,7 @@ KResultOr<FlatPtr> Process::sys$chdir(Userspace<const char*> user_path, size_t p
 
 KResultOr<FlatPtr> Process::sys$fchdir(int fd)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     auto description = fds().file_description(fd);
     if (!description)
@@ -43,6 +45,7 @@ KResultOr<FlatPtr> Process::sys$fchdir(int fd)
 
 KResultOr<FlatPtr> Process::sys$getcwd(Userspace<char*> buffer, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(rpath);
 
     if (size > NumericLimits<ssize_t>::max())

--- a/Kernel/Syscalls/chmod.cpp
+++ b/Kernel/Syscalls/chmod.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$chmod(Userspace<const char*> user_path, size_t path_length, mode_t mode)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(fattr);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())
@@ -22,6 +23,7 @@ KResultOr<FlatPtr> Process::sys$chmod(Userspace<const char*> user_path, size_t p
 
 KResultOr<FlatPtr> Process::sys$fchmod(int fd, mode_t mode)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(fattr);
     auto description = fds().file_description(fd);
     if (!description)

--- a/Kernel/Syscalls/chown.cpp
+++ b/Kernel/Syscalls/chown.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$fchown(int fd, uid_t uid, gid_t gid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(chown);
     auto description = fds().file_description(fd);
     if (!description)
@@ -20,6 +21,7 @@ KResultOr<FlatPtr> Process::sys$fchown(int fd, uid_t uid, gid_t gid)
 
 KResultOr<FlatPtr> Process::sys$chown(Userspace<const Syscall::SC_chown_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(chown);
     Syscall::SC_chown_params params;
     if (!copy_from_user(&params, user_params))

--- a/Kernel/Syscalls/chroot.cpp
+++ b/Kernel/Syscalls/chroot.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$chroot(Userspace<const char*> user_path, size_t path_length, int mount_flags)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     if (!is_superuser())
         return EPERM;
     REQUIRE_PROMISE(chroot);

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$clock_gettime(clockid_t clock_id, Userspace<timespec*> user_ts)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
 
     if (!TimeManagement::is_valid_clock_id(clock_id))
@@ -26,6 +27,7 @@ KResultOr<FlatPtr> Process::sys$clock_gettime(clockid_t clock_id, Userspace<time
 
 KResultOr<FlatPtr> Process::sys$clock_settime(clockid_t clock_id, Userspace<const timespec*> user_ts)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(settime);
 
     if (!is_superuser())
@@ -47,6 +49,7 @@ KResultOr<FlatPtr> Process::sys$clock_settime(clockid_t clock_id, Userspace<cons
 
 KResultOr<FlatPtr> Process::sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_clock_nanosleep_params params;
@@ -89,6 +92,7 @@ KResultOr<FlatPtr> Process::sys$clock_nanosleep(Userspace<const Syscall::SC_cloc
 
 KResultOr<FlatPtr> Process::sys$adjtime(Userspace<const timeval*> user_delta, Userspace<timeval*> user_old_delta)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     if (user_old_delta) {
         timespec old_delta_ts = TimeManagement::the().remaining_epoch_time_adjustment();
         timeval old_delta;
@@ -114,6 +118,7 @@ KResultOr<FlatPtr> Process::sys$adjtime(Userspace<const timeval*> user_delta, Us
 
 KResultOr<FlatPtr> Process::sys$gettimeofday(Userspace<timeval*> user_tv)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     auto tv = kgettimeofday().to_timeval();
     if (!copy_to_user(user_tv, &tv))

--- a/Kernel/Syscalls/debug.cpp
+++ b/Kernel/Syscalls/debug.cpp
@@ -13,18 +13,21 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$dump_backtrace()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     dump_backtrace();
     return 0;
 }
 
 KResultOr<FlatPtr> Process::sys$dbgputch(u8 ch)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     dbgputch(ch);
     return 0;
 }
 
 KResultOr<FlatPtr> Process::sys$dbgputstr(Userspace<const u8*> characters, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     if (size == 0)
         return 0;
 

--- a/Kernel/Syscalls/disown.cpp
+++ b/Kernel/Syscalls/disown.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$disown(ProcessID pid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(proc);
     auto process = Process::from_pid(pid);
     if (!process)

--- a/Kernel/Syscalls/dup2.cpp
+++ b/Kernel/Syscalls/dup2.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$dup2(int old_fd, int new_fd)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     auto description = fds().file_description(old_fd);
     if (!description)

--- a/Kernel/Syscalls/emuctl.cpp
+++ b/Kernel/Syscalls/emuctl.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$emuctl()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     return ENOSYS;
 }
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -931,6 +931,7 @@ KResult Process::exec(String path, Vector<String> arguments, Vector<String> envi
 
 KResultOr<FlatPtr> Process::sys$execve(Userspace<const Syscall::SC_execve_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(exec);
 
     // NOTE: Be extremely careful with allocating any kernel memory in exec().

--- a/Kernel/Syscalls/exit.cpp
+++ b/Kernel/Syscalls/exit.cpp
@@ -7,11 +7,17 @@
 #include <Kernel/KSyms.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
+#include <Kernel/Thread.h>
 
 namespace Kernel {
 
 void Process::sys$exit(int status)
 {
+    // FIXME: We have callers from kernel which don't aquire the big process lock.
+    if (Thread::current()->previous_mode() == Thread::PreviousMode::UserMode) {
+        VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    }
+
     {
         ProtectedDataMutationScope scope { *this };
         m_termination_status = status;

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     dbgln_if(IO_DEBUG, "sys$fcntl: fd={}, cmd={}, arg={}", fd, cmd, arg);
     auto description = fds().file_description(fd);

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -16,6 +16,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$fork(RegisterState& regs)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(proc);
     RefPtr<Thread> child_first_thread;
     auto child = Process::create(child_first_thread, m_name, uid(), gid(), pid(), m_is_kernel_process, m_cwd, m_executable, m_tty, this);

--- a/Kernel/Syscalls/ftruncate.cpp
+++ b/Kernel/Syscalls/ftruncate.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$ftruncate(int fd, Userspace<off_t*> userspace_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     off_t length;
     if (!copy_from_user(&length, userspace_length))

--- a/Kernel/Syscalls/futex.cpp
+++ b/Kernel/Syscalls/futex.cpp
@@ -84,6 +84,7 @@ void Process::clear_futex_queues_on_exec()
 
 KResultOr<FlatPtr> Process::sys$futex(Userspace<const Syscall::SC_futex_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     Syscall::SC_futex_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;

--- a/Kernel/Syscalls/get_dir_entries.cpp
+++ b/Kernel/Syscalls/get_dir_entries.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$get_dir_entries(int fd, Userspace<void*> user_buffer, size_t user_size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     if (user_size > NumericLimits<ssize_t>::max())
         return EINVAL;

--- a/Kernel/Syscalls/get_stack_bounds.cpp
+++ b/Kernel/Syscalls/get_stack_bounds.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$get_stack_bounds(Userspace<FlatPtr*> user_stack_base, Userspace<size_t*> user_stack_size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     auto& regs = Thread::current()->get_register_dump_from_stack();
     FlatPtr stack_pointer = regs.userspace_sp();
     auto* stack_region = space().find_region_containing(Range { VirtualAddress(stack_pointer), 1 });

--- a/Kernel/Syscalls/getrandom.cpp
+++ b/Kernel/Syscalls/getrandom.cpp
@@ -15,6 +15,7 @@ namespace Kernel {
 // do, we should be able of the caveats that Linux has dealt with.
 KResultOr<FlatPtr> Process::sys$getrandom(Userspace<void*> buffer, size_t buffer_size, [[maybe_unused]] unsigned flags)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(stdio);
     if (buffer_size > NumericLimits<ssize_t>::max())
         return EINVAL;

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -10,30 +10,35 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$getuid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return uid();
 }
 
 KResultOr<FlatPtr> Process::sys$getgid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return gid();
 }
 
 KResultOr<FlatPtr> Process::sys$geteuid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return euid();
 }
 
 KResultOr<FlatPtr> Process::sys$getegid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return egid();
 }
 
 KResultOr<FlatPtr> Process::sys$getresuid(Userspace<uid_t*> ruid, Userspace<uid_t*> euid, Userspace<uid_t*> suid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (!copy_to_user(ruid, &m_uid) || !copy_to_user(euid, &m_euid) || !copy_to_user(suid, &m_suid))
         return EFAULT;
@@ -42,6 +47,7 @@ KResultOr<FlatPtr> Process::sys$getresuid(Userspace<uid_t*> ruid, Userspace<uid_
 
 KResultOr<FlatPtr> Process::sys$getresgid(Userspace<gid_t*> rgid, Userspace<gid_t*> egid, Userspace<gid_t*> sgid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (!copy_to_user(rgid, &m_gid) || !copy_to_user(egid, &m_egid) || !copy_to_user(sgid, &m_sgid))
         return EFAULT;
@@ -50,6 +56,7 @@ KResultOr<FlatPtr> Process::sys$getresgid(Userspace<gid_t*> rgid, Userspace<gid_
 
 KResultOr<FlatPtr> Process::sys$getgroups(size_t count, Userspace<gid_t*> user_gids)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (!count)
         return extra_gids().size();

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -13,6 +13,7 @@ extern Mutex* g_hostname_lock;
 
 KResultOr<FlatPtr> Process::sys$gethostname(Userspace<char*> buffer, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
@@ -26,6 +27,7 @@ KResultOr<FlatPtr> Process::sys$gethostname(Userspace<char*> buffer, size_t size
 
 KResultOr<FlatPtr> Process::sys$sethostname(Userspace<const char*> hostname, size_t length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_NO_PROMISES;
     if (!is_superuser())
         return EPERM;

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -13,7 +13,7 @@ extern Mutex* g_hostname_lock;
 
 KResultOr<FlatPtr> Process::sys$gethostname(Userspace<char*> buffer, size_t size)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     REQUIRE_PROMISE(stdio);
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
@@ -27,7 +27,7 @@ KResultOr<FlatPtr> Process::sys$gethostname(Userspace<char*> buffer, size_t size
 
 KResultOr<FlatPtr> Process::sys$sethostname(Userspace<const char*> hostname, size_t length)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     REQUIRE_NO_PROMISES;
     if (!is_superuser())
         return EPERM;

--- a/Kernel/Syscalls/inode_watcher.cpp
+++ b/Kernel/Syscalls/inode_watcher.cpp
@@ -15,6 +15,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$create_inode_watcher(u32 flags)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
 
     int fd = m_fds.allocate();
@@ -42,6 +43,7 @@ KResultOr<FlatPtr> Process::sys$create_inode_watcher(u32 flags)
 
 KResultOr<FlatPtr> Process::sys$inode_watcher_add_watch(Userspace<const Syscall::SC_inode_watcher_add_watch_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
 
     Syscall::SC_inode_watcher_add_watch_params params;
@@ -75,6 +77,7 @@ KResultOr<FlatPtr> Process::sys$inode_watcher_add_watch(Userspace<const Syscall:
 
 KResultOr<FlatPtr> Process::sys$inode_watcher_remove_watch(int fd, int wd)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     auto description = fds().file_description(fd);
     if (!description)
         return EBADF;

--- a/Kernel/Syscalls/ioctl.cpp
+++ b/Kernel/Syscalls/ioctl.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$ioctl(int fd, unsigned request, FlatPtr arg)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     auto description = fds().file_description(fd);
     if (!description)
         return EBADF;

--- a/Kernel/Syscalls/keymap.cpp
+++ b/Kernel/Syscalls/keymap.cpp
@@ -13,6 +13,7 @@ constexpr size_t map_name_max_size = 50;
 
 KResultOr<FlatPtr> Process::sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     REQUIRE_PROMISE(setkeymap);
 
     if (!is_superuser())

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -98,6 +98,7 @@ KResult Process::do_killself(int signal)
 
 KResultOr<FlatPtr> Process::sys$kill(pid_t pid_or_pgid, int signal)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (pid_or_pgid == pid().value())
         REQUIRE_PROMISE(stdio);
     else
@@ -125,6 +126,7 @@ KResultOr<FlatPtr> Process::sys$kill(pid_t pid_or_pgid, int signal)
 
 KResultOr<FlatPtr> Process::sys$killpg(pid_t pgrp, int signum)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     if (signum < 1 || signum >= 32)
         return EINVAL;

--- a/Kernel/Syscalls/link.cpp
+++ b/Kernel/Syscalls/link.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$link(Userspace<const Syscall::SC_link_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(cpath);
     Syscall::SC_link_params params;
     if (!copy_from_user(&params, user_params))
@@ -27,6 +28,7 @@ KResultOr<FlatPtr> Process::sys$link(Userspace<const Syscall::SC_link_params*> u
 
 KResultOr<FlatPtr> Process::sys$symlink(Userspace<const Syscall::SC_symlink_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(cpath);
     Syscall::SC_symlink_params params;
     if (!copy_from_user(&params, user_params))

--- a/Kernel/Syscalls/lseek.cpp
+++ b/Kernel/Syscalls/lseek.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$lseek(int fd, Userspace<off_t*> userspace_offset, int whence)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     auto description = fds().file_description(fd);
     if (!description)

--- a/Kernel/Syscalls/mkdir.cpp
+++ b/Kernel/Syscalls/mkdir.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$mkdir(Userspace<const char*> user_path, size_t path_length, mode_t mode)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(cpath);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())

--- a/Kernel/Syscalls/mknod.cpp
+++ b/Kernel/Syscalls/mknod.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$mknod(Userspace<const Syscall::SC_mknod_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(dpath);
     Syscall::SC_mknod_params params;
     if (!copy_from_user(&params, user_params))

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -127,6 +127,7 @@ static bool validate_inode_mmap_prot(const Process& process, int prot, const Ino
 
 KResultOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_mmap_params params;
@@ -282,6 +283,7 @@ static KResultOr<Range> expand_range_to_page_boundaries(FlatPtr address, size_t 
 
 KResultOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int prot)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     if (prot & PROT_EXEC) {
@@ -436,6 +438,7 @@ KResultOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int
 
 KResultOr<FlatPtr> Process::sys$madvise(Userspace<void*> address, size_t size, int advice)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     auto range_or_error = expand_range_to_page_boundaries(address, size);
@@ -485,6 +488,7 @@ KResultOr<FlatPtr> Process::sys$madvise(Userspace<void*> address, size_t size, i
 
 KResultOr<FlatPtr> Process::sys$set_mmap_name(Userspace<const Syscall::SC_set_mmap_name_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_set_mmap_name_params params;
@@ -519,6 +523,7 @@ KResultOr<FlatPtr> Process::sys$set_mmap_name(Userspace<const Syscall::SC_set_mm
 
 KResultOr<FlatPtr> Process::sys$munmap(Userspace<void*> addr, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     auto result = space().unmap_mmap_range(VirtualAddress { addr }, size);
@@ -529,6 +534,7 @@ KResultOr<FlatPtr> Process::sys$munmap(Userspace<void*> addr, size_t size)
 
 KResultOr<FlatPtr> Process::sys$mremap(Userspace<const Syscall::SC_mremap_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_mremap_params params {};
@@ -578,6 +584,7 @@ KResultOr<FlatPtr> Process::sys$mremap(Userspace<const Syscall::SC_mremap_params
 
 KResultOr<FlatPtr> Process::sys$allocate_tls(Userspace<const char*> initial_data, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     if (!size || size % PAGE_SIZE != 0)
@@ -639,6 +646,7 @@ KResultOr<FlatPtr> Process::sys$allocate_tls(Userspace<const char*> initial_data
 
 KResultOr<FlatPtr> Process::sys$msyscall(Userspace<void*> address)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (space().enforces_syscall_regions())
         return EPERM;
 

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -17,6 +17,7 @@ extern HashMap<String, OwnPtr<Module>>* g_modules;
 
 KResultOr<FlatPtr> Process::sys$module_load(Userspace<const char*> user_path, size_t path_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (!is_superuser())
         return EPERM;
 
@@ -146,6 +147,7 @@ KResultOr<FlatPtr> Process::sys$module_load(Userspace<const char*> user_path, si
 
 KResultOr<FlatPtr> Process::sys$module_unload(Userspace<const char*> user_name, size_t name_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (!is_superuser())
         return EPERM;
 

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -19,6 +19,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (!is_superuser())
         return EPERM;
 
@@ -116,6 +117,7 @@ KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*>
 
 KResultOr<FlatPtr> Process::sys$umount(Userspace<const char*> user_mountpoint, size_t mountpoint_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (!is_superuser())
         return EPERM;
 

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -14,6 +14,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$open(Userspace<const Syscall::SC_open_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_open_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
@@ -77,6 +78,7 @@ KResultOr<FlatPtr> Process::sys$open(Userspace<const Syscall::SC_open_params*> u
 
 KResultOr<FlatPtr> Process::sys$close(int fd)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     auto description = fds().file_description(fd);
     dbgln_if(IO_DEBUG, "sys$close({}) {}", fd, description.ptr());

--- a/Kernel/Syscalls/perf_event.cpp
+++ b/Kernel/Syscalls/perf_event.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$perf_event(int type, FlatPtr arg1, FlatPtr arg2)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     auto events_buffer = current_perf_events_buffer();
     if (!events_buffer) {
         if (!create_perf_events_buffer_if_needed())

--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$pipe(int pipefd[2], int flags)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (fds().open_count() + 2 > fds().max_open())
         return EMFILE;

--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_pledge_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;

--- a/Kernel/Syscalls/prctl.cpp
+++ b/Kernel/Syscalls/prctl.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$prctl(int option, FlatPtr arg1, [[maybe_unused]] FlatPtr arg2)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     switch (option) {
     case PR_GET_DUMPABLE:
         return is_dumpable();

--- a/Kernel/Syscalls/process.cpp
+++ b/Kernel/Syscalls/process.cpp
@@ -11,7 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$getpid()
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     REQUIRE_PROMISE(stdio);
     return pid().value();
 }

--- a/Kernel/Syscalls/process.cpp
+++ b/Kernel/Syscalls/process.cpp
@@ -11,18 +11,21 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$getpid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return pid().value();
 }
 
 KResultOr<FlatPtr> Process::sys$getppid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return m_ppid.value();
 }
 
 KResultOr<FlatPtr> Process::sys$get_process_name(Userspace<char*> buffer, size_t buffer_size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (m_name.length() + 1 > buffer_size)
         return ENAMETOOLONG;
@@ -34,6 +37,7 @@ KResultOr<FlatPtr> Process::sys$get_process_name(Userspace<char*> buffer, size_t
 
 KResultOr<FlatPtr> Process::sys$set_process_name(Userspace<const char*> user_name, size_t user_name_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     if (user_name_length > 256)
         return ENAMETOOLONG;
@@ -49,6 +53,7 @@ KResultOr<FlatPtr> Process::sys$set_process_name(Userspace<const char*> user_nam
 
 KResultOr<FlatPtr> Process::sys$set_coredump_metadata(Userspace<const Syscall::SC_set_coredump_metadata_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_set_coredump_metadata_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -19,6 +19,7 @@ u64 g_profiling_event_mask;
 
 KResultOr<FlatPtr> Process::sys$profiling_enable(pid_t pid, u64 event_mask)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_NO_PROMISES;
 
     if (pid == -1) {
@@ -68,6 +69,7 @@ KResultOr<FlatPtr> Process::sys$profiling_enable(pid_t pid, u64 event_mask)
 
 KResultOr<FlatPtr> Process::sys$profiling_disable(pid_t pid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_NO_PROMISES;
 
     if (pid == -1) {
@@ -97,6 +99,7 @@ KResultOr<FlatPtr> Process::sys$profiling_disable(pid_t pid)
 
 KResultOr<FlatPtr> Process::sys$profiling_free_buffer(pid_t pid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_NO_PROMISES;
 
     if (pid == -1) {

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -157,6 +157,7 @@ static KResultOr<u32> handle_ptrace(const Kernel::Syscall::SC_ptrace_params& par
 
 KResultOr<FlatPtr> Process::sys$ptrace(Userspace<const Syscall::SC_ptrace_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(ptrace);
     Syscall::SC_ptrace_params params {};
     if (!copy_from_user(&params, user_params))

--- a/Kernel/Syscalls/purge.cpp
+++ b/Kernel/Syscalls/purge.cpp
@@ -15,6 +15,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$purge(int mode)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_NO_PROMISES;
     if (!is_superuser())
         return EPERM;

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -14,6 +14,7 @@ using BlockFlags = Thread::FileBlocker::BlockFlags;
 
 KResultOr<FlatPtr> Process::sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (iov_count < 0)
         return EINVAL;
@@ -70,6 +71,7 @@ KResultOr<FlatPtr> Process::sys$readv(int fd, Userspace<const struct iovec*> iov
 
 KResultOr<FlatPtr> Process::sys$read(int fd, Userspace<u8*> buffer, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (size == 0)
         return 0;

--- a/Kernel/Syscalls/readlink.cpp
+++ b/Kernel/Syscalls/readlink.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$readlink(Userspace<const Syscall::SC_readlink_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
 
     Syscall::SC_readlink_params params;

--- a/Kernel/Syscalls/realpath.cpp
+++ b/Kernel/Syscalls/realpath.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$realpath(Userspace<const Syscall::SC_realpath_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
 
     Syscall::SC_realpath_params params;

--- a/Kernel/Syscalls/rename.cpp
+++ b/Kernel/Syscalls/rename.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$rename(Userspace<const Syscall::SC_rename_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(cpath);
     Syscall::SC_rename_params params;
     if (!copy_from_user(&params, user_params))

--- a/Kernel/Syscalls/rmdir.cpp
+++ b/Kernel/Syscalls/rmdir.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$rmdir(Userspace<const char*> user_path, size_t path_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(cpath);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$yield()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     Thread::current()->yield_and_release_relock_big_lock();
     return 0;
@@ -17,6 +18,7 @@ KResultOr<FlatPtr> Process::sys$yield()
 
 KResultOr<FlatPtr> Process::sys$sched_setparam(int pid, Userspace<const struct sched_param*> user_param)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     struct sched_param desired_param;
     if (!copy_from_user(&desired_param, user_param))
@@ -42,6 +44,7 @@ KResultOr<FlatPtr> Process::sys$sched_setparam(int pid, Userspace<const struct s
 
 KResultOr<FlatPtr> Process::sys$sched_getparam(pid_t pid, Userspace<struct sched_param*> user_param)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     int priority;
     {

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -10,9 +10,9 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$yield()
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this);
     REQUIRE_PROMISE(stdio);
-    Thread::current()->yield_and_release_relock_big_lock();
+    Thread::current()->yield_assuming_not_holding_big_lock();
     return 0;
 }
 

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -16,6 +16,7 @@ using BlockFlags = Thread::FileBlocker::BlockFlags;
 
 KResultOr<FlatPtr> Process::sys$select(Userspace<const Syscall::SC_select_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     Syscall::SC_select_params params {};
 
@@ -129,6 +130,7 @@ KResultOr<FlatPtr> Process::sys$select(Userspace<const Syscall::SC_select_params
 
 KResultOr<FlatPtr> Process::sys$poll(Userspace<const Syscall::SC_poll_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_poll_params params;

--- a/Kernel/Syscalls/sendfd.cpp
+++ b/Kernel/Syscalls/sendfd.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$sendfd(int sockfd, int fd)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(sendfd);
     auto socket_description = fds().file_description(sockfd);
     if (!socket_description)
@@ -34,6 +35,7 @@ KResultOr<FlatPtr> Process::sys$sendfd(int sockfd, int fd)
 
 KResultOr<FlatPtr> Process::sys$recvfd(int sockfd, int options)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(recvfd);
     auto socket_description = fds().file_description(sockfd);
     if (!socket_description)

--- a/Kernel/Syscalls/setpgid.cpp
+++ b/Kernel/Syscalls/setpgid.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$getsid(pid_t pid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     if (pid == 0)
         return sid().value();
@@ -26,6 +27,7 @@ KResultOr<FlatPtr> Process::sys$getsid(pid_t pid)
 
 KResultOr<FlatPtr> Process::sys$setsid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     InterruptDisabler disabler;
     bool found_process_with_same_pgid_as_my_pid = false;
@@ -45,6 +47,7 @@ KResultOr<FlatPtr> Process::sys$setsid()
 
 KResultOr<FlatPtr> Process::sys$getpgid(pid_t pid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     if (pid == 0)
         return pgid().value();
@@ -57,6 +60,7 @@ KResultOr<FlatPtr> Process::sys$getpgid(pid_t pid)
 
 KResultOr<FlatPtr> Process::sys$getpgrp()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return pgid().value();
 }
@@ -77,6 +81,7 @@ SessionID Process::get_sid_from_pgid(ProcessGroupID pgid)
 
 KResultOr<FlatPtr> Process::sys$setpgid(pid_t specified_pid, pid_t specified_pgid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
     ScopedSpinLock lock(g_processes_lock); // FIXME: Use a ProcessHandle
     ProcessID pid = specified_pid ? ProcessID(specified_pid) : this->pid();

--- a/Kernel/Syscalls/setuid.cpp
+++ b/Kernel/Syscalls/setuid.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$seteuid(uid_t new_euid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_euid != uid() && new_euid != suid() && !is_superuser())
@@ -26,6 +27,7 @@ KResultOr<FlatPtr> Process::sys$seteuid(uid_t new_euid)
 
 KResultOr<FlatPtr> Process::sys$setegid(gid_t new_egid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_egid != gid() && new_egid != sgid() && !is_superuser())
@@ -41,6 +43,7 @@ KResultOr<FlatPtr> Process::sys$setegid(gid_t new_egid)
 
 KResultOr<FlatPtr> Process::sys$setuid(uid_t new_uid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_uid != uid() && new_uid != euid() && !is_superuser())
@@ -58,6 +61,7 @@ KResultOr<FlatPtr> Process::sys$setuid(uid_t new_uid)
 
 KResultOr<FlatPtr> Process::sys$setgid(gid_t new_gid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_gid != gid() && new_gid != egid() && !is_superuser())
@@ -75,6 +79,7 @@ KResultOr<FlatPtr> Process::sys$setgid(gid_t new_gid)
 
 KResultOr<FlatPtr> Process::sys$setreuid(uid_t new_ruid, uid_t new_euid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_ruid == (uid_t)-1)
@@ -100,6 +105,7 @@ KResultOr<FlatPtr> Process::sys$setreuid(uid_t new_ruid, uid_t new_euid)
 
 KResultOr<FlatPtr> Process::sys$setresuid(uid_t new_ruid, uid_t new_euid, uid_t new_suid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_ruid == (uid_t)-1)
@@ -125,6 +131,7 @@ KResultOr<FlatPtr> Process::sys$setresuid(uid_t new_ruid, uid_t new_euid, uid_t 
 
 KResultOr<FlatPtr> Process::sys$setresgid(gid_t new_rgid, gid_t new_egid, gid_t new_sgid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
 
     if (new_rgid == (gid_t)-1)
@@ -150,6 +157,7 @@ KResultOr<FlatPtr> Process::sys$setresgid(gid_t new_rgid, gid_t new_egid, gid_t 
 
 KResultOr<FlatPtr> Process::sys$setgroups(size_t count, Userspace<const gid_t*> user_gids)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(id);
     if (!is_superuser())
         return EPERM;

--- a/Kernel/Syscalls/shutdown.cpp
+++ b/Kernel/Syscalls/shutdown.cpp
@@ -14,6 +14,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$reboot()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (!is_superuser())
         return EPERM;
 
@@ -34,6 +35,7 @@ KResultOr<FlatPtr> Process::sys$reboot()
 
 KResultOr<FlatPtr> Process::sys$halt()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (!is_superuser())
         return EPERM;
 

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$sigprocmask(int how, Userspace<const sigset_t*> set, Userspace<sigset_t*> old_set)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(sigaction);
     auto current_thread = Thread::current();
     u32 previous_signal_mask;
@@ -43,6 +44,7 @@ KResultOr<FlatPtr> Process::sys$sigprocmask(int how, Userspace<const sigset_t*> 
 
 KResultOr<FlatPtr> Process::sys$sigpending(Userspace<sigset_t*> set)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     auto pending_signals = Thread::current()->pending_signals();
     if (!copy_to_user(set, &pending_signals))
@@ -52,6 +54,7 @@ KResultOr<FlatPtr> Process::sys$sigpending(Userspace<sigset_t*> set)
 
 KResultOr<FlatPtr> Process::sys$sigaction(int signum, Userspace<const sigaction*> user_act, Userspace<sigaction*> user_old_act)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(sigaction);
     if (signum < 1 || signum >= 32 || signum == SIGKILL || signum == SIGSTOP)
         return EINVAL;
@@ -77,6 +80,7 @@ KResultOr<FlatPtr> Process::sys$sigaction(int signum, Userspace<const sigaction*
 
 KResultOr<FlatPtr> Process::sys$sigreturn([[maybe_unused]] RegisterState& registers)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     SmapDisabler disabler;
 

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -34,6 +34,7 @@ void Process::setup_socket_fd(int fd, NonnullRefPtr<FileDescription> description
 
 KResultOr<FlatPtr> Process::sys$socket(int domain, int type, int protocol)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE_FOR_SOCKET_DOMAIN(domain);
 
     if ((type & SOCK_TYPE_MASK) == SOCK_RAW && !is_superuser())
@@ -53,6 +54,7 @@ KResultOr<FlatPtr> Process::sys$socket(int domain, int type, int protocol)
 
 KResultOr<FlatPtr> Process::sys$bind(int sockfd, Userspace<const sockaddr*> address, socklen_t address_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     auto description = fds().file_description(sockfd);
     if (!description)
         return EBADF;
@@ -65,6 +67,7 @@ KResultOr<FlatPtr> Process::sys$bind(int sockfd, Userspace<const sockaddr*> addr
 
 KResultOr<FlatPtr> Process::sys$listen(int sockfd, int backlog)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     if (backlog < 0)
         return EINVAL;
     auto description = fds().file_description(sockfd);
@@ -81,6 +84,7 @@ KResultOr<FlatPtr> Process::sys$listen(int sockfd, int backlog)
 
 KResultOr<FlatPtr> Process::sys$accept4(Userspace<const Syscall::SC_accept4_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(accept);
 
     Syscall::SC_accept4_params params;
@@ -148,6 +152,7 @@ KResultOr<FlatPtr> Process::sys$accept4(Userspace<const Syscall::SC_accept4_para
 
 KResultOr<FlatPtr> Process::sys$connect(int sockfd, Userspace<const sockaddr*> user_address, socklen_t user_address_size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     int fd = m_fds.allocate();
     if (fd < 0)
         return fd;
@@ -165,6 +170,7 @@ KResultOr<FlatPtr> Process::sys$connect(int sockfd, Userspace<const sockaddr*> u
 
 KResultOr<FlatPtr> Process::sys$shutdown(int sockfd, int how)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (how & ~SHUT_RDWR)
         return EINVAL;
@@ -181,6 +187,7 @@ KResultOr<FlatPtr> Process::sys$shutdown(int sockfd, int how)
 
 KResultOr<FlatPtr> Process::sys$sendmsg(int sockfd, Userspace<const struct msghdr*> user_msg, int flags)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     struct msghdr msg;
     if (!copy_from_user(&msg, user_msg))
@@ -219,6 +226,7 @@ KResultOr<FlatPtr> Process::sys$sendmsg(int sockfd, Userspace<const struct msghd
 
 KResultOr<FlatPtr> Process::sys$recvmsg(int sockfd, Userspace<struct msghdr*> user_msg, int flags)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     struct msghdr msg;
@@ -326,6 +334,7 @@ int Process::get_sock_or_peer_name(const Params& params)
 
 KResultOr<FlatPtr> Process::sys$getsockname(Userspace<const Syscall::SC_getsockname_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_getsockname_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
@@ -334,6 +343,7 @@ KResultOr<FlatPtr> Process::sys$getsockname(Userspace<const Syscall::SC_getsockn
 
 KResultOr<FlatPtr> Process::sys$getpeername(Userspace<const Syscall::SC_getpeername_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_getpeername_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
@@ -342,6 +352,7 @@ KResultOr<FlatPtr> Process::sys$getpeername(Userspace<const Syscall::SC_getpeern
 
 KResultOr<FlatPtr> Process::sys$getsockopt(Userspace<const Syscall::SC_getsockopt_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_getsockopt_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
@@ -369,6 +380,7 @@ KResultOr<FlatPtr> Process::sys$getsockopt(Userspace<const Syscall::SC_getsockop
 
 KResultOr<FlatPtr> Process::sys$setsockopt(Userspace<const Syscall::SC_setsockopt_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_setsockopt_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;
@@ -385,6 +397,7 @@ KResultOr<FlatPtr> Process::sys$setsockopt(Userspace<const Syscall::SC_setsockop
 
 KResultOr<FlatPtr> Process::sys$socketpair(Userspace<const Syscall::SC_socketpair_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_socketpair_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;

--- a/Kernel/Syscalls/stat.cpp
+++ b/Kernel/Syscalls/stat.cpp
@@ -14,6 +14,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$fstat(int fd, Userspace<stat*> user_statbuf)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     auto description = fds().file_description(fd);
     if (!description)
@@ -27,6 +28,7 @@ KResultOr<FlatPtr> Process::sys$fstat(int fd, Userspace<stat*> user_statbuf)
 
 KResultOr<FlatPtr> Process::sys$stat(Userspace<const Syscall::SC_stat_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
     Syscall::SC_stat_params params;
     if (!copy_from_user(&params, user_params))

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -71,6 +71,7 @@ KResultOr<FlatPtr> Process::do_statvfs(String path, statvfs* buf)
 
 KResultOr<FlatPtr> Process::sys$statvfs(Userspace<const Syscall::SC_statvfs_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
 
     Syscall::SC_statvfs_params params;
@@ -85,6 +86,7 @@ KResultOr<FlatPtr> Process::sys$statvfs(Userspace<const Syscall::SC_statvfs_para
 
 KResultOr<FlatPtr> Process::sys$fstatvfs(int fd, statvfs* buf)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
     auto description = fds().file_description(fd);

--- a/Kernel/Syscalls/sync.cpp
+++ b/Kernel/Syscalls/sync.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$sync()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     VirtualFileSystem::sync();
     return 0;

--- a/Kernel/Syscalls/sysconf.cpp
+++ b/Kernel/Syscalls/sysconf.cpp
@@ -11,6 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$sysconf(int name)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     switch (name) {
     case _SC_MONOTONIC_CLOCK:
         return 1;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -18,6 +18,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::SC_create_thread_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(thread);
 
     Syscall::SC_create_thread_params params;
@@ -91,6 +92,7 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
 
 void Process::sys$exit_thread(Userspace<void*> exit_value, Userspace<void*> stack_location, size_t stack_size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(thread);
 
     if (this->thread_count() == 1) {
@@ -114,6 +116,7 @@ void Process::sys$exit_thread(Userspace<void*> exit_value, Userspace<void*> stac
 
 KResultOr<FlatPtr> Process::sys$detach_thread(pid_t tid)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(thread);
     auto thread = Thread::from_tid(tid);
     if (!thread || thread->pid() != pid())
@@ -128,6 +131,7 @@ KResultOr<FlatPtr> Process::sys$detach_thread(pid_t tid)
 
 KResultOr<FlatPtr> Process::sys$join_thread(pid_t tid, Userspace<void**> exit_value)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(thread);
 
     auto thread = Thread::from_tid(tid);
@@ -161,6 +165,7 @@ KResultOr<FlatPtr> Process::sys$join_thread(pid_t tid, Userspace<void**> exit_va
 
 KResultOr<FlatPtr> Process::sys$kill_thread(pid_t tid, int signal)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(thread);
 
     if (signal < 0 || signal >= 32)
@@ -182,6 +187,7 @@ KResultOr<FlatPtr> Process::sys$kill_thread(pid_t tid, int signal)
 
 KResultOr<FlatPtr> Process::sys$set_thread_name(pid_t tid, Userspace<const char*> user_name, size_t user_name_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     auto name = copy_string_from_user(user_name, user_name_length);
     if (name.is_null())
@@ -201,6 +207,7 @@ KResultOr<FlatPtr> Process::sys$set_thread_name(pid_t tid, Userspace<const char*
 
 KResultOr<FlatPtr> Process::sys$get_thread_name(pid_t tid, Userspace<char*> buffer, size_t buffer_size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(thread);
     if (buffer_size == 0)
         return EINVAL;
@@ -221,6 +228,7 @@ KResultOr<FlatPtr> Process::sys$get_thread_name(pid_t tid, Userspace<char*> buff
 
 KResultOr<FlatPtr> Process::sys$gettid()
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     return Thread::current()->tid().value();
 }

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -33,7 +33,7 @@ KResultOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<c
     if (user_sp.has_overflow())
         return EOVERFLOW;
 
-    if (!MM.validate_user_stack(*this, VirtualAddress(user_sp.value() - 4)))
+    if (!MM.validate_user_stack(this->space(), VirtualAddress(user_sp.value() - 4)))
         return EFAULT;
 
     // FIXME: return EAGAIN if Thread::all_threads().size() is greater than PTHREAD_THREADS_MAX

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -228,7 +228,7 @@ KResultOr<FlatPtr> Process::sys$get_thread_name(pid_t tid, Userspace<char*> buff
 
 KResultOr<FlatPtr> Process::sys$gettid()
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     REQUIRE_PROMISE(stdio);
     return Thread::current()->tid().value();
 }

--- a/Kernel/Syscalls/times.cpp
+++ b/Kernel/Syscalls/times.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$times(Userspace<tms*> user_times)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     tms times = {};
     times.tms_utime = m_ticks_in_user;

--- a/Kernel/Syscalls/ttyname.cpp
+++ b/Kernel/Syscalls/ttyname.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$ttyname(int fd, Userspace<char*> buffer, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(tty);
     auto description = fds().file_description(fd);
     if (!description)
@@ -29,6 +30,7 @@ KResultOr<FlatPtr> Process::sys$ttyname(int fd, Userspace<char*> buffer, size_t 
 
 KResultOr<FlatPtr> Process::sys$ptsname(int fd, Userspace<char*> buffer, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(tty);
     auto description = fds().file_description(fd);
     if (!description)

--- a/Kernel/Syscalls/umask.cpp
+++ b/Kernel/Syscalls/umask.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$umask(mode_t mask)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     auto old_mask = m_umask;
     ProtectedDataMutationScope scope { *this };

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -10,7 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$uname(Userspace<utsname*> user_buf)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     extern String* g_hostname;
     extern Mutex* g_hostname_lock;
 

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -10,6 +10,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$uname(Userspace<utsname*> user_buf)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     extern String* g_hostname;
     extern Mutex* g_hostname_lock;
 

--- a/Kernel/Syscalls/unlink.cpp
+++ b/Kernel/Syscalls/unlink.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$unlink(Userspace<const char*> user_path, size_t path_length)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(cpath);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -26,6 +26,7 @@ static void update_intermediate_node_permissions(UnveilNode& root_node, UnveilAc
 
 KResultOr<FlatPtr> Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     Syscall::SC_unveil_params params;
     if (!copy_from_user(&params, user_params))
         return EFAULT;

--- a/Kernel/Syscalls/utime.cpp
+++ b/Kernel/Syscalls/utime.cpp
@@ -12,6 +12,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$utime(Userspace<const char*> user_path, size_t path_length, Userspace<const struct utimbuf*> user_buf)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(fattr);
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -20,6 +20,7 @@ KResultOr<siginfo_t> Process::do_waitid(idtype_t idtype, int id, int options)
 
 KResultOr<FlatPtr> Process::sys$waitid(Userspace<const Syscall::SC_waitid_params*> user_params)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(proc);
 
     Syscall::SC_waitid_params params;

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$writev(int fd, Userspace<const struct iovec*> iov, int iov_count)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (iov_count < 0)
         return EINVAL;
@@ -98,6 +99,7 @@ KResultOr<FlatPtr> Process::do_write(FileDescription& description, const UserOrK
 
 KResultOr<FlatPtr> Process::sys$write(int fd, Userspace<const u8*> data, size_t size)
 {
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
     if (size == 0)
         return 0;

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -636,7 +636,7 @@ Region* MemoryManager::find_user_region_from_vaddr(Space& space, VirtualAddress 
     return find_user_region_from_vaddr_no_lock(space, vaddr);
 }
 
-void MemoryManager::validate_syscall_preconditions(Space& space, RegisterState& regs)
+void MemoryManager::validate_syscall_preconditions(Space& space, RegisterState const& regs)
 {
     // We take the space lock once here and then use the no_lock variants
     // to avoid excessive spinlock recursion in this extemely common path.

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -134,7 +134,8 @@ public:
     static void enter_process_paging_scope(Process&);
     static void enter_space(Space&);
 
-    bool validate_user_stack(Process const&, VirtualAddress) const;
+    bool validate_user_stack_no_lock(Space&, VirtualAddress) const;
+    bool validate_user_stack(Space&, VirtualAddress) const;
 
     enum class ShouldZeroFill {
         No,

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -189,6 +189,8 @@ public:
     }
 
     static Region* find_user_region_from_vaddr(Space&, VirtualAddress);
+    static Region* find_user_region_from_vaddr_no_lock(Space&, VirtualAddress);
+    static void validate_syscall_preconditions(Space&, RegisterState&);
 
     void dump_kernel_regions();
 

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -190,7 +190,7 @@ public:
 
     static Region* find_user_region_from_vaddr(Space&, VirtualAddress);
     static Region* find_user_region_from_vaddr_no_lock(Space&, VirtualAddress);
-    static void validate_syscall_preconditions(Space&, RegisterState&);
+    static void validate_syscall_preconditions(Space&, RegisterState const&);
 
     void dump_kernel_regions();
 


### PR DESCRIPTION
Currently all syscalls run under the Process:m_big_lock, which is an
obvious bottleneck. Long term we would like to remove the big lock and
replace it with the required fine grained locking.

To facilitate this goal we need a way of gradually decomposing the big
lock into the all of the required fine grained locks. This PR
introduces instrumentation to the syscall table, allowing the big lock
requirement to be toggled on/off per syscall. And then starts switching
specific syscalls that don't currently need locking over to not aquire 
the big lock,. 

Eventually when we are finished, no syscall will required the big lock,
and we'll be able to remove all of this instrumentation.