### PR TITLE
LibJS: Start implementing Temporal.PlainYearMonth

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -144,6 +144,8 @@ set(SOURCES
     Runtime/Temporal/PlainTimeConstructor.cpp
     Runtime/Temporal/PlainTimePrototype.cpp
     Runtime/Temporal/PlainYearMonth.cpp
+    Runtime/Temporal/PlainYearMonthConstructor.cpp
+    Runtime/Temporal/PlainYearMonthPrototype.cpp
     Runtime/Temporal/Temporal.cpp
     Runtime/Temporal/TimeZone.cpp
     Runtime/Temporal/TimeZoneConstructor.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -76,14 +76,15 @@
     __JS_ENUMERATE(Float32Array, float32_array, Float32ArrayPrototype, Float32ArrayConstructor, float)                          \
     __JS_ENUMERATE(Float64Array, float64_array, Float64ArrayPrototype, Float64ArrayConstructor, double)
 
-#define JS_ENUMERATE_TEMPORAL_OBJECTS                                                                \
-    __JS_ENUMERATE(Calendar, calendar, CalendarPrototype, CalendarConstructor)                       \
-    __JS_ENUMERATE(Duration, duration, DurationPrototype, DurationConstructor)                       \
-    __JS_ENUMERATE(Instant, instant, InstantPrototype, InstantConstructor)                           \
-    __JS_ENUMERATE(PlainDate, plain_date, PlainDatePrototype, PlainDateConstructor)                  \
-    __JS_ENUMERATE(PlainDateTime, plain_date_time, PlainDateTimePrototype, PlainDateTimeConstructor) \
-    __JS_ENUMERATE(PlainTime, plain_time, PlainTimePrototype, PlainTimeConstructor)                  \
-    __JS_ENUMERATE(TimeZone, time_zone, TimeZonePrototype, TimeZoneConstructor)                      \
+#define JS_ENUMERATE_TEMPORAL_OBJECTS                                                                    \
+    __JS_ENUMERATE(Calendar, calendar, CalendarPrototype, CalendarConstructor)                           \
+    __JS_ENUMERATE(Duration, duration, DurationPrototype, DurationConstructor)                           \
+    __JS_ENUMERATE(Instant, instant, InstantPrototype, InstantConstructor)                               \
+    __JS_ENUMERATE(PlainDate, plain_date, PlainDatePrototype, PlainDateConstructor)                      \
+    __JS_ENUMERATE(PlainDateTime, plain_date_time, PlainDateTimePrototype, PlainDateTimeConstructor)     \
+    __JS_ENUMERATE(PlainTime, plain_time, PlainTimePrototype, PlainTimeConstructor)                      \
+    __JS_ENUMERATE(PlainYearMonth, plain_year_month, PlainYearMonthPrototype, PlainYearMonthConstructor) \
+    __JS_ENUMERATE(TimeZone, time_zone, TimeZonePrototype, TimeZoneConstructor)                          \
     __JS_ENUMERATE(ZonedDateTime, zoned_date_time, ZonedDateTimePrototype, ZonedDateTimeConstructor)
 
 #define JS_ENUMERATE_ITERATOR_PROTOTYPES                         \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -180,6 +180,7 @@
     M(TemporalInvalidPlainDate, "Invalid plain date")                                                                                   \
     M(TemporalInvalidPlainDateTime, "Invalid plain date time")                                                                          \
     M(TemporalInvalidPlainTime, "Invalid plain time")                                                                                   \
+    M(TemporalInvalidPlainYearMonth, "Invalid plain year month")                                                                        \
     M(TemporalInvalidTime, "Invalid time")                                                                                              \
     M(TemporalInvalidTimeZoneName, "Invalid time zone name")                                                                            \
     M(TemporalMissingRequiredProperty, "Required property {} is missing or undefined")                                                  \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -81,6 +81,8 @@
 #include <LibJS/Runtime/Temporal/PlainDateTimePrototype.h>
 #include <LibJS/Runtime/Temporal/PlainTimeConstructor.h>
 #include <LibJS/Runtime/Temporal/PlainTimePrototype.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonthConstructor.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonthPrototype.h>
 #include <LibJS/Runtime/Temporal/Temporal.h>
 #include <LibJS/Runtime/Temporal/TimeZoneConstructor.h>
 #include <LibJS/Runtime/Temporal/TimeZonePrototype.h>

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -370,11 +370,13 @@ Object* get_temporal_calendar_with_iso_default(GlobalObject& global_object, Obje
         return &static_cast<PlainDate&>(item).calendar();
     if (is<PlainDateTime>(item))
         return &static_cast<PlainDateTime&>(item).calendar();
+    // TODO: PlainMonthDay
     if (is<PlainTime>(item))
         return &static_cast<PlainTime&>(item).calendar();
+    if (is<PlainYearMonth>(item))
+        return &static_cast<PlainYearMonth&>(item).calendar();
     if (is<ZonedDateTime>(item))
         return &static_cast<ZonedDateTime&>(item).calendar();
-    // TODO: The rest of the Temporal built-ins (PlainMonthDay, PlainYearMonth)
 
     // 2. Let calendar be ? Get(item, "calendar").
     auto calendar = item.get(vm.names.calendar);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -13,6 +13,7 @@
 #include <LibJS/Runtime/Temporal/PlainDate.h>
 #include <LibJS/Runtime/Temporal/PlainDateTime.h>
 #include <LibJS/Runtime/Temporal/PlainTime.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 #include <LibJS/Runtime/Temporal/ZonedDateTime.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -299,11 +300,13 @@ Object* to_temporal_calendar(GlobalObject& global_object, Value temporal_calenda
             return &static_cast<PlainDate&>(temporal_calendar_like_object).calendar();
         if (is<PlainDateTime>(temporal_calendar_like_object))
             return &static_cast<PlainDateTime&>(temporal_calendar_like_object).calendar();
+        // TODO: PlainMonthDay
         if (is<PlainTime>(temporal_calendar_like_object))
             return &static_cast<PlainTime&>(temporal_calendar_like_object).calendar();
+        if (is<PlainYearMonth>(temporal_calendar_like_object))
+            return &static_cast<PlainYearMonth&>(temporal_calendar_like_object).calendar();
         if (is<ZonedDateTime>(temporal_calendar_like_object))
             return &static_cast<ZonedDateTime&>(temporal_calendar_like_object).calendar();
-        // TODO: The rest of the Temporal built-ins (PlainMonthDay, PlainYearMonth)
 
         // b. If ? HasProperty(temporalCalendarLike, "calendar") is false, return temporalCalendarLike.
         auto has_property = temporal_calendar_like_object.has_property(vm.names.calendar);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -97,7 +97,7 @@ Vector<String> calendar_fields(GlobalObject& global_object, Object& calendar, Ve
         return {};
 
     // 2. Let fieldsArray be ! CreateArrayFromList(fieldNames).
-    Vector<Value> field_names_values;
+    auto field_names_values = MarkedValueList { vm.heap() };
     for (auto& field_name : field_names)
         field_names_values.append(js_string(vm, field_name));
     Value fields_array = Array::create_from(global_object, field_names_values);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -718,11 +718,13 @@ i32 iso_year(Object& temporal_object)
     // NOTE: Asserted by the VERIFY_NOT_REACHED at the end
 
     // 2. Return 𝔽(temporalObject.[[ISOYear]]).
-    // TODO: add the rest of the builtins with a [[ISOYear]] slot (PlainYearMonth, PlainMonthDay)
     if (is<PlainDate>(temporal_object))
         return static_cast<PlainDate&>(temporal_object).iso_year();
     if (is<PlainDateTime>(temporal_object))
         return static_cast<PlainDateTime&>(temporal_object).iso_year();
+    if (is<PlainYearMonth>(temporal_object))
+        return static_cast<PlainYearMonth&>(temporal_object).iso_year();
+    // TODO: PlainMonthDay
     VERIFY_NOT_REACHED();
 }
 
@@ -733,11 +735,13 @@ u8 iso_month(Object& temporal_object)
     // NOTE: Asserted by the VERIFY_NOT_REACHED at the end
 
     // 2. Return 𝔽(temporalObject.[[ISOMonth]]).
-    // TODO: add the rest of the builtins with a [[ISOMonth]] slot (PlainYearMonth, PlainMonthDay)
     if (is<PlainDate>(temporal_object))
         return static_cast<PlainDate&>(temporal_object).iso_month();
     if (is<PlainDateTime>(temporal_object))
         return static_cast<PlainDateTime&>(temporal_object).iso_month();
+    if (is<PlainYearMonth>(temporal_object))
+        return static_cast<PlainYearMonth&>(temporal_object).iso_month();
+    // TODO: PlainMonthDay
     VERIFY_NOT_REACHED();
 }
 
@@ -748,11 +752,13 @@ String iso_month_code(Object& temporal_object)
     // NOTE: Asserted by the VERIFY_NOT_REACHED at the end
 
     // 2. Return ! BuildISOMonthCode(temporalObject.[[ISOMonth]]).
-    // TODO: add the rest of the builtins with a [[ISOMonth]] slot (PlainYearMonth, PlainMonthDay)
     if (is<PlainDate>(temporal_object))
         return build_iso_month_code(static_cast<PlainDate&>(temporal_object).iso_month());
     if (is<PlainDateTime>(temporal_object))
         return build_iso_month_code(static_cast<PlainDateTime&>(temporal_object).iso_month());
+    if (is<PlainYearMonth>(temporal_object))
+        return build_iso_month_code(static_cast<PlainYearMonth&>(temporal_object).iso_month());
+    // TODO: PlainMonthDay
     VERIFY_NOT_REACHED();
 }
 
