### PR TITLE
LibJS+LibRegex+LibUnicode: Unicode property escapes!

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -319,6 +319,7 @@ if (BUILD_LAGOM)
     file(GLOB LIBREGEX_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibRegex/*.cpp")
     lagom_lib(Regex regex
         SOURCES ${LIBREGEX_SOURCES} ${LIBREGEX_LIBC_SOURCES}
+        LIBS LagomUnicode
     )
 
     # Shell

--- a/Userland/Libraries/LibC/regex.h
+++ b/Userland/Libraries/LibC/regex.h
@@ -37,6 +37,7 @@ enum __Regex_Error {
     __Regex_EmptySubExpression,         // Sub expression has empty content.
     __Regex_InvalidCaptureGroup,        // Content of capture group is invalid.
     __Regex_InvalidNameForCaptureGroup, // Name of capture group is invalid.
+    __Regex_InvalidNameForProperty,     // Name of property is invalid.
 };
 
 enum ReError {

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2020,7 +2020,9 @@ void RegExpLiteral::dump(int indent) const
 Value RegExpLiteral::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
-    return regexp_create(global_object, js_string(interpreter.heap(), pattern()), js_string(interpreter.heap(), flags()));
+
+    Regex<ECMA262> regex(parsed_regex(), parsed_pattern(), parsed_flags());
+    return RegExpObject::create(global_object, move(regex), pattern(), flags());
 }
 
 void ArrayExpression::dump(int indent) const

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -19,6 +19,7 @@
 #include <LibJS/Runtime/PropertyName.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibJS/SourceRange.h>
+#include <LibRegex/Regex.h>
 
 namespace JS {
 
@@ -758,8 +759,11 @@ public:
 
 class RegExpLiteral final : public Literal {
 public:
-    explicit RegExpLiteral(SourceRange source_range, String pattern, String flags)
+    RegExpLiteral(SourceRange source_range, regex::Parser::Result parsed_regex, String parsed_pattern, regex::RegexOptions<ECMAScriptFlags> parsed_flags, String pattern, String flags)
         : Literal(source_range)
+        , m_parsed_regex(move(parsed_regex))
+        , m_parsed_pattern(move(parsed_pattern))
+        , m_parsed_flags(move(parsed_flags))
         , m_pattern(move(pattern))
         , m_flags(move(flags))
     {
@@ -769,10 +773,16 @@ public:
     virtual void dump(int indent) const override;
     virtual void generate_bytecode(Bytecode::Generator&) const override;
 
+    regex::Parser::Result const& parsed_regex() const { return m_parsed_regex; }
+    String const& parsed_pattern() const { return m_parsed_pattern; }
+    regex::RegexOptions<ECMAScriptFlags> const& parsed_flags() const { return m_parsed_flags; }
     String const& pattern() const { return m_pattern; }
     String const& flags() const { return m_flags; }
 
 private:
+    regex::Parser::Result m_parsed_regex;
+    String m_parsed_pattern;
+    regex::RegexOptions<ECMAScriptFlags> m_parsed_flags;
     String m_pattern;
     String m_flags;
 };

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -6,40 +6,40 @@
 
 #pragma once
 
+#include <AK/Result.h>
 #include <LibJS/AST.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibRegex/Regex.h>
-
-struct Flags {
-    regex::RegexOptions<ECMAScriptFlags> effective_flags;
-    regex::RegexOptions<ECMAScriptFlags> declared_flags;
-};
 
 namespace JS {
 
 RegExpObject* regexp_create(GlobalObject&, Value pattern, Value flags);
 
+Result<regex::RegexOptions<ECMAScriptFlags>, String> regex_flags_from_string(StringView flags);
+String parse_regex_pattern(StringView pattern, bool unicode);
+
 class RegExpObject : public Object {
     JS_OBJECT(RegExpObject, Object);
 
 public:
-    static RegExpObject* create(GlobalObject&, String original_pattern, String parsed_pattern, String flags);
+    // JS regexps are all 'global' by default as per our definition, but the "global" flag enables "stateful".
+    // FIXME: Enable 'BrowserExtended' only if in a browser context.
+    static constexpr regex::RegexOptions<ECMAScriptFlags> default_flags { (regex::ECMAScriptFlags)regex::AllFlags::Global | (regex::ECMAScriptFlags)regex::AllFlags::SkipTrimEmptyMatches | regex::ECMAScriptFlags::BrowserExtended };
 
-    RegExpObject(String original_pattern, String parsed_pattern, String flags, Object& prototype);
+    static RegExpObject* create(GlobalObject&, Regex<ECMA262> regex, String pattern, String flags);
+
+    RegExpObject(Regex<ECMA262> regex, String pattern, String flags, Object& prototype);
     virtual void initialize(GlobalObject&) override;
     virtual ~RegExpObject() override;
 
-    const String& pattern() const { return m_original_pattern; }
+    const String& pattern() const { return m_pattern; }
     const String& flags() const { return m_flags; }
-    const regex::RegexOptions<ECMAScriptFlags>& declared_options() { return m_active_flags.declared_flags; }
     const Regex<ECMA262>& regex() { return m_regex; }
     const Regex<ECMA262>& regex() const { return m_regex; }
 
 private:
-    String m_original_pattern;
-    String m_parsed_pattern;
+    String m_pattern;
     String m_flags;
-    Flags m_active_flags;
     Regex<ECMA262> m_regex;
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -52,3 +52,11 @@ test("regexp object as pattern parameter", () => {
     expect(RegExp(regex_like_object_with_flags, "").toString()).toBe("/foo/");
     expect(RegExp(regex_like_object_with_flags, "y").toString()).toBe("/foo/y");
 });
+
+test("regexp literals are re-useable", () => {
+    for (var i = 0; i < 2; ++i) {
+        const re = /test/;
+        expect(re.test("te")).toBeFalse();
+        expect(re.test("test")).toBeTrue();
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.test.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.test.js
@@ -91,3 +91,15 @@ test("override exec with non-function", () => {
     re.exec = 3;
     expect(re.test("test")).toBe(true);
 });
+
+test("property escapes", () => {
+    expect(/\p{ASCII}/.test("a")).toBeFalse();
+    expect(/\p{ASCII}/.test("p{ASCII}")).toBeTrue();
+    expect(/\p{ASCII}/u.test("a")).toBeTrue();
+    expect(/\p{ASCII}/u.test("😀")).toBeFalse();
+    expect(/\p{ASCII_Hex_Digit}/u.test("1")).toBeTrue();
+    expect(/\p{ASCII_Hex_Digit}/u.test("a")).toBeTrue();
+    expect(/\p{ASCII_Hex_Digit}/u.test("x")).toBeFalse();
+    expect(/\p{Any}/u.test("\u0378")).toBeTrue();
+    expect(/\p{Assigned}/u.test("\u0378")).toBeFalse();
+});

--- a/Userland/Libraries/LibRegex/CMakeLists.txt
+++ b/Userland/Libraries/LibRegex/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 )
 
 serenity_lib(LibRegex regex)
-target_link_libraries(LibRegex LibC LibCore)
+target_link_libraries(LibRegex LibC LibCore LibUnicode)

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -18,6 +18,7 @@
 #include <AK/TypeCasts.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibUnicode/Forward.h>
 
 namespace regex {
 
@@ -65,6 +66,7 @@ enum class OpCodeId : ByteCodeValueType {
     __ENUMERATE_CHARACTER_COMPARE_TYPE(CharRange)        \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(Reference)        \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(NamedReference)   \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Property)         \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(RangeExpressionDummy)
 
 enum class CharacterCompareType : ByteCodeValueType {
@@ -722,6 +724,7 @@ private:
     ALWAYS_INLINE static bool compare_string(MatchInput const& input, MatchState& state, RegexStringView const& str, bool& had_zero_length_match);
     ALWAYS_INLINE static void compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
     ALWAYS_INLINE static void compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
+    ALWAYS_INLINE static void compare_property(MatchInput const& input, MatchState& state, Unicode::Property property, bool inverse, bool& inverse_matched);
 };
 
 template<typename T>

--- a/Userland/Libraries/LibRegex/RegexError.h
+++ b/Userland/Libraries/LibRegex/RegexError.h
@@ -34,6 +34,7 @@ enum class Error : u8 {
     EmptySubExpression = __Regex_EmptySubExpression,                 // Sub expression has empty content.
     InvalidCaptureGroup = __Regex_InvalidCaptureGroup,               // Content of capture group is invalid.
     InvalidNameForCaptureGroup = __Regex_InvalidNameForCaptureGroup, // Name of capture group is invalid.
+    InvalidNameForProperty = __Regex_InvalidNameForProperty,         // Name of property is invalid.
 };
 
 inline String get_error_string(Error error)
@@ -73,6 +74,8 @@ inline String get_error_string(Error error)
         return "Content of capture group is invalid.";
     case Error::InvalidNameForCaptureGroup:
         return "Name of capture group is invalid.";
+    case Error::InvalidNameForProperty:
+        return "Name of property is invalid.";
     }
     return "Undefined error.";
 }

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -19,6 +19,15 @@ static RegexDebug s_regex_dbg(stderr);
 #endif
 
 template<class Parser>
+regex::Parser::Result Regex<Parser>::parse_pattern(StringView pattern, typename ParserTraits<Parser>::OptionsType regex_options)
+{
+    regex::Lexer lexer(pattern);
+
+    Parser parser(lexer, regex_options);
+    return parser.parse();
+}
+
+template<class Parser>
 Regex<Parser>::Regex(String pattern, typename ParserTraits<Parser>::OptionsType regex_options)
     : pattern_value(move(pattern))
 {
@@ -27,6 +36,15 @@ Regex<Parser>::Regex(String pattern, typename ParserTraits<Parser>::OptionsType 
     Parser parser(lexer, regex_options);
     parser_result = parser.parse();
 
+    if (parser_result.error == regex::Error::NoError)
+        matcher = make<Matcher<Parser>>(this, regex_options);
+}
+
+template<class Parser>
+Regex<Parser>::Regex(regex::Parser::Result parse_result, String pattern, typename ParserTraits<Parser>::OptionsType regex_options)
+    : pattern_value(move(pattern))
+    , parser_result(move(parse_result))
+{
     if (parser_result.error == regex::Error::NoError)
         matcher = make<Matcher<Parser>>(this, regex_options);
 }

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -44,7 +44,7 @@ template<class Parser>
 class Matcher final {
 
 public:
-    Matcher(Regex<Parser> const& pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
+    Matcher(Regex<Parser> const* pattern, Optional<typename ParserTraits<Parser>::OptionsType> regex_options = {})
         : m_pattern(pattern)
         , m_regex_options(regex_options.value_or({}))
     {
@@ -59,11 +59,16 @@ public:
         return m_regex_options;
     }
 
+    void reset_pattern(Badge<Regex<Parser>>, Regex<Parser> const* pattern)
+    {
+        m_pattern = pattern;
+    }
+
 private:
     Optional<bool> execute(MatchInput const& input, MatchState& state, MatchOutput& output, size_t recursion_level) const;
     ALWAYS_INLINE Optional<bool> execute_low_prio_forks(MatchInput const& input, MatchState& original_state, MatchOutput& output, Vector<MatchState> states, size_t recursion_level) const;
 
-    Regex<Parser> const& m_pattern;
+    Regex<Parser> const* m_pattern;
     typename ParserTraits<Parser>::OptionsType const m_regex_options;
 };
 
@@ -75,10 +80,10 @@ public:
     OwnPtr<Matcher<Parser>> matcher { nullptr };
     mutable size_t start_offset { 0 };
 
-    explicit Regex(StringView pattern, typename ParserTraits<Parser>::OptionsType regex_options = {});
+    explicit Regex(String pattern, typename ParserTraits<Parser>::OptionsType regex_options = {});
     ~Regex() = default;
-    Regex(Regex&&) = default;
-    Regex& operator=(Regex&&) = default;
+    Regex(Regex&&);
+    Regex& operator=(Regex&&);
 
     typename ParserTraits<Parser>::OptionsType options() const;
     void print_bytecode(FILE* f = stdout) const;

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -80,7 +80,10 @@ public:
     OwnPtr<Matcher<Parser>> matcher { nullptr };
     mutable size_t start_offset { 0 };
 
+    static regex::Parser::Result parse_pattern(StringView pattern, typename ParserTraits<Parser>::OptionsType regex_options = {});
+
     explicit Regex(String pattern, typename ParserTraits<Parser>::OptionsType regex_options = {});
+    Regex(regex::Parser::Result parse_result, String pattern, typename ParserTraits<Parser>::OptionsType regex_options = {});
     ~Regex() = default;
     Regex(Regex&&);
     Regex& operator=(Regex&&);

--- a/Userland/Libraries/LibRegex/RegexOptions.h
+++ b/Userland/Libraries/LibRegex/RegexOptions.h
@@ -74,13 +74,13 @@ public:
 
     RegexOptions() = default;
 
-    RegexOptions(T flags)
+    constexpr RegexOptions(T flags)
         : m_flags(flags)
     {
     }
 
     template<class U>
-    RegexOptions(RegexOptions<U> other)
+    constexpr RegexOptions(RegexOptions<U> other)
         : m_flags((T) static_cast<FlagsUnderlyingType>(other.value()))
     {
     }
@@ -88,16 +88,16 @@ public:
     operator bool() const { return !!*this; }
     bool operator!() const { return (FlagsUnderlyingType)m_flags == 0; }
 
-    RegexOptions<T> operator|(T flag) const { return RegexOptions<T> { (T)((FlagsUnderlyingType)m_flags | (FlagsUnderlyingType)flag) }; }
-    RegexOptions<T> operator&(T flag) const { return RegexOptions<T> { (T)((FlagsUnderlyingType)m_flags & (FlagsUnderlyingType)flag) }; }
+    constexpr RegexOptions<T> operator|(T flag) const { return RegexOptions<T> { (T)((FlagsUnderlyingType)m_flags | (FlagsUnderlyingType)flag) }; }
+    constexpr RegexOptions<T> operator&(T flag) const { return RegexOptions<T> { (T)((FlagsUnderlyingType)m_flags & (FlagsUnderlyingType)flag) }; }
 
-    RegexOptions<T>& operator|=(T flag)
+    constexpr RegexOptions<T>& operator|=(T flag)
     {
         m_flags = (T)((FlagsUnderlyingType)m_flags | (FlagsUnderlyingType)flag);
         return *this;
     }
 
-    RegexOptions<T>& operator&=(T flag)
+    constexpr RegexOptions<T>& operator&=(T flag)
     {
         m_flags = (T)((FlagsUnderlyingType)m_flags & (FlagsUnderlyingType)flag);
         return *this;
@@ -114,19 +114,19 @@ private:
 };
 
 template<class T>
-inline RegexOptions<T> operator|(T lhs, T rhs)
+constexpr RegexOptions<T> operator|(T lhs, T rhs)
 {
     return RegexOptions<T> { lhs } |= rhs;
 }
 
 template<class T>
-inline RegexOptions<T> operator&(T lhs, T rhs)
+constexpr RegexOptions<T> operator&(T lhs, T rhs)
 {
     return RegexOptions<T> { lhs } &= rhs;
 }
 
 template<class T>
-inline T operator~(T flag)
+constexpr T operator~(T flag)
 {
     return (T) ~((FlagsUnderlyingType)flag);
 }

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -15,6 +15,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibUnicode/Forward.h>
 
 namespace regex {
 
@@ -212,6 +213,7 @@ private:
     StringView read_digits_as_string(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1);
     Optional<unsigned> read_digits(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1);
     StringView read_capture_group_specifier(bool take_starting_angle_bracket = false);
+    Optional<Unicode::Property> read_unicode_property_escape();
 
     bool parse_pattern(ByteCode&, size_t&, bool unicode, bool named);
     bool parse_disjunction(ByteCode&, size_t&, bool unicode, bool named);
@@ -225,6 +227,7 @@ private:
     bool parse_capture_group(ByteCode&, size_t&, bool unicode, bool named);
     Optional<CharClass> parse_character_class_escape(bool& out_inverse, bool expect_backslash = false);
     bool parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&, bool unicode);
+    bool parse_unicode_property_escape(Unicode::Property& property, bool& negated);
 
     // Used only by B.1.4, Regular Expression Patterns (Extended for use in browsers)
     bool parse_quantifiable_assertion(ByteCode&, size_t&, bool named);

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -222,4 +222,73 @@ bool code_point_has_property([[maybe_unused]] u32 code_point, [[maybe_unused]] P
 #endif
 }
 
+bool is_ecma262_property([[maybe_unused]] Property property)
+{
+#if ENABLE_UNICODE_DATA
+    // EMCA-262 only allows a subset of Unicode properties: https://tc39.es/ecma262/#table-binary-unicode-properties
+    // Note: Some of the properties in the above link are not yet parsed by the LibUnicode generator. They are left
+    //       commented out here until they are parsed and can be used.
+    switch (property) {
+    case Unicode::Property::ASCII:
+    case Unicode::Property::ASCII_Hex_Digit:
+    case Unicode::Property::Alphabetic:
+    case Unicode::Property::Any:
+    case Unicode::Property::Assigned:
+    case Unicode::Property::Bidi_Control:
+    // case Unicode::Property::Bidi_Mirrored:
+    case Unicode::Property::Case_Ignorable:
+    case Unicode::Property::Cased:
+    case Unicode::Property::Changes_When_Casefolded:
+    case Unicode::Property::Changes_When_Casemapped:
+    case Unicode::Property::Changes_When_Lowercased:
+    // case Unicode::Property::Changes_When_NFKC_Casefolded:
+    case Unicode::Property::Changes_When_Titlecased:
+    case Unicode::Property::Changes_When_Uppercased:
+    case Unicode::Property::Dash:
+    case Unicode::Property::Default_Ignorable_Code_Point:
+    case Unicode::Property::Deprecated:
+    case Unicode::Property::Diacritic:
+    // case Unicode::Property::Emoji:
+    // case Unicode::Property::Emoji_Component:
+    // case Unicode::Property::Emoji_Modifier:
+    // case Unicode::Property::Emoji_Modifier_Base:
+    // case Unicode::Property::Emoji_Presentation:
+    // case Unicode::Property::Extended_Pictographic:
+    case Unicode::Property::Extender:
+    case Unicode::Property::Grapheme_Base:
+    case Unicode::Property::Grapheme_Extend:
+    case Unicode::Property::Hex_Digit:
+    case Unicode::Property::IDS_Binary_Operator:
+    case Unicode::Property::IDS_Trinary_Operator:
+    case Unicode::Property::ID_Continue:
+    case Unicode::Property::ID_Start:
+    case Unicode::Property::Ideographic:
+    case Unicode::Property::Join_Control:
+    case Unicode::Property::Logical_Order_Exception:
+    case Unicode::Property::Lowercase:
+    case Unicode::Property::Math:
+    case Unicode::Property::Noncharacter_Code_Point:
+    case Unicode::Property::Pattern_Syntax:
+    case Unicode::Property::Pattern_White_Space:
+    case Unicode::Property::Quotation_Mark:
+    case Unicode::Property::Radical:
+    case Unicode::Property::Regional_Indicator:
+    case Unicode::Property::Sentence_Terminal:
+    case Unicode::Property::Soft_Dotted:
+    case Unicode::Property::Terminal_Punctuation:
+    case Unicode::Property::Unified_Ideograph:
+    case Unicode::Property::Uppercase:
+    case Unicode::Property::Variation_Selector:
+    case Unicode::Property::White_Space:
+    case Unicode::Property::XID_Continue:
+    case Unicode::Property::XID_Start:
+        return true;
+    default:
+        return false;
+    }
+#else
+    return false;
+#endif
+}
+
 }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -25,12 +25,7 @@ namespace Unicode {
 
 static bool has_property(UnicodeData const& unicode_data, Property property)
 {
-    for (u32 i = 0; i < unicode_data.prop_list_size; ++i) {
-        if (unicode_data.prop_list[i] == property)
-            return true;
-    }
-
-    return false;
+    return (unicode_data.properties & property) == property;
 }
 
 static bool is_cased_letter(UnicodeData const& unicode_data)

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -9,6 +9,7 @@
 #include <AK/Forward.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <LibUnicode/Forward.h>
 
 namespace Unicode {
 
@@ -19,5 +20,8 @@ u32 to_unicode_uppercase(u32 code_point);
 
 String to_unicode_lowercase_full(StringView const&);
 String to_unicode_uppercase_full(StringView const&);
+
+Optional<Property> property_from_string(StringView const&);
+bool code_point_has_property(u32 code_point, Property property);
 
 }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -23,5 +23,6 @@ String to_unicode_uppercase_full(StringView const&);
 
 Optional<Property> property_from_string(StringView const&);
 bool code_point_has_property(u32 code_point, Property property);
+bool is_ecma262_property(Property);
 
 }

--- a/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
+++ b/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
@@ -573,6 +573,7 @@ int main(int argc, char** argv)
     char const* unicode_data_path = nullptr;
     char const* special_casing_path = nullptr;
     char const* prop_list_path = nullptr;
+    char const* derived_core_prop_path = nullptr;
     char const* word_break_path = nullptr;
 
     Core::ArgsParser args_parser;
@@ -581,6 +582,7 @@ int main(int argc, char** argv)
     args_parser.add_option(unicode_data_path, "Path to UnicodeData.txt file", "unicode-data-path", 'u', "unicode-data-path");
     args_parser.add_option(special_casing_path, "Path to SpecialCasing.txt file", "special-casing-path", 's', "special-casing-path");
     args_parser.add_option(prop_list_path, "Path to PropList.txt file", "prop-list-path", 'p', "prop-list-path");
+    args_parser.add_option(derived_core_prop_path, "Path to DerivedCoreProperties.txt file", "derived-core-prop-path", 'd', "derived-core-prop-path");
     args_parser.add_option(word_break_path, "Path to WordBreakProperty.txt file", "word-break-path", 'w', "word-break-path");
     args_parser.parse(argc, argv);
 
@@ -609,11 +611,13 @@ int main(int argc, char** argv)
     auto unicode_data_file = open_file(unicode_data_path, "-u/--unicode-data-path");
     auto special_casing_file = open_file(special_casing_path, "-s/--special-casing-path");
     auto prop_list_file = open_file(prop_list_path, "-p/--prop-list-path");
+    auto derived_core_prop_file = open_file(derived_core_prop_path, "-d/--derived-core-prop-path");
     auto word_break_file = open_file(word_break_path, "-w/--word-break-path");
 
     UnicodeData unicode_data {};
     parse_special_casing(special_casing_file, unicode_data);
     parse_prop_list(prop_list_file, unicode_data.prop_list);
+    parse_prop_list(derived_core_prop_file, unicode_data.prop_list);
     parse_prop_list(word_break_file, unicode_data.word_break_prop_list);
     parse_unicode_data(unicode_data_file, unicode_data);
 

--- a/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
+++ b/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
@@ -166,8 +166,7 @@ static void parse_prop_list(Core::File& file, PropList& prop_list)
         VERIFY(segments.size() == 2);
 
         auto code_point_range = segments[0].trim_whitespace();
-        auto property = segments[1].trim_whitespace().to_string();
-        property.replace("_", "", true);
+        auto property = segments[1].trim_whitespace();
 
         auto& code_points = prop_list.ensure(property);
 

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Unicode {
+
+enum class Condition;
+enum class GeneralCategory;
+enum class Locale;
+enum class Property : u64;
+enum class WordBreakProperty;
+
+struct SpecialCasing;
+struct UnicodeData;
+
+}

--- a/Userland/Libraries/LibUnicode/unicode_data.cmake
+++ b/Userland/Libraries/LibUnicode/unicode_data.cmake
@@ -9,6 +9,9 @@ set(SPECIAL_CASING_PATH ${CMAKE_BINARY_DIR}/UCD/SpecialCasing.txt)
 set(PROP_LIST_URL https://www.unicode.org/Public/13.0.0/ucd/PropList.txt)
 set(PROP_LIST_PATH ${CMAKE_BINARY_DIR}/UCD/PropList.txt)
 
+set(DERIVED_CORE_PROP_URL https://www.unicode.org/Public/13.0.0/ucd/DerivedCoreProperties.txt)
+set(DERIVED_CORE_PROP_PATH ${CMAKE_BINARY_DIR}/UCD/DerivedCoreProperties.txt)
+
 set(WORD_BREAK_URL https://www.unicode.org/Public/13.0.0/ucd/auxiliary/WordBreakProperty.txt)
 set(WORD_BREAK_PATH ${CMAKE_BINARY_DIR}/UCD/WordBreakProperty.txt)
 
@@ -25,6 +28,10 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         message(STATUS "Downloading UCD PropList.txt from ${PROP_LIST_URL}...")
         file(DOWNLOAD ${PROP_LIST_URL} ${PROP_LIST_PATH} INACTIVITY_TIMEOUT 10)
     endif()
+    if (NOT EXISTS ${DERIVED_CORE_PROP_PATH})
+        message(STATUS "Downloading UCD DerivedCoreProperties.txt from ${DERIVED_CORE_PROP_URL}...")
+        file(DOWNLOAD ${DERIVED_CORE_PROP_URL} ${DERIVED_CORE_PROP_PATH} INACTIVITY_TIMEOUT 10)
+    endif()
     if (NOT EXISTS ${WORD_BREAK_PATH})
         message(STATUS "Downloading UCD WordBreakProperty.txt from ${WORD_BREAK_URL}...")
         file(DOWNLOAD ${WORD_BREAK_URL} ${WORD_BREAK_PATH} INACTIVITY_TIMEOUT 10)
@@ -40,7 +47,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_DATA_HEADER}
-        COMMAND ${write_if_different} ${UNICODE_DATA_HEADER} $<TARGET_FILE:GenerateUnicodeData> -h -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -w ${WORD_BREAK_PATH}
+        COMMAND ${write_if_different} ${UNICODE_DATA_HEADER} $<TARGET_FILE:GenerateUnicodeData> -h -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -w ${WORD_BREAK_PATH}
         VERBATIM
         DEPENDS GenerateUnicodeData
         MAIN_DEPENDENCY ${UNICODE_DATA_PATH} ${SPECIAL_CASING_PATH}
@@ -48,7 +55,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_DATA_IMPLEMENTATION}
-        COMMAND ${write_if_different} ${UNICODE_DATA_IMPLEMENTATION} $<TARGET_FILE:GenerateUnicodeData> -c -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -w ${WORD_BREAK_PATH}
+        COMMAND ${write_if_different} ${UNICODE_DATA_IMPLEMENTATION} $<TARGET_FILE:GenerateUnicodeData> -c -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -w ${WORD_BREAK_PATH}
         VERBATIM
         DEPENDS GenerateUnicodeData
         MAIN_DEPENDENCY ${UNICODE_DATA_PATH} ${SPECIAL_CASING_PATH}

--- a/Userland/Libraries/LibUnicode/unicode_data.cmake
+++ b/Userland/Libraries/LibUnicode/unicode_data.cmake
@@ -12,6 +12,9 @@ set(PROP_LIST_PATH ${CMAKE_BINARY_DIR}/UCD/PropList.txt)
 set(DERIVED_CORE_PROP_URL https://www.unicode.org/Public/13.0.0/ucd/DerivedCoreProperties.txt)
 set(DERIVED_CORE_PROP_PATH ${CMAKE_BINARY_DIR}/UCD/DerivedCoreProperties.txt)
 
+set(PROP_ALIAS_URL https://www.unicode.org/Public/13.0.0/ucd/PropertyAliases.txt)
+set(PROP_ALIAS_PATH ${CMAKE_BINARY_DIR}/UCD/PropertyAliases.txt)
+
 set(WORD_BREAK_URL https://www.unicode.org/Public/13.0.0/ucd/auxiliary/WordBreakProperty.txt)
 set(WORD_BREAK_PATH ${CMAKE_BINARY_DIR}/UCD/WordBreakProperty.txt)
 
@@ -32,6 +35,10 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         message(STATUS "Downloading UCD DerivedCoreProperties.txt from ${DERIVED_CORE_PROP_URL}...")
         file(DOWNLOAD ${DERIVED_CORE_PROP_URL} ${DERIVED_CORE_PROP_PATH} INACTIVITY_TIMEOUT 10)
     endif()
+    if (NOT EXISTS ${PROP_ALIAS_PATH})
+        message(STATUS "Downloading UCD PropertyAliases.txt from ${PROP_ALIAS_URL}...")
+        file(DOWNLOAD ${PROP_ALIAS_URL} ${PROP_ALIAS_PATH} INACTIVITY_TIMEOUT 10)
+    endif()
     if (NOT EXISTS ${WORD_BREAK_PATH})
         message(STATUS "Downloading UCD WordBreakProperty.txt from ${WORD_BREAK_URL}...")
         file(DOWNLOAD ${WORD_BREAK_URL} ${WORD_BREAK_PATH} INACTIVITY_TIMEOUT 10)
@@ -47,7 +54,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_DATA_HEADER}
-        COMMAND ${write_if_different} ${UNICODE_DATA_HEADER} $<TARGET_FILE:GenerateUnicodeData> -h -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -w ${WORD_BREAK_PATH}
+        COMMAND ${write_if_different} ${UNICODE_DATA_HEADER} $<TARGET_FILE:GenerateUnicodeData> -h -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -a ${PROP_ALIAS_PATH} -w ${WORD_BREAK_PATH}
         VERBATIM
         DEPENDS GenerateUnicodeData
         MAIN_DEPENDENCY ${UNICODE_DATA_PATH} ${SPECIAL_CASING_PATH}
@@ -55,7 +62,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_DATA_IMPLEMENTATION}
-        COMMAND ${write_if_different} ${UNICODE_DATA_IMPLEMENTATION} $<TARGET_FILE:GenerateUnicodeData> -c -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -w ${WORD_BREAK_PATH}
+        COMMAND ${write_if_different} ${UNICODE_DATA_IMPLEMENTATION} $<TARGET_FILE:GenerateUnicodeData> -c -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -a ${PROP_ALIAS_PATH} -w ${WORD_BREAK_PATH}
         VERBATIM
         DEPENDS GenerateUnicodeData
         MAIN_DEPENDENCY ${UNICODE_DATA_PATH} ${SPECIAL_CASING_PATH}


### PR DESCRIPTION
Definitely not fully implemented according to the spec(s), but it's a nice start :grin:

Fixes about 150 test262 tests.

This probably conflicts with #9017 