### PR TITLE
Add 'link status' indication for network adapters and other small things

### DIFF
--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -58,6 +58,8 @@ private:
             obj.add("packets_out", adapter.packets_out());
             obj.add("bytes_out", adapter.bytes_out());
             obj.add("link_up", adapter.link_up());
+            obj.add("link_speed", adapter.link_speed());
+            obj.add("link_full_duplex", adapter.link_full_duplex());
             obj.add("mtu", adapter.mtu());
         });
         array.finish();

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -466,4 +466,29 @@ void E1000NetworkAdapter::receive()
     }
 }
 
+i32 E1000NetworkAdapter::link_speed()
+{
+    if (!link_up())
+        return NetworkAdapter::LINKSPEED_INVALID;
+
+    u32 speed = in32(REG_STATUS) & STATUS_SPEED;
+    switch (speed) {
+    case STATUS_SPEED_10MB:
+        return 10;
+    case STATUS_SPEED_100MB:
+        return 100;
+    case STATUS_SPEED_1000MB1:
+    case STATUS_SPEED_1000MB2:
+        return 1000;
+    default:
+        return NetworkAdapter::LINKSPEED_INVALID;
+    }
+}
+
+bool E1000NetworkAdapter::link_full_duplex()
+{
+    u32 status = in32(REG_STATUS);
+    return !!(status & STATUS_FD);
+}
+
 }

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -27,6 +27,8 @@ public:
 
     virtual void send_raw(ReadonlyBytes) override;
     virtual bool link_up() override;
+    virtual i32 link_speed() override;
+    virtual bool link_full_duplex() override;
 
     virtual StringView purpose() const override { return class_name(); }
 

--- a/Kernel/Net/LoopbackAdapter.h
+++ b/Kernel/Net/LoopbackAdapter.h
@@ -23,6 +23,8 @@ public:
     virtual void send_raw(ReadonlyBytes) override;
     virtual StringView class_name() const override { return "LoopbackAdapter"; }
     virtual bool link_up() override { return true; }
+    virtual bool link_full_duplex() override { return true; }
+    virtual int link_speed() override { return 1000; }
 };
 
 }

--- a/Kernel/Net/NE2000NetworkAdapter.h
+++ b/Kernel/Net/NE2000NetworkAdapter.h
@@ -29,6 +29,12 @@ public:
         // just assume that it's up.
         return true;
     }
+    virtual i32 link_speed()
+    {
+        // Can only do 10mbit..
+        return 10;
+    }
+    virtual bool link_full_duplex() { return true; }
 
     virtual StringView purpose() const override { return class_name(); }
 

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -42,6 +42,8 @@ struct PacketWithTimestamp : public RefCounted<PacketWithTimestamp> {
 class NetworkAdapter : public RefCounted<NetworkAdapter>
     , public Weakable<NetworkAdapter> {
 public:
+    static constexpr i32 LINKSPEED_INVALID = -1;
+
     virtual ~NetworkAdapter();
 
     virtual StringView class_name() const = 0;
@@ -53,6 +55,12 @@ public:
     IPv4Address ipv4_broadcast() const { return IPv4Address { (m_ipv4_address.to_u32() & m_ipv4_netmask.to_u32()) | ~m_ipv4_netmask.to_u32() }; }
     IPv4Address ipv4_gateway() const { return m_ipv4_gateway; }
     virtual bool link_up() { return false; }
+    virtual i32 link_speed()
+    {
+        // In Mbit/sec.
+        return LINKSPEED_INVALID;
+    }
+    virtual bool link_full_duplex() { return false; }
 
     void set_ipv4_address(const IPv4Address&);
     void set_ipv4_netmask(const IPv4Address&);

--- a/Kernel/Net/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8139NetworkAdapter.cpp
@@ -260,6 +260,9 @@ void RTL8139NetworkAdapter::reset()
     // choose irqs, then clear any pending
     out16(REG_IMR, INT_RXOK | INT_RXERR | INT_TXOK | INT_TXERR | INT_RX_BUFFER_OVERFLOW | INT_LINK_CHANGE | INT_RX_FIFO_OVERFLOW | INT_LENGTH_CHANGE | INT_SYSTEM_ERROR);
     out16(REG_ISR, 0xffff);
+
+    // Set the initial link up status.
+    m_link_up = (in8(REG_MSR) & MSR_LINKB) == 0;
 }
 
 UNMAP_AFTER_INIT void RTL8139NetworkAdapter::read_mac_address()

--- a/Kernel/Net/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/RTL8139NetworkAdapter.h
@@ -26,6 +26,8 @@ public:
 
     virtual void send_raw(ReadonlyBytes) override;
     virtual bool link_up() override { return m_link_up; }
+    virtual i32 link_speed() override;
+    virtual bool link_full_duplex() override;
 
     virtual StringView purpose() const override { return class_name(); }
 

--- a/Kernel/Net/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8168NetworkAdapter.cpp
@@ -172,6 +172,11 @@ namespace Kernel {
 
 #define MISC2_PFM_D3COLD_ENABLE 0x40
 
+#define PHYSTATUS_FULLDUP 0x01
+#define PHYSTATUS_1000MF 0x10
+#define PHYSTATUS_100M 0x08
+#define PHYSTATUS_10M 0x04
+
 #define TX_BUFFER_SIZE 0x1FF8
 #define RX_BUFFER_SIZE 0x1FF8 // FIXME: this should be increased (0x3FFF)
 
@@ -1631,4 +1636,27 @@ String RTL8168NetworkAdapter::possible_device_name()
     }
     VERIFY_NOT_REACHED();
 }
