### PR TITLE
AudioWidget: Proper volume changes when scrolling on the widget

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -124,10 +124,8 @@ private:
     {
         if (m_audio_muted)
             return;
-        int volume = clamp(m_audio_volume - event.wheel_delta() * 5, 0, 100);
-        float volume_log = ((volume / 100.0f) * (volume / 100.0f)) * 100.0f;
-        m_audio_client->set_main_mix_volume(volume_log);
-        m_slider->set_value(20 - (volume / 5));
+        int new_slider_value = m_slider->value() + event.wheel_delta() / 4;
+        m_slider->set_value(new_slider_value);
         update();
     }
 


### PR DESCRIPTION
Because setting the slider's value in the mouse wheel handler will cause the volume logarithm logic and the volume setting to happen anyways, we don't need to do it in the mouse wheel handler again. By just moving the slider up and down with the scroll wheel, we mimic normal SliderWidget behavior that doesn't exhibit the multiple previous bugs.

This should be merged after #9005, because they may have conflicts.