### PR TITLE
FAQ: remove question about only supporting 32 bit

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -14,7 +14,7 @@ There are no ISO images. This project does not cater to non-technical users.
 
 ## Why is the system 32-bit?
 
-That's what Andreas was most familiar with when starting out. There's some interest in supporting 64-bit systems and that will eventually happen, but it's just another feature.
+That's what Andreas was most familiar with when starting out. A 64-bit port, however, is now available!
 
 ## I did a `git pull` and now the build is broken! What do I do?
 


### PR DESCRIPTION
As the system now supports x86_64, this question about the system being 32 bit is no longer relevant.