### PR TITLE
LibGUI: Custom HeaderView minimum width

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -179,6 +179,16 @@ void AbstractTableView::set_column_width(int column, int width)
     column_header().set_section_size(column, width);
 }
 
+int AbstractTableView::minimum_column_width(int)
+{
+    return 2;
+}
+
+int AbstractTableView::minimum_row_height(int)
+{
+    return 2;
+}
+
 Gfx::TextAlignment AbstractTableView::column_header_alignment(int column_index) const
 {
     if (!model())

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -39,6 +39,8 @@ public:
     int column_width(int column) const;
     void set_column_width(int column, int width);
     void set_default_column_width(int column, int width);
+    virtual int minimum_column_width(int column);
+    virtual int minimum_row_height(int row);
 
     Gfx::TextAlignment column_header_alignment(int column) const;
     void set_column_header_alignment(int column, Gfx::TextAlignment);

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -17,8 +17,6 @@
 
 namespace GUI {
 
-static constexpr int minimum_column_size = 2;
-
 HeaderView::HeaderView(AbstractTableView& table_view, Gfx::Orientation orientation)
     : m_table_view(table_view)
     , m_orientation(orientation)
@@ -179,8 +177,13 @@ void HeaderView::mousemove_event(MouseEvent& event)
     if (m_in_section_resize) {
         auto delta = event.position() - m_section_resize_origin;
         int new_size = m_section_resize_original_width + delta.primary_offset_for_orientation(m_orientation);
-        if (new_size <= minimum_column_size)
-            new_size = minimum_column_size;
+
+        auto minimum_size = orientation() == Orientation::Horizontal
+            ? m_table_view.minimum_column_width(m_resizing_section)
+            : m_table_view.minimum_row_height(m_resizing_section);
+
+        if (new_size <= minimum_size)
+            new_size = minimum_size;
         VERIFY(m_resizing_section >= 0 && m_resizing_section < model()->column_count());
         set_section_size(m_resizing_section, new_size);
         return;
@@ -393,8 +396,10 @@ void HeaderView::set_section_alignment(int section, Gfx::TextAlignment alignment
 
 void HeaderView::set_default_section_size(int section, int size)
 {
-    if (orientation() == Gfx::Orientation::Horizontal && size < minimum_column_size)
-        size = minimum_column_size;
+    auto minimum_column_width = m_table_view.minimum_column_width(section);
+
+    if (orientation() == Gfx::Orientation::Horizontal && size < minimum_column_width)
+        size = minimum_column_width;
 
     auto& data = section_data(section);
     if (data.default_size == size)

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -738,4 +738,20 @@ Gfx::IntRect TreeView::content_rect(ModelIndex const& index) const
     return found_rect;
 }
 
+int TreeView::minimum_column_width(int column)
+{
+    if (column != model()->tree_column()) {
+        return 2;
+    }
+
+    int maximum_indent_level = 1;
+
+    traverse_in_paint_order([&](ModelIndex const&, Gfx::IntRect const&, Gfx::IntRect const&, int indent_level) {
+        maximum_indent_level = max(maximum_indent_level, indent_level);
+        return IterationDecision::Continue;
+    });
+
+    return indent_width_in_pixels() * maximum_indent_level + icon_size() + icon_spacing() + 2;
+}
+
 }

--- a/Userland/Libraries/LibGUI/TreeView.h
+++ b/Userland/Libraries/LibGUI/TreeView.h
@@ -36,6 +36,8 @@ public:
     virtual Gfx::IntRect content_rect(ModelIndex const&) const override;
     virtual Gfx::IntRect paint_invalidation_rect(ModelIndex const& index) const override { return content_rect(index); }
 
+    virtual int minimum_column_width(int column) override;
+
 protected:
     TreeView();
 


### PR DESCRIPTION
**LibGUI: Let the table view tell HeaderView about the min. section size**

Previously HeaderView would just assume that each column or row could
have a minimum size of 2. This makes it so that AbstractTableView
subclasses can provide a new minimum value for a specific column.

**LibGUI: Do not allow tree column to shrink beyond indent and icon**

We always display the tree indent and the icon, so we shouldn't allow
the tree column to shrink beyond that size.

