### PR TITLE
Kernel: Remove OOM unsafe API KBuffer::create_with_size + public DoubleBuffer Constructor

### DIFF
--- a/Kernel/DoubleBuffer.cpp
+++ b/Kernel/DoubleBuffer.cpp
@@ -26,11 +26,6 @@ OwnPtr<DoubleBuffer> DoubleBuffer::try_create(size_t capacity)
     return adopt_own_if_nonnull(new (nothrow) DoubleBuffer(capacity, storage.release_nonnull()));
 }
 
-DoubleBuffer::DoubleBuffer(size_t capacity)
-    : DoubleBuffer(capacity, KBuffer::try_create_with_size(capacity * 2, Region::Access::Read | Region::Access::Write, "DoubleBuffer").release_nonnull())
-{
-}
-
 DoubleBuffer::DoubleBuffer(size_t capacity, NonnullOwnPtr<KBuffer> storage)
     : m_write_buffer(&m_buffer1)
     , m_read_buffer(&m_buffer2)

--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -16,8 +16,8 @@ namespace Kernel {
 
 class DoubleBuffer {
 public:
+    [[nodiscard]] static OwnPtr<DoubleBuffer> try_create(size_t capacity = 65536);
     explicit DoubleBuffer(size_t capacity = 65536);
-
     [[nodiscard]] KResultOr<size_t> write(const UserOrKernelBuffer&, size_t);
     [[nodiscard]] KResultOr<size_t> write(const u8* data, size_t size)
     {
@@ -47,6 +47,7 @@ public:
     }
 
 private:
+    explicit DoubleBuffer(size_t capacity, NonnullOwnPtr<KBuffer> storage);
     void flip();
     void compute_lockfree_metadata();
 
@@ -60,7 +61,7 @@ private:
     InnerBuffer m_buffer1;
     InnerBuffer m_buffer2;
 
-    KBuffer m_storage;
+    NonnullOwnPtr<KBuffer> m_storage;
     Function<void()> m_unblock_callback;
     size_t m_capacity { 0 };
     size_t m_read_buffer_index { 0 };

--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -17,7 +17,6 @@ namespace Kernel {
 class DoubleBuffer {
 public:
     [[nodiscard]] static OwnPtr<DoubleBuffer> try_create(size_t capacity = 65536);
-    explicit DoubleBuffer(size_t capacity = 65536);
     [[nodiscard]] KResultOr<size_t> write(const UserOrKernelBuffer&, size_t);
     [[nodiscard]] KResultOr<size_t> write(const u8* data, size_t size)
     {

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -15,6 +15,7 @@ public:
     TYPEDEF_DISTINCT_ORDERED_ID(u64, BlockIndex);
 
     virtual ~BlockBasedFileSystem() override;
+    virtual bool initialize() override;
 
     u64 logical_block_size() const { return m_logical_block_size; };
 

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -89,6 +89,7 @@ const ext2_group_desc& Ext2FS::group_descriptor(GroupIndex group_index) const
 bool Ext2FS::initialize()
 {
     MutexLocker locker(m_lock);
+
     VERIFY((sizeof(ext2_super_block) % logical_block_size()) == 0);
     auto super_block_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&m_super_block);
     bool success = raw_read_blocks(2, (sizeof(ext2_super_block) / logical_block_size()), super_block_buffer);
@@ -114,6 +115,11 @@ bool Ext2FS::initialize()
 
     set_block_size(EXT2_BLOCK_SIZE(&super_block));
     set_fragment_size(EXT2_FRAG_SIZE(&super_block));
+
+    // Note: This depends on the block size being available.
+    auto baseclass_result = BlockBasedFileSystem::initialize();
+    if (!baseclass_result)
+        return baseclass_result;
 
     VERIFY(block_size() <= (int)max_block_size);
 

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -168,15 +168,15 @@ private:
     bool m_block_group_descriptors_dirty { false };
 
     struct CachedBitmap {
-        CachedBitmap(BlockIndex bi, KBuffer&& buf)
+        CachedBitmap(BlockIndex bi, NonnullOwnPtr<KBuffer> buf)
             : bitmap_block_index(bi)
             , buffer(move(buf))
         {
         }
         BlockIndex bitmap_block_index { 0 };
         bool dirty { false };
-        KBuffer buffer;
-        BitmapView bitmap(u32 blocks_per_group) { return BitmapView { buffer.data(), blocks_per_group }; }
+        NonnullOwnPtr<KBuffer> buffer;
+        BitmapView bitmap(u32 blocks_per_group) { return BitmapView { buffer->data(), blocks_per_group }; }
     };
 
     KResultOr<CachedBitmap*> get_bitmap_block(BlockIndex);

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -24,7 +24,7 @@ public:
         Writer
     };
 
-    static NonnullRefPtr<FIFO> create(uid_t);
+    static RefPtr<FIFO> try_create(uid_t);
     virtual ~FIFO() override;
 
     uid_t uid() const { return m_uid; }
@@ -49,11 +49,11 @@ private:
     virtual StringView class_name() const override { return "FIFO"; }
     virtual bool is_fifo() const override { return true; }
 
-    explicit FIFO(uid_t);
+    explicit FIFO(uid_t, NonnullOwnPtr<DoubleBuffer> buffer);
 
     unsigned m_writers { 0 };
     unsigned m_readers { 0 };
-    DoubleBuffer m_buffer;
+    NonnullOwnPtr<DoubleBuffer> m_buffer;
 
     uid_t m_uid { 0 };
 

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -185,8 +185,11 @@ NonnullRefPtr<FIFO> Inode::fifo()
     VERIFY(metadata().is_fifo());
 
     // FIXME: Release m_fifo when it is closed by all readers and writers
-    if (!m_fifo)
-        m_fifo = FIFO::create(metadata().uid);
+    if (!m_fifo) {
+        m_fifo = FIFO::try_create(metadata().uid);
+        // FIXME: We need to be able to observe OOM here.
+        VERIFY(!m_fifo.is_null());
+    }
 
     VERIFY(m_fifo);
     return *m_fifo;

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -120,11 +120,6 @@ public:
         return adopt_own_if_nonnull(new (nothrow) KBuffer(impl.release_nonnull()));
     }
 
-    [[nodiscard]] static KBuffer create_with_size(size_t size, Region::Access access = Region::Access::Read | Region::Access::Write, StringView name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
-    {
-        return KBuffer(KBufferImpl::create_with_size(size, access, name, strategy));
-    }
-
     [[nodiscard]] static KBuffer copy(const void* data, size_t size, Region::Access access = Region::Access::Read | Region::Access::Write, StringView name = "KBuffer")
     {
         return KBuffer(KBufferImpl::copy(data, size, access, name));

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -241,11 +241,11 @@ KResultOr<size_t> IPv4Socket::sendto(FileDescription&, const UserOrKernelBuffer&
             return ENOMEM;
         routing_decision.adapter->fill_in_ipv4_header(*packet, local_address(), routing_decision.next_hop,
             m_peer_address, (IPv4Protocol)protocol(), data_length, m_ttl);
-        if (!data.read(packet->buffer.data() + ipv4_payload_offset, data_length)) {
+        if (!data.read(packet->buffer->data() + ipv4_payload_offset, data_length)) {
             routing_decision.adapter->release_packet_buffer(*packet);
             return EFAULT;
         }
-        routing_decision.adapter->send_packet({ packet->buffer.data(), packet->buffer.size() });
+        routing_decision.adapter->send_packet(packet->bytes());
         routing_decision.adapter->release_packet_buffer(*packet);
         return data_length;
     }

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -74,7 +74,7 @@ public:
     BufferMode buffer_mode() const { return m_buffer_mode; }
 
 protected:
-    IPv4Socket(int type, int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
+    IPv4Socket(int type, int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer, OwnPtr<KBuffer> optional_scratch_buffer);
     virtual StringView class_name() const override { return "IPv4Socket"; }
 
     PortAllocationResult allocate_local_port_if_needed();
@@ -130,7 +130,7 @@ private:
 
     BufferMode m_buffer_mode { BufferMode::Packets };
 
-    Optional<KBuffer> m_scratch_buffer;
+    OwnPtr<KBuffer> m_scratch_buffer;
 };
 
 }

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -74,7 +74,7 @@ public:
     BufferMode buffer_mode() const { return m_buffer_mode; }
 
 protected:
-    IPv4Socket(int type, int protocol);
+    IPv4Socket(int type, int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
     virtual StringView class_name() const override { return "IPv4Socket"; }
 
     PortAllocationResult allocate_local_port_if_needed();
@@ -91,6 +91,8 @@ protected:
 
     void set_local_address(IPv4Address address) { m_local_address = address; }
     void set_peer_address(IPv4Address address) { m_peer_address = address; }
+
+    static OwnPtr<DoubleBuffer> create_receive_buffer();
 
 private:
     virtual bool is_ipv4() const override { return true; }
@@ -115,7 +117,7 @@ private:
 
     SinglyLinkedListWithCount<ReceivedPacket> m_receive_queue;
 
-    DoubleBuffer m_receive_buffer { 256 * KiB };
+    NonnullOwnPtr<DoubleBuffer> m_receive_buffer;
 
     u16 m_local_port { 0 };
     u16 m_peer_port { 0 };

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -51,7 +51,7 @@ public:
     virtual KResult chmod(FileDescription&, mode_t) override;
 
 private:
-    explicit LocalSocket(int type);
+    explicit LocalSocket(int type, NonnullOwnPtr<DoubleBuffer> client_buffer, NonnullOwnPtr<DoubleBuffer> server_buffer);
     virtual StringView class_name() const override { return "LocalSocket"; }
     virtual bool is_local() const override { return true; }
     bool has_attached_peer(const FileDescription&) const;
@@ -93,8 +93,8 @@ private:
     bool m_accept_side_fd_open { false };
     sockaddr_un m_address { 0, { 0 } };
 
-    DoubleBuffer m_for_client;
-    DoubleBuffer m_for_server;
+    NonnullOwnPtr<DoubleBuffer> m_for_client;
+    NonnullOwnPtr<DoubleBuffer> m_for_server;
 
     NonnullRefPtrVector<FileDescription> m_fds_for_client;
     NonnullRefPtrVector<FileDescription> m_fds_for_server;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -28,13 +28,15 @@ class NetworkAdapter;
 using NetworkByteBuffer = AK::Detail::ByteBuffer<1500>;
 
 struct PacketWithTimestamp : public RefCounted<PacketWithTimestamp> {
-    PacketWithTimestamp(KBuffer buffer, Time timestamp)
+    PacketWithTimestamp(NonnullOwnPtr<KBuffer> buffer, Time timestamp)
         : buffer(move(buffer))
         , timestamp(timestamp)
     {
     }
 
-    KBuffer buffer;
+    ReadonlyBytes bytes() { return { buffer->data(), buffer->size() }; };
+
+    NonnullOwnPtr<KBuffer> buffer;
     Time timestamp;
     IntrusiveListNode<PacketWithTimestamp, RefPtr<PacketWithTimestamp>> packet_node;
 };

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -254,8 +254,8 @@ void handle_icmp(EthernetFrameHeader const& eth, IPv4Packet const& ipv4_packet, 
             return;
         }
         adapter->fill_in_ipv4_header(*packet, adapter->ipv4_address(), eth.source(), ipv4_packet.source(), IPv4Protocol::ICMP, icmp_packet_size, 64);
-        memset(packet->buffer.data() + ipv4_payload_offset, 0, sizeof(ICMPEchoPacket));
-        auto& response = *(ICMPEchoPacket*)(packet->buffer.data() + ipv4_payload_offset);
+        memset(packet->buffer->data() + ipv4_payload_offset, 0, sizeof(ICMPEchoPacket));
+        auto& response = *(ICMPEchoPacket*)(packet->buffer->data() + ipv4_payload_offset);
         response.header.set_type(ICMPType::EchoReply);
         response.header.set_code(0);
         response.identifier = request.identifier;
@@ -264,7 +264,7 @@ void handle_icmp(EthernetFrameHeader const& eth, IPv4Packet const& ipv4_packet, 
             memcpy(response.payload(), request.payload(), icmp_payload_size);
         response.header.set_checksum(internet_checksum(&response, icmp_packet_size));
         // FIXME: What is the right TTL value here? Is 64 ok? Should we use the same TTL as the echo request?
-        adapter->send_packet({ packet->buffer.data(), packet->buffer.size() });
+        adapter->send_packet(packet->bytes());
         adapter->release_packet_buffer(*packet);
     }
 }
@@ -359,7 +359,7 @@ void send_tcp_rst(IPv4Packet const& ipv4_packet, TCPPacket const& tcp_packet, Re
     rst_packet.set_flags(TCPFlags::RST | TCPFlags::ACK);
     rst_packet.set_checksum(TCPSocket::compute_tcp_checksum(ipv4_packet.source(), ipv4_packet.destination(), rst_packet, 0));
 
-    routing_decision.adapter->send_packet({ packet->buffer.data(), packet->buffer.size() });
+    routing_decision.adapter->send_packet(packet->bytes());
     routing_decision.adapter->release_packet_buffer(*packet);
 }
 

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -347,8 +347,9 @@ void send_tcp_rst(IPv4Packet const& ipv4_packet, TCPPacket const& tcp_packet, Re
     routing_decision.adapter->fill_in_ipv4_header(*packet, ipv4_packet.destination(),
         routing_decision.next_hop, ipv4_packet.source(), IPv4Protocol::TCP,
         buffer_size - ipv4_payload_offset, 64);
-    memset(packet->buffer.data() + ipv4_payload_offset, 0, sizeof(TCPPacket));
-    auto& rst_packet = *(TCPPacket*)(packet->buffer.data() + ipv4_payload_offset);
+
+    auto& rst_packet = *(TCPPacket*)(packet->buffer->data() + ipv4_payload_offset);
+    rst_packet = {};
     rst_packet.set_source_port(tcp_packet.destination_port());
     rst_packet.set_destination_port(tcp_packet.source_port());
     rst_packet.set_window_size(0);

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -165,7 +165,7 @@ protected:
     void set_direction(Direction direction) { m_direction = direction; }
 
 private:
-    explicit TCPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
+    explicit TCPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer, OwnPtr<KBuffer> scratch_buffer);
     virtual StringView class_name() const override { return "TCPSocket"; }
 
     virtual void shut_down_for_writing() override;

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -18,7 +18,7 @@ namespace Kernel {
 class TCPSocket final : public IPv4Socket {
 public:
     static void for_each(Function<void(const TCPSocket&)>);
-    static KResultOr<NonnullRefPtr<TCPSocket>> create(int protocol);
+    static KResultOr<NonnullRefPtr<TCPSocket>> create(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
     virtual ~TCPSocket() override;
 
     enum class Direction {
@@ -165,7 +165,7 @@ protected:
     void set_direction(Direction direction) { m_direction = direction; }
 
 private:
-    explicit TCPSocket(int protocol);
+    explicit TCPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
     virtual StringView class_name() const override { return "TCPSocket"; }
 
     virtual void shut_down_for_writing() override;

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -43,8 +43,8 @@ SocketHandle<UDPSocket> UDPSocket::from_port(u16 port)
     return { *socket };
 }
 
-UDPSocket::UDPSocket(int protocol)
-    : IPv4Socket(SOCK_DGRAM, protocol)
+UDPSocket::UDPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer)
+    : IPv4Socket(SOCK_DGRAM, protocol, move(receive_buffer))
 {
 }
 
@@ -54,9 +54,9 @@ UDPSocket::~UDPSocket()
     sockets_by_port().resource().remove(local_port());
 }
 
-KResultOr<NonnullRefPtr<UDPSocket>> UDPSocket::create(int protocol)
+KResultOr<NonnullRefPtr<UDPSocket>> UDPSocket::create(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer)
 {
-    auto socket = adopt_ref_if_nonnull(new (nothrow) UDPSocket(protocol));
+    auto socket = adopt_ref_if_nonnull(new (nothrow) UDPSocket(protocol, move(receive_buffer)));
     if (socket)
         return socket.release_nonnull();
     return ENOMEM;

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -44,7 +44,7 @@ SocketHandle<UDPSocket> UDPSocket::from_port(u16 port)
 }
 
 UDPSocket::UDPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer)
-    : IPv4Socket(SOCK_DGRAM, protocol, move(receive_buffer))
+    : IPv4Socket(SOCK_DGRAM, protocol, move(receive_buffer), {})
 {
 }
 

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -84,8 +84,8 @@ KResultOr<size_t> UDPSocket::protocol_send(const UserOrKernelBuffer& data, size_
     auto packet = routing_decision.adapter->acquire_packet_buffer(ipv4_payload_offset + udp_buffer_size);
     if (!packet)
         return ENOMEM;
-    memset(packet->buffer.data() + ipv4_payload_offset, 0, sizeof(UDPPacket));
-    auto& udp_packet = *reinterpret_cast<UDPPacket*>(packet->buffer.data() + ipv4_payload_offset);
+    memset(packet->buffer->data() + ipv4_payload_offset, 0, sizeof(UDPPacket));
+    auto& udp_packet = *reinterpret_cast<UDPPacket*>(packet->buffer->data() + ipv4_payload_offset);
     udp_packet.set_source_port(local_port());
     udp_packet.set_destination_port(peer_port());
     udp_packet.set_length(udp_buffer_size);
@@ -94,7 +94,7 @@ KResultOr<size_t> UDPSocket::protocol_send(const UserOrKernelBuffer& data, size_
 
     routing_decision.adapter->fill_in_ipv4_header(*packet, local_address(), routing_decision.next_hop,
         peer_address(), IPv4Protocol::UDP, udp_buffer_size, ttl());
-    routing_decision.adapter->send_packet({ packet->buffer.data(), packet->buffer.size() });
+    routing_decision.adapter->send_packet(packet->bytes());
     return data_length;
 }
 

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -13,14 +13,14 @@ namespace Kernel {
 
 class UDPSocket final : public IPv4Socket {
 public:
-    static KResultOr<NonnullRefPtr<UDPSocket>> create(int protocol);
+    static KResultOr<NonnullRefPtr<UDPSocket>> create(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
     virtual ~UDPSocket() override;
 
     static SocketHandle<UDPSocket> from_port(u16);
     static void for_each(Function<void(const UDPSocket&)>);
 
 private:
-    explicit UDPSocket(int protocol);
+    explicit UDPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
     virtual StringView class_name() const override { return "UDPSocket"; }
     static Lockable<HashMap<u16, UDPSocket*>>& sockets_by_port();
 

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -35,10 +35,12 @@ KResultOr<FlatPtr> Process::sys$module_load(Userspace<const char*> user_path, si
         return payload_or_error.error();
 
     auto& payload = *payload_or_error.value();
-    auto storage = KBuffer::create_with_size(payload.size());
-    memcpy(storage.data(), payload.data(), payload.size());
+    auto storage = KBuffer::try_create_with_size(payload.size());
+    if (!storage)
+        return ENOMEM;
+    memcpy(storage->data(), payload.data(), payload.size());
 
-    auto elf_image = try_make<ELF::Image>(storage.data(), storage.size());
+    auto elf_image = try_make<ELF::Image>(storage->data(), storage->size());
     if (!elf_image)
         return ENOMEM;
     if (!elf_image->parse())

--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -20,7 +20,9 @@ KResultOr<FlatPtr> Process::sys$pipe(int pipefd[2], int flags)
         return EINVAL;
 
     u32 fd_flags = (flags & O_CLOEXEC) ? FD_CLOEXEC : 0;
-    auto fifo = FIFO::create(uid());
+    auto fifo = FIFO::try_create(uid());
+    if (!fifo)
+        return ENOMEM;
 
     auto open_reader_result = fifo->open_direction(FIFO::Direction::Reader);
     if (open_reader_result.is_error())

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -16,7 +16,7 @@ class SlavePTY;
 
 class MasterPTY final : public CharacterDevice {
 public:
-    explicit MasterPTY(unsigned index);
+    [[nodiscard]] static RefPtr<MasterPTY> try_create(unsigned index);
     virtual ~MasterPTY() override;
 
     unsigned index() const { return m_index; }
@@ -33,6 +33,7 @@ public:
     virtual String device_name() const override;
 
 private:
+    explicit MasterPTY(unsigned index, NonnullOwnPtr<DoubleBuffer> buffer);
     // ^CharacterDevice
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
@@ -46,7 +47,7 @@ private:
     RefPtr<SlavePTY> m_slave;
     unsigned m_index;
     bool m_closed { false };
-    DoubleBuffer m_buffer;
+    NonnullOwnPtr<DoubleBuffer> m_buffer;
     String m_pts_name;
 };
 

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -40,7 +40,7 @@ KResultOr<NonnullRefPtr<FileDescription>> PTYMultiplexer::open(int options)
     if (m_freelist.is_empty())
         return EBUSY;
     auto master_index = m_freelist.take_last();
-    auto master = try_create<MasterPTY>(master_index);
+    auto master = MasterPTY::try_create(master_index);
     if (!master)
         return ENOMEM;
     dbgln_if(PTMX_DEBUG, "PTYMultiplexer::open: Vending master {}", master->index());


### PR DESCRIPTION
More progress on OOM Hardening the Kernel. 

Related: #6369 