### PR TITLE
Add sockopt IP_DONTFRAG and more 'ping' arguments

### DIFF
--- a/Kernel/Net/IPv4.h
+++ b/Kernel/Net/IPv4.h
@@ -70,6 +70,13 @@ public:
         else
             m_flags_and_fragment = (u16)m_flags_and_fragment & ((u16)IPv4PacketFlags::MoreFragments);
     }
+    void set_dont_fragment(bool dont_fragment)
+    {
+        if (dont_fragment)
+            m_flags_and_fragment = (u16)m_flags_and_fragment | ((u16)IPv4PacketFlags::DontFragment);
+        else
+            m_flags_and_fragment = (u16)m_flags_and_fragment & ((u16)IPv4PacketFlags::DontFragment);
+    }
     void set_fragment_offset(u16 offset)
     {
         m_flags_and_fragment = flags() | (offset & 0x1fff);

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -125,6 +125,7 @@ private:
     u32 m_bytes_received { 0 };
 
     u8 m_ttl { 64 };
+    bool m_dontfrag { false };
 
     bool m_can_read { false };
 

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -42,7 +42,7 @@ void NetworkAdapter::send(const MACAddress& destination, const ARPPacket& packet
     send_packet({ (const u8*)eth, size_in_bytes });
 }
 
-void NetworkAdapter::fill_in_ipv4_header(PacketWithTimestamp& packet, IPv4Address const& source_ipv4, MACAddress const& destination_mac, IPv4Address const& destination_ipv4, IPv4Protocol protocol, size_t payload_size, u8 ttl)
+void NetworkAdapter::fill_in_ipv4_header(PacketWithTimestamp& packet, IPv4Address const& source_ipv4, MACAddress const& destination_mac, IPv4Address const& destination_ipv4, IPv4Protocol protocol, size_t payload_size, u8 ttl, bool dont_fragment)
 {
     size_t ipv4_packet_size = sizeof(IPv4Packet) + payload_size;
     VERIFY(ipv4_packet_size <= mtu());
@@ -63,6 +63,7 @@ void NetworkAdapter::fill_in_ipv4_header(PacketWithTimestamp& packet, IPv4Addres
     ipv4.set_length(sizeof(IPv4Packet) + payload_size);
     ipv4.set_ident(1);
     ipv4.set_ttl(ttl);
+    ipv4.set_dont_fragment(dont_fragment);
     ipv4.set_checksum(ipv4.compute_checksum());
 }
 

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -69,7 +69,7 @@ public:
     void set_ipv4_gateway(const IPv4Address&);
 
     void send(const MACAddress&, const ARPPacket&);
-    void fill_in_ipv4_header(PacketWithTimestamp&, IPv4Address const&, MACAddress const&, IPv4Address const&, IPv4Protocol, size_t, u8);
+    void fill_in_ipv4_header(PacketWithTimestamp&, IPv4Address const&, MACAddress const&, IPv4Address const&, IPv4Protocol, size_t, u8, bool dont_fragment = false);
 
     size_t dequeue_packet(u8* buffer, size_t buffer_size, Time& packet_timestamp);
 

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -539,6 +539,9 @@ enum {
 #define IP_MULTICAST_LOOP 3
 #define IP_ADD_MEMBERSHIP 4
 #define IP_DROP_MEMBERSHIP 5
+#define IP_MULTICAST_IF 6
+#define IP_MULTICAST_TTL 7
+#define IP_DONTFRAG 8
 
 struct ucred {
     pid_t pid;

--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -27,6 +27,7 @@ in_addr_t inet_addr(const char*);
 #define IP_DROP_MEMBERSHIP 5
 #define IP_MULTICAST_IF 6
 #define IP_MULTICAST_TTL 7
+#define IP_DONTFRAG 8
 
 /* Make sure these don't overlap with any other IPv4 and IPv6 options */
 #define MCAST_JOIN_SOURCE_GROUP 100

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -71,6 +71,11 @@ int main(int argc, char** argv)
         payload_size = 32 - sizeof(struct icmphdr);
     }
 
+    if (payload_size > (int)(10 * MiB)) {
+        warnln("Payload size too big - maximum is 10 MiB.");
+        return 1;
+    }
+
     if (interval < 1) {
         warnln("Interval must be at least 1 second.");
         return 1;

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -32,6 +32,7 @@ static const char* host;
 static int payload_size = -1;
 static int interval = 1;
 static int ttl = 64;
+static bool dont_frag = false;
 
 static void closing_statistics()
 {
@@ -66,6 +67,7 @@ int main(int argc, char** argv)
     args_parser.add_option(payload_size, "Amount of bytes to send as payload in the ECHO_REQUEST packets.", "size", 's', "size");
     args_parser.add_option(interval, "Packet interval in seconds", "interval", 'i', "interval");
     args_parser.add_option(ttl, "TTL of the ECHO_REQUEST packets.", "ttl", 'm', "ttl");
+    args_parser.add_option(dont_frag, "Disable fragmentation.", "df", 'D');
     args_parser.parse(argc, argv);
 
     if (payload_size < 0) {
@@ -113,6 +115,15 @@ int main(int argc, char** argv)
     if (rc < 0) {
         perror("setsockopt");
         return 1;
+    }
+
+    if (dont_frag) {
+        int value = 1;
+        rc = setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, &value, sizeof(value));
+        if (rc < 0) {
+            perror("setsockopt");
+            return 1;
+        }
     }
 
     auto* hostent = gethostbyname(host);

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -31,6 +31,7 @@ static int max_ms;
 static const char* host;
 static int payload_size = -1;
 static int interval = 1;
+static int ttl = 64;
 
 static void closing_statistics()
 {
@@ -64,6 +65,7 @@ int main(int argc, char** argv)
     args_parser.add_option(count, "Stop after sending specified number of ECHO_REQUEST packets.", "count", 'c', "count");
     args_parser.add_option(payload_size, "Amount of bytes to send as payload in the ECHO_REQUEST packets.", "size", 's', "size");
     args_parser.add_option(interval, "Packet interval in seconds", "interval", 'i', "interval");
+    args_parser.add_option(ttl, "TTL of the ECHO_REQUEST packets.", "ttl", 'm', "ttl");
     args_parser.parse(argc, argv);
 
     if (payload_size < 0) {
@@ -102,6 +104,12 @@ int main(int argc, char** argv)
     };
 
     int rc = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    if (rc < 0) {
+        perror("setsockopt");
+        return 1;
+    }
+
+    rc = setsockopt(fd, IPPROTO_IP, IP_TTL, &ttl, sizeof(ttl));
     if (rc < 0) {
         perror("setsockopt");
         return 1;

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -30,6 +30,7 @@ static int min_ms;
 static int max_ms;
 static const char* host;
 static int payload_size = -1;
+static int interval = 1;
 
 static void closing_statistics()
 {
@@ -62,11 +63,17 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(host, "Host to ping", "host");
     args_parser.add_option(count, "Stop after sending specified number of ECHO_REQUEST packets.", "count", 'c', "count");
     args_parser.add_option(payload_size, "Amount of bytes to send as payload in the ECHO_REQUEST packets.", "size", 's', "size");
+    args_parser.add_option(interval, "Packet interval in seconds", "interval", 'i', "interval");
     args_parser.parse(argc, argv);
 
     if (payload_size < 0) {
         // Use the default.
         payload_size = 32 - sizeof(struct icmphdr);
+    }
+
+    if (interval < 1) {
+        warnln("Interval must be at least 1 second.");
+        return 1;
     }
 
     int fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
@@ -213,7 +220,7 @@ int main(int argc, char** argv)
             break;
         }
 
-        sleep(1);
+        sleep(interval);
     }
 
     return 0;


### PR DESCRIPTION
Added the sockopt IP_DONTFRAG to set the DF-bit on IP-level sockets.

Added the following ping options:
* -D: prevent fragmentation
* -i: interval between requests
* -m: set the TTL on request packets

Also prevent the user from chewing up a lot of memory using -s.