### PR TITLE
LibJS: make statements return undefined unless it's empty BlockStatement

### DIFF
--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -175,10 +175,10 @@ Value Interpreter::execute_statement(GlobalObject& global_object, const Statemen
     auto& block = static_cast<const ScopeNode&>(statement);
     enter_scope(block, scope_type, global_object);
 
-    Value last_value;
+    Value last_value = js_undefined();
     for (auto& node : block.children()) {
         auto value = node.execute(*this, global_object);
-        if (!value.is_empty())
+        if (!value.is_empty() && !(value.is_undefined() && is<BlockStatement>(node)))
             last_value = value;
         if (vm().should_unwind()) {
             if (!block.label().is_null() && vm().should_unwind_until(ScopeType::Breakable, block.label()))


### PR DESCRIPTION
Previously statements return value was initialized to Empty, but
returning Undefined is a more common behavior for statements.

Also, we do an extra check for for empty BlockStatements, since
statements like `{2;}{}` evaluate to the value of the last non-empty
block.

Fixes 8 libjs-test262 tests.