### PR TITLE
Ports/dosbox-staging: Change 'serenity*' build target to '*serenity*'

### DIFF
--- a/Ports/dosbox-staging/package.sh
+++ b/Ports/dosbox-staging/package.sh
@@ -16,5 +16,5 @@ export CPPFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2"
 
 pre_configure() {
     run ./autogen.sh
-    run sed -i 's@irix\* \\@irix* | serenity* \\@' config.sub
+    run sed -i 's@irix\* \\@irix* | *serenity* \\@' config.sub
 }


### PR DESCRIPTION
The serenity build target in config.sub did not match 'i686-pc-serenity'.
This commit changes the build target from 'serenity*' to '\*serenity\*'.