### PR TITLE
LibGfx: Use correct variable size on bitmap to buffer convertion

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -199,7 +199,7 @@ RefPtr<Bitmap> Bitmap::try_create_with_anonymous_buffer(BitmapFormat format, Cor
 RefPtr<Bitmap> Bitmap::try_create_from_serialized_byte_buffer(ByteBuffer&& buffer)
 {
     InputMemoryStream stream { buffer };
-    unsigned actual_size;
+    size_t actual_size;
     unsigned width;
     unsigned height;
     unsigned scale_factor;
@@ -247,7 +247,7 @@ RefPtr<Bitmap> Bitmap::try_create_from_serialized_byte_buffer(ByteBuffer&& buffe
 
 ByteBuffer Bitmap::serialize_to_byte_buffer() const
 {
-    auto buffer = ByteBuffer::create_uninitialized(5 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes());
+    auto buffer = ByteBuffer::create_uninitialized(sizeof(size_t) + 4 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes());
     OutputMemoryStream stream { buffer };
 
     auto write = [&]<typename T>(T value) {


### PR DESCRIPTION
The issue was that `size_in_bytes()` returns `size_t`, but the buffer used a size of the `unsigned` for itself, which only matched on 32-bit
systems and caused an assert error otherwise.

This fixes a crash on drag in FileManager on non 32-bit systems!