### PR TITLE
LibWeb: Add auto as a recognized argument of flex-basis

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -41,7 +41,7 @@ public:
 };
 
 struct FlexBasisData {
-    CSS::FlexBasis type { CSS::FlexBasis::Content };
+    CSS::FlexBasis type { CSS::FlexBasis::Auto };
     CSS::Length length {};
 };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -285,6 +285,9 @@ Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
     if (value.value()->is_identifier() && value.value()->to_identifier() == CSS::ValueID::Content)
         return { { CSS::FlexBasis::Content, {} } };
 
+    if (value.value()->is_auto())
+        return { { CSS::FlexBasis::Auto, {} } };
+
     if (value.value()->is_length())
         return { { CSS::FlexBasis::Length, value.value()->to_length() } };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -96,7 +96,8 @@ enum class FlexWrap {
 
 enum class FlexBasis {
     Content,
-    Length
+    Length,
+    Auto,
 };
 
 enum class WhiteSpace {

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -311,6 +311,7 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
         } else {
             // E
             // FIXME: This is probably too naive.
+            // FIXME: Care about FlexBasis::Auto
             if (has_definite_main_size(child_box)) {
                 flex_item.flex_base_size = specified_main_size(child_box);
             } else {


### PR DESCRIPTION
There isn't actually any special treatment of this over 'content' in
the FlexFormattingContext, for now both are treated the same.
Fixes #9225 