### PR TITLE
Kernel: Make Process::FileDescriptions::allocate return KResultOr<int>

### DIFF
--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -15,8 +15,8 @@ namespace Kernel {
 class FileDescription;
 
 struct SocketPair {
+    NonnullRefPtr<FileDescription> description0;
     NonnullRefPtr<FileDescription> description1;
-    NonnullRefPtr<FileDescription> description2;
 };
 
 class LocalSocket final : public Socket {

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -465,14 +465,14 @@ size_t Process::FileDescriptions::open_count() const
     return count;
 }
 
-int Process::FileDescriptions::allocate(int first_candidate_fd)
+KResultOr<int> Process::FileDescriptions::allocate(int first_candidate_fd)
 {
     ScopedSpinLock lock(m_fds_lock);
     for (size_t i = first_candidate_fd; i < max_open(); ++i) {
         if (!m_fds_metadatas[i])
             return i;
     }
-    return -EMFILE;
+    return KResult(EMFILE);
 }
 
 Time kgettimeofday()

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -641,7 +641,7 @@ public:
         void enumerate(Function<void(const FileDescriptionAndFlags&)>) const;
         void change_each(Function<void(FileDescriptionAndFlags&)>);
 
-        int allocate(int first_candidate_fd = 0);
+        KResultOr<int> allocate(int first_candidate_fd = 0);
         size_t open_count() const;
 
         bool try_resize(size_t size) { return m_fds_metadatas.try_resize(size); }

--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -25,10 +25,10 @@ KResultOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
 
-    int new_fd = m_fds.allocate();
-    if (new_fd < 0)
-        return new_fd;
-
+    auto new_fd_or_error = m_fds.allocate();
+    if (new_fd_or_error.is_error())
+        return new_fd_or_error.error();
+    auto new_fd = new_fd_or_error.value();
     auto vmobject = AnonymousVMObject::try_create_purgeable_with_size(size, AllocationStrategy::Reserve);
     if (!vmobject)
         return ENOMEM;

--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -28,7 +28,7 @@ KResultOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     auto new_fd_or_error = m_fds.allocate();
     if (new_fd_or_error.is_error())
         return new_fd_or_error.error();
-    auto new_fd = new_fd_or_error.value();
+    auto new_fd = new_fd_or_error.release_value();
     auto vmobject = AnonymousVMObject::try_create_purgeable_with_size(size, AllocationStrategy::Reserve);
     if (!vmobject)
         return ENOMEM;
@@ -48,8 +48,8 @@ KResultOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     if (options & O_CLOEXEC)
         fd_flags |= FD_CLOEXEC;
 
-    m_fds[new_fd].set(move(description), fd_flags);
-    return new_fd;
+    m_fds[new_fd.fd].set(move(description), fd_flags);
+    return new_fd.fd;
 }
 
 }

--- a/Kernel/Syscalls/dup2.cpp
+++ b/Kernel/Syscalls/dup2.cpp
@@ -20,6 +20,8 @@ KResultOr<FlatPtr> Process::sys$dup2(int old_fd, int new_fd)
         return new_fd;
     if (new_fd < 0 || static_cast<size_t>(new_fd) >= fds().max_open())
         return EINVAL;
