### PR TITLE
Services: Improve handling of app files and terminal applications in LaunchServer

### DIFF
--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,14 +23,19 @@ auto Launcher::Details::from_details_str(const String& details_str) -> NonnullRe
     auto obj = json.value().as_object();
     details->executable = obj.get("executable").to_string();
     details->name = obj.get("name").to_string();
+    details->run_in_terminal = obj.get("run_in_terminal").to_bool();
     if (auto type_value = obj.get_ptr("type")) {
         auto type_str = type_value->to_string();
-        if (type_str == "app")
+        if (type_str == "default")
+            details->launcher_type = LauncherType::Default;
+        else if (type_str == "application")
             details->launcher_type = LauncherType::Application;
         else if (type_str == "userpreferred")
             details->launcher_type = LauncherType::UserPreferred;
         else if (type_str == "userdefault")
             details->launcher_type = LauncherType::UserDefault;
+        else
+            VERIFY_NOT_REACHED();
     }
     return details;
 }

--- a/Userland/Libraries/LibDesktop/Launcher.h
+++ b/Userland/Libraries/LibDesktop/Launcher.h
@@ -27,6 +27,7 @@ public:
         String name;
         String executable;
         LauncherType launcher_type { LauncherType::Default };
+        bool run_in_terminal { false };
 
         static NonnullRefPtr<Details> from_details_str(const String&);
     };

--- a/Userland/Services/LaunchServer/ClientConnection.cpp
+++ b/Userland/Services/LaunchServer/ClientConnection.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Nicholas Hollett <niax@niax.co.uk>
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,6 +31,11 @@ void ClientConnection::die()
 
 Messages::LaunchServer::OpenUrlResponse ClientConnection::open_url(URL const& url, String const& handler_name)
 {
+    if (!url.is_valid()) {
+        did_misbehave("Got request to open invalid URL");
+        return nullptr;
+    }
+
     if (!m_allowlist.is_empty()) {
         bool allowed = false;
         auto request_url_without_fragment = url;
@@ -53,11 +59,21 @@ Messages::LaunchServer::OpenUrlResponse ClientConnection::open_url(URL const& ur
 
 Messages::LaunchServer::GetHandlersForUrlResponse ClientConnection::get_handlers_for_url(URL const& url)
 {
+    if (!url.is_valid()) {
+        did_misbehave("Got request to get handlers for invalid URL");
+        return nullptr;
+    }
+
     return Launcher::the().handlers_for_url(url);
 }
 
 Messages::LaunchServer::GetHandlersWithDetailsForUrlResponse ClientConnection::get_handlers_with_details_for_url(URL const& url)
 {
+    if (!url.is_valid()) {
+        did_misbehave("Got request to get handlers with details for invalid URL");
+        return nullptr;
+    }
+
     return Launcher::the().handlers_with_details_for_url(url);
 }
 

--- a/Userland/Services/LaunchServer/Launcher.h
+++ b/Userland/Services/LaunchServer/Launcher.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Nicholas Hollett <niax@niax.co.uk>
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,52 +8,62 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <AK/HashTable.h>
 #include <AK/URL.h>
-#include <LibCore/ConfigFile.h>
+#include <LibCore/FileWatcher.h>
 #include <LibDesktop/AppFile.h>
 
 namespace LaunchServer {
 
-struct Handler {
+struct Handler : public RefCounted<Handler> {
     enum class Type {
         Default = 0,
         Application,
         UserPreferred,
         UserDefault
     };
+
+    Handler(Type handler_type, const String& name, const String& executable, bool run_in_terminal = false)
+        : handler_type { handler_type }
+        , name { name }
+        , executable { executable }
+        , run_in_terminal { run_in_terminal }
+    {
+    }
+
     Type handler_type;
     String name;
     String executable;
-    HashTable<String> file_types {};
-    HashTable<String> protocols {};
+    bool run_in_terminal { false };
 
-    static String name_from_executable(const StringView&);
-    void from_executable(Type, const String&);
     String to_details_str() const;
+    static String to_details_str(Type handler_type, const String& name, const String& executable, bool run_in_terminal = false);
 };
 
 class Launcher {
 public:
-    Launcher();
+    Launcher(const String& app_file_dir = Desktop::AppFile::APP_FILES_DIRECTORY);
     static Launcher& the();
 
-    void load_handlers(const String& af_dir = Desktop::AppFile::APP_FILES_DIRECTORY);
-    void load_config(const Core::ConfigFile&);
     bool open_url(const URL&, const String& handler_name);
     Vector<String> handlers_for_url(const URL&);
     Vector<String> handlers_with_details_for_url(const URL&);
 
 private:
-    HashMap<String, Handler> m_handlers;
-    HashMap<String, String> m_protocol_handlers;
-    HashMap<String, String> m_file_handlers;
+    void load_default_handlers();
+    void load_config();
 
-    Handler get_handler_for_executable(Handler::Type, const String&) const;
-    void for_each_handler(const String& key, HashMap<String, String>& user_preferences, Function<bool(const Handler&)> f);
-    void for_each_handler_for_path(const String&, Function<bool(const Handler&)> f);
     bool open_file_url(const URL&);
-    bool open_with_user_preferences(const HashMap<String, String>& user_preferences, const String& key, const Vector<String>& arguments, const String& default_program = {});
-    bool open_with_handler_name(const URL&, const String& handler_name);
+    bool open_with_handler_name(const URL&, const String& executable);
+
+    Vector<String> get_handlers(const URL&, bool with_details = false) const;
+    bool run_in_terminal(const String& path) const;
+    String get_name_for_executable(const String& executable) const;
+
+    String m_app_file_dir;
+    RefPtr<Core::FileWatcher> m_config_file_watcher;
+    HashMap<String, NonnullRefPtr<Handler>> m_default_file_handlers;
+    HashMap<String, NonnullRefPtr<Handler>> m_default_protocol_handlers;
+    HashMap<String, NonnullRefPtr<Handler>> m_file_handlers;
+    HashMap<String, NonnullRefPtr<Handler>> m_protocol_handlers;
 };
 }

--- a/Userland/Services/LaunchServer/main.cpp
+++ b/Userland/Services/LaunchServer/main.cpp
@@ -17,10 +17,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     Core::EventLoop event_loop;
     auto server = Core::LocalServer::construct();
 
-    auto launcher = LaunchServer::Launcher();
-
-    launcher.load_handlers();
-    launcher.load_config(Core::ConfigFile::get_for_app("LaunchServer"));
+    LaunchServer::Launcher launcher;
 
     if (pledge("stdio accept rpath proc exec", nullptr) < 0) {
         perror("pledge");


### PR DESCRIPTION
LaunchServer should treat file associations in app files as default handlers and determine which applications should be launched in Terminal. Fixes #6988 in which LaunchServer is inconsistent between the `open()` and `get_handlers_for_url()` IPC calls.

Update FileManager and TerminalWidget to handle non-GUI applications by launching them in Terminal.