### PR TITLE
Meta: Remove syslog.h from clang-format exclusion list

### DIFF
--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -12,7 +12,6 @@ if [ "$#" -eq "1" ]; then
             '*.h' \
             ':!:Base' \
             ':!:Kernel/FileSystem/ext2_fs.h' \
-            ':!:Userland/Libraries/LibC/syslog.h' \
             ':!:Userland/DevTools/HackStudio/LanguageServers/Cpp/Tests/*' \
             ':!:Userland/Libraries/LibCpp/Tests/*'
     )


### PR DESCRIPTION
Before Libraries was moved to Userland/Libraries syslog.h had a bunch
of manually aligned defines and array initializations.

Andreas seems to have formatted the file with clang-format as part of
that file move. Since syslog.h is now properly formatted, we don't
need to exclude it from the linter list.