### PR TITLE
Ports: Compile ncurses as a shared library

### DIFF
--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -2,7 +2,7 @@
 port=ncurses
 version=6.2
 useconfigure=true
-configopts="--with-termlib --enable-pc-files --with-pkg-config=/usr/local/lib/pkgconfig --with-pkg-config-libdir=/usr/local/lib/pkgconfig --without-ada --enable-sigwinch"
+configopts="--with-termlib --enable-pc-files --with-pkg-config=/usr/local/lib/pkgconfig --with-pkg-config-libdir=/usr/local/lib/pkgconfig --without-ada --enable-sigwinch --with-shared"
 files="https://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz
 https://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz.sig ncurses-${version}.tar.gz.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"

--- a/Ports/ncurses/patches/fix-configure.patch
+++ b/Ports/ncurses/patches/fix-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 06f344f3e..240cd098b 100755
+--- a/configure
++++ b/configure
+@@ -5943,7 +5943,7 @@ echo "${ECHO_T}$cf_cv_ldflags_search_paths_first" >&6
+ 		fi
+ 		cf_cv_rm_so_locs=yes
+ 		;;
+-	(linux*|gnu*|k*bsd*-gnu)
++	(linux*|gnu*|k*bsd*-gnu|*serenity*)
+ 		if test "$DFT_LWR_MODEL" = "shared" && test -n "$LD_RPATH_OPT" ; then
+ 			LOCAL_LDFLAGS="${LD_RPATH_OPT}\$(LOCAL_LIBDIR)"
+ 			LOCAL_LDFLAGS2="$LOCAL_LDFLAGS"


### PR DESCRIPTION
This sets the `--with-shared` switch for the configure script so that ncurses is compiled as a shared library in addition the default which is a static library. Without the `--with-shared` switch ncurses will only be compiled as a static library.

To properly set the environment variables `LOCAL_LDFLAGS` and `LOCAL_LDFLAGS2`,  a case in the configure script had to be updated to include `*serenity*`.