### PR TITLE
LibUnicode+LibRegex: Parse General Category property escapes and `\p{Type=Value}` escapes

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -287,7 +287,7 @@ public:
     [[nodiscard]] String reverse() const;
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -216,7 +216,7 @@ public:
     [[nodiscard]] bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -656,17 +656,27 @@ TEST_CASE(ECMA262_property_match)
         { "\\p{ASCII}", "p{ASCII}", true },
         { "\\p{ASCII}", "a", true, ECMAScriptFlags::Unicode },
         { "\\p{ASCII}", "😀", false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII}", "a", false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII}", "😀", true, ECMAScriptFlags::Unicode },
         { "\\p{ASCII_Hex_Digit}", "1", true, ECMAScriptFlags::Unicode },
         { "\\p{ASCII_Hex_Digit}", "a", true, ECMAScriptFlags::Unicode },
         { "\\p{ASCII_Hex_Digit}", "x", false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII_Hex_Digit}", "1", false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII_Hex_Digit}", "a", false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII_Hex_Digit}", "x", true, ECMAScriptFlags::Unicode },
         { "\\p{Any}", "\xcd\xb8", true, ECMAScriptFlags::Unicode },       // U+0378, which is an unassigned code point.
+        { "\\P{Any}", "\xcd\xb8", false, ECMAScriptFlags::Unicode },      // U+0378, which is an unassigned code point.
         { "\\p{Assigned}", "\xcd\xb8", false, ECMAScriptFlags::Unicode }, // U+0378, which is an unassigned code point.