@@ -763,11 +769,13 @@ u8 iso_day(Object& temporal_object)
     // NOTE: Asserted by the VERIFY_NOT_REACHED at the end
 
     // 2. Return 𝔽(temporalObject.[[ISODay]]).
-    // TODO: add the rest of the builtins with a [[ISODay]] slot (PlainYearMonth, PlainMonthDay)
     if (is<PlainDate>(temporal_object))
         return static_cast<PlainDate&>(temporal_object).iso_day();
     if (is<PlainDateTime>(temporal_object))
         return static_cast<PlainDateTime&>(temporal_object).iso_day();
+    if (is<PlainYearMonth>(temporal_object))
+        return static_cast<PlainYearMonth&>(temporal_object).iso_day();
+    // TODO: PlainMonthDay
     VERIFY_NOT_REACHED();
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -20,7 +20,7 @@ public:
     Calendar(String identifier, Object& prototype);
     virtual ~Calendar() override = default;
 
-    String const& identifier() const { return m_identifier; }
+    [[nodiscard]] String const& identifier() const { return m_identifier; }
 
 private:
     // 12.5 Properties of Temporal.Calendar Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-calendar-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -10,6 +10,7 @@
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/CalendarPrototype.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 
 namespace JS::Temporal {
 
@@ -120,8 +121,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::year)
 
     auto temporal_date_like = vm.argument(0);
     // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then
