### PR TITLE
LibWeb: Fix crash related to inline CSS + JavaScript

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -32,6 +32,12 @@ ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element&
 {
 }
 
+ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element& element, CSSStyleDeclaration& declaration)
+    : CSSStyleDeclaration(move(declaration.m_properties), move(declaration.m_custom_properties))
+    , m_element(element.make_weak_ptr<DOM::Element>())
+{
+}
+
 ElementInlineCSSStyleDeclaration::~ElementInlineCSSStyleDeclaration()
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -44,6 +44,7 @@ protected:
     explicit CSSStyleDeclaration(Vector<StyleProperty>&&, HashMap<String, StyleProperty>&&);
 
 private:
+    friend class ElementInlineCSSStyleDeclaration;
     friend class Bindings::CSSStyleDeclarationWrapper;
 
     Vector<StyleProperty> m_properties;
@@ -53,6 +54,7 @@ private:
 class ElementInlineCSSStyleDeclaration final : public CSSStyleDeclaration {
 public:
     static NonnullRefPtr<ElementInlineCSSStyleDeclaration> create(DOM::Element& element) { return adopt_ref(*new ElementInlineCSSStyleDeclaration(element)); }
+    static NonnullRefPtr<ElementInlineCSSStyleDeclaration> create_and_take_properties_from(DOM::Element& element, CSSStyleDeclaration& declaration) { return adopt_ref(*new ElementInlineCSSStyleDeclaration(element, declaration)); }
     virtual ~ElementInlineCSSStyleDeclaration() override;
 
     DOM::Element* element() { return m_element.ptr(); }
@@ -60,6 +62,7 @@ public:
 
 private:
     explicit ElementInlineCSSStyleDeclaration(DOM::Element&);
+    explicit ElementInlineCSSStyleDeclaration(DOM::Element&, CSSStyleDeclaration&);
 
     WeakPtr<DOM::Element> m_element;
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -158,8 +158,11 @@ void Element::parse_attribute(const FlyString& name, const String& value)
             m_classes.unchecked_append(new_class);
         }
     } else if (name == HTML::AttributeNames::style) {
-        m_inline_style = parse_css_declaration(CSS::ParsingContext(document()), value);
-        set_needs_style_update(true);
+        auto parsed_style = parse_css_declaration(CSS::ParsingContext(document()), value);
+        if (!parsed_style.is_null()) {
+            m_inline_style = CSS::ElementInlineCSSStyleDeclaration::create_and_take_properties_from(*this, parsed_style.release_nonnull());
+            set_needs_style_update(true);
+        }
     }
 }
 


### PR DESCRIPTION
When inline CSS is loaded from `style` attributes in an HTML file, it is loaded and attached to the element as a `Web::CSS::CSSStyleDeclaration` instead of a `Web::CSS::ElementInlineCSSStyleDeclaration`. This causes a crash later in `Web::Bindings::CSSStyleDeclarationWrapper::internal_set`, which attempts to `verify_cast` the inline CSS attached to the element to `Web::CSS::ElementInlineCSSStyleDeclaration`.

This small patch fixes this crash.  
(I am still very new to the world of C++, the code may contain severe problems. Sorry if that is the case.)

Here is a minimal sample HTML file that demonstrates the bug:
```html
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8">
        <title>test</title>
    </head>
    <body>
        <p id="hi" style="color: red">hello world!</p>
        <script>
            document.getElementById("hi").style.color = "blue";
        </script>
    </body>
</html>
```