### PR TITLE
LibJS: Implement Temporal.TimeZone.prototype.getOffsetNanosecondsFor()

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -435,10 +435,7 @@ Object* create_unmapped_arguments_object(GlobalObject& global_object, Vector<Val
     }
 
     // 7. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
-    // FIXME: This is not guaranteed to be %Array.prototype.values%!
-    auto array_prototype_values = global_object.array_prototype()->get(vm.names.values);
-    if (vm.exception())
-        return {};
+    auto* array_prototype_values = global_object.array_prototype_values_function();
     object->define_property_or_throw(*vm.well_known_symbol_iterator(), { .value = array_prototype_values, .writable = true, .enumerable = false, .configurable = true });
     VERIFY(!vm.exception());
 
@@ -530,10 +527,7 @@ Object* create_mapped_arguments_object(GlobalObject& global_object, FunctionObje
     }
 
     // 20. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
-    // FIXME: This is not guaranteed to be %Array.prototype.values%!
-    auto array_prototype_values = global_object.array_prototype()->get(vm.names.values);
-    if (vm.exception())
-        return {};
+    auto* array_prototype_values = global_object.array_prototype_values_function();
     object->define_property_or_throw(*vm.well_known_symbol_iterator(), { .value = array_prototype_values, .writable = true, .enumerable = false, .configurable = true });
     VERIFY(!vm.exception());
 

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -182,6 +182,7 @@ namespace JS {
     P(getMilliseconds)                       \
     P(getMinutes)                            \
     P(getMonth)                              \
+    P(getOffsetNanosecondsFor)               \
     P(getOwnPropertyDescriptor)              \
     P(getOwnPropertyDescriptors)             \
     P(getOwnPropertyNames)                   \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -36,8 +36,8 @@ public:
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct constructor
     GeneratorObjectPrototype* generator_object_prototype() { return m_generator_object_prototype; }
 
+    FunctionObject* array_prototype_values_function() const { return m_array_prototype_values_function; }
     FunctionObject* eval_function() const { return m_eval_function; }
-
     FunctionObject* throw_type_error_function() const { return m_throw_type_error_function; }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
@@ -95,6 +95,10 @@ private:
 
     GlobalEnvironment* m_environment { nullptr };
 
+    FunctionObject* m_array_prototype_values_function { nullptr };
+    FunctionObject* m_eval_function { nullptr };
+    FunctionObject* m_throw_type_error_function { nullptr };
+
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* m_##snake_name##_constructor { nullptr };                           \
     Object* m_##snake_name##_prototype { nullptr };
@@ -111,9 +115,6 @@ private:
     Object* m_##snake_name##_prototype { nullptr };
     JS_ENUMERATE_ITERATOR_PROTOTYPES
 #undef __JS_ENUMERATE
-
-    FunctionObject* m_eval_function;
-    FunctionObject* m_throw_type_error_function;
 };
 
 template<typename ConstructorType>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -383,7 +383,7 @@ Optional<ISODateTime> parse_iso_date_time(GlobalObject& global_object, [[maybe_u
     // 5. Set year to ! ToIntegerOrInfinity(year).
     i32 year = Value(js_string(vm, normalized_year)).to_integer_or_infinity(global_object);
 
-    i32 month;
+    u8 month;
     // 6. If month is undefined, then
     if (!month_part.has_value()) {
         // a. Set month to 1.
@@ -392,10 +392,10 @@ Optional<ISODateTime> parse_iso_date_time(GlobalObject& global_object, [[maybe_u
     // 7. Else,
     else {
         // a. Set month to ! ToIntegerOrInfinity(month).
-        month = Value(js_string(vm, *month_part)).to_integer_or_infinity(global_object);
+        month = *month_part->to_uint<u8>();
     }
 
-    i32 day;
+    u8 day;
     // 8. If day is undefined, then
     if (!day_part.has_value()) {
         // a. Set day to 1.
@@ -404,17 +404,17 @@ Optional<ISODateTime> parse_iso_date_time(GlobalObject& global_object, [[maybe_u
     // 9. Else,
     else {
         // a. Set day to ! ToIntegerOrInfinity(day).
-        day = Value(js_string(vm, *day_part)).to_integer_or_infinity(global_object);
+        day = *day_part->to_uint<u8>();
     }
 
     // 10. Set hour to ! ToIntegerOrInfinity(hour).
-    i32 hour = Value(js_string(vm, hour_part.value_or(""sv))).to_integer_or_infinity(global_object);
+    u8 hour = hour_part->to_uint<u8>().value_or(0);
 
     // 11. Set minute to ! ToIntegerOrInfinity(minute).
-    i32 minute = Value(js_string(vm, minute_part.value_or(""sv))).to_integer_or_infinity(global_object);
+    u8 minute = minute_part->to_uint<u8>().value_or(0);
 
     // 12. Set second to ! ToIntegerOrInfinity(second).
-    i32 second = Value(js_string(vm, second_part.value_or(""sv))).to_integer_or_infinity(global_object);
+    u8 second = second_part->to_uint<u8>().value_or(0);
 
     // 13. If second is 60, then
     if (second == 60) {
@@ -422,22 +422,22 @@ Optional<ISODateTime> parse_iso_date_time(GlobalObject& global_object, [[maybe_u
         second = 59;
     }
 
-    i32 millisecond;
-    i32 microsecond;
-    i32 nanosecond;
+    u16 millisecond;
+    u16 microsecond;
+    u16 nanosecond;
     // 14. If fraction is not undefined, then
     if (fraction_part.has_value()) {
         // a. Set fraction to the string-concatenation of the previous value of fraction and the string "000000000".
         auto fraction = String::formatted("{}000000000", *fraction_part);
         // b. Let millisecond be the String value equal to the substring of fraction from 0 to 3.
         // c. Set millisecond to ! ToIntegerOrInfinity(millisecond).
-        millisecond = Value(js_string(vm, fraction.substring(0, 3))).to_integer_or_infinity(global_object);
+        millisecond = *fraction.substring(0, 3).to_uint<u16>();
         // d. Let microsecond be the String value equal to the substring of fraction from 3 to 6.
         // e. Set microsecond to ! ToIntegerOrInfinity(microsecond).
-        microsecond = Value(js_string(vm, fraction.substring(3, 3))).to_integer_or_infinity(global_object);
+        microsecond = *fraction.substring(3, 3).to_uint<u16>();
         // f. Let nanosecond be the String value equal to the substring of fraction from 6 to 9.
         // g. Set nanosecond to ! ToIntegerOrInfinity(nanosecond).
-        nanosecond = Value(js_string(vm, fraction.substring(6, 3))).to_integer_or_infinity(global_object);
+        nanosecond = *fraction.substring(6, 3).to_uint<u16>();
     }
     // 15. Else,
     else {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -22,17 +22,18 @@ enum class OptionType {
 
 struct ISODateTime {
     i32 year;
-    i32 month;
-    i32 day;
-    i32 hour;
-    i32 minute;
-    i32 second;
-    i32 millisecond;
-    i32 microsecond;
-    i32 nanosecond;
-    Optional<String> calendar;
+    u8 month;
+    u8 day;
+    u8 hour;
+    u8 minute;
+    u8 second;
+    u16 millisecond;
+    u16 microsecond;
+    u16 nanosecond;
+    Optional<String> calendar = {};
 };
 
+// FIXME: Use more narrow types for most of these (u8/u16)
 struct TemporalInstant {
     i32 year;
     i32 month;
@@ -46,6 +47,7 @@ struct TemporalInstant {
     Optional<String> time_zone_offset;
 };
 
+// FIXME: Use more narrow type for month/day (u8)
 struct TemporalDate {
     i32 year;
     i32 month;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -292,11 +292,12 @@ Object* to_temporal_calendar(GlobalObject& global_object, Value temporal_calenda
     if (temporal_calendar_like.is_object()) {
         auto& temporal_calendar_like_object = temporal_calendar_like.as_object();
         // a. If temporalCalendarLike has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
-        // TODO: The rest of the Temporal built-ins
-        if (is<PlainDate>(temporal_calendar_like_object)) {
-            // i. Return temporalCalendarLike.[[Calendar]].
+        // i. Return temporalCalendarLike.[[Calendar]].
+        if (is<PlainDate>(temporal_calendar_like_object))
             return &static_cast<PlainDate&>(temporal_calendar_like_object).calendar();
-        }
+        if (is<PlainDateTime>(temporal_calendar_like_object))
+            return &static_cast<PlainDateTime&>(temporal_calendar_like_object).calendar();
+        // TODO: The rest of the Temporal built-ins (PlainMonthDay, PlainTime, PlainYearMonth, ZonedDateTime)
 
         // b. If ? HasProperty(temporalCalendarLike, "calendar") is false, return temporalCalendarLike.
         auto has_property = temporal_calendar_like_object.has_property(vm.names.calendar);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -356,11 +356,12 @@ Object* get_temporal_calendar_with_iso_default(GlobalObject& global_object, Obje
     auto& vm = global_object.vm();
 
     // 1. If item has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
-    // TODO: The rest of the Temporal built-ins
-    if (is<PlainDate>(item)) {
-        // a. Return item.[[Calendar]].
+    // a. Return item.[[Calendar]].
+    if (is<PlainDate>(item))
         return &static_cast<PlainDate&>(item).calendar();
-    }
+    if (is<PlainDateTime>(item))
+        return &static_cast<PlainDateTime&>(item).calendar();
+    // TODO: The rest of the Temporal built-ins (PlainMonthDay, PlainTime, PlainYearMonth, ZonedDateTime)
 
     // 2. Let calendar be ? Get(item, "calendar").
     auto calendar = item.get(vm.names.calendar);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -92,6 +92,15 @@ TimeZone* create_temporal_time_zone(GlobalObject& global_object, String const& i
     return object;
 }
 
+// 11.6.5 GetIANATimeZoneOffsetNanoseconds ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezoneoffsetnanoseconds
+i64 get_iana_time_zone_offset_nanoseconds([[maybe_unused]] BigInt const& epoch_nanoseconds, [[maybe_unused]] String const& time_zone_identifier)
+{
+    // The abstract operation GetIANATimeZoneOffsetNanoseconds is an implementation-defined algorithm that returns an integer representing the offset of the IANA time zone identified by timeZoneIdentifier from UTC, at the instant corresponding to epochNanoseconds.
+    // Given the same values of epochNanoseconds and timeZoneIdentifier, the result must be the same for the lifetime of the surrounding agent.
+    // TODO: Implement this
+    return 0;
+}
+
 // https://tc39.es/proposal-temporal/#prod-TimeZoneNumericUTCOffset
 static bool parse_time_zone_numeric_utc_offset_syntax(String const& offset_string, StringView& sign, StringView& hours, Optional<StringView>& minutes, Optional<StringView>& seconds, Optional<StringView>& fraction)
 {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -39,6 +39,7 @@ bool is_valid_time_zone_name(String const& time_zone);
 String canonicalize_time_zone_name(String const& time_zone);
 String default_time_zone();
 TimeZone* create_temporal_time_zone(GlobalObject&, String const& identifier, FunctionObject* new_target = nullptr);
+i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, String const& time_zone_identifier);
 double parse_time_zone_offset_string(GlobalObject&, String const&);
 String format_time_zone_offset_string(double offset_nanoseconds);
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(id_getter);
+    JS_DECLARE_NATIVE_FUNCTION(get_offset_nanoseconds_for);
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(to_json);
 };

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getOffsetNanosecondsFor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getOffsetNanosecondsFor.js
@@ -1,0 +1,25 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Temporal.TimeZone.prototype.getOffsetNanosecondsFor).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        const timeZone = new Temporal.TimeZone("UTC");
+        const instant = new Temporal.Instant(0n);
+        expect(timeZone.getOffsetNanosecondsFor(instant)).toBe(0);
+    });
+
+    test("custom offset", () => {
+        const timeZone = new Temporal.TimeZone("+01:30");
+        const instant = new Temporal.Instant(0n);
+        expect(timeZone.getOffsetNanosecondsFor(instant)).toBe(5400000000000);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.TimeZone object", () => {
+        expect(() => {
+            Temporal.TimeZone.prototype.getOffsetNanosecondsFor.call("foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.TimeZone");
+    });
+});


### PR DESCRIPTION
This was initially just a part of implementing `Temporal.Now.plainDate()`, but that turned out to be a *massive* yakstack, so I'm separating it.