### PR TITLE
LibJS: Implement Temporal.Now.plainDate{,Time}{,ISO}()

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SOURCES
     Runtime/Temporal/PlainDateTimeConstructor.cpp
     Runtime/Temporal/PlainDateTimePrototype.cpp
     Runtime/Temporal/PlainTime.cpp
+    Runtime/Temporal/PlainYearMonth.cpp
     Runtime/Temporal/Temporal.cpp
     Runtime/Temporal/TimeZone.cpp
     Runtime/Temporal/TimeZoneConstructor.cpp

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -283,6 +283,7 @@ namespace JS {
     P(parseFloat)                            \
     P(parseInt)                              \
     P(plainDate)                             \
+    P(plainDateISO)                          \
     P(pop)                                   \
     P(pow)                                   \
     P(preventExtensions)                     \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -284,6 +284,7 @@ namespace JS {
     P(parseInt)                              \
     P(plainDate)                             \
     P(plainDateISO)                          \
+    P(plainDateTime)                         \
     P(pop)                                   \
     P(pow)                                   \
     P(preventExtensions)                     \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -285,6 +285,7 @@ namespace JS {
     P(plainDate)                             \
     P(plainDateISO)                          \
     P(plainDateTime)                         \
+    P(plainDateTimeISO)                      \
     P(pop)                                   \
     P(pow)                                   \
     P(preventExtensions)                     \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -282,6 +282,7 @@ namespace JS {
     P(parse)                                 \
     P(parseFloat)                            \
     P(parseInt)                              \
+    P(plainDate)                             \
     P(pop)                                   \
     P(pow)                                   \
     P(preventExtensions)                     \

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -86,6 +86,18 @@ private:
     bool m_is_invalid { false };
 };
 
+u16 day_within_year(double);
+u8 date_from_time(double);
+u16 days_in_year(i32);
+double day_from_year(i32);
+i32 year_from_time(double);
+bool in_leap_year(double);
+u8 month_from_time(double);
+u8 hour_from_time(double);
+u8 min_from_time(double);
+u8 sec_from_time(double);
+u16 ms_from_time(double);
+double day(double);
 Value make_time(GlobalObject& global_object, Value hour, Value min, Value sec, Value ms);
 Value make_day(GlobalObject& global_object, Value year, Value month, Value date);
 Value make_date(Value day, Value time);

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -174,6 +174,7 @@
     M(TemporalInvalidEpochNanoseconds, "Invalid epoch nanoseconds value, must be in range -86400 * 10^17 to 86400 * 10^17")             \
     M(TemporalInvalidISODate, "Invalid ISO date")                                                                                       \
     M(TemporalInvalidMonthCode, "Invalid month code")                                                                                   \
+    M(TemporalInvalidOffsetNanosecondsValue, "Invalid offset nanoseconds value, must be in range -86400 * 10^9 to 86400 * 10^9")        \
     M(TemporalInvalidPlainDate, "Invalid plain date")                                                                                   \
     M(TemporalInvalidPlainDateTime, "Invalid plain date time")                                                                          \
     M(TemporalInvalidTime, "Invalid time")                                                                                              \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -240,6 +240,7 @@ void GlobalObject::initialize_global_object()
 
     m_array_prototype_values_function = &m_array_prototype->get_without_side_effects(vm.names.values).as_function();
     m_eval_function = &get_without_side_effects(vm.names.eval).as_function();
+    m_temporal_time_zone_prototype_get_offset_nanoseconds_for_function = &m_temporal_time_zone_prototype->get_without_side_effects(vm.names.getOffsetNanosecondsFor).as_function();
 }
 
 GlobalObject::~GlobalObject()
@@ -258,6 +259,7 @@ void GlobalObject::visit_edges(Visitor& visitor)
     visitor.visit(m_environment);
     visitor.visit(m_array_prototype_values_function);
     visitor.visit(m_eval_function);
+    visitor.visit(m_temporal_time_zone_prototype_get_offset_nanoseconds_for_function);
     visitor.visit(m_throw_type_error_function);
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -38,6 +38,7 @@ public:
 
     FunctionObject* array_prototype_values_function() const { return m_array_prototype_values_function; }
     FunctionObject* eval_function() const { return m_eval_function; }
+    FunctionObject* temporal_time_zone_prototype_get_offset_nanoseconds_for_function() const { return m_temporal_time_zone_prototype_get_offset_nanoseconds_for_function; }
     FunctionObject* throw_type_error_function() const { return m_throw_type_error_function; }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
@@ -97,6 +98,7 @@ private:
 
     FunctionObject* m_array_prototype_values_function { nullptr };
     FunctionObject* m_eval_function { nullptr };
+    FunctionObject* m_temporal_time_zone_prototype_get_offset_nanoseconds_for_function { nullptr };
     FunctionObject* m_throw_type_error_function { nullptr };
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -32,6 +32,7 @@ void Now::initialize(GlobalObject& global_object)
     define_native_function(vm.names.timeZone, time_zone, 0, attr);
     define_native_function(vm.names.instant, instant, 0, attr);
     define_native_function(vm.names.plainDateTime, plain_date_time, 1, attr);
+    define_native_function(vm.names.plainDateTimeISO, plain_date_time_iso, 0, attr);
     define_native_function(vm.names.plainDate, plain_date, 1, attr);
     define_native_function(vm.names.plainDateISO, plain_date_iso, 0, attr);
 }
@@ -57,6 +58,20 @@ JS_DEFINE_NATIVE_FUNCTION(Now::plain_date_time)
     auto temporal_time_zone_like = vm.argument(1);
 
     // 1. Return ? SystemDateTime(temporalTimeZoneLike, calendar).
+    return system_date_time(global_object, temporal_time_zone_like, calendar);
+}
+
+// 2.1.4 Temporal.Now.plainDateTimeISO ( [ temporalTimeZoneLike ] ), https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso
+JS_DEFINE_NATIVE_FUNCTION(Now::plain_date_time_iso)
+{
+    auto temporal_time_zone_like = vm.argument(0);
+
+    // 1, Let calendar be ? GetISO8601Calendar().
+    auto* calendar = get_iso8601_calendar(global_object);
+    if (vm.exception())
+        return {};
+
+    // 2. Return ? SystemDateTime(temporalTimeZoneLike, calendar).
     return system_date_time(global_object, temporal_time_zone_like, calendar);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -32,6 +32,7 @@ void Now::initialize(GlobalObject& global_object)
     define_native_function(vm.names.timeZone, time_zone, 0, attr);
     define_native_function(vm.names.instant, instant, 0, attr);
     define_native_function(vm.names.plainDate, plain_date, 1, attr);
+    define_native_function(vm.names.plainDateISO, plain_date_iso, 0, attr);
 }
 
 // 2.1.1 Temporal.Now.timeZone ( ), https://tc39.es/proposal-temporal/#sec-temporal.now.timezone
