### PR TITLE
HackStudio: Fix issues with retaining state of previous project after opening a different one

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -43,6 +43,8 @@ EditorWrapper::EditorWrapper()
     };
 
     m_editor->on_change = [this] {
+        if (this->on_change)
+            this->on_change();
         bool was_dirty = m_document_dirty;
         m_document_dirty = true;
         if (!was_dirty)

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -52,6 +52,8 @@ public:
     void update_diff();
     Vector<Diff::Hunk> const& hunks() const { return m_hunks; }
 
+    Function<void()> on_change;
+
 private:
     EditorWrapper();
 

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -148,5 +148,9 @@ void FindInFilesWidget::focus_textbox_and_select_all()
     m_textbox->select_all();
     m_textbox->set_focus(true);
 }
+void FindInFilesWidget::reset()
+{
+    m_result_view->set_model(nullptr);
+}
 
 }

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.h
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.h
@@ -20,6 +20,8 @@ public:
 
     void focus_textbox_and_select_all();
 
+    void reset();
+
 private:
     explicit FindInFilesWidget();
 

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -164,4 +164,12 @@ void GitWidget::show_diff(const LexicalPath& file_path)
     VERIFY(original_content.has_value() && diff.has_value());
     m_view_diff_callback(original_content.value(), diff.value());
 }
+
+void GitWidget::change_repo(LexicalPath const& repo_root)
+{
+    m_repo_root = repo_root;
+    m_git_repo = nullptr;
+    m_unstaged_files->set_model(nullptr);
+    m_staged_files->set_model(nullptr);
+}
 }

--- a/Userland/DevTools/HackStudio/Git/GitWidget.h
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.h
@@ -24,6 +24,7 @@ public:
     void refresh();
     void set_view_diff_callback(ViewDiffCallback callback);
     bool initialized() const { return !m_git_repo.is_null(); };
+    void change_repo(LexicalPath const& repo_root);
 
 private:
     explicit GitWidget(const LexicalPath& repo_root);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -200,6 +200,7 @@ void HackStudioWidget::open_project(const String& root_path)
         m_open_files_vector.clear();
         add_new_editor(*m_editors_splitter);
         m_todo_entries_widget->clear();
+        m_terminal_wrapper->clear_including_history();
     }
     m_project = Project::open_with_root_path(root_path);
     VERIFY(m_project);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -199,6 +199,7 @@ void HackStudioWidget::open_project(const String& root_path)
         m_open_files.clear();
         m_open_files_vector.clear();
         add_new_editor(*m_editors_splitter);
+        m_todo_entries_widget->clear();
     }
     m_project = Project::open_with_root_path(root_path);
     VERIFY(m_project);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -202,6 +202,10 @@ void HackStudioWidget::open_project(const String& root_path)
         m_project_tree_view->set_model(m_project->model());
         m_project_tree_view->update();
     }
+    if (m_git_widget) {
+        m_git_widget->change_repo(LexicalPath(root_path));
+        m_git_widget->refresh();
+    }
     if (Debugger::is_initialized()) {
         auto& debugger = Debugger::the();
         debugger.reset_breakpoints();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -199,6 +199,7 @@ void HackStudioWidget::open_project(const String& root_path)
         m_open_files.clear();
         m_open_files_vector.clear();
         add_new_editor(*m_editors_splitter);
+        m_find_in_files_widget->reset();
         m_todo_entries_widget->clear();
         m_terminal_wrapper->clear_including_history();
         stop_debugger_if_running();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -203,6 +203,7 @@ void HackStudioWidget::open_project(const String& root_path)
         m_todo_entries_widget->clear();
         m_terminal_wrapper->clear_including_history();
         stop_debugger_if_running();
+        update_gml_preview();
     }
     m_project = Project::open_with_root_path(root_path);
     VERIFY(m_project);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -189,6 +189,8 @@ void HackStudioWidget::on_action_tab_change()
 
 void HackStudioWidget::open_project(const String& root_path)
 {
+    if (warn_unsaved_changes("There are unsaved changes, do you want to save before closing current project?") == ContinueDecision::No)
+        return;
     if (chdir(root_path.characters()) < 0) {
         perror("chdir");
         exit(1);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -294,7 +294,7 @@ bool HackStudioWidget::open_file(const String& full_filename)
     current_editor().set_focus(true);
 
     current_editor().on_cursor_change = [this] { update_statusbar(); };
-    current_editor().on_change = [this] { update_gml_preview(); };
+    current_editor_wrapper().on_change = [this] { update_gml_preview(); };
     update_gml_preview();
 
     return true;
@@ -540,7 +540,7 @@ void HackStudioWidget::add_new_editor(GUI::Widget& parent)
     wrapper->editor().set_focus(true);
     wrapper->set_project_root(LexicalPath(m_project->root_path()));
     wrapper->editor().on_cursor_change = [this] { update_statusbar(); };
-    wrapper->editor().on_change = [this] { update_gml_preview(); };
+    wrapper->on_change = [this] { update_gml_preview(); };
     set_edit_mode(EditMode::Text);
 }
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -300,6 +300,33 @@ bool HackStudioWidget::open_file(const String& full_filename)
     return true;
 }
 
