### PR TITLE
Settings: Match window options between applications

### DIFF
--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -42,6 +42,7 @@ int main(int argc, char** argv)
     window->set_title("Display Settings");
     window->resize(400, 480);
     window->set_resizable(false);
+    window->set_minimizable(false);
 
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -103,6 +103,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_title("Keyboard Settings");
     window->resize(300, 70);
+    window->set_resizable(false);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& root_widget = window->set_main_widget<GUI::Widget>();

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -104,6 +104,7 @@ int main(int argc, char** argv)
     window->set_title("Keyboard Settings");
     window->resize(300, 70);
     window->set_resizable(false);
+    window->set_minimizable(false);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& root_widget = window->set_main_widget<GUI::Widget>();


### PR DESCRIPTION
Brings the window options between the settings applications inline with
another.
