### PR TITLE
SystemServer: Handle missing service executable gracefully

### DIFF
--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -131,6 +131,11 @@ void Service::activate()
 
 void Service::spawn(int socket_fd)
 {
+    if (!Core::File::exists(m_executable_path)) {
+        dbgln("{}: binary \"{}\" does not exist, skipping service.", name(), m_executable_path);
+        return;
+    }
+
     dbgln_if(SERVICE_DEBUG, "Spawning {}", name());
 
     m_run_timer.start();


### PR DESCRIPTION
I use the `configure-components` functionality locally during
development. There are a few services (SpiceAgent) which aren't marked
as required components, and hence aren't built in all configurations,
but we still try to launch them in all configurations.

Instead of letting the forked SystemServer process crash, lets
gracefully handle the situation of a missing binary and provide a
message to the user.