### PR TITLE
LibJS: Add all missing Temporal.PlainDateTime getters & Temporal.PlainTime.prototype.toPlainDateTime

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -381,6 +381,7 @@ namespace JS {
     P(toLocaleUpperCase)                     \
     P(toLowerCase)                           \
     P(toPlainDate)                           \
+    P(toPlainDateTime)                       \
     P(toString)                              \
     P(toTemporalInstant)                     \
     P(toTimeString)                          \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -42,6 +42,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.dayOfYear, day_of_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.weekOfYear, week_of_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInWeek, days_in_week_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -279,6 +280,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_week_getter)
 
     // 4. Return ? CalendarDaysInWeek(calendar, dateTime).
     return calendar_days_in_week(global_object, calendar, *date_time);
+}
+
+// 5.3.18 get Temporal.PlainDateTime.prototype.daysInMonth, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinmonth
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_month_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarDaysInMonth(calendar, dateTime).
+    return calendar_days_in_month(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -36,6 +36,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.minute, minute_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.second, second_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.millisecond, millisecond_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.microsecond, microsecond_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -183,6 +184,19 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::millisecond_getter)
 
     // 3. Return 𝔽(dateTime.[[ISOMillisecond]]).
     return Value(date_time->iso_millisecond());
+}
+
+// 5.3.12 get Temporal.PlainDateTime.prototype.microsecond, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.microsecond
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::microsecond_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return 𝔽(dateTime.[[ISOMicrosecond]]).
+    return Value(date_time->iso_microsecond());
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -29,6 +29,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
 
     define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -76,6 +77,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::year_getter)
 
     // 4. Return ? CalendarYear(calendar, dateTime).
     return Value(calendar_year(global_object, calendar, *date_time));
+}
+
+// 5.3.5 get Temporal.PlainDateTime.prototype.month, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.month
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarMonth(calendar, dateTime).
+    return Value(calendar_month(global_object, calendar, *date_time));
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -40,6 +40,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.nanosecond, nanosecond_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.dayOfWeek, day_of_week_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.dayOfYear, day_of_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.weekOfYear, week_of_year_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -245,6 +246,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_of_year_getter)
 
     // 4. Return ? CalendarDayOfYear(calendar, dateTime).
     return calendar_day_of_year(global_object, calendar, *date_time);
+}
+
+// 5.3.16 get Temporal.PlainDateTime.prototype.weekOfYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::week_of_year_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarWeekOfYear(calendar, dateTime).
+    return calendar_week_of_year(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -32,6 +32,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.day, day_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.hour, hour_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -127,6 +128,19 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_getter)
 
     // 4. Return ? CalendarDay(calendar, dateTime).
     return Value(calendar_day(global_object, calendar, *date_time));
+}
+
+// 5.3.8 get Temporal.PlainDateTime.prototype.hour, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.hour
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::hour_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return 𝔽(dateTime.[[ISOHour]]).
+    return Value(date_time->iso_hour());
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -45,6 +45,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthsInYear, months_in_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.inLeapYear, in_leap_year_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -330,6 +331,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::months_in_year_getter)
 
     // 4. Return ? CalendarMonthsInYear(calendar, dateTime).
     return calendar_months_in_year(global_object, calendar, *date_time);
+}
+
+// 5.3.21 get Temporal.PlainDateTime.prototype.inLeapYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.inleapyear
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::in_leap_year_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarInLeapYear(calendar, dateTime).
+    return calendar_in_leap_year(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -34,6 +34,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.day, day_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.hour, hour_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.minute, minute_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.second, second_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -155,6 +156,19 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::minute_getter)
 
     // 3. Return 𝔽(dateTime.[[ISOMinute]]).
     return Value(date_time->iso_minute());
+}
+
+// 5.3.10 get Temporal.PlainDateTime.prototype.second, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.second
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::second_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return 𝔽(dateTime.[[ISOSecond]]).
+    return Value(date_time->iso_second());
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -37,6 +37,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.second, second_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.millisecond, millisecond_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.microsecond, microsecond_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.nanosecond, nanosecond_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -197,6 +198,19 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::microsecond_getter)
 
     // 3. Return 𝔽(dateTime.[[ISOMicrosecond]]).
     return Value(date_time->iso_microsecond());
