### PR TITLE
HackStudio: Show text editor after starting the application

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -515,6 +515,7 @@ void HackStudioWidget::add_new_editor(GUI::Widget& parent)
     wrapper->set_project_root(LexicalPath(m_project->root_path()));
     wrapper->editor().on_cursor_change = [this] { update_statusbar(); };
     wrapper->editor().on_change = [this] { update_gml_preview(); };
+    set_edit_mode(EditMode::Text);
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_switch_to_next_editor_action()


### PR DESCRIPTION
The user can now start typing text instead of creating a file first.

This also enables drag-and-dropping a file as soon as the application starts.