### PR TITLE
Base: Add file associations for multiple programs

### DIFF
--- a/Base/home/anon/.config/LaunchServer.ini
+++ b/Base/home/anon/.config/LaunchServer.ini
@@ -18,6 +18,8 @@ font=/bin/FontEditor
 sheets=/bin/Spreadsheet
 gml=/bin/Playground
 pdf=/bin/PDFViewer
+profile=/bin/Profiler
+pp=/bin/PixelPaint
 directory=/bin/FileManager
 *=/bin/TextEditor
 

--- a/Base/res/apps/ImageViewer.af
+++ b/Base/res/apps/ImageViewer.af
@@ -4,4 +4,4 @@ Executable=/bin/ImageViewer
 Category=Graphics
 
 [Launcher]
-FileTypes=pbm,pgm,png,ppm,gif,jpg,jpeg,dds
+FileTypes=bmp,pbm,pgm,png,ppm,gif,jpg,jpeg,dds

--- a/Base/res/apps/PDFViewer.af
+++ b/Base/res/apps/PDFViewer.af
@@ -2,3 +2,6 @@
 Name=PDF Viewer
 Executable=/bin/PDFViewer
 Category=Graphics
+
+[Launcher]
+FileTypes=pdf

--- a/Base/res/apps/Playground.af
+++ b/Base/res/apps/Playground.af
@@ -2,3 +2,6 @@
 Name=GML Playground
 Executable=/bin/Playground
 Category=Development
+
+[Launcher]
+FileTypes=gml

--- a/Base/res/apps/SoundPlayer.af
+++ b/Base/res/apps/SoundPlayer.af
@@ -4,4 +4,4 @@ Executable=/bin/SoundPlayer
 Category=Sound
 
 [Launcher]
-FileTypes=wav
+FileTypes=flac,m3u,m3u8,wav


### PR DESCRIPTION
This change adds missing file association for the following programs:
 - ImageViewer
 - PDFViewer
 - PixelPaint
 - Playground
 - Profiler
 - SoundPlayer