### PR TITLE
TextEditor: Restrict file access further

### DIFF
--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
 
         file_to_edit_full_path = Core::File::real_path_for(parsed_argument.filename());
         dbgln("unveil for: {}", file_to_edit_full_path);
-        if (unveil(file_to_edit_full_path.characters(), "rwc") < 0) {
+        if (unveil(file_to_edit_full_path.characters(), "r") < 0) {
             perror("unveil");
             return 1;
         }


### PR DESCRIPTION
Only read access to the file_to_edit is required since
FileSystemAccessServer handles all other requests.