### PR TITLE
HackStudio: Remove noop code when opening the project

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -210,8 +210,6 @@ void HackStudioWidget::open_project(const String& root_path)
         debugger.reset_breakpoints();
         debugger.set_source_root(m_project->root_path());
     }
-    for (auto& editor_wrapper : m_all_editor_wrappers)
-        editor_wrapper.set_project_root(LexicalPath(m_project->root_path()));
 }
 
 Vector<String> HackStudioWidget::selected_file_paths() const


### PR DESCRIPTION
28b1e66b51ec7b4552a12ac5ee37ecd6b96d4541 made that the `m_all_editor_wrappers` vector is cleared everytime a project path is changed (the `m_project` if check is just for the app launch – the vector is empty there anyway), making the code never execute.