### PR TITLE
Vim: Add future support for commands which require more than 2 keys

### DIFF
--- a/Kernel/API/KeyCode.h
+++ b/Kernel/API/KeyCode.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/Types.h>
 
 #define ENUMERATE_KEY_CODES                          \
@@ -127,6 +128,10 @@ enum KeyCode : u8 {
 };
 const int key_code_count = Key_Super;
 
+#define __ENUMERATE_KEY_CODE(name, ui_name) ui_name,
+static const char* str_key_codes[] = { ENUMERATE_KEY_CODES };
+#undef __ENUMERATE_KEY_CODE
+
 enum KeyModifier {
     Mod_None = 0x00,
     Mod_Alt = 0x01,
@@ -166,4 +171,14 @@ inline const char* key_code_to_string(KeyCode key)
     default:
         return nullptr;
     }
+}
+
+inline KeyCode string_to_key_code(const String& str)
+{
+    int n = sizeof(str_key_codes) / sizeof(str_key_codes[0]);
+    for (int i = 0; i < n; i++) {
+        if (String(str_key_codes[i]) == String(str.characters()))
+            return (KeyCode)i;
+    }
+    return KeyCode::Key_Invalid;
 }


### PR DESCRIPTION
This is a rough draft and some corners have been cut, but I am curious what people that work on the vim emulator think of a change like this. Mainly regarding removing the on_key_in_xxx_mode functions and replacing them by moving all supported commands into the initialize_commands() function in that format, then doing everything else in the on_key method. I think the way the keys for each command are laid out in a string is cleaner, but at the same time I feel like having all the execution functions laid out like that would be quite messy. I don't know... 

Here is a description of the changes.

Add VimKey, represents a key entered by a user as part of a command.
Add VimCommand, represents a command in vim. It has a list of VimKeys, which must be entered to execute the command, a list of vim modes in which the command is allowed and a function that executes the command. The constructor of VimCommand takes a String of keys which is then parsed into a list of VimKeys. Single keys such as 'd', 'D', '$', which may require shift but not control are represented as they are, the parser will determine if the key requires shift, then find the KeyCode for the entered key and that key is then parsed. Control keys and keys like 'Escape' are formatted as '<Escape>' (Escape), '<C-w>' (Control w),'<S-Left>' (Shift Left arrow), etc. Control and shift are the only modifiers, represented by C and S followed by a hyphen (-). Shift should only be used when it cannot be represented in the character, for example, '$' should be entered as '$' not '<S-4>' or '<S-$>'. Keys that do not have standard characters should be spelt and capitalized as they are found in the ui_name of the __ENUMERATE_KEY_CODES macro in KeyCode.h.

The VimEditingEngine now has:
A list of VimKeys, which store the keys entered by the user, in the order they are entered until the list matches a command or doesn't match any command, in both cases, the list is cleared. A list of VimCommands, which stores every command that the engine supports. The list is populated in initialize_commands() which is called in the VimEditingEngine's constructor. An add_key() function, which would eventually replace the virtual on_key function. Creates a VimKey from a given KeyEvent and adds the VimKey to the list of keys mentioned above, then checks the new list of keys against the list of commands, if a matching command is found, execute the command. Clear the keys if a command is found or no matching command is found. This method would be updated to include insert mode functionality.