### PR TITLE
Everywhere: Prefix hexadecimal numbers with 0x

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -91,6 +91,15 @@ public:
     u32 to_u32(u32 default_value = 0) const { return to_number<u32>(default_value); }
     u64 to_u64(u64 default_value = 0) const { return to_number<u64>(default_value); }
 
+    FlatPtr to_addr(FlatPtr default_value = 0) const
+    {
+#ifdef __LP64__
+        return to_u64(default_value);
+#else
+        return to_u32(default_value);
+#endif
+    }
+
     bool to_bool(bool default_value = false) const
     {
         if (!is_bool())

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -23,6 +23,8 @@ concept TimeSpecType = requires(T t)
     t.tv_nsec;
 };
 
+// FIXME: remove once Clang formats these properly.
+// clang-format off
 namespace AK {
 
 // Month and day start at 1. Month must be >= 1 and <= 12.
@@ -287,6 +289,7 @@ inline bool operator!=(const T& a, const T& b)
 }
 
 }
+// clang-format on
 
 using AK::day_of_week;
 using AK::day_of_year;

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -192,21 +192,21 @@ static void dump(const RegisterState& regs)
 
     dbgln("Exception code: {:04x} (isr: {:04x})", regs.exception_code, regs.isr_number);
 #if ARCH(I386)
-    dbgln("    pc={:04x}:{:08x} eflags={:08x}", (u16)regs.cs, regs.eip, regs.eflags);
-    dbgln(" stack={:04x}:{:08x}", ss, esp);
-    dbgln("    ds={:04x} es={:04x} fs={:04x} gs={:04x}", (u16)regs.ds, (u16)regs.es, (u16)regs.fs, (u16)regs.gs);
-    dbgln("   eax={:08x} ebx={:08x} ecx={:08x} edx={:08x}", regs.eax, regs.ebx, regs.ecx, regs.edx);
-    dbgln("   ebp={:08x} esp={:08x} esi={:08x} edi={:08x}", regs.ebp, regs.esp, regs.esi, regs.edi);
-    dbgln("   cr0={:08x} cr2={:08x} cr3={:08x} cr4={:08x}", read_cr0(), read_cr2(), read_cr3(), read_cr4());
+    dbgln("    pc={:#04x}:{:p} eflags={:p}", (u16)regs.cs, regs.eip, regs.eflags);
+    dbgln(" stack={:#04x}:{:p}", ss, esp);
+    dbgln("    ds={:#04x} es={:#04x} fs={:#04x} gs={:#04x}", (u16)regs.ds, (u16)regs.es, (u16)regs.fs, (u16)regs.gs);
+    dbgln("   eax={:p} ebx={:p} ecx={:p} edx={:p}", regs.eax, regs.ebx, regs.ecx, regs.edx);
+    dbgln("   ebp={:p} esp={:p} esi={:p} edi={:p}", regs.ebp, regs.esp, regs.esi, regs.edi);
+    dbgln("   cr0={:p} cr2={:p} cr3={:p} cr4={:p}", read_cr0(), read_cr2(), read_cr3(), read_cr4());
 #else
-    dbgln("    pc={:04x}:{:16x} rflags={:16x}", (u16)regs.cs, regs.rip, regs.rflags);
-    dbgln(" stack={:16x}", rsp);
+    dbgln("    pc={:#04x}:{:p} rflags={:p}", (u16)regs.cs, regs.rip, regs.rflags);
+    dbgln(" stack={:p}", rsp);
     // FIXME: Add fs_base and gs_base here
-    dbgln("   rax={:16x} rbx={:16x} rcx={:16x} rdx={:16x}", regs.rax, regs.rbx, regs.rcx, regs.rdx);
-    dbgln("   rbp={:16x} rsp={:16x} rsi={:16x} rdi={:16x}", regs.rbp, regs.rsp, regs.rsi, regs.rdi);
-    dbgln("    r8={:16x}  r9={:16x} r10={:16x} r11={:16x}", regs.r8, regs.r9, regs.r10, regs.r11);
-    dbgln("   r12={:16x} r13={:16x} r14={:16x} r15={:16x}", regs.r12, regs.r13, regs.r14, regs.r15);
-    dbgln("   cr0={:16x} cr2={:16x} cr3={:16x} cr4={:16x}", read_cr0(), read_cr2(), read_cr3(), read_cr4());
+    dbgln("   rax={:p} rbx={:p} rcx={:p} rdx={:p}", regs.rax, regs.rbx, regs.rcx, regs.rdx);
+    dbgln("   rbp={:p} rsp={:p} rsi={:p} rdi={:p}", regs.rbp, regs.rsp, regs.rsi, regs.rdi);
+    dbgln("    r8={:p}  r9={:p} r10={:p} r11={:p}", regs.r8, regs.r9, regs.r10, regs.r11);
+    dbgln("   r12={:p} r13={:p} r14={:p} r15={:p}", regs.r12, regs.r13, regs.r14, regs.r15);
+    dbgln("   cr0={:p} cr2={:p} cr3={:p} cr4={:p}", read_cr0(), read_cr2(), read_cr3(), read_cr4());
 #endif
 }
 

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -442,13 +442,13 @@ OwnPtr<KBuffer> PCIDeviceAttributeSysFSComponent::try_to_generate_buffer() const
     String value;
     switch (m_field_bytes_width) {
     case 1:
-        value = String::formatted("0x{:x}", PCI::read8(m_device->address(), m_offset));
+        value = String::formatted("{:#x}", PCI::read8(m_device->address(), m_offset));
         break;
     case 2:
-        value = String::formatted("0x{:x}", PCI::read16(m_device->address(), m_offset));
+        value = String::formatted("{:#x}", PCI::read16(m_device->address(), m_offset));
         break;
     case 4:
-        value = String::formatted("0x{:x}", PCI::read32(m_device->address(), m_offset));
+        value = String::formatted("{:#x}", PCI::read32(m_device->address(), m_offset));
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -65,7 +65,7 @@ KResultOr<size_t> Pipe::control_transfer(u8 request_type, u8 request, u16 value,
 
     transfer->set_setup_packet(usb_request);
 
-    dbgln_if(USB_DEBUG, "Pipe: Transfer allocated @ {:08x}", transfer->buffer_physical());
+    dbgln_if(USB_DEBUG, "Pipe: Transfer allocated @ {}", transfer->buffer_physical());
     auto transfer_len_or_error = UHCIController::the().submit_control_transfer(*transfer);
 
     if (transfer_len_or_error.is_error())

--- a/Kernel/Graphics/VirtIOGPU/GPU.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU.cpp
@@ -69,7 +69,7 @@ bool GPU::handle_device_config_change()
         clear_pending_events(VIRTIO_GPU_EVENT_DISPLAY);
     }
     if (events & ~VIRTIO_GPU_EVENT_DISPLAY) {
-        dbgln("GPU: Got unknown device config change event: 0x{:x}", events);
+        dbgln("GPU: Got unknown device config change event: {:#x}", events);
         return false;
     }
     return true;

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -151,7 +151,7 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr base_pointer, bool use_ksym
         if (symbol.symbol->address == g_highest_kernel_symbol_address && offset > 4096)
             dbgln("{:p}", symbol.address);
         else
-            dbgln("{:p}  {} +0x{:x}", symbol.address, symbol.symbol->name, offset);
+            dbgln("{:p}  {} +{:#x}", symbol.address, symbol.symbol->name, offset);
     }
 }
 