+}
+
+// 5.3.13 get Temporal.PlainDateTime.prototype.nanosecond, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.nanosecond
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::nanosecond_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return 𝔽(dateTime.[[ISONanosecond]]).
+    return Value(date_time->iso_nanosecond());
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -35,6 +35,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.hour, hour_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.minute, minute_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.second, second_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.millisecond, millisecond_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -169,6 +170,19 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::second_getter)
 
     // 3. Return 𝔽(dateTime.[[ISOSecond]]).
     return Value(date_time->iso_second());
+}
+
+// 5.3.11 get Temporal.PlainDateTime.prototype.millisecond, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.millisecond
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::millisecond_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return 𝔽(dateTime.[[ISOMillisecond]]).
+    return Value(date_time->iso_millisecond());
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -44,6 +44,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.daysInWeek, days_in_week_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.monthsInYear, months_in_year_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -313,6 +314,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_year_getter)
 
     // 4. Return ? CalendarDaysInYear(calendar, dateTime).
     return calendar_days_in_year(global_object, calendar, *date_time);
+}
+
+// 5.3.20 get Temporal.PlainDateTime.prototype.monthsInYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthsinyear
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::months_in_year_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarMonthsInYear(calendar, dateTime).
+    return calendar_months_in_year(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -43,6 +43,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.weekOfYear, week_of_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInWeek, days_in_week_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -296,6 +297,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_month_getter)
 
     // 4. Return ? CalendarDaysInMonth(calendar, dateTime).
     return calendar_days_in_month(global_object, calendar, *date_time);
+}
+
+// 5.3.19 get Temporal.PlainDateTime.prototype.daysInYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinyear
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_year_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarDaysInYear(calendar, dateTime).
+    return calendar_days_in_year(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -33,6 +33,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.day, day_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.hour, hour_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.minute, minute_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -141,6 +142,19 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::hour_getter)
 
     // 3. Return 𝔽(dateTime.[[ISOHour]]).
     return Value(date_time->iso_hour());
+}
+
+// 5.3.9 get Temporal.PlainDateTime.prototype.minute, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.minute
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::minute_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return 𝔽(dateTime.[[ISOMinute]]).
+    return Value(date_time->iso_minute());
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -39,6 +39,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.microsecond, microsecond_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.nanosecond, nanosecond_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.dayOfWeek, day_of_week_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.dayOfYear, day_of_year_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -228,6 +229,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_of_week_getter)
 
     // 4. Return ? CalendarDayOfWeek(calendar, dateTime).
     return calendar_day_of_week(global_object, calendar, *date_time);
+}
+
+// 5.3.15 get Temporal.PlainDateTime.prototype.dayOfYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofyear
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_of_year_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarDayOfYear(calendar, dateTime).
+    return calendar_day_of_year(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>
 #include <LibJS/Runtime/Temporal/PlainDateTime.h>
 #include <LibJS/Runtime/Temporal/PlainDateTimePrototype.h>
@@ -27,6 +28,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), "Temporal.PlainDateTime"), Attribute::Configurable);
 
     define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -58,6 +60,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::calendar_getter)
 
     // 3. Return dateTime.[[Calendar]].
     return Value(&date_time->calendar());
+}
+
+// 5.3.4 get Temporal.PlainDateTime.prototype.year, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.year
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::year_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarYear(calendar, dateTime).
+    return Value(calendar_year(global_object, calendar, *date_time));
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -31,6 +31,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.day, day_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -110,6 +111,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_code_getter)
 
     // 4. Return ? CalendarMonthCode(calendar, dateTime).
     return js_string(vm, calendar_month_code(global_object, calendar, *date_time));
+}
+
+// 5.3.7 get Temporal.PlainDateTime.prototype.day, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.day
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarDay(calendar, dateTime).
+    return Value(calendar_day(global_object, calendar, *date_time));
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -38,6 +38,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.millisecond, millisecond_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.microsecond, microsecond_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.nanosecond, nanosecond_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.dayOfWeek, day_of_week_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -211,6 +212,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::nanosecond_getter)
 
     // 3. Return 𝔽(dateTime.[[ISONanosecond]]).
     return Value(date_time->iso_nanosecond());
+}
+
+// 5.3.14 get Temporal.PlainDateTime.prototype.dayOfWeek, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofweek
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_of_week_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarDayOfWeek(calendar, dateTime).
+    return calendar_day_of_week(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -30,6 +30,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -93,6 +94,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_getter)
 
     // 4. Return ? CalendarMonth(calendar, dateTime).
     return Value(calendar_month(global_object, calendar, *date_time));
