### PR TITLE
AudioServer+AudioApplet: Persist user settings

### DIFF
--- a/Userland/Applets/Audio/CMakeLists.txt
+++ b/Userland/Applets/Audio/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_app(Audio.Applet ICON audio-volume-high)
-target_link_libraries(Audio.Applet LibGUI LibGfx LibAudio)
+target_link_libraries(Audio.Applet LibGUI LibGfx LibAudio LibCore)


### PR DESCRIPTION
AudioServer as well as the audio applet now persist their settings to two config files, so that volume, mute state, and percentage display persist between reboots.

The new configuration files, with their keys, are:

* `Audio.ini` for AudioServer
```ini
[Master]
Volume=<volume percentage>
Mute=<whether to mute audio>
```

* `AudioApplet.ini` for the audio applet
```ini
[Applet]
ShowPercent=<whether to show percentage in the task bar>
```