### PR TITLE
Kernel+LibCore+LibHTTP: Properly handle TCP/HTTP closed connections.

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -38,8 +38,10 @@ void TCPSocket::set_state(State new_state)
 
     m_state = new_state;
 
-    if (new_state == State::Established && m_direction == Direction::Outgoing)
+    if (new_state == State::Established && m_direction == Direction::Outgoing) {
         m_role = Role::Connected;
+        [[maybe_unused]] auto rc = set_so_error(KSuccess);
+    }
 
     if (new_state == State::Closed) {
         closing_sockets().with_exclusive([&](auto& table) {

--- a/Userland/Libraries/LibCore/Socket.h
+++ b/Userland/Libraries/LibCore/Socket.h
@@ -43,6 +43,7 @@ public:
     int destination_port() const { return m_destination_port; }
 
     Function<void()> on_connected;
+    Function<void()> on_error;
     Function<void()> on_ready_to_read;
 
 protected:

--- a/Userland/Libraries/LibHTTP/HttpJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpJob.cpp
@@ -20,6 +20,12 @@ void HttpJob::start()
         dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_connected callback");
         on_socket_connected();
     };
+    m_socket->on_error = [this] {
+        dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_error callback");
+        deferred_invoke([this](auto&) {
+            did_fail(Core::NetworkJob::Error::ConnectionFailed);
+        });
+    };
     bool success = m_socket->connect(m_request.url().host(), m_request.url().port());
     if (!success) {
         deferred_invoke([this](auto&) {


### PR DESCRIPTION
Resolves #7966

**Kernel: Clear SO_ERROR on successful socket connection**
When TCP sockets successfully establish a connection, any SO_ERROR
should be cleared back to success. For example, SO_ERROR gets set to
EINPROGRESS on asynchronous connect calls and should be cleared when
the socket moves to the Established state.

**LibCore: Add on_error callback for socket**

**LibHttp: Implement on_error callback**
Previously the system assumed that when it reached the callback
connection the socket was establish, and it would continue processing
the HTTP request.

This would lead to the unintentional consequences of the browser hanging
when attempting to connect to a closed port. This patch allows the HTTP
request to fail in the case of an error.

**LibCore: Check the status of the socket after EINPROGRESS**
Previously the system would assume the socket was connected after the
file descriptor became writeable. Just because the fd is signaled as
ready for output does not necessarily indicate the socket is connected.
Instead, we should check the status of the socket with SO_ERROR and
handle successes/errors accordingly.