@@ -60,6 +61,25 @@ JS_DEFINE_NATIVE_FUNCTION(Now::plain_date)
         return {};
 
     // 2. Return ? CreateTemporalDate(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[Calendar]]).
+    return create_temporal_date(global_object, date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->calendar());
+}
+
+// 2.1.8 Temporal.Now.plainDateISO ( [ temporalTimeZoneLike ] ), https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso
+JS_DEFINE_NATIVE_FUNCTION(Now::plain_date_iso)
+{
+    auto temporal_time_zone_like = vm.argument(0);
+
+    // 1. Let calendar be ? GetISO8601Calendar().
+    auto* calendar = get_iso8601_calendar(global_object);
+    if (vm.exception())
+        return {};
+
+    // 2. Let dateTime be ? SystemDateTime(temporalTimeZoneLike, calendar).
+    auto* date_time = system_date_time(global_object, temporal_time_zone_like, calendar);
+    if (vm.exception())
+        return {};
+
+    // 3. Return ? CreateTemporalDate(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[Calendar]]).
     return create_temporal_date(global_object, date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->calendar());
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -6,8 +6,11 @@
 
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/Instant.h>
 #include <LibJS/Runtime/Temporal/Now.h>
+#include <LibJS/Runtime/Temporal/PlainDate.h>
+#include <LibJS/Runtime/Temporal/PlainDateTime.h>
 #include <LibJS/Runtime/Temporal/TimeZone.h>
 #include <time.h>
 
@@ -28,6 +31,7 @@ void Now::initialize(GlobalObject& global_object)
 
     define_native_function(vm.names.timeZone, time_zone, 0, attr);
     define_native_function(vm.names.instant, instant, 0, attr);
+    define_native_function(vm.names.plainDate, plain_date, 1, attr);
 }
 
 // 2.1.1 Temporal.Now.timeZone ( ), https://tc39.es/proposal-temporal/#sec-temporal.now.timezone
