### PR TITLE
Persistent model indices, part 1: Persistent model indices and granular updates

### DIFF
--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     Painter.cpp
     PasswordInputDialog.cpp
     PasswordInputDialogGML.h
+    PersistentModelIndex.cpp
     ProcessChooser.cpp
     Progressbar.cpp
     RadioButton.cpp

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -93,7 +93,9 @@ public:
         ModelIndex index(int column) const;
         void traverse_if_needed();
         void reify_if_needed();
-        bool fetch_data(const String& full_path, bool is_root);
+        bool fetch_data(String const& full_path, bool is_root);
+
+        OwnPtr<Node> create_child(String const& child_name);
     };
 
     static NonnullRefPtr<FileSystemModel> create(String root_path = "/", Mode mode = Mode::FilesAndDirectories)
@@ -154,6 +156,8 @@ private:
 
     bool fetch_thumbnail_for(const Node& node);
     GUI::Icon icon_for(const Node& node) const;
+
+    void handle_file_event(Core::FileWatcherEvent const& event);
 
     String m_root_path;
     Mode m_mode { Invalid };

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -81,9 +81,9 @@ public:
 
         FileSystemModel& m_model;
 
-        Node* parent { nullptr };
-        NonnullOwnPtrVector<Node> children;
-        bool has_traversed { false };
+        Node* m_parent { nullptr };
+        NonnullOwnPtrVector<Node> m_children;
+        bool m_has_traversed { false };
 
         bool m_selected { false };
 

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -49,6 +49,8 @@ class MultiView;
 class OpacitySlider;
 class PaintEvent;
 class Painter;
+class PersistentHandle;
+class PersistentModelIndex;
 class RadioButton;
 class ResizeCorner;
 class ResizeEvent;

--- a/Userland/Libraries/LibGUI/Model.cpp
+++ b/Userland/Libraries/LibGUI/Model.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGUI/AbstractView.h>
 #include <LibGUI/Model.h>
