### PR TITLE
SystemMonitor: Use kill(pid,0) to check for kill permission

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -87,8 +87,8 @@ private:
 
 static bool can_access_pid(pid_t pid)
 {
-    auto path = String::formatted("/proc/{}", pid);
-    return access(path.characters(), X_OK) == 0;
+    int rc = kill(pid, 0);
+    return rc == 0;
 }
 
 int main(int argc, char** argv)

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -353,8 +353,13 @@ int main(int argc, char** argv)
             process_properties_action->activate();
     };
 
+    static pid_t last_selected_pid;
+
     process_table_view.on_selection_change = [&] {
         pid_t pid = selected_id(ProcessModel::Column::PID);
+        if (pid == last_selected_pid || pid < 1)
+            return;
+        last_selected_pid = pid;
         bool has_access = can_access_pid(pid);
         kill_action->set_enabled(has_access);
         stop_action->set_enabled(has_access);


### PR DESCRIPTION
Checking for access to path is not a reliable way to confirm permission to run kill on a process since it always returns true after, I guess, the changes in ProcFS(?).
Instead we can invoke kill() with 0 as a signal, this checks for permissions and returns 0 if the process exists and -1 if there is an error like EPERM.

Also added an early return if the process_table_view is not focused since we don't want to do unnecessary checks when another tab is active or when the window is in the background.