### PR TITLE
Kernel: Un-unmap-after-init CommandLine::boot_mode() 

### DIFF
--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -24,6 +24,7 @@
 #include <Kernel/Arch/x86/Processor.h>
 #include <Kernel/Arch/x86/RegisterState.h>
 #include <Kernel/Arch/x86/TrapFrame.h>
+#include <Kernel/KSyms.h>
 
 extern FlatPtr start_of_unmap_after_init;
 extern FlatPtr end_of_unmap_after_init;
@@ -323,7 +324,8 @@ void page_fault_handler(TrapFrame* trap)
 
     if (fault_address >= (FlatPtr)&start_of_unmap_after_init && fault_address < (FlatPtr)&end_of_unmap_after_init) {
         dump(regs);
-        PANIC("Attempt to access UNMAP_AFTER_INIT section");
+        auto sym = symbolicate_kernel_address(fault_address);
+        PANIC("Attempt to access UNMAP_AFTER_INIT section ({:#p}: {})", fault_address, sym ? sym->name : "(Unknown)");
     }
 
     if (fault_address >= (FlatPtr)&start_of_kernel_ksyms && fault_address < (FlatPtr)&end_of_kernel_ksyms) {

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -191,7 +191,7 @@ UNMAP_AFTER_INIT AHCIResetMode CommandLine::ahci_reset_mode() const
     PANIC("Unknown AHCIResetMode: {}", ahci_reset_mode);
 }
 
-UNMAP_AFTER_INIT BootMode CommandLine::boot_mode() const
+BootMode CommandLine::boot_mode() const
 {
     const auto boot_mode = lookup("boot_mode"sv).value_or("graphical"sv);
     if (boot_mode == "no-fbdev"sv) {


### PR DESCRIPTION
This function is now used when the kernel panics, so unmapping it would
make the kernel panic while in panic, which is not a good thing :P