### PR TITLE
Meta: Add run-local.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ compile_commands.json
 .clangd
 .idea/
 cmake-build-debug/
+run-local.sh
 sync-local.sh
 .vim/
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -8,6 +8,12 @@ die() {
     exit 1
 }
 
+SCRIPT_DIR="$(dirname "${0}")"
+
+# https://www.shellcheck.net/wiki/SC1090 No need to shellcheck private config.
+# shellcheck source=/dev/null
+[ -x "$SCRIPT_DIR/../run-local.sh" ] && . "$SCRIPT_DIR/../run-local.sh"
+
 #SERENITY_PACKET_LOGGING_ARG="-object filter-dump,id=hue,netdev=breh,file=e1000.pcap"
 
 KVM_SUPPORT="0"
@@ -25,8 +31,6 @@ if [ "$(uname)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
         SERENITY_VIRT_TECH_ARG="--accel hvf"
     fi
 fi
-
-SCRIPT_DIR="$(dirname "${0}")"
 
 # Prepend the toolchain qemu directory so we pick up QEMU from there
 PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"


### PR DESCRIPTION
This allows one to set their desired parameters for run.sh without the
need to set them in every terminal session or add it to the user account
shell files. If a run-config.sh file exists next to run.sh and is
executable, it will be sourced. The file can contain any variables that
are expected to be set in run.sh.

This should probably also be added to documentation somewhere. Thoughts?