### PR TITLE
UserspaceEmulator+LibC: Add support for Region-of-Interest profiling

### DIFF
--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -86,6 +86,8 @@ String ProfileModel::column_name(int column) const
         return "Object";
     case Column::StackFrame:
         return "Stack Frame";
+    case Column::SymbolAddress:
+        return "Symbol Address";
     default:
         VERIFY_NOT_REACHED();
         return {};
@@ -129,6 +131,14 @@ GUI::Variant ProfileModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
                 return String::formatted("{} ({})", node->process().basename, node->process().pid);
             }
             return node->symbol();
+        }
+        if (index.column() == Column::SymbolAddress) {
+            if (node->is_root())
+                return "";
+            auto library = node->process().library_metadata.library_containing(node->address());
+            if (!library)
+                return "";
+            return String::formatted("{:p} (offset {:p})", node->address(), node->address() - library->base);
         }
         return {};
     }

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -24,6 +24,7 @@ public:
         SelfCount,
         ObjectName,
         StackFrame,
+        SymbolAddress,
         __Count
     };
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -30,6 +30,7 @@
 extern bool g_dump_profile;
 extern unsigned g_profile_instruction_interval;
 extern Optional<OutputFileStream> g_profile_stream;
+extern bool g_in_region_of_interest;
 
 namespace UserspaceEmulator {
 
@@ -473,6 +474,8 @@ void Emulator::dump_backtrace()
 
 void Emulator::emit_profile_sample(AK::OutputStream& output)
 {
+    if (!g_in_region_of_interest)
+        return;
     StringBuilder builder;
     timeval tv {};
     gettimeofday(&tv, nullptr);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -12,6 +12,7 @@
 #include "Report.h"
 #include "SoftCPU.h"
 #include "SoftMMU.h"
+#include <AK/FileStream.h>
 #include <AK/MappedFile.h>
 #include <AK/Types.h>
 #include <LibDebug/DebugInfo.h>
@@ -31,6 +32,23 @@ public:
     static Emulator& the();
 
     Emulator(String const& executable_path, Vector<String> const& arguments, Vector<String> const& environment);
+
+    void set_profiling_details(bool should_dump_profile, size_t instruction_interval, OutputFileStream* profile_stream)
+    {
+        m_is_profiling = should_dump_profile;
+        m_profile_instruction_interval = instruction_interval;
+        m_profile_stream = profile_stream;
+    }
+
+    void set_in_region_of_interest(bool value)
+    {
+        m_is_in_region_of_interest = value;
+    }
+
+    OutputFileStream& profile_stream() { return *m_profile_stream; }
+    bool is_profiling() const { return m_is_profiling; }
+    bool is_in_region_of_interest() const { return m_is_in_region_of_interest; }
+    size_t profile_instruction_interval() const { return m_profile_instruction_interval; }
 
     bool load_elf();
     void dump_backtrace();
@@ -271,6 +289,11 @@ private:
     HashMap<String, CachedELF> m_dynamic_library_cache;
 
     RangeAllocator m_range_allocator;
+
+    OutputFileStream* m_profile_stream { nullptr };
+    bool m_is_profiling { false };
+    size_t m_profile_instruction_interval { 0 };
+    bool m_is_in_region_of_interest { false };
 };
 
 ALWAYS_INLINE bool Emulator::is_in_libc() const

--- a/Userland/DevTools/UserspaceEmulator/EmulatorControl.h
+++ b/Userland/DevTools/UserspaceEmulator/EmulatorControl.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/StdLibExtras.h>
+#include <serenity.h>
+
+namespace UserspaceEmulator {
+
+enum class Command {
+    MarkROIStart = 5,
+    MarkROIEnd = 6,
+};
+
+inline void control(Command command)
+{
+    emuctl(to_underlying(command), 0, 0);
+}
+
+}

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -30,6 +30,7 @@
 
 extern bool g_dump_profile;
 extern Optional<OutputFileStream> g_profile_stream;
+extern bool g_in_region_of_interest;
 
 namespace UserspaceEmulator {
 
@@ -1118,7 +1119,7 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
 int Emulator::virt$emuctl(FlatPtr arg1, FlatPtr arg2, FlatPtr arg3)
 {
     auto* tracer = malloc_tracer();
-    if (!tracer)
+    if (arg1 <= 4 && !tracer)
         return 0;
     switch (arg1) {
     case 1:
@@ -1132,6 +1133,14 @@ int Emulator::virt$emuctl(FlatPtr arg1, FlatPtr arg2, FlatPtr arg3)
         return 0;
     case 4:
         tracer->target_did_change_chunk_size({}, arg3, arg2);
+        return 0;
+    case 5: // mark ROI start
+        if (g_in_region_of_interest)
+            return -EINVAL;
+        g_in_region_of_interest = true;
+        return 0;
+    case 6: // mark ROI end
+        g_in_region_of_interest = false;
         return 0;
     default:
         return -EINVAL;

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -18,6 +18,7 @@
 #include <string.h>
 
 bool g_report_to_debug = false;
+bool g_in_region_of_interest = true;
 bool g_dump_profile = false;
 unsigned g_profile_instruction_interval = 0;
 Optional<OutputFileStream> g_profile_stream;
@@ -28,6 +29,7 @@ int main(int argc, char** argv, char** env)
     bool pause_on_startup { false };
     String profile_dump_path;
     FILE* profile_output_file { nullptr };
+    bool enable_roi_mode { false };
 
     Core::ArgsParser parser;
     parser.set_stop_on_first_non_option(true);
@@ -36,6 +38,7 @@ int main(int argc, char** argv, char** env)
     parser.add_option(g_dump_profile, "Generate a ProfileViewer-compatible profile", "profile", 0);
     parser.add_option(g_profile_instruction_interval, "Set the profile instruction capture interval, 128 by default", "profile-interval", 'i', "#instructions");
     parser.add_option(profile_dump_path, "File path for profile dump", "profile-file", 0, "path");
+    parser.add_option(enable_roi_mode, "Enable Region-of-Interest mode for profiling", "roi", 0);
 
     parser.add_positional_argument(arguments, "Command to emulate", "command");
 
@@ -43,6 +46,9 @@ int main(int argc, char** argv, char** env)
 
     if (g_dump_profile && g_profile_instruction_interval == 0)
         g_profile_instruction_interval = 128;
+
+    if (enable_roi_mode)
+        g_in_region_of_interest = false;
 
     String executable_path;
     if (arguments[0].contains("/"sv))

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -151,4 +151,9 @@ u16 internet_checksum(const void* ptr, size_t count)
         checksum = (checksum & 0xffff) + (checksum >> 16);
     return htons(~checksum);
 }
+
+int emuctl(uintptr_t command, uintptr_t arg0, uintptr_t arg1)
+{
+    return syscall(SC_emuctl, command, arg0, arg1);
+}
 }

--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -129,4 +129,6 @@ int setkeymap(const char* name, const uint32_t* map, uint32_t* const shift_map, 
 
 uint16_t internet_checksum(const void* ptr, size_t count);
 
+int emuctl(uintptr_t command, uintptr_t arg0, uintptr_t arg1);
+
 __END_DECLS


### PR DESCRIPTION
A chunk of #9278, as this is not really related to the main changes in that PR (as that will be a draft for some time).

Quick crash course of UE RoI profiling:
- `#include <DevTools/UserspaceEmulator/EmulatorControl.h>`
- Insert `UserspaceEmulator::control(UserspaceEmulator::Command::MarkROIStart)` at the start of the region you wish to profile
- Insert `UserspaceEmulator::control(UserspaceEmulator::Command::MarkROIEnd)` at the end of the region you wish to profile
- Run with `ue --profile --roi --profile-file ~/whatever.profile -- whatever`

Note that the generated binary can still be run outside UE, as the `emuctl` syscall used by this mechanism is ignored by the kernel.