### PR TITLE
AudioApplet: Read and save showing the audio volume to the config file

### DIFF
--- a/Base/home/anon/.config/AudioApplet.ini
+++ b/Base/home/anon/.config/AudioApplet.ini
@@ -1,0 +1,2 @@
+[Layout]
+ShowPercent=0


### PR DESCRIPTION
The 'Show percent' checkbox will now remember its value after reboots.