### PR TITLE
Everywhere: Replace Model::update() with Model::invalidate()

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -97,11 +97,6 @@ GUI::Variant ClipboardHistoryModel::data(const GUI::ModelIndex& index, GUI::Mode
     }
 }
 
-void ClipboardHistoryModel::update()
-{
-    did_update();
-}
-
 void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)
 {
     m_history_items.remove_first_matching([&](GUI::Clipboard::DataAndType& existing) {
@@ -112,7 +107,7 @@ void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)
         m_history_items.take_last();
 
     m_history_items.prepend(item);
-    update();
+    invalidate();
 }
 
 void ClipboardHistoryModel::remove_item(int index)

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -35,7 +35,6 @@ private:
     virtual String column_name(int) const override;
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
     // ^GUI::Clipboard::ClipboardClient
     virtual void clipboard_content_did_change(const String&) override { add_item(GUI::Clipboard::the().data_and_type()); }

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -146,7 +146,7 @@ BookmarksBarWidget::BookmarksBarWidget(const String& bookmarks_file, bool enable
     fields.empend("title", "Title", Gfx::TextAlignment::CenterLeft);
     fields.empend("url", "Url", Gfx::TextAlignment::CenterRight);
     set_model(GUI::JsonArrayModel::create(bookmarks_file, move(fields)));
-    model()->update();
+    model()->invalidate();
 }
 
 BookmarksBarWidget::~BookmarksBarWidget()

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -98,10 +98,6 @@ AddEventDialog::MonthListModel::~MonthListModel()
 {
 }
 
-void AddEventDialog::MonthListModel::update()
-{
-}
-
 int AddEventDialog::MonthListModel::row_count(const GUI::ModelIndex&) const
 {
     return 12;

--- a/Userland/Applications/Calendar/AddEventDialog.h
+++ b/Userland/Applications/Calendar/AddEventDialog.h
@@ -39,7 +39,6 @@ private:
         virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
         virtual String column_name(int) const override;
         virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-        virtual void update() override;
 
     private:
         MonthListModel();

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -360,7 +360,7 @@ void DirectoryView::open(String const& path)
     auto real_path = Core::File::real_path_for(path);
 
     if (model().root_path() == real_path) {
-        model().update();
+        model().invalidate();
         return;
     }
 
@@ -382,7 +382,7 @@ void DirectoryView::open_parent_directory()
 
 void DirectoryView::refresh()
 {
-    model().update();
+    model().invalidate();
 }
 
 void DirectoryView::open_previous_directory()

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -500,7 +500,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     };
 
     auto refresh_tree_view = [&] {
-        directories_model->update();
+        directories_model->invalidate();
 
         auto current_path = directory_view.path();
 

--- a/Userland/Applications/Help/ManualModel.cpp
+++ b/Userland/Applications/Help/ManualModel.cpp
@@ -172,8 +172,3 @@ TriState ManualModel::data_matches(const GUI::ModelIndex& index, const GUI::Vari
 
     return view_result.value().contains(term.as_string()) ? TriState::True : TriState::False;
 }
-
-void ManualModel::update()
-{
-    did_update();
-}

--- a/Userland/Applications/Help/ManualModel.h
+++ b/Userland/Applications/Help/ManualModel.h
@@ -32,7 +32,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual TriState data_matches(const GUI::ModelIndex&, const GUI::Variant&) const override;
-    virtual void update() override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -109,11 +109,11 @@ int main(int argc, char* argv[])
         if (auto model = search_list_view.model()) {
             auto& search_model = *static_cast<GUI::FilteringProxyModel*>(model);
             search_model.set_filter_term(search_box.text());
-            search_model.update();
+            search_model.invalidate();
         }
     };
     search_list_view.set_model(GUI::FilteringProxyModel::construct(model));
-    search_list_view.model()->update();
+    search_list_view.model()->invalidate();
 
     tree_view.set_model(model);
     left_tab_bar.set_fixed_width(200);

--- a/Userland/Applications/HexEditor/SearchResultsModel.h
+++ b/Userland/Applications/HexEditor/SearchResultsModel.h
@@ -75,8 +75,6 @@ public:
         return {};
     }
 
-    virtual void update() override { }
-
 private:
     Vector<Match> m_matches;
 };

--- a/Userland/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Userland/Applications/IRCClient/IRCAppWindow.cpp
@@ -62,7 +62,7 @@ void IRCAppWindow::setup_client()
         return static_cast<IRCWindow*>(m_container->active_widget());
     };
     m_client->aid_update_window_list = [this] {
-        m_window_list->model()->update();
+        m_window_list->model()->invalidate();
     };
     m_client->on_nickname_changed = [this](const String&) {
         update_title();

--- a/Userland/Applications/IRCClient/IRCChannel.cpp
+++ b/Userland/Applications/IRCClient/IRCChannel.cpp
@@ -36,7 +36,7 @@ void IRCChannel::add_member(const String& name, char prefix)
         }
     }
     m_members.append({ name, prefix });
-    m_member_model->update();
+    m_member_model->invalidate();
 }
 
 void IRCChannel::remove_member(const String& name)
@@ -69,7 +69,7 @@ void IRCChannel::handle_join(const String& nick, const String& hostmask)
         return;
     }
     add_member(nick, (char)0);
-    m_member_model->update();
+    m_member_model->invalidate();
     if (m_client.show_join_part_messages())
         add_message(String::formatted("*** {} [{}] has joined {}", nick, hostmask, m_name), Color::MidGreen);
 }
@@ -83,7 +83,7 @@ void IRCChannel::handle_part(const String& nick, const String& hostmask)
     } else {
         remove_member(nick);
     }
-    m_member_model->update();
+    m_member_model->invalidate();
     if (m_client.show_join_part_messages())
         add_message(String::formatted("*** {} [{}] has parted from {}", nick, hostmask, m_name), Color::MidGreen);
 }
@@ -97,7 +97,7 @@ void IRCChannel::handle_quit(const String& nick, const String& hostmask, const S
     } else {
         remove_member(nick);
     }
