### PR TITLE
Meta: Don't use x86_64 QEMU for the i686 kernel

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -18,13 +18,20 @@ else
     kernel_base=0xc0200000
 fi
 
+# FIXME: This doesn't work when running QEMU inside the WSL2 VM
+if command -v wslpath >/dev/null; then
+    gdb_host=$(powershell.exe "(Test-Connection -ComputerName (hostname) -Count 1).IPV4Address.IPAddressToString" | tr -d '\r\n')
+else
+    gdb_host=localhost
+fi
+
 exec $SERENITY_KERNEL_DEBUGGER \
     -ex "file $(dirname "$0")/../Build/${SERENITY_ARCH:-i686}/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
     -ex "add-symbol-file $(dirname "$0")/../Build/${SERENITY_ARCH:-i686}/Kernel/Kernel -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
-    -ex 'target remote localhost:1234' \
+    -ex "target remote ${gdb_host}:1234" \
     -ex "source $(dirname "$0")/serenity_gdb.py" \
     -ex "layout asm" \
     -ex "fs next" \

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -55,12 +55,9 @@ if [ -z "$SERENITY_QEMU_BIN" ]; then
             QEMU_BINARY_SUFFIX=".exe"
         fi
     fi
-    if command -v "${QEMU_BINARY_PREFIX}qemu-system-x86_64${QEMU_BINARY_SUFFIX}" >/dev/null; then
+    if [ "$SERENITY_ARCH" = "x86_64" ]; then
         SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-x86_64${QEMU_BINARY_SUFFIX}"
     else
-        if [ "$SERENITY_ARCH" = "x86_64" ]; then
-            die "Please install the 64-bit QEMU system emulator (qemu-system-x86_64)."
-        fi
         SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-i386${QEMU_BINARY_SUFFIX}"
     fi
 fi


### PR DESCRIPTION
**Meta: Don't use x86_64 QEMU for the i686 kernel**

This seemed like a good idea at the time to avoid an unnecessary dependency on qemu-system-i368. However this makes debugging the kernel with GDB more difficult because GDB assumes that the QEMU architectures matches the kernel architecture.

**Meta: Allow attaching GDB to the QEMU instance on the WSL2 host**
