### PR TITLE
Mandelbrot: Panning + zooming

### DIFF
--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -147,6 +147,7 @@ private:
     virtual void mousedown_event(GUI::MouseEvent& event) override;
     virtual void mousemove_event(GUI::MouseEvent& event) override;
     virtual void mouseup_event(GUI::MouseEvent& event) override;
+    virtual void mousewheel_event(GUI::MouseEvent& event) override;
     virtual void resize_event(GUI::ResizeEvent& event) override;
 
     bool m_dragging { false };
@@ -215,6 +216,33 @@ void Mandelbrot::mouseup_event(GUI::MouseEvent& event)
     }
 
     return GUI::Widget::mouseup_event(event);
+}
+
+void Mandelbrot::mousewheel_event(GUI::MouseEvent& event)
+{
+    static constexpr double zoom_in_multiplier = 0.8;
+    static constexpr double zoom_out_multiplier = 1.25;
+
+    bool zooming_in = event.wheel_delta() < 0;
+    double multiplier = zooming_in ? zoom_in_multiplier : zoom_out_multiplier;
+
+    auto relative_rect = this->relative_rect();
+    Gfx::IntRect zoomed_rect = relative_rect;
+
+    zoomed_rect.set_width(zoomed_rect.width() * multiplier);
+    zoomed_rect.set_height(zoomed_rect.height() * multiplier);
+
+    auto leftover_width = abs(relative_rect.width() - zoomed_rect.width());
+    auto leftover_height = abs(relative_rect.height() - zoomed_rect.height());
+
+    double cursor_x_percentage = static_cast<double>(event.position().x()) / relative_rect.width();
+    double cursor_y_percentage = static_cast<double>(event.position().y()) / relative_rect.height();
+
+    zoomed_rect.set_x((zooming_in ? 1 : -1) * leftover_width * cursor_x_percentage);
+    zoomed_rect.set_y((zooming_in ? 1 : -1) * leftover_height * cursor_y_percentage);
+
+    m_set.zoom(zoomed_rect);
+    update();
 }
 
 void Mandelbrot::resize_event(GUI::ResizeEvent& event)

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -137,7 +137,7 @@ private:
     }
 };
 
-class Mandelbrot : public GUI::Widget {
+class Mandelbrot : public GUI::Frame {
     C_OBJECT(Mandelbrot)
 
     void export_image(String const& export_path);
@@ -158,7 +158,10 @@ private:
 
 void Mandelbrot::paint_event(GUI::PaintEvent& event)
 {
+    Frame::paint_event(event);
+
     GUI::Painter painter(*this);
+    painter.add_clip_rect(frame_inner_rect());
     painter.add_clip_rect(event.rect());
     painter.draw_scaled_bitmap(rect(), m_set.bitmap(), m_set.bitmap().rect());
 


### PR DESCRIPTION
**Mandelbrot: Use a GUI::Frame to paint into**

This allows us to have a frame border which looks nicer.

**Mandelbrot: Add mousewheel zooming**

This allows the user to zoom in with a up scroll of the mousewheel and
zoom out with a down scroll.

**Mandelbrot: Add panning**

Adds the ability to use the middle-mouse click to pan the current view.

**Mandelbrot: Only recalculate missing areas after panning**

We can reuse the areas that we have from before and just recalculate
the areas that are fresh. This makes panning super smooth. :^)