### PR TITLE
TextEditor: Set modified flag after save 

### DIFF
--- a/Userland/Libraries/LibGUI/Command.h
+++ b/Userland/Libraries/LibGUI/Command.h
@@ -18,8 +18,8 @@ public:
     virtual void redo() { }
 
     virtual String action_text() const { return {}; }
-    virtual bool no_action() const { return false; }
     virtual bool merge_with(Command const&) { return false; }
+    virtual bool merge() const { return true; }
 
 protected:
     Command() { }

--- a/Userland/Libraries/LibGUI/Command.h
+++ b/Userland/Libraries/LibGUI/Command.h
@@ -18,6 +18,7 @@ public:
     virtual void redo() { }
 
     virtual String action_text() const { return {}; }
+    virtual bool no_action() const { return false; }
     virtual bool merge_with(Command const&) { return false; }
 
 protected:

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -881,6 +881,21 @@ void RemoveTextCommand::undo()
     m_document.set_all_cursors(new_cursor);
 }
 
+SaveFileCommand::SaveFileCommand(TextDocument& document)
+    : TextDocumentUndoCommand(document)
+{
+}
+
+String SaveFileCommand::action_text() const
+{
+    return "Save file";
+}
+
+bool SaveFileCommand::no_action() const 
+{
+    return true;
+}
+
 TextPosition TextDocument::insert_at(const TextPosition& position, const StringView& text, const Client* client)
 {
     TextPosition cursor = position;

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -743,10 +743,11 @@ TextDocumentUndoCommand::~TextDocumentUndoCommand()
 {
 }
 
-InsertTextCommand::InsertTextCommand(TextDocument& document, const String& text, const TextPosition& position)
+InsertTextCommand::InsertTextCommand(TextDocument& document, const String& text, const TextPosition& position, bool merge)
     : TextDocumentUndoCommand(document)
     , m_text(text)
     , m_range({ position, position })
+    , m_merge(merge)
 {
 }
 
@@ -837,10 +838,11 @@ void InsertTextCommand::undo()
     m_document.set_all_cursors(m_range.start());
 }
 
-RemoveTextCommand::RemoveTextCommand(TextDocument& document, const String& text, const TextRange& range)
+RemoveTextCommand::RemoveTextCommand(TextDocument& document, const String& text, const TextRange& range, bool merge)
     : TextDocumentUndoCommand(document)
     , m_text(text)
     , m_range(range)
+    , m_merge(merge)
 {
 }
 
@@ -879,21 +881,6 @@ void RemoveTextCommand::undo()
 {
     auto new_cursor = m_document.insert_at(m_range.start(), m_text);
     m_document.set_all_cursors(new_cursor);
-}
-
-SaveFileCommand::SaveFileCommand(TextDocument& document)
-    : TextDocumentUndoCommand(document)
-{
-}
-
-String SaveFileCommand::action_text() const
-{
-    return "Save file";
-}
-
-bool SaveFileCommand::no_action() const 
-{
-    return true;
 }
 
 TextPosition TextDocument::insert_at(const TextPosition& position, const StringView& text, const Client* client)

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -211,7 +211,6 @@ public:
     virtual String action_text() const override;
     const String& text() const { return m_text; }
     const TextRange& range() const { return m_range; }
-
 private:
     String m_text;
     TextRange m_range;
@@ -225,10 +224,16 @@ public:
     const TextRange& range() const { return m_range; }
     virtual bool merge_with(GUI::Command const&) override;
     virtual String action_text() const override;
-
 private:
     String m_text;
     TextRange m_range;
+};
+
+class SaveFileCommand : public TextDocumentUndoCommand {
+public:
+    SaveFileCommand(TextDocument&);
+    virtual bool no_action() const override;
+    virtual String action_text() const override;
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -203,7 +203,7 @@ protected:
 
 class InsertTextCommand : public TextDocumentUndoCommand {
 public:
-    InsertTextCommand(TextDocument&, const String&, const TextPosition&);
+    InsertTextCommand(TextDocument&, const String&, const TextPosition&, bool);
     virtual void perform_formatting(const TextDocument::Client&) override;
     virtual void undo() override;
     virtual void redo() override;
@@ -211,29 +211,27 @@ public:
     virtual String action_text() const override;
     const String& text() const { return m_text; }
     const TextRange& range() const { return m_range; }
+    virtual bool merge() const override { return m_merge; }
+
 private:
     String m_text;
     TextRange m_range;
+    bool m_merge;
 };
 
 class RemoveTextCommand : public TextDocumentUndoCommand {
 public:
-    RemoveTextCommand(TextDocument&, const String&, const TextRange&);
+    RemoveTextCommand(TextDocument&, const String&, const TextRange&, bool);
     virtual void undo() override;
     virtual void redo() override;
     const TextRange& range() const { return m_range; }
     virtual bool merge_with(GUI::Command const&) override;
     virtual String action_text() const override;
+    virtual bool merge() const override { return m_merge; }
+
 private:
     String m_text;
     TextRange m_range;
+    bool m_merge;
 };
-
-class SaveFileCommand : public TextDocumentUndoCommand {
-public:
-    SaveFileCommand(TextDocument&);
-    virtual bool no_action() const override;
-    virtual String action_text() const override;
-};
-
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1281,6 +1281,7 @@ bool TextEditor::write_to_file_and_close(int fd)
         }
     }
     document().set_unmodified();
