### PR TITLE
AK+LibJS: Reduce memory usage with large strings and arguments lists

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -12,6 +12,7 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
+#include <AK/Utf16View.h>
 #include <AK/Utf32View.h>
 
 namespace AK {
@@ -109,6 +110,16 @@ void StringBuilder::append_code_point(u32 code_point)
         append(0xef);
         append(0xbf);
         append(0xbd);
+    }
+}
+
+void StringBuilder::append(Utf16View const& utf16_view)
+{
+    for (size_t i = 0; i < utf16_view.length_in_code_units();) {
+        auto code_point = utf16_view.code_point_at(i);
+        append_code_point(code_point);
+
+        i += (code_point > 0xffff ? 2 : 1);
     }
 }
 

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -35,7 +35,7 @@ StringBuilder::StringBuilder(size_t initial_capacity)
     m_buffer.ensure_capacity(initial_capacity);
 }
 
-void StringBuilder::append(const StringView& str)
+void StringBuilder::append(StringView const& str)
 {
     if (str.is_empty())
         return;
@@ -43,7 +43,7 @@ void StringBuilder::append(const StringView& str)
     m_buffer.append(str.characters_without_null_termination(), str.length());
 }
 
-void StringBuilder::append(const char* characters, size_t length)
+void StringBuilder::append(char const* characters, size_t length)
 {
     append(StringView { characters, length });
 }
@@ -54,7 +54,7 @@ void StringBuilder::append(char ch)
     m_buffer.append(&ch, 1);
 }
 
