### PR TITLE
LibC: Declare wide character type functions in wctype.h

### DIFF
--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -4,16 +4,68 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
-#include <assert.h>
 #include <wctype.h>
 
 extern "C" {
 
-wctype_t wctype(const char*)
+int iswalnum(wint_t wc)
 {
-    dbgln("FIXME: Implement wctype()");
-    TODO();
+    return __inline_isalnum(wc);
+}
+
+int iswalpha(wint_t wc)
+{
+    return __inline_isalpha(wc);
+}
+
+int iswcntrl(wint_t wc)
+{
+    return __inline_iscntrl(wc);
+}
+
+int iswdigit(wint_t wc)
+{
+    return __inline_isdigit(wc);
+}
+
+int iswxdigit(wint_t wc)
+{
+    return __inline_isxdigit(wc);
+}
+
+int iswspace(wint_t wc)
+{
+    return __inline_isspace(wc);
+}
+
+int iswpunct(wint_t wc)
+{
+    return __inline_ispunct(wc);
+}
+
+int iswprint(wint_t wc)
+{
+    return __inline_isprint(wc);
+}
+
+int iswgraph(wint_t wc)
+{
+    return __inline_isgraph(wc);
+}
+
+int iswlower(wint_t wc)
+{
+    return __inline_islower(wc);
+}
+
+int iswupper(wint_t wc)
+{
+    return __inline_isupper(wc);
+}
+
+int iswblank(wint_t wc)
+{
+    return __inline_isblank(wc);
 }
 
 int iswctype(wint_t, wctype_t)
@@ -22,9 +74,31 @@ int iswctype(wint_t, wctype_t)
     TODO();
 }
 
-int iswprint(wint_t)
+wctype_t wctype(const char*)
 {
-    dbgln("FIXME: Implement iswprint()");
+    dbgln("FIXME: Implement wctype()");
+    TODO();
+}
+
+wint_t towlower(wint_t wc)
+{
+    return __inline_tolower(wc);
+}
+
+wint_t towupper(wint_t wc)
+{
+    return __inline_toupper(wc);
+}
+
+wint_t towctrans(wint_t, wctrans_t)
+{
+    dbgln("FIXME: Implement towctrans()");
+    TODO();
+}
+
+wctrans_t wctrans(const char*)
+{
+    dbgln("FIXME: Implement wctrans()");
     TODO();
 }
 }

--- a/Userland/Libraries/LibC/wctype.h
+++ b/Userland/Libraries/LibC/wctype.h
@@ -6,12 +6,32 @@
 
 #pragma once
 
+#include <AK/Format.h>
+#include <assert.h>
+#include <ctype.h>
 #include <wchar.h>
 
 __BEGIN_DECLS
 
-wctype_t wctype(const char* name);
-int iswctype(wint_t wc, wctype_t desc);
+typedef const int* wctrans_t;
+
+int iswalnum(wint_t wc);
+int iswalpha(wint_t wc);
+int iswcntrl(wint_t wc);
+int iswdigit(wint_t wc);
+int iswxdigit(wint_t wc);
+int iswspace(wint_t wc);
+int iswpunct(wint_t wc);
 int iswprint(wint_t wc);
+int iswgraph(wint_t wc);
+int iswlower(wint_t wc);
+int iswupper(wint_t wc);
+int iswblank(wint_t wc);
+int iswctype(wint_t, wctype_t);
+wctype_t wctype(const char*);
+wint_t towlower(wint_t wc);
+wint_t towupper(wint_t wc);
+wint_t towctrans(wint_t, wctrans_t);
+wctrans_t wctrans(const char*);
 
 __END_DECLS


### PR DESCRIPTION
Declares all wide character handling functions in wctype.h. All calls
are forwarded to the corresponding character handling function in
ctype.h.

These functions are declared, but not implemented:
- iswctype
- wctype
- towctrans
- wctrans

This should also resolve a build issue with the 'sed' port getting
confused with iswprint being declared twice. Seems like it expected
more functions from wctype.h and then had a backup strategy of adding
its own wctype.h. At least that is my theory since this branch now
seemingly builds 'sed' fine.