### PR TITLE
TextEditor: Allow starting with a file argument that doesn't exist

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -693,6 +693,13 @@ bool MainWidget::read_file_and_close(int fd, String const& path)
     return true;
 }
 
+void MainWidget::open_nonexistent_file(String const& path)
+{
+    m_editor->set_text({});
+    set_path(path);
+    m_editor->set_focus(true);
+}
+
 bool MainWidget::request_close()
 {
     if (!editor().document().is_modified())

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -25,6 +25,7 @@ class MainWidget final : public GUI::Widget {
 public:
     virtual ~MainWidget() override;
     bool read_file_and_close(int fd, String const& path);
+    void open_nonexistent_file(String const& path);
     bool request_close();
 
     GUI::TextEditor& editor() { return *m_editor; }

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -36,12 +36,14 @@ int main(int argc, char** argv)
     if (file_to_edit) {
         FileArgument parsed_argument(file_to_edit);
 
-        file_to_edit_full_path = Core::File::real_path_for(parsed_argument.filename());
+        file_to_edit_full_path = Core::File::absolute_path(parsed_argument.filename());
         VERIFY(!file_to_edit_full_path.is_empty());
-        dbgln("unveil for: {}", file_to_edit_full_path);
-        if (unveil(file_to_edit_full_path.characters(), "r") < 0) {
-            perror("unveil");
-            return 1;
+        if (Core::File::exists(parsed_argument.filename())) {
+            dbgln("unveil for: {}", file_to_edit_full_path);
+            if (unveil(file_to_edit_full_path.characters(), "r") < 0) {
+                perror("unveil");
+                return 1;
+            }
         }
     }
 
@@ -107,17 +109,21 @@ int main(int argc, char** argv)
     if (file_to_edit) {
         // A file name was passed, parse any possible line and column numbers included.
         FileArgument parsed_argument(file_to_edit);
-        auto file = Core::File::open(file_to_edit_full_path, Core::OpenMode::ReadOnly);
+        if (Core::File::exists(file_to_edit_full_path)) {
+            auto file = Core::File::open(file_to_edit_full_path, Core::OpenMode::ReadOnly);
 
-        if (file.is_error()) {
-            GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", file_to_edit_full_path, file.error()));
-            return 1;
+            if (file.is_error()) {
+                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", file_to_edit_full_path, file.error()));
+                return 1;
+            }
+
+            if (!text_widget.read_file_and_close(file.value()->leak_fd(), file_to_edit_full_path))
+                return 1;
+
+            text_widget.editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));
+        } else {
+            text_widget.open_nonexistent_file(file_to_edit_full_path);
         }
-
-        if (!text_widget.read_file_and_close(file.value()->leak_fd(), file_to_edit_full_path))
-            return 1;
-
-        text_widget.editor().set_cursor_and_focus_line(parsed_argument.line().value_or(1) - 1, parsed_argument.column().value_or(0));
     }
     text_widget.update_title();
 


### PR DESCRIPTION
If TextEditor is started with an argument for a file that doesn't exist, we now allow editing it.

The file will be created once it is saved.