### PR TITLE
Kernel: Disambiguate instruction size for mov in read_gs_ptr

### DIFF
--- a/Kernel/Arch/x86/ASM_wrapper.h
+++ b/Kernel/Arch/x86/ASM_wrapper.h
@@ -75,7 +75,7 @@ ALWAYS_INLINE FlatPtr read_gs_ptr(FlatPtr offset)
 ALWAYS_INLINE void write_gs_ptr(u32 offset, FlatPtr val)
 {
     asm volatile(
-        "mov %[val], %%gs:%a[off]" ::[off] "ir"(offset), [val] "ir"(val)
+        "mov %[val], %%gs:%a[off]" ::[off] "ir"(offset), [val] "r"(val)
         : "memory");
 }
 


### PR DESCRIPTION
Previously we allowed using immediate values here which is ambiguous as to which specific mov instruction the compiler should choose.