### PR TITLE
PixelPaint: Show image coordinates in the status bar

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -207,6 +207,10 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
     auto image_event = event_with_pan_and_scale_applied(event);
 
     m_active_tool->on_mousemove(*m_active_layer, layer_event, image_event);
+
+    if (on_image_mouse_position_change) {
+        on_image_mouse_position_change(image_event.position());
+    }
 }
 
 void ImageEditor::mouseup_event(GUI::MouseEvent& event)
@@ -247,6 +251,12 @@ void ImageEditor::keyup_event(GUI::KeyEvent& event)
 {
     if (m_active_tool)
         m_active_tool->on_keyup(event);
+}
+
+void ImageEditor::leave_event(Core::Event&)
+{
+    if (on_leave)
+        on_leave();
 }
 
 void ImageEditor::set_active_layer(Layer* layer)

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -66,6 +66,10 @@ public:
 
     Function<void(String const&)> on_image_title_change;
 
+    Function<void(Gfx::IntPoint const&)> on_image_mouse_position_change;
+
+    Function<void(void)> on_leave;
+
     Gfx::FloatRect layer_rect_to_editor_rect(Layer const&, Gfx::IntRect const&) const;
     Gfx::FloatRect image_rect_to_editor_rect(Gfx::IntRect const&) const;
     Gfx::FloatRect editor_rect_to_image_rect(Gfx::IntRect const&) const;
@@ -86,6 +90,7 @@ private:
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void leave_event(Core::Event&) override;
 
     virtual void image_did_change(Gfx::IntRect const&) override;
     virtual void image_select_layer(Layer*) override;

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -572,6 +572,21 @@ int main(int argc, char** argv)
             tab_widget.set_tab_title(image_editor, title);
         };
 
+        auto& statusbar = *main_widget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
+        image_editor.on_image_mouse_position_change = [&](auto const& mouse_position) {
+            auto const& image_size = current_image_editor()->image().size();
+            auto image_rectangle = Gfx::IntRect { 0, 0, image_size.width(), image_size.height() };
+            if (image_rectangle.contains(mouse_position)) {
+                statusbar.set_override_text(mouse_position.to_string());
+            } else {
+                statusbar.set_override_text({});
+            }
+        };
+
+        image_editor.on_leave = [&]() {
+            statusbar.set_override_text({});
+        };
+
         // NOTE: We invoke the above hook directly here to make sure the tab title is set up.
         image_editor.on_image_title_change(image->title());
 


### PR DESCRIPTION
This makes the coordinates show up in the status bar when hovering over the image.
I felt that this was missing while watching the July update video.


![2021-08-01T12:20:20](https://user-images.githubusercontent.com/23107133/127767543-c2e1be97-5d5d-4912-9a2f-dba4257f67d6.png)
