### PR TITLE
LibGUI:  Move Action handling from WindowServerConnection to Widget

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -183,6 +183,7 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
             operation = Calculator::Operation::Percent;
             break;
         default:
+            event.ignore();
             return;
         }
 

--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -91,8 +91,9 @@ void EllipseTool::on_keydown(GUI::KeyEvent& event)
     if (event.key() == Key_Escape && m_drawing_button != GUI::MouseButton::None) {
         m_drawing_button = GUI::MouseButton::None;
         m_editor->update();
-        event.accept();
+        return;
     }
+    event.ignore();
 }
 
 GUI::Widget* EllipseTool::get_properties_widget()

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -260,6 +260,8 @@ void ImageEditor::keydown_event(GUI::KeyEvent& event)
 {
     if (m_active_tool)
         m_active_tool->on_keydown(event);
+    else
+        event.ignore();
 }
 
 void ImageEditor::keyup_event(GUI::KeyEvent& event)

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -96,8 +96,9 @@ void LineTool::on_keydown(GUI::KeyEvent& event)
     if (event.key() == Key_Escape && m_drawing_button != GUI::MouseButton::None) {
         m_drawing_button = GUI::MouseButton::None;
         m_editor->update();
-        event.accept();
+        return;
     }
+    event.ignore();
 }
 
 GUI::Widget* LineTool::get_properties_widget()

--- a/Userland/Applications/PixelPaint/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/MoveTool.cpp
@@ -53,12 +53,16 @@ void MoveTool::on_mouseup(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 
 void MoveTool::on_keydown(GUI::KeyEvent& event)
 {
-    if (event.modifiers() != 0)
+    if (event.modifiers() != 0) {
+        event.ignore();
         return;
+    }
 
     auto* layer = m_editor->active_layer();
-    if (!layer)
+    if (!layer) {
+        event.ignore();
         return;
+    }
 
     auto new_location = layer->location();
 
@@ -76,6 +80,7 @@ void MoveTool::on_keydown(GUI::KeyEvent& event)
         new_location.translate_by(1, 0);
         break;
     default:
+        event.ignore();
         return;
     }
 

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
@@ -107,10 +107,16 @@ void RectangleSelectTool::on_mouseup(Layer&, GUI::MouseEvent&, GUI::MouseEvent& 
 
 void RectangleSelectTool::on_keydown(GUI::KeyEvent& key_event)
 {
-    if (key_event.key() == KeyCode::Key_Space)
+    if (key_event.key() == KeyCode::Key_Space) {
         m_moving_mode = MovingMode::MovingOrigin;
-    else if (key_event.key() == KeyCode::Key_Control)
+        return;
+    }
+    if (key_event.key() == KeyCode::Key_Control) {
         m_moving_mode = MovingMode::AroundCenter;
+        return;
+    }
+
+    key_event.ignore();
 }
 
 void RectangleSelectTool::on_keyup(GUI::KeyEvent& key_event)

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -95,8 +95,9 @@ void RectangleTool::on_keydown(GUI::KeyEvent& event)
     if (event.key() == Key_Escape && m_drawing_button != GUI::MouseButton::None) {
         m_drawing_button = GUI::MouseButton::None;
         m_editor->update();
-        event.accept();
+        return;
     }
+    event.ignore();
 }
 
 GUI::Widget* RectangleTool::get_properties_widget()

--- a/Userland/Applications/PixelPaint/Tool.h
+++ b/Userland/Applications/PixelPaint/Tool.h
@@ -25,7 +25,7 @@ public:
     virtual void on_context_menu(Layer&, GUI::ContextMenuEvent&) { }
     virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) { }
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) { }
-    virtual void on_keydown(GUI::KeyEvent&) { }
+    virtual void on_keydown(GUI::KeyEvent& event) { event.ignore(); }
     virtual void on_keyup(GUI::KeyEvent&) { }
     virtual void on_tool_activation() { }
     virtual GUI::Widget* get_properties_widget() { return nullptr; }

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -219,8 +219,10 @@ void Game::update_score(int to_add)
 
 void Game::keydown_event(GUI::KeyEvent& event)
 {
-    if (m_new_game_animation || m_game_over_animation)
+    if (m_new_game_animation || m_game_over_animation) {
+        event.ignore();
         return;
+    }
 
     if (event.shift() && event.key() == KeyCode::Key_F12) {
         start_game_over_animation();
@@ -230,6 +232,8 @@ void Game::keydown_event(GUI::KeyEvent& event)
         draw_cards();
     } else if (event.shift() && event.key() == KeyCode::Key_F11) {
         dump_layout();
+    } else {
+        event.ignore();
     }
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -836,6 +836,7 @@ void TextEditor::keydown_event(KeyEvent& event)
     }
 
     if (event.key() == KeyCode::Key_Delete) {
+        do_delete();
         if (m_autocomplete_box)
             m_autocomplete_box->close();
         return;

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -324,6 +324,7 @@ protected:
     virtual void did_end_inspection() override;
 
     void show_or_hide_tooltip();
+    bool try_trigger_action(KeyEvent& event);
 
 private:
     void handle_paint_event(PaintEvent&);
@@ -336,6 +337,8 @@ private:
     void handle_leave_event(Core::Event&);
     void focus_previous_widget(FocusSource, bool siblings_only);
     void focus_next_widget(FocusSource, bool siblings_only);
+
+    Action* look_for_action(KeyEvent const& event);
 
     virtual bool load_from_json(const JsonObject&, RefPtr<Core::Object> (*unregistered_child_handler)(const String&)) override;
 

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -205,6 +205,9 @@ void TerminalWidget::event(Core::Event& event)
 
 void TerminalWidget::keydown_event(GUI::KeyEvent& event)
 {
+    if (try_trigger_action(event))
+        return;
+
     if (m_ptm_fd == -1) {
         event.ignore();
         return GUI::Frame::keydown_event(event);

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -236,6 +236,9 @@ void InProcessWebView::mousewheel_event(GUI::MouseEvent& event)
 
 void InProcessWebView::keydown_event(GUI::KeyEvent& event)
 {
+    if (try_trigger_action(event))
+        return;
+
     bool page_accepted_event = page().handle_keydown(event.key(), event.modifiers(), event.code_point());
 
     if (event.modifiers() == 0) {
@@ -272,8 +275,6 @@ void InProcessWebView::keydown_event(GUI::KeyEvent& event)
             break;
         }
     }
-
-    event.accept();
 }
 
 URL InProcessWebView::url() const

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -162,6 +162,9 @@ void OutOfProcessWebView::handle_resize()
 
 void OutOfProcessWebView::keydown_event(GUI::KeyEvent& event)
 {
+    if (try_trigger_action(event))
+        return;
+
     client().async_key_down(event.key(), event.modifiers(), event.code_point());
 }
 


### PR DESCRIPTION
This PR moves the Action execution handling from `WindowServerConnection` to `Widget`.
When a key event gets posted in the event loop it will bubble up through the hierarchy until it reaches the top Widget under Window. Only if the event is marked as ignored when it reaches the last widget it will search for a suitable Action.
This means that it's up to the widget to choose if it wants to accept the event and thereby not trigger any action, or mark the event as ignored to let possible actions be triggered.

This requires some adjustment in the widgets `keydown_event()` since we previously relied on the Action having precedence.

~~This allows a widget to disable actions with certain modifiers while the widget is focused. The main use is TextEditor which previously would miss Key & Shift+Key keypresses when an action used the respective keys as shortcuts.
Exceptions can be added for keys we always need to trigger actions, like F1 or Del.~~