### PR TITLE
LibCpp: Bunch of parser improvements

### DIFF
--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -113,6 +113,27 @@ String Reference::to_string() const
     return builder.to_string();
 }
 
+String FunctionType::to_string() const
+{
+    StringBuilder builder;
+    builder.append(m_return_type->to_string());
+    builder.append("(");
+    bool first = true;
+    for (auto& parameter : m_parameters) {
+        if (first)
+            first = false;
+        else
+            builder.append(", ");
+        builder.append(parameter.type()->to_string());
+        if (!parameter.name().is_empty()) {
+            builder.append(" ");
+            builder.append(parameter.name());
+        }
+    }
+    builder.append(")");
+    return builder.to_string();
+}
+
 void Parameter::dump(FILE* output, size_t indent) const
 {
     ASTNode::dump(output, indent);
@@ -380,6 +401,19 @@ void Reference::dump(FILE* output, size_t indent) const
     if (!m_referenced_type.is_null()) {
         m_referenced_type->dump(output, indent + 1);
     }
+}
+
+void FunctionType::dump(FILE* output, size_t indent) const
+{
+    ASTNode::dump(output, indent);
+    if (m_return_type)
+        m_return_type->dump(output, indent + 1);
+    print_indent(output, indent + 1);
+    outln("(");
+    for (auto& parameter : m_parameters)
+        parameter.dump(output, indent + 2);
+    print_indent(output, indent + 1);
+    outln(")");
 }
 
 void MemberExpression::dump(FILE* output, size_t indent) const

--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -287,7 +287,9 @@ void EnumDeclaration::dump(FILE* output, size_t indent) const
     outln(output, "{}", m_name);
     for (auto& entry : m_entries) {
         print_indent(output, indent + 1);
-        outln(output, "{}", entry);
+        outln(output, "{}", entry.name);
+        if (entry.value)
+            entry.value->dump(output, indent + 2);
     }
 }
 

--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -100,6 +100,19 @@ String Pointer::to_string() const
     return builder.to_string();
 }
 
+String Reference::to_string() const
+{
+    if (!m_referenced_type)
+        return {};
+    StringBuilder builder;
+    builder.append(m_referenced_type->to_string());
+    if (m_kind == Kind::Lvalue)
+        builder.append("&");
+    else
+        builder.append("&&");
+    return builder.to_string();
+}
+
 void Parameter::dump(FILE* output, size_t indent) const
 {
     ASTNode::dump(output, indent);
@@ -356,6 +369,16 @@ void Pointer::dump(FILE* output, size_t indent) const
     ASTNode::dump(output, indent);
     if (!m_pointee.is_null()) {
         m_pointee->dump(output, indent + 1);
+    }
+}
+
+void Reference::dump(FILE* output, size_t indent) const
+{
+    ASTNode::dump(output, indent);
+    print_indent(output, indent + 1);
+    outln(output, "{}", m_kind == Kind::Lvalue ? "&" : "&&");
+    if (!m_referenced_type.is_null()) {
+        m_referenced_type->dump(output, indent + 1);
     }
 }
 

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -616,11 +616,15 @@ public:
     };
 
     void set_type(Type type) { m_type = type; }
-    void add_entry(StringView entry) { m_entries.append(move(entry)); }
+    void add_entry(StringView entry, RefPtr<Expression> value = nullptr) { m_entries.append({ entry, move(value) }); }
 
 private:
     Type m_type { Type::RegularEnum };
-    Vector<StringView> m_entries;
+    struct EnumerationEntry {
+        StringView name;
+        RefPtr<Expression> value;
+    };
+    Vector<EnumerationEntry> m_entries;
 };
 
 class StructOrClassDeclaration : public Declaration {

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -281,6 +281,33 @@ private:
     RefPtr<Type> m_pointee;
 };
 