-    m_member_model->update();
+    m_member_model->invalidate();
     add_message(String::formatted("*** {} [{}] has quit ({})", nick, hostmask, message), Color::MidGreen);
 }
 
@@ -114,7 +114,7 @@ void IRCChannel::notify_nick_changed(const String& old_nick, const String& new_n
     for (auto& member : m_members) {
         if (member.name == old_nick) {
             member.name = new_nick;
-            m_member_model->update();
+            m_member_model->invalidate();
             if (m_client.show_nick_change_messages())
                 add_message(String::formatted("~ {} changed nickname to {}", old_nick, new_nick), Color::MidMagenta);
             return;

--- a/Userland/Applications/IRCClient/IRCChannelMemberListModel.cpp
+++ b/Userland/Applications/IRCClient/IRCChannelMemberListModel.cpp
@@ -50,11 +50,6 @@ GUI::Variant IRCChannelMemberListModel::data(const GUI::ModelIndex& index, GUI::
     return {};
 }
 
-void IRCChannelMemberListModel::update()
-{
-    did_update();
-}
-
 String IRCChannelMemberListModel::nick_at(const GUI::ModelIndex& index) const
 {
     return data(index, GUI::ModelRole::Display).to_string();

--- a/Userland/Applications/IRCClient/IRCChannelMemberListModel.h
+++ b/Userland/Applications/IRCClient/IRCChannelMemberListModel.h
@@ -23,7 +23,6 @@ public:
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual String column_name(int column) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
     virtual String nick_at(const GUI::ModelIndex& index) const;
 
 private:

--- a/Userland/Applications/IRCClient/IRCClient.cpp
+++ b/Userland/Applications/IRCClient/IRCClient.cpp
@@ -817,7 +817,7 @@ void IRCClient::register_subwindow(IRCWindow& subwindow)
         subwindow.set_log_buffer(*m_log);
     }
     m_windows.append(&subwindow);
-    m_client_window_list_model->update();
+    m_client_window_list_model->invalidate();
 }
 
 void IRCClient::unregister_subwindow(IRCWindow& subwindow)
@@ -831,7 +831,7 @@ void IRCClient::unregister_subwindow(IRCWindow& subwindow)
             break;
         }
     }
-    m_client_window_list_model->update();
+    m_client_window_list_model->invalidate();
 }
 
 void IRCClient::handle_user_command(const String& input)
@@ -1079,7 +1079,7 @@ void IRCClient::handle_kick_user_action(const String& channel, const String& nic
 void IRCClient::handle_close_query_action(const String& nick)
 {
     m_queries.remove(nick);
-    m_client_window_list_model->update();
+    m_client_window_list_model->invalidate();
 }
 
 void IRCClient::handle_join_action(const String& channel)

--- a/Userland/Applications/IRCClient/IRCWindowListModel.cpp
+++ b/Userland/Applications/IRCClient/IRCWindowListModel.cpp
@@ -64,8 +64,3 @@ GUI::Variant IRCWindowListModel::data(const GUI::ModelIndex& index, GUI::ModelRo
     }
     return {};
 }
-
-void IRCWindowListModel::update()
-{
-    did_update();
-}

--- a/Userland/Applications/IRCClient/IRCWindowListModel.h
+++ b/Userland/Applications/IRCClient/IRCWindowListModel.h
@@ -25,7 +25,6 @@ public:
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual String column_name(int column) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
 private:
     explicit IRCWindowListModel(IRCClient&);

--- a/Userland/Applications/KeyboardSettings/CharacterMapFileListModel.h
+++ b/Userland/Applications/KeyboardSettings/CharacterMapFileListModel.h
@@ -39,11 +39,6 @@ public:
         return {};
     }
 
-    virtual void update() override
-    {
-        did_update();
-    }
-
 private:
     explicit CharacterMapFileListModel(Vector<String>& filenames)
         : m_filenames(filenames)

--- a/Userland/Applications/Mail/AccountHolder.cpp
+++ b/Userland/Applications/Mail/AccountHolder.cpp
@@ -75,5 +75,5 @@ void AccountHolder::add_account_with_name_and_mailboxes(String name, Vector<IMAP
 
 void AccountHolder::rebuild_tree()
 {
-    m_mailbox_tree_model->update();
+    m_mailbox_tree_model->invalidate();
 }

--- a/Userland/Applications/Mail/InboxModel.cpp
+++ b/Userland/Applications/Mail/InboxModel.cpp
@@ -43,8 +43,3 @@ GUI::Variant InboxModel::data(GUI::ModelIndex const& index, GUI::ModelRole role)
     }
     return {};
 }
-
-void InboxModel::update()
-{
-    did_update();
-}

--- a/Userland/Applications/Mail/InboxModel.h
+++ b/Userland/Applications/Mail/InboxModel.h
@@ -33,7 +33,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
 private:
     InboxModel(Vector<InboxEntry>);

--- a/Userland/Applications/Mail/MailboxTreeModel.cpp
+++ b/Userland/Applications/Mail/MailboxTreeModel.cpp
@@ -113,8 +113,3 @@ GUI::Variant MailboxTreeModel::data(GUI::ModelIndex const& index, GUI::ModelRole
 
     return {};
 }
-
-void MailboxTreeModel::update()
-{
-    did_update();
-}

--- a/Userland/Applications/Mail/MailboxTreeModel.h
+++ b/Userland/Applications/Mail/MailboxTreeModel.h
@@ -25,7 +25,6 @@ public:
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;
-    virtual void update() override;
 
 private:
     explicit MailboxTreeModel(AccountHolder const&);

--- a/Userland/Applications/PDFViewer/OutlineModel.cpp
+++ b/Userland/Applications/PDFViewer/OutlineModel.cpp
@@ -61,11 +61,6 @@ GUI::Variant OutlineModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     }
 }
 
