### PR TITLE
MouseSettings: Use latest (unsaved) setting for testing double-click

### DIFF
--- a/Userland/Applications/MouseSettings/DoubleClickArrowWidget.cpp
+++ b/Userland/Applications/MouseSettings/DoubleClickArrowWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mathias Jakobsen <mathias@jbcoding.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -54,10 +55,22 @@ void DoubleClickArrowWidget::paint_event(GUI::PaintEvent& event)
     text_rect.set_height(font().glyph_height());
 }
 
-void DoubleClickArrowWidget::doubleclick_event(GUI::MouseEvent&)
+void DoubleClickArrowWidget::mousedown_event(GUI::MouseEvent&)
 {
-    m_inverted = !m_inverted;
-    update();
+    if (!m_double_click_timer.is_valid()) {
+        m_double_click_timer.start();
+        return;
+    }
+
+    auto elapsed_time = m_double_click_timer.elapsed();
+    if (elapsed_time <= m_double_click_speed) {
+        dbgln("Double-click in {}ms", elapsed_time);
+        m_inverted = !m_inverted;
+        update();
+    }
+
+    // Reset the timer after each click
+    m_double_click_timer.start();
 }
 
 }

--- a/Userland/Applications/MouseSettings/DoubleClickArrowWidget.h
+++ b/Userland/Applications/MouseSettings/DoubleClickArrowWidget.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mathias Jakobsen <mathias@jbcoding.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <LibCore/ElapsedTimer.h>
 #include <LibGUI/Widget.h>
 
 namespace MouseSettings {
@@ -20,11 +22,12 @@ public:
 private:
     DoubleClickArrowWidget();
     virtual void paint_event(GUI::PaintEvent&) override;
-    virtual void doubleclick_event(GUI::MouseEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
 
     RefPtr<Gfx::Bitmap> m_arrow_bitmap;
     int m_double_click_speed { 0 };
     bool m_inverted { false };
+    Core::ElapsedTimer m_double_click_timer;
 };
 
 }


### PR DESCRIPTION
Instead of using the doubleclick_event this uses the current double-
click speed setting to check whether or not the colors of the double-
click icon should be inverted. This allows us to use the current (and
unsaved) setting for comparison instead of having to apply the settings
first.