### PR TITLE
DisplaySettings: Open the wallpaper file picker in the wallpaper path, and other small fixes

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettings.gml
+++ b/Userland/Applications/DisplaySettings/BackgroundSettings.gml
@@ -39,7 +39,7 @@
 
             @GUI::Button {
                 name: "wallpaper_open_button"
-                tooltip: "Select wallpaper from file system."
+                tooltip: "Select wallpaper from file system"
                 text: "Browse..."
                 shrink_to_fit: true
             }

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -61,7 +61,7 @@ void BackgroundSettingsWidget::create_frame()
 
     auto& button = *find_descendant_of_type_named<GUI::Button>("wallpaper_open_button");
     button.on_click = [this](auto) {
-        auto path = GUI::FilePicker::get_open_filepath(nullptr, "Select wallpaper from file system", "/res/wallpapers");
+        auto path = GUI::FilePicker::get_open_filepath(window(), "Select wallpaper from file system", "/res/wallpapers");
         if (!path.has_value())
             return;
         m_wallpaper_view->selection().clear();

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -61,7 +61,7 @@ void BackgroundSettingsWidget::create_frame()
 
     auto& button = *find_descendant_of_type_named<GUI::Button>("wallpaper_open_button");
     button.on_click = [this](auto) {
-        auto path = GUI::FilePicker::get_open_filepath(nullptr, "Select wallpaper from file system.");
+        auto path = GUI::FilePicker::get_open_filepath(nullptr, "Select wallpaper from file system.", "/res/wallpapers");
         if (!path.has_value())
             return;
         m_wallpaper_view->selection().clear();

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -61,7 +61,7 @@ void BackgroundSettingsWidget::create_frame()
 
     auto& button = *find_descendant_of_type_named<GUI::Button>("wallpaper_open_button");
     button.on_click = [this](auto) {
-        auto path = GUI::FilePicker::get_open_filepath(nullptr, "Select wallpaper from file system.", "/res/wallpapers");
+        auto path = GUI::FilePicker::get_open_filepath(nullptr, "Select wallpaper from file system", "/res/wallpapers");
         if (!path.has_value())
             return;
         m_wallpaper_view->selection().clear();


### PR DESCRIPTION
- **DisplaySettings: Open the wallpaper file picker in the wallpaper path**

  This small change can indirectly tell you where wallpapers are saved.

- **DisplaySettings: Remove the trailing dot from the button**

- **DisplaySettings: Pass the parent window to the FilePicker**

  Prior this change, closing the Display Settings application didn't close the File Picker.

… am I splitting commits *too much*?