### PR TITLE
UserspaceEmulator: Optionally generate a Profiler-compatible profile

### DIFF
--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -57,7 +57,7 @@ public:
                 first = false;
             else
                 append(separator);
-            append(item);
+            appendff("{}", item);
         }
     }
 

--- a/Userland/DevTools/Profiler/DisassemblyModel.h
+++ b/Userland/DevTools/Profiler/DisassemblyModel.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibDebug/DebugInfo.h>
 #include <LibGUI/Model.h>
 #include <LibX86/Instruction.h>
 
@@ -21,6 +22,7 @@ struct InstructionData {
     FlatPtr address { 0 };
     u32 event_count { 0 };
     float percent { 0 };
+    Debug::DebugInfo::SourcePositionWithInlines source_position_with_inlines;
 };
 
 class DisassemblyModel final : public GUI::Model {
@@ -35,6 +37,7 @@ public:
         SampleCount,
         InstructionBytes,
         Disassembly,
+        SourceLocation,
         __Count
     };
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -419,8 +419,9 @@ MmapRegion const* Emulator::load_library_from_adress(FlatPtr address)
         if (file_or_error.is_error())
             return {};
 
-        auto debug_info = make<Debug::DebugInfo>(make<ELF::Image>(file_or_error.value()->bytes()));
-        m_dynamic_library_cache.set(lib_path, CachedELF { file_or_error.release_value(), move(debug_info) });
+        auto image = make<ELF::Image>(file_or_error.value()->bytes());
+        auto debug_info = make<Debug::DebugInfo>(*image);
+        m_dynamic_library_cache.set(lib_path, CachedELF { file_or_error.release_value(), move(debug_info), move(image) });
     }
     return region;
 }

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -257,6 +257,7 @@ private:
     struct CachedELF {
         NonnullRefPtr<MappedFile> mapped_file;
         NonnullOwnPtr<Debug::DebugInfo> debug_info;
+        NonnullOwnPtr<ELF::Image> image;
     };
 
     HashMap<String, CachedELF> m_dynamic_library_cache;

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -96,6 +96,9 @@ private:
     void register_signal_handlers();
     void setup_signal_trampoline();
 
+    void emit_profile_sample(AK::OutputStream&);
+    void emit_profile_event(AK::OutputStream&, StringView event_name, String contents);
+
     int virt$emuctl(FlatPtr, FlatPtr, FlatPtr);
     int virt$fork();
     int virt$execve(FlatPtr);

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -5,31 +5,44 @@
  */
 
 #include "Emulator.h"
+#include <AK/FileStream.h>
 #include <AK/Format.h>
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <serenity.h>
 #include <string.h>
 
 bool g_report_to_debug = false;
