### PR TITLE
HackStudio: Add the ability to open the GML Preview in a new window

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     Git/GitFilesView.cpp
     Git/GitRepo.cpp
     Git/GitWidget.cpp
+    Dialogs/GML/GMLPreviewDialog.cpp
     GMLPreviewWidget.cpp
     HackStudioWidget.cpp
     Language.cpp

--- a/Userland/DevTools/HackStudio/Dialogs/GML/GMLPreviewDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/GML/GMLPreviewDialog.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Conor Byrne <cbyrneee@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GMLPreviewDialog.h"
+#include <LibGUI/BoxLayout.h>
+
+namespace HackStudio {
+
+GMLPreviewDialog::GMLPreviewDialog(String const& content, String const& filename)
+    : GUI::Dialog(nullptr)
+{
+    set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-hack-studio.png"));
+    center_on_screen();
+    resize(300, 300);
+    set_resizable(true);
+
+    m_gml_preview = set_main_widget<GMLPreviewWidget>(content);
+    m_gml_preview->set_fill_with_background_color(true);
+
+    load_gml(content, filename);
+}
+
+void GMLPreviewDialog::load_gml(String const& content, String const& filename)
+{
+    m_gml_preview->load_gml(content);
+    set_title(String::formatted("GML Preview: {}", filename));
+}
+
+}

--- a/Userland/DevTools/HackStudio/Dialogs/GML/GMLPreviewDialog.h
+++ b/Userland/DevTools/HackStudio/Dialogs/GML/GMLPreviewDialog.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Conor Byrne <cbyrneee@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "../../GMLPreviewWidget.h"
+#include <AK/LexicalPath.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/Window.h>
+
+namespace HackStudio {
+
+class GMLPreviewDialog final : public GUI::Dialog {
+    C_OBJECT(GMLPreviewDialog)
+
+public:
+    void load_gml(String const& content, String const& filename);
+
+private:
+    GMLPreviewDialog(String const& content, String const& filename);
+
+    RefPtr<GMLPreviewWidget> m_gml_preview;
+};
+
+}

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -11,6 +11,7 @@
 #include "ClassViewWidget.h"
 #include "Debugger/DebugInfoWidget.h"
 #include "Debugger/DisassemblyWidget.h"
+#include "Dialogs/GML/GMLPreviewDialog.h"
 #include "EditorWrapper.h"
 #include "FindInFilesWidget.h"
 #include "GMLPreviewWidget.h"
@@ -86,6 +87,7 @@ private:
     NonnullRefPtr<GUI::Action> create_add_editor_action();
     NonnullRefPtr<GUI::Action> create_add_terminal_action();
     NonnullRefPtr<GUI::Action> create_remove_current_terminal_action();
+    NonnullRefPtr<GUI::Action> create_open_gml_preview_window_action();
     NonnullRefPtr<GUI::Action> create_debug_action();
     NonnullRefPtr<GUI::Action> create_build_action();
     NonnullRefPtr<GUI::Action> create_run_action();
@@ -167,6 +169,7 @@ private:
     RefPtr<GUI::Action> m_add_editor_action;
     RefPtr<GUI::Action> m_add_terminal_action;
     RefPtr<GUI::Action> m_remove_current_terminal_action;
+    RefPtr<GUI::Action> m_open_gml_preview_window_action;
     RefPtr<GUI::Action> m_stop_action;
     RefPtr<GUI::Action> m_debug_action;
     RefPtr<GUI::Action> m_build_action;
@@ -176,5 +179,7 @@ private:
     RefPtr<GUI::Action> m_no_wrapping_action;
     RefPtr<GUI::Action> m_wrap_anywhere_action;
     RefPtr<GUI::Action> m_wrap_at_words_action;
+
+    RefPtr<GMLPreviewDialog> m_gml_preview_dialog;
 };
 }


### PR DESCRIPTION
This pull request further improves the GML support in HackStudio. The user now has the option to open a GML preview which is similar to the action tab's GML preview, in another window which can be resized however you want unlike the action tab.

**Notes:**
- Internally, the dialog uses ``HackStudio::GMLPreviewWidget`` which makes its behavior the exact same as the action tab's preview.
- This dialog updates in real-time just like the action bar widget, and will react if you switch between GML files.
- If an existing dialog is open, but hidden behind a window, it will be moved to the front of the screen.

**Screenshot:**
![image](https://user-images.githubusercontent.com/71222289/127497023-649c0a82-2ad1-4dea-8a3f-b4d429f92584.png)

