### PR TITLE
LibJS: General parser fixes and partial unicode support

### DIFF
--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -549,6 +549,9 @@ Token Lexer::next()
         while (m_current_char != stop_char && m_current_char != '\r' && m_current_char != '\n' && !is_eof()) {
             if (m_current_char == '\\') {
                 consume();
+                if (m_current_char == '\r' && m_position < m_source.length() && m_source[m_position] == '\n') {
+                    consume();
+                }
             }
             consume();
         }

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -9,6 +9,8 @@
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/HashMap.h>
+#include <AK/Utf8View.h>
+#include <LibUnicode/CharacterTypes.h>
 #include <stdio.h>
 
 namespace JS {
@@ -186,6 +188,26 @@ void Lexer::consume()
         } else {
             dbgln_if(LEXER_DEBUG, "Previous was CR, this is LF - not incrementing line number again.");
         }
+    } else if (is_unicode_character()) {
+        size_t char_size = 1;
+        if ((m_current_char & 64) == 0) {
+            // invalid char
+        } else if ((m_current_char & 32) == 0) {
+            char_size = 2;
+        } else if ((m_current_char & 16) == 0) {
+            char_size = 3;
+        } else if ((m_current_char & 8) == 0) {
+            char_size = 4;
+        }
+
+        VERIFY(char_size > 1);
+        --char_size;
+
+        m_position += char_size;
+        if (did_reach_eof())
+            return;
+
+        m_line_column++;
     } else {
         m_line_column++;
     }
@@ -310,21 +332,67 @@ bool Lexer::is_line_terminator() const
 {
     if (m_current_char == '\n' || m_current_char == '\r')
         return true;
-    if (m_position > 0 && m_position + 1 < m_source.length()) {
-        auto three_chars_view = m_source.substring_view(m_position - 1, 3);
-        return (three_chars_view == LINE_SEPARATOR) || (three_chars_view == PARAGRAPH_SEPARATOR);
-    }
+    if (!is_unicode_character())
+        return false;
+
+    auto code_point = current_code_point();
+    return code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR;
+}
+
+bool Lexer::is_unicode_character() const
+{
+    return (m_current_char & 128) != 0;
+}
+
+u32 Lexer::current_code_point() const
+{
+    static constexpr const u32 REPLACEMENT_CHARACTER = 0xFFFD;
+    if (m_position == 0)
+        return REPLACEMENT_CHARACTER;
+    Utf8View utf_8_view { m_source.substring_view(m_position - 1) };
+    return *utf_8_view.begin();
+}
+
+bool Lexer::is_whitespace() const
+{
+    if (is_ascii_space(m_current_char))
+        return true;
+    if (!is_unicode_character())
+        return false;
+    auto code_point = current_code_point();
+    if (code_point == NO_BREAK_SPACE)
+        return true;
+
+    static auto space_separator_category = Unicode::general_category_from_string("Space_Separator"sv);
+    if (space_separator_category.has_value())
+        return Unicode::code_point_has_general_category(code_point, *space_separator_category);
     return false;
 }
 
 bool Lexer::is_identifier_start() const
 {
-    return is_ascii_alpha(m_current_char) || m_current_char == '_' || m_current_char == '$';
+    if (!is_unicode_character())
+        return is_ascii_alpha(m_current_char) || m_current_char == '_' || m_current_char == '$';
+    auto code_point = current_code_point();
+
+    static auto id_start_category = Unicode::property_from_string("ID_Start"sv);
+    if (id_start_category.has_value())
+        return Unicode::code_point_has_property(code_point, *id_start_category);
+    return false;
 }
 
 bool Lexer::is_identifier_middle() const
 {
-    return is_identifier_start() || is_ascii_digit(m_current_char);
+    if (!is_unicode_character())
+        return is_identifier_start() || is_ascii_digit(m_current_char);
+    auto code_point = current_code_point();
+    if (code_point == ZERO_WIDTH_NON_JOINER || code_point == ZERO_WIDTH_JOINER)
+        return true;
+
+    static auto id_continue_category = Unicode::property_from_string("ID_Continue"sv);
+    if (id_continue_category.has_value())
+        return Unicode::code_point_has_property(code_point, *id_continue_category);
+    return false;
 }
 
 bool Lexer::is_line_comment_start(bool line_has_token_yet) const
@@ -390,10 +458,10 @@ Token Lexer::next()
                 do {
                     consume();
                 } while (is_line_terminator());
