### PR TITLE
Solitaire: Don't allow the player to draw cards while mouse is down

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -226,7 +226,7 @@ void Game::keydown_event(GUI::KeyEvent& event)
         start_game_over_animation();
     } else if (event.key() == KeyCode::Key_Tab) {
         auto_move_eligible_cards_to_foundations();
-    } else if (event.key() == KeyCode::Key_Space) {
+    } else if (event.key() == KeyCode::Key_Space && m_mouse_down != true) {
         draw_cards();
     } else if (event.shift() && event.key() == KeyCode::Key_F11) {
         dump_layout();


### PR DESCRIPTION
This is my solution to Issue number #9222 
I added a check to an else if statement to make sure that cards could only be drawn if the mouse click wasn't down.