-void StringBuilder::appendvf(const char* fmt, va_list ap)
+void StringBuilder::appendvf(char const* fmt, va_list ap)
 {
     printf_internal([this](char*&, char ch) {
         append(ch);
@@ -71,7 +71,7 @@ String StringBuilder::to_string() const
 {
     if (is_empty())
         return String::empty();
-    return String((const char*)data(), length());
+    return String((char const*)data(), length());
 }
 
 String StringBuilder::build() const
@@ -112,7 +112,7 @@ void StringBuilder::append_code_point(u32 code_point)
     }
 }
 
-void StringBuilder::append(const Utf32View& utf32_view)
+void StringBuilder::append(Utf32View const& utf32_view)
 {
     for (size_t i = 0; i < utf32_view.length(); ++i) {
         auto code_point = utf32_view.code_points()[i];
@@ -128,7 +128,7 @@ void StringBuilder::append_as_lowercase(char ch)
         append(ch);
 }
 
-void StringBuilder::append_escaped_for_json(const StringView& string)
+void StringBuilder::append_escaped_for_json(StringView const& string)
 {
     for (auto ch : string) {
         switch (ch) {

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -21,18 +21,18 @@ public:
     explicit StringBuilder(size_t initial_capacity = inline_capacity);
     ~StringBuilder() = default;
 
-    void append(const StringView&);
-    void append(const Utf32View&);
+    void append(StringView const&);
+    void append(Utf32View const&);
     void append(char);
     void append_code_point(u32);
-    void append(const char*, size_t);
-    void appendvf(const char*, va_list);
+    void append(char const*, size_t);
+    void appendvf(char const*, va_list);
 
     void append_as_lowercase(char);
-    void append_escaped_for_json(const StringView&);
+    void append_escaped_for_json(StringView const&);
 
     template<typename... Parameters>
-    void appendff(CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters)
+    void appendff(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
         vformat(*this, fmtstr.view(), VariadicFormatParams { parameters... });
     }
@@ -49,7 +49,7 @@ public:
     void trim(size_t count) { m_buffer.resize(m_buffer.size() - count); }
 
     template<class SeparatorType, class CollectionType>
-    void join(const SeparatorType& separator, const CollectionType& collection)
+    void join(SeparatorType const& separator, CollectionType const& collection)
     {
         bool first = true;
         for (auto& item : collection) {
@@ -64,7 +64,7 @@ public:
 private:
     void will_append(size_t);
     u8* data() { return m_buffer.data(); }
-    const u8* data() const { return m_buffer.data(); }
+    u8 const* data() const { return m_buffer.data(); }
 
     static constexpr size_t inline_capacity = 128;
     AK::Detail::ByteBuffer<inline_capacity> m_buffer;

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -22,6 +22,7 @@ public:
     ~StringBuilder() = default;
 
     void append(StringView const&);
+    void append(Utf16View const&);
     void append(Utf32View const&);
     void append(char);
     void append_code_point(u32);

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
@@ -119,5 +120,13 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<AK::Utf16View> : Formatter<FormatString> {
+    void format(FormatBuilder& builder, AK::Utf16View const& value)
+    {
+        return builder.builder().append(value);
+    }
+};
 
 using AK::Utf16View;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -312,6 +312,8 @@ set(AK_SOURCES
     ../AK/Time.cpp
     ../AK/Format.cpp
     ../AK/UUID.cpp
+    ../AK/Utf8View.cpp
+    ../AK/Utf16View.cpp
 )
 
 set(ELF_SOURCES

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -44,7 +44,7 @@ Value Interpreter::run(Executable const& executable, BasicBlock const* entry_poi
 
     vm().set_last_value(Badge<Interpreter> {}, {});
 
-    ExecutionContext execution_context;
+    ExecutionContext execution_context(vm().heap());
     if (vm().execution_context_stack().is_empty()) {
         execution_context.this_value = &global_object();
         static FlyString global_execution_context_name = "(*BC* global execution context)";

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -157,6 +157,7 @@ set(SOURCES
     Runtime/TypedArray.cpp
     Runtime/TypedArrayConstructor.cpp
     Runtime/TypedArrayPrototype.cpp
+    Runtime/Utf16String.cpp
     Runtime/Value.cpp
     Runtime/VM.cpp
     Runtime/WeakContainer.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -169,6 +169,7 @@ class Statement;
 class StringOrSymbol;
 class Symbol;
 class Token;
+class Utf16String;
 class VM;
 class Value;
 class WeakContainer;

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -45,7 +45,7 @@ void Interpreter::run(GlobalObject& global_object, const Program& program)
 
     vm.set_last_value(Badge<Interpreter> {}, {});
 
-    ExecutionContext execution_context;
+    ExecutionContext execution_context(heap());
     execution_context.current_node = &program;
     execution_context.this_value = &global_object;
     static FlyString global_execution_context_name = "(global execution context)";

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -595,17 +595,17 @@ String get_substitution(GlobalObject& global_object, Utf16View const& matched, U
             result.append('$');
             ++i;
         } else if (next == '&') {
-            result.append(matched.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
+            result.append(matched);
             ++i;
         } else if (next == '`') {
             auto substring = str.substring_view(0, position);
-            result.append(substring.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
+            result.append(substring);
             ++i;
         } else if (next == '\'') {
             auto tail_pos = position + matched.length_in_code_units();
             if (tail_pos < str.length_in_code_units()) {
                 auto substring = str.substring_view(tail_pos);
-                result.append(substring.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
+                result.append(substring);
             }
             ++i;
         } else if (is_ascii_digit(next)) {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -29,6 +29,7 @@
 #include <LibJS/Runtime/PropertyName.h>
 #include <LibJS/Runtime/ProxyObject.h>
 #include <LibJS/Runtime/Reference.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 
@@ -576,7 +577,7 @@ String get_substitution(GlobalObject& global_object, Utf16View const& matched, U
     auto replace_string = replacement.to_utf16_string(global_object);
     if (vm.exception())
         return {};
-    Utf16View replace_view { replace_string };
+    auto replace_view = replace_string.view();
 
     StringBuilder result;
 

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -17,7 +17,7 @@ PrimitiveString::PrimitiveString(String string)
 {
 }
 
-PrimitiveString::PrimitiveString(Vector<u16> string)
+PrimitiveString::PrimitiveString(Utf16String string)
     : m_utf16_string(move(string))
     , m_has_utf16_string(true)
 {
@@ -30,16 +30,16 @@ PrimitiveString::~PrimitiveString()
 String const& PrimitiveString::string() const
 {
     if (!m_has_utf8_string) {
-        m_utf8_string = utf16_string_view().to_utf8(Utf16View::AllowInvalidCodeUnits::Yes);
+        m_utf8_string = m_utf16_string.to_utf8();
         m_has_utf8_string = true;
     }
     return m_utf8_string;
 }
 
-Vector<u16> const& PrimitiveString::utf16_string() const
+Utf16String const& PrimitiveString::utf16_string() const
 {
     if (!m_has_utf16_string) {
-        m_utf16_string = AK::utf8_to_utf16(m_utf8_string);
+        m_utf16_string = Utf16String(m_utf8_string);
         m_has_utf16_string = true;
     }
     return m_utf16_string;
@@ -47,24 +47,12 @@ Vector<u16> const& PrimitiveString::utf16_string() const
 
 Utf16View PrimitiveString::utf16_string_view() const
 {
-    return Utf16View { utf16_string() };
+    return utf16_string().view();
 }
 
 PrimitiveString* js_string(Heap& heap, Utf16View const& view)
 {
-    if (view.is_empty())
-        return &heap.vm().empty_string();
-
-    if (view.length_in_code_units() == 1) {
-        u16 code_unit = view.code_unit_at(0);
-        if (is_ascii(code_unit))
-            return &heap.vm().single_ascii_character_string(static_cast<u8>(code_unit));
-    }
-
-    Vector<u16> string;
-    string.ensure_capacity(view.length_in_code_units());
-    string.append(view.data(), view.length_in_code_units());
-    return js_string(heap, move(string));
+    return js_string(heap, Utf16String(view));
 }
 
 PrimitiveString* js_string(VM& vm, Utf16View const& view)
@@ -72,13 +60,13 @@ PrimitiveString* js_string(VM& vm, Utf16View const& view)
     return js_string(vm.heap(), view);
 }
 
-PrimitiveString* js_string(Heap& heap, Vector<u16> string)
+PrimitiveString* js_string(Heap& heap, Utf16String string)
 {
     if (string.is_empty())
         return &heap.vm().empty_string();
 
-    if (string.size() == 1) {
-        u16 code_unit = string.at(0);
+    if (string.length_in_code_units() == 1) {
+        u16 code_unit = string.code_unit_at(0);
         if (is_ascii(code_unit))
             return &heap.vm().single_ascii_character_string(static_cast<u8>(code_unit));
     }
@@ -86,7 +74,7 @@ PrimitiveString* js_string(Heap& heap, Vector<u16> string)
     return heap.allocate_without_global_object<PrimitiveString>(move(string));
 }
 
-PrimitiveString* js_string(VM& vm, Vector<u16> string)
+PrimitiveString* js_string(VM& vm, Utf16String string)
 {
     return js_string(vm.heap(), move(string));
 }

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -7,15 +7,15 @@
 #pragma once
 
 #include <AK/String.h>
-#include <AK/Vector.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 
 class PrimitiveString final : public Cell {
 public:
     explicit PrimitiveString(String);
-    explicit PrimitiveString(Vector<u16>);
+    explicit PrimitiveString(Utf16String);
     virtual ~PrimitiveString();
 
     PrimitiveString(PrimitiveString const&) = delete;
@@ -23,7 +23,7 @@ public:
 
     String const& string() const;
 
-    Vector<u16> const& utf16_string() const;
+    Utf16String const& utf16_string() const;
     Utf16View utf16_string_view() const;
 
 private:
@@ -32,15 +32,15 @@ private:
     mutable String m_utf8_string;
     mutable bool m_has_utf8_string { false };
 
-    mutable Vector<u16> m_utf16_string;
+    mutable Utf16String m_utf16_string;
     mutable bool m_has_utf16_string { false };
 };
 
 PrimitiveString* js_string(Heap&, Utf16View const&);
 PrimitiveString* js_string(VM&, Utf16View const&);
 
-PrimitiveString* js_string(Heap&, Vector<u16>);
-PrimitiveString* js_string(VM&, Vector<u16>);
+PrimitiveString* js_string(Heap&, Utf16String);
+PrimitiveString* js_string(VM&, Utf16String);
 
 PrimitiveString* js_string(Heap&, String);
 PrimitiveString* js_string(VM&, String);

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -22,9 +22,11 @@ public:
     PrimitiveString& operator=(PrimitiveString const&) = delete;
 
     String const& string() const;
+    bool has_utf8_string() const { return m_has_utf8_string; }
 
     Utf16String const& utf16_string() const;
     Utf16View utf16_string_view() const;
+    bool has_utf16_string() const { return m_has_utf16_string; }
 
 private:
     virtual const char* class_name() const override { return "PrimitiveString"; }

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -7,10 +7,11 @@
 #pragma once
 
 #include <LibJS/Runtime/RegExpObject.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 
-Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Utf16View const& string);
+Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Utf16String string);
 size_t advance_string_index(Utf16View const& string, size_t index, bool unicode);
 
 class RegExpPrototype final : public Object {

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -10,12 +10,12 @@
 namespace JS {
 
 // 22.2.7.1 CreateRegExpStringIterator ( R, S, global, fullUnicode ), https://tc39.es/ecma262/#sec-createregexpstringiterator
-RegExpStringIterator* RegExpStringIterator::create(GlobalObject& global_object, Object& regexp_object, Vector<u16> string, bool global, bool unicode)
+RegExpStringIterator* RegExpStringIterator::create(GlobalObject& global_object, Object& regexp_object, Utf16String string, bool global, bool unicode)
 {
     return global_object.heap().allocate<RegExpStringIterator>(global_object, *global_object.regexp_string_iterator_prototype(), regexp_object, move(string), global, unicode);
 }
 
-RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, Vector<u16> string, bool global, bool unicode)
+RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode)
     : Object(prototype)
     , m_regexp_object(regexp_object)
     , m_string(move(string))

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -8,6 +8,7 @@
 
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 
@@ -15,13 +16,13 @@ class RegExpStringIterator final : public Object {
     JS_OBJECT(RegExpStringIterator, Object);
 
 public:
-    static RegExpStringIterator* create(GlobalObject&, Object& regexp_object, Vector<u16> string, bool global, bool unicode);
+    static RegExpStringIterator* create(GlobalObject&, Object& regexp_object, Utf16String string, bool global, bool unicode);
 
-    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, Vector<u16> string, bool global, bool unicode);
+    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode);
     virtual ~RegExpStringIterator() override = default;
 
     Object& regexp_object() { return m_regexp_object; }
-    Utf16View string() const { return Utf16View { m_string }; }
+    Utf16View string() const { return m_string.view(); }
     bool global() const { return m_global; }
     bool unicode() const { return m_unicode; }
 
@@ -32,7 +33,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     Object& m_regexp_object;
-    Vector<u16> m_string;
+    Utf16String m_string;
     bool m_global { false };
     bool m_unicode { false };
     bool m_done { false };

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -22,7 +22,7 @@ public:
     virtual ~RegExpStringIterator() override = default;
 
     Object& regexp_object() { return m_regexp_object; }
-    Utf16View string() const { return m_string.view(); }
+    Utf16String string() const { return m_string; }
     bool global() const { return m_global; }
     bool unicode() const { return m_unicode; }
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -76,7 +76,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpStringIteratorPrototype::next)
         if (vm.exception())
             return {};
 
-        last_index = advance_string_index(iterator.string(), last_index, iterator.unicode());
+        last_index = advance_string_index(iterator.string().view(), last_index, iterator.unicode());
 
         iterator.regexp_object().set(vm.names.lastIndex, Value(last_index), Object::ShouldThrowExceptions::Yes);
         if (vm.exception())

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/RegExpPrototype.h>
 #include <LibJS/Runtime/RegExpStringIterator.h>
 #include <LibJS/Runtime/RegExpStringIteratorPrototype.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -13,6 +13,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/StringConstructor.h>
 #include <LibJS/Runtime/StringObject.h>
+#include <LibJS/Runtime/Utf16String.h>
 
 namespace JS {
 
@@ -135,7 +136,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_char_code)
         string.append(code_unit);
     }
 
-    return js_string(vm, move(string));
+    return js_string(vm, Utf16String(move(string)));
 }
 
 // 22.1.2.2 String.fromCodePoint ( ...codePoints ), https://tc39.es/ecma262/#sec-string.fromcodepoint
@@ -161,7 +162,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::from_code_point)
         AK::code_point_to_utf16(string, static_cast<u32>(code_point));
     }
 
-    return js_string(vm, move(string));
+    return js_string(vm, Utf16String(move(string)));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringView.h>
+#include <AK/Utf16View.h>
+#include <LibJS/Runtime/Utf16String.h>
+
+namespace JS {
+namespace Detail {
+
+static NonnullRefPtr<Utf16StringImpl> the_empty_utf16_string()
+{
+    static NonnullRefPtr<Utf16StringImpl> empty_string = Utf16StringImpl::create();
+    return empty_string;
+}
+
+Utf16StringImpl::Utf16StringImpl(Vector<u16> string)
+    : m_string(move(string))
+{
+}
+
+NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create()
+{
+    return adopt_ref(*new Utf16StringImpl());
+}
+
+NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Vector<u16> string)
+{
+    return adopt_ref(*new Utf16StringImpl(move(string)));
+}
+
+NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(StringView const& string)
+{
+    return create(AK::utf8_to_utf16(string));
+}
+
+NonnullRefPtr<Utf16StringImpl> Utf16StringImpl::create(Utf16View const& view)
+{
+    Vector<u16> string;
+    string.ensure_capacity(view.length_in_code_units());
+    string.append(view.data(), view.length_in_code_units());
+    return create(move(string));
+}
+
+Vector<u16> const& Utf16StringImpl::string() const
+{
+    return m_string;
+}
+
+Utf16View Utf16StringImpl::view() const
+{
+    return Utf16View { m_string };
+}
+
+}
+
+Utf16String::Utf16String()
+    : m_string(Detail::the_empty_utf16_string())
+{
+}
+
+Utf16String::Utf16String(Vector<u16> string)
+    : m_string(Detail::Utf16StringImpl::create(move(string)))
+{
+}
+
+Utf16String::Utf16String(StringView const& string)
+    : m_string(Detail::Utf16StringImpl::create(move(string)))
+{
+}
+
+Utf16String::Utf16String(Utf16View const& string)
+    : m_string(Detail::Utf16StringImpl::create(move(string)))
+{
+}
+
+Vector<u16> const& Utf16String::string() const
+{
+    return m_string->string();
+}
+
+Utf16View Utf16String::view() const
+{
+    return m_string->view();
+}
+
+Utf16View Utf16String::substring_view(size_t code_unit_offset, size_t code_unit_length) const
+{
+    return view().substring_view(code_unit_offset, code_unit_length);
+}
+
+Utf16View Utf16String::substring_view(size_t code_unit_offset) const
+{
+    return view().substring_view(code_unit_offset);
+}
+
+String Utf16String::to_utf8() const
+{
+    return view().to_utf8(Utf16View::AllowInvalidCodeUnits::Yes);
+}
+
+u16 Utf16String::code_unit_at(size_t index) const
+{
+    return view().code_unit_at(index);
+}
+
+size_t Utf16String::length_in_code_units() const
+{
+    return view().length_in_code_units();
+}
+
+bool Utf16String::is_empty() const
+{
+    return view().is_empty();
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/String.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+
+namespace JS {
+namespace Detail {
+
+class Utf16StringImpl : public RefCounted<Utf16StringImpl> {
+public:
+    ~Utf16StringImpl() = default;
+
+    static NonnullRefPtr<Utf16StringImpl> create();
+    static NonnullRefPtr<Utf16StringImpl> create(Vector<u16>);
+    static NonnullRefPtr<Utf16StringImpl> create(StringView const&);
+    static NonnullRefPtr<Utf16StringImpl> create(Utf16View const&);
+
+    Vector<u16> const& string() const;
+    Utf16View view() const;
+
+private:
+    Utf16StringImpl() = default;
+    explicit Utf16StringImpl(Vector<u16> string);
+
+    Vector<u16> m_string;
+};
+
+}
+
+class Utf16String {
+public:
+    Utf16String();
+    explicit Utf16String(Vector<u16>);
+    explicit Utf16String(StringView const&);
+    explicit Utf16String(Utf16View const&);
+
+    Vector<u16> const& string() const;
+    Utf16View view() const;
+    Utf16View substring_view(size_t code_unit_offset, size_t code_unit_length) const;
+    Utf16View substring_view(size_t code_unit_offset) const;
+
+    String to_utf8() const;
+    u16 code_unit_at(size_t index) const;
+
+    size_t length_in_code_units() const;
+    bool is_empty() const;
+
+private:
+    NonnullRefPtr<Detail::Utf16StringImpl> m_string;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -43,11 +43,16 @@ struct ScopeFrame {
 };
 
 struct ExecutionContext {
+    explicit ExecutionContext(Heap& heap)
+        : arguments(heap)
+    {
+    }
+
     const ASTNode* current_node { nullptr };
     FlyString function_name;
     FunctionObject* function { nullptr };
     Value this_value;
-    Vector<Value> arguments;
+    MarkedValueList arguments;
     Object* arguments_object { nullptr };
     Environment* lexical_environment { nullptr };
     Environment* variable_environment { nullptr };

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1100,6 +1100,21 @@ Value add(GlobalObject& global_object, Value lhs, Value rhs)
     if (vm.exception())
         return {};
 
+    if (lhs_primitive.is_string() && rhs_primitive.is_string()) {
+        auto const& lhs_string = lhs_primitive.as_string();
+        auto const& rhs_string = rhs_primitive.as_string();
+
+        if (lhs_string.has_utf16_string() && rhs_string.has_utf16_string()) {
+            auto const& lhs_utf16_string = lhs_string.utf16_string();
+            auto const& rhs_utf16_string = rhs_string.utf16_string();
+
+            Vector<u16> combined;
+            combined.ensure_capacity(lhs_utf16_string.length_in_code_units() + rhs_utf16_string.length_in_code_units());
+            combined.extend(lhs_utf16_string.string());
+            combined.extend(rhs_utf16_string.string());
+            return js_string(vm.heap(), Utf16String(move(combined)));
+        }
+    }
     if (lhs_primitive.is_string() || rhs_primitive.is_string()) {
         auto lhs_string = lhs_primitive.to_string(global_object);
         if (vm.exception())

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -8,7 +8,6 @@
 #include <AK/AllOf.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
-#include <AK/Utf16View.h>
 #include <AK/Utf8View.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
@@ -363,7 +362,7 @@ String Value::to_string(GlobalObject& global_object, bool legacy_null_to_empty_s
     }
 }
 
-Vector<u16> Value::to_utf16_string(GlobalObject& global_object) const
+Utf16String Value::to_utf16_string(GlobalObject& global_object) const
 {
     if (m_type == Type::String)
         return m_value.as_string->utf16_string();
@@ -372,7 +371,7 @@ Vector<u16> Value::to_utf16_string(GlobalObject& global_object) const
     if (global_object.vm().exception())
         return {};
 
-    return AK::utf8_to_utf16(utf8_string);
+    return Utf16String(utf8_string);
 }
 
 // 7.1.2 ToBoolean ( argument ), https://tc39.es/ecma262/#sec-toboolean

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -18,6 +18,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/Utf16String.h>
 #include <math.h>
 
 // 2 ** 53 - 1
@@ -246,7 +247,7 @@ public:
     u64 encoded() const { return m_value.encoded; }
 
     String to_string(GlobalObject&, bool legacy_null_to_empty_string = false) const;
-    Vector<u16> to_utf16_string(GlobalObject&) const;
+    Utf16String to_utf16_string(GlobalObject&) const;
     PrimitiveString* to_primitive_string(GlobalObject&);
     Value to_primitive(GlobalObject&, PreferredType preferred_type = PreferredType::Default) const;
     Object* to_object(GlobalObject&) const;


### PR DESCRIPTION
The primary goal here is to reduce memory usage to the point that the test262 tests under `RegExp/property-escapes/generated` no longer crash due to reaching the test262 memory limit.

First, this adds a very simple ref-counted UTF-16 string class. Previously, we were passing around / copying `Vector<u16>`s within `PrimitiveString`. Adding a ref-counted wrapper around those vectors makes copying the string objects much cheaper (as we often need to do when returning objects from `RegExpExec`). This class lives in LibJS rather than AK to discourage its usage outside of LibJS.

Second, this reduces the amount of UTF-16 to UTF-8 transcodings held in memory in a couple of ways:
* `StringBuilder` / `AK::format` can now deal with `Utf16View` directly. Previously, we needed to convert the entire string to UTF-8 before formatting a UTF-16 string, whereas now we can do so without holding the entire extra copy in memory.
* When creating a new `PrimitiveString` as the result of joining two existing UTF-16 `PrimitiveString`, we return the result in UTF-16 as well.

Last, these test262 tests end up reaching `VM::call_internal` with argument lists up to 10,000 elements large. The way we were constructing the `ExecutionContext` meant that this list was copied, rather than moved. That copying is eliminated.