### PR TITLE
Calculator: Add a new KeypadValue class

### DIFF
--- a/Userland/Applications/Calculator/CMakeLists.txt
+++ b/Userland/Applications/Calculator/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     Calculator.cpp
     CalculatorWidget.cpp
     Keypad.cpp
+    KeypadValue.cpp
     CalculatorGML.h
 )
 

--- a/Userland/Applications/Calculator/Calculator.cpp
+++ b/Userland/Applications/Calculator/Calculator.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Calculator.h"
+#include "KeypadValue.h"
 #include <AK/Assertions.h>
 #include <AK/Math.h>
 
@@ -16,9 +17,9 @@ Calculator::~Calculator()
 {
 }
 
-double Calculator::begin_operation(Operation operation, double argument)
+KeypadValue Calculator::begin_operation(Operation operation, KeypadValue argument)
 {
-    double res = 0.0;
+    KeypadValue res = 0;
 
     switch (operation) {
     case Operation::None:
@@ -33,30 +34,30 @@ double Calculator::begin_operation(Operation operation, double argument)
         return argument;
 
     case Operation::Sqrt:
-        if (argument < 0.0) {
+        if (argument < 0) {
             m_has_error = true;
             return argument;
         }
-        res = AK::sqrt(argument);
+        res = KeypadValue { AK::sqrt((double)argument) };
         clear_operation();
         break;
     case Operation::Inverse:
-        if (argument == 0.0) {
+        if (argument == 0) {
             m_has_error = true;
             return argument;
         }
-        res = 1 / argument;
+        res = KeypadValue { 1.0 / (double)argument };
         clear_operation();
         break;
     case Operation::Percent:
-        res = argument * 0.01;
+        res = argument * KeypadValue { 1, 2 }; // also known as `KeypadValue{0.01}`
         break;
     case Operation::ToggleSign:
         res = -argument;
         break;
 
     case Operation::MemClear:
-        m_mem = 0.0;
+        m_mem = 0;
         res = argument;
         break;
     case Operation::MemRecall:
@@ -67,7 +68,7 @@ double Calculator::begin_operation(Operation operation, double argument)
         res = argument;
         break;
     case Operation::MemAdd:
-        m_mem += argument;
+        m_mem = m_mem + argument; //avoids the need for operator+=()
         res = m_mem;
         break;
     }
@@ -75,9 +76,9 @@ double Calculator::begin_operation(Operation operation, double argument)
     return res;
 }
 
-double Calculator::finish_operation(double argument)
+KeypadValue Calculator::finish_operation(KeypadValue argument)
 {
-    double res = 0.0;
+    KeypadValue res = 0;
 
     switch (m_operation_in_progress) {
     case Operation::None:
@@ -93,11 +94,11 @@ double Calculator::finish_operation(double argument)
         res = m_saved_argument * argument;
         break;
     case Operation::Divide:
-        if (argument == 0.0) {
+        if (argument == 0) {
             m_has_error = true;
             return argument;
         }
-        res = m_saved_argument / argument;
+        res = KeypadValue { (double)m_saved_argument / (double)argument };
         break;
 
     case Operation::Sqrt:
@@ -118,6 +119,6 @@ double Calculator::finish_operation(double argument)
 void Calculator::clear_operation()
 {
     m_operation_in_progress = Operation::None;
-    m_saved_argument = 0.0;
+    m_saved_argument = 0;
     clear_error();
 }

--- a/Userland/Applications/Calculator/Calculator.h
+++ b/Userland/Applications/Calculator/Calculator.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "KeypadValue.h"
+
 // This type implements the regular calculator
 // behavior, such as performing arithmetic
 // operations and providing a memory cell.
@@ -36,8 +38,8 @@ public:
         MemAdd
     };
 
-    double begin_operation(Operation, double);
-    double finish_operation(double);
+    KeypadValue begin_operation(Operation, KeypadValue);
+    KeypadValue finish_operation(KeypadValue);
 
     bool has_error() const { return m_has_error; }
 
@@ -46,7 +48,7 @@ public:
 
 private:
     Operation m_operation_in_progress { Operation::None };
-    double m_saved_argument { 0.0 };
-    double m_mem { 0.0 };
+    KeypadValue m_saved_argument { (i64)0 };
+    KeypadValue m_mem { (i64)0 };
     bool m_has_error { false };
 };

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "CalculatorWidget.h"
+#include "KeypadValue.h"
 #include <Applications/Calculator/CalculatorGML.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
@@ -96,8 +97,8 @@ CalculatorWidget::CalculatorWidget()
 
     m_equals_button = *find_descendant_of_type_named<GUI::Button>("equal_button");
     m_equals_button->on_click = [this](auto) {
-        double argument = m_keypad.value();
-        double res = m_calculator.finish_operation(argument);
+        KeypadValue argument = m_keypad.value();
+        KeypadValue res = m_calculator.finish_operation(argument);
         m_keypad.set_value(res);
         update_display();
     };
@@ -110,8 +111,8 @@ CalculatorWidget::~CalculatorWidget()
 void CalculatorWidget::add_operation_button(GUI::Button& button, Calculator::Operation operation)
 {
     button.on_click = [this, operation](auto) {
-        double argument = m_keypad.value();
-        double res = m_calculator.begin_operation(operation, argument);
+        KeypadValue argument = m_keypad.value();
+        KeypadValue res = m_calculator.begin_operation(operation, argument);
         m_keypad.set_value(res);
         update_display();
     };
@@ -130,7 +131,7 @@ String CalculatorWidget::get_entry()
     return m_entry->text();
 }
 
-void CalculatorWidget::set_entry(double value)
+void CalculatorWidget::set_entry(KeypadValue value)
 {
     m_keypad.set_value(value);
     update_display();

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -9,6 +9,7 @@
 
 #include "Calculator.h"
 #include "Keypad.h"
+#include "KeypadValue.h"
 #include <AK/Vector.h>
 #include <LibGUI/Widget.h>
 
@@ -17,7 +18,7 @@ class CalculatorWidget final : public GUI::Widget {
 public:
     virtual ~CalculatorWidget() override;
     String get_entry();
-    void set_entry(double);
+    void set_entry(KeypadValue);
 
 private:
     CalculatorWidget();

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -6,6 +6,8 @@
  */
 
 #include "Keypad.h"
+#include "KeypadValue.h"
+#include <AK/Math.h>
 #include <AK/StringBuilder.h>
 
 Keypad::Keypad()
@@ -97,51 +99,29 @@ void Keypad::type_backspace()
     }
 }
 
-double Keypad::value() const
+KeypadValue Keypad::value() const
 {
-    double res = 0.0;
-
-    u64 frac = m_frac_value.value();
-    for (int i = 0; i < m_frac_length; i++) {
-        u8 digit = frac % 10;
-        res += digit;
-        res /= 10.0;
-        frac /= 10;
-    }
-
-    res += m_int_value.value();
+    KeypadValue frac_part = { (i64)m_frac_value.value(), m_frac_length };
+    KeypadValue int_part = { (i64)m_int_value.value() };
+    KeypadValue res = int_part + frac_part;
     if (m_negative)
         res = -res;
-
     return res;
 }
 
-void Keypad::set_value(double value)
+void Keypad::set_value(KeypadValue value)
 {
     m_state = State::External;
 
-    if (value < 0.0) {
+    if (value.m_value < 0) {
         m_negative = true;
         value = -value;
     } else
         m_negative = false;
 
-    m_int_value = value;
-    value -= m_int_value.value();
-
-    m_frac_value = 0;
-    m_frac_length = 0;
-    while (value != 0) {
-        value *= 10.0;
-        int digit = value;
-        m_frac_value *= 10;
-        m_frac_value += digit;
-        m_frac_length++;
-        value -= digit;
-
-        if (m_frac_length > 6)
-            break;
-    }
+    m_int_value = value.m_value / (u64)AK::pow(10.0, (double)value.m_decimal_places);
+    m_frac_value = value.m_value % (u64)AK::pow(10.0, (double)value.m_decimal_places);
+    m_frac_length = value.m_decimal_places;
 }
 
 String Keypad::to_string() const

--- a/Userland/Applications/Calculator/Keypad.h
+++ b/Userland/Applications/Calculator/Keypad.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "KeypadValue.h"
 #include <AK/String.h>
 
 // This type implements number typing and
@@ -22,8 +23,8 @@ public:
     void type_decimal_point();
     void type_backspace();
 
-    double value() const;
-    void set_value(double);
+    KeypadValue value() const;
+    void set_value(KeypadValue);
 
     String to_string() const;
 

--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "KeypadValue.h"
+#include <AK/Math.h>
+#include <AK/String.h>
+
+KeypadValue::KeypadValue(i64 value, u8 decimal_places)
+    : m_value(value)
+    , m_decimal_places(decimal_places)
+{
+}
+
+KeypadValue::KeypadValue(i64 value)
+    : m_value(value)
+{
+}
+
+KeypadValue KeypadValue::operator+(KeypadValue const& rhs)
+{
+    return operator_helper<KeypadValue>(*this, rhs, [](KeypadValue const&, KeypadValue const& more_decimal_places, i64 less_decimal_places_equalized, i64 more_decimal_places_equalized, bool) -> KeypadValue {
+        return {
+            more_decimal_places_equalized + less_decimal_places_equalized,
+            more_decimal_places.m_decimal_places
+        };
+    });
+}
+
+KeypadValue KeypadValue::operator-(KeypadValue const& rhs)
+{
+    return *this + (-rhs);
+}
+
+KeypadValue KeypadValue::operator*(KeypadValue const& rhs)
+{
+    return operator_helper<KeypadValue>(*this, rhs, [](KeypadValue const& less_decimal_places, KeypadValue const& more_decimal_places, i64, i64, bool) -> KeypadValue {
+        return {
+            less_decimal_places.m_value * more_decimal_places.m_value,
+            (u8)(less_decimal_places.m_decimal_places + more_decimal_places.m_decimal_places)
+        };
+    });
+}
+
+KeypadValue KeypadValue::operator-(void) const
+{
+    return { -m_value, m_decimal_places };
+}
+
+bool KeypadValue::operator<(KeypadValue const& rhs)
+{
+    return operator_helper<bool>(*this, rhs, [](KeypadValue const&, KeypadValue const&, i64 less_decimal_places_equalized, i64 more_decimal_places_equalized, bool lhs_is_less) {
+        if (lhs_is_less)
+            return (less_decimal_places_equalized < more_decimal_places_equalized);
+        else
+            return (more_decimal_places_equalized < less_decimal_places_equalized);
+    });
+}
+
+bool KeypadValue::operator==(KeypadValue const& rhs)
+{
+    return operator_helper<bool>(*this, rhs, [](KeypadValue const&, KeypadValue const&, i64 less_decimal_places_equalized, i64 more_decimal_places_equalized, bool) {
+        return less_decimal_places_equalized == more_decimal_places_equalized;
+    });
+}
+
+// This is a helper function for the operators. A lot of them need to do very similar calculations, so this function
+// does the calculations for them and calls them on the result. In case they don't need the result of a particular
+// calculation, they simply ignore that argument.
+// The arguments to this function are the operands on the left- and right-hand sides and the callback to call on the
+// values computed by this function.
+// The first two KeypadValues it passes to the callback are the two original operands, but sorted by the amount of
+// decimal places.
+// The next two i64s it passes to the callback are these sorted KeypadValues, but normalized, which means that if
+// you have for example 12.1 (represented as {121, 1}) and 54.23 (represented as {5423, 2}), you will get 1210 and
+// 5423, so that you can compare these two i64s directly in order to compare the original KeypadValues.
+// Unfortunately, not all operators are symmetric, so the last boolean tells the callback whether the left-hand side
+// was the KeypadValue with less decimal places (true), or the one with more decimal places (false).
+template<typename T, typename F>
+ALWAYS_INLINE T KeypadValue::operator_helper(KeypadValue const& lhs, KeypadValue const& rhs, F callback)
+{
+    KeypadValue const& less_decimal_places = (lhs.m_decimal_places < rhs.m_decimal_places) ? lhs : rhs;
+    KeypadValue const& more_decimal_places = (lhs.m_decimal_places < rhs.m_decimal_places) ? rhs : lhs;
+
+    i64 more_decimal_places_equalized = more_decimal_places.m_value;
+    i64 less_decimal_places_equalized = (i64)AK::pow(10.0, (double)(more_decimal_places.m_decimal_places - less_decimal_places.m_decimal_places)) * less_decimal_places.m_value;
+
+    bool lhs_is_less = (lhs.m_decimal_places < rhs.m_decimal_places);
+
+    return callback(less_decimal_places, more_decimal_places,
+        less_decimal_places_equalized, more_decimal_places_equalized,
+        lhs_is_less);
+}
+
+KeypadValue::KeypadValue(double d)
+{
+    bool negative = false;
+    if (d < 0) {
+        negative = true;
+        d = -d;
+    }
+    i8 current_pow = 0;
+    while (AK::pow(10.0, (double)current_pow) <= d)
+        current_pow += 1;
+    current_pow -= 1;
+    while (d != 0) {
+        m_value *= 10;
+        m_value += (u64)(d / AK::pow(10.0, (double)current_pow)) % 10;
+        if (current_pow < 0)
+            m_decimal_places += 1;
+        current_pow -= 1;
+        if (m_decimal_places > 6)
+            break;
+    }
+    m_value = negative ? (-m_value) : m_value;
+}
+
+KeypadValue::operator double()
+{
+    double res = (double)m_value / AK::pow(10.0, (double)m_decimal_places);
+    return res;
+}

--- a/Userland/Applications/Calculator/KeypadValue.h
+++ b/Userland/Applications/Calculator/KeypadValue.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <AK/String.h>
+#include <AK/Types.h>
+
+class KeypadValue {
+    friend class Keypad;
+
+public:
+    KeypadValue(i64, u8);
+    KeypadValue(i64);
+
+    KeypadValue operator+(KeypadValue const&);
+    KeypadValue operator-(KeypadValue const&);
+    KeypadValue operator*(KeypadValue const&);
+    KeypadValue operator-(void) const;
+    bool operator<(KeypadValue const&);
+    bool operator>(KeypadValue const&);
+    bool operator==(KeypadValue const&);
+
+    explicit KeypadValue(double);
+    explicit operator double();
+
+private:
+    template<typename T, typename F>
+    T operator_helper(KeypadValue const& lhs, KeypadValue const& rhs, F callback);
+
+    // This class represents a pair of a value together with the amount of decimal places that value is offset by.
+    // For example, if we were to represent the value -123.55 in this format, m_value would be -12355 and
+    // m_decimal_places would be 2, because when you shift -12355 2 digits to the right, you get -123.55.
+    // This way, most operations don't have to be performed on doubles, but can be performed without loss of
+    // precision on this class.
+    i64 m_value { 0 };
+    u8 m_decimal_places { 0 };
+};


### PR DESCRIPTION
This PR adds a new class that abstracts away KeypadValue's internal representation (value + exponent) and does all of Calculator's arithmetic on this KeypadValue class instead of on double. double is only used for operations where implementing it in terms of KeypadValue wouldn't be obvious (such as square root).