### PR TITLE
Help: Add check for pushing current page to history

### DIFF
--- a/Userland/Applications/Help/History.cpp
+++ b/Userland/Applications/Help/History.cpp
@@ -8,6 +8,9 @@
 
 void History::push(const StringView& history_item)
 {
+    if (!m_items.is_empty() && m_items[m_current_history_item] == history_item)
+        return;
+
     m_items.shrink(m_current_history_item + 1);
     m_items.append(history_item);
     m_current_history_item++;


### PR DESCRIPTION
Simple check to prevent the current home-page to be added at startup. Fixing #8774.