### PR TITLE
LibAudio: Make read samples signed when decoding fixed FLAC subframes, Make lossy flacs playable

### DIFF
--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -594,7 +594,7 @@ Vector<i32> FlacLoaderPlugin::parse_subframe(FlacSubframeHeader& subframe_header
 
         samples.ensure_capacity(m_current_frame->sample_count);
         for (u32 i = 0; i < m_current_frame->sample_count; ++i) {
-            samples.unchecked_append(sign_extend(constant_value, subframe_header.bits_per_sample));
+            samples.unchecked_append(sign_extend(constant_value, subframe_header.bits_per_sample - subframe_header.wasted_bits_per_sample));
         }
         break;
     }
@@ -643,8 +643,7 @@ Vector<i32> FlacLoaderPlugin::decode_custom_lpc(FlacSubframeHeader& subframe, In
 
     // warm-up samples
     for (auto i = 0; i < subframe.order; ++i) {
-        decoded.unchecked_append(sign_extend(bit_input.read_bits_big_endian(subframe.bits_per_sample - subframe.wasted_bits_per_sample), subframe.bits_per_sample));
-        decoded[i] <<= subframe.wasted_bits_per_sample;
+        decoded.unchecked_append(sign_extend(bit_input.read_bits_big_endian(subframe.bits_per_sample - subframe.wasted_bits_per_sample), subframe.bits_per_sample - subframe.wasted_bits_per_sample));
     }
 
     // precision of the coefficients
@@ -693,7 +692,7 @@ Vector<i32> FlacLoaderPlugin::decode_fixed_lpc(FlacSubframeHeader& subframe, Inp
 
     // warm-up samples
     for (auto i = 0; i < subframe.order; ++i) {
-        decoded.unchecked_append(sign_extend(bit_input.read_bits_big_endian(subframe.bits_per_sample - subframe.wasted_bits_per_sample), subframe.bits_per_sample));
+        decoded.unchecked_append(sign_extend(bit_input.read_bits_big_endian(subframe.bits_per_sample - subframe.wasted_bits_per_sample), subframe.bits_per_sample - subframe.wasted_bits_per_sample));
     }
 
     decode_residual(decoded, subframe, bit_input);

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -569,7 +569,6 @@ FlacSubframeHeader FlacLoaderPlugin::next_subframe_header(InputBitStream& bit_st
     u8 k = 0;
     if (has_wasted_bits) {
         bool current_k_bit = 0;
-        u8 k = 0;
         do {
             current_k_bit = bit_stream.read_bit_big_endian();
             ++k;

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -595,7 +595,7 @@ Vector<i32> FlacLoaderPlugin::parse_subframe(FlacSubframeHeader& subframe_header
 
         samples.ensure_capacity(m_current_frame->sample_count);
         for (u32 i = 0; i < m_current_frame->sample_count; ++i) {
-            samples.unchecked_append(constant_value);
+            samples.unchecked_append(sign_extend(constant_value, subframe_header.bits_per_sample));
         }
         break;
     }
@@ -694,7 +694,7 @@ Vector<i32> FlacLoaderPlugin::decode_fixed_lpc(FlacSubframeHeader& subframe, Inp
 
     // warm-up samples
     for (auto i = 0; i < subframe.order; ++i) {
-        decoded.unchecked_append(bit_input.read_bits_big_endian(subframe.bits_per_sample - subframe.wasted_bits_per_sample));
+        decoded.unchecked_append(sign_extend(bit_input.read_bits_big_endian(subframe.bits_per_sample - subframe.wasted_bits_per_sample), subframe.bits_per_sample));
     }
 
     decode_residual(decoded, subframe, bit_input);


### PR DESCRIPTION
General flac fix:

- **LibAudio: Make read samples signed when decoding fixed FLAC subframes**

  Prior this change, decoding fixed subframes produced "unpleasant crackling noices".

  While the type doesn't appear so often when using the default settings, encoding files in flac(1) with `--fast` option uses fixed subframes almost every time.

  This also applies the logic to the constant subframes, which isn't so important, as the type is generally for the silence, but let's use it as well to avoid inconsistency.

---
Making lossy flacs playable:

- **LibAudio: Fix calculation of wasted bits-per-sample**

  The value was always zero.

- **LibAudio: Make playing lossy flacs more truthful**

  Playing a lossy flac file resulted in hearing something you'd not like to play.  Instead of your lovely bass, you had sounds as if you put a CD-ROM disc to a CD player.

  It turned out that the size for making signed values was too big, making all the values unsigned.

  I've used [lossyWav] (the [posix port] to be exact) to generate such files.

[lossyWav]: https://wiki.hydrogenaud.io/index.php?title=LossyWAV
[posix port]: https://github.com/MoSal/lossywav-for-posix

*Note: this should be tested/merged on top of #9184 since flacs are currently broken :^(*