### PR TITLE
Spreadsheet: Call SheetModel::update() instead of invalidate()

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -6,7 +6,6 @@
 
 #include "SpreadsheetView.h"
 #include "CellTypeDialog.h"
-#include "SpreadsheetModel.h"
 #include <AK/ScopeGuard.h>
 #include <AK/URL.h>
 #include <LibCore/MimeData.h>
@@ -144,12 +143,13 @@ void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
 
 void SpreadsheetView::update_with_model()
 {
-    m_table_view->model()->invalidate();
+    m_sheet_model->update();
     m_table_view->update();
 }
 
 SpreadsheetView::SpreadsheetView(Sheet& sheet)
     : m_sheet(sheet)
+    , m_sheet_model(SheetModel::create(*m_sheet))
 {
     set_layout<GUI::VerticalBoxLayout>().set_margins({ 2, 2, 2, 2 });
     m_table_view = add<InfinitelyScrollableTableView>();
@@ -158,7 +158,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
     m_table_view->set_edit_triggers(GUI::AbstractView::EditTrigger::EditKeyPressed | GUI::AbstractView::AnyKeyPressed | GUI::AbstractView::DoubleClicked);
     m_table_view->set_tab_key_navigation_enabled(true);
     m_table_view->row_header().set_visible(true);
-    m_table_view->set_model(SheetModel::create(*m_sheet));
+    m_table_view->set_model(m_sheet_model);
     m_table_view->on_reaching_vertical_end = [&]() {
         for (size_t i = 0; i < 100; ++i) {
             auto index = m_sheet->add_row();

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Spreadsheet.h"
+#include "SpreadsheetModel.h"
 #include <LibGUI/AbstractTableView.h>
 #include <LibGUI/ModelEditingDelegate.h>
 #include <LibGUI/TableView.h>
@@ -155,6 +156,7 @@ private:
     };
 
     NonnullRefPtr<Sheet> m_sheet;
+    NonnullRefPtr<SheetModel> m_sheet_model;
     RefPtr<InfinitelyScrollableTableView> m_table_view;
     RefPtr<GUI::Menu> m_cell_range_context_menu;
 };


### PR DESCRIPTION
SheetModel has its own custom updating method, and that must be called
in order to update the spreadsheet.