### PR TITLE
HackStudio+TextEditor: Add syntax highlighting for HTML, Shell, and SQL files

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -633,9 +633,11 @@ void MainWidget::set_path(StringView const& path)
         m_gml_highlight->activate();
     } else if (m_extension == "ini") {
         m_ini_highlight->activate();
+    } else if (m_extension == "sh" || m_extension == "bash") {
+        m_shell_highlight->activate();
     } else if (m_extension == "sql") {
         m_sql_highlight->activate();
-    } else if (m_extension == "html") {
+    } else if (m_extension == "html" || m_extension == "htm") {
         m_html_highlight->activate();
     } else {
         m_plain_text_highlight->activate();
@@ -644,7 +646,7 @@ void MainWidget::set_path(StringView const& path)
     if (m_auto_detect_preview_mode) {
         if (m_extension == "md")
             set_preview_mode(PreviewMode::Markdown);
-        else if (m_extension == "html")
+        else if (m_extension == "html" || m_extension == "htm")
             set_preview_mode(PreviewMode::HTML);
         else
             set_preview_mode(PreviewMode::None);

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -625,9 +625,10 @@ void MainWidget::set_path(StringView const& path)
         m_extension = lexical_path.extension();
     }
 
-    if (m_extension == "c" || m_extension == "cc" || m_extension == "cxx" || m_extension == "cpp" || m_extension == "h") {
+    if (m_extension == "c" || m_extension == "cc" || m_extension == "cxx" || m_extension == "cpp" || m_extension == "c++"
+        || m_extension == "h" || m_extension == "hh" || m_extension == "hxx" || m_extension == "hpp" || m_extension == "h++") {
         m_cpp_highlight->activate();
-    } else if (m_extension == "js" || m_extension == "json") {
+    } else if (m_extension == "js" || m_extension == "mjs" || m_extension == "json") {
         m_js_highlight->activate();
     } else if (m_extension == "gml") {
         m_gml_highlight->activate();

--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -50,5 +50,5 @@ set(SOURCES
 )
 
 serenity_app(HackStudio ICON app-hack-studio)
-target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibCpp LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell LibSymbolication LibRegex)
+target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibCpp LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell LibSymbolication LibRegex LibSQL)
 add_dependencies(HackStudio CppLanguageServer)

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -29,9 +29,11 @@
 #include <LibGUI/Window.h>
 #include <LibJS/SyntaxHighlighter.h>
 #include <LibMarkdown/Document.h>
+#include <LibSQL/AST/SyntaxHighlighter.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
+#include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>
 #include <LibWeb/OutOfProcessWebView.h>
 #include <Shell/SyntaxHighlighter.h>
 #include <fcntl.h>
@@ -597,6 +599,9 @@ void Editor::set_syntax_highlighter_for(const CodeDocument& document)
     case Language::GML:
         set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());
         break;
+    case Language::HTML:
+        set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
+        break;
     case Language::JavaScript:
         set_syntax_highlighter(make<JS::SyntaxHighlighter>());
         break;
@@ -605,6 +610,9 @@ void Editor::set_syntax_highlighter_for(const CodeDocument& document)
         break;
     case Language::Shell:
         set_syntax_highlighter(make<Shell::SyntaxHighlighter>());
+        break;
+    case Language::SQL:
+        set_syntax_highlighter(make<SQL::AST::SyntaxHighlighter>());
         break;
     default:
         set_syntax_highlighter({});

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -13,17 +13,17 @@ Language language_from_file_extension(const String& extension)
     VERIFY(!extension.starts_with("."));
     if (extension == "cpp" || extension == "h")
         return Language::Cpp;
-    else if (extension == "js" || extension == "json")
+    if (extension == "js" || extension == "json")
         return Language::JavaScript;
-    else if (extension == "html" || extension == "htm")
+    if (extension == "html" || extension == "htm")
         return Language::HTML;
-    else if (extension == "gml")
+    if (extension == "gml")
         return Language::GML;
-    else if (extension == "ini")
+    if (extension == "ini")
         return Language::Ini;
-    else if (extension == "sh" || extension == "bash")
+    if (extension == "sh" || extension == "bash")
         return Language::Shell;
-    else if (extension == "sql")
+    if (extension == "sql")
         return Language::SQL;
 
     return Language::Unknown;
@@ -46,21 +46,21 @@ String language_name_from_file_extension(const String& extension)
     VERIFY(!extension.starts_with("."));
     if (extension == "cpp" || extension == "h")
         return "C++";
-    else if (extension == "js" || extension == "json")
+    if (extension == "js" || extension == "json")
         return "JavaScript";
