### PR TITLE
Ports: Add menu entry for PHP

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -8,7 +8,7 @@ Make sure you also have all the following dependencies installed:
 
 ```console
 # core
-brew install coreutils e2fsprogs qemu bash gcc@10 ninja cmake ccache rsync
+brew install coreutils e2fsprogs qemu bash gcc@10 imagemagick ninja cmake ccache rsync
 
 # (option 1) fuse + ext2
 brew install m4 autoconf automake libtool

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -127,7 +127,7 @@ install_icon() {
         if [ -n "$index" ]; then
             run convert "${icon}[${index}]" "app-${icon_size}.png"
         else
-            run convert "$icon" -resize $icon_size "app-${icon_size}.png"
+            run convert "$icon[0]" -resize $icon_size "app-${icon_size}.png"
         fi
     done
     run objcopy --add-section serenity_icon_s="app-16x16.png" "${DESTDIR}${launcher}"

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -145,21 +145,22 @@ install_launcher() {
         echo "Syntax: install_launcher <name> <category> <command>"
         exit 1
     fi
-    launcher_name="$1"
-    launcher_category="$2"
-    launcher_command="$3"
-    launcher_filename="${launcher_name,,}"
+    local launcher_name="$1"
+    local launcher_category="$2"
+    local launcher_command="$3"
+    local launcher_filename="${launcher_name,,}"
     launcher_filename="${launcher_filename// /}"
+    local icon_override=""
     case "$launcher_command" in
         *\ *)
             mkdir -p $DESTDIR/usr/local/libexec
             launcher_executable="/usr/local/libexec/$launcher_filename"
             cat >"$DESTDIR/$launcher_executable" <<SCRIPT
 #!/bin/sh
-set -e
 exec $(printf '%q ' $launcher_command)
 SCRIPT
             chmod +x "$DESTDIR/$launcher_executable"
+            icon_override="IconPath=${launcher_command%% *}"
             ;;
         *)
             launcher_executable="$launcher_command"
@@ -172,8 +173,8 @@ Name=$launcher_name
 Executable=$launcher_executable
 Category=$launcher_category
 RunInTerminal=$launcher_run_in_terminal
+${icon_override}
 CONFIG
-    unset launcher_filename
 }
 # Checks if a function is defined. In this case, if the function is not defined in the port's script, then we will use our defaults. This way, ports don't need to include these functions every time, but they can override our defaults if needed.
 func_defined() {

--- a/Ports/php/package.sh
+++ b/Ports/php/package.sh
@@ -14,6 +14,11 @@ configopts="
     --with-zlib
     --without-pcre-jit
 "
+launcher_name="PHP"
+launcher_category="Development"
+launcher_command="/usr/local/bin/php -a"
+launcher_run_in_terminal="true"
+icon_file="win32/build/php.ico"
 
 export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2"
 export LIBS="-ldl"

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -124,11 +124,9 @@ bool AppFile::spawn() const
     if ((errno = posix_spawn(&child_pid, executable().characters(), nullptr, nullptr, const_cast<char**>(argv), environ))) {
         perror("posix_spawn");
         return false;
-    } else {
-        if (disown(child_pid) < 0) {
-            perror("disown");
-            return false;
-        }
+    } else if (disown(child_pid) < 0) {
+        perror("disown");
+        return false;
     }
 
     return true;

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -87,6 +87,21 @@ String AppFile::category() const
     return m_config->read_entry("App", "Category").trim_whitespace();
 }
 
+String AppFile::icon_path() const
+{
+    return m_config->read_entry("App", "IconPath").trim_whitespace();
+}
+
+GUI::Icon AppFile::icon() const
+{
+    auto override_icon = icon_path();
+    // FIXME: support pointing to actual .ico files
+    if (!override_icon.is_empty())
+        return GUI::FileIconProvider::icon_for_path(override_icon);
+
+    return GUI::FileIconProvider::icon_for_path(executable());
+}
+
 bool AppFile::run_in_terminal() const
 {
     return m_config->read_bool_entry("App", "RunInTerminal", false);

--- a/Userland/Libraries/LibDesktop/AppFile.h
+++ b/Userland/Libraries/LibDesktop/AppFile.h
@@ -27,12 +27,12 @@ public:
     String executable() const;
     String category() const;
     String description() const;
+    String icon_path() const;
+    GUI::Icon icon() const;
     bool run_in_terminal() const;
     Vector<String> launcher_file_types() const;
     Vector<String> launcher_protocols() const;
     bool spawn() const;
-
-    GUI::Icon icon() const { return GUI::FileIconProvider::icon_for_path(executable()); };
 
 private:
     explicit AppFile(const StringView& path);

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -71,6 +71,7 @@ struct AppMetadata {
     String executable;
     String name;
     String category;
+    GUI::Icon icon;
     bool run_in_terminal;
 };
 Vector<AppMetadata> g_apps;
@@ -91,7 +92,7 @@ Vector<String> discover_apps_and_categories()
     HashTable<String> seen_app_categories;
     Desktop::AppFile::for_each([&](auto af) {
         if (access(af->executable().characters(), X_OK) == 0) {
-            g_apps.append({ af->executable(), af->name(), af->category(), af->run_in_terminal() });
+            g_apps.append({ af->executable(), af->name(), af->category(), af->icon(), af->run_in_terminal() });
             seen_app_categories.set(af->category());
         }
     });
@@ -172,7 +173,7 @@ NonnullRefPtr<GUI::Menu> build_system_menu()
             continue;
         }
 
-        auto icon = GUI::FileIconProvider::icon_for_executable(app.executable).bitmap_for_size(16);
+        auto icon = app.icon.bitmap_for_size(16);
 
         if constexpr (SYSTEM_MENU_DEBUG) {
             if (icon)


### PR DESCRIPTION
I wanted to add PHP to the menu, and in the process of doing so improved some components:

* Ports now report when ImageMagick is unavailable
* Ports are now able to create a resized icon file from an `.ico` with multiple indices
* Taskbar now uses the icon as provided by AppFile
* AppFile now supports overriding the icon, which is useful when pointing to shell scripts for example
* Ports learned how to override the application icon when generating a shell script

<img width="808" alt="Screenshot 2021-08-04 at 13 14 14" src="https://user-images.githubusercontent.com/3210731/128173082-ba6cb35a-c431-4563-b3bf-a4aa7240668a.png">