### PR TITLE
Kernel: Put a note about the unconditional unblanking of bochs-display

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -78,9 +78,9 @@ UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::Address pci_add
     if (id.vendor_id == 0x80ee && id.device_id == 0xbeef)
         m_io_required = true;
 
-    // FIXME: Although this helps with setting the screen to work on some cases,
-    // we need to check we actually can access the VGA MMIO remapped ioports before
-    // doing the unblanking.
+    // Note: According to Gerd Hoffmann - "The linux driver simply does
+    // the unblank unconditionally. With bochs-display this is not needed but
+    // it also has no bad side effect".
     unblank();
     set_safe_resolution();
 }


### PR DESCRIPTION
This removes the FIXME note and explains why it's not so bad to do this.

From the mail I received from Gerd Hoffmann (https://github.com/kraxel):
```
> *However,* I also found that it's hard to distinguish between the
> bochs-display device and secondary-vga device in QEMU. Both use PCI class
> "Display controller" (0x3), and subclass "Other" (0x80), which seems
> reasonable, but the struggle is how to know if I can actually access VGA
> MMIO or not.

Accessing vga mmio should be possible without problems, even if it has
no effect / is not needed for unblanking.  There used to be a bug (see
commit f872c76296b991fde4db5fb87a1cfbd8d4c22c88), but it was fixed a
year ago and it also didn't affect x86.

> I'd be happy to read your thoughts on what to do with this. Maybe I can
> write a patch for this in QEMU (and in the linux bochs drm driver), if it
> seems like a good idea for you.

I don't think this is worth the trouble.  The linux driver simply does
the unblank unconditionally.  With bochs-display this is not needed but
it also has no bad side effects.
```