### PR TITLE
LibGfx: More TextLayout fixes :^)

### DIFF
--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -120,6 +120,7 @@ Vector<String, 32> TextLayout::wrap_lines(TextElision elision, TextWrapping wrap
     Vector<String> lines;
     StringBuilder builder;
     size_t line_width = 0;
+    size_t current_block = 0;
     bool did_not_finish = false;
     for (Block& block : blocks) {
         switch (block.type) {
@@ -133,11 +134,17 @@ Vector<String, 32> TextLayout::wrap_lines(TextElision elision, TextWrapping wrap
                 goto blocks_processed;
             }
 
+            current_block++;
             continue;
         }
         case BlockType::Whitespace:
         case BlockType::Word: {
             size_t block_width = font().width(block.characters);
+            // FIXME: This should look at the specific advance amount of the
+            //        last character, but we don't support that yet.
+            if (current_block != blocks.size() - 1) {
+                block_width += font().glyph_spacing();
+            }
 
             if (wrapping == TextWrapping::Wrap && line_width + block_width > static_cast<unsigned>(m_rect.width())) {
                 lines.append(builder.to_string());
@@ -152,6 +159,7 @@ Vector<String, 32> TextLayout::wrap_lines(TextElision elision, TextWrapping wrap
 
             builder.append(block.characters.as_string());
             line_width += block_width;
+            current_block++;
         }
         }
     }

--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -139,24 +139,15 @@ Vector<String, 32> TextLayout::wrap_lines(TextElision elision, TextWrapping wrap
         case BlockType::Word: {
             size_t block_width = font().width(block.characters);
 
-            if (line_width > 0) {
-                block_width += font().glyph_width('x');
-
-                if (wrapping == TextWrapping::Wrap && line_width + block_width > static_cast<unsigned>(m_rect.width())) {
-                    lines.append(builder.to_string());
-                    builder.clear();
-                    line_width = 0;
-
-                    if (lines.size() == max_lines_that_can_fit && fit_within_rect == FitWithinRect::Yes) {
-                        did_not_finish = true;
-                        goto blocks_processed;
-                    }
-                }
+            if (wrapping == TextWrapping::Wrap && line_width + block_width > static_cast<unsigned>(m_rect.width())) {
+                lines.append(builder.to_string());
+                builder.clear();
+                line_width = 0;
             }
 
             if (lines.size() == max_lines_that_can_fit && fit_within_rect == FitWithinRect::Yes) {
                 did_not_finish = true;
-                break;
+                goto blocks_processed;
             }
 
             builder.append(block.characters.as_string());


### PR DESCRIPTION
**LibGfx: Remove extra space considered during wrapping**

This was previously required because the whitespace was consumed and
manually added back after the fact, but now that we preserve whitespace,
this breaks wrapping of text with whitespace after it.

**LibGfx: Take the glyph spacing into account when building a line**

Without this, a word might be added to a line despite going outside the
rect, due to the glyph spacing between blocks not being considered.