### PR TITLE
Everywhere: Replace most cases of exit() with Application::quit()

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
         if (!app_state.selected_index.has_value())
             return;
         app_state.results[app_state.selected_index.value()].activate();
-        exit(0);
+        GUI::Application::the()->quit();
     };
     text_box.on_up_pressed = [&]() {
         if (!app_state.visible_result_count)
@@ -278,7 +278,7 @@ int main(int argc, char** argv)
         mark_selected_item();
     };
     text_box.on_escape_pressed = []() {
-        exit(0);
+        GUI::Application::the()->quit();
     };
 
     db.on_new_results = [&](auto results) {
@@ -298,7 +298,7 @@ int main(int argc, char** argv)
             match.set_subtitle(result.subtitle());
             match.on_selected = [&result]() {
                 result.activate();
-                exit(0);
+                GUI::Application::the()->quit();
             };
         }
 

--- a/Userland/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Userland/Applications/IRCClient/IRCAppWindow.cpp
@@ -73,8 +73,10 @@ void IRCAppWindow::setup_client()
 
     if (m_client->hostname().is_empty()) {
         String value;
-        if (GUI::InputBox::show(this, value, "Enter server:", "Connect to server") == GUI::InputBox::ExecCancel)
-            ::exit(0);
+        if (GUI::InputBox::show(this, value, "Enter server:", "Connect to server") == GUI::InputBox::ExecCancel) {
+            GUI::Application::the()->quit();
+            return;
+        }
 
         m_client->set_server(value, 6667);
     }

--- a/Userland/Demos/Screensaver/Screensaver.cpp
+++ b/Userland/Demos/Screensaver/Screensaver.cpp
@@ -52,18 +52,18 @@ void Screensaver::mousemove_event(GUI::MouseEvent& event)
     if (m_mouse_origin.is_null()) {
         m_mouse_origin = event.position();
     } else if (event.position().distance_from(m_mouse_origin) > max_distance_move) {
-        ::exit(0);
+        GUI::Application::the()->quit();
     }
 }
 
 void Screensaver::mousedown_event(GUI::MouseEvent&)
 {
-    ::exit(0);
+    GUI::Application::the()->quit();
 }
 
 void Screensaver::keydown_event(GUI::KeyEvent&)
 {
-    ::exit(0);
+    GUI::Application::the()->quit();
 }
 
 void Screensaver::paint_event(GUI::PaintEvent& event)

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -80,12 +80,12 @@ void Starfield::mousemove_event(GUI::MouseEvent&)
 
 void Starfield::mousedown_event(GUI::MouseEvent&)
 {
-    ::exit(0);
+    GUI::Application::the()->quit();
 }
 
 void Starfield::keydown_event(GUI::KeyEvent&)
 {
-    ::exit(0);
+    GUI::Application::the()->quit();
 }
 
 void Starfield::paint_event(GUI::PaintEvent& event)

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.cpp
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.cpp
@@ -34,7 +34,6 @@ void ClientConnection::die()
 {
     s_connections.remove(client_id());
     GUI::Application::the()->quit();
-    exit(0);
 }
 
 RefPtr<GUI::Window> ClientConnection::create_dummy_child_window(i32 window_server_client_id, i32 parent_window_id)


### PR DESCRIPTION
Application::quit() is nicer for most cases where exit() is used. Cases
where exit() is used intentionally for early termination are left
intact.