### PR TITLE
HackStudio+LibGUI+Playground: Add proper GML support to HackStudio

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     Git/GitFilesView.cpp
     Git/GitRepo.cpp
     Git/GitWidget.cpp
+    GMLPreviewWidget.cpp
     HackStudioWidget.cpp
     Language.cpp
     LanguageClient.cpp

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -19,6 +19,7 @@
 #include <LibCpp/SyntaxHighlighter.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/GMLAutocompleteProvider.h>
 #include <LibGUI/GMLSyntaxHighlighter.h>
 #include <LibGUI/INISyntaxHighlighter.h>
 #include <LibGUI/Label.h>
@@ -480,6 +481,8 @@ void Editor::set_document(GUI::TextDocument& doc)
         }
         m_language_client->open_file(code_document.file_path(), fd);
         close(fd);
+    } else {
+        set_autocomplete_provider_for(code_document);
     }
 }
 
@@ -605,6 +608,17 @@ void Editor::set_syntax_highlighter_for(const CodeDocument& document)
         break;
     default:
         set_syntax_highlighter({});
+    }
+}
+
+void Editor::set_autocomplete_provider_for(CodeDocument const& document)
+{
+    switch (document.language()) {
+    case Language::GML:
+        set_autocomplete_provider(make<GUI::GMLAutocompleteProvider>());
+        break;
+    default:
+        set_autocomplete_provider({});
     }
 }
 

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -97,6 +97,7 @@ private:
     void flush_file_content_to_langauge_server();
     void set_syntax_highlighter_for(const CodeDocument&);
     void set_language_client_for(const CodeDocument&);
+    void set_autocomplete_provider_for(CodeDocument const&);
     void handle_function_parameters_hint_request();
 
     explicit Editor();

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Conor Byrne <cbyrneee@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GMLPreviewWidget.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Label.h>
+
+namespace HackStudio {
+
+GMLPreviewWidget::GMLPreviewWidget(String const& gml_content)
+{
+    set_layout<GUI::VerticalBoxLayout>();
+    load_gml(gml_content);
+}
+
+void GMLPreviewWidget::load_gml(String const& gml)
+{
+    remove_all_children();
+
+    if (gml.is_empty()) {
+        auto& label = add<GUI::Label>();
+        label.set_text("Open a .gml file to show the preview");
+
+        return;
+    }
+
+    load_from_gml(gml, [](const String& name) -> RefPtr<Core::Object> {
+        return GUI::Label::construct(String::formatted("{} is not registered as a GML element!", name));
+    });
+
+    if (children().is_empty()) {
+        auto& label = add<GUI::Label>();
+        label.set_text("Failed to load GML!");
+    }
+}
+
+}

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.h
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, Conor Byrne <cbyrneee@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/LexicalPath.h>
+#include <LibGUI/Widget.h>
+
+namespace HackStudio {
+
+class GMLPreviewWidget final : public GUI::Widget {
+    C_OBJECT(GMLPreviewWidget)
+public:
+    void load_gml(String const&);
+
+private:
+    explicit GMLPreviewWidget(String const&);
+};
+
+}

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -285,6 +285,9 @@ bool HackStudioWidget::open_file(const String& full_filename)
     current_editor().set_focus(true);
 
     current_editor().on_cursor_change = [this] { update_statusbar(); };
+    current_editor().on_change = [this] { update_gml_preview(); };
+    update_gml_preview();
+
     return true;
 }
 
@@ -501,6 +504,7 @@ void HackStudioWidget::add_new_editor(GUI::Widget& parent)
     wrapper->editor().set_focus(true);
     wrapper->set_project_root(LexicalPath(m_project->root_path()));
     wrapper->editor().on_cursor_change = [this] { update_statusbar(); };
+    wrapper->editor().on_change = [this] { update_gml_preview(); };
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_switch_to_next_editor_action()
@@ -905,6 +909,7 @@ void HackStudioWidget::create_action_tab(GUI::Widget& parent)
         m_diff_viewer->set_content(original_content, diff);
         set_edit_mode(EditMode::Diff);
     });