+#include <LibGUI/PersistentModelIndex.h>
 
 namespace GUI {
 
@@ -69,6 +70,25 @@ void Model::register_client(ModelClient& client)
 void Model::unregister_client(ModelClient& client)
 {
     m_clients.remove(&client);
+}
+
+WeakPtr<PersistentHandle> Model::register_persistent_index(Badge<PersistentModelIndex>, const ModelIndex& index)
+{
+    if (!index.is_valid())
+        return {};
+
+    auto it = m_persistent_handles.find(index);
+    // Easy modo: we already have a handle for this model index.
+    if (it != m_persistent_handles.end()) {
+        return it->value->make_weak_ptr();
+    }
+
+    // Hard modo: create a new persistent handle.
+    auto handle = adopt_own(*new PersistentHandle(index));
+    auto weak_handle = handle->make_weak_ptr();
+    m_persistent_handles.set(index, move(handle));
+
+    return weak_handle;
 }
 
 RefPtr<Core::MimeData> Model::mime_data(const ModelSelection& selection) const

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -8,10 +8,13 @@
 
 #include <AK/Badge.h>
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/MimeData.h>
+#include <LibGUI/Forward.h>
 #include <LibGUI/ModelIndex.h>
 #include <LibGUI/ModelRole.h>
 #include <LibGUI/ModelSelection.h>
@@ -83,6 +86,8 @@ public:
 
     void register_client(ModelClient&);
     void unregister_client(ModelClient&);
+
+    WeakPtr<PersistentHandle> register_persistent_index(Badge<PersistentModelIndex>, ModelIndex const&);
 
 protected:
     Model();

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -35,6 +36,13 @@ public:
     virtual ~ModelClient() { }
 
     virtual void model_did_update(unsigned flags) = 0;
+
+    virtual void model_did_insert_rows([[maybe_unused]] ModelIndex const& parent, [[maybe_unused]] int first, [[maybe_unused]] int last) { }
+    virtual void model_did_insert_columns([[maybe_unused]] ModelIndex const& parent, [[maybe_unused]] int first, [[maybe_unused]] int last) { }
+    virtual void model_did_move_rows([[maybe_unused]] ModelIndex const& source_parent, [[maybe_unused]] int first, [[maybe_unused]] int last, [[maybe_unused]] ModelIndex const& target_parent, [[maybe_unused]] int target_index) { }
+    virtual void model_did_move_columns([[maybe_unused]] ModelIndex const& source_parent, [[maybe_unused]] int first, [[maybe_unused]] int last, [[maybe_unused]] ModelIndex const& target_parent, [[maybe_unused]] int target_index) { }
+    virtual void model_did_delete_rows([[maybe_unused]] ModelIndex const& parent, [[maybe_unused]] int first, [[maybe_unused]] int last) { }
+    virtual void model_did_delete_columns([[maybe_unused]] ModelIndex const& parent, [[maybe_unused]] int first, [[maybe_unused]] int last) { }
 };
 
 class Model : public RefCounted<Model> {
@@ -93,6 +101,7 @@ protected:
     Model();
 
     void for_each_view(Function<void(AbstractView&)>);
+    void for_each_client(Function<void(ModelClient&)>);
     void did_update(unsigned flags = UpdateFlag::InvalidateAllIndices);
 
     static bool string_matches(const StringView& str, const StringView& needle, unsigned flags)
@@ -107,7 +116,85 @@ protected:
 
     ModelIndex create_index(int row, int column, const void* data = nullptr) const;
 
+    void begin_insert_rows(ModelIndex const& parent, int first, int last);
+    void begin_insert_columns(ModelIndex const& parent, int first, int last);
+    void begin_move_rows(ModelIndex const& source_parent, int first, int last, ModelIndex const& target_parent, int target_index);
+    void begin_move_columns(ModelIndex const& source_parent, int first, int last, ModelIndex const& target_parent, int target_index);
+    void begin_delete_rows(ModelIndex const& parent, int first, int last);
+    void begin_delete_columns(ModelIndex const& parent, int first, int last);
+
+    void end_insert_rows();
+    void end_insert_columns();
+    void end_move_rows();
+    void end_move_columns();
+    void end_delete_rows();
+    void end_delete_columns();
+
+    void change_persistent_index_list(Vector<ModelIndex> const& old_indices, Vector<ModelIndex> const& new_indices);
+
 private:
+    enum class OperationType {
+        Invalid = 0,
+        Insert,
+        Move,
+        Delete,
+        Reset
+    };
+    enum class Direction {
+        Row,
+        Column
+    };
+
+    struct Operation {
+        OperationType type { OperationType::Invalid };
+        Direction direction { Direction::Row };
+        ModelIndex source_parent;
+        int first { 0 };
+        int last { 0 };
+        ModelIndex target_parent;
+        int target { 0 };
+
+        Operation(OperationType type)
+            : type(type)
+        {
+        }
+
+        Operation(OperationType type, Direction direction, ModelIndex const& parent, int first, int last)
+            : type(type)
+            , direction(direction)
+            , source_parent(parent)
+            , first(first)
+            , last(last)
+        {
+        }
+
+        Operation(OperationType type, Direction direction, ModelIndex const& source_parent, int first, int last, ModelIndex const& target_parent, int target)
+            : type(type)
+            , direction(direction)
+            , source_parent(source_parent)
+            , first(first)
+            , last(last)
+            , target_parent(target_parent)
+            , target(target)
+        {
+        }
+    };
+
+    void handle_insert(Operation const&);
+    void handle_move(Operation const&);
+    void handle_delete(Operation const&);
+
+    template<bool IsRow>
+    void save_deleted_indices(ModelIndex const& parent, int first, int last);
+
+    HashMap<ModelIndex, OwnPtr<PersistentHandle>> m_persistent_handles;
+    Vector<Operation> m_operation_stack;
+    // NOTE: We need to save which indices have been deleted before the delete
+    // actually happens, because we can't figure out which persistent handles
+    // belong to us in end_delete_rows/columns (because accessing the parents of
+    // the indices might be impossible).
+    Vector<Vector<ModelIndex>> m_deleted_indices_stack;
+
     HashTable<AbstractView*> m_views;
     HashTable<ModelClient*> m_clients;
 };

--- a/Userland/Libraries/LibGUI/ModelIndex.h
+++ b/Userland/Libraries/LibGUI/ModelIndex.h
@@ -77,7 +77,10 @@ struct Formatter<GUI::ModelIndex> : Formatter<FormatString> {
 
 template<>
 struct Traits<GUI::ModelIndex> : public GenericTraits<GUI::ModelIndex> {
-    static unsigned hash(const GUI::ModelIndex& index) { return pair_int_hash(index.row(), index.column()); }
+    static unsigned hash(const GUI::ModelIndex& index)
+    {
+        return pair_int_hash(pair_int_hash(index.row(), index.column()), reinterpret_cast<FlatPtr>(index.internal_data()));
+    }
 };
 
 }

