### PR TITLE
Kernel: Make -pie work for x86_64

### DIFF
--- a/Kernel/Arch/x86/x86_64/Boot/ap_setup.S
+++ b/Kernel/Arch/x86/x86_64/Boot/ap_setup.S
@@ -141,7 +141,7 @@ apic_ap_start64:
 
     /* push the Processor pointer this CPU is going to use */
     movq (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %rax
-    movabsq $(kernel_base), %r8
+    leaq kernel_base(%rip), %r8
     movq (%r8), %r8
     addq %r8, %rax
     movq 0(%rax, %rsi, 4), %rax
@@ -157,9 +157,9 @@ apic_ap_start64:
     /* We are in identity mapped P0x8000 and the BSP will unload this code
        once all APs are initialized, so call init_ap but return to our
        infinite loop */
-    movabs $loop, %rax
+    leaq loop(%rip), %rax
     pushq %rax
-    movabs $init_ap, %rax
+    leaq init_ap(%rip), %rax
     jmp *(%rax)
 
 loop:

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -47,7 +47,7 @@ NAKED void do_assume_context(Thread*, u32)
         "    movq %r12, %rsi \n"                          // from_thread
         "    pushq %r12 \n"                               // to_thread (for thread_context_first_enter)
         "    pushq %r12 \n"                               // from_thread (for thread_context_first_enter)
-        "    movabs $thread_context_first_enter, %r12 \n" // should be same as regs.rip
+        "    leaq thread_context_first_enter(%rip), %r12 \n" // should be same as regs.rip
         "    pushq %r12 \n"
         "    jmp enter_thread_context \n");
     // clang-format on
@@ -191,7 +191,7 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
         "pushq %%r14 \n"
         "pushq %%r15 \n"
         "movq %%rsp, %[from_rsp] \n"
-        "movabs $1f, %%rbx \n"
+        "leaq 1f(%%rip), %%rbx \n"
         "movq %%rbx, %[from_rip] \n"
         "movq %[to_rsp0], %%rbx \n"
         "movl %%ebx, %[tss_rsp0l] \n"

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -351,10 +351,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 # Zero any registers used within a function on return (to reduce data lifetime and ROP gadgets).
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fzero-call-used-regs=used-gpr")
-
-if (NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib -nostdinc -nostdinc++")
-endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib -nostdinc -nostdinc++")
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=large -mno-red-zone")

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -357,12 +357,13 @@ if (NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
 endif()
 
 if ("${SERENITY_ARCH}" STREQUAL "x86_64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=large -fno-pic -mno-red-zone")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=large -mno-red-zone")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new=8")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -fPIE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new=4")
 endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -Wl,--no-dynamic-linker")
 
 # Kernel Undefined Behavior Sanitizer (KUBSAN)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -13,6 +13,7 @@ else()
 endif()
 
 add_executable(${PREKERNEL_TARGET} ${SOURCES})
+target_compile_options(${PREKERNEL_TARGET} PRIVATE -no-pie -fno-pic)
 
 target_link_options(${PREKERNEL_TARGET} PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld -nostdlib)
 set_target_properties(${PREKERNEL_TARGET} PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -308,6 +308,7 @@ void signal_trampoline_dummy()
     // necessary to preserve it here.
     asm(
         ".intel_syntax noprefix\n"
+        ".globl asm_signal_trampoline\n"
         "asm_signal_trampoline:\n"
         "push ebp\n"
         "mov ebp, esp\n"
@@ -319,6 +320,7 @@ void signal_trampoline_dummy()
         "add esp, 8\n"
         "mov eax, %P0\n"
         "int 0x82\n" // sigreturn syscall
+        ".globl asm_signal_trampoline_end\n"
         "asm_signal_trampoline_end:\n"
         ".att_syntax" ::"i"(Syscall::SC_sigreturn));
 #elif ARCH(X86_64)
@@ -329,6 +331,7 @@ void signal_trampoline_dummy()
     // necessary to preserve it here.
     asm(
         ".intel_syntax noprefix\n"
+        ".globl asm_signal_trampoline\n"
         "asm_signal_trampoline:\n"
         "push rbp\n"
         "mov rbp, rsp\n"
@@ -339,6 +342,7 @@ void signal_trampoline_dummy()
         "add rsp, 8\n"
         "mov rax, %P0\n"
         "int 0x82\n" // sigreturn syscall
+        ".globl asm_signal_trampoline_end\n"
         "asm_signal_trampoline_end:\n"
         ".att_syntax" ::"i"(Syscall::SC_sigreturn));
 #endif


### PR DESCRIPTION
**Kernel: Make -pie work for x86_64**

**Prekernel: Don't build the prekernel as a PIE image**

This is unnecessary because the prekernel is always loaded at a known base address.

**Kernel: Make some of the assembly code position-independent on x86_64**

**Kernel: Always build the kernel without default libs**

When building the kernel from within SerenityOS we would link it against default libs which doesn't really make sense to me.