### PR TITLE
Browser+LibWeb: Tweak favicon loading and remove debug spam

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -515,10 +515,6 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
 
     m_tab_widget->set_bar_visible(!is_fullscreen() && m_tab_widget->children().size() > 1);
 
-    auto default_favicon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png");
-    VERIFY(default_favicon);
-    m_tab_widget->set_tab_icon(new_tab, default_favicon);
-
     new_tab.on_title_change = [this, &new_tab](auto& title) {
         m_tab_widget->set_tab_title(new_tab, title);
         if (m_tab_widget->active_widget() == &new_tab)

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -560,7 +560,7 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
 
     new_tab.load(url);
 
-    dbgln("Added new tab {:p}, loading {}", &new_tab, url);
+    dbgln_if(SPAM_DEBUG, "Added new tab {:p}, loading {}", &new_tab, url);
 
     if (activate)
         m_tab_widget->set_active_widget(&new_tab);

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -171,7 +171,7 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
         ResourceLoader::the().load(
             favicon_url,
             [this, favicon_url](auto data, auto&, auto) {
-                dbgln("Favicon downloaded, {} bytes from {}", data.size(), favicon_url);
+                dbgln_if(SPAM_DEBUG, "Favicon downloaded, {} bytes from {}", data.size(), favicon_url);
                 RefPtr<Gfx::Bitmap> favicon_bitmap;
                 auto decoder = Gfx::ImageDecoder::try_create(data);
                 if (!decoder) {
@@ -181,7 +181,7 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
                     if (!favicon_bitmap)
                         dbgln("Could not decode favicon {}", favicon_url);
                     else
-                        dbgln("Decoded favicon, {}", favicon_bitmap->size());
+                        dbgln_if(IMAGE_DECODER_DEBUG, "Decoded favicon, {}", favicon_bitmap->size());
                 }
                 load_favicon(favicon_bitmap);
             },
@@ -197,7 +197,7 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
 
 bool FrameLoader::load(const URL& url, Type type)
 {
-    dbgln("FrameLoader::load: {}", url);
+    dbgln_if(SPAM_DEBUG, "FrameLoader::load: {}", url);
 
     if (!url.is_valid()) {
         load_error_page(url, "Invalid URL");
@@ -275,9 +275,9 @@ void FrameLoader::resource_did_load()
     }
 
     if (resource()->has_encoding()) {
-        dbgln("This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
+        dbgln_if(RESOURCE_DEBUG, "This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
     } else {
-        dbgln("This content has MIME type '{}', encoding unknown", resource()->mime_type());
+        dbgln_if(RESOURCE_DEBUG, "This content has MIME type '{}', encoding unknown", resource()->mime_type());
     }
 
     auto document = DOM::Document::create();

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -40,6 +40,7 @@ private:
     virtual void resource_did_fail() override;
 
     void load_error_page(const URL& failed_url, const String& error_message);
+    void load_favicon(RefPtr<Gfx::Bitmap> bitmap = nullptr);
     bool parse_document(DOM::Document&, const ByteBuffer& data);
 
     BrowsingContext& m_browsing_context;

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -105,7 +105,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
     }
 
     if (url.protocol() == "about") {
-        dbgln("Loading about: URL {}", url);
+        dbgln_if(SPAM_DEBUG, "Loading about: URL {}", url);
         deferred_invoke([success_callback = move(success_callback)](auto&) {
             success_callback(String::empty().to_byte_buffer(), {}, {});
         });
@@ -113,7 +113,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
     }
 
     if (url.protocol() == "data") {
-        dbgln("ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
+        dbgln_if(SPAM_DEBUG, "ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
             url.data_mime_type(),
             url.data_payload_is_base64(),
             url.data_payload());
@@ -213,7 +213,7 @@ bool ResourceLoader::is_port_blocked(int port)
 
 void ResourceLoader::clear_cache()
 {
-    dbgln("Clearing {} items from ResourceLoader cache", s_resource_cache.size());
+    dbgln_if(CACHE_DEBUG, "Clearing {} items from ResourceLoader cache", s_resource_cache.size());
     s_resource_cache.clear();
 }
 


### PR DESCRIPTION
Previously in Browser, when we navigate back from a page that has an icon to a page that does not have an icon, the icon does not update and the old icon is displayed because FrameLoader does not set the default favicon when the favicon cannot be loaded. This patch ensures that Browser receives a new icon bitmap every time a load takes place.