### PR TITLE
LibGUI: Fix multi line Tooltip Height

### DIFF
--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -131,7 +131,10 @@ private:
             if (ip_address != "null")
                 connected_adapters++;
 
-            adapter_info.appendff("{}: {}\n", ifname, ip_address);
+            if (!adapter_info.is_empty())
+                adapter_info.append('\n');
+
+            adapter_info.appendff("{}: {}", ifname, ip_address);
         });
 
         // show connected icon so long as at least one adapter is connected

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -28,7 +28,9 @@ public:
     {
         m_label->set_text(Gfx::parse_ampersand_string(tooltip));
         int tooltip_width = m_label->min_width() + 10;
-        int tooltip_height = m_label->font().glyph_height() * max(1, m_label->text().count("\n")) + 8;
+        int line_count = m_label->text().count("\n");
+        int glyph_height = m_label->font().glyph_height();
+        int tooltip_height = glyph_height * (1 + line_count) + ((glyph_height + 1) / 2) * line_count + 8;
 
         Gfx::IntRect desktop_rect = Desktop::the().rect();
         if (tooltip_width > desktop_rect.width())


### PR DESCRIPTION
Tooltips had a wrong calculation for the height of a Tooltip Window,
because they forgot to take into account the line spacing.