### PR TITLE
Kernel: Fix the variable declaration for some linker script symbols

### DIFF
--- a/Kernel/Arch/x86/common/SafeMem.cpp
+++ b/Kernel/Arch/x86/common/SafeMem.cpp
@@ -9,33 +9,33 @@
 
 #define CODE_SECTION(section_name) __attribute__((section(section_name)))
 
-extern "C" u8* start_of_safemem_text;
-extern "C" u8* end_of_safemem_text;
+extern "C" u8 start_of_safemem_text[];
+extern "C" u8 end_of_safemem_text[];
 
-extern "C" u8* safe_memcpy_ins_1;
-extern "C" u8* safe_memcpy_1_faulted;
-extern "C" u8* safe_memcpy_ins_2;
-extern "C" u8* safe_memcpy_2_faulted;
-extern "C" u8* safe_strnlen_ins;
-extern "C" u8* safe_strnlen_faulted;
-extern "C" u8* safe_memset_ins_1;
-extern "C" u8* safe_memset_1_faulted;
-extern "C" u8* safe_memset_ins_2;
-extern "C" u8* safe_memset_2_faulted;
+extern "C" u8 safe_memcpy_ins_1[];
+extern "C" u8 safe_memcpy_1_faulted[];
+extern "C" u8 safe_memcpy_ins_2[];
+extern "C" u8 safe_memcpy_2_faulted[];
+extern "C" u8 safe_strnlen_ins[];
+extern "C" u8 safe_strnlen_faulted[];
+extern "C" u8 safe_memset_ins_1[];
+extern "C" u8 safe_memset_1_faulted[];
+extern "C" u8 safe_memset_ins_2[];
+extern "C" u8 safe_memset_2_faulted[];
 
-extern "C" u8* start_of_safemem_atomic_text;
-extern "C" u8* end_of_safemem_atomic_text;
+extern "C" u8 start_of_safemem_atomic_text[];
+extern "C" u8 end_of_safemem_atomic_text[];
 
