### PR TITLE
TextEditor: Allow non-existent files to be opened and created

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -664,6 +664,14 @@ void MainWidget::update_title()
     window()->set_title(builder.to_string());
 }
 
+bool MainWidget::open_new_file(String const& path)
+{
+    VERIFY(path.starts_with("/"sv));
+    set_path(path);
+    m_editor->set_focus(true);
+    return true;
+}
+
 bool MainWidget::read_file_and_close(int fd, String const& path)
 {
     VERIFY(path.starts_with("/"sv));

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -24,6 +24,7 @@ class MainWidget final : public GUI::Widget {
 
 public:
     virtual ~MainWidget() override;
+    bool open_new_file(String const& path);
     bool read_file_and_close(int fd, String const& path);
     bool request_close();
 


### PR DESCRIPTION
The ability for new files to be opened, via `TextEditor new_file.txt`, was removed with the addition of `unveil` calls, this will fix that.