### PR TITLE
Kernel: Do not cancel stale timers when servicing sys$alarm

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -139,9 +139,9 @@ public:
     }
     static Time from_timespec(const struct timespec&);
     static Time from_timeval(const struct timeval&);
-    static Time min() { return Time(-0x8000'0000'0000'0000LL, 0); };
-    static Time zero() { return Time(0, 0); };
-    static Time max() { return Time(0x7fff'ffff'ffff'ffffLL, 999'999'999); };
+    constexpr static Time min() { return Time(-0x8000'0000'0000'0000LL, 0); };
+    constexpr static Time zero() { return Time(0, 0); };
+    constexpr static Time max() { return Time(0x7fff'ffff'ffff'ffffLL, 999'999'999); };
 
     // Truncates towards zero (2.8s to 2s, -2.8s to -2s).
     i64 to_truncated_seconds() const;

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -15,13 +15,14 @@ KResultOr<FlatPtr> Process::sys$alarm(unsigned seconds)
     REQUIRE_PROMISE(stdio);
     unsigned previous_alarm_remaining = 0;
     if (m_alarm_timer) {
-        if (TimerQueue::the().cancel_timer(*m_alarm_timer)) {
+        bool was_in_use = false;
+        if (TimerQueue::the().cancel_timer(*m_alarm_timer, &was_in_use)) {
             // The timer hasn't fired. Round up the remaining time (if any)
             Time remaining = m_alarm_timer->remaining() + Time::from_nanoseconds(999'999'999);
             previous_alarm_remaining = remaining.to_truncated_seconds();
         }
         // We had an existing alarm, must return a non-zero value here!
-        if (previous_alarm_remaining == 0)
+        if (was_in_use && previous_alarm_remaining == 0)
             previous_alarm_remaining = 1;
     }
 

--- a/Tests/Kernel/TestKernelAlarm.cpp
+++ b/Tests/Kernel/TestKernelAlarm.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Time.h>
+#include <LibTest/TestCase.h>
+#include <unistd.h>
+
+// Regression test for issues #9071
+// See: https://github.com/SerenityOS/serenity/issues/9071
+TEST_CASE(regression_inifinite_loop)
+{
+    constexpr auto hour_long_timer_value = Time::from_seconds(60 * 60);
+
+    // Create an alarm timer significantly far into the future.
+    auto previous_time = alarm(hour_long_timer_value.to_seconds());
+    EXPECT_EQ(previous_time, 0u);
+
+    // Update the alarm with a zero value before the previous timer expires.
+    previous_time = alarm(0);
+    EXPECT_EQ(previous_time, hour_long_timer_value.to_seconds());
+
+    // Update the alarm with a zero value again, this shouldn't get stuck
+    // in an infinite loop trying to cancel the previous timer in the kernel.
+    previous_time = alarm(0);
+    EXPECT_EQ(previous_time, 0u);
+}


### PR DESCRIPTION
- **Kernel: Do not cancel stale timers when servicing sys$alarm**

    The sys$alarm() syscall has logic to cache a m_alarm_timer to avoid
    allocating a new timer for every call to alarm. Unfortunately that
    logic was broken, and there were conditions in which we could have
    a timer allocated, but it was no longer on the timer queue, and we
    would attempt to cancel that timer again resulting in an infinite
    loop waiting for the timers callback to fire.

    To fix this, we need to track if a timer is currently in use or not,
    allowing us to avoid attempting to cancel inactive timers.

    Luke and Tom did the initial investigation, I just happened to have
    time to write a repro and attempt a fix, so I'm adding them as the
    as co-authors of this commit.

    Co-authored-by: Luke <luke.wilde@live.co.uk>
    Co-authored-by: Tom <tomut@yahoo.com>

- **Tests: Add coverage for sys$alarm() canceling a stale timer**

    This is a regression test to validate the functionality that was
    reported broken in #9071, where the kernel would spin attempting
    to cancel a stale timer.


- **AK: Mark Time::max() / Time::min() / Time::zero() as constexpr**

    No reason for these static helper functions to not be constexpr.

CC: @Lubrsi / @tomuta 