### PR TITLE
LibIPC: Fix losing messages when connection is closed

### DIFF
--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -197,8 +197,9 @@ protected:
             if (nread == 0) {
                 if (bytes.is_empty()) {
                     deferred_invoke([this](auto&) { shutdown(); });
+                    return false;
                 }
-                return false;
+                break;
             }
             bytes.append(buffer, nread);
         }


### PR DESCRIPTION
This fixes not processing any messages read up until a connection
close is detected. We were returning from the function despite having
read some messages.

_This fixes wsctl's messages sometimes not being processed_