### PR TITLE
CI: Do not change the system gcc version to 10

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,9 +48,6 @@ jobs:
         sudo add-apt-repository ppa:canonical-server/server-backports
         sudo apt-get update
         sudo apt-get install libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 ccache
-    - name: Use GCC 10 instead
-      run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-
     - name: Install JS dependencies
       run: sudo npm install -g prettier@2.2.1
     - name: Install Python dependencies


### PR DESCRIPTION
Because the Serenity tooling autodetects the presence of gcc 10
it is no longer necessary to change the system gcc version to 10.