### PR TITLE
Browser: Show a message when attempting to search with no search engine

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -21,6 +21,7 @@
 #include <LibGUI/Button.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Toolbar.h>
@@ -145,6 +146,11 @@ Tab::Tab(BrowserWindow& window, Type type)
     m_location_box->set_placeholder("Address");
 
     m_location_box->on_return_pressed = [this] {
+        if (m_location_box->text().starts_with('?') && g_search_engine.is_empty()) {
+            GUI::MessageBox::show(&this->window(), "Select a search engine in the Settings menu before searching.", "No search engine selected", GUI::MessageBox::Type::Information);
+            return;
+        }
+
         auto url = url_from_user_input(m_location_box->text());
         load(url);
         view().set_focus(true);


### PR DESCRIPTION
Previously, it just showed an error message saying that "" failed to load, which made me think that search engines were broken:

![Screenshot at 2021-07-30 11-56-16](https://user-images.githubusercontent.com/222642/127645762-158e8d3c-678f-4860-8ac1-28e281c7c63e.png)

Now it looks like this instead:
![image](https://user-images.githubusercontent.com/222642/127645894-ddfe6e37-876d-4479-92a0-a17b642bff29.png)