### PR TITLE
LibWeb: Fix missing SVG context when painting layout tree

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -69,6 +69,9 @@ public:
     bool is_parent_node() const { return is_element() || is_document() || is_document_fragment(); }
     bool is_slottable() const { return is_element() || is_text(); }
 
+    virtual bool requires_svg_container() const { return false; }
+    virtual bool is_svg_container() const { return false; }
+
     // NOTE: This is intended for the JS bindings.
     u16 node_type() const { return (u16)m_type; }
 

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -37,6 +37,7 @@ void SVGSVGBox::after_children_paint(PaintContext& context, PaintPhase phase)
     SVGGraphicsBox::after_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
+    context.clear_svg_context();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -19,7 +19,11 @@ public:
     RefPtr<Layout::Node> build(DOM::Node&);
 
 private:
-    void create_layout_tree(DOM::Node&);
+    struct Context {
+        bool has_svg_root = false;
+    };
+
+    void create_layout_tree(DOM::Node&, Context&);
 
     void push_parent(Layout::NodeWithStyle& node) { m_parent_stack.append(&node); }
     void pop_parent() { m_parent_stack.take_last(); }

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -29,6 +29,7 @@ public:
     bool has_svg_context() const { return m_svg_context.has_value(); }
     SVGContext& svg_context() { return m_svg_context.value(); }
     void set_svg_context(SVGContext context) { m_svg_context = context; }
+    void clear_svg_context() { m_svg_context.clear(); }
 
     bool should_show_line_box_borders() const { return m_should_show_line_box_borders; }
     void set_should_show_line_box_borders(bool value) { m_should_show_line_box_borders = value; }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -31,6 +31,9 @@ StackingContext::StackingContext(Box& box, StackingContext* parent)
 
 void StackingContext::paint_descendants(PaintContext& context, Node& box, StackingContextPaintPhase phase)
 {
+    if (phase == StackingContextPaintPhase::Foreground)
+        box.before_children_paint(context, PaintPhase::Foreground);
+
     box.for_each_child([&](auto& child) {
         if (child.establishes_stacking_context())
             return;
@@ -55,9 +58,7 @@ void StackingContext::paint_descendants(PaintContext& context, Node& box, Stacki
         case StackingContextPaintPhase::Foreground:
             if (!child.is_positioned()) {
                 child.paint(context, PaintPhase::Foreground);
-                child.before_children_paint(context, PaintPhase::Foreground);
                 paint_descendants(context, child, phase);
-                child.after_children_paint(context, PaintPhase::Foreground);
             }
             break;
         case StackingContextPaintPhase::FocusAndOverlay:
@@ -69,6 +70,9 @@ void StackingContext::paint_descendants(PaintContext& context, Node& box, Stacki
             break;
         }
     });
+
+    if (phase == StackingContextPaintPhase::Foreground)
+        box.after_children_paint(context, PaintPhase::Foreground);
 }
 
 void StackingContext::paint_internal(PaintContext& context)

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -14,6 +14,8 @@ class SVGElement : public DOM::Element {
 public:
     using WrapperType = Bindings::SVGElementWrapper;
 
+    virtual bool requires_svg_container() const override { return true; }
+
 protected:
     SVGElement(DOM::Document&, QualifiedName);
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -22,6 +22,9 @@ public:
     unsigned width() const;
     unsigned height() const;
 
+    virtual bool requires_svg_container() const override { return false; }
+    virtual bool is_svg_container() const override { return true; }
+
 private:
     RefPtr<Gfx::Bitmap> m_bitmap;
 };


### PR DESCRIPTION
The browser had a failed assertion in [SVGPathBox::paint](https://github.com/SerenityOS/serenity/blob/feacf774fbf1eb7569e36abcb5e6995a5ee9ac93/Userland/Libraries/LibWeb/Layout/SVGPathBox.cpp#L51) when it called `context.svg_context()`, because sometimes the optional svg context was empty. It had two possible causes:

- The `SVGSVGBox::before_children_paint` was not called, therefore no svg context was created
- The svg element ( for example `<path>` ) was outside of a `<svg>` container. This is invalid, but now it is silently ignored