### PR TITLE
LibWeb: Enable data urls in CSS parser

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1199,16 +1199,9 @@ Vector<Vector<StyleComponentValueRule>> Parser::parse_a_comma_separated_list_of_
 Optional<URL> Parser::parse_url_function(ParsingContext const& context, StyleComponentValueRule const& component_value)
 {
     // FIXME: Handle list of media queries. https://www.w3.org/TR/css-cascade-3/#conditional-import
-    // FIXME: Handle data: urls (RFC2397)
-
-    auto is_data_url = [](StringView& url_string) -> bool {
-        return url_string.starts_with("data:", CaseSensitivity::CaseInsensitive);
-    };
 
     if (component_value.is(Token::Type::Url)) {
         auto url_string = component_value.token().url();
-        if (is_data_url(url_string))
-            return {};
         return context.complete_url(url_string);
     }
     if (component_value.is_function() && component_value.function().name().equals_ignoring_case("url")) {
@@ -1220,8 +1213,6 @@ Optional<URL> Parser::parse_url_function(ParsingContext const& context, StyleCom
                 continue;
             if (value.is(Token::Type::String)) {
                 auto url_string = value.token().string();
-                if (is_data_url(url_string))
-                    return {};
                 return context.complete_url(url_string);
             }
             break;

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -105,7 +105,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
     }
 
     if (url.protocol() == "about") {
-        dbgln("Loading about: URL {}", url);
+        dbgln_if(RESOURCE_DEBUG, "Loading about: URL {}", url);
         deferred_invoke([success_callback = move(success_callback)](auto&) {
             success_callback(String::empty().to_byte_buffer(), {}, {});
         });
@@ -113,7 +113,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
     }
 
     if (url.protocol() == "data") {
-        dbgln("ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
+        dbgln_if(RESOURCE_DEBUG, "ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
             url.data_mime_type(),
             url.data_payload_is_base64(),
             url.data_payload());
@@ -213,7 +213,7 @@ bool ResourceLoader::is_port_blocked(int port)
 
 void ResourceLoader::clear_cache()
 {
-    dbgln("Clearing {} items from ResourceLoader cache", s_resource_cache.size());
+    dbgln_if(CACHE_DEBUG, "Clearing {} items from ResourceLoader cache", s_resource_cache.size());
     s_resource_cache.clear();
 }
 


### PR DESCRIPTION
Not sure why this is not enabled before since URL and ResourceLoader already support data urls. This also cleans up some `dbgln`s in ResourceLoader so it does not log the entire payload of the data url.