### PR TITLE
LibGUI: Implement ValueSlider and use it in PixelPaint

### DIFF
--- a/Userland/Applications/PixelPaint/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/BrushTool.cpp
@@ -11,7 +11,7 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Rect.h>
 
@@ -126,15 +126,12 @@ GUI::Widget* BrushTool::get_properties_widget()
         size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         size_label.set_fixed_size(80, 20);
 
-        auto& size_slider = size_container.add<GUI::HorizontalSlider>();
-        size_slider.set_fixed_height(20);
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
         size_slider.set_range(1, 100);
         size_slider.set_value(m_size);
-        size_slider.set_tooltip(String::formatted("{}px", m_size));
 
         size_slider.on_change = [&](int value) {
             m_size = value;
-            size_slider.set_tooltip(String::formatted("{}px", value));
         };
 
         auto& hardness_container = m_properties_widget->add<GUI::Widget>();
@@ -145,15 +142,12 @@ GUI::Widget* BrushTool::get_properties_widget()
         hardness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         hardness_label.set_fixed_size(80, 20);
 
-        auto& hardness_slider = hardness_container.add<GUI::HorizontalSlider>();
-        hardness_slider.set_fixed_height(20);
+        auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
         hardness_slider.set_range(1, 99);
         hardness_slider.set_value(m_hardness);
-        hardness_slider.set_tooltip(String::formatted("{}%", m_hardness));
 
         hardness_slider.on_change = [&](int value) {
             m_hardness = value;
-            hardness_slider.set_tooltip(String::formatted("{}%", value));
         };
     }
 

--- a/Userland/Applications/PixelPaint/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/BucketTool.cpp
@@ -11,7 +11,7 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Rect.h>
 
@@ -98,15 +98,12 @@ GUI::Widget* BucketTool::get_properties_widget()
         threshold_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         threshold_label.set_fixed_size(80, 20);
 
-        auto& threshold_slider = threshold_container.add<GUI::HorizontalSlider>();
-        threshold_slider.set_fixed_height(20);
+        auto& threshold_slider = threshold_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
         threshold_slider.set_range(0, 100);
         threshold_slider.set_value(m_threshold);
-        threshold_slider.set_tooltip(String::formatted("{}%", m_threshold));
 
         threshold_slider.on_change = [&](int value) {
             m_threshold = value;
-            threshold_slider.set_tooltip(String::formatted("{}%", value));
         };
     }
 

--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -13,7 +13,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/RadioButton.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/Rect.h>
 
 namespace PixelPaint {
@@ -109,15 +109,12 @@ GUI::Widget* EllipseTool::get_properties_widget()
         thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         thickness_label.set_fixed_size(80, 20);
 
-        auto& thickness_slider = thickness_container.add<GUI::HorizontalSlider>();
-        thickness_slider.set_fixed_height(20);
+        auto& thickness_slider = thickness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
         thickness_slider.set_range(1, 10);
         thickness_slider.set_value(m_thickness);
-        thickness_slider.set_tooltip(String::formatted("{}px", m_thickness));
 
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
-            thickness_slider.set_tooltip(String::formatted("{}px", value));
         };
 
         auto& mode_container = m_properties_widget->add<GUI::Widget>();

