### PR TITLE
CI: Don't build libjs for Lagom twice

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -64,29 +64,21 @@ jobs:
 
       - name: Create build directory
         run: |
-          mkdir -p Build/lagom
-          mkdir -p Build/lagom/UCD
+          mkdir -p libjs-test262/Build/UCD
 
       - name: UnicodeData cache
         # TODO: Change the version to the released version when https://github.com/actions/cache/pull/489 (or 571) is merged.
         uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
         with:
-          path: ${{ github.workspace }}/Build/lagom/UCD
+          path: ${{ github.workspace }}/libjs-test262/Build/UCD
           key: UnicodeData-${{ hashFiles('Userland/Libraries/LibUnicode/unicode_data.cmake') }}
 
-      - name: Build test-js
-        run: |
-          cd Build/lagom
-          cmake -GNinja -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DBUILD_LAGOM=ON ../../Meta/Lagom
-          ninja test-js
-
-      - name: Build libjs-test262-runner
+      - name: Build libjs-test262-runner and test-js
         working-directory: libjs-test262
         run: |
-          mkdir -p Build
           cd Build
           cmake -GNinja -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} ..
-          ninja libjs-test262-runner
+          ninja libjs-test262-runner test-js
 
       - name: Run test262 and test262-parser-tests
         working-directory: libjs-test262


### PR DESCRIPTION
We need test-js for the parser tests for test262, but we don't need to
rebuild all of Lagom twice. This was missed when we did the initial
change to shared libraries. Before #9017, the Lagom build for test-js
is what built libLagom.a for the libjs-test262-runner to link against.

Now that we are building libjs.so and its dependencies in the runner's
build directory, we should build test-js there as well.

Requires linusg/libjs-test262#32 in order to properly find the built
test-js.