### PR TITLE
Meta: Make rsync a hard dependency and remove the fallback code

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -32,19 +32,16 @@ fi
 umask 0022
 
 printf "installing base system... "
-if command -v rsync >/dev/null; then
-    if rsync --chown 2>&1 | grep "missing argument" >/dev/null; then
-        rsync -aH --chown=0:0 --inplace "$SERENITY_SOURCE_DIR"/Base/ mnt/
-        rsync -aH --chown=0:0 --inplace Root/ mnt/
-    else
-        rsync -aH --inplace "$SERENITY_SOURCE_DIR"/Base/ mnt/
-        rsync -aH --inplace Root/ mnt/
-        chown -R 0:0 mnt/
-    fi
+if ! command -v rsync >/dev/null; then
+    die "Please install rsync."
+fi
+
+if rsync --chown 2>&1 | grep "missing argument" >/dev/null; then
+    rsync -aH --chown=0:0 --inplace "$SERENITY_SOURCE_DIR"/Base/ mnt/
+    rsync -aH --chown=0:0 --inplace Root/ mnt/
 else
-    echo "Please install rsync to speed up image creation times, falling back to cp for now"
-    $CP -PdR "$SERENITY_SOURCE_DIR"/Base/* mnt/
-    $CP -PdR Root/* mnt/
+    rsync -aH --inplace "$SERENITY_SOURCE_DIR"/Base/ mnt/
+    rsync -aH --inplace Root/ mnt/
     chown -R 0:0 mnt/
 fi
 SERENITY_ARCH="${SERENITY_ARCH:-i686}"


### PR DESCRIPTION
Previously we'd fall back to using cp if rsync wasn't available. Not only is this considerably slower it also breaks when some of the files in the target directory are symlinks because cp tries to dereference them.

Also, I believe symlinks caused cp to overwrite host files at least in one case. I remember there being a discussion about someone's host `/bin/less` binary getting overwritten by one of our build targets.