-void OutlineModel::update()
-{
-    did_update();
-}
-
 GUI::ModelIndex OutlineModel::parent_index(const GUI::ModelIndex& index) const
 {
     if (!index.is_valid())

--- a/Userland/Applications/PDFViewer/OutlineModel.h
+++ b/Userland/Applications/PDFViewer/OutlineModel.h
@@ -19,7 +19,6 @@ public:
     virtual int row_count(const GUI::ModelIndex&) const override;
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
-    virtual void update() override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
 

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -59,8 +59,6 @@ public:
         return {};
     }
 
-    virtual void update() override { }
-
 private:
     NonnullRefPtrVector<Desktop::AppFile> m_apps;
 };

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -92,10 +92,6 @@ String PlaylistModel::column_name(int column) const
     VERIFY_NOT_REACHED();
 }
 
-void PlaylistModel::update()
-{
-}
-
 void PlaylistTableView::doubleclick_event(GUI::MouseEvent& event)
 {
     AbstractView::doubleclick_event(event);

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.h
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.h
@@ -24,7 +24,6 @@ public:
     int row_count(const GUI::ModelIndex&) const override { return m_playlist_items.size(); }
     int column_count(const GUI::ModelIndex&) const override { return 6; }
     GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    void update() override;
     String column_name(int column) const override;
     Vector<M3UEntry>& items() { return m_playlist_items; }
 

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -258,7 +258,7 @@ void SoundPlayerWidgetAdvancedView::read_playlist(StringView path)
     for (auto& item : *items)
         m_playlist_model->items().append(item);
     set_playlist_visible(true);
-    m_playlist_model->update();
+    m_playlist_model->invalidate();
 
     open_file(items->at(0).path);
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -27,7 +27,6 @@ public:
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_keys.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
-    virtual void update() override { }
 
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role = GUI::ModelRole::Display) const override
     {
@@ -46,7 +45,7 @@ public:
         object.for_each_member([this](auto& name, auto&) {
             m_keys.append(name);
         });
-        did_update();
+        invalidate();
     }
 
 private:

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -146,7 +146,7 @@ void SheetModel::set_data(const GUI::ModelIndex& index, const GUI::Variant& valu
 
     auto& cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
     cell.set_data(value.to_string());
-    update();
+    invalidate();
 }
 
 void SheetModel::update()

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -23,10 +23,11 @@ public:
     virtual RefPtr<Core::MimeData> mime_data(const GUI::ModelSelection&) const override;
     virtual bool is_editable(const GUI::ModelIndex&) const override;
     virtual void set_data(const GUI::ModelIndex&, const GUI::Variant&) override;
-    virtual void update() override;
     virtual bool is_column_sortable(int) const override { return false; }
     virtual StringView drag_data_type() const override { return "text/x-spreadsheet-data"; }
     Sheet& sheet() { return *m_sheet; }
+
+    void update();
 
 private:
     explicit SheetModel(Sheet& sheet)

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -144,7 +144,7 @@ void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
 
 void SpreadsheetView::update_with_model()
 {
-    m_table_view->model()->update();
+    m_table_view->model()->invalidate();
     m_table_view->update();
 }
 

--- a/Userland/Applications/SystemMonitor/DevicesModel.cpp
+++ b/Userland/Applications/SystemMonitor/DevicesModel.cpp
@@ -118,8 +118,9 @@ GUI::Variant DevicesModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
-void DevicesModel::update()
+void DevicesModel::invalidate()
 {
+    // FIXME: granularly update this.
     auto proc_devices = Core::File::construct("/proc/devices");
     if (!proc_devices->open(Core::OpenMode::ReadOnly))
         VERIFY_NOT_REACHED();
@@ -172,5 +173,5 @@ void DevicesModel::update()
     fill_in_paths_from_dir("/dev");
     fill_in_paths_from_dir("/dev/pts");
 
-    did_update();
+    Model::invalidate();
 }

--- a/Userland/Applications/SystemMonitor/DevicesModel.h
+++ b/Userland/Applications/SystemMonitor/DevicesModel.h
@@ -28,7 +28,9 @@ public:
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual String column_name(int column) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
+
+    // FIXME: This should be moved to granularly updating itself.
+    virtual void invalidate() override;
 
 private:
     DevicesModel();

--- a/Userland/Applications/SystemMonitor/InterruptsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/InterruptsWidget.cpp
@@ -44,5 +44,5 @@ InterruptsWidget::~InterruptsWidget()
 
 void InterruptsWidget::update_model()
 {
-    m_interrupt_table_view->model()->update();
+    m_interrupt_model->invalidate();
 }

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -117,7 +117,7 @@ NetworkStatisticsWidget::~NetworkStatisticsWidget()
 
 void NetworkStatisticsWidget::update_models()
 {
-    m_adapter_table_view->model()->update();
-    m_tcp_socket_table_view->model()->update();
-    m_udp_socket_table_view->model()->update();
+    m_adapter_model->invalidate();
+    m_tcp_socket_model->invalidate();
+    m_udp_socket_model->invalidate();
 }

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -122,5 +122,5 @@ void ProcessMemoryMapWidget::set_pid(pid_t pid)
 void ProcessMemoryMapWidget::refresh()
 {
     if (m_pid != -1)
-        m_json_model->update();
+        m_json_model->invalidate();
 }

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -60,8 +60,8 @@ public:
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual String column_name(int column) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
     virtual bool is_column_sortable(int column_index) const override { return column_index != Column::Icon; }
+    void update();
 
     struct CpuInfo {
         u32 id;

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -57,11 +57,6 @@ public:
         return {};
     }
 
-    virtual void update() override
-    {
-        did_update(GUI::Model::DontInvalidateIndices);
-    }
-
     virtual void model_did_update([[maybe_unused]] unsigned flags) override
     {
         refresh();
@@ -77,7 +72,7 @@ public:
                 break;
             }
         }
