### PR TITLE
Assistant: Add provider to take and open a screenshot

### DIFF
--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -96,6 +96,22 @@ public:
     virtual Gfx::Bitmap const* bitmap() const override;
 };
 
+class ScreenshotResult final : public Result {
+public:
+    explicit ScreenshotResult(String title)
+        : Result(move(title), "'Enter' will write screenshot to home folder and open it in Image Viewer"sv, 100)
+        , m_bitmap(GUI::Icon::default_icon("filetype-image").bitmap_for_size(16))
+    {
+    }
+    ~ScreenshotResult() override = default;
+    void activate() const override;
+
+    virtual Gfx::Bitmap const* bitmap() const override { return m_bitmap; }
+
+private:
+    RefPtr<Gfx::Bitmap> m_bitmap;
+};
+
 class TerminalResult final : public Result {
 public:
     explicit TerminalResult(String command)
@@ -160,6 +176,11 @@ private:
 };
 
 class TerminalProvider final : public Provider {
+public:
+    void query(String const& query, Function<void(NonnullRefPtrVector<Result>)> on_complete) override;
+};
+
+class ScreenshotProvider final : public Provider {
 public:
     void query(String const& query, Function<void(NonnullRefPtrVector<Result>)> on_complete) override;
 };

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -126,6 +126,7 @@ public:
         m_providers.append(make<AppProvider>());
         m_providers.append(make<CalculatorProvider>());
         m_providers.append(make<FileProvider>());
+        m_providers.append(make<ScreenshotProvider>());
         m_providers.append(make<TerminalProvider>());
         m_providers.append(make<URLProvider>());
     }


### PR DESCRIPTION
Users of Assistant can now take screenshots via prefixing the
input with  "shot." The rest of the input will be used to determine the
file name of the screenshot; if none is supplied, one will be generated
using the same template string as `/bin/shot`. A full shot will be taken,
saved to the user's home folder, and then opend in Image Viewer.

One flaw with this implementation is that the Assistant window isn't dismissed
before the screenshot is taken, meaning the window is included and can
possibly obscure content.

Another is that there is no support for any other of `shot`'s arguments,
the biggest being the ability to take a region screenshot