### PR TITLE
Kernel: Introduce LockLocation abstraction, Add lock debugging to ProtectedValue / RefCountedContended 

### DIFF
--- a/Kernel/Locking/ContendedResource.h
+++ b/Kernel/Locking/ContendedResource.h
@@ -16,9 +16,9 @@ class LockedResource {
     AK_MAKE_NONCOPYABLE(LockedResource);
 
 public:
-    LockedResource(T* value, Mutex& mutex)
+    LockedResource(T* value, Mutex& mutex, LockLocation const& location)
         : m_value(value)
-        , m_mutex_locker(mutex, LockingMode)
+        , m_mutex_locker(mutex, LockingMode, location)
     {
     }
 

--- a/Kernel/Locking/LockLocation.h
+++ b/Kernel/Locking/LockLocation.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if LOCK_DEBUG
+#    include <AK/SourceLocation.h>
+#endif
+
+// Abstract SourceLocation away from the kernel's locking API to avoid a
+// significant amount of #ifdefs in Mutex / MutexLocker / etc.
+//
+// To do this we declare LockLocation to be a zero sized struct which will
+// get optimized out during normal compilation. When LOCK_DEBUG is enabled,
+// we forward the implementation to AK::SourceLocation and get rich debugging
+// information for every caller.
+
+namespace Kernel {
+
+#if LOCK_DEBUG
+using LockLocation = SourceLocation;
+#else
+struct LockLocation {
+    static constexpr LockLocation current() { return {}; }
+};
+#endif
+
+}

--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -13,7 +13,7 @@
 
 namespace Kernel {
 
-void Mutex::lock(Mode mode, [[maybe_unused]] const LockLocation& location)
+void Mutex::lock(Mode mode, [[maybe_unused]] LockLocation const& location)
 {
     // NOTE: This may be called from an interrupt handler (not an IRQ handler)
     // and also from within critical sections!
@@ -312,7 +312,7 @@ auto Mutex::force_unlock_if_locked(u32& lock_count_to_restore) -> Mode
     return current_mode;
 }
 
-void Mutex::restore_lock(Mode mode, u32 lock_count, [[maybe_unused]] const LockLocation& location)
+void Mutex::restore_lock(Mode mode, u32 lock_count, [[maybe_unused]] LockLocation const& location)
 {
     VERIFY(mode != Mode::Unlocked);
     VERIFY(lock_count > 0);

--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -4,22 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#ifdef LOCK_DEBUG
-#    include <AK/SourceLocation.h>
-#endif
 #include <Kernel/Debug.h>
 #include <Kernel/KSyms.h>
+#include <Kernel/Locking/LockLocation.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Locking/SpinLock.h>
 #include <Kernel/Thread.h>
 
 namespace Kernel {
 
-#if LOCK_DEBUG
-void Mutex::lock(Mode mode, const SourceLocation& location)
-#else
-void Mutex::lock(Mode mode)
-#endif
+void Mutex::lock(Mode mode, [[maybe_unused]] const LockLocation& location)
 {
     // NOTE: This may be called from an interrupt handler (not an IRQ handler)
     // and also from within critical sections!
@@ -318,11 +312,7 @@ auto Mutex::force_unlock_if_locked(u32& lock_count_to_restore) -> Mode
     return current_mode;
 }
 
-#if LOCK_DEBUG
-void Mutex::restore_lock(Mode mode, u32 lock_count, const SourceLocation& location)
-#else
-void Mutex::restore_lock(Mode mode, u32 lock_count)
-#endif
+void Mutex::restore_lock(Mode mode, u32 lock_count, [[maybe_unused]] const LockLocation& location)
 {
     VERIFY(mode != Mode::Unlocked);
     VERIFY(lock_count > 0);

--- a/Kernel/Locking/Mutex.h
+++ b/Kernel/Locking/Mutex.h
@@ -32,8 +32,8 @@ public:
     }
     ~Mutex() = default;
 
-    void lock(Mode mode = Mode::Exclusive, const LockLocation& location = LockLocation::current());
-    void restore_lock(Mode, u32, const LockLocation& location = LockLocation::current());
+    void lock(Mode mode = Mode::Exclusive, LockLocation const& location = LockLocation::current());
+    void restore_lock(Mode, u32, LockLocation const& location = LockLocation::current());
 
     void unlock();
     [[nodiscard]] Mode force_unlock_if_locked(u32&);
@@ -111,7 +111,7 @@ public:
     {
     }
 
-    ALWAYS_INLINE explicit MutexLocker(Mutex& l, Mutex::Mode mode = Mutex::Mode::Exclusive, const LockLocation& location = LockLocation::current())
+    ALWAYS_INLINE explicit MutexLocker(Mutex& l, Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
         : m_lock(&l)
     {
         m_lock->lock(mode, location);
@@ -131,7 +131,7 @@ public:
         m_lock->unlock();
     }
 
-    ALWAYS_INLINE void attach_and_lock(Mutex& lock, Mutex::Mode mode = Mutex::Mode::Exclusive, const LockLocation& location = LockLocation::current())
+    ALWAYS_INLINE void attach_and_lock(Mutex& lock, Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
     {
         VERIFY(!m_locked);
         m_lock = &lock;
@@ -140,7 +140,7 @@ public:
         m_lock->lock(mode, location);
     }
 
-    ALWAYS_INLINE void lock(Mutex::Mode mode = Mutex::Mode::Exclusive, const LockLocation& location = LockLocation::current())
+    ALWAYS_INLINE void lock(Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
     {
         VERIFY(m_lock);
         VERIFY(!m_locked);

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -514,7 +514,7 @@ void Thread::finalize()
         dbgln("Thread {} leaking {} Locks!", *this, lock_count());
         ScopedSpinLock list_lock(m_holding_locks_lock);
         for (auto& info : m_holding_locks_list) {
-            const auto& location = info.source_location;
+            const auto& location = info.lock_location;
             dbgln(" - Mutex: \"{}\" @ {} locked in function \"{}\" at \"{}:{}\" with a count of: {}", info.lock->name(), info.lock, location.function_name(), location.filename(), location.line_number(), info.count);
         }
         VERIFY_NOT_REACHED();

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -12,9 +12,6 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
-#ifdef LOCK_DEBUG
-#    include <AK/SourceLocation.h>
-#endif
 #include <AK/String.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
@@ -27,6 +24,7 @@
 #include <Kernel/Forward.h>
 #include <Kernel/KResult.h>
 #include <Kernel/KString.h>
+#include <Kernel/Locking/LockLocation.h>
 #include <Kernel/Locking/LockMode.h>
 #include <Kernel/Memory/VirtualRange.h>
 #include <Kernel/Scheduler.h>
@@ -1152,7 +1150,7 @@ public:
     RecursiveSpinLock& get_lock() const { return m_lock; }
 
 #if LOCK_DEBUG
-    void holding_lock(Mutex& lock, int refs_delta, const SourceLocation& location)
+    void holding_lock(Mutex& lock, int refs_delta, const LockLocation& location)
     {
         VERIFY(refs_delta != 0);
         m_holding_locks.fetch_add(refs_delta, AK::MemoryOrder::memory_order_relaxed);
@@ -1317,7 +1315,7 @@ private:
 #if LOCK_DEBUG
     struct HoldingLockInfo {
         Mutex* lock;
-        SourceLocation source_location;
+        LockLocation lock_location;
         unsigned count;
     };
     Atomic<u32> m_holding_locks { 0 };

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1150,7 +1150,7 @@ public:
     RecursiveSpinLock& get_lock() const { return m_lock; }
 
 #if LOCK_DEBUG
-    void holding_lock(Mutex& lock, int refs_delta, const LockLocation& location)
+    void holding_lock(Mutex& lock, int refs_delta, LockLocation const& location)
     {
         VERIFY(refs_delta != 0);
         m_holding_locks.fetch_add(refs_delta, AK::MemoryOrder::memory_order_relaxed);


### PR DESCRIPTION
Add lock debugging support to the new `ProtectedValue<T>` and `RefCountedContended<T>` classes,
and cleanup and reduce ifdefing needed for LOCK_DEBUG support. 

 - Kernel: Add lock debugging to ProtectedValue / RefCountedContended

    Enable the LOCK_DEBUG functionality for these new APIs, as it looks
    like we want to move the whole system to use this in the not so distant
    future. :^)

- Kernel: Reduce LOCK_DEBUG ifdefs by utilizing Kernel::LockLocation

    The LOCK_DEBUG conditional code is pretty ugly for a feature that we
    only use rarely. We can remove a significant amount of this code by
    utilizing a zero sized fake type when not building in LOCK_DEBUG mode.

    This lets us keep the same API, but just let the compiler optimize it
    away when don't actually care about the location the caller came from.

- Kernel: Introduce LockLocation abstraction from SourceLocation

    Introduce a zero sized type to represent a SourceLocation, when we
    don't want to compile with SourceLocation support.