### PR TITLE
Meta: Auto-detect where QEMU is installed on Windows

### DIFF
--- a/Documentation/BuildInstructionsWindows.md
+++ b/Documentation/BuildInstructionsWindows.md
@@ -34,12 +34,6 @@ will need to install the tools as well as the system emulators for i386 and x86_
 
 ![QEMU Components](QEMU_Components.png)
 
-Locate the `qemu-system-x86_64.exe` executable in WSL.
-By default this will be at `/mnt/c/Program Files/qemu/qemu-system-x86_64.exe`.
-
-Set the `SERENITY_QEMU_BIN` environment variable to that location. For example: \
-`export SERENITY_QEMU_BIN='/mnt/c/Program Files/qemu/qemu-system-x86_64.exe'`
-
 Run `Meta/serenity.sh run` to build and run SerenityOS as usual.
 
 ### Hardware acceleration

--- a/Documentation/BuildInstructionsWindows.md
+++ b/Documentation/BuildInstructionsWindows.md
@@ -48,10 +48,6 @@ following command in an elevated PowerShell session: \
 
 ![WHPX Windows Feature](WHPX_Feature.png)
 
-Set the `SERENITY_VIRT_TECH_ARG` environment variable in your WSL2 shell: \
-`export SERENITY_VIRT_TECH_ARG="-accel whpx,kernel-irqchip=off"`
+You may have to reboot after enabling the WHPX feature.
 
-You might want to add those environment variables to your shell's configuration file, so that you don't have to set them
-manually each time you start a new shell.
-
-Start the VM with `Meta/serenity.sh run` as usual.
+Afterwards you can start the VM with `Meta/serenity.sh run` as usual.

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -60,16 +60,6 @@ fi
 
 [ -z "$SERENITY_RAM_SIZE" ] && SERENITY_RAM_SIZE=512M
 
-if command -v wslpath >/dev/null; then
-    case "$SERENITY_QEMU_BIN" in
-        /mnt/?/*)
-            [ -z "$SERENITY_QEMU_CPU" ] && SERENITY_QEMU_CPU="max,vmx=off"
-            SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE disable_virtio"
-    esac
-fi
-
-[ -z "$SERENITY_QEMU_CPU" ] && SERENITY_QEMU_CPU="max"
-
 [ -z "$SERENITY_DISK_IMAGE" ] && {
     if [ "$SERENITY_RUN" = qgrub ]; then
         SERENITY_DISK_IMAGE="grub_disk_image"
@@ -99,6 +89,23 @@ if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ]; then
     echo "Please install a newer version of QEMU or use the Toolchain/BuildQemu.sh script."
     die
 fi
+
+if command -v wslpath >/dev/null; then
+    case "$SERENITY_QEMU_BIN" in
+        /mnt/?/*)
+            if [ -z "$SERENITY_VIRT_TECH_ARG" ]; then
+                if [ "$installed_major_version" -gt 5 ]; then
+                    SERENITY_VIRT_TECH_ARG="-accel whpx,kernel-irqchip=off -accel tcg"
+                else
+                    SERENITY_VIRT_TECH_ARG="-accel whpx -accel tcg"
+                fi
+            fi
+            [ -z "$SERENITY_QEMU_CPU" ] && SERENITY_QEMU_CPU="max,vmx=off"
+            SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE disable_virtio"
+    esac
+fi
+
+[ -z "$SERENITY_QEMU_CPU" ] && SERENITY_QEMU_CPU="max"
 
 if [ -z "$SERENITY_SPICE" ] && "${SERENITY_QEMU_BIN}" -chardev help | grep -iq qemu-vdagent; then
     SERENITY_SPICE_SERVER_CHARDEV="-chardev qemu-vdagent,clipboard=on,mouse=off,id=vdagent,name=vdagent"

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -38,13 +38,21 @@ PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
 SERENITY_RUN="${SERENITY_RUN:-$1}"
 
 if [ -z "$SERENITY_QEMU_BIN" ]; then
-    if command -v qemu-system-x86_64 >/dev/null; then
-        SERENITY_QEMU_BIN="qemu-system-x86_64"
+    if command -v wslpath >/dev/null; then
+        QEMU_INSTALL_DIR=$(reg.exe query 'HKLM\Software\QEMU' /v Install_Dir /t REG_SZ | grep '^    Install_Dir' | sed 's/    / /g' | cut -f4- -d' ')
+        if [ -z "$QEMU_INSTALL_DIR" ]; then
+            die "Could not determine where QEMU for Windows is installed. Please make sure QEMU is installed or set SERENITY_QEMU_BIN if it is already installed."
+        fi
+        QEMU_BINARY_PREFIX="$(wslpath -- "${QEMU_INSTALL_DIR}" | tr -d '\r\n')/"
+        QEMU_BINARY_SUFFIX=".exe"
+    fi
+    if command -v "${QEMU_BINARY_PREFIX}qemu-system-x86_64${QEMU_BINARY_SUFFIX}" >/dev/null; then
+        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-x86_64${QEMU_BINARY_SUFFIX}"
     else
         if [ "$SERENITY_ARCH" = "x86_64" ]; then
             die "Please install the 64-bit QEMU system emulator (qemu-system-x86_64)."
         fi
-        SERENITY_QEMU_BIN="qemu-system-i386"
+        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-i386${QEMU_BINARY_SUFFIX}"
     fi
 fi
 


### PR DESCRIPTION
**Meta: Auto-detect where QEMU is installed on Windows**

**Meta: Automatically enable WHPX when possible**

**Meta: Detect nested KVM support for WSL2 and use that when available**

This allows running QEMU inside WSL2 for hosts which have nested KVM and WSLg support (e.g. Windows 11).

Running QEMU inside the WSL2 VM is slightly slower than running QEMU on Windows, probably because of how WSLg handles screen updates.