### PR TITLE
CI: Fix node-version typo

### DIFF
--- a/.github/workflows/twitter.yml
+++ b/.github/workflows/twitter.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node_version: '14'
+          node-version: '14'
       - run: npm i twit
       - run: |
           node ${{ github.workspace }}/Meta/tweet-commits.js << EOF


### PR DESCRIPTION
Otherwise this generates an "unexpected inputs" warning.