### PR TITLE
LibWeb: Don't draw zero-length line for text-decoration: blink

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -65,6 +65,7 @@ void TextNode::paint_text_decoration(Gfx::Painter& painter, LineBoxFragment cons
     } break;
     case CSS::TextDecorationLine::Blink:
         // Conforming user agents may simply not blink the text
+        return;
         break;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -48,7 +48,6 @@ void TextNode::paint_text_decoration(Gfx::Painter& painter, LineBoxFragment cons
     switch (computed_values().text_decoration_line()) {
     case CSS::TextDecorationLine::None:
         return;
-        break;
     case CSS::TextDecorationLine::Underline:
         line_start_point = fragment_box.top_left().translated(0, baseline + 2);
         line_end_point = fragment_box.top_right().translated(0, baseline + 2);
@@ -66,7 +65,6 @@ void TextNode::paint_text_decoration(Gfx::Painter& painter, LineBoxFragment cons
     case CSS::TextDecorationLine::Blink:
         // Conforming user agents may simply not blink the text
         return;
-        break;
     }
 
     painter.draw_line(line_start_point, line_end_point, computed_values().color());


### PR DESCRIPTION
This patch doesn't make any visible change but increases the
correctness of the text-decoration: blink path. Previously the painter
would be instructed to draw a line that doesn't have any length when
encountering the blink property instead of simply doing nothing.
This closes #9141 