### PR TITLE
Meta+Kernel: Immediately fail the on-target CI job when a panic occurs

### DIFF
--- a/Kernel/Arch/x86/common/CPU.cpp
+++ b/Kernel/Arch/x86/common/CPU.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Arch/x86/CPU.h>
 #include <Kernel/Arch/x86/Processor.h>
 #include <Kernel/KSyms.h>
+#include <Kernel/Panic.h>
 #include <Kernel/Process.h>
 
 void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func)
@@ -27,10 +28,7 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
     if (process)
         MM.enter_process_paging_scope(*process);
 
-    Kernel::dump_backtrace();
-    Processor::halt();
-
-    abort();
+    PANIC("Aborted");
 }
 
 [[noreturn]] void _abort()

--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -6,16 +6,29 @@
 
 #include <AK/Format.h>
 #include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/CommandLine.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 
 namespace Kernel {
 
+[[noreturn]] static void __reset()
+{
+    // FIXME: This works for i686/x86_64, but needs to be ported to any other arch when needed.
+    asm(
+        "lidt 0\n"
+        "movl $0, 0\n");
+
+    __builtin_unreachable();
+}
+
 void __panic(const char* file, unsigned int line, const char* function)
 {
     critical_dmesgln("at {}:{} in {}", file, line, function);
     dump_backtrace();
-    Processor::halt();
+    if (kernel_command_line().boot_mode() == BootMode::SelfTest)
+        __reset();
+    else
+        Processor::halt();
 }
-
 }

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -255,6 +255,7 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
         -m $SERENITY_RAM_SIZE \
         -cpu $SERENITY_QEMU_CPU \
         -d guest_errors \
+        -no-reboot \
         -smp 2 \
         -drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk \
         -device ich9-ahci \


### PR DESCRIPTION
cc @gunnarbeutner: the triple-fault seems to work, but I'm far from an x86 expert, so pls take a look :P