+        { "\\P{Assigned}", "\xcd\xb8", true, ECMAScriptFlags::Unicode },  // U+0378, which is an unassigned code point.
         { "\\p{Lu}", "a", false, ECMAScriptFlags::Unicode },
         { "\\p{Lu}", "A", true, ECMAScriptFlags::Unicode },
         { "\\p{Lu}", "9", false, ECMAScriptFlags::Unicode },
         { "\\p{Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
         { "\\p{Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
         { "\\p{Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
+        { "\\P{Cased_Letter}", "a", false, ECMAScriptFlags::Unicode },
+        { "\\P{Cased_Letter}", "A", false, ECMAScriptFlags::Unicode },
+        { "\\P{Cased_Letter}", "9", true, ECMAScriptFlags::Unicode },
         { "\\p{General_Category=Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
         { "\\p{General_Category=Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
         { "\\p{General_Category=Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -661,6 +661,12 @@ TEST_CASE(ECMA262_property_match)
         { "\\p{ASCII_Hex_Digit}", "x", false, ECMAScriptFlags::Unicode },
         { "\\p{Any}", "\xcd\xb8", true, ECMAScriptFlags::Unicode },       // U+0378, which is an unassigned code point.
         { "\\p{Assigned}", "\xcd\xb8", false, ECMAScriptFlags::Unicode }, // U+0378, which is an unassigned code point.
+        { "\\p{Lu}", "a", false, ECMAScriptFlags::Unicode },
+        { "\\p{Lu}", "A", true, ECMAScriptFlags::Unicode },
+        { "\\p{Lu}", "9", false, ECMAScriptFlags::Unicode },
+        { "\\p{Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
+        { "\\p{Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
+        { "\\p{Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -667,6 +667,12 @@ TEST_CASE(ECMA262_property_match)
         { "\\p{Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
         { "\\p{Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
         { "\\p{Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
+        { "\\p{General_Category=Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
+        { "\\p{General_Category=Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
+        { "\\p{General_Category=Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
+        { "\\p{gc=Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
+        { "\\p{gc=Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
+        { "\\p{gc=Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -537,6 +537,10 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
             auto property = static_cast<Unicode::Property>(m_bytecode->at(offset++));
             compare_property(input, state, property, current_inversion_state(), inverse_matched);
 
+        } else if (compare_type == CharacterCompareType::GeneralCategory) {
+            auto general_category = static_cast<Unicode::GeneralCategory>(m_bytecode->at(offset++));
+            compare_general_category(input, state, general_category, current_inversion_state(), inverse_matched);
+
         } else {
             warnln("Undefined comparison: {}", (int)compare_type);
             VERIFY_NOT_REACHED();
@@ -733,6 +737,22 @@ ALWAYS_INLINE void OpCode_Compare::compare_property(MatchInput const& input, Mat
 
     u32 code_point = input.view[state.string_position];
     bool equal = Unicode::code_point_has_property(code_point, property);
+
+    if (equal) {
+        if (inverse)
+            inverse_matched = true;
+        else
+            ++state.string_position;
+    }
+}
+
+ALWAYS_INLINE void OpCode_Compare::compare_general_category(MatchInput const& input, MatchState& state, Unicode::GeneralCategory general_category, bool inverse, bool& inverse_matched)
+{
+    if (state.string_position == input.view.length())
+        return;
+
+    u32 code_point = input.view[state.string_position];
+    bool equal = Unicode::code_point_has_general_category(code_point, general_category);
 
     if (equal) {
         if (inverse)

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -67,6 +67,7 @@ enum class OpCodeId : ByteCodeValueType {
     __ENUMERATE_CHARACTER_COMPARE_TYPE(Reference)        \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(NamedReference)   \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(Property)         \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(GeneralCategory)  \
     __ENUMERATE_CHARACTER_COMPARE_TYPE(RangeExpressionDummy)
 
 enum class CharacterCompareType : ByteCodeValueType {
@@ -725,6 +726,7 @@ private:
     ALWAYS_INLINE static void compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
     ALWAYS_INLINE static void compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
     ALWAYS_INLINE static void compare_property(MatchInput const& input, MatchState& state, Unicode::Property property, bool inverse, bool& inverse_matched);
+    ALWAYS_INLINE static void compare_general_category(MatchInput const& input, MatchState& state, Unicode::GeneralCategory general_category, bool inverse, bool& inverse_matched);
 };
 
 template<typename T>

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1546,15 +1546,18 @@ bool ECMA262Parser::parse_atom_escape(ByteCode& stack, size_t& match_length_mini
         bool negated = false;
 
         if (parse_unicode_property_escape(property, negated)) {
+            Vector<CompareTypeAndValuePair> compares;
             if (negated)
-                stack.insert_bytecode_compare_values({ { CharacterCompareType::Inverse, 0 } });
+                compares.empend(CompareTypeAndValuePair { CharacterCompareType::Inverse, 0 });
             property.visit(
                 [&](Unicode::Property property) {
-                    stack.insert_bytecode_compare_values({ { CharacterCompareType::Property, (ByteCodeValueType)(property) } });
+                    compares.empend(CompareTypeAndValuePair { CharacterCompareType::Property, (ByteCodeValueType)property });
                 },
                 [&](Unicode::GeneralCategory general_category) {
-                    stack.insert_bytecode_compare_values({ { CharacterCompareType::GeneralCategory, (ByteCodeValueType)(general_category) } });
+                    compares.empend(CompareTypeAndValuePair { CharacterCompareType::GeneralCategory, (ByteCodeValueType)general_category });
                 });
+            stack.insert_bytecode_compare_values(move(compares));
+            match_length_minimum += 1;
             return true;
         }
     }

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -213,7 +213,9 @@ private:
     StringView read_digits_as_string(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1);
     Optional<unsigned> read_digits(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1);
     StringView read_capture_group_specifier(bool take_starting_angle_bracket = false);
-    Optional<Unicode::Property> read_unicode_property_escape();
+
+    using PropertyEscape = Variant<Unicode::Property, Unicode::GeneralCategory>;
+    Optional<PropertyEscape> read_unicode_property_escape();
 
     bool parse_pattern(ByteCode&, size_t&, bool unicode, bool named);
     bool parse_disjunction(ByteCode&, size_t&, bool unicode, bool named);
@@ -227,7 +229,7 @@ private:
     bool parse_capture_group(ByteCode&, size_t&, bool unicode, bool named);
     Optional<CharClass> parse_character_class_escape(bool& out_inverse, bool expect_backslash = false);
     bool parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&, bool unicode);
-    bool parse_unicode_property_escape(Unicode::Property& property, bool& negated);
+    bool parse_unicode_property_escape(PropertyEscape& property, bool& negated);
 
     // Used only by B.1.4, Regular Expression Patterns (Extended for use in browsers)
     bool parse_quantifiable_assertion(ByteCode&, size_t&, bool named);

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -22,6 +22,11 @@ namespace Unicode {
 
 #if ENABLE_UNICODE_DATA
 
+static bool has_general_category(UnicodeData const& unicode_data, GeneralCategory general_category)
+{
+    return (unicode_data.general_category & general_category) != GeneralCategory::None;
+}
+
 static bool has_property(UnicodeData const& unicode_data, Property property)
 {
     return (unicode_data.properties & property) == property;
@@ -194,6 +199,28 @@ String to_unicode_uppercase_full(StringView const& string)
     return builder.build();
 #else
     return string.to_uppercase_string();
+#endif
+}
+
+Optional<GeneralCategory> general_category_from_string([[maybe_unused]] StringView const& general_category)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::general_category_from_string(general_category);
+#else
+    return {};
+#endif
+}
+
+bool code_point_has_general_category([[maybe_unused]] u32 code_point, [[maybe_unused]] GeneralCategory general_category)
+{
+#if ENABLE_UNICODE_DATA
+    auto unicode_data = Detail::unicode_data_for_code_point(code_point);
+    if (!unicode_data.has_value())
+        return false;
+
+    return has_general_category(*unicode_data, general_category);
+#else
+    return {};
 #endif
 }
 

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -21,6 +21,9 @@ u32 to_unicode_uppercase(u32 code_point);
 String to_unicode_lowercase_full(StringView const&);
 String to_unicode_uppercase_full(StringView const&);
 
+Optional<GeneralCategory> general_category_from_string(StringView const&);
+bool code_point_has_general_category(u32 code_point, GeneralCategory general_category);
+
 Optional<Property> property_from_string(StringView const&);
 bool code_point_has_property(u32 code_point, Property property);
 bool is_ecma262_property(Property);

--- a/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
+++ b/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
@@ -103,8 +103,17 @@ struct UnicodeData {
     };
     Vector<Alias> general_category_aliases;
 
-    PropList prop_list;
+    // The Unicode standard defines additional properties (Any, Assigned, ASCII) which are not in
+    // any UCD file. Assigned is set as the default enum value 0 so "property & Assigned == Assigned"
+    // is always true. Any is not assigned code points here because this file only parses assigned
+    // code points, whereas Any will include unassigned code points.
+    // https://unicode.org/reports/tr18/#General_Category_Property
+    PropList prop_list {
+        { "Any"sv, {} },
+        { "ASCII"sv, { { 0, 0, 0x7f } } },
+    };
     Vector<Alias> prop_aliases;
+
     PropList word_break_prop_list;
 };
 
@@ -774,15 +783,6 @@ int main(int argc, char** argv)
     parse_prop_list(derived_core_prop_file, unicode_data.prop_list);
     parse_alias_list(prop_alias_file, unicode_data.prop_list, unicode_data.prop_aliases);
     parse_prop_list(word_break_file, unicode_data.word_break_prop_list);
-
-    // The Unicode standard defines additional properties (Any, Assigned, ASCII) which are not in
-    // any UCD file. Assigned is set as the default enum value 0 so "property & Assigned == Assigned"
-    // is always true. Any is not assigned code points here because this file only parses assigned
-    // code points, whereas Any will include unassigned code points.
-    // https://unicode.org/reports/tr18/#General_Category_Property
-    unicode_data.prop_list.set("Any"sv, {});
-    unicode_data.prop_list.set("ASCII"sv, { { 0, 0, 0x7f } });
-
     parse_unicode_data(unicode_data_file, unicode_data);
     parse_value_alias_list(prop_value_alias_file, "gc"sv, unicode_data.general_categories, unicode_data.general_category_unions, unicode_data.general_category_aliases);
 

--- a/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
+++ b/Userland/Libraries/LibUnicode/CodeGenerators/GenerateUnicodeData.cpp
@@ -478,7 +478,7 @@ namespace Unicode {
 
     generate_enum("Locale"sv, "None"sv, move(unicode_data.locales));
     generate_enum("Condition"sv, "None"sv, move(unicode_data.conditions));
-    generate_enum("GeneralCategory"sv, "None"sv, move(unicode_data.general_categories), move(unicode_data.general_category_unions), move(unicode_data.general_category_aliases), true);
+    generate_enum("GeneralCategory"sv, "None"sv, unicode_data.general_categories, unicode_data.general_category_unions, unicode_data.general_category_aliases, true);
     generate_enum("Property"sv, "Assigned"sv, unicode_data.prop_list.keys(), {}, unicode_data.prop_aliases, true);
     generate_enum("WordBreakProperty"sv, "Other"sv, unicode_data.word_break_prop_list.keys());
 
@@ -541,6 +541,7 @@ namespace Detail {
 
 Optional<UnicodeData> unicode_data_for_code_point(u32 code_point);
 Optional<Property> property_from_string(StringView const& property);
+Optional<GeneralCategory> general_category_from_string(StringView const& general_category);
 
 }
 
@@ -710,6 +711,32 @@ Optional<Property> property_from_string(StringView const& property)
         generator.append(R"~~~(
     if (property == "@property@"sv)
         return Property::@property@;)~~~");
+    }
+
+    generator.append(R"~~~(
+    return {};
+}
+
+Optional<GeneralCategory> general_category_from_string(StringView const& general_category)
+{)~~~");
+
+    for (auto const& general_category : unicode_data.general_categories) {
+        generator.set("general_category", general_category);
+        generator.append(R"~~~(
+    if (general_category == "@general_category@"sv)
+        return GeneralCategory::@general_category@;)~~~");
+    }
+    for (auto const& union_ : unicode_data.general_category_unions) {
+        generator.set("general_category", union_.alias);
+        generator.append(R"~~~(
+    if (general_category == "@general_category@"sv)
+        return GeneralCategory::@general_category@;)~~~");
+    }
+    for (auto const& alias : unicode_data.general_category_aliases) {
+        generator.set("general_category", alias.alias);
+        generator.append(R"~~~(
+    if (general_category == "@general_category@"sv)
+        return GeneralCategory::@general_category@;)~~~");
     }
 
     generator.append(R"~~~(

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -11,7 +11,7 @@
 namespace Unicode {
 
 enum class Condition;
-enum class GeneralCategory;
+enum class GeneralCategory : u64;
 enum class Locale;
 enum class Property : u64;
 enum class WordBreakProperty;

--- a/Userland/Libraries/LibUnicode/unicode_data.cmake
+++ b/Userland/Libraries/LibUnicode/unicode_data.cmake
@@ -15,6 +15,9 @@ set(DERIVED_CORE_PROP_PATH ${CMAKE_BINARY_DIR}/UCD/DerivedCoreProperties.txt)
 set(PROP_ALIAS_URL https://www.unicode.org/Public/13.0.0/ucd/PropertyAliases.txt)
 set(PROP_ALIAS_PATH ${CMAKE_BINARY_DIR}/UCD/PropertyAliases.txt)
 
+set(PROP_VALUE_ALIAS_URL https://www.unicode.org/Public/13.0.0/ucd/PropertyValueAliases.txt)
+set(PROP_VALUE_ALIAS_PATH ${CMAKE_BINARY_DIR}/UCD/PropertyValueAliases.txt)
+
 set(WORD_BREAK_URL https://www.unicode.org/Public/13.0.0/ucd/auxiliary/WordBreakProperty.txt)
 set(WORD_BREAK_PATH ${CMAKE_BINARY_DIR}/UCD/WordBreakProperty.txt)
 
@@ -39,6 +42,10 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         message(STATUS "Downloading UCD PropertyAliases.txt from ${PROP_ALIAS_URL}...")
         file(DOWNLOAD ${PROP_ALIAS_URL} ${PROP_ALIAS_PATH} INACTIVITY_TIMEOUT 10)
     endif()
+    if (NOT EXISTS ${PROP_VALUE_ALIAS_PATH})
+        message(STATUS "Downloading UCD PropertyValueAliases.txt from ${PROP_VALUE_ALIAS_URL}...")
+        file(DOWNLOAD ${PROP_VALUE_ALIAS_URL} ${PROP_VALUE_ALIAS_PATH} INACTIVITY_TIMEOUT 10)
+    endif()
     if (NOT EXISTS ${WORD_BREAK_PATH})
         message(STATUS "Downloading UCD WordBreakProperty.txt from ${WORD_BREAK_URL}...")
         file(DOWNLOAD ${WORD_BREAK_URL} ${WORD_BREAK_PATH} INACTIVITY_TIMEOUT 10)
@@ -54,7 +61,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_DATA_HEADER}
-        COMMAND ${write_if_different} ${UNICODE_DATA_HEADER} $<TARGET_FILE:GenerateUnicodeData> -h -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -a ${PROP_ALIAS_PATH} -w ${WORD_BREAK_PATH}
+        COMMAND ${write_if_different} ${UNICODE_DATA_HEADER} $<TARGET_FILE:GenerateUnicodeData> -h -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -a ${PROP_ALIAS_PATH} -v ${PROP_VALUE_ALIAS_PATH} -w ${WORD_BREAK_PATH}
         VERBATIM
         DEPENDS GenerateUnicodeData
         MAIN_DEPENDENCY ${UNICODE_DATA_PATH} ${SPECIAL_CASING_PATH}
@@ -62,7 +69,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_DATA_IMPLEMENTATION}
-        COMMAND ${write_if_different} ${UNICODE_DATA_IMPLEMENTATION} $<TARGET_FILE:GenerateUnicodeData> -c -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -a ${PROP_ALIAS_PATH} -w ${WORD_BREAK_PATH}
+        COMMAND ${write_if_different} ${UNICODE_DATA_IMPLEMENTATION} $<TARGET_FILE:GenerateUnicodeData> -c -u ${UNICODE_DATA_PATH} -s ${SPECIAL_CASING_PATH} -p ${PROP_LIST_PATH} -d ${DERIVED_CORE_PROP_PATH} -a ${PROP_ALIAS_PATH} -v ${PROP_VALUE_ALIAS_PATH} -w ${WORD_BREAK_PATH}
         VERBATIM
         DEPENDS GenerateUnicodeData
         MAIN_DEPENDENCY ${UNICODE_DATA_PATH} ${SPECIAL_CASING_PATH}


### PR DESCRIPTION
Unfortunately this doesn't pass any new `RegExp/property-escapes` test262 tests. The tests that would pass should be fixed by #9127.

The AK change is a bit of a drive-by fix - I use `is_one_of` in the following LibRegex commit, noticed the issue when I looked up the definition.

Edit: The last commit here (Generate negated property escapes as a single instruction) is because negated properties will break after #9127 is merged. Not an issue with that PR, but with the original property escape commit. I think it breaks because the inversion state is reverted when the previous regex state is restored in iterative execute loop.