### PR TITLE
Meta: Prefer to use -machine pcspk-audiodev for QEMU >=5.1

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -82,6 +82,7 @@ fi
 
 SERENITY_QEMU_MIN_REQ_VERSION=5
 installed_major_version=$("$SERENITY_QEMU_BIN" -version | head -n 1 | sed -E 's/QEMU emulator version ([1-9][0-9]*|0).*/\1/')
+installed_minor_version=$("$SERENITY_QEMU_BIN" -version | head -n 1 | sed -E 's/QEMU emulator version [0-9]+\.([1-9][0-9]*|0).*/\1/')
 if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ]; then
     echo "Required QEMU >= 5.0! Found $($SERENITY_QEMU_BIN -version | head -n 1)"
     echo "Please install a newer version of QEMU or use the Toolchain/BuildQemu.sh script."
@@ -104,10 +105,10 @@ else
     SERENITY_AUDIO_BACKEND="-audiodev pa,id=snd0"
 fi
 
-if [ "$installed_major_version" -gt 5 ]; then
-    SERENITY_AUDIO_HW="-machine pcspk-audiodev=snd0"
-else
+if [ "$installed_major_version" -eq 5 ] && [ "$installed_minor_version" -eq 0 ]; then
     SERENITY_AUDIO_HW="-soundhw pcspk"
+else
+    SERENITY_AUDIO_HW="-machine pcspk-audiodev=snd0"
 fi
 
 SERENITY_SCREENS="${SERENITY_SCREENS:-1}"

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -38,9 +38,12 @@ PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
 SERENITY_RUN="${SERENITY_RUN:-$1}"
 
 if [ -z "$SERENITY_QEMU_BIN" ]; then
-    if [ "$SERENITY_ARCH" = "x86_64" ]; then
+    if command -v qemu-system-x86_64 >/dev/null; then
         SERENITY_QEMU_BIN="qemu-system-x86_64"
     else
+        if [ "$SERENITY_ARCH" = "x86_64" ]; then
+            die "Please install the 64-bit QEMU system emulator (qemu-system-x86_64)."
+        fi
         SERENITY_QEMU_BIN="qemu-system-i386"
     fi
 fi


### PR DESCRIPTION
**Meta: Prefer to use -machine pcspk-audiodev for QEMU >=5.1**

This gets rid of the following warning message from QEMU on startup:

```
qemu-system-i386: warning: '-soundhw pcspk' is deprecated, please set a backend using '-machine pcspk-audiodev=<name>' instead
```

Fixes #4093.

**Meta: Prefer to use the 64-bit QEMU binary if that's available**

Some users might not have qemu-system-i386 installed.