### PR TITLE
Label Widget: Improve word wrapping and adding an word_wrap_mode 

### DIFF
--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGUI/Frame.h>
+#include <LibGUI/WordWrapMode.h>
 #include <LibGfx/TextAlignment.h>
 
 namespace GUI {
@@ -36,6 +37,9 @@ public:
     bool is_word_wrap() const { return m_word_wrap; }
     void set_word_wrap(bool);
 
+    GUI::WordWrapMode word_wrap_mode() const { return m_word_wrap_mode; }
+    void set_word_wrap_mode(GUI::WordWrapMode mode) { m_word_wrap_mode = mode; }
+
     Gfx::IntRect text_rect(size_t line = 0) const;
 
 protected:
@@ -47,6 +51,7 @@ protected:
 private:
     void size_to_fit();
     void wrap_text();
+    size_t next_substring_size(String*, size_t);
 
     String m_text;
     RefPtr<Gfx::Bitmap> m_icon;
@@ -54,6 +59,7 @@ private:
     bool m_should_stretch_icon { false };
     bool m_autosize { false };
     bool m_word_wrap { false };
+    GUI::WordWrapMode m_word_wrap_mode { GUI::WordWrapMode::Word };
     Vector<String> m_lines;
 };
 

--- a/Userland/Libraries/LibGUI/WordWrapMode.h
+++ b/Userland/Libraries/LibGUI/WordWrapMode.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021-2021, Vinicius Sugimoto <vtmsugimoto@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+
+namespace GUI {
+
+#define GUI_ENUMERATE_WORD_WRAP_MODES(M) \
+    M(Word)                              \
+    M(Anywhere)
+
+enum class WordWrapMode {
+#define __ENUMERATE(x) x,
+    GUI_ENUMERATE_WORD_WRAP_MODES(__ENUMERATE)
+#undef __ENUMERATE
+};
+
+ALWAYS_INLINE Optional<WordWrapMode> word_wrap_mode_from_string(StringView const& string)
+{
+#define __ENUMERATE(x) \
+    if (string == #x)  \
+        return WordWrapMode::x;
+    GUI_ENUMERATE_WORD_WRAP_MODES(__ENUMERATE)
+#undef __ENUMERATE
+    return {};
+}
+
+ALWAYS_INLINE const char* to_string(WordWrapMode mode)
+{
+#define __ENUMERATE(x)           \
+    if (mode == WordWrapMode::x) \
+        return #x;
+    GUI_ENUMERATE_WORD_WRAP_MODES(__ENUMERATE)
+#undef __ENUMERATE
+    return {};
+}
+
+}


### PR DESCRIPTION
The word_wrap_mode configuration can be set to
GUI::WordWrapMode::Word (default) or GUI::WordWrapMode::Anywhere.
GUI::WordWrapMode::Word will wrap text on spaces, without breaking
words, and long words that won't fit in a full line will be elided.
GUI::WordWrapMode::Anywhere will wrap text using all the available
space in a line, breaking mid-word if necessary.