### PR TITLE
Kernel: Properly implement TCP RST/ACK

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -460,8 +460,6 @@ void handle_tcp(IPv4Packet const& ipv4_packet, Time const& packet_timestamp)
             socket->set_setup_state(Socket::SetupState::Completed);
             return;
         case TCPFlags::ACK | TCPFlags::RST:
-            socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
-            send_delayed_tcp_ack(socket);
             socket->set_state(TCPSocket::State::Closed);
             socket->set_error(TCPSocket::Error::RSTDuringConnect);
             socket->set_setup_state(Socket::SetupState::Completed);

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -159,14 +159,14 @@ public:
 
     virtual bool can_write(const FileDescription&, size_t) const override;
 
+    static NetworkOrdered<u16> compute_tcp_checksum(IPv4Address const& source, IPv4Address const& destination, TCPPacket const&, u16 payload_size);
+
 protected:
     void set_direction(Direction direction) { m_direction = direction; }
 
 private:
     explicit TCPSocket(int protocol);
     virtual StringView class_name() const override { return "TCPSocket"; }
-
-    static NetworkOrdered<u16> compute_tcp_checksum(const IPv4Address& source, const IPv4Address& destination, const TCPPacket&, u16 payload_size);
 
     virtual void shut_down_for_writing() override;
 


### PR DESCRIPTION
**Kernel: Do not send delayed ack in response to RST/ACK**
In accordance with RFC 793, if the receiver is in the SYN-SENT state
it should respond to a RST by aborting the connection and immediately
move to the CLOSED state.

Previously the system would ACK all RST/ACKs, and the remote peer would
just respond with more RST packets.

**Kernel: Send RST/ACK if no socket is available**
Previously there was no way for Serenity to send a packet without an
established socket connection, and there was no way to appropriately
respond to a SYN packet on a non-listening port. This patch will respond
to any non-established socket attempts with the appropraite RST/ACK,
letting the client know to close the connection.