### PR TITLE
Toolchain+Ports: Ignore -arch on macOS M1 hosts

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -16,6 +16,8 @@ fi
 if [ "$(uname -s)" = "Darwin" ]; then
     export PATH="/usr/local/opt/e2fsprogs/bin:$PATH"
     export PATH="/usr/local/opt/e2fsprogs/sbin:$PATH"
+    export PATH="/opt/homebrew/opt/e2fsprogs/bin:$PATH"
+    export PATH="/opt/homebrew/opt/e2fsprogs/sbin:$PATH"
 fi
 
 SCRIPT_DIR="$(dirname "${0}")"

--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -6331,3 +6331,15 @@ diff -Naur gcc-11.1.0/gcc/config/host-darwin.c gcc-11.1.0.serenity/gcc/config/ho
  
  /* Yes, this is really supposed to work.  */
  /* This allows for a pagesize of 16384, which we have on Darwin20, but should
+diff -Naur gcc-11.1.0/gcc/common.opt gcc-11.1.0.serenity/gcc/common.opt
+--- gcc-11.1.0/gcc/common.opt	2021-07-24 02:52:10.000000000 +0200
++++ gcc-11.1.0.serenity/gcc/common.opt	2021-04-27 12:00:13.000000000 +0200
+@@ -3490,4 +3490,8 @@
+ Common Var(flag_ipa_ra) Optimization
+ Use caller save register across calls if possible.
+ 
++arch
++Driver Ignore Separate
++-arch <name>	Generate output for architecture <name>.
++
+ ; This comment is to ensure we retain the blank line above.

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -6331,3 +6331,15 @@ diff -Naur gcc-11.1.0/gcc/config/host-darwin.c gcc-11.1.0.serenity/gcc/config/ho
  
  /* Yes, this is really supposed to work.  */
  /* This allows for a pagesize of 16384, which we have on Darwin20, but should
+diff -Naur gcc-11.1.0/gcc/common.opt gcc-11.1.0.serenity/gcc/common.opt
+--- gcc-11.1.0/gcc/common.opt	2021-07-24 02:52:10.000000000 +0200
++++ gcc-11.1.0.serenity/gcc/common.opt	2021-04-27 12:00:13.000000000 +0200
+@@ -3490,4 +3490,8 @@
+ Common Var(flag_ipa_ra) Optimization
+ Use caller save register across calls if possible.
+ 
++arch
++Driver Ignore Separate
++-arch <name>	Generate output for architecture <name>.
++
+ ; This comment is to ensure we retain the blank line above.


### PR DESCRIPTION
With these changes I'm able to build SerenityOS on my M1 MacBook without any further tweaks.

**Toolchain+Ports: Ignore -arch on macOS M1 hosts**

CMake specifies -arch arm64 for our toolchain. Unfortunately that's an option GCC only understands when built for macOS. This causes the build to fail.

I haven't been able to get CMake to not specify that option so this adds a dummy option to GCC.

**Meta: Add Homebrew paths for macOS on M1 to the PATH env variable**

<img width="1680" alt="Screenshot 2021-07-24 at 03 23 04" src="https://user-images.githubusercontent.com/388571/126853678-7eec49fb-d61e-46e0-8b77-bae9e4b8bce9.png">