### PR TITLE
PixelPaint: Use unveil and FileSystemAccessServer

### DIFF
--- a/AK/MappedFile.cpp
+++ b/AK/MappedFile.cpp
@@ -21,6 +21,15 @@ Result<NonnullRefPtr<MappedFile>, OSError> MappedFile::map(const String& path)
     if (fd < 0)
         return OSError(errno);
 
+    return map_from_fd_and_close(fd, path);
+}
+
+Result<NonnullRefPtr<MappedFile>, OSError> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] String const& path)
+{
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+        return OSError(errno);
+    }
+
     ScopeGuard fd_close_guard = [fd] {
         close(fd);
     };

--- a/AK/MappedFile.cpp
+++ b/AK/MappedFile.cpp
@@ -15,7 +15,7 @@
 
 namespace AK {
 
-Result<NonnullRefPtr<MappedFile>, OSError> MappedFile::map(const String& path)
+Result<NonnullRefPtr<MappedFile>, OSError> MappedFile::map(String const& path)
 {
     int fd = open(path.characters(), O_RDONLY | O_CLOEXEC, 0);
     if (fd < 0)

--- a/AK/MappedFile.h
+++ b/AK/MappedFile.h
@@ -19,7 +19,7 @@ class MappedFile : public RefCounted<MappedFile> {
     AK_MAKE_NONMOVABLE(MappedFile);
 
 public:
-    static Result<NonnullRefPtr<MappedFile>, OSError> map(const String& path);
+    static Result<NonnullRefPtr<MappedFile>, OSError> map(String const& path);
     static Result<NonnullRefPtr<MappedFile>, OSError> map_from_fd_and_close(int fd, String const& path);
     ~MappedFile();
 

--- a/AK/MappedFile.h
+++ b/AK/MappedFile.h
@@ -20,6 +20,7 @@ class MappedFile : public RefCounted<MappedFile> {
 
 public:
     static Result<NonnullRefPtr<MappedFile>, OSError> map(const String& path);
+    static Result<NonnullRefPtr<MappedFile>, OSError> map_from_fd_and_close(int fd, String const& path);
     ~MappedFile();
 
     void* data() { return m_data; }

--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -2,7 +2,7 @@ serenity_component(
     PixelPaint
     RECOMMENDED
     TARGETS PixelPaint
-    DEPENDS ImageDecoder
+    DEPENDS ImageDecoder FileSystemAccessServer
 )
 
 compile_gml(PixelPaintWindow.gml PixelPaintWindowGML.h pixel_paint_window_gml)
@@ -38,4 +38,4 @@ set(SOURCES
 )
 
 serenity_app(PixelPaint ICON app-pixel-paint)
-target_link_libraries(PixelPaint LibImageDecoderClient LibGUI LibGfx)
+target_link_libraries(PixelPaint LibImageDecoderClient LibGUI LibGfx LibFileSystemAccessClient)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -12,6 +12,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
 #include <AK/Vector.h>
+#include <LibCore/File.h>
 #include <LibGUI/Command.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>
@@ -40,7 +41,8 @@ protected:
 class Image : public RefCounted<Image> {
 public:
     static RefPtr<Image> try_create_with_size(Gfx::IntSize const&);
-    static Result<NonnullRefPtr<Image>, String> try_create_from_file(String const& file_path);
+    static Result<NonnullRefPtr<Image>, String> try_create_from_fd_and_close(int fd, String const& file_path);
+    static Result<NonnullRefPtr<Image>, String> try_create_from_path(String const& file_path);
     static RefPtr<Image> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
@@ -58,9 +60,10 @@ public:
     void restore_snapshot(Image const&);
 
     void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
+    Result<void, String> write_to_fd_and_close(int fd) const;
     Result<void, String> write_to_file(String const& file_path) const;
-    Result<void, String> export_bmp_to_file(String const& file_path, bool preserve_alpha_channel);
-    Result<void, String> export_png_to_file(String const& file_path, bool preserve_alpha_channel);
+    Result<void, String> export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel);
+    Result<void, String> export_png_to_fd_and_close(int fd, bool preserve_alpha_channel);
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);
@@ -89,7 +92,9 @@ public:
 private:
     explicit Image(Gfx::IntSize const&);
 
-    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_file(String const& file_path);
+    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_fd(int fd, String const& file_path);
+    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_path(String const& file_path);
+    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_file(Core::File& file, String const& file_path);
 
     void did_change(Gfx::IntRect const& modified_rect = {});
     void did_modify_layer_stack();

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -95,7 +95,7 @@ PaletteWidget::PaletteWidget()
     bottom_color_container.set_layout<GUI::HorizontalBoxLayout>();
     bottom_color_container.layout()->set_spacing(1);
 
-    auto result = load_palette_file("/res/color-palettes/default.palette");
+    auto result = load_palette_path("/res/color-palettes/default.palette");
     if (result.is_error()) {
         GUI::MessageBox::show_error(window(), String::formatted("Loading default palette failed: {}", result.error()));
         display_color_list(fallback_colors());
@@ -192,14 +192,8 @@ Vector<Color> PaletteWidget::colors()
     return colors;
 }
 
-Result<Vector<Color>, String> PaletteWidget::load_palette_file(String const& file_path)
+Result<Vector<Color>, String> PaletteWidget::load_palette_file(Core::File& file)
 {
-    auto file_or_error = Core::File::open(file_path, Core::OpenMode::ReadOnly);
-    if (file_or_error.is_error())
-        return file_or_error.error();
-
-    auto& file = *file_or_error.value();
-
     Vector<Color> palette;
 
     while (file.can_read_line()) {
@@ -224,20 +218,39 @@ Result<Vector<Color>, String> PaletteWidget::load_palette_file(String const& fil
     return palette;
 }
 
-Result<void, String> PaletteWidget::save_palette_file(Vector<Color> palette, String const& file_path)
+Result<Vector<Color>, String> PaletteWidget::load_palette_fd_and_close(int fd)
 {
-    auto file_or_error = Core::File::open(file_path, Core::OpenMode::WriteOnly);
+    auto file = Core::File::construct();
+    file->open(fd, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
+    if (file->has_error())
+        return String { file->error_string() };
+
+    return load_palette_file(file);
+}
+
+Result<Vector<Color>, String> PaletteWidget::load_palette_path(String const& file_path)
+{
+    auto file_or_error = Core::File::open(file_path, Core::OpenMode::ReadOnly);
     if (file_or_error.is_error())
         return file_or_error.error();
 
     auto& file = *file_or_error.value();
+    return load_palette_file(file);
+}
+
+Result<void, String> PaletteWidget::save_palette_fd_and_close(Vector<Color> palette, int fd)
+{
+    auto file = Core::File::construct();
+    file->open(fd, Core::OpenMode::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
+    if (file->has_error())
+        return String { file->error_string() };
 
     for (auto& color : palette) {
-        file.write(color.to_string_without_alpha());
-        file.write("\n");
+        file->write(color.to_string_without_alpha());
+        file->write("\n");
     }
 
-    file.close();
+    file->close();
 
     return {};
 }

--- a/Userland/Applications/PixelPaint/PaletteWidget.h
+++ b/Userland/Applications/PixelPaint/PaletteWidget.h
@@ -28,13 +28,16 @@ public:
 
     Vector<Color> colors();
 
-    static Result<Vector<Color>, String> load_palette_file(String const&);
-    static Result<void, String> save_palette_file(Vector<Color>, String const&);
+    static Result<Vector<Color>, String> load_palette_fd_and_close(int);
+    static Result<Vector<Color>, String> load_palette_path(String const&);
+    static Result<void, String> save_palette_fd_and_close(Vector<Color>, int);
     static Vector<Color> fallback_colors();
 
     void set_image_editor(ImageEditor&);
 
 private:
+    static Result<Vector<Color>, String> load_palette_file(Core::File&);
+
     explicit PaletteWidget();
 
     ImageEditor* m_editor { nullptr };

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -19,10 +19,10 @@
 #include <Applications/PixelPaint/PixelPaintWindowGML.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
-#include <LibGUI/FilePicker.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
@@ -47,6 +47,45 @@ int main(int argc, char** argv)
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(image_file, "Image file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
+
+    String file_to_edit_full_path;
+
+    if (image_file) {
+        file_to_edit_full_path = Core::File::absolute_path(image_file);
+        VERIFY(!file_to_edit_full_path.is_empty());
+        if (Core::File::exists(file_to_edit_full_path)) {
+            dbgln("unveil for: {}", file_to_edit_full_path);
+            if (unveil(file_to_edit_full_path.characters(), "r") < 0) {
+                perror("unveil");
+                return 1;
+            }
+        }
+    }
+
+    if (unveil("/res", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/tmp/portal/clipboard", "rw") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/tmp/portal/filesystemaccess", "rw") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/tmp/portal/image", "rw") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil(nullptr, nullptr) < 0) {
+        perror("unveil");
+        return 1;
+    }
 
     auto app_icon = GUI::Icon::default_icon("app-pixel-paint");
 
@@ -109,7 +148,7 @@ int main(int argc, char** argv)
         window);
 
     auto open_image_file = [&](auto& path) {
-        auto image_or_error = PixelPaint::Image::try_create_from_file(path);
+        auto image_or_error = PixelPaint::Image::try_create_from_path(path);
         if (image_or_error.is_error()) {
             GUI::MessageBox::show_error(window, String::formatted("Unable to open file: {}", path));
             return;
@@ -119,26 +158,38 @@ int main(int argc, char** argv)
         layer_list_widget.set_image(&image);
     };
 
-    auto open_image_action = GUI::CommonActions::make_open_action([&](auto&) {
-        Optional<String> open_path = GUI::FilePicker::get_open_filepath(window);
-        if (!open_path.has_value())
+    auto open_image_fd = [&](int fd, auto& path) {
+        auto image_or_error = PixelPaint::Image::try_create_from_fd_and_close(fd, path);
+        if (image_or_error.is_error()) {
+            GUI::MessageBox::show_error(window, String::formatted("Unable to open file: {}, {}", path, image_or_error.error()));
             return;
-        open_image_file(open_path.value());
+        }
+        auto& image = *image_or_error.value();
+        create_new_editor(image);
+        layer_list_widget.set_image(&image);
+    };
+
+    auto open_image_action = GUI::CommonActions::make_open_action([&](auto&) {
+        auto result = FileSystemAccessClient::Client::the().open_file(window->window_id());
+        if (result.error != 0)
+            return;
+
+        open_image_fd(*result.fd, *result.chosen_file);
     });
 
     auto save_image_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
         auto* editor = current_image_editor();
         if (!editor)
             return;
-        auto save_path = GUI::FilePicker::get_save_filepath(window, "untitled", "pp");
-        if (!save_path.has_value())
+        auto save_result = FileSystemAccessClient::Client::the().save_file(window->window_id(), "untitled", "pp");
+        if (save_result.error != 0)
             return;
-        auto result = editor->image().write_to_file(save_path.value());
+        auto result = editor->image().write_to_fd_and_close(*save_result.fd);
         if (result.is_error()) {
-            GUI::MessageBox::show_error(window, String::formatted("Could not save {}: {}", save_path.value(), result.error()));
+            GUI::MessageBox::show_error(window, String::formatted("Could not save {}: {}", *save_result.chosen_file, result.error()));
             return;
         }
-        editor->image().set_path(save_path.value());
+        editor->image().set_path(*save_result.chosen_file);
     });
 
     auto& file_menu = window->add_menu("&File");
@@ -153,11 +204,11 @@ int main(int argc, char** argv)
                 auto* editor = current_image_editor();
                 if (!editor)
                     return;
-                auto save_path = GUI::FilePicker::get_save_filepath(window, "untitled", "bmp");
-                if (!save_path.has_value())
+                auto save_result = FileSystemAccessClient::Client::the().save_file(window->window_id(), "untitled", "bmp");
+                if (save_result.error != 0)
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
-                auto result = editor->image().export_bmp_to_file(save_path.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
+                auto result = editor->image().export_bmp_to_fd_and_close(*save_result.fd, preserve_alpha_channel == GUI::MessageBox::ExecYes);
                 if (result.is_error())
                     GUI::MessageBox::show_error(window, String::formatted("Export to BMP failed: {}", result.error()));
             },
@@ -166,11 +217,11 @@ int main(int argc, char** argv)
         GUI::Action::create(
             "As &PNG", [&](auto&) {
                 auto* editor = current_image_editor();
-                auto save_path = GUI::FilePicker::get_save_filepath(window, "untitled", "png");
-                if (!save_path.has_value())
+                auto save_result = FileSystemAccessClient::Client::the().save_file(window->window_id(), "untitled", "png");
+                if (save_result.error != 0)
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
-                auto result = editor->image().export_png_to_file(save_path.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
+                auto result = editor->image().export_png_to_fd_and_close(*save_result.fd, preserve_alpha_channel == GUI::MessageBox::ExecYes);
                 if (result.is_error())
                     GUI::MessageBox::show_error(window, String::formatted("Export to PNG failed: {}", result.error()));
             },
@@ -268,11 +319,11 @@ int main(int argc, char** argv)
         window));
     edit_menu.add_action(GUI::Action::create(
         "&Load Color Palette", [&](auto&) {
-            auto open_path = GUI::FilePicker::get_open_filepath(window, "Load Color Palette");
-            if (!open_path.has_value())
+            auto open_result = FileSystemAccessClient::Client::the().open_file(window->window_id(), "Load Color Palette");
+            if (open_result.error != 0)
                 return;
 
-            auto result = PixelPaint::PaletteWidget::load_palette_file(open_path.value());
+            auto result = PixelPaint::PaletteWidget::load_palette_fd_and_close(*open_result.fd);
             if (result.is_error()) {
                 GUI::MessageBox::show_error(window, String::formatted("Loading color palette failed: {}", result.error()));
                 return;
@@ -283,11 +334,11 @@ int main(int argc, char** argv)
         window));
     edit_menu.add_action(GUI::Action::create(
         "Sa&ve Color Palette", [&](auto&) {
-            auto save_path = GUI::FilePicker::get_save_filepath(window, "untitled", "palette");
-            if (!save_path.has_value())
+            auto save_result = FileSystemAccessClient::Client::the().save_file(window->window_id(), "untitled", "palette");
+            if (save_result.error != 0)
                 return;
 
-            auto result = PixelPaint::PaletteWidget::save_palette_file(palette_widget.colors(), save_path.value());
+            auto result = PixelPaint::PaletteWidget::save_palette_fd_and_close(palette_widget.colors(), *save_result.fd);
             if (result.is_error())
                 GUI::MessageBox::show_error(window, String::formatted("Writing color palette failed: {}", result.error()));
         },
@@ -650,9 +701,8 @@ int main(int argc, char** argv)
         });
     };
 
-    auto image_file_real_path = Core::File::real_path_for(image_file);
-    if (Core::File::exists(image_file_real_path)) {
-        open_image_file(image_file_real_path);
+    if (Core::File::exists(file_to_edit_full_path)) {
+        open_image_file(file_to_edit_full_path);
     } else {
         auto image = PixelPaint::Image::try_create_with_size({ 480, 360 });
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -8,7 +8,6 @@
 // clang-format off
 #include <LibGUI/WindowServerConnection.h>
 // clang-format on
-#include <LibCore/StandardPaths.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Window.h>
 
@@ -40,7 +39,7 @@ Result Client::request_file(i32 parent_window_id, String const& path, Core::Open
     return m_promise->await();
 }
 
-Result Client::open_file(i32 parent_window_id)
+Result Client::open_file(i32 parent_window_id, String const& window_title, StringView const& path)
 {
     m_promise = Core::Promise<Result>::construct();
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -52,7 +51,7 @@ Result Client::open_file(i32 parent_window_id)
         GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_open_file(parent_window_server_client_id, parent_window_id, Core::StandardPaths::home_directory(), Core::OpenMode::ReadOnly);
+    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, Core::OpenMode::ReadOnly);
 
     return m_promise->await();
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -10,6 +10,7 @@
 #include <FileSystemAccessServer/FileSystemAccessServerEndpoint.h>
 #include <LibCore/File.h>
 #include <LibCore/Promise.h>
+#include <LibCore/StandardPaths.h>
 #include <LibIPC/ServerConnection.h>
 
 namespace FileSystemAccessClient {
@@ -27,7 +28,7 @@ class Client final
 
 public:
     Result request_file(i32 parent_window_id, String const& path, Core::OpenMode mode);
-    Result open_file(i32 parent_window_id);
+    Result open_file(i32 parent_window_id, String const& window_title = {}, StringView const& path = Core::StandardPaths::home_directory());
     Result save_file(i32 parent_window_id, String const& name, String const ext);
 
     static Client& the();

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.cpp
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.cpp
@@ -107,14 +107,14 @@ void ClientConnection::request_file(i32 window_server_client_id, i32 parent_wind
     }
 }
 
-void ClientConnection::prompt_open_file(i32 window_server_client_id, i32 parent_window_id, String const& path_to_view, Core::OpenMode const& requested_access)
+void ClientConnection::prompt_open_file(i32 window_server_client_id, i32 parent_window_id, String const& window_title, String const& path_to_view, Core::OpenMode const& requested_access)
 {
     auto relevant_permissions = requested_access & (Core::OpenMode::ReadOnly | Core::OpenMode::WriteOnly);
     VERIFY(relevant_permissions != Core::OpenMode::NotOpen);
 
     auto main_window = create_dummy_child_window(window_server_client_id, parent_window_id);
 
-    auto user_picked_file = GUI::FilePicker::get_open_filepath(main_window, "Select file", path_to_view);
+    auto user_picked_file = GUI::FilePicker::get_open_filepath(main_window, window_title, path_to_view);
 
     prompt_helper(user_picked_file, requested_access);
 }

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.h
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.h
@@ -27,7 +27,7 @@ public:
 
 private:
     virtual void request_file(i32, i32, String const&, Core::OpenMode const&) override;
-    virtual void prompt_open_file(i32, i32, String const&, Core::OpenMode const&) override;
+    virtual void prompt_open_file(i32, i32, String const&, String const&, Core::OpenMode const&) override;
     virtual void prompt_save_file(i32, i32, String const&, String const&, String const&, Core::OpenMode const&) override;
 
     void prompt_helper(Optional<String> const&, Core::OpenMode const&);

--- a/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
+++ b/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
@@ -4,7 +4,7 @@
 endpoint FileSystemAccessServer
 {
     request_file(i32 window_server_client_id, i32 window_id, String path, Core::OpenMode requested_access) =|
-    prompt_open_file(i32 window_server_client_id, i32 window_id, String path_to_view, Core::OpenMode requested_access) =|
+    prompt_open_file(i32 window_server_client_id, i32 window_id, String window_title, String path_to_view, Core::OpenMode requested_access) =|
     prompt_save_file(i32 window_server_client_id, i32 window_id,String title, String ext, String path_to_view, Core::OpenMode requested_access) =|
 
     expose_window_server_client_id() => (i32 client_id)


### PR DESCRIPTION
This will hide most of the file system from PixelPaint while still allowing a user to choose to open and save files through a cross-process `FilePicker`.