### PR TITLE
AK+LibJS+LibRegex: Support UTF-16 in LibRegex, use UTF-16 in RegExp.prototype

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Utf16View.h>
@@ -208,6 +209,22 @@ bool Utf16View::operator==(Utf16View const& other) const
 
     for (size_t i = 0; i < length_in_code_units(); ++i) {
         if (m_code_units[i] != other.m_code_units[i])
+            return false;
+    }
+
+    return true;
+}
+
+bool Utf16View::equals_ignoring_case(Utf16View const& other) const
+{
+    if (length_in_code_units() == 0)
+        return other.length_in_code_units() == 0;
+    if (length_in_code_units() != other.length_in_code_units())
+        return false;
+
+    for (size_t i = 0; i < length_in_code_units(); ++i) {
+        // FIXME: Handle non-ASCII case insensitive comparisons.
+        if (to_ascii_lowercase(m_code_units[i]) != to_ascii_lowercase(other.m_code_units[i]))
             return false;
     }
 

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -104,6 +104,8 @@ public:
         return validate(valid_code_units);
     }
 
+    bool equals_ignoring_case(Utf16View const&) const;
+
 private:
     u16 const* begin_ptr() const { return m_code_units.data(); }
     u16 const* end_ptr() const { return begin_ptr() + m_code_units.size(); }

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -17,6 +17,7 @@ namespace AK {
 
 Vector<u16> utf8_to_utf16(StringView const&);
 Vector<u16> utf8_to_utf16(Utf8View const&);
+Vector<u16> utf32_to_utf16(Utf32View const&);
 
 class Utf16View;
 
@@ -67,8 +68,6 @@ public:
     {
     }
 
-    Utf16View& operator=(Utf16View const&) = default;
-    Utf16View& operator=(Utf16View&&) = default;
     bool operator==(Utf16View const& other) const;
 
     enum class AllowInvalidCodeUnits {
@@ -78,6 +77,7 @@ public:
 
     String to_utf8(AllowInvalidCodeUnits = AllowInvalidCodeUnits::No) const;
 
+    bool is_null() const { return m_code_units.is_null(); }
     bool is_empty() const { return m_code_units.is_empty(); }
     size_t length_in_code_units() const { return m_code_units.size(); }
     size_t length_in_code_points() const;
@@ -88,8 +88,14 @@ public:
     u16 const* data() const { return m_code_units.data(); }
     u16 code_unit_at(size_t index) const;
 
+    size_t code_point_offset_of(size_t code_unit_offset) const;
+    size_t code_unit_offset_of(size_t code_point_offset) const;
+
     Utf16View substring_view(size_t code_unit_offset, size_t code_unit_length) const;
     Utf16View substring_view(size_t code_unit_offset) const { return substring_view(code_unit_offset, length_in_code_units() - code_unit_offset); }
+
+    Utf16View unicode_substring_view(size_t code_point_offset, size_t code_point_length) const;
+    Utf16View unicode_substring_view(size_t code_point_offset) const { return unicode_substring_view(code_point_offset, length_in_code_points() - code_point_offset); }
 
     bool validate(size_t& valid_code_units) const;
     bool validate() const

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -510,6 +510,11 @@ TEST_CASE(ECMA262_parse)
         { "\\uxxxx", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
         { "\\ud83d", regex::Error::NoError, ECMAScriptFlags::Unicode },
         { "\\ud83d\\uxxxx", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\u{0}", regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\u{10ffff}", regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\u{10ffff", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\u{10ffffx", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\u{110000}", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {
@@ -605,6 +610,7 @@ TEST_CASE(ECMA262_unicode_match)
         { "\\ude00", "😀", false, ECMAScriptFlags::Unicode },
         { "\\ud83d\\ude00", "😀", true },
         { "\\ud83d\\ude00", "😀", true, ECMAScriptFlags::Unicode },
+        { "\\u{1f600}", "😀", true, ECMAScriptFlags::Unicode },
         { "\\ud83d\\ud83d", "\xed\xa0\xbd\xed\xa0\xbd", true },
         { "\\ud83d\\ud83d", "\xed\xa0\xbd\xed\xa0\xbd", true, ECMAScriptFlags::Unicode },
     };

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -175,7 +175,7 @@ void NewRegExp::execute_impl(Bytecode::Interpreter& interpreter) const
     auto source = interpreter.current_executable().get_string(m_source_index);
     auto flags = interpreter.current_executable().get_string(m_flags_index);
 
-    interpreter.accumulator() = RegExpObject::create(interpreter.global_object(), source, flags);
+    interpreter.accumulator() = regexp_create(interpreter.global_object(), js_string(interpreter.vm(), source), js_string(interpreter.vm(), flags));
 }
 
 void CopyObjectExcludingProperties::execute_impl(Bytecode::Interpreter& interpreter) const

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -30,7 +30,7 @@ Object* get_prototype_from_constructor(GlobalObject&, FunctionObject const& cons
 Object* create_unmapped_arguments_object(GlobalObject&, Vector<Value> const& arguments);
 Object* create_mapped_arguments_object(GlobalObject&, FunctionObject&, Vector<FunctionNode::Parameter> const&, Vector<Value> const& arguments, Environment&);
 Value canonical_numeric_index_string(GlobalObject&, PropertyName const&);
-String get_substitution(GlobalObject&, String const& matched, String const& str, size_t position, Vector<Value> const& captures, Value named_captures, Value replacement);
+String get_substitution(GlobalObject&, Utf16View const& matched, Utf16View const& str, size_t position, Vector<Value> const& captures, Value named_captures, Value replacement);
 
 enum class CallerMode {
     Strict,

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/RegExpObject.h>
+#include <LibJS/Runtime/StringPrototype.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS {
@@ -88,17 +89,18 @@ static Flags options_from(GlobalObject& global_object, const String& flags)
     return options;
 }
 
-RegExpObject* RegExpObject::create(GlobalObject& global_object, String pattern, String flags)
+RegExpObject* RegExpObject::create(GlobalObject& global_object, String original_pattern, String parsed_pattern, String flags)
 {
-    return global_object.heap().allocate<RegExpObject>(global_object, pattern, flags, *global_object.regexp_prototype());
+    return global_object.heap().allocate<RegExpObject>(global_object, move(original_pattern), move(parsed_pattern), move(flags), *global_object.regexp_prototype());
 }
 
-RegExpObject::RegExpObject(String pattern, String flags, Object& prototype)
+RegExpObject::RegExpObject(String original_pattern, String parsed_pattern, String flags, Object& prototype)
     : Object(prototype)
-    , m_pattern(pattern)
-    , m_flags(flags)
+    , m_original_pattern(move(original_pattern))
+    , m_parsed_pattern(move(parsed_pattern))
+    , m_flags(move(flags))
     , m_active_flags(options_from(global_object(), m_flags))
-    , m_regex(pattern, m_active_flags.effective_flags)
+    , m_regex(m_parsed_pattern, m_active_flags.effective_flags)
 {
     if (m_regex.parser_result.error != regex::Error::NoError) {
         vm().throw_exception<SyntaxError>(global_object(), ErrorType::RegExpCompileError, m_regex.error_string());
@@ -120,14 +122,7 @@ void RegExpObject::initialize(GlobalObject& global_object)
 RegExpObject* regexp_create(GlobalObject& global_object, Value pattern, Value flags)
 {
     auto& vm = global_object.vm();
-    String p;
-    if (pattern.is_undefined()) {
-        p = String::empty();
-    } else {
-        p = pattern.to_string(global_object);
-        if (vm.exception())
-            return {};
-    }
+
     String f;
     if (flags.is_undefined()) {
         f = String::empty();
@@ -136,7 +131,46 @@ RegExpObject* regexp_create(GlobalObject& global_object, Value pattern, Value fl
         if (vm.exception())
             return {};
     }
-    auto* object = RegExpObject::create(global_object, move(p), move(f));
+
+    String original_pattern;
+    String parsed_pattern;
+
+    if (pattern.is_undefined()) {
+        original_pattern = String::empty();
+        parsed_pattern = String::empty();
+    } else {
+        auto utf16_pattern = pattern.to_utf16_string(global_object);
+        if (vm.exception())
+            return {};
+
+        Utf16View utf16_pattern_view { utf16_pattern };
+        bool unicode = f.find('u').has_value();
+        StringBuilder builder;
+
+        // If the Unicode flag is set, append each code point to the pattern. Otherwise, append each
+        // code unit. But unlike the spec, multi-byte code units must be escaped for LibRegex to parse.
+        for (size_t i = 0; i < utf16_pattern_view.length_in_code_units();) {
+            if (unicode) {
+                auto code_point = code_point_at(utf16_pattern_view, i);
+                builder.append_code_point(code_point.code_point);
+                i += code_point.code_unit_count;
+                continue;
+            }
+
+            u16 code_unit = utf16_pattern_view.code_unit_at(i);
+            ++i;
+
+            if (code_unit > 0x7f)
+                builder.appendff("\\u{:04x}", code_unit);
+            else
+                builder.append_code_point(code_unit);
+        }
+
+        original_pattern = utf16_pattern_view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes);
+        parsed_pattern = builder.build();
+    }
+
+    auto* object = RegExpObject::create(global_object, move(original_pattern), move(parsed_pattern), move(f));
     object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -23,20 +23,21 @@ class RegExpObject : public Object {
     JS_OBJECT(RegExpObject, Object);
 
 public:
-    static RegExpObject* create(GlobalObject&, String pattern, String flags);
+    static RegExpObject* create(GlobalObject&, String original_pattern, String parsed_pattern, String flags);
 
-    RegExpObject(String pattern, String flags, Object& prototype);
+    RegExpObject(String original_pattern, String parsed_pattern, String flags, Object& prototype);
     virtual void initialize(GlobalObject&) override;
     virtual ~RegExpObject() override;
 
-    const String& pattern() const { return m_pattern; }
+    const String& pattern() const { return m_original_pattern; }
     const String& flags() const { return m_flags; }
     const regex::RegexOptions<ECMAScriptFlags>& declared_options() { return m_active_flags.declared_flags; }
     const Regex<ECMA262>& regex() { return m_regex; }
     const Regex<ECMA262>& regex() const { return m_regex; }
 
 private:
-    String m_pattern;
+    String m_original_pattern;
+    String m_parsed_pattern;
     String m_flags;
     Flags m_active_flags;
     Regex<ECMA262> m_regex;

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -787,14 +787,14 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
 // 22.2.5.11 RegExp.prototype [ @@search ] ( string ), https://tc39.es/ecma262/#sec-regexp.prototype-@@search
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_search)
 {
-    auto string_value = vm.argument(0);
-
     auto* regexp_object = this_object_from(vm, global_object);
     if (!regexp_object)
         return {};
-    auto string = string_value.to_string(global_object);
+
+    auto string = vm.argument(0).to_utf16_string(global_object);
     if (vm.exception())
         return {};
+    Utf16View string_view { string };
 
     auto previous_last_index = regexp_object->get(vm.names.lastIndex);
     if (vm.exception())
@@ -805,7 +805,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_search)
             return {};
     }
 
-    auto result = regexp_exec(global_object, *regexp_object, string);
+    auto result = regexp_exec(global_object, *regexp_object, string_view);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -101,15 +102,6 @@ size_t advance_string_index(Utf16View const& string, size_t index, bool unicode)
 
     auto code_point = code_point_at(string, index);
     return index + code_point.code_unit_count;
-}
-
-// 22.2.5.2.3 AdvanceStringIndex ( S, index, unicode ), https://tc39.es/ecma262/#sec-advancestringindex
-size_t advance_string_index(String const& string, size_t index, bool unicode)
-{
-    auto utf16_string = AK::utf8_to_utf16(string);
-    Utf16View utf16_string_view { utf16_string };
-
-    return advance_string_index(utf16_string_view, index, unicode);
 }
 
 static void increment_last_index(GlobalObject& global_object, Object& regexp_object, Utf16View const& string, bool unicode)
@@ -345,15 +337,6 @@ Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Utf16View 
     }
 
     return regexp_builtin_exec(global_object, static_cast<RegExpObject&>(regexp_object), string);
-}
-
-// 22.2.5.2.1 RegExpExec ( R, S ), https://tc39.es/ecma262/#sec-regexpexec
-Value regexp_exec(GlobalObject& global_object, Object& regexp_object, String const& string)
-{
-    auto utf16_string = AK::utf8_to_utf16(string);
-    Utf16View utf16_string_view { utf16_string };
-
-    return regexp_exec(global_object, regexp_object, utf16_string_view);
 }
 
 // 1.1.4.3 get RegExp.prototype.hasIndices, https://tc39.es/proposal-regexp-match-indices/#sec-get-regexp.prototype.hasIndices

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -10,9 +10,7 @@
 
 namespace JS {
 
-Value regexp_exec(GlobalObject& global_object, Object& regexp_object, String const& string);
 Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Utf16View const& string);
-size_t advance_string_index(String const& string, size_t index, bool unicode);
 size_t advance_string_index(Utf16View const& string, size_t index, bool unicode);
 
 class RegExpPrototype final : public Object {

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -11,7 +11,9 @@
 namespace JS {
 
 Value regexp_exec(GlobalObject& global_object, Object& regexp_object, String const& string);
+Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Utf16View const& string);
 size_t advance_string_index(String const& string, size_t index, bool unicode);
+size_t advance_string_index(Utf16View const& string, size_t index, bool unicode);
 
 class RegExpPrototype final : public Object {
     JS_OBJECT(RegExpPrototype, Object);

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -10,12 +10,12 @@
 namespace JS {
 
 // 22.2.7.1 CreateRegExpStringIterator ( R, S, global, fullUnicode ), https://tc39.es/ecma262/#sec-createregexpstringiterator
-RegExpStringIterator* RegExpStringIterator::create(GlobalObject& global_object, Object& regexp_object, String string, bool global, bool unicode)
+RegExpStringIterator* RegExpStringIterator::create(GlobalObject& global_object, Object& regexp_object, Vector<u16> string, bool global, bool unicode)
 {
     return global_object.heap().allocate<RegExpStringIterator>(global_object, *global_object.regexp_string_iterator_prototype(), regexp_object, move(string), global, unicode);
 }
 
-RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, String string, bool global, bool unicode)
+RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, Vector<u16> string, bool global, bool unicode)
     : Object(prototype)
     , m_regexp_object(regexp_object)
     , m_string(move(string))

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Utf16View.h>
 #include <LibJS/Runtime/Object.h>
 
 namespace JS {
@@ -14,13 +15,13 @@ class RegExpStringIterator final : public Object {
     JS_OBJECT(RegExpStringIterator, Object);
 
 public:
-    static RegExpStringIterator* create(GlobalObject&, Object& regexp_object, String string, bool global, bool unicode);
+    static RegExpStringIterator* create(GlobalObject&, Object& regexp_object, Vector<u16> string, bool global, bool unicode);
 
-    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, String string, bool global, bool unicode);
+    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, Vector<u16> string, bool global, bool unicode);
     virtual ~RegExpStringIterator() override = default;
 
     Object& regexp_object() { return m_regexp_object; }
-    String const& string() const { return m_string; }
+    Utf16View string() const { return Utf16View { m_string }; }
     bool global() const { return m_global; }
     bool unicode() const { return m_unicode; }
 
@@ -31,7 +32,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     Object& m_regexp_object;
-    String m_string;
+    Vector<u16> m_string;
     bool m_global { false };
     bool m_unicode { false };
     bool m_done { false };

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -839,13 +839,16 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match)
         if (vm.exception())
             return {};
     }
-    auto s = this_object.to_string(global_object);
+
+    auto string = this_object.to_utf16_string(global_object);
     if (vm.exception())
         return {};
+    Utf16View utf16_string_view { string };
+
     auto rx = regexp_create(global_object, regexp, js_undefined());
     if (!rx)
         return {};
-    return rx->invoke(*vm.well_known_symbol_match(), js_string(vm, s));
+    return rx->invoke(*vm.well_known_symbol_match(), js_string(vm, utf16_string_view));
 }
 
 // 22.1.3.12 String.prototype.matchAll ( regexp ), https://tc39.es/ecma262/#sec-string.prototype.matchall
@@ -879,13 +882,16 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match_all)
         if (vm.exception())
             return {};
     }
