### PR TITLE
Kernel: Fix boot profiling after big process lock separation regression

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -355,6 +355,7 @@ void init_stage2(void*)
 
     if (boot_profiling) {
         dbgln("Starting full system boot profiling");
+        MutexLocker mutex_locker(Process::current()->big_lock());
         auto result = Process::current()->sys$profiling_enable(-1, ~0ull);
         VERIFY(!result.is_error());
     }


### PR DESCRIPTION
When I laid down the foundation for the start of the big process lock
separation, I added asserts to all system call implementations to
validate we hold the big process lock in the locations we think we
should be.

Adding that assert to sys$profiling_enable broke boot time profiling as
we were never holding the lock on boot. Even though it's not technically
required, lets make sure to hold the lock while enabling to appease the
assert.