### PR TITLE
NotificationServer: Expand the notification when hovered + friends

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -171,7 +171,7 @@ void AbstractButton::keyup_event(KeyEvent& event)
     Widget::keyup_event(event);
 }
 
-void AbstractButton::paint_text(Painter& painter, const Gfx::IntRect& rect, const Gfx::Font& font, Gfx::TextAlignment text_alignment)
+void AbstractButton::paint_text(Painter& painter, const Gfx::IntRect& rect, const Gfx::Font& font, Gfx::TextAlignment text_alignment, Gfx::TextWrapping text_wrapping)
 {
     auto clipped_rect = rect.intersected(this->rect());
 
@@ -183,7 +183,7 @@ void AbstractButton::paint_text(Painter& painter, const Gfx::IntRect& rect, cons
 
     if (text().is_empty())
         return;
-    painter.draw_text(clipped_rect, text(), font, text_alignment, palette().color(foreground_role()), Gfx::TextElision::Right);
+    painter.draw_text(clipped_rect, text(), font, text_alignment, palette().color(foreground_role()), Gfx::TextElision::Right, text_wrapping);
 }
 
 void AbstractButton::change_event(Event& event)

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGUI/Widget.h>
+#include <LibGfx/TextWrapping.h>
 
 namespace GUI {
 
@@ -51,7 +52,7 @@ protected:
     virtual void leave_event(Core::Event&) override;
     virtual void change_event(Event&) override;
 
-    void paint_text(Painter&, const Gfx::IntRect&, const Gfx::Font&, Gfx::TextAlignment);
+    void paint_text(Painter&, const Gfx::IntRect&, const Gfx::Font&, Gfx::TextAlignment, Gfx::TextWrapping);
 
 private:
     String m_text;

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -68,11 +68,11 @@ Application* Application::the()
     return *s_the;
 }
 
-Application::Application(int argc, char** argv)
+Application::Application(int argc, char** argv, Core::EventLoop::MakeInspectable make_inspectable)
 {
     VERIFY(!*s_the);
     *s_the = *this;
-    m_event_loop = make<Core::EventLoop>();
+    m_event_loop = make<Core::EventLoop>(make_inspectable);
     WindowServerConnection::the();
     Clipboard::initialize({});
     if (argc > 0)

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -10,6 +10,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
+#include <LibCore/EventLoop.h>
 #include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Shortcut.h>
@@ -79,7 +80,7 @@ public:
     Function<void(Action&)> on_action_leave;
 
 private:
-    Application(int argc, char** argv);
+    Application(int argc, char** argv, Core::EventLoop::MakeInspectable = Core::EventLoop::MakeInspectable::No);
 
     virtual void event(Core::Event&) override;
 

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -85,7 +85,7 @@ void Button::paint_event(PaintEvent& event)
     if (text_rect.width() > content_rect.width())
         text_rect.set_width(content_rect.width());
     text_rect.align_within(content_rect, text_alignment());
-    paint_text(painter, text_rect, font, text_alignment());
+    paint_text(painter, text_rect, font, text_alignment(), Gfx::TextWrapping::DontWrap);
 
     if (is_focused()) {
         Gfx::IntRect focus_rect;

--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -56,7 +56,7 @@ void CheckBox::paint_event(PaintEvent& event)
 
     Gfx::StylePainter::paint_check_box(painter, box_rect, palette(), is_enabled(), is_checked(), is_being_pressed());
 
-    paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft);
+    paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft, Gfx::TextWrapping::DontWrap);
 
     if (is_focused())
         painter.draw_focus_rect(text_rect.inflated(6, 6), palette().focus_outline());

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Utf8View.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
+#include <LibGfx/TextLayout.h>
 
 REGISTER_WIDGET(GUI, Label)
 
@@ -27,7 +29,6 @@ Label::Label(String text)
 
     REGISTER_STRING_PROPERTY("text", text, set_text);
     REGISTER_BOOL_PROPERTY("autosize", is_autosize, set_autosize);
-    REGISTER_BOOL_PROPERTY("word_wrap", is_word_wrap, set_word_wrap);
 }
 
 Label::~Label()