--- a/Userland/Applications/PixelPaint/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/EraseTool.cpp
@@ -13,7 +13,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/Bitmap.h>
 
 namespace PixelPaint {
@@ -28,7 +28,7 @@ EraseTool::~EraseTool()
 
 Gfx::IntRect EraseTool::build_rect(Gfx::IntPoint const& pos, Gfx::IntRect const& widget_rect)
 {
-    const int eraser_size = (m_base_eraser_size * m_thickness);
+    const int eraser_size = m_thickness;
     const int eraser_radius = eraser_size / 2;
     const auto ex = pos.x();
     const auto ey = pos.y();
@@ -83,15 +83,12 @@ GUI::Widget* EraseTool::get_properties_widget()
         thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         thickness_label.set_fixed_size(80, 20);
 
-        auto& thickness_slider = thickness_container.add<GUI::HorizontalSlider>();
-        thickness_slider.set_fixed_height(20);
-        thickness_slider.set_range(1, 5);
+        auto& thickness_slider = thickness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
+        thickness_slider.set_range(1, 50);
         thickness_slider.set_value(m_thickness);
-        thickness_slider.set_tooltip(String::formatted("{}px", m_base_eraser_size * m_thickness));
 
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
-            thickness_slider.set_tooltip(String::formatted("{}px", m_base_eraser_size * value));
         };
 
         auto& checkbox_container = m_properties_widget->add<GUI::Widget>();

--- a/Userland/Applications/PixelPaint/EraseTool.h
+++ b/Userland/Applications/PixelPaint/EraseTool.h
@@ -30,7 +30,6 @@ private:
 
     bool m_use_secondary_color { false };
     int m_thickness { 1 };
-    const int m_base_eraser_size { 10 };
 };
 
 }

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -13,7 +13,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 
 namespace PixelPaint {
 
@@ -114,15 +114,12 @@ GUI::Widget* LineTool::get_properties_widget()
         thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         thickness_label.set_fixed_size(80, 20);
 
-        auto& thickness_slider = thickness_container.add<GUI::HorizontalSlider>();
-        thickness_slider.set_fixed_height(20);
+        auto& thickness_slider = thickness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
         thickness_slider.set_range(1, 10);
         thickness_slider.set_value(m_thickness);
-        thickness_slider.set_tooltip(String::formatted("{}px", m_thickness));
 
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
-            thickness_slider.set_tooltip(String::formatted("{}px", value));
         };
     }
 