+
+bool RTL8168NetworkAdapter::link_full_duplex()
+{
+    u8 phystatus = in8(REG_PHYSTATUS);
+    return !!(phystatus & (PHYSTATUS_FULLDUP | PHYSTATUS_1000MF));
+}
+
+i32 RTL8168NetworkAdapter::link_speed()
+{
+    if (!link_up())
+        return NetworkAdapter::LINKSPEED_INVALID;
+
+    u8 phystatus = in8(REG_PHYSTATUS);
+    if (phystatus & PHYSTATUS_1000MF)
+        return 1000;
+    if (phystatus & PHYSTATUS_100M)
+        return 100;
+    if (phystatus & PHYSTATUS_10M)
+        return 10;
+
+    return NetworkAdapter::LINKSPEED_INVALID;
+}
+
 }

--- a/Kernel/Net/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/RTL8168NetworkAdapter.h
@@ -26,6 +26,8 @@ public:
 
     virtual void send_raw(ReadonlyBytes) override;
     virtual bool link_up() override { return m_link_up; }
+    virtual bool link_full_duplex() override;
+    virtual i32 link_speed() override;
 
     virtual StringView purpose() const override { return class_name(); }
 

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -124,6 +124,8 @@ private:
             auto& if_object = value.as_object();
             auto ip_address = if_object.get("ipv4_address").to_string();
             auto ifname = if_object.get("name").to_string();
+            auto link_up = if_object.get("link_up").as_bool();
+            auto link_speed = if_object.get("link_speed").to_i32();
 
             if (!include_loopback)
                 if (ifname == "loop")
@@ -134,7 +136,11 @@ private:
             if (!adapter_info.is_empty())
                 adapter_info.append('\n');
 
-            adapter_info.appendff("{}: {}", ifname, ip_address);
+            adapter_info.appendff("{}: {} ", ifname, ip_address);
+            if (!link_up)
+                adapter_info.appendff("(down)");
+            else
+                adapter_info.appendff("({} Mb/s)", link_speed);
         });
 
         // show connected icon so long as at least one adapter is connected

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -122,7 +122,7 @@ private:
         int connected_adapters = 0;
         json.value().as_array().for_each([&adapter_info, include_loopback, &connected_adapters](auto& value) {
             auto& if_object = value.as_object();
-            auto ip_address = if_object.get("ipv4_address").to_string();
+            auto ip_address = if_object.get("ipv4_address").as_string_or("no IP");
             auto ifname = if_object.get("name").to_string();
             auto link_up = if_object.get("link_up").as_bool();
             auto link_speed = if_object.get("link_speed").to_i32();

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -48,6 +48,14 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_adapters_fields.empend("name", "Name", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("class_name", "Class", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("mac_address", "MAC", Gfx::TextAlignment::CenterLeft);
+        net_adapters_fields.empend("Link status", Gfx::TextAlignment::CenterLeft,
+            [this](JsonObject const& object) -> String {
+                if (!object.get("link_up").as_bool())
+                    return "Down";
+
+                return String::formatted("{} Mb/s {}-duplex", object.get("link_speed").to_i32(),
+                    object.get("link_full_duplex").as_bool() ? "full" : "half");
+            });
         net_adapters_fields.empend("ipv4_address", "IPv4", Gfx::TextAlignment::CenterLeft);
         net_adapters_fields.empend("packets_in", "Pkt In", Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("packets_out", "Pkt Out", Gfx::TextAlignment::CenterRight);

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -56,7 +56,10 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
                 return String::formatted("{} Mb/s {}-duplex", object.get("link_speed").to_i32(),
                     object.get("link_full_duplex").as_bool() ? "full" : "half");
             });
-        net_adapters_fields.empend("ipv4_address", "IPv4", Gfx::TextAlignment::CenterLeft);
+        net_adapters_fields.empend("IPv4", Gfx::TextAlignment::CenterLeft,
+            [this](JsonObject const& object) -> String {
+                return object.get("ipv4_address").as_string_or("");
+            });
         net_adapters_fields.empend("packets_in", "Pkt In", Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("packets_out", "Pkt Out", Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("bytes_in", "Bytes In", Gfx::TextAlignment::CenterRight);


### PR DESCRIPTION
Changes in this PR:
* Read the link speed and duplex for all supported network adapters and display them in the applet and SystemMonitor.
* Fix for RTL8139-driver not working because link status is not initialized.
* Friendlier representation of a NIC that has no IPv4-address.

How things look when the link is up:
![image](https://user-images.githubusercontent.com/11619441/127748539-885dcc69-62ea-41de-ac93-9ae8b4ac3405.png)
![image](https://user-images.githubusercontent.com/11619441/127748542-237d38a0-a3d6-4615-ba78-71d21acca206.png)

How things look when the link is down:
![image](https://user-images.githubusercontent.com/11619441/127748613-565c2e4b-5b72-49c0-847c-e6bb662c95e0.png)
![image](https://user-images.githubusercontent.com/11619441/127748596-7396064a-741a-4c05-8929-6f68cccd6658.png)

I didn't test the RTL8168 driver as qemu cannot emulate that device