### PR TITLE
CI: Cancel duplicate commit linters and notifications for pull requests

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -2,6 +2,10 @@ name: Discord notifications
 
 on: [push, pull_request_target]
 
+concurrency:
+  group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
+  cancel-in-progress: true
+
 jobs:
   notify_discord:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -4,6 +4,10 @@ on: [pull_request_target]
 
 # Make sure to update Meta/lint-commit.sh to match this script when adding new checks!
 
+concurrency:
+  group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
+  cancel-in-progress: true
+
 jobs:
   lint_commits:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
These duplicates are created when branches are force pushed to,
resulting in wasted runners on the old CI instance.

Given that these are pretty quick to run, this helps when runners are
heavily backed up.

For example, #9052 was force pushed to while runners were heavily
backed up, leaving duplicate runners:
![Screenshot from 2021-07-27 22-39-58](https://user-images.githubusercontent.com/25595356/127232640-b444f82d-dd5e-46aa-aced-12433a3af418.png)