-        update();
+        invalidate();
     }
 
 private:

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -225,11 +225,11 @@ int main(int argc, char** argv)
     process_table_view.set_column_visible(ProcessModel::Column::DirtyPrivate, true);
 
     process_table_view.set_key_column_and_sort_order(ProcessModel::Column::CPU, GUI::SortOrder::Descending);
-    process_table_view.model()->update();
+    process_model->update();
 
     auto& refresh_timer = window->add<Core::Timer>(
         3000, [&] {
-            process_table_view.model()->update();
+            process_model->update();
             if (auto* memory_stats_widget = MemoryStatsWidget::the())
                 memory_stats_widget->refresh();
         });
@@ -567,11 +567,12 @@ NonnullRefPtr<GUI::Widget> build_file_systems_tab()
         df_fields.empend("free_inode_count", "Free inodes", Gfx::TextAlignment::CenterRight);
         df_fields.empend("total_inode_count", "Total inodes", Gfx::TextAlignment::CenterRight);
         df_fields.empend("block_size", "Block size", Gfx::TextAlignment::CenterRight);
+
         fs_table_view.set_model(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/proc/df", move(df_fields))));
 
         fs_table_view.set_column_painting_delegate(3, make<ProgressbarPaintingDelegate>());
 
-        fs_table_view.model()->update();
+        fs_table_view.model()->invalidate();
     };
     return fs_widget;
 }
@@ -629,7 +630,7 @@ NonnullRefPtr<GUI::Widget> build_pci_devices_tab()
             });
 
         pci_table_view.set_model(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/proc/pci", move(pci_fields))));
-        pci_table_view.model()->update();
+        pci_table_view.model()->invalidate();
     };
 
     return pci_widget;
@@ -645,7 +646,7 @@ NonnullRefPtr<GUI::Widget> build_devices_tab()
 
         auto& devices_table_view = self.add<GUI::TableView>();
         devices_table_view.set_model(GUI::SortingProxyModel::create(DevicesModel::create()));
-        devices_table_view.model()->update();
+        devices_table_view.model()->invalidate();
     };
 
     return devices_widget;
@@ -748,8 +749,9 @@ NonnullRefPtr<GUI::Widget> build_processors_tab()
         processors_field.empend("type", "Type", Gfx::TextAlignment::CenterRight);
 
         auto& processors_table_view = self.add<GUI::TableView>();
-        processors_table_view.set_model(GUI::JsonArrayModel::create("/proc/cpuinfo", move(processors_field)));
-        processors_table_view.model()->update();
+        auto json_model = GUI::JsonArrayModel::create("/proc/cpuinfo", move(processors_field));
+        processors_table_view.set_model(json_model);
+        json_model->invalidate();
     };
 
     return processors_widget;

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -26,7 +26,6 @@ public:
             return Gfx::to_string(m_color_roles[(size_t)index.row()]);
         return {};
     }
-    virtual void update() { did_update(); }
 
     explicit ColorRoleModel(const Vector<Gfx::ColorRole>& color_roles)
         : m_color_roles(color_roles)

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -51,7 +51,7 @@ public:
         }
         return {};
     }
-    virtual void update() override
+    virtual void update()
     {
         m_cursors.clear();
 
@@ -131,7 +131,7 @@ public:
         }
         return {};
     }
-    virtual void update() override
+    virtual void update()
     {
         m_icon_sets.clear();
 

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -290,7 +290,7 @@ GalleryWidget::GalleryWidget()
 
     m_cursors_tableview->set_model(sorting_proxy_model);
     m_cursors_tableview->set_key_column_and_sort_order(MouseCursorModel::Column::Name, GUI::SortOrder::Ascending);
-    m_cursors_tableview->model()->update();
+    m_cursors_tableview->model()->invalidate();
     m_cursors_tableview->set_column_width(0, 25);
 
     m_cursors_tableview->on_activation = [&](const GUI::ModelIndex& index) {
@@ -363,7 +363,7 @@ GalleryWidget::GalleryWidget()
 
     m_icons_tableview->set_model(sorting_proxy_icons_model);
     m_icons_tableview->set_key_column_and_sort_order(FileIconsModel::Column::Name, GUI::SortOrder::Ascending);
-    m_icons_tableview->model()->update();
+    m_icons_tableview->model()->invalidate();
     m_icons_tableview->set_column_width(0, 36);
     m_icons_tableview->set_column_width(1, 20);
 }

--- a/Userland/DevTools/HackStudio/ClassViewWidget.h
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.h
@@ -45,7 +45,6 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole role) const override;
-    virtual void update() override { did_update(); }
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& parent_index = GUI::ModelIndex()) const override;
 

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
@@ -33,7 +33,6 @@ public:
 
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
-    virtual void update() override { }
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
 
     struct FrameInfo {

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.cpp
@@ -111,9 +111,4 @@ GUI::Variant DisassemblyModel::data(const GUI::ModelIndex& index, GUI::ModelRole
     return {};
 }
 
-void DisassemblyModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/DisassemblyModel.h
@@ -46,7 +46,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
 private:
     DisassemblyModel(const Debug::DebugSession&, const PtraceRegisters&);

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
@@ -136,9 +136,4 @@ GUI::Variant RegistersModel::data(const GUI::ModelIndex& index, GUI::ModelRole r
     return {};
 }
 
-void RegistersModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.h
@@ -42,7 +42,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
     const PtraceRegisters& raw_registers() const { return m_raw_registers; }
 

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -158,11 +158,6 @@ GUI::Variant VariablesModel::data(const GUI::ModelIndex& index, GUI::ModelRole r
     }
 }
 
