### PR TITLE
AK, Kernel: Print TODO when a TODO() is executed

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -12,5 +12,6 @@
 #    include <assert.h>
 #    define VERIFY assert
 #    define VERIFY_NOT_REACHED() assert(false)
-#    define TODO VERIFY_NOT_REACHED
+static constexpr bool TODO = false;
+#    define TODO() VERIFY(TODO)
 #endif

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -25,4 +25,6 @@ extern "C" {
 
 #define VERIFY_INTERRUPTS_DISABLED() VERIFY(!(cpu_flags() & 0x200))
 #define VERIFY_INTERRUPTS_ENABLED() VERIFY(cpu_flags() & 0x200)
-#define TODO VERIFY_NOT_REACHED
+
+static constexpr bool TODO = false;
+#define TODO() VERIFY(TODO)


### PR DESCRIPTION
Previously we would just print "ASSERTION FAILED: false", which was
kinda cryptic and also didn't make it clear whether this was a TODO or
an unreachable condition. Now, we actually print "ASSERTION FAILED:
TODO", making it crystal clear.