### PR TITLE
Ports: Make libxml2 work when Python is installed

### DIFF
--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -5,7 +5,7 @@ version="2.9.12"
 files="ftp://xmlsoft.org/libxml2/libxml2-${version}.tar.gz libxml2-${version}.tar.gz c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
 auth_type=sha256
 depends="libiconv"
-configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local --without-python"
 
 install() {
     # Leave out DESTDIR - otherwise the prefix breaks


### PR DESCRIPTION
Building libxml2 fails when Python was previously installed.