### PR TITLE
HackStudio: Add 'Save as...' action

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -600,7 +600,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_action()
 {
     return GUI::CommonActions::make_save_action([&](auto&) {
         if (active_file().is_empty())
-            return;
+            m_save_as_action->activate();
 
         current_editor_wrapper().save();
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -116,6 +116,7 @@ HackStudioWidget::HackStudioWidget(const String& path_to_project)
     m_remove_current_editor_action = create_remove_current_editor_action();
     m_open_action = create_open_action();
     m_save_action = create_save_action();
+    m_save_as_action = create_save_as_action();
     m_new_project_action = create_new_project_action();
 
     create_action_tab(*m_right_hand_splitter);
@@ -608,6 +609,29 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_action()
     });
 }
 
+NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
+{
+    return GUI::CommonActions::make_save_as_action([&](auto&) {
+        auto const old_filename = current_editor_wrapper().filename();
+        LexicalPath const old_path(old_filename);
+
+        Optional<String> save_path = GUI::FilePicker::get_save_filepath(window(),
+            old_filename.is_null() ? "Untitled" : old_path.title(),
+            old_filename.is_null() ? "txt" : old_path.extension(),
+            Core::File::absolute_path(old_path.dirname()));
+        if (!save_path.has_value()) {
+            return;
+        }
+
+        current_editor_wrapper().set_filename(save_path.value());
+        current_editor_wrapper().save();
+
+        auto new_project_file = m_project->get_file(save_path.value());
+        m_open_files.set(save_path.value(), *new_project_file);
+        m_open_files_vector.append(save_path.value());
+    });
+}
+
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_remove_current_terminal_action()
 {
     return GUI::Action::create("Remove &Current Terminal", { Mod_Alt | Mod_Shift, Key_T }, [this](auto&) {
@@ -955,6 +979,7 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
     file_menu.add_action(*m_new_project_action);
     file_menu.add_action(*m_open_action);
     file_menu.add_action(*m_save_action);
+    file_menu.add_action(*m_save_as_action);
     file_menu.add_separator();
     file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -82,6 +82,7 @@ private:
     NonnullRefPtr<GUI::Action> create_remove_current_editor_action();
     NonnullRefPtr<GUI::Action> create_open_action();
     NonnullRefPtr<GUI::Action> create_save_action();
+    NonnullRefPtr<GUI::Action> create_save_as_action();
     NonnullRefPtr<GUI::Action> create_show_in_file_manager_action();
     NonnullRefPtr<GUI::Action> create_add_editor_action();
     NonnullRefPtr<GUI::Action> create_add_terminal_action();
@@ -164,6 +165,7 @@ private:
     RefPtr<GUI::Action> m_remove_current_editor_action;
     RefPtr<GUI::Action> m_open_action;
     RefPtr<GUI::Action> m_save_action;
+    RefPtr<GUI::Action> m_save_as_action;
     RefPtr<GUI::Action> m_add_editor_action;
     RefPtr<GUI::Action> m_add_terminal_action;
     RefPtr<GUI::Action> m_remove_current_terminal_action;


### PR DESCRIPTION
- **HackStudio: Add 'Save as...' action**

  Not adding it to the toolbar, because it has the same icon as a typical 'Save' action.

- **HackStudio: Show the 'Save as' dialog when saving uncreated file**

  Previously when user wanted to save an uncreated file, the program would just quietly ignore the save request, without giving any message.
  This can be seen when creating a new editor in split view mode.