### PR TITLE
PixelPaint: Remove context menus for tools and use ToolPropertiesWidget instead

### DIFF
--- a/Userland/Applications/PixelPaint/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/EllipseTool.h
@@ -20,9 +20,9 @@ public:
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
-    virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
+    virtual GUI::Widget* get_properties_widget() override;
 
 private:
     enum class Mode {
@@ -32,12 +32,11 @@ private:
 
     void draw_using(GUI::Painter&, Gfx::IntRect const&);
 
+    RefPtr<GUI::Widget> m_properties_widget;
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
     Gfx::IntPoint m_ellipse_start_position;
     Gfx::IntPoint m_ellipse_end_position;
-    RefPtr<GUI::Menu> m_context_menu;
     int m_thickness { 1 };
-    GUI::ActionGroup m_thickness_actions;
     Mode m_mode { Mode::Outline };
 };
 

--- a/Userland/Applications/PixelPaint/EraseTool.h
+++ b/Userland/Applications/PixelPaint/EraseTool.h
@@ -21,16 +21,15 @@ public:
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
-    virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
+    virtual GUI::Widget* get_properties_widget() override;
 
 private:
     Gfx::Color get_color() const;
     Gfx::IntRect build_rect(Gfx::IntPoint const& pos, Gfx::IntRect const& widget_rect);
-    RefPtr<GUI::Menu> m_context_menu;
+    RefPtr<GUI::Widget> m_properties_widget;
 
     bool m_use_secondary_color { false };
     int m_thickness { 1 };
-    GUI::ActionGroup m_thickness_actions;
 };
 
 }

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -9,8 +9,11 @@
 #include "Layer.h"
 #include <AK/Math.h>
 #include <LibGUI/Action.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Slider.h>
 
 namespace PixelPaint {
 
@@ -97,25 +100,30 @@ void LineTool::on_keydown(GUI::KeyEvent& event)
     }
 }
 
-void LineTool::on_tool_button_contextmenu(GUI::ContextMenuEvent& event)
+GUI::Widget* LineTool::get_properties_widget()
 {
-    if (!m_context_menu) {
-        m_context_menu = GUI::Menu::construct();
-        m_thickness_actions.set_exclusive(true);
-        auto insert_action = [&](int size, bool checked = false) {
-            auto action = GUI::Action::create_checkable(String::number(size), [this, size](auto&) {
-                m_thickness = size;
-            });
-            action->set_checked(checked);
-            m_thickness_actions.add_action(*action);
-            m_context_menu->add_action(move(action));
+    if (!m_properties_widget) {
+        m_properties_widget = GUI::Widget::construct();
+        m_properties_widget->set_layout<GUI::VerticalBoxLayout>();
+
+        auto& thickness_container = m_properties_widget->add<GUI::Widget>();
+        thickness_container.set_fixed_height(20);
+        thickness_container.set_layout<GUI::HorizontalBoxLayout>();
+
+        auto& thickness_label = thickness_container.add<GUI::Label>("Thickness:");
+        thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        thickness_label.set_fixed_size(80, 20);
+
+        auto& thickness_slider = thickness_container.add<GUI::HorizontalSlider>();
+        thickness_slider.set_fixed_height(20);
+        thickness_slider.set_range(1, 10);
+        thickness_slider.set_value(m_thickness);
+        thickness_slider.on_change = [&](int value) {
+            m_thickness = value;
         };
-        insert_action(1, true);
-        insert_action(2);
-        insert_action(3);
-        insert_action(4);
     }
-    m_context_menu->popup(event.screen_position());
+
+    return m_properties_widget.ptr();
 }
 
 }

--- a/Userland/Applications/PixelPaint/LineTool.h
+++ b/Userland/Applications/PixelPaint/LineTool.h
@@ -20,17 +20,16 @@ public:
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
-    virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
+    virtual GUI::Widget* get_properties_widget() override;
 
 private:
+    RefPtr<GUI::Widget> m_properties_widget;
+
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
     Gfx::IntPoint m_line_start_position;
     Gfx::IntPoint m_line_end_position;
-
-    RefPtr<GUI::Menu> m_context_menu;
-    GUI::ActionGroup m_thickness_actions;
     int m_thickness { 1 };
 };
 

--- a/Userland/Applications/PixelPaint/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/MoveTool.cpp
@@ -85,35 +85,4 @@ void MoveTool::on_keydown(GUI::KeyEvent& event)
     m_editor->layers_did_change();
 }
 
