### PR TITLE
WindowServer: Reuse config variable from the class on theme change

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1955,10 +1955,9 @@ bool WindowManager::update_theme(String theme_path, String theme_name)
         return false;
     Gfx::set_system_theme(new_theme);
     m_palette = Gfx::PaletteImpl::create_with_anonymous_buffer(new_theme);
-    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini");
-    wm_config->write_entry("Theme", "Name", theme_name);
-    wm_config->remove_entry("Background", "Color");
-    wm_config->sync();
+    m_config->write_entry("Theme", "Name", theme_name);
+    m_config->remove_entry("Background", "Color");
+    m_config->sync();
     invalidate_after_theme_or_font_change();
     return true;
 }


### PR DESCRIPTION
When changing the theme, there were two `Core::ConfigFile` instances (one class scoped – `m_config` and one function scoped – `wm_config`) fighting over the file, resulting in not saving the new theme name to the config. :^(

This makes WindowServer remember selected theme from the menu after reboot!