### PR TITLE
Everywhere: Cleanup unused headers, reduce include scope of some ocasionally used headers

### DIFF
--- a/Kernel/Arch/x86/common/CPU.cpp
+++ b/Kernel/Arch/x86/common/CPU.cpp
@@ -6,8 +6,6 @@
 
 #include <AK/Assertions.h>
 #include <Kernel/Arch/x86/CPU.h>
-#include <Kernel/Arch/x86/Processor.h>
-#include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -17,6 +17,7 @@
 #include <Kernel/Random.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Thread.h>
+#include <Kernel/ThreadTracer.h>
 
 #include <LibC/mallocdefs.h>
 

--- a/Kernel/Arch/x86/i386/ASM_wrapper.cpp
+++ b/Kernel/Arch/x86/i386/ASM_wrapper.cpp
@@ -7,7 +7,6 @@
 #include <AK/Types.h>
 
 #include <Kernel/Arch/x86/ASM_wrapper.h>
-#include <Kernel/Arch/x86/Processor.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {

--- a/Kernel/Arch/x86/i386/Processor.cpp
+++ b/Kernel/Arch/x86/i386/Processor.cpp
@@ -7,7 +7,6 @@
 #include <AK/StdLibExtras.h>
 #include <Kernel/Arch/x86/Processor.h>
 #include <Kernel/Arch/x86/TrapFrame.h>
-#include <Kernel/Panic.h>
 #include <Kernel/Process.h>
 #include <Kernel/Random.h>
 #include <Kernel/Sections.h>

--- a/Kernel/Arch/x86/x86_64/ASM_wrapper.cpp
+++ b/Kernel/Arch/x86/x86_64/ASM_wrapper.cpp
@@ -7,7 +7,6 @@
 #include <AK/Types.h>
 
 #include <Kernel/Arch/x86/ASM_wrapper.h>
-#include <Kernel/Arch/x86/Processor.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Atomic.h>
 #include <AK/Checked.h>
-#include <AK/Singleton.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Debug.h>

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Checked.h>
-#include <AK/Singleton.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Graphics/FramebufferDevice.h>
 #include <Kernel/Graphics/GraphicsManagement.h>

--- a/Kernel/Interrupts/GenericInterruptHandler.cpp
+++ b/Kernel/Interrupts/GenericInterruptHandler.cpp
@@ -8,7 +8,6 @@
 #include <Kernel/Assertions.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Interrupts/InterruptManagement.h>
