### PR TITLE
LibJS: Implement non-ECMA-402 String.prototype.toLocale{Lower,Upper}Case

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -368,8 +368,10 @@ namespace JS {
     P(toISOString)                           \
     P(toJSON)                                \
     P(toLocaleDateString)                    \
+    P(toLocaleLowerCase)                     \
     P(toLocaleString)                        \
     P(toLocaleTimeString)                    \
+    P(toLocaleUpperCase)                     \
     P(toLowerCase)                           \
     P(toPlainDate)                           \
     P(toString)                              \

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -117,6 +117,8 @@ void StringPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.startsWith, starts_with, 1, attr);
     define_native_function(vm.names.endsWith, ends_with, 1, attr);
     define_native_function(vm.names.indexOf, index_of, 1, attr);
+    define_native_function(vm.names.toLocaleLowerCase, to_locale_lowercase, 0, attr);
+    define_native_function(vm.names.toLocaleUpperCase, to_locale_uppercase, 0, attr);
     define_native_function(vm.names.toLowerCase, to_lowercase, 0, attr);
     define_native_function(vm.names.toUpperCase, to_uppercase, 0, attr);
     define_native_function(vm.names.toString, to_string, 0, attr);
@@ -376,6 +378,30 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::index_of)
 
     auto index = string_index_of(utf16_string_view, utf16_search_view, start);
     return index.has_value() ? Value(*index) : Value(-1);
+}
+
+// 22.1.3.24 String.prototype.toLocaleLowerCase ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-string.prototype.tolocalelowercase
+// NOTE: This is the minimum toLocaleLowerCase implementation for engines without ECMA-402.
+JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_locale_lowercase)
+{
+    auto string = ak_string_from(vm, global_object);
+    if (!string.has_value())
+        return {};
+
+    auto lowercase = Unicode::to_unicode_lowercase_full(*string);
+    return js_string(vm, move(lowercase));
+}
+
+// 22.1.3.25 String.prototype.toLocaleUpperCase ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-string.prototype.tolocaleuppercase
+// NOTE: This is the minimum toLocaleUpperCase implementation for engines without ECMA-402.
+JS_DEFINE_NATIVE_FUNCTION(StringPrototype::to_locale_uppercase)
+{
+    auto string = ak_string_from(vm, global_object);
+    if (!string.has_value())
+        return {};
+
+    auto uppercase = Unicode::to_unicode_uppercase_full(*string);
+    return js_string(vm, move(uppercase));
 }
 
 // 22.1.3.26 String.prototype.toLowerCase ( ), https://tc39.es/ecma262/#sec-string.prototype.tolowercase

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -34,6 +34,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(starts_with);
     JS_DECLARE_NATIVE_FUNCTION(ends_with);
     JS_DECLARE_NATIVE_FUNCTION(index_of);
+    JS_DECLARE_NATIVE_FUNCTION(to_locale_lowercase);
+    JS_DECLARE_NATIVE_FUNCTION(to_locale_uppercase);
     JS_DECLARE_NATIVE_FUNCTION(to_lowercase);
     JS_DECLARE_NATIVE_FUNCTION(to_uppercase);
     JS_DECLARE_NATIVE_FUNCTION(to_string);

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.toLocaleLowerCase.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.toLocaleLowerCase.js
@@ -1,0 +1,28 @@
+test("basic functionality", () => {
+    expect(String.prototype.toLocaleLowerCase).toHaveLength(0);
+
+    expect("ω".toLocaleLowerCase()).toBe("ω");
+    expect("Ω".toLocaleLowerCase()).toBe("ω");
+    expect("😀".toLocaleLowerCase()).toBe("😀");
+
+    expect("foo".toLocaleLowerCase()).toBe("foo");
+    expect("Foo".toLocaleLowerCase()).toBe("foo");
+    expect("FOO".toLocaleLowerCase()).toBe("foo");
+
+    expect(("b" + "a" + +"a" + "a").toLocaleLowerCase()).toBe("banana");
+});
+
+test("special case folding", () => {
+    expect("\u00DF".toLocaleLowerCase()).toBe("\u00DF");
+    expect("\u0130".toLocaleLowerCase()).toBe("\u0069\u0307");
+    expect("\uFB00".toLocaleLowerCase()).toBe("\uFB00");
+    expect("\uFB01".toLocaleLowerCase()).toBe("\uFB01");
+    expect("\uFB02".toLocaleLowerCase()).toBe("\uFB02");
+    expect("\uFB03".toLocaleLowerCase()).toBe("\uFB03");
+    expect("\uFB04".toLocaleLowerCase()).toBe("\uFB04");
+    expect("\uFB05".toLocaleLowerCase()).toBe("\uFB05");
+    expect("\uFB06".toLocaleLowerCase()).toBe("\uFB06");
+    expect("\u1FB7".toLocaleLowerCase()).toBe("\u1FB7");
+    expect("\u1FC7".toLocaleLowerCase()).toBe("\u1FC7");
+    expect("\u1FF7".toLocaleLowerCase()).toBe("\u1FF7");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.toLocaleUpperCase.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.toLocaleUpperCase.js
@@ -1,0 +1,30 @@
+test("basic functionality", () => {
+    expect(String.prototype.toLocaleUpperCase).toHaveLength(0);
+
+    expect("ω".toLocaleUpperCase()).toBe("Ω");
+    expect("Ω".toLocaleUpperCase()).toBe("Ω");
+    expect("😀".toLocaleUpperCase()).toBe("😀");
+
+    expect("foo".toLocaleUpperCase()).toBe("FOO");
+    expect("Foo".toLocaleUpperCase()).toBe("FOO");
+    expect("FOO".toLocaleUpperCase()).toBe("FOO");
+
+    expect(("b" + "a" + +"n" + "a").toLocaleUpperCase()).toBe("BANANA");
+});
+
+test("special case folding", () => {
+    expect("\u00DF".toLocaleUpperCase()).toBe("\u0053\u0053");
+    expect("\u0130".toLocaleUpperCase()).toBe("\u0130");
+    expect("\uFB00".toLocaleUpperCase()).toBe("\u0046\u0046");
+    expect("\uFB01".toLocaleUpperCase()).toBe("\u0046\u0049");
+    expect("\uFB02".toLocaleUpperCase()).toBe("\u0046\u004C");
+    expect("\uFB03".toLocaleUpperCase()).toBe("\u0046\u0046\u0049");
+    expect("\uFB04".toLocaleUpperCase()).toBe("\u0046\u0046\u004C");
+    expect("\uFB05".toLocaleUpperCase()).toBe("\u0053\u0054");
+    expect("\uFB06".toLocaleUpperCase()).toBe("\u0053\u0054");
+    expect("\u0390".toLocaleUpperCase()).toBe("\u0399\u0308\u0301");
+    expect("\u03B0".toLocaleUpperCase()).toBe("\u03A5\u0308\u0301");
+    expect("\u1FB7".toLocaleUpperCase()).toBe("\u0391\u0342\u0399");
+    expect("\u1FC7".toLocaleUpperCase()).toBe("\u0397\u0342\u0399");
+    expect("\u1FF7".toLocaleUpperCase()).toBe("\u03A9\u0342\u0399");
+});


### PR DESCRIPTION
With this, we pass all but 1 `String.prototype.toLocaleLowerCase` test, which is just the same failure we have with `String.prototype.toLowerCase` regarding not yet parsing WordBreakProperty.txt.