+class Reference : public Type {
+public:
+    virtual ~Reference() override = default;
+    virtual const char* class_name() const override { return "Reference"; }
+    virtual void dump(FILE* = stdout, size_t indent = 0) const override;
+    virtual String to_string() const override;
+
+    enum class Kind {
+        Lvalue,
+        Rvalue,
+    };
+
+    Reference(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename, Kind kind)
+        : Type(parent, start, end, filename)
+        , m_kind(kind)
+    {
+    }
+
+    const Type* referenced_type() const { return m_referenced_type.ptr(); }
+    void set_referenced_type(RefPtr<Type>&& pointee) { m_referenced_type = move(pointee); }
+    Kind kind() const { return m_kind; }
+
+private:
+    RefPtr<Type const> m_referenced_type;
+    Kind m_kind;
+};
+
 class FunctionDefinition : public ASTNode {
 public:
     virtual ~FunctionDefinition() override = default;

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -308,6 +308,26 @@ private:
     Kind m_kind;
 };
 
+class FunctionType : public Type {
+public:
+    virtual ~FunctionType() override = default;
+    virtual const char* class_name() const override { return "FunctionType"; }
+    virtual void dump(FILE* = stdout, size_t indent = 0) const override;
+    virtual String to_string() const override;
+
+    FunctionType(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
+        : Type(parent, start, end, filename)
+    {
+    }
+
+    void set_return_type(Type& type) { m_return_type = type; }
+    void set_parameters(NonnullRefPtrVector<Parameter> parameters) { m_parameters = move(parameters); }
+
+private:
+    RefPtr<Type> m_return_type;
+    NonnullRefPtrVector<Parameter> m_parameters;
+};
+
 class FunctionDefinition : public ASTNode {
 public:
     virtual ~FunctionDefinition() override = default;

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -556,8 +556,16 @@ Vector<Token> Lexer::lex()
                     begin_token();
                 }
             } else {
-                while (peek() && peek() != '\n')
-                    consume();
+                while (peek()) {
+                    if (peek() == '\\' && peek(1) == '\n') {
+                        consume();
+                        consume();
+                    } else if (peek() == '\n') {
+                        break;
+                    } else {
+                        consume();
+                    }
+                }
 
                 commit_token(Token::Type::PreprocessorStatement);
             }

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1261,7 +1261,7 @@ Vector<StringView> Parser::parse_type_qualifiers()
         if (token.type() != Token::Type::Keyword)
             break;
         auto text = text_of_token(token);
-        if (text == "static" || text == "const") {
+        if (text == "static" || text == "const" || text == "extern") {
             qualifiers.append(text);
             consume();
         } else {
@@ -1280,7 +1280,7 @@ Vector<StringView> Parser::parse_function_qualifiers()
         if (token.type() != Token::Type::Keyword)
             break;
         auto text = text_of_token(token);
-        if (text == "static" || text == "inline") {
+        if (text == "static" || text == "inline" || text == "extern") {
             qualifiers.append(text);
             consume();
         } else {

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1255,7 +1255,19 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
         type = ref;
     }
 
+    if (peek().type() == Token::Type::LeftParen) {
+        consume();
+        auto fn_type = create_ast_node<FunctionType>(parent, type->start(), position());
+        fn_type->set_return_type(*type);
+        type->set_parent(*fn_type);
+        if (auto parameters = parse_parameter_list(*type); parameters.has_value())
+            fn_type->set_parameters(parameters.release_value());
+        consume(Token::Type::RightParen);
+        type = fn_type;
+    }
+
     type->set_end(position());
+
     return type;
 }
 

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1219,6 +1219,9 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
     if (match_keyword("auto")) {
         consume(Token::Type::Keyword);
         named_type->set_auto(true);
+        auto original_qualifiers = named_type->qualifiers();
+        original_qualifiers.extend(parse_type_qualifiers());
+        named_type->set_qualifiers(move(original_qualifiers));
         named_type->set_end(position());
         return named_type;
     }
@@ -1234,6 +1237,10 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
     }
     named_type->set_name(parse_name(*named_type));
 
+    auto original_qualifiers = named_type->qualifiers();
+    original_qualifiers.extend(parse_type_qualifiers());
+    named_type->set_qualifiers(move(original_qualifiers));
+
     NonnullRefPtr<Type> type = named_type;
     while (!eof() && peek().type() == Token::Type::Asterisk) {
         type->set_end(position());
@@ -1241,6 +1248,7 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
         auto ptr = create_ast_node<Pointer>(parent, type->start(), asterisk.end());
         type->set_parent(*ptr);
         ptr->set_pointee(type);
+        ptr->set_qualifiers(parse_type_qualifiers());
         ptr->set_end(position());
         type = ptr;
     }

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1237,6 +1237,16 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
         type = ptr;
     }
 
