### PR TITLE
Kernel: Make it possible to expand the eternal heap

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -16,6 +16,11 @@ static char s_cmd_line[1024];
 static constexpr StringView s_embedded_cmd_line = "";
 static CommandLine* s_the;
 
+bool CommandLine::initialized()
+{
+    return s_the != nullptr;
+}
+
 UNMAP_AFTER_INIT void CommandLine::early_initialize(const char* cmd_line)
 {
     if (!cmd_line)

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -48,6 +48,8 @@ public:
     static void early_initialize(const char* cmd_line);
     static void initialize();
 
+    static bool initialized();
+
     enum class Validate {
         Yes,
         No,

--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -33,6 +33,8 @@ void __panic(const char* file, unsigned int line, const char* function)
 
     critical_dmesgln("at {}:{} in {}", file, line, function);
     dump_backtrace(PrintToScreen::Yes);
+    if (!CommandLine::initialized())
+        Processor::halt();
     switch (kernel_command_line().panic_mode()) {
     case PanicMode::Shutdown:
         __shutdown();


### PR DESCRIPTION
We do this by allocating more eternal heaps on a single static
eternal region in the kernel image. If we run out of allocation
space in an eternal heap, we simply build another eternal heap
and allocate from it.

cc @awesomekling @linusg