### PR TITLE
PixelPaint: Don't remove widgets in ToolPropertiesWidget on Tool change

### DIFF
--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
@@ -20,6 +20,8 @@ ToolPropertiesWidget::ToolPropertiesWidget()
     m_group_box = add<GUI::GroupBox>("Tool properties");
     auto& layout = m_group_box->set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins({ 10, 20, 10, 10 });
+    m_tool_widget_stack = m_group_box->add<GUI::StackWidget>();
+    m_blank_widget = m_tool_widget_stack->add<GUI::Widget>();
 }
 
 void ToolPropertiesWidget::set_active_tool(Tool* tool)
@@ -27,13 +29,18 @@ void ToolPropertiesWidget::set_active_tool(Tool* tool)
     if (tool == m_active_tool)
         return;
 
-    if (m_active_tool_widget != nullptr)
-        m_group_box->remove_child(*m_active_tool_widget);
-
     m_active_tool = tool;
     m_active_tool_widget = tool->get_properties_widget();
-    if (m_active_tool_widget != nullptr)
-        m_group_box->add_child(*m_active_tool_widget);
+
+    if (m_active_tool_widget == nullptr) {
+        m_tool_widget_stack->set_active_widget(m_blank_widget);
+        return;
+    }
+
+    if (!m_tool_widget_stack->is_ancestor_of(*m_active_tool_widget))
+        m_tool_widget_stack->add_child(*m_active_tool_widget);
+
+    m_tool_widget_stack->set_active_widget(m_active_tool_widget);
 }
 
 ToolPropertiesWidget::~ToolPropertiesWidget()

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.h
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.h
@@ -8,6 +8,7 @@
 
 #include <AK/RefPtr.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/StackWidget.h>
 #include <LibGUI/Widget.h>
 
 namespace PixelPaint {
@@ -28,6 +29,8 @@ private:
     RefPtr<GUI::GroupBox> m_group_box;
 
     Tool* m_active_tool { nullptr };
+    RefPtr<GUI::StackWidget> m_tool_widget_stack;
+    RefPtr<GUI::Widget> m_blank_widget;
     GUI::Widget* m_active_tool_widget { nullptr };
 };
 


### PR DESCRIPTION
Previously changing tools while simultaneously using a widget like a slider would result in a `event_dispatch()` failure.
~~Instead keep them as children once added and just change the visibility when switching between them.~~

Instead use a StackWidget to keep them as children and set the active widget.