### PR TITLE
LibLine: Make display refresh write the entire buffer out at once instead of one syscall per char 

### DIFF
--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -383,7 +383,7 @@ private:
     }
 
     void recalculate_origin();
-    void reposition_cursor(bool to_end = false);
+    void reposition_cursor(OutputStream&, bool to_end = false);
 
     struct CodepointRange {
         size_t start { 0 };

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -342,12 +342,13 @@ void Editor::enter_search()
         auto& search_string = search_string_result.value();
 
         // Manually cleanup the search line.
-        reposition_cursor();
+        OutputFileStream stderr_stream { stderr };
+        reposition_cursor(stderr_stream);
         auto search_metrics = actual_rendered_string_metrics(search_string);
         auto metrics = actual_rendered_string_metrics(search_prompt);
-        VT::clear_lines(0, metrics.lines_with_addition(search_metrics, m_num_columns) + search_end_row - m_origin_row - 1);
+        VT::clear_lines(0, metrics.lines_with_addition(search_metrics, m_num_columns) + search_end_row - m_origin_row - 1, stderr_stream);
 
-        reposition_cursor();
+        reposition_cursor(stderr_stream);
 
         m_refresh_needed = true;
         m_cached_prompt_valid = false;
@@ -432,8 +433,9 @@ void Editor::go_end()
 
 void Editor::clear_screen()
 {
-    fprintf(stderr, "\033[3J\033[H\033[2J"); // Clear screen.
-    VT::move_absolute(1, 1);
+    warn("\033[3J\033[H\033[2J");
+    OutputFileStream stream { stderr };
+    VT::move_absolute(1, 1, stream);
     set_origin(1, 1);
     m_refresh_needed = true;
     m_cached_prompt_valid = false;

--- a/Userland/Libraries/LibLine/VT.h
+++ b/Userland/Libraries/LibLine/VT.h
@@ -12,13 +12,13 @@
 namespace Line {
 namespace VT {
 
-void save_cursor();
-void restore_cursor();
-void clear_to_end_of_line();
-void clear_lines(size_t count_above, size_t count_below = 0);
-void move_relative(int x, int y);
-void move_absolute(u32 x, u32 y);
-void apply_style(const Style&, bool is_starting = true);
+void save_cursor(OutputStream&);
+void restore_cursor(OutputStream&);
+void clear_to_end_of_line(OutputStream&);
+void clear_lines(size_t count_above, size_t count_below, OutputStream&);
+void move_relative(int x, int y, OutputStream&);
+void move_absolute(u32 x, u32 y, OutputStream&);
+void apply_style(const Style&, OutputStream&, bool is_starting = true);
 
 }
 }

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -20,6 +20,7 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
     size_t longest_suggestion_length = 0;
     size_t longest_suggestion_byte_length = 0;
 
+    manager.set_start_index(0);
     manager.for_each_suggestion([&](auto& suggestion, auto) {
         longest_suggestion_length = max(longest_suggestion_length, suggestion.text_view.length());
         longest_suggestion_byte_length = max(longest_suggestion_byte_length, suggestion.text_string.length());


### PR DESCRIPTION
Previously, we were generating the display update one character at a
time, and writing them one at a time to stderr, which is not buffered,
doing so caused one syscall per character printed which is s l o w (TM)
This commit makes LibLine write the update contents into a buffer, and
flush it after all the update is generated :^)