### PR TITLE
Kernel: Print panic backtrace to both the screen and serial

### DIFF
--- a/Kernel/KSyms.h
+++ b/Kernel/KSyms.h
@@ -15,6 +15,11 @@ struct KernelSymbol {
     const char* name;
 };
 
+enum class PrintToScreen {
+    No,
+    Yes,
+};
+
 FlatPtr address_for_kernel_symbol(const StringView& name);
 const KernelSymbol* symbolicate_kernel_address(FlatPtr);
 void load_kernel_symbol_table();
@@ -23,6 +28,6 @@ extern bool g_kernel_symbols_available;
 extern FlatPtr g_lowest_kernel_symbol_address;
 extern FlatPtr g_highest_kernel_symbol_address;
 
-void dump_backtrace();
+void dump_backtrace(PrintToScreen print_to_screen = PrintToScreen::No);
 
 }

--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -26,7 +26,7 @@ namespace Kernel {
 void __panic(const char* file, unsigned int line, const char* function)
 {
     critical_dmesgln("at {}:{} in {}", file, line, function);
-    dump_backtrace();
+    dump_backtrace(PrintToScreen::Yes);
     if (kernel_command_line().boot_mode() == BootMode::SelfTest)
         __shutdown();
     else


### PR DESCRIPTION
Previously it would only print the backtrace to serial, which would be
inaccessible if you don't have serial setup.