+}
+
+// 5.3.6 get Temporal.PlainDateTime.prototype.monthCode, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthcode
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_code_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarMonthCode(calendar, dateTime).
+    return js_string(vm, calendar_month_code(global_object, calendar, *date_time));
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -41,6 +41,7 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.dayOfWeek, day_of_week_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.dayOfYear, day_of_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.weekOfYear, week_of_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.daysInWeek, days_in_week_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
@@ -262,6 +263,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::week_of_year_getter)
 
     // 4. Return ? CalendarWeekOfYear(calendar, dateTime).
     return calendar_week_of_year(global_object, calendar, *date_time);
+}
+
+// 5.3.17 get Temporal.PlainDateTime.prototype.daysInWeek, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinweek
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_week_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto* date_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be dateTime.[[Calendar]].
+    auto& calendar = date_time->calendar();
+
+    // 4. Return ? CalendarDaysInWeek(calendar, dateTime).
+    return calendar_days_in_week(global_object, calendar, *date_time);
 }
 
 // 5.3.35 Temporal.PlainDateTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -21,6 +21,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -24,6 +24,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_getter);
+    JS_DECLARE_NATIVE_FUNCTION(hour_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -25,6 +25,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_getter);
     JS_DECLARE_NATIVE_FUNCTION(hour_getter);