@@ -43,15 +44,6 @@ void Label::set_autosize(bool autosize)
         size_to_fit();
 }
 
-void Label::set_word_wrap(bool wrap)
-{
-    if (m_word_wrap == wrap)
-        return;
-    m_word_wrap = wrap;
-    if (is_word_wrap())
-        wrap_text();
-}
-
 void Label::set_icon(const Gfx::Bitmap* icon)
 {
     if (m_icon == icon)
@@ -65,21 +57,19 @@ void Label::set_text(String text)
     if (text == m_text)
         return;
     m_text = move(text);
-    if (is_word_wrap())
-        wrap_text();
+
     if (m_autosize)
         size_to_fit();
     update();
     did_change_text();
 }
 
-Gfx::IntRect Label::text_rect(size_t line) const
+Gfx::IntRect Label::text_rect() const
 {
     int indent = 0;
     if (frame_thickness() > 0)
         indent = font().glyph_width('x') / 2;
     auto rect = frame_inner_rect();
-    rect.translate_by(indent, line * (font().glyph_height() + 1));
     rect.set_width(rect.width() - indent * 2);
     return rect;
 }
@@ -103,26 +93,12 @@ void Label::paint_event(PaintEvent& event)
     if (text().is_empty())
         return;
 
-    if (is_word_wrap()) {
-        wrap_text();
-        for (size_t i = 0; i < m_lines.size(); i++) {
-            auto& line = m_lines[i];
-            auto text_rect = this->text_rect(i);
-            if (is_enabled()) {
-                painter.draw_text(text_rect, line, m_text_alignment, palette().color(foreground_role()), Gfx::TextElision::None);
-            } else {
-                painter.draw_text(text_rect.translated(1, 1), line, font(), text_alignment(), Color::White, Gfx::TextElision::Right);
-                painter.draw_text(text_rect, line, font(), text_alignment(), Color::from_rgb(0x808080), Gfx::TextElision::Right);
-            }
-        }
+    auto text_rect = this->text_rect();
+    if (is_enabled()) {
+        painter.draw_text(text_rect, text(), m_text_alignment, palette().color(foreground_role()), Gfx::TextElision::Right);
     } else {
-        auto text_rect = this->text_rect();
-        if (is_enabled()) {
-            painter.draw_text(text_rect, text(), m_text_alignment, palette().color(foreground_role()), Gfx::TextElision::Right);
-        } else {
-            painter.draw_text(text_rect.translated(1, 1), text(), font(), text_alignment(), Color::White, Gfx::TextElision::Right);
-            painter.draw_text(text_rect, text(), font(), text_alignment(), Color::from_rgb(0x808080), Gfx::TextElision::Right);
-        }
+        painter.draw_text(text_rect.translated(1, 1), text(), font(), text_alignment(), Color::White, Gfx::TextElision::Right);
+        painter.draw_text(text_rect, text(), font(), text_alignment(), Color::from_rgb(0x808080), Gfx::TextElision::Right);
     }
 }
 
@@ -131,58 +107,11 @@ void Label::size_to_fit()
     set_fixed_width(font().width(m_text));
 }
 
