### PR TITLE
AK: Make Time class constexpr

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -18,39 +18,6 @@
 
 namespace AK {
 
-int day_of_year(int year, unsigned month, int day)
-{
-    VERIFY(month >= 1 && month <= 12);
-
-    constexpr Array seek_table = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
-    int day_of_year = seek_table[month - 1] + day - 1;
-
-    if (is_leap_year(year) && month >= 3)
-        day_of_year++;
-
-    return day_of_year;
-}
-
-int days_in_month(int year, unsigned month)
-{
-    VERIFY(month >= 1 && month <= 12);
-    if (month == 2)
-        return is_leap_year(year) ? 29 : 28;
-
-    bool is_long_month = (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12);
-    return is_long_month ? 31 : 30;
-}
-
-unsigned day_of_week(int year, unsigned month, int day)
-{
-    VERIFY(month >= 1 && month <= 12);
-    constexpr Array seek_table = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
-    if (month < 3)
-        --year;
-
-    return (year + year / 4 - year / 100 + year / 400 + seek_table[month - 1] + day) % 7;
-}
-
 Time Time::from_timespec(const struct timespec& ts)
 {
     i32 nsecs = ts.tv_nsec;

--- a/Tests/AK/TestTime.cpp
+++ b/Tests/AK/TestTime.cpp
@@ -261,3 +261,113 @@ TEST_CASE(truncation)
     EXPECT_EQ(TIME(9223372036854, 775'807'000).to_truncated_microseconds(), 0x7fff'ffff'ffff'ffff);
     EXPECT_EQ(TIME(9223372036854, 775'808'000).to_truncated_microseconds(), 0x7fff'ffff'ffff'ffff);
 }
+
+TEST_CASE(leap_year_multiple_of_4)
+{
+    EXPECT(is_leap_year(1980));
+    EXPECT(!is_leap_year(1981));
+    EXPECT(!is_leap_year(1981));
+    EXPECT(!is_leap_year(1981));
+    EXPECT(is_leap_year(1984));
+
+    static_assert(is_leap_year(1980));
+    static_assert(!is_leap_year(1981));
+    static_assert(!is_leap_year(1981));
+    static_assert(!is_leap_year(1981));
+    static_assert(is_leap_year(1984));
+}
+
+TEST_CASE(leap_year_multiple_of_400_not_100)
+{
+    EXPECT(is_leap_year(2000));
+    EXPECT(!is_leap_year(1900));
+
+    static_assert(is_leap_year(2000));
+    static_assert(!is_leap_year(1900));
+}
+
+TEST_CASE(days_in_year)
+{
+    EXPECT_EQ(days_in_year(2000), 366u);
+    EXPECT_EQ(days_in_year(2001), 365u);
+
+    static_assert(days_in_year(2000) == 366u);
+    static_assert(days_in_year(2001) == 365u);
+}
+
+TEST_CASE(years_to_days_since_epoch)
+{
+    EXPECT_EQ(years_to_days_since_epoch(2000), 10957);
+    EXPECT_EQ(years_to_days_since_epoch(1950), -7305);
+
+    static_assert(years_to_days_since_epoch(2000) == 10957);
+    static_assert(years_to_days_since_epoch(1950) == -7305);
+}
+
+TEST_CASE(day_of_year)
+{
+    EXPECT_EQ(day_of_year(2000, 1, 1), 0);
+    EXPECT_EQ(day_of_year(2000, 3, 1), 60);
+    EXPECT_EQ(day_of_year(2001, 3, 1), 59);
+
+    static_assert(day_of_year(2000, 1, 1) == 0);
+    static_assert(day_of_year(2000, 3, 1) == 60);
+    static_assert(day_of_year(2001, 3, 1) == 59);
+}
+
+TEST_CASE(day_of_week)
+{
+    EXPECT_EQ(day_of_week(2000, 1, 1), 6u);
+    EXPECT_EQ(day_of_week(2000, 3, 1), 3u);
+    EXPECT_EQ(day_of_week(2001, 3, 1), 4u);
+
+    static_assert(day_of_week(2000, 1, 1) == 6u);
+    static_assert(day_of_week(2000, 3, 1) == 3u);
+    static_assert(day_of_week(2001, 3, 1) == 4u);
+}
+
+TEST_CASE(days_in_month)
+{
+    EXPECT_EQ(days_in_month(2000, 1), 31);
+    EXPECT_EQ(days_in_month(2000, 2), 29);
+    EXPECT_EQ(days_in_month(2000, 3), 31);
+    EXPECT_EQ(days_in_month(2000, 4), 30);
+    EXPECT_EQ(days_in_month(2000, 5), 31);
+    EXPECT_EQ(days_in_month(2000, 6), 30);
+    EXPECT_EQ(days_in_month(2000, 7), 31);
+    EXPECT_EQ(days_in_month(2000, 8), 31);
+    EXPECT_EQ(days_in_month(2000, 9), 30);
+    EXPECT_EQ(days_in_month(2000, 10), 31);
+    EXPECT_EQ(days_in_month(2000, 11), 30);
+    EXPECT_EQ(days_in_month(2000, 12), 31);
+
+    EXPECT_EQ(days_in_month(2001, 2), 28);
+
+    static_assert(days_in_month(2000, 1) == 31);
+    static_assert(days_in_month(2000, 2) == 29);
+    static_assert(days_in_month(2000, 3) == 31);
+    static_assert(days_in_month(2000, 4) == 30);
+    static_assert(days_in_month(2000, 5) == 31);
+    static_assert(days_in_month(2000, 6) == 30);
+    static_assert(days_in_month(2000, 7) == 31);
+    static_assert(days_in_month(2000, 8) == 31);
+    static_assert(days_in_month(2000, 9) == 30);
+    static_assert(days_in_month(2000, 10) == 31);
+    static_assert(days_in_month(2000, 11) == 30);
+    static_assert(days_in_month(2000, 12) == 31);
+
+    static_assert(days_in_month(2001, 2) == 28);
+}
+
+TEST_CASE(constexpr_default_constructor)
+{
+    constexpr auto t = Time {};
+    static_assert(t.is_zero());
+}
+
+TEST_CASE(constexpr_equality)
+{
+    constexpr auto t = Time {};
+    static_assert(t == Time {});
+    static_assert(t != Time {}.from_seconds(1));
+}


### PR DESCRIPTION
Problem:
- Some of the `Time` class member functions are decorated `constexpr`,
  but they are not all necessarily `constexpr` capable.

Solution:
- Decorate functions with `constexpr` keyword.
- Add compile-time tests to ensure evaluation within `constexpr`
  context.
- Add run-time tests to ensure the run-time behavior and `constexpr`
  behavior are the same.