### PR TITLE
WindowServer: Fix rendering overlays when there's no desktop window

### DIFF
--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -224,6 +224,7 @@ private:
     Gfx::DisjointRectSet m_overlay_rects;
     Gfx::DisjointRectSet m_dirty_screen_rects;
     Gfx::DisjointRectSet m_opaque_wallpaper_rects;
+    Gfx::DisjointRectSet m_transparent_wallpaper_rects;
 
     String m_wallpaper_path { "" };
     WallpaperMode m_wallpaper_mode { WallpaperMode::Unchecked };


### PR DESCRIPTION
We were missing to account for areas that are not covered by any
window. If any of these areas are covered by an overlay we need to
render the wallpaper into transparency and also render the overlay
over them.

This fixes not rendering overlays properly when e.g. the FileManager
(desktop) crashed as there is no longer any window underneath.