### PR TITLE
Toolchain+Meta: Add include-what-you-use linter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(ENABLE_USB_IDS_DOWNLOAD "Enable download of the usb.ids database at build
 option(BUILD_LAGOM "Build parts of the system targeting the host OS for fuzzing/testing" OFF)
 option(ENABLE_KERNEL_LTO "Build the kernel with link-time optimization" OFF)
 option(USE_CLANG_TOOLCHAIN "Build the kernel with the experimental Clang toolchain" OFF)
+option(LINT_IWYU "Use include-what-you-use to analyze #includes (requires the Clang toolchain)" OFF)
 
 include(Meta/CMake/wasm_spec_tests.cmake)
 
@@ -202,6 +203,10 @@ else()
     set(CMAKE_AR ${TOOLCHAIN_PREFIX}gcc-ar)
     set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
     set(CMAKE_CXXFILT ${TOOLCHAIN_PREFIX}c++filt)
+endif()
+
+if(LINT_IWYU)
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${CMAKE_SOURCE_DIR}/Toolchain/Local/iwyu/${SERENITY_ARCH}/bin/include-what-you-use;-Xiwyu;--no_default_mappings)
 endif()
 
 foreach(lang ASM C CXX OBJC OBJCXX)

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -46,6 +46,7 @@ There are some optional features that can be enabled during compilation that are
 - `USE_CLANG_TOOLCHAIN`: uses the alternative Clang-based toolchain for building SerenityOS instead of the established GCC-based one. See the [Clang-based toolchain](#clang-based-toolchain) section below.
 - `BUILD_<component>`: builds the specified component, e.g. `BUILD_HEARTS` (note: must be all caps). Check the components.ini file in your build directory for a list of available components. Make sure to run `ninja clean` and `rm -rf Build/i686/Root` after disabling components. These options can be easily configured by using the `ConfigureComponents` utility. See the [Component Configuration](#component-configuration) section below.
 - `BUILD_EVERYTHING`: builds all optional components, overrides other `BUILD_<component>` flags when enabled
+- `LINT_IWYU`: use [include-what-you-use](https://include-what-you-use.org/) to analyze `#includes`. Requires the Clang toolchain to be installed.
 
 Many parts of the SerenityOS codebase have debug functionality, mostly consisting of additional messages printed to the debug console. This is done via the `<component_name>_DEBUG` macros, which can be enabled individually at build time. They are listed in [this file](../Meta/CMake/all_the_debug_macros.cmake).
 

--- a/Toolchain/BuildIWYU.sh
+++ b/Toolchain/BuildIWYU.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ARCH=${ARCH:-"i686"}
+
+BUILD="$DIR/Build/iwyu/$ARCH"
+PREFIX="$DIR/Local/iwyu/$ARCH"
+
+
+IWYU_VERSION=0.16
+IWYU_NAME="include-what-you-use-$IWYU_VERSION"
+IWYU_PKG="$IWYU_NAME.tar.gz"
+IWYU_URL="https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/$IWYU_VERSION.tar.gz"
+
+
+pushd "$DIR/Tarballs"
+    if [ -e "$IWYU_PKG" ]; then
+        echo "Skipped downloading IWYU"
+    else
+        rm -f "$IWYU_PKG"
+        curl -L "$IWYU_URL" -o "$IWYU_PKG"
+    fi
+
+    if [ -d "$IWYU_NAME" ]; then
+        rm -rf "$IWYU_NAME"
+        rm -rf "$BUILD/iwyu/$ARCH"
+    fi
+
+    echo "Extracting IWYU..."
+    tar -xzf "$IWYU_PKG"
+popd
+
+mkdir -p "$BUILD"
+pushd "$BUILD"
+    cmake "$DIR/Tarballs/$IWYU_NAME" \
+        -GNinja \
+        -DCMAKE_PREFIX_PATH="$DIR/Local/clang/$ARCH/lib/" \
+        -DIWYU_LINK_CLANG_DYLIB=ON \
+        -DCMAKE_INSTALL_PREFIX="$PREFIX" || exit 1
+
+    ninja || exit 1
+    ninja install || exit 1
+popd


### PR DESCRIPTION
This Clang-based tool can help us eliminate unused includes and limit
the number of headers that are transitively included. IWYU links against
the libraries used by our Clang toolchain and integrates seamlessly with
the existing CMake build system.

More information: https://include-what-you-use.org/

cc @bgianfo 