+bool g_dump_profile = false;
+unsigned g_profile_instruction_interval = 0;
+Optional<OutputFileStream> g_profile_stream;
 
 int main(int argc, char** argv, char** env)
 {
     Vector<String> arguments;
     bool pause_on_startup { false };
+    String profile_dump_path;
+    FILE* profile_output_file { nullptr };
 
     Core::ArgsParser parser;
     parser.set_stop_on_first_non_option(true);
     parser.add_option(g_report_to_debug, "Write reports to the debug log", "report-to-debug", 0);
     parser.add_option(pause_on_startup, "Pause on startup", "pause", 'p');
+    parser.add_option(g_dump_profile, "Generate a ProfileViewer-compatible profile", "profile", 0);
+    parser.add_option(g_profile_instruction_interval, "Set the profile instruction capture interval, 128 by default", "profile-interval", 'i', "#instructions");
+    parser.add_option(profile_dump_path, "File path for profile dump", "profile-file", 0, "path");
 
     parser.add_positional_argument(arguments, "Command to emulate", "command");
 
     parser.parse(argc, argv);
+
+    if (g_dump_profile && g_profile_instruction_interval == 0)
+        g_profile_instruction_interval = 128;
 
     String executable_path;
     if (arguments[0].contains("/"sv))
@@ -39,6 +52,28 @@ int main(int argc, char** argv, char** env)
     if (executable_path.is_empty()) {
         reportln("Cannot find executable for '{}'.", arguments[0]);
         return 1;
+    }
+
+    if (g_dump_profile && profile_dump_path.is_empty())
+        profile_dump_path = String::formatted("{}.{}.profile", executable_path, getpid());
+
+    if (g_dump_profile) {
+        profile_output_file = fopen(profile_dump_path.characters(), "w+");
+        if (profile_output_file == nullptr) {
+            auto error_string = strerror(errno);
+            warnln("Failed to open '{}' for writing: {}", profile_dump_path, error_string);
+            return 1;
+        }
+        g_profile_stream = OutputFileStream { profile_output_file };
+
+        g_profile_stream->write_or_error(R"({"events":[)"sv.bytes());
+        timeval tv {};
+        gettimeofday(&tv, nullptr);
+        g_profile_stream->write_or_error(
+            String::formatted(
+                R"~({{"type": "process_create", "parent_pid": 1, "executable": "{}", "pid": {}, "tid": {}, "timestamp": {}, "lost_samples": 0, "stack": []}})~",
+                executable_path, getpid(), gettid(), tv.tv_sec * 1000 + tv.tv_usec / 1000)
+                .bytes());
     }
 
     Vector<String> environment;
@@ -67,5 +102,10 @@ int main(int argc, char** argv, char** env)
     if (pause_on_startup)
         emulator.pause();
 
-    return emulator.exec();
+    rc = emulator.exec();
+
+    if (g_dump_profile) {
+        g_profile_stream->write_or_error(R"(]})"sv.bytes());
+    }
+    return rc;
 }

