### PR TITLE
 Ports/stress-ng: Remove custom pause function from patch

### DIFF
--- a/Ports/stress-ng/patches/0002-missing-types-and-functionality.patch
+++ b/Ports/stress-ng/patches/0002-missing-types-and-functionality.patch
@@ -26,17 +26,8 @@ diff -ur stress-ng-master/core-helper.c stress-ng-master-2/core-helper.c
  	return max - opened;
 +#endif
  }
- 
+
  /*
-@@ -2026,3 +2030,8 @@
- 	return 0;
- #endif
- }
-+
-+int pause(void)
-+{
-+	asm ("pause");
-+}
 diff -ur stress-ng-master/core-job.c stress-ng-master-2/core-job.c
 --- stress-ng-master/core-job.c	2020-11-07 10:52:22.000000000 -0800
 +++ stress-ng-master-2/core-job.c	2020-11-08 22:32:06.607668500 -0800


### PR DESCRIPTION
This PR removes the custom `pause` function in the patch script for the port `stress-ng`.

Fixes #9324 