--- a/Kernel/Net/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8168NetworkAdapter.cpp
@@ -1572,7 +1572,7 @@ void RTL8168NetworkAdapter::identify_chip_version()
         }
         break;
     default:
-        dbgln_if(RTL8168_DEBUG, "Unable to determine device version: {#04x}", registers);
+        dbgln_if(RTL8168_DEBUG, "Unable to determine device version: {:#04x}", registers);
         m_version = ChipVersion::Unknown;
         m_version_uncertain = true;
         break;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -295,12 +295,7 @@ bool Scheduler::context_switch(Thread* thread)
             from_thread->set_state(Thread::Runnable);
 
 #ifdef LOG_EVERY_CONTEXT_SWITCH
-        const auto msg =
-#    if ARCH(I386)
-            "Scheduler[{}]: {} -> {} [prio={}] {:04x}:{:08x}";
-#    else
-            "Scheduler[{}]: {} -> {} [prio={}] {:04x}:{:16x}";
-#    endif
+        const auto msg = "Scheduler[{}]: {} -> {} [prio={}] {:#04x}:{:p}";
 
         dbgln(msg,
             Processor::id(), from_thread->tid().value(),

--- a/Kernel/Storage/AHCIController.cpp
+++ b/Kernel/Storage/AHCIController.cpp
@@ -92,7 +92,7 @@ AHCI::HBADefinedCapabilities AHCIController::capabilities() const
     u32 capabilities = hba().control_regs.cap;
     u32 extended_capabilities = hba().control_regs.cap2;
 
-    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Capabilities = 0x{:08x}, Extended Capabilities = 0x{:08x}", pci_address(), capabilities, extended_capabilities);
+    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Capabilities = {:#08x}, Extended Capabilities = {:#08x}", pci_address(), capabilities, extended_capabilities);
 
     return (AHCI::HBADefinedCapabilities) {
         (capabilities & 0b11111) + 1,
@@ -144,7 +144,7 @@ void AHCIController::initialize()
     dbgln("{}: AHCI command list entries count - {}", pci_address(), hba_capabilities().max_command_list_entries_count);
 
     u32 version = hba().control_regs.version;
-    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Version = 0x{:08x}", pci_address(), version);
+    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Version = {:#08x}", pci_address(), version);
 
     hba().control_regs.ghc = 0x80000000; // Ensure that HBA knows we are AHCI aware.
     PCI::enable_interrupt_line(pci_address());

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -196,7 +196,7 @@ void AHCIPort::eject()
 
     while (1) {
         if (m_port_registers.serr != 0) {
-            dbgln_if(AHCI_DEBUG, "AHCI Port {}: Eject Drive failed, SError 0x{:08x}", representative_port_index(), (u32)m_port_registers.serr);
+            dbgln_if(AHCI_DEBUG, "AHCI Port {}: Eject Drive failed, SError {:#08x}", representative_port_index(), (u32)m_port_registers.serr);
             try_disambiguate_sata_error();
             VERIFY_NOT_REACHED();
         }
@@ -241,7 +241,7 @@ bool AHCIPort::initialize_without_reset()
 bool AHCIPort::initialize(ScopedSpinLock<SpinLock<u8>>& main_lock)
 {
     VERIFY(m_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Initialization. Signature = 0x{:08x}", representative_port_index(), static_cast<u32>(m_port_registers.sig));
+    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Initialization. Signature = {:#08x}", representative_port_index(), static_cast<u32>(m_port_registers.sig));
     if (!is_phy_enabled()) {
         // Note: If PHY is not enabled, just clear the interrupt status and enable interrupts, in case
         // we are going to hotplug a device later.
@@ -524,7 +524,7 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
     // handshake error bit in PxSERR register if CFL is incorrect.
     command_list_entries[unused_command_header.value()].attributes = (size_t)FIS::DwordCount::RegisterHostToDevice | AHCI::CommandHeaderAttributes::P | (is_atapi_attached() ? AHCI::CommandHeaderAttributes::A : 0) | (direction == AsyncBlockDeviceRequest::RequestType::Write ? AHCI::CommandHeaderAttributes::W : 0);
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: CLE: ctba=0x{:08x}, ctbau=0x{:08x}, prdbc=0x{:08x}, prdtl=0x{:04x}, attributes=0x{:04x}", representative_port_index(), (u32)command_list_entries[unused_command_header.value()].ctba, (u32)command_list_entries[unused_command_header.value()].ctbau, (u32)command_list_entries[unused_command_header.value()].prdbc, (u16)command_list_entries[unused_command_header.value()].prdtl, (u16)command_list_entries[unused_command_header.value()].attributes);
+    dbgln_if(AHCI_DEBUG, "AHCI Port {}: CLE: ctba={:#08x}, ctbau={:#08x}, prdbc={:#08x}, prdtl={:#04x}, attributes={:#04x}", representative_port_index(), (u32)command_list_entries[unused_command_header.value()].ctba, (u32)command_list_entries[unused_command_header.value()].ctbau, (u32)command_list_entries[unused_command_header.value()].prdbc, (u16)command_list_entries[unused_command_header.value()].prdtl, (u16)command_list_entries[unused_command_header.value()].attributes);
 
     auto command_table_region = MM.allocate_kernel_region(m_command_table_pages[unused_command_header.value()].paddr().page_base(), page_round_up(sizeof(AHCI::CommandTable)), "AHCI Command Table", Region::Access::Read | Region::Access::Write, Region::Cacheable::No);
     auto& command_table = *(volatile AHCI::CommandTable*)command_table_region->vaddr().as_ptr();
@@ -638,7 +638,7 @@ bool AHCIPort::identify_device(ScopedSpinLock<SpinLock<u8>>& main_lock)
 
         while (1) {
             if (m_port_registers.serr != 0) {
-                dbgln("AHCI Port {}: Identify failed, SError 0x{:08x}", representative_port_index(), (u32)m_port_registers.serr);
+                dbgln("AHCI Port {}: Identify failed, SError {:#08x}", representative_port_index(), (u32)m_port_registers.serr);
                 try_disambiguate_sata_error();
                 return false;
             }

--- a/Kernel/Storage/IDEChannel.cpp
+++ b/Kernel/Storage/IDEChannel.cpp
@@ -408,7 +408,7 @@ UNMAP_AFTER_INIT void IDEChannel::detect_disks()
         if (identify_block.commands_and_feature_sets_supported[1] & (1 << 10))
             max_addressable_block = identify_block.user_addressable_logical_sectors_count;
 
-        dbgln("IDEChannel: {} {} {} device found: Name={}, Capacity={}, Capabilities=0x{:04x}", channel_type_string(), channel_string(i), interface_type == PATADiskDevice::InterfaceType::ATA ? "ATA" : "ATAPI", ((char*)bbuf.data() + 54), max_addressable_block * 512, capabilities);
+        dbgln("IDEChannel: {} {} {} device found: Name={}, Capacity={}, Capabilities={:#04x}", channel_type_string(), channel_string(i), interface_type == PATADiskDevice::InterfaceType::ATA ? "ATA" : "ATAPI", ((char*)bbuf.data() + 54), max_addressable_block * 512, capabilities);
         if (i == 0) {
             m_master = PATADiskDevice::create(m_parent_controller, *this, PATADiskDevice::DriveType::Master, interface_type, capabilities, max_addressable_block);
         } else {

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -109,7 +109,7 @@ KResultOr<FlatPtr> handle(RegisterState& regs, FlatPtr function, FlatPtr arg1, F
     current_thread->did_syscall();
 
     if (function >= Function::__Count) {
-        dbgln("Unknown syscall {} requested ({:08x}, {:08x}, {:08x})", function, arg1, arg2, arg3);
+        dbgln("Unknown syscall {} requested ({:p}, {:p}, {:p})", function, arg1, arg2, arg3);
         return ENOSYS;
     }
 

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -64,7 +64,7 @@ KResultOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     child_regs.gs = regs.gs;
     child_regs.ss = regs.userspace_ss;
 
-    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:04x}:{:08x} with stack {:04x}:{:08x}, kstack {:04x}:{:08x}",
+    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:#04x}:{:p}, kstack {:#04x}:{:p}",
         child_regs.cs, child_regs.eip, child_regs.ss, child_regs.esp, child_regs.ss0, child_regs.esp0);
 #else
     auto& child_regs = child_first_thread->m_regs;
@@ -88,7 +88,7 @@ KResultOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     child_regs.rip = regs.rip;
     child_regs.cs = regs.cs;
 
-    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:04x}:{:16x} with stack {:08x}, kstack {:08x}",
+    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:p}, kstack {:p}",
         child_regs.cs, child_regs.rip, child_regs.rsp, child_regs.rsp0);
 #endif
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1030,11 +1030,7 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
     auto signal_trampoline_addr = process.signal_trampoline().get();
     regs.set_ip_reg(signal_trampoline_addr);
 
-#if ARCH(I386)
-    dbgln_if(SIGNAL_DEBUG, "Thread in state '{}' has been primed with signal handler {:04x}:{:08x} to deliver {}", state_string(), m_regs.cs, m_regs.ip(), signal);
-#else
-    dbgln_if(SIGNAL_DEBUG, "Thread in state '{}' has been primed with signal handler {:04x}:{:16x} to deliver {}", state_string(), m_regs.cs, m_regs.ip(), signal);
-#endif
+    dbgln_if(SIGNAL_DEBUG, "Thread in state '{}' has been primed with signal handler {:#04x}:{:p} to deliver {}", state_string(), m_regs.cs, m_regs.ip(), signal);
 
     return DispatchSignalResult::Continue;
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1160,9 +1160,9 @@ static bool symbolicate(RecognizedSymbol const& symbol, Process& process, String
             if (auto* region = process.space().find_region_containing({ VirtualAddress(symbol.address), sizeof(FlatPtr) })) {
                 size_t offset = symbol.address - region->vaddr().get();
                 if (auto region_name = region->name(); !region_name.is_null() && !region_name.is_empty())
-                    builder.appendff("{:p}  {} + 0x{:x}\n", (void*)symbol.address, region_name, offset);
+                    builder.appendff("{:p}  {} + {:#x}\n", (void*)symbol.address, region_name, offset);
                 else
-                    builder.appendff("{:p}  {:p} + 0x{:x}\n", (void*)symbol.address, region->vaddr().as_ptr(), offset);
+                    builder.appendff("{:p}  {:p} + {:#x}\n", (void*)symbol.address, region->vaddr().as_ptr(), offset);
             } else {
                 builder.appendff("{:p}\n", symbol.address);
             }
@@ -1173,7 +1173,7 @@ static bool symbolicate(RecognizedSymbol const& symbol, Process& process, String
     if (symbol.symbol->address == g_highest_kernel_symbol_address && offset > 4096) {
         builder.appendff("{:p}\n", (void*)(mask_kernel_addresses ? 0xdeadc0de : symbol.address));
     } else {
-        builder.appendff("{:p}  {} + 0x{:x}\n", (void*)(mask_kernel_addresses ? 0xdeadc0de : symbol.address), symbol.symbol->name, offset);
+        builder.appendff("{:p}  {} + {:#x}\n", (void*)(mask_kernel_addresses ? 0xdeadc0de : symbol.address), symbol.symbol->name, offset);
     }
     return true;
 }

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -1121,7 +1121,13 @@ void MemoryManager::unregister_region(Region& region)
 void MemoryManager::dump_kernel_regions()
 {
     dbgln("Kernel regions:");
-    dbgln("BEGIN         END        SIZE       ACCESS NAME");
+#if ARCH(I386)
+    auto addr_padding = "";
+#else
+    auto addr_padding = "        ";
+#endif
+    dbgln("BEGIN{}         END{}        SIZE{}       ACCESS NAME",
+        addr_padding, addr_padding, addr_padding);
     ScopedSpinLock lock(s_mm_lock);
     for (auto& region : m_kernel_regions) {
         dbgln("{:p} -- {:p} {:p} {:c}{:c}{:c}{:c}{:c}{:c} {}",

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -325,16 +325,16 @@ UNMAP_AFTER_INIT void MemoryManager::parse_memory_map()
     m_system_memory_info.user_physical_pages_uncommitted = m_system_memory_info.user_physical_pages;
 
     for (auto& used_range : m_used_memory_ranges) {
-        dmesgln("MM: {} range @ {} - {} (size 0x{:x})", UserMemoryRangeTypeNames[to_underlying(used_range.type)], used_range.start, used_range.end.offset(-1), used_range.end.as_ptr() - used_range.start.as_ptr());
+        dmesgln("MM: {} range @ {} - {} (size {:#x})", UserMemoryRangeTypeNames[to_underlying(used_range.type)], used_range.start, used_range.end.offset(-1), used_range.end.as_ptr() - used_range.start.as_ptr());
     }
 
     for (auto& region : m_super_physical_regions) {
-        dmesgln("MM: Super physical region: {} - {} (size 0x{:x})", region.lower(), region.upper().offset(-1), PAGE_SIZE * region.size());
+        dmesgln("MM: Super physical region: {} - {} (size {:#x})", region.lower(), region.upper().offset(-1), PAGE_SIZE * region.size());
         region.initialize_zones();
     }
 
     for (auto& region : m_user_physical_regions) {
-        dmesgln("MM: User physical region: {} - {} (size 0x{:x})", region.lower(), region.upper().offset(-1), PAGE_SIZE * region.size());
+        dmesgln("MM: User physical region: {} - {} (size {:#x})", region.lower(), region.upper().offset(-1), PAGE_SIZE * region.size());
         region.initialize_zones();
     }
 }

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -1121,10 +1121,10 @@ void MemoryManager::unregister_region(Region& region)
 void MemoryManager::dump_kernel_regions()
 {
     dbgln("Kernel regions:");
-    dbgln("BEGIN       END         SIZE        ACCESS  NAME");
+    dbgln("BEGIN         END        SIZE       ACCESS NAME");
     ScopedSpinLock lock(s_mm_lock);
     for (auto& region : m_kernel_regions) {
-        dbgln("{:08x} -- {:08x} {:08x} {:c}{:c}{:c}{:c}{:c}{:c} {}",
+        dbgln("{:p} -- {:p} {:p} {:c}{:c}{:c}{:c}{:c}{:c} {}",
             region.vaddr().get(),
             region.vaddr().offset(region.size() - 1).get(),
             region.size(),

--- a/Kernel/VM/Range.h
+++ b/Kernel/VM/Range.h
@@ -63,6 +63,6 @@ template<>
 struct AK::Formatter<Kernel::Range> : Formatter<FormatString> {
     void format(FormatBuilder& builder, Kernel::Range value)
     {
-        return Formatter<FormatString>::format(builder, "{} - {} (size 0x{:08x})", value.base().as_ptr(), value.base().offset(value.size() - 1).as_ptr(), value.size());
+        return Formatter<FormatString>::format(builder, "{} - {} (size {:p})", value.base().as_ptr(), value.base().offset(value.size() - 1).as_ptr(), value.size());
     }
 };

--- a/Kernel/VM/Space.cpp
+++ b/Kernel/VM/Space.cpp
@@ -316,7 +316,13 @@ KResultOr<Vector<Region*, 2>> Space::try_split_region_around_range(const Region&
 void Space::dump_regions()
 {
     dbgln("Process regions:");
-    dbgln("BEGIN         END        SIZE       ACCESS NAME");
+#if ARCH(I386)
+    auto addr_padding = "";
+#else
+    auto addr_padding = "        ";
+#endif
+    dbgln("BEGIN{}         END{}        SIZE{}       ACCESS NAME",
+        addr_padding, addr_padding, addr_padding);
 
     ScopedSpinLock lock(m_lock);
 

--- a/Kernel/VM/Space.cpp
+++ b/Kernel/VM/Space.cpp
@@ -316,13 +316,13 @@ KResultOr<Vector<Region*, 2>> Space::try_split_region_around_range(const Region&
 void Space::dump_regions()
 {
     dbgln("Process regions:");
-    dbgln("BEGIN       END         SIZE        ACCESS  NAME");
+    dbgln("BEGIN         END        SIZE       ACCESS NAME");
 
     ScopedSpinLock lock(m_lock);
 
     for (auto& sorted_region : m_regions) {
         auto& region = *sorted_region;
-        dbgln("{:08x} -- {:08x} {:08x} {:c}{:c}{:c}{:c}{:c}{:c} {}", region.vaddr().get(), region.vaddr().offset(region.size() - 1).get(), region.size(),
+        dbgln("{:p} -- {:p} {:p} {:c}{:c}{:c}{:c}{:c}{:c} {}", region.vaddr().get(), region.vaddr().offset(region.size() - 1).get(), region.size(),
             region.is_readable() ? 'R' : ' ',
             region.is_writable() ? 'W' : ' ',
             region.is_executable() ? 'X' : ' ',

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -86,21 +86,15 @@ static TitleAndText build_cpu_registers(const ELF::Core::ThreadInfo& thread_info
     StringBuilder builder;
 
 #if ARCH(I386)
-    builder.appendff("eax={:08x} ebx={:08x} ecx={:08x} edx={:08x}", regs.eax, regs.ebx, regs.ecx, regs.edx);
-    builder.append('\n');
-    builder.appendff("ebp={:08x} esp={:08x} esi={:08x} edi={:08x}", regs.ebp, regs.esp, regs.esi, regs.edi);
-    builder.append('\n');
-    builder.appendff("eip={:08x} eflags={:08x}", regs.eip, regs.eflags);
+    builder.appendff("eax={:p} ebx={:p} ecx={:p} edx={:p}\n", regs.eax, regs.ebx, regs.ecx, regs.edx);
+    builder.appendff("ebp={:p} esp={:p} esi={:p} edi={:p}\n", regs.ebp, regs.esp, regs.esi, regs.edi);
+    builder.appendff("eip={:p} eflags={:p}", regs.eip, regs.eflags);
 #else
-    builder.appendff("rax={:16x} rbx={:16x} rcx={:16x} rdx={:16x}", regs.rax, regs.rbx, regs.rcx, regs.rdx);
-    builder.append('\n');
-    builder.appendff("rbp={:16x} rsp={:16x} rsi={:16x} rdi={:16x}", regs.rbp, regs.rsp, regs.rsi, regs.rdi);
-    builder.append('\n');
-    builder.appendff(" r8={:16x}  r9={:16x} r10={:16x} r11={:16x}", regs.r8, regs.r9, regs.r10, regs.r11);
-    builder.append('\n');
-    builder.appendff("r12={:16x} r13={:16x} r14={:16x} r15={:16x}", regs.r12, regs.r13, regs.r14, regs.r15);
-    builder.append('\n');
-    builder.appendff("rip={:16x} rflags={:16x}", regs.rip, regs.rflags);
+    builder.appendff("rax={:p} rbx={:p} rcx={:p} rdx={:p}\n", regs.rax, regs.rbx, regs.rcx, regs.rdx);
+    builder.appendff("rbp={:p} rsp={:p} rsi={:p} rdi={:p}\n", regs.rbp, regs.rsp, regs.rsi, regs.rdi);
+    builder.appendff(" r8={:p}  r9={:p} r10={:p} r11={:p}\n", regs.r8, regs.r9, regs.r10, regs.r11);
+    builder.appendff("r12={:p} r13={:p} r14={:p} r15={:p}\n", regs.r12, regs.r13, regs.r14, regs.r15);
+    builder.appendff("rip={:p} rflags={:p}", regs.rip, regs.rflags);
 #endif
 
     return {

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -39,13 +39,13 @@ static void handle_sigint(int)
 static void handle_print_registers(const PtraceRegisters& regs)
 {
 #if ARCH(I386)
-    outln("eax={:08x} ebx={:08x} ecx={:08x} edx={:08x}", regs.eax, regs.ebx, regs.ecx, regs.edx);
-    outln("esp={:08x} ebp={:08x} esi={:08x} edi={:08x}", regs.esp, regs.ebp, regs.esi, regs.edi);
-    outln("eip={:08x} eflags={:08x}", regs.eip, regs.eflags);
+    outln("eax={:p} ebx={:p} ecx={:p} edx={:p}", regs.eax, regs.ebx, regs.ecx, regs.edx);
+    outln("esp={:p} ebp={:p} esi={:p} edi={:p}", regs.esp, regs.ebp, regs.esi, regs.edi);
+    outln("eip={:p} eflags={:p}", regs.eip, regs.eflags);
 #else
-    outln("rax={:016x} rbx={:016x} rcx={:016x} rdx={:016x}", regs.rax, regs.rbx, regs.rcx, regs.rdx);
-    outln("rsp={:016x} rbp={:016x} rsi={:016x} rdi={:016x}", regs.rsp, regs.rbp, regs.rsi, regs.rdi);
-    outln("rip={:016x} rflags={:08x}", regs.rip, regs.rflags);
+    outln("rax={:p} rbx={:p} rcx={:p} rdx={:p}", regs.rax, regs.rbx, regs.rcx, regs.rdx);
+    outln("rsp={:p} rbp={:p} rsi={:p} rdi={:p}", regs.rsp, regs.rbp, regs.rsi, regs.rdi);
+    outln("rip={:p} rflags={:p}", regs.rip, regs.rflags);
 #endif
 }
 

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
@@ -87,7 +87,7 @@ GUI::Variant RegistersModel::data(const GUI::ModelIndex& index, GUI::ModelRole r
         if (index.column() == Column::Register)
             return reg.name;
         if (index.column() == Column::Value)
-            return String::formatted("{:08x}", reg.value);
+            return String::formatted("{:p}", reg.value);
         return {};
     }
     return {};

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -852,7 +852,7 @@ u32 Emulator::virt$mmap(u32 params_addr)
         else {
             // mmap(nullptr, …, MAP_FIXED) is technically okay, but tends to be a bug.
             // Therefore, refuse to be helpful.
-            reportln("\n=={}==  \033[31;1mTried to mmap at nullptr with MAP_FIXED.\033[0m, 0x{:x} bytes.", getpid(), params.size);
+            reportln("\n=={}==  \033[31;1mTried to mmap at nullptr with MAP_FIXED.\033[0m, {:#x} bytes.", getpid(), params.size);
             dump_backtrace();
         }
     } else {

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -79,9 +79,9 @@ SoftCPU::SoftCPU(Emulator& emulator)
 
 void SoftCPU::dump() const
 {
-    outln(" eax={:08x}  ebx={:08x}  ecx={:08x}  edx={:08x}  ebp={:08x}  esp={:08x}  esi={:08x}  edi={:08x} o={:d} s={:d} z={:d} a={:d} p={:d} c={:d}",
+    outln(" eax={:p}  ebx={:p}  ecx={:p}  edx={:p}  ebp={:p}  esp={:p}  esi={:p}  edi={:p} o={:d} s={:d} z={:d} a={:d} p={:d} c={:d}",
         eax(), ebx(), ecx(), edx(), ebp(), esp(), esi(), edi(), of(), sf(), zf(), af(), pf(), cf());
-    outln("#eax={:08x} #ebx={:08x} #ecx={:08x} #edx={:08x} #ebp={:08x} #esp={:08x} #esi={:08x} #edi={:08x} #f={}",
+    outln("#eax={:p} #ebx={:p} #ecx={:p} #edx={:p} #ebp={:p} #esp={:p} #esi={:p} #edi={:p} #f={}",
         eax().shadow(), ebx().shadow(), ecx().shadow(), edx().shadow(), ebp().shadow(), esp().shadow(), esi().shadow(), edi().shadow(), m_flags_tainted);
     fflush(stdout);
 }
@@ -106,7 +106,7 @@ ValueWithShadow<u8> SoftCPU::read_memory8(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read8(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory8: @{:04x}:{:08x} -> {:02x} ({:02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory8: @{:#04x}:{:p} -> {:#02x} ({:#02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -114,7 +114,7 @@ ValueWithShadow<u16> SoftCPU::read_memory16(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read16(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory16: @{:04x}:{:08x} -> {:04x} ({:04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory16: @{:#04x}:{:p} -> {:#04x} ({:#04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -122,7 +122,7 @@ ValueWithShadow<u32> SoftCPU::read_memory32(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read32(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory32: @{:04x}:{:08x} -> {:08x} ({:08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory32: @{:#04x}:{:p} -> {:#08x} ({:#08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -130,7 +130,7 @@ ValueWithShadow<u64> SoftCPU::read_memory64(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read64(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory64: @{:04x}:{:08x} -> {:016x} ({:016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory64: @{:#04x}:{:p} -> {:#016x} ({:#016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -138,56 +138,56 @@ ValueWithShadow<u128> SoftCPU::read_memory128(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read128(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory128: @{:04x}:{:08x} -> {:032x} ({:032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory128: @{:#04x}:{:p} -> {:#032x} ({:#032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 ValueWithShadow<u256> SoftCPU::read_memory256(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read256(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory256: @{:04x}:{:08x} -> {:064x} ({:064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory256: @{:#04x}:{:p} -> {:#064x} ({:#064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
 void SoftCPU::write_memory8(X86::LogicalAddress address, ValueWithShadow<u8> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory8: @{:04x}:{:08x} <- {:02x} ({:02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory8: @{:#04x}:{:p} <- {:#02x} ({:#02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write8(address, value);
 }
 
 void SoftCPU::write_memory16(X86::LogicalAddress address, ValueWithShadow<u16> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory16: @{:04x}:{:08x} <- {:04x} ({:04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory16: @{:#04x}:{:p} <- {:#04x} ({:#04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write16(address, value);
 }
 
 void SoftCPU::write_memory32(X86::LogicalAddress address, ValueWithShadow<u32> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory32: @{:04x}:{:08x} <- {:08x} ({:08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory32: @{:#04x}:{:p} <- {:#08x} ({:#08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write32(address, value);
 }
 
 void SoftCPU::write_memory64(X86::LogicalAddress address, ValueWithShadow<u64> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory64: @{:04x}:{:08x} <- {:016x} ({:016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory64: @{:#04x}:{:p} <- {:#016x} ({:#016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write64(address, value);
 }
 
 void SoftCPU::write_memory128(X86::LogicalAddress address, ValueWithShadow<u128> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory128: @{:04x}:{:08x} <- {:032x} ({:032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory128: @{:#04x}:{:p} <- {:#032x} ({:#032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write128(address, value);
 }
 
 void SoftCPU::write_memory256(X86::LogicalAddress address, ValueWithShadow<u256> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory256: @{:04x}:{:08x} <- {:064x} ({:064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory256: @{:#04x}:{:p} <- {:#064x} ({:#064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write256(address, value);
 }
 
@@ -1327,7 +1327,7 @@ void SoftCPU::CPUID(const X86::Instruction&)
         return;
     }
 
-    dbgln("Unhandled CPUID with eax={:08x}", eax().value());
+    dbgln("Unhandled CPUID with eax={:p}", eax().value());
 }
 
 void SoftCPU::CWD(const X86::Instruction&)

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -451,7 +451,7 @@ void DebugSession::update_loaded_libs()
         if (file_or_error.is_error())
             return IterationDecision::Continue;
 
-        FlatPtr base_address = entry.as_object().get("address").as_u32();
+        FlatPtr base_address = entry.as_object().get("address").to_addr();
         auto debug_info = make<DebugInfo>(make<ELF::Image>(file_or_error.value()->bytes()), m_source_root, base_address);
         auto lib = make<LoadedLibrary>(lib_name, file_or_error.release_value(), move(debug_info), base_address);
         m_loaded_libraries.set(lib_name, move(lib));

--- a/Userland/Libraries/LibELF/CoreDump.h
+++ b/Userland/Libraries/LibELF/CoreDump.h
@@ -50,8 +50,8 @@ struct [[gnu::packed]] ThreadInfo {
 
 struct [[gnu::packed]] MemoryRegionInfo {
     NotesEntryHeader header;
-    uint32_t region_start;
-    uint32_t region_end;
+    uint64_t region_start;
+    uint64_t region_end;
     uint16_t program_header_index;
     char region_name[]; // Null terminated
 

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -60,8 +60,8 @@ public:
         StringView name() const { return m_dynamic.symbol_string_table_string(m_sym.st_name); }
         const char* raw_name() const { return m_dynamic.raw_symbol_string_table_string(m_sym.st_name); }
         unsigned section_index() const { return m_sym.st_shndx; }
-        unsigned value() const { return m_sym.st_value; }
-        unsigned size() const { return m_sym.st_size; }
+        FlatPtr value() const { return m_sym.st_value; }
+        size_t size() const { return m_sym.st_size; }
         unsigned index() const { return m_index; }
 #if ARCH(I386)
         unsigned type() const

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -332,7 +332,7 @@ Image::SortedSymbol* Image::find_sorted_symbol(FlatPtr address) const
     return &m_sorted_symbols[index];
 }
 
-Optional<Image::Symbol> Image::find_symbol(u32 address, u32* out_offset) const
+Optional<Image::Symbol> Image::find_symbol(FlatPtr address, u32* out_offset) const
 {
     auto symbol_count = this->symbol_count();
     if (!symbol_count)
@@ -358,7 +358,7 @@ NEVER_INLINE void Image::sort_symbols() const
 }
 
 #ifndef KERNEL
-String Image::symbolicate(u32 address, u32* out_offset) const
+String Image::symbolicate(FlatPtr address, u32* out_offset) const
 {
     auto symbol_count = this->symbol_count();
     if (!symbol_count) {

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -51,8 +51,8 @@ public:
 
         StringView name() const { return m_image.table_string(m_sym.st_name); }
         unsigned section_index() const { return m_sym.st_shndx; }
-        unsigned value() const { return m_sym.st_value; }
-        unsigned size() const { return m_sym.st_size; }
+        FlatPtr value() const { return m_sym.st_value; }
+        size_t size() const { return m_sym.st_size; }
         unsigned index() const { return m_index; }
 #if ARCH(I386)
         unsigned type() const
@@ -93,11 +93,11 @@ public:
         unsigned index() const { return m_program_header_index; }
         u32 type() const { return m_program_header.p_type; }
         u32 flags() const { return m_program_header.p_flags; }
-        u32 offset() const { return m_program_header.p_offset; }
+        size_t offset() const { return m_program_header.p_offset; }
         VirtualAddress vaddr() const { return VirtualAddress(m_program_header.p_vaddr); }
-        u32 size_in_memory() const { return m_program_header.p_memsz; }
-        u32 size_in_image() const { return m_program_header.p_filesz; }
-        u32 alignment() const { return m_program_header.p_align; }
+        size_t size_in_memory() const { return m_program_header.p_memsz; }
+        size_t size_in_image() const { return m_program_header.p_filesz; }
+        size_t alignment() const { return m_program_header.p_align; }
         bool is_readable() const { return flags() & PF_R; }
         bool is_writable() const { return flags() & PF_W; }
         bool is_executable() const { return flags() & PF_X; }
@@ -121,16 +121,16 @@ public:
         ~Section() { }
 
         StringView name() const { return m_image.section_header_table_string(m_section_header.sh_name); }
-        unsigned type() const { return m_section_header.sh_type; }
-        unsigned offset() const { return m_section_header.sh_offset; }
-        unsigned size() const { return m_section_header.sh_size; }
-        unsigned entry_size() const { return m_section_header.sh_entsize; }
-        unsigned entry_count() const { return !entry_size() ? 0 : size() / entry_size(); }
-        u32 address() const { return m_section_header.sh_addr; }
+        u32 type() const { return m_section_header.sh_type; }
+        size_t offset() const { return m_section_header.sh_offset; }
+        size_t size() const { return m_section_header.sh_size; }
+        size_t entry_size() const { return m_section_header.sh_entsize; }
+        size_t entry_count() const { return !entry_size() ? 0 : size() / entry_size(); }
+        FlatPtr address() const { return m_section_header.sh_addr; }
         const char* raw_data() const { return m_image.raw_data(m_section_header.sh_offset); }
         ReadonlyBytes bytes() const { return { raw_data(), size() }; }
         Optional<RelocationSection> relocations() const;
-        u32 flags() const { return m_section_header.sh_flags; }
+        auto flags() const { return m_section_header.sh_flags; }
         bool is_writable() const { return flags() & SHF_WRITE; }
         bool is_executable() const { return flags() & PF_X; }
 
@@ -147,7 +147,7 @@ public:
             : Section(section.m_image, section.m_section_index)
         {
         }
-        unsigned relocation_count() const { return entry_count(); }
+        size_t relocation_count() const { return entry_count(); }
         Relocation relocation(unsigned index) const;
 
         template<VoidFunction<Image::Relocation&> F>
@@ -164,7 +164,7 @@ public:
 
         ~Relocation() { }
 
-        unsigned offset() const { return m_rel.r_offset; }
+        size_t offset() const { return m_rel.r_offset; }
 #if ARCH(I386)
         unsigned type() const
         {
@@ -230,9 +230,9 @@ public:
     bool has_symbols() const { return symbol_count(); }
 #ifndef KERNEL
     Optional<Symbol> find_demangled_function(const StringView& name) const;
-    String symbolicate(u32 address, u32* offset = nullptr) const;
+    String symbolicate(FlatPtr address, u32* offset = nullptr) const;
 #endif
-    Optional<Image::Symbol> find_symbol(u32 address, u32* offset = nullptr) const;
+    Optional<Image::Symbol> find_symbol(FlatPtr address, u32* offset = nullptr) const;
 
 private:
     const char* raw_data(unsigned offset) const;
@@ -252,7 +252,7 @@ private:
     unsigned m_string_table_section_index { 0 };
 
     struct SortedSymbol {
-        u32 address;
+        FlatPtr address;
         StringView name;
         String demangled_name;
         Optional<Image::Symbol> symbol;

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -510,7 +510,7 @@ public:
 
     const String to_string() const
     {
-        return String::formatted("[0x{:02X}] {}", (int)opcode_id(), name(opcode_id()));
+        return String::formatted("[{:#02X}] {}", (int)opcode_id(), name(opcode_id()));
     }
 
     virtual const String arguments_string() const = 0;

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -108,7 +108,7 @@ Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid)
 
         stack.ensure_capacity(json.value().as_array().size());
         for (auto& value : json.value().as_array().values()) {
-            stack.append(value.to_u32());
+            stack.append(value.to_addr());
         }
     }
 
@@ -129,8 +129,8 @@ Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid)
         for (auto& region_value : json.value().as_array().values()) {
             auto& region = region_value.as_object();
             auto name = region.get("name").to_string();
-            auto address = region.get("address").to_u32();
-            auto size = region.get("size").to_u32();
+            auto address = region.get("address").to_addr();
+            auto size = region.get("size").to_addr();
 
             String path;
             if (name == "/usr/lib/Loader.so") {

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -158,7 +158,7 @@ ParseResult<FunctionType> FunctionType::parse(InputStream& stream)
         return with_eof_check(stream, ParseError::ExpectedKindTag);
 
     if (tag != Constants::function_signature_tag) {
-        dbgln("Expected 0x60, but found 0x{:x}", tag);
+        dbgln("Expected 0x60, but found {:#x}", tag);
         return with_eof_check(stream, ParseError::InvalidTag);
     }
 

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -51,7 +51,7 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
     const char* begin_color = g_should_output_color ? "\033[34;1m" : "";
     const char* end_color = g_should_output_color ? "\033[0m" : "";
 #if ARCH(I386)
-    outln("=> {}SC_{}(0x{:x}, 0x{:x}, 0x{:x}){}",
+    outln("=> {}SC_{}({:#x}, {:#x}, {:#x}){}",
         begin_color,
         Syscall::to_string((Syscall::Function)regs.eax),
         regs.edx,
@@ -59,7 +59,7 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
         regs.ebx,
         end_color);
 #else
-    outln("=> {}SC_{}(0x{:x}, 0x{:x}, 0x{:x}){}",
+    outln("=> {}SC_{}({:#x}, {:#x}, {:#x}){}",
         begin_color,
         Syscall::to_string((Syscall::Function)regs.rax),
         regs.rdx,

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -55,16 +55,12 @@ int main(int argc, char** argv)
 
     Vector<JsonValue> sorted_regions = json.value().as_array().values();
     quick_sort(sorted_regions, [](auto& a, auto& b) {
-        return a.as_object().get("address").to_u64() < b.as_object().get("address").to_u64();
+        return a.as_object().get("address").to_addr() < b.as_object().get("address").to_addr();
     });
 
     for (auto& value : sorted_regions) {
         auto& map = value.as_object();
-#if ARCH(I386)
-        auto address = map.get("address").to_u32();
-#else
-        auto address = map.get("address").to_u64();
-#endif
+        auto address = map.get("address").to_addr();
         auto size = map.get("size").to_string();
 
         auto access = String::formatted("{}{}{}{}{}",

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -43,10 +43,16 @@ int main(int argc, char** argv)
 
     outln("{}:", pid);
 
+#if ARCH(I386)
+    auto padding = "";
+#else
+    auto padding = "        ";
+#endif
+
     if (extended) {
-        outln("Address           Size   Resident      Dirty Access  VMObject Type  Purgeable   CoW Pages Name");
+        outln("Address{}           Size   Resident      Dirty Access  VMObject Type  Purgeable   CoW Pages Name", padding);
     } else {
-        outln("Address           Size Access  Name");
+        outln("Address{}           Size Access  Name", padding);
     }
 
     auto file_contents = file->read_all();

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -44,9 +44,9 @@ int main(int argc, char** argv)
     outln("{}:", pid);
 
     if (extended) {
-        outln("Address         Size   Resident      Dirty Access  VMObject Type  Purgeable   CoW Pages Name");
+        outln("Address           Size   Resident      Dirty Access  VMObject Type  Purgeable   CoW Pages Name");
     } else {
-        outln("Address         Size Access  Name");
+        outln("Address           Size Access  Name");
     }
 
     auto file_contents = file->read_all();
@@ -74,11 +74,7 @@ int main(int argc, char** argv)
             (map.get("shared").to_bool() ? "s" : "-"),
             (map.get("syscall").to_bool() ? "c" : "-"));
 
-#if ARCH(I386)
-        out("{:08x}  ", address);
-#else
-        out("{:16x}  ", address);
-#endif
+        out("{:p}  ", address);
         out("{:>10} ", size);
         if (extended) {
             auto resident = map.get("amount_resident").to_string();

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -520,6 +520,12 @@ int main(int argc, char** argv)
         outln();
     }
 
+#if ARCH(I386)
+    auto addr_padding = "";
+#else
+    auto addr_padding = "        ";
+#endif
+
     if (display_section_headers) {
         if (!display_all) {
             outln("There are {} section headers, starting at offset {:#x}:", header.e_shnum, header.e_shoff);
@@ -530,7 +536,7 @@ int main(int argc, char** argv)
             outln("There are no sections in this file.");
         } else {
             outln("Section Headers:");
-            outln("  Name                Type            Address    Offset     Size       Flags");
+            outln("  Name                Type            Address{}    Offset{}     Size{}       Flags", addr_padding, addr_padding, addr_padding);
 
             elf_image.for_each_section([](const ELF::Image::Section& section) {
                 out("  {:19} ", section.name());
@@ -557,7 +563,7 @@ int main(int argc, char** argv)
             outln("There are no program headers in this file.");
         } else {
             outln("Program Headers:");
-            outln("  Type           Offset     VirtAddr   PhysAddr   FileSiz    MemSiz     Flg  Align");
+            outln("  Type           Offset     VirtAddr{}   PhysAddr{}   FileSiz    MemSiz     Flg  Align", addr_padding, addr_padding);
 
             elf_image.for_each_program_header([](const ELF::Image::ProgramHeader& program_header) {
                 out("  ");
@@ -714,7 +720,7 @@ int main(int argc, char** argv)
 
             if (object->symbol_count()) {
                 // FIXME: Add support for init/fini/start/main sections
-                outln("   Num: Value      Size       Type     Bind     Name");
+                outln("   Num: Value{}      Size{}       Type     Bind     Name", addr_padding, addr_padding);
                 object->for_each_symbol([](const ELF::DynamicObject::Symbol& sym) {
                     out("  {:>4}: ", sym.index());
                     out("{:p} ", sym.value());
@@ -736,7 +742,7 @@ int main(int argc, char** argv)
     if (display_symbol_table) {
         if (elf_image.symbol_count()) {
             outln("Symbol table '{}' contains {} entries:", ELF_SYMTAB, elf_image.symbol_count());
-            outln("   Num: Value      Size       Type     Bind     Name");
+            outln("   Num: Value{}      Size{}       Type     Bind     Name", addr_padding, addr_padding);
 
             elf_image.for_each_symbol([](const ELF::Image::Symbol& sym) {
                 out("  {:>4}: ", sym.index());

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -530,14 +530,14 @@ int main(int argc, char** argv)
             outln("There are no sections in this file.");
         } else {
             outln("Section Headers:");
-            outln("  Name                Type            Address  Offset   Size     Flags");
+            outln("  Name                Type            Address    Offset     Size       Flags");
 
             elf_image.for_each_section([](const ELF::Image::Section& section) {
                 out("  {:19} ", section.name());
                 out("{:15} ", object_section_header_type_to_string(section.type()));
-                out("{:08x} ", section.address());
-                out("{:08x} ", section.offset());
-                out("{:08x} ", section.size());
+                out("{:p} ", section.address());
+                out("{:p} ", section.offset());
+                out("{:p} ", section.size());
                 out("{}", section.flags());
                 outln();
             });
@@ -714,11 +714,11 @@ int main(int argc, char** argv)
 
             if (object->symbol_count()) {
                 // FIXME: Add support for init/fini/start/main sections
-                outln("   Num: Value    Size     Type     Bind     Name");
+                outln("   Num: Value      Size       Type     Bind     Name");
                 object->for_each_symbol([](const ELF::DynamicObject::Symbol& sym) {
                     out("  {:>4}: ", sym.index());
-                    out("{:08x} ", sym.value());
-                    out("{:08x} ", sym.size());
+                    out("{:p} ", sym.value());
+                    out("{:p} ", sym.size());
                     out("{:8} ", object_symbol_type_to_string(sym.type()));
                     out("{:8} ", object_symbol_binding_to_string(sym.bind()));
                     out("{}", sym.name());
@@ -736,12 +736,12 @@ int main(int argc, char** argv)
     if (display_symbol_table) {
         if (elf_image.symbol_count()) {
             outln("Symbol table '{}' contains {} entries:", ELF_SYMTAB, elf_image.symbol_count());
-            outln("   Num: Value    Size     Type     Bind     Name");
+            outln("   Num: Value      Size       Type     Bind     Name");
 
             elf_image.for_each_symbol([](const ELF::Image::Symbol& sym) {
                 out("  {:>4}: ", sym.index());
-                out("{:08x} ", sym.value());
-                out("{:08x} ", sym.size());
+                out("{:p} ", sym.value());
+                out("{:p} ", sym.size());
                 out("{:8} ", object_symbol_type_to_string(sym.type()));
                 out("{:8} ", object_symbol_binding_to_string(sym.bind()));
                 out("{}", sym.name());

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -643,10 +643,10 @@ int main(int argc, char** argv)
                 outln("Relocation section '{}' at offset {:#08x} contains zero entries:", object->relocation_section().name(), object->relocation_section().offset());
             } else {
                 outln("Relocation section '{}' at offset {:#08x} contains {} entries:", object->relocation_section().name(), object->relocation_section().offset(), object->relocation_section().entry_count());
-                outln("  Offset{}      Type               Sym Value{}   Sym Name", addr_padding, addr_padding);
+                outln("  Offset{}      Type                Sym Value{}   Sym Name", addr_padding, addr_padding);
                 object->relocation_section().for_each_relocation([](const ELF::DynamicObject::Relocation& reloc) {
                     out("  {:p} ", reloc.offset());
-                    out(" {:17} ", object_relocation_type_to_string(reloc.type()));
+                    out(" {:18} ", object_relocation_type_to_string(reloc.type()));
                     out(" {:p} ", reloc.symbol().value());
                     out(" {}", reloc.symbol().name());
                     outln();
@@ -658,10 +658,10 @@ int main(int argc, char** argv)
                 outln("Relocation section '{}' at offset {:#08x} contains zero entries:", object->plt_relocation_section().name(), object->plt_relocation_section().offset());
             } else {
                 outln("Relocation section '{}' at offset {:#08x} contains {} entries:", object->plt_relocation_section().name(), object->plt_relocation_section().offset(), object->plt_relocation_section().entry_count());
-                outln("  Offset{}      Type               Sym Value{}   Sym Name", addr_padding, addr_padding);
+                outln("  Offset{}      Type                Sym Value{}   Sym Name", addr_padding, addr_padding);
                 object->plt_relocation_section().for_each_relocation([](const ELF::DynamicObject::Relocation& reloc) {
                     out("  {:p} ", reloc.offset());
-                    out(" {:17} ", object_relocation_type_to_string(reloc.type()));
+                    out(" {:18} ", object_relocation_type_to_string(reloc.type()));
                     out(" {:p} ", reloc.symbol().value());
                     out(" {}", reloc.symbol().name());
                     outln();

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -563,18 +563,19 @@ int main(int argc, char** argv)
             outln("There are no program headers in this file.");
         } else {
             outln("Program Headers:");
-            outln("  Type           Offset     VirtAddr{}   PhysAddr{}   FileSiz    MemSiz     Flg  Align", addr_padding, addr_padding);
+            outln("  Type           Offset{}     VirtAddr{}   PhysAddr{}   FileSiz{}    MemSiz{}     Flg  Align",
+                addr_padding, addr_padding, addr_padding, addr_padding, addr_padding);
 
             elf_image.for_each_program_header([](const ELF::Image::ProgramHeader& program_header) {
                 out("  ");
                 out("{:14} ", object_program_header_type_to_string(program_header.type()));
-                out("{:#08x} ", program_header.offset());
+                out("{:p} ", program_header.offset());
                 out("{:p} ", program_header.vaddr().as_ptr());
                 out("{:p} ", program_header.vaddr().as_ptr()); // FIXME: assumes PhysAddr = VirtAddr
-                out("{:#08x} ", program_header.size_in_image());
-                out("{:#08x} ", program_header.size_in_memory());
+                out("{:p} ", program_header.size_in_image());
+                out("{:p} ", program_header.size_in_memory());
                 out("{:04x} ", program_header.flags());
-                out("{:#08x}", program_header.alignment());
+                out("{:p}", program_header.alignment());
                 outln();
 
                 if (program_header.type() == PT_INTERP)
@@ -642,11 +643,11 @@ int main(int argc, char** argv)
                 outln("Relocation section '{}' at offset {:#08x} contains zero entries:", object->relocation_section().name(), object->relocation_section().offset());
             } else {
                 outln("Relocation section '{}' at offset {:#08x} contains {} entries:", object->relocation_section().name(), object->relocation_section().offset(), object->relocation_section().entry_count());
-                outln("  Offset      Type               Sym Value   Sym Name");
+                outln("  Offset{}      Type               Sym Value{}   Sym Name", addr_padding, addr_padding);
                 object->relocation_section().for_each_relocation([](const ELF::DynamicObject::Relocation& reloc) {
-                    out("  {:#08x} ", reloc.offset());
+                    out("  {:p} ", reloc.offset());
                     out(" {:17} ", object_relocation_type_to_string(reloc.type()));
-                    out(" {:#08x} ", reloc.symbol().value());
+                    out(" {:p} ", reloc.symbol().value());
                     out(" {}", reloc.symbol().name());
                     outln();
                 });
@@ -657,11 +658,11 @@ int main(int argc, char** argv)
                 outln("Relocation section '{}' at offset {:#08x} contains zero entries:", object->plt_relocation_section().name(), object->plt_relocation_section().offset());
             } else {
                 outln("Relocation section '{}' at offset {:#08x} contains {} entries:", object->plt_relocation_section().name(), object->plt_relocation_section().offset(), object->plt_relocation_section().entry_count());
-                outln("  Offset      Type               Sym Value   Sym Name");
+                outln("  Offset{}      Type               Sym Value{}   Sym Name", addr_padding, addr_padding);
                 object->plt_relocation_section().for_each_relocation([](const ELF::DynamicObject::Relocation& reloc) {
-                    out("  {:#08x} ", reloc.offset());
+                    out("  {:p} ", reloc.offset());
                     out(" {:17} ", object_relocation_type_to_string(reloc.type()));
-                    out(" {:#08x} ", reloc.symbol().value());
+                    out(" {:p} ", reloc.symbol().value());
                     out(" {}", reloc.symbol().name());
                     outln();
                 });


### PR DESCRIPTION
**Everywhere: Prefix hexadecimal numbers with 0x**

Depending on the values it might be difficult to figure out whether a value is decimal or hexadecimal. So let's make this more obvious. Also this allows copying and pasting those numbers into GNOME calculator and probably also other apps which auto-detect the base.

**Everywhere: Prefer using {:#x} over 0x{:x}**

We have a dedicated format specifier which adds the "0x" prefix, so let's use that instead of adding it manually.

**AK: Add a getter to JsonValue to get machine-native addresses**

**Utilities: Make sure columns are properly aligned for pmap on x86_64**

**Utilities: Make sure columns are properly aligned for readelf on x86_64**

**LibELF+Utilities: Avoid truncating 64-bit values**

This fixes displaying 64-bit addresses in readelf and also fixes showing backtraces from core dumps on x86_64.

**Utilities: Make the columns for readelf fit all reloc types on x86_64**

**Kernel: Make sure crash dumps are properly aligned on x86_64**

**Kernel: Fix incorrect format template**

clang-format >=12 format this file incorrectly/differently.