--- a/Userland/Libraries/LibGUI/PersistentModelIndex.cpp
+++ b/Userland/Libraries/LibGUI/PersistentModelIndex.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/PersistentModelIndex.h>
+
+namespace GUI {
+
+PersistentModelIndex::PersistentModelIndex(ModelIndex const& index)
+{
+    if (!index.is_valid())
+        return;
+
+    auto* model = const_cast<Model*>(index.model());
+    m_handle = model->register_persistent_index({}, index);
+}
+
+int PersistentModelIndex::row() const
+{
+    if (!has_valid_handle())
+        return -1;
+    return m_handle->m_index.row();
+}
+
+int PersistentModelIndex::column() const
+{
+    if (!has_valid_handle())
+        return -1;
+    return m_handle->m_index.column();
+}
+
+PersistentModelIndex PersistentModelIndex::parent() const
+{
+    if (!has_valid_handle())
+        return {};
+    return { m_handle->m_index.parent() };
+}
+
+PersistentModelIndex PersistentModelIndex::sibling_at_column(int column) const
+{
+    if (!has_valid_handle())
+        return {};
+
+    return { m_handle->m_index.sibling_at_column(column) };
+}
+
+Variant PersistentModelIndex::data(ModelRole role) const
+{
+    if (!has_valid_handle())
+        return {};
+    return { m_handle->m_index.data(role) };
+}
+
+PersistentModelIndex::operator ModelIndex() const
+{
+    if (!has_valid_handle())
+        return {};
+    else
+        return m_handle->m_index;
+}
+
+bool PersistentModelIndex::operator==(PersistentModelIndex const& other) const
+{
+    bool is_this_valid = has_valid_handle();
+    bool is_other_valid = other.has_valid_handle();
+
+    if (!is_this_valid && !is_other_valid)
+        return true;
+    if (is_this_valid != is_other_valid)
+        return false;
+
+    return m_handle->m_index == other.m_handle->m_index;
+}
+
+bool PersistentModelIndex::operator!=(PersistentModelIndex const& other) const
+{
+    return !(*this == other);
+}
+
+bool PersistentModelIndex::operator==(ModelIndex const& other) const
+{
+    if (!has_valid_handle()) {
+        return !other.is_valid();
+    }
+
+    return m_handle->m_index == other;
+}
+
+bool PersistentModelIndex::operator!=(ModelIndex const& other) const
+{
+    return !(*this == other);
+}
+
+}

