### PR TITLE
LibIPC: Pass only message size to decoder

### DIFF
--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -216,7 +216,7 @@ protected:
             if (message_size == 0 || bytes.size() - index - sizeof(uint32_t) < message_size)
                 break;
             index += sizeof(message_size);
-            auto remaining_bytes = ReadonlyBytes { bytes.data() + index, bytes.size() - index };
+            auto remaining_bytes = ReadonlyBytes { bytes.data() + index, message_size };
             if (auto message = LocalEndpoint::decode_message(remaining_bytes, m_socket->fd())) {
                 m_unprocessed_messages.append(message.release_nonnull());
             } else if (auto message = PeerEndpoint::decode_message(remaining_bytes, m_socket->fd())) {


### PR DESCRIPTION
Fixes #9015.