### PR TITLE
WindowServer: Don't draw separator between pin window & close for modals

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -803,9 +803,8 @@ void Window::ensure_window_menu()
             m_window_menu_pin_item->set_icon(&pin_icon());
             m_window_menu_pin_item->set_checkable(true);
             m_window_menu->add_item(move(pin_item));
+            m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
         }
-
-        m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
 
         auto close_item = make<MenuItem>(*m_window_menu, (unsigned)WindowMenuAction::Close, "&Close");
         m_window_menu_close_item = close_item.ptr();


### PR DESCRIPTION
Modal windows cannot be pinned and thus we end up drawing 2 separators.