### PR TITLE
LibAudio: Initialize `m_stream` before parsing a FLAC header

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -28,11 +28,15 @@ FlacLoaderPlugin::FlacLoaderPlugin(const StringView& path)
         return;
     }
 
+    m_stream = make<FlacInputStream>(Core::InputFileStream(*m_file));
+    if (!m_stream) {
+        m_error_string = String::formatted("Can't open memory stream");
+        return;
+    }
+
     m_valid = parse_header();
     if (!m_valid)
         return;
-
-    m_stream = make<FlacInputStream>(Core::InputFileStream(*m_file));
     reset();
     if (!m_valid)
         return;


### PR DESCRIPTION
Before this change opening the file in the system resulted in crash caused by assertion saying:

```
SoundPlayer(32:32): ASSERTION FAILED: m_ptr
../.././AK/OwnPtr.h:139
[#0 SoundPlayer(32:32)]: Terminating SoundPlayer(32) due to signal 6
[#0 FinalizerTask(4:4)]: 0xdeadc0de
```

The issue was that 845d403 started using `m_stream` in the `parse_header()` function, but that variable wasn't initialized if the Loader plugin was created using a file path (which is used everywhere except for the fuzz testing), resulting in a crash mentioned above.