### PR TITLE
Shell: Remove dbgln related to process group IDs

### DIFF
--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -128,7 +128,6 @@ int main(int argc, char** argv)
         }
     } else if (sid != pid) {
         if (getpgid(pid) != pid) {
-            dbgln("We were already in a session with sid={} (we are {}), let's do some gymnastics", sid, pid);
             if (setpgid(pid, sid) < 0) {
                 auto strerr = strerror(errno);
                 dbgln("couldn't setpgid: {}", strerr);


### PR DESCRIPTION
This is insignificant debugging information and will print out during
runs with Lagom.