### PR TITLE
LaunchServer: Do not provide file handlers for special files

### DIFF
--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -266,6 +266,9 @@ void Launcher::for_each_handler_for_path(const String& path, Function<bool(const
         return;
     }
 
+    if (!S_ISREG(st.st_mode) && !S_ISLNK(st.st_mode))
+        return;
+
     if ((st.st_mode & S_IFMT) == S_IFREG && (st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)))
         f(get_handler_for_executable(Handler::Type::Application, path));
 


### PR DESCRIPTION
With this change, LaunchServer will always return an empty list of file handlers for special files e.g. sockets and devices. Before this change, TextEditor was always returned as a default handler for these files.

The issue was mentioned in #3558, although it does not fix the issue itself.