-void VariablesModel::update()
-{
-    did_update();
-}
-
 RefPtr<VariablesModel> VariablesModel::create(const PtraceRegisters& regs)
 {
     auto lib = Debugger::the().session()->library_at(regs.ip());

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.h
@@ -23,7 +23,6 @@ public:
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
-    virtual void update() override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& = GUI::ModelIndex()) const override;
 

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.cpp
@@ -24,7 +24,7 @@ ProjectTemplatesModel::ProjectTemplatesModel()
     if (!watcher_or_error.is_error()) {
         m_file_watcher = watcher_or_error.release_value();
         m_file_watcher->on_change = [&](auto) {
-            update();
+            invalidate();
         };
 
         auto watch_result = m_file_watcher->add_watch(

--- a/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.h
+++ b/Userland/DevTools/HackStudio/Dialogs/ProjectTemplatesModel.h
@@ -37,8 +37,8 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
+    void update();
     void rescan_templates();
 
 private:

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.cpp
@@ -76,7 +76,6 @@ public:
         return {};
     }
 
-    virtual void update() override { }
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& = GUI::ModelIndex()) const override
     {
         if (row < 0 || row >= (int)m_matches.size())

--- a/Userland/DevTools/HackStudio/Git/GitFilesModel.h
+++ b/Userland/DevTools/HackStudio/Git/GitFilesModel.h
@@ -27,7 +27,6 @@ public:
 
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
-    virtual void update() override { }
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
 
 private:

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -268,7 +268,7 @@ bool HackStudioWidget::open_file(const String& full_filename)
             }
         }
 
-        m_open_files_view->model()->update();
+        m_open_files_view->model()->invalidate();
     }
 
     current_editor().set_document(const_cast<GUI::TextDocument&>(new_project_file->document()));
@@ -1115,7 +1115,7 @@ void HackStudioWidget::handle_external_file_deletion(const String& filepath)
         }
     }
 
-    m_open_files_view->model()->update();
+    m_open_files_view->model()->invalidate();
 }
 
 HackStudioWidget::~HackStudioWidget()

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -74,7 +74,6 @@ public:
         }
         return {};
     }
-    virtual void update() override {};
 
     const Vector<Suggestion>& suggestions() const { return m_suggestions; }
 

--- a/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
+++ b/Userland/DevTools/HackStudio/ToDoEntriesWidget.cpp
@@ -71,7 +71,6 @@ public:
         return {};
     }
 
-    virtual void update() override { }
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& = GUI::ModelIndex()) const override
     {
         if (row < 0 || row >= (int)m_matches.size())

--- a/Userland/DevTools/Inspector/RemoteObject.cpp
+++ b/Userland/DevTools/Inspector/RemoteObject.cpp
@@ -16,7 +16,7 @@ RemoteObject::RemoteObject()
 
 RemoteObjectPropertyModel& RemoteObject::property_model()
 {
-    m_property_model->update();
+    m_property_model->invalidate();
     return *m_property_model;
 }
 

--- a/Userland/DevTools/Inspector/RemoteObjectGraphModel.cpp
+++ b/Userland/DevTools/Inspector/RemoteObjectGraphModel.cpp
@@ -95,9 +95,4 @@ GUI::Variant RemoteObjectGraphModel::data(const GUI::ModelIndex& index, GUI::Mod
     return {};
 }
 
-void RemoteObjectGraphModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/DevTools/Inspector/RemoteObjectGraphModel.h
+++ b/Userland/DevTools/Inspector/RemoteObjectGraphModel.h
@@ -30,7 +30,6 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
-    virtual void update() override;
 
 private:
     explicit RemoteObjectGraphModel(RemoteProcess&);

--- a/Userland/DevTools/Inspector/RemoteObjectPropertyModel.cpp
+++ b/Userland/DevTools/Inspector/RemoteObjectPropertyModel.cpp
@@ -67,11 +67,6 @@ GUI::Variant RemoteObjectPropertyModel::data(const GUI::ModelIndex& index, GUI::
     return {};
 }
 
-void RemoteObjectPropertyModel::update()
-{
-    did_update();
-}
-
 void RemoteObjectPropertyModel::set_data(const GUI::ModelIndex& index, const GUI::Variant& new_value)
 {
     if (!index.is_valid())

--- a/Userland/DevTools/Inspector/RemoteObjectPropertyModel.h
+++ b/Userland/DevTools/Inspector/RemoteObjectPropertyModel.h
@@ -34,7 +34,6 @@ public:
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual void set_data(const GUI::ModelIndex&, const GUI::Variant&) override;
-    virtual void update() override;
     virtual bool is_editable(const GUI::ModelIndex& index) const override { return index.column() == Column::Value; }
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -71,7 +71,7 @@ void RemoteProcess::handle_get_all_objects_response(const JsonObject& response)
         }
     }
 
-    m_object_graph_model->update();
+    m_object_graph_model->invalidate();
 
     if (on_update)
         on_update();

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -207,9 +207,4 @@ GUI::Variant DisassemblyModel::data(const GUI::ModelIndex& index, GUI::ModelRole
     return {};
 }
 
-void DisassemblyModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/DevTools/Profiler/DisassemblyModel.h
+++ b/Userland/DevTools/Profiler/DisassemblyModel.h
@@ -47,7 +47,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
     virtual bool is_column_sortable(int) const override { return false; }
 
 private:

--- a/Userland/DevTools/Profiler/IndividualSampleModel.cpp
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.cpp
@@ -67,9 +67,4 @@ GUI::Variant IndividualSampleModel::data(const GUI::ModelIndex& index, GUI::Mode
     return {};
 }
 
-void IndividualSampleModel::update()
-{
-    did_update(Model::InvalidateAllIndices);
-}
-
 }

--- a/Userland/DevTools/Profiler/IndividualSampleModel.h
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.h
@@ -32,7 +32,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
 private:
     IndividualSampleModel(Profile&, size_t event_index);

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -187,7 +187,7 @@ void Profile::rebuild_tree()
     sort_profile_nodes(roots);
 
     m_roots = move(roots);
-    m_model->update();
+    m_model->invalidate();
 }
 
 Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const StringView& path)
@@ -378,7 +378,7 @@ void Profile::set_timestamp_filter_range(u64 start, u64 end)
     m_timestamp_filter_range_end = max(start, end);
 
     rebuild_tree();
-    m_samples_model->update();
+    m_samples_model->invalidate();
 }
 
 void Profile::clear_timestamp_filter_range()
