### PR TITLE
Kernel: Embed the right symbol count into the kernel.map file on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ else()
     set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}strip)
     set(CMAKE_AR ${TOOLCHAIN_PREFIX}gcc-ar)
     set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
+    set(CMAKE_CXXFILT ${TOOLCHAIN_PREFIX}c++filt)
 endif()
 
 foreach(lang ASM C CXX OBJC OBJCXX)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -451,7 +451,7 @@ add_dependencies(Kernel kernel_heap)
 
 add_custom_command(
     TARGET Kernel POST_BUILD
-    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env CXXFILT=${CMAKE_CXXFILT} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
     COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
     COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel

--- a/Kernel/mkmap.sh
+++ b/Kernel/mkmap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 tmp=$(mktemp)
 nm -n Kernel | grep -vE \\.Lubsan_data | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
-printf "%08x\n" "$(wc -l "$tmp" | cut -f1 -d' ')" > kernel.map
+printf "%08x\n" "$(wc -l "$tmp" | awk '{print $1}')" > kernel.map
 c++filt < "$tmp" >> kernel.map
 rm -f "$tmp"

--- a/Kernel/mkmap.sh
+++ b/Kernel/mkmap.sh
@@ -2,5 +2,6 @@
 tmp=$(mktemp)
 nm -n Kernel | grep -vE \\.Lubsan_data | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
 printf "%08x\n" "$(wc -l "$tmp" | awk '{print $1}')" > kernel.map
-c++filt < "$tmp" >> kernel.map
+CXXFILT="${CXXFILT:-c++filt}"
+"$CXXFILT" < "$tmp" >> kernel.map
 rm -f "$tmp"


### PR DESCRIPTION
**Kernel: Embed the right symbol count into the kernel.map file on macOS**

On macOS the wc tool prefixes its output with a bunch of spaces which resulted in us incorrectly using "00000000" as the symbol count.

Fixes #9080.

**Kernel: Use our toolchain's c++filt tool for the kernel map**

The host's version of c++filt might not work on some operating systems, e.g. macOS.