### PR TITLE
TextEditor: App crashes when cutting from empty lines

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -350,6 +350,8 @@ String TextDocument::text_in_range(const TextRange& a_range) const
         auto& line = this->line(i);
         size_t selection_start_column_on_line = range.start().line() == i ? range.start().column() : 0;
         size_t selection_end_column_on_line = range.end().line() == i ? range.end().column() : line.length();
+        if (selection_end_column_on_line > line.length())
+            selection_end_column_on_line = line.length();
         builder.append(Utf32View(line.code_points() + selection_start_column_on_line, selection_end_column_on_line - selection_start_column_on_line));
         if (i != range.end().line())
             builder.append('\n');


### PR DESCRIPTION
Ensure that the provided range's end column is within the bounds
of the line.

Fixes https://github.com/SerenityOS/serenity/issues/8769

----

The problem in this case was that the range provided to `TextDocument::text_in_range` was asking for chars 0-1 of the line when the line is empty. I saw two options for fixing this. 

Option 1: Fix it in the VimEditingEngine, have it detect that we're trying to yank something non-existent and handle it better.
Option 2: Fix it downstream in `TextDocument::text_in_range`, have it detect the invalid scenario and correct it

I chose option 2, but depending on your way of thinking you could make a solid argument for option 1.