### PR TITLE
LibX86: Stub out Disassembler::next() for x86_64

### DIFF
--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -345,11 +345,7 @@ void* DebugSession::single_step()
     regs.rflags &= ~(TRAP_FLAG);
 #endif
     set_registers(regs);
-#if ARCH(I386)
-    return (void*)regs.eip;
-#else
-    TODO();
-#endif
+    return (void*)regs.ip();
 }
 
 void DebugSession::detach()

--- a/Userland/Libraries/LibX86/Disassembler.h
+++ b/Userland/Libraries/LibX86/Disassembler.h
@@ -22,7 +22,12 @@ public:
     {
         if (!m_stream.can_read())
             return {};
+#if ARCH(I386)
         return Instruction::from_stream(m_stream, true, true);
+#else
+        dbgln("FIXME: Implement disassembly support for x86_64");
+        return {};
+#endif
     }
 
 private:


### PR DESCRIPTION
**LibX86: Stub out Disassembler::next() for x86_64**

LibX86 doesn't currently support x86_64 opcodes which causes Profiler to crash when clicking on any symbol in the call graph.

**LibDebug: Make single-stepping work for x86_64**