### PR TITLE
Kernel: Fix kernel panic when blocking on the process' big lock

### DIFF
--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -12,7 +12,7 @@ KResultOr<FlatPtr> Process::sys$yield()
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     REQUIRE_PROMISE(stdio);
-    Thread::current()->yield_assuming_not_holding_big_lock();
+    Thread::current()->yield_without_releasing_big_lock();
     return 0;
 }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -836,7 +836,7 @@ public:
         while (state() == Thread::Stopped) {
             lock.unlock();
             // We shouldn't be holding the big lock here
-            yield_assuming_not_holding_big_lock();
+            yield_without_releasing_big_lock();
             lock.lock();
         }
     }
@@ -922,7 +922,7 @@ public:
             // Yield to the scheduler, and wait for us to resume unblocked.
             VERIFY(!g_scheduler_lock.own_lock());
             VERIFY(Processor::in_critical());
-            yield_assuming_not_holding_big_lock();
+            yield_without_releasing_big_lock();
             VERIFY(Processor::in_critical());
 
             ScopedSpinLock block_lock2(m_block_lock);
@@ -1371,7 +1371,13 @@ private:
     bool m_is_profiling_suppressed { false };
 
     void yield_and_release_relock_big_lock();
-    void yield_assuming_not_holding_big_lock();
+
+    enum class VerifyLockNotHeld {
+        Yes,
+        No
+    };
+
+    void yield_without_releasing_big_lock(VerifyLockNotHeld verify_lock_not_held = VerifyLockNotHeld::Yes);
     void drop_thread_count(bool);
 
 public:


### PR DESCRIPTION
Another thread might end up marking the blocking thread as holding the lock before it gets a chance to finish invoking the scheduler.

Steps to reproduce:

1. Enable `SCHEDULE_ON_ALL_PROCESSORS`.
2. Start the VM with `smp=on`.
3. Start Assistant and observe the following kernel panic (happens about 50% of the time for me):

```
[Assistant(33:34)]: ASSERTION FAILED: !process().big_lock().own_lock()
[Assistant(33:34)]: ../../Kernel/Thread.cpp:418 in void Kernel::Thread::yield_assuming_not_holding_big_lock()
[Assistant(33:34)]: KERNEL PANIC! :^(
[Assistant(33:34)]: Aborted
[Assistant(33:34)]: at ../../Kernel/Arch/x86/common/CPU.cpp:29 in void abort()
[Assistant(33:34)]: Kernel + 0x007cca52  Kernel::__panic(char const*, unsigned int, char const*) +0x68
[Assistant(33:34)]: Kernel + 0x00c057de  abort.localalias +0x1ed
[Assistant(33:34)]: Kernel + 0x00c0586f  void AK::critical_dmesgln<char const*>(AK::Format::Detail::CheckedFormatString<AK::Detail::__IdentityType<char const*>::Type>&&, char const* const&) +0x0
[Assistant(33:34)]: Kernel + 0x00b0f35e  Kernel::Thread::yield_assuming_not_holding_big_lock() [clone .localalias] +0x49e
[Assistant(33:34)]: Kernel + 0x00b2e456  Kernel::Thread::block(Kernel::Mutex&, Kernel::ScopedSpinLock<Kernel::SpinLock<unsigned char> >&, unsigned int) +0xe0c
[Assistant(33:34)]: Kernel + 0x0067b6af  Kernel::Mutex::block(Kernel::Thread&, Kernel::LockMode, Kernel::ScopedSpinLock<Kernel::SpinLock<unsigned char> >&, unsigned int) [clone .localalias] +0x551
[Assistant(33:34)]: Kernel + 0x00686202  Kernel::Mutex::lock(Kernel::LockMode) +0x1396
[Assistant(33:34)]: Kernel + 0x008a6aa8  Kernel::Syscall::handle(Kernel::RegisterState&, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int) +0x819
[Assistant(33:34)]: Kernel + 0x008a8b90  syscall_handler +0x14a6
[Assistant(33:34)]: Kernel + 0x008a5551  syscall_asm_entry +0x31
```