### PR TITLE
FileManager: Don't show overly long directory names in errors

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -20,6 +20,7 @@
 
 namespace FileManager {
 
+String limit_error_path(String const& path_name, int saved_errno);
 void spawn_terminal(String const& directory);
 
 class LauncherHandler : public RefCounted<LauncherHandler> {


### PR DESCRIPTION
When `mkdir()` fails because the path is too long, our error
indicating that shouldn't try to show the overly long path,
because `MessageBox::build()` will construct a very large
message box out of that error, which
`Window::create_backing_store()` will not like at all.