-void Label::wrap_text()
+int Label::preferred_height() const
 {
-    Vector<String> words;
-    Optional<size_t> start;
-    for (size_t i = 0; i < m_text.length(); i++) {
-        switch (m_text[i]) {
-        case '\n':
-        case '\r':
-        case '\t':
-        case ' ': {
-            if (start.has_value())
-                words.append(m_text.substring(start.value(), i - start.value()));
-            start.clear();
-            continue;
-        }
-        default: {
-            if (!start.has_value())
-                start = i;
-        }
-        }
-    }
-
-    if (start.has_value())
-        words.append(m_text.substring(start.value(), m_text.length() - start.value()));
-
-    auto rect = frame_inner_rect();
-    if (frame_thickness() > 0)
-        rect.set_width(rect.width() - font().glyph_width('x'));
-
-    Vector<String> lines;
-    StringBuilder builder;
-    int line_width = 0;
-    for (auto& word : words) {
-        int word_width = font().width(word);
-        if (line_width > 0)
-            word_width += font().glyph_width('x');
-        if (line_width + word_width > rect.width()) {
-            lines.append(builder.to_string());
-            builder.clear();
-            line_width = 0;
-        }
-        if (line_width > 0)
-            builder.append(' ');
-        builder.append(word);
-        line_width += word_width;
-    }
-
-    auto last_line = builder.to_string();
-    if (!last_line.is_empty())
-        lines.append(last_line);
-
-    m_lines = lines;
+    // FIXME: The 4 is taken from Gfx::Painter and should be available as
+    //        a constant instead.
+    return Gfx::TextLayout(&font(), Utf8View { m_text }, text_rect()).bounding_rect(Gfx::TextWrapping::Wrap, 4).height();
 }
 
 }

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -33,10 +33,9 @@ public:
     bool is_autosize() const { return m_autosize; }
     void set_autosize(bool);
 
-    bool is_word_wrap() const { return m_word_wrap; }
-    void set_word_wrap(bool);
+    int preferred_height() const;
 
-    Gfx::IntRect text_rect(size_t line = 0) const;
+    Gfx::IntRect text_rect() const;
 
 protected:
     explicit Label(String text = {});
@@ -46,15 +45,12 @@ protected:
 
 private:
     void size_to_fit();
-    void wrap_text();
 
     String m_text;
     RefPtr<Gfx::Bitmap> m_icon;
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::Center };
     bool m_should_stretch_icon { false };
     bool m_autosize { false };
-    bool m_word_wrap { false };
-    Vector<String> m_lines;
 };
 
 }

--- a/Userland/Libraries/LibGUI/RadioButton.cpp
+++ b/Userland/Libraries/LibGUI/RadioButton.cpp
@@ -50,7 +50,7 @@ void RadioButton::paint_event(PaintEvent& event)
 
     Gfx::IntRect text_rect { circle_rect.right() + 7, 0, font().width(text()), font().glyph_height() };
     text_rect.center_vertically_within(rect());
-    paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft);
+    paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft, Gfx::TextWrapping::DontWrap);
 
     if (is_focused())
         painter.draw_focus_rect(text_rect.inflated(6, 6), palette().focus_outline());

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -523,8 +523,9 @@ void Widget::focusout_event(FocusEvent&)
 {
 }
 
-void Widget::enter_event(Core::Event&)
+void Widget::enter_event(Core::Event& event)
 {
+    event.ignore();
 }
 
 void Widget::leave_event(Core::Event&)

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1138,4 +1138,20 @@ bool Widget::is_visible_for_timer_purposes() const
     return is_visible() && Object::is_visible_for_timer_purposes();
 }
 
+bool Widget::is_parent_of(Widget const* widget) const
+{
+    if (widget == nullptr)
+        return false;
+
+    Widget const* current_widget = widget->parent_widget();
+
+    while (current_widget != nullptr) {
+        if (current_widget == this)
+            return true;
+        current_widget = current_widget->parent_widget();
+    }
+
+    return false;
+}
+
 }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -280,6 +280,8 @@ public:
 
     bool has_pending_drop() const;
 
+    bool is_parent_of(Widget const*) const;
+
 protected:
     Widget();
 

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -572,10 +572,24 @@ void Window::handle_drag_move_event(DragEvent& event)
     }
 }
 
-void Window::handle_left_event()
+void Window::enter_event(Core::Event&)
+{
+}
+
+void Window::leave_event(Core::Event&)
+{
+}
+
+void Window::handle_entered_event(Core::Event& event)
+{
+    enter_event(event);
+}
+
+void Window::handle_left_event(Core::Event& event)
 {
     set_hovered_widget(nullptr);
     Application::the()->set_drag_hovered_widget({}, nullptr);
+    leave_event(event);
 }
 
 void Window::event(Core::Event& event)
@@ -605,8 +619,11 @@ void Window::event(Core::Event& event)
     if (event.type() == Event::WindowCloseRequest)
         return handle_close_request();
 
