### PR TITLE
Userland: Use /proc/kernel_base to determine the kernel base address

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -49,5 +49,5 @@ set(SOURCES
 )
 
 serenity_app(HackStudio ICON app-hack-studio)
-target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibCpp LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell LibRegex)
+target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibCpp LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell LibSymbolication LibRegex)
 add_dependencies(HackStudio CppLanguageServer)

--- a/Userland/DevTools/Profiler/CMakeLists.txt
+++ b/Userland/DevTools/Profiler/CMakeLists.txt
@@ -19,4 +19,4 @@ set(SOURCES
         )
 
 serenity_app(Profiler ICON app-profiler)
-target_link_libraries(Profiler LibGUI LibDesktop LibX86)
+target_link_libraries(Profiler LibGUI LibDesktop LibX86 LibSymbolication)

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -8,6 +8,7 @@
 #include "Profile.h"
 #include <AK/StringBuilder.h>
 #include <LibGUI/FileIconProvider.h>
+#include <LibSymbolication/Symbolication.h>
 #include <ctype.h>
 #include <stdio.h>
 
@@ -105,13 +106,8 @@ GUI::Variant ProfileModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
             if (node->is_root()) {
                 return GUI::FileIconProvider::icon_for_executable(node->process().executable);
             }
-            // FIXME: Use /proc for this
-#if ARCH(I386)
-            FlatPtr kernel_base = 0xc0000000;
-#else
-            FlatPtr kernel_base = 0x2000000000;
-#endif
-            if (node->address() >= kernel_base)
+            auto maybe_kernel_base = Symbolication::kernel_base();
+            if (maybe_kernel_base.has_value() && node->address() >= maybe_kernel_base.value())
                 return m_kernel_frame_icon;
             return m_user_frame_icon;
         }

--- a/Userland/Libraries/LibSymbolication/Symbolication.h
+++ b/Userland/Libraries/LibSymbolication/Symbolication.h
@@ -18,6 +18,7 @@ struct Symbol {
     Vector<Debug::DebugInfo::SourcePosition> source_positions;
 };
 
+Optional<FlatPtr> kernel_base();
 Vector<Symbol> symbolicate_thread(pid_t pid, pid_t tid);
 Optional<Symbol> symbolicate(String const& path, FlatPtr address);
 


### PR DESCRIPTION
This removes all the hard-coded kernel base addresses from userspace tools.

One downside for this is that e.g. Profiler no longer uses a different color for kernel symbols when run as a non-root user.