-extern "C" u8* safe_atomic_fetch_add_relaxed_ins;
-extern "C" u8* safe_atomic_fetch_add_relaxed_faulted;
-extern "C" u8* safe_atomic_exchange_relaxed_ins;
-extern "C" u8* safe_atomic_exchange_relaxed_faulted;
-extern "C" u8* safe_atomic_load_relaxed_ins;
-extern "C" u8* safe_atomic_load_relaxed_faulted;
-extern "C" u8* safe_atomic_store_relaxed_ins;
-extern "C" u8* safe_atomic_store_relaxed_faulted;
-extern "C" u8* safe_atomic_compare_exchange_relaxed_ins;
-extern "C" u8* safe_atomic_compare_exchange_relaxed_faulted;
+extern "C" u8 safe_atomic_fetch_add_relaxed_ins[];
+extern "C" u8 safe_atomic_fetch_add_relaxed_faulted[];
+extern "C" u8 safe_atomic_exchange_relaxed_ins[];
+extern "C" u8 safe_atomic_exchange_relaxed_faulted[];
+extern "C" u8 safe_atomic_load_relaxed_ins[];
+extern "C" u8 safe_atomic_load_relaxed_faulted[];
+extern "C" u8 safe_atomic_store_relaxed_ins[];
+extern "C" u8 safe_atomic_store_relaxed_faulted[];
+extern "C" u8 safe_atomic_compare_exchange_relaxed_ins[];
+extern "C" u8 safe_atomic_compare_exchange_relaxed_faulted[];
 
 namespace Kernel {
 
@@ -266,16 +266,16 @@ bool handle_safe_access_fault(RegisterState& regs, FlatPtr fault_address)
     if (ip >= (FlatPtr)&start_of_safemem_text && ip < (FlatPtr)&end_of_safemem_text) {
         // If we detect that the fault happened in safe_memcpy() safe_strnlen(),
         // or safe_memset() then resume at the appropriate _faulted label
-        if (ip == (FlatPtr)&safe_memcpy_ins_1)
-            ip = (FlatPtr)&safe_memcpy_1_faulted;
-        else if (ip == (FlatPtr)&safe_memcpy_ins_2)
-            ip = (FlatPtr)&safe_memcpy_2_faulted;
-        else if (ip == (FlatPtr)&safe_strnlen_ins)
-            ip = (FlatPtr)&safe_strnlen_faulted;
-        else if (ip == (FlatPtr)&safe_memset_ins_1)
-            ip = (FlatPtr)&safe_memset_1_faulted;
-        else if (ip == (FlatPtr)&safe_memset_ins_2)
-            ip = (FlatPtr)&safe_memset_2_faulted;
+        if (ip == (FlatPtr)safe_memcpy_ins_1)
+            ip = (FlatPtr)safe_memcpy_1_faulted;
+        else if (ip == (FlatPtr)safe_memcpy_ins_2)
+            ip = (FlatPtr)safe_memcpy_2_faulted;
+        else if (ip == (FlatPtr)safe_strnlen_ins)
+            ip = (FlatPtr)safe_strnlen_faulted;
+        else if (ip == (FlatPtr)safe_memset_ins_1)
+            ip = (FlatPtr)safe_memset_1_faulted;
+        else if (ip == (FlatPtr)safe_memset_ins_2)
+            ip = (FlatPtr)safe_memset_2_faulted;
         else
             return false;
 
@@ -292,16 +292,16 @@ bool handle_safe_access_fault(RegisterState& regs, FlatPtr fault_address)
         // If we detect that a fault happened in one of the atomic safe_
         // functions, resume at the appropriate _faulted label and set
         // the edx/rdx register to 1 to indicate an error
-        if (ip == (FlatPtr)&safe_atomic_fetch_add_relaxed_ins)
-            ip = (FlatPtr)&safe_atomic_fetch_add_relaxed_faulted;
-        else if (ip == (FlatPtr)&safe_atomic_exchange_relaxed_ins)
-            ip = (FlatPtr)&safe_atomic_exchange_relaxed_faulted;
-        else if (ip == (FlatPtr)&safe_atomic_load_relaxed_ins)
-            ip = (FlatPtr)&safe_atomic_load_relaxed_faulted;
-        else if (ip == (FlatPtr)&safe_atomic_store_relaxed_ins)
-            ip = (FlatPtr)&safe_atomic_store_relaxed_faulted;
-        else if (ip == (FlatPtr)&safe_atomic_compare_exchange_relaxed_ins)
-            ip = (FlatPtr)&safe_atomic_compare_exchange_relaxed_faulted;
+        if (ip == (FlatPtr)safe_atomic_fetch_add_relaxed_ins)
+            ip = (FlatPtr)safe_atomic_fetch_add_relaxed_faulted;
+        else if (ip == (FlatPtr)safe_atomic_exchange_relaxed_ins)
+            ip = (FlatPtr)safe_atomic_exchange_relaxed_faulted;
+        else if (ip == (FlatPtr)safe_atomic_load_relaxed_ins)
+            ip = (FlatPtr)safe_atomic_load_relaxed_faulted;
+        else if (ip == (FlatPtr)safe_atomic_store_relaxed_ins)
+            ip = (FlatPtr)safe_atomic_store_relaxed_faulted;
+        else if (ip == (FlatPtr)safe_atomic_compare_exchange_relaxed_ins)
+            ip = (FlatPtr)safe_atomic_compare_exchange_relaxed_faulted;
         else
             return false;
 

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -13,7 +13,7 @@
 #include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/PageDirectory.h>
 
-extern u8* end_of_kernel_image;
+extern u8 end_of_kernel_image[];
 
 namespace Kernel {
 
@@ -34,7 +34,7 @@ RefPtr<PageDirectory> PageDirectory::find_by_cr3(FlatPtr cr3)
 UNMAP_AFTER_INIT PageDirectory::PageDirectory()
 {
     // make sure this starts in a new page directory to make MemoryManager::initialize_physical_pages() happy
-    FlatPtr start_of_range = ((FlatPtr)&end_of_kernel_image & ~(FlatPtr)0x1fffff) + 0x200000;
+    FlatPtr start_of_range = ((FlatPtr)end_of_kernel_image & ~(FlatPtr)0x1fffff) + 0x200000;
     m_range_allocator.initialize_with_range(VirtualAddress(start_of_range), KERNEL_PD_END - start_of_range);
     m_identity_range_allocator.initialize_with_range(VirtualAddress(FlatPtr(0x00000000)), 0x00200000);
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -61,20 +61,20 @@
 
 // Defined in the linker script
 typedef void (*ctor_func_t)();
-extern ctor_func_t start_heap_ctors;
-extern ctor_func_t end_heap_ctors;
-extern ctor_func_t start_ctors;
-extern ctor_func_t end_ctors;
+extern ctor_func_t start_heap_ctors[];
+extern ctor_func_t end_heap_ctors[];
+extern ctor_func_t start_ctors[];
+extern ctor_func_t end_ctors[];
 
 extern size_t __stack_chk_guard;
 size_t __stack_chk_guard;
 
-extern "C" u8* start_of_safemem_text;
-extern "C" u8* end_of_safemem_text;
-extern "C" u8* start_of_safemem_atomic_text;
-extern "C" u8* end_of_safemem_atomic_text;
+extern "C" u8 start_of_safemem_text[];
+extern "C" u8 end_of_safemem_text[];
+extern "C" u8 start_of_safemem_atomic_text[];
+extern "C" u8 end_of_safemem_atomic_text[];
 
-extern "C" u8* end_of_kernel_image;
+extern "C" u8 end_of_kernel_image[];
 
 multiboot_module_entry_t multiboot_copy_boot_modules_array[16];
 size_t multiboot_copy_boot_modules_count;
@@ -149,7 +149,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     s_bsp_processor.early_initialize(0);
 
     // Invoke the constructors needed for the kernel heap
-    for (ctor_func_t* ctor = &start_heap_ctors; ctor < &end_heap_ctors; ctor++)
+    for (ctor_func_t* ctor = start_heap_ctors; ctor < end_heap_ctors; ctor++)
         (*ctor)();
     kmalloc_init();
     slab_alloc_init();
@@ -163,12 +163,12 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     MemoryManager::initialize(0);
 
     // Ensure that the safemem sections are not empty. This could happen if the linker accidentally discards the sections.
-    VERIFY(&start_of_safemem_text != &end_of_safemem_text);
-    VERIFY(&start_of_safemem_atomic_text != &end_of_safemem_atomic_text);
+    VERIFY(start_of_safemem_text != end_of_safemem_text);
+    VERIFY(start_of_safemem_atomic_text != end_of_safemem_atomic_text);
 
     // Invoke all static global constructors in the kernel.
     // Note that we want to do this as early as possible.
-    for (ctor_func_t* ctor = &start_ctors; ctor < &end_ctors; ctor++)
+    for (ctor_func_t* ctor = start_ctors; ctor < end_ctors; ctor++)
         (*ctor)();
 
     APIC::initialize();


### PR DESCRIPTION
Despite what the declaration would have us believe these are not "u8*". If they were we wouldn't have to use the & operator to get the address of them and then cast them to "u8*"/FlatPtr afterwards.