-    // TODO PlainYearMonth objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
         temporal_date_like = to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())
@@ -151,8 +151,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::month)
 
     auto temporal_date_like = vm.argument(0);
     // 5. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then
-    // TODO PlainYearMonth objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
         temporal_date_like = to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())
@@ -178,8 +177,8 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::month_code)
 
     auto temporal_date_like = vm.argument(0);
     // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]], [[InitializedTemporalMonthDay]], or [[InitializedTemporalYearMonth]] internal slot, then
-    // TODO PlainMonthDay & PlainYearMonth objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    // TODO PlainMonthDay objects
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
         temporal_date_like = to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())
@@ -318,11 +317,9 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::days_in_month)
     // 3. Assert: calendar.[[Identifier]] is "iso8601".
     VERIFY(calendar->identifier() == "iso8601"sv);
 
-    // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slots, then
     auto temporal_date_like = vm.argument(0);
-    // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalMonthDay]] internal slot, then
-    // TODO PlainMonthDay objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slots, then
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
         temporal_date_like = to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())
@@ -348,8 +345,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::days_in_year)
 
     auto temporal_date_like = vm.argument(0);
     // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then
-    // TODO PlainYearMonth objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
         temporal_date_like = to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())
@@ -375,8 +371,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::months_in_year)
 
     auto temporal_date_like = vm.argument(0);
     // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then
-    // TODO PlainYearMonth objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Perform ? ToTemporalDate(temporalDateLike).
         (void)to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())
@@ -402,8 +397,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::in_leap_year)
 
     auto temporal_date_like = vm.argument(0);
     // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then
