### PR TITLE
LibGUI: Always reset pressed close button index on mouse up in TabWidget

### DIFF
--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -362,6 +362,7 @@ void TabWidget::mouseup_event(MouseEvent& event)
         return;
 
     auto close_button_rect = this->close_button_rect(m_pressed_close_button_index);
+    m_pressed_close_button_index = -1;
 
     if (close_button_rect.contains(event.position())) {
         auto* widget = m_tabs[m_pressed_close_button_index].widget;
@@ -369,7 +370,6 @@ void TabWidget::mouseup_event(MouseEvent& event)
             if (on_tab_close_click && widget)
                 on_tab_close_click(*widget);
         });
-        m_pressed_close_button_index = -1;
         return;
     }
 }


### PR DESCRIPTION
Previously it would only do this if the mouse was over the close 
button.

If you released the mouse outside the close button, the close button
would appear permanently depressed afterwards.

Before:
![Peek 2021-07-28 00-26](https://user-images.githubusercontent.com/25595356/127240254-771bb032-1080-4082-b8e6-f7490aa48e2f.gif)

After:
![Peek 2021-07-28 00-25](https://user-images.githubusercontent.com/25595356/127240244-b38bcb13-5147-461f-9283-f039fc6a42dd.gif)
