### PR TITLE
Kernel: Disable big process lock for sys$sync

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -106,7 +106,7 @@ enum class NeedsBigProcessLock {
     S(mkdir, NeedsBigProcessLock::Yes)                      \
     S(times, NeedsBigProcessLock::Yes)                      \
     S(utime, NeedsBigProcessLock::Yes)                      \
-    S(sync, NeedsBigProcessLock::Yes)                       \
+    S(sync, NeedsBigProcessLock::No)                        \
     S(ptsname, NeedsBigProcessLock::Yes)                    \
     S(select, NeedsBigProcessLock::Yes)                     \
     S(unlink, NeedsBigProcessLock::Yes)                     \

--- a/Kernel/Syscalls/sync.cpp
+++ b/Kernel/Syscalls/sync.cpp
@@ -11,7 +11,7 @@ namespace Kernel {
 
 KResultOr<FlatPtr> Process::sys$sync()
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     REQUIRE_PROMISE(stdio);
     VirtualFileSystem::sync();
     return 0;


### PR DESCRIPTION
This syscall doesn't touch any intra-process shared resources and only calls VirtualFileSystem::sync, which is self-locking.

(Missed this obvious one in the last PR :sweat_smile:)