### PR TITLE
AK + Kernel: Utilize KResult + AK::Userspace<T> in the ioctl interface

### DIFF
--- a/AK/MACAddress.h
+++ b/AK/MACAddress.h
@@ -84,6 +84,11 @@ public:
         return all_of(m_data.begin(), m_data.end(), [](const auto octet) { return octet == 0; });
     }
 
+    void copy_to(Bytes destination) const
+    {
+        m_data.span().copy_to(destination);
+    }
+
 private:
     Array<u8, s_mac_address_length> m_data {};
 };

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -311,38 +311,38 @@ KResultOr<size_t> KeyboardDevice::write(FileDescription&, u64, const UserOrKerne
     return 0;
 }
 
-int KeyboardDevice::ioctl(FileDescription&, unsigned request, Userspace<void*> arg)
+KResult KeyboardDevice::ioctl(FileDescription&, unsigned request, Userspace<void*> arg)
 {
     switch (request) {
     case KEYBOARD_IOCTL_GET_NUM_LOCK: {
         auto output = static_ptr_cast<bool*>(arg);
         if (!copy_to_user(output, &m_num_lock_on))
-            return -EFAULT;
-        return 0;
+            return EFAULT;
+        return KSuccess;
     }
     case KEYBOARD_IOCTL_SET_NUM_LOCK: {
         // In this case we expect the value to be a boolean and not a pointer.
         auto num_lock_value = static_cast<u8>(arg.ptr());
         if (num_lock_value != 0 && num_lock_value != 1)
-            return -EINVAL;
+            return EINVAL;
         m_num_lock_on = !!num_lock_value;
-        return 0;
+        return KSuccess;
     }
     case KEYBOARD_IOCTL_GET_CAPS_LOCK: {
         auto output = static_ptr_cast<bool*>(arg);
         if (!copy_to_user(output, &m_caps_lock_on))
-            return -EFAULT;
-        return 0;
+            return EFAULT;
+        return KSuccess;
     }
     case KEYBOARD_IOCTL_SET_CAPS_LOCK: {
         auto caps_lock_value = static_cast<u8>(arg.ptr());
         if (caps_lock_value != 0 && caps_lock_value != 1)
-            return -EINVAL;
+            return EINVAL;
         m_caps_lock_on = !!caps_lock_value;
-        return 0;
+        return KSuccess;
     }
     default:
-        return -EINVAL;
+        return EINVAL;
     };
 }
 

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -37,7 +37,7 @@ public:
     virtual mode_t required_mode() const override { return 0440; }
 
     // ^File
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
 
     virtual String device_name() const override { return String::formatted("keyboard{}", minor()); }
 

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -37,7 +37,7 @@ public:
     virtual mode_t required_mode() const override { return 0440; }
 
     // ^File
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
 
     virtual String device_name() const override { return String::formatted("keyboard{}", minor()); }
 

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -35,9 +35,9 @@ KResult File::close()
     return KSuccess;
 }
 
-int File::ioctl(FileDescription&, unsigned, Userspace<void*>)
+KResult File::ioctl(FileDescription&, unsigned, Userspace<void*>)
 {
-    return -ENOTTY;
+    return ENOTTY;
 }
 
 KResultOr<Region*> File::mmap(Process&, FileDescription&, const Range&, u64, int, bool)

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringView.h>
+#include <AK/Userspace.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Process.h>
@@ -34,7 +35,7 @@ KResult File::close()
     return KSuccess;
 }
 
-int File::ioctl(FileDescription&, unsigned, FlatPtr)
+int File::ioctl(FileDescription&, unsigned, Userspace<void*>)
 {
     return -ENOTTY;
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -87,7 +87,7 @@ public:
     virtual void did_seek(FileDescription&, off_t) { }
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) = 0;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) = 0;
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg);
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg);
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared);
     virtual KResult stat(::stat&) const { return EBADF; }
 

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -87,7 +87,7 @@ public:
     virtual void did_seek(FileDescription&, off_t) { }
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) = 0;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) = 0;
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg);
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg);
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared);
     virtual KResult stat(::stat&) const { return EBADF; }
 

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -62,34 +62,34 @@ KResultOr<size_t> InodeFile::write(FileDescription& description, u64 offset, con
     return nwritten;
 }
 