-            } else if (is_ascii_space(m_current_char)) {
+            } else if (is_whitespace()) {
                 do {
                     consume();
-                } while (is_ascii_space(m_current_char));
+                } while (is_whitespace());
             } else if (is_line_comment_start(line_has_token_yet)) {
                 consume();
                 do {

--- a/Userland/Libraries/LibJS/Lexer.h
+++ b/Userland/Libraries/LibJS/Lexer.h
@@ -25,6 +25,8 @@ public:
 
     void disallow_html_comments() { m_allow_html_comments = false; };
 
+    Token force_slash_as_regex();
+
 private:
     void consume();
     bool consume_exponent();
@@ -46,6 +48,8 @@ private:
     template<typename Callback>
     bool match_numeric_literal_separator_followed_by(Callback) const;
     bool slash_means_division() const;
+
+    TokenType consume_regex_literal();
 
     StringView m_source;
     size_t m_position { 0 };

--- a/Userland/Libraries/LibJS/Lexer.h
+++ b/Userland/Libraries/LibJS/Lexer.h
@@ -34,8 +34,13 @@ private:
     bool consume_hexadecimal_number();
     bool consume_binary_number();
     bool consume_decimal_number();
+
+    bool is_unicode_character() const;
+    u32 current_code_point() const;
+
     bool is_eof() const;
     bool is_line_terminator() const;
+    bool is_whitespace() const;
     bool is_identifier_start() const;
     bool is_identifier_middle() const;
     bool is_line_comment_start(bool line_has_token_yet) const;

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -400,6 +400,10 @@ NonnullRefPtr<Statement> Parser::parse_statement(AllowLabelledFunction allow_lab
     case TokenType::Semicolon:
         consume();
         return create_ast_node<EmptyStatement>({ m_state.current_token.filename(), rule_start.position(), position() });
+    case TokenType::Slash:
+    case TokenType::SlashEquals:
+        m_state.current_token = m_state.lexer.force_slash_as_regex();
+        [[fallthrough]];
     default:
         if (match_identifier_name()) {
             auto result = try_parse_labelled_statement(allow_labelled_function);
@@ -2556,6 +2560,8 @@ bool Parser::match_expression() const
         || type == TokenType::This
         || type == TokenType::Super
         || type == TokenType::RegexLiteral
+        || type == TokenType::Slash       // Wrongly recognized regex by lexer
+        || type == TokenType::SlashEquals // Wrongly recognized regex by lexer (/=a/ is a valid regex)
         || type == TokenType::Yield
         || match_unary_prefixed_expression();
 }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1721,6 +1721,8 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(u8 parse_options)
 
     TemporaryChange super_property_access_rollback(m_state.allow_super_property_lookup, !!(parse_options & FunctionNodeParseOptions::AllowSuperPropertyLookup));
     TemporaryChange super_constructor_call_rollback(m_state.allow_super_constructor_call, !!(parse_options & FunctionNodeParseOptions::AllowSuperConstructorCall));
+    TemporaryChange break_context_rollback(m_state.in_break_context, false);
+    TemporaryChange continue_context_rollback(m_state.in_continue_context, false);
 
     ScopePusher scope(*this, ScopePusher::Var, Parser::Scope::Function);
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1290,7 +1290,7 @@ NonnullRefPtr<Expression> Parser::parse_expression(int min_precedence, Associati
 
             Associativity new_associativity = operator_associativity(m_state.current_token.type());
             expression = parse_secondary_expression(move(expression), new_precedence, new_associativity);
-            while (match(TokenType::TemplateLiteralStart)) {
+            while (match(TokenType::TemplateLiteralStart) && !is<UpdateExpression>(*expression)) {
                 auto template_literal = parse_template_literal(true);
                 expression = create_ast_node<TaggedTemplateLiteral>({ m_state.current_token.filename(), rule_start.position(), position() }, move(expression), move(template_literal));
             }
@@ -2694,8 +2694,8 @@ bool Parser::match_secondary_expression(const Vector<TokenType>& forbidden) cons
         || type == TokenType::ParenOpen
         || type == TokenType::Period
         || type == TokenType::BracketOpen
-        || type == TokenType::PlusPlus
-        || type == TokenType::MinusMinus
+        || (type == TokenType::PlusPlus && !m_state.current_token.trivia_contains_line_terminator())
+        || (type == TokenType::MinusMinus && !m_state.current_token.trivia_contains_line_terminator())
         || type == TokenType::In
         || type == TokenType::Instanceof
         || type == TokenType::QuestionMark

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -820,7 +820,7 @@ Parser::PrimaryExpressionParseResult Parser::parse_primary_expression()
 
             auto arrow_function_result = try_parse_arrow_function_expression(true);
             if (!arrow_function_result.is_null())
-                return { arrow_function_result.release_nonnull() };
+                return { arrow_function_result.release_nonnull(), false };
 
             set_try_parse_arrow_function_expression_failed_at_position(paren_position, true);
         }
@@ -846,7 +846,7 @@ Parser::PrimaryExpressionParseResult Parser::parse_primary_expression()
         if (!try_parse_arrow_function_expression_failed_at_position(position())) {
             auto arrow_function_result = try_parse_arrow_function_expression(false);
             if (!arrow_function_result.is_null())
-                return { arrow_function_result.release_nonnull() };
+                return { arrow_function_result.release_nonnull(), false };
 
             set_try_parse_arrow_function_expression_failed_at_position(position(), true);
         }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1297,6 +1297,9 @@ NonnullRefPtr<Expression> Parser::parse_expression(int min_precedence, Associati
         }
     }
 
+    if (is<SuperExpression>(*expression))
+        syntax_error("'super' keyword unexpected here");
+
     check_for_invalid_object_property(expression);
 
     if (match(TokenType::Comma) && min_precedence <= 1) {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1630,7 +1630,7 @@ NonnullRefPtr<YieldExpression> Parser::parse_yield_expression()
             yield_from = true;
         }
 
-        if (yield_from || match_expression())
+        if (yield_from || match_expression() || match(TokenType::Class))
             argument = parse_expression(0);
     }
 

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -159,8 +159,9 @@ private:
     bool match_secondary_expression(const Vector<TokenType>& forbidden = {}) const;
     bool match_statement() const;
     bool match_export_or_import() const;
-    bool match_declaration() const;
-    bool match_variable_declaration() const;
+    bool match_declaration();
+    bool try_match_let_declaration();
+    bool match_variable_declaration();
     bool match_identifier() const;
     bool match_identifier_name() const;
     bool match_property_key() const;

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -120,8 +120,8 @@ public:
             String source_string { source };
             source_string.replace("\r\n", "\n");
             source_string.replace("\r", "\n");
-            source_string.replace(LINE_SEPARATOR, "\n");
-            source_string.replace(PARAGRAPH_SEPARATOR, "\n");
+            source_string.replace(LINE_SEPARATOR_STRING, "\n");
+            source_string.replace(PARAGRAPH_SEPARATOR_STRING, "\n");
             StringBuilder builder;
             builder.append(source_string.split_view('\n', true)[position.value().line - 1]);
             builder.append('\n');

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -42,7 +42,7 @@ public:
     template<typename FunctionNodeType>
     NonnullRefPtr<FunctionNodeType> parse_function_node(u8 parse_options = FunctionNodeParseOptions::CheckForFunctionAndName);
     Vector<FunctionNode::Parameter> parse_formal_parameters(int& function_length, u8 parse_options = 0);
-    RefPtr<BindingPattern> parse_binding_pattern();
+    RefPtr<BindingPattern> parse_binding_pattern(bool strict_checks = false);
 
     struct PrimaryExpressionParseResult {
         NonnullRefPtr<Expression> result;

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -50,7 +50,13 @@ public:
     };
 
     NonnullRefPtr<Declaration> parse_declaration();
-    NonnullRefPtr<Statement> parse_statement();
+
+    enum class AllowLabelledFunction {
+        No,
+        Yes
+    };
+
+    NonnullRefPtr<Statement> parse_statement(AllowLabelledFunction allow_labelled_function = AllowLabelledFunction::No);
     NonnullRefPtr<BlockStatement> parse_block_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement(bool& is_strict, bool error_on_binding = false);
     NonnullRefPtr<ReturnStatement> parse_return_statement();
@@ -91,7 +97,7 @@ public:
     NonnullRefPtr<ExportStatement> parse_export_statement(Program& program);
 
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
-    RefPtr<Statement> try_parse_labelled_statement();
+    RefPtr<Statement> try_parse_labelled_statement(AllowLabelledFunction allow_function);
     RefPtr<MetaProperty> try_parse_new_target_expression();
 
     struct Error {

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -85,8 +85,8 @@ static String escape_regexp_pattern(const RegExpObject& regexp_object)
     // FIXME: Check u flag and escape accordingly
     pattern.replace("\n", "\\n", true);
     pattern.replace("\r", "\\r", true);
-    pattern.replace(LINE_SEPARATOR, "\\u2028", true);
-    pattern.replace(PARAGRAPH_SEPARATOR, "\\u2029", true);
+    pattern.replace(LINE_SEPARATOR_STRING, "\\u2028", true);
+    pattern.replace(PARAGRAPH_SEPARATOR_STRING, "\\u2029", true);
     pattern.replace("/", "\\/", true);
     return pattern;
 }

--- a/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
@@ -3,4 +3,22 @@ test("slash token resolution in lexer", () => {
     expect("``/foo/").not.toEval();
     expect("1/foo/").not.toEval();
     expect("1/foo").toEval();
+
+    expect("{} /foo/").toEval();
+    expect("{} /=/").toEval();
+    expect("{} /=a/").toEval();
+    expect("{} /* */ /=a/").toEval();
+    expect("{} /* /a/ */ /=a/").toEval();
+
+    expect("(function () {} / 1)").toEval();
+    expect("(function () {} / 1)").toEval();
+
+    expect("+a++ / 1").toEval();
+    expect("+a-- / 1").toEval();
+    expect("a.in / b").toEval();
+    expect("a.instanceof / b").toEval();
+
+    // FIXME: Even more 'reserved' words are valid however the cases below do still need to pass.
+    //expect("a.void / b").toEval();
+    expect("void / b/").toEval();
 });

--- a/Userland/Libraries/LibJS/Token.cpp
+++ b/Userland/Libraries/LibJS/Token.cpp
@@ -130,7 +130,7 @@ String Token::string_value(StringValueStatus& status) const
             continue;
         }
         // Line continuation
-        if (lexer.next_is(LINE_SEPARATOR) || lexer.next_is(PARAGRAPH_SEPARATOR)) {
+        if (lexer.next_is(LINE_SEPARATOR_STRING) || lexer.next_is(PARAGRAPH_SEPARATOR_STRING)) {
             lexer.ignore(3);
             continue;
         }
@@ -281,7 +281,7 @@ bool Token::is_identifier_name() const
 
 bool Token::trivia_contains_line_terminator() const
 {
-    return m_trivia.contains('\n') || m_trivia.contains('\r') || m_trivia.contains(LINE_SEPARATOR) || m_trivia.contains(PARAGRAPH_SEPARATOR);
+    return m_trivia.contains('\n') || m_trivia.contains('\r') || m_trivia.contains(LINE_SEPARATOR_STRING) || m_trivia.contains(PARAGRAPH_SEPARATOR_STRING);
 }
 
 }

--- a/Userland/Libraries/LibJS/Token.h
+++ b/Userland/Libraries/LibJS/Token.h
@@ -13,11 +13,22 @@ namespace JS {
 
 // U+2028 LINE SEPARATOR
 constexpr const char line_separator_chars[] { (char)0xe2, (char)0x80, (char)0xa8, 0 };
-constexpr const StringView LINE_SEPARATOR { line_separator_chars };
+constexpr const StringView LINE_SEPARATOR_STRING { line_separator_chars };
+constexpr const u32 LINE_SEPARATOR { 0x2028 };
 
 // U+2029 PARAGRAPH SEPARATOR
 constexpr const char paragraph_separator_chars[] { (char)0xe2, (char)0x80, (char)0xa9, 0 };
-constexpr const StringView PARAGRAPH_SEPARATOR { paragraph_separator_chars };
+constexpr const StringView PARAGRAPH_SEPARATOR_STRING { paragraph_separator_chars };
+constexpr const u32 PARAGRAPH_SEPARATOR { 0x2029 };
+
+// U+00A0 NO BREAK SPACE
+constexpr const u32 NO_BREAK_SPACE { 0x00A0 };
+
+// U+200C ZERO WIDTH NON-JOINER
+constexpr const u32 ZERO_WIDTH_NON_JOINER { 0x200C };
+
+// U+200D ZERO WIDTH JOINER
+constexpr const u32 ZERO_WIDTH_JOINER { 0x200D };
 
 #define ENUMERATE_JS_TOKENS                                     \
     __ENUMERATE_JS_TOKEN(Ampersand, Operator)                   \


### PR DESCRIPTION
Fixes a bunch of test262-parser tests and has no regressions in test262.

The parser is quite messy (even more now) but I plan to try to kind of fix that in a future PR since bindings and variable scoping checks are getting very complicated and duplicated all over the place.