--- a/Userland/Libraries/LibCoreDump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoreDump/Backtrace.cpp
@@ -35,7 +35,8 @@ ELFObjectInfo const* Backtrace::object_info_for_region(ELF::Core::MemoryRegionIn
         return nullptr;
 
     auto image = make<ELF::Image>(file_or_error.value()->bytes());
-    auto info = make<ELFObjectInfo>(file_or_error.release_value(), make<Debug::DebugInfo>(move(image)));
+    auto& image_reference = *image;
+    auto info = make<ELFObjectInfo>(file_or_error.release_value(), make<Debug::DebugInfo>(image_reference), move(image));
     auto* info_ptr = info.ptr();
     m_debug_info_cache.set(path, move(info));
     return info_ptr;

--- a/Userland/Libraries/LibCoreDump/Backtrace.h
+++ b/Userland/Libraries/LibCoreDump/Backtrace.h
@@ -14,14 +14,16 @@
 namespace CoreDump {
 
 struct ELFObjectInfo {
-    ELFObjectInfo(NonnullRefPtr<MappedFile> file, NonnullOwnPtr<Debug::DebugInfo>&& debug_info)
+    ELFObjectInfo(NonnullRefPtr<MappedFile> file, NonnullOwnPtr<Debug::DebugInfo>&& debug_info, NonnullOwnPtr<ELF::Image> image)
         : file(move(file))
         , debug_info(move(debug_info))
+        , image(move(image))
     {
     }
 
     NonnullRefPtr<MappedFile> file;
     NonnullOwnPtr<Debug::DebugInfo> debug_info;
+    NonnullOwnPtr<ELF::Image> image;
 };
 
 class Backtrace {

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -15,11 +15,11 @@
 
 namespace Debug {
 
-DebugInfo::DebugInfo(NonnullOwnPtr<const ELF::Image> elf, String source_root, FlatPtr base_address)
-    : m_elf(move(elf))
+DebugInfo::DebugInfo(ELF::Image const& elf, String source_root, FlatPtr base_address)
+    : m_elf(elf)
     , m_source_root(move(source_root))
     , m_base_address(base_address)
-    , m_dwarf_info(*m_elf)
+    , m_dwarf_info(m_elf)
 {
     prepare_variable_scopes();
     prepare_lines();

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -24,9 +24,9 @@ class DebugInfo {
     AK_MAKE_NONMOVABLE(DebugInfo);
 
 public:
-    explicit DebugInfo(NonnullOwnPtr<const ELF::Image>, String source_root = {}, FlatPtr base_address = 0);
+    explicit DebugInfo(ELF::Image const&, String source_root = {}, FlatPtr base_address = 0);
 
-    ELF::Image const& elf() const { return *m_elf; }
+    ELF::Image const& elf() const { return m_elf; }
 
     struct SourcePosition {
         FlyString file_path;
@@ -124,7 +124,7 @@ private:
     Optional<Dwarf::LineProgram::DirectoryAndFile> get_source_path_of_inline(const Dwarf::DIE&) const;
     Optional<uint32_t> get_line_of_inline(const Dwarf::DIE&) const;
 
-    NonnullOwnPtr<const ELF::Image> m_elf;
+    ELF::Image const& m_elf;
     String m_source_root;
     FlatPtr m_base_address { 0 };
     Dwarf::DwarfInfo m_dwarf_info;

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -448,8 +448,9 @@ void DebugSession::update_loaded_libs()
             return IterationDecision::Continue;
 
         FlatPtr base_address = entry.as_object().get("address").to_addr();
-        auto debug_info = make<DebugInfo>(make<ELF::Image>(file_or_error.value()->bytes()), m_source_root, base_address);
-        auto lib = make<LoadedLibrary>(lib_name, file_or_error.release_value(), move(debug_info), base_address);
+        auto image = make<ELF::Image>(file_or_error.value()->bytes());
+        auto debug_info = make<DebugInfo>(*image, m_source_root, base_address);
+        auto lib = make<LoadedLibrary>(lib_name, file_or_error.release_value(), move(image), move(debug_info), base_address);
         m_loaded_libraries.set(lib_name, move(lib));
 
         return IterationDecision::Continue;

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -129,12 +129,14 @@ public:
     struct LoadedLibrary {
         String name;
         NonnullRefPtr<MappedFile> file;
+        NonnullOwnPtr<ELF::Image> image;
         NonnullOwnPtr<DebugInfo> debug_info;
         FlatPtr base_address;
 
-        LoadedLibrary(String const& name, NonnullRefPtr<MappedFile> file, NonnullOwnPtr<DebugInfo>&& debug_info, FlatPtr base_address)
+        LoadedLibrary(String const& name, NonnullRefPtr<MappedFile> file, NonnullOwnPtr<ELF::Image> image, NonnullOwnPtr<DebugInfo>&& debug_info, FlatPtr base_address)
             : name(name)
             , file(move(file))
+            , image(move(image))
             , debug_info(move(debug_info))
             , base_address(base_address)
         {

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -18,6 +18,7 @@ namespace Symbolication {
 struct CachedELF {
     NonnullRefPtr<MappedFile> mapped_file;
     NonnullOwnPtr<Debug::DebugInfo> debug_info;
+    NonnullOwnPtr<ELF::Image> image;
 };
 
 static HashMap<String, OwnPtr<CachedELF>> s_cache;
@@ -73,7 +74,7 @@ Optional<Symbol> symbolicate(String const& path, FlatPtr address)
             s_cache.set(path, {});
             {};
         }
-        auto cached_elf = make<CachedELF>(mapped_file.release_value(), make<Debug::DebugInfo>(move(elf)));
+        auto cached_elf = make<CachedELF>(mapped_file.release_value(), make<Debug::DebugInfo>(*elf), move(elf));
         s_cache.set(path, move(cached_elf));
     }
 


### PR DESCRIPTION
`ue --profile --profile-file ~/some-file.profile id` can now generate a
full profile (instruction-by-instruction, if needed), at the cost of not
being able to see past the syscall boundary (a.la. callgrind).
This makes it significantly easier to profile seemingly fast userspace
things, like Loader.so :^)