### PR TITLE
IntrusiveRedBlackTree: Remove redundant subtraction of 0

### DIFF
--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -143,7 +143,7 @@ private:
 
     static V* node_to_value(TreeNode& node)
     {
-        return (V*)((u8*)&node - ((u8*)&(((V*)nullptr)->*member) - (u8*)nullptr));
+        return bit_cast<V*>(bit_cast<u8*>(&node) - bit_cast<u8*>(member));
     }
 };
 


### PR DESCRIPTION
Problem:
- ToT clang will not build due to casting `nullptr` to `u8*`. This is
  redundant because it casts to get a `0` then subtracts it.

Solution:
- Remove it since subtracting `0` doesn't do anything.