### PR TITLE
Kernel: Reduce useful ROP gadgets by zeroing used function registers

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -349,6 +349,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-80387 -mno-mmx -mno-sse -mno-sse2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-asynchronous-unwind-tables")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+# Zero any registers used within a function on return (to reduce data lifetime and ROP gadgets).
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fzero-call-used-regs=used-gpr")
+
 if (NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib -nostdinc -nostdinc++")
 endif()


### PR DESCRIPTION
GCC-11 added a new option `-fzero-call-used-regs` which causes the
compiler to zero function arguments before return of a function. The
goal being to reduce the possible attack surface by disarming ROP
gadgets that might be potentially useful to attackers, and reducing
the risk of information leaks via stale register data. You can find
the GCC commit below[0].

This is a mitigation I noticed on the Linux KSPP issue tracker[1] and
thought it would be useful mitigation for the SerenityOS Kernel.

The reduction in ROP gadgets is observable using the ropgadget utility:

    $ ROPgadget --nosys --nojop --binary Kernel | tail -n1
    Unique gadgets found: 42754

    $ ROPgadget --nosys --nojop --binary Kernel.RegZeroing | tail -n1
    Unique gadgets found: 41238

The size difference for the i686 Kernel binary is negligible:

    $ size Kernel Kernel.RegZerogin
        text    data     bss     dec      hex filename
    13253648 7729637 6302360 27285645 1a0588d Kernel
    13277504 7729637 6302360 27309501 1a0b5bd Kernel.RegZeroing

We don't have any great workloads to measure regressions in Kernel
performance, but Kees Cook mentioned he measured only around %1
performance regression with this enabled on his Linux kernel build.[2]

References:
[0] https://github.com/gcc-mirror/gcc/commit/d10f3e900b0377b4760a090b0f90371bcef01686
[1] https://github.com/KSPP/linux/issues/84
[2] https://lore.kernel.org/lkml/20210714220129.844345-1-keescook@chromium.org/