### PR TITLE
Kernel: Properly support SO_ERROR

### DIFF
--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -343,9 +343,8 @@ KResultOr<size_t> LocalSocket::recvfrom(FileDescription& description, UserOrKern
         }
     } else if (!can_read(description, 0)) {
         auto unblock_flags = Thread::FileDescriptionBlocker::BlockFlags::None;
-        if (Thread::current()->block<Thread::ReadBlocker>({}, description, unblock_flags).was_interrupted()) {
+        if (Thread::current()->block<Thread::ReadBlocker>({}, description, unblock_flags).was_interrupted())
             return set_so_error(EINTR);
-        }
     }
     if (!has_attached_peer(description) && socket_buffer->is_empty())
         return 0;

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -181,14 +181,13 @@ KResult Socket::getsockopt(FileDescription&, int level, int option, Userspace<vo
     case SO_ERROR: {
         if (size < sizeof(int))
             return EINVAL;
-        dbgln("getsockopt(SO_ERROR): FIXME!");
-        int errno = 0;
+        int errno = so_error().error();
         if (!copy_to_user(static_ptr_cast<int*>(value), &errno))
             return EFAULT;
         size = sizeof(int);
         if (!copy_to_user(value_size, &size))
             return EFAULT;
-        return KSuccess;
+        return set_so_error(KSuccess);
     }
     case SO_BINDTODEVICE:
         if (size < IFNAMSIZ)

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -130,6 +130,13 @@ protected:
 
     Role m_role { Role::None };
 
+    KResult so_error() const { return m_so_error; }
+    KResult set_so_error(KResult error)
+    {
+        m_so_error = error;
+        return error;
+    }
+
 protected:
     ucred m_origin { 0, 0, 0 };
     ucred m_acceptor { 0, 0, 0 };
@@ -153,6 +160,8 @@ private:
     Time m_receive_timeout {};
     Time m_send_timeout {};
     int m_timestamp { 0 };
+
+    KResult m_so_error { KSuccess };
 
     NonnullRefPtrVector<Socket> m_pending;
 };


### PR DESCRIPTION
This seemed like the least intrusive implementation. Open to suggestions. 

**Kernel: Add so_error to keep track of the socket's error state**
This sets the m_so_error variable every time the socket returns an
error.

**Kernel: Properly implement SO_ERROR option**
This fixes the placeholder stub for the SO_ERROR via getsockopt. It
leverages the m_so_error value that each socket maintains. The SO_ERROR
option obtains and then clears this field, which is useful when checking
for errors that occur between socket calls. This uses an integer value
to return the SO_ERROR status.

Resolves #146
