### PR TITLE
LibRegex: Clear previous capture group contents in ECMA262 mode

### DIFF
--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -12,7 +12,7 @@
 
 namespace regex {
 
-const char* OpCode::name(OpCodeId opcode_id)
+char const* OpCode::name(OpCodeId opcode_id)
 {
     switch (opcode_id) {
 #define __ENUMERATE_OPCODE(x) \
@@ -26,12 +26,12 @@ const char* OpCode::name(OpCodeId opcode_id)
     }
 }
 
-const char* OpCode::name() const
+char const* OpCode::name() const
 {
     return name(opcode_id());
 }
 
-const char* execution_result_name(ExecutionResult result)
+char const* execution_result_name(ExecutionResult result)
 {
     switch (result) {
 #define __ENUMERATE_EXECUTION_RESULT(x) \
@@ -45,7 +45,7 @@ const char* execution_result_name(ExecutionResult result)
     }
 }
 
-const char* boundary_check_type_name(BoundaryCheckType ty)
+char const* boundary_check_type_name(BoundaryCheckType ty)
 {
     switch (ty) {
 #define __ENUMERATE_BOUNDARY_CHECK_TYPE(x) \
@@ -59,7 +59,7 @@ const char* boundary_check_type_name(BoundaryCheckType ty)
     }
 }
 
-const char* character_compare_type_name(CharacterCompareType ch_compare_type)
+char const* character_compare_type_name(CharacterCompareType ch_compare_type)
 {
     switch (ch_compare_type) {
 #define __ENUMERATE_CHARACTER_COMPARE_TYPE(x) \
@@ -73,7 +73,7 @@ const char* character_compare_type_name(CharacterCompareType ch_compare_type)
     }
 }
 
-static const char* character_class_name(CharClass ch_class)
+static char const* character_class_name(CharClass ch_class)
 {
     switch (ch_class) {
 #define __ENUMERATE_CHARACTER_CLASS(x) \
@@ -177,7 +177,7 @@ OpCode& ByteCode::get_opcode(MatchState& state) const
     return opcode;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (state.string_position > input.view.length() || state.instruction_position >= m_bytecode->size())
         return ExecutionResult::Succeeded;
@@ -185,13 +185,13 @@ ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(const MatchInput& input, Matc
     return ExecutionResult::Failed;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Save::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Save::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     input.saved_positions.append(state.string_position);
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (input.saved_positions.is_empty())
         return ExecutionResult::Failed;
@@ -200,7 +200,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(const MatchInput& input, M
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(const MatchInput&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const&, MatchState& state, MatchOutput&) const
 {
     if (count() > state.string_position)
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -209,7 +209,7 @@ ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(const MatchInput&, MatchSta
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(const MatchInput& input, MatchState&, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input, MatchState&, MatchOutput&) const
 {
     VERIFY(count() > 0);
 
@@ -217,25 +217,25 @@ ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(const MatchInput& input,
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(const MatchInput&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(MatchInput const&, MatchState& state, MatchOutput&) const
 {
     state.instruction_position += offset();
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkJump::execute(const MatchInput&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ForkJump::execute(MatchInput const&, MatchState& state, MatchOutput&) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     return ExecutionResult::Fork_PrioHigh;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkStay::execute(const MatchInput&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ForkStay::execute(MatchInput const&, MatchState& state, MatchOutput&) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     return ExecutionResult::Fork_PrioLow;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (0 == state.string_position && (input.regex_options & AllFlags::MatchNotBeginOfLine))
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -248,7 +248,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(const MatchInput& input
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     auto isword = [](auto ch) { return is_ascii_alphanumeric(ch) || ch == '_'; };
     auto is_word_boundary = [&] {
@@ -282,7 +282,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(const MatchInput& in
     VERIFY_NOT_REACHED();
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (state.string_position == input.view.length() && (input.regex_options & AllFlags::MatchNotEndOfLine))
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -294,7 +294,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(const MatchInput& input, 
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (input.match_index < state.capture_group_matches.size()) {
         auto& group = state.capture_group_matches[input.match_index];
@@ -304,7 +304,7 @@ ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(const MatchInput
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (input.match_index >= state.capture_group_matches.size()) {
         state.capture_group_matches.ensure_capacity(input.match_index);
@@ -324,7 +324,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(const MatchIn
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     auto& match = state.capture_group_matches.at(input.match_index).at(id());
     auto start_position = match.left_column;
@@ -349,7 +349,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(const MatchI
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ClearNamedCaptureGroup::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ClearNamedCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (input.match_index < state.capture_group_matches.size()) {
         auto& group = state.named_capture_group_matches[input.match_index];
@@ -358,7 +358,7 @@ ALWAYS_INLINE ExecutionResult OpCode_ClearNamedCaptureGroup::execute(const Match
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveLeftNamedCaptureGroup::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveLeftNamedCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     if (input.match_index >= state.named_capture_group_matches.size()) {
         state.named_capture_group_matches.ensure_capacity(input.match_index);
@@ -370,7 +370,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveLeftNamedCaptureGroup::execute(const Ma
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     StringView capture_group_name = name();
 
@@ -399,7 +399,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(const M
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(const MatchInput& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
 {
     bool inverse { false };
     bool temporary_inverse { false };
@@ -458,7 +458,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(const MatchInput& input, M
         } else if (compare_type == CharacterCompareType::String) {
             VERIFY(!current_inversion_state());
 
-            const auto& length = m_bytecode->at(offset++);
+            auto const& length = m_bytecode->at(offset++);
 
             // We want to compare a string that is definitely longer than the available string
             if (input.view.length() < state.string_position + length)
@@ -513,7 +513,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(const MatchInput& input, M
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
 
         } else if (compare_type == CharacterCompareType::NamedReference) {
-            auto ptr = (const char*)m_bytecode->at(offset++);
+            auto ptr = (char const*)m_bytecode->at(offset++);
             auto length = (size_t)m_bytecode->at(offset++);
             StringView name { ptr, length };
 
@@ -546,7 +546,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(const MatchInput& input, M
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_char(const MatchInput& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched)
+ALWAYS_INLINE void OpCode_Compare::compare_char(MatchInput const& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched)
 {
     if (state.string_position == input.view.length())
         return;
@@ -568,7 +568,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_char(const MatchInput& input, MatchSt
     }
 }
 
-ALWAYS_INLINE bool OpCode_Compare::compare_string(const MatchInput& input, MatchState& state, RegexStringView const& str, bool& had_zero_length_match)
+ALWAYS_INLINE bool OpCode_Compare::compare_string(MatchInput const& input, MatchState& state, RegexStringView const& str, bool& had_zero_length_match)
 {
     if (state.string_position + str.length() > input.view.length()) {
         if (str.is_empty()) {
@@ -596,7 +596,7 @@ ALWAYS_INLINE bool OpCode_Compare::compare_string(const MatchInput& input, Match
     return equals;
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_character_class(const MatchInput& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched)
+ALWAYS_INLINE void OpCode_Compare::compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched)
 {
     switch (character_class) {
     case CharClass::Alnum:
@@ -702,7 +702,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_character_class(const MatchInput& inp
     }
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_character_range(const MatchInput& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched)
+ALWAYS_INLINE void OpCode_Compare::compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched)
 {
     if (input.regex_options & AllFlags::Insensitive) {
         from = to_ascii_lowercase(from);
@@ -718,12 +718,12 @@ ALWAYS_INLINE void OpCode_Compare::compare_character_range(const MatchInput& inp
     }
 }
 
-const String OpCode_Compare::arguments_string() const
+String const OpCode_Compare::arguments_string() const
 {
     return String::formatted("argc={}, args={} ", arguments_count(), arguments_size());
 }
 
-const Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<MatchInput> input) const
+Vector<String> const OpCode_Compare::variable_arguments_to_string(Optional<MatchInput> input) const
 {
     Vector<String> result;
 
@@ -758,7 +758,7 @@ const Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<Match
                 }
             }
         } else if (compare_type == CharacterCompareType::NamedReference) {
-            auto ptr = (const char*)m_bytecode->at(offset++);
+            auto ptr = (char const*)m_bytecode->at(offset++);
             auto length = m_bytecode->at(offset++);
             result.empend(String::formatted("name='{}'", StringView { ptr, (size_t)length }));
         } else if (compare_type == CharacterCompareType::Reference) {

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -105,8 +105,8 @@ enum class BoundaryCheckType : ByteCodeValueType {
 };
 
 struct CharRange {
-    const u32 from;
-    const u32 to;
+    u32 const from;
+    u32 const to;
 
     CharRange(u64 value)
         : from(value >> 32)
@@ -137,7 +137,7 @@ public:
         ensure_opcodes_initialized();
     }
 
-    ByteCode(const ByteCode&) = default;
+    ByteCode(ByteCode const&) = default;
     virtual ~ByteCode() = default;
 
     ByteCode& operator=(ByteCode&&) = default;
@@ -232,7 +232,7 @@ public:
         empend(capture_groups_count);
     }
 
-    void insert_bytecode_group_capture_left(const StringView& name)
+    void insert_bytecode_group_capture_left(StringView const& name)
     {
         empend(static_cast<ByteCodeValueType>(OpCodeId::SaveLeftNamedCaptureGroup));
         empend(reinterpret_cast<ByteCodeValueType>(name.characters_without_null_termination()));
@@ -245,7 +245,7 @@ public:
         empend(capture_groups_count);
     }
 
-    void insert_bytecode_group_capture_right(const StringView& name)
+    void insert_bytecode_group_capture_right(StringView const& name)
     {
         empend(static_cast<ByteCodeValueType>(OpCodeId::SaveRightNamedCaptureGroup));
         empend(reinterpret_cast<ByteCodeValueType>(name.characters_without_null_termination()));
@@ -462,7 +462,7 @@ public:
     OpCode& get_opcode(MatchState& state) const;
 
 private:
-    void insert_string(const StringView& view)
+    void insert_string(StringView const& view)
     {
         empend((ByteCodeValueType)view.length());
         for (size_t i = 0; i < view.length(); ++i)
@@ -489,11 +489,11 @@ enum class ExecutionResult : u8 {
 #undef __ENUMERATE_EXECUTION_RESULT
 };
 
-const char* execution_result_name(ExecutionResult result);
-const char* opcode_id_name(OpCodeId opcode_id);
-const char* boundary_check_type_name(BoundaryCheckType);
-const char* character_compare_type_name(CharacterCompareType result);
-const char* execution_result_name(ExecutionResult result);
+char const* execution_result_name(ExecutionResult result);
+char const* opcode_id_name(OpCodeId opcode_id);
+char const* boundary_check_type_name(BoundaryCheckType);
+char const* character_compare_type_name(CharacterCompareType result);
+char const* execution_result_name(ExecutionResult result);
 
 class OpCode {
 public:
@@ -502,7 +502,7 @@ public:
 
     virtual OpCodeId opcode_id() const = 0;
     virtual size_t size() const = 0;
-    virtual ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const = 0;
+    virtual ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const = 0;
 
     ALWAYS_INLINE ByteCodeValueType argument(size_t offset) const
     {
@@ -510,27 +510,27 @@ public:
         return m_bytecode->at(state().instruction_position + 1 + offset);
     }
 
-    ALWAYS_INLINE const char* name() const;
-    static const char* name(const OpCodeId);
+    ALWAYS_INLINE char const* name() const;
+    static char const* name(OpCodeId const);
 
     ALWAYS_INLINE void set_state(MatchState& state) { m_state = &state; }
 
     ALWAYS_INLINE void set_bytecode(ByteCode& bytecode) { m_bytecode = &bytecode; }
 
-    ALWAYS_INLINE const MatchState& state() const
+    ALWAYS_INLINE MatchState const& state() const
     {
         VERIFY(m_state);
         return *m_state;
     }
 
-    const String to_string() const
+    String const to_string() const
     {
         return String::formatted("[{:#02X}] {}", (int)opcode_id(), name(opcode_id()));
     }
 
-    virtual const String arguments_string() const = 0;
+    virtual String const arguments_string() const = 0;
 
-    ALWAYS_INLINE const ByteCode& bytecode() const { return *m_bytecode; }
+    ALWAYS_INLINE ByteCode const& bytecode() const { return *m_bytecode; }
 
 protected:
     ByteCode* m_bytecode { nullptr };
@@ -539,53 +539,53 @@ protected:
 
 class OpCode_Exit final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Exit; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    const String arguments_string() const override { return ""; }
+    String const arguments_string() const override { return ""; }
 };
 
 class OpCode_FailForks final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t count() const { return argument(0); }
-    const String arguments_string() const override { return String::formatted("count={}", count()); }
+    String const arguments_string() const override { return String::formatted("count={}", count()); }
 };
 
 class OpCode_Save final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Save; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    const String arguments_string() const override { return ""; }
+    String const arguments_string() const override { return ""; }
 };
 
 class OpCode_Restore final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Restore; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    const String arguments_string() const override { return ""; }
+    String const arguments_string() const override { return ""; }
 };
 
 class OpCode_GoBack final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::GoBack; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t count() const { return argument(0); }
-    const String arguments_string() const override { return String::formatted("count={}", count()); }
+    String const arguments_string() const override { return String::formatted("count={}", count()); }
 };
 
 class OpCode_Jump final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Jump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    const String arguments_string() const override
+    String const arguments_string() const override
     {
         return String::formatted("offset={} [&{}]", offset(), state().instruction_position + size() + offset());
     }
@@ -593,11 +593,11 @@ public:
 
 class OpCode_ForkJump final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkJump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    const String arguments_string() const override
+    String const arguments_string() const override
     {
         return String::formatted("offset={} [&{}], sp: {}", offset(), state().instruction_position + size() + offset(), state().string_position);
     }
@@ -605,11 +605,11 @@ public:
 
 class OpCode_ForkStay final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkStay; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    const String arguments_string() const override
+    String const arguments_string() const override
     {
         return String::formatted("offset={} [&{}], sp: {}", offset(), state().instruction_position + size() + offset(), state().string_position);
     }
@@ -617,47 +617,47 @@ public:
 
 class OpCode_CheckBegin final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBegin; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    const String arguments_string() const override { return ""; }
+    String const arguments_string() const override { return ""; }
 };
 
 class OpCode_CheckEnd final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckEnd; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    const String arguments_string() const override { return ""; }
+    String const arguments_string() const override { return ""; }
 };
 
 class OpCode_CheckBoundary final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBoundary; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t arguments_count() const { return 1; }
     ALWAYS_INLINE BoundaryCheckType type() const { return static_cast<BoundaryCheckType>(argument(0)); }
-    const String arguments_string() const override { return String::formatted("kind={} ({})", (long unsigned int)argument(0), boundary_check_type_name(type())); }
+    String const arguments_string() const override { return String::formatted("kind={} ({})", (long unsigned int)argument(0), boundary_check_type_name(type())); }
 };
 
 class OpCode_ClearCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ClearCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    const String arguments_string() const override { return String::formatted("id={}", id()); }
+    String const arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_ClearNamedCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ClearNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 3; }
     ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
     ALWAYS_INLINE size_t length() const { return argument(1); }
-    const String arguments_string() const override
+    String const arguments_string() const override
     {
         return String::formatted("name={}, length={}", name(), length());
     }
@@ -665,30 +665,30 @@ public:
 
 class OpCode_SaveLeftCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    const String arguments_string() const override { return String::formatted("id={}", id()); }
+    String const arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveRightCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    const String arguments_string() const override { return String::formatted("id={}", id()); }
+    String const arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveLeftNamedCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 3; }
     ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
     ALWAYS_INLINE size_t length() const { return argument(1); }
-    const String arguments_string() const override
+    String const arguments_string() const override
     {
         return String::formatted("name={}, length={}", name(), length());
     }
@@ -696,12 +696,12 @@ public:
 
 class OpCode_SaveRightNamedCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 3; }
     ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
     ALWAYS_INLINE size_t length() const { return argument(1); }
-    const String arguments_string() const override
+    String const arguments_string() const override
     {
         return String::formatted("name={}, length={}", name(), length());
     }
@@ -709,50 +709,50 @@ public:
 
 class OpCode_Compare final : public OpCode {
 public:
-    ExecutionResult execute(const MatchInput& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Compare; }
     ALWAYS_INLINE size_t size() const override { return arguments_size() + 3; }
     ALWAYS_INLINE size_t arguments_count() const { return argument(0); }
     ALWAYS_INLINE size_t arguments_size() const { return argument(1); }
-    const String arguments_string() const override;
-    const Vector<String> variable_arguments_to_string(Optional<MatchInput> input = {}) const;
+    String const arguments_string() const override;
+    Vector<String> const variable_arguments_to_string(Optional<MatchInput> input = {}) const;
 
 private:
-    ALWAYS_INLINE static void compare_char(const MatchInput& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static bool compare_string(const MatchInput& input, MatchState& state, RegexStringView const& str, bool& had_zero_length_match);
-    ALWAYS_INLINE static void compare_character_class(const MatchInput& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static void compare_character_range(const MatchInput& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
+    ALWAYS_INLINE static void compare_char(MatchInput const& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched);
+    ALWAYS_INLINE static bool compare_string(MatchInput const& input, MatchState& state, RegexStringView const& str, bool& had_zero_length_match);
+    ALWAYS_INLINE static void compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
+    ALWAYS_INLINE static void compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
 };
 
 template<typename T>
-bool is(const OpCode&);
+bool is(OpCode const&);
 
 template<typename T>
-ALWAYS_INLINE bool is(const OpCode&)
+ALWAYS_INLINE bool is(OpCode const&)
 {
     return false;
 }
 
 template<typename T>
-ALWAYS_INLINE bool is(const OpCode* opcode)
+ALWAYS_INLINE bool is(OpCode const* opcode)
 {
     return is<T>(*opcode);
 }
 
 template<>
-ALWAYS_INLINE bool is<OpCode_ForkStay>(const OpCode& opcode)
+ALWAYS_INLINE bool is<OpCode_ForkStay>(OpCode const& opcode)
 {
     return opcode.opcode_id() == OpCodeId::ForkStay;
 }
 
 template<>
-ALWAYS_INLINE bool is<OpCode_Exit>(const OpCode& opcode)
+ALWAYS_INLINE bool is<OpCode_Exit>(OpCode const& opcode)
 {
     return opcode.opcode_id() == OpCodeId::Exit;
 }
 
 template<>
-ALWAYS_INLINE bool is<OpCode_Compare>(const OpCode& opcode)
+ALWAYS_INLINE bool is<OpCode_Compare>(OpCode const& opcode)
 {
     return opcode.opcode_id() == OpCodeId::Compare;
 }

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -33,7 +33,7 @@ public:
     }
 
     template<typename T>
-    void print_bytecode(const Regex<T>& regex) const
+    void print_bytecode(Regex<T> const& regex) const
     {
         MatchState state;
         auto& bytecode = regex.parser_result.bytecode;
@@ -52,7 +52,7 @@ public:
         fflush(m_file);
     }
 
-    void print_opcode(const String& system, OpCode& opcode, MatchState& state, size_t recursion = 0, bool newline = true) const
+    void print_opcode(String const& system, OpCode& opcode, MatchState& state, size_t recursion = 0, bool newline = true) const
     {
         out(m_file, "{:15} | {:5} | {:9} | {:35} | {:30} | {:20}",
             system.characters(),
@@ -69,7 +69,7 @@ public:
         }
     }
 
-    void print_result(const OpCode& opcode, const ByteCode& bytecode, const MatchInput& input, MatchState& state, ExecutionResult result) const
+    void print_result(OpCode const& opcode, ByteCode const& bytecode, MatchInput const& input, MatchState& state, ExecutionResult result) const
     {
         StringBuilder builder;
         builder.append(execution_result_name(result));

--- a/Userland/Libraries/LibRegex/RegexLexer.cpp
+++ b/Userland/Libraries/LibRegex/RegexLexer.cpp
@@ -12,7 +12,7 @@
 
 namespace regex {
 
-const char* Token::name(const TokenType type)
+char const* Token::name(TokenType const type)
 {
     switch (type) {
 #define __ENUMERATE_REGEX_TOKEN(x) \
@@ -26,12 +26,12 @@ const char* Token::name(const TokenType type)
     }
 }
 
-const char* Token::name() const
+char const* Token::name() const
 {
     return name(m_type);
 }
 
-Lexer::Lexer(const StringView source)
+Lexer::Lexer(StringView const source)
     : m_source(source)
 {
 }

--- a/Userland/Libraries/LibRegex/RegexLexer.h
+++ b/Userland/Libraries/LibRegex/RegexLexer.h
@@ -43,7 +43,7 @@ enum class TokenType {
 class Token {
 public:
     Token() = default;
-    Token(const TokenType type, const size_t start_position, const StringView value)
+    Token(TokenType const type, size_t const start_position, StringView const value)
         : m_type(type)
         , m_position(start_position)
         , m_value(value)
@@ -51,11 +51,11 @@ public:
     }
 
     TokenType type() const { return m_type; }
-    const StringView& value() const { return m_value; }
+    StringView const& value() const { return m_value; }
     size_t position() const { return m_position; }
 
-    const char* name() const;
-    static const char* name(const TokenType);
+    char const* name() const;
+    static char const* name(TokenType const);
 
 private:
     TokenType m_type { TokenType::Eof };
@@ -66,14 +66,14 @@ private:
 class Lexer {
 public:
     Lexer() = default;
-    explicit Lexer(const StringView source);
+    explicit Lexer(StringView const source);
     Token next();
     void reset();
     void back(size_t offset);
-    void set_source(const StringView source) { m_source = source; }
+    void set_source(StringView const source) { m_source = source; }
     bool try_skip(char);
     char skip();
-    const auto& source() const { return m_source; }
+    auto const& source() const { return m_source; }
 
 private:
     ALWAYS_INLINE int peek(size_t offset = 0) const;

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -23,17 +23,17 @@ namespace regex {
 
 class RegexStringView {
 public:
-    RegexStringView(const char* chars)
+    RegexStringView(char const* chars)
         : m_view(StringView { chars })
     {
     }
 
-    RegexStringView(const String& string)
+    RegexStringView(String const& string)
         : m_view(string.view())
     {
     }
 
-    RegexStringView(const StringView view)
+    RegexStringView(StringView const view)
         : m_view(view)
     {
     }
@@ -48,17 +48,17 @@ public:
     {
     }
 
-    const StringView& string_view() const
+    StringView const& string_view() const
     {
         return m_view.get<StringView>();
     }
 
-    const Utf32View& u32_view() const
+    Utf32View const& u32_view() const
     {
         return m_view.get<Utf32View>();
     }
 
-    const Utf8View& u8_view() const
+    Utf8View const& u8_view() const
     {
         return m_view.get<Utf8View>();
     }
@@ -184,7 +184,7 @@ public:
             });
     }
 
-    bool operator==(const char* cstring) const
+    bool operator==(char const* cstring) const
     {
         return m_view.visit(
             [&](Utf32View) { return to_string() == cstring; },
@@ -192,12 +192,12 @@ public:
             [&](StringView view) { return view == cstring; });
     }
 
-    bool operator!=(const char* cstring) const
+    bool operator!=(char const* cstring) const
     {
         return !(*this == cstring);
     }
 
-    bool operator==(const String& string) const
+    bool operator==(String const& string) const
     {
         return m_view.visit(
             [&](Utf32View) { return to_string() == string; },
@@ -205,7 +205,7 @@ public:
             [&](StringView view) { return view == string; });
     }
 
-    bool operator==(const StringView& string) const
+    bool operator==(StringView const& string) const
     {
         return m_view.visit(
             [&](Utf32View) { return to_string() == string; },
@@ -213,12 +213,12 @@ public:
             [&](StringView view) { return view == string; });
     }
 
-    bool operator!=(const StringView& other) const
+    bool operator!=(StringView const& other) const
     {
         return !(*this == other);
     }
 
-    bool operator==(const Utf32View& other) const
+    bool operator==(Utf32View const& other) const
     {
         return m_view.visit(
             [&](Utf32View view) {
@@ -228,12 +228,12 @@ public:
             [&](StringView view) { return view == RegexStringView { other }.to_string(); });
     }
 
-    bool operator!=(const Utf32View& other) const
+    bool operator!=(Utf32View const& other) const
     {
         return !(*this == other);
     }
 
-    bool operator==(const Utf8View& other) const
+    bool operator==(Utf8View const& other) const
     {
         return m_view.visit(
             [&](Utf32View) {
@@ -243,17 +243,17 @@ public:
             [&](StringView view) { return other.as_string() == view; });
     }
 
-    bool operator!=(const Utf8View& other) const
+    bool operator!=(Utf8View const& other) const
     {
         return !(*this == other);
     }
 
-    bool equals(const RegexStringView& other) const
+    bool equals(RegexStringView const& other) const
     {
         return other.m_view.visit([&](auto const& view) { return operator==(view); });
     }
 
-    bool equals_ignoring_case(const RegexStringView& other) const
+    bool equals_ignoring_case(RegexStringView const& other) const
     {
         // FIXME: Implement equals_ignoring_case() for unicode.
         return m_view.visit(
@@ -265,7 +265,7 @@ public:
             [](auto&) -> bool { TODO(); });
     }
 
-    bool starts_with(const StringView& str) const
+    bool starts_with(StringView const& str) const
     {
         return m_view.visit(
             [&](Utf32View) -> bool {
@@ -275,7 +275,7 @@ public:
             [&](StringView view) { return view.starts_with(str); });
     }
 
-    bool starts_with(const Utf32View& str) const
+    bool starts_with(Utf32View const& str) const
     {
         return m_view.visit(
             [&](Utf32View view) -> bool {
@@ -315,7 +315,7 @@ public:
     Match() = default;
     ~Match() = default;
 
-    Match(const RegexStringView view_, const size_t line_, const size_t column_, const size_t global_offset_)
+    Match(RegexStringView const view_, size_t const line_, size_t const column_, size_t const global_offset_)
         : view(view_)
         , line(line_)
         , column(column_)
@@ -324,7 +324,7 @@ public:
     {
     }
 
-    Match(const String string_, const size_t line_, const size_t column_, const size_t global_offset_)
+    Match(String const string_, size_t const line_, size_t const column_, size_t const global_offset_)
         : string(string_)
         , view(string.value().view())
         , line(line_)
@@ -382,7 +382,7 @@ using regex::RegexStringView;
 
 template<>
 struct AK::Formatter<regex::RegexStringView> : Formatter<StringView> {
-    void format(FormatBuilder& builder, const regex::RegexStringView& value)
+    void format(FormatBuilder& builder, regex::RegexStringView const& value)
     {
         auto string = value.to_string();
         return Formatter<StringView>::format(builder, string);

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -54,7 +54,7 @@ String Regex<Parser>::error_string(Optional<String> message) const
 }
 
 template<typename Parser>
-RegexResult Matcher<Parser>::match(const RegexStringView& view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options) const
+RegexResult Matcher<Parser>::match(RegexStringView const& view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options) const
 {
     AllOptions options = m_regex_options | regex_options.value_or({}).value();
 
@@ -67,7 +67,7 @@ RegexResult Matcher<Parser>::match(const RegexStringView& view, Optional<typenam
 }
 
 template<typename Parser>
-RegexResult Matcher<Parser>::match(const Vector<RegexStringView> views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options) const
+RegexResult Matcher<Parser>::match(Vector<RegexStringView> const views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options) const
 {
     // If the pattern *itself* isn't stateful, reset any changes to start_offset.
     if (!((AllFlags)m_regex_options.value() & AllFlags::Internal_Stateful))
@@ -288,7 +288,7 @@ RegexResult Matcher<Parser>::match(const Vector<RegexStringView> views, Optional
 }
 
 template<class Parser>
-Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& state, MatchOutput& output, size_t recursion_level) const
+Optional<bool> Matcher<Parser>::execute(MatchInput const& input, MatchState& state, MatchOutput& output, size_t recursion_level) const
 {
     if (recursion_level > c_max_recursion)
         return false;
@@ -358,7 +358,7 @@ Optional<bool> Matcher<Parser>::execute(const MatchInput& input, MatchState& sta
 }
 
 template<class Parser>
-ALWAYS_INLINE Optional<bool> Matcher<Parser>::execute_low_prio_forks(const MatchInput& input, MatchState& original_state, MatchOutput& output, Vector<MatchState> states, size_t recursion_level) const
+ALWAYS_INLINE Optional<bool> Matcher<Parser>::execute_low_prio_forks(MatchInput const& input, MatchState& original_state, MatchOutput& output, Vector<MatchState> states, size_t recursion_level) const
 {
     for (auto& state : states) {
 

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -23,8 +23,8 @@
 
 namespace regex {
 
-static const constexpr size_t c_max_recursion = 5000;
-static const constexpr size_t c_match_preallocation_count = 0;
+static constexpr const size_t c_max_recursion = 5000;
+static constexpr const size_t c_match_preallocation_count = 0;
 
 struct RegexResult final {
     bool success { false };
@@ -44,15 +44,15 @@ template<class Parser>
 class Matcher final {
 
 public:
-    Matcher(const Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+    Matcher(Regex<Parser> const& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
         : m_pattern(pattern)
         , m_regex_options(regex_options.value_or({}))
     {
     }
     ~Matcher() = default;
 
-    RegexResult match(const RegexStringView&, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
-    RegexResult match(const Vector<RegexStringView>, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
+    RegexResult match(RegexStringView const&, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
+    RegexResult match(Vector<RegexStringView> const, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
 
     typename ParserTraits<Parser>::OptionsType options() const
     {
@@ -60,11 +60,11 @@ public:
     }
 
 private:
-    Optional<bool> execute(const MatchInput& input, MatchState& state, MatchOutput& output, size_t recursion_level) const;
-    ALWAYS_INLINE Optional<bool> execute_low_prio_forks(const MatchInput& input, MatchState& original_state, MatchOutput& output, Vector<MatchState> states, size_t recursion_level) const;
+    Optional<bool> execute(MatchInput const& input, MatchState& state, MatchOutput& output, size_t recursion_level) const;
+    ALWAYS_INLINE Optional<bool> execute_low_prio_forks(MatchInput const& input, MatchState& original_state, MatchOutput& output, Vector<MatchState> states, size_t recursion_level) const;
 
-    const Regex<Parser>& m_pattern;
-    const typename ParserTraits<Parser>::OptionsType m_regex_options;
+    Regex<Parser> const& m_pattern;
+    typename ParserTraits<Parser>::OptionsType const m_regex_options;
 };
 
 template<class Parser>
@@ -84,21 +84,21 @@ public:
     void print_bytecode(FILE* f = stdout) const;
     String error_string(Optional<String> message = {}) const;
 
-    RegexResult match(const RegexStringView view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    RegexResult match(RegexStringView const view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return {};
         return matcher->match(view, regex_options);
     }
 
-    RegexResult match(const Vector<RegexStringView> views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    RegexResult match(Vector<RegexStringView> const views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return {};
         return matcher->match(views, regex_options);
     }
 
-    String replace(const RegexStringView view, const StringView& replacement_pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    String replace(RegexStringView const view, StringView const& replacement_pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return {};
@@ -137,9 +137,9 @@ public:
         return builder.to_string();
     }
 
-    // FIXME: replace(const Vector<RegexStringView>, ...)
+    // FIXME: replace(Vector<RegexStringView> const , ...)
 
-    RegexResult search(const RegexStringView view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    RegexResult search(RegexStringView const view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return {};
@@ -155,7 +155,7 @@ public:
         return matcher->match(view, options);
     }
 
-    RegexResult search(const Vector<RegexStringView> views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    RegexResult search(Vector<RegexStringView> const views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return {};
@@ -171,31 +171,31 @@ public:
         return matcher->match(views, options);
     }
 
-    bool match(const RegexStringView view, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    bool match(RegexStringView const view, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         m = match(view, regex_options);
         return m.success;
     }
 
-    bool match(const Vector<RegexStringView> views, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    bool match(Vector<RegexStringView> const views, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         m = match(views, regex_options);
         return m.success;
     }
 
-    bool search(const RegexStringView view, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    bool search(RegexStringView const view, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         m = search(view, regex_options);
         return m.success;
     }
 
-    bool search(const Vector<RegexStringView> views, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    bool search(Vector<RegexStringView> const views, RegexResult& m, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         m = search(views, regex_options);
         return m.success;
     }
 
-    bool has_match(const RegexStringView view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    bool has_match(RegexStringView const view, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return false;
@@ -203,7 +203,7 @@ public:
         return result.success;
     }
 
-    bool has_match(const Vector<RegexStringView> views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
+    bool has_match(Vector<RegexStringView> const views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {}) const
     {
         if (!matcher || parser_result.error != Error::NoError)
             return false;
@@ -214,61 +214,61 @@ public:
 
 // free standing functions for match, search and has_match
 template<class Parser>
-RegexResult match(const RegexStringView view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+RegexResult match(RegexStringView const view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.match(view, regex_options);
 }
 
 template<class Parser>
-RegexResult match(const Vector<RegexStringView> view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+RegexResult match(Vector<RegexStringView> const view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.match(view, regex_options);
 }
 
 template<class Parser>
-bool match(const RegexStringView view, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+bool match(RegexStringView const view, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.match(view, regex_options);
 }
 
 template<class Parser>
-bool match(const Vector<RegexStringView> view, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+bool match(Vector<RegexStringView> const view, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.match(view, regex_options);
 }
 
 template<class Parser>
-RegexResult search(const RegexStringView view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+RegexResult search(RegexStringView const view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.search(view, regex_options);
 }
 
 template<class Parser>
-RegexResult search(const Vector<RegexStringView> views, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+RegexResult search(Vector<RegexStringView> const views, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.search(views, regex_options);
 }
 
 template<class Parser>
-bool search(const RegexStringView view, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+bool search(RegexStringView const view, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.search(view, regex_options);
 }
 
 template<class Parser>
-bool search(const Vector<RegexStringView> views, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+bool search(Vector<RegexStringView> const views, Regex<Parser>& pattern, RegexResult&, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.search(views, regex_options);
 }
 
 template<class Parser>
-bool has_match(const RegexStringView view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+bool has_match(RegexStringView const view, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.has_match(view, regex_options);
 }
 
 template<class Parser>
-bool has_match(const Vector<RegexStringView> views, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+bool has_match(Vector<RegexStringView> const views, Regex<Parser>& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
 {
     return pattern.has_match(views, regex_options);
 }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -55,7 +55,7 @@ ALWAYS_INLINE Token Parser::consume(TokenType type, Error error)
     return consume();
 }
 
-ALWAYS_INLINE bool Parser::consume(const String& str)
+ALWAYS_INLINE bool Parser::consume(String const& str)
 {
     size_t potentially_go_back { 1 };
     for (auto ch : str) {

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -78,7 +78,7 @@ protected:
     ALWAYS_INLINE bool match_ordinary_characters();
     ALWAYS_INLINE Token consume();
     ALWAYS_INLINE Token consume(TokenType type, Error error);
-    ALWAYS_INLINE bool consume(const String&);
+    ALWAYS_INLINE bool consume(String const&);
     ALWAYS_INLINE bool try_skip(StringView);
     ALWAYS_INLINE bool lookahead_any(StringView);
     ALWAYS_INLINE char skip();


### PR DESCRIPTION
ECMA262 requires that the capture groups only contain the values from
the last iteration, e.g. `((c)(a)?(b))` should _not_ contain 'a' in the
second capture group when matching "cabcb".

This fixes (at least?) one test from test262 (`test262/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T6.js (strict mode)`) found in #8931.