### PR TITLE
LibJS: More this values fixes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -542,10 +542,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::to_locale_string)
             return {};
         if (value.is_nullish())
             continue;
-        auto* value_object = value.to_object(global_object);
-        if (!value_object)
-            return {};
-        auto locale_string_result = value_object->invoke(vm.names.toLocaleString);
+        auto locale_string_result = value.invoke(global_object, vm.names.toLocaleString);
         if (vm.exception())
             return {};
         auto string = locale_string_result.to_string(global_object);

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -846,18 +846,16 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_string)
 // 21.4.4.37 Date.prototype.toJSON ( key ), https://tc39.es/ecma262/#sec-date.prototype.tojson
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_json)
 {
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
+    auto this_value = vm.this_value(global_object);
 
-    auto time_value = Value(this_object).to_primitive(global_object, Value::PreferredType::Number);
+    auto time_value = this_value.to_primitive(global_object, Value::PreferredType::Number);
     if (vm.exception())
         return {};
 
     if (time_value.is_number() && !time_value.is_finite_number())
         return js_null();
 
-    return this_object->invoke(vm.names.toISOString);
+    return this_value.invoke(global_object, vm.names.toISOString);
 }
 
 // 14.1.1 Date.prototype.toTemporalInstant ( ), https://tc39.es/proposal-temporal/#sec-date.prototype.totemporalinstant

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -163,4 +163,16 @@ inline GlobalObject* Shape::global_object() const
 template<>
 inline bool Object::fast_is<GlobalObject>() const { return is_global_object(); }
 
+template<typename... Args>
+[[nodiscard]] ALWAYS_INLINE Value Value::invoke(GlobalObject& global_object, PropertyName const& property_name, Args... args)
+{
+    if constexpr (sizeof...(Args) > 0) {
+        MarkedValueList arglist { global_object.vm().heap() };
+        (..., arglist.append(move(args)));
+        return invoke_internal(global_object, property_name, move(arglist));
+    }
+
+    return invoke_internal(global_object, property_name, Optional<MarkedValueList> {});
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -1199,17 +1199,4 @@ Value Object::ordinary_to_primitive(Value::PreferredType preferred_type) const
     return {};
 }
 
-Value Object::invoke_internal(PropertyName const& property_name, Optional<MarkedValueList> arguments)
-{
-    auto& vm = this->vm();
-    auto property = get(property_name);
-    if (vm.exception())
-        return {};
-    if (!property.is_function()) {
-        vm.throw_exception<TypeError>(global_object(), ErrorType::NotAFunction, property.to_string_without_side_effects());
-        return {};
-    }
-    return vm.call(property.as_function(), this, move(arguments));
-}
-
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -150,20 +150,6 @@ public:
     IndexedProperties& indexed_properties() { return m_indexed_properties; }
     void set_indexed_property_elements(Vector<Value>&& values) { m_indexed_properties = IndexedProperties(move(values)); }
 
-    [[nodiscard]] Value invoke_internal(PropertyName const&, Optional<MarkedValueList> arguments);
-
-    template<typename... Args>
-    [[nodiscard]] ALWAYS_INLINE Value invoke(PropertyName const& property_name, Args... args)
-    {
-        if constexpr (sizeof...(Args) > 0) {
-            MarkedValueList arglist { heap() };
-            (..., arglist.append(move(args)));
-            return invoke(property_name, move(arglist));
-        }
-
-        return invoke(property_name);
-    }
-
     Shape& shape() { return *m_shape; }
     Shape const& shape() const { return *m_shape; }
 
@@ -200,14 +186,5 @@ private:
     Vector<Value> m_storage;
     IndexedProperties m_indexed_properties;
 };
-
-template<>
-[[nodiscard]] ALWAYS_INLINE Value Object::invoke(PropertyName const& property_name, MarkedValueList arguments) { return invoke_internal(property_name, move(arguments)); }
-
-template<>
-[[nodiscard]] ALWAYS_INLINE Value Object::invoke(PropertyName const& property_name, Optional<MarkedValueList> arguments) { return invoke_internal(property_name, move(arguments)); }
-
-template<>
-[[nodiscard]] ALWAYS_INLINE Value Object::invoke(PropertyName const& property_name) { return invoke(property_name, Optional<MarkedValueList> {}); }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -145,10 +145,8 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_string)
 // 20.1.3.5 Object.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-object.prototype.tolocalestring
 JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_locale_string)
 {
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    return this_object->invoke(vm.names.toString);
+    auto this_value = vm.this_value(global_object);
+    return this_value.invoke(global_object, vm.names.toString);
 }
 
 // 20.1.3.7 Object.prototype.valueOf ( ), https://tc39.es/ecma262/#sec-object.prototype.valueof

