### PR TITLE
Meta: Fix compatibility with QEMU 5.x

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -196,7 +196,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -device secondary-vga
 -device bochs-display,bus=pcie.6,addr=0x10.0x0
 -device piix3-ide
--drive file=${SERENITY_DISK_IMAGE},id=disk,if=none
+-drive file=${SERENITY_DISK_IMAGE},format=raw,id=disk,if=none
 -device ahci,id=ahci
 -device ide-hd,bus=ahci.0,drive=disk,unit=0
 -usb

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -104,6 +104,12 @@ else
     SERENITY_AUDIO_BACKEND="-audiodev pa,id=snd0"
 fi
 
+if [ "$installed_major_version" -gt 5 ]; then
+    SERENITY_AUDIO_HW="-machine pcspk-audiodev=snd0"
+else
+    SERENITY_AUDIO_HW="-soundhw pcspk"
+fi
+
 SERENITY_SCREENS="${SERENITY_SCREENS:-1}"
 if  [ "$SERENITY_SPICE" ]; then
     SERENITY_QEMU_DISPLAY_BACKEND="${SERENITY_QEMU_DISPLAY_BACKEND:-spice-app}"
@@ -157,7 +163,7 @@ $SERENITY_SPICE_SERVER_CHARDEV
 -device isa-debugcon,chardev=stdout
 -device virtio-rng-pci
 $SERENITY_AUDIO_BACKEND
--machine pcspk-audiodev=snd0
+$SERENITY_AUDIO_HW
 -device sb16,audiodev=snd0
 -device pci-bridge,chassis_nr=1,id=bridge1 -device $SERENITY_ETHERNET_DEVICE_TYPE,bus=bridge1
 -device i82801b11-bridge,bus=bridge1,id=bridge2 -device sdhci-pci,bus=bridge2
@@ -199,7 +205,8 @@ $SERENITY_EXTRA_QEMU_ARGS
 -device virtconsole,chardev=stdout
 -device isa-debugcon,chardev=stdout
 -device virtio-rng-pci
--soundhw pcspk
+$SERENITY_AUDIO_BACKEND
+$SERENITY_AUDIO_HW
 -device sb16
 "
 


### PR DESCRIPTION
**Meta: Fix compatibility with QEMU 5.x**

QEMU 5 doesn't support -machine pcspk-audiodev so we need to fall back to using -soundhw for that.

**Meta: Explicitly specify the disk format in the QEMU options**

Otherwise we're getting this warning:

```
WARNING: Image format was not specified for '_disk_image' and probing
         guessed raw. Automatically detecting the format is dangerous
         for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
```