-    auto s = this_object.to_string(global_object);
+
+    auto string = this_object.to_utf16_string(global_object);
     if (vm.exception())
         return {};
+    Utf16View utf16_string_view { string };
+
     auto rx = regexp_create(global_object, regexp, js_string(vm, "g"));
     if (!rx)
         return {};
-    return rx->invoke(*vm.well_known_symbol_match_all(), js_string(vm, s));
+    return rx->invoke(*vm.well_known_symbol_match_all(), js_string(vm, utf16_string_view));
 }
 
 // 22.1.3.17 String.prototype.replace ( searchValue, replaceValue ), https://tc39.es/ecma262/#sec-string.prototype.replace

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -910,10 +910,10 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace)
             return {};
     }
 
-    auto string = this_object.to_string(global_object);
+    auto string = this_object.to_utf16_string(global_object);
     if (vm.exception())
         return {};
-    auto search_string = search_value.to_string(global_object);
+    auto search_string = search_value.to_utf16_string(global_object);
     if (vm.exception())
         return {};
 
@@ -926,11 +926,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace)
             return {};
     }
 
-    auto utf16_string = AK::utf8_to_utf16(string);
-    Utf16View utf16_string_view { utf16_string };
-
-    auto utf16_search_string = AK::utf8_to_utf16(search_string);
-    Utf16View utf16_search_view { utf16_search_string };
+    Utf16View utf16_string_view { string };
+    Utf16View utf16_search_view { search_string };
 
     Optional<size_t> position = string_index_of(utf16_string_view, utf16_search_view, 0);
     if (!position.has_value())
