### PR TITLE
Improve launching applications from Terminal

### DIFF
--- a/Base/home/anon/.config/LaunchServer.ini
+++ b/Base/home/anon/.config/LaunchServer.ini
@@ -19,7 +19,6 @@ sheets=/bin/Spreadsheet
 gml=/bin/Playground
 pdf=/bin/PDFViewer
 directory=/bin/FileManager
-*=/bin/TextEditor
 
 [Protocol]
 gemini=/bin/Browser

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -91,6 +91,11 @@ bool Launcher::seal_allowlist()
     return true;
 }
 
+bool Launcher::launch(const String& handler_name)
+{
+    return connection().launch(handler_name);
+}
+
 bool Launcher::open(const URL& url, const String& handler_name)
 {
     return connection().open_url(url, handler_name);

--- a/Userland/Libraries/LibDesktop/Launcher.h
+++ b/Userland/Libraries/LibDesktop/Launcher.h
@@ -35,6 +35,7 @@ public:
     [[nodiscard]] static bool add_allowed_handler_with_any_url(const String& handler);
     [[nodiscard]] static bool add_allowed_handler_with_only_specific_urls(const String& handler, const Vector<URL>&);
     [[nodiscard]] static bool seal_allowlist();
+    static bool launch(const String& handler_name);
     static bool open(const URL&, const String& handler_name = {});
     static bool open(const URL&, const Details& details);
     static Vector<String> get_handlers_for_url(const URL&);

--- a/Userland/Services/LaunchServer/ClientConnection.cpp
+++ b/Userland/Services/LaunchServer/ClientConnection.cpp
@@ -28,6 +28,21 @@ void ClientConnection::die()
     s_connections.remove(client_id());
 }
 
+Messages::LaunchServer::LaunchResponse ClientConnection::launch(String const& handler_name)
+{
+    auto allowed = any_of(m_allowlist.begin(), m_allowlist.end(), [&](auto& allowed_handler) {
+        return allowed_handler.handler_name == handler_name;
+    });
+
+    if (!m_allowlist.is_empty() && !allowed) {
+        // You are not on the list, go home!
+        did_misbehave(String::formatted("Client requested a handler that was not on the list: '{}'", handler_name).characters());
+        return nullptr;
+    }
+
+    return Launcher::the().launch(handler_name);
+}
+
 Messages::LaunchServer::OpenUrlResponse ClientConnection::open_url(URL const& url, String const& handler_name)
 {
     if (!m_allowlist.is_empty()) {

--- a/Userland/Services/LaunchServer/ClientConnection.h
+++ b/Userland/Services/LaunchServer/ClientConnection.h
@@ -22,6 +22,7 @@ public:
 private:
     explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
 
+    virtual Messages::LaunchServer::LaunchResponse launch(String const&) override;
     virtual Messages::LaunchServer::OpenUrlResponse open_url(URL const&, String const&) override;
     virtual Messages::LaunchServer::GetHandlersForUrlResponse get_handlers_for_url(URL const&) override;
     virtual Messages::LaunchServer::GetHandlersWithDetailsForUrlResponse get_handlers_with_details_for_url(URL const&) override;

--- a/Userland/Services/LaunchServer/LaunchServer.ipc
+++ b/Userland/Services/LaunchServer/LaunchServer.ipc
@@ -2,6 +2,7 @@
 
 endpoint LaunchServer
 {
+    launch(String handler_name) => (bool response)
     open_url(URL url, String handler_name) => (bool response)
     get_handlers_for_url(URL url) => (Vector<String> handlers)
     get_handlers_with_details_for_url(URL url) => (Vector<String> handlers_details)

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -154,6 +154,15 @@ Vector<String> Launcher::handlers_with_details_for_url(const URL& url)
     return handlers;
 }
 
+bool Launcher::launch(const String& handler_name)
+{
+    auto handler_optional = m_handlers.get(handler_name);
+    if (!handler_optional.has_value())
+        return false;
+
+    return spawn(handler_optional.value().executable, {});
+}
+
 bool Launcher::open_url(const URL& url, const String& handler_name)
 {
     if (!handler_name.is_null())
@@ -336,4 +345,5 @@ bool Launcher::open_file_url(const URL& url)
 
     return open_with_user_preferences(m_file_handlers, extension, additional_parameters, default_handler);
 }
+
 }

--- a/Userland/Services/LaunchServer/Launcher.h
+++ b/Userland/Services/LaunchServer/Launcher.h
@@ -39,6 +39,7 @@ public:
 
     void load_handlers(const String& af_dir = Desktop::AppFile::APP_FILES_DIRECTORY);
     void load_config(const Core::ConfigFile&);
+    bool launch(const String& string);
     bool open_url(const URL&, const String& handler_name);
     Vector<String> handlers_for_url(const URL&);
     Vector<String> handlers_with_details_for_url(const URL&);


### PR DESCRIPTION
Currently, right-clicking applications inside the terminal presents the options to launch the application via itself or Text Editor.
![image](https://user-images.githubusercontent.com/8739722/126153940-c3e5f849-6c12-4852-a5b0-91f1aaff49f0.png)
This pull request changes the current behavior to launch applications without URLs, by creating an appropriate IPC call to the LauncherServer and differentiating by the LauncherType attribute.
![image](https://user-images.githubusercontent.com/8739722/126154293-38f452ae-7428-49b3-b9d6-e7fe16ce4e5a.png)
While preserving the behavior of opening files (test.html)
![image](https://user-images.githubusercontent.com/8739722/126154402-3696705a-e9e9-4517-91cc-3c05bd530e27.png)

Note: the last commit also changes the LauncherServer.ini in that the TextEditor is no longer the default for all files. Previously every file could be launched using the Text Editor which appears to be odd in most cases. The Text Editor AppFile already includes most of the actual useful file extensions.
