### PR TITLE
Utilities: Add half-page scrolling to 'less', and number modifiers to some of its commands

### DIFF
--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -400,10 +400,12 @@ int main(int argc, char** argv)
             if (sequence == "" || sequence == "q") {
                 break;
             } else if (sequence == "j" || sequence == "\e[B" || sequence == "\n") {
-                if (!modifier_buffer.is_empty())
-                    pager.down_n(modifier_buffer.build().to_uint().value_or(1));
-                else
-                    pager.down();
+                if (!emulate_more) {
+                    if (!modifier_buffer.is_empty())
+                        pager.down_n(modifier_buffer.build().to_uint().value_or(1));
+                    else
+                        pager.down();
+                }
             } else if (sequence == "k" || sequence == "\e[A") {
                 if (!emulate_more) {
                     if (!modifier_buffer.is_empty())
@@ -412,22 +414,26 @@ int main(int argc, char** argv)
                         pager.up();
                 }
             } else if (sequence == "g") {
-                if (!modifier_buffer.is_empty())
-                    pager.go_to_line(modifier_buffer.build().to_uint().value());
-                else
-                    pager.top();
+                if (!emulate_more) {
+                    if (!modifier_buffer.is_empty())
+                        pager.go_to_line(modifier_buffer.build().to_uint().value());
+                    else
+                        pager.top();
+                }
             } else if (sequence == "G") {
-                if (!modifier_buffer.is_empty())
-                    pager.go_to_line(modifier_buffer.build().to_uint().value());
-                else
-                    pager.bottom();
+                if (!emulate_more) {
+                    if (!modifier_buffer.is_empty())
+                        pager.go_to_line(modifier_buffer.build().to_uint().value());
+                    else
+                        pager.bottom();
+                }
             } else if (sequence == " " || sequence == "\e[6~") {
                 pager.down_page();
-            } else if (sequence == "\e[5~") {
+            } else if (sequence == "\e[5~" && !emulate_more) {
                 pager.up_page();
             } else if (sequence == "d") {
                 pager.down_half_page();
-            } else if (sequence == "u") {
+            } else if (sequence == "u" && !emulate_more) {
                 pager.up_half_page();
             }
 

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -141,7 +141,7 @@ public:
     {
         clear_status();
 
-        while (n - (m_lines.size() - m_line) > 0) {
+        while (n - (m_lines.size() - m_line) + m_height - 1 > 0) {
             if (!read_line())
                 break;
         }
@@ -158,8 +158,6 @@ public:
 
     void bottom()
     {
-        while (read_line())
-            ;
         down_n(m_lines.size() - m_line);
     }
 


### PR DESCRIPTION
'less' can now:
- Scroll half-pages using 'u' and 'd'
- Scroll up or down any number lines by typing a number followed by 'j', 'k', 'return', 'up' or 'down'
- Navigate to specific line numbers by typing a number before 'g' or 'G'