@@ -42,6 +46,21 @@ JS_DEFINE_NATIVE_FUNCTION(Now::instant)
 {
     // 1. Return ! SystemInstant().
     return system_instant(global_object);
+}
+
+// 2.1.7 Temporal.Now.plainDate ( calendar [ , temporalTimeZoneLike ] ), https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate
+JS_DEFINE_NATIVE_FUNCTION(Now::plain_date)
+{
+    auto calendar = vm.argument(0);
+    auto temporal_time_zone_like = vm.argument(1);
+
+    // 1. Let dateTime be ? SystemDateTime(temporalTimeZoneLike, calendar).
+    auto* date_time = system_date_time(global_object, temporal_time_zone_like, calendar);
+    if (vm.exception())
+        return {};
+
+    // 2. Return ? CreateTemporalDate(dateTime.[[ISOYear]], dateTime.[[ISOMonth]], dateTime.[[ISODay]], dateTime.[[Calendar]]).
+    return create_temporal_date(global_object, date_time->iso_year(), date_time->iso_month(), date_time->iso_day(), date_time->calendar());
 }
 
 // 2.2.1 SystemTimeZone ( ), https://tc39.es/proposal-temporal/#sec-temporal-systemtimezone
@@ -85,6 +104,35 @@ Instant* system_instant(GlobalObject& global_object)
 
     // 2. Return ! CreateTemporalInstant(ns).
     return create_temporal_instant(global_object, *ns);
+}
+
+// 2.2.4 SystemDateTime ( temporalTimeZoneLike, calendarLike ), https://tc39.es/proposal-temporal/#sec-temporal-systemdatetime
+PlainDateTime* system_date_time(GlobalObject& global_object, Value temporal_time_zone_like, Value calendar_like)
+{
+    auto& vm = global_object.vm();
+    Object* time_zone;
+
+    // 1. If temporalTimeZoneLike is undefined, then
+    if (temporal_time_zone_like.is_undefined()) {
+        // a. Let timeZone be ! SystemTimeZone().
+        time_zone = system_time_zone(global_object);
+    } else {
+        // a. Let timeZone be ? ToTemporalTimeZone(temporalTimeZoneLike).
+        time_zone = to_temporal_time_zone(global_object, temporal_time_zone_like);
+        if (vm.exception())
+            return {};
+    }
+
+    // 3. Let calendar be ? ToTemporalCalendar(calendarLike).
+    auto* calendar = to_temporal_calendar(global_object, calendar_like);
+    if (vm.exception())
+        return {};
+
+    // 4. Let instant be ! SystemInstant().
+    auto* instant = system_instant(global_object);
+
+    // 5. Return ? BuiltinTimeZoneGetPlainDateTimeFor(timeZone, instant, calendar).
+    return builtin_time_zone_get_plain_date_time_for(global_object, *time_zone, *instant, *calendar);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -31,6 +31,7 @@ void Now::initialize(GlobalObject& global_object)
 
     define_native_function(vm.names.timeZone, time_zone, 0, attr);
     define_native_function(vm.names.instant, instant, 0, attr);
+    define_native_function(vm.names.plainDateTime, plain_date_time, 1, attr);
     define_native_function(vm.names.plainDate, plain_date, 1, attr);
     define_native_function(vm.names.plainDateISO, plain_date_iso, 0, attr);
 }
@@ -47,6 +48,16 @@ JS_DEFINE_NATIVE_FUNCTION(Now::instant)
 {
     // 1. Return ! SystemInstant().
     return system_instant(global_object);
+}
+
+// 2.1.3 Temporal.Now.plainDateTime ( calendar [ , temporalTimeZoneLike ] ), https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime
+JS_DEFINE_NATIVE_FUNCTION(Now::plain_date_time)
+{
+    auto calendar = vm.argument(0);
+    auto temporal_time_zone_like = vm.argument(1);
+
+    // 1. Return ? SystemDateTime(temporalTimeZoneLike, calendar).
+    return system_date_time(global_object, temporal_time_zone_like, calendar);
 }
 
 // 2.1.7 Temporal.Now.plainDate ( calendar [ , temporalTimeZoneLike ] ), https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -22,6 +22,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(time_zone);
     JS_DECLARE_NATIVE_FUNCTION(instant);
     JS_DECLARE_NATIVE_FUNCTION(plain_date_time);
