### PR TITLE
LibGUI+Browser: Do not paste bitmaps

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -151,7 +151,12 @@ Tab::Tab(BrowserWindow& window, Type type)
     };
 
     m_location_box->add_custom_context_menu_action(GUI::Action::create("Paste && Go", [this](auto&) {
-        m_location_box->set_text(GUI::Clipboard::the().data());
+        if (!GUI::Clipboard::the().mime_type().starts_with("text/"))
+            return;
+        auto const& paste_text = GUI::Clipboard::the().data();
+        if (paste_text.is_empty())
+            return;
+        m_location_box->set_text(paste_text);
         m_location_box->on_return_pressed();
     }));
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -98,6 +98,9 @@ void TextEditor::create_actions()
             this);
     }
     m_select_all_action = CommonActions::make_select_all_action([this](auto&) { select_all(); }, this);
+    Clipboard::the().on_change = [this](auto const& mime_type) {
+        m_paste_action->set_enabled(is_editable() && mime_type.starts_with("text/") && !Clipboard::the().data().is_empty());
+    };
 }
 
 void TextEditor::set_text(StringView const& text)
@@ -1395,6 +1398,9 @@ void TextEditor::copy()
 void TextEditor::paste()
 {
     if (!is_editable())
+        return;
+
+    if (!Clipboard::the().mime_type().starts_with("text/"))
         return;
 
     auto paste_text = Clipboard::the().data();


### PR DESCRIPTION
This prevents GUI::TextBox and the `Paste & Go` action in the browser from trying to paste a bitmap. Also, the paste action is enabled and disabled on clipboard change depending on the mime type to reflect if the clipboard data can be pasted.