### PR TITLE
Lagom: Fix oss-fuzz build error due to CMake typo

### DIFF
--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -3,7 +3,7 @@ function(add_simple_fuzzer name)
 
   if (ENABLE_OSS_FUZZ)
       target_link_libraries(${name}
-          PUBLIC {$ARGN} LagomCore)
+          PUBLIC ${ARGN} LagomCore)
   else()
     target_compile_options(${name}
       PRIVATE $<$<CXX_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>


### PR DESCRIPTION
The OSS-Fuzz build was failing with the following error:

 /usr/bin/ld: cannot find -l{}

CC: @ADKaster 