-void MoveTool::on_context_menu(Layer& layer, GUI::ContextMenuEvent& event)
-{
-    if (!m_context_menu) {
-        m_context_menu = GUI::Menu::construct();
-        m_context_menu->add_action(GUI::CommonActions::make_move_to_front_action(
-            [this](auto&) {
-                m_editor->image().move_layer_to_front(*m_context_menu_layer);
-                m_editor->layers_did_change();
-            },
-            m_editor));
-        m_context_menu->add_action(GUI::CommonActions::make_move_to_back_action(
-            [this](auto&) {
-                m_editor->image().move_layer_to_back(*m_context_menu_layer);
-                m_editor->layers_did_change();
-            },
-            m_editor));
-        m_context_menu->add_separator();
-        m_context_menu->add_action(GUI::Action::create(
-            "&Delete Layer", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"), [this](auto&) {
-                m_editor->image().remove_layer(*m_context_menu_layer);
-                // FIXME: This should not be done imperatively here. Perhaps a Image::Client interface that ImageEditor can implement?
-                if (m_editor->active_layer() == m_context_menu_layer)
-                    m_editor->set_active_layer(nullptr);
-                m_editor->layers_did_change();
-            },
-            m_editor));
-    }
-    m_context_menu_layer = layer;
-    m_context_menu->popup(event.screen_position());
-}
-
 }

--- a/Userland/Applications/PixelPaint/MoveTool.h
+++ b/Userland/Applications/PixelPaint/MoveTool.h
@@ -19,14 +19,11 @@ public:
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
-    virtual void on_context_menu(Layer&, GUI::ContextMenuEvent&) override;
 
 private:
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
-    RefPtr<GUI::Menu> m_context_menu;
-    RefPtr<Layer> m_context_menu_layer;
 };
 
 }

--- a/Userland/Applications/PixelPaint/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/PenTool.cpp
@@ -63,27 +63,6 @@ void PenTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent
     m_last_drawing_event_position = event.position();
 }
 
-void PenTool::on_tool_button_contextmenu(GUI::ContextMenuEvent& event)
-{
-    if (!m_context_menu) {
-        m_context_menu = GUI::Menu::construct();
-        m_thickness_actions.set_exclusive(true);
-        auto insert_action = [&](int size, bool checked = false) {
-            auto action = GUI::Action::create_checkable(String::number(size), [this, size](auto&) {
-                m_thickness = size;
-            });
-            action->set_checked(checked);
-            m_thickness_actions.add_action(*action);
-            m_context_menu->add_action(move(action));
-        };
-        insert_action(1, true);
-        insert_action(2);
-        insert_action(3);
-        insert_action(4);
-    }
-    m_context_menu->popup(event.screen_position());
-}
-
 GUI::Widget* PenTool::get_properties_widget()
 {
     if (!m_properties_widget) {

--- a/Userland/Applications/PixelPaint/PenTool.h
+++ b/Userland/Applications/PixelPaint/PenTool.h
@@ -20,15 +20,12 @@ public:
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
-    virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
 
 private:
     Gfx::IntPoint m_last_drawing_event_position { -1, -1 };
-    RefPtr<GUI::Menu> m_context_menu;
     RefPtr<GUI::Widget> m_properties_widget;
     int m_thickness { 1 };
-    GUI::ActionGroup m_thickness_actions;
 };
 
 }

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -8,8 +8,11 @@
 #include "ImageEditor.h"
 #include "Layer.h"
 #include <LibGUI/Action.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/RadioButton.h>
 #include <LibGfx/Rect.h>
 
 namespace PixelPaint {
@@ -96,21 +99,39 @@ void RectangleTool::on_keydown(GUI::KeyEvent& event)
     }
 }
 
-void RectangleTool::on_tool_button_contextmenu(GUI::ContextMenuEvent& event)
+GUI::Widget* RectangleTool::get_properties_widget()
 {
-    if (!m_context_menu) {
-        m_context_menu = GUI::Menu::construct();
-        m_context_menu->add_action(GUI::Action::create("Fill", [this](auto&) {
-            m_mode = Mode::Fill;
-        }));
-        m_context_menu->add_action(GUI::Action::create("Outline", [this](auto&) {
+    if (!m_properties_widget) {
+        m_properties_widget = GUI::Widget::construct();
+        m_properties_widget->set_layout<GUI::VerticalBoxLayout>();
+
+        auto& mode_container = m_properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(70);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Mode:");
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(80, 20);
+
+        auto& mode_radio_container = mode_container.add<GUI::Widget>();
+        mode_radio_container.set_layout<GUI::VerticalBoxLayout>();
+        auto& outline_mode_radio = mode_radio_container.add<GUI::RadioButton>("Outline");
+        auto& fill_mode_radio = mode_radio_container.add<GUI::RadioButton>("Fill");
+        auto& gradient_mode_radio = mode_radio_container.add<GUI::RadioButton>("Gradient");
+
+        outline_mode_radio.on_checked = [&](bool) {
             m_mode = Mode::Outline;
-        }));
-        m_context_menu->add_action(GUI::Action::create("Gradient", [this](auto&) {
+        };
+        fill_mode_radio.on_checked = [&](bool) {
+            m_mode = Mode::Fill;
+        };
+        gradient_mode_radio.on_checked = [&](bool) {
             m_mode = Mode::Gradient;
-        }));
+        };
+
+        outline_mode_radio.set_checked(true);
     }
-    m_context_menu->popup(event.screen_position());
+
+    return m_properties_widget.ptr();
 }
 
 }

