### PR TITLE
Pong+Breakout+Piano+Calculator+KeyboardMapper: Add menus before showing the window

### DIFF
--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -46,7 +46,6 @@ int main(int argc, char** argv)
 
     auto& widget = window->set_main_widget<CalculatorWidget>();
 
-    window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& file_menu = window->add_menu("&File");
@@ -70,5 +69,8 @@ int main(int argc, char** argv)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Calculator", app_icon, window));
+
+    window->show();
+
     return app->exec();
 }

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -41,7 +41,6 @@ int main(int argc, char** argv)
     window->set_main_widget<KeyboardMapperWidget>();
     window->resize(775, 315);
     window->set_resizable(false);
-    window->show();
 
     auto keyboard_mapper_widget = (KeyboardMapperWidget*)window->main_widget();
     if (path != nullptr) {
@@ -91,6 +90,8 @@ int main(int argc, char** argv)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Keyboard Mapper", app_icon, window));
+
+    window->show();
 
     return app->exec();
 }

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -53,7 +53,6 @@ int main(int argc, char** argv)
     window->set_title("Piano");
     window->resize(840, 600);
     window->set_icon(app_icon.bitmap_for_size(16));
-    window->show();
 
     auto main_widget_updater = Core::Timer::construct(static_cast<int>((1 / 60.0) * 1000), [&] {
         Core::EventLoop::current().post_event(main_widget, make<Core::CustomEvent>(0));
@@ -84,6 +83,8 @@ int main(int argc, char** argv)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Piano", app_icon, window));
+
+    window->show();
 
     return app->exec();
 }

--- a/Userland/Games/Breakout/main.cpp
+++ b/Userland/Games/Breakout/main.cpp
@@ -45,7 +45,6 @@ int main(int argc, char** argv)
     auto app_icon = GUI::Icon::default_icon("app-breakout");
     window->set_icon(app_icon.bitmap_for_size(16));
     auto& game = window->set_main_widget<Breakout::Game>();
-    window->show();
 
     auto& game_menu = window->add_menu("&Game");
     game_menu.add_action(GUI::Action::create_checkable("&Pause", { {}, Key_P }, [&](auto& action) {
@@ -60,6 +59,8 @@ int main(int argc, char** argv)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Breakout", app_icon, window));
+
+    window->show();
 
     return app->exec();
 }

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -53,7 +53,6 @@ int main(int argc, char** argv)
     window->set_double_buffering_enabled(false);
     window->set_main_widget<Pong::Game>();
     window->set_resizable(false);
-    window->show();
 
     auto& game_menu = window->add_menu("&Game");
     game_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
@@ -62,6 +61,8 @@ int main(int argc, char** argv)
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Pong", app_icon, window));
+
+    window->show();
 
     return app->exec();
 }


### PR DESCRIPTION
Otherwise, space is reserved but menus aren't shown.