### PR TITLE
Ports: `qt6-qtbase` 

### DIFF
--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -1,13 +1,30 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=Qt6
+port=qt6-qtbase
 version=6.1.1
+#depends="zlib"
 workdir=qtbase-everywhere-src-6.1.1
 useconfigure=true
 files="https://download.qt.io/official_releases/qt/6.1/6.1.1/submodules/qtbase-everywhere-src-6.1.1.tar.xz qt6-qtbase-6.1.1.tar.xz"
-configopts="-GNinja -DCMAKE_CROSSCOMPILING=ON -DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt -DQT_HOST_PATH=/usr/lib64/qt6 -DQt6HostInfo_DIR=/usr/lib64/cmake/Qt6HostInfo -DQt6CoreTools_DIR=//usr/lib64/cmake/Qt6CoreTools/ -DQt6GuiTools_DIR=/usr/lib64/cmake/Qt6GuiTools/ -DQt6WidgetsTools_DIR=/usr/lib64/cmake/Qt6WidgetsTools/  -DQT_FEATURE_sql=OFF -DQT_FEATURE_opengl=OFF -DQT_FEATURE_gui=OFF -DQT_FEATURE_network=OFF -DQT_FEATURE_concurrent=OFF  -DQT_FEATURE_testlib=OFF -DQT_FEATURE_systemsemaphore=OFF -DQT_FEATURE_sharedmemory=OFF -DQT_FEATURE_thread=OFF"
+configopts="-GNinja -DCMAKE_CROSSCOMPILING=ON -DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt -DQT_HOST_PATH=/usr -DQT_FEATURE_cxx20=ON -DBUILD_SHARED_LIBS=OFF"
 
 configure() {
-    run cmake $configopts
+    QT_HOST_PATH=/usr
+    QT_HOST_CMAKE_PATH=${QT_HOST_PATH}/lib64/cmake
+    QT_HOST_TOOLS="HostInfo CoreTools GuiTools WidgetsTools"
+    QT_HOST_TOOLS_PATH="${QT_HOST_CMAKE_PATH}/Qt6%s/\n"
+
+    QT_DISABLED_FEATURES="sql opengl dbus systemsemaphore sharedmemory thread network"
+
+    for i in ${QT_HOST_TOOLS}; do
+        if [[ ! -d $(printf QT_HOST_TOOLS_PATH $i) ]]; then
+            echo "You need to have local Qt $version installed (path "$(printf QT_HOST_TOOLS_PATH $i)" is missing"
+        fi
+    done
+
+    MERGED_HOST_TOOLS=$(for i in ${QT_HOST_TOOLS}; do echo "-DQt6${i}_DIR=${QT_HOST_CMAKE_PATH}/Qt6${i}/"; done)
+    MERGED_DISABLED_FEATURES=$(for i in ${QT_DISABLED_FEATURES}; do echo "-DQT_FEATURE_${i}=OFF"; done)
+
+    run cmake $configopts ${MERGED_HOST_TOOLS} ${MERGED_DISABLED_FEATURES}
 }
 
 build() {

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -7,14 +7,14 @@ useconfigure=true
 files="https://download.qt.io/official_releases/qt/6.1/6.1.1/submodules/qtbase-everywhere-src-6.1.1.tar.xz qt6-qtbase-6.1.1.tar.xz"
 configopts="-GNinja -DCMAKE_CROSSCOMPILING=ON -DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt -DQT_HOST_PATH=/usr -DQT_FEATURE_cxx20=ON -DBUILD_SHARED_LIBS=OFF"
 
+QT_HOST_PATH=/usr
+QT_HOST_CMAKE_PATH=${QT_HOST_PATH}/lib64/cmake
+QT_HOST_TOOLS="HostInfo CoreTools GuiTools WidgetsTools"
+QT_HOST_TOOLS_PATH="${QT_HOST_CMAKE_PATH}/Qt6%s/\n"
+
+QT_DISABLED_FEATURES="sql opengl dbus systemsemaphore sharedmemory thread network"
+
 configure() {
-    QT_HOST_PATH=/usr
-    QT_HOST_CMAKE_PATH=${QT_HOST_PATH}/lib64/cmake
-    QT_HOST_TOOLS="HostInfo CoreTools GuiTools WidgetsTools"
-    QT_HOST_TOOLS_PATH="${QT_HOST_CMAKE_PATH}/Qt6%s/\n"
-
-    QT_DISABLED_FEATURES="sql opengl dbus systemsemaphore sharedmemory thread network"
-
     for i in ${QT_HOST_TOOLS}; do
         if [[ ! -d $(printf QT_HOST_TOOLS_PATH $i) ]]; then
             echo "You need to have local Qt $version installed (path "$(printf QT_HOST_TOOLS_PATH $i)" is missing"
@@ -33,6 +33,18 @@ build() {
 
 install() {
     run ninja install
+
+    echo "================================================================================"
+    echo "|                                 NOTICE                                       |"
+    echo "================================================================================"
+    echo -e "You have just installed a static testing build of Qt $version.\n"
+    echo "Please be aware that this build is STATIC, so you'll have to rebuild everything dependening on it to benefit from new stuff. Plugins very likely won't work at all, unless built in directly into this package."
+    echo "Also, the following Qt modules are disabled for now:"
+    echo -e "\t" "$QT_DISABLED_FEATURES"
+    echo "Work on enabling Qt modules will be hapenning here:"
+    echo -e "\t" "https://github.com/SerenityOS/serenity/tree/master/Ports/qt6-qtbase"
+    echo "The development of the Qt Serenity platform plugin is hapenning here. Fixes for things like input handling, window management and theme integration should go here:"
+    echo -e "\t" "https://github.com/MartinBriza/QSerenityPlatform"
 }
 
 clean() {

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=Qt6
+version=6.1.1
+workdir=qtbase-everywhere-src-6.1.1
+useconfigure=true
+files="https://download.qt.io/official_releases/qt/6.1/6.1.1/submodules/qtbase-everywhere-src-6.1.1.tar.xz qt6-qtbase-6.1.1.tar.xz"
+configopts="-GNinja -DCMAKE_CROSSCOMPILING=ON -DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt -DQT_HOST_PATH=/usr/lib64/qt6 -DQt6HostInfo_DIR=/usr/lib64/cmake/Qt6HostInfo -DQt6CoreTools_DIR=//usr/lib64/cmake/Qt6CoreTools/ -DQt6GuiTools_DIR=/usr/lib64/cmake/Qt6GuiTools/ -DQt6WidgetsTools_DIR=/usr/lib64/cmake/Qt6WidgetsTools/  -DQT_FEATURE_sql=OFF -DQT_FEATURE_opengl=OFF -DQT_FEATURE_gui=OFF -DQT_FEATURE_network=OFF -DQT_FEATURE_concurrent=OFF  -DQT_FEATURE_testlib=OFF -DQT_FEATURE_systemsemaphore=OFF -DQT_FEATURE_sharedmemory=OFF -DQT_FEATURE_thread=OFF"
+
+configure() {
+    run cmake $configopts
+}
+
+build() {
+    run ninja
+}
+
+install() {
+    run ninja install
+}
+
+clean() {
+    run ninja clean
+}

--- a/Ports/qt6-qtbase/package.sh
+++ b/Ports/qt6-qtbase/package.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=qt6-qtbase
-version=6.1.1
+version=6.2.0
 #depends="zlib"
-workdir=qtbase-everywhere-src-6.1.1
+workdir=qtbase-everywhere-src-6.2.0
 useconfigure=true
-files="https://download.qt.io/official_releases/qt/6.1/6.1.1/submodules/qtbase-everywhere-src-6.1.1.tar.xz qt6-qtbase-6.1.1.tar.xz"
-configopts="-GNinja -DCMAKE_CROSSCOMPILING=ON -DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt -DQT_HOST_PATH=/usr -DQT_FEATURE_cxx20=ON -DBUILD_SHARED_LIBS=OFF"
+files="https://download.qt.io/official_releases/qt/6.2/6.2.0/submodules/qtbase-everywhere-src-6.2.0.tar.xz qt6-qtbase-6.2.0.tar.xz"
+configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-GNinja" "-DCMAKE_CROSSCOMPILING=ON" "-DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON" "-DQT_HOST_PATH=/usr" "-DQT_FEATURE_cxx20=ON" "-DBUILD_SHARED_LIBS=OFF")
 
 QT_HOST_PATH=/usr
 QT_HOST_CMAKE_PATH=${QT_HOST_PATH}/lib64/cmake
@@ -24,7 +24,7 @@ configure() {
     MERGED_HOST_TOOLS=$(for i in ${QT_HOST_TOOLS}; do echo "-DQt6${i}_DIR=${QT_HOST_CMAKE_PATH}/Qt6${i}/"; done)
     MERGED_DISABLED_FEATURES=$(for i in ${QT_DISABLED_FEATURES}; do echo "-DQT_FEATURE_${i}=OFF"; done)
 
-    run cmake $configopts ${MERGED_HOST_TOOLS} ${MERGED_DISABLED_FEATURES}
+    run cmake ${configopts[@]} ${MERGED_HOST_TOOLS} ${MERGED_DISABLED_FEATURES}
 }
 
 build() {

--- a/Ports/qt6-qtbase/patches/0001-Add-a-SerenityOS-platform-definition.patch
+++ b/Ports/qt6-qtbase/patches/0001-Add-a-SerenityOS-platform-definition.patch
@@ -1,0 +1,198 @@
+From 10ce996693b688adcebe0794aa028598e8666839 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 17:43:20 +0200
+Subject: [PATCH 1/8] Add a SerenityOS platform definition
+
+---
+ cmake/QtBuild.cmake                   |  2 +
+ mkspecs/serenity-g++/qmake.conf       | 25 ++++++++
+ mkspecs/serenity-g++/qplatformdefs.h  | 83 +++++++++++++++++++++++++++
+ src/corelib/global/qsystemdetection.h |  3 +
+ src/gui/CMakeLists.txt                |  2 +
+ util/cmake/helper.py                  |  1 +
+ 6 files changed, 116 insertions(+)
+ create mode 100644 mkspecs/serenity-g++/qmake.conf
+ create mode 100644 mkspecs/serenity-g++/qplatformdefs.h
+
+diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
+index 8547ff09..0d132ca1 100644
+--- a/cmake/QtBuild.cmake
++++ b/cmake/QtBuild.cmake
+@@ -304,6 +304,8 @@ elseif(APPLE)
+     set(QT_DEFAULT_MKSPEC macx-clang)
+ elseif(EMSCRIPTEN)
+     set(QT_DEFAULT_MKSPEC wasm-emscripten)
++elseif(SERENITYOS)
++    set(QT_DEFAULT_MKSPEC serenity-g++)
+ elseif(QNX)
+     # Certain POSIX defines are not set if we don't compile with -std=gnuXX
+     set(QT_ENABLE_CXX_EXTENSIONS ON)
+diff --git a/mkspecs/serenity-g++/qmake.conf b/mkspecs/serenity-g++/qmake.conf
+new file mode 100644
+index 00000000..00d5ae2c
+--- /dev/null
++++ b/mkspecs/serenity-g++/qmake.conf
+@@ -0,0 +1,25 @@
++#
++# qmake configuration for serenity-g++
++#
++
++MAKEFILE_GENERATOR      = ninja
++QMAKE_PLATFORM          = serenity
++
++include(../common/unix.conf)
++
++QMAKE_LIBS              = -lpthread
++QMAKE_INCDIR            =
++QMAKE_LIBDIR            =
++
++QMAKE_LIBS_THREAD       = -lpthread -lrt
++
++QMAKE_LIBS_NETWORK      = -lnetwork
++QMAKE_LIBS_OPENGL       = -lGL
++QMAKE_LIBS_OPENGL_QT    = -lGL
++
++QMAKE_AR                = ar cqs
++QMAKE_OBJCOPY           = objcopy
++QMAKE_NM                = nm -P
++QMAKE_RANLIB            =
++
++load(qt_config)
+diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
+new file mode 100644
+index 00000000..1a2f0cc2
+--- /dev/null
++++ b/mkspecs/serenity-g++/qplatformdefs.h
+@@ -0,0 +1,83 @@
++/****************************************************************************
++**
++** Copyright (C) 2014 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author Tobias Koenig <tobias.koenig@kdab.com>
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the qmake spec of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QPLATFORMDEFS_H
++#define QPLATFORMDEFS_H
++
++// Get Qt defines/settings
++
++#include "qglobal.h"
++
++// Set any POSIX/XOPEN defines at the top of this file to turn on specific APIs
++
++#include <unistd.h>
++
++#include <pthread.h>
++#include <dirent.h>
++#include <fcntl.h>
++#include <grp.h>
++#include <pwd.h>
++#include <signal.h>
++#include <dlfcn.h>
++
++#include <sys/types.h>
++#include <sys/ioctl.h>
++#include <sys/time.h>
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <sys/wait.h>
++#include <netinet/in.h>
++
++#include "../common/posix/qplatformdefs.h"
++
++#ifdef QT_POSIX_IPC
++#define QT_POSIX_IPC 1
++//#undef QT_POSIX_IPC
++#endif
++
++#ifdef QT_OPEN_LARGEFILE
++#undef QT_OPEN_LARGEFILE
++#endif
++#define QT_OPEN_LARGEFILE   0
++
++#ifdef QT_LARGEFILE_SUPPORT
++#undef QT_LARGEFILE_SUPPORT
++#endif
++
++#endif // QPLATFORMDEFS_H
+diff --git a/src/corelib/global/qsystemdetection.h b/src/corelib/global/qsystemdetection.h
+index c8f98042..5c534c4a 100644
+--- a/src/corelib/global/qsystemdetection.h
++++ b/src/corelib/global/qsystemdetection.h
+@@ -72,6 +72,7 @@
+      ANDROID  - Android platform
+      HAIKU    - Haiku
+      WEBOS    - LG WebOS
++     SERENITY - SerenityOS
+ 
+    The following operating systems have variants:
+      LINUX    - both Q_OS_LINUX and Q_OS_ANDROID are defined when building for Android
+@@ -165,6 +166,8 @@
+ #  define Q_OS_VXWORKS
+ #elif defined(__HAIKU__)
+ #  define Q_OS_HAIKU
++#elif defined(__serenity__)
++#  define Q_OS_SERENITY
+ #elif defined(__MAKEDEPEND__)
+ #else
+ #  error "Qt has not been ported to this OS - see http://www.qt-project.org/"
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index bb21d1b9..7b02a270 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -29,6 +29,8 @@ if (QT_FEATURE_gui)
+         set(_default_platform "haiku")
+     elseif(WASM)
+         set(_default_platform "wasm")
++    elseif(SERENITY)
++        set(_default_platform "serenity")
+     else()
+         set(_default_platform "xcb")
+     endif()
+diff --git a/util/cmake/helper.py b/util/cmake/helper.py
+index dd91a5ab..6247563b 100644
+--- a/util/cmake/helper.py
++++ b/util/cmake/helper.py
+@@ -733,6 +733,7 @@ platform_mapping = {
+     "macx": "MACOS",
+     "macos": "MACOS",
+     "macx-icc": "(MACOS AND ICC)",
++    "serenity": "SERENITY",
+ }
+ 
+ 
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0002-HACK-add-CODESET-definition.patch
+++ b/Ports/qt6-qtbase/patches/0002-HACK-add-CODESET-definition.patch
@@ -1,0 +1,24 @@
+From c76fa8abca6468daacfe597d60f755a030416a56 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:21:45 +0200
+Subject: [PATCH 2/8] HACK: add CODESET definition
+
+---
+ mkspecs/serenity-g++/qplatformdefs.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
+index 1a2f0cc2..a7a01665 100644
+--- a/mkspecs/serenity-g++/qplatformdefs.h
++++ b/mkspecs/serenity-g++/qplatformdefs.h
+@@ -80,4 +80,7 @@
+ #undef QT_LARGEFILE_SUPPORT
+ #endif
+ 
++// used in nl_langinfo in qcoreapplication.cpp
++#define CODESET 0
++
+ #endif // QPLATFORMDEFS_H
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0003-HACK-add-FIONREAD-definition.patch
+++ b/Ports/qt6-qtbase/patches/0003-HACK-add-FIONREAD-definition.patch
@@ -1,0 +1,24 @@
+From 22116a0c0a4c327bee0dbf2ddf997813c2b7fd3e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:21:58 +0200
+Subject: [PATCH 3/8] HACK: add FIONREAD definition
+
+---
+ mkspecs/serenity-g++/qplatformdefs.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
+index a7a01665..082d8a0c 100644
+--- a/mkspecs/serenity-g++/qplatformdefs.h
++++ b/mkspecs/serenity-g++/qplatformdefs.h
+@@ -83,4 +83,7 @@
+ // used in nl_langinfo in qcoreapplication.cpp
+ #define CODESET 0
+ 
++// TODO used in qprocess_unix.cpp
++#define FIONREAD      0x541B
++
+ #endif // QPLATFORMDEFS_H
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0004-HACK-hard-pass-on-shared-memory-and-semaphores.patch
+++ b/Ports/qt6-qtbase/patches/0004-HACK-hard-pass-on-shared-memory-and-semaphores.patch
@@ -33,29 +33,6 @@ index 1c585f5b..a96d8206 100644
  )
  qt_feature_definition("systemsemaphore" "QT_NO_SYSTEMSEMAPHORE" NEGATE VALUE "1")
  qt_feature("xmlstream" PUBLIC
-diff --git a/src/corelib/configure.json b/src/corelib/configure.json
-index 9c8615cf..5b7e68c0 100644
---- a/src/corelib/configure.json
-+++ b/src/corelib/configure.json
-@@ -783,7 +783,7 @@
-             "purpose": "Provides access to a shared memory segment.",
-             "section": "Kernel",
-             "condition": [
--                "config.android || config.win32 || (!config.vxworks && (tests.ipc_sysv || tests.ipc_posix))"
-+                "false"
-             ],
-             "output": [ "publicFeature", "feature" ]
-         },
-@@ -798,8 +798,7 @@
-             "purpose": "Provides a general counting system semaphore.",
-             "section": "Kernel",
-             "condition": [
--                "!config.integrity && !config.vxworks && !config.rtems",
--                "config.android || config.win32 || tests.ipc_sysv || tests.ipc_posix"
-+                "false"
-             ],
-             "output": [ "publicFeature", "feature" ]
-         },
 diff --git a/src/corelib/kernel/qcore_unix_p.h b/src/corelib/kernel/qcore_unix_p.h
 index abe9bb37..c43e6d06 100644
 --- a/src/corelib/kernel/qcore_unix_p.h

--- a/Ports/qt6-qtbase/patches/0004-HACK-hard-pass-on-shared-memory-and-semaphores.patch
+++ b/Ports/qt6-qtbase/patches/0004-HACK-hard-pass-on-shared-memory-and-semaphores.patch
@@ -1,0 +1,110 @@
+From 7d6de8fce218809be7cc1531a2cca8d29a27083a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:16:44 +0200
+Subject: [PATCH 4/8] HACK: hard pass on shared memory and semaphores
+
+---
+ src/corelib/configure.cmake             | 4 ++--
+ src/corelib/configure.json              | 5 ++---
+ src/corelib/kernel/qcore_unix_p.h       | 2 +-
+ src/corelib/kernel/qsharedmemory_p.h    | 4 +++-
+ src/corelib/kernel/qsystemsemaphore_p.h | 3 +++
+ 5 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/src/corelib/configure.cmake b/src/corelib/configure.cmake
+index 1c585f5b..a96d8206 100644
+--- a/src/corelib/configure.cmake
++++ b/src/corelib/configure.cmake
+@@ -719,7 +719,7 @@ qt_feature("sharedmemory" PUBLIC
+     SECTION "Kernel"
+     LABEL "QSharedMemory"
+     PURPOSE "Provides access to a shared memory segment."
+-    CONDITION ( ANDROID OR WIN32 OR ( NOT VXWORKS AND ( TEST_ipc_sysv OR TEST_ipc_posix ) ) )
++    CONDITION ( QT_FEATURE_sharedmemory )
+ )
+ qt_feature_definition("sharedmemory" "QT_NO_SHAREDMEMORY" NEGATE VALUE "1")
+ qt_feature("shortcut" PUBLIC
+@@ -732,7 +732,7 @@ qt_feature("systemsemaphore" PUBLIC
+     SECTION "Kernel"
+     LABEL "QSystemSemaphore"
+     PURPOSE "Provides a general counting system semaphore."
+-    CONDITION ( NOT INTEGRITY AND NOT VXWORKS AND NOT rtems ) AND ( ANDROID OR WIN32 OR TEST_ipc_sysv OR TEST_ipc_posix )
++    CONDITION ( QT_FEATURE_systemsemaphore )
+ )
+ qt_feature_definition("systemsemaphore" "QT_NO_SYSTEMSEMAPHORE" NEGATE VALUE "1")
+ qt_feature("xmlstream" PUBLIC
+diff --git a/src/corelib/configure.json b/src/corelib/configure.json
+index 9c8615cf..5b7e68c0 100644
+--- a/src/corelib/configure.json
++++ b/src/corelib/configure.json
+@@ -783,7 +783,7 @@
+             "purpose": "Provides access to a shared memory segment.",
+             "section": "Kernel",
+             "condition": [
+-                "config.android || config.win32 || (!config.vxworks && (tests.ipc_sysv || tests.ipc_posix))"
++                "false"
+             ],
+             "output": [ "publicFeature", "feature" ]
+         },
+@@ -798,8 +798,7 @@
+             "purpose": "Provides a general counting system semaphore.",
+             "section": "Kernel",
+             "condition": [
+-                "!config.integrity && !config.vxworks && !config.rtems",
+-                "config.android || config.win32 || tests.ipc_sysv || tests.ipc_posix"
++                "false"
+             ],
+             "output": [ "publicFeature", "feature" ]
+         },
+diff --git a/src/corelib/kernel/qcore_unix_p.h b/src/corelib/kernel/qcore_unix_p.h
+index abe9bb37..c43e6d06 100644
+--- a/src/corelib/kernel/qcore_unix_p.h
++++ b/src/corelib/kernel/qcore_unix_p.h
+@@ -79,7 +79,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ 
+-#if !defined(QT_POSIX_IPC) && !defined(QT_NO_SHAREDMEMORY) && !defined(Q_OS_ANDROID)
++#if !defined(QT_POSIX_IPC) && !defined(QT_NO_SHAREDMEMORY) && !defined(Q_OS_ANDROID) && !defined(Q_OS_SERENITY)
+ #  include <sys/ipc.h>
+ #endif
+ 
+diff --git a/src/corelib/kernel/qsharedmemory_p.h b/src/corelib/kernel/qsharedmemory_p.h
+index e06e7e86..95a36b23 100644
+--- a/src/corelib/kernel/qsharedmemory_p.h
++++ b/src/corelib/kernel/qsharedmemory_p.h
+@@ -51,6 +51,8 @@
+ // We mean it.
+ //
+ 
++#define QT_NO_SHAREDMEMORY
++#define QT_NO_SYSTEMSEMAPHORE
+ #include "qsharedmemory.h"
+ 
+ #include <QtCore/qstring.h>
+@@ -78,7 +80,7 @@ QT_END_NAMESPACE
+ # include "private/qobject_p.h"
+ #endif
+ 
+-#if !defined(Q_OS_WIN) && !defined(Q_OS_ANDROID) && !defined(Q_OS_INTEGRITY) && !defined(Q_OS_RTEMS)
++#if !defined(Q_OS_WIN) && !defined(Q_OS_ANDROID) && !defined(Q_OS_INTEGRITY) && !defined(Q_OS_RTEMS) && !defined(Q_OS_SERENITY)
+ #  include <sys/sem.h>
+ #endif
+ 
+diff --git a/src/corelib/kernel/qsystemsemaphore_p.h b/src/corelib/kernel/qsystemsemaphore_p.h
+index 56619d73..ab1c7b4d 100644
+--- a/src/corelib/kernel/qsystemsemaphore_p.h
++++ b/src/corelib/kernel/qsystemsemaphore_p.h
+@@ -51,6 +51,9 @@
+ // We mean it.
+ //
+ 
++#define QT_NO_SHAREDMEMORY
++#define QT_NO_SYSTEMSEMAPHORE
++
+ #include "qsystemsemaphore.h"
+ 
+ #ifndef QT_NO_SYSTEMSEMAPHORE
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0005-HACK-use-char-instead-of-wchar_t.patch
+++ b/Ports/qt6-qtbase/patches/0005-HACK-use-char-instead-of-wchar_t.patch
@@ -1,0 +1,175 @@
+From af7aefc71ad88989df76f086037b0802e226ede2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:17:31 +0200
+Subject: [PATCH 5/8] HACK: use char instead of wchar_t
+
+---
+ src/corelib/text/qcollator_p.h       |  2 +-
+ src/corelib/text/qcollator_posix.cpp | 19 +++++++++++--------
+ src/corelib/text/qstring.h           | 18 +++++++++++-------
+ src/corelib/text/qstringview.h       |  4 ++--
+ 4 files changed, 25 insertions(+), 18 deletions(-)
+
+diff --git a/src/corelib/text/qcollator_p.h b/src/corelib/text/qcollator_p.h
+index b1a483c4..24b77c75 100644
+--- a/src/corelib/text/qcollator_p.h
++++ b/src/corelib/text/qcollator_p.h
+@@ -81,7 +81,7 @@ typedef int CollatorType;
+ const CollatorType NoCollator = 0;
+ 
+ #else // posix - ignores CollatorType collator, only handles system locale
+-typedef QList<wchar_t> CollatorKeyType;
++typedef QList<char> CollatorKeyType;
+ typedef bool CollatorType;
+ const CollatorType NoCollator = false;
+ #endif
+diff --git a/src/corelib/text/qcollator_posix.cpp b/src/corelib/text/qcollator_posix.cpp
+index 92148fa3..215737c7 100644
+--- a/src/corelib/text/qcollator_posix.cpp
++++ b/src/corelib/text/qcollator_posix.cpp
+@@ -42,7 +42,6 @@
+ #include "qstring.h"
+ 
+ #include <cstring>
+-#include <cwchar>
+ 
+ QT_BEGIN_NAMESPACE
+ 
+@@ -65,7 +64,7 @@ void QCollatorPrivate::cleanup()
+ {
+ }
+ 
+-static void stringToWCharArray(QVarLengthArray<wchar_t> &ret, QStringView string)
++static void stringToWCharArray(QVarLengthArray<char> &ret, QStringView string)
+ {
+     ret.resize(string.length());
+     int len = string.toWCharArray(ret.data());
+@@ -85,10 +84,10 @@ int QCollator::compare(QStringView s1, QStringView s2) const
+     if (d->dirty)
+         d->init();
+ 
+-    QVarLengthArray<wchar_t> array1, array2;
++    QVarLengthArray<char> array1, array2;
+     stringToWCharArray(array1, s1);
+     stringToWCharArray(array2, s2);
+-    return std::wcscoll(array1.constData(), array2.constData());
++    return strcoll(array1.constData(), array2.constData());
+ }
+ 
+ QCollatorSortKey QCollator::sortKey(const QString &string) const
+@@ -96,13 +95,16 @@ QCollatorSortKey QCollator::sortKey(const QString &string) const
+     if (d->dirty)
+         d->init();
+ 
+-    QVarLengthArray<wchar_t> original;
++    QVarLengthArray<char> original;
+     stringToWCharArray(original, string);
+-    QList<wchar_t> result(original.size());
++    QList<char> result(original.size());
++    std::copy(original.cbegin(), original.cend(), result.begin());
++#if 0
+     if (d->isC()) {
+         std::copy(original.cbegin(), original.cend(), result.begin());
+     } else {
+-        size_t size = std::wcsxfrm(result.data(), original.constData(), string.size());
++        size_t size = strlen(original);//std::wcsxfrm(result.data(), original.constData(), string.size());
++        strncpy(result, original, size);
+         if (size > uint(result.size())) {
+             result.resize(size+1);
+             size = std::wcsxfrm(result.data(), original.constData(), string.size());
+@@ -110,12 +112,13 @@ QCollatorSortKey QCollator::sortKey(const QString &string) const
+         result.resize(size+1);
+         result[size] = 0;
+     }
++#endif
+     return QCollatorSortKey(new QCollatorSortKeyPrivate(std::move(result)));
+ }
+ 
+ int QCollatorSortKey::compare(const QCollatorSortKey &otherKey) const
+ {
+-    return std::wcscmp(d->m_key.constData(), otherKey.d->m_key.constData());
++    return strcmp(d->m_key.constData(), otherKey.d->m_key.constData());
+ }
+ 
+ QT_END_NAMESPACE
+diff --git a/src/corelib/text/qstring.h b/src/corelib/text/qstring.h
+index 153a9e04..e2eb58e2 100644
+--- a/src/corelib/text/qstring.h
++++ b/src/corelib/text/qstring.h
+@@ -57,6 +57,10 @@
+ #include <QtCore/qstringtokenizer.h>
+ 
+ #include <string>
++namespace std {
++    typedef string wstring;
++}
++
+ #include <iterator>
+ 
+ #include <stdarg.h>
+@@ -779,8 +783,8 @@ public:
+     { return fromUcs4(reinterpret_cast<const char32_t *>(str), size); }
+ #endif
+ 
+-    inline qsizetype toWCharArray(wchar_t *array) const;
+-    [[nodiscard]] static inline QString fromWCharArray(const wchar_t *string, qsizetype size = -1);
++    inline qsizetype toWCharArray(char *array) const;
++    [[nodiscard]] static inline QString fromWCharArray(const char *string, qsizetype size = -1);
+ 
+     QString &setRawData(const QChar *unicode, qsizetype size);
+     QString &setUnicode(const QChar *unicode, qsizetype size);
+@@ -1253,14 +1257,14 @@ QT_WARNING_PUSH
+ QT_WARNING_DISABLE_MSVC(4127)   // "conditional expression is constant"
+ QT_WARNING_DISABLE_INTEL(111)   // "statement is unreachable"
+ 
+-inline qsizetype QString::toWCharArray(wchar_t *array) const
++inline qsizetype QString::toWCharArray(char *array) const
+ {
+     return qToStringViewIgnoringNull(*this).toWCharArray(array);
+ }
+ 
+-qsizetype QStringView::toWCharArray(wchar_t *array) const
++qsizetype QStringView::toWCharArray(char *array) const
+ {
+-    if (sizeof(wchar_t) == sizeof(QChar)) {
++    if (sizeof(char) == sizeof(QChar)) {
+         if (auto src = data())
+             memcpy(array, src, sizeof(QChar) * size());
+         return size();
+@@ -1272,9 +1276,9 @@ qsizetype QStringView::toWCharArray(wchar_t *array) const
+ 
+ QT_WARNING_POP
+ 
+-inline QString QString::fromWCharArray(const wchar_t *string, qsizetype size)
++inline QString QString::fromWCharArray(const char *string, qsizetype size)
+ {
+-    return sizeof(wchar_t) == sizeof(QChar) ? fromUtf16(reinterpret_cast<const char16_t *>(string), size)
++    return sizeof(char) == sizeof(QChar) ? fromUtf16(reinterpret_cast<const char16_t *>(string), size)
+                                             : fromUcs4(reinterpret_cast<const char32_t *>(string), size);
+ }
+ 
+diff --git a/src/corelib/text/qstringview.h b/src/corelib/text/qstringview.h
+index c0082b70..59bf96e8 100644
+--- a/src/corelib/text/qstringview.h
++++ b/src/corelib/text/qstringview.h
+@@ -80,7 +80,7 @@ struct IsCompatibleCharTypeHelper
+                              std::is_same<Char, QChar>::value ||
+                              std::is_same<Char, ushort>::value ||
+                              std::is_same<Char, char16_t>::value ||
+-                             (std::is_same<Char, wchar_t>::value && sizeof(wchar_t) == sizeof(QChar))> {};
++                             (std::is_same<Char, char>::value && sizeof(char) == sizeof(QChar))> {};
+ template <typename Char>
+ struct IsCompatibleCharType
+     : IsCompatibleCharTypeHelper<typename std::remove_cv<typename std::remove_reference<Char>::type>::type> {};
+@@ -383,7 +383,7 @@ public:
+     [[nodiscard]] Q_CORE_EXPORT float toFloat(bool *ok = nullptr) const;
+     [[nodiscard]] Q_CORE_EXPORT double toDouble(bool *ok = nullptr) const;
+ 
+-    [[nodiscard]] inline qsizetype toWCharArray(wchar_t *array) const; // defined in qstring.h
++    [[nodiscard]] inline qsizetype toWCharArray(char *array) const; // defined in qstring.h
+ 
+ 
+     [[nodiscard]] Q_CORE_EXPORT
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0006-HACK-work-around-the-need-to-use-UTIME_NOW.patch
+++ b/Ports/qt6-qtbase/patches/0006-HACK-work-around-the-need-to-use-UTIME_NOW.patch
@@ -1,0 +1,25 @@
+From d7e2cf2d0adaef782bf2083b62db151a180675bb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:18:03 +0200
+Subject: [PATCH 6/8] HACK: work around the need to use UTIME_NOW
+
+---
+ qmake/library/ioutils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qmake/library/ioutils.cpp b/qmake/library/ioutils.cpp
+index 3a93298f..c310a502 100644
+--- a/qmake/library/ioutils.cpp
++++ b/qmake/library/ioutils.cpp
+@@ -228,7 +228,7 @@ bool IoUtils::touchFile(const QString &targetFileName, const QString &referenceF
+         *errorString = fL1S("Cannot stat() reference file %1: %2.").arg(referenceFileName, fL1S(strerror(errno)));
+         return false;
+     }
+-#    if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L
++#    if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L && !defined(Q_OS_SERENITY)
+     const struct timespec times[2] = { { 0, UTIME_NOW }, st.st_mtim };
+     const bool utimeError = utimensat(AT_FDCWD, targetFileName.toLocal8Bit().constData(), times, 0) < 0;
+ #    else
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0007-Do-not-include-langinfo.patch
+++ b/Ports/qt6-qtbase/patches/0007-Do-not-include-langinfo.patch
@@ -11,17 +11,15 @@ diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcorea
 index 23a39916..e04875b4 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
-@@ -103,7 +103,9 @@
- 
+@@ -106,7 +106,7 @@
+
  #ifdef Q_OS_UNIX
  #  include <locale.h>
--#  include <langinfo.h>
-+# ifndef Q_OS_SERENITY
-+#   include <langinfo.h>
-+# endif
+-#  ifndef Q_OS_INTEGRITY
++#  if !defined(Q_OS_INTEGRITY) && !defined(Q_OS_SERENITY)
+ #    include <langinfo.h>
+ #  endif
  #  include <unistd.h>
- #  include <sys/types.h>
- #endif
 -- 
 2.31.1
 

--- a/Ports/qt6-qtbase/patches/0007-Do-not-include-langinfo.patch
+++ b/Ports/qt6-qtbase/patches/0007-Do-not-include-langinfo.patch
@@ -1,0 +1,27 @@
+From 2672f339054f04deee8f873547f42fb153b22de2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:18:41 +0200
+Subject: [PATCH 7/8] Do not include langinfo
+
+---
+ src/corelib/kernel/qcoreapplication.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 23a39916..e04875b4 100644
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
+@@ -103,7 +103,9 @@
+ 
+ #ifdef Q_OS_UNIX
+ #  include <locale.h>
+-#  include <langinfo.h>
++# ifndef Q_OS_SERENITY
++#   include <langinfo.h>
++# endif
+ #  include <unistd.h>
+ #  include <sys/types.h>
+ #endif
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0008-HACK-avoid-using-SYMLOOP_MAX.patch
+++ b/Ports/qt6-qtbase/patches/0008-HACK-avoid-using-SYMLOOP_MAX.patch
@@ -1,0 +1,25 @@
+From 764067a4d9e9d9e0943c7ea0e1074b464c41754d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Thu, 12 Aug 2021 19:18:55 +0200
+Subject: [PATCH 8/8] HACK: avoid using SYMLOOP_MAX
+
+---
+ src/corelib/time/qtimezoneprivate_tz.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/corelib/time/qtimezoneprivate_tz.cpp b/src/corelib/time/qtimezoneprivate_tz.cpp
+index fb6baf6e..9668415b 100644
+--- a/src/corelib/time/qtimezoneprivate_tz.cpp
++++ b/src/corelib/time/qtimezoneprivate_tz.cpp
+@@ -1264,6 +1264,8 @@ private:
+ #ifdef SYMLOOP_MAX
+         // If defined, at runtime it can only be greater than this, so this is a safe bet:
+         return SYMLOOP_MAX;
++#elif defined(Q_OS_SERENITY)
++        return 120;
+ #else
+         errno = 0;
+         long result = sysconf(_SC_SYMLOOP_MAX);
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0009-Fix-testlib-build-on-Serenity.patch
+++ b/Ports/qt6-qtbase/patches/0009-Fix-testlib-build-on-Serenity.patch
@@ -1,0 +1,25 @@
+From b953eeceecd9fb585a2b0bb0a8be3f9a4b0389ec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Sun, 15 Aug 2021 14:38:01 +0200
+Subject: [PATCH 09/10] Fix testlib build on Serenity
+
+---
+ src/testlib/qtestcase.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/testlib/qtestcase.cpp b/src/testlib/qtestcase.cpp
+index 77d0c305..803a5235 100644
+--- a/src/testlib/qtestcase.cpp
++++ b/src/testlib/qtestcase.cpp
+@@ -1652,7 +1652,7 @@ public:
+ 
+     // tvOS/watchOS both define SA_ONSTACK (in sys/signal.h) but mark sigaltstack() as
+     // unavailable (__WATCHOS_PROHIBITED __TVOS_PROHIBITED in signal.h)
+-#  if defined(SA_ONSTACK) && !defined(Q_OS_TVOS) && !defined(Q_OS_WATCHOS)
++#  if defined(SA_ONSTACK) && !defined(Q_OS_TVOS) && !defined(Q_OS_WATCHOS) && !defined(Q_OS_SERENITY)
+         // Let the signal handlers use an alternate stack
+         // This is necessary if SIGSEGV is to catch a stack overflow
+ #    if defined(Q_CC_GNU) && defined(Q_OF_ELF)
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0010-Add-a-simple-serenity-platform-plugin.patch
+++ b/Ports/qt6-qtbase/patches/0010-Add-a-simple-serenity-platform-plugin.patch
@@ -1,0 +1,1274 @@
+From 72e39f24ee9b3f8244a5dca700f4a5832cc655b0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Fri, 13 Aug 2021 16:49:37 +0200
+Subject: [PATCH 10/10] Add a simple serenity platform plugin
+
+---
+ mkspecs/serenity-g++/qmake.conf               |   1 +
+ src/gui/CMakeLists.txt                        |   2 +-
+ src/gui/configure.cmake                       |   8 +-
+ src/plugins/platforms/CMakeLists.txt          |   3 +
+ src/plugins/platforms/serenity/CMakeLists.txt |  48 +++
+ src/plugins/platforms/serenity/main.cpp       |  64 ++++
+ .../serenity/qserenitybackingstore.cpp        | 103 ++++++
+ .../serenity/qserenitybackingstore.h          |  64 ++++
+ .../serenity/qserenityintegration.cpp         | 167 ++++++++++
+ .../platforms/serenity/qserenityintegration.h |  95 ++++++
+ .../platforms/serenity/qserenityscreen.cpp    |  50 +++
+ .../platforms/serenity/qserenityscreen.h      |  66 ++++
+ .../platforms/serenity/qserenitystring.cpp    |   9 +
+ .../platforms/serenity/qserenitystring.h      |  14 +
+ .../platforms/serenity/qserenitywindow.cpp    | 302 ++++++++++++++++++
+ .../platforms/serenity/qserenitywindow.h      | 101 ++++++
+ src/plugins/platforms/serenity/serenity.json  |   3 +
+ 17 files changed, 1098 insertions(+), 2 deletions(-)
+ create mode 100644 src/plugins/platforms/serenity/CMakeLists.txt
+ create mode 100644 src/plugins/platforms/serenity/main.cpp
+ create mode 100644 src/plugins/platforms/serenity/qserenitybackingstore.cpp
+ create mode 100644 src/plugins/platforms/serenity/qserenitybackingstore.h
+ create mode 100644 src/plugins/platforms/serenity/qserenityintegration.cpp
+ create mode 100644 src/plugins/platforms/serenity/qserenityintegration.h
+ create mode 100644 src/plugins/platforms/serenity/qserenityscreen.cpp
+ create mode 100644 src/plugins/platforms/serenity/qserenityscreen.h
+ create mode 100644 src/plugins/platforms/serenity/qserenitystring.cpp
+ create mode 100644 src/plugins/platforms/serenity/qserenitystring.h
+ create mode 100644 src/plugins/platforms/serenity/qserenitywindow.cpp
+ create mode 100644 src/plugins/platforms/serenity/qserenitywindow.h
+ create mode 100644 src/plugins/platforms/serenity/serenity.json
+
+diff --git a/mkspecs/serenity-g++/qmake.conf b/mkspecs/serenity-g++/qmake.conf
+index 00d5ae2c..5060af6e 100644
+--- a/mkspecs/serenity-g++/qmake.conf
++++ b/mkspecs/serenity-g++/qmake.conf
+@@ -4,6 +4,7 @@
+ 
+ MAKEFILE_GENERATOR      = ninja
+ QMAKE_PLATFORM          = serenity
++QT_QPA_DEFAULT_PLATFORM = serenity
+ 
+ include(../common/unix.conf)
+ 
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 7b02a270..658449cd 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -29,7 +29,7 @@ if (QT_FEATURE_gui)
+         set(_default_platform "haiku")
+     elseif(WASM)
+         set(_default_platform "wasm")
+-    elseif(SERENITY)
++    elseif(SERENITYOS)
+         set(_default_platform "serenity")
+     else()
+         set(_default_platform "xcb")
+diff --git a/src/gui/configure.cmake b/src/gui/configure.cmake
+index b5c47a0d..c8f73547 100644
+--- a/src/gui/configure.cmake
++++ b/src/gui/configure.cmake
+@@ -1186,6 +1186,11 @@ qt_feature("undogroup" PUBLIC
+     CONDITION QT_FEATURE_undostack
+ )
+ qt_feature_definition("undogroup" "QT_NO_UNDOGROUP" NEGATE VALUE "1")
++qt_feature("serenity" PRIVATE
++    SECTION "Platform plugins"
++    LABEL "SerenityOS"
++    CONDITION SERENITYOS
++)
+ qt_configure_add_summary_section(NAME "Qt Gui")
+ qt_configure_add_summary_entry(ARGS "accessibility")
+ qt_configure_add_summary_entry(ARGS "freetype")
+@@ -1278,6 +1283,7 @@ qt_configure_add_summary_entry(ARGS "direct2d1_1") ### special case
+ qt_configure_add_summary_entry(ARGS "directwrite")
+ qt_configure_add_summary_entry(ARGS "directwrite3")
+ qt_configure_end_summary_section() # end of "Windows" section
++qt_configure_add_summary_entry(ARGS "serenity")
+ qt_configure_end_summary_section() # end of "QPA backends" section
+ qt_configure_add_report_entry(
+     TYPE NOTE
+@@ -1302,7 +1308,7 @@ qt_configure_add_report_entry(
+ qt_configure_add_report_entry(
+     TYPE ERROR
+     MESSAGE "The OpenGL functionality tests failed!  You might need to modify the include and library search paths by editing QMAKE_INCDIR_OPENGL[_ES2], QMAKE_LIBDIR_OPENGL[_ES2] and QMAKE_LIBS_OPENGL[_ES2] in the mkspec for your platform."
+-    CONDITION QT_FEATURE_gui AND NOT WATCHOS AND ( NOT INPUT_opengl STREQUAL 'no' ) AND NOT QT_FEATURE_opengl_desktop AND NOT QT_FEATURE_opengles2 AND NOT QT_FEATURE_opengl_dynamic
++    CONDITION QT_FEATURE_gui AND NOT WATCHOS AND NOT SERENITYOS AND ( NOT INPUT_opengl STREQUAL 'no' ) AND NOT QT_FEATURE_opengl_desktop AND NOT QT_FEATURE_opengles2 AND NOT QT_FEATURE_opengl_dynamic
+ )
+ qt_configure_add_report_entry(
+     TYPE WARNING
+diff --git a/src/plugins/platforms/CMakeLists.txt b/src/plugins/platforms/CMakeLists.txt
+index 7f0ada80..daf0106a 100644
+--- a/src/plugins/platforms/CMakeLists.txt
++++ b/src/plugins/platforms/CMakeLists.txt
+@@ -52,3 +52,6 @@ endif()
+ if(QT_FEATURE_integrityfb)
+     # add_subdirectory(integrity) # special case TODO
+ endif()
++if(SERENITYOS)
++    add_subdirectory(serenity)
++endif()
+diff --git a/src/plugins/platforms/serenity/CMakeLists.txt b/src/plugins/platforms/serenity/CMakeLists.txt
+new file mode 100644
+index 00000000..970c7759
+--- /dev/null
++++ b/src/plugins/platforms/serenity/CMakeLists.txt
+@@ -0,0 +1,48 @@
++# Generated from minimal.pro.
++
++#####################################################################
++## QSerenityIntegrationPlugin Plugin:
++#####################################################################
++
++set(HAVE_VIDEO_SERENITY TRUE)
++set(HAVE_AUDIO_SERENITY TRUE)
++
++set(CXX_STANDARD 20)
++
++qt_internal_add_plugin(QSerenityIntegrationPlugin
++    OUTPUT_NAME qserenity
++    TYPE platforms
++    DEFAULT_IF ${QT_QPA_DEFAULT_PLATFORM} MATCHES serenity # special case
++    SOURCES
++        main.cpp
++        qserenitybackingstore.cpp qserenitybackingstore.h
++        qserenityintegration.cpp qserenityintegration.h
++        qserenityscreen.cpp qserenityscreen.h
++        qserenitywindow.cpp qserenitywindow.h
++        qserenitystring.cpp qserenitystring.h
++    DEFINES
++        QT_NO_FOREACH
++    INCLUDE_DIRECTORIES
++        ${CMAKE_CURRENT_SOURCE_DIR}
++        ${SERENITY_INSTALL_ROOT}/usr/local/include
++        ${SERENITY_INSTALL_ROOT}/usr/include
++    LIBRARIES
++        Qt::Core
++        Qt::CorePrivate
++        Qt::Gui
++        Qt::GuiPrivate
++        ipc 
++        gui
++        gfx
++        core
++)
++
++
++#### Keys ignored in scope 1:.:.:minimal.pro:<TRUE>:
++# OTHER_FILES = "minimal.json"
++
++## Scopes:
++#####################################################################
++
++#### Keys ignored in scope 3:.:.:minimal.pro:NOT TARGET___equals____ss_QT_DEFAULT_QPA_PLUGIN:
++# PLUGIN_EXTENDS = "-"
+diff --git a/src/plugins/platforms/serenity/main.cpp b/src/plugins/platforms/serenity/main.cpp
+new file mode 100644
+index 00000000..8311914d
+--- /dev/null
++++ b/src/plugins/platforms/serenity/main.cpp
+@@ -0,0 +1,64 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++
++#include <qpa/qplatformintegrationplugin.h>
++#include "qserenityintegration.h"
++
++QT_BEGIN_NAMESPACE
++
++class QSerenityIntegrationPlugin : public QPlatformIntegrationPlugin
++{
++    Q_OBJECT
++    Q_PLUGIN_METADATA(IID QPlatformIntegrationFactoryInterface_iid FILE "serenity.json")
++public:
++    QPlatformIntegration *create(const QString&, const QStringList&) override;
++};
++
++QPlatformIntegration *QSerenityIntegrationPlugin::create(const QString& system, const QStringList& paramList)
++{
++    if (!system.compare(QLatin1String("serenity"), Qt::CaseInsensitive))
++        return new QSerenityIntegration(paramList);
++
++    return 0;
++}
++
++QT_END_NAMESPACE
++
++#include "main.moc"
+diff --git a/src/plugins/platforms/serenity/qserenitybackingstore.cpp b/src/plugins/platforms/serenity/qserenitybackingstore.cpp
+new file mode 100644
+index 00000000..524ba09a
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenitybackingstore.cpp
+@@ -0,0 +1,103 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++
++#include "qserenitybackingstore.h"
++#include "qserenityintegration.h"
++#include "qscreen.h"
++#include <QtCore/qdebug.h>
++#include <qpa/qplatformscreen.h>
++
++#include <iostream>
++#include <cstdlib>
++
++QSerenityBackingStore::QSerenityBackingStore(QWindow *window)
++    : QPlatformBackingStore(window)
++
++{
++}
++
++QSerenityBackingStore::~QSerenityBackingStore()
++{
++}
++
++QPaintDevice *QSerenityBackingStore::paintDevice()
++{
++    return &mImage;
++}
++
++void QSerenityBackingStore::flush(QWindow *window, const QRegion &region, const QPoint &offset)
++{
++    Q_UNUSED(window);
++    Q_UNUSED(region);
++    Q_UNUSED(offset);
++
++    QPlatformWindow *platformWindow = this->window()->handle();
++    QSerenityWindow *qSerenityWindow = dynamic_cast<QSerenityWindow*>(platformWindow);
++
++    auto proxyWidget = qSerenityWindow->proxyWidget();
++
++    for (auto &r : region) {
++        for (int i = offset.x() + r.left(); i < mImage.width() && i < offset.x() + r.right(); i++) {
++            for (int j = offset.y() + r.top(); j < mImage.height() && j < offset.y() + r.bottom(); j++) {
++                auto currentColor = mImage.pixel(i, j);
++                proxyWidget->m_buffer->set_pixel(i, j, Gfx::Color(currentColor >> 16 & 0xFF, currentColor >> 8 & 0xFF, currentColor & 0xFF));
++            }
++        }
++        proxyWidget->update(Gfx::IntRect(r.x() + offset.x(), r.y() + offset.y(), r.width(), r.height()));
++    }
++}
++
++void QSerenityBackingStore::resize(const QSize &size, const QRegion &)
++{
++    QPlatformWindow *platformWindow = window()->handle();
++    QSerenityWindow *qSerenityWindow = dynamic_cast<QSerenityWindow*>(platformWindow);
++
++    auto proxyWidget = qSerenityWindow->proxyWidget();
++
++    QImage::Format format = QGuiApplication::primaryScreen()->handle()->format();
++    if (mImage.size() != size) {
++        mImage = QImage(size, format);
++        proxyWidget->m_buffer = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, Gfx::IntSize(window()->width(), window()->height()));
++        proxyWidget->m_buffer->set_volatile();
++        proxyWidget->resize(Gfx::IntSize(size.width(), size.height()));
++        proxyWidget->update();
++    }
++}
++QT_END_NAMESPACE
+diff --git a/src/plugins/platforms/serenity/qserenitybackingstore.h b/src/plugins/platforms/serenity/qserenitybackingstore.h
+new file mode 100644
+index 00000000..5446f78f
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenitybackingstore.h
+@@ -0,0 +1,64 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QBACKINGSTORE_MINIMAL_H
++#define QBACKINGSTORE_MINIMAL_H
++
++#include <qpa/qplatformbackingstore.h>
++#include <qpa/qplatformwindow.h>
++#include <QtGui/QImage>
++
++QT_BEGIN_NAMESPACE
++
++class QSerenityBackingStore : public QPlatformBackingStore
++{
++public:
++    QSerenityBackingStore(QWindow *window);
++    ~QSerenityBackingStore();
++
++    QPaintDevice *paintDevice() override;
++    void flush(QWindow *window, const QRegion &region, const QPoint &offset) override;
++    void resize(const QSize &size, const QRegion &staticContents) override;
++private:
++    QImage mImage;
++};
++
++QT_END_NAMESPACE
++
++#endif
+diff --git a/src/plugins/platforms/serenity/qserenityintegration.cpp b/src/plugins/platforms/serenity/qserenityintegration.cpp
+new file mode 100644
+index 00000000..71687c6d
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenityintegration.cpp
+@@ -0,0 +1,167 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++
++#include "qserenityintegration.h"
++#include "qserenitybackingstore.h"
++
++#include <QtGui/private/qpixmap_raster_p.h>
++#include <QtGui/private/qguiapplication_p.h>
++#include <qpa/qplatformwindow.h>
++#include <qpa/qwindowsysteminterface.h>
++
++#include <QtGui/private/qfreetypefontdatabase_p.h>
++#include <QtGui/private/qgenericunixeventdispatcher_p.h>
++
++#  include <QtGui/private/qgenericunixfontdatabase_p.h>
++#  include <qpa/qplatformfontdatabase.h>
++
++#include <iostream>
++
++#include <stdlib.h>
++
++#include <LibCore/EventLoop.h>
++
++QT_BEGIN_NAMESPACE
++
++class QCoreTextFontEngine;
++
++QSerenityIntegration::QSerenityIntegration(const QStringList &parameters)
++    : m_fontDatabase(0)
++{
++    qputenv("QT_ENABLE_REGEXP_JIT", "0");
++    qputenv("QT_QPA_FONTDIR", "/res/fonts");
++
++    if (pledge("stdio recvfd sendfd rpath wpath cpath unix getkeymap fattr prot_exec", nullptr) < 0) {
++        perror("pledge");
++    }
++    else {
++        perror("pledge");
++    }
++    app = GUI::Application::construct(0, nullptr);
++
++    m_primaryScreen = new QSerenityScreen();
++
++    QWindowSystemInterface::handleScreenAdded(m_primaryScreen);
++}
++
++QSerenityIntegration::~QSerenityIntegration()
++{
++    QWindowSystemInterface::handleScreenRemoved(m_primaryScreen);
++    delete m_fontDatabase;
++}
++
++bool QSerenityIntegration::hasCapability(QPlatformIntegration::Capability cap) const
++{
++    switch (cap) {
++    case ThreadedPixmaps: return true;
++    case MultipleWindows: return true;
++    case NonFullScreenWindows: return true;
++    case RhiBasedRendering: return false;
++    case PaintEvents: return true;
++    case WindowManagement: return true;
++    default: return QPlatformIntegration::hasCapability(cap);
++    }
++}
++
++// Dummy font database that does not scan the fonts directory to be
++// used for command line tools like qmlplugindump that do not create windows
++// unless DebugBackingStore is activated.
++class DummyFontDatabase : public QPlatformFontDatabase
++{
++public:
++    virtual void populateFontDatabase() override {}
++};
++
++QPlatformFontDatabase *QSerenityIntegration::fontDatabase() const
++{
++    m_fontDatabase = new QFreeTypeFontDatabase;
++    //m_fontDatabase->addApplicationFont("", "/res/fonts/SerenitySans-Regular.ttf");
++    return m_fontDatabase;
++}
++
++QPlatformWindow *QSerenityIntegration::createPlatformWindow(QWindow *window) const
++{
++    QPlatformWindow *w = new QSerenityWindow(window);
++    w->requestActivateWindow();
++    return w;
++}
++
++QPlatformBackingStore *QSerenityIntegration::createPlatformBackingStore(QWindow *window) const
++{
++    std::cerr << "Creating a new backing store" << std::endl;
++    return new QSerenityBackingStore(window);
++}
++
++QAbstractEventDispatcher *QSerenityIntegration::createEventDispatcher() const
++{
++    return new QSerenityEventDispatcher();
++}
++
++QSerenityIntegration *QSerenityIntegration::instance()
++{
++    return static_cast<QSerenityIntegration *>(QGuiApplicationPrivate::platformIntegration());
++}
++
++QT_END_NAMESPACE
++
++QSerenityEventDispatcher::QSerenityEventDispatcher(QObject *parent)
++    : QUnixEventDispatcherQPA(parent)
++{
++}
++
++QSerenityEventDispatcher::~QSerenityEventDispatcher() {
++
++}
++
++bool QSerenityEventDispatcher::processEvents(QEventLoop::ProcessEventsFlags flags) {
++    processSerenityEvents();
++    // while this whole class is hacking, this is another layer of hacks: clear the WaitForMoreEvents flag to process everything immediatelly
++    // makes everything run way smoother at the cost of eating all the CPU
++    return QUnixEventDispatcherQPA::processEvents(flags & (~QEventLoop::WaitForMoreEvents));
++}
++
++bool QSerenityEventDispatcher::processSerenityEvents() {
++    auto& loop = Core::EventLoop::current();
++    if (loop.was_exit_requested())
++        exit(0);
++    loop.pump(Core::EventLoop::WaitMode::PollForEvents);
++
++    return true;
++}
+diff --git a/src/plugins/platforms/serenity/qserenityintegration.h b/src/plugins/platforms/serenity/qserenityintegration.h
+new file mode 100644
+index 00000000..8a785ae0
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenityintegration.h
+@@ -0,0 +1,95 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QPLATFORMINTEGRATION_SERENITY_H
++#define QPLATFORMINTEGRATION_SERENITY_H
++
++#include <qpa/qplatformintegration.h>
++#include <qpa/qplatformscreen.h>
++
++#include "qserenityscreen.h"
++#include "qserenitywindow.h"
++
++#include <LibGUI/Application.h>
++
++#include <private/qunixeventdispatcher_qpa_p.h>
++
++#include <QTimer>
++
++QT_BEGIN_NAMESPACE
++
++class QSerenityEventDispatcher : public QUnixEventDispatcherQPA {
++    Q_OBJECT
++public:
++    explicit QSerenityEventDispatcher(QObject *parent = nullptr);
++    ~QSerenityEventDispatcher();
++
++private slots:
++    bool processSerenityEvents();
++
++protected:
++    bool processEvents(QEventLoop::ProcessEventsFlags flags) override;
++
++private:
++};
++
++class QSerenityIntegration : public QPlatformIntegration
++{
++public:
++    explicit QSerenityIntegration(const QStringList &parameters);
++    ~QSerenityIntegration();
++
++    bool hasCapability(QPlatformIntegration::Capability cap) const override;
++    QPlatformFontDatabase *fontDatabase() const override;
++
++    QPlatformWindow *createPlatformWindow(QWindow *window) const override;
++    QPlatformBackingStore *createPlatformBackingStore(QWindow *window) const override;
++    QAbstractEventDispatcher *createEventDispatcher() const override;
++
++    static QSerenityIntegration *instance();
++
++private:
++    mutable QPlatformFontDatabase *m_fontDatabase;
++    QSerenityScreen *m_primaryScreen;
++    RefPtr<GUI::Application> app;
++};
++
++QT_END_NAMESPACE
++
++#endif
+diff --git a/src/plugins/platforms/serenity/qserenityscreen.cpp b/src/plugins/platforms/serenity/qserenityscreen.cpp
+new file mode 100644
+index 00000000..f13f5acb
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenityscreen.cpp
+@@ -0,0 +1,50 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++
++#include "qserenityscreen.h"
++
++QSerenityScreen::QSerenityScreen() 
++        : mDepth(32), mFormat(QImage::Format_ARGB32_Premultiplied)
++{
++    // TODO
++    mGeometry = QRect(0, 0, 1280, 1024);
++    mDepth = 32;
++    mFormat = QImage::Format_ARGB32_Premultiplied;
++}
+diff --git a/src/plugins/platforms/serenity/qserenityscreen.h b/src/plugins/platforms/serenity/qserenityscreen.h
+new file mode 100644
+index 00000000..b0089d9e
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenityscreen.h
+@@ -0,0 +1,66 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QPLATFORMSCREEN_SERENITY_H
++#define QPLATFORMSCREEN_SERENITY_H
++
++#include <qpa/qplatformscreen.h>
++
++QT_BEGIN_NAMESPACE
++
++class QSerenityScreen : public QPlatformScreen
++{
++public:
++    QSerenityScreen();
++
++    QRect geometry() const override { return mGeometry; }
++    int depth() const override { return mDepth; }
++    QImage::Format format() const override { return mFormat; }
++
++public:
++    QRect mGeometry;
++    int mDepth;
++    QImage::Format mFormat;
++    QSize mPhysicalSize;
++};
++
++
++QT_END_NAMESPACE
++
++#endif // QPLATFORMSCREEN_SERENITY_H
+diff --git a/src/plugins/platforms/serenity/qserenitystring.cpp b/src/plugins/platforms/serenity/qserenitystring.cpp
+new file mode 100644
+index 00000000..c055cb3c
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenitystring.cpp
+@@ -0,0 +1,9 @@
++#include "qserenitystring.h"
++
++AK::String QSerenityString::fromQString(const QString &str) {
++    return AK::String(str.toStdString().c_str());
++}
++
++QString QSerenityString::toQString(const AK::String &v) {
++    return QString(v.characters());
++}
+diff --git a/src/plugins/platforms/serenity/qserenitystring.h b/src/plugins/platforms/serenity/qserenitystring.h
+new file mode 100644
+index 00000000..b155a523
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenitystring.h
+@@ -0,0 +1,14 @@
++#ifndef QSERENITYSTRING_H
++#define QSERENITYSTRING_H
++
++#include <AK/String.h>
++#include <QString>
++
++class QSerenityString
++{
++public:
++    static AK::String fromQString(const QString &str);
++    static QString toQString(const AK::String &v);
++};
++
++#endif // QSERENITYSTRING_H
+diff --git a/src/plugins/platforms/serenity/qserenitywindow.cpp b/src/plugins/platforms/serenity/qserenitywindow.cpp
+new file mode 100644
+index 00000000..f31639b6
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenitywindow.cpp
+@@ -0,0 +1,302 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#include "qserenitywindow.h"
++
++#include <iostream>
++
++#include <private/qguiapplication_p.h>
++
++#include <Kernel/API/KeyCode.h>
++
++static QMap<KeyCode, int> keyMap {
++    { KeyCode::Key_Invalid, 0 },
++    { KeyCode::Key_Escape, Qt::Key_Escape },
++    { KeyCode::Key_Tab, Qt::Key_Tab },
++    { KeyCode::Key_Backspace, Qt::Key_Backspace },
++    { KeyCode::Key_Return, Qt::Key_Return },
++    { KeyCode::Key_Insert, Qt::Key_Insert },
++    { KeyCode::Key_Delete, Qt::Key_Delete },
++    { KeyCode::Key_PrintScreen, Qt::Key_Print },
++    { KeyCode::Key_SysRq, Qt::Key_SysReq },
++    { KeyCode::Key_Home, Qt::Key_Home },
++    { KeyCode::Key_End, Qt::Key_End },
++    { KeyCode::Key_Left, Qt::Key_Left },
++    { KeyCode::Key_Up, Qt::Key_Up },
++    { KeyCode::Key_Right, Qt::Key_Right },
++    { KeyCode::Key_Down, Qt::Key_Down },
++    { KeyCode::Key_PageUp, Qt::Key_PageUp },
++    { KeyCode::Key_PageDown, Qt::Key_PageDown },
++    { KeyCode::Key_LeftShift, Qt::Key_Shift },
++    { KeyCode::Key_RightShift, Qt::Key_Shift },
++    { KeyCode::Key_Control, Qt::Key_Control },
++    { KeyCode::Key_Alt, Qt::Key_Alt },
++    { KeyCode::Key_CapsLock, Qt::Key_CapsLock },
++    { KeyCode::Key_NumLock, Qt::Key_NumLock },
++    { KeyCode::Key_ScrollLock, Qt::Key_ScrollLock },
++    { KeyCode::Key_F1, Qt::Key_F1 },
++    { KeyCode::Key_F2, Qt::Key_F2 },
++    { KeyCode::Key_F3, Qt::Key_F3 },
++    { KeyCode::Key_F4, Qt::Key_F4 },
++    { KeyCode::Key_F5, Qt::Key_F5 },
++    { KeyCode::Key_F6, Qt::Key_F6 },
++    { KeyCode::Key_F7, Qt::Key_F7 },
++    { KeyCode::Key_F8, Qt::Key_F8 },
++    { KeyCode::Key_F9, Qt::Key_F9 },
++    { KeyCode::Key_F10, Qt::Key_F10 },
++    { KeyCode::Key_F11, Qt::Key_F11 },
++    { KeyCode::Key_F12, Qt::Key_F12 },
++    { KeyCode::Key_Space, Qt::Key_Space },
++    { KeyCode::Key_ExclamationPoint, Qt::Key_Exclam },
++    { KeyCode::Key_DoubleQuote, Qt::Key_QuoteDbl },
++    { KeyCode::Key_Hashtag, Qt::Key_NumberSign },
++    { KeyCode::Key_Dollar, Qt::Key_Dollar },
++    { KeyCode::Key_Percent, Qt::Key_Percent },
++    { KeyCode::Key_Ampersand, Qt::Key_Ampersand },
++    { KeyCode::Key_Apostrophe, Qt::Key_Apostrophe },
++    { KeyCode::Key_LeftParen, Qt::Key_ParenLeft },
++    { KeyCode::Key_RightParen, Qt::Key_ParenRight },
++    { KeyCode::Key_Asterisk, Qt::Key_Asterisk },
++    { KeyCode::Key_Plus, Qt::Key_Plus },
++    { KeyCode::Key_Comma, Qt::Key_Comma },
++    { KeyCode::Key_Minus, Qt::Key_Minus },
++    { KeyCode::Key_Period, Qt::Key_Period },
++    { KeyCode::Key_Slash, Qt::Key_Slash },
++    { KeyCode::Key_0, Qt::Key_0 },
++    { KeyCode::Key_1, Qt::Key_1 },
++    { KeyCode::Key_2, Qt::Key_2 },
++    { KeyCode::Key_3, Qt::Key_3 },
++    { KeyCode::Key_4, Qt::Key_4 },
++    { KeyCode::Key_5, Qt::Key_5 },
++    { KeyCode::Key_6, Qt::Key_6 },
++    { KeyCode::Key_7, Qt::Key_7 },
++    { KeyCode::Key_8, Qt::Key_8 },
++    { KeyCode::Key_9, Qt::Key_9 },
++    { KeyCode::Key_Colon, Qt::Key_Colon },
++    { KeyCode::Key_Semicolon, Qt::Key_Semicolon },
++    { KeyCode::Key_LessThan, Qt::Key_Less },
++    { KeyCode::Key_Equal, Qt::Key_Equal },
++    { KeyCode::Key_GreaterThan, Qt::Key_Greater },
++    { KeyCode::Key_QuestionMark, Qt::Key_Question },
++    { KeyCode::Key_AtSign, Qt::Key_At },
++    { KeyCode::Key_A, Qt::Key_A },
++    { KeyCode::Key_B, Qt::Key_B },
++    { KeyCode::Key_C, Qt::Key_C },
++    { KeyCode::Key_D, Qt::Key_D },
++    { KeyCode::Key_E, Qt::Key_E },
++    { KeyCode::Key_F, Qt::Key_F },
++    { KeyCode::Key_G, Qt::Key_G },
++    { KeyCode::Key_H, Qt::Key_H },
++    { KeyCode::Key_I, Qt::Key_I },
++    { KeyCode::Key_J, Qt::Key_J },
++    { KeyCode::Key_K, Qt::Key_K },
++    { KeyCode::Key_L, Qt::Key_L },
++    { KeyCode::Key_M, Qt::Key_M },
++    { KeyCode::Key_N, Qt::Key_N },
++    { KeyCode::Key_O, Qt::Key_O },
++    { KeyCode::Key_P, Qt::Key_P },
++    { KeyCode::Key_Q, Qt::Key_Q },
++    { KeyCode::Key_R, Qt::Key_R },
++    { KeyCode::Key_S, Qt::Key_S },
++    { KeyCode::Key_T, Qt::Key_T },
++    { KeyCode::Key_U, Qt::Key_U },
++    { KeyCode::Key_V, Qt::Key_V },
++    { KeyCode::Key_W, Qt::Key_W },
++    { KeyCode::Key_X, Qt::Key_X },
++    { KeyCode::Key_Y, Qt::Key_Y },
++    { KeyCode::Key_Z, Qt::Key_Z },
++    { KeyCode::Key_LeftBracket, Qt::Key_BracketLeft },
++    { KeyCode::Key_RightBracket, Qt::Key_BracketRight },
++    { KeyCode::Key_Backslash, Qt::Key_Backslash },
++    { KeyCode::Key_Circumflex, Qt::Key_AsciiCircum },
++    { KeyCode::Key_Underscore, Qt::Key_Underscore },
++    { KeyCode::Key_LeftBrace, Qt::Key_BraceLeft },
++    { KeyCode::Key_RightBrace, Qt::Key_BraceRight },
++    { KeyCode::Key_Pipe, Qt::Key_Bar }, // maybe wrong
++    { KeyCode::Key_Tilde, Qt::Key_AsciiTilde },
++    { KeyCode::Key_Backtick, Qt::Key_Agrave }, // maybe wrong
++    { KeyCode::Key_Super, Qt::Key_Meta },
++    { KeyCode::Key_Menu, Qt::Key_Menu }
++};
++
++QSerenityWindow::QSerenityWindow(QWindow *window)
++    : QPlatformWindow(window)
++    , m_window(GUI::Window::construct())
++    , m_proxyWidget(SerenityProxyWidget::construct(this))
++{
++    std::cerr << "Creating a new window" << std::endl;
++
++    if (window->width() > 0 && window->height() > 0)
++        m_window->resize(window->width(), window->height());
++    m_window->set_double_buffering_enabled(false);
++
++    m_window->set_main_widget(m_proxyWidget);
++    m_window->set_title(QSerenityString::fromQString(window->title()));
++    m_window->show();
++
++    std::cerr << "Native window set up\n";
++}
++
++void QSerenityWindow::setWindowTitle(const QString &text)
++{
++    m_window->set_title(QSerenityString::fromQString(text));
++}
++
++QRect QSerenityWindow::geometry() const {
++    return QRect(m_window->rect().x(), m_window->rect().y(), m_window->rect().width(), m_window->rect().height());
++}
++
++SerenityProxyWidget::SerenityProxyWidget(QSerenityWindow *window)
++    : m_qtWindow(window)
++{
++    std::cerr << __FUNCTION__ << std::endl;
++    m_buffer = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, Gfx::IntSize(window->window()->width(), window->window()->height()));
++    update();
++}
++
++void SerenityProxyWidget::paint_event(GUI::PaintEvent &event) {
++    // std::cerr << __FUNCTION__ << std::endl;
++
++    GUI::Painter painter(*this);
++    painter.add_clip_rect(event.rect());
++    painter.blit(event.rect().location(), *m_buffer, event.rect());
++}
++
++void SerenityProxyWidget::resize_event(GUI::ResizeEvent &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++
++    //m_qtWindow->window()->resize(event.size().width(), event.size().height());
++    //m_qtBackingStore->resize(QSize(event.size().width(), event.size().height()), QRegion());
++
++    auto qtEvent = new QResizeEvent(QSize(event.size().width(), event.size().height()), m_qtWindow->window()->size());
++    qApp->postEvent(m_qtWindow->window(), qtEvent);
++}
++
++void SerenityProxyWidget::show_event(GUI::ShowEvent &) {
++    std::cerr << __FUNCTION__ << std::endl;
++}
++
++void SerenityProxyWidget::hide_event(GUI::HideEvent &) {
++    std::cerr << __FUNCTION__ << std::endl;
++
++}
++
++void SerenityProxyWidget::mousedown_event(GUI::MouseEvent &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++
++    QWindow *qtWindow = m_qtWindow->window();
++    QPlatformWindow *platformWindow = qtWindow->handle();
++    auto qtEvent = new QMouseEvent(QEvent::MouseButtonPress, QPointF(event.x(), event.y()), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
++    qApp->postEvent(qtWindow, qtEvent);
++}
++
++void SerenityProxyWidget::mousemove_event(GUI::MouseEvent &event) {
++    //std::cerr << __FUNCTION__ << std::endl;
++
++    QWindow *qtWindow = m_qtWindow->window();
++    QPlatformWindow *platformWindow = qtWindow->handle();
++    auto qtEvent = new QMouseEvent(QEvent::MouseMove, QPointF(event.x(), event.y()), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
++    qApp->postEvent(qtWindow, qtEvent);
++}
++
++void SerenityProxyWidget::mouseup_event(GUI::MouseEvent &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++
++    QWindow *qtWindow = m_qtWindow->window();
++    QPlatformWindow *platformWindow = qtWindow->handle();
++    auto qtEvent = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(event.x(), event.y()), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
++    qApp->postEvent(qtWindow, qtEvent);
++}
++
++void SerenityProxyWidget::keydown_event(GUI::KeyEvent &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++
++    Qt::KeyboardModifiers modifiers = Qt::NoModifier;
++    if (event.ctrl())
++        modifiers |= Qt::ControlModifier;
++    if (event.alt())
++        modifiers |= Qt::AltModifier;
++    if (event.shift())
++        modifiers |= Qt::ShiftModifier;
++    if (event.super())
++        modifiers |= Qt::MetaModifier;
++
++    QWindow *qtWindow = m_qtWindow->window();
++    QPlatformWindow *platformWindow = qtWindow->handle();
++    int k = keyMap.value(event.key(), 0);
++    if (k < 0x01000000) {
++        QWindowSystemInterface::handleKeyEvent<QWindowSystemInterface::SynchronousDelivery>(qtWindow, QEvent::KeyPress, k, modifiers, QChar(event.code_point()));
++    }
++    else {
++        QWindowSystemInterface::handleKeyEvent<QWindowSystemInterface::SynchronousDelivery>(qtWindow, QEvent::KeyPress, k, modifiers);
++    }
++}
++
++void SerenityProxyWidget::keyup_event(GUI::KeyEvent &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++
++    Qt::KeyboardModifiers modifiers = Qt::NoModifier;
++    if (event.ctrl())
++        modifiers |= Qt::ControlModifier;
++    if (event.alt())
++        modifiers |= Qt::AltModifier;
++    if (event.shift())
++        modifiers |= Qt::ShiftModifier;
++    if (event.super())
++        modifiers |= Qt::MetaModifier;
++
++    QWindow *qtWindow = m_qtWindow->window();
++    QPlatformWindow *platformWindow = qtWindow->handle();
++    int k = keyMap.value(event.key(), 0);
++    QWindowSystemInterface::handleKeyEvent<QWindowSystemInterface::SynchronousDelivery>(qtWindow, QEvent::KeyRelease, k, modifiers);
++}
++
++void SerenityProxyWidget::enter_event(Core::Event &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++    QWindow *qtWindow = m_qtWindow->window();
++    QWindowSystemInterface::handleEnterEvent<QWindowSystemInterface::SynchronousDelivery>(qtWindow);
++}
++
++void SerenityProxyWidget::leave_event(Core::Event &event) {
++    std::cerr << __FUNCTION__ << std::endl;
++    QWindow *qtWindow = m_qtWindow->window();
++    QWindowSystemInterface::handleLeaveEvent<QWindowSystemInterface::SynchronousDelivery>(qtWindow);
++}
++
++
+diff --git a/src/plugins/platforms/serenity/qserenitywindow.h b/src/plugins/platforms/serenity/qserenitywindow.h
+new file mode 100644
+index 00000000..f4c657ab
+--- /dev/null
++++ b/src/plugins/platforms/serenity/qserenitywindow.h
+@@ -0,0 +1,101 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the plugins of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QPLATFORMWINDOW_SERENITY_H
++#define QPLATFORMWINDOW_SERENITY_H
++
++#include <qpa/qplatformwindow.h>
++
++#include <LibCore/EventLoop.h>
++#include <LibGUI/Application.h>
++#include <LibGUI/Painter.h>
++#include <LibGUI/Widget.h>
++#include <LibGUI/Window.h>
++#include <LibGfx/Bitmap.h>
++
++#include "qserenitystring.h"
++
++namespace GUI {
++    class Window;
++}
++
++class QSerenityWindow;
++
++class SerenityProxyWidget : public GUI::Widget {
++    C_OBJECT(SerenityProxyWidget)
++public:
++    explicit SerenityProxyWidget(QSerenityWindow*);
++    RefPtr<Gfx::Bitmap> m_buffer;
++
++protected:
++    void paint_event(GUI::PaintEvent&) override;
++    void resize_event(GUI::ResizeEvent&) override;
++    void show_event(GUI::ShowEvent&) override;
++    void hide_event(GUI::HideEvent&) override;
++
++    void mousedown_event(GUI::MouseEvent&) override;
++    void mousemove_event(GUI::MouseEvent&) override;
++    void mouseup_event(GUI::MouseEvent&) override;
++
++    void keydown_event(GUI::KeyEvent& event) override;
++    void keyup_event(GUI::KeyEvent& event) override;
++
++    void enter_event(Core::Event&) override;
++    void leave_event(Core::Event&) override;
++
++private:
++    QSerenityWindow* m_qtWindow = nullptr;
++};
++
++class QSerenityWindow : public QPlatformWindow
++{
++public:
++    QSerenityWindow(QWindow *window);
++
++    virtual void setWindowTitle(const QString &text) override;
++    virtual QRect geometry() const;
++
++    SerenityProxyWidget *proxyWidget() { return m_proxyWidget; }
++private:
++    GUI::Window *w;
++    NonnullRefPtr<GUI::Window> m_window;
++    NonnullRefPtr<SerenityProxyWidget> m_proxyWidget;
++};
++
++#endif // QPLATFORMWINDOW_SERENITY_H
+diff --git a/src/plugins/platforms/serenity/serenity.json b/src/plugins/platforms/serenity/serenity.json
+new file mode 100644
+index 00000000..2ee4d065
+--- /dev/null
++++ b/src/plugins/platforms/serenity/serenity.json
+@@ -0,0 +1,3 @@
++{
++    "Keys": [ "serenity" ]
++}
+-- 
+2.31.1
+

--- a/Ports/qt6-qtbase/patches/0011-Ignore-configure-errors.patch
+++ b/Ports/qt6-qtbase/patches/0011-Ignore-configure-errors.patch
@@ -1,0 +1,20 @@
+--- qtbase-everywhere-src-6.2.0/src/corelib/configure.cmake.orig	2021-10-16 10:39:58.958770525 +0200
++++ qtbase-everywhere-src-6.2.0/src/corelib/configure.cmake	2021-10-16 10:40:05.525713892 +0200
+@@ -951,7 +951,7 @@
+     CONDITION QT_FEATURE_journald OR QT_FEATURE_syslog OR ( QNX AND QT_FEATURE_slog2 )
+ )
+ qt_configure_add_report_entry(
+-    TYPE ERROR
++    TYPE NOTE
+     MESSAGE "C++11 <random> is required and is missing or failed to compile."
+     CONDITION NOT TEST_cxx11_random
+ )
+@@ -961,7 +961,7 @@
+     CONDITION INPUT_doubleconversion STREQUAL 'no' AND NOT TEST_xlocalescanprint
+ )
+ qt_configure_add_report_entry(
+-    TYPE ERROR
++    TYPE NOTE
+     MESSAGE "detected a std::atomic implementation that fails for function pointers.  Please apply the patch corresponding to your Standard Library vendor, found in qtbase/config.tests/atomicfptr"
+     CONDITION NOT TEST_atomicfptr
+ )

--- a/Ports/qt6-qtbase/patches/0012-Fix-build-wit-Qt-6.2.0.patch
+++ b/Ports/qt6-qtbase/patches/0012-Fix-build-wit-Qt-6.2.0.patch
@@ -1,0 +1,141 @@
+From b095dea1c29ee189ffa3be1d724f6cef7db74242 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20B=C5=99=C3=ADza?= <m@rtinbriza.cz>
+Date: Sat, 23 Oct 2021 00:24:40 +0200
+Subject: [PATCH] Fix build with Qt 6.2.0
+
+---
+ configure.cmake                                          | 1 +
+ examples/gui/analogclock/CMakeLists.txt                  | 1 +
+ mkspecs/serenity-g++/qplatformdefs.h                     | 4 +++-
+ src/corelib/global/qglobal.h                             | 1 +
+ src/platformsupport/devicediscovery/CMakeLists.txt       | 1 +
+ src/platformsupport/devicediscovery/qdevicediscovery_p.h | 2 ++
+ src/plugins/platforms/serenity/qserenityscreen.h         | 2 ++
+ src/plugins/platforms/serenity/qserenitystring.h         | 2 ++
+ src/plugins/platforms/serenity/qserenitywindow.h         | 2 ++
+ 9 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/configure.cmake b/configure.cmake
+index 5705e376..41ccb236 100644
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -572,6 +572,7 @@ qt_feature("c++20" PUBLIC
+ qt_feature_config("c++20" QMAKE_PUBLIC_QT_CONFIG)
+ qt_feature("c++2a" PUBLIC
+     LABEL "C++20"
++    AUTODETECT ON
+     CONDITION QT_FEATURE_cxx20
+ )
+ qt_feature_config("c++2a" QMAKE_PUBLIC_QT_CONFIG)
+diff --git a/examples/gui/analogclock/CMakeLists.txt b/examples/gui/analogclock/CMakeLists.txt
+index 20bedf5a..083ca504 100644
+--- a/examples/gui/analogclock/CMakeLists.txt
++++ b/examples/gui/analogclock/CMakeLists.txt
+@@ -3,6 +3,7 @@
+ cmake_minimum_required(VERSION 3.16)
+ project(analogclock LANGUAGES CXX)
+ 
++add_definitions(-D_GLIBCXX_HAVE_MBSTATE_T)
+ 
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ 
+diff --git a/mkspecs/serenity-g++/qplatformdefs.h b/mkspecs/serenity-g++/qplatformdefs.h
+index 082d8a0c..e674a2f1 100644
+--- a/mkspecs/serenity-g++/qplatformdefs.h
++++ b/mkspecs/serenity-g++/qplatformdefs.h
+@@ -42,6 +42,8 @@
+ 
+ // Get Qt defines/settings
+ 
++#define _GLIBCXX_HAVE_MBSTATE_T 1
++
+ #include "qglobal.h"
+ 
+ // Set any POSIX/XOPEN defines at the top of this file to turn on specific APIs
+@@ -84,6 +86,6 @@
+ #define CODESET 0
+ 
+ // TODO used in qprocess_unix.cpp
+-#define FIONREAD      0x541B
++// #define FIONREAD      0x541B
+ 
+ #endif // QPLATFORMDEFS_H
+diff --git a/src/corelib/global/qglobal.h b/src/corelib/global/qglobal.h
+index de4b9817..a2c288dc 100644
+--- a/src/corelib/global/qglobal.h
++++ b/src/corelib/global/qglobal.h
+@@ -134,6 +134,7 @@
+ 
+ #ifdef __cplusplus
+ 
++#define _GLIBCXX_HAVE_MBSTATE_T 1
+ #include <algorithm>
+ 
+ #if !defined(QT_NAMESPACE) || defined(Q_MOC_RUN) /* user namespace */
+diff --git a/src/platformsupport/devicediscovery/CMakeLists.txt b/src/platformsupport/devicediscovery/CMakeLists.txt
+index e9b87d81..f67a6a54 100644
+--- a/src/platformsupport/devicediscovery/CMakeLists.txt
++++ b/src/platformsupport/devicediscovery/CMakeLists.txt
+@@ -12,6 +12,7 @@ qt_internal_add_module(DeviceDiscoverySupportPrivate
+         qdevicediscovery_p.h
+     DEFINES
+         QT_NO_CAST_FROM_ASCII
++        _GLIBCXX_HAVE_MBSTATE_T
+     PUBLIC_LIBRARIES
+         Qt::CorePrivate
+ )
+diff --git a/src/platformsupport/devicediscovery/qdevicediscovery_p.h b/src/platformsupport/devicediscovery/qdevicediscovery_p.h
+index f1f50e97..097b9597 100644
+--- a/src/platformsupport/devicediscovery/qdevicediscovery_p.h
++++ b/src/platformsupport/devicediscovery/qdevicediscovery_p.h
+@@ -51,6 +51,8 @@
+ // We mean it.
+ //
+ 
++#define _GLIBCXX_HAVE_MBSTATE_T 1
++
+ #include <QObject>
+ #include <QSocketNotifier>
+ #include <QStringList>
+diff --git a/src/plugins/platforms/serenity/qserenityscreen.h b/src/plugins/platforms/serenity/qserenityscreen.h
+index b0089d9e..39e62aff 100644
+--- a/src/plugins/platforms/serenity/qserenityscreen.h
++++ b/src/plugins/platforms/serenity/qserenityscreen.h
+@@ -40,6 +40,8 @@
+ #ifndef QPLATFORMSCREEN_SERENITY_H
+ #define QPLATFORMSCREEN_SERENITY_H
+ 
++#define AK_DONT_REPLACE_STD
++
+ #include <qpa/qplatformscreen.h>
+ 
+ QT_BEGIN_NAMESPACE
+diff --git a/src/plugins/platforms/serenity/qserenitystring.h b/src/plugins/platforms/serenity/qserenitystring.h
+index b155a523..014dafba 100644
+--- a/src/plugins/platforms/serenity/qserenitystring.h
++++ b/src/plugins/platforms/serenity/qserenitystring.h
+@@ -1,6 +1,8 @@
+ #ifndef QSERENITYSTRING_H
+ #define QSERENITYSTRING_H
+ 
++#define AK_DONT_REPLACE_STD
++
+ #include <AK/String.h>
+ #include <QString>
+ 
+diff --git a/src/plugins/platforms/serenity/qserenitywindow.h b/src/plugins/platforms/serenity/qserenitywindow.h
+index f4c657ab..1bffe964 100644
+--- a/src/plugins/platforms/serenity/qserenitywindow.h
++++ b/src/plugins/platforms/serenity/qserenitywindow.h
+@@ -40,6 +40,8 @@
+ #ifndef QPLATFORMWINDOW_SERENITY_H
+ #define QPLATFORMWINDOW_SERENITY_H
+ 
++#define AK_DONT_REPLACE_STD
++
+ #include <qpa/qplatformwindow.h>
+ 
+ #include <LibCore/EventLoop.h>
+-- 
+2.33.1
+

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -20,6 +20,12 @@
 #include <sys/mman.h>
 #include <syscall.h>
 
+extern "C"{
+    // BAD
+    __attribute__((malloc)) __attribute__((alloc_size(2))) __attribute__((alloc_align(1))) void* memalign(size_t alignment, size_t size);
+}
+
+
 class PthreadMutexLocker {
 public:
     ALWAYS_INLINE explicit PthreadMutexLocker(pthread_mutex_t& mutex)
@@ -448,6 +454,12 @@ void* calloc(size_t count, size_t size)
     return ptr;
 }
 
+// BAD BAD
+[[gnu::flatten]] void* memalign(size_t, size_t size) {
+    // VERY VERY BAD
+    return malloc(size);
+}
+
 size_t malloc_size(void* ptr)
 {
     MemoryAuditingSuppressor suppressor;
@@ -546,3 +558,4 @@ void serenity_dump_malloc_stats()
     dbgln("number of frees: {}", g_malloc_stats.number_of_frees);
 }
 }
+

--- a/Userland/Libraries/LibC/mntent.cpp
+++ b/Userland/Libraries/LibC/mntent.cpp
@@ -16,4 +16,26 @@ struct mntent* getmntent(FILE*)
     TODO();
     return nullptr;
 }
+
+FILE *setmntent(const char*, const char*)
+{
+    dbgln("FIXME: Implement setmntent()");
+    TODO();
+    return nullptr;
+}
+
+int endmntent(FILE*)
+{
+    dbgln("FIXME: Implement endmntent()");
+    TODO();
+    return 0;
+}
+
+struct mntent *getmntent_r(FILE *, struct mntent*, char*, int)
+{
+    dbgln("FIXME: Implement getmntent_r()");
+    TODO();
+    return 0;
+}
+
 }

--- a/Userland/Libraries/LibC/mntent.h
+++ b/Userland/Libraries/LibC/mntent.h
@@ -24,5 +24,9 @@ struct mntent {
 };
 
 struct mntent* getmntent(FILE* stream);
+FILE *setmntent(const char *filename, const char *type);
+int endmntent(FILE *streamp);
+struct mntent *getmntent_r(FILE *streamp, struct mntent *mntbuf, char *buf, int buflen);
+
 
 __END_DECLS


### PR DESCRIPTION
**Don't worry about the lack of activity, I'm going to finish this when I have time to implement memalign. I'm busy with real life stuff and work now.** 

I did a lot of nasty things but it builds and now basic QtGui and QtWidgets applications work. Just a static build at this moment 
because of dynamic linker errors that I don't remember (and each build takes ages so I just bailed on that for now)

Since I haven't really implemented `memalign`, this is not in state to be merged or even considered (yet). I'll probably look into that and creating a Serenity platform plugin over the weekend.

Closes #152 .

### Current state of the main package (as of Aug 15, 2021):
 - [x] QtWidgets + QtGui
 - [x] QtDeclarative + QtQuickControls2 (the QML module builds but doesn't work due to static linking - can't find the plugins)
 - [ ] Improve the build script to handle custom setups better (host Qt installation is required)
 - [ ] Fix plugins with dynamically linked build (and stop using the annoying static build process)
 - [ ] Implement `memalign`

### Platform plugin
 - Further development will happen in https://github.com/MartinBriza/QSerenityPlatform

 **Features:**
 - [ ] Figure out an out-of-tree build (not sure if possible with static Qt)
 - [x] Basic windowing
 - [x] Basic (stupid) input handling
 - [ ] Proper mouse event handling (now only LeftButton is sent for each click)
 - [ ] Check if keyboard mapping is actually right (I guesstimated the implementation)
 - [ ] Implement QEventDispatcher using Core::EventLoop so it doesn't take 100% CPU
 - [ ] Implement more window types for menus and popups
 - [ ] Maybe it shouldn't crash when resizing large windows
 - [ ] Clipboard handling
 - [ ] ... tons and tons of more stuff

### Not planned:
 - [ ] QtNetwork (a lot of gaps in the current network stack)
 - [ ] QtSql (didn't consider that necessary ATM)
 - [x] QtTest (fixed that to make QtDeclarative build)
 - [ ] OpenGL (doesn't seem necessary now)
 - [ ] Shared memory (not implemented anymore in the kernel)
 - [ ] System semaphore (this should probably work but it's not necessary now)