@@ -387,7 +387,7 @@ void Profile::clear_timestamp_filter_range()
         return;
     m_has_timestamp_filter_range = false;
     rebuild_tree();
-    m_samples_model->update();
+    m_samples_model->invalidate();
 }
 
 void Profile::add_process_filter(pid_t pid, EventSerialNumber start_valid, EventSerialNumber end_valid)
@@ -399,8 +399,8 @@ void Profile::add_process_filter(pid_t pid, EventSerialNumber start_valid, Event
 
     rebuild_tree();
     if (m_disassembly_model)
-        m_disassembly_model->update();
-    m_samples_model->update();
+        m_disassembly_model->invalidate();
+    m_samples_model->invalidate();
 }
 
 void Profile::remove_process_filter(pid_t pid, EventSerialNumber start_valid, EventSerialNumber end_valid)
@@ -414,8 +414,8 @@ void Profile::remove_process_filter(pid_t pid, EventSerialNumber start_valid, Ev
 
     rebuild_tree();
     if (m_disassembly_model)
-        m_disassembly_model->update();
-    m_samples_model->update();
+        m_disassembly_model->invalidate();
+    m_samples_model->invalidate();
 }
 
 void Profile::clear_process_filter()
@@ -425,8 +425,8 @@ void Profile::clear_process_filter()
     m_process_filters.clear();
     rebuild_tree();
     if (m_disassembly_model)
-        m_disassembly_model->update();
-    m_samples_model->update();
+        m_disassembly_model->invalidate();
+    m_samples_model->invalidate();
 }
 
 bool Profile::process_filter_contains(pid_t pid, EventSerialNumber serial)

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -135,9 +135,4 @@ GUI::Variant ProfileModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
-void ProfileModel::update()
-{
-    did_update(Model::InvalidateAllIndices);
-}
-
 }

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -35,7 +35,6 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
-    virtual void update() override;
     virtual int tree_column() const override { return Column::StackFrame; }
     virtual bool is_column_sortable(int) const override { return false; }
 

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -94,9 +94,4 @@ GUI::Variant SamplesModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
-void SamplesModel::update()
-{
-    did_update(Model::InvalidateAllIndices);
-}
-
 }

--- a/Userland/DevTools/Profiler/SamplesModel.h
+++ b/Userland/DevTools/Profiler/SamplesModel.h
@@ -36,7 +36,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
     virtual bool is_column_sortable(int) const override { return false; }
 
 private:

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -173,7 +173,6 @@ protected:
 
     bool m_editable { false };
     bool m_searchable { true };
-    ModelIndex m_edit_index;
     RefPtr<Widget> m_edit_widget;
     Gfx::IntRect m_edit_widget_content_rect;
     OwnPtr<ModelEditingDelegate> m_editing_delegate;
@@ -181,20 +180,22 @@ protected:
     Gfx::IntPoint m_left_mousedown_position;
     bool m_might_drag { false };
 
-    ModelIndex m_hovered_index;
-    ModelIndex m_highlighted_search_index;
-
     int m_key_column { -1 };
     SortOrder m_sort_order;
 
+    ModelIndex m_edit_index;
+    ModelIndex m_hovered_index;
+    ModelIndex m_highlighted_search_index;
+
 private:
-    RefPtr<Model> m_model;
-    ModelSelection m_selection;
     ModelIndex m_selection_start_index;
-    String m_searching;
-    RefPtr<Core::Timer> m_searching_timer;
     ModelIndex m_cursor_index;
     ModelIndex m_drop_candidate_index;
+
+    RefPtr<Model> m_model;
+    ModelSelection m_selection;
+    String m_searching;
+    RefPtr<Core::Timer> m_searching_timer;
     SelectionBehavior m_selection_behavior { SelectionBehavior::SelectItems };
     SelectionMode m_selection_mode { SelectionMode::SingleSelection };
     unsigned m_edit_triggers { EditTrigger::DoubleClicked | EditTrigger::EditKeyPressed };

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -69,10 +69,6 @@ public:
 
         return {};
     }
-    virtual void update() override
-    {
-        did_update();
-    };
 
     void set_suggestions(Vector<AutocompleteProvider::Entry>&& suggestions) { m_suggestions = move(suggestions); }
 
@@ -110,7 +106,7 @@ void AutocompleteBox::update_suggestions(Vector<AutocompleteProvider::Entry>&& s
             m_suggestion_view->set_cursor(m_suggestion_view->model()->index(0), GUI::AbstractView::SelectionUpdate::Set);
     }
 
-    m_suggestion_view->model()->update();
+    m_suggestion_view->model()->invalidate();
     m_suggestion_view->update();
     if (!has_suggestions)
         close();

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -135,7 +135,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
                 if (rc < 0) {
                     MessageBox::show(this, String::formatted("mkdir(\"{}\") failed: {}", new_dir_path, strerror(errno)), "Error", MessageBox::Type::Error);
                 } else {
-                    m_model->update();
+                    m_model->invalidate();
                 }
             }
         },
@@ -178,7 +178,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
     m_context_menu->add_action(GUI::Action::create_checkable(
         "Show dotfiles", { Mod_Ctrl, Key_H }, [&](auto& action) {
             m_model->set_should_show_dotfiles(action.is_checked());
-            m_model->update();
+            m_model->invalidate();
         },
         this));
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -286,7 +286,7 @@ FileSystemModel::FileSystemModel(String root_path, Mode mode)
         did_update();
     };
 
-    update();
+    invalidate();
 }
 
 FileSystemModel::~FileSystemModel()
@@ -364,7 +364,7 @@ void FileSystemModel::set_root_path(String root_path)
         m_root_path = {};
     else
         m_root_path = LexicalPath::canonicalized_path(move(root_path));
-    update();
+    invalidate();
 
     if (m_root->has_error()) {
         if (on_directory_change_error)
@@ -374,7 +374,7 @@ void FileSystemModel::set_root_path(String root_path)
     }
 }
 
