### PR TITLE
HackStudio+LibCpp: Run clang-format

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/complete_includes.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/complete_includes.cpp
@@ -1,5 +1,4 @@
 #include "sample_heade
 #include <sys/cdef
 
-void foo() {}
-
+void foo() { }

--- a/Userland/Libraries/LibCpp/Tests/struct.ast
+++ b/Userland/Libraries/LibCpp/Tests/struct.ast
@@ -1,41 +1,41 @@
-TranslationUnit[1:0->12:0]
-  StructOrClassDeclaration[1:7->7:0]
+TranslationUnit[1:0->11:0]
+  StructOrClassDeclaration[1:7->6:0]
   MyStruct
-    VariableDeclaration[3:4->4:4]
-      NamedType[3:4->3:8]
+    VariableDeclaration[2:4->3:4]
+      NamedType[2:4->2:8]
         int
       x
-    VariableDeclaration[4:4->5:0]
-      Pointer[4:4->4:14]
-        NamedType[4:4->4:12]
+    VariableDeclaration[3:4->4:0]
+      Pointer[3:4->3:14]
+        NamedType[3:4->3:12]
           s
       next
-  FunctionDeclaration[7:0->12:0]
-    NamedType[7:0->7:4]
+  FunctionDeclaration[6:0->11:0]
+    NamedType[6:0->6:4]
       int
     foo
     (
     )
-    FunctionDefinition[8:0->12:0]
+    FunctionDefinition[7:0->11:0]
     {
-      VariableDeclaration[9:4->9:14]
-        NamedType[9:4->9:13]
+      VariableDeclaration[8:4->8:14]
+        NamedType[8:4->8:13]
           MyStruct
         s
-      FunctionCall[10:4->10:23]
-        Name[10:4->10:10]
+      FunctionCall[9:4->9:23]
+        Name[9:4->9:10]
         printf
-        StringLiteral[10:11->10:16]
+        StringLiteral[9:11->9:16]
           "%d\n"
-        MemberExpression[10:19->10:22]
-          Name[10:19->10:20]
+        MemberExpression[9:19->9:22]
+          Name[9:19->9:20]
           s
-          Identifier[10:21->10:21]
+          Identifier[9:21->9:21]
           x
-      ReturnStatement[11:4->11:14]
-        MemberExpression[11:11->11:14]
-          Name[11:11->11:12]
+      ReturnStatement[10:4->10:14]
+        MemberExpression[10:11->10:14]
+          Name[10:11->10:12]
           s
-          Identifier[11:13->11:13]
+          Identifier[10:13->10:13]
           x
     }

--- a/Userland/Libraries/LibCpp/Tests/struct.cpp
+++ b/Userland/Libraries/LibCpp/Tests/struct.cpp
@@ -1,6 +1,5 @@
 
-struct MyStruct
-{
+struct MyStruct {
     int x;
     struct s* next;
 };


### PR DESCRIPTION
I basically ran clang-format on all *.cpp and *.h files and these two
were the only ones that needed to be reformatted.

Also had to update struct.ast as line numbers changed.