### PR TITLE
LibGUI: TreeView selection behavior improvements

### DIFF
--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -137,6 +137,7 @@ int main(int argc, char** argv)
     auto& tree_view = bottom_splitter.add<GUI::TreeView>();
     tree_view.set_should_fill_selected_rows(true);
     tree_view.set_column_headers_visible(true);
+    tree_view.set_selection_behavior(GUI::TreeView::SelectionBehavior::SelectRows);
     tree_view.set_model(profile->model());
 
     auto& disassembly_view = bottom_splitter.add<GUI::TableView>();

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -34,6 +34,7 @@ TreeView::MetadataForIndex& TreeView::ensure_metadata_for_index(const ModelIndex
 
 TreeView::TreeView()
 {
+    set_selection_behavior(SelectionBehavior::SelectItems);
     set_fill_with_background_color(true);
     set_background_role(ColorRole::Base);
     set_foreground_role(ColorRole::BaseText);

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -373,6 +373,11 @@ void TreeView::paint_event(PaintEvent& event)
             x_offset += column_width + horizontal_padding() * 2;
         }
 
+        if (selection_behavior() == SelectionBehavior::SelectRows && is_focused() && index == cursor_index()) {
+            painter.draw_rect(row_rect, palette().color(background_role()));
+            painter.draw_focus_rect(row_rect, palette().focus_outline());
+        }
+
         return IterationDecision::Continue;
     });
 }

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -313,12 +313,13 @@ void TreeView::paint_event(PaintEvent& event)
                 int indent_width = indent_width_in_pixels() * indent_level;
 
                 Gfx::IntRect icon_rect = { rect.x(), rect.y(), icon_size(), icon_size() };
-                Gfx::IntRect text_rect = {
+                Gfx::IntRect background_rect = {
                     icon_rect.right() + 1 + icon_spacing(), rect.y(),
-                    column_width - indent_width - icon_size() - 1 - icon_spacing() + horizontal_padding(), rect.height()
+                    min(rect.width(), column_width - indent_width) - icon_size() - icon_spacing(), rect.height()
                 };
+                Gfx::IntRect text_rect = background_rect.shrunken(text_padding() * 2, 0);
 
-                painter.fill_rect(text_rect, background_color);
+                painter.fill_rect(background_rect, background_color);
 
                 auto icon = index.data(ModelRole::Icon);
                 if (icon.is_icon()) {
@@ -333,13 +334,9 @@ void TreeView::paint_event(PaintEvent& event)
                 }
                 draw_item_text(painter, index, is_selected_row, text_rect, index.data().to_string(), font_for_index(index), Gfx::TextAlignment::CenterLeft, Gfx::TextElision::Right);
 
-                if (is_focused() && index == cursor_index()) {
-                    auto focus_rect = text_rect;
-                    focus_rect.set_left(focus_rect.left() - 2);
-                    focus_rect.set_width(focus_rect.width() + 2);
-
-                    painter.draw_rect(focus_rect, palette().color(background_role()));
-                    painter.draw_focus_rect(focus_rect, palette().focus_outline());
+                if (selection_behavior() == SelectionBehavior::SelectItems && is_focused() && index == cursor_index()) {
+                    painter.draw_rect(background_rect, palette().color(background_role()));
+                    painter.draw_focus_rect(background_rect, palette().focus_outline());
                 }
 
                 auto index_at_indent = index;
@@ -701,7 +698,7 @@ void TreeView::update_column_sizes()
         int cell_width = 0;
         if (cell_data.is_valid()) {
             cell_width = font().width(cell_data.to_string());
-            cell_width += horizontal_padding() * 2 + indent_level * indent_width_in_pixels() + icon_size() / 2;
+            cell_width += horizontal_padding() * 2 + indent_level * indent_width_in_pixels() + icon_size() / 2 + text_padding() * 2;
         }
         tree_column_width = max(tree_column_width, cell_width);
         return IterationDecision::Continue;


### PR DESCRIPTION
Fixes some bugs I created, and improves TreeView focus rects a bit. :^)

**LibGUI: Default TreeView to SelectionBehavior::SelectItems**

AbstractTableView (which TreeView inherits from) sets the selection
behavior of the view to SelectRows. This is not how TreeViews are used
in most of the system, and TreeView::paint_event actually always draws
with the assumption of selecting individual items. This commit defines
the expected selection behavior for TreeViews. Users of TreeView can
still override this via TreeView::set_selection_behavior.

**LibGUI: Partially restore original TreeView column painting behavior**

TreeView now prints columns mostly like it used to. The paddings are now
properly applied, though. focus_rect drawing has been gated behind a
selection_behavior() check to make sure we don't draw a focus rect
around the column text when we're supposed to draw it over the entire
row.

**Profiler: Use SelectionBehavior::SelectRows**

Profiler uses the TreeView in a tabular fashion, and so should set the
selection behavior appropriately.

**LibGUI: Draw a focus rect over the entire row when selection_behavior...**

...is SelectRows.