### PR TITLE
LibC: Don't truncate arguments for ioctl() on x86_64

### DIFF
--- a/Userland/Libraries/LibC/ioctl.cpp
+++ b/Userland/Libraries/LibC/ioctl.cpp
@@ -16,7 +16,7 @@ int ioctl(int fd, unsigned request, ...)
 {
     va_list ap;
     va_start(ap, request);
-    unsigned arg = va_arg(ap, unsigned);
+    FlatPtr arg = va_arg(ap, FlatPtr);
     int rc = syscall(SC_ioctl, fd, request, arg);
     va_end(ap);
     __RETURN_WITH_ERRNO(rc, rc, -1);


### PR DESCRIPTION
Among other things this makes "less" work on x86_64.