--- a/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/OrdinaryFunctionObject.cpp
@@ -132,6 +132,7 @@ FunctionEnvironment* OrdinaryFunctionObject::create_environment(FunctionObject& 
     auto* environment = heap().allocate<FunctionEnvironment>(global_object(), m_environment, variables);
     environment->set_function_object(function_being_invoked);
     if (m_is_arrow_function) {
+        environment->set_this_binding_status(FunctionEnvironment::ThisBindingStatus::Lexical);
         if (is<FunctionEnvironment>(m_environment))
             environment->set_new_target(static_cast<FunctionEnvironment*>(m_environment)->new_target());
     }

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -67,11 +67,9 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::then)
 // 27.2.5.1 Promise.prototype.catch ( onRejected ), https://tc39.es/ecma262/#sec-promise.prototype.catch
 JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::catch_)
 {
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
+    auto this_value = vm.this_value(global_object);
     auto on_rejected = vm.argument(0);
-    return this_object->invoke(vm.names.then, js_undefined(), on_rejected);
+    return this_value.invoke(global_object, vm.names.then, js_undefined(), on_rejected);
 }
 
 // 27.2.5.3 Promise.prototype.finally ( onFinally ), https://tc39.es/ecma262/#sec-promise.prototype.finally
@@ -104,7 +102,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
             auto* value_thunk = NativeFunction::create(global_object, "", [value](auto&, auto&) -> Value {
                 return value;
             });
-            return promise->invoke(vm.names.then, value_thunk);
+            return Value(promise).invoke(global_object, vm.names.then, value_thunk);
         });
         then_finally_function->define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
@@ -123,14 +121,14 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
                 vm.throw_exception(global_object, reason);
                 return {};
             });
-            return promise->invoke(vm.names.then, thrower);
+            return Value(promise).invoke(global_object, vm.names.then, thrower);
         });
         catch_finally_function->define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 
         then_finally = Value(then_finally_function);
         catch_finally = Value(catch_finally_function);
     }
-    return promise->invoke(vm.names.then, then_finally, catch_finally);
+    return Value(promise).invoke(global_object, vm.names.then, then_finally, catch_finally);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -878,7 +878,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match)
     auto rx = regexp_create(global_object, regexp, js_undefined());
     if (!rx)
         return {};
-    return rx->invoke(*vm.well_known_symbol_match(), js_string(vm, utf16_string_view));
+    return Value(rx).invoke(global_object, *vm.well_known_symbol_match(), js_string(vm, utf16_string_view));
 }
 
 // 22.1.3.12 String.prototype.matchAll ( regexp ), https://tc39.es/ecma262/#sec-string.prototype.matchall
@@ -921,7 +921,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match_all)
     auto rx = regexp_create(global_object, regexp, js_string(vm, "g"));
     if (!rx)
         return {};
-    return rx->invoke(*vm.well_known_symbol_match_all(), js_string(vm, utf16_string_view));
+    return Value(rx).invoke(global_object, *vm.well_known_symbol_match_all(), js_string(vm, utf16_string_view));
 }
 
 // 22.1.3.17 String.prototype.replace ( searchValue, replaceValue ), https://tc39.es/ecma262/#sec-string.prototype.replace
@@ -1119,7 +1119,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::search)
     auto rx = regexp_create(global_object, regexp, js_undefined());
     if (!rx)
         return {};