-    // TODO PlainYearMonth objects
-    if (!temporal_date_like.is_object() || !is<PlainDate>(temporal_date_like.as_object())) {
+    if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
         temporal_date_like = to_temporal_date(global_object, temporal_date_like);
         if (vm.exception())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -18,16 +18,16 @@ public:
     Duration(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds, Object& prototype);
     virtual ~Duration() override = default;
 
-    double years() const { return m_years; }
-    double months() const { return m_months; }
-    double weeks() const { return m_weeks; }
-    double days() const { return m_days; }
-    double hours() const { return m_hours; }
-    double minutes() const { return m_minutes; }
-    double seconds() const { return m_seconds; }
-    double milliseconds() const { return m_milliseconds; }
-    double microseconds() const { return m_microseconds; }
-    double nanoseconds() const { return m_nanoseconds; }
+    [[nodiscard]] double years() const { return m_years; }
+    [[nodiscard]] double months() const { return m_months; }
+    [[nodiscard]] double weeks() const { return m_weeks; }
+    [[nodiscard]] double days() const { return m_days; }
+    [[nodiscard]] double hours() const { return m_hours; }
+    [[nodiscard]] double minutes() const { return m_minutes; }
+    [[nodiscard]] double seconds() const { return m_seconds; }
+    [[nodiscard]] double milliseconds() const { return m_milliseconds; }
+    [[nodiscard]] double microseconds() const { return m_microseconds; }
+    [[nodiscard]] double nanoseconds() const { return m_nanoseconds; }
 
 private:
     // 7.4 Properties of Temporal.Duration Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-duration-instances

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -20,7 +20,7 @@ public:
     Instant(BigInt& nanoseconds, Object& prototype);
     virtual ~Instant() override = default;
 
-    BigInt const& nanoseconds() const { return m_nanoseconds; }
+    [[nodiscard]] BigInt const& nanoseconds() const { return m_nanoseconds; }
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -4,9 +4,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/PlainDate.h>
 #include <LibJS/Runtime/Temporal/PlainYearMonth.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonthConstructor.h>
 
 namespace JS::Temporal {
+
+// 9 Temporal.PlainYearMonth Objects, https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects
+PlainYearMonth::PlainYearMonth(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype)
+    : Object(prototype)
+    , m_iso_year(iso_year)
+    , m_iso_month(iso_month)
+    , m_iso_day(iso_day)
+    , m_calendar(calendar)
+{
+}
+
+void PlainYearMonth::visit_edges(Visitor& visitor)
+{
+    visitor.visit(&m_calendar);
+}
 
 // 9.5.5 BalanceISOYearMonth ( year, month ), https://tc39.es/proposal-temporal/#sec-temporal-balanceisoyearmonth
 ISOYearMonth balance_iso_year_month(i32 year, i32 month)
@@ -21,6 +40,70 @@ ISOYearMonth balance_iso_year_month(i32 year, i32 month)
 
     // 4. Return the new Record { [[Year]]: year, [[Month]]: month }.
     return ISOYearMonth { .year = year, .month = static_cast<u8>(month) };
+}
+
+// 9.5.4 ISOYearMonthWithinLimits ( year, month ), https://tc39.es/proposal-temporal/#sec-temporal-isoyearmonthwithinlimits
+bool iso_year_month_within_limits(i32 year, u8 month)
+{
+    // 1. Assert: year and month are integers.
+
+    // 2. If year < −271821 or year > 275760, then
+    if (year < -271821 || year > 275760) {
+        // a. Return false.
+        return false;
+    }
+
+    // 3. If year is −271821 and month < 4, then
+    if (year == -271821 && month < 4) {
+        // a. Return false.
+        return false;
+    }
+
+    // 4. If year is 275760 and month > 9, then
+    if (year == 275760 && month > 9) {
+        // a. Return false.
+        return false;
+    }
+
+    // 5. Return true.
+    return true;
+}
+
+// 9.5.7 CreateTemporalYearMonth ( isoYear, isoMonth, calendar, referenceISODay [ , newTarget ] ), https://tc39.es/proposal-temporal/#sec-temporal-createtemporalyearmonth
+PlainYearMonth* create_temporal_year_month(GlobalObject& global_object, i32 iso_year, u8 iso_month, Object& calendar, u8 reference_iso_day, FunctionObject* new_target)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Assert: isoYear, isoMonth, and referenceISODay are integers.
+    // 2. Assert: Type(calendar) is Object.
+
+    // 3. If ! IsValidISODate(isoYear, isoMonth, referenceISODay) is false, throw a RangeError exception.
+    if (!is_valid_iso_date(iso_year, iso_month, reference_iso_day)) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::TemporalInvalidPlainYearMonth);
+        return {};
+    }
+
+    // 4. If ! ISOYearMonthWithinLimits(isoYear, isoMonth) is false, throw a RangeError exception.
+    if (!iso_year_month_within_limits(iso_year, iso_month)) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::TemporalInvalidPlainYearMonth);
+        return {};
+    }
+
+    // 5. If newTarget is not present, set it to %Temporal.PlainYearMonth%.
+    if (!new_target)
+        new_target = global_object.temporal_plain_year_month_constructor();
+
+    // 6. Let object be ? OrdinaryCreateFromConstructor(newTarget, "%Temporal.PlainYearMonth.prototype%", « [[InitializedTemporalYearMonth]], [[ISOYear]], [[ISOMonth]], [[ISODay]], [[Calendar]] »).
+    // 7. Set object.[[ISOYear]] to isoYear.
+    // 8. Set object.[[ISOMonth]] to isoMonth.
+    // 9. Set object.[[Calendar]] to calendar.
+    // 10. Set object.[[ISODay]] to referenceISODay.
+    auto* object = ordinary_create_from_constructor<PlainYearMonth>(global_object, *new_target, &GlobalObject::temporal_plain_year_month_prototype, iso_year, iso_month, reference_iso_day, calendar);
+    if (vm.exception())
+        return {};
+
+    // 11. Return object.
+    return object;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
@@ -6,10 +6,32 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Temporal/AbstractOperations.h>
-#include <LibJS/Runtime/Value.h>
+#include <LibJS/Runtime/Object.h>
 
 namespace JS::Temporal {
+
+class PlainYearMonth final : public Object {
+    JS_OBJECT(PlainYearMonth, Object);
+
+public:
+    PlainYearMonth(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype);
+    virtual ~PlainYearMonth() override = default;
+
+    [[nodiscard]] i32 iso_year() const { return m_iso_year; }
+    [[nodiscard]] u8 iso_month() const { return m_iso_month; }
+    [[nodiscard]] u8 iso_day() const { return m_iso_day; }
+    [[nodiscard]] Object const& calendar() const { return m_calendar; }
+    [[nodiscard]] Object& calendar() { return m_calendar; }
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    // 9.4 Properties of Temporal.PlainYearMonth Instances, https://tc39.es/proposal-temporal/#sec-properties-of-temporal-plainyearmonth-instances
+    i32 m_iso_year { 0 }; // [[ISOYear]]
+    u8 m_iso_month { 0 }; // [[ISOMonth]]
+    u8 m_iso_day { 0 };   // [[ISODay]]
+    Object& m_calendar;   // [[Calendar]]
+};
 
 struct ISOYearMonth {
     i32 year;
@@ -17,5 +39,7 @@ struct ISOYearMonth {
 };
 
 ISOYearMonth balance_iso_year_month(i32 year, i32 month);
+bool iso_year_month_within_limits(i32 year, u8 month);
+PlainYearMonth* create_temporal_year_month(GlobalObject&, i32 iso_year, u8 iso_month, Object& calendar, u8 reference_iso_day, FunctionObject* new_target = nullptr);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/Calendar.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonth.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonthConstructor.h>
+
+namespace JS::Temporal {
+
+// 9.1 The Temporal.PlainYearMonth Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor
+PlainYearMonthConstructor::PlainYearMonthConstructor(GlobalObject& global_object)
+    : NativeFunction(vm().names.PlainYearMonth.as_string(), *global_object.function_prototype())
+{
+}
+
+void PlainYearMonthConstructor::initialize(GlobalObject& global_object)
+{
+    NativeFunction::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 9.2.1 Temporal.PlainYearMonth.prototype, https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-prototype
+    define_direct_property(vm.names.prototype, global_object.temporal_plain_year_month_prototype(), 0);
+
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
+}
+
+// 9.1.1 Temporal.PlainYearMonth ( isoYear, isoMonth [ , calendarLike [ , referenceISODay ] ] ), https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth
+Value PlainYearMonthConstructor::call()
+{
+    auto& vm = this->vm();
+
+    // 1. If NewTarget is undefined, throw a TypeError exception.
+    vm.throw_exception<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Temporal.PlainYearMonth");
+    return {};
+}
+
+// 9.1.1 Temporal.PlainYearMonth ( isoYear, isoMonth [ , calendarLike [ , referenceISODay ] ] ), https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth
+Value PlainYearMonthConstructor::construct(FunctionObject& new_target)
+{
+    auto& vm = this->vm();
+    auto& global_object = this->global_object();
+
+    auto iso_year = vm.argument(0);
+    auto iso_month = vm.argument(1);
+    auto calendar_like = vm.argument(2);
+    auto reference_iso_day = vm.argument(3);
+
+    // 2. If referenceISODay is undefined, then
+    if (reference_iso_day.is_undefined()) {
+        // a. Set referenceISODay to 1𝔽.
+        reference_iso_day = Value(1);
+    }
+
+    // 3. Let y be ? ToIntegerOrInfinity(isoYear).
+    auto y = iso_year.to_integer_or_infinity(global_object);
+    if (vm.exception())
+        return {};
+
+    // 4. If y is +∞ or -∞, throw a RangeError exception.
+    if (Value(y).is_infinity()) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::TemporalInvalidPlainYearMonth);
+        return {};
+    }
+
+    // 5. Let m be ? ToIntegerOrInfinity(isoMonth).
+    auto m = iso_month.to_integer_or_infinity(global_object);
+    if (vm.exception())
+        return {};
+
+    // 6. If m is +∞ or -∞, throw a RangeError exception.
+    if (Value(m).is_infinity()) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::TemporalInvalidPlainYearMonth);
+        return {};
+    }
+
+    // 7. Let calendar be ? ToTemporalCalendarWithISODefault(calendarLike).
+    auto* calendar = to_temporal_calendar_with_iso_default(global_object, calendar_like);
+    if (vm.exception())
+        return {};
+
+    // 8. Let ref be ? ToIntegerOrInfinity(referenceISODay).
+    auto ref = reference_iso_day.to_integer_or_infinity(global_object);
+    if (vm.exception())
+        return {};
+
+    // 9. If ref is +∞ or -∞, throw a RangeError exception.
+    if (Value(ref).is_infinity()) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::TemporalInvalidPlainYearMonth);
+        return {};
+    }
+
+    // IMPLEMENTATION DEFINED: This is an optimization that allows us to treat these doubles as normal integers from this point onwards.
+    // This does not change the exposed behaviour as the call to CreateTemporalYearMonth will immediately check that these values are valid
+    // ISO values (for years: -273975 - 273975, for months: 1 - 12, for days: 1 - 31) all of which are subsets of this check.
+    if (!AK::is_within_range<i32>(y) || !AK::is_within_range<u8>(m) || !AK::is_within_range<u8>(ref)) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::TemporalInvalidPlainYearMonth);
+        return {};
+    }
+
+    // 10. Return ? CreateTemporalYearMonth(y, m, calendar, ref, NewTarget).
+    return create_temporal_year_month(global_object, y, m, *calendar, ref, &new_target);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS::Temporal {
+
+class PlainYearMonthConstructor final : public NativeFunction {
+    JS_OBJECT(PlainYearMonthConstructor, NativeFunction);
+
+public:
+    explicit PlainYearMonthConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~PlainYearMonthConstructor() override = default;
+
+    virtual Value call() override;
+    virtual Value construct(FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -34,6 +34,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthsInYear, months_in_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.inLeapYear, in_leap_year_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -156,6 +157,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::months_in_year_getter)
 
     // 4. Return ? CalendarMonthsInYear(calendar, yearMonth).
     return Value(calendar_months_in_year(global_object, calendar, *year_month));
+}
+
+// 9.3.10 get Temporal.PlainYearMonth.prototype.inLeapYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.inleapyear
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::in_leap_year_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return ? CalendarInLeapYear(calendar, yearMonth).
+    return Value(calendar_in_leap_year(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -32,6 +32,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -122,6 +123,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::days_in_year_getter)
 
     // 4. Return ? CalendarDaysInYear(calendar, yearMonth).
     return Value(calendar_days_in_year(global_object, calendar, *year_month));
+}
+
+// 9.3.8 get Temporal.PlainYearMonth.prototype.daysInMonth, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinmonth
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::days_in_month_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return ? CalendarDaysInMonth(calendar, yearMonth).
+    return Value(calendar_days_in_month(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -30,6 +30,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -88,6 +89,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::month_getter)
 
     // 4. Return 𝔽(? CalendarMonth(calendar, yearMonth)).
     return Value(calendar_month(global_object, calendar, *year_month));
+}
+
+// 9.3.6 get Temporal.PlainYearMonth.prototype.monthCode, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthCode
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::month_code_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return ? CalendarMonthCode(calendar, yearMonth).
+    return js_string(vm, calendar_month_code(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 #include <LibJS/Runtime/Temporal/PlainYearMonthPrototype.h>
 
@@ -27,6 +28,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), "Temporal.PlainYearMonth"), Attribute::Configurable);
 
     define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -53,6 +55,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::calendar_getter)
 
     // 3. Return plainYearMonth.[[Calendar]].
     return Value(&plain_year_month->calendar());
