### PR TITLE
LibGfx: Fix writing PNG headers on x86_64

### DIFF
--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -79,7 +79,7 @@ void PNGChunk::store_type()
 
 void PNGChunk::store_data_length()
 {
-    auto data_length = BigEndian(m_data.size() - sizeof(data_length_type) - m_type.length());
+    auto data_length = BigEndian<u32>(m_data.size() - sizeof(data_length_type) - m_type.length());
     __builtin_memcpy(m_data.offset_pointer(0), &data_length, sizeof(u32));
 }
 

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -79,8 +79,8 @@ void PNGChunk::store_type()
 
 void PNGChunk::store_data_length()
 {
-    auto data_lenth = BigEndian(m_data.size() - sizeof(data_length_type) - m_type.length());
-    __builtin_memcpy(m_data.offset_pointer(0), &data_lenth, sizeof(u32));
+    auto data_length = BigEndian(m_data.size() - sizeof(data_length_type) - m_type.length());
+    __builtin_memcpy(m_data.offset_pointer(0), &data_length, sizeof(u32));
 }
 
 u32 PNGChunk::crc()


### PR DESCRIPTION
**LibGfx: Fix a spelling mistake in a variable name**

**LibGfx: Fix writing PNG headers on x86_64**

m_data.size() returns a size_t which is a 64-bit type on x86_64. This resulted in us incorrectly using zero in the PNG header.