### PR TITLE
Shell: Make sure TTY echo is enabled when running external commands 

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -568,8 +568,11 @@ int Shell::run_command(const StringView& cmd, Optional<SourcePosition> source_po
     }
 
     tcgetattr(0, &termios);
+    tcsetattr(0, TCSANOW, &default_termios);
 
     command->run(*this);
+
+    tcsetattr(0, TCSANOW, &termios);
 
     if (!has_error(ShellError::None)) {
         possibly_print_error();


### PR DESCRIPTION
When running external commands via "Shell -c" LibLine turns of TTY echo before running the command. This ensures that it is turned on.

Steps to reproduce:

1. Start Python with "Shell -c python3" or via the taskbar.
2. Note that input isn't echoed.