### PR TITLE
VirtualFileSystem: Return early in rename() when old_path==new_path

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -549,6 +549,9 @@ KResult VirtualFileSystem::rename(StringView old_path, StringView new_path, Cust
     if (new_basename.is_empty() || new_basename == "."sv || new_basename == ".."sv)
         return EINVAL;
 
+    if (old_basename == new_basename && old_parent_inode.index() == new_parent_inode.index())
+        return KSuccess;
+
     if (!new_custody_or_error.is_error()) {
         auto& new_custody = *new_custody_or_error.value();
         auto& new_inode = new_custody.inode();


### PR DESCRIPTION
This change fixes disappearing symlink after trying to do the following
thing:
  cp /res/icons/16x16/add-event.png .
  ln -s add-event.png a
  mv a a