### PR TITLE
LibELF: Fix pointer arithmetic UBSAN crash and clean up patch values

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -468,9 +468,9 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
         //     We could explicitly do them first using m_number_of_relocations from DT_RELCOUNT
         //     However, our compiler is nice enough to put them at the front of the relocations for us :)
         if (relocation.addend_used())
-            *patch_ptr = (FlatPtr)m_dynamic_object->base_address().as_ptr() + relocation.addend();
+            *patch_ptr = m_dynamic_object->base_address().offset(relocation.addend()).get();
         else
-            *patch_ptr += (FlatPtr)m_dynamic_object->base_address().as_ptr();
+            *patch_ptr += m_dynamic_object->base_address().get();
         break;
     }
 #if ARCH(I386)
@@ -508,10 +508,10 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(const ELF::DynamicO
             // The patch method returns the address for the LAZY fixup path, but we don't need it here
             m_dynamic_object->patch_plt_entry(relocation.offset_in_section());
         } else {
-            u8* relocation_address = relocation.address().as_ptr();
+            auto relocation_address = (FlatPtr*)relocation.address().as_ptr();
 
             if (m_elf_image.is_dynamic())
-                *(FlatPtr*)relocation_address += (FlatPtr)m_dynamic_object->base_address().as_ptr();
+                *relocation_address += m_dynamic_object->base_address().get();
         }
         break;
     }

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -321,7 +321,7 @@ void DynamicLoader::load_program_headers()
     for (auto& text_region : text_regions) {
         FlatPtr ph_text_desired_base = text_region.desired_load_address().get();
         FlatPtr ph_text_base = text_region.desired_load_address().page_base().get();
-        FlatPtr ph_text_end = ph_text_base + round_up_to_power_of_two(text_region.size_in_memory() + (size_t)(text_region.desired_load_address().as_ptr() - ph_text_base), PAGE_SIZE);
+        FlatPtr ph_text_end = ph_text_base + round_up_to_power_of_two(text_region.size_in_memory() + text_region.desired_load_address().get() - ph_text_base, PAGE_SIZE);
 
         // Now we can map the text segment at the reserved address.
         auto* text_segment_begin = (u8*)mmap_with_name(
@@ -355,7 +355,7 @@ void DynamicLoader::load_program_headers()
 
     for (auto& data_region : data_regions) {
         FlatPtr ph_data_base = data_region.desired_load_address().page_base().get();
-        FlatPtr ph_data_end = ph_data_base + round_up_to_power_of_two(data_region.size_in_memory() + (size_t)(data_region.desired_load_address().as_ptr() - ph_data_base), PAGE_SIZE);
+        FlatPtr ph_data_end = ph_data_base + round_up_to_power_of_two(data_region.size_in_memory() + data_region.desired_load_address().get() - ph_data_base, PAGE_SIZE);
 
         auto* data_segment_address = (u8*)reservation + ph_data_base - ph_load_base;
         size_t data_segment_size = ph_data_end - ph_data_base;

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -67,19 +67,19 @@ void DynamicObject::parse()
     for_each_dynamic_entry([&](const DynamicEntry& entry) {
         switch (entry.tag()) {
         case DT_INIT:
-            m_init_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_init_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_FINI:
-            m_fini_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_fini_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_INIT_ARRAY:
-            m_init_array_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_init_array_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_INIT_ARRAYSZ:
             m_init_array_size = entry.val();
             break;
         case DT_FINI_ARRAY:
-            m_fini_array_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_fini_array_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_FINI_ARRAYSZ:
             m_fini_array_size = entry.val();
@@ -87,18 +87,18 @@ void DynamicObject::parse()
         case DT_HASH:
             // Use SYSV hash only if GNU hash is not available
             if (m_hash_type == HashType::SYSV) {
-                m_hash_table_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+                m_hash_table_offset = entry.ptr() - m_elf_base_address.get();
             }
             break;
         case DT_GNU_HASH:
             m_hash_type = HashType::GNU;
-            m_hash_table_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_hash_table_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_SYMTAB:
-            m_symbol_table_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_symbol_table_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_STRTAB:
-            m_string_table_offset = entry.ptr() - (FlatPtr)m_elf_base_address.as_ptr();
+            m_string_table_offset = entry.ptr() - m_elf_base_address.get();
             break;
         case DT_STRSZ:
             m_size_of_string_table = entry.val();
@@ -457,7 +457,7 @@ VirtualAddress DynamicObject::patch_plt_entry(u32 relocation_offset)
     VERIFY(relocation.type() == R_X86_64_JUMP_SLOT);
 #endif
     auto symbol = relocation.symbol();
-    u8* relocation_address = relocation.address().as_ptr();
+    auto relocation_address = (FlatPtr*)relocation.address().as_ptr();
 
     VirtualAddress symbol_location;
     auto result = DynamicLoader::lookup_symbol(symbol);
@@ -470,7 +470,7 @@ VirtualAddress DynamicObject::patch_plt_entry(u32 relocation_offset)
 
     dbgln_if(DYNAMIC_LOAD_DEBUG, "DynamicLoader: Jump slot relocation: putting {} ({}) into PLT at {}", symbol.name(), symbol_location, (void*)relocation_address);
 
-    *(FlatPtr*)relocation_address = symbol_location.get();
+    *relocation_address = symbol_location.get();
 
     return symbol_location;
 }


### PR DESCRIPTION
### LibELF: Fix 'applying offset produced null pointer' UBSAN failure 
These integer => pointer => integer conversions were technically prone to UB, since they were used as offsets (which are perfectly fine to be zero), but we calculated them with pointer arithmetic. This made Clang insert pointer overflow UBSAN checks, which trigger in case of a zero result.

### LibELF: Remove `(FlatPtr)something.as_ptr()` idiom 
his is equivalent to `something.get()`, but more verbose.