### PR TITLE
LibWeb + LibJS: Fix WindowObject functions and other things for css3test

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -253,6 +253,7 @@ namespace JS {
     P(length)                                \
     P(link)                                  \
     P(load)                                  \
+    P(localeCompare)                         \
     P(log)                                   \
     P(log1p)                                 \
     P(log2)                                  \

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -153,6 +153,7 @@ void StringPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.strike, strike, 0, attr);
     define_native_function(vm.names.sub, sub, 0, attr);
     define_native_function(vm.names.sup, sup, 0, attr);
+    define_native_function(vm.names.localeCompare, locale_compare, 1, attr);
     define_native_function(*vm.well_known_symbol_iterator(), symbol_iterator, 0, attr);
 }
 
@@ -1200,6 +1201,27 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::sub)
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::sup)
 {
     return create_html(global_object, vm.this_value(global_object), "sup", String::empty(), Value());
+}
+
+// 22.1.3.10 String.prototype.localeCompare ( that [ , reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-string.prototype.localecompare
+// NOTE: This is the minimum localeCompare implementation for engines without ECMA-402.
+JS_DEFINE_NATIVE_FUNCTION(StringPrototype::locale_compare)
+{
+    auto string = ak_string_from(vm, global_object);
+    if (!string.has_value())
+        return {};
+
+    auto that_string = vm.argument(0).to_string(global_object);
+    if (vm.exception())
+        return {};
+
+    // FIXME: Actually compare the string not just according to their bits.
+    if (string == that_string)
+        return Value(0);
+    if (string.value() < that_string)
+        return Value(-1);
+
+    return Value(1);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -69,6 +69,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(strike);
     JS_DECLARE_NATIVE_FUNCTION(sub);
     JS_DECLARE_NATIVE_FUNCTION(sup);
+    JS_DECLARE_NATIVE_FUNCTION(locale_compare);
 
     JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);
 };

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.localeCompare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.localeCompare.js
@@ -1,0 +1,39 @@
+test("basic functionality", () => {
+    expect(String.prototype.localeCompare).toHaveLength(1);
+
+    expect("".localeCompare("")).toBe(0);
+    expect("a".localeCompare("a")).toBe(0);
+    expect("6".localeCompare("6")).toBe(0);
+
+    function compareBoth(a, b) {
+        const aTob = a.localeCompare(b);
+        const bToa = b.localeCompare(a);
+
+        expect(aTob).toBe(1);
+        expect(aTob).toBe(-bToa);
+    }
+
+    compareBoth("a", "");
+    compareBoth("1", "");
+    compareBoth("a", "A");
+    compareBoth("7", "3");
+    compareBoth("0000", "0");
+
+    expect("undefined".localeCompare()).toBe(0);
+    expect("undefined".localeCompare(undefined)).toBe(0);
+
+    expect("null".localeCompare(null)).toBe(0);
+    expect("null".localeCompare(undefined)).not.toBe(0);
+    expect("null".localeCompare()).toBe(-1);
+
+    expect(() => {
+        String.prototype.localeCompare.call(undefined, undefined);
+    }).toThrowWithMessage(TypeError, "undefined cannot be converted to an object");
+});
+
+test("UTF-16", () => {
+    var s = "😀😀";
+    expect(s.localeCompare("😀😀")).toBe(0);
+    expect(s.localeCompare("\ud83d")).toBe(1);
+    expect(s.localeCompare("😀😀s")).toBe(-1);
+});