+}
+
+// 9.3.4 get Temporal.PlainYearMonth.prototype.year, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.year
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::year_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return 𝔽(? CalendarYear(calendar, yearMonth)).
+    return Value(calendar_year(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -29,6 +29,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
 
     define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -71,6 +72,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::year_getter)
 
     // 4. Return 𝔽(? CalendarYear(calendar, yearMonth)).
     return Value(calendar_year(global_object, calendar, *year_month));
+}
+
+// 9.3.5 get Temporal.PlainYearMonth.prototype.month, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.month
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::month_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return 𝔽(? CalendarMonth(calendar, yearMonth)).
+    return Value(calendar_month(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -35,6 +35,9 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthsInYear, months_in_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.inLeapYear, in_leap_year_getter, {}, Attribute::Configurable);
+
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -173,6 +176,14 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::in_leap_year_getter)
 
     // 4. Return ? CalendarInLeapYear(calendar, yearMonth).
     return Value(calendar_in_leap_year(global_object, calendar, *year_month));
+}
+
+// 9.3.20 Temporal.PlainYearMonth.prototype.valueOf ( ), https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::value_of)
+{
+    // 1. Throw a TypeError exception.
+    vm.throw_exception<TypeError>(global_object, ErrorType::Convert, "Temporal.PlainYearMonth", "a primitive value");
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -18,6 +18,11 @@ PlainYearMonthPrototype::PlainYearMonthPrototype(GlobalObject& global_object)
 void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
 {
     Object::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 9.3.2 Temporal.PlainYearMonth.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype-@@tostringtag
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), "Temporal.PlainYearMonth"), Attribute::Configurable);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonthPrototype.h>
+
+namespace JS::Temporal {
+
+// 9.3 Properties of the Temporal.PlainYearMonth Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainyearmonth-prototype-object
+PlainYearMonthPrototype::PlainYearMonthPrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
+{
+    Object::initialize(global_object);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -38,6 +38,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.valueOf, value_of, 0, attr);
+    define_native_function(vm.names.getISOFields, get_iso_fields, 0, attr);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -184,6 +185,34 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::value_of)
     // 1. Throw a TypeError exception.
     vm.throw_exception<TypeError>(global_object, ErrorType::Convert, "Temporal.PlainYearMonth", "a primitive value");
     return {};