+    if (!eof() && (peek().type() == Token::Type::And || peek().type() == Token::Type::AndAnd)) {
+        type->set_end(position());
+        auto ref_token = consume();
+        auto ref = create_ast_node<Reference>(parent, type->start(), ref_token.end(), ref_token.type() == Token::Type::And ? Reference::Kind::Lvalue : Reference::Kind::Rvalue);
+        type->set_parent(*ref);
+        ref->set_referenced_type(type);
+        ref->set_end(position());
+        type = ref;
+    }
+
     type->set_end(position());
     return type;
 }

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -700,7 +700,12 @@ bool Parser::match_class_declaration()
 
     consume(Token::Type::Identifier);
 
-    if (peek().type() == Token::Type::Colon) {
+    auto has_final = match_keyword("final");
+
+    if (peek(has_final ? 1 : 0).type() == Token::Type::Colon) {
+        if (has_final)
+            consume();
+
         do {
             consume();
 
@@ -1158,8 +1163,13 @@ NonnullRefPtr<StructOrClassDeclaration> Parser::parse_class_declaration(ASTNode&
     auto name_token = consume(Token::Type::Identifier);
     decl->set_name(text_of_token(name_token));
 
+    auto has_final = match_keyword("final");
+
     // FIXME: Don't ignore this.
-    if (peek().type() == Token::Type::Colon) {
+    if (peek(has_final ? 1 : 0).type() == Token::Type::Colon) {
+        if (has_final)
+            consume();
+
         do {
             consume();
 

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -132,7 +132,7 @@ NonnullRefPtr<FunctionDeclaration> Parser::parse_function_declaration(ASTNode& p
 
     consume(Token::Type::RightParen);
 
-    if (match_keyword("const")) {
+    while (match_keyword("const") || match_keyword("override")) {
         consume();
         // FIXME: Note that this function is supposed to be a class member, and `this` has to be const, somehow.
     }
@@ -744,7 +744,7 @@ bool Parser::match_function_declaration()
 
     while (consume().type() != Token::Type::RightParen && !eof()) { };
 
-    if (match_keyword("const"))
+    while (match_keyword("const") || match_keyword("override"))
         consume();
 
     if (peek(Token::Type::Semicolon).has_value() || peek(Token::Type::LeftCurly).has_value())

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1076,7 +1076,13 @@ NonnullRefPtr<EnumDeclaration> Parser::parse_enum_declaration(ASTNode& parent)
     enum_decl->set_name(text_of_token(name_token));
     consume(Token::Type::LeftCurly);
     while (!eof() && peek().type() != Token::Type::RightCurly) {
-        enum_decl->add_entry(text_of_token(consume(Token::Type::Identifier)));
+        auto name = text_of_token(consume(Token::Type::Identifier));
+        RefPtr<Expression> value;
+        if (peek().type() == Token::Type::Equals) {
+            consume();
+            value = parse_expression(enum_decl);
+        }
+        enum_decl->add_entry(name, move(value));
         if (peek().type() != Token::Type::Comma) {
             break;
         }

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -695,6 +695,19 @@ bool Parser::match_class_declaration()
 
     consume(Token::Type::Identifier);
 
+    if (peek().type() == Token::Type::Colon) {
+        do {
+            consume();
+
+            while (match_keyword("private") || match_keyword("public") || match_keyword("protected") || match_keyword("virtual"))
+                consume();
+
+            if (!match_name())
+                return false;
+            parse_name(get_dummy_node());
+        } while (peek().type() == Token::Type::Comma);
+    }
+
     return match(Token::Type::LeftCurly);
 }
 
@@ -1136,6 +1149,18 @@ NonnullRefPtr<StructOrClassDeclaration> Parser::parse_class_declaration(ASTNode&
 
     auto name_token = consume(Token::Type::Identifier);
     decl->set_name(text_of_token(name_token));
+
+    // FIXME: Don't ignore this.
+    if (peek().type() == Token::Type::Colon) {
+        do {
+            consume();
+
+            while (match_keyword("private") || match_keyword("public") || match_keyword("protected") || match_keyword("virtual"))
+                consume();
+
+            parse_name(get_dummy_node());
+        } while (peek().type() == Token::Type::Comma);
+    }
 
     consume(Token::Type::LeftCurly);
 

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -301,10 +301,10 @@ bool Parser::match_variable_declaration()
     parse_type(get_dummy_node());
 
     // Identifier
-    if (!peek(Token::Type::Identifier).has_value()) {
+    if (!match_name())
         return false;
-    }
-    consume();
+
+    parse_name(get_dummy_node());
 
     if (match(Token::Type::Equals)) {
         consume(Token::Type::Equals);

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -132,6 +132,11 @@ NonnullRefPtr<FunctionDeclaration> Parser::parse_function_declaration(ASTNode& p
 
     consume(Token::Type::RightParen);
 
+    if (match_keyword("const")) {
+        consume();
+        // FIXME: Note that this function is supposed to be a class member, and `this` has to be const, somehow.
+    }
+
     RefPtr<FunctionDefinition> body;
     Position func_end {};
     if (peek(Token::Type::LeftCurly).has_value()) {
@@ -738,6 +743,9 @@ bool Parser::match_function_declaration()
     consume();
 
     while (consume().type() != Token::Type::RightParen && !eof()) { };
+
+    if (match_keyword("const"))
+        consume();
 
     if (peek(Token::Type::Semicolon).has_value() || peek(Token::Type::LeftCurly).has_value())
         return true;

--- a/Userland/Utilities/cpp-parser.cpp
+++ b/Userland/Utilities/cpp-parser.cpp
@@ -13,7 +13,9 @@ int main(int argc, char** argv)
     Core::ArgsParser args_parser;
     const char* path = nullptr;
     bool tokens_mode = false;
+    bool preprocess_mode = false;
     args_parser.add_option(tokens_mode, "Print Tokens", "tokens", 'T');
+    args_parser.add_option(preprocess_mode, "Print Preprocessed source", "preprocessed", 'P');
     args_parser.add_positional_argument(path, "Cpp File", "cpp-file", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
@@ -26,7 +28,15 @@ int main(int argc, char** argv)
     }
     auto content = file->read_all();
     StringView content_view(content);
-    ::Cpp::Parser parser(content_view, path);
+
+    ::Cpp::Preprocessor processor(path, content_view);
+    auto preprocessed_content = processor.process();
+    if (preprocess_mode) {
+        outln(preprocessed_content);
+        return 0;
+    }
+
+    ::Cpp::Parser parser(preprocessed_content, path);
     if (tokens_mode) {
         parser.print_tokens();
         return 0;


### PR DESCRIPTION
Most of these basically ignore things, as we don't really have the means to represent them (e.g. `virtual`, or `const`-ness of a member function, or inherited classes, etc), so I didn't include any tests.
cc @itamar8910, if you want, I could add tests for the things that actually have an AST representation (e.g. reference types, east const, function types)