-void FileSystemModel::update()
+void FileSystemModel::invalidate()
 {
     m_root = adopt_own(*new Node(*this));
 
@@ -383,7 +383,7 @@ void FileSystemModel::update()
 
     m_root->reify_if_needed();
 
-    did_update();
+    Model::invalidate();
 }
 
 int FileSystemModel::row_count(const ModelIndex& index) const
@@ -665,7 +665,9 @@ void FileSystemModel::set_should_show_dotfiles(bool show)
     if (m_should_show_dotfiles == show)
         return;
     m_should_show_dotfiles = show;
-    update();
+
+    // FIXME: add a way to granularly update in this case.
+    invalidate();
 }
 
 bool FileSystemModel::is_editable(const ModelIndex& index) const

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -122,7 +122,6 @@ public:
     virtual int column_count(const ModelIndex& = ModelIndex()) const override;
     virtual String column_name(int column) const override;
     virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
-    virtual void update() override;
     virtual ModelIndex parent_index(const ModelIndex&) const override;
     virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const override;
     virtual StringView drag_data_type() const override { return "text/uri-list"; }
@@ -132,6 +131,7 @@ public:
     virtual bool is_searchable() const override { return true; }
     virtual void set_data(const ModelIndex&, const Variant&) override;
     virtual Vector<ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
+    virtual void invalidate() override;
 
     static String timestamp_string(time_t timestamp)
     {

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -44,9 +44,9 @@ Variant FilteringProxyModel::data(const ModelIndex& index, ModelRole role) const
     return m_matching_indices[index.row()].data(role);
 }
 
-void FilteringProxyModel::update()
+void FilteringProxyModel::invalidate()
 {
-    m_model.update();
+    m_model.invalidate();
     filter();
     did_update();
 }
@@ -84,7 +84,7 @@ void FilteringProxyModel::set_filter_term(const StringView& term)
     if (m_filter_term == term)
         return;
     m_filter_term = term;
-    update();
+    invalidate();
 }
 
 ModelIndex FilteringProxyModel::map(const ModelIndex& index) const

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -26,7 +26,7 @@ public:
     virtual int row_count(const ModelIndex& = ModelIndex()) const override;
     virtual int column_count(const ModelIndex& = ModelIndex()) const override;
     virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
-    virtual void update() override;
+    virtual void invalidate() override;
     virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const override;
     virtual bool is_searchable() const override;
     virtual Vector<ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -71,7 +71,7 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
         if (m_weight.has_value())
             index_of_old_weight_in_new_list = m_weights.find_first_index(m_weight.value());
 
-        m_weight_list_view->model()->update();
+        m_weight_list_view->model()->invalidate();
         m_weight_list_view->set_cursor(m_weight_list_view->model()->index(index_of_old_weight_in_new_list.value_or(0)), GUI::AbstractView::SelectionUpdate::Set);
         update_font();
     };
@@ -110,7 +110,7 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
             }
         });
         quick_sort(m_sizes);
-        m_size_list_view->model()->update();
+        m_size_list_view->model()->invalidate();
         m_size_list_view->set_selection_mode(GUI::AbstractView::SelectionMode::SingleSelection);
 
         if (m_size.has_value()) {
@@ -188,8 +188,8 @@ void FontPicker::set_font(const Gfx::Font* font)
         m_size = {};
         m_weights.clear();
         m_sizes.clear();
-        m_weight_list_view->model()->update();
-        m_size_list_view->model()->update();
+        m_weight_list_view->model()->invalidate();
+        m_size_list_view->model()->invalidate();
         return;
     }
 

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -77,11 +77,6 @@ public:
         return {};
     }
 
-    virtual void update() override
-    {
-        did_update();
-    }
-
 protected:
     explicit ItemListModel(const Container& data, Optional<size_t> row_count = {}) requires(!IsTwoDimensional)
         : m_data(data)

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -10,7 +10,7 @@
 
 namespace GUI {
 
-void JsonArrayModel::update()
+void JsonArrayModel::invalidate()
 {
     auto file = Core::File::construct(m_json_path);
     if (!file->open(Core::OpenMode::ReadOnly)) {
@@ -131,7 +131,7 @@ void JsonArrayModel::set_json_path(const String& json_path)
         return;
 
     m_json_path = json_path;
-    update();
+    invalidate();
 }
 
 }

--- a/Userland/Libraries/LibGUI/JsonArrayModel.h
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.h
@@ -50,7 +50,7 @@ public:
     virtual int column_count(const ModelIndex& = ModelIndex()) const override { return m_fields.size(); }
     virtual String column_name(int column) const override { return m_fields[column].column_name; }
     virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
-    virtual void update() override;
+    virtual void invalidate() override;
 
     const String& json_path() const { return m_json_path; }
     void set_json_path(const String& json_path);

--- a/Userland/Libraries/LibGUI/Model.cpp
+++ b/Userland/Libraries/LibGUI/Model.cpp
@@ -29,6 +29,11 @@ void Model::unregister_view(Badge<AbstractView>, AbstractView& view)
     m_clients.remove(&view);
 }
 
+void Model::invalidate()
+{
+    did_update();
+}
+
 void Model::for_each_view(Function<void(AbstractView&)> callback)
 {
     for (auto* view : m_views)

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -56,7 +56,7 @@ public:
     virtual String column_name(int) const { return {}; }
     virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const = 0;
     virtual TriState data_matches(const ModelIndex&, const Variant&) const { return TriState::Unknown; }
-    virtual void update() = 0;
+    virtual void invalidate();
     virtual ModelIndex parent_index(const ModelIndex&) const { return {}; }
     virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const;
     virtual bool is_editable(const ModelIndex&) const { return false; }

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -65,7 +65,7 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
         done(ExecCancel);
     };
 
-    m_table_view->model()->update();
+    m_table_view->model()->invalidate();
 
     m_refresh_timer = add<Core::Timer>();
 