@@ -948,7 +945,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace)
         if (vm.exception())
             return {};
     } else {
-        replacement = get_substitution(global_object, search_string, string, *position, {}, js_undefined(), replace_value);
+        replacement = get_substitution(global_object, utf16_search_view, utf16_string_view, *position, {}, js_undefined(), replace_value);
         if (vm.exception())
             return {};
     }
@@ -1004,10 +1001,10 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
         }
     }
 
-    auto string = this_object.to_string(global_object);
+    auto string = this_object.to_utf16_string(global_object);
     if (vm.exception())
         return {};
-    auto search_string = search_value.to_string(global_object);
+    auto search_string = search_value.to_utf16_string(global_object);
     if (vm.exception())
         return {};
 
@@ -1020,12 +1017,10 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
             return {};
     }
 
-    auto utf16_string = AK::utf8_to_utf16(string);
-    Utf16View utf16_string_view { utf16_string };
+    Utf16View utf16_string_view { string };
     auto string_length = utf16_string_view.length_in_code_units();
 
-    auto utf16_search_string = AK::utf8_to_utf16(search_string);
-    Utf16View utf16_search_view { utf16_search_string };
+    Utf16View utf16_search_view { search_string };
     auto search_length = utf16_search_view.length_in_code_units();
 
     Vector<size_t> match_positions;
