### PR TITLE
AudioWidget: Store and load audio and widget settings

### DIFF
--- a/Userland/Applets/Audio/CMakeLists.txt
+++ b/Userland/Applets/Audio/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_app(Audio.Applet ICON audio-volume-high)
-target_link_libraries(Audio.Applet LibGUI LibGfx LibAudio)
+target_link_libraries(Audio.Applet LibGUI LibGfx LibAudio LibCore)


### PR DESCRIPTION
A new user config file, AudioApplet.ini, is used to store settings for audio configuration (volume, muted state) and widget settings (show percentage). The audio settings are stored on every change reported by audio server, so that e.g. the volume persists between reboots.