### PR TITLE
LibGUI: Allow Clipboard to have multiple callbacks

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -10,7 +10,8 @@
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/Model.h>
 
-class ClipboardHistoryModel final : public GUI::Model {
+class ClipboardHistoryModel final : public GUI::Model
+    , public GUI::Clipboard::ClipboardClient {
 public:
     static NonnullRefPtr<ClipboardHistoryModel> create();
 
@@ -24,15 +25,20 @@ public:
     virtual ~ClipboardHistoryModel() override;
 
     const GUI::Clipboard::DataAndType& item_at(int index) const { return m_history_items[index]; }
-    void add_item(const GUI::Clipboard::DataAndType& item);
     void remove_item(int index);
 
 private:
+    void add_item(const GUI::Clipboard::DataAndType& item);
+
+    // ^GUI::Model
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }
     virtual String column_name(int) const override;
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual void update() override;
+
+    // ^GUI::Clipboard::ClipboardClient
+    virtual void clipboard_content_did_change(const String&) override { add_item(GUI::Clipboard::the().data_and_type()); }
 
     Vector<GUI::Clipboard::DataAndType> m_history_items;
     size_t m_history_limit { 20 };

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -49,11 +49,6 @@ int main(int argc, char* argv[])
     auto model = ClipboardHistoryModel::create();
     table_view.set_model(model);
 
-    GUI::Clipboard::the().on_change = [&](const String&) {
-        auto item = GUI::Clipboard::the().data_and_type();
-        model->add_item(item);
-    };
-
     table_view.on_activation = [&](const GUI::ModelIndex& index) {
         auto& data_and_type = model->item_at(index.row());
         GUI::Clipboard::the().set_data(data_and_type.data, data_and_type.mime_type, data_and_type.metadata);

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -83,6 +83,7 @@ void TextEditor::create_actions()
     m_cut_action->set_enabled(false);
     m_copy_action->set_enabled(false);
     m_paste_action = CommonActions::make_paste_action([&](auto&) { paste(); }, this);
+    m_paste_action->set_enabled(is_editable() && Clipboard::the().mime_type().starts_with("text/") && !Clipboard::the().data().is_empty());
     m_delete_action = CommonActions::make_delete_action([&](auto&) { do_delete(); }, this);
     if (is_multi_line()) {
         m_go_to_line_action = Action::create(
@@ -98,9 +99,6 @@ void TextEditor::create_actions()
             this);
     }
     m_select_all_action = CommonActions::make_select_all_action([this](auto&) { select_all(); }, this);
-    Clipboard::the().on_change = [this](auto const& mime_type) {
-        m_paste_action->set_enabled(is_editable() && mime_type.starts_with("text/") && !Clipboard::the().data().is_empty());
-    };
 }
 
 void TextEditor::set_text(StringView const& text)
@@ -1799,6 +1797,11 @@ void TextEditor::document_did_set_text()
 void TextEditor::document_did_set_cursor(TextPosition const& position)
 {
     set_cursor(position);
+}
+
+void TextEditor::clipboard_content_did_change(String const& mime_type)
+{
+    m_paste_action->set_enabled(is_editable() && mime_type.starts_with("text/") && !Clipboard::the().data().is_empty());
 }
 
 void TextEditor::set_document(TextDocument& document)

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -12,6 +12,8 @@
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/AbstractScrollableWidget.h>
+#include <LibGUI/Action.h>
+#include <LibGUI/Clipboard.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/TextDocument.h>
 #include <LibGUI/TextRange.h>
@@ -24,7 +26,8 @@ namespace GUI {
 class TextEditor
     : public AbstractScrollableWidget
     , public TextDocument::Client
-    , public Syntax::HighlighterClient {
+    , public Syntax::HighlighterClient
+    , public Clipboard::ClipboardClient {
     C_OBJECT(TextEditor);
 
 public:
@@ -251,6 +254,9 @@ private:
     virtual String highlighter_did_request_text() const final { return text(); }
     virtual GUI::TextDocument& highlighter_did_request_document() final { return document(); }
     virtual GUI::TextPosition highlighter_did_request_cursor() const final { return m_cursor; }
+
+    // ^Clipboard::ClipboardClient
+    virtual void clipboard_content_did_change(String const& mime_type) override;
 
     void create_actions();
     void paint_ruler(Painter&);

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -143,10 +143,6 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy, RefPtr<Co
     m_context_menu->add_separator();
     m_context_menu->add_action(clear_including_history_action());
 
-    GUI::Clipboard::the().on_change = [this](const String&) {
-        update_paste_action();
-    };
-
     update_copy_action();
     update_paste_action();
 

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -11,6 +11,7 @@
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/Timer.h>
+#include <LibGUI/Clipboard.h>
 #include <LibGUI/Frame.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Rect.h>
@@ -22,7 +23,8 @@ namespace VT {
 
 class TerminalWidget final
     : public GUI::Frame
-    , public VT::TerminalClient {
+    , public VT::TerminalClient
+    , public GUI::Clipboard::ClipboardClient {
     C_OBJECT(TerminalWidget);
 
 public:
@@ -122,6 +124,9 @@ private:
     virtual void terminal_history_changed(int delta) override;
     virtual void emit(const u8*, size_t) override;
     virtual void set_cursor_style(CursorStyle) override;
+
+    // ^GUI::Clipboard::ClipboardClient
+    virtual void clipboard_content_did_change(const String&) override { update_paste_action(); }
 
     void set_logical_focus(bool);
 


### PR DESCRIPTION
Widgets (for example TextEditor) can use `Clipboard.add_callback` to add a callback, which will get called along with `Clipboard.on_change`. This way the callback registered by the widgets will not interfere with each other or `Clipboard.on_change`, which is typically registered in the application itself.