+void HackStudioWidget::close_file_in_all_editors(String const& filename)
+{
+    m_open_files.remove(filename);
+    m_open_files_vector.remove_all_matching(
+        [&filename](String const& element) { return element == filename; });
+
+    for (auto& editor_wrapper : m_all_editor_wrappers) {
+        Editor& editor = editor_wrapper.editor();
+        String editor_file_path = editor.code_document().file_path();
+        String relative_editor_file_path = LexicalPath::relative_path(editor_file_path, project().root_path());
+
+        if (relative_editor_file_path == filename) {
+            if (m_open_files_vector.is_empty()) {
+                editor.set_document(CodeDocument::create());
+                editor_wrapper.set_filename("");
+            } else {
+                auto& first_path = m_open_files_vector[0];
+                auto& document = m_open_files.get(first_path).value()->code_document();
+                editor.set_document(document);
+                editor_wrapper.set_filename(first_path);
+            }
+        }
+    }
+
+    m_open_files_view->model()->invalidate();
+}
+
 EditorWrapper& HackStudioWidget::current_editor_wrapper()
 {
     VERIFY(m_current_editor_wrapper);
@@ -1117,29 +1144,7 @@ void HackStudioWidget::update_statusbar()
 
 void HackStudioWidget::handle_external_file_deletion(const String& filepath)
 {
-    m_open_files.remove(filepath);
-    m_open_files_vector.remove_all_matching(
-        [&filepath](const String& element) { return element == filepath; });
-
-    for (auto& editor_wrapper : m_all_editor_wrappers) {
-        Editor& editor = editor_wrapper.editor();
-        String editor_file_path = editor.code_document().file_path();
-        String relative_editor_file_path = LexicalPath::relative_path(editor_file_path, project().root_path());
-
-        if (relative_editor_file_path == filepath) {
-            if (m_open_files_vector.is_empty()) {
-                editor.set_document(CodeDocument::create());
-                editor_wrapper.set_filename("");
-            } else {
-                auto& first_path = m_open_files_vector[0];
-                auto& document = m_open_files.get(first_path).value()->code_document();
-                editor.set_document(document);
-                editor_wrapper.set_filename(first_path);
-            }
-        }
-    }
-
-    m_open_files_view->model()->invalidate();
+    close_file_in_all_editors(filepath);
 }
 
 HackStudioWidget::~HackStudioWidget()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -201,6 +201,7 @@ void HackStudioWidget::open_project(const String& root_path)
         add_new_editor(*m_editors_splitter);
         m_todo_entries_widget->clear();
         m_terminal_wrapper->clear_including_history();
+        stop_debugger_if_running();
     }
     m_project = Project::open_with_root_path(root_path);
     VERIFY(m_project);
@@ -1149,7 +1150,7 @@ void HackStudioWidget::handle_external_file_deletion(const String& filepath)
     close_file_in_all_editors(filepath);
 }
 
-HackStudioWidget::~HackStudioWidget()
+void HackStudioWidget::stop_debugger_if_running()
 {
     if (!m_debugger_thread.is_null()) {
         Debugger::the().stop();
@@ -1160,6 +1161,11 @@ HackStudioWidget::~HackStudioWidget()
             dbgln("error joining debugger thread");
         }
     }
