### PR TITLE
Assistant: Only open one Assistant at once 

### DIFF
--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     IODevice.cpp
     LocalServer.cpp
     LocalSocket.cpp
+    LockFile.cpp
     MimeData.cpp
     NetworkJob.cpp
     NetworkResponse.cpp

--- a/Userland/Libraries/LibCore/LockFile.cpp
+++ b/Userland/Libraries/LibCore/LockFile.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@ualberta.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/File.h>
+#include <LibCore/LockFile.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+namespace Core {
+
+LockFile::LockFile(char const* filename, Type type)
+    : m_filename(filename)
+{
+    if (!Core::File::ensure_parent_directories(m_filename))
+        return;
+
+    m_fd = open(filename, O_RDONLY | O_CREAT, 0666);
+    if (m_fd == -1) {
+        m_errno = errno;
+        return;
+    }
+
+    if (flock(m_fd, LOCK_NB | ((type == Type::Exclusive) ? LOCK_EX : LOCK_SH)) == -1) {
+        m_errno = errno;
+        close(m_fd);
+        m_fd = -1;
+    }
+}
+
+LockFile::~LockFile()
+{
+    release();
+}
+
+bool LockFile::is_held() const
+{
+    return m_fd != -1;
+}
+
+void LockFile::release()
+{
+    if (m_fd == -1)
+        return;
+
+    unlink(m_filename);
+    flock(m_fd, LOCK_NB | LOCK_UN);
+    close(m_fd);
+
+    m_fd = -1;
+}
+
+}

--- a/Userland/Libraries/LibCore/LockFile.h
+++ b/Userland/Libraries/LibCore/LockFile.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@ualberta.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Core {
+
+class LockFile {
+public:
+    enum class Type {
+        Exclusive,
+        Shared
+    };
+
+    LockFile(LockFile const& other) = delete;
+    LockFile(char const* filename, Type type = Type::Exclusive);
+    ~LockFile();
+
+    bool is_held() const;
+    int error_code() const { return m_errno; }
+    void release();
+
+private:
+    int m_fd { -1 };
+    int m_errno { 0 };
+    char const* m_filename { nullptr };
+};
+
+}


### PR DESCRIPTION
I found myself accidentally opening two assistants at once with the Window+Space shortcut. Since only one assistant window is usable at the same time, I made assistant only spawn 1 instance at most.

closes #8451