### PR TITLE
AK: Implement any_of using common implementation

### DIFF
--- a/AK/AnyOf.h
+++ b/AK/AnyOf.h
@@ -24,11 +24,7 @@ constexpr bool any_of(
 template<IterableContainer Container>
 constexpr bool any_of(Container&& container, auto const& predicate)
 {
-    for (auto&& entry : container) {
-        if (predicate(entry))
-            return true;
-    }
-    return false;
+    return any_of(container.begin(), container.end(), predicate);
 }
 
 }


### PR DESCRIPTION
Problem:
- `any_of` is implemented in 2 different ways, one for the entire
  container and a different implementation for a partial container
  using iterators.

Solution:
- Follow the "don't repeat yourself" (DRY) idiom and implement the
  entire container version in terms of the partial version.