### PR TITLE
LibGUI: Some small invalidation rect tightening on TabWidget and Scrollbar

### DIFF
--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -327,6 +327,9 @@ Scrollbar::Component Scrollbar::component_at_position(const Gfx::IntPoint& posit
 
 void Scrollbar::mousemove_event(MouseEvent& event)
 {
+    if (!is_scrollable())
+        return;
+
     m_last_mouse_position = event.position();
 
     auto old_hovered_component = m_hovered_component;

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -412,6 +412,7 @@ void TabWidget::update_bar()
 {
     auto invalidation_rect = bar_rect();
     invalidation_rect.set_height(invalidation_rect.height() + 1);
+    invalidation_rect.set_right(button_rect(static_cast<int>(m_tabs.size() - 1)).right());
     update(invalidation_rect);
 }
 


### PR DESCRIPTION
This tightens the invalidation rect for TabWidget so that only the tabs are repainted and not the blank area to the right. Also disables repaint for Scrollbar on mousemove if it's not scrollable.