### PR TITLE
Documentation: Always install e2fsprogs on MacOS

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -8,10 +8,10 @@ Make sure you also have all the following dependencies installed:
 
 ```console
 # core
-brew install coreutils qemu bash gcc@10 ninja cmake ccache rsync
+brew install coreutils e2fsprogs qemu bash gcc@10 ninja cmake ccache rsync
 
 # (option 1) fuse + ext2
-brew install e2fsprogs m4 autoconf automake libtool
+brew install m4 autoconf automake libtool
 brew install --cask osxfuse
 Toolchain/BuildFuseExt2.sh
 


### PR DESCRIPTION
The `Meta/build-image-qemu.sh` script runs mke2fs in both the FUSE and genext2fs options, so always install e2fsprogs.