+    m_gml_preview_widget = m_action_tab_widget->add_tab<GMLPreviewWidget>("GML Preview", "");
 
     ToDoEntries::the().on_update = [this]() {
         m_todo_entries_widget->refresh();
@@ -1145,6 +1150,12 @@ bool HackStudioWidget::any_document_is_dirty() const
         }
     }
     return false;
+}
+
+void HackStudioWidget::update_gml_preview()
+{
+    auto gml_content = current_editor_wrapper().filename().ends_with(".gml") ? current_editor_wrapper().editor().text() : "";
+    m_gml_preview_widget->load_gml(gml_content);
 }
 
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -13,6 +13,7 @@
 #include "Debugger/DisassemblyWidget.h"
 #include "EditorWrapper.h"
 #include "FindInFilesWidget.h"
+#include "GMLPreviewWidget.h"
 #include "Git/DiffViewer.h"
 #include "Git/GitWidget.h"
 #include "Locator.h"
@@ -119,6 +120,8 @@ private:
     void hide_action_tabs();
     bool any_document_is_dirty() const;
 
+    void update_gml_preview();
+
     NonnullRefPtrVector<EditorWrapper> m_all_editor_wrappers;
     RefPtr<EditorWrapper> m_current_editor_wrapper;
 
@@ -135,6 +138,7 @@ private:
     RefPtr<GUI::Splitter> m_editors_splitter;
     RefPtr<DiffViewer> m_diff_viewer;
     RefPtr<GitWidget> m_git_widget;
+    RefPtr<GMLPreviewWidget> m_gml_preview_widget;
     RefPtr<ClassViewWidget> m_class_view;
     RefPtr<GUI::Menu> m_project_tree_view_context_menu;
     RefPtr<GUI::Statusbar> m_statusbar;

--- a/Userland/DevTools/Playground/CMakeLists.txt
+++ b/Userland/DevTools/Playground/CMakeLists.txt
@@ -6,7 +6,6 @@ serenity_component(
 
 set(SOURCES
     main.cpp
-    GMLAutocompleteProvider.cpp
 )
 
 serenity_app(Playground ICON app-playground)

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "GMLAutocompleteProvider.h"
 #include <AK/URL.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/FilePicker.h>
+#include <LibGUI/GMLAutocompleteProvider.h>
 #include <LibGUI/GMLFormatter.h>
 #include <LibGUI/GMLLexer.h>
 #include <LibGUI/GMLSyntaxHighlighter.h>
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
     auto& preview = splitter.add<GUI::Frame>();
 
     editor.set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());
-    editor.set_autocomplete_provider(make<GMLAutocompleteProvider>());
+    editor.set_autocomplete_provider(make<GUI::GMLAutocompleteProvider>());
     editor.set_should_autocomplete_automatically(true);
     editor.set_automatic_indentation_enabled(true);
 

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     FontPicker.cpp
     FontPickerDialogGML.h
     Frame.cpp
+    GMLAutocompleteProvider.cpp
     GMLFormatter.cpp
     GMLLexer.cpp
     GMLParser.cpp

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "GMLAutocompleteProvider.h"
+#include "GMLLexer.h"
 #include <AK/QuickSort.h>
-#include <LibGUI/GMLLexer.h>
+
+namespace GUI {
 
 void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> callback)
 {
@@ -206,4 +208,6 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     entries.extend(move(class_entries));
 
     callback(move(entries));
+}
+
 }

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
-#include <LibGUI/AutocompleteProvider.h>
+#include "AutocompleteProvider.h"
+
+namespace GUI {
 
 class GMLAutocompleteProvider final : public virtual GUI::AutocompleteProvider {
 public:
@@ -21,3 +23,5 @@ private:
 
     virtual void provide_completions(Function<void(Vector<Entry>)> callback) override;
 };
+
+}


### PR DESCRIPTION
Prior to this pull request, you would have to use GML Playground to receieve auto-completion for GML files. 
This PR moves ``GMLAutocompleteProvider`` to ``LibGUI``, allowing any application to provide GML autocompletion! (in this case, HackStudio)

This also adds support for previewing your GML inside of HackStudio.

**Screenshot:**
![image](https://user-images.githubusercontent.com/71222289/127387380-71fb8c6e-ebe4-407f-bb87-2e5e25d2c1f1.png)
