### PR TITLE
Prekernel: Make sure the last few bytes of the kernel image are mapped

### DIFF
--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -72,7 +72,7 @@ extern "C" [[noreturn]] void init()
     ElfW(Phdr)* kernel_program_headers = (ElfW(Phdr*))((char*)kernel_elf_header + kernel_elf_header->e_phoff);
 
     FlatPtr kernel_load_base = kernel_program_headers[0].p_vaddr;
-    FlatPtr kernel_load_end = kernel_program_headers[kernel_elf_header->e_phnum - 1].p_vaddr;
+    FlatPtr kernel_load_end = kernel_program_headers[kernel_elf_header->e_phnum - 1].p_vaddr + kernel_program_headers[kernel_elf_header->e_phnum - 1].p_memsz;
 
     // align to 1GB
     kernel_load_base &= ~(FlatPtr)0x3fffffff;


### PR DESCRIPTION
Depending on the exact layout of the .ksyms section the kernel would fail to boot because the kernel_load_end variable didn't account for the section's size.