-int InodeFile::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
+KResult InodeFile::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
 {
     (void)description;
 
     switch (request) {
     case FIBMAP: {
         if (!Process::current()->is_superuser())
-            return -EPERM;
+            return EPERM;
 
         auto user_block_number = static_ptr_cast<int*>(arg);
         int block_number = 0;
         if (!copy_from_user(&block_number, user_block_number))
-            return -EFAULT;
+            return EFAULT;
 
         if (block_number < 0)
-            return -EINVAL;
+            return EINVAL;
 
         auto block_address = inode().get_block_address(block_number);
         if (block_address.is_error())
             return block_address.error();
 
         if (!copy_to_user(user_block_number, &block_address.value()))
-            return -EFAULT;
+            return EFAULT;
 
-        return 0;
+        return KSuccess;
     }
     default:
-        return -EINVAL;
+        return EINVAL;
     }
 }
 

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -32,7 +32,7 @@ public:
 
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
     virtual KResult stat(::stat& buffer) const override { return inode().metadata().stat(buffer); }
 

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -32,7 +32,7 @@ public:
 
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
     virtual KResult stat(::stat& buffer) const override { return inode().metadata().stat(buffer); }
 

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -22,7 +22,7 @@ class FramebufferDevice : public BlockDevice {
 public:
     static NonnullRefPtr<FramebufferDevice> create(const GraphicsDevice&, size_t, PhysicalAddress, size_t, size_t, size_t);
 
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
     // ^Device

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -22,7 +22,7 @@ class FramebufferDevice : public BlockDevice {
 public:
     static NonnullRefPtr<FramebufferDevice> create(const GraphicsDevice&, size_t, PhysicalAddress, size_t, size_t, size_t);
 
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
     // ^Device

--- a/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.cpp
@@ -140,7 +140,7 @@ void FrameBufferDevice::set_buffer(int buffer_index)
     buffer.dirty_rect = {};
 }
 
-int FrameBufferDevice::ioctl(FileDescription&, unsigned request, Userspace<void*> arg)
+KResult FrameBufferDevice::ioctl(FileDescription&, unsigned request, Userspace<void*> arg)
 {
     REQUIRE_PROMISE(video);
     switch (request) {
@@ -148,20 +148,20 @@ int FrameBufferDevice::ioctl(FileDescription&, unsigned request, Userspace<void*
         auto out = static_ptr_cast<size_t*>(arg);
         size_t value = m_buffer_size * 2;
         if (!copy_to_user(out, &value))
-            return -EFAULT;
-        return 0;
+            return EFAULT;
+        return KSuccess;
     }
     case FB_IOCTL_SET_RESOLUTION: {
         auto user_resolution = static_ptr_cast<FBResolution*>(arg);
         FBResolution resolution;
         if (!copy_from_user(&resolution, user_resolution))
-            return -EFAULT;
+            return EFAULT;
         if (!try_to_set_resolution(resolution.width, resolution.height))
-            return -EINVAL;
+            return EINVAL;
         resolution.pitch = pitch();
         if (!copy_to_user(user_resolution, &resolution))
-            return -EFAULT;
-        return 0;
+            return EFAULT;
+        return KSuccess;
     }
     case FB_IOCTL_GET_RESOLUTION: {
         auto user_resolution = static_ptr_cast<FBResolution*>(arg);
@@ -170,33 +170,33 @@ int FrameBufferDevice::ioctl(FileDescription&, unsigned request, Userspace<void*
         resolution.width = width();
         resolution.height = height();
         if (!copy_to_user(user_resolution, &resolution))
-            return -EFAULT;
-        return 0;
+            return EFAULT;
+        return KSuccess;
     }
     case FB_IOCTL_SET_BUFFER: {
         auto buffer_index = static_cast<int>(arg.ptr());
         if (!is_valid_buffer_index(buffer_index))
-            return -EINVAL;
+            return EINVAL;
         if (m_last_set_buffer_index.exchange(buffer_index) != buffer_index && m_are_writes_active)
             set_buffer(buffer_index);
-        return 0;
+        return KSuccess;
     }
     case FB_IOCTL_FLUSH_BUFFERS: {
         auto user_flush_rects = static_ptr_cast<FBFlushRects*>(arg);
         FBFlushRects flush_rects;
         if (!copy_from_user(&flush_rects, user_flush_rects))
-            return -EFAULT;
+            return EFAULT;
         if (!is_valid_buffer_index(flush_rects.buffer_index))
-            return -EINVAL;
+            return EINVAL;
         if (Checked<unsigned>::multiplication_would_overflow(flush_rects.count, sizeof(FBRect)))
-            return -EFAULT;
+            return EFAULT;
         if (m_are_writes_active && flush_rects.count > 0) {
             auto& buffer = buffer_from_index(flush_rects.buffer_index);
             MutexLocker locker(m_gpu.operation_lock());
             for (unsigned i = 0; i < flush_rects.count; i++) {
                 FBRect user_dirty_rect;
                 if (!copy_from_user(&user_dirty_rect, &flush_rects.rects[i]))
-                    return -EFAULT;
+                    return EFAULT;
                 Protocol::Rect dirty_rect {
                     .x = user_dirty_rect.x,
                     .y = user_dirty_rect.y,
@@ -222,22 +222,22 @@ int FrameBufferDevice::ioctl(FileDescription&, unsigned request, Userspace<void*
                 }
             }
         }
-        return 0;
+        return KSuccess;
     }
     case FB_IOCTL_GET_BUFFER_OFFSET: {
         auto user_buffer_offset = static_ptr_cast<FBBufferOffset*>(arg);
         FBBufferOffset buffer_offset;
         if (!copy_from_user(&buffer_offset, user_buffer_offset))
-            return -EFAULT;
+            return EFAULT;
         if (!is_valid_buffer_index(buffer_offset.buffer_index))
-            return -EINVAL;
+            return EINVAL;
         buffer_offset.offset = (size_t)buffer_offset.buffer_index * m_buffer_size;
         if (!copy_to_user(user_buffer_offset, &buffer_offset))
-            return -EFAULT;
-        return 0;
+            return EFAULT;
+        return KSuccess;
     }
     default:
-        return -EINVAL;
+        return EINVAL;
     };
 }
 

--- a/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.h
@@ -60,7 +60,7 @@ private:
     void create_buffer(Buffer&, size_t, size_t);
     void set_buffer(int);
 
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override { return EINVAL; }

--- a/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.h
@@ -60,7 +60,7 @@ private:
     void create_buffer(Buffer&, size_t, size_t);
     void set_buffer(int);
 
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override { return EINVAL; }

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -46,7 +46,7 @@ public:
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
 
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
 
     bool did_receive(const IPv4Address& peer_address, u16 peer_port, ReadonlyBytes, const Time&);
 

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -46,7 +46,7 @@ public:
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
 
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
 
     bool did_receive(const IPv4Address& peer_address, u16 peer_port, ReadonlyBytes, const Time&);
 

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -106,7 +106,7 @@ KResult MasterPTY::close()
     return KSuccess;
 }
 
-int MasterPTY::ioctl(FileDescription& description, unsigned request, FlatPtr arg)
+int MasterPTY::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
 {
     REQUIRE_PROMISE(tty);
     if (!m_slave)

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -106,14 +106,14 @@ KResult MasterPTY::close()
     return KSuccess;
 }
 
-int MasterPTY::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
+KResult MasterPTY::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
 {
     REQUIRE_PROMISE(tty);
     if (!m_slave)
-        return -EIO;
+        return EIO;
     if (request == TIOCSWINSZ || request == TIOCGPGRP)
         return m_slave->ioctl(description, request, arg);
-    return -EINVAL;
+    return EINVAL;
 }
 
 String MasterPTY::absolute_path(const FileDescription&) const

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -40,7 +40,7 @@ private:
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResult close() override;
     virtual bool is_master_pty() const override { return true; }
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual StringView class_name() const override { return "MasterPTY"; }
 
     RefPtr<SlavePTY> m_slave;

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -40,7 +40,7 @@ private:
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResult close() override;
     virtual bool is_master_pty() const override { return true; }
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual StringView class_name() const override { return "MasterPTY"; }
 
     RefPtr<SlavePTY> m_slave;

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -469,8 +469,13 @@ int TTY::ioctl(FileDescription&, unsigned request, Userspace<void*> arg)
     }
 #endif
     switch (request) {
-    case TIOCGPGRP:
-        return this->pgid().value();
+    case TIOCGPGRP: {
+        auto user_pgid = static_ptr_cast<pid_t*>(arg);
+        auto pgid = this->pgid().value();
+        if (!copy_to_user(user_pgid, &pgid))
+            return -EFAULT;
+        return 0;
+    }
     case TIOCSPGRP: {
         ProcessGroupID pgid = static_cast<pid_t>(arg.ptr());
         if (pgid <= 0)

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -25,7 +25,7 @@ public:
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override final;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override final;
     virtual String absolute_path(const FileDescription&) const override { return tty_name(); }
 
     virtual String const& tty_name() const = 0;
@@ -40,7 +40,7 @@ public:
         return 0;
     }
 
-    int set_termios(const termios&);
+    KResult set_termios(const termios&);
     bool should_generate_signals() const { return m_termios.c_lflag & ISIG; }
     bool should_flush_on_signal() const { return !(m_termios.c_lflag & NOFLSH); }
     bool should_echo_input() const { return m_termios.c_lflag & ECHO; }

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -25,7 +25,7 @@ public:
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override final;
+    virtual int ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override final;
     virtual String absolute_path(const FileDescription&) const override { return tty_name(); }
 
     virtual String const& tty_name() const = 0;

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -257,7 +257,11 @@ pid_t setsid()
 
 pid_t tcgetpgrp(int fd)
 {
-    return ioctl(fd, TIOCGPGRP);
+    pid_t pgrp;
+    int rc = ioctl(fd, TIOCGPGRP, &pgrp);
+    if (rc < 0)
+        return rc;
+    return pgrp;
 }
 
 int tcsetpgrp(int fd, pid_t pgid)


### PR DESCRIPTION
In the interest of keeping the Kernel IOCTL API updated with the stye of the rest of the system, switch to returning `KResult` and taking `Userspace<void*>`. 

- **Kernel: Modify the IOCTL API to return KResult**

    The kernel has been gradually moving towards KResult from just bare
    int's, this change migrates the IOCTL paths.

-  **Kernel+LibC: Use argument for TIOCGPGRP ioctl value**

    In preparation for modifying the Kernel IOCTL API to return KResult
    instead of int, we need to fix this ioctl to an argument to receive
    it's return value, instead of using the actual function return value.

- **Kernel: Utilize AK::Userspace<T> in the ioctl interface**

    It's easy to forget the responsibility of validating and safely copying
    kernel parameters in code that is far away from syscalls. ioctl's are
    one such example, and bugs there are just as dangerous as at the root
    syscall level.

    To avoid this case, utilize the AK::Userspace<T> template in the ioctl
    kernel interface so that implementors have no choice but to properly
    validate and copy ioctl pointer arguments.

- **AK: Add copy_to span method for AK::MACAddress**