### PR TITLE
Pong: Disable resizing the window

### DIFF
--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char** argv)
     window->set_title("Pong");
     window->set_double_buffering_enabled(false);
     window->set_main_widget<Pong::Game>();
+    window->set_resizable(false);
     window->show();
 
     auto menubar = GUI::Menubar::construct();


### PR DESCRIPTION
The game doesn't handle resize events.

It's a pretty lazy fix.  The proper way would be to actually allow the game to be resized, with some scaling trickery, but most games here don't do that anyway, so I guess that's good enough. ¯\\_(ツ)_/¯