+    JS_DECLARE_NATIVE_FUNCTION(plain_date_time_iso);
     JS_DECLARE_NATIVE_FUNCTION(plain_date);
     JS_DECLARE_NATIVE_FUNCTION(plain_date_iso);
 };

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -22,6 +22,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(time_zone);
     JS_DECLARE_NATIVE_FUNCTION(instant);
     JS_DECLARE_NATIVE_FUNCTION(plain_date);
+    JS_DECLARE_NATIVE_FUNCTION(plain_date_iso);
 };
 
 TimeZone* system_time_zone(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -21,10 +21,12 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(time_zone);
     JS_DECLARE_NATIVE_FUNCTION(instant);
+    JS_DECLARE_NATIVE_FUNCTION(plain_date);
 };
 
 TimeZone* system_time_zone(GlobalObject&);
 BigInt* system_utc_epoch_nanoseconds(GlobalObject&);
 Instant* system_instant(GlobalObject&);
+PlainDateTime* system_date_time(GlobalObject&, Value temporal_time_zone_like, Value calendar_like);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -21,6 +21,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(time_zone);
     JS_DECLARE_NATIVE_FUNCTION(instant);
+    JS_DECLARE_NATIVE_FUNCTION(plain_date_time);
     JS_DECLARE_NATIVE_FUNCTION(plain_date);
     JS_DECLARE_NATIVE_FUNCTION(plain_date_iso);
 };

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,10 +35,17 @@ private:
     Object& m_calendar;   // [[Calendar]]
 };
 
+struct ISODate {
+    i32 year;
+    u8 month;
+    u8 day;
+};
+
 PlainDate* create_temporal_date(GlobalObject&, i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, FunctionObject* new_target = nullptr);
 PlainDate* to_temporal_date(GlobalObject&, Value item, Object* options = nullptr);
 Optional<TemporalDate> regulate_iso_date(GlobalObject&, double year, double month, double day, String const& overflow);
 bool is_valid_iso_date(i32 year, u8 month, u8 day);