+    if (event.type() == Event::WindowEntered)
+        return handle_entered_event(event);
+
     if (event.type() == Event::WindowLeft)
-        return handle_left_event();
+        return handle_left_event(event);
 
     if (event.type() == Event::Resize)
         return handle_resize_event(static_cast<ResizeEvent&>(event));

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -802,7 +802,7 @@ void Window::set_hovered_widget(Widget* widget)
     if (widget == m_hovered_widget)
         return;
 
-    if (m_hovered_widget)
+    if (m_hovered_widget && !m_hovered_widget->is_parent_of(widget))
         Core::EventLoop::current().post_event(*m_hovered_widget, make<Event>(Event::Leave));
 
     m_hovered_widget = widget;

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -208,6 +208,9 @@ protected:
     virtual void wm_event(WMEvent&);
     virtual void screen_rects_change_event(ScreenRectsChangeEvent&);
 
+    virtual void enter_event(Core::Event&);
+    virtual void leave_event(Core::Event&);
+
 private:
     void update_cursor();
     void focus_a_widget_if_possible(FocusSource);
@@ -224,7 +227,8 @@ private:
     void handle_fonts_change_event(FontsChangeEvent&);
     void handle_screen_rects_change_event(ScreenRectsChangeEvent&);
     void handle_drag_move_event(DragEvent&);
-    void handle_left_event();
+    void handle_entered_event(Core::Event&);
+    void handle_left_event(Core::Event&);
 
     void server_did_destroy();
 

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     StylePainter.cpp
     SystemTheme.cpp
     TextDirection.cpp
+    TextLayout.cpp
     Triangle.cpp
     Typeface.cpp
     WindowTheme.cpp

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -15,7 +15,9 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/TextAlignment.h>
+#include <LibGfx/TextDirection.h>
 #include <LibGfx/TextElision.h>