-    return rx->invoke(*vm.well_known_symbol_search(), js_string(vm, utf16_string_view));
+    return Value(rx).invoke(global_object, *vm.well_known_symbol_search(), js_string(vm, utf16_string_view));
 }
 
 // B.2.3.2.1 CreateHTML ( string, tag, attribute, value ), https://tc39.es/ecma262/#sec-createhtml

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -129,7 +129,7 @@ double calendar_year(GlobalObject& global_object, Object& calendar, Object& date
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Let result be ? Invoke(calendar, "year", « dateLike »).
-    auto result = calendar.invoke(vm.names.year, &date_like);
+    auto result = Value(&calendar).invoke(global_object, vm.names.year, &date_like);
     if (vm.exception())
         return {};
 
@@ -150,7 +150,7 @@ double calendar_month(GlobalObject& global_object, Object& calendar, Object& dat
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Let result be ? Invoke(calendar, "month", « dateLike »).
-    auto result = calendar.invoke(vm.names.month, &date_like);
+    auto result = Value(&calendar).invoke(global_object, vm.names.month, &date_like);
     if (vm.exception())
         return {};
 
@@ -171,7 +171,7 @@ String calendar_month_code(GlobalObject& global_object, Object& calendar, Object
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Let result be ? Invoke(calendar, "monthCode", « dateLike »).
-    auto result = calendar.invoke(vm.names.monthCode, &date_like);
+    auto result = Value(&calendar).invoke(global_object, vm.names.monthCode, &date_like);
     if (vm.exception())
         return {};
 
@@ -192,7 +192,7 @@ double calendar_day(GlobalObject& global_object, Object& calendar, Object& date_
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Let result be ? Invoke(calendar, "day", « dateLike »).
-    auto result = calendar.invoke(vm.names.day, &date_like);
+    auto result = Value(&calendar).invoke(global_object, vm.names.day, &date_like);
     if (vm.exception())
         return {};
 
@@ -213,7 +213,7 @@ Value calendar_day_of_week(GlobalObject& global_object, Object& calendar, Object
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "dayOfWeek", « dateLike »).
-    return calendar.invoke(vm.names.dayOfWeek, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.dayOfWeek, &date_like);
 }
 
 // 12.1.14 CalendarDayOfYear ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendardayofyear
@@ -223,7 +223,7 @@ Value calendar_day_of_year(GlobalObject& global_object, Object& calendar, Object
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "dayOfYear", « dateLike »).
-    return calendar.invoke(vm.names.dayOfYear, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.dayOfYear, &date_like);
 }
 
 // 12.1.15 CalendarWeekOfYear ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendarweekofyear
@@ -233,7 +233,7 @@ Value calendar_week_of_year(GlobalObject& global_object, Object& calendar, Objec
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "weekOfYear", « dateLike »).
-    return calendar.invoke(vm.names.weekOfYear, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.weekOfYear, &date_like);
 }
 
 // 12.1.16 CalendarDaysInWeek ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendardaysinweek
@@ -243,7 +243,7 @@ Value calendar_days_in_week(GlobalObject& global_object, Object& calendar, Objec
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "daysInWeek", « dateLike »).
-    return calendar.invoke(vm.names.daysInWeek, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.daysInWeek, &date_like);
 }
 
 // 12.1.17 CalendarDaysInMonth ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendardaysinmonth
@@ -253,7 +253,7 @@ Value calendar_days_in_month(GlobalObject& global_object, Object& calendar, Obje
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "daysInMonth", « dateLike »).
-    return calendar.invoke(vm.names.daysInMonth, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.daysInMonth, &date_like);
 }
 
 // 12.1.18 CalendarDaysInYear ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendardaysinyear
@@ -263,7 +263,7 @@ Value calendar_days_in_year(GlobalObject& global_object, Object& calendar, Objec
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "daysInYear", « dateLike »).
-    return calendar.invoke(vm.names.daysInYear, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.daysInYear, &date_like);
 }
 
 // 12.1.19 CalendarMonthsInYear ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthsinyear
@@ -273,7 +273,7 @@ Value calendar_months_in_year(GlobalObject& global_object, Object& calendar, Obj
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "monthsInYear", « dateLike »).
-    return calendar.invoke(vm.names.monthsInYear, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.monthsInYear, &date_like);
 }
 
 // 12.1.20 CalendarInLeapYear ( calendar, dateLike ), https://tc39.es/proposal-temporal/#sec-temporal-calendarinleapyear
@@ -283,7 +283,7 @@ Value calendar_in_leap_year(GlobalObject& global_object, Object& calendar, Objec
     // 1. Assert: Type(calendar) is Object.
 
     // 2. Return ? Invoke(calendar, "inLeapYear", « dateLike »).
-    return calendar.invoke(vm.names.inLeapYear, &date_like);
+    return Value(&calendar).invoke(global_object, vm.names.inLeapYear, &date_like);
 }
 
 // 12.1.21 ToTemporalCalendar ( temporalCalendarLike ), https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendar
@@ -396,7 +396,7 @@ PlainDate* date_from_fields(GlobalObject& global_object, Object& calendar, Objec
     // 2. Assert: Type(fields) is Object.
 
     // 3. Let date be ? Invoke(calendar, "dateFromFields", « fields, options »).
-    auto date = calendar.invoke(vm.names.dateFromFields, &fields, &options);
+    auto date = Value(&calendar).invoke(global_object, vm.names.dateFromFields, &fields, &options);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1521,10 +1521,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_locale_string)
             return {};
         if (value.is_nullish())
             continue;
-        auto* value_object = value.to_object(global_object);
-        if (!value_object)
-            return {};
-        auto locale_string_result = value_object->invoke(vm.names.toLocaleString);
+        auto locale_string_result = value.invoke(global_object, vm.names.toLocaleString);
         if (vm.exception())
             return {};
         auto string = locale_string_result.to_string(global_object);

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -290,8 +290,13 @@ public:
 
     bool operator==(Value const&) const;
 
+    template<typename... Args>
+    [[nodiscard]] ALWAYS_INLINE Value invoke(GlobalObject& global_object, PropertyName const& property_name, Args... args);
+
 private:
     Type m_type { Type::Empty };
