### PR TITLE
LibRegex: Make Fork{Jump,Stay} non-recursive

### DIFF
--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+#include <AK/Types.h>
+#include <AK/kmalloc.h>
+#include <sys/mman.h>
+
+namespace AK {
+
+template<bool use_mmap = false>
+class BumpAllocator {
+public:
+    BumpAllocator()
+    {
+        if constexpr (use_mmap)
+            m_chunk_size = 4 * MiB;
+        else
+            m_chunk_size = kmalloc_good_size(4 * KiB);
+    }
+
+    ~BumpAllocator()
+    {
+        deallocate_all();
+    }
+
+    void* allocate(size_t size, size_t align)
+    {
+        VERIFY(size < m_chunk_size - sizeof(ChunkHeader));
+        if (!m_current_chunk) {
+            if (!allocate_a_chunk())
+                return nullptr;
+        }
+
+    allocate_again:;
+        VERIFY(m_current_chunk != 0);
+
+        auto aligned_ptr = align_up_to(m_byte_offset_into_current_chunk + m_current_chunk, align);
+        auto next_offset = aligned_ptr + size - m_current_chunk;
+        if (next_offset > m_chunk_size) {
+            if (!allocate_a_chunk())
+                return nullptr;
+            goto allocate_again;
+        }
+        m_byte_offset_into_current_chunk = next_offset;
+        return (void*)aligned_ptr;
+    }
+
+    template<typename T>
+    T* allocate()
+    {
+        return (T*)allocate(sizeof(T), alignof(T));
+    }
+
+    void deallocate_all()
+    {
+        if (!m_head_chunk)
+            return;
+        for_each_chunk([this](auto chunk) {
+            if constexpr (use_mmap) {
+                munmap((void*)chunk, m_chunk_size);
+            } else {
+                kfree_sized((void*)chunk, m_chunk_size);
+            }
+        });
+    }
+
+protected:
+    template<typename TFn>
+    void for_each_chunk(TFn&& fn)
+    {
+        auto head_chunk = m_head_chunk;
+        while (head_chunk) {
+            auto& chunk_header = *(ChunkHeader const*)head_chunk;
+            VERIFY(chunk_header.magic == chunk_magic);
+            if (head_chunk == m_current_chunk)
+                VERIFY(chunk_header.next_chunk == 0);
+            auto next_chunk = chunk_header.next_chunk;
+            fn(head_chunk);
+            head_chunk = next_chunk;
+        }
+    }
+
+    bool allocate_a_chunk()
+    {
+        // dbgln("Allocated {} entries in previous chunk and have {} unusable bytes", m_allocations_in_previous_chunk, m_chunk_size - m_byte_offset_into_current_chunk);
+        // m_allocations_in_previous_chunk = 0;
+        void* new_chunk;
+        if constexpr (use_mmap) {
+#ifdef __serenity__
+            new_chunk = serenity_mmap(nullptr, m_chunk_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_RANDOMIZED | MAP_PRIVATE, 0, 0, m_chunk_size, "BumpAllocator Chunk");
+#else
+            new_chunk = mmap(nullptr, m_chunk_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
+#endif
+            if (new_chunk == MAP_FAILED)
+                return false;
+        } else {
+            new_chunk = kmalloc(m_chunk_size);
+            if (!new_chunk)
+                return false;
+        }
+
+        auto& new_header = *(ChunkHeader*)new_chunk;
+        new_header.magic = chunk_magic;
+        new_header.next_chunk = 0;
+        m_byte_offset_into_current_chunk = sizeof(ChunkHeader);
+
+        if (!m_head_chunk) {
+            VERIFY(!m_current_chunk);
+            m_head_chunk = (FlatPtr)new_chunk;
+            m_current_chunk = (FlatPtr)new_chunk;
+            return true;
+        }
+
+        VERIFY(m_current_chunk);
+        auto& old_header = *(ChunkHeader*)m_current_chunk;
+        VERIFY(old_header.next_chunk == 0);
+        old_header.next_chunk = (FlatPtr)new_chunk;
+        m_current_chunk = (FlatPtr)new_chunk;
+        return true;
+    }
+
+    constexpr static FlatPtr chunk_magic = sizeof(FlatPtr) == sizeof(u32) ? 0xdfdfdfdfu : 0xdfdfdfdfdfdfdfdfull;
+    struct ChunkHeader {
+        FlatPtr magic;
+        FlatPtr next_chunk;
+    };
+    FlatPtr m_head_chunk { 0 };
+    FlatPtr m_current_chunk { 0 };
+    size_t m_byte_offset_into_current_chunk { 0 };
+    size_t m_chunk_size { 0 };
+    // size_t m_allocations_in_previous_chunk { 0 };
+};
+
+template<typename T, bool use_mmap = false>
+class UniformBumpAllocator : protected BumpAllocator<use_mmap> {
+public:
+    UniformBumpAllocator() = default;
+    ~UniformBumpAllocator()
+    {
+        destroy_all();
+    }
+
+    T* allocate()
+    {
+        return BumpAllocator<use_mmap>::template allocate<T>();
+    }
+
+    void deallocate_all()
+    {
+        destroy_all();
+        BumpAllocator<use_mmap>::deallocate_all();
+    }
+
+    void destroy_all()
+    {
+        this->for_each_chunk([&](auto chunk) {
+            auto base_ptr = align_up_to(chunk + sizeof(typename BumpAllocator<use_mmap>::ChunkHeader), alignof(T));
+            FlatPtr end_offset = this->m_chunk_size;
+            if (chunk == this->m_current_chunk)
+                end_offset = this->m_byte_offset_into_current_chunk;
+            for (; base_ptr - chunk < end_offset; base_ptr += sizeof(T))
+                reinterpret_cast<T*>(base_ptr)->~T();
+        });
+    }
+};
+
+}
+
+using AK::BumpAllocator;
+using AK::UniformBumpAllocator;

--- a/AK/Tuple.h
+++ b/AK/Tuple.h
@@ -59,15 +59,17 @@ private:
 
 template<typename T, typename... TRest>
 struct Tuple<T, TRest...> : Tuple<TRest...> {
-    Tuple(T&& first, TRest&&... rest)
-        : Tuple<TRest...>(forward<TRest>(rest)...)
-        , value(forward<T>(first))
+
+    template<typename FirstT, typename... RestT>
+    Tuple(FirstT&& first, RestT&&... rest)
+        : Tuple<TRest...>(forward<RestT>(rest)...)
+        , value(forward<FirstT>(first))
     {
     }
 
-    Tuple(const T& first, const TRest&... rest)
-        : Tuple<TRest...>(rest...)
-        , value(first)
+    Tuple(T&& first, TRest&&... rest)
+        : Tuple<TRest...>(move(rest)...)
+        , value(move(first))
     {
     }
 

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -726,3 +726,19 @@ TEST_CASE(case_insensitive_match)
         EXPECT_EQ(result.matches.at(0).column, 4ul);
     }
 }
