### PR TITLE
Kernel: Remove double-counting of allocated pages in AnonymousVMObject

### DIFF
--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -131,7 +131,7 @@ AnonymousVMObject::AnonymousVMObject(size_t size, AllocationStrategy strategy, O
     if (strategy == AllocationStrategy::AllocateNow) {
         // Allocate all pages right now. We know we can get all because we committed the amount needed
         for (size_t i = 0; i < page_count(); ++i)
-            physical_pages()[i] = MM.allocate_committed_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
+            physical_pages()[i] = m_unused_committed_pages->take_one();
     } else {
         auto& initial_page = (strategy == AllocationStrategy::Reserve) ? MM.lazy_committed_page() : MM.shared_zero_page();
         for (size_t i = 0; i < page_count(); ++i)

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -840,7 +840,7 @@ RefPtr<PhysicalPage> MemoryManager::find_free_user_physical_page(bool committed)
     return page;
 }
 
-NonnullRefPtr<PhysicalPage> MemoryManager::allocate_committed_user_physical_page(ShouldZeroFill should_zero_fill)
+NonnullRefPtr<PhysicalPage> MemoryManager::allocate_committed_user_physical_page(Badge<CommittedPhysicalPageSet>, ShouldZeroFill should_zero_fill)
 {
     ScopedSpinLock lock(s_mm_lock);
     auto page = find_free_user_physical_page(true);
@@ -1134,7 +1134,7 @@ NonnullRefPtr<PhysicalPage> CommittedPhysicalPageSet::take_one()
 {
     VERIFY(m_page_count > 0);
     --m_page_count;
-    return MM.allocate_committed_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
+    return MM.allocate_committed_user_physical_page({}, MemoryManager::ShouldZeroFill::Yes);
 }
 
 void CommittedPhysicalPageSet::uncommit_one()

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -174,7 +174,7 @@ public:
     Optional<CommittedPhysicalPageSet> commit_user_physical_pages(size_t page_count);
     void uncommit_user_physical_pages(Badge<CommittedPhysicalPageSet>, size_t page_count);
 
-    NonnullRefPtr<PhysicalPage> allocate_committed_user_physical_page(ShouldZeroFill = ShouldZeroFill::Yes);
+    NonnullRefPtr<PhysicalPage> allocate_committed_user_physical_page(Badge<CommittedPhysicalPageSet>, ShouldZeroFill = ShouldZeroFill::Yes);
     RefPtr<PhysicalPage> allocate_user_physical_page(ShouldZeroFill = ShouldZeroFill::Yes, bool* did_purge = nullptr);
     RefPtr<PhysicalPage> allocate_supervisor_physical_page();
     NonnullRefPtrVector<PhysicalPage> allocate_contiguous_supervisor_physical_pages(size_t size);


### PR DESCRIPTION
When constructing an AnonymousVMObject with the AllocateNow allocation strategy we accidentally allocated the committed pages directly through MemoryManager instead of taking them from our m_unused_physical_pages CommittedPhysicalPageSet, which meant they were counted as allocated in MemoryManager, but were still counted as unallocated in the PageSet, who would then try to uncommit them on destruction, resulting in a failed assertion.

To help prevent similar issues in the future a Badge<T> was added to MM::allocate_committed_user_physical_page to prevent allocation of commited pages not via a CommittedPhysicalPageSet.