### PR TITLE
FileManager: Change the cwd when opening a directory

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -94,7 +94,7 @@ void DirectoryView::handle_activation(GUI::ModelIndex const& index)
 {
     if (!index.is_valid())
         return;
-    dbgln("on activation: {},{}, this={:p}, m_model={:p}", index.row(), index.column(), this, m_model.ptr());
+
     auto& node = this->node(index);
     auto path = node.full_path();
 

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -49,7 +49,7 @@ public:
 
     virtual ~DirectoryView() override;
 
-    void open(String const& path);
+    bool open(String const& path);
     String path() const { return model().root_path(); }
     void open_parent_directory();
     void open_previous_directory();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -496,7 +496,8 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     progressbar.set_frame_thickness(1);
 
     location_textbox.on_return_pressed = [&] {
-        directory_view.open(location_textbox.text());
+        if (directory_view.open(location_textbox.text()))
+            location_textbox.set_focus(false);
     };
 
     auto refresh_tree_view = [&] {


### PR DESCRIPTION
The `open()` function of DirectoryView should change the current working directory, so that the "Go to Location" menu item can process relative paths correctly. Update other functions in DirectoryView to use `open()` when opening a directory.