### PR TITLE
LibWeb: Add more support for text-decoration-line

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -63,6 +63,7 @@ private:
     virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     void split_into_lines_by_rules(InlineFormattingContext&, LayoutMode, bool do_collapse, bool do_wrap_lines, bool do_wrap_breaks);
     void paint_cursor_if_needed(PaintContext&, const LineBoxFragment&) const;
+    void paint_text_decoration(Gfx::Painter&, LineBoxFragment const&) const;
 
     String m_text_for_rendering;
 };


### PR DESCRIPTION
Now, line-through and overline are supported as well.
The font-rendering-stuff is a bit fiddly, but I think I figured it out.
The code now respects line-height, as it didn't do that before.
I can't test font-sizes right now as that seems to be broken...