### PR TITLE
LibWeb: Add support for box-shadow

### DIFF
--- a/Base/res/html/misc/box-shadow.html
+++ b/Base/res/html/misc/box-shadow.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Box-Shadow</title>
+  <style>
+
+    .box {
+      border: 1px solid black;
+      height: 100px;
+      width: 100px;
+      margin: 50px;
+    }
+  </style>
+</head>
+
+<body>
+<h1>Box-shadow Tests</h1>
+
+<div class="box" style="box-shadow: 20px 10px magenta">
+  <p>box-shadow: 20px 10px magenta</p>
+</div>
+
+<div class="box" style="box-shadow: -40px -20px magenta">
+  <p>box-shadow: -40px -20px magenta</p>
+</div>
+
+<div class="box" style="box-shadow: 20px 10px rgba(255,0,255,0.5)">
+  <p>box-shadow: 20px 10px rgba(255,0,255,0.5)</p>
+</div>
+
+<div class="box" style="box-shadow: -40px -20px rgba(255,0,255,0.5)">
+  <p>box-shadow: -40px -20px rgba(255,0,255,0.5)</p>
+</div>
+
+<div class="box" style="box-shadow: 20px 10px 5px magenta">
+  <p>box-shadow: 20px 10px 5px magenta</p>
+</div>
+
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -46,6 +46,7 @@
     <p>This page loaded in <b><span id="loadtime"></span></b> ms</p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="box-shadow.html">Box-shadow</a></li>
         <li><a href="calc.html">calc Property</a></li>
         <li><a href="opacity.html">CSS opacity property</a></li>
         <li><a href="justify-content.html">Flexbox justify-content</a></li>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -45,6 +45,13 @@ struct FlexBasisData {
     CSS::Length length {};
 };
 
+struct BoxShadowData {
+    CSS::Length offset_x {};
+    CSS::Length offset_y {};
+    CSS::Length blur_radius {};
+    Color color {};
+};
+
 class ComputedValues {
 public:
     CSS::Float float_() const { return m_noninherited.float_; }
@@ -64,6 +71,7 @@ public:
     Optional<float> flex_shrink_factor() const { return m_noninherited.flex_shrink_factor; }
     Optional<float> opacity() const { return m_noninherited.opacity; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
+    Optional<BoxShadowData> box_shadow() const { return m_noninherited.box_shadow; }
     const CSS::Length& width() const { return m_noninherited.width; }
     const CSS::Length& min_width() const { return m_noninherited.min_width; }
     const CSS::Length& max_width() const { return m_noninherited.max_width; }
@@ -148,6 +156,7 @@ protected:
         CSS::Overflow overflow_x { InitialValues::overflow() };
         CSS::Overflow overflow_y { InitialValues::overflow() };
         Optional<float> opacity;
+        Optional<BoxShadowData> box_shadow {};
     } m_noninherited;
 };
 
@@ -197,6 +206,7 @@ public:
     void set_flex_shrink_factor(Optional<float> value) { m_noninherited.flex_shrink_factor = value; }
     void set_opacity(Optional<float> value) { m_noninherited.opacity = value; }
     void set_justify_content(CSS::JustifyContent value) { m_noninherited.justify_content = value; }
+    void set_box_shadow(Optional<BoxShadowData> value) { m_noninherited.box_shadow = move(value); }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -175,6 +175,10 @@
     "inherited": false,
     "initial": "auto"
   },
+  "box-shadow":{
+    "inherited": false,
+    "initial": "none"
+  },
   "caption-side": {
     "inherited": true,
     "initial": "top"

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -764,4 +764,18 @@ Optional<CSS::Repeat> StyleProperties::background_repeat_y() const
         return {};
     }
 }
