### PR TITLE
WindowServer: Fix menu over-drawing

### DIFF
--- a/Userland/Services/WindowServer/AppletManager.cpp
+++ b/Userland/Services/WindowServer/AppletManager.cpp
@@ -94,8 +94,6 @@ void AppletManager::add_applet(Window& applet)
     });
 
     relayout();
-
-    MenuManager::the().refresh();
 }
 
 void AppletManager::relayout()

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -93,10 +93,12 @@ public:
     static constexpr int right_padding() { return 14; }
 
     void draw();
+    void draw(MenuItem const&, bool = false);
     const Gfx::Font& font() const;
 
     MenuItem* item_with_identifier(unsigned);
     void redraw();
+    void redraw(MenuItem const&);
 
     MenuItem* hovered_item() const;
 
@@ -130,6 +132,7 @@ private:
 
     void handle_mouse_move_event(const MouseEvent&);
     size_t visible_item_count() const;
+    Gfx::IntRect stripe_rect();
 
     int item_index_at(const Gfx::IntPoint&);
     static constexpr int padding_between_text_and_shortcut() { return 50; }

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -43,6 +43,7 @@ void MenuManager::refresh()
 {
     ClientConnection::for_each_client([&](ClientConnection& client) {
         client.for_each_menu([&](Menu& menu) {
+            dbgln("MenuManager::refresh {}", &menu);
             menu.redraw();
             return IterationDecision::Continue;
         });
@@ -220,7 +221,6 @@ void MenuManager::close_everyone()
     }
     m_open_menu_stack.clear();
     clear_current_menu();
-    refresh();
 }
 
 void MenuManager::close_everyone_not_in_lineage(Menu& menu)
@@ -247,7 +247,6 @@ void MenuManager::close_menus(const Vector<Menu&>& menus)
             return entry == &menu;
         });
     }
-    refresh();
 }
 
 static void collect_menu_subtree(Menu& menu, Vector<Menu&>& menus)
@@ -313,8 +312,6 @@ void MenuManager::open_menu(Menu& menu, bool as_current_menu)
         // other menu is current
         set_current_menu(&menu);
     }
-
-    refresh();
 }
 
 void MenuManager::clear_current_menu()

--- a/Userland/Services/WindowServer/MenuManager.h
+++ b/Userland/Services/WindowServer/MenuManager.h
@@ -23,8 +23,6 @@ public:
     MenuManager();
     virtual ~MenuManager() override;
 
-    void refresh();
-
     bool is_open(const Menu&) const;
     bool has_open_menu() const { return !m_open_menu_stack.is_empty(); }
 
@@ -54,6 +52,8 @@ private:
 
     virtual void event(Core::Event&) override;
     void handle_mouse_event(MouseEvent&);
+
+    void refresh();
 
     WeakPtr<Menu> m_current_menu;
     WeakPtr<Window> m_previous_input_window;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -605,7 +605,6 @@ void WindowManager::notify_rect_changed(Window& window, Gfx::IntRect const& old_
     if (window.type() == WindowType::Applet)
         AppletManager::the().relayout();
 
-    MenuManager::the().refresh();
     reevaluate_hovered_window(&window);
 }
 


### PR DESCRIPTION
We only need to re-draw the item being selected and the item being
deselected. We also don't care anymore if applets were added or
removed as we no longer have a global menu bar.

Before:

https://user-images.githubusercontent.com/10320822/126081520-b46aed30-f020-4c22-964a-465d4170751a.mp4

After:

https://user-images.githubusercontent.com/10320822/126081522-4c4de761-9fd8-4a9e-bbb8-7aff6e2e387b.mp4
