### PR TITLE
Kernel+LibC: Implement file advisory locks

### DIFF
--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -7,6 +7,7 @@
 #include <AK/StringView.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileDescription.h>
+#include <Kernel/Process.h>
 
 namespace Kernel {
 
@@ -53,5 +54,4 @@ void File::detach(FileDescription&)
 {
     m_attach_count--;
 }
-
 }

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -74,6 +74,9 @@ FileDescription::~FileDescription()
     (void)m_file->close();
     if (m_inode)
         m_inode->detach(*this);
+
+    if (m_inode)
+        m_inode->remove_flocks_for_description(*this);
 }
 
 KResult FileDescription::attach()
@@ -446,4 +449,19 @@ FileBlockCondition& FileDescription::block_condition()
     return m_file->block_condition();
 }
 
+KResult FileDescription::apply_flock(Process const& process, Userspace<flock const*> lock)
+{
+    if (!m_inode)
+        return EBADF;
+
+    return m_inode->apply_flock(process, *this, lock);
+}
+
+KResult FileDescription::get_flock(Userspace<flock*> lock) const
+{
+    if (!m_inode)
+        return EBADF;
+
+    return m_inode->get_flock(*this, lock);
+}
 }

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -127,6 +127,9 @@ public:
 
     FileBlockCondition& block_condition();
 
+    KResult apply_flock(Process const&, Userspace<flock const*>);
+    KResult get_flock(Userspace<flock*>) const;
+
 private:
     friend class VirtualFileSystem;
     explicit FileDescription(File&);

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -97,6 +97,11 @@ public:
 
     NonnullRefPtr<FIFO> fifo();
 
+    KResult can_apply_flock(FileDescription const&, flock const&) const;
+    KResult apply_flock(Process const&, FileDescription const&, Userspace<flock const*>);
+    KResult get_flock(FileDescription const&, Userspace<flock*>) const;
+    void remove_flocks_for_description(FileDescription const&);
+
 protected:
     Inode(FileSystem&, InodeIndex);
     void set_metadata_dirty(bool);
@@ -118,6 +123,16 @@ private:
     bool m_metadata_dirty { false };
     RefPtr<FIFO> m_fifo;
     IntrusiveListNode<Inode> m_inode_list_node;
+
+    struct Flock {
+        short type;
+        off_t start;
+        off_t len;
+        FileDescription const* owner;
+        pid_t pid;
+    };
+
+    Vector<Flock> m_flocks;
 
 public:
     using List = IntrusiveList<Inode, RawPtr<Inode>, &Inode::m_inode_list_node>;

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -42,6 +42,10 @@ KResultOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
         break;
     case F_ISTTY:
         return description->is_tty();
+    case F_GETLK:
+        return description->get_flock(Userspace<flock*>(arg));
+    case F_SETLK:
+        return description->apply_flock(*Process::current(), Userspace<const flock*>(arg));
     default:
         return EINVAL;
     }

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -108,6 +108,9 @@ enum {
 #define F_GETFL 3
 #define F_SETFL 4
 #define F_ISTTY 5
+#define F_GETLK 6
+#define F_SETLK 7
+#define F_SETLKW 8
 
 #define FD_CLOEXEC 1
 
@@ -745,4 +748,16 @@ struct statvfs {
     unsigned long f_fsid;
     unsigned long f_flag;
     unsigned long f_namemax;
+};
+
+#define F_RDLCK ((short)0)
+#define F_WRLCK ((short)1)
+#define F_UNLCK ((short)2)
+
+struct flock {
+    short l_type;
+    short l_whence;
+    off_t l_start;
+    off_t l_len;
+    pid_t l_pid;
 };

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIBC_SOURCES
     strings.cpp
     stubs.cpp
     syslog.cpp
+    sys/file.cpp
     sys/mman.cpp
     sys/prctl.cpp
     sys/ptrace.cpp

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -18,6 +18,9 @@ __BEGIN_DECLS
 #define F_GETFL 3
 #define F_SETFL 4
 #define F_ISTTY 5
+#define F_GETLK 6
+#define F_SETLK 7
+#define F_SETLKW 8
 
 #define FD_CLOEXEC 1
 
@@ -48,12 +51,9 @@ int create_inode_watcher(unsigned flags);
 int inode_watcher_add_watch(int fd, const char* path, size_t path_length, unsigned event_mask);
 int inode_watcher_remove_watch(int fd, int wd);
 
-#define F_RDLCK 0
-#define F_WRLCK 1
-#define F_UNLCK 2
-#define F_GETLK 5
-#define F_SETLK 6
-#define F_SETLKW 7
+#define F_RDLCK ((short)0)
+#define F_WRLCK ((short)1)
+#define F_UNLCK ((short)2)
 
 struct flock {
     short l_type;

--- a/Userland/Libraries/LibC/sys/file.cpp
+++ b/Userland/Libraries/LibC/sys/file.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@ualberta.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/file.h>
+
+extern "C" {
+
+int flock(int fd, int operation)
+{
+    struct flock lock {
+        short(operation & 0b11), SEEK_SET, 0, 0, 0
+    };
+    if (operation & LOCK_NB) {
+        return fcntl(fd, F_SETLK, &lock);
+    }
+
+    // FIXME: Implement F_SETLKW in fcntl.
+    VERIFY_NOT_REACHED();
+}
+}

--- a/Userland/Libraries/LibC/sys/file.h
+++ b/Userland/Libraries/LibC/sys/file.h
@@ -5,3 +5,16 @@
  */
 
 #pragma once
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+#define LOCK_SH 0
+#define LOCK_EX 1
+#define LOCK_UN 2
+#define LOCK_NB (1 << 2)
+
+int flock(int fd, int operation);
+
+__END_DECLS


### PR DESCRIPTION
Advisory locks provide an unenforced mutex on ranges of bytes in a file, or the whole file. I plan to use this to implement some kind of `Core::LockFile` at some point.

The `fcntl(2)` interface is POSIX, and `flock(2)` is common to BSD and Linux.