+}
+
+HackStudioWidget::~HackStudioWidget()
+{
+    stop_debugger_if_running();
 }
 
 HackStudioWidget::ContinueDecision HackStudioWidget::warn_unsaved_changes(const String& prompt)

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -194,16 +194,7 @@ void HackStudioWidget::open_project(const String& root_path)
         exit(1);
     }
     if (m_project) {
-        m_editors_splitter->remove_all_children();
-        m_all_editor_wrappers.clear();
-        m_open_files.clear();
-        m_open_files_vector.clear();
-        add_new_editor(*m_editors_splitter);
-        m_find_in_files_widget->reset();
-        m_todo_entries_widget->clear();
-        m_terminal_wrapper->clear_including_history();
-        stop_debugger_if_running();
-        update_gml_preview();
+        close_current_project();
     }
     m_project = Project::open_with_root_path(root_path);
     VERIFY(m_project);
@@ -1163,6 +1154,20 @@ void HackStudioWidget::stop_debugger_if_running()
             dbgln("error joining debugger thread");
         }
     }
+}
+
+void HackStudioWidget::close_current_project()
+{
+    m_editors_splitter->remove_all_children();
+    m_all_editor_wrappers.clear();
+    m_open_files.clear();
+    m_open_files_vector.clear();
+    add_new_editor(*m_editors_splitter);
+    m_find_in_files_widget->reset();
+    m_todo_entries_widget->clear();
+    m_terminal_wrapper->clear_including_history();
+    stop_debugger_if_running();
+    update_gml_preview();
 }
 
 HackStudioWidget::~HackStudioWidget()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -103,6 +103,7 @@ private:
     void update_statusbar();
 
     void handle_external_file_deletion(const String& filepath);
+    void stop_debugger_if_running();
 
     void create_open_files_view(GUI::Widget& parent);
     void create_toolbar(GUI::Widget& parent);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -35,6 +35,7 @@ class HackStudioWidget : public GUI::Widget {
 public:
     virtual ~HackStudioWidget() override;
     bool open_file(const String& filename);
+    void close_file_in_all_editors(String const& filename);
 
     void update_actions();
     Project& project();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -104,6 +104,7 @@ private:
 
     void handle_external_file_deletion(const String& filepath);
     void stop_debugger_if_running();
+    void close_current_project();
 
     void create_open_files_view(GUI::Widget& parent);
     void create_toolbar(GUI::Widget& parent);

--- a/Userland/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.cpp
@@ -152,6 +152,11 @@ void TerminalWrapper::kill_running_command()
     [[maybe_unused]] auto rc = killpg(m_pid, SIGTERM);
 }
 
+void TerminalWrapper::clear_including_history()
+{
+    m_terminal_widget->clear_including_history();
+}
+
 TerminalWrapper::TerminalWrapper(bool user_spawned)
     : m_user_spawned(user_spawned)
 {

--- a/Userland/DevTools/HackStudio/TerminalWrapper.h
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.h
@@ -18,6 +18,7 @@ public:
 
     void run_command(const String&);
     void kill_running_command();
+    void clear_including_history();
 
     bool user_spawned() const { return m_user_spawned; }
     VT::TerminalWidget& terminal() { return *m_terminal_widget; }

--- a/Userland/DevTools/HackStudio/ToDoEntries.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntries.cpp
@@ -31,4 +31,9 @@ Vector<Cpp::Parser::TodoEntry> ToDoEntries::get_entries()
     return ret;
 }
 
+void ToDoEntries::clear_entries()
+{
+    m_document_to_entries.clear();
+}
+
 }

--- a/Userland/DevTools/HackStudio/ToDoEntries.h
+++ b/Userland/DevTools/HackStudio/ToDoEntries.h
@@ -24,6 +24,8 @@ public:
 
     Vector<Cpp::Parser::TodoEntry> get_entries();
 
+    void clear_entries();
+
     Function<void()> on_update = nullptr;
 
 private:

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
@@ -91,6 +91,12 @@ void ToDoEntriesWidget::refresh()
     m_result_view->set_model(results_model);
 }
 
+void ToDoEntriesWidget::clear()
+{
+    ToDoEntries::the().clear_entries();
+    refresh();
+}
+
 ToDoEntriesWidget::ToDoEntriesWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.h
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.h
@@ -18,6 +18,8 @@ public:
 
     void refresh();
 
+    void clear();
+
 private:
     explicit ToDoEntriesWidget();
 


### PR DESCRIPTION
Previously when a you opened a different project or created a new one, many of the widgets within HackStudio would not update to reflect this. This pull request fixes many of these issues, as well as fixing a bug with GitWidget in particular, which would cause HackStudio to crash when trying to create a git repository after switching to a different project.