-#include <Kernel/Interrupts/PIC.h>
 
 namespace Kernel {
 GenericInterruptHandler& GenericInterruptHandler::from(u8 interrupt_number)

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Optional.h>
-#include <Kernel/ACPI/MultiProcessorParser.h>
 #include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Interrupts/APIC.h>

--- a/Kernel/Mutex.cpp
+++ b/Kernel/Mutex.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/SourceLocation.h>
+#ifdef LOCK_DEBUG
+#    include <AK/SourceLocation.h>
+#endif
 #include <Kernel/Debug.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Mutex.h>

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -31,6 +31,7 @@
 #include <Kernel/StdLib.h>
 #include <Kernel/TTY/TTY.h>
 #include <Kernel/Thread.h>
+#include <Kernel/ThreadTracer.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/PageDirectory.h>
 #include <Kernel/VM/SharedInodeVMObject.h>

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -20,7 +20,6 @@
 #include <Kernel/KBufferBuilder.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Module.h>
-#include <Kernel/Panic.h>
 #include <Kernel/PerformanceEventBuffer.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
@@ -32,7 +31,6 @@
 #include <Kernel/Thread.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/PageDirectory.h>
-#include <Kernel/VM/PrivateInodeVMObject.h>
 #include <Kernel/VM/SharedInodeVMObject.h>
 #include <LibC/errno_numbers.h>
 #include <LibC/limits.h>

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -12,7 +12,9 @@
 #include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/CoreDump.h>
 #include <Kernel/Debug.h>
-#include <Kernel/Devices/KCOVDevice.h>
+#ifdef ENABLE_KERNEL_COVERAGE_COLLECTION
+#    include <Kernel/Devices/KCOVDevice.h>
+#endif
 #include <Kernel/Devices/NullDevice.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -6,11 +6,9 @@
 
 #pragma once
 
-#include <AK/Checked.h>
 #include <AK/Concepts.h>
 #include <AK/HashMap.h>
 #include <AK/IntrusiveList.h>
-#include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/String.h>
 #include <AK/Userspace.h>
@@ -30,8 +28,6 @@
 #include <Kernel/ThreadTracer.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/UnveilNode.h>
-#include <Kernel/VM/AllocationStrategy.h>
-#include <Kernel/VM/RangeAllocator.h>
 #include <Kernel/VM/Space.h>
 #include <LibC/elf.h>
 #include <LibC/signal_numbers.h>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -25,7 +25,6 @@
 #include <Kernel/ProcessGroup.h>
 #include <Kernel/StdLib.h>
 #include <Kernel/Thread.h>
-#include <Kernel/ThreadTracer.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/UnveilNode.h>
 #include <Kernel/VM/Space.h>

--- a/Kernel/ProcessGroup.h
+++ b/Kernel/ProcessGroup.h
@@ -9,7 +9,6 @@
 #include <AK/IntrusiveList.h>
 #include <AK/RefCounted.h>
 #include <AK/Weakable.h>
-#include <Kernel/Mutex.h>
 #include <Kernel/SpinLock.h>
 #include <Kernel/UnixTypes.h>
 

--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Assertions.h>
 #include <AK/Time.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/RTC.h>

--- a/Kernel/SanCov.cpp
+++ b/Kernel/SanCov.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <Kernel/Devices/KCOVDevice.h>
-#include <Kernel/Process.h>
 #include <Kernel/Thread.h>
 
 extern bool g_in_early_boot;

--- a/Kernel/Storage/AHCIPortHandler.h
+++ b/Kernel/Storage/AHCIPortHandler.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <Kernel/Devices/Device.h>
 #include <Kernel/IO.h>

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <Kernel/FileSystem/Custody.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Syscalls/chmod.cpp
+++ b/Kernel/Syscalls/chmod.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/StringView.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -7,7 +7,6 @@
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
-#include <Kernel/Panic.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/Region.h>

--- a/Kernel/Syscalls/get_stack_bounds.cpp
+++ b/Kernel/Syscalls/get_stack_bounds.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Panic.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/Region.h>
 

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Custody.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <Kernel/FileSystem/FIFO.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Process.h>
 
 namespace Kernel {

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <Kernel/CoreDump.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/ScopeGuard.h>
 #include <Kernel/Process.h>
+#include <Kernel/ThreadTracer.h>
 #include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/PrivateInodeVMObject.h>
 #include <Kernel/VM/ProcessPagingScope.h>

--- a/Kernel/Syscalls/purge.cpp
+++ b/Kernel/Syscalls/purge.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/NonnullRefPtrVector.h>
-#include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/InodeVMObject.h>

--- a/Kernel/Syscalls/readlink.cpp
+++ b/Kernel/Syscalls/readlink.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/StringView.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -6,7 +6,6 @@
 
 #include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/Arch/x86/SmapDisabler.h>
-#include <Kernel/Panic.h>
 #include <Kernel/Process.h>
 
 namespace Kernel {

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <Kernel/FileSystem/FileDescription.h>
-#include <Kernel/Net/IPv4Socket.h>
 #include <Kernel/Net/LocalSocket.h>
 #include <Kernel/Process.h>
 #include <Kernel/UnixTypes.h>

--- a/Kernel/Syscalls/stat.cpp
+++ b/Kernel/Syscalls/stat.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/NonnullRefPtrVector.h>
 #include <Kernel/FileSystem/Custody.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <Kernel/FileSystem/Custody.h>
-#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -7,12 +7,9 @@
 #include <AK/Checked.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
-#include <AK/StringView.h>
-#include <Kernel/Panic.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/MemoryManager.h>
-#include <Kernel/VM/PageDirectory.h>
 
 namespace Kernel {
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -8,7 +8,6 @@
 
 #include <AK/Concepts.h>
 #include <AK/EnumBits.h>
-#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Optional.h>

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -12,7 +12,9 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
-#include <AK/SourceLocation.h>
+#ifdef LOCK_DEBUG
+#    include <AK/SourceLocation.h>
+#endif
 #include <AK/String.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -28,7 +28,6 @@
 #include <Kernel/KResult.h>
 #include <Kernel/LockMode.h>
 #include <Kernel/Scheduler.h>
-#include <Kernel/ThreadTracer.h>
 #include <Kernel/TimerQueue.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/VM/Range.h>

--- a/Kernel/Time/PIT.cpp
+++ b/Kernel/Time/PIT.cpp
@@ -7,7 +7,6 @@
 #include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/IO.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
-#include <Kernel/Interrupts/PIC.h>
 #include <Kernel/Scheduler.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Thread.h>

--- a/Kernel/TimerQueue.cpp
+++ b/Kernel/TimerQueue.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/NonnullOwnPtr.h>
 #include <AK/Singleton.h>
 #include <AK/Time.h>
 #include <Kernel/Scheduler.h>

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -8,10 +8,8 @@
 #include <AK/Types.h>
 #include <Kernel/ConsoleDevice.h>
 #include <Kernel/Devices/PCISerialDevice.h>
-#include <Kernel/Graphics/Console/Console.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 #include <Kernel/IO.h>
-#include <Kernel/Process.h>
 #include <Kernel/SpinLock.h>
 #include <Kernel/TTY/ConsoleManagement.h>
 #include <Kernel/kstdio.h>

--- a/Tests/AK/TestBase64.cpp
+++ b/Tests/AK/TestBase64.cpp
@@ -7,7 +7,6 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/Base64.h>
-#include <AK/ByteBuffer.h>
 #include <AK/String.h>
 #include <string.h>
 

--- a/Tests/AK/TestFind.cpp
+++ b/Tests/AK/TestFind.cpp
@@ -8,7 +8,6 @@
 
 #include <AK/Array.h>
 #include <AK/Find.h>
-#include <AK/Vector.h>
 
 TEST_CASE(should_return_end_if_not_in_container)
 {

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -7,7 +7,6 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/HashMap.h>
-#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/String.h>

--- a/Tests/AK/TestQuickSort.cpp
+++ b/Tests/AK/TestQuickSort.cpp
@@ -6,7 +6,6 @@
 
 #include <LibTest/TestCase.h>
 
-#include <AK/Checked.h>
 #include <AK/Noncopyable.h>
 #include <AK/QuickSort.h>
 #include <AK/StdLibExtras.h>

--- a/Tests/AK/TestUFixedBigInt.cpp
+++ b/Tests/AK/TestUFixedBigInt.cpp
@@ -11,8 +11,6 @@
 #include <AK/Random.h>
 #include <AK/UFixedBigInt.h>
 
-#include <time.h>
-
 constexpr int test_iterations = 32;
 
 TEST_CASE(one_plus_one)

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -14,7 +14,6 @@
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 

--- a/Userland/Applets/DesktopPicker/main.cpp
+++ b/Userland/Applets/DesktopPicker/main.cpp
@@ -6,9 +6,7 @@
 
 #include "DesktopStatusWindow.h"
 #include <LibGUI/Application.h>
-#include <LibGUI/Frame.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Window.h>
 #include <LibGUI/WindowManagerServerConnection.h>
 #include <WindowServer/Window.h>
 #include <serenity.h>

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/CircularQueue.h>
 #include <AK/JsonObject.h>
 #include <LibCore/ArgsParser.h>

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/ElapsedTimer.h>
 #include <LibCore/File.h>
 #include <LibGL/GL/gl.h>
 #include <LibGL/GLContext.h>
@@ -22,7 +21,6 @@
 #include <unistd.h>
 
 #include "Mesh.h"
-#include "MeshLoader.h"
 #include "WavefrontOBJLoader.h"
 
 static constexpr u16 RENDER_WIDTH = 640;

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -30,7 +30,6 @@
 #include <LibGUI/Widget.h>
 #include <LibJS/Interpreter.h>
 #include <LibWeb/Dump.h>
-#include <LibWeb/InProcessWebView.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/OutOfProcessWebView.h>

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -17,10 +17,8 @@
 #include <LibJS/SyntaxHighlighter.h>
 #include <LibWeb/Bindings/DOMExceptionWrapper.h>
 #include <LibWeb/DOM/DocumentType.h>
-#include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOMTreeModel.h>
-#include <LibWeb/HTML/HTMLBodyElement.h>
 
 namespace Browser {
 

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -10,14 +10,12 @@
 #include <LibGUI/Button.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/Label.h>
-#include <LibGUI/Layout.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Color.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 
 static const char* short_month_names[] = {

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -16,7 +16,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Toolbar.h>
-#include <LibGUI/ToolbarContainer.h>
 #include <LibGUI/Window.h>
 #include <unistd.h>
 

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -6,13 +6,11 @@
 
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
-#include <AK/Demangle.h>
 #include <AK/OwnPtr.h>
 #include <AK/Platform.h>
 #include <AK/StringBuilder.h>
 #include <LibC/sys/arch/i386/regs.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/File.h>
 #include <LibDebug/DebugInfo.h>
 #include <LibDebug/DebugSession.h>
 #include <LibLine/Editor.h>
@@ -21,7 +19,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 RefPtr<Line::Editor> editor;

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -5,9 +5,7 @@
  */
 
 #include "DesktopSettingsWidget.h"
-#include <AK/StringBuilder.h>
 #include <Applications/DisplaySettings/DesktopSettingsGML.h>
-#include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Desktop.h>
 #include <LibGUI/Label.h>

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -7,11 +7,9 @@
 
 #include "MonitorSettingsWidget.h"
 #include <Applications/DisplaySettings/MonitorSettingsGML.h>
-#include <LibCore/ConfigFile.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/ComboBox.h>
-#include <LibGUI/Desktop.h>
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/RadioButton.h>

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -9,7 +9,6 @@
 #include "DesktopSettingsWidget.h"
 #include "FontSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
-#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -18,7 +17,6 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Window.h>
-#include <LibGfx/Bitmap.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "DirectoryView.h"
-#include "FileOperationProgressWidget.h"
 #include "FileUtils.h"
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -7,7 +7,6 @@
 #include "PropertiesWindow.h"
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
-#include <AK/StringBuilder.h>
 #include <Applications/FileManager/PropertiesWindowGeneralTabGML.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/BoxLayout.h>
@@ -20,7 +19,6 @@
 #include <LibGUI/SeparatorWidget.h>
 #include <LibGUI/TabWidget.h>
 #include <grp.h>
-#include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <string.h>

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -16,7 +16,6 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
-#include <LibCore/MimeData.h>
 #include <LibCore/StandardPaths.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
@@ -28,8 +27,6 @@
 #include <LibGUI/Desktop.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibGUI/FileSystemModel.h>
-#include <LibGUI/InputBox.h>
-#include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
@@ -37,7 +34,6 @@
 #include <LibGUI/Progressbar.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/Statusbar.h>
-#include <LibGUI/TextEditor.h>
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/ToolbarContainer.h>
 #include <LibGUI/TreeView.h>
@@ -45,9 +41,7 @@
 #include <LibGUI/Window.h>
 #include <LibGfx/Palette.h>
 #include <pthread.h>
-#include <serenity.h>
 #include <signal.h>
-#include <spawn.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/wait.h>

--- a/Userland/Applications/FontEditor/NewFontDialog.cpp
+++ b/Userland/Applications/FontEditor/NewFontDialog.cpp
@@ -20,7 +20,6 @@
 #include <LibGUI/Widget.h>
 #include <LibGUI/Wizards/WizardDialog.h>
 #include <LibGfx/BitmapFont.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
 static constexpr int s_max_width = 32;

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -11,7 +11,6 @@
 #include <Applications/HexEditor/FindDialogGML.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
-#include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/RadioButton.h>
 #include <LibGUI/TextBox.h>

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -25,10 +25,8 @@
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
-#include <LibGUI/TextEditor.h>
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/ToolbarContainer.h>
-#include <stdio.h>
 #include <string.h>
 
 REGISTER_WIDGET(HexEditor, HexEditor);

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -7,7 +7,6 @@
 #include "HexEditorWidget.h"
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
-#include <LibGfx/Bitmap.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/Userland/Applications/IRCClient/IRCChannel.cpp
+++ b/Userland/Applications/IRCClient/IRCChannel.cpp
@@ -7,7 +7,6 @@
 #include "IRCChannel.h"
 #include "IRCChannelMemberListModel.h"
 #include "IRCClient.h"
-#include <stdio.h>
 
 IRCChannel::IRCChannel(IRCClient& client, const String& name)
     : m_client(client)

--- a/Userland/Applications/IRCClient/IRCLogBuffer.cpp
+++ b/Userland/Applications/IRCClient/IRCLogBuffer.cpp
@@ -5,12 +5,10 @@
  */
 
 #include "IRCLogBuffer.h"
-#include <AK/StringBuilder.h>
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
-#include <LibWeb/HTML/HTMLBodyElement.h>
 #include <time.h>
 
 NonnullRefPtr<IRCLogBuffer> IRCLogBuffer::create()

--- a/Userland/Applications/IRCClient/IRCQuery.cpp
+++ b/Userland/Applications/IRCClient/IRCQuery.cpp
@@ -6,7 +6,6 @@
 
 #include "IRCQuery.h"
 #include "IRCClient.h"
-#include <stdio.h>
 
 IRCQuery::IRCQuery(IRCClient& client, const String& name)
     : m_client(client)

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -7,7 +7,6 @@
 #include "ViewWidget.h"
 #include <AK/URL.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/MimeData.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>

--- a/Userland/Applications/KeyboardMapper/KeyButton.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyButton.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "KeyButton.h"
-#include <LibGUI/Button.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Font.h>

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -13,8 +13,6 @@
 #include <LibGUI/RadioButton.h>
 #include <LibKeyboard/CharacterMap.h>
 #include <LibKeyboard/CharacterMapFile.h>
-#include <fcntl.h>
-#include <stdio.h>
 #include <string.h>
 
 KeyboardMapperWidget::KeyboardMapperWidget()

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -7,7 +7,6 @@
 #include "CharacterMapFileListModel.h"
 #include <AK/JsonObject.h>
 #include <AK/QuickSort.h>
-#include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -10,7 +10,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
-#include <LibGfx/Bitmap.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.cpp
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.cpp
@@ -12,11 +12,9 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
-#include <LibGUI/Event.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Widget.h>
-#include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <WindowServer/Screen.h>
 #include <WindowServer/WindowManager.h>

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -10,14 +10,11 @@
 #include "AudioPlayerLoop.h"
 #include "MainWidget.h"
 #include "TrackManager.h"
-#include <AK/Array.h>
 #include <AK/Queue.h>
 #include <LibAudio/Buffer.h>
 #include <LibAudio/ClientConnection.h>
 #include <LibAudio/WavWriter.h>
 #include <LibCore/EventLoop.h>
-#include <LibCore/File.h>
-#include <LibCore/Object.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/FilePicker.h>
@@ -25,8 +22,6 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
-#include <LibGfx/Bitmap.h>
-#include <LibThreading/Thread.h>
 
 int main(int argc, char** argv)
 {

--- a/Userland/Applications/PixelPaint/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/PickerTool.cpp
@@ -7,7 +7,6 @@
 #include "PickerTool.h"
 #include "ImageEditor.h"
 #include "Layer.h"
-#include <LibGfx/Bitmap.h>
 
 namespace PixelPaint {
 

--- a/Userland/Applications/PixelPaint/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/SprayTool.cpp
@@ -16,7 +16,6 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Slider.h>
 #include <LibGfx/Bitmap.h>
-#include <stdio.h>
 
 namespace PixelPaint {
 

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -6,7 +6,6 @@
 
 #include "BarsVisualizationWidget.h"
 #include "AudioAlgorithms.h"
-#include <AK/Complex.h>
 #include <AK/Math.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Menu.h>

--- a/Userland/Applications/SoundPlayer/M3UParser.cpp
+++ b/Userland/Applications/SoundPlayer/M3UParser.cpp
@@ -5,12 +5,9 @@
  */
 
 #include "M3UParser.h"
-#include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Utf8View.h>
-#include <LibCore/FileStream.h>
-#include <ctype.h>
 
 M3UParser::M3UParser()
 {

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -6,7 +6,6 @@
 
 #include "PlaylistWidget.h"
 #include "Player.h"
-#include "SoundPlayerWidgetAdvancedView.h"
 #include <AK/LexicalPath.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/HeaderView.h>

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -8,13 +8,11 @@
 #include <AK/LexicalPath.h>
 #include <AK/Queue.h>
 #include <AK/QuickSort.h>
-#include <AK/RefCounted.h>
 #include <AK/URL.h>
 #include <Applications/SpaceAnalyzer/SpaceAnalyzerGML.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibDesktop/Launcher.h>
-#include <LibGUI/AboutDialog.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Breadcrumbbar.h>
 #include <LibGUI/Clipboard.h>

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -8,8 +8,6 @@
 #include "Spreadsheet.h"
 #include "Workbook.h"
 #include <AK/JsonArray.h>
-#include <AK/JsonObject.h>
-#include <AK/JsonParser.h>
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <Applications/Spreadsheet/CSVExportGML.h>
@@ -21,9 +19,7 @@
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/RadioButton.h>
-#include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
-#include <LibGUI/Wizards/AbstractWizardPage.h>
 #include <LibGUI/Wizards/WizardDialog.h>
 #include <LibGUI/Wizards/WizardPage.h>
 #include <unistd.h>

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -6,8 +6,6 @@
 
 #include "ImportDialog.h"
 #include "Spreadsheet.h"
-#include <AK/JsonArray.h>
-#include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
 #include <AK/LexicalPath.h>
 #include <Applications/Spreadsheet/CSVImportGML.h>
@@ -21,7 +19,6 @@
 #include <LibGUI/StackWidget.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
-#include <LibGUI/Wizards/AbstractWizardPage.h>
 #include <LibGUI/Wizards/WizardDialog.h>
 #include <LibGUI/Wizards/WizardPage.h>
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -8,7 +8,6 @@
 #include "CellSyntaxHighlighter.h"
 #include "HelpWindow.h"
 #include "LibGUI/InputBox.h"
-#include <LibCore/File.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/FilePicker.h>

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -9,18 +9,11 @@
 #include "ImportDialog.h"
 #include "JSIntegration.h"
 #include "Readers/CSV.h"
-#include "Writers/CSV.h"
 #include <AK/ByteBuffer.h>
-#include <AK/JsonArray.h>
-#include <AK/JsonObjectSerializer.h>
-#include <AK/Stream.h>
 #include <LibCore/File.h>
-#include <LibCore/FileStream.h>
 #include <LibCore/MimeData.h>
 #include <LibGUI/TextBox.h>
-#include <LibJS/Parser.h>
 #include <LibJS/Runtime/GlobalObject.h>
-#include <string.h>
 
 namespace Spreadsheet {
 

--- a/Userland/Applications/SystemMonitor/DevicesModel.cpp
+++ b/Userland/Applications/SystemMonitor/DevicesModel.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "DevicesModel.h"
-#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <LibCore/DirIterator.h>

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -6,16 +6,13 @@
 
 #include "MemoryStatsWidget.h"
 #include "GraphWidget.h"
-#include <AK/ByteBuffer.h>
 #include <AK/JsonObject.h>
 #include <LibCore/File.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/StylePainter.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 static MemoryStatsWidget* s_the;

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -37,7 +37,6 @@
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/TableView.h>
-#include <LibGUI/Toolbar.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/FontDatabase.h>

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibAudio/ClientConnection.h>
-#include <LibCore/EventLoop.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/ImageWidget.h>

--- a/Userland/Demos/Eyes/EyesWidget.cpp
+++ b/Userland/Demos/Eyes/EyesWidget.cpp
@@ -6,7 +6,6 @@
 
 #include "EyesWidget.h"
 #include <AK/Math.h>
-#include <AK/StdLibExtraDetails.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
-#include <LibGfx/Bitmap.h>
 #include <unistd.h>
 
 int main(int argc, char* argv[])

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -13,7 +13,6 @@
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Bitmap.h>
-#include <WindowServer/Screen.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>

--- a/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.cpp
@@ -8,7 +8,6 @@
 #include "DebuggerVariableJSObject.h"
 #include "Debugger.h"
 #include <LibJS/Runtime/Error.h>
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/PropertyName.h>
 

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
@@ -12,7 +12,6 @@
 #include <LibSymbolication/Symbolication.h>
 #include <LibX86/Disassembler.h>
 #include <LibX86/ELFSymbolProvider.h>
-#include <ctype.h>
 #include <stdio.h>
 
 namespace HackStudio {

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -18,11 +18,8 @@
 #include <LibGUI/IconView.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
-#include <LibGUI/RadioButton.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
-#include <LibGfx/Font.h>
-#include <LibGfx/FontDatabase.h>
 #include <LibRegex/Regex.h>
 
 namespace HackStudio {

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -9,12 +9,9 @@
 
 #include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
-#include <Kernel/API/InodeWatcherEvent.h>
 #include <LibCore/DirIterator.h>
-#include <LibGUI/Icon.h>
 #include <LibGUI/Variant.h>
 #include <LibGfx/TextAlignment.h>
-#include <ctype.h>
 #include <stdio.h>
 
 namespace HackStudio {

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -30,7 +30,6 @@
 #include <LibJS/SyntaxHighlighter.h>
 #include <LibMarkdown/Document.h>
 #include <LibSQL/AST/SyntaxHighlighter.h>
-#include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
 #include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -7,7 +7,6 @@
 #include "EditorWrapper.h"
 #include "Editor.h"
 #include "HackStudio.h"
-#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>

--- a/Userland/DevTools/HackStudio/Git/DiffViewer.cpp
+++ b/Userland/DevTools/HackStudio/Git/DiffViewer.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGfx/Color.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 

--- a/Userland/DevTools/HackStudio/Git/GitRepo.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.cpp
@@ -6,8 +6,6 @@
 
 #include "GitRepo.h"
 #include <LibCore/Command.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace HackStudio {
 

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -14,7 +14,6 @@
 #include <LibGUI/InputBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
-#include <LibGUI/Model.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
 #include <stdio.h>

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -10,7 +10,6 @@
 #include "ToDoEntries.h"
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
 #include <LibGUI/Notification.h>
 
 namespace HackStudio {

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -10,7 +10,6 @@
 #include "Project.h"
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Menubar.h>

--- a/Userland/DevTools/Inspector/RemoteObjectGraphModel.cpp
+++ b/Userland/DevTools/Inspector/RemoteObjectGraphModel.cpp
@@ -7,7 +7,6 @@
 #include "RemoteObjectGraphModel.h"
 #include "RemoteObject.h"
 #include "RemoteProcess.h"
-#include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <LibGUI/Application.h>
 #include <stdio.h>

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -8,7 +8,6 @@
 #include "RemoteObject.h"
 #include "RemoteObjectGraphModel.h"
 #include "RemoteObjectPropertyModel.h"
-#include <stdio.h>
 #include <stdlib.h>
 
 namespace Inspector {

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -12,7 +12,6 @@
 #include <LibSymbolication/Symbolication.h>
 #include <LibX86/Disassembler.h>
 #include <LibX86/ELFSymbolProvider.h>
-#include <ctype.h>
 #include <stdio.h>
 
 namespace Profiler {

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -6,10 +6,8 @@
 
 #include "ProfileModel.h"
 #include "Profile.h"
-#include <AK/StringBuilder.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibSymbolication/Symbolication.h>
-#include <ctype.h>
 #include <stdio.h>
 
 namespace Profiler {

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -7,7 +7,6 @@
 #include "SamplesModel.h"
 #include "Profile.h"
 #include <AK/StringBuilder.h>
-#include <stdio.h>
 
 namespace Profiler {
 

--- a/Userland/DevTools/Profiler/TimelineHeader.cpp
+++ b/Userland/DevTools/Profiler/TimelineHeader.cpp
@@ -9,9 +9,7 @@
 #include "Profile.h"
 #include <AK/LexicalPath.h>
 #include <LibGUI/FileIconProvider.h>
-#include <LibGUI/Icon.h>
 #include <LibGUI/Painter.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
 namespace Profiler {

--- a/Userland/DevTools/Profiler/TimelineTrack.cpp
+++ b/Userland/DevTools/Profiler/TimelineTrack.cpp
@@ -8,7 +8,6 @@
 #include "Profile.h"
 #include "TimelineView.h"
 #include <LibGUI/Painter.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
 namespace Profiler {

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -12,7 +12,6 @@
 #include "TimelineView.h"
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ElapsedTimer.h>
-#include <LibCore/EventLoop.h>
 #include <LibCore/ProcessStatisticsReader.h>
 #include <LibCore/Timer.h>
 #include <LibDesktop/Launcher.h>

--- a/Userland/DevTools/StateMachineGenerator/main.cpp
+++ b/Userland/DevTools/StateMachineGenerator/main.cpp
@@ -14,7 +14,6 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <ctype.h>
-#include <string.h>
 
 struct Range {
     int begin;

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -8,9 +8,7 @@
 #include "SoftCPU.h"
 #include "Emulator.h"
 #include <AK/Assertions.h>
-#include <AK/BitCast.h>
 #include <AK/Debug.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -8,7 +8,6 @@
 #include <AK/Random.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/Account.h>
-#include <LibCore/File.h>
 #ifndef AK_OS_MACOS
 #    include <crypt.h>
 #endif

--- a/Userland/Libraries/LibCore/AnonymousBuffer.cpp
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.cpp
@@ -5,8 +5,6 @@
  */
 
 #include <LibCore/AnonymousBuffer.h>
-#include <LibIPC/Decoder.h>
-#include <LibIPC/Encoder.h>
 #include <LibIPC/File.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -5,13 +5,11 @@
  */
 
 #include "Command.h"
-#include <AK/ByteBuffer.h>
 #include <AK/Format.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/File.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <pwd.h>
 #include <stdio.h>
-#include <unistd.h>
 
 namespace Core {
 

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -9,7 +9,6 @@
 #include <AK/Time.h>
 #include <LibCore/DateTime.h>
 #include <errno.h>
-#include <sys/time.h>
 #include <time.h>
 
 namespace Core {

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Badge.h>
-#include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/IDAllocator.h>
@@ -26,11 +25,9 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>
-#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibCore/FileWatcher.cpp
+++ b/Userland/Libraries/LibCore/FileWatcher.cpp
@@ -7,21 +7,16 @@
 
 #include "FileWatcher.h"
 #include <AK/Debug.h>
-#include <AK/Function.h>
 #include <AK/LexicalPath.h>
-#include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
-#include <AK/RefCounted.h>
 #include <AK/Result.h>
 #include <AK/String.h>
 #include <Kernel/API/InodeWatcherEvent.h>
 #include <Kernel/API/InodeWatcherFlags.h>
-#include <LibCore/DirIterator.h>
 #include <LibCore/Notifier.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 namespace Core {

--- a/Userland/Libraries/LibCore/Notifier.cpp
+++ b/Userland/Libraries/LibCore/Notifier.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Notifier.h>

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -14,10 +14,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <sys/socket.h>
-#include <unistd.h>
 
 namespace Core {
 

--- a/Userland/Libraries/LibCore/UDPServer.cpp
+++ b/Userland/Libraries/LibCore/UDPServer.cpp
@@ -8,7 +8,6 @@
 #include <AK/Types.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/UDPServer.h>
-#include <LibCore/UDPSocket.h>
 #include <errno.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibGUI/AbstractSlider.cpp
+++ b/Userland/Libraries/LibGUI/AbstractSlider.cpp
@@ -9,7 +9,6 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Slider.h>
 #include <LibGfx/Palette.h>
-#include <LibGfx/StylePainter.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <LibGUI/AbstractTableView.h>
 #include <LibGUI/Action.h>
@@ -13,7 +12,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Scrollbar.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Palette.h>
 

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Font.h>
-#include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 

--- a/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
+++ b/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
@@ -6,10 +6,8 @@
 
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
-#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/CommonLocationsProvider.h>

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -9,7 +9,6 @@
 #include <LibGUI/Desktop.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <string.h>
-#include <unistd.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/DisplayLink.cpp
+++ b/Userland/Libraries/LibGUI/DisplayLink.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Badge.h>
-#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <LibGUI/DisplayLink.h>
 #include <LibGUI/WindowServerConnection.h>

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/FontPickerWeightModel.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/ListView.h>
-#include <LibGUI/Scrollbar.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/FontDatabase.h>

--- a/Userland/Libraries/LibGUI/GMLParser.cpp
+++ b/Userland/Libraries/LibGUI/GMLParser.cpp
@@ -10,7 +10,6 @@
 #include <AK/Queue.h>
 #include <LibGUI/GMLLexer.h>
 #include <LibGUI/GMLParser.h>
-#include <ctype.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/GMLSyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/GMLSyntaxHighlighter.cpp
@@ -6,8 +6,6 @@
 
 #include <LibGUI/GMLLexer.h>
 #include <LibGUI/GMLSyntaxHighlighter.h>
-#include <LibGUI/TextEditor.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
 namespace GUI {

--- a/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
@@ -6,8 +6,6 @@
 
 #include <LibGUI/INILexer.h>
 #include <LibGUI/INISyntaxHighlighter.h>
-#include <LibGUI/TextEditor.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
 namespace GUI {

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/TextBox.h>
 #include <LibGfx/Font.h>
-#include <stdio.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -8,7 +8,6 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/TextLayout.h>
 #include <LibGfx/TextWrapping.h>

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -10,7 +10,6 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGfx/Font.h>
-#include <stdio.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/ModelSelection.cpp
+++ b/Userland/Libraries/LibGUI/ModelSelection.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <LibGUI/AbstractView.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/ModelSelection.h>

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Assertions.h>
 #include <AK/StdLibExtras.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Slider.h>

--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -11,9 +11,7 @@
 #include <LibGUI/Model.h>
 #include <LibGUI/ModelEditingDelegate.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Scrollbar.h>
 #include <LibGUI/TableView.h>
-#include <LibGUI/TextBox.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Palette.h>
 

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -11,7 +11,6 @@
 #include <AK/Utf8View.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/TextDocument.h>
-#include <LibGUI/TextEditor.h>
 #include <LibRegex/Regex.h>
 
 namespace GUI {

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
@@ -7,7 +7,6 @@
 #include <LibGUI/Event.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowManagerServerConnection.h>
-#include <WindowServer/Window.h>
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -10,14 +10,12 @@
 #include <LibCore/MimeData.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/Clipboard.h>
 #include <LibGUI/Desktop.h>
 #include <LibGUI/DisplayLink.h>
 #include <LibGUI/DragOperation.h>
 #include <LibGUI/EmojiInputDialog.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Menu.h>
-#include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Bitmap.h>

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Vector.h>
 #include <LibGfx/BMPWriter.h>
 #include <LibGfx/Bitmap.h>
 

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Array.h>
-#include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
@@ -14,7 +13,6 @@
 #include <AK/MemoryStream.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <LibGfx/GIFLoader.h>
-#include <stdio.h>
 #include <string.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -13,7 +13,6 @@
 #include <AK/Types.h>
 #include <LibGfx/ICOLoader.h>
 #include <LibGfx/PNGLoader.h>
-#include <stdio.h>
 #include <string.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/PGMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PGMLoader.cpp
@@ -9,7 +9,6 @@
 #include "Streamer.h"
 #include <AK/Endian.h>
 #include <AK/LexicalPath.h>
-#include <AK/MappedFile.h>
 #include <AK/StringBuilder.h>
 #include <string.h>
 

--- a/Userland/Libraries/LibGfx/PPMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PPMLoader.cpp
@@ -9,7 +9,6 @@
 #include "Streamer.h"
 #include <AK/Endian.h>
 #include <AK/LexicalPath.h>
-#include <AK/MappedFile.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <string.h>

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
@@ -10,7 +10,6 @@
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibCore/File.h>
-#include <LibGfx/FontDatabase.h>
 #include <LibGfx/TrueTypeFont/Cmap.h>
 #include <LibGfx/TrueTypeFont/Font.h>
 #include <LibGfx/TrueTypeFont/Glyf.h>

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Function.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -10,7 +10,6 @@
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/Register.h>
-#include <LibJS/Forward.h>
 
 namespace JS::Bytecode {
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AK/HashTable.h>
-#include <LibJS/AST.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Runtime/Array.h>

--- a/Userland/Libraries/LibJS/Bytecode/Pass/DumpCFG.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/DumpCFG.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibJS/Bytecode/PassManager.h>
-#include <stdio.h>
 
 namespace JS::Bytecode::Passes {
 

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
@@ -6,10 +6,8 @@
 
 #include <AK/Platform.h>
 #include <AK/Vector.h>
-#include <LibJS/Forward.h>
 #include <LibJS/Heap/BlockAllocator.h>
 #include <LibJS/Heap/HeapBlock.h>
-#include <stdlib.h>
 #include <sys/mman.h>
 
 #ifdef HAS_ADDRESS_SANITIZER

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -9,8 +9,6 @@
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Noncopyable.h>
-#include <AK/String.h>
-#include <AK/TypeCasts.h>
 #include <LibJS/Forward.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/ScopeGuard.h>
-#include <AK/StringBuilder.h>
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/FunctionEnvironment.h>

--- a/Userland/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Userland/Libraries/LibJS/MarkupGenerator.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/HashTable.h>
 #include <AK/StringBuilder.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Lexer.h>
 #include <LibJS/MarkupGenerator.h>
 #include <LibJS/Runtime/Array.h>

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -8,7 +8,6 @@
 #include <AK/CharacterTypes.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
-#include <AK/Result.h>
 #include <AK/TemporaryChange.h>
 #include <AK/Utf16View.h>
 #include <LibJS/Interpreter.h>

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Function.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/BigIntObject.h>
 #include <LibJS/Runtime/BigIntPrototype.h>
 #include <LibJS/Runtime/Error.h>

--- a/Userland/Libraries/LibJS/Runtime/BooleanPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Function.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/BooleanPrototype.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/DataViewPrototype.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/StringBuilder.h>
 #include <LibCore/DateTime.h>
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <time.h>

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/Function.h>
 #include <AK/String.h>
+#include <AK/TypeCasts.h>
 #include <LibCore/DateTime.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibJS/Runtime/BigInt.h>

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/FinalizationRegistryPrototype.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Function.h>
 #include <AK/StringBuilder.h>
-#include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/BoundFunction.h>

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/MapIterator.h>
 #include <LibJS/Runtime/MapPrototype.h>
 

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Function.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NumberObject.h>

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -6,8 +6,6 @@
  */
 
 #include <AK/String.h>
-#include <AK/TemporaryChange.h>
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Accessor.h>

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
@@ -10,7 +10,6 @@
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Interpreter.h>
-#include <LibJS/Bytecode/PassManager.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -7,6 +7,7 @@
 #include <AK/Debug.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/JobCallback.h>

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Function.h>
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/RegExpObject.h>

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -9,7 +9,6 @@
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/IteratorOperations.h>
-#include <LibJS/Runtime/Set.h>
 #include <LibJS/Runtime/SetIterator.h>
 #include <LibJS/Runtime/SetIteratorPrototype.h>
 

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashTable.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/SetIterator.h>
 #include <LibJS/Runtime/SetPrototype.h>
 

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/IteratorOperations.h>

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Symbol.h>
 #include <LibJS/Runtime/SymbolObject.h>
-#include <LibJS/Runtime/SymbolPrototype.h>
-#include <LibJS/Runtime/Value.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <AK/Function.h>
-#include <LibJS/Heap/Heap.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Duration.h>
 #include <LibJS/Runtime/Temporal/DurationConstructor.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Duration.h>
 #include <LibJS/Runtime/Temporal/DurationPrototype.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Instant.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Checked.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Instant.h>
 #include <LibJS/Runtime/Temporal/TimeZone.h>

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -6,15 +6,12 @@
  */
 
 #include <AK/AllOf.h>
-#include <AK/FlyString.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf16View.h>
 #include <AK/Utf8View.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
-#include <LibJS/Heap/Heap.h>
-#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Accessor.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/BigInt.h>
@@ -31,7 +28,6 @@
 #include <LibJS/Runtime/ProxyObject.h>
 #include <LibJS/Runtime/RegExpObject.h>
 #include <LibJS/Runtime/StringObject.h>
-#include <LibJS/Runtime/Symbol.h>
 #include <LibJS/Runtime/SymbolObject.h>
 #include <LibJS/Runtime/Value.h>
 #include <math.h>

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashTable.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/WeakMapPrototype.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/WeakRefPrototype.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashTable.h>
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/WeakSetPrototype.h>
 
 namespace JS {

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -5,8 +5,6 @@
  */
 
 #include <AK/Debug.h>
-#include <LibGUI/TextEditor.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 #include <LibJS/Lexer.h>
 #include <LibJS/SyntaxHighlighter.h>

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "RegexMatcher.h"
-#include "RegexDebug.h"
-#include "RegexParser.h"
 #include <AK/Debug.h>
-#include <AK/ScopedValueRollback.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#if REGEX_DEBUG
+#    include <LibRegex/RegexDebug.h>
+#endif
+#include <LibRegex/RegexMatcher.h>
+#include <LibRegex/RegexParser.h>
 
 namespace regex {
 

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -7,7 +7,6 @@
 #include <AK/Debug.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/Timer.h>
-#include <LibCrypto/ASN1/DER.h>
 #include <LibCrypto/PK/Code/EMSA_PSS.h>
 #include <LibTLS/TLSv12.h>
 

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -9,7 +9,6 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/File.h>
-#include <LibCore/FileStream.h>
 #include <LibCore/Timer.h>
 #include <LibCrypto/ASN1/ASN1.h>
 #include <LibCrypto/ASN1/PEM.h>

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Terminal.h"
 #include <AK/Debug.h>
 #include <AK/Queue.h>
 #include <AK/StringBuilder.h>

--- a/Userland/Libraries/LibWeb/Bindings/HTMLCollectionWrapperCustom.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/HTMLCollectionWrapperCustom.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ScopeGuard.h>
 #include <LibWeb/Bindings/HTMLCollectionWrapper.h>
 #include <LibWeb/Bindings/NodeWrapper.h>
 #include <LibWeb/Bindings/NodeWrapperFactory.h>

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/NonnullOwnPtr.h>
-#include <AK/NonnullOwnPtrVector.h>
 #include <AK/Variant.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -6,7 +6,6 @@
 
 #include "Selector.h"
 #include <AK/StringUtils.h>
-#include <LibWeb/CSS/Selector.h>
 #include <ctype.h>
 
 namespace Web::CSS {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -9,7 +9,6 @@
 #include <LibGfx/FontDatabase.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/FontCache.h>
-#include <ctype.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
@@ -10,7 +10,6 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
 #include <ctype.h>
-#include <stdio.h>
 
 static String title_casify(const String& dashy_name)
 {

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -10,7 +10,6 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
 #include <ctype.h>
-#include <stdio.h>
 
 static String title_casify(const String& dashy_name)
 {

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_cpp.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_cpp.cpp
@@ -10,7 +10,6 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
 #include <ctype.h>
-#include <stdio.h>
 
 static String title_casify(const String& dashy_name)
 {

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_ValueID_h.cpp
@@ -10,7 +10,6 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
 #include <ctype.h>
-#include <stdio.h>
 
 static String title_casify(const String& dashy_name)
 {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -9,7 +9,6 @@
 #include <LibWeb/CSS/Parser/DeprecatedCSSParser.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleInvalidator.h>
-#include <LibWeb/CSS/StyleResolver.h>
 #include <LibWeb/DOM/DOMException.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Assertions.h>
 #include <AK/TypeCasts.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Node.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
@@ -5,10 +5,8 @@
  */
 
 #include <LibCore/Timer.h>
-#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/HTML/HTMLBlinkElement.h>
-#include <LibWeb/Layout/Node.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/FontDatabase.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -5,10 +5,8 @@
  */
 
 #include <AK/URL.h>
-#include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/Clipboard.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
@@ -19,7 +17,6 @@
 #include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
 #include <LibWeb/InProcessWebView.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
-#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/BrowsingContext.h>

--- a/Userland/Libraries/LibWeb/Layout/BlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockBox.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibGfx/Painter.h>
-#include <LibWeb/CSS/StyleResolver.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Layout/BlockBox.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -6,7 +6,6 @@
 
 #include <LibGfx/DisjointRectSet.h>
 #include <LibGfx/Filters/FastBoxBlurFilter.h>
-#include <LibGfx/Filters/SpatialGaussianBlurFilter.h>
 #include <LibGfx/Painter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -16,7 +16,6 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Page/BrowsingContext.h>
-#include <typeinfo>
 
 namespace Web::Layout {
 

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/CharacterTypes.h>
-#include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <LibGfx/Painter.h>
 #include <LibWeb/DOM/Document.h>

--- a/Userland/Libraries/LibWeb/LayoutTreeModel.cpp
+++ b/Userland/Libraries/LibWeb/LayoutTreeModel.cpp
@@ -8,7 +8,6 @@
 #include <AK/StringBuilder.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/DOM/Text.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <ctype.h>

--- a/Userland/Libraries/LibWeb/Loader/CSSLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/CSSLoader.cpp
@@ -6,9 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/URL.h>
-#include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/Parser/DeprecatedCSSParser.h>
-#include <LibWeb/CSS/StyleSheet.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Loader/CSSLoader.h>

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -17,7 +17,6 @@
 #include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
 #include <LibWeb/Loader/FrameLoader.h>
 #include <LibWeb/Loader/ResourceLoader.h>
-#include <LibWeb/Namespace.h>
 #include <LibWeb/Page/BrowsingContext.h>
 #include <LibWeb/Page/Page.h>
 

--- a/Userland/Libraries/LibWeb/Loader/ImageResource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ImageResource.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Function.h>
 #include <LibGfx/Bitmap.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibWeb/Loader/ImageResource.h>

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -7,7 +7,6 @@
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <LibGfx/Painter.h>
-#include <LibWeb/DOM/Node.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
 #include <LibWeb/Painting/StackingContext.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -9,9 +9,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
-#include <LibWeb/SVG/SVGPathElement.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
-#include <ctype.h>
 
 namespace Web::SVG {
 

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceConstructor.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceConstructor.h>

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObjectPrototype.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObjectPrototype.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "WebAssemblyInstanceObject.h"
+#include <AK/TypeCasts.h>
 #include <LibWeb/WebAssembly/WebAssemblyInstanceObjectPrototype.h>
 
 namespace Web::Bindings {

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyMemoryConstructor.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/WebAssembly/WebAssemblyMemoryConstructor.h>

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleConstructor.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyModuleConstructor.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/WindowObject.h>

--- a/Userland/Libraries/LibX86/Instruction.cpp
+++ b/Userland/Libraries/LibX86/Instruction.cpp
@@ -7,7 +7,6 @@
 #include <AK/StringBuilder.h>
 #include <LibX86/Instruction.h>
 #include <LibX86/Interpreter.h>
-#include <stdio.h>
 
 #if defined(__GNUC__) && !defined(__clang__)
 #    pragma GCC optimize("O3")

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -8,12 +8,6 @@
 #include "Mixer.h"
 #include <AudioServer/AudioClientEndpoint.h>
 #include <LibAudio/Buffer.h>
-#include <errno.h>
-#include <stdio.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/uio.h>
-#include <unistd.h>
 
 namespace AudioServer {
 

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -10,7 +10,6 @@
 #include <AudioServer/ClientConnection.h>
 #include <AudioServer/Mixer.h>
 #include <pthread.h>
-#include <strings.h>
 
 namespace AudioServer {
 

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "Mixer.h"
-#include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
 
 int main(int, char**)

--- a/Userland/Services/ChessEngine/ChessEngine.cpp
+++ b/Userland/Services/ChessEngine/ChessEngine.cpp
@@ -6,7 +6,6 @@
 
 #include "ChessEngine.h"
 #include "MCTSTree.h"
-#include <AK/Debug.h>
 #include <AK/Random.h>
 #include <LibCore/ElapsedTimer.h>
 

--- a/Userland/Services/Clipboard/ClientConnection.cpp
+++ b/Userland/Services/Clipboard/ClientConnection.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <Clipboard/ClientConnection.h>
 #include <Clipboard/ClipboardClientEndpoint.h>
 #include <Clipboard/Storage.h>

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -7,7 +7,6 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <errno.h>
-#include <serenity.h>
 #include <spawn.h>
 #include <stdio.h>
 #include <sys/ioctl.h>

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -7,7 +7,6 @@
 
 #include "DNSName.h"
 #include <AK/Random.h>
-#include <AK/Vector.h>
 #include <ctype.h>
 
 namespace LookupServer {

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -9,11 +9,9 @@
 #include "DNSName.h"
 #include "DNSPacketHeader.h"
 #include <AK/Debug.h>
-#include <AK/IPv4Address.h>
 #include <AK/MemoryStream.h>
 #include <AK/StringBuilder.h>
 #include <arpa/inet.h>
-#include <ctype.h>
 #include <stdlib.h>
 
 namespace LookupServer {

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -7,7 +7,6 @@
 #include "LookupServer.h"
 #include "ClientConnection.h"
 #include "DNSPacket.h"
-#include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
 #include <AK/HashMap.h>
 #include <AK/Random.h>
@@ -16,7 +15,6 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
-#include <LibCore/LocalSocket.h>
 #include <LibCore/UDPSocket.h>
 #include <stdio.h>
 #include <time.h>

--- a/Userland/Services/RequestServer/GeminiProtocol.cpp
+++ b/Userland/Services/RequestServer/GeminiProtocol.cpp
@@ -8,7 +8,6 @@
 #include <LibGemini/GeminiRequest.h>
 #include <RequestServer/GeminiProtocol.h>
 #include <RequestServer/GeminiRequest.h>
-#include <fcntl.h>
 
 namespace RequestServer {
 

--- a/Userland/Services/RequestServer/HttpProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpProtocol.cpp
@@ -10,11 +10,9 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/URL.h>
-#include <LibHTTP/HttpJob.h>
 #include <RequestServer/ClientConnection.h>
 #include <RequestServer/HttpCommon.h>
 #include <RequestServer/HttpProtocol.h>
-#include <RequestServer/HttpRequest.h>
 #include <RequestServer/Request.h>
 
 namespace RequestServer {

--- a/Userland/Services/RequestServer/HttpsProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpsProtocol.cpp
@@ -10,11 +10,9 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/URL.h>
-#include <LibHTTP/HttpsJob.h>
 #include <RequestServer/ClientConnection.h>
 #include <RequestServer/HttpCommon.h>
 #include <RequestServer/HttpsProtocol.h>
-#include <RequestServer/HttpsRequest.h>
 #include <RequestServer/Request.h>
 
 namespace RequestServer {

--- a/Userland/Services/RequestServer/Request.cpp
+++ b/Userland/Services/RequestServer/Request.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <RequestServer/ClientConnection.h>
 #include <RequestServer/Request.h>
 

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -14,9 +14,6 @@
 #include <LibCore/File.h>
 #include <LibCore/Socket.h>
 #include <fcntl.h>
-#include <grp.h>
-#include <libgen.h>
-#include <pwd.h>
 #include <sched.h>
 #include <stdio.h>
 #include <sys/ioctl.h>

--- a/Userland/Services/Taskbar/TaskbarButton.cpp
+++ b/Userland/Services/Taskbar/TaskbarButton.cpp
@@ -11,7 +11,6 @@
 #include <LibGUI/WindowManagerServerConnection.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Font.h>
-#include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 

--- a/Userland/Services/TelnetServer/Parser.cpp
+++ b/Userland/Services/TelnetServer/Parser.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Function.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -5,14 +5,12 @@
  */
 
 #include "Client.h"
-#include <AK/ByteBuffer.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/TCPServer.h>
-#include <LibCore/TCPSocket.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <AK/Debug.h>
 #include <AK/JsonObject.h>
 #include <LibGfx/Bitmap.h>

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -6,14 +6,10 @@
  */
 
 #include "WebContentConsoleClient.h"
-#include <LibJS/Console.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/MarkupGenerator.h>
 #include <LibJS/Parser.h>
 #include <LibWeb/Bindings/DOMExceptionWrapper.h>
-#include <LibWeb/DOM/DocumentType.h>
-#include <LibWeb/DOM/Text.h>
-#include <LibWeb/DOMTreeModel.h>
 
 namespace WebContent {
 

--- a/Userland/Services/WebSocket/ClientConnection.cpp
+++ b/Userland/Services/WebSocket/ClientConnection.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <LibWebSocket/ConnectionInfo.h>
 #include <LibWebSocket/Message.h>
 #include <WebSocket/ClientConnection.h>

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -6,22 +6,14 @@
 
 #include <AK/Debug.h>
 #include <Kernel/API/MousePacket.h>
-#include <LibCore/LocalSocket.h>
-#include <LibCore/Object.h>
 #include <WindowServer/ClientConnection.h>
 #include <WindowServer/Cursor.h>
-#include <WindowServer/Event.h>
 #include <WindowServer/EventLoop.h>
 #include <WindowServer/Screen.h>
 #include <WindowServer/WMClientConnection.h>
 #include <WindowServer/WindowManager.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <time.h>
 #include <unistd.h>
 
 namespace WindowServer {

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <Kernel/API/FB.h>
 #include <Services/WindowServer/ScreenLayout.h>
 #include <errno.h>

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -16,7 +16,6 @@
 #include <AK/Badge.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
-#include <WindowServer/WindowClientEndpoint.h>
 
 namespace WindowServer {
 

--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/ByteBuffer.h>
 #include <AK/IPv4Address.h>
 #include <AK/JsonObject.h>
 #include <AK/MACAddress.h>
@@ -13,7 +12,6 @@
 #include <AK/Types.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
-#include <net/if.h>
 #include <net/route.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>

--- a/Userland/Utilities/chgrp.cpp
+++ b/Userland/Utilities/chgrp.cpp
@@ -4,14 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>
 #include <grp.h>
-#include <pwd.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 int main(int argc, char** argv)

--- a/Userland/Utilities/cpp-parser.cpp
+++ b/Userland/Utilities/cpp-parser.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AK/Forward.h"
-#include "LibCpp/AST.h"
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCpp/Parser.h>

--- a/Userland/Utilities/dmesg.cpp
+++ b/Userland/Utilities/dmesg.cpp
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <LibCore/File.h>
-#include <assert.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -14,13 +14,10 @@
 #include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
-#include <LibCore/Object.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 struct DuOption {
     enum class TimeType {

--- a/Userland/Utilities/errno.cpp
+++ b/Userland/Utilities/errno.cpp
@@ -6,7 +6,6 @@
 
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
-#include <stdlib.h>
 
 int main(int argc, char** argv)
 {

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -12,7 +12,6 @@
 #include <AK/Vector.h>
 #include <LibCore/DirIterator.h>
 #include <errno.h>
-#include <getopt.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -5,8 +5,6 @@
  */
 
 #include <AK/Assertions.h>
-#include <AK/ByteBuffer.h>
-#include <AK/Demangle.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StringBuilder.h>

--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Assertions.h>
-#include <AK/ByteBuffer.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>

--- a/Userland/Utilities/groupadd.cpp
+++ b/Userland/Utilities/groupadd.cpp
@@ -8,7 +8,6 @@
 
 #include <LibCore/ArgsParser.h>
 #include <ctype.h>
-#include <errno.h>
 #include <grp.h>
 #include <string.h>
 #include <unistd.h>

--- a/Userland/Utilities/groupdel.cpp
+++ b/Userland/Utilities/groupdel.cpp
@@ -8,7 +8,6 @@
 
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
-#include <ctype.h>
 #include <grp.h>
 #include <pwd.h>
 #include <unistd.h>

--- a/Userland/Utilities/head.cpp
+++ b/Userland/Utilities/head.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
 #include <LibCore/ArgsParser.h>
 #include <errno.h>

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/ConfigFile.h>
 #include <LibKeyboard/CharacterMap.h>
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
 int main(int argc, char** argv)

--- a/Userland/Utilities/ln.cpp
+++ b/Userland/Utilities/ln.cpp
@@ -6,9 +6,7 @@
 
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
-#include <errno.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
 int main(int argc, char** argv)

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/GenericLexer.h>
-#include <AK/HashMap.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>

--- a/Userland/Utilities/notify.cpp
+++ b/Userland/Utilities/notify.cpp
@@ -8,7 +8,6 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/Notification.h>
 #include <LibGfx/Bitmap.h>
-#include <stdio.h>
 
 int main(int argc, char** argv)
 {

--- a/Userland/Utilities/nproc.cpp
+++ b/Userland/Utilities/nproc.cpp
@@ -7,7 +7,6 @@
 #include <AK/JsonObject.h>
 #include <LibCore/File.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
 int main()

--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -5,10 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Types.h>
 #include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/File.h>
 #include <LibCore/GetPassword.h>
 #include <string.h>
 #include <unistd.h>

--- a/Userland/Utilities/profile.cpp
+++ b/Userland/Utilities/profile.cpp
@@ -8,7 +8,6 @@
 #include <serenity.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 int main(int argc, char** argv)
 {

--- a/Userland/Utilities/rmdir.cpp
+++ b/Userland/Utilities/rmdir.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
-#include <errno.h>
 #include <stdio.h>
 #include <unistd.h>
 

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -10,7 +10,6 @@
 #include <LibCore/StandardPaths.h>
 #include <LibLine/Editor.h>
 #include <LibSQL/AST/Lexer.h>
-#include <LibSQL/AST/Parser.h>
 #include <LibSQL/AST/Token.h>
 #include <LibSQL/SQLClient.h>
 #include <unistd.h>

--- a/Userland/Utilities/stty.cpp
+++ b/Userland/Utilities/stty.cpp
@@ -13,7 +13,6 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
-#include <LibCore/ArgsParser.h>
 #include <ctype.h>
 #include <fcntl.h>
 #include <getopt.h>

--- a/Userland/Utilities/su.cpp
+++ b/Userland/Utilities/su.cpp
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Vector.h>
 #include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/GetPassword.h>
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
 extern "C" int main(int, char**);

--- a/Userland/Utilities/sync.cpp
+++ b/Userland/Utilities/sync.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <stdio.h>
 #include <unistd.h>
 
 int main(int, char**)

--- a/Userland/Utilities/test.cpp
+++ b/Userland/Utilities/test.cpp
@@ -9,7 +9,6 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <LibCore/File.h>
-#include <getopt.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/Userland/Utilities/touch.cpp
+++ b/Userland/Utilities/touch.cpp
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 #include <utime.h>
 

--- a/Userland/Utilities/tr.cpp
+++ b/Userland/Utilities/tr.cpp
@@ -5,10 +5,8 @@
  */
 
 #include <AK/String.h>
-#include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 int main(int argc, char** argv)
 {

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Types.h>
 #include <LibCore/Account.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <LibCore/DateTime.h>


### PR DESCRIPTION
Here's some numbers just for fun, the benchmark is very naive and variable.
The test also leans pretty hard on the kernel's disk cache, so these numbers have very little weight...

Here's my system info:
```
$ inxi -C -D -m

Memory:    RAM: total: 31.18 GiB used: 18.82 GiB (60.4%)
           Array-1: capacity: 32 GiB slots: 2 EC: None
           Device-1: ChannelA-DIMM0 size: 16 GiB speed: 2400 MT/s
           Device-2: ChannelB-DIMM0 size: 16 GiB speed: 2400 MT/s

CPU:       Info: Quad Core model: Intel Core i7-8705G bits: 64 type: MT MCP L2 cache: 8 MiB
           Speed: 3700 MHz min/max: 800/4100 MHz Core speeds (MHz): 1: 3700 2: 3700 3: 3700 4: 3700 5: 3700 6: 3700 7: 3700
           8: 3700

Drives:    Local Storage: total: 476.94 GiB used: 714.94 GiB (149.9%)
           ID-1: /dev/nvme0n1 vendor: Samsung model: SSD 970 PRO 512GB size: 476.94 GiB
```

Before:
```
(master) $ hyperfine --prepare 'ninja clean && ccache -C' -r 3 'ninja Kernel/Kernel'
Benchmark #1: ninja Kernel/Kernel
  Time (mean ± σ):     93.158 s ±  7.025 s    [User: 637.220 s, System: 29.089 s]
  Range (min … max):   89.025 s … 101.269 s    3 runs
```
After:
```
(cleanup-more-unused-headers) $ hyperfine --prepare 'ninja clean && ccache -C' -r 3 'ninja Kernel/Kernel'
Benchmark #1: ninja Kernel/Kernel
  Time (mean ± σ):     89.024 s ±  1.090 s    [User: 634.288 s, System: 28.569 s]
  Range (min … max):   88.338 s … 90.281 s    3 runs
