### PR TITLE
LibSQL: Use compiler generated default functions

### DIFF
--- a/Userland/Libraries/LibSQL/Key.cpp
+++ b/Userland/Libraries/LibSQL/Key.cpp
@@ -9,11 +9,6 @@
 
 namespace SQL {
 
-Key::Key()
-    : Tuple()
-{
-}
-
 Key::Key(TupleDescriptor const& descriptor)
     : Tuple(descriptor)
 {

--- a/Userland/Libraries/LibSQL/Key.h
+++ b/Userland/Libraries/LibSQL/Key.h
@@ -14,12 +14,11 @@ namespace SQL {
 
 class Key : public Tuple {
 public:
-    Key();
+    Key() = default;
     explicit Key(TupleDescriptor const&);
     explicit Key(RefPtr<IndexDef>);
     Key(TupleDescriptor const&, ByteBuffer&, size_t& offset);
     Key(RefPtr<IndexDef>, ByteBuffer&, size_t& offset);
-    Key(Key const&) = default;
     RefPtr<IndexDef> index() const { return m_index; }
     [[nodiscard]] virtual size_t data_length() const override { return Tuple::data_length() + sizeof(u32); }
 


### PR DESCRIPTION
Problem:
- Clang ToT generates warnings due to user-declared functions causing
  the implicitly generated assignment operator to not be generated.

Solution:
- Declare the default constructor `= default`.
- Remove the default copy constructor declaration.