### PR TITLE
LibGUI: Do not wrap text in statusbar segments

### DIFF
--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -377,4 +377,10 @@ T* Object::find_descendant_of_type_named(String const& name) requires IsBaseOf<O
         { Gfx::FontWeight::ExtraBold, "ExtraBold" },                 \
         { Gfx::FontWeight::Black, "Black" },                         \
         { Gfx::FontWeight::ExtraBlack, "ExtraBlack" })
+
+#define REGISTER_TEXT_WRAPPING_PROPERTY(property_name, getter, setter) \
+    REGISTER_ENUM_PROPERTY(                                            \
+        property_name, getter, setter, Gfx::TextWrapping,              \
+        { Gfx::TextWrapping::Wrap, "Wrap" },                           \
+        { Gfx::TextWrapping::DontWrap, "DontWrap" })
 }

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -21,6 +21,7 @@ Label::Label(String text)
     : m_text(move(text))
 {
     REGISTER_TEXT_ALIGNMENT_PROPERTY("text_alignment", text_alignment, set_text_alignment);
+    REGISTER_TEXT_WRAPPING_PROPERTY("text_wrapping", text_wrapping, set_text_wrapping);
 
     set_frame_thickness(0);
     set_frame_shadow(Gfx::FrameShadow::Plain);
@@ -91,10 +92,10 @@ void Label::paint_event(PaintEvent& event)
 
     auto text_rect = this->text_rect();
     if (is_enabled()) {
-        painter.draw_text(text_rect, text(), m_text_alignment, palette().color(foreground_role()), Gfx::TextElision::Right, Gfx::TextWrapping::Wrap);
+        painter.draw_text(text_rect, text(), text_alignment(), palette().color(foreground_role()), Gfx::TextElision::Right, text_wrapping());
     } else {
-        painter.draw_text(text_rect.translated(1, 1), text(), font(), text_alignment(), Color::White, Gfx::TextElision::Right, Gfx::TextWrapping::Wrap);
-        painter.draw_text(text_rect, text(), font(), text_alignment(), Color::from_rgb(0x808080), Gfx::TextElision::Right, Gfx::TextWrapping::Wrap);
+        painter.draw_text(text_rect.translated(1, 1), text(), font(), text_alignment(), Color::White, Gfx::TextElision::Right, text_wrapping());
+        painter.draw_text(text_rect, text(), font(), text_alignment(), Color::from_rgb(0x808080), Gfx::TextElision::Right, text_wrapping());
     }
 }
 

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -8,6 +8,7 @@
 
 #include <LibGUI/Frame.h>
 #include <LibGfx/TextAlignment.h>
+#include <LibGfx/TextWrapping.h>
 
 namespace GUI {
 
@@ -26,6 +27,9 @@ public:
 
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
     void set_text_alignment(Gfx::TextAlignment text_alignment) { m_text_alignment = text_alignment; }
+
+    Gfx::TextWrapping text_wrapping() const { return m_text_wrapping; }
+    void set_text_wrapping(Gfx::TextWrapping text_wrapping) { m_text_wrapping = text_wrapping; }
 
     bool should_stretch_icon() const { return m_should_stretch_icon; }
     void set_should_stretch_icon(bool b) { m_should_stretch_icon = b; }
@@ -49,6 +53,7 @@ private:
     String m_text;
     RefPtr<Gfx::Bitmap> m_icon;
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::Center };
+    Gfx::TextWrapping m_text_wrapping { Gfx::TextWrapping::Wrap };
     bool m_should_stretch_icon { false };
     bool m_autosize { false };
 };

--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -43,6 +43,7 @@ NonnullRefPtr<Label> Statusbar::create_label()
     label->set_frame_shape(Gfx::FrameShape::Panel);
     label->set_frame_thickness(1);
     label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
     return label;
 }
 


### PR DESCRIPTION
**LibCore: Support registration of TextWrapping properties**

This is basically a named boolean.

**LibGUI: Do not wrap text in statusbar segments**

This commit adds a new property to `Label` which allows one to enable or
disable text wrapping. `Statusbar` now uses this property to disable text
wrapping in its segments, since text wrapping in statusbars doesn't make
sense.