### PR TITLE
AK: Improve the parsing of data urls

### DIFF
--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -215,7 +216,20 @@ TEST_CASE(data_url)
     EXPECT(url.host().is_null());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), "test");
+    EXPECT(!url.data_payload_is_base64());
     EXPECT_EQ(url.serialize(), "data:text/html,test");
+}
+
+TEST_CASE(data_url_default_mime_type)
+{
+    URL url("data:,test");
+    EXPECT(url.is_valid());
+    EXPECT_EQ(url.scheme(), "data");
+    EXPECT(url.host().is_null());
+    EXPECT_EQ(url.data_mime_type(), "text/plain");
+    EXPECT_EQ(url.data_payload(), "test");
+    EXPECT(!url.data_payload_is_base64());
+    EXPECT_EQ(url.serialize(), "data:text/plain,test");
 }
 
 TEST_CASE(data_url_encoded)
@@ -226,6 +240,7 @@ TEST_CASE(data_url_encoded)
     EXPECT(url.host().is_null());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), "Hello friends,%0X%X0");
+    EXPECT(!url.data_payload_is_base64());
     EXPECT_EQ(url.serialize(), "data:text/html,Hello friends,%0X%X0");
 }
 
@@ -237,7 +252,32 @@ TEST_CASE(data_url_base64_encoded)
     EXPECT(url.host().is_null());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), "test");
+    EXPECT(url.data_payload_is_base64());
     EXPECT_EQ(url.serialize(), "data:text/html;base64,test");
+}
+
+TEST_CASE(data_url_base64_encoded_default_mime_type)
+{
+    URL url("data:;base64,test");
+    EXPECT(url.is_valid());
+    EXPECT_EQ(url.scheme(), "data");
+    EXPECT(url.host().is_null());
+    EXPECT_EQ(url.data_mime_type(), "text/plain");
+    EXPECT_EQ(url.data_payload(), "test");
+    EXPECT(url.data_payload_is_base64());
+    EXPECT_EQ(url.serialize(), "data:text/plain;base64,test");
+}
+
+TEST_CASE(data_url_base64_encoded_with_whitespace)
+{
+    URL url("data: text/html ;     bAsE64 , test with whitespace ");
+    EXPECT(url.is_valid());
+    EXPECT_EQ(url.scheme(), "data");
+    EXPECT(url.host().is_null());
+    EXPECT_EQ(url.data_mime_type(), "text/html");
+    EXPECT_EQ(url.data_payload(), " test with whitespace ");
+    EXPECT(url.data_payload_is_base64());
+    EXPECT_EQ(url.serialize(), "data:text/html;base64, test with whitespace ");
 }
 
 TEST_CASE(trailing_slash_with_complete_url)


### PR DESCRIPTION
Improve the parsing of data urls in URLParser to bring it more up-to-spec. At the moment, we cannot parse the components of the MIME type since it is represented as a string, but the spec requires it to be parsed as a "MIME type record".

[RFC2397](https://datatracker.ietf.org/doc/html/rfc2397) specifies that a data url without a MIME type should have the MIME type `text/plain;charset=US-ASCII`. However, the [spec](https://fetch.spec.whatwg.org/#data-urls) does not provide information to handle this situation. I think that currently, for simplicity, data urls without a MIME type should have the MIME type `text/plain`.