+    execute<SaveFileCommand>();
     return true;
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1281,7 +1281,9 @@ bool TextEditor::write_to_file_and_close(int fd)
         }
     }
     document().set_unmodified();
-    execute<SaveFileCommand>();
+
+    m_merge_command = false;
+
     return true;
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -312,11 +312,12 @@ private:
     template<class T, class... Args>
     inline void execute(Args&&... args)
     {
-        auto command = make<T>(*m_document, forward<Args>(args)...);
+        auto command = make<T>(*m_document, forward<Args>(args)..., m_merge_command);
         command->perform_formatting(*this);
         will_execute(*command);
         command->execute_from(*this);
         m_document->add_to_undo_stack(move(command));
+        m_merge_command = true;
     }
 
     virtual void will_execute(TextDocumentUndoCommand const&) { }
@@ -392,6 +393,8 @@ private:
     RefPtr<Gfx::Bitmap> m_icon;
 
     bool m_text_is_secret { false };
+
+    bool m_merge_command { true };
 };
 
 }

--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -56,24 +56,19 @@ void UndoStack::redo()
 void UndoStack::push(NonnullOwnPtr<Command> command)
 {
     // If the stack cursor is behind the top of the stack, nuke everything from here to the top.
-    while (m_stack.size() != m_stack_index && !command->no_action())
+    while (m_stack.size() != m_stack_index)
         m_stack.take_last();
 
     if (m_clean_index.has_value() && m_clean_index.value() > m_stack.size())
         m_clean_index = {};
 
     if (!m_stack.is_empty()) {
-        if (m_merge && m_stack.last().merge_with(*command))
+        if (command->merge() && m_stack.last().merge_with(*command))
             return;
     }
 
-    if(command->no_action()) {
-        m_merge = false;
-    } else {
-        m_stack.append(move(command));
-        m_stack_index = m_stack.size();
-        m_merge = true;
-    }
+    m_stack.append(move(command));
+    m_stack_index = m_stack.size();
 
     if (on_state_change)
         on_state_change();

--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -56,19 +56,24 @@ void UndoStack::redo()
 void UndoStack::push(NonnullOwnPtr<Command> command)
 {
     // If the stack cursor is behind the top of the stack, nuke everything from here to the top.
-    while (m_stack.size() != m_stack_index)
+    while (m_stack.size() != m_stack_index && !command->no_action())
         m_stack.take_last();
 
     if (m_clean_index.has_value() && m_clean_index.value() > m_stack.size())
         m_clean_index = {};
 
     if (!m_stack.is_empty()) {
-        if (m_stack.last().merge_with(*command))
+        if (m_merge && m_stack.last().merge_with(*command))
             return;
     }
 
-    m_stack.append(move(command));
-    m_stack_index = m_stack.size();
+    if(command->no_action()) {
+        m_merge = false;
+    } else {
+        m_stack.append(move(command));
+        m_stack_index = m_stack.size();
+        m_merge = true;
+    }
 
     if (on_state_change)
         on_state_change();

--- a/Userland/Libraries/LibGUI/UndoStack.h
+++ b/Userland/Libraries/LibGUI/UndoStack.h
@@ -39,6 +39,7 @@ private:
     NonnullOwnPtrVector<Command> m_stack;
     size_t m_stack_index { 0 };
     Optional<size_t> m_clean_index;
+    bool m_merge { true };
 };
 
 }

--- a/Userland/Libraries/LibGUI/UndoStack.h
+++ b/Userland/Libraries/LibGUI/UndoStack.h
@@ -39,7 +39,6 @@ private:
     NonnullOwnPtrVector<Command> m_stack;
     size_t m_stack_index { 0 };
     Optional<size_t> m_clean_index;
-    bool m_merge { true };
 };
 
 }


### PR DESCRIPTION
Solution for #8902 by adding a SaveCommand to the TextEditor. This command does not add any actions to the UndoStack and won't be merged with undo/redo actions that were previously added to the UndoStack. This way the modified flag gets set after saving the file without losing undo/redo functionality.