+ISODate balance_iso_date(i32 year, i32 month, i32 day);
 i8 compare_iso_date(i32 year1, u8 month1, u8 day1, i32 year2, u8 month2, u8 day2);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <LibJS/Runtime/BigInt.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Temporal/AbstractOperations.h>
 
 namespace JS::Temporal {
 
@@ -48,6 +49,7 @@ private:
 
 BigInt* get_epoch_from_iso_parts(GlobalObject&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
 bool iso_date_time_within_limits(GlobalObject&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
+ISODateTime balance_iso_date_time(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, i64 nanosecond);
 PlainDateTime* create_temporal_date_time(GlobalObject&, i32 iso_year, u8 iso_month, u8 iso_day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, Object& calendar, FunctionObject* new_target = nullptr);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
@@ -54,4 +54,57 @@ bool is_valid_time(u8 hour, u8 minute, u8 second, u16 millisecond, u16 microseco
     return true;
 }
 
+// 4.5.6 BalanceTime ( hour, minute, second, millisecond, microsecond, nanosecond ), https://tc39.es/proposal-temporal/#sec-temporal-balancetime
+DaysAndTime balance_time(i64 hour, i64 minute, i64 second, i64 millisecond, i64 microsecond, i64 nanosecond)
+{
+    // 1. Assert: hour, minute, second, millisecond, microsecond, and nanosecond are integers.
+
+    // 2. Set microsecond to microsecond + floor(nanosecond / 1000).
+    microsecond += nanosecond / 1000;
+
+    // 3. Set nanosecond to nanosecond modulo 1000.
+    nanosecond %= 1000;
+
+    // 4. Set millisecond to millisecond + floor(microsecond / 1000).
+    millisecond += microsecond / 1000;
+
+    // 5. Set microsecond to microsecond modulo 1000.
+    microsecond %= 1000;
+
+    // 6. Set second to second + floor(millisecond / 1000).
+    second += millisecond / 1000;
+
+    // 7. Set millisecond to millisecond modulo 1000.
+    millisecond %= 1000;
+
+    // 8. Set minute to minute + floor(second / 60).
+    minute += second / 60;
+
+    // 9. Set second to second modulo 60.
+    second %= 60;
+
+    // 10. Set hour to hour + floor(minute / 60).
+    hour += minute / 60;
+
+    // 11. Set minute to minute modulo 60.
+    minute %= 60;
+
+    // 12. Let days be floor(hour / 24).
+    u8 days = hour / 24;
+
+    // 13. Set hour to hour modulo 24.
+    hour %= 24;
+
+    // 14. Return the new Record { [[Days]]: days, [[Hour]]: hour, [[Minute]]: minute, [[Second]]: second, [[Millisecond]]: millisecond, [[Microsecond]]: microsecond, [[Nanosecond]]: nanosecond }.
+    return DaysAndTime {
+        .days = static_cast<i32>(days),
+        .hour = static_cast<u8>(hour),
+        .minute = static_cast<u8>(minute),
+        .second = static_cast<u8>(second),
+        .millisecond = static_cast<u16>(millisecond),
+        .microsecond = static_cast<u16>(microsecond),
+        .nanosecond = static_cast<u16>(nanosecond),
+    };
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
@@ -10,6 +10,17 @@
 
 namespace JS::Temporal {
 
+struct DaysAndTime {
+    i32 days;
+    u8 hour;
+    u8 minute;
+    u8 second;
+    u16 millisecond;
+    u16 microsecond;
+    u16 nanosecond;
+};
+
 bool is_valid_time(u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
+DaysAndTime balance_time(i64 hour, i64 minute, i64 second, i64 millisecond, i64 microsecond, i64 nanosecond);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Temporal/PlainYearMonth.h>
+
+namespace JS::Temporal {
+
+// 9.5.5 BalanceISOYearMonth ( year, month ), https://tc39.es/proposal-temporal/#sec-temporal-balanceisoyearmonth
+ISOYearMonth balance_iso_year_month(i32 year, i32 month)
+{
+    // 1. Assert: year and month are integers.
+
+    // 2. Set year to year + floor((month - 1) / 12).
+    year += (month - 1) / 12;
+
+    // 3. Set month to (month − 1) modulo 12 + 1.
+    month = (month - 1) % 12 + 1;
+
+    // 4. Return the new Record { [[Year]]: year, [[Month]]: month }.
+    return ISOYearMonth { .year = year, .month = static_cast<u8>(month) };
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Temporal/AbstractOperations.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS::Temporal {
+
+struct ISOYearMonth {
+    i32 year;
+    u8 month;
+};
+
+ISOYearMonth balance_iso_year_month(i32 year, i32 month);
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Temporal/AbstractOperations.h>
 
 namespace JS::Temporal {
 
@@ -38,10 +39,15 @@ private:
 bool is_valid_time_zone_name(String const& time_zone);
 String canonicalize_time_zone_name(String const& time_zone);
 String default_time_zone();
+String parse_temporal_time_zone(GlobalObject&, String const&);
 TimeZone* create_temporal_time_zone(GlobalObject&, String const& identifier, FunctionObject* new_target = nullptr);
+Optional<ISODateTime> get_iso_parts_from_epoch(BigInt const& epoch_nanoseconds);
 i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, String const& time_zone_identifier);
 double parse_time_zone_offset_string(GlobalObject&, String const&);
 String format_time_zone_offset_string(double offset_nanoseconds);
+Object* to_temporal_time_zone(GlobalObject&, Value temporal_time_zone_like);
+double get_offset_nanoseconds_for(GlobalObject&, Object& time_zone, Instant&);
+PlainDateTime* builtin_time_zone_get_plain_date_time_for(GlobalObject&, Object& time_zone, Instant&, Object& calendar);
 
 bool is_valid_time_zone_numeric_utc_offset_syntax(String const&);
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDate.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDate.js
@@ -1,0 +1,27 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Temporal.Now.plainDate).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainDate = Temporal.Now.plainDate(calendar);
+        expect(plainDate).toBeInstanceOf(Temporal.PlainDate);
+        expect(plainDate.calendar).toBe(calendar);
+    });
+
+    test("custom time zone", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const timeZone = {
+            getOffsetNanosecondsFor() {
+                return 86400000000000;
+            },
+        };
+        const plainDate = Temporal.Now.plainDate(calendar);
+        const plainDateWithOffset = Temporal.Now.plainDate(calendar, timeZone);
+        // Yes, this will fail if a day, month, or year change happens between the above two lines :^)
+        expect(plainDateWithOffset.year).toBe(plainDate.year);
+        expect(plainDateWithOffset.month).toBe(plainDate.month);
+        expect(plainDateWithOffset.day).toBe(plainDate.day + 1);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateISO.js
@@ -1,0 +1,25 @@
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Temporal.Now.plainDateISO).toHaveLength(0);
+    });
+
+    test("basic functionality", () => {
+        const plainDate = Temporal.Now.plainDateISO();
+        expect(plainDate).toBeInstanceOf(Temporal.PlainDate);
+        expect(plainDate.calendar.id).toBe("iso8601");
+    });
+
+    test("custom time zone", () => {
+        const timeZone = {
+            getOffsetNanosecondsFor() {
+                return 86400000000000;
+            },
+        };
+        const plainDate = Temporal.Now.plainDateISO();
+        const plainDateWithOffset = Temporal.Now.plainDateISO(timeZone);
+        // Yes, this will fail if a day, month, or year change happens between the above two lines :^)
+        expect(plainDateWithOffset.year).toBe(plainDate.year);
+        expect(plainDateWithOffset.month).toBe(plainDate.month);
+        expect(plainDateWithOffset.day).toBe(plainDate.day + 1);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
@@ -1,0 +1,33 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Temporal.Now.plainDateTime).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainDateTime = Temporal.Now.plainDateTime(calendar);
+        expect(plainDateTime).toBeInstanceOf(Temporal.PlainDateTime);
+        expect(plainDateTime.calendar).toBe(calendar);
+    });
+
+    test("custom time zone", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const timeZone = {
+            getOffsetNanosecondsFor() {
+                return 86400000000000;
+            },
+        };
+        const plainDateTime = Temporal.Now.plainDateTime(calendar);
+        const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
+        // Yes, this will fail if a day, month, or year change happens between the above two lines :^)
+        // FIXME: enable these once the getters are implemented
+        // expect(plainDateTimeWithOffset.year).toBe(plainDateTime.year);
+        // expect(plainDateTimeWithOffset.month).toBe(plainDateTime.month);
+        // expect(plainDateTimeWithOffset.day).toBe(plainDateTime.day + 1);
+        // expect(plainDateTimeWithOffset.hour).not.toBe(plainDateTime.hour);
+        // expect(plainDateTimeWithOffset.minute).not.toBe(plainDateTime.minute);
+        // expect(plainDateTimeWithOffset.second).not.toBe(plainDateTime.second);
+        // expect(plainDateTimeWithOffset.millisecond).not.toBe(plainDateTime.millisecond);
+        // microsecond, and nanosecond not checked here as they could easily be the same for both
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
@@ -1,0 +1,31 @@
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Temporal.Now.plainDateTimeISO).toHaveLength(0);
+    });
+
+    test("basic functionality", () => {
+        const plainDateTime = Temporal.Now.plainDateTimeISO();
+        expect(plainDateTime).toBeInstanceOf(Temporal.PlainDateTime);
+        expect(plainDateTime.calendar.id).toBe("iso8601");
+    });
+
+    test("custom time zone", () => {
+        const timeZone = {
+            getOffsetNanosecondsFor() {
+                return 86400000000000;
+            },
+        };
+        const plainDateTime = Temporal.Now.plainDateTimeISO();
+        const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
+        // Yes, this will fail if a day, month, or year change happens between the above two lines :^)
+        // FIXME: enable these once the getters are implemented
+        // expect(plainDateTimeWithOffset.year).toBe(plainDateTime.year);
+        // expect(plainDateTimeWithOffset.month).toBe(plainDateTime.month);
+        // expect(plainDateTimeWithOffset.day).toBe(plainDateTime.day + 1);
+        // expect(plainDateTimeWithOffset.hour).not.toBe(plainDateTime.hour);
+        // expect(plainDateTimeWithOffset.minute).not.toBe(plainDateTime.minute);
+        // expect(plainDateTimeWithOffset.second).not.toBe(plainDateTime.second);
+        // expect(plainDateTimeWithOffset.millisecond).not.toBe(plainDateTime.millisecond);
+        // microsecond, and nanosecond not checked here as they could easily be the same for both
+    });
+});


### PR DESCRIPTION
Ticks 4 checkboxes in #8982, and a shedload of AOs.