### PR TITLE
LibGUI+Applications: Rename Model::is_valid to is_within_range

### DIFF
--- a/Userland/Applications/SystemMonitor/DevicesModel.cpp
+++ b/Userland/Applications/SystemMonitor/DevicesModel.cpp
@@ -54,7 +54,7 @@ String DevicesModel::column_name(int column) const
 
 GUI::Variant DevicesModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
-    VERIFY(is_valid(index));
+    VERIFY(is_within_range(index));
 
     if (role == GUI::ModelRole::TextAlignment) {
         switch (index.column()) {

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -130,7 +130,7 @@ static String pretty_byte_size(size_t size)
 
 GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
-    VERIFY(is_valid(index));
+    VERIFY(is_within_range(index));
 
     if (role == GUI::ModelRole::TextAlignment) {
         switch (index.column()) {

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -116,7 +116,7 @@ Locator::Locator(Core::Object* parent)
         else
             new_index = m_suggestion_view->model()->index(0);
 
-        if (m_suggestion_view->model()->is_valid(new_index)) {
+        if (m_suggestion_view->model()->is_within_range(new_index)) {
             m_suggestion_view->selection().set(new_index);
             m_suggestion_view->scroll_into_view(new_index, Orientation::Vertical);
         }
@@ -128,7 +128,7 @@ Locator::Locator(Core::Object* parent)
         else
             new_index = m_suggestion_view->model()->index(0);
 
-        if (m_suggestion_view->model()->is_valid(new_index)) {
+        if (m_suggestion_view->model()->is_within_range(new_index)) {
             m_suggestion_view->selection().set(new_index);
             m_suggestion_view->scroll_into_view(new_index, Orientation::Vertical);
         }

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -61,17 +61,17 @@ void AbstractView::model_did_update(unsigned int flags)
     } else {
         // FIXME: These may no longer point to whatever they did before,
         //        but let's be optimistic until we can be sure about it.
-        if (!model()->is_valid(m_edit_index)) {
+        if (!model()->is_within_range(m_edit_index)) {
             stop_editing();
             m_edit_index = {};
         }
-        if (!model()->is_valid(m_hovered_index))
+        if (!model()->is_within_range(m_hovered_index))
             m_hovered_index = {};
-        if (!model()->is_valid(m_cursor_index))
+        if (!model()->is_within_range(m_cursor_index))
             m_cursor_index = {};
-        if (!model()->is_valid(m_drop_candidate_index))
+        if (!model()->is_within_range(m_drop_candidate_index))
             m_drop_candidate_index = {};
-        selection().remove_matching([this](auto& index) { return !model()->is_valid(index); });
+        selection().remove_matching([this](auto& index) { return !model()->is_within_range(index); });
     }
     m_selection_start_index = {};
 }
@@ -442,7 +442,7 @@ void AbstractView::set_cursor(ModelIndex index, SelectionUpdate selection_update
     if (selection_mode() == SelectionMode::SingleSelection && (selection_update == SelectionUpdate::Ctrl || selection_update == SelectionUpdate::Shift))
         selection_update = SelectionUpdate::Set;
 
-    if (model()->is_valid(index)) {
+    if (model()->is_within_range(index)) {
         if (selection_update == SelectionUpdate::Set) {
             set_selection(index);
             set_selection_start_index(index);

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -145,7 +145,7 @@ void AutocompleteBox::next_suggestion()
     else
         new_index = m_suggestion_view->model()->index(0);
 
-    if (m_suggestion_view->model()->is_valid(new_index)) {
+    if (m_suggestion_view->model()->is_within_range(new_index)) {
         m_suggestion_view->selection().set(new_index);
         m_suggestion_view->scroll_into_view(new_index, Orientation::Vertical);
     }
@@ -159,7 +159,7 @@ void AutocompleteBox::previous_suggestion()
     else
         new_index = m_suggestion_view->model()->index(0);
 
-    if (m_suggestion_view->model()->is_valid(new_index)) {
+    if (m_suggestion_view->model()->is_within_range(new_index)) {
         m_suggestion_view->selection().set(new_index);
         m_suggestion_view->scroll_into_view(new_index, Orientation::Vertical);
     }
@@ -174,7 +174,7 @@ void AutocompleteBox::apply_suggestion()
         return;
 
     auto selected_index = m_suggestion_view->selection().first();
-    if (!selected_index.is_valid() || !m_suggestion_view->model()->is_valid(selected_index))
+    if (!selected_index.is_valid() || !m_suggestion_view->model()->is_within_range(selected_index))
         return;
 
     auto suggestion_index = m_suggestion_view->model()->index(selected_index.row(), AutocompleteSuggestionModel::Column::Name);

--- a/Userland/Libraries/LibGUI/ColumnsView.cpp
+++ b/Userland/Libraries/LibGUI/ColumnsView.cpp
@@ -295,8 +295,8 @@ void ColumnsView::move_cursor(CursorMovement movement, SelectionUpdate selection
         break;
     case CursorMovement::Right:
         new_index = model.index(0, m_model_column, cursor_index());
-        if (model.is_valid(new_index)) {
-            if (model.is_valid(cursor_index()))
+        if (model.is_within_range(new_index)) {
+            if (model.is_within_range(cursor_index()))
                 push_column(cursor_index());
             update();
         }

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -69,7 +69,7 @@ public:
     virtual bool is_column_sortable([[maybe_unused]] int column_index) const { return true; }
     virtual void sort([[maybe_unused]] int column, SortOrder) { }
 
-    bool is_valid(const ModelIndex& index) const
+    bool is_within_range(ModelIndex const& index) const
     {
         auto parent_index = this->parent_index(index);
         return index.row() >= 0 && index.row() < row_count(parent_index) && index.column() >= 0 && index.column() < column_count(parent_index);

--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -220,7 +220,7 @@ void TableView::move_cursor(CursorMovement movement, SelectionUpdate selection_u
         int items_per_page = visible_content_rect().height() / row_height();
         auto old_index = selection().first();
         auto new_index = model.index(max(0, old_index.row() - items_per_page), old_index.column());
-        if (model.is_valid(new_index))
+        if (model.is_within_range(new_index))
             set_cursor(new_index, selection_update);
         break;
     }
@@ -228,7 +228,7 @@ void TableView::move_cursor(CursorMovement movement, SelectionUpdate selection_u
         int items_per_page = visible_content_rect().height() / row_height();
         auto old_index = selection().first();
         auto new_index = model.index(min(model.row_count() - 1, old_index.row() + items_per_page), old_index.column());
-        if (model.is_valid(new_index))
+        if (model.is_within_range(new_index))
             set_cursor(new_index, selection_update);
         break;
     }


### PR DESCRIPTION
The previous name did not describe what the function checked, and was
easy to confuse with `ModelIndex::is_valid`.

This commit has no functional changes.