### PR TITLE
SoundPlayer: Use full path for playlist items

### DIFF
--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -288,13 +288,12 @@ void SoundPlayerWidgetAdvancedView::try_fill_missing_info(Vector<M3UEntry>& entr
     LexicalPath playlist_path(playlist_p);
     Vector<M3UEntry*> to_delete;
     for (auto& entry : entries) {
-        LexicalPath entry_path(entry.path);
-        if (!entry_path.is_absolute()) {
-            entry.path = String::formatted("{}/{}", playlist_path.dirname(), entry_path.basename());
+        if (!LexicalPath(entry.path).is_absolute()) {
+            entry.path = String::formatted("{}/{}", playlist_path.dirname(), entry.path);
         }
 
         if (!Core::File::exists(entry.path)) {
-            GUI::MessageBox::show(window(), String::formatted("The file \"{}\" present in the playlist does not exist or was not found. This file will be ignored.", entry_path.basename()), "Error reading playlist", GUI::MessageBox::Type::Warning);
+            GUI::MessageBox::show(window(), String::formatted("The file \"{}\" present in the playlist does not exist or was not found. This file will be ignored.", entry.path), "Error reading playlist", GUI::MessageBox::Type::Warning);
             to_delete.append(&entry);
             continue;
         }


### PR DESCRIPTION
This fixes an issue with not opening tracks if they have been placed in a subfolder.