### PR TITLE
Meta: Bring lint-commit.sh up to date with the CI commit linter

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -2,6 +2,8 @@ name: Commit linter
 
 on: [pull_request_target]
 
+# Make sure to update Meta/lint-commit.sh to match this script when adding new checks!
+
 jobs:
   lint_commits:
     runs-on: ubuntu-20.04

--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -28,11 +28,17 @@ while read -r line; do
     error "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)"
   fi
 
+  title_case_pattern="^\S.*?: [A-Z0-9]"
+  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -P -v -q "$title_case_pattern"); then
+    error "First word of commit after the subsystem is not capitalized"
+  fi
+
   if [[ $line_number -eq 1 ]] && [[ "$line" =~ \.$ ]]; then
     error "Commit title ends in a period"
   fi
 
-  if [[ $line_length -gt 72 ]]; then
+  url_pattern="([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&\/=]|-)+"
+  if [[ $line_length -gt 72 ]] && (echo "$line" | grep -P -v -q "$url_pattern"); then
     error "Commit message lines are too long (maximum allowed is 72 characters)"
   fi
 done <"$commit_file"


### PR DESCRIPTION
This was missing 2 of the recently added checks. Also added a reminder in the CI linter to update the Meta (commit hook) version.