@@ -77,7 +77,7 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
             previous_selected_pid = pid_as_variant.as_i32();
         }
 
-        m_table_view->model()->update();
+        m_table_view->model()->invalidate();
 
         if (previous_selected_pid == -1) {
             return;

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.h
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.h
@@ -28,7 +28,8 @@ public:
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual String column_name(int column_index) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
+
+    void update();
 
 private:
     RunningProcessesModel();

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -14,7 +14,7 @@ SortingProxyModel::SortingProxyModel(NonnullRefPtr<Model> source)
     : m_source(move(source))
 {
     m_source->register_client(*this);
-    invalidate();
+    update_sort();
 }
 
 SortingProxyModel::~SortingProxyModel()
@@ -22,7 +22,13 @@ SortingProxyModel::~SortingProxyModel()
     m_source->unregister_client(*this);
 }
 
-void SortingProxyModel::invalidate(unsigned int flags)
+void SortingProxyModel::invalidate()
+{
+    source().invalidate();
+    Model::invalidate();
+}
+
+void SortingProxyModel::update_sort(unsigned flags)
 {
     if (flags == UpdateFlag::DontInvalidateIndices) {
         sort(m_last_key_column, m_last_sort_order);
@@ -40,7 +46,7 @@ void SortingProxyModel::invalidate(unsigned int flags)
 
 void SortingProxyModel::model_did_update(unsigned flags)
 {
-    invalidate(flags);
+    update_sort(flags);
 }
 
 bool SortingProxyModel::accepts_drag(const ModelIndex& proxy_index, const Vector<String>& mime_types) const
@@ -108,11 +114,6 @@ String SortingProxyModel::column_name(int column) const
 Variant SortingProxyModel::data(const ModelIndex& proxy_index, ModelRole role) const
 {
     return source().data(map_to_source(proxy_index), role);
-}
-
-void SortingProxyModel::update()
-{
-    source().update();
 }
 
 StringView SortingProxyModel::drag_data_type() const

--- a/Userland/Libraries/LibGUI/SortingProxyModel.h
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.h
@@ -21,7 +21,7 @@ public:
     virtual int column_count(const ModelIndex& = ModelIndex()) const override;
     virtual String column_name(int) const override;
     virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
-    virtual void update() override;
+    virtual void invalidate() override;
     virtual StringView drag_data_type() const override;
     virtual ModelIndex parent_index(const ModelIndex&) const override;
     virtual ModelIndex index(int row, int column, const ModelIndex& parent) const override;
@@ -63,7 +63,7 @@ private:
     Model& source() { return *m_source; }
     const Model& source() const { return *m_source; }
 
-    void invalidate(unsigned flags = Model::UpdateFlag::DontInvalidateIndices);
+    void update_sort(unsigned = UpdateFlag::DontInvalidateIndices);
     InternalMapIterator build_mapping(const ModelIndex& proxy_index);
 
     NonnullRefPtr<Model> m_source;

--- a/Userland/Libraries/LibWeb/DOMTreeJSONModel.cpp
+++ b/Userland/Libraries/LibWeb/DOMTreeJSONModel.cpp
@@ -152,11 +152,6 @@ GUI::Variant DOMTreeJSONModel::data(const GUI::ModelIndex& index, GUI::ModelRole
     return {};
 }
 
-void DOMTreeJSONModel::update()
-{
-    did_update();
-}
-
 void DOMTreeJSONModel::map_dom_nodes_to_parent(JsonObject const* parent, JsonObject const* node)
 {
     m_dom_node_to_parent_map.set(node, parent);

--- a/Userland/Libraries/LibWeb/DOMTreeJSONModel.h
+++ b/Userland/Libraries/LibWeb/DOMTreeJSONModel.h
@@ -32,7 +32,6 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
-    virtual void update() override;
 
 private:
     explicit DOMTreeJSONModel(JsonObject);

--- a/Userland/Libraries/LibWeb/DOMTreeModel.cpp
+++ b/Userland/Libraries/LibWeb/DOMTreeModel.cpp
@@ -131,9 +131,4 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
-void DOMTreeModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/Libraries/LibWeb/DOMTreeModel.h
+++ b/Userland/Libraries/LibWeb/DOMTreeModel.h
@@ -25,7 +25,6 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
-    virtual void update() override;
 
 private:
     explicit DOMTreeModel(DOM::Document&);

--- a/Userland/Libraries/LibWeb/LayoutTreeModel.cpp
+++ b/Userland/Libraries/LibWeb/LayoutTreeModel.cpp
@@ -134,9 +134,4 @@ GUI::Variant LayoutTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole 
     return {};
 }
 
-void LayoutTreeModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/Libraries/LibWeb/LayoutTreeModel.h
+++ b/Userland/Libraries/LibWeb/LayoutTreeModel.h
@@ -25,7 +25,6 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
-    virtual void update() override;
 
 private:
     explicit LayoutTreeModel(DOM::Document&);

--- a/Userland/Libraries/LibWeb/StylePropertiesModel.cpp
+++ b/Userland/Libraries/LibWeb/StylePropertiesModel.cpp
@@ -53,9 +53,4 @@ GUI::Variant StylePropertiesModel::data(const GUI::ModelIndex& index, GUI::Model
     return {};
 }
 
-void StylePropertiesModel::update()
-{
-    did_update();
-}
-
 }

--- a/Userland/Libraries/LibWeb/StylePropertiesModel.h
+++ b/Userland/Libraries/LibWeb/StylePropertiesModel.h
@@ -28,7 +28,6 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual void update() override;
 
 private:
     explicit StylePropertiesModel(const CSS::StyleProperties& properties);


### PR DESCRIPTION
Most of the models were just calling `did_update` anyway, which is
pointless since it can be unified to the base `Model` class. Instead, code
calling `update()` will now call `invalidate()`, which functions identically
and is more obvious in what it does.

Additionally, a default implementation is provided, which removes the
need to add empty implementations of `update()` for each model subclass.

This commit has no functional changes.