### PR TITLE
LibJS: Cast length to signed integer before subtraction

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1521,7 +1521,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::find_last)
 
     // 4. Let k be len - 1.
     // 5. Repeat, while k ≥ 0,
-    for (i64 k = length - 1; k >= 0; --k) {
+    for (i64 k = static_cast<i64>(length) - 1; k >= 0; --k) {
         // a. Let Pk be ! ToString(𝔽(k)).
         auto property_name = PropertyName { k };
 
@@ -1570,7 +1570,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::find_last_index)
 
     // 4. Let k be len - 1.
     // 5. Repeat, while k ≥ 0,
-    for (i64 k = length - 1; k >= 0; --k) {
+    for (i64 k = static_cast<i64>(length) - 1; k >= 0; --k) {
         // a. Let Pk be ! ToString(𝔽(k)).
         auto property_name = PropertyName { k };
 


### PR DESCRIPTION
`length` is `size_t` as returned, and so subtracting from it may cause
underflow. We handle this case by just casting it to a signed value, and
the for loop predicate takes care of the rest.