+
+TEST_CASE(extremely_long_fork_chain)
+{
+    Regex<ECMA262> re("(?:aa)*");
+    auto result = re.match(String::repeated('a', 100'000));
+    EXPECT_EQ(result.success, true);
+}
+
+static auto g_lots_of_a_s = String::repeated('a', 10'000'000);
+
+BENCHMARK_CASE(fork_performance)
+{
+    Regex<ECMA262> re("(?:aa)*");
+    auto result = re.match(g_lots_of_a_s);
+    EXPECT_EQ(result.success, true);
+}

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -469,6 +469,7 @@ struct MatchState {
     Vector<Match> matches;
     Vector<Vector<Match>> capture_group_matches;
     Vector<HashMap<String, Match>> named_capture_group_matches;
+    size_t recursion_level { 0 };
 };
 
 struct MatchOutput {

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -111,7 +111,7 @@ RegexResult Matcher<Parser>::match(RegexStringView const& view, Optional<typenam
 }
 
 template<typename Parser>
-RegexResult Matcher<Parser>::match(Vector<RegexStringView> const views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options) const
+RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optional<typename ParserTraits<Parser>::OptionsType> regex_options) const
 {
     // If the pattern *itself* isn't stateful, reset any changes to start_offset.
     if (!((AllFlags)m_regex_options.value() & AllFlags::Internal_Stateful))

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -52,7 +52,7 @@ public:
     ~Matcher() = default;
 
     RegexResult match(RegexStringView const&, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
-    RegexResult match(Vector<RegexStringView> const, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
+    RegexResult match(Vector<RegexStringView> const&, Optional<typename ParserTraits<Parser>::OptionsType> = {}) const;
 
     typename ParserTraits<Parser>::OptionsType options() const
     {

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -65,8 +65,7 @@ public:
     }
 
 private:
-    Optional<bool> execute(MatchInput const& input, MatchState& state, MatchOutput& output, size_t recursion_level) const;
-    ALWAYS_INLINE Optional<bool> execute_low_prio_forks(MatchInput const& input, MatchState& original_state, MatchOutput& output, Vector<MatchState> states, size_t recursion_level) const;
+    Optional<bool> execute(MatchInput const& input, MatchState& state, MatchOutput& output) const;
 
     Regex<Parser> const* m_pattern;
     typename ParserTraits<Parser>::OptionsType const m_regex_options;


### PR DESCRIPTION
cc @trflynn89 - you reported this.
This _shouldn't_ have any obvious issues ~~(except leaking some strings - I'll be figuring that out next, and if that fails...well, we can still have it, just more slow)~~ - String leakage fixed :^)

- **AK: Correct Tuple's constructor signatures**
    Random drive-by fix, not related to this specific PR
- **LibRegex: Make Fork{Jump,Stay} non-recursive**
- **LibRegex: Add some tests for Fork{Stay,Jump} performance**
    Recursive -> non-recursive impl
- **AK: Add a simple bump allocator**
- **LibRegex: Use a bump-allocated linked list for fork save states**
    `UniformBumpAllocator<T>` allows allocating only values of type `T`, and gives you the nice ability to actually call their dtors when they're deallocated :P
- **LibRegex: Make Matcher<>::match(Vector<>) take a reference to the vector**
    Another drive-by fix, but this time it's actually related to performance :P