### PR TITLE
TextEditor: Unveil full path to config file

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -9,7 +9,6 @@
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <Applications/TextEditor/TextEditorWindowGML.h>
-#include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCpp/SyntaxHighlighter.h>
 #include <LibDesktop/Launcher.h>
@@ -47,7 +46,7 @@ MainWidget::MainWidget()
 {
     load_from_gml(text_editor_window_gml);
 
-    m_config = Core::ConfigFile::open_for_app("TextEditor", Core::ConfigFile::AllowWriting::Yes);
+    m_config = open_config_file();
 
     m_toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     m_toolbar_container = *find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
@@ -343,6 +342,15 @@ MainWidget::MainWidget()
 
 MainWidget::~MainWidget()
 {
+}
+
+static RefPtr<Core::ConfigFile> s_config;
+
+RefPtr<Core::ConfigFile> MainWidget::open_config_file()
+{
+    if (!s_config)
+        s_config = Core::ConfigFile::open_for_app("TextEditor", Core::ConfigFile::AllowWriting::Yes);
+    return s_config;
 }
 
 Web::OutOfProcessWebView& MainWidget::ensure_web_view()

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -8,6 +8,7 @@
 
 #include <AK/Function.h>
 #include <AK/LexicalPath.h>
+#include <LibCore/ConfigFile.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
@@ -41,6 +42,8 @@ public:
 
     void update_title();
     void initialize_menubar(GUI::Window&);
+
+    static RefPtr<Core::ConfigFile> open_config_file();
 
 private:
     MainWidget();

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv)
     parser.parse(argc, argv);
 
     String file_to_edit_full_path;
+    auto config_filename = MainWidget::open_config_file()->filename();
 
     if (file_to_edit) {
         FileArgument parsed_argument(file_to_edit);
@@ -47,7 +48,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (unveil(Core::StandardPaths::config_directory().characters(), "rw") < 0) {
+    if (unveil(config_filename.characters(), "rwc") < 0) {
         perror("unveil");
         return 1;
     }


### PR DESCRIPTION
Unveil ~/.config/TextEditor.ini instead of the whole config directory.