### PR TITLE
PixelPaint: Adjust update rects on Tools

### DIFF
--- a/Userland/Applications/PixelPaint/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/BrushTool.cpp
@@ -35,7 +35,7 @@ void BrushTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEve
     for (int i = 0; i < first_draw_opacity; ++i)
         draw_point(layer.bitmap(), m_editor->color_for(event), event.position());
 
-    layer.did_modify_bitmap();
+    layer.did_modify_bitmap(Gfx::IntRect::centered_on(event.position(), Gfx::IntSize { m_size * 2, m_size * 2 }));
     m_last_position = event.position();
 }
 

--- a/Userland/Applications/PixelPaint/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/EraseTool.cpp
@@ -42,7 +42,7 @@ void EraseTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEve
     Gfx::IntRect r = build_rect(event.position(), layer.rect());
     GUI::Painter painter(layer.bitmap());
     painter.clear_rect(r, get_color());
-    layer.did_modify_bitmap();
+    layer.did_modify_bitmap(r.inflated(2, 2));
 }
 
 void EraseTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
@@ -51,7 +51,7 @@ void EraseTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEve
         Gfx::IntRect r = build_rect(event.position(), layer.rect());
         GUI::Painter painter(layer.bitmap());
         painter.clear_rect(r, get_color());
-        layer.did_modify_bitmap();
+        layer.did_modify_bitmap(r.inflated(2, 2));
     }
 }
 

--- a/Userland/Applications/PixelPaint/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/PenTool.cpp
@@ -31,7 +31,7 @@ void PenTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent
 
     GUI::Painter painter(layer.bitmap());
     painter.draw_line(event.position(), event.position(), m_editor->color_for(event), m_thickness);
-    layer.did_modify_bitmap(Gfx::IntRect::centered_on(event.position(), Gfx::IntSize { m_thickness, m_thickness }));
+    layer.did_modify_bitmap(Gfx::IntRect::centered_on(event.position(), Gfx::IntSize { m_thickness + 2, m_thickness + 2 }));
     m_last_drawing_event_position = event.position();
 }
 
@@ -57,7 +57,7 @@ void PenTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent
         painter.draw_line(event.position(), event.position(), m_editor->color_for(event), m_thickness);
         changed_rect = Gfx::IntRect::from_two_points(event.position(), event.position());
     }
-    changed_rect.inflate(m_thickness, m_thickness);
+    changed_rect.inflate(m_thickness + 2, m_thickness + 2);
     layer.did_modify_bitmap(changed_rect);
 
     m_last_drawing_event_position = event.position();

--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -24,7 +24,7 @@ Selection::Selection(ImageEditor& editor)
         ++m_marching_ants_offset;
         m_marching_ants_offset %= (marching_ant_length * 2);
         if (!is_empty() || m_in_interactive_selection)
-            m_editor.update();
+            m_editor.update(m_editor.image_rect_to_editor_rect(bounding_rect().inflated(10, 10)).to_type<int>());
     });
     m_marching_ants_timer->start();
 }


### PR DESCRIPTION
This adjusts some of the update rects for Tools in PixelPaint. When zoomed in to pixel level while using PenTool the image could be misaligned with the update rect causing the rendering glitch seen below. Inflating the rect by 2x2 ensures that this doesn't happen.
Likewise when zoomed out the Selection rect will be misaligned/off by rounding errors. Inflating by 10x10 takes care of this within reasonable zoom levels.

![Screenshot_20210807_181249](https://user-images.githubusercontent.com/69970419/128627831-b28d2919-8dd3-4c25-88e7-765c1f48717c.png)