+    JS_DECLARE_NATIVE_FUNCTION(minute_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -32,6 +32,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(nanosecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_of_week_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_of_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(week_of_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -23,6 +23,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
+    JS_DECLARE_NATIVE_FUNCTION(day_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -36,6 +36,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(days_in_week_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -30,6 +30,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(millisecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(microsecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(nanosecond_getter);
+    JS_DECLARE_NATIVE_FUNCTION(day_of_week_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -29,6 +29,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(second_getter);
     JS_DECLARE_NATIVE_FUNCTION(millisecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(microsecond_getter);
+    JS_DECLARE_NATIVE_FUNCTION(nanosecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -31,6 +31,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(microsecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(nanosecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_of_week_getter);
+    JS_DECLARE_NATIVE_FUNCTION(day_of_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -35,6 +35,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(week_of_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_week_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
+    JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -22,6 +22,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
+    JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -37,6 +37,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(in_leap_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -27,6 +27,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(hour_getter);
     JS_DECLARE_NATIVE_FUNCTION(minute_getter);
     JS_DECLARE_NATIVE_FUNCTION(second_getter);
+    JS_DECLARE_NATIVE_FUNCTION(millisecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -33,6 +33,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(day_of_week_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_of_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(week_of_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(days_in_week_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -26,6 +26,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(day_getter);
     JS_DECLARE_NATIVE_FUNCTION(hour_getter);
     JS_DECLARE_NATIVE_FUNCTION(minute_getter);
+    JS_DECLARE_NATIVE_FUNCTION(second_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -28,6 +28,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(minute_getter);
     JS_DECLARE_NATIVE_FUNCTION(second_getter);
     JS_DECLARE_NATIVE_FUNCTION(millisecond_getter);
+    JS_DECLARE_NATIVE_FUNCTION(microsecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -34,6 +34,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(day_of_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(week_of_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_week_getter);
+    JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -6,6 +6,8 @@
 
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
+#include <LibJS/Runtime/Temporal/PlainDate.h>
+#include <LibJS/Runtime/Temporal/PlainDateTime.h>
 #include <LibJS/Runtime/Temporal/PlainTime.h>
 #include <LibJS/Runtime/Temporal/PlainTimePrototype.h>
 
@@ -35,6 +37,7 @@ void PlainTimePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.nanosecond, nanosecond_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.toPlainDateTime, to_plain_date_time, 1, attr);
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
@@ -140,6 +143,24 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::nanosecond_getter)
 
     // 3. Return 𝔽(temporalTime.[[ISONanosecond]]).
     return Value(temporal_time->iso_nanosecond());
+}
+
+// 4.3.17 Temporal.PlainTime.prototype.toPlainDateTime ( temporalDate )
+JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::to_plain_date_time)
+{
+    // 1. Let temporalTime be the this value.
+    // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
+    auto* temporal_time = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Set temporalDate to ? ToTemporalDate(temporalDate).
+    auto* temporal_date = to_temporal_date(global_object, vm.argument(0));
+    if (vm.exception())
+        return {};
+
+    // 4. Return ? CreateTemporalDateTime(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]], temporalTime.[[ISOHour]], temporalTime.[[ISOMinute]], temporalTime.[[ISOSecond]], temporalTime.[[ISOMillisecond]], temporalTime.[[ISOMicrosecond]], temporalTime.[[ISONanosecond]], temporalDate.[[Calendar]]).
+    return create_temporal_date_time(global_object, temporal_date->iso_year(), temporal_date->iso_month(), temporal_date->iso_day(), temporal_time->iso_hour(), temporal_time->iso_minute(), temporal_time->iso_second(), temporal_time->iso_millisecond(), temporal_time->iso_microsecond(), temporal_time->iso_nanosecond(), temporal_date->calendar());
 }
 
 // 4.3.23 Temporal.PlainTime.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
@@ -26,6 +26,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(millisecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(microsecond_getter);
     JS_DECLARE_NATIVE_FUNCTION(nanosecond_getter);
+    JS_DECLARE_NATIVE_FUNCTION(to_plain_date_time);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.day.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.day.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 29);
+        expect(plainDateTime.day).toBe(29);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "day", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.dayOfWeek.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.dayOfWeek.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.dayOfWeek).toBe(5);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "dayOfWeek", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.dayOfYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.dayOfYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.dayOfYear).toBe(211);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "dayOfYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.daysInMonth.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.daysInMonth.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.daysInMonth).toBe(31);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "daysInMonth", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.daysInWeek.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.daysInWeek.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.daysInWeek).toBe(7);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "daysInWeek", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.daysInYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.daysInYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.daysInYear).toBe(365);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "daysInYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.hour.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.hour.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30, 1);
+        expect(plainDateTime.hour).toBe(1);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "hour", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.inLeapYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.inLeapYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.inLeapYear).toBeFalse();
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "inLeapYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.microsecond.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.microsecond.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30, 1, 4, 32, 111, 420);
+        expect(plainDateTime.microsecond).toBe(420);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "microsecond", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.millisecond.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.millisecond.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30, 1, 4, 32, 111);
+        expect(plainDateTime.millisecond).toBe(111);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "millisecond", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.minute.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.minute.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30, 1, 4);
+        expect(plainDateTime.minute).toBe(4);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "minute", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.month.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.month.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 29);
+        expect(plainDateTime.month).toBe(7);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "month", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.monthCode.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.monthCode.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 29);
+        expect(plainDateTime.monthCode).toBe("M07");
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "monthCode", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.monthsInYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.monthsInYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.monthsInYear).toBe(12);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "monthsInYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.nanosecond.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.nanosecond.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30, 1, 4, 32, 111, 420, 963);
+        expect(plainDateTime.nanosecond).toBe(963);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "nanosecond", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.second.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.second.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30, 1, 4, 32);
+        expect(plainDateTime.second).toBe(32);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "second", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.weekOfYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.weekOfYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 30);
+        expect(plainDateTime.weekOfYear).toBe(30);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "weekOfYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.year.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.year.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainDateTime = new Temporal.PlainDateTime(2021, 7, 29);
+        expect(plainDateTime.year).toBe(2021);
+    });
+});
+
+test("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "year", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.prototype.toPlainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.prototype.toPlainDateTime.js
@@ -1,0 +1,20 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Temporal.PlainTime.prototype.toPlainDateTime).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        const plainDate = new Temporal.PlainDate(2021, 7, 29);
+        const plainTime = new Temporal.PlainTime(23, 45, 12, 1, 2, 3);
+        const plainDateTime = plainTime.toPlainDateTime(plainDate);
+        expect(plainDateTime.year).toBe(2021);
+        expect(plainDateTime.month).toBe(7);
+        expect(plainDateTime.day).toBe(29);
+        expect(plainDateTime.hour).toBe(23);
+        expect(plainDateTime.minute).toBe(45);
+        expect(plainDateTime.second).toBe(12);
+        expect(plainDateTime.millisecond).toBe(1);
+        expect(plainDateTime.microsecond).toBe(2);
+        expect(plainDateTime.nanosecond).toBe(3);
+    });
+});


### PR DESCRIPTION
This ticks 19 checkboxes in #8982.