--- a/Userland/Applications/PixelPaint/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/RectangleTool.h
@@ -20,9 +20,9 @@ public:
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
-    virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
+    virtual GUI::Widget* get_properties_widget() override;
 
 private:
     enum class Mode {
@@ -33,10 +33,10 @@ private:
 
     void draw_using(GUI::Painter&, Gfx::IntRect const&);
 
+    RefPtr<GUI::Widget> m_properties_widget;
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
     Gfx::IntPoint m_rectangle_start_position;
     Gfx::IntPoint m_rectangle_end_position;
-    RefPtr<GUI::Menu> m_context_menu;
     Mode m_mode { Mode::Outline };
 };
 

--- a/Userland/Applications/PixelPaint/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/SprayTool.cpp
@@ -88,27 +88,6 @@ void SprayTool::on_mouseup(Layer&, GUI::MouseEvent&, GUI::MouseEvent&)
     }
 }
 
-void SprayTool::on_tool_button_contextmenu(GUI::ContextMenuEvent& event)
-{
-    if (!m_context_menu) {
-        m_context_menu = GUI::Menu::construct();
-        m_thickness_actions.set_exclusive(true);
-        auto insert_action = [&](int size, bool checked = false) {
-            auto action = GUI::Action::create_checkable(String::number(size), [this, size](auto&) {
-                m_thickness = size;
-            });
-            action->set_checked(checked);
-            m_thickness_actions.add_action(*action);
-            m_context_menu->add_action(move(action));
-        };
-        insert_action(1, true);
-        insert_action(2);
-        insert_action(3);
-        insert_action(4);
-    }
-    m_context_menu->popup(event.screen_position());
-}
-
 GUI::Widget* SprayTool::get_properties_widget()
 {
     if (!m_properties_widget) {

--- a/Userland/Applications/PixelPaint/SprayTool.h
+++ b/Userland/Applications/PixelPaint/SprayTool.h
@@ -21,7 +21,6 @@ public:
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
-    virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
 
 private:
@@ -31,8 +30,6 @@ private:
     RefPtr<Core::Timer> m_timer;
     Gfx::IntPoint m_last_pos;
     Color m_color;
-    RefPtr<GUI::Menu> m_context_menu;
-    GUI::ActionGroup m_thickness_actions;
     int m_thickness { 10 };
     int m_density { 40 };
 };

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -369,6 +369,31 @@ int main(int argc, char** argv)
         },
         window));
     layer_menu.add_separator();
+    layer_menu.add_action(GUI::CommonActions::make_move_to_front_action(
+        [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            auto active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+            editor->image().move_layer_to_front(*active_layer);
+            editor->layers_did_change();
+        },
+        window));
+    layer_menu.add_action(GUI::CommonActions::make_move_to_back_action(
+        [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            auto active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+            editor->image().move_layer_to_back(*active_layer);
+            editor->layers_did_change();
+        },
+        window));
+    layer_menu.add_separator();
     layer_menu.add_action(GUI::Action::create(
         "Move Active Layer &Up", { Mod_Ctrl, Key_PageUp }, [&](auto&) {
             auto* editor = current_image_editor();
@@ -393,7 +418,7 @@ int main(int argc, char** argv)
         window));
     layer_menu.add_separator();
     layer_menu.add_action(GUI::Action::create(
-        "&Remove Active Layer", { Mod_Ctrl, Key_D }, [&](auto&) {
+        "&Remove Active Layer", { Mod_Ctrl, Key_D }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"), [&](auto&) {
             auto* editor = current_image_editor();
             if (!editor)
                 return;


### PR DESCRIPTION
This PR moves all the tool properties in PixelPaint to ToolPropertiesWidget and removes the old context menus. It's more consistent to have them all in the same place since they were kind of hidden to the user and not really self explanatory previously.
There's still some work and polishing to be done to make all the properties widgets look and feel right.

This also moves the layer actions from the MoveTool context menu to the Layer menu. It's getting quite crowded (both in code and on screen) so some way of organizing the actions could be done, either via sub-menus or restructuring.

![Screenshot_20210803_002744](https://user-images.githubusercontent.com/69970419/127931593-6916cad8-b758-4eef-ae82-e66827bbbfcf.png)