### PR TITLE
Everywhere: Make use of container version of all_of

### DIFF
--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -199,8 +199,7 @@ private:
                 return false;
             };
             auto references_all_arguments = AK::all_of(
-                all_parameters.begin(),
-                all_parameters.end(),
+                all_parameters,
                 [&](auto& entry) {
                     return contains(
                         check.used_arguments.begin(),

--- a/AK/MACAddress.h
+++ b/AK/MACAddress.h
@@ -81,7 +81,7 @@ public:
 
     constexpr bool is_zero() const
     {
-        return all_of(m_data.begin(), m_data.end(), [](const auto octet) { return octet == 0; });
+        return all_of(m_data, [](const auto octet) { return octet == 0; });
     }
 
 private:

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -284,7 +284,7 @@ bool contains(const StringView& str, const StringView& needle, CaseSensitivity c
 
 bool is_whitespace(const StringView& str)
 {
-    return all_of(str.begin(), str.end(), is_ascii_space);
+    return all_of(str, is_ascii_space);
 }
 
 StringView trim(const StringView& str, const StringView& characters, TrimMode mode)

--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -70,7 +70,7 @@ bool UUID::operator==(const UUID& other) const
 
 bool UUID::is_zero() const
 {
-    return all_of(m_uuid_buffer.begin(), m_uuid_buffer.end(), [](const auto octet) { return octet == 0; });
+    return all_of(m_uuid_buffer, [](const auto octet) { return octet == 0; });
 }
 
 }

--- a/Kernel/Storage/Partition/DiskPartitionMetadata.cpp
+++ b/Kernel/Storage/Partition/DiskPartitionMetadata.cpp
@@ -34,7 +34,7 @@ bool DiskPartitionMetadata::PartitionType::is_uuid() const
 }
 bool DiskPartitionMetadata::PartitionType::is_valid() const
 {
-    return !all_of(m_partition_type.begin(), m_partition_type.end(), [](const auto octet) { return octet == 0; });
+    return !all_of(m_partition_type, [](const auto octet) { return octet == 0; });
 }
 
 DiskPartitionMetadata::DiskPartitionMetadata(u64 start_block, u64 end_block, u8 partition_type)

--- a/Kernel/Storage/Partition/GUIDPartitionTable.cpp
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.cpp
@@ -118,7 +118,7 @@ bool GUIDPartitionTable::initialize()
 
 bool GUIDPartitionTable::is_unused_entry(Array<u8, 16> partition_type) const
 {
-    return all_of(partition_type.begin(), partition_type.end(), [](const auto octet) { return octet == 0; });
+    return all_of(partition_type, [](const auto octet) { return octet == 0; });
 }
 
 }

--- a/Userland/Libraries/LibIMAP/Objects.cpp
+++ b/Userland/Libraries/LibIMAP/Objects.cpp
@@ -120,7 +120,7 @@ String serialize_astring(StringView string)
         auto non_atom_chars = { '(', ')', '{', ' ', '%', '*', '"', '\\', ']' };
         return AK::find(non_atom_chars.begin(), non_atom_chars.end(), x) != non_atom_chars.end();
     };
-    auto is_atom = all_of(string.begin(), string.end(), [&](auto ch) { return is_ascii_control(ch) && !is_non_atom_char(ch); });
+    auto is_atom = all_of(string, [&](auto ch) { return is_ascii_control(ch) && !is_non_atom_char(ch); });
     if (is_atom) {
         return string;
     }

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
@@ -59,7 +59,7 @@ OrdinaryFunctionObject::OrdinaryFunctionObject(GlobalObject& global_object, cons
         set_this_mode(ThisMode::Global);
 
     // 15.1.3 Static Semantics: IsSimpleParameterList, https://tc39.es/ecma262/#sec-static-semantics-issimpleparameterlist
-    set_has_simple_parameter_list(all_of(m_parameters.begin(), m_parameters.end(), [&](auto& parameter) {
+    set_has_simple_parameter_list(all_of(m_parameters, [&](auto& parameter) {
         if (parameter.is_rest)
             return false;
         if (parameter.default_value)

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -57,7 +57,7 @@ static bool is_valid_bigint_value(StringView string)
     string = string.trim_whitespace();
     if (string.length() > 1 && (string[0] == '-' || string[0] == '+'))
         string = string.substring_view(1, string.length() - 1);
-    return all_of(string.begin(), string.end(), [](auto ch) { return isdigit(ch); });
+    return all_of(string, [](auto ch) { return isdigit(ch); });
 }
 
 ALWAYS_INLINE bool both_number(const Value& lhs, const Value& rhs)

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -231,7 +231,7 @@ Optional<Core::DateTime> parse_date_time(StringView date_string)
     unsigned year = 0;
 
     auto to_uint = [](StringView token, unsigned& result) {
-        if (!all_of(token.begin(), token.end(), isdigit))
+        if (!all_of(token, isdigit))
             return false;
 
         if (auto converted = token.to_uint(); converted.has_value()) {


### PR DESCRIPTION
Problem:
- New `all_of` implementation takes the entire container so the user
  does not need to pass explicit begin/end iterators. This is unused
  except is in tests.

Solution:
- Make use of the new and more user-friendly version where possible.