--- a/Userland/Libraries/LibGUI/PersistentModelIndex.h
+++ b/Userland/Libraries/LibGUI/PersistentModelIndex.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/WeakPtr.h>
+#include <LibGUI/Model.h>
+#include <LibGUI/ModelIndex.h>
+
+namespace GUI {
+
+/// A PersistentHandle is an internal data structure used to keep track of the
+/// target of multiple PersistentModelIndex instances.
+class PersistentHandle : public Weakable<PersistentHandle> {
+    friend Model;
+    friend PersistentModelIndex;
+    friend AK::Traits<GUI::PersistentModelIndex>;
+
+    PersistentHandle(ModelIndex const& index)
+        : m_index(index)
+    {
+    }
+
+    ModelIndex m_index;
+};
+
+class PersistentModelIndex {
+public:
+    PersistentModelIndex() { }
+    PersistentModelIndex(ModelIndex const&);
+    PersistentModelIndex(PersistentModelIndex const&) = default;
+    PersistentModelIndex(PersistentModelIndex&&) = default;
+
+    PersistentModelIndex& operator=(PersistentModelIndex const&) = default;
+    PersistentModelIndex& operator=(PersistentModelIndex&&) = default;
+
+    bool is_valid() const { return has_valid_handle() && m_handle->m_index.is_valid(); }
+    bool has_valid_handle() const { return !m_handle.is_null(); }
+
+    int row() const;
+    int column() const;
+    PersistentModelIndex parent() const;
+    PersistentModelIndex sibling_at_column(int column) const;
+    Variant data(ModelRole = ModelRole::Display) const;
+
+    void* internal_data() const
+    {
+        if (has_valid_handle())
+            return m_handle->m_index.internal_data();
+        else
+            return nullptr;
+    }
+
+    operator ModelIndex() const;
+    bool operator==(PersistentModelIndex const&) const;
+    bool operator!=(PersistentModelIndex const&) const;
+    bool operator==(ModelIndex const&) const;
+    bool operator!=(ModelIndex const&) const;
+
+private:
+    friend AK::Traits<GUI::PersistentModelIndex>;
+
+    WeakPtr<PersistentHandle> m_handle;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Formatter<GUI::PersistentModelIndex> : Formatter<FormatString> {
+    void format(FormatBuilder& builder, const GUI::PersistentModelIndex& value)
+    {
+        return Formatter<FormatString>::format(builder, "PersistentModelIndex({},{},{})", value.row(), value.column(), value.internal_data());
+    }
+};
+
+template<>
+struct Traits<GUI::PersistentModelIndex> : public GenericTraits<GUI::PersistentModelIndex> {
+    static unsigned hash(const GUI::PersistentModelIndex& index)
+    {
+        if (index.has_valid_handle())
+            return Traits<GUI::ModelIndex>::hash(index.m_handle->m_index);
+        else
+            return 0;
+    }
+};
+
+}

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -175,6 +175,9 @@ void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sor
     auto old_source_rows = mapping.source_rows;
 
     int row_count = source().row_count(mapping.source_parent);
+    mapping.source_rows.resize(row_count);
+    mapping.proxy_rows.resize(row_count);
+
     for (int i = 0; i < row_count; ++i)
         mapping.source_rows[i] = i;
 


### PR DESCRIPTION
This is the first in multiple PRs which attempt to fix the biggest issue with LibGUI models which is the fact that they lose state anytime their data updates, even if that change could have been handled granularly. This causes things like the File Manager tree view collapsing when certain operations happen, and items in list/table views losing selection when even the smallest changes happen. The solution is to have a system in place which allows the model to emit a series of operations which will tell the views what has happened to the model's data, so that the views can react without losing their selection/hover/etc. indices.

The idea is taken from Qt (like models themselves), and the interface for persistent model indices is pretty much analogous to Qt's solution.

This PR implements the first part which is the `PersistentModelIndex` class itself. It behaves mostly like a `ModelIndex` does, but it also auto-registers itself with the source `Model` object when it is constructed. The `Model` will then return a `PersistentHandle` which the `PersistentModelIndex` will hold a weak reference to. This `PersistentHandle` object is owned by the `Model`, and will be updated (or deleted) when the model's data updates via the various events that the model can emit.

When a model has seen an update in its data that it can represent via inserts/moves/deletes, it will use the corresponding protected functions. These functions store a stack of operations delimited by matching `begin_*` and `end_*` calls for each operation. The implementation works this way due to some operations causing a cascade for later ones. For example, if multiple deletes of rows occur, the first actual deleted row must be the one at the bottom, since otherwise the indices for the other delete operations would be invalid and the model subclass would have to manually compensate for that. Instead, the model can just queue a bunch of `begin_delete_rows` operations and then execute them all by calling `end_delete_rows` a matching amount of times.

When an `end_*` call happens, the corresponding operation is popped from the operation stack and the `PersistentHandle` objects that are stored are modified. Since the handle objects are weakly pointed to by `PersistentModelIndex` objects, this means that the index that they are pointing to are automatically updated as well. Finally, after the operation is complete, a `did_update` is emitted to the clients to let them redraw, handle the updates etc. Alongside a generic `did_update`, more specific events are also fired based on operations. The reason that the generic `did_update` event is still fired is to not force applications which don't require granular operations to listen to granular events.

This PR also contains an example usage of this new granular updates API in `FileSystemModel`. `FileSystemModel` now handles events it obtains from `Core::FileWatcher` in order to pinpoint which file has changed/added/removed and only updates that file, using the system described above.

Please note that this PR doesn't as of yet bring any visible changes to the system due to most models that have updating data being wrapped in `SortingProxyModel`. `SortingProxyModel` does not currently handle these granular updates, and data is still lost even if the source model does a granular update. This will be fixed in the upcoming PRs by replacing `SortingProxyModel` and `FilteringProxyModel` to a common proxy model which handles both sorting and filtering and emits granular updates while doing so.