### PR TITLE
Pixelpaint Guides: show offset and add snapping

### DIFF
--- a/Userland/Applications/PixelPaint/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/GuideTool.cpp
@@ -6,6 +6,7 @@
 
 #include "GuideTool.h"
 #include "ImageEditor.h"
+#include <LibGUI/Application.h>
 #include <LibGUI/Menu.h>
 
 namespace PixelPaint {
@@ -70,14 +71,17 @@ void GuideTool::on_mousedown(Layer&, GUI::MouseEvent& mouse_event, GUI::MouseEve
 
     m_selected_guide = closest_guide(image_event.position());
 
-    if (m_selected_guide)
+    if (m_selected_guide) {
         m_guide_origin = m_selected_guide->offset();
+        GUI::Application::the()->show_tooltip_immediately(String::formatted("{}", m_guide_origin), GUI::Application::the()->tooltip_source_widget());
+    }
 }
 
 void GuideTool::on_mouseup(Layer&, GUI::MouseEvent&, GUI::MouseEvent&)
 {
     m_guide_origin = 0;
     m_event_origin = { 0, 0 };
+    GUI::Application::the()->hide_tooltip();
 
     if (!m_selected_guide)
         return;
@@ -107,6 +111,8 @@ void GuideTool::on_mousemove(Layer&, GUI::MouseEvent&, GUI::MouseEvent& image_ev
 
     auto new_offset = (float)relevant_offset + m_guide_origin;
     m_selected_guide->set_offset(new_offset);
+
+    GUI::Application::the()->show_tooltip_immediately(String::formatted("{}", new_offset), GUI::Application::the()->tooltip_source_widget());
 
     editor()->layers_did_change();
 }

--- a/Userland/Applications/PixelPaint/GuideTool.h
+++ b/Userland/Applications/PixelPaint/GuideTool.h
@@ -23,13 +23,18 @@ public:
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_context_menu(Layer&, GUI::ContextMenuEvent&) override;
 
+    virtual GUI::Widget* get_properties_widget() override;
+
 private:
     RefPtr<Guide> closest_guide(Gfx::IntPoint const&);
+
+    RefPtr<GUI::Widget> m_properties_widget;
 
     RefPtr<Guide> m_selected_guide;
     RefPtr<Guide> m_context_menu_guide;
     Gfx::IntPoint m_event_origin;
     float m_guide_origin { 0 };
     RefPtr<GUI::Menu> m_context_menu;
+    int m_snap_size { 10 };
 };
 }

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -36,6 +36,7 @@ public:
     void unregister_global_shortcut_action(Badge<Action>, Action&);
 
     void show_tooltip(String, const Widget* tooltip_source_widget);
+    void show_tooltip_immediately(String, const Widget* tooltip_source_widget);
     void hide_tooltip();
     Widget* tooltip_source_widget() { return m_tooltip_source_widget; };
 
@@ -85,7 +86,7 @@ private:
 
     virtual void event(Core::Event&) override;
 
-    void tooltip_show_timer_did_fire();
+    void request_tooltip_show();
     void tooltip_hide_timer_did_fire();
 
     void set_drag_hovered_widget_impl(Widget*, const Gfx::IntPoint& = {}, Vector<String> = {});


### PR DESCRIPTION
This PR adds a tooltip to the GuideTool which shows the current offset of the Guide that is changing.
Also, when holding Shift, we can snap to a multiple of a value, which is controlled by the property widget.