### PR TITLE
LibAudio: Fix UTF-8 decoding logic in FLAC decoding :^)

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -512,7 +512,10 @@ FlacSubframeHeader FlacLoaderPlugin::next_subframe_header(InputBitStream& bit_st
     }
 
     // zero-bit padding
-    bit_stream.read_bit_big_endian();
+    if (bit_stream.read_bit_big_endian() != 0) {
+        m_error_string = "Zero bit padding";
+        return {};
+    };
 
     // subframe type (encoding)
     u8 subframe_code = bit_stream.read_bits_big_endian(6);

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -802,7 +802,7 @@ u64 read_utf8_char(InputStream& input)
     u8 bits_from_start_byte = 8 - (length + 1);
     u8 start_byte_bitmask = AK::exp2(bits_from_start_byte) - 1;
     character = start_byte_bitmask & start_byte;
-    for (u8 i = length; i > 0; --i) {
+    for (u8 i = length - 1; i > 0; --i) {
         input.read(single_byte_buffer);
         u8 current_byte = single_byte_buffer[0];
         character = (character << 6) | (current_byte & 0b00111111);


### PR DESCRIPTION
The problem here was that the multi-byte UTF-8 encoded characters were taking one byte too much, misaligning the data completely
and eventually crashing the program on the 128th frame.

This change reduces the for loop by one, as it has been already calculated from the `start_byte` variable.