### PR TITLE
Toolchain: Reduce Clang toolchain's disk usage

### DIFF
--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -392,6 +392,9 @@ pushd "$DIR/Build/clang/$ARCH"
     popd
 popd
 
+# === REMOVE UNNECESSARY BUILD ARTIFACTS ===
+rm -r "$PREFIX"/lib/libclang*.a "$PREFIX"/lib/libLLVM*.a "$PREFIX"/lib/liblld*.a
+
 # === SAVE TO CACHE ===
 pushd "$DIR"
     if [ "$TRY_USE_LOCAL_TOOLCHAIN" = "y" ]; then

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -259,6 +259,9 @@ pushd "$DIR/Build/clang/$ARCH"
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
             -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_LLVM_BUILD_LLVM_DYLIB=ON \
+            -DLLVM_LINK_LLVM_DYLIB=ON \
+            -DLLVM_INSTALL_UTILS=OFF \
             ${dev:+"-DLLVM_CCACHE_BUILD=ON"} || exit 1
 
         buildstep "llvm+clang/build" ninja -j "$MAKEJOBS" || exit 1


### PR DESCRIPTION
This PR switches our Clang toolchain to link against internal libraries dynamically and removes static libraries from the tar.

With this, the size of the compressed toolchain is under 80 MiB, so it might fit comfortably in the 5 GB artifact storage.