+}
+
+// 9.3.22 Temporal.PlainYearMonth.prototype.getISOFields ( ), https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.getisofields
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::get_iso_fields)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let fields be ! OrdinaryObjectCreate(%Object.prototype%).
+    auto* fields = Object::create(global_object, global_object.object_prototype());
+
+    // 4. Perform ! CreateDataPropertyOrThrow(fields, "calendar", yearMonth.[[Calendar]]).
+    fields->create_data_property_or_throw(vm.names.calendar, Value(&year_month->calendar()));
+
+    // 5. Perform ! CreateDataPropertyOrThrow(fields, "isoDay", 𝔽(yearMonth.[[ISODay]])).
+    fields->create_data_property_or_throw(vm.names.isoDay, Value(year_month->iso_day()));
+
+    // 6. Perform ! CreateDataPropertyOrThrow(fields, "isoMonth", 𝔽(yearMonth.[[ISOMonth]])).
+    fields->create_data_property_or_throw(vm.names.isoMonth, Value(year_month->iso_month()));
+
+    // 7. Perform ! CreateDataPropertyOrThrow(fields, "isoYear", 𝔽(yearMonth.[[ISOYear]])).
+    fields->create_data_property_or_throw(vm.names.isoYear, Value(year_month->iso_year()));
+
+    // 8. Return fields.
+    return fields;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 #include <LibJS/Runtime/Temporal/PlainYearMonthPrototype.h>
 
 namespace JS::Temporal {
@@ -23,6 +25,34 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
 
     // 9.3.2 Temporal.PlainYearMonth.prototype[ @@toStringTag ], https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), "Temporal.PlainYearMonth"), Attribute::Configurable);
+
+    define_native_accessor(vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+}
+
+static PlainYearMonth* typed_this(GlobalObject& global_object)
+{
+    auto& vm = global_object.vm();
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return {};
+    if (!is<PlainYearMonth>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Temporal.PlainYearMonth");
+        return {};
+    }
+    return static_cast<PlainYearMonth*>(this_object);
+}
+
+// 9.3.3 get Temporal.PlainYearMonth.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendar
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::calendar_getter)
+{
+    // 1. Let plainYearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(plainYearMonth, [[InitializedTemporalYearMonth]]).
+    auto* plain_year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Return plainYearMonth.[[Calendar]].
+    return Value(&plain_year_month->calendar());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -31,6 +31,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.month, month_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -105,6 +106,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::month_code_getter)
 
     // 4. Return ? CalendarMonthCode(calendar, yearMonth).
     return js_string(vm, calendar_month_code(global_object, calendar, *year_month));
