### PR TITLE
Assistant: Quit the application after losing focus

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -280,6 +280,10 @@ int main(int argc, char** argv)
     text_box.on_escape_pressed = []() {
         GUI::Application::the()->quit();
     };
+    window->on_active_window_change = [](bool is_active_window) {
+        if (!is_active_window)
+            GUI::Application::the()->quit();
+    };
 
     db.on_new_results = [&](auto results) {
         if (results.is_empty())

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -491,6 +491,8 @@ void Window::handle_became_active_or_inactive_event(Core::Event& event)
         Application::the()->window_did_become_active({}, *this);
     else
         Application::the()->window_did_become_inactive({}, *this);
+    if (on_active_window_change)
+        on_active_window_change(event.type() == Event::WindowBecameActive);
     if (m_main_widget)
         m_main_widget->dispatch_event(event, this);
     if (m_focused_widget)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -83,6 +83,7 @@ public:
     Function<void()> on_close;
     Function<CloseRequestDecision()> on_close_request;
     Function<void(bool is_active_input)> on_active_input_change;
+    Function<void(bool is_active_window)> on_active_window_change;
 
     int x() const { return rect().x(); }
     int y() const { return rect().y(); }


### PR DESCRIPTION
Prior to this change, Assistant would just stay in the background, unless one pressed an Escape key or launched some app.