### PR TITLE
Toolchain+Ports: Let -nostdlib make us not link against libgcc_s

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -349,6 +349,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-80387 -mno-mmx -mno-sse -mno-sse2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-asynchronous-unwind-tables")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+# FIXME: remove -nodefaultlibs after the next toolchain update
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nodefaultlibs -nostdlib")
 
 if (USE_CLANG_TOOLCHAIN)

--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -152,7 +152,7 @@ diff -Naur gcc-11.2.0/gcc/config/serenity.h gcc-11.2.0.serenity/gcc/config/seren
 +#define ENDFILE_SPEC "%{shared|static-pie|!no-pie:crtendS.o%s; :crtend.o%s} crtn.o%s"
 +
 +#undef LINK_SPEC
-+#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} %{!fbuilding-libgcc:%{!nodefaultlibs:-lgcc_s} -dynamic-linker /usr/lib/Loader.so}}"
++#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} %{!fbuilding-libgcc:%{!nostdlib:%{!nodefaultlibs:-lgcc_s}} -dynamic-linker /usr/lib/Loader.so}}"
 +
 +#undef CC1_SPEC
 +#define CC1_SPEC "-ftls-model=initial-exec %{!fno-pic:%{!fno-PIC:%{!fpic:%{!fPIC: -fPIC}}}} -fno-semantic-interposition"

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -152,7 +152,7 @@ diff -Naur gcc-11.2.0/gcc/config/serenity.h gcc-11.2.0.serenity/gcc/config/seren
 +#define ENDFILE_SPEC "%{shared|static-pie|!no-pie:crtendS.o%s; :crtend.o%s} crtn.o%s"
 +
 +#undef LINK_SPEC
-+#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} %{!fbuilding-libgcc:%{!nodefaultlibs:-lgcc_s} -dynamic-linker /usr/lib/Loader.so}}"
++#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} %{!fbuilding-libgcc:%{!nostdlib:%{!nodefaultlibs:-lgcc_s}} -dynamic-linker /usr/lib/Loader.so}}"
 +
 +#undef CC1_SPEC
 +#define CC1_SPEC "-ftls-model=initial-exec %{!fno-pic:%{!fno-PIC:%{!fpic:%{!fPIC: -fPIC}}}} -fno-semantic-interposition"

--- a/Userland/DynamicLoader/CMakeLists.txt
+++ b/Userland/DynamicLoader/CMakeLists.txt
@@ -26,7 +26,8 @@ add_definitions(-D_DYNAMIC_LOADER)
 
 set(SOURCES ${LOADER_SOURCES} ${AK_SOURCES} ${ELF_SOURCES} ${LIBC_SOURCES1} ${LIBC_SOURCES2} ${LIBC_SOURCES3} ${LIBSYSTEM_SOURCES})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -nostdlib -pie -fpic -DNO_TLS")
+# FIXME: remove -nodefaultlibs after the next toolchain update
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -nodefaultlibs -nostdlib -pie -fpic -DNO_TLS")
 
 set_source_files_properties (../Libraries/LibC/ssp.cpp PROPERTIES COMPILE_FLAGS
     "-fno-stack-protector")


### PR DESCRIPTION
**Toolchain+Ports: Let -nostdlib make us not link against libgcc_s**

For now this is not a mandatory toolchain rebuild.

**DynamicLoader: Make sure we don't link against libgcc_s**

This bug was reintroduced by the removal of -fbuilding-gcc.