### PR TITLE
LibWeb: Fix incompatibility of the "contenteditable" attribute

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -33,13 +33,13 @@ HTMLElement::~HTMLElement()
 HTMLElement::ContentEditableState HTMLElement::content_editable_state() const
 {
     auto contenteditable = attribute(HTML::AttributeNames::contenteditable);
-    // "true" and the empty string map to the "true" state.
-    if ((!contenteditable.is_null() && contenteditable.is_empty()) || contenteditable.equals_ignoring_case("true"))
+    // "true", an empty string or a missing value map to the "true" state.
+    if (contenteditable.is_empty() || contenteditable.equals_ignoring_case("true"))
         return ContentEditableState::True;
     // "false" maps to the "false" state.
     if (contenteditable.equals_ignoring_case("false"))
         return ContentEditableState::False;
-    // "inherit", an invalid value, and a missing value all map to the "inherit" state.
+    // An invalid value maps to the "inherit" state.
     return ContentEditableState::Inherit;
 }
 


### PR DESCRIPTION
Having no value for `contenteditable` maps to the inherited state, so this page is actually not editable.