### PR TITLE
SystemMonitor: Register ProcessStateModel with ProcessModel on construct

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -23,9 +23,14 @@ public:
         : m_target(target)
         , m_pid(pid)
     {
+        m_target.register_client(*this);
         refresh();
     }
-    virtual ~ProcessStateModel() override { }
+
+    virtual ~ProcessStateModel() override
+    {
+        m_target.unregister_client(*this);
+    }
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_target.column_count({}); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 2; }


### PR DESCRIPTION
Since this was missing, ProcessStateModel never received
model_did_update, and it was possible for the ProcessModel index to go
stale and show another process.

Fixes #9129.