### PR TITLE
Kernel: Fix CPU initialization for SMP

### DIFF
--- a/Kernel/Arch/x86/i386/Boot/ap_setup.S
+++ b/Kernel/Arch/x86/i386/Boot/ap_setup.S
@@ -109,7 +109,7 @@ apic_ap_start32_2:
 
     /* push the Processor pointer this CPU is going to use */
     movl (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %eax
-    addl kernel_load_base, %eax
+    addl kernel_mapping_base, %eax
     movl 0(%eax, %esi, 4), %eax
     push %eax
 

--- a/Kernel/Arch/x86/x86_64/Boot/ap_setup.S
+++ b/Kernel/Arch/x86/x86_64/Boot/ap_setup.S
@@ -141,7 +141,7 @@ apic_ap_start64:
 
     /* push the Processor pointer this CPU is going to use */
     movq (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %rax
-    leaq kernel_load_base(%rip), %r8
+    leaq kernel_mapping_base(%rip), %r8
     movq (%r8), %r8
     addq %r8, %rax
     movq 0(%rax, %rsi, 4), %rax


### PR DESCRIPTION
This was broken by the KASLR changes.