### PR TITLE
FileManager: Rename action rearrangement, Enable/Disable mkdir and touch actions on path change

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -919,6 +919,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     main_toolbar.add_action(mkdir_action);
     main_toolbar.add_action(touch_action);
     main_toolbar.add_action(focus_dependent_delete_action);
+    main_toolbar.add_action(directory_view.rename_action());
 
     main_toolbar.add_separator();
     main_toolbar.add_action(cut_action);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1063,7 +1063,6 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     tree_view_directory_context_menu->add_action(copy_action);
     tree_view_directory_context_menu->add_action(paste_action);
     tree_view_directory_context_menu->add_action(tree_view_delete_action);
-    tree_view_directory_context_menu->add_action(directory_view.rename_action());
     tree_view_directory_context_menu->add_separator();
     tree_view_directory_context_menu->add_action(properties_action);
     tree_view_directory_context_menu->add_separator();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1002,6 +1002,8 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
             return;
         }
 
+        mkdir_action->set_enabled(can_write_in_path);
+        touch_action->set_enabled(can_write_in_path);
         paste_action->set_enabled(can_write_in_path && GUI::Clipboard::the().mime_type() == "text/uri-list");
         go_forward_action->set_enabled(directory_view.path_history_position() < directory_view.path_history_size() - 1);
         go_back_action->set_enabled(directory_view.path_history_position() > 0);


### PR DESCRIPTION
- **FileManager: Add the rename action to the toolbar**

  When I was adding the action in #8713, the action did not have an icon yet.  Now, since it has an icon now, we can add it to the toolbar!

- **FileManager: Remove the rename action from the tree view context menu**

  The action never worked properly here.  It used the selection from the directory view, instead of the tree view.  Furthermore, the tree view isn't even editable.

  Just making tree view editable wouldn't fix it – it'd probably need something like creating an `on_stop_editing()` function in the AbstractView to change the path after the rename.

  For now, I'll remove the action from the menu as a "temporary fix".

- **FileManager: Enable/Disable mkdir and touch actions on path change**

  This change disables the icons in read-only directories.

  *Off the commit note: Disabled icon for the “New Directory” action seems a bit off.*
  ![disabled-new-directory](https://user-images.githubusercontent.com/16520278/127753684-72156eb4-681c-4fec-ab68-c549bda8e285.png)
