### PR TITLE
FileManager+Taskbar: Set chdir when opening applications; Use the current directory as one of the initial locations 

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -98,8 +98,9 @@ int main(int argc, char** argv)
 
     // our initial location is defined as, in order of precedence:
     // 1. the command-line path argument (e.g. FileManager /bin)
-    // 2. the user's home directory
-    // 3. the root directory
+    // 2. the current directory
+    // 3. the user's home directory
+    // 4. the root directory
 
     if (!initial_location.is_empty()) {
         if (!ignore_path_resolution)
@@ -108,6 +109,9 @@ int main(int argc, char** argv)
         if (!Core::File::is_directory(initial_location))
             is_selection_mode = true;
     }
+
+    if (initial_location.is_empty())
+        initial_location = Core::File::current_working_directory();
 
     if (initial_location.is_empty())
         initial_location = Core::StandardPaths::home_directory();


### PR DESCRIPTION
- **Taskbar: Set chdir to the home directory when opening applications**

  Although the chdir was set up for the applications opened from the quick launch, the regular application list hadn't do this.

  This meant that you could spawn a Terminal or HackStudio project in the root directory, which isn't so bad, but it's better to stick to the user home directory.

- **FileManager: Set chdir to the current path when opening applications**

- **FileManager: Use the current directory as one of the initial locations**

  This change makes `cd /bin; FileManager` open the app in /bin.