+}
+
+// 9.3.7 get Temporal.PlainYearMonth.prototype.daysInYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinyear
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::days_in_year_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return ? CalendarDaysInYear(calendar, yearMonth).
+    return Value(calendar_days_in_year(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -33,6 +33,7 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInYear, days_in_year_getter, {}, Attribute::Configurable);
     define_native_accessor(vm.names.daysInMonth, days_in_month_getter, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.monthsInYear, months_in_year_getter, {}, Attribute::Configurable);
 }
 
 static PlainYearMonth* typed_this(GlobalObject& global_object)
@@ -139,6 +140,22 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::days_in_month_getter)
 
     // 4. Return ? CalendarDaysInMonth(calendar, yearMonth).
     return Value(calendar_days_in_month(global_object, calendar, *year_month));
+}
+
+// 9.3.9 get Temporal.PlainYearMonth.prototype.monthsInYear, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthsinyear
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::months_in_year_getter)
+{
+    // 1. Let yearMonth be the this value.
+    // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto* year_month = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be yearMonth.[[Calendar]].
+    auto& calendar = year_month->calendar();
+
+    // 4. Return ? CalendarMonthsInYear(calendar, yearMonth).
+    return Value(calendar_months_in_year(global_object, calendar, *year_month));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -21,6 +21,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(month_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -24,6 +24,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -17,6 +17,9 @@ public:
     explicit PlainYearMonthPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~PlainYearMonthPrototype() override = default;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -23,6 +23,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
+    JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -27,6 +27,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
     JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(in_leap_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(value_of);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -28,6 +28,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(in_leap_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
+    JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -26,6 +26,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
     JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
+    JS_DECLARE_NATIVE_FUNCTION(in_leap_year_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -25,6 +25,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(days_in_month_getter);
+    JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
+
+namespace JS::Temporal {
+
+class PlainYearMonthPrototype final : public Object {
+    JS_OBJECT(PlainYearMonthPrototype, Object);
+
+public:
+    explicit PlainYearMonthPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~PlainYearMonthPrototype() override = default;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(year_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -22,6 +22,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
+    JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/Temporal/PlainDateConstructor.h>
 #include <LibJS/Runtime/Temporal/PlainDateTimeConstructor.h>
 #include <LibJS/Runtime/Temporal/PlainTimeConstructor.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonthConstructor.h>
 #include <LibJS/Runtime/Temporal/Temporal.h>
 #include <LibJS/Runtime/Temporal/TimeZoneConstructor.h>
 #include <LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h>
@@ -41,6 +42,7 @@ void Temporal::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.PlainDate, global_object.temporal_plain_date_constructor(), attr);
     define_direct_property(vm.names.PlainDateTime, global_object.temporal_plain_date_time_constructor(), attr);
     define_direct_property(vm.names.PlainTime, global_object.temporal_plain_time_constructor(), attr);
+    define_direct_property(vm.names.PlainYearMonth, global_object.temporal_plain_year_month_constructor(), attr);
     define_direct_property(vm.names.TimeZone, global_object.temporal_time_zone_constructor(), attr);
     define_direct_property(vm.names.ZonedDateTime, global_object.temporal_zoned_date_time_constructor(), attr);
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -22,8 +22,8 @@ public:
     TimeZone(String identifier, Object& prototype);
     virtual ~TimeZone() override = default;
 
-    String const& identifier() const { return m_identifier; }
-    Optional<OffsetType> const& offset_nanoseconds() const { return m_offset_nanoseconds; }
+    [[nodiscard]] String const& identifier() const { return m_identifier; }
+    [[nodiscard]] Optional<OffsetType> const& offset_nanoseconds() const { return m_offset_nanoseconds; }
     void set_offset_nanoseconds(OffsetType offset_nanoseconds) { m_offset_nanoseconds = offset_nanoseconds; };
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
@@ -18,12 +18,12 @@ public:
     ZonedDateTime(BigInt& nanoseconds, Object& time_zone, Object& calendar, Object& prototype);
     virtual ~ZonedDateTime() override = default;
 
-    BigInt const& nanoseconds() const { return m_nanoseconds; }
-    BigInt& nanoseconds() { return m_nanoseconds; }
-    Object const& time_zone() const { return m_time_zone; }
-    Object& time_zone() { return m_time_zone; }
-    Object const& calendar() const { return m_calendar; }
-    Object& calendar() { return m_calendar; }
+    [[nodiscard]] BigInt const& nanoseconds() const { return m_nanoseconds; }
+    [[nodiscard]] BigInt& nanoseconds() { return m_nanoseconds; }
+    [[nodiscard]] Object const& time_zone() const { return m_time_zone; }
+    [[nodiscard]] Object& time_zone() { return m_time_zone; }
+    [[nodiscard]] Object const& calendar() const { return m_calendar; }
+    [[nodiscard]] Object& calendar() { return m_calendar; }
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.js
@@ -1,0 +1,53 @@
+describe("errors", () => {
+    test("called without new", () => {
+        expect(() => {
+            Temporal.PlainYearMonth();
+        }).toThrowWithMessage(
+            TypeError,
+            "Temporal.PlainYearMonth constructor must be called with 'new'"
+        );
+    });
+
+    test("cannot pass Infinity", () => {
+        expect(() => {
+            new Temporal.PlainYearMonth(Infinity);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+        expect(() => {
+            new Temporal.PlainYearMonth(0, Infinity);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+        expect(() => {
+            new Temporal.PlainYearMonth(0, 0, {}, Infinity);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+        expect(() => {
+            new Temporal.PlainYearMonth(-Infinity);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+        expect(() => {
+            new Temporal.PlainYearMonth(0, -Infinity);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+        expect(() => {
+            new Temporal.PlainYearMonth(0, 0, {}, -Infinity);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+    });
+
+    test("cannot pass invalid ISO month/day", () => {
+        expect(() => {
+            new Temporal.PlainYearMonth(0, 0);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+        expect(() => {
+            new Temporal.PlainYearMonth(0, 1, {}, 0);
+        }).toThrowWithMessage(RangeError, "Invalid plain year month");
+    });
+});
+
+describe("normal behavior", () => {
+    test("length is 2", () => {
+        expect(Temporal.PlainYearMonth).toHaveLength(2);
+    });
+
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(typeof plainYearMonth).toBe("object");
+        expect(plainYearMonth).toBeInstanceOf(Temporal.PlainYearMonth);
+        expect(Object.getPrototypeOf(plainYearMonth)).toBe(Temporal.PlainYearMonth.prototype);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.@@toStringTag.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.@@toStringTag.js
@@ -1,0 +1,3 @@
+test("basic functionality", () => {
+    expect(Temporal.PlainYearMonth.prototype[Symbol.toStringTag]).toBe("Temporal.PlainYearMonth");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.calendar.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.calendar.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7, calendar);
+        expect(plainYearMonth.calendar).toBe(calendar);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "calendar", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.daysInMonth.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.daysInMonth.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.daysInMonth).toBe(31);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "daysInMonth", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.daysInYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.daysInYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.daysInYear).toBe(365);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "daysInYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.getISOFields.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.getISOFields.js
@@ -1,0 +1,27 @@
+describe("normal behavior", () => {
+    test("length is 0", () => {
+        expect(Temporal.PlainYearMonth.prototype.getISOFields).toHaveLength(0);
+    });
+
+    test("basic functionality", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7, calendar, 6);
+        const fields = plainYearMonth.getISOFields();
+        expect(fields).toEqual({ calendar, isoDay: 6, isoMonth: 7, isoYear: 2021 });
+        // Test field order
+        expect(Object.getOwnPropertyNames(fields)).toEqual([
+            "calendar",
+            "isoDay",
+            "isoMonth",
+            "isoYear",
+        ]);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Temporal.PlainYearMonth.prototype.getISOFields.call("foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.inLeapYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.inLeapYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.inLeapYear).toBe(false);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "inLeapYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.month.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.month.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.month).toBe(7);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "month", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.monthCode.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.monthCode.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.monthCode).toBe("M07");
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "monthCode", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.monthsInYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.monthsInYear.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.monthsInYear).toBe(12);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "monthsInYear", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.valueOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.valueOf.js
@@ -1,0 +1,11 @@
+describe("errors", () => {
+    test("throws TypeError", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(() => {
+            plainYearMonth.valueOf();
+        }).toThrowWithMessage(
+            TypeError,
+            "Cannot convert Temporal.PlainYearMonth to a primitive value"
+        );
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.year.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.year.js
@@ -1,0 +1,14 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const plainYearMonth = new Temporal.PlainYearMonth(2021, 7);
+        expect(plainYearMonth.year).toBe(2021);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "year", "foo");
+        }).toThrowWithMessage(TypeError, "Not a Temporal.PlainYearMonth");
+    });
+});


### PR DESCRIPTION
Ticks ~11~ 13 checkboxes in #8982, and fixes 3 test262 tests.