### PR TITLE
PixelPaint: Add layer rotation and flipping

### DIFF
--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -90,6 +90,25 @@ void Layer::set_name(String name)
     m_image.layer_did_modify_properties({}, *this);
 }
 
+void Layer::flip(Gfx::Orientation orientation)
+{
+    m_bitmap->flip(orientation);
+    did_modify_bitmap({});
+}
+
+Result<void, String> Layer::rotate(Gfx::RotationDirection rotation_direction)
+{
+    auto rotated_bitmap = m_bitmap->rotated(rotation_direction);
+    if (!rotated_bitmap) {
+        return String("Layer rotation failed");
+    }
+
+    m_bitmap = rotated_bitmap.release_nonnull();
+    did_modify_bitmap({});
+
+    return {};
+}
+
 RefPtr<Gfx::Bitmap> Layer::try_copy_bitmap(Selection const& selection) const
 {
     if (selection.is_empty()) {

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -8,6 +8,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
+#include <AK/Result.h>
 #include <AK/String.h>
 #include <AK/Weakable.h>
 #include <LibGfx/Bitmap.h>
@@ -56,6 +57,9 @@ public:
 
     int opacity_percent() const { return m_opacity_percent; }
     void set_opacity_percent(int);
+
+    void flip(Gfx::Orientation orientation);
+    Result<void, String> rotate(Gfx::RotationDirection rotation_direction);
 
     RefPtr<Gfx::Bitmap> try_copy_bitmap(Selection const&) const;
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -437,6 +437,73 @@ int main(int argc, char** argv)
         },
         window));
 
+    layer_menu.add_separator();
+    auto& layer_transform_menu = layer_menu.add_submenu("Transform");
+    layer_transform_menu.add_action(GUI::Action::create(
+        "Flip Horizontally", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+
+            auto* active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+
+            active_layer->flip(Gfx::Orientation::Horizontal);
+            editor->did_complete_action();
+        },
+        window));
+    layer_transform_menu.add_action(GUI::Action::create(
+        "Flip Vertically", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+
+            auto* active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+
+            active_layer->flip(Gfx::Orientation::Vertical);
+            editor->did_complete_action();
+        },
+        window));
+    layer_transform_menu.add_action(GUI::Action::create(
+        "Rotate 90 Degrees Clockwise", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+
+            auto* active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+
+            auto result = active_layer->rotate(Gfx::RotationDirection::Clockwise);
+            if (result.is_error()) {
+                GUI::MessageBox::show_error(window, result.error());
+            }
+
+            editor->did_complete_action();
+        },
+        window));
+    layer_transform_menu.add_action(GUI::Action::create(
+        "Rotate 90 Degrees Counterclockwise", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+
+            auto* active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+
+            auto result = active_layer->rotate(Gfx::RotationDirection::CounterClockwise);
+            if (result.is_error()) {
+                GUI::MessageBox::show_error(window, result.error());
+            }
+
+            editor->did_complete_action();
+        },
+        window));
+
     auto& filter_menu = window->add_menu("&Filter");
     auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");
 

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -302,6 +302,14 @@ RefPtr<Gfx::Bitmap> Bitmap::clone() const
     return new_bitmap;
 }
 
+void Bitmap::flip(Gfx::Orientation orientation)
+{
+    if (orientation == Orientation::Vertical)
+        this->flip_vertically();
+    else
+        this->flip_horizontally();
+}
+
 RefPtr<Gfx::Bitmap> Bitmap::rotated(Gfx::RotationDirection rotation_direction) const
 {
     auto new_bitmap = Gfx::Bitmap::try_create(this->format(), { height(), width() }, scale());
@@ -595,6 +603,32 @@ void Bitmap::allocate_palette_from_format(BitmapFormat format, const Vector<RGBA
     if (!source_palette.is_empty()) {
         VERIFY(source_palette.size() == size);
         memcpy(m_palette, source_palette.data(), size * sizeof(RGBA32));
+    }
+}
+
+void Bitmap::flip_vertically()
+{
+    auto w = this->physical_width();
+    auto h = this->physical_height();
+    for (int i = 0; i < w; i++) {
+        for (int j = 0; j < h / 2; j++) {
+            Color tmp = this->get_pixel(i, j);
+            this->set_pixel(i, j, this->get_pixel(i, h - j - 1));
+            this->set_pixel(i, h - j - 1, tmp);
+        }
+    }
+}
+
+void Bitmap::flip_horizontally()
+{
+    auto w = this->physical_width();
+    auto h = this->physical_height();
+    for (int i = 0; i < w / 2; i++) {
+        for (int j = 0; j < h; j++) {
+            Color tmp = this->get_pixel(i, j);
+            this->set_pixel(i, j, this->get_pixel(w - i - 1, j));
+            this->set_pixel(w - i - 1, j, tmp);
+        }
     }
 }
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -110,6 +110,8 @@ public:
 
     [[nodiscard]] RefPtr<Gfx::Bitmap> clone() const;
 
+    void flip(Gfx::Orientation);
+
     [[nodiscard]] RefPtr<Gfx::Bitmap> rotated(Gfx::RotationDirection) const;
     [[nodiscard]] RefPtr<Gfx::Bitmap> flipped(Gfx::Orientation) const;
     [[nodiscard]] RefPtr<Gfx::Bitmap> scaled(int sx, int sy) const;
@@ -243,6 +245,8 @@ private:
     static Optional<BackingStore> try_allocate_backing_store(BitmapFormat format, IntSize const& size, int scale_factor);
 
     void allocate_palette_from_format(BitmapFormat, const Vector<RGBA32>& source_palette);
+    void flip_horizontally();
+    void flip_vertically();
 
     IntSize m_size;
     int m_scale;


### PR DESCRIPTION
This makes rotating/flipping a layer in PixelPaint possible through a Transform sub-menu in the Layer menu.

![2021-08-02T08:07:20](https://user-images.githubusercontent.com/23107133/127812061-d202bcc6-48d6-44a5-acd0-766c237c9ede.png)
