### PR TITLE
LibWeb: Fix regression of "contenteditable" attribute

### DIFF
--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html contenteditable="true">
+<html>
 
 <head>
     <title>Welcome!</title>

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -34,12 +34,12 @@ HTMLElement::ContentEditableState HTMLElement::content_editable_state() const
 {
     auto contenteditable = attribute(HTML::AttributeNames::contenteditable);
     // "true", an empty string or a missing value map to the "true" state.
-    if (contenteditable.is_empty() || contenteditable.equals_ignoring_case("true"))
+    if ((!contenteditable.is_null() && contenteditable.is_empty()) || contenteditable.equals_ignoring_case("true"))
         return ContentEditableState::True;
     // "false" maps to the "false" state.
     if (contenteditable.equals_ignoring_case("false"))
         return ContentEditableState::False;
-    // An invalid value maps to the "inherit" state.
+    // Having no such attribute or an invalid value maps to the "inherit" state.
     return ContentEditableState::Inherit;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -40,9 +40,9 @@ public:
 
     struct Attribute {
         String prefix;
-        String local_name;
+        String local_name { "" };
         String namespace_;
-        String value;
+        String value { "" };
         Position name_start_position;
         Position value_start_position;
         Position name_end_position;


### PR DESCRIPTION
My last PR regarding the "contenteditable" attribute had an error that caused all web content to be editable (sorry about that). Added default initializers to `local_name` and `value` of `struct Attribute` so the tokenizer emits a String that is non-null but empty for a missing value. Also removed the "contenteditable" attribute from the welcome page since that is a little bit confusing.