+#include <LibGfx/TextWrapping.h>
 
 namespace Gfx {
 
@@ -60,13 +62,13 @@ public:
     void blit_offset(const IntPoint&, const Gfx::Bitmap&, const IntRect& src_rect, const IntPoint&);
     void blit_disabled(const IntPoint&, const Gfx::Bitmap&, const IntRect&, const Palette&);
     void blit_tiled(const IntRect&, const Gfx::Bitmap&, const IntRect& src_rect);
-    void draw_text(const IntRect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
-    void draw_text(const IntRect&, const StringView&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
-    void draw_text(const IntRect&, const Utf32View&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
-    void draw_text(const IntRect&, const Utf32View&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
-    void draw_text(Function<void(const IntRect&, u32)>, const IntRect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None);
-    void draw_text(Function<void(const IntRect&, u32)>, const IntRect&, const Utf8View&, const Font&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None);
-    void draw_text(Function<void(const IntRect&, u32)>, const IntRect&, const Utf32View&, const Font&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None);
+    void draw_text(const IntRect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
+    void draw_text(const IntRect&, const StringView&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
+    void draw_text(const IntRect&, const Utf32View&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
+    void draw_text(const IntRect&, const Utf32View&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
+    void draw_text(Function<void(const IntRect&, u32)>, const IntRect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
+    void draw_text(Function<void(const IntRect&, u32)>, const IntRect&, const Utf8View&, const Font&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
+    void draw_text(Function<void(const IntRect&, u32)>, const IntRect&, const Utf32View&, const Font&, TextAlignment = TextAlignment::TopLeft, TextElision = TextElision::None, TextWrapping = TextWrapping::Wrap);
     void draw_ui_text(const Gfx::IntRect&, const StringView&, const Gfx::Font&, TextAlignment, Gfx::Color);
     void draw_glyph(const IntPoint&, u32, Color);
     void draw_glyph(const IntPoint&, u32, const Font&, Color);
@@ -151,6 +153,12 @@ protected:
     IntRect m_clip_origin;
     NonnullRefPtr<Gfx::Bitmap> m_target;
     Vector<State, 4> m_state_stack;
+
+private:
+    Vector<DirectionalRun> split_text_into_directional_runs(Utf8View const&, TextDirection initial_direction);
+    bool text_contains_bidirectional_text(Utf8View const&, TextDirection);
+    template<typename DrawGlyphFunction>
+    void do_draw_text(IntRect const&, Utf8View const& text, Font const&, TextAlignment, TextElision, TextWrapping, DrawGlyphFunction);
 };
 
 class PainterStateSaver {

--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TextLayout.h"
+
+namespace Gfx {
+
+// HACK: We need to point to some valid memory with Utf8Views.
+char const s_the_newline[] = "\n";
+
+IntRect TextLayout::bounding_rect(TextWrapping wrapping, int line_spacing) const
+{
+    auto lines = wrap_lines(TextElision::None, wrapping, line_spacing, FitWithinRect::No);
+    if (!lines.size()) {
+        return {};
+    }
+
+    IntRect bounding_rect = {
+        0, 0, 0, static_cast<int>((lines.size() * (m_font->glyph_height() + line_spacing)) - line_spacing)
+    };
+
+    for (auto& line : lines) {
+        auto line_width = m_font->width(line);
+        if (line_width > bounding_rect.width())
+            bounding_rect.set_width(line_width);
+    }
+
+    return bounding_rect;
+}
+
+Vector<String, 32> TextLayout::wrap_lines(TextElision elision, TextWrapping wrapping, int line_spacing, FitWithinRect fit_within_rect) const
+{
+    Vector<Utf8View> words;
+
+    Optional<size_t> start_byte_offset;
+    size_t current_byte_offset = 0;
+    for (auto it = m_text.begin(); !it.done(); ++it) {
+        current_byte_offset = m_text.iterator_offset(it);
+
+        switch (*it) {
+        case '\n':
+        case '\r':
+        case '\t':
+        case ' ': {
+            if (start_byte_offset.has_value())
+                words.append(m_text.substring_view(start_byte_offset.value(), current_byte_offset - start_byte_offset.value()));
+            start_byte_offset.clear();
+
+            if (*it == '\n') {
+                words.append(Utf8View { s_the_newline });
+            }
+
+            continue;
+        }
+        default: {
+            if (!start_byte_offset.has_value())
+                start_byte_offset = current_byte_offset;
+        }
+        }
+    }
+
+    if (start_byte_offset.has_value())
+        words.append(m_text.substring_view(start_byte_offset.value(), m_text.byte_length() - start_byte_offset.value()));
+
+    size_t max_lines_that_can_fit = 0;
+    if (m_rect.height() >= m_font->glyph_height()) {
+        // NOTE: If glyph height is 10 and line spacing is 1, we can fit a
+        // single line into a 10px rect and a 20px rect, but 2 lines into a
+        // 21px rect.
+        max_lines_that_can_fit = 1 + (m_rect.height() - m_font->glyph_height()) / (m_font->glyph_height() + line_spacing);
+    }
+
+    if (max_lines_that_can_fit == 0)
+        return {};
+
+    Vector<String> lines;
+    StringBuilder builder;
+    size_t line_width = 0;
+    bool did_not_finish = false;
+    for (auto& word : words) {
+
+        if (word.as_string() == s_the_newline) {
+            lines.append(builder.to_string());
+            builder.clear();
+            line_width = 0;
+
+            if (lines.size() == max_lines_that_can_fit && fit_within_rect == FitWithinRect::Yes) {
+                did_not_finish = true;
+                break;
+            }
+        } else {
+            size_t word_width = font().width(word);
+
+            if (line_width > 0) {
+                word_width += font().glyph_width('x');
+
+                if (wrapping == TextWrapping::Wrap && line_width + word_width > static_cast<unsigned>(m_rect.width())) {
+                    lines.append(builder.to_string());
+                    builder.clear();
+                    line_width = 0;
+
+                    if (lines.size() == max_lines_that_can_fit && fit_within_rect == FitWithinRect::Yes) {
+                        did_not_finish = true;
+                        break;
+                    }
+                }
+
+                builder.append(' ');
+            }
+            if (lines.size() == max_lines_that_can_fit && fit_within_rect == FitWithinRect::Yes) {
+                did_not_finish = true;
+                break;
+            }
+
+            builder.append(word.as_string());
+            line_width += word_width;
+        }
+    }
+
+    if (!did_not_finish) {
+        auto last_line = builder.to_string();
+        if (!last_line.is_empty())
+            lines.append(last_line);
+    }
+
+    switch (elision) {
+    case TextElision::None:
+        break;
+    case TextElision::Right: {
+        lines.at(lines.size() - 1) = elide_text_from_right(Utf8View { lines.at(lines.size() - 1) }, did_not_finish);
+        break;
+    }
+    }
+
+    return lines;
+}
+
+String TextLayout::elide_text_from_right(Utf8View text, bool force_elision) const
+{
+    size_t text_width = m_font->width(text);
+    if (force_elision || text_width > static_cast<unsigned>(m_rect.width())) {
+        size_t ellipsis_width = m_font->width("...");
+        size_t current_width = ellipsis_width;
+        size_t glyph_spacing = m_font->glyph_spacing();
+
+        // FIXME: This code will break when the font has glyphs with advance
+        //        amounts different from the actual width of the glyph
+        //        (which is the case with many TrueType fonts).
+        if (ellipsis_width < text_width) {
+            size_t offset = 0;
+            for (auto it = text.begin(); !it.done(); ++it) {
+                auto code_point = *it;
+                int glyph_width = m_font->glyph_or_emoji_width(code_point);
+                // NOTE: Glyph spacing should not be added after the last glyph on the line,
+                //       but since we are here because the last glyph does not actually fit on the line,
+                //       we don't have to worry about spacing.
+                int width_with_this_glyph_included = current_width + glyph_width + glyph_spacing;
+                if (width_with_this_glyph_included > m_rect.width())
+                    break;
+                current_width += glyph_width + glyph_spacing;
+                offset = text.iterator_offset(it);
+            }
+
+            StringBuilder builder;
+            builder.append(text.substring_view(0, offset).as_string());
+            builder.append("...");
+            return builder.to_string();
+        }
+    }
+
+    return text.as_string();
+}
+
+}

--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "AK/Forward.h"
+#include "LibGfx/Forward.h"
+#include <AK/String.h>
+#include <AK/Utf32View.h>
+#include <AK/Utf8View.h>
+#include <AK/Vector.h>
+#include <LibGfx/Font.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/TextElision.h>
+#include <LibGfx/TextWrapping.h>
+
+namespace Gfx {
+
+enum class FitWithinRect {
+    Yes,
+    No
+};
+
+// FIXME: This currently isn't an ideal way of doing things; ideally, TextLayout
+// would be doing the rendering by painting individual glyphs. However, this
+// would regress our Unicode bidirectional text support. Therefore, fixing this
+// requires:
+// - Moving the bidirectional algorithm either here, or some place TextLayout
+//   can access;
+// - Making TextLayout render the given text into something like a Vector<Line>
+//   where:
+//   using Line = Vector<DirectionalRun>;
+//   struct DirectionalRun {
+//       Utf32View glyphs;
+//       Vector<int> advance;
+//       TextDirection direction;
+//   };
+// - Either;
+//   a) Making TextLayout output these Lines directly using a given Painter, or
+//   b) Taking the Lines from TextLayout and painting each glyph.
+class TextLayout {
+public:
+    TextLayout(Gfx::Font const* font, Utf8View const& text, IntRect const& rect)
+        : m_font(font)
+        , m_text(text)
+        , m_rect(rect)
+    {
+    }
+
+    Font const& font() const { return *m_font; }
+    void set_font(Font const* font) { m_font = font; }
+
+    Utf8View const& text() const { return m_text; }
+    void set_text(Utf8View const& text) { m_text = text; }
+
+    IntRect const& rect() const { return m_rect; }
+    void set_rect(IntRect const& rect) { m_rect = rect; }
+
+    Vector<String, 32> lines(TextElision elision, TextWrapping wrapping, int line_spacing) const
+    {
+        return wrap_lines(elision, wrapping, line_spacing, FitWithinRect::Yes);
+    }
+
+    IntRect bounding_rect(TextWrapping wrapping, int line_spacing) const;
+
+private:
+    Vector<String, 32> wrap_lines(TextElision, TextWrapping, int line_spacing, FitWithinRect) const;
+    String elide_text_from_right(Utf8View, bool force_elision) const;
+
+    Font const* m_font;
+    Utf8View m_text;
+    IntRect m_rect;
+};
+
+}

--- a/Userland/Libraries/LibGfx/TextWrapping.h
+++ b/Userland/Libraries/LibGfx/TextWrapping.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx {
+
+enum class TextWrapping {
+    Wrap,
+    DontWrap,
+};
+
+}

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -66,8 +66,8 @@ NotificationWindow::NotificationWindow(i32 client_id, const String& text, const 
     m_original_rect = rect;
 
     auto& widget = set_main_widget<GUI::Widget>();
-    widget.set_fill_with_background_color(true);
 
+    widget.set_fill_with_background_color(true);
     widget.set_layout<GUI::HorizontalBoxLayout>();
     widget.layout()->set_margins({ 8, 8, 8, 8 });
     widget.layout()->set_spacing(6);
@@ -87,13 +87,10 @@ NotificationWindow::NotificationWindow(i32 client_id, const String& text, const 
     m_text_label = &left_container.add<GUI::Label>(text);
     m_text_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    widget.set_tooltip(text);
-    m_title_label->set_tooltip(text);
-    m_text_label->set_tooltip(text);
-
-    auto& right_container = widget.add<GUI::Widget>();
-    right_container.set_fixed_width(36);
-    right_container.set_layout<GUI::HorizontalBoxLayout>();
+    // FIXME: There used to be code for setting the tooltip here, but since we
+    // expand the notification now we no longer set the tooltip. Should there be
+    // a limit to the lines shown in an expanded notification, at which point a
+    // tooltip should be set?
 
     on_close = [this] {
         s_windows.remove(m_id);
@@ -111,22 +108,54 @@ RefPtr<NotificationWindow> NotificationWindow::get_window_by_id(i32 id)
     return window.value_or(nullptr);
 }
 
-void NotificationWindow::set_text(const String& value)
+void NotificationWindow::resize_to_fit_text()
 {
-    m_text_label->set_text(value);
+    auto line_height = m_text_label->font().glyph_height();
+    auto total_height = m_text_label->preferred_height();
+
+    m_text_label->set_fixed_height(total_height);
+    set_height(40 - line_height + total_height);
 }
 
-void NotificationWindow::set_title(const String& value)
+void NotificationWindow::enter_event(Core::Event&)
+{
+    m_hovering = true;
+    resize_to_fit_text();
+    move_to_front();
+}
+
+void NotificationWindow::leave_event(Core::Event&)
+{
+    m_hovering = false;
+    m_text_label->set_fixed_height(-1);
+    set_height(40);
+}
+
+void NotificationWindow::set_text(String const& value)
+{
+    m_text_label->set_text(value);
+    if (m_hovering)
+        resize_to_fit_text();
+}
+
+void NotificationWindow::set_title(String const& value)
 {
     m_title_label->set_text(value);
 }
 
-void NotificationWindow::set_image(const Gfx::ShareableBitmap& image)
+void NotificationWindow::set_image(Gfx::ShareableBitmap const& image)
 {
     m_image->set_visible(image.is_valid());
     if (image.is_valid()) {
         m_image->set_bitmap(image.bitmap());
     }
+}
+
+void NotificationWindow::set_height(int height)
+{
+    auto rect = this->rect();
+    rect.set_height(height);
+    set_rect(rect);
 }
 
 void NotificationWindow::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -24,10 +24,17 @@ public:
 
     static RefPtr<NotificationWindow> get_window_by_id(i32 id);
 
+protected:
+    virtual void enter_event(Core::Event&) override;
+    virtual void leave_event(Core::Event&) override;
+
 private:
     NotificationWindow(i32 client_id, const String& text, const String& title, const Gfx::ShareableBitmap&);
 
     virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
+
+    void resize_to_fit_text();
+    void set_height(int);
 
     Gfx::IntRect m_original_rect;
     i32 m_id;
@@ -35,6 +42,7 @@ private:
     GUI::Label* m_text_label;
     GUI::Label* m_title_label;
     GUI::ImageWidget* m_image;
+    bool m_hovering { false };
 };
 
 }

--- a/Userland/Services/Taskbar/TaskbarButton.cpp
+++ b/Userland/Services/Taskbar/TaskbarButton.cpp
@@ -71,8 +71,8 @@ static void paint_custom_progressbar(GUI::Painter& painter, const Gfx::IntRect& 
         painter.fill_rect_with_gradient(rect, start_color, end_color);
 
         if (!text.is_null()) {
-            painter.draw_text(text_rect.translated(1, 1), text, font, text_alignment, palette.base_text(), Gfx::TextElision::Right);
-            painter.draw_text(text_rect, text, font, text_alignment, palette.base_text().inverted(), Gfx::TextElision::Right);
+            painter.draw_text(text_rect.translated(1, 1), text, font, text_alignment, palette.base_text(), Gfx::TextElision::Right, Gfx::TextWrapping::DontWrap);
+            painter.draw_text(text_rect, text, font, text_alignment, palette.base_text().inverted(), Gfx::TextElision::Right, Gfx::TextWrapping::DontWrap);
         }
     }
 
@@ -82,7 +82,7 @@ static void paint_custom_progressbar(GUI::Painter& painter, const Gfx::IntRect& 
     Gfx::PainterStateSaver saver(painter);
     painter.add_clip_rect(hole_rect);
     if (!text.is_null())
-        painter.draw_text(text_rect, text, font, text_alignment, palette.base_text(), Gfx::TextElision::Right);
+        painter.draw_text(text_rect, text, font, text_alignment, palette.base_text(), Gfx::TextElision::Right, Gfx::TextWrapping::DontWrap);
 }
 
 void TaskbarButton::paint_event(GUI::PaintEvent& event)
@@ -138,5 +138,5 @@ void TaskbarButton::paint_event(GUI::PaintEvent& event)
     }
 
     if (!window.progress().has_value())
-        paint_text(painter, text_rect, font, text_alignment());
+        paint_text(painter, text_rect, font, text_alignment(), Gfx::TextWrapping::DontWrap);
 }


### PR DESCRIPTION
**LibGUI: Let GUI applications create an inspectable EventLoop**

GUI applications automatically have `EventLoop`s created for them via
`GUI::Application`; however before this commit it was not possible to make
the appliaction event loop inspectable. This exposes a third optional
argument to `GUI::Application` which allows one to make the application
event loop inspectable.

**LibGUI: Add virtual handlers for `WindowEntered` and `WindowLeft` events**

These can be useful if an application wants to react to the cursor
entering the window at any point, rather than just on a widget.

**LibGUI: Only dispatch `Leave` if the now-hovered widget isn't a child**

Without this change, when the mouse starts hovering over a child widget,
the parent would receive a Leave event despite the parent widget not
losing mouse hover.

**LibGUI: Ignore the `Enter` event by default**

If this is not ignored by default, then one can move the mouse fast
enough to skip hovering over a parent element and hover directly over
the child, causing the parent to never receive an `Enter` event.

**Userland: Move text wrapping/elision into the new TextLayout :^)**

This class now contains all the fun bits about laying out text in a
rect. It will handle line wrapping at a certain width, cutting off lines
that don't fit the given rect, and handling text elision.
`Painter::draw_text` now internally uses this.

Future work here would be not laying out text twice (once actually
preparing the lines to be rendered and once to get the bounding box),
and possibly adding left elision if necessary.

Additionally, this commit makes the `Utf32View` versions of
`Painter::draw_text` convert to `Utf8View` internally. The intention is to
completely remove those versions, but they're kept at the moment to keep
the scope of this PR small.
    
**NotificationServer: Expand the notification when hovered**

Now, instead of showing a tooltip, the entire notification will be
shown when the user hovers over a notification. In the future, limiting
the amount of lines shown in the notification might be a good idea.