### PR TITLE
Tests: Fix AK/TestJSON.cpp by not relying on disk resources

### DIFF
--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -71,6 +71,3 @@ set(AK_TEST_SOURCES
 foreach(source ${AK_TEST_SOURCES})
     serenity_test(${source} AK)
 endforeach()
-
-get_filename_component(TEST_FRM_RESOLVED ./test.frm REALPATH)
-install(FILES ${TEST_FRM_RESOLVED} DESTINATION usr/Tests/AK)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -15,20 +15,29 @@
 
 TEST_CASE(load_form)
 {
-    FILE* fp = fopen("test.frm", "r");
-    VERIFY(fp);
+    String raw_form_json = R"(
+    {
+        "name": "Form1",
+        "widgets": [
+            {
+                "enabled": true,
+                "forecolor": "#000000ff",
+                "ruler_visible": false,
+                "autofill": false,
+                "x": 155,
+                "tooltip": null,
+                "height": 121,
+                "width": 126,
+                "y": 10,
+                "class": "GTextEditor",
+                "text": "Hi",
+                "backcolor": "#c0c0c0ff",
+                "visible":true
+            }
+        ]
+    })";
 
-    StringBuilder builder;
-    for (;;) {
-        char buffer[1024];
-        if (!fgets(buffer, sizeof(buffer), fp))
-            break;
-        builder.append(buffer);
-    }
-
-    fclose(fp);
-
-    JsonValue form_json = JsonValue::from_string(builder.to_string()).value();
+    JsonValue form_json = JsonValue::from_string(raw_form_json).value();
 
     EXPECT(form_json.is_object());
 

--- a/Tests/AK/test.frm
+++ b/Tests/AK/test.frm
@@ -1,1 +1,0 @@
-../../Base/home/anon/Source/little/test.frm


### PR DESCRIPTION
The following commit broke Tests/AK/TestJSON.cpp as it removed the
file that the test loaded from disk to validate JSON parsing.

    commit ad141a228696d4e0f80add20d3e40a1fa3e82972
    Author: Andreas Kling <kling@serenityos.org>
    Date:   Sat Jul 31 15:26:14 2021 +0200

        Base: Remove "test.frm" from HackStudio test project

Instead of restoring the file, lets just embed a bit of JSON in the
test case to avoid using external resources, as they obviously are
surprising and make the test less portable across environments.