@@ -1053,7 +1048,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
             if (vm.exception())
                 return {};
         } else {
-            replacement = get_substitution(global_object, search_string, string, position, {}, js_undefined(), replace_value);
+            replacement = get_substitution(global_object, utf16_search_view, utf16_string_view, position, {}, js_undefined(), replace_value);
             if (vm.exception())
                 return {};
         }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1085,13 +1085,16 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::search)
         if (vm.exception())
             return {};
     }
-    auto s = this_object.to_string(global_object);
+
+    auto string = this_object.to_utf16_string(global_object);
     if (vm.exception())
         return {};
+    Utf16View utf16_string_view { string };
+
     auto rx = regexp_create(global_object, regexp, js_undefined());
     if (!rx)
         return {};
-    return rx->invoke(*vm.well_known_symbol_search(), js_string(vm, s));
+    return rx->invoke(*vm.well_known_symbol_search(), js_string(vm, utf16_string_view));
 }
 
 // B.2.3.2.1 CreateHTML ( string, tag, attribute, value ), https://tc39.es/ecma262/#sec-createhtml

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
@@ -45,3 +45,13 @@ test("override exec with non-function", () => {
     re.exec = 3;
     expect("test".match(re)).not.toBeNull();
 });
+
+test("UTF-16", () => {
+    expect("😀".match("foo")).toBeNull();
+    expect("😀".match("\ud83d")).toEqual(["\ud83d"]);
+    expect("😀".match("\ude00")).toEqual(["\ude00"]);
+    expect("😀😀".match("\ud83d")).toEqual(["\ud83d"]);
+    expect("😀😀".match("\ude00")).toEqual(["\ude00"]);
+    expect("😀😀".match(/\ud83d/g)).toEqual(["\ud83d", "\ud83d"]);
+    expect("😀😀".match(/\ude00/g)).toEqual(["\ude00", "\ude00"]);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.matchAll.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.matchAll.js
@@ -76,3 +76,63 @@ test("basic functionality", () => {
         expect(next.value).toBeUndefined();
     }
 });
+
+test("UTF-16", () => {
+    {
+        var iterator = "😀".matchAll("foo");
+
+        var next = iterator.next();
+        expect(next.done).toBeTrue();
+        expect(next.value).toBeUndefined();
+
+        next = iterator.next();
+        expect(next.done).toBeTrue();
+        expect(next.value).toBeUndefined();
+    }
+    {
+        var iterator = "😀".matchAll("\ud83d");
+
+        var next = iterator.next();
+        expect(next.done).toBeFalse();
+        expect(next.value).toEqual(["\ud83d"]);
+        expect(next.value.index).toBe(0);
+
+        next = iterator.next();
+        expect(next.done).toBeTrue();
+        expect(next.value).toBeUndefined();
+    }
+    {
+        var iterator = "😀😀".matchAll("\ud83d");
+
+        var next = iterator.next();
+        expect(next.done).toBeFalse();
+        expect(next.value).toEqual(["\ud83d"]);
+        expect(next.value.index).toBe(0);
+
+        next = iterator.next();
+        expect(next.done).toBeFalse();
+        expect(next.value).toEqual(["\ud83d"]);
+        expect(next.value.index).toBe(2);
+
+        next = iterator.next();
+        expect(next.done).toBeTrue();
+        expect(next.value).toBeUndefined();
+    }
+    {
+        var iterator = "😀😀".matchAll("\ude00");
+
+        var next = iterator.next();
+        expect(next.done).toBeFalse();
+        expect(next.value).toEqual(["\ude00"]);
+        expect(next.value.index).toBe(1);
+
+        next = iterator.next();
+        expect(next.done).toBeFalse();
+        expect(next.value).toEqual(["\ude00"]);
+        expect(next.value.index).toBe(3);
+
+        next = iterator.next();
+        expect(next.done).toBeTrue();
+        expect(next.value).toBeUndefined();
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -238,7 +238,11 @@ test("UTF-16", () => {
     expect("😀".replace("\ud83d", "")).toBe("\ude00");
     expect("😀".replace("\ude00", "")).toBe("\ud83d");
 
-    // FIXME: RegExp.prototype [ @@replace ] also needs to support UTF-16.
-    // expect("😀".replace(/\ud83d/, "")).toBe("\ude00");
-    // expect("😀".replace(/\ude00/, "")).toBe("\ud83d");
+    expect("😀".replace(/\ud83d/, "")).toBe("\ude00");
+    expect("😀".replace(/\ude00/, "")).toBe("\ud83d");
+    expect("😀".replace(/\ud83d\ude00/, "")).toBe("");
+
+    expect("😀".replace(/\ud83d/u, "")).toBe("😀");
+    expect("😀".replace(/\ude00/u, "")).toBe("😀");
+    expect("😀".replace(/\ud83d\ude00/u, "")).toBe("");
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replaceAll.js
@@ -151,7 +151,18 @@ test("UTF-16", () => {
     expect("😀😀😀".replaceAll("\ud83d", "")).toBe("\ude00\ude00\ude00");
     expect("😀😀😀".replaceAll("\ude00", "")).toBe("\ud83d\ud83d\ud83d");
 
-    // FIXME: RegExp.prototype [ @@replace ] also needs to support UTF-16.
-    // expect("😀".replaceAll(/\ud83d/g, "")).toBe("\ude00");
-    // expect("😀".replaceAll(/\ude00/g, "")).toBe("\ud83d");
+    expect("😀".replaceAll(/\ud83d/g, "")).toBe("\ude00");
+    expect("😀".replaceAll(/\ude00/g, "")).toBe("\ud83d");
+    expect("😀".replaceAll(/\ud83d\ude00/g, "")).toBe("");
+    expect("😀😀😀".replaceAll(/\ud83d/g, "")).toBe("\ude00\ude00\ude00");
+    expect("😀😀😀".replaceAll(/\ude00/g, "")).toBe("\ud83d\ud83d\ud83d");
+    expect("😀😀😀".replaceAll(/\ud83d\ude00/g, "")).toBe("");
+
+    expect("😀".replaceAll(/\ud83d/gu, "")).toBe("😀");
+    expect("😀".replaceAll(/\ude00/gu, "")).toBe("😀");
+    expect("😀".replaceAll(/\ud83d\ude00/gu, "")).toBe("");
+    expect("😀😀😀".replaceAll(/\ud83d/gu, "")).toBe("😀😀😀");
+    expect("😀😀😀".replaceAll(/\ude00/gu, "")).toBe("😀😀😀");
+    expect("😀😀😀".replaceAll(/\ude00/gu, "")).toBe("😀😀😀");
+    expect("😀😀😀".replaceAll(/\ud83d\ude00/gu, "")).toBe("");
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.search.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.search.js
@@ -46,10 +46,15 @@ test("override exec with non-function", () => {
     expect("test".search(re)).toBe(0);
 });
 
-// FIXME: RegExp.prototype [ @@search ] needs to support UTF-16.
-// test("UTF-16", () => {
-//     var s = "😀";
-//     expect(s.search("😀")).toBe(0);
-//     expect(s.search("\ud83d")).toBe(0);
-//     expect(s.search("\ude00")).toBe(1);
-// });
+test("UTF-16", () => {
+    var s = "😀";
+    expect(s.search("😀")).toBe(0);
+    expect(s.search("\ud83d")).toBe(0);
+    expect(s.search("\ude00")).toBe(1);
+    expect(s.search("foo")).toBe(-1);
+
+    s = "\u{80}\u{160}";
+    expect(s.search("\u{80}")).toBe(0);
+    expect(s.search("\u{160}")).toBe(1);
+    expect(s.search("foo")).toBe(-1);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.split.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.split.js
@@ -73,7 +73,10 @@ test("UTF-16", () => {
     expect(s.split("\ud83d")).toEqual(["", "\ude00"]);
     expect(s.split("\ude00")).toEqual(["\ud83d", ""]);
 
-    // FIXME: RegExp.prototype [ @@split ] also needs to support UTF-16.
-    // expect(s.split(/\ud83d/)).toEqual(["", "\ude00"]);
-    // expect(s.split(/\ude00/)).toEqual(["\ud83d", ""]);
+    expect(s.split(/\ud83d/)).toEqual(["", "\ude00"]);
+    expect(s.split(/\ude00/)).toEqual(["\ud83d", ""]);
+
+    s = "😀😀😀";
+    expect(s.split(/\ud83d/)).toEqual(["", "\ude00", "\ude00", "\ude00"]);
+    expect(s.split(/\ude00/)).toEqual(["\ud83d", "\ud83d", "\ud83d", ""]);
 });

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -465,12 +465,13 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
 
             Optional<String> str;
+            Vector<u16> utf16;
             Vector<u32> data;
             data.ensure_capacity(length);
             for (size_t i = offset; i < offset + length; ++i)
                 data.unchecked_append(m_bytecode->at(i));
 
-            auto view = input.view.construct_as_same(data, str);
+            auto view = input.view.construct_as_same(data, str, utf16);
             offset += length;
             if (!compare_string(input, state, view, had_zero_length_match))
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -553,7 +554,8 @@ ALWAYS_INLINE void OpCode_Compare::compare_char(MatchInput const& input, MatchSt
 
     auto input_view = input.view.substring_view(state.string_position, 1);
     Optional<String> str;
-    auto compare_view = input_view.construct_as_same({ &ch1, 1 }, str);
+    Vector<u16> utf16;
+    auto compare_view = input_view.construct_as_same({ &ch1, 1 }, str, utf16);
     bool equal;
     if (input.regex_options & AllFlags::Insensitive)
         equal = input_view.equals_ignoring_case(compare_view);

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -335,6 +335,11 @@ public:
                     [&](StringView other_view) { return view.equals_ignoring_case(other_view); },
                     [](auto&) -> bool { TODO(); });
             },
+            [&](Utf16View view) {
+                return other.m_view.visit(
+                    [&](Utf16View other_view) { return view.equals_ignoring_case(other_view); },
+                    [](auto&) -> bool { TODO(); });
+            },
             [](auto&) -> bool { TODO(); });
     }
 

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -84,6 +84,10 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const views, Optional
     output.operations = 0;
     size_t lines_to_skip = 0;
 
+    bool unicode = input.regex_options.has_flag_set(AllFlags::Unicode);
+    for (auto& view : views)
+        const_cast<RegexStringView&>(view).set_unicode(unicode);
+
     if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
         if (views.size() > 1 && input.start_offset > views.first().length()) {
             dbgln_if(REGEX_DEBUG, "Started with start={}, goff={}, skip={}", input.start_offset, input.global_offset, lines_to_skip);


### PR DESCRIPTION
~~Fun fact! We now have only one single `RegExp.prototype` test262 failure (not sure why):
`test262/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T6.js (strict mode)`~~

EVEN MORE fun fact, we now pass all `RegExp.prototype` tests :D