### PR TITLE
Kernel + Tests: Random collection of fixes and improvements.

### DIFF
--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -196,13 +196,7 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
 
     static constexpr FlatPtr iopl_mask = 3u << 12;
 
-    FlatPtr flags;
-#if ARCH(I386)
-    flags = regs.eflags;
-#else
-    flags = regs.rflags;
-#endif
-
+    FlatPtr flags = regs.flags();
     if ((flags & (iopl_mask)) != 0) {
         PANIC("Syscall from process with IOPL != 0");
     }

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -67,7 +67,7 @@ KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*>
 
     RefPtr<FileSystem> fs;
 
-    if (fs_type == "ext2" || fs_type == "Ext2FS") {
+    if (fs_type == "ext2"sv || fs_type == "Ext2FS"sv) {
         if (description.is_null())
             return EBADF;
         if (!description->file().is_block_device())
@@ -80,20 +80,20 @@ KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*>
         dbgln("mount: attempting to mount {} on {}", description->absolute_path(), target);
 
         fs = Ext2FS::create(*description);
-    } else if (fs_type == "9p" || fs_type == "Plan9FS") {
+    } else if (fs_type == "9p"sv || fs_type == "Plan9FS"sv) {
         if (description.is_null())
             return EBADF;
 
         fs = Plan9FS::create(*description);
-    } else if (fs_type == "proc" || fs_type == "ProcFS") {
+    } else if (fs_type == "proc"sv || fs_type == "ProcFS"sv) {
         fs = ProcFS::create();
-    } else if (fs_type == "devpts" || fs_type == "DevPtsFS") {
+    } else if (fs_type == "devpts"sv || fs_type == "DevPtsFS"sv) {
         fs = DevPtsFS::create();
-    } else if (fs_type == "dev" || fs_type == "DevFS") {
+    } else if (fs_type == "dev"sv || fs_type == "DevFS"sv) {
         fs = DevFS::create();
-    } else if (fs_type == "sys" || fs_type == "SysFS") {
+    } else if (fs_type == "sys"sv || fs_type == "SysFS"sv) {
         fs = SysFS::create();
-    } else if (fs_type == "tmp" || fs_type == "TmpFS") {
+    } else if (fs_type == "tmp"sv || fs_type == "TmpFS"sv) {
         fs = TmpFS::create();
     } else {
         return ENODEV;

--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -39,7 +39,7 @@ KResultOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params
         auto parts = pledge_spec.split_view(' ');
         for (auto& part : parts) {
 #define __ENUMERATE_PLEDGE_PROMISE(x)   \
-    if (part == #x) {                   \
+    if (part == StringView { #x }) {    \
         mask |= (1u << (u32)Pledge::x); \
         continue;                       \
     }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -107,9 +107,9 @@ static Processor s_bsp_processor; // global but let's keep it "private"
 // init_stage2() function. Initialization continues there.
 
 extern "C" {
-PhysicalAddress start_of_prekernel_image;
-PhysicalAddress end_of_prekernel_image;
-FlatPtr kernel_base;
+READONLY_AFTER_INIT PhysicalAddress start_of_prekernel_image;
+READONLY_AFTER_INIT PhysicalAddress end_of_prekernel_image;
+READONLY_AFTER_INIT FlatPtr kernel_base;
 #if ARCH(X86_64)
 PhysicalAddress boot_pml4t;
 #endif

--- a/Tests/Kernel/TestKernelUnveil.cpp
+++ b/Tests/Kernel/TestKernelUnveil.cpp
@@ -5,7 +5,35 @@
  */
 
 #include <LibTest/TestCase.h>
+#include <errno.h>
 #include <unistd.h>
+
+TEST_CASE(test_argument_validation)
+{
+    auto res = unveil("/etc", "aaaaaaaaaaaa");
+    EXPECT_EQ(res, -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    res = unveil(nullptr, "r");
+    EXPECT_EQ(res, -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    res = unveil("/etc", nullptr);
+    EXPECT_EQ(res, -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    res = unveil("", "r");
+    EXPECT_EQ(res, -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    res = unveil("test", "r");
+    EXPECT_EQ(res, -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    res = unveil("/etc", "f");
+    EXPECT_EQ(res, -1);
+    EXPECT_EQ(errno, EINVAL);
+}
 
 TEST_CASE(test_failures)
 {


### PR DESCRIPTION
- **Kernel: Use StringView when parsing pledges in sys$pledge(..)**

    This ensures no potential allocation as in some cases the pledge char*
    could be promoted to AK::String by the compiler to execute the
    comparison.

- **Tests: Add test coverage for sys$pledge(..) argument validation**

- **Kernel: Fix bug where we half apply pledges in sys$pledge(..)**

    This bug manifests it self when the caller to sys$pledge() passes valid
    promises, but invalid execpromises. The code would apply the promises
    and then return an error for the execpromises. This leaves the user in
    a confusing state, as the promises were silently applied, but we return
    an error suggesting the operation has failed.

    Avoid this situation by tweaking the implementation to only apply the
    promises / execpromises after all validation has occurred.

 - **Kernel: Migrate sys$pledge to use the KString API**

    This avoids potential unhandled OOM that's possible with the old
    copy_string_from_user API.

- **Kernel: Annotate kernel_base and friends as READONLY_AFTER_INIT**

    We don't want kernel_base to be modifiable by an attacker or a stray
    memory scribbler bug, so lets mark it as READONLY_AFTER_INIT.

- **Tests: Add test coverage for sys$unveil(..) argument validation**

- **Kernel: Migrate sys$unveil to use the KString API**

    This avoids potential unhandled OOM that's possible with the old
    copy_string_from_user API.

- **Kernel: Use StringView literals for fs_type match in sys$mount(..)**

- **Kernel: Remove another ARCH ifdef using RegisterState::flags()**