+
+Optional<CSS::BoxShadowData> StyleProperties::box_shadow() const
+{
+    auto value_or_error = property(CSS::PropertyID::BoxShadow);
+    if (!value_or_error.has_value())
+        return {};
+
+    auto value = value_or_error.value();
+    if (!value->is_box_shadow())
+        return {};
+
+    auto box = verify_cast<CSS::BoxShadowStyleValue>(value.ptr());
+    return { { box->offset_x(), box->offset_y(), box->blur_radius(), box->color() } };
+}
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -62,6 +62,7 @@ public:
     Optional<CSS::Overflow> overflow_y() const;
     Optional<CSS::Repeat> background_repeat_x() const;
     Optional<CSS::Repeat> background_repeat_y() const;
+    Optional<CSS::BoxShadowData> box_shadow() const;
 
     const Gfx::Font& font() const
     {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -228,6 +228,7 @@ public:
         Numeric,
         ValueList,
         Calculated,
+        BoxShadow,
     };
 
     Type type() const { return m_type; }
@@ -251,6 +252,7 @@ public:
     {
         return is_inherit() || is_initial() || is_custom_property();
     }
+    bool is_box_shadow() const { return type() == Type::BoxShadow; }
 
     bool is_calculated() const
     {
@@ -340,6 +342,38 @@ private:
     }
 
     String m_string;
+};
+
+class BoxShadowStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<BoxShadowStyleValue> create(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
+    {
+        return adopt_ref(*new BoxShadowStyleValue(offset_x, offset_y, blur_radius, color));
+    }
+    virtual ~BoxShadowStyleValue() override { }
+
+    Length const& offset_x() const { return m_offset_x; }
+    Length const& offset_y() const { return m_offset_y; }
+    Length const& blur_radius() const { return m_blur_radius; }
+    Color const& color() const { return m_color; }
+
+    String to_string() const override { return String::formatted("BoxShadow offset_x: {}, offset_y: {}, blur_radius: {}, color: {}",
+        m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string()); }
+
+private:
+    explicit BoxShadowStyleValue(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
+        : StyleValue(Type::BoxShadow)
+        , m_offset_x(offset_x)
+        , m_offset_y(offset_y)
+        , m_blur_radius(blur_radius)
+        , m_color(color)
+    {
+    }
+
+    Length m_offset_x;
+    Length m_offset_y;
+    Length m_blur_radius;
+    Color m_color;
 };
 
 class LengthStyleValue : public StyleValue {

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -111,6 +111,7 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) override;
     virtual void paint_border(PaintContext& context);
+    virtual void paint_box_shadow(PaintContext& context);
     virtual void paint_background(PaintContext& context);
 
     Vector<LineBox>& line_boxes() { return m_line_boxes; }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -350,6 +350,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     computed_values.set_margin(specified_style.length_box(CSS::PropertyID::MarginLeft, CSS::PropertyID::MarginTop, CSS::PropertyID::MarginRight, CSS::PropertyID::MarginBottom, CSS::Length::make_px(0)));
     computed_values.set_padding(specified_style.length_box(CSS::PropertyID::PaddingLeft, CSS::PropertyID::PaddingTop, CSS::PropertyID::PaddingRight, CSS::PropertyID::PaddingBottom, CSS::Length::make_px(0)));
 
+    computed_values.set_box_shadow(specified_style.box_shadow());
+
     auto do_border_style = [&](CSS::BorderData& border, CSS::PropertyID width_property, CSS::PropertyID color_property, CSS::PropertyID style_property) {
         border.color = specified_style.color_or_fallback(color_property, document(), Color::Transparent);
         border.line_style = specified_style.line_style(style_property).value_or(CSS::LineStyle::None);


### PR DESCRIPTION
This PR adds basic support for the `box-shadow` property.
It gets parsed and passed around LibWeb and eventually rendered.
There is no support for blurred shadows for now (they just become solid) as the Filters don't quite seem to cut it currently.
![image](https://user-images.githubusercontent.com/6002167/126834921-d9cfe2cd-2a71-4193-8804-a655facb54bf.png)