+    if (!m_fds.m_fds_metadatas[new_fd].is_allocated())
+        m_fds.m_fds_metadatas[new_fd].allocate();
     m_fds[new_fd].set(*description);
     return new_fd;
 }

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -591,12 +591,13 @@ KResult Process::do_exec(NonnullRefPtr<FileDescription> main_program_description
 
     int main_program_fd = -1;
     if (interpreter_description) {
-        main_program_fd = m_fds.allocate().value();
-        VERIFY(main_program_fd >= 0);
+        auto main_program_fd_wrapper = m_fds.allocate().release_value();
+        VERIFY(main_program_fd_wrapper.fd >= 0);
         auto seek_result = main_program_description->seek(0, SEEK_SET);
         VERIFY(!seek_result.is_error());
         main_program_description->set_readable(true);
-        m_fds[main_program_fd].set(move(main_program_description), FD_CLOEXEC);
+        m_fds[main_program_fd_wrapper.fd].set(move(main_program_description), FD_CLOEXEC);
+        main_program_fd = main_program_fd_wrapper.fd;
     }
 
     new_main_thread = nullptr;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -591,7 +591,7 @@ KResult Process::do_exec(NonnullRefPtr<FileDescription> main_program_description
 
     int main_program_fd = -1;
     if (interpreter_description) {
-        main_program_fd = m_fds.allocate();
+        main_program_fd = m_fds.allocate().value();
         VERIFY(main_program_fd >= 0);
         auto seek_result = main_program_description->seek(0, SEEK_SET);
         VERIFY(!seek_result.is_error());

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -28,9 +28,9 @@ KResultOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
         auto new_fd_or_error = fds().allocate(arg_fd);
         if (new_fd_or_error.is_error())
             return new_fd_or_error.error();
-        auto new_fd = new_fd_or_error.value();
-        m_fds[new_fd].set(*description);
-        return new_fd;
+        auto new_fd = new_fd_or_error.release_value();
+        m_fds[new_fd.fd].set(*description);
+        return new_fd.fd;
     }
     case F_GETFD:
         return m_fds[fd].flags();

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -25,9 +25,10 @@ KResultOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
         int arg_fd = (int)arg;
         if (arg_fd < 0)
             return EINVAL;
-        int new_fd = fds().allocate(arg_fd);
-        if (new_fd < 0)
-            return new_fd;
+        auto new_fd_or_error = fds().allocate(arg_fd);
+        if (new_fd_or_error.is_error())
+            return new_fd_or_error.error();
+        auto new_fd = new_fd_or_error.value();
         m_fds[new_fd].set(*description);
         return new_fd;
     }

--- a/Kernel/Syscalls/inode_watcher.cpp
+++ b/Kernel/Syscalls/inode_watcher.cpp
@@ -18,9 +18,10 @@ KResultOr<FlatPtr> Process::sys$create_inode_watcher(u32 flags)
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(rpath);
 
-    int fd = m_fds.allocate();
-    if (fd < 0)
-        return fd;
+    auto fd_or_error = m_fds.allocate();
+    if (fd_or_error.is_error())
+        return fd_or_error.error();
+    auto fd = fd_or_error.value();
 
     auto watcher_or_error = InodeWatcher::create();
     if (watcher_or_error.is_error())

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -45,10 +45,11 @@ KResultOr<FlatPtr> Process::sys$open(Userspace<const Syscall::SC_open_params*> u
         return path.error();
 
     dbgln_if(IO_DEBUG, "sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path.value()->view(), options, mode);
-    int fd = m_fds.allocate();
-    if (fd < 0)
-        return fd;
 
+    auto fd_or_error = m_fds.allocate();
+    if (fd_or_error.is_error())
+        return fd_or_error.error();
+    auto fd = fd_or_error.value();
     RefPtr<Custody> base;
     if (dirfd == AT_FDCWD) {
         base = current_directory();

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -49,7 +49,7 @@ KResultOr<FlatPtr> Process::sys$open(Userspace<const Syscall::SC_open_params*> u
     auto fd_or_error = m_fds.allocate();
     if (fd_or_error.is_error())
         return fd_or_error.error();
-    auto fd = fd_or_error.value();
+    auto new_fd = fd_or_error.release_value();
     RefPtr<Custody> base;
     if (dirfd == AT_FDCWD) {
         base = current_directory();
@@ -73,8 +73,8 @@ KResultOr<FlatPtr> Process::sys$open(Userspace<const Syscall::SC_open_params*> u
         return ENXIO;
 
     u32 fd_flags = (options & O_CLOEXEC) ? FD_CLOEXEC : 0;
-    m_fds[fd].set(move(description), fd_flags);
-    return fd;
+    m_fds[new_fd.fd].set(move(description), fd_flags);
+    return new_fd.fd;
 }
 
 KResultOr<FlatPtr> Process::sys$close(int fd)

--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -33,19 +33,20 @@ KResultOr<FlatPtr> Process::sys$pipe(int pipefd[2], int flags)
     auto reader_fd_or_error = m_fds.allocate();
     if (reader_fd_or_error.is_error())
         return reader_fd_or_error.error();
-    auto reader_fd = reader_fd_or_error.value();
-    m_fds[reader_fd].set(open_reader_result.release_value(), fd_flags);
-    m_fds[reader_fd].description()->set_readable(true);
-    if (!copy_to_user(&pipefd[0], &reader_fd))
+    auto reader_fd = reader_fd_or_error.release_value();
+    m_fds[reader_fd.fd].set(open_reader_result.release_value(), fd_flags);
+    m_fds[reader_fd.fd].description()->set_readable(true);
+    if (!copy_to_user(&pipefd[0], &reader_fd.fd))
         return EFAULT;
 
     auto writer_fd_or_error = m_fds.allocate();
     if (writer_fd_or_error.is_error())
         return writer_fd_or_error.error();
-    auto writer_fd = writer_fd_or_error.value();
-    m_fds[writer_fd].set(open_writer_result.release_value(), fd_flags);
-    m_fds[writer_fd].description()->set_writable(true);
-    if (!copy_to_user(&pipefd[1], &writer_fd))
+    auto writer_fd = writer_fd_or_error.release_value();
+    m_fds[writer_fd.fd].set(open_writer_result.release_value(), fd_flags);
+    m_fds[writer_fd.fd].description()->set_writable(true);
+
+    if (!copy_to_user(&pipefd[1], &writer_fd.fd))
         return EFAULT;
 
     return 0;

--- a/Kernel/Syscalls/sendfd.cpp
+++ b/Kernel/Syscalls/sendfd.cpp
@@ -49,7 +49,7 @@ KResultOr<FlatPtr> Process::sys$recvfd(int sockfd, int options)
     auto new_fd_or_error = m_fds.allocate();
     if (new_fd_or_error.is_error())
         return new_fd_or_error.error();
-    auto new_fd = new_fd_or_error.value();
+    auto new_fd = new_fd_or_error.release_value();
 
     auto& local_socket = static_cast<LocalSocket&>(socket);
     auto received_descriptor_or_error = local_socket.recvfd(*socket_description);
@@ -61,8 +61,8 @@ KResultOr<FlatPtr> Process::sys$recvfd(int sockfd, int options)
     if (options & O_CLOEXEC)
         fd_flags |= FD_CLOEXEC;
 
-    m_fds[new_fd].set(*received_descriptor_or_error.value(), fd_flags);
-    return new_fd;
+    m_fds[new_fd.fd].set(*received_descriptor_or_error.value(), fd_flags);
+    return new_fd.fd;
 }
 
 }

--- a/Kernel/Syscalls/sendfd.cpp
+++ b/Kernel/Syscalls/sendfd.cpp
@@ -46,9 +46,10 @@ KResultOr<FlatPtr> Process::sys$recvfd(int sockfd, int options)
     if (!socket.is_local())
         return EAFNOSUPPORT;
 
-    int new_fd = m_fds.allocate();
-    if (new_fd < 0)
-        return new_fd;
+    auto new_fd_or_error = m_fds.allocate();
+    if (new_fd_or_error.is_error())
+        return new_fd_or_error.error();
+    auto new_fd = new_fd_or_error.value();
 
     auto& local_socket = static_cast<LocalSocket&>(socket);
     auto received_descriptor_or_error = local_socket.recvfd(*socket_description);

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -153,9 +153,6 @@ KResultOr<FlatPtr> Process::sys$accept4(Userspace<const Syscall::SC_accept4_para
 KResultOr<FlatPtr> Process::sys$connect(int sockfd, Userspace<const sockaddr*> user_address, socklen_t user_address_size)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
-    int fd = m_fds.allocate();
-    if (fd < 0)
-        return fd;
     auto description = fds().file_description(sockfd);
     if (!description)
         return EBADF;


### PR DESCRIPTION
- **Kernel: Avoid file descriptor leak in Process::sys$socketpair on error**

    Previously it was possible to leak the file descriptor if we error out
    after allocating the first descriptor. Now we perform both fd
    allocations back to back so we can handle the potential error when
    processing the second fd allocation.

- **Kernel: Track allocated FileDescriptionAndFlag elements in each Process**

    The way the Process::FileDescriptions::allocate() API works today means
    that two callers who allocate back to back without associating a
    FileDescription with the allocated FD, will receive the same FD and thus
    one will stomp over the other.

    Naively tracking which FileDescriptions are allocated and moving onto
    the next would introduce other bugs however, as now if you "allocate"
    a fd and then return early further down the control flow of the syscall
    you would leak that fd.

    This change modifies this behavior by tracking which descriptions are
    allocated and then having an RAII type to "deallocate" the fd if the
    association is not setup the end of it's scope.

- **Kernel: Make Process::FileDescriptions::allocate return KResultOr<int>**

    Modernize more error checking by utilizing KResultOr.

- **Kernel: Remove unused fd allocation from Process::sys$connect(..)**