+
+    [[nodiscard]] Value invoke_internal(GlobalObject& global_object, PropertyName const&, Optional<MarkedValueList> arguments);
 
     i32 to_i32_slow_case(GlobalObject&) const;
 

--- a/Userland/Libraries/LibJS/Tests/this-value-strict.js
+++ b/Userland/Libraries/LibJS/Tests/this-value-strict.js
@@ -1,0 +1,424 @@
+"use strict";
+
+// Note the globalThisValue and globalObject do not need to be the same.
+const globalThisValue = this;
+const globalObject = (0, eval)("this");
+
+// These tests are done in global state to ensure that is possible
+const globalArrow = () => {
+    expect(this).toBe(globalThisValue);
+    return this;
+};
+
+function globalFunction() {
+    expect(this).toBe(undefined);
+
+    expect(globalArrow()).toBe(globalThisValue);
+
+    const arrowInGlobalFunction = () => this;
+    expect(arrowInGlobalFunction()).toBe(undefined);
+
+    return arrowInGlobalFunction;
+}
+
+expect(globalArrow()).toBe(globalThisValue);
+expect(globalFunction()()).toBe(undefined);
+
+const arrowFromGlobalFunction = globalFunction();
+
+const customThisValue = {
+    isCustomThis: true,
+    variant: 0,
+};
+
+const otherCustomThisValue = {
+    isCustomThis: true,
+    variant: 1,
+};
+
+describe("describe with arrow function", () => {
+    expect(this).toBe(globalThisValue);
+
+    test("nested test with normal function should get global object", function () {
+        expect(this).toBe(undefined);
+    });
+
+    test("nested test with arrow function should get same this value as enclosing function", () => {
+        expect(this).toBe(globalThisValue);
+    });
+});
+
+describe("describe with normal function", function () {
+    expect(this).toBe(undefined);
+    test("nested test with normal function should get global object", function () {
+        expect(this).toBe(undefined);
+    });
+
+    test("nested test with arrow function should get same this value as enclosing function", () => {
+        expect(this).toBe(undefined);
+    });
+});
+
+describe("basic behavior", () => {
+    expect(this).toBe(globalThisValue);
+
+    expect(arrowFromGlobalFunction()).toBeUndefined();
+
+    expect(customThisValue).not.toBe(otherCustomThisValue);
+
+    test("binding arrow function does not influence this value", () => {
+        const boundGlobalArrow = globalArrow.bind({ shouldNotBeHere: true });
+
+        expect(boundGlobalArrow()).toBe(globalThisValue);
+    });
+
+    function functionInArrow() {
+        expect(arrowFromGlobalFunction()).toBeUndefined();
+        return this;
+    }
+
+    function functionWithArrow() {
+        expect(arrowFromGlobalFunction()).toBeUndefined();
+        return () => {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            return this;
+        };
+    }
+
+    function strictFunction() {
+        "use strict";
+        return this;
+    }
+
+    test("functions get globalObject as this value", () => {
+        expect(functionInArrow()).toBeUndefined();
+        expect(functionWithArrow()()).toBeUndefined();
+    });
+
+    test("strict functions get undefined as this value", () => {
+        expect(strictFunction()).toBeUndefined();
+    });
+
+    test("bound function gets overwritten this value", () => {
+        const boundFunction = functionInArrow.bind(customThisValue);
+        expect(boundFunction()).toBe(customThisValue);
+
+        const boundFunctionWithArrow = functionWithArrow.bind(customThisValue);
+        expect(boundFunctionWithArrow()()).toBe(customThisValue);
+
+        // However we cannot bind the arrow function itself
+        const failingArrowBound = boundFunctionWithArrow().bind(otherCustomThisValue);
+        expect(failingArrowBound()).toBe(customThisValue);
+
+        const boundStrictFunction = strictFunction.bind(customThisValue);
+        expect(boundStrictFunction()).toBe(customThisValue);
+    });
+});
+
+describe("functions on created objects", () => {
+    const obj = {
+        func: function () {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            return this;
+        },
+
+        funcWithArrow: function () {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            return () => this;
+        },
+
+        arrow: () => {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            return this;
+        },
+        otherProperty: "yes",
+    };
+
+    test("function get this value of associated object", () => {
+        expect(obj.func()).toBe(obj);
+    });
+
+    test("arrow function on object get above this value", () => {
+        expect(obj.arrow()).toBe(globalThisValue);
+    });
+
+    test("arrow function from normal function from object has object as this value", () => {
+        expect(obj.funcWithArrow()()).toBe(obj);
+    });
+
+    test("bound overwrites value of normal object function", () => {
+        const boundFunction = obj.func.bind(customThisValue);
+        expect(boundFunction()).toBe(customThisValue);
+
+        const boundFunctionWithArrow = obj.funcWithArrow.bind(customThisValue);
+        expect(boundFunctionWithArrow()()).toBe(customThisValue);
+
+        const boundArrowFunction = obj.arrow.bind(customThisValue);
+        expect(boundArrowFunction()).toBe(globalThisValue);
+    });
+
+    test("also works for object defined in function", () => {
+        (function () {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+
+            // It is bound below
+            expect(this).toBe(customThisValue);
+
+            const obj2 = {
+                func: function () {
+                    expect(arrowFromGlobalFunction()).toBeUndefined();
+                    return this;
+                },
+
+                arrow: () => {
+                    expect(arrowFromGlobalFunction()).toBeUndefined();
+                    return this;
+                },
+                otherProperty: "also",
+            };
+
+            expect(obj2.func()).toBe(obj2);
+            expect(obj2.arrow()).toBe(customThisValue);
+        }.bind(customThisValue)());
+    });
+});
+
+describe("behavior with classes", () => {
+    class Basic {
+        constructor(value) {
+            expect(this).toBeInstanceOf(Basic);
+            this.arrowFunctionInClass = () => {
+                return this;
+            };
+
+            this.value = value;
+
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+        }
+
+        func() {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            return this;
+        }
+    }
+
+    const basic = new Basic(14);
+    const basic2 = new Basic(457);
+
+    expect(basic).not.toBe(basic2);
+
+    test("calling functions on class should give instance as this value", () => {
+        expect(basic.func()).toBe(basic);
+        expect(basic2.func()).toBe(basic2);
+    });
+
+    test("calling arrow function created in constructor should give instance as this value", () => {
+        expect(basic.arrowFunctionInClass()).toBe(basic);
+        expect(basic2.arrowFunctionInClass()).toBe(basic2);
+    });
+
+    test("can bind function in class", () => {
+        const boundFunction = basic.func.bind(customThisValue);
+        expect(boundFunction()).toBe(customThisValue);
+
+        const boundFunction2 = basic2.func.bind(otherCustomThisValue);
+        expect(boundFunction2()).toBe(otherCustomThisValue);
+    });
+});
+
+describe("derived classes behavior", () => {
+    class Base {
+        baseFunction() {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+
+            return this;
+        }
+    }
+
+    class Derived extends Base {
+        constructor(value) {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            const arrowMadeBeforeSuper = () => {
+                expect(this).toBeInstanceOf(Derived);
+                return this;
+            };
+            super();
+            expect(arrowMadeBeforeSuper()).toBe(this);
+
+            this.arrowMadeBeforeSuper = arrowMadeBeforeSuper;
+            this.arrowMadeAfterSuper = () => {
+                expect(this).toBeInstanceOf(Derived);
+                return this;
+            };
+            this.value = value;
+        }
+
+        derivedFunction() {
+            expect(arrowFromGlobalFunction()).toBeUndefined();
+            return this;
+        }
+    }
+
+    test("can create derived with arrow functions using this before super", () => {
+        const testDerived = new Derived(-89);
+        expect(testDerived.arrowMadeBeforeSuper()).toBe(testDerived);
+        expect(testDerived.arrowMadeAfterSuper()).toBe(testDerived);
+    });
+
+    test("base and derived functions get correct this values", () => {
+        const derived = new Derived(12);
+
+        expect(derived.derivedFunction()).toBe(derived);
+        expect(derived.baseFunction()).toBe(derived);
+    });
+
+    test("can bind derived and base functions", () => {
+        const derived = new Derived(846);
+
+        const boundDerivedFunction = derived.derivedFunction.bind(customThisValue);
+        expect(boundDerivedFunction()).toBe(customThisValue);
+
+        const boundBaseFunction = derived.baseFunction.bind(otherCustomThisValue);
+        expect(boundBaseFunction()).toBe(otherCustomThisValue);
+    });
+});
+
+describe("proxy behavior", () => {
+    test("with no handler it makes no difference", () => {
+        const globalArrowProxyNoHandler = new Proxy(globalArrow, {});
+        expect(globalArrowProxyNoHandler()).toBe(globalThisValue);
+    });
+
+    test("proxy around global arrow still gives correct this value", () => {
+        let lastThisArg = null;
+
+        const handler = {
+            apply(target, thisArg, argArray) {
+                expect(target).toBe(globalArrow);
+                lastThisArg = thisArg;
+                expect(this).toBe(handler);
+
+                return target(...argArray);
+            },
+        };
+
+        const globalArrowProxy = new Proxy(globalArrow, handler);
+        expect(globalArrowProxy()).toBe(globalThisValue);
+        expect(lastThisArg).toBeUndefined();
+
+        const boundProxy = globalArrowProxy.bind(customThisValue);
+        expect(boundProxy()).toBe(globalThisValue);
+        expect(lastThisArg).toBe(customThisValue);
+
+        expect(globalArrowProxy.call(15)).toBe(globalThisValue);
+        expect(lastThisArg).toBe(15);
+    });
+});
+
+describe("derived classes which access this before super should fail", () => {
+    class Base {}
+
+    test("direct access of this should throw reference error", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                this.something = "this will fail";
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test("access of this via a arrow function", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                const arrow = () => this;
+                arrow();
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test("access of this via a eval", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                eval("this.foo = 'bar'");
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test.skip("access of this via a eval in arrow function", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                const arrow = () => eval("() => this")();
+                arrow();
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test("access of this via arrow function even if bound with something else", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                const arrow = () => this;
+                const boundArrow = arrow.bind(customThisValue);
+                boundArrow();
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+});
+
+describe("in strict mode primitive this values are not converted to objects", () => {
+    const array = [true, false];
+
+    // Technically the comma is implementation defined here. (Also for tests below.)
+    expect(array.toLocaleString()).toBe("true,false");
+
+    test("directly overwriting toString", () => {
+        let count = 0;
+        Boolean.prototype.toString = function () {
+            count++;
+            return typeof this;
+        };
+
+        expect(array.toLocaleString()).toBe("boolean,boolean");
+        expect(count).toBe(2);
+    });
+
+    test("overwriting toString with a getter", () => {
+        let count = 0;
+
+        Object.defineProperty(Boolean.prototype, "toString", {
+            get() {
+                count++;
+                const that = typeof this;
+                return function () {
+                    return that;
+                };
+            },
+        });
+
+        expect(array.toLocaleString()).toBe("boolean,boolean");
+        expect(count).toBe(2);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/this-value.js
+++ b/Userland/Libraries/LibJS/Tests/this-value.js
@@ -1,0 +1,446 @@
+// Note the globalThisValue and globalObject do not need to be the same.
+const globalThisValue = this;
+const globalObject = (0, eval)("this");
+
+// These tests are done in global state to ensure that is possible
+const globalArrow = () => {
+    expect(this).toBe(globalThisValue);
+    return this;
+};
+
+function globalFunction() {
+    expect(this).toBe(globalObject);
+
+    expect(globalArrow()).toBe(globalThisValue);
+
+    const arrowInGlobalFunction = () => this;
+    expect(arrowInGlobalFunction()).toBe(globalObject);
+
+    return arrowInGlobalFunction;
+}
+
+expect(globalArrow()).toBe(globalThisValue);
+expect(globalFunction()()).toBe(globalObject);
+
+const arrowFromGlobalFunction = globalFunction();
+
+const customThisValue = {
+    isCustomThis: true,
+    variant: 0,
+};
+
+const otherCustomThisValue = {
+    isCustomThis: true,
+    variant: 1,
+};
+
+describe("describe with arrow function", () => {
+    expect(this).toBe(globalThisValue);
+
+    test("nested test with normal function should get global object", function () {
+        expect(this).toBe(globalObject);
+    });
+
+    test("nested test with arrow function should get same this value as enclosing function", () => {
+        expect(this).toBe(globalThisValue);
+    });
+});
+
+describe("describe with normal function", function () {
+    expect(this).toBe(globalObject);
+    test("nested test with normal function should get global object", function () {
+        expect(this).toBe(globalObject);
+    });
+
+    test("nested test with arrow function should get same this value as enclosing function", () => {
+        expect(this).toBe(globalObject);
+    });
+});
+
+describe("basic behavior", () => {
+    expect(this).toBe(globalThisValue);
+
+    expect(arrowFromGlobalFunction()).toBe(globalObject);
+
+    expect(customThisValue).not.toBe(otherCustomThisValue);
+
+    test("binding arrow function does not influence this value", () => {
+        const boundGlobalArrow = globalArrow.bind({ shouldNotBeHere: true });
+
+        expect(boundGlobalArrow()).toBe(globalThisValue);
+    });
+
+    function functionInArrow() {
+        expect(arrowFromGlobalFunction()).toBe(globalObject);
+        return this;
+    }
+
+    function functionWithArrow() {
+        expect(arrowFromGlobalFunction()).toBe(globalObject);
+        return () => {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            return this;
+        };
+    }
+
+    function strictFunction() {
+        "use strict";
+        return this;
+    }
+
+    test("functions get globalObject as this value", () => {
+        expect(functionInArrow()).toBe(globalObject);
+        expect(functionWithArrow()()).toBe(globalObject);
+    });
+
+    test("strict functions get undefined as this value", () => {
+        expect(strictFunction()).toBeUndefined();
+    });
+
+    test("bound function gets overwritten this value", () => {
+        const boundFunction = functionInArrow.bind(customThisValue);
+        expect(boundFunction()).toBe(customThisValue);
+
+        const boundFunctionWithArrow = functionWithArrow.bind(customThisValue);
+        expect(boundFunctionWithArrow()()).toBe(customThisValue);
+
+        // However we cannot bind the arrow function itself
+        const failingArrowBound = boundFunctionWithArrow().bind(otherCustomThisValue);
+        expect(failingArrowBound()).toBe(customThisValue);
+
+        const boundStrictFunction = strictFunction.bind(customThisValue);
+        expect(boundStrictFunction()).toBe(customThisValue);
+    });
+});
+
+describe("functions on created objects", () => {
+    const obj = {
+        func: function () {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            return this;
+        },
+
+        funcWithArrow: function () {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            return () => this;
+        },
+
+        arrow: () => {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            return this;
+        },
+        otherProperty: "yes",
+    };
+
+    test("function get this value of associated object", () => {
+        expect(obj.func()).toBe(obj);
+    });
+
+    test("arrow function on object get above this value", () => {
+        expect(obj.arrow()).toBe(globalThisValue);
+    });
+
+    test("arrow function from normal function from object has object as this value", () => {
+        expect(obj.funcWithArrow()()).toBe(obj);
+    });
+
+    test("bound overwrites value of normal object function", () => {
+        const boundFunction = obj.func.bind(customThisValue);
+        expect(boundFunction()).toBe(customThisValue);
+
+        const boundFunctionWithArrow = obj.funcWithArrow.bind(customThisValue);
+        expect(boundFunctionWithArrow()()).toBe(customThisValue);
+
+        const boundArrowFunction = obj.arrow.bind(customThisValue);
+        expect(boundArrowFunction()).toBe(globalThisValue);
+    });
+
+    test("also works for object defined in function", () => {
+        (function () {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+
+            // It is bound below
+            expect(this).toBe(customThisValue);
+
+            const obj2 = {
+                func: function () {
+                    expect(arrowFromGlobalFunction()).toBe(globalObject);
+                    return this;
+                },
+
+                arrow: () => {
+                    expect(arrowFromGlobalFunction()).toBe(globalObject);
+                    return this;
+                },
+                otherProperty: "also",
+            };
+
+            expect(obj2.func()).toBe(obj2);
+            expect(obj2.arrow()).toBe(customThisValue);
+        }.bind(customThisValue)());
+    });
+});
+
+describe("behavior with classes", () => {
+    class Basic {
+        constructor(value) {
+            expect(this).toBeInstanceOf(Basic);
+            this.arrowFunctionInClass = () => {
+                return this;
+            };
+
+            this.value = value;
+
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+        }
+
+        func() {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            return this;
+        }
+    }
+
+    const basic = new Basic(14);
+    const basic2 = new Basic(457);
+
+    expect(basic).not.toBe(basic2);
+
+    test("calling functions on class should give instance as this value", () => {
+        expect(basic.func()).toBe(basic);
+        expect(basic2.func()).toBe(basic2);
+    });
+
+    test("calling arrow function created in constructor should give instance as this value", () => {
+        expect(basic.arrowFunctionInClass()).toBe(basic);
+        expect(basic2.arrowFunctionInClass()).toBe(basic2);
+    });
+
+    test("can bind function in class", () => {
+        const boundFunction = basic.func.bind(customThisValue);
+        expect(boundFunction()).toBe(customThisValue);
+
+        const boundFunction2 = basic2.func.bind(otherCustomThisValue);
+        expect(boundFunction2()).toBe(otherCustomThisValue);
+    });
+});
+
+describe("derived classes behavior", () => {
+    class Base {
+        baseFunction() {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+
+            return this;
+        }
+    }
+
+    class Derived extends Base {
+        constructor(value) {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            const arrowMadeBeforeSuper = () => {
+                expect(this).toBeInstanceOf(Derived);
+                return this;
+            };
+            super();
+            expect(arrowMadeBeforeSuper()).toBe(this);
+
+            this.arrowMadeBeforeSuper = arrowMadeBeforeSuper;
+            this.arrowMadeAfterSuper = () => {
+                expect(this).toBeInstanceOf(Derived);
+                return this;
+            };
+            this.value = value;
+        }
+
+        derivedFunction() {
+            expect(arrowFromGlobalFunction()).toBe(globalObject);
+            return this;
+        }
+    }
+
+    test("can create derived with arrow functions using this before super", () => {
+        const testDerived = new Derived(-89);
+        expect(testDerived.arrowMadeBeforeSuper()).toBe(testDerived);
+        expect(testDerived.arrowMadeAfterSuper()).toBe(testDerived);
+    });
+
+    test("base and derived functions get correct this values", () => {
+        const derived = new Derived(12);
+
+        expect(derived.derivedFunction()).toBe(derived);
+        expect(derived.baseFunction()).toBe(derived);
+    });
+
+    test("can bind derived and base functions", () => {
+        const derived = new Derived(846);
+
+        const boundDerivedFunction = derived.derivedFunction.bind(customThisValue);
+        expect(boundDerivedFunction()).toBe(customThisValue);
+
+        const boundBaseFunction = derived.baseFunction.bind(otherCustomThisValue);
+        expect(boundBaseFunction()).toBe(otherCustomThisValue);
+    });
+});
+
+describe("proxy behavior", () => {
+    test("with no handler it makes no difference", () => {
+        const globalArrowProxyNoHandler = new Proxy(globalArrow, {});
+        expect(globalArrowProxyNoHandler()).toBe(globalThisValue);
+    });
+
+    test("proxy around global arrow still gives correct this value", () => {
+        let lastThisArg = null;
+
+        const handler = {
+            apply(target, thisArg, argArray) {
+                expect(target).toBe(globalArrow);
+                lastThisArg = thisArg;
+                expect(this).toBe(handler);
+
+                return target(...argArray);
+            },
+        };
+
+        const globalArrowProxy = new Proxy(globalArrow, handler);
+        expect(globalArrowProxy()).toBe(globalThisValue);
+        expect(lastThisArg).toBeUndefined();
+
+        const boundProxy = globalArrowProxy.bind(customThisValue);
+        expect(boundProxy()).toBe(globalThisValue);
+        expect(lastThisArg).toBe(customThisValue);
+
+        expect(globalArrowProxy.call(15)).toBe(globalThisValue);
+        expect(lastThisArg).toBe(15);
+    });
+});
+
+describe("derived classes which access this before super should fail", () => {
+    class Base {}
+
+    test("direct access of this should throw reference error", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                this.something = "this will fail";
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test("access of this via a arrow function", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                const arrow = () => this;
+                arrow();
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test("access of this via a eval", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                eval("this.foo = 'bar'");
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test.skip("access of this via a eval in arrow function", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                const arrow = () => eval("() => this")();
+                arrow();
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+
+    test("access of this via arrow function even if bound with something else", () => {
+        class IncorrectConstructor extends Base {
+            constructor() {
+                const arrow = () => this;
+                const boundArrow = arrow.bind(customThisValue);
+                boundArrow();
+                super();
+            }
+        }
+
+        expect(() => {
+            new IncorrectConstructor();
+        }).toThrowWithMessage(ReferenceError, "|this| has not been initialized");
+    });
+});
+
+describe("with statements", () => {
+    test("this value is still the global object", () => {
+        const obj = { haveValue: true, hello: "friends" };
+        with (obj) {
+            expect(this).toBe(globalThisValue);
+            expect(hello).toBe("friends");
+        }
+    });
+
+    test("with gets this value form outer scope", () => {
+        const obj = { haveValue: true, hello: "friends" };
+
+        function callme() {
+            with (obj) {
+                expect(this).toBe(customThisValue);
+                expect(hello).toBe("friends");
+            }
+        }
+
+        const boundMe = callme.bind(customThisValue);
+        boundMe();
+    });
+});
+
+describe("in non strict mode primitive this values are converted to objects", () => {
+    const array = [true, false];
+
+    // Technically the comma is implementation defined here. (Also for tests below.)
+    expect(array.toLocaleString()).toBe("true,false");
+
+    test("directly overwriting toString", () => {
+        let count = 0;
+        Boolean.prototype.toString = function () {
+            count++;
+            return typeof this;
+        };
+
+        expect(array.toLocaleString()).toBe("object,object");
+        expect(count).toBe(2);
+    });
+
+    test("overwriting toString with a getter", () => {
+        let count = 0;
+
+        Object.defineProperty(Boolean.prototype, "toString", {
+            get() {
+                count++;
+                const that = typeof this;
+                return function () {
+                    return that;
+                };
+            },
+        });
+
+        expect(array.toLocaleString()).toBe("object,object");
+        expect(count).toBe(2);
+    });
+});


### PR DESCRIPTION
Browser is still working :heavy_check_mark: 
No regressions in test262 :heavy_check_mark: 
Added a large this value test :heavy_check_mark: 

Fixes #9024 and fixes #9025.

If there are still cases which are not covered (or not covered enough) in the test please let me know so we can add them.
I'm sure there are still some cases which are broken or should be handled differently.

Also on a personal note I now consider Array to be spec compliant! :tada: 
`test/built-ins/Array                                                             2799/2801  ( 99.93%) [ ✅ 2799  ❌ 1     💥️ 1     ]` which was my original goal when I started working on LibJS. The failures are one from generator functions the other from realm exceptions which I will ignore (although that is what I said about the this value failures...)