### PR TITLE
Meta: Ignore everything after the git cut line in a `lint-commit.sh` hook

### DIFF
--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -17,6 +17,11 @@ fi
 
 line_number=0
 while read -r line; do
+  # break on git cut line, used by git commit --verbose
+  if [[ "$line" == "# ------------------------ >8 ------------------------" ]]; then
+    break
+  fi
+
   # ignore comment lines
   [[ "$line" =~ ^#.* ]] && continue
 


### PR DESCRIPTION
I have set up a `commit.verbose` variable in my git config, which shows the patch diff on bottom of the commit message.

Unfortunately the character limit was also applied to the diff, which meant that I got a false-positive lint error almost every time.

the cut-line in git: https://github.com/git/git/blob/eb27b338a3e71c7c4079fbac8aeae3f8fbb5c687/wt-status.c#L24-L25