### PR TITLE
LibWeb: Return correct selection_rect when the node is at the end

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -137,7 +137,7 @@ Gfx::FloatRect LineBoxFragment::selection_rect(const Gfx::Font& font) const
             return {};
 
         auto selection_start_in_this_fragment = 0;
-        auto selection_end_in_this_fragment = min(selection.end().index_in_node, m_length);
+        auto selection_end_in_this_fragment = min(selection.end().index_in_node - m_start, m_length);
         auto pixel_distance_to_first_selected_character = font.width(text.substring_view(0, selection_start_in_this_fragment));
         auto pixel_width_of_selection = font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment)) + 1;
 


### PR DESCRIPTION
When the selection state of the node is SelectionState::End, the end position of the selection within the fragment is not properly
calculated, because it forgets to subtract m_start from index_in_node, unlike SelectionState::StartAndEnd. This resulted in a wrong selection shadow being painted when the node is at the end of the selection.

This change resolves #5880.