### PR TITLE
Kernel: Shutdown on panic in self-test mode

### DIFF
--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -7,19 +7,20 @@
 #include <AK/Format.h>
 #include <Kernel/Arch/x86/Processor.h>
 #include <Kernel/CommandLine.h>
+#include <Kernel/IO.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 
 namespace Kernel {
 
-[[noreturn]] static void __reset()
+[[noreturn]] static void __shutdown()
 {
-    // FIXME: This works for i686/x86_64, but needs to be ported to any other arch when needed.
-    asm(
-        "lidt 0\n"
-        "movl $0, 0\n");
-
-    __builtin_unreachable();
+    // Note: This will invoke QEMU Shutdown, but for other platforms (or emulators),
+    // this has no effect on the system, so we still need to halt afterwards.
+    // We also try the Bochs/Old QEMU shutdown method, if the first didn't work.
+    IO::out16(0x604, 0x2000);
+    IO::out16(0xb004, 0x2000);
+    Processor::halt();
 }
 
 void __panic(const char* file, unsigned int line, const char* function)
@@ -27,7 +28,7 @@ void __panic(const char* file, unsigned int line, const char* function)
     critical_dmesgln("at {}:{} in {}", file, line, function);
     dump_backtrace();
     if (kernel_command_line().boot_mode() == BootMode::SelfTest)
-        __reset();
+        __shutdown();
     else
         Processor::halt();
 }


### PR DESCRIPTION
Instead of doing a reset via triple-fault, let's just shutdown the QEMU
virtual machine because this is already a QEMU-specific handling code
for Self-Test CI mode.

cc @alimpfard 