### PR TITLE
KeyboardPreferences: Save Keyboard config in user directory

### DIFF
--- a/Base/etc/Keyboard.ini
+++ b/Base/etc/Keyboard.ini
@@ -1,2 +1,0 @@
-[Mapping]
-Keymap=en-us

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -146,6 +146,7 @@ int main(int argc, char** argv)
         }
 
         config->write_bool_entry("StartupEnable", "NumLock", num_lock_checkbox.is_checked());
+        config->write_entry("StartupEnable", "Keymap", character_map_file_combo.text());
         config->sync();
 
         if (quit)

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -146,7 +146,6 @@ int main(int argc, char** argv)
         }
 
         config->write_bool_entry("StartupEnable", "NumLock", num_lock_checkbox.is_checked());
-        config->write_entry("StartupEnable", "Keymap", character_map_file_combo.text());
         config->sync();
 
         if (quit)

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -21,16 +21,15 @@ int main()
     }
 
     auto keyboard_settings_config = Core::ConfigFile::get_for_app("KeyboardSettings");
+    auto mapping_config = Core::ConfigFile::get_for_app("Keyboard");
 
     if (unveil(keyboard_settings_config->filename().characters(), "r") < 0) {
         perror("unveil user keyboard settings");
         return 1;
     }
 
-    auto mapping_config = Core::ConfigFile::get_for_app("Keyboard");
-
     if (unveil(mapping_config->filename().characters(), "r") < 0) {
-        perror("unveil user keyboard settings");
+        perror("unveil user keyboard mapping settings");
         return 1;
     }
 

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -45,6 +45,10 @@ int main()
     auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini"));
     auto keymap = mapper_config->read_entry("Mapping", "Keymap", "");
 
+    auto keymap_user_settings = keyboard_settings_config->read_entry("StartupEnable", "Keymap", "");
+    if (keymap_user_settings != keymap)
+        keymap = keymap_user_settings;
+
     pid_t child_pid;
     const char* argv[] = { "/bin/keymap", keymap.characters(), nullptr };
     if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -23,11 +23,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (unveil("/etc/Keyboard.ini", "rwc") < 0) {
-        perror("unveil /etc/Keyboard.ini");
-        return 1;
-    }
-
     const char* path = nullptr;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "The mapping file to be used", "file", Core::ArgsParser::Required::No);
@@ -38,6 +33,12 @@ int main(int argc, char** argv)
             perror("unveil path");
             return 1;
         }
+    }
+
+    auto mapper_config = Core::ConfigFile::get_for_app("Keyboard");
+    if (unveil(mapper_config->filename().characters(), "rwc") < 0) {
+        perror("unveil");
+        return 1;
     }
 
     if (unveil(nullptr, nullptr) < 0) {
@@ -69,7 +70,6 @@ int main(int argc, char** argv)
         return rc;
     }
 
-    auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini"));
     mapper_config->write_entry("Mapping", "Keymap", path);
     mapper_config->sync();
 

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -18,6 +18,8 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    auto mapper_config = Core::ConfigFile::get_for_app("Keyboard");
+
     if (unveil("/res/keymaps", "r") < 0) {
         perror("unveil");
         return 1;
@@ -35,7 +37,6 @@ int main(int argc, char** argv)
         }
     }
 
-    auto mapper_config = Core::ConfigFile::get_for_app("Keyboard");
     if (unveil(mapper_config->filename().characters(), "rwc") < 0) {
         perror("unveil");
         return 1;


### PR DESCRIPTION
Hello!

This is my first contribution to this project. 👋 

This patch changes the place we store the currently selected keyboard map from system-wide to user-wide.

Keyboard mapping is now stored in `$HOME/.config/Keyboard.ini`

This makes it resist changes when rebuilding the system image, and would allow multiple users to use different keyboard mappings
