### PR TITLE
PixelPaint: Fix layer order

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -189,13 +189,13 @@ void LayerListWidget::mouseup_event(GUI::MouseEvent& event)
     if (!m_moving_gadget_index.has_value())
         return;
 
-    size_t old_index = m_moving_gadget_index.value();
-    size_t new_index = hole_index_during_move();
-    if (new_index >= m_image->layer_count())
-        new_index = m_image->layer_count() - 1;
+    size_t old_layer_index = (m_image->layer_count() - 1) - m_moving_gadget_index.value();
+    size_t new_layer_index = (m_image->layer_count() - 1) - hole_index_during_move();
+    if (new_layer_index >= m_image->layer_count())
+        new_layer_index = m_image->layer_count() - 1;
 
     m_moving_gadget_index = {};
-    m_image->change_layer_index(old_index, new_index);
+    m_image->change_layer_index(old_layer_index, new_layer_index);
 }
 
 void LayerListWidget::context_menu_event(GUI::ContextMenuEvent& event)
@@ -204,8 +204,9 @@ void LayerListWidget::context_menu_event(GUI::ContextMenuEvent& event)
 
     auto gadget_index = gadget_at(translated_event_point);
     if (gadget_index.has_value()) {
-        auto& layer = m_image->layer(gadget_index.value());
-        m_selected_layer_index = gadget_index.value();
+        auto layer_index = (m_gadgets.size() - 1) - gadget_index.value();
+        auto& layer = m_image->layer(layer_index);
+        m_selected_layer_index = layer_index;
         set_selected_layer(&layer);
     }
 
@@ -219,8 +220,9 @@ void LayerListWidget::image_did_add_layer(size_t layer_index)
         m_gadgets[m_moving_gadget_index.value()].is_moving = false;
         m_moving_gadget_index = {};
     }
-    Gadget gadget { layer_index, {}, false, {} };
-    m_gadgets.insert(layer_index, gadget);
+    auto gadget_index = m_image->layer_count() - 1 - layer_index;
+    Gadget gadget { gadget_index, {}, false, {} };
+    m_gadgets.insert(gadget_index, gadget);
     relayout_gadgets();
 }
 
@@ -230,7 +232,8 @@ void LayerListWidget::image_did_remove_layer(size_t layer_index)
         m_gadgets[m_moving_gadget_index.value()].is_moving = false;
         m_moving_gadget_index = {};
     }
-    m_gadgets.remove(layer_index);
+    auto gadget_index = m_image->layer_count() - layer_index;
+    m_gadgets.remove(gadget_index);
     m_selected_layer_index = 0;
     relayout_gadgets();
 }
@@ -245,7 +248,8 @@ void LayerListWidget::image_did_modify_layer_bitmap(size_t layer_index)
     Gfx::IntRect adjusted_rect;
     Gfx::IntRect thumbnail_rect;
     Gfx::IntRect text_rect;
-    get_gadget_rects(m_gadgets[layer_index], adjusted_rect, thumbnail_rect, text_rect);
+    auto gadget_index = (m_image->layer_count() - 1) - layer_index;
+    get_gadget_rects(m_gadgets[gadget_index], adjusted_rect, thumbnail_rect, text_rect);
     update(thumbnail_rect);
 }
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -44,8 +44,8 @@ void LayerListWidget::rebuild_gadgets()
 {
     m_gadgets.clear();
     if (m_image) {
-        for (size_t layer_index = 0; layer_index < m_image->layer_count(); ++layer_index) {
-            m_gadgets.append({ layer_index, {}, false, {} });
+        for (size_t layer_index = m_image->layer_count(); layer_index != 0; --layer_index) {
+            m_gadgets.append({ layer_index - 1, {}, false, {} });
         }
     }
     relayout_gadgets();
@@ -124,9 +124,10 @@ void LayerListWidget::paint_event(GUI::PaintEvent& event)
 
 Optional<size_t> LayerListWidget::gadget_at(Gfx::IntPoint const& position)
 {
-    for (size_t i = 0; i < m_gadgets.size(); ++i) {
-        if (m_gadgets[i].rect.contains(position))
-            return i;
+    for (size_t i = m_gadgets.size(); i != 0; --i) {
+        auto gadget_index = i - 1;
+        if (m_gadgets[gadget_index].rect.contains(position))
+            return gadget_index;
     }
     return {};
 }
@@ -144,11 +145,14 @@ void LayerListWidget::mousedown_event(GUI::MouseEvent& event)
     if (!gadget_index.has_value())
         return;
 
+    // We need to compute a different layer index because the gadget list is in the reverse order
+    auto layer_index = gadget_index.value() - m_gadgets.size() - 1;
+
     m_moving_gadget_index = gadget_index;
     m_selected_layer_index = gadget_index.value();
     m_moving_event_origin = translated_event_point;
     auto& gadget = m_gadgets[m_moving_gadget_index.value()];
-    auto& layer = m_image->layer(gadget_index.value());
+    auto& layer = m_image->layer(layer_index);
     set_selected_layer(&layer);
     gadget.is_moving = true;
     gadget.movement_delta = {};

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -331,7 +331,10 @@ void LayerListWidget::set_selected_layer(Layer* layer)
     for (size_t i = 0; i < m_image->layer_count(); ++i) {
         if (layer == &m_image->layer(i)) {
             m_image->layer(i).set_selected(true);
-            scroll_into_view(m_gadgets[i].rect, false, true);
+            // The index of the gadget corresponding to the layer isn't the same as the layer itself,
+            // we have to reverse it.
+            auto gadget_index = (m_image->layer_count() - 1) - i;
+            scroll_into_view(m_gadgets[gadget_index].rect, false, true);
             m_selected_layer_index = i;
         } else {
             m_image->layer(i).set_selected(false);

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -146,7 +146,7 @@ void LayerListWidget::mousedown_event(GUI::MouseEvent& event)
         return;
 
     // We need to compute a different layer index because the gadget list is in the reverse order
-    auto layer_index = gadget_index.value() - m_gadgets.size() - 1;
+    auto layer_index = (m_gadgets.size() - 1) - gadget_index.value();
 
     m_moving_gadget_index = gadget_index;
     m_selected_layer_index = gadget_index.value();


### PR DESCRIPTION
PixelPaint's layer used to be shown from bottom-most to topmost, making the background layer the top one, which is opposite to the behaviour of most other paint applications, as it makes more sense for the background layer to be at the bottom of the layer list.