--- a/Userland/Libraries/LibWeb/Bindings/CSSStyleDeclarationWrapperCustom.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/CSSStyleDeclarationWrapperCustom.cpp
@@ -11,6 +11,13 @@
 
 namespace Web::Bindings {
 
+bool CSSStyleDeclarationWrapper::internal_has_property(JS::PropertyName const& name) const
+{
+    // FIXME: These should actually use camelCase versions of the property names!
+    auto property_id = CSS::property_id_from_string(name.to_string());
+    return property_id != CSS::PropertyID::Invalid;
+}
+
 JS::Value CSSStyleDeclarationWrapper::internal_get(const JS::PropertyName& name, JS::Value receiver) const
 {
     // FIXME: These should actually use camelCase versions of the property names!

--- a/Userland/Libraries/LibWeb/Bindings/CSSStyleDeclarationWrapperCustom.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/CSSStyleDeclarationWrapperCustom.cpp
@@ -13,13 +13,17 @@ namespace Web::Bindings {
 
 bool CSSStyleDeclarationWrapper::internal_has_property(JS::PropertyName const& name) const
 {
+    if (!name.is_string())
+        return Base::internal_has_property(name);
     // FIXME: These should actually use camelCase versions of the property names!
     auto property_id = CSS::property_id_from_string(name.to_string());
     return property_id != CSS::PropertyID::Invalid;
 }
 
-JS::Value CSSStyleDeclarationWrapper::internal_get(const JS::PropertyName& name, JS::Value receiver) const
+JS::Value CSSStyleDeclarationWrapper::internal_get(JS::PropertyName const& name, JS::Value receiver) const
 {
+    if (!name.is_string())
+        return Base::internal_get(name, receiver);
     // FIXME: These should actually use camelCase versions of the property names!
     auto property_id = CSS::property_id_from_string(name.to_string());
     if (property_id == CSS::PropertyID::Invalid)
@@ -31,8 +35,10 @@ JS::Value CSSStyleDeclarationWrapper::internal_get(const JS::PropertyName& name,
     return js_string(vm(), String::empty());
 }
 
-bool CSSStyleDeclarationWrapper::internal_set(const JS::PropertyName& name, JS::Value value, JS::Value receiver)
+bool CSSStyleDeclarationWrapper::internal_set(JS::PropertyName const& name, JS::Value value, JS::Value receiver)
 {
+    if (!name.is_string())
+        return Base::internal_set(name, value, receiver);
     // FIXME: These should actually use camelCase versions of the property names!
     auto property_id = CSS::property_id_from_string(name.to_string());
     if (property_id == CSS::PropertyID::Invalid)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.idl
@@ -1,4 +1,4 @@
-[CustomGet,CustomSet]
+[CustomGet,CustomSet,CustomHasProperty]
 interface CSSStyleDeclaration {
 
     readonly attribute unsigned long length;

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -813,6 +813,12 @@ public:
 )~~~");
     }
 
+    if (interface.extended_attributes.contains("CustomHasProperty")) {
+        generator.append(R"~~~(
+    virtual bool internal_has_property(JS::PropertyName const&) const override;
+)~~~");
+    }
+
     if (interface.wrapper_base_class == "Wrapper") {
         generator.append(R"~~~(
     @fully_qualified_name@& impl() { return *m_impl; }

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -1307,6 +1307,8 @@ namespace Web::Bindings {
 )~~~");
     }
 
+    // FIXME: Currently almost everything gets default_attributes but it should be configurable per attribute.
+    //        See the spec links for details
     generator.append(R"~~~(
 }
 
@@ -1317,10 +1319,11 @@ namespace Web::Bindings {
 void @prototype_class@::initialize(JS::GlobalObject& global_object)
 {
     [[maybe_unused]] auto& vm = this->vm();
-    [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable | JS::Attribute::Configurable;
+    [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable;
 
 )~~~");
 
+    // https://heycam.github.io/webidl/#es-attributes
     for (auto& attribute : interface.attributes) {
         auto attribute_generator = generator.fork();
         attribute_generator.set("attribute.name", attribute.name);
@@ -1336,6 +1339,7 @@ void @prototype_class@::initialize(JS::GlobalObject& global_object)
 )~~~");
     }
 
+    // https://heycam.github.io/webidl/#es-constants
     for (auto& constant : interface.constants) {
         auto constant_generator = generator.fork();
         constant_generator.set("constant.name", constant.name);
@@ -1346,6 +1350,7 @@ void @prototype_class@::initialize(JS::GlobalObject& global_object)
 )~~~");
     }
 
+    // https://heycam.github.io/webidl/#es-operations
     for (auto& function : interface.functions) {
         auto function_generator = generator.fork();
         function_generator.set("function.name", function.name);

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -17,7 +17,7 @@
 #include <LibCore/File.h>
 #include <ctype.h>
 
-static String make_input_acceptable_cpp(const String& input)
+static String make_input_acceptable_cpp(String const& input)
 {
     if (input.is_one_of("class", "template", "for", "default", "char", "namespace")) {
         StringBuilder builder;
@@ -147,7 +147,7 @@ struct Interface {
     String prototype_base_class;
 };
 
-static OwnPtr<Interface> parse_interface(StringView filename, const StringView& input)
+static OwnPtr<Interface> parse_interface(StringView filename, StringView const& input)
 {
     auto interface = make<Interface>();
 
@@ -170,7 +170,7 @@ static OwnPtr<Interface> parse_interface(StringView filename, const StringView& 
         }
     };
 
-    auto assert_string = [&](const StringView& expected) {
+    auto assert_string = [&](StringView const& expected) {
         if (!lexer.consume_specific(expected))
             report_parsing_error(String::formatted("expected '{}'", expected), filename, input, lexer.tell());
     };
@@ -369,17 +369,17 @@ static OwnPtr<Interface> parse_interface(StringView filename, const StringView& 
 
 }
 
-static void generate_constructor_header(const IDL::Interface&);
-static void generate_constructor_implementation(const IDL::Interface&);
-static void generate_prototype_header(const IDL::Interface&);
-static void generate_prototype_implementation(const IDL::Interface&);
-static void generate_header(const IDL::Interface&);
-static void generate_implementation(const IDL::Interface&);
+static void generate_constructor_header(IDL::Interface const&);
+static void generate_constructor_implementation(IDL::Interface const&);
+static void generate_prototype_header(IDL::Interface const&);
+static void generate_prototype_implementation(IDL::Interface const&);
+static void generate_header(IDL::Interface const&);
+static void generate_implementation(IDL::Interface const&);
 
 int main(int argc, char** argv)
 {
     Core::ArgsParser args_parser;
-    const char* path = nullptr;
+    char const* path = nullptr;
     bool header_mode = false;
     bool implementation_mode = false;
     bool constructor_header_mode = false;
@@ -468,7 +468,7 @@ int main(int argc, char** argv)
     return 0;
 }
 
-static bool should_emit_wrapper_factory(const IDL::Interface& interface)
+static bool should_emit_wrapper_factory(IDL::Interface const& interface)
 {
     // FIXME: This is very hackish.
     if (interface.name == "Event")
@@ -488,7 +488,7 @@ static bool should_emit_wrapper_factory(const IDL::Interface& interface)
     return true;
 }
 
-static bool is_wrappable_type(const IDL::Type& type)
+static bool is_wrappable_type(IDL::Type const& type)
 {
     if (type.name == "Node")
         return true;
@@ -508,7 +508,7 @@ static bool is_wrappable_type(const IDL::Type& type)
 }
 
 template<typename ParameterType>
-static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, const String& js_name, const String& js_suffix, const String& cpp_name, bool return_void = false, bool legacy_null_to_empty_string = false, bool optional = false, Optional<String> optional_default_value = {})
+static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, String const& js_name, String const& js_suffix, String const& cpp_name, bool return_void = false, bool legacy_null_to_empty_string = false, bool optional = false, Optional<String> optional_default_value = {})
 {
     auto scoped_generator = generator.fork();
     scoped_generator.set("cpp_name", make_input_acceptable_cpp(cpp_name));
@@ -726,7 +726,7 @@ static void generate_argument_count_check(SourceGenerator& generator, FunctionTy
 )~~~");
 }
 
-static void generate_arguments(SourceGenerator& generator, const Vector<IDL::Parameter>& parameters, StringBuilder& arguments_builder, bool return_void = false)
+static void generate_arguments(SourceGenerator& generator, Vector<IDL::Parameter> const& parameters, StringBuilder& arguments_builder, bool return_void = false)
 {
     auto arguments_generator = generator.fork();
 
@@ -747,7 +747,7 @@ static void generate_arguments(SourceGenerator& generator, const Vector<IDL::Par
     arguments_builder.join(", ", parameter_names);
 }
 
-static void generate_header(const IDL::Interface& interface)
+static void generate_header(IDL::Interface const& interface)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
@@ -809,19 +809,19 @@ public:
     }
     if (interface.extended_attributes.contains("CustomSet")) {
         generator.append(R"~~~(
-    virtual bool internal_set(const JS::PropertyName&, JS::Value, JS::Value receiver) override;
+    virtual bool internal_set(JS::PropertyName const&, JS::Value, JS::Value receiver) override;
 )~~~");
     }
 
     if (interface.wrapper_base_class == "Wrapper") {
         generator.append(R"~~~(
     @fully_qualified_name@& impl() { return *m_impl; }
-    const @fully_qualified_name@& impl() const { return *m_impl; }
+    @fully_qualified_name@ const& impl() const { return *m_impl; }
 )~~~");
     } else {
         generator.append(R"~~~(
     @fully_qualified_name@& impl() { return static_cast<@fully_qualified_name@&>(@wrapper_base_class@::impl()); }
-    const @fully_qualified_name@& impl() const { return static_cast<const @fully_qualified_name@&>(@wrapper_base_class@::impl()); }
+    @fully_qualified_name@ const& impl() const { return static_cast<@fully_qualified_name@ const&>(@wrapper_base_class@::impl()); }
 )~~~");
     }
 
@@ -852,7 +852,7 @@ private:
     outln("{}", generator.as_string_view());
 }
 
-void generate_implementation(const IDL::Interface& interface)
+void generate_implementation(IDL::Interface const& interface)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
@@ -957,7 +957,7 @@ void @wrapper_class@::initialize(JS::GlobalObject& global_object)
     outln("{}", generator.as_string_view());
 }
 
-static void generate_constructor_header(const IDL::Interface& interface)
+static void generate_constructor_header(IDL::Interface const& interface)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
@@ -994,7 +994,7 @@ private:
     outln("{}", generator.as_string_view());
 }
 
-void generate_constructor_implementation(const IDL::Interface& interface)
+void generate_constructor_implementation(IDL::Interface const& interface)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
@@ -1137,7 +1137,7 @@ define_direct_property("@constant.name@", JS::Value((i32)@constant.value@), JS::
     outln("{}", generator.as_string_view());
 }
 
-static void generate_prototype_header(const IDL::Interface& interface)
+static void generate_prototype_header(IDL::Interface const& interface)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
@@ -1194,7 +1194,7 @@ private:
     outln("{}", generator.as_string_view());
 }
 
-void generate_prototype_implementation(const IDL::Interface& interface)
+void generate_prototype_implementation(IDL::Interface const& interface)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };


### PR DESCRIPTION
Most of the changes could have quite a big impact but everything seems to line up with the big browsers.

I left some comments to clarify some things

Fixes #8989 
And you can now go to http://css3test.com and run `window.onload()` in the js console to run the CSS3 tests
(It does crash fairly quickly in parse_calc_value)