-    else if (extension == "gml")
+    if (extension == "gml")
         return "GML";
-    else if (extension == "ini")
+    if (extension == "ini")
         return "Ini";
-    else if (extension == "sh" || extension == "bash")
+    if (extension == "sh" || extension == "bash")
         return "Shell";
-    else if (extension == "md")
+    if (extension == "md")
         return "Markdown";
-    else if (extension == "html" || extension == "htm")
+    if (extension == "html" || extension == "htm")
         return "HTML";
-    else if (extension == "sql")
+    if (extension == "sql")
         return "SQL";
-    else if (extension == "txt")
+    if (extension == "txt")
         return "Plaintext";
 
     return "Unknown";

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -11,9 +11,10 @@ namespace HackStudio {
 Language language_from_file_extension(const String& extension)
 {
     VERIFY(!extension.starts_with("."));
-    if (extension == "cpp" || extension == "h")
+    if (extension == "c" || extension == "cc" || extension == "cxx" || extension == "cpp" || extension == "c++"
+        || extension == "h" || extension == "cc" || extension == "hxx" || extension == "hpp" || extension == "h++")
         return Language::Cpp;
-    if (extension == "js" || extension == "json")
+    if (extension == "js" || extension == "mjs" || extension == "json")
         return Language::JavaScript;
     if (extension == "html" || extension == "htm")
         return Language::HTML;
@@ -44,9 +45,10 @@ Language language_from_name(const String& name)
 String language_name_from_file_extension(const String& extension)
 {
     VERIFY(!extension.starts_with("."));
-    if (extension == "cpp" || extension == "h")
+    if (extension == "c" || extension == "cc" || extension == "cxx" || extension == "cpp" || extension == "c++"
+        || extension == "h" || extension == "hh" || extension == "hxx" || extension == "hpp" || extension == "h++")
         return "C++";
-    if (extension == "js" || extension == "json")
+    if (extension == "js" || extension == "mjs" || extension == "json")
         return "JavaScript";
     if (extension == "gml")
         return "GML";

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -13,14 +13,18 @@ Language language_from_file_extension(const String& extension)
     VERIFY(!extension.starts_with("."));
     if (extension == "cpp" || extension == "h")
         return Language::Cpp;
-    else if (extension == "js")
+    else if (extension == "js" || extension == "json")
         return Language::JavaScript;
+    else if (extension == "html" || extension == "htm")
+        return Language::HTML;
     else if (extension == "gml")
         return Language::GML;
     else if (extension == "ini")
         return Language::Ini;
-    else if (extension == "sh")
+    else if (extension == "sh" || extension == "bash")
         return Language::Shell;
+    else if (extension == "sql")
+        return Language::SQL;
 
     return Language::Unknown;
 }
@@ -42,18 +46,20 @@ String language_name_from_file_extension(const String& extension)
     VERIFY(!extension.starts_with("."));
     if (extension == "cpp" || extension == "h")
         return "C++";
-    else if (extension == "js")
+    else if (extension == "js" || extension == "json")
         return "JavaScript";
     else if (extension == "gml")
         return "GML";
     else if (extension == "ini")
         return "Ini";
-    else if (extension == "sh")
+    else if (extension == "sh" || extension == "bash")
         return "Shell";
     else if (extension == "md")
         return "Markdown";
-    else if (extension == "html")
+    else if (extension == "html" || extension == "htm")
         return "HTML";
+    else if (extension == "sql")
+        return "SQL";
     else if (extension == "txt")
         return "Plaintext";
 

--- a/Userland/DevTools/HackStudio/Language.h
+++ b/Userland/DevTools/HackStudio/Language.h
@@ -13,9 +13,11 @@ enum class Language {
     Unknown,
     Cpp,
     JavaScript,
+    HTML,
     GML,
     Ini,
     Shell,
+    SQL,
 };
 
 Language language_from_file_extension(const String&);


### PR DESCRIPTION
- **TextEditor: Add automatic syntax highlighting for Shell and .htm files**
- **HackStudio: Add syntax highlighting for HTML, Shell, and SQL files**
  
  `.html` files were recognised before – the name was shown on the statusbar, but it didn't actually enable the syntax highlighting.

  This also sneaks a highlighting for JSON using JS highlighting. It isn't technically correct, but so does TextEditor. :^)

- **HackStudio: Don't use 'else' after 'return'**
- **HackStudio+TextEditor: Sync extensions from the FileIconProvider file**
  
  This adds more possible extensions for highlighting C/C++ files and JavaScript module files.