### PR TITLE
LibAudio: Fix reading block size from the end of the header in FLAC, Implement loaded_samples()

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -235,6 +235,7 @@ RefPtr<Buffer> FlacLoaderPlugin::get_more_samples([[maybe_unused]] size_t max_by
         --samples_to_read;
     }
 
+    m_loaded_samples += samples.size();
     return Buffer::create_with_samples(move(samples));
 }
 

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -296,17 +296,17 @@ void FlacLoaderPlugin::next_frame()
 
     // Conditional header variables
     if (sample_count == FLAC_BLOCKSIZE_AT_END_OF_HEADER_8) {
-        sample_count = bit_stream.read_bits(8) + 1;
+        sample_count = bit_stream.read_bits_big_endian(8) + 1;
     } else if (sample_count == FLAC_BLOCKSIZE_AT_END_OF_HEADER_16) {
-        sample_count = bit_stream.read_bits(16) + 1;
+        sample_count = bit_stream.read_bits_big_endian(16) + 1;
     }
 
     if (frame_sample_rate == FLAC_SAMPLERATE_AT_END_OF_HEADER_8) {
-        frame_sample_rate = bit_stream.read_bits(8) * 1000;
+        frame_sample_rate = bit_stream.read_bits_big_endian(8) * 1000;
     } else if (frame_sample_rate == FLAC_SAMPLERATE_AT_END_OF_HEADER_16) {
-        frame_sample_rate = bit_stream.read_bits(16);
+        frame_sample_rate = bit_stream.read_bits_big_endian(16);
     } else if (frame_sample_rate == FLAC_SAMPLERATE_AT_END_OF_HEADER_16X10) {
-        frame_sample_rate = bit_stream.read_bits(16) * 10;
+        frame_sample_rate = bit_stream.read_bits_big_endian(16) * 10;
     }
 
     // TODO: check header checksum, see above

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -67,8 +67,7 @@ public:
     virtual void reset() override;
     virtual void seek(const int position) override;
 
-    // FIXME
-    virtual int loaded_samples() override { return 0; }
+    virtual int loaded_samples() override { return m_loaded_samples; }
     virtual int total_samples() override { return m_total_samples; }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
@@ -119,6 +118,7 @@ private:
     u32 m_max_frame_size { 0 }; // 24 bit
     u64 m_total_samples { 0 };  // 36 bit
     u8 m_md5_checksum[128 / 8]; // 128 bit (!)
+    size_t m_loaded_samples { 0 };
 
     // keep track of the start of the data in the FLAC stream to seek back more easily
     u64 m_data_start_location { 0 };


### PR DESCRIPTION
**LibAudio: Don't read too much bytes in FLAC**

This fixes crash when reading the end of the file.

The logic is mostly borrowed from WavLoader.

**LibAudio: Read custom block sizes and sample rates as big endian**

This fixes stucking in a loop at the end of the file, as
(a) custom block sizes are usually placed there, as the remaining size might not be simply calculated as a power of two, and
(b) the number of bytes to read was incorrect (the program said the block size was 32525, where `flac -a` said it's actually 3200).

Unfortunately, I couldn't trigger the bug for the sample rates, so it may be not true, but I'd doubt it, giving the fact that flac almost everywhere uses big endian numbers.

**LibAudio: Implement loaded_samples() in the FLAC Loader**

This makes aplay show current playback position.

---
sry for the edits. my comments were a bit incorrect before.