### PR TITLE
Kernel: Remove the always 1-sized super physical regions Vector

### DIFF
--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -248,7 +248,7 @@ private:
     SystemMemoryInfo m_system_memory_info;
 
     NonnullOwnPtrVector<PhysicalRegion> m_user_physical_regions;
-    NonnullOwnPtrVector<PhysicalRegion> m_super_physical_regions;
+    OwnPtr<PhysicalRegion> m_super_physical_region;
     OwnPtr<PhysicalRegion> m_physical_pages_region;
     PhysicalPageEntry* m_physical_page_entries { nullptr };
     size_t m_physical_page_entries_count { 0 };


### PR DESCRIPTION
Since we only ever add 1 super physical region, theres no reason to add the extra redirection and allocation that comes with a dynamically sized Vector.