--- a/Userland/Applications/PixelPaint/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/PenTool.cpp
@@ -12,7 +12,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 
 namespace PixelPaint {
 
@@ -77,15 +77,12 @@ GUI::Widget* PenTool::get_properties_widget()
         thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         thickness_label.set_fixed_size(80, 20);
 
-        auto& thickness_slider = thickness_container.add<GUI::HorizontalSlider>();
-        thickness_slider.set_fixed_height(20);
+        auto& thickness_slider = thickness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
         thickness_slider.set_range(1, 20);
         thickness_slider.set_value(m_thickness);
-        thickness_slider.set_tooltip(String::formatted("{}px", m_thickness));
 
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
-            thickness_slider.set_tooltip(String::formatted("{}px", value));
         };
     }
 

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
@@ -14,7 +14,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 
 namespace PixelPaint {
 
@@ -153,16 +153,13 @@ GUI::Widget* RectangleSelectTool::get_properties_widget()
     feather_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
     feather_label.set_fixed_size(80, 20);
 
-    const int feather_slider_max = 10000;
-    auto& feather_slider = feather_container.add<GUI::HorizontalSlider>();
-    feather_slider.set_fixed_height(20);
+    const int feather_slider_max = 100;
+    auto& feather_slider = feather_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
     feather_slider.set_range(0, feather_slider_max);
     feather_slider.set_value((int)floorf(m_edge_feathering * (float)feather_slider_max));
-    feather_slider.set_tooltip(String::formatted("{:.2}", (float)m_edge_feathering / (float)feather_slider_max));
 
     feather_slider.on_change = [&](int value) {
         m_edge_feathering = (float)value / (float)feather_slider_max;
-        feather_slider.set_tooltip(String::formatted("{:.2}", (float)value / (float)feather_slider_max));
     };
 
     auto& mode_container = m_properties_widget->add<GUI::Widget>();

--- a/Userland/Applications/PixelPaint/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/SprayTool.cpp
@@ -14,7 +14,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/Bitmap.h>
 
 namespace PixelPaint {
@@ -102,15 +102,12 @@ GUI::Widget* SprayTool::get_properties_widget()
         size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         size_label.set_fixed_size(80, 20);
 
-        auto& size_slider = size_container.add<GUI::HorizontalSlider>();
-        size_slider.set_fixed_height(20);
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
         size_slider.set_range(1, 20);
         size_slider.set_value(m_thickness);
-        size_slider.set_tooltip(String::formatted("{}", m_thickness));
 
         size_slider.on_change = [&](int value) {
             m_thickness = value;
-            size_slider.set_tooltip(String::formatted("{}", value));
         };
 
         auto& density_container = m_properties_widget->add<GUI::Widget>();
@@ -121,15 +118,12 @@ GUI::Widget* SprayTool::get_properties_widget()
         density_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         density_label.set_fixed_size(80, 20);
 
-        auto& density_slider = density_container.add<GUI::HorizontalSlider>();
-        density_slider.set_fixed_height(30);
+        auto& density_slider = density_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
         density_slider.set_range(1, 100);
         density_slider.set_value(m_density);
-        density_slider.set_tooltip(String::formatted("{}%", m_density));
 
         density_slider.on_change = [&](int value) {
             m_density = value;
-            density_slider.set_tooltip(String::formatted("{}%", value));
         };
     }
 

--- a/Userland/Applications/PixelPaint/ZoomTool.cpp
+++ b/Userland/Applications/PixelPaint/ZoomTool.cpp
@@ -8,7 +8,7 @@
 #include "ImageEditor.h"
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
-#include <LibGUI/Slider.h>
+#include <LibGUI/ValueSlider.h>
 
 namespace PixelPaint {
 
@@ -43,15 +43,12 @@ GUI::Widget* ZoomTool::get_properties_widget()
         sensitivity_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         sensitivity_label.set_fixed_size(80, 20);
 
-        auto& sensitivity_slider = sensitivity_container.add<GUI::HorizontalSlider>();
-        sensitivity_slider.set_fixed_height(20);
+        auto& sensitivity_slider = sensitivity_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
         sensitivity_slider.set_range(1, 100);
         sensitivity_slider.set_value(100 * m_sensitivity);
-        sensitivity_slider.set_tooltip(String::formatted("{:.2}", (double)m_sensitivity / 100.0));
 
         sensitivity_slider.on_change = [&](int value) {
             m_sensitivity = (double)value / 100.0;
-            sensitivity_slider.set_tooltip(String::formatted("{:.2}", (double)value / 100.0));
         };
     }
 

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -27,7 +27,7 @@ public:
     bool jump_to_cursor() const { return m_jump_to_cursor; }
 
     void set_range(int min, int max);
-    void set_value(int);
+    virtual void set_value(int);
 
     void set_min(int min) { set_range(min, max()); }
     void set_max(int max) { set_range(min(), max); }

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
     ToolbarContainer.cpp
     TreeView.cpp
     UndoStack.cpp
+    ValueSlider.cpp
     Variant.cpp
     VimEditingEngine.cpp
     Widget.cpp

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -74,6 +74,7 @@ class FontsChangeEvent;
 class Toolbar;
 class ToolbarContainer;
 class TreeView;
+class ValueSlider;
 class Variant;
 class VerticalBoxLayout;
 class VerticalSlider;

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2021, Marcus Nilsson <brainbomb@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/TextBox.h>
+#include <LibGUI/ValueSlider.h>
+#include <LibGfx/FontDatabase.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/StylePainter.h>
+
+REGISTER_WIDGET(GUI, ValueSlider)
+
+namespace GUI {
+
+ValueSlider::ValueSlider(Gfx::Orientation orientation, String suffix)
+    : AbstractSlider(orientation)
+    , m_suffix(move(suffix))
+{
+    //FIXME: Implement vertical mode
+    VERIFY(orientation == Orientation::Horizontal);
+
+    set_fixed_height(20);
+
+    m_textbox = add<GUI::TextBox>();
+    m_textbox->set_relative_rect({ 0, 0, 34, 20 });
+    m_textbox->set_font_fixed_width(true);
+    m_textbox->set_font_size(8);
+
+    m_textbox->on_change = [&]() {
+        String value = m_textbox->text();
+        if (value.ends_with(m_suffix, AK::CaseSensitivity::CaseInsensitive))
+            value = value.substring_view(0, value.length() - m_suffix.length());
+        auto integer_value = value.to_int();
+        if (integer_value.has_value())
+            AbstractSlider::set_value(integer_value.value());
+    };
+
+    m_textbox->on_return_pressed = [&]() {
+        m_textbox->on_change();
+        m_textbox->set_text(formatted_value());
+    };
+
+    m_textbox->on_up_pressed = [&]() {
+        if (value() < max())
+            AbstractSlider::set_value(value() + 1);
+        m_textbox->set_text(formatted_value());
+    };
+
+    m_textbox->on_down_pressed = [&]() {
+        if (value() > min())
+            AbstractSlider::set_value(value() - 1);
+        m_textbox->set_text(formatted_value());
+    };
+
+    m_textbox->on_focusout = [&]() {
+        m_textbox->on_return_pressed();
+    };
+
+    m_textbox->on_escape_pressed = [&]() {
+        m_textbox->clear_selection();
+        m_textbox->set_text(formatted_value());
+        parent_widget()->set_focus(true);
+    };
+}
+
+ValueSlider::~ValueSlider()
+{
+}
+
+String ValueSlider::formatted_value() const
+{
+    return String::formatted("{:2}{}", value(), m_suffix);
+}
+
+void ValueSlider::paint_event(PaintEvent& event)
+{
+    GUI::Painter painter(*this);
+    painter.add_clip_rect(event.rect());
+
+    painter.fill_rect_with_gradient(m_orientation, bar_rect(), palette().active_window_border1(), palette().active_window_border2());
+    auto unfilled_rect = bar_rect();
+    unfilled_rect.set_left(knob_rect().right());
+    painter.fill_rect(unfilled_rect, palette().base());
+
+    Gfx::StylePainter::paint_frame(painter, bar_rect(), palette(), Gfx::FrameShape::Container, Gfx::FrameShadow::Sunken, 2);
+    Gfx::StylePainter::paint_button(painter, knob_rect(), palette(), Gfx::ButtonStyle::Normal, false, m_hovered);
+
+    auto paint_knurl = [&](int x, int y) {
+        painter.set_pixel(x, y, palette().threed_shadow1());
+        painter.set_pixel(x + 1, y, palette().threed_shadow1());
+        painter.set_pixel(x, y + 1, palette().threed_shadow1());
+        painter.set_pixel(x + 1, y + 1, palette().threed_highlight());
+    };
+
+    auto knurl_rect = knob_rect().shrunken(4, 8);
+
+    if (m_knob_style == KnobStyle::Wide) {
+        for (int i = 0; i < 4; ++i) {
+            paint_knurl(knurl_rect.x(), knurl_rect.y() + (i * 3));
+            paint_knurl(knurl_rect.x() + 3, knurl_rect.y() + (i * 3));
+            paint_knurl(knurl_rect.x() + 6, knurl_rect.y() + (i * 3));
+        }
+    } else {
+        for (int i = 0; i < 4; ++i)
+            paint_knurl(knurl_rect.x(), knurl_rect.y() + (i * 3));
+    }
+}
+
+Gfx::IntRect ValueSlider::bar_rect() const
+{
+    auto bar_rect = rect();
+    bar_rect.set_width(rect().width() - m_textbox->width());
+    bar_rect.set_x(m_textbox->width());
+    return bar_rect;
+}
+
+Gfx::IntRect ValueSlider::knob_rect() const
+{
+    int knob_thickness = m_knob_style == KnobStyle::Wide ? 13 : 7;
+
+    Gfx::IntRect knob_rect = bar_rect();
+    knob_rect.set_width(knob_thickness);
+
+    int knob_offset = (int)((float)bar_rect().left() + (float)(value() - min()) / (float)(max() - min()) * (float)(bar_rect().width() - knob_thickness));
+    knob_rect.set_left(knob_offset);
+    knob_rect.center_vertically_within(bar_rect());
+    return knob_rect;
+}
+
+int ValueSlider::value_at(const Gfx::IntPoint& position) const
+{
+    if (position.x() < bar_rect().left())
+        return min();
+    if (position.x() > bar_rect().right())
+        return max();
+    float relative_offset = (float)(position.x() - bar_rect().left()) / (float)bar_rect().width();
+    return (int)(relative_offset * (float)max());
+}
+
+void ValueSlider::set_value(int value)
+{
+    AbstractSlider::set_value(value);
+    m_textbox->set_text(formatted_value());
+}
+
+void ValueSlider::leave_event(Core::Event&)
+{
+    if (!m_hovered)
+        return;
+
+    m_hovered = false;
+    update(knob_rect());
+}
+
+void ValueSlider::mousewheel_event(MouseEvent& event)
+{
+    if (event.wheel_delta() < 0)
+        set_value(value() + 1);
+    else
+        set_value(value() - 1);
+}
+
+void ValueSlider::mousemove_event(MouseEvent& event)
+{
+    bool is_hovered = knob_rect().contains(event.position());
+    if (is_hovered != m_hovered) {
+        m_hovered = is_hovered;
+        update(knob_rect());
+    }
+
+    if (!m_dragging)
+        return;
+
+    set_value(value_at(event.position()));
+}
+
+void ValueSlider::mousedown_event(MouseEvent& event)
+{
+    if (event.button() != MouseButton::Left)
+        return;
+
+    m_textbox->set_focus(true);
+
+    if (bar_rect().contains(event.position())) {
+        m_dragging = true;
+        set_value(value_at(event.position()));
+    }
+}
+
+void ValueSlider::mouseup_event(MouseEvent& event)
+{
+    if (event.button() != MouseButton::Left)
+        return;
+
+    m_dragging = false;
+}
+
+}

--- a/Userland/Libraries/LibGUI/ValueSlider.h
+++ b/Userland/Libraries/LibGUI/ValueSlider.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Marcus Nilsson <brainbomb@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/AbstractSlider.h>
+
+namespace GUI {
+
+class ValueSlider : public AbstractSlider {
+    C_OBJECT(ValueSlider);
+
+public:
+    enum class KnobStyle {
+        Wide,
+        Thin,
+    };
+
+    virtual ~ValueSlider() override;
+
+    void set_suffix(String suffix) { m_suffix = move(suffix); }
+    void set_knob_style(KnobStyle knobstyle) { m_knob_style = knobstyle; }
+
+    virtual void set_value(int value) override;
+
+protected:
+    virtual void paint_event(PaintEvent&) override;
+    virtual void mousedown_event(MouseEvent&) override;
+    virtual void mousemove_event(MouseEvent&) override;
+    virtual void mouseup_event(MouseEvent&) override;
+    virtual void mousewheel_event(MouseEvent&) override;
+    virtual void leave_event(Core::Event&) override;
+
+private:
+    explicit ValueSlider(Gfx::Orientation = Gfx::Orientation::Horizontal, String suffix = "");
+
+    String formatted_value() const;
+    int value_at(const Gfx::IntPoint& position) const;
+    Gfx::IntRect bar_rect() const;
+    Gfx::IntRect knob_rect() const;
+
+    String m_suffix {};
+    Orientation m_orientation { Orientation::Horizontal };
+    KnobStyle m_knob_style { KnobStyle::Thin };
+    RefPtr<GUI::TextBox> m_textbox;
+    bool m_dragging { false };
+    bool m_hovered { false };
+};
+
+}


### PR DESCRIPTION
![Screenshot_20210805_213650](https://user-images.githubusercontent.com/69970419/128503141-0555f6a1-f432-4959-9652-0b47f315b633.png)

This PR implements a new slider called ValueSlider, used when you want to display values alongside a slider and have the option to edit them directly. It's main target has been tool properties in PixelPaint but of course it should be general enough to be used in other applications as well. That's why I really stress for feedback on the design so it's not implemented and left unused.

Some thing to point out:
- **No vertical mode yet**. I'd like it to be tried out and tweaked before implementing vertical mode. I guess using it as a volume slider/mixer is the general use case for that.
- Trying to type in 'p' or another key that's used as a shortcut in the textbox will cause the tool to change (and cause a crash until #9231 is merged). I'm going to check in on that behaviour in the next couple of days and see if it's possible to implement a way to let the textbox have precedence.
- The displayed value is coupled with the set value for the slider, so values above 100x or 99xx does not display well. It would be possible to implement a settable multiplier/divisor when you want the range of larger values but displayed in a compact format. Or we could add an optional callback so that the end user can control display/input format. This is why I changed the thickness of EraseTool to be settable 1-50px and `feather_slider_max` on RectangleSelectTool to 100 instead of 10000, I didn't notice any change in behaviour of the feathering because of this.