### PR TITLE
Fix many small broken layouts, and inconsistent margins.

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWindow.gml
+++ b/Userland/Applications/Calculator/CalculatorWindow.gml
@@ -1,5 +1,5 @@
 @GUI::Widget {
-    fixed_width: 254
+    fixed_width: 250
     fixed_height: 215
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout
@@ -13,7 +13,7 @@
 
         @GUI::Widget {
             layout: @GUI::VerticalBoxLayout {
-                margins: [10, 2, 10, 0]
+                margins: [8, 8, 8, 8]
             }
 
             @GUI::TextBox {

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_title("Calculator");
     window->set_resizable(false);
-    window->resize(254, 215);
+    window->resize(250, 215);
 
     auto& widget = window->set_main_widget<CalculatorWidget>();
 

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -142,7 +142,7 @@ PropertiesWindow::PropertiesWindow(String const& path, bool disable_rename, Wind
 
     auto& button_widget = main_widget.add<GUI::Widget>();
     button_widget.set_layout<GUI::HorizontalBoxLayout>();
-    button_widget.set_fixed_height(24);
+    button_widget.set_fixed_height(22);
     button_widget.layout()->set_spacing(5);
 
     button_widget.layout()->add_spacer();

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -74,7 +74,7 @@
                 title: "Metadata"
                 fixed_height: 220
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [8, 16, 8, 4]
+                    margins: [8, 16, 8, 8]
                 }
 
                 @GUI::Widget {

--- a/Userland/Applications/HexEditor/FindDialog.gml
+++ b/Userland/Applications/HexEditor/FindDialog.gml
@@ -11,6 +11,7 @@
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout
+        fixed_height: 22
 
         @GUI::Label {
             text: "Value to find"
@@ -20,7 +21,6 @@
 
         @GUI::TextBox {
             name: "text_editor"
-            fixed_height: 20
         }
     }
 
@@ -32,6 +32,7 @@
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout
+        fixed_height: 22
 
         @GUI::Button {
             name: "find_button"

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Keyboard Settings");
-    window->resize(300, 70);
+    window->resize(300, 78);
     window->set_resizable(false);
     window->set_minimizable(false);
     window->set_icon(app_icon.bitmap_for_size(16));
@@ -155,7 +155,8 @@ int main(int argc, char** argv)
     auto& bottom_widget = root_widget.add<GUI::Widget>();
     bottom_widget.set_layout<GUI::HorizontalBoxLayout>();
     bottom_widget.layout()->add_spacer();
-    bottom_widget.set_fixed_height(22);
+    bottom_widget.set_fixed_height(30);
+    bottom_widget.set_content_margins({ 0, 4, 0, 4 });
 
     auto& ok_button = bottom_widget.add<GUI::Button>();
     ok_button.set_text("OK");

--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -2,12 +2,13 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [10, 10, 10, 10]
+        margins: [4, 4, 4, 4]
     }
 
     @GUI::Widget {
+        max_height: 32
         layout: @GUI::HorizontalBoxLayout {
-            spacing: 10
+            spacing: 16
         }
 
         @GUI::ImageWidget {
@@ -22,7 +23,9 @@
     }
 
     @GUI::Widget {
-        layout: @GUI::HorizontalBoxLayout
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [4, 4, 4, 4]
+        }
 
         @GUI::Label {
             text: "Open:"
@@ -37,6 +40,7 @@
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout
+        fixed_height: 22
 
         // HACK: using an empty widget as a spacer
         @GUI::Widget
@@ -44,19 +48,19 @@
         @GUI::Button {
             name: "ok_button"
             text: "OK"
-            fixed_width: 75
+            fixed_width: 80
         }
 
         @GUI::Button {
             name: "cancel_button"
             text: "Cancel"
-            fixed_width: 75
+            fixed_width: 80
         }
 
         @GUI::Button {
             name: "browse_button"
             text: "Browse..."
-            fixed_width: 75
+            fixed_width: 80
         }
     }
 }

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -33,7 +33,7 @@ RunWindow::RunWindow()
 
     set_title("Run");
     set_icon(app_icon.bitmap_for_size(16));
-    resize(345, 140);
+    resize(345, 100);
     set_resizable(false);
     set_minimizable(false);
 

--- a/Userland/Applications/Run/main.cpp
+++ b/Userland/Applications/Run/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
     auto app = GUI::Application::construct(argc, argv);
     auto window = RunWindow::construct();
 
-    window->move_to(12, GUI::Desktop::the().rect().bottom() - GUI::Desktop::the().taskbar_height() - 12 - window->height());
+    window->move_to(16, GUI::Desktop::the().rect().bottom() - GUI::Desktop::the().taskbar_height() - 16 - window->height());
     window->show();
 
     return app->exec();

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -22,7 +22,7 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
     , m_name(name)
     , m_icon(icon)
 {
-    resize(413, 205);
+    resize(413, 204);
     set_title(String::formatted("About {}", m_name));
     set_resizable(false);
 
@@ -56,12 +56,13 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
 
     auto& right_container = content_container.add<Widget>();
     right_container.set_layout<VerticalBoxLayout>();
-    right_container.layout()->set_margins({ 0, 12, 12, 8 });
+    right_container.layout()->set_margins({ 0, 12, 4, 4 });
 
     auto make_label = [&](const StringView& text, bool bold = false) {
         auto& label = right_container.add<Label>(text);
         label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         label.set_fixed_height(14);
+        label.set_content_margins({ 0, 0, 8, 0 });
         if (bold)
             label.set_font(Gfx::FontDatabase::default_font().bold_variant());
     };
@@ -75,11 +76,11 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
     right_container.layout()->add_spacer();
 
     auto& button_container = right_container.add<Widget>();
-    button_container.set_fixed_height(23);
+    button_container.set_fixed_height(22);
     button_container.set_layout<HorizontalBoxLayout>();
     button_container.layout()->add_spacer();
     auto& ok_button = button_container.add<Button>("OK");
-    ok_button.set_fixed_size(80, 23);
+    ok_button.set_fixed_width(80);
     ok_button.on_click = [this](auto) {
         done(Dialog::ExecOK);
     };

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -65,7 +65,7 @@
             layout: @GUI::VerticalBoxLayout
 
             @GUI::Widget {
-                fixed_height: 24
+                fixed_height: 22
                 layout: @GUI::HorizontalBoxLayout
 
                 @GUI::TextBox {
@@ -84,7 +84,7 @@
             }
 
             @GUI::Widget {
-                fixed_height: 24
+                fixed_height: 22
                 layout: @GUI::HorizontalBoxLayout
 
                 @GUI::Widget

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -33,7 +33,6 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     auto& widget = set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);
     widget.set_layout<GUI::VerticalBoxLayout>();
-    widget.layout()->set_margins({ 0, 0, 0, 2 });
 
     m_table_view = widget.add<GUI::TableView>();
     auto sorting_model = GUI::SortingProxyModel::create(RunningProcessesModel::create());
@@ -46,11 +45,12 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     auto& button_container = widget.add<GUI::Widget>();
     button_container.set_fixed_height(30);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
+    button_container.set_content_margins({ 0, 4, 0, 4 });
     button_container.layout()->set_margins({ 0, 0, 4, 0 });
     button_container.layout()->add_spacer();
 
     auto& select_button = button_container.add<GUI::Button>(m_button_label);
-    select_button.set_fixed_size(80, 24);
+    select_button.set_fixed_width(80);
     select_button.on_click = [this](auto) {
         if (m_table_view->selection().is_empty()) {
             GUI::MessageBox::show(this, "No process selected!", m_window_title, GUI::MessageBox::Type::Error);
@@ -60,7 +60,7 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
         set_pid_from_index_and_close(index);
     };
     auto& cancel_button = button_container.add<GUI::Button>("Cancel");
-    cancel_button.set_fixed_size(80, 24);
+    cancel_button.set_fixed_width(80);
     cancel_button.on_click = [this](auto) {
         done(ExecCancel);
     };


### PR DESCRIPTION
This Fixes many occurrences of inconsistent margins of buttons to window borders, broken layouts with odd spacing, needlessly set fixed_height-s, and inconsistent spacing between applications.
Examples (BEFORE / bad / the kind of things i set out to fix):
![button corner spacing inconsistency](https://user-images.githubusercontent.com/28605587/127214834-fc3c94fc-a1de-4c6b-ae2a-e34a00c5c5c9.png)
![HexEditor search dialog](https://user-images.githubusercontent.com/28605587/127215115-09662483-9aff-40c5-a94c-cb088f89bfc3.png)


