### PR TITLE
Spreadsheet: Fix column index string to number conversion

### DIFF
--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -283,6 +283,15 @@ TEST_CASE(find_with_empty_needle)
     EXPECT_EQ(string.find_all(""sv), (Vector<size_t> { 0u, 1u, 2u, 3u }));
 }
 
+TEST_CASE(bijective_base)
+{
+    EXPECT_EQ(String::bijective_base_from(0), "A");
+    EXPECT_EQ(String::bijective_base_from(25), "Z");
+    EXPECT_EQ(String::bijective_base_from(26), "AA");
+    EXPECT_EQ(String::bijective_base_from(52), "BA");
+    EXPECT_EQ(String::bijective_base_from(704), "ABC");
+}
+
 TEST_CASE(roman_numerals)
 {
     auto zero = String::roman_number_from(0);

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -90,12 +90,13 @@ static size_t convert_from_string(StringView str, unsigned base = 26, StringView
     VERIFY(base >= 2 && base <= map.length());
 
     size_t value = 0;
-    for (size_t i = str.length(); i > 0; --i) {
-        auto digit_value = map.find(str[i - 1]).value_or(0);
+    auto const len = str.length();
+    for (auto i = 0u; i < len; i++) {
+        size_t digit_value = map.find(str[i]).value_or(0);
         // NOTE: Refer to the note in `String::bijective_base_from()'.
-        if (i == str.length() && str.length() > 1)
+        if (i == 0 && len > 1)
             ++digit_value;
-        value = value * base + digit_value;
+        value += digit_value * AK::pow<float>(base, len - 1 - i);
     }
 
     return value;


### PR DESCRIPTION
Issue: In Spreadsheet application, we have `convert_from_string` function to get column index from a string.
It was giving wrong output.
e.g. `convert_from_string("AB") == 52`. Correct output is 27.

Fixed calculation of index and added error handling.

Testing:
Added test case for `AK::String::bijective_base_from`
`convert_from_string` function is `static`, so manually tested output for few input values.