### PR TITLE
PixelPaint: Let Tools have different cursors

### DIFF
--- a/Userland/Applications/PixelPaint/BrushTool.h
+++ b/Userland/Applications/PixelPaint/BrushTool.h
@@ -19,6 +19,7 @@ public:
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;

--- a/Userland/Applications/PixelPaint/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/EllipseTool.h
@@ -23,6 +23,7 @@ public:
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     enum class Mode {

--- a/Userland/Applications/PixelPaint/GuideTool.h
+++ b/Userland/Applications/PixelPaint/GuideTool.h
@@ -24,6 +24,7 @@ public:
     virtual void on_context_menu(Layer&, GUI::ContextMenuEvent&) override;
 
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     RefPtr<Guide> closest_guide(Gfx::IntPoint const&);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -181,6 +181,7 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
     if (event.button() == GUI::MouseButton::Middle) {
         m_click_position = event.position();
         m_saved_pan_origin = m_pan_origin;
+        set_override_cursor(Gfx::StandardCursor::Drag);
         return;
     }
 
@@ -227,6 +228,8 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
 
 void ImageEditor::mouseup_event(GUI::MouseEvent& event)
 {
+    set_override_cursor(m_active_cursor);
+
     if (!m_active_layer || !m_active_tool)
         return;
     auto layer_event = event_adjusted_for_layer(event, *m_active_layer);
@@ -265,8 +268,15 @@ void ImageEditor::keyup_event(GUI::KeyEvent& event)
         m_active_tool->on_keyup(event);
 }
 
+void ImageEditor::enter_event(Core::Event&)
+{
+    set_override_cursor(m_active_cursor);
+}
+
 void ImageEditor::leave_event(Core::Event&)
 {
+    set_override_cursor(Gfx::StandardCursor::None);
+
     if (on_leave)
         on_leave();
 }
@@ -304,8 +314,10 @@ void ImageEditor::set_active_tool(Tool* tool)
 
     m_active_tool = tool;
 
-    if (m_active_tool)
+    if (m_active_tool) {
         m_active_tool->setup(*this);
+        m_active_cursor = m_active_tool->cursor();
+    }
 }
 
 void ImageEditor::layers_did_change()

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -100,6 +100,7 @@ private:
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;
 
     virtual void image_did_change(Gfx::IntRect const&) override;
@@ -129,6 +130,8 @@ private:
     Gfx::FloatPoint m_pan_origin;
     Gfx::FloatPoint m_saved_pan_origin;
     Gfx::IntPoint m_click_position;
+
+    Gfx::StandardCursor m_active_cursor { Gfx::StandardCursor::None };
 
     Selection m_selection;
 };

--- a/Userland/Applications/PixelPaint/LineTool.h
+++ b/Userland/Applications/PixelPaint/LineTool.h
@@ -23,6 +23,7 @@ public:
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;

--- a/Userland/Applications/PixelPaint/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/MoveTool.cpp
@@ -32,7 +32,6 @@ void MoveTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEven
     m_layer_being_moved = layer;
     m_event_origin = image_event.position();
     m_layer_origin = layer.location();
-    m_editor->window()->set_cursor(Gfx::StandardCursor::Move);
 }
 
 void MoveTool::on_mousemove(Layer&, GUI::MouseEvent&, GUI::MouseEvent& image_event)
@@ -49,7 +48,6 @@ void MoveTool::on_mouseup(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
     if (event.button() != GUI::MouseButton::Left)
         return;
     m_layer_being_moved = nullptr;
-    m_editor->window()->set_cursor(Gfx::StandardCursor::None);
     m_editor->did_complete_action();
 }
 

--- a/Userland/Applications/PixelPaint/MoveTool.h
+++ b/Userland/Applications/PixelPaint/MoveTool.h
@@ -19,6 +19,7 @@ public:
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Move; }
 
 private:
     RefPtr<Layer> m_layer_being_moved;

--- a/Userland/Applications/PixelPaint/PenTool.h
+++ b/Userland/Applications/PixelPaint/PenTool.h
@@ -21,6 +21,7 @@ public:
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     Gfx::IntPoint m_last_drawing_event_position { -1, -1 };

--- a/Userland/Applications/PixelPaint/PickerTool.h
+++ b/Userland/Applications/PixelPaint/PickerTool.h
@@ -16,6 +16,7 @@ public:
     virtual ~PickerTool() override;
 
     virtual void on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 };
 
 }

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.h
@@ -26,6 +26,7 @@ public:
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     enum class MovingMode {

--- a/Userland/Applications/PixelPaint/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/RectangleTool.h
@@ -23,6 +23,7 @@ public:
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     enum class Mode {

--- a/Userland/Applications/PixelPaint/SprayTool.h
+++ b/Userland/Applications/PixelPaint/SprayTool.h
@@ -22,6 +22,7 @@ public:
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_mousemove(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     void paint_it();

--- a/Userland/Applications/PixelPaint/Tool.h
+++ b/Userland/Applications/PixelPaint/Tool.h
@@ -8,6 +8,7 @@
 
 #include <LibGUI/Event.h>
 #include <LibGUI/Forward.h>
+#include <LibGfx/StandardCursor.h>
 
 namespace PixelPaint {
 
@@ -27,6 +28,7 @@ public:
     virtual void on_keydown(GUI::KeyEvent&) { }
     virtual void on_keyup(GUI::KeyEvent&) { }
     virtual GUI::Widget* get_properties_widget() { return nullptr; }
+    virtual Gfx::StandardCursor cursor() { return Gfx::StandardCursor::None; }
 
     void clear() { m_editor = nullptr; }
     void setup(ImageEditor&);


### PR DESCRIPTION
This adds support for the Tools in PixelPaint to use different cursors within ImageEditor.
For now most of them get the crosshair cursor since it's the most fitting, but of course custom cursors are on the way :^)