### PR TITLE
LibGUI: Ensure that edit actions are disabled for password boxes

### DIFF
--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -77,8 +77,7 @@ PasswordBox::PasswordBox()
     : TextBox()
 {
     set_substitution_code_point('*');
-    undo_action().set_enabled(false);
-    redo_action().set_enabled(false);
+    set_text_is_secret(true);
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1478,7 +1478,7 @@ void TextEditor::set_mode(const Mode mode)
     m_mode = mode;
     switch (mode) {
     case Editable:
-        m_cut_action->set_enabled(has_selection());
+        m_cut_action->set_enabled(has_selection() && !text_is_secret());
         m_delete_action->set_enabled(true);
         m_paste_action->set_enabled(true);
         set_accepts_emoji_input(true);
@@ -1502,8 +1502,8 @@ void TextEditor::set_mode(const Mode mode)
 
 void TextEditor::did_update_selection()
 {
-    m_cut_action->set_enabled(is_editable() && has_selection());
-    m_copy_action->set_enabled(has_selection());
+    m_cut_action->set_enabled(is_editable() && has_selection() && !text_is_secret());
+    m_copy_action->set_enabled(has_selection() && !text_is_secret());
     if (on_selection_change)
         on_selection_change();
     if (is_wrapping_enabled()) {
@@ -1774,8 +1774,8 @@ void TextEditor::document_did_update_undo_stack()
         return builder.to_string();
     };
 
-    m_undo_action->set_enabled(can_undo());
-    m_redo_action->set_enabled(can_redo());
+    m_undo_action->set_enabled(can_undo() && !text_is_secret());
+    m_redo_action->set_enabled(can_redo() && !text_is_secret());
 
     m_undo_action->set_text(make_action_text("&Undo", document().undo_stack().undo_action_text()));
     m_redo_action->set_text(make_action_text("&Redo", document().undo_stack().redo_action_text()));
@@ -1978,6 +1978,13 @@ void TextEditor::redo()
 {
     clear_selection();
     document().redo();
+}
+
+void TextEditor::set_text_is_secret(bool text_is_secret)
+{
+    m_text_is_secret = text_is_secret;
+    document_did_update_undo_stack();
+    did_update_selection();
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1478,14 +1478,14 @@ void TextEditor::set_mode(const Mode mode)
     m_mode = mode;
     switch (mode) {
     case Editable:
-        m_cut_action->set_enabled(true && has_selection());
+        m_cut_action->set_enabled(has_selection());
         m_delete_action->set_enabled(true);
         m_paste_action->set_enabled(true);
         set_accepts_emoji_input(true);
         break;
     case DisplayOnly:
     case ReadOnly:
-        m_cut_action->set_enabled(false && has_selection());
+        m_cut_action->set_enabled(false);
         m_delete_action->set_enabled(false);
         m_paste_action->set_enabled(false);
         set_accepts_emoji_input(false);

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -203,6 +203,9 @@ public:
 
     void delete_text_range(TextRange);
 
+    bool text_is_secret() const { return m_text_is_secret; }
+    void set_text_is_secret(bool text_is_secret);
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 
@@ -387,6 +390,8 @@ private:
     Gfx::IntPoint m_last_mousemove_position;
 
     RefPtr<Gfx::Bitmap> m_icon;
+
+    bool m_text_is_secret { false };
 };
 
 }


### PR DESCRIPTION
This ensures that the user can't copy/cut text from password boxes which would reveal the password. It also makes sure that the undo/redo actions stay disabled because it's difficult to reason about what these do exactly without being able to see the result.