### PR TITLE
LibRegex: A handful of ECMA-262 compliance and performace fixes

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -557,6 +557,8 @@ TEST_CASE(ECMA262_parse)
         { "[\\0]"sv, regex::Error::NoError, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::BrowserExtended) },
         { "[\\00]"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
         { "[\\00]"sv, regex::Error::InvalidPattern, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::BrowserExtended) },
+        { "\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "[\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/]"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {
@@ -605,6 +607,8 @@ TEST_CASE(ECMA262_match)
         { "((...)X)+"sv, "fooXbarXbazX"sv, true },
         { "(?:)"sv, ""sv, true },
         { "\\^"sv, "^"sv },
+        { "\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/"sv, "^$\\.*+?()[]{}|/"sv, true, ECMAScriptFlags::Unicode },
+        { "[\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/]{15}"sv, "^$\\.*+?()[]{}|/"sv, true, ECMAScriptFlags::Unicode },
         // ECMA262, B.1.4. Regular Expression Pattern extensions for browsers
         { "{"sv, "{"sv, true, ECMAScriptFlags::BrowserExtended },
         { "\\5"sv, "\5"sv, true, ECMAScriptFlags::BrowserExtended },

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -569,6 +569,14 @@ TEST_CASE(ECMA262_parse)
         { "}"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
         { "}"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
         { "\\}"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "a{9007199254740991}"sv }, // 2^53 - 1
+        { "a{9007199254740991,}"sv },
+        { "a{9007199254740991,9007199254740991}"sv },
+        { "a{9007199254740992}"sv, regex::Error::InvalidBraceContent },
+        { "a{9007199254740992,}"sv, regex::Error::InvalidBraceContent },
+        { "a{9007199254740991,9007199254740992}"sv, regex::Error::InvalidBraceContent },
+        { "a{9007199254740992,9007199254740991}"sv, regex::Error::InvalidBraceContent },
+        { "a{9007199254740992,9007199254740992}"sv, regex::Error::InvalidBraceContent },
     };
 
     for (auto& test : tests) {
@@ -619,6 +627,14 @@ TEST_CASE(ECMA262_match)
         { "\\^"sv, "^"sv },
         { "\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/"sv, "^$\\.*+?()[]{}|/"sv, true, ECMAScriptFlags::Unicode },
         { "[\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/]{15}"sv, "^$\\.*+?()[]{}|/"sv, true, ECMAScriptFlags::Unicode },
+        { "(a{2}){3}"sv, "aaaaaa"sv },
+        { "(a{2}){3}"sv, "aaaabaa"sv, false },
+        { "(a{2}){4}"sv, "aaaaaaaa"sv },
+        { "(a{2}){4}"sv, "aaaaaabaa"sv, false },
+        { "(a{3}){2}"sv, "aaaaaa"sv },
+        { "(a{3}){2}"sv, "aaaabaa"sv, false },
+        { "(a{4}){2}"sv, "aaaaaaaa"sv },
+        { "(a{4}){2}"sv, "aaaaaabaa"sv, false },
         // ECMA262, B.1.4. Regular Expression Pattern extensions for browsers
         { "{"sv, "{"sv, true, ECMAScriptFlags::BrowserExtended },
         { "\\5"sv, "\5"sv, true, ECMAScriptFlags::BrowserExtended },

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -478,71 +478,71 @@ TEST_CASE(simple_period_end_benchmark)
 TEST_CASE(ECMA262_parse)
 {
     struct _test {
-        const char* pattern;
+        StringView pattern;
         regex::Error expected_error { regex::Error::NoError };
         regex::ECMAScriptFlags flags {};
     };
 
     constexpr _test tests[] {
-        { "^hello.$" },
-        { "^(hello.)$" },
-        { "^h{0,1}ello.$" },
-        { "^hello\\W$" },
-        { "^hell\\w.$" },
-        { "^hell\\x6f1$" }, // ^hello1$
-        { "^hel(?:l\\w).$" },
-        { "^hel(?<LO>l\\w).$" },
-        { "^[-a-zA-Z\\w\\s]+$" },
-        { "\\bhello\\B" },
-        { "^[\\w+/_-]+[=]{0,2}$" },                        // #4189
-        { "^(?:[^<]*(<[\\w\\W]+>)[^>]*$|#([\\w\\-]*)$)" }, // #4189
-        { "\\/" },                                         // #4189
-        { ",/=-:" },                                       // #4243
-        { "\\x" },                                         // Even invalid escapes are allowed if ~unicode.
-        { "\\x1" },                                        // Even invalid escapes are allowed if ~unicode.
-        { "\\x1", regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
-        { "\\x11" },
-        { "\\x11", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
-        { "\\", regex::Error::InvalidTrailingEscape },
-        { "(?", regex::Error::InvalidCaptureGroup },
-        { "\\u1234", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
-        { "[\\u1234]", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
-        { "\\u1", regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
-        { "[\\u1]", regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
-        { ",(?", regex::Error::InvalidCaptureGroup }, // #4583
-        { "{1}", regex::Error::InvalidPattern },
-        { "{1,2}", regex::Error::InvalidPattern },
-        { "\\uxxxx", regex::Error::NoError },
-        { "\\uxxxx", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\ud83d", regex::Error::NoError, ECMAScriptFlags::Unicode },
-        { "\\ud83d\\uxxxx", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\u{0}", regex::Error::NoError, ECMAScriptFlags::Unicode },
-        { "\\u{10ffff}", regex::Error::NoError, ECMAScriptFlags::Unicode },
-        { "\\u{10ffff", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\u{10ffffx", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\u{110000}", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\p", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\p{", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\p{}", regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
-        { "\\p{AsCiI}", regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
-        { "\\p{hello friends}", regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
-        { "\\p{Prepended_Concatenation_Mark}", regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
-        { "\\p{ASCII}", regex::Error::NoError, ECMAScriptFlags::Unicode },
-        { "\\\\p{1}", regex::Error::NoError, ECMAScriptFlags::Unicode },
-        { "\\\\p{AsCiI}", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\\\p{ASCII}", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\c", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
-        { "\\c", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "[\\c]", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
-        { "[\\c]", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\c`", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
-        { "\\c`", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "[\\c`]", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
-        { "[\\c`]", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
-        { "\\A", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
-        { "\\A", regex::Error::InvalidCharacterClass, ECMAScriptFlags::Unicode },
-        { "[\\A]", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
-        { "[\\A]", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "^hello.$"sv },
+        { "^(hello.)$"sv },
+        { "^h{0,1}ello.$"sv },
+        { "^hello\\W$"sv },
+        { "^hell\\w.$"sv },
+        { "^hell\\x6f1$"sv }, // ^hello1$
+        { "^hel(?:l\\w).$"sv },
+        { "^hel(?<LO>l\\w).$"sv },
+        { "^[-a-zA-Z\\w\\s]+$"sv },
+        { "\\bhello\\B"sv },
+        { "^[\\w+/_-]+[=]{0,2}$"sv },                        // #4189
+        { "^(?:[^<]*(<[\\w\\W]+>)[^>]*$|#([\\w\\-]*)$)"sv }, // #4189
+        { "\\/"sv },                                         // #4189
+        { ",/=-:"sv },                                       // #4243
+        { "\\x"sv },                                         // Even invalid escapes are allowed if ~unicode.
+        { "\\x1"sv },                                        // Even invalid escapes are allowed if ~unicode.
+        { "\\x1"sv, regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
+        { "\\x11"sv },
+        { "\\x11"sv, regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
+        { "\\"sv, regex::Error::InvalidTrailingEscape },
+        { "(?"sv, regex::Error::InvalidCaptureGroup },
+        { "\\u1234"sv, regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
+        { "[\\u1234]"sv, regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
+        { "\\u1"sv, regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
+        { "[\\u1]"sv, regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
+        { ",(?"sv, regex::Error::InvalidCaptureGroup }, // #4583
+        { "{1}"sv, regex::Error::InvalidPattern },
+        { "{1,2}"sv, regex::Error::InvalidPattern },
+        { "\\uxxxx"sv, regex::Error::NoError },
+        { "\\uxxxx"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\ud83d"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\ud83d\\uxxxx"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\u{0}"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\u{10ffff}"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\u{10ffff"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\u{10ffffx"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\u{110000}"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\p"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\p{"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\p{}"sv, regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
+        { "\\p{AsCiI}"sv, regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
+        { "\\p{hello friends}"sv, regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
+        { "\\p{Prepended_Concatenation_Mark}"sv, regex::Error::InvalidNameForProperty, ECMAScriptFlags::Unicode },
+        { "\\p{ASCII}"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\\\p{1}"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "\\\\p{AsCiI}"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\\\p{ASCII}"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\c"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "\\c"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "[\\c]"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "[\\c]"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\c`"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "\\c`"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "[\\c`]"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "[\\c`]"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\A"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "\\A"sv, regex::Error::InvalidCharacterClass, ECMAScriptFlags::Unicode },
+        { "[\\A]"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "[\\A]"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {
@@ -562,50 +562,50 @@ TEST_CASE(ECMA262_parse)
 TEST_CASE(ECMA262_match)
 {
     struct _test {
-        const char* pattern;
-        const char* subject;
+        StringView pattern;
+        StringView subject;
         bool matches { true };
         ECMAScriptFlags options {};
     };
     // clang-format off
     constexpr _test tests[] {
-        { "^hello.$", "hello1" },
-        { "^(hello.)$", "hello1" },
-        { "^h{0,1}ello.$", "ello1" },
-        { "^hello\\W$", "hello!" },
-        { "^hell\\w.$", "hellx!" },
-        { "^hell\\x6f1$", "hello1" },
-        { "^hel(?<LO>l.)1$", "hello1" },
-        { "^hel(?<LO>l.)1*\\k<LO>.$", "hello1lo1" },
-        { "^[-a-z1-3\\s]+$", "hell2 o1" },
-        { "^[\\0-\\x1f]$", "\n" },
-        { .pattern = "\\bhello\\B", .subject = "hello1", .options = ECMAScriptFlags::Global },
-        { "\\b.*\\b", "hello1" },
-        { "[^\\D\\S]{2}", "1 " },
-        { "bar(?=f.)foo", "barfoo" },
-        { "bar(?=foo)bar", "barbar", false },
-        { "bar(?!foo)bar", "barbar", true },
-        { "bar(?!bar)bar", "barbar", false },
-        { "bar.*(?<=foo)", "barbar", false },
-        { "bar.*(?<!foo)", "barbar", true },
-        { "((...)X)+", "fooXbarXbazX", true },
-        { "(?:)", "", true },
-        { "\\^", "^" },
+        { "^hello.$"sv, "hello1"sv },
+        { "^(hello.)$"sv, "hello1"sv },
+        { "^h{0,1}ello.$"sv, "ello1"sv },
+        { "^hello\\W$"sv, "hello!"sv },
+        { "^hell\\w.$"sv, "hellx!"sv },
+        { "^hell\\x6f1$"sv, "hello1"sv },
+        { "^hel(?<LO>l.)1$"sv, "hello1"sv },
+        { "^hel(?<LO>l.)1*\\k<LO>.$"sv, "hello1lo1"sv },
+        { "^[-a-z1-3\\s]+$"sv, "hell2 o1"sv },
+        { "^[\\0-\\x1f]$"sv, "\n"sv },
+        { .pattern = "\\bhello\\B"sv, .subject = "hello1"sv, .options = ECMAScriptFlags::Global },
+        { "\\b.*\\b"sv, "hello1"sv },
+        { "[^\\D\\S]{2}"sv, "1 "sv },
+        { "bar(?=f.)foo"sv, "barfoo"sv },
+        { "bar(?=foo)bar"sv, "barbar"sv, false },
+        { "bar(?!foo)bar"sv, "barbar"sv, true },
+        { "bar(?!bar)bar"sv, "barbar"sv, false },
+        { "bar.*(?<=foo)"sv, "barbar"sv, false },
+        { "bar.*(?<!foo)"sv, "barbar"sv, true },
+        { "((...)X)+"sv, "fooXbarXbazX"sv, true },
+        { "(?:)"sv, ""sv, true },
+        { "\\^"sv, "^"sv },
         // ECMA262, B.1.4. Regular Expression Pattern extensions for browsers
-        { "{", "{", true, ECMAScriptFlags::BrowserExtended },
-        { "\\5", "\5", true, ECMAScriptFlags::BrowserExtended },
-        { "\\05", "\5", true, ECMAScriptFlags::BrowserExtended },
-        { "\\455", "\45""5", true, ECMAScriptFlags::BrowserExtended },
-        { "\\314", "\314", true, ECMAScriptFlags::BrowserExtended },
-        { "\\c", "\\c", true, ECMAScriptFlags::BrowserExtended },
-        { "\\cf", "\06", true, ECMAScriptFlags::BrowserExtended },
-        { "\\c1", "\\c1", true, ECMAScriptFlags::BrowserExtended },
-        { "[\\c1]", "\x11", true, ECMAScriptFlags::BrowserExtended },
-        { "[\\w-\\d]", "-", true, ECMAScriptFlags::BrowserExtended },
-        { "^(?:^^\\.?|[!+-]|!=|!==|#|%|%=|&|&&|&&=|&=|\\(|\\*|\\*=|\\+=|,|-=|->|\\/|\\/=|:|::|;|<|<<|<<=|<=|=|==|===|>|>=|>>|>>=|>>>|>>>=|[?@[^]|\\^=|\\^\\^|\\^\\^=|{|\\||\\|=|\\|\\||\\|\\|=|~|break|case|continue|delete|do|else|finally|instanceof|return|throw|try|typeof)\\s*(\\/(?=[^*/])(?:[^/[\\\\]|\\\\[\\S\\s]|\\[(?:[^\\\\\\]]|\\\\[\\S\\s])*(?:]|$))+\\/)",
-                 "return /xx/", true, ECMAScriptFlags::BrowserExtended
+        { "{"sv, "{"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\5"sv, "\5"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\05"sv, "\5"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\455"sv, "\45""5"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\314"sv, "\314"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\c"sv, "\\c"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\cf"sv, "\06"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "\\c1"sv, "\\c1"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "[\\c1]"sv, "\x11"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "[\\w-\\d]"sv, "-"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "^(?:^^\\.?|[!+-]|!=|!==|#|%|%=|&|&&|&&=|&=|\\(|\\*|\\*=|\\+=|,|-=|->|\\/|\\/=|:|::|;|<|<<|<<=|<=|=|==|===|>|>=|>>|>>=|>>>|>>>=|[?@[^]|\\^=|\\^\\^|\\^\\^=|{|\\||\\|=|\\|\\||\\|\\|=|~|break|case|continue|delete|do|else|finally|instanceof|return|throw|try|typeof)\\s*(\\/(?=[^*/])(?:[^/[\\\\]|\\\\[\\S\\s]|\\[(?:[^\\\\\\]]|\\\\[\\S\\s])*(?:]|$))+\\/)"sv,
+                 "return /xx/"sv, true, ECMAScriptFlags::BrowserExtended
         }, // #5517, appears to be matching JS expressions that involve regular expressions...
-        { "a{2,}", "aaaa" }, // #5518
+        { "a{2,}"sv, "aaaa"sv }, // #5518
     };
     // clang-format on
 
@@ -627,21 +627,21 @@ TEST_CASE(ECMA262_match)
 TEST_CASE(ECMA262_unicode_match)
 {
     struct _test {
-        char const* pattern;
-        char const* subject;
+        StringView pattern;
+        StringView subject;
         bool matches { true };
         ECMAScriptFlags options {};
     };
     _test tests[] {
-        { "\\ud83d", "😀", true },
-        { "\\ud83d", "😀", false, ECMAScriptFlags::Unicode },
-        { "\\ude00", "😀", true },
-        { "\\ude00", "😀", false, ECMAScriptFlags::Unicode },
-        { "\\ud83d\\ude00", "😀", true },
-        { "\\ud83d\\ude00", "😀", true, ECMAScriptFlags::Unicode },
-        { "\\u{1f600}", "😀", true, ECMAScriptFlags::Unicode },
-        { "\\ud83d\\ud83d", "\xed\xa0\xbd\xed\xa0\xbd", true },
-        { "\\ud83d\\ud83d", "\xed\xa0\xbd\xed\xa0\xbd", true, ECMAScriptFlags::Unicode },
+        { "\\ud83d"sv, "😀"sv, true },
+        { "\\ud83d"sv, "😀"sv, false, ECMAScriptFlags::Unicode },
+        { "\\ude00"sv, "😀"sv, true },
+        { "\\ude00"sv, "😀"sv, false, ECMAScriptFlags::Unicode },
+        { "\\ud83d\\ude00"sv, "😀"sv, true },
+        { "\\ud83d\\ude00"sv, "😀"sv, true, ECMAScriptFlags::Unicode },
+        { "\\u{1f600}"sv, "😀"sv, true, ECMAScriptFlags::Unicode },
+        { "\\ud83d\\ud83d"sv, "\xed\xa0\xbd\xed\xa0\xbd"sv, true },
+        { "\\ud83d\\ud83d"sv, "\xed\xa0\xbd\xed\xa0\xbd"sv, true, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {
@@ -667,56 +667,56 @@ TEST_CASE(ECMA262_unicode_match)
 TEST_CASE(ECMA262_property_match)
 {
     struct _test {
-        char const* pattern;
-        char const* subject;
+        StringView pattern;
+        StringView subject;
         bool matches { true };
         ECMAScriptFlags options {};
     };
 
     constexpr _test tests[] {
-        { "\\p{ASCII}", "a", false },
-        { "\\p{ASCII}", "p{ASCII}", true },
-        { "\\p{ASCII}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{ASCII}", "😀", false, ECMAScriptFlags::Unicode },
-        { "\\P{ASCII}", "a", false, ECMAScriptFlags::Unicode },
-        { "\\P{ASCII}", "😀", true, ECMAScriptFlags::Unicode },
-        { "\\p{ASCII_Hex_Digit}", "1", true, ECMAScriptFlags::Unicode },
-        { "\\p{ASCII_Hex_Digit}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{ASCII_Hex_Digit}", "x", false, ECMAScriptFlags::Unicode },
-        { "\\P{ASCII_Hex_Digit}", "1", false, ECMAScriptFlags::Unicode },
-        { "\\P{ASCII_Hex_Digit}", "a", false, ECMAScriptFlags::Unicode },
-        { "\\P{ASCII_Hex_Digit}", "x", true, ECMAScriptFlags::Unicode },
-        { "\\p{Any}", "\xcd\xb8", true, ECMAScriptFlags::Unicode },       // U+0378, which is an unassigned code point.
-        { "\\P{Any}", "\xcd\xb8", false, ECMAScriptFlags::Unicode },      // U+0378, which is an unassigned code point.
-        { "\\p{Assigned}", "\xcd\xb8", false, ECMAScriptFlags::Unicode }, // U+0378, which is an unassigned code point.
-        { "\\P{Assigned}", "\xcd\xb8", true, ECMAScriptFlags::Unicode },  // U+0378, which is an unassigned code point.
-        { "\\p{Lu}", "a", false, ECMAScriptFlags::Unicode },
-        { "\\p{Lu}", "A", true, ECMAScriptFlags::Unicode },
-        { "\\p{Lu}", "9", false, ECMAScriptFlags::Unicode },
-        { "\\p{Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
-        { "\\p{Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
-        { "\\P{Cased_Letter}", "a", false, ECMAScriptFlags::Unicode },
-        { "\\P{Cased_Letter}", "A", false, ECMAScriptFlags::Unicode },
-        { "\\P{Cased_Letter}", "9", true, ECMAScriptFlags::Unicode },
-        { "\\p{General_Category=Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{General_Category=Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
-        { "\\p{General_Category=Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
-        { "\\p{gc=Cased_Letter}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{gc=Cased_Letter}", "A", true, ECMAScriptFlags::Unicode },
-        { "\\p{gc=Cased_Letter}", "9", false, ECMAScriptFlags::Unicode },
-        { "\\p{Script=Latin}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{Script=Latin}", "A", true, ECMAScriptFlags::Unicode },
-        { "\\p{Script=Latin}", "9", false, ECMAScriptFlags::Unicode },
-        { "\\p{sc=Latin}", "a", true, ECMAScriptFlags::Unicode },
-        { "\\p{sc=Latin}", "A", true, ECMAScriptFlags::Unicode },
-        { "\\p{sc=Latin}", "9", false, ECMAScriptFlags::Unicode },
-        { "\\p{Script_Extensions=Deva}", "a", false, ECMAScriptFlags::Unicode },
-        { "\\p{Script_Extensions=Beng}", "\xe1\xb3\x95", true, ECMAScriptFlags::Unicode }, // U+01CD5
-        { "\\p{Script_Extensions=Deva}", "\xe1\xb3\x95", true, ECMAScriptFlags::Unicode }, // U+01CD5
-        { "\\p{scx=Deva}", "a", false, ECMAScriptFlags::Unicode },
-        { "\\p{scx=Beng}", "\xe1\xb3\x95", true, ECMAScriptFlags::Unicode }, // U+01CD5
-        { "\\p{scx=Deva}", "\xe1\xb3\x95", true, ECMAScriptFlags::Unicode }, // U+01CD5
+        { "\\p{ASCII}"sv, "a"sv, false },
+        { "\\p{ASCII}"sv, "p{ASCII}"sv, true },
+        { "\\p{ASCII}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{ASCII}"sv, "😀"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII}"sv, "a"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII}"sv, "😀"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{ASCII_Hex_Digit}"sv, "1"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{ASCII_Hex_Digit}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{ASCII_Hex_Digit}"sv, "x"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII_Hex_Digit}"sv, "1"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII_Hex_Digit}"sv, "a"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{ASCII_Hex_Digit}"sv, "x"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{Any}"sv, "\xcd\xb8"sv, true, ECMAScriptFlags::Unicode },       // U+0378, which is an unassigned code point.
+        { "\\P{Any}"sv, "\xcd\xb8"sv, false, ECMAScriptFlags::Unicode },      // U+0378, which is an unassigned code point.
+        { "\\p{Assigned}"sv, "\xcd\xb8"sv, false, ECMAScriptFlags::Unicode }, // U+0378, which is an unassigned code point.
+        { "\\P{Assigned}"sv, "\xcd\xb8"sv, true, ECMAScriptFlags::Unicode },  // U+0378, which is an unassigned code point.
+        { "\\p{Lu}"sv, "a"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{Lu}"sv, "A"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{Lu}"sv, "9"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{Cased_Letter}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{Cased_Letter}"sv, "A"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{Cased_Letter}"sv, "9"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{Cased_Letter}"sv, "a"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{Cased_Letter}"sv, "A"sv, false, ECMAScriptFlags::Unicode },
+        { "\\P{Cased_Letter}"sv, "9"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{General_Category=Cased_Letter}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{General_Category=Cased_Letter}"sv, "A"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{General_Category=Cased_Letter}"sv, "9"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{gc=Cased_Letter}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{gc=Cased_Letter}"sv, "A"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{gc=Cased_Letter}"sv, "9"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{Script=Latin}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{Script=Latin}"sv, "A"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{Script=Latin}"sv, "9"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{sc=Latin}"sv, "a"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{sc=Latin}"sv, "A"sv, true, ECMAScriptFlags::Unicode },
+        { "\\p{sc=Latin}"sv, "9"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{Script_Extensions=Deva}"sv, "a"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{Script_Extensions=Beng}"sv, "\xe1\xb3\x95"sv, true, ECMAScriptFlags::Unicode }, // U+01CD5
+        { "\\p{Script_Extensions=Deva}"sv, "\xe1\xb3\x95"sv, true, ECMAScriptFlags::Unicode }, // U+01CD5
+        { "\\p{scx=Deva}"sv, "a"sv, false, ECMAScriptFlags::Unicode },
+        { "\\p{scx=Beng}"sv, "\xe1\xb3\x95"sv, true, ECMAScriptFlags::Unicode }, // U+01CD5
+        { "\\p{scx=Deva}"sv, "\xe1\xb3\x95"sv, true, ECMAScriptFlags::Unicode }, // U+01CD5
     };
 
     for (auto& test : tests) {
@@ -742,19 +742,19 @@ TEST_CASE(ECMA262_property_match)
 TEST_CASE(replace)
 {
     struct _test {
-        const char* pattern;
-        const char* replacement;
-        const char* subject;
-        const char* expected;
+        StringView pattern;
+        StringView replacement;
+        StringView subject;
+        StringView expected;
         ECMAScriptFlags options {};
     };
 
     constexpr _test tests[] {
-        { "foo(.+)", "aaa", "test", "test" },
-        { "foo(.+)", "test\\1", "foobar", "testbar" },
-        { "foo(.+)", "\\2\\1", "foobar", "\\2bar" },
-        { "foo(.+)", "\\\\\\1", "foobar", "\\bar" },
-        { "foo(.)", "a\\1", "fooxfooy", "axay", ECMAScriptFlags::Multiline },
+        { "foo(.+)"sv, "aaa"sv, "test"sv, "test"sv },
+        { "foo(.+)"sv, "test\\1"sv, "foobar"sv, "testbar"sv },
+        { "foo(.+)"sv, "\\2\\1"sv, "foobar"sv, "\\2bar"sv },
+        { "foo(.+)"sv, "\\\\\\1"sv, "foobar"sv, "\\bar"sv },
+        { "foo(.)"sv, "a\\1"sv, "fooxfooy"sv, "axay"sv, ECMAScriptFlags::Multiline },
     };
 
     for (auto& test : tests) {

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -559,6 +559,12 @@ TEST_CASE(ECMA262_parse)
         { "[\\00]"sv, regex::Error::InvalidPattern, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::BrowserExtended) },
         { "\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
         { "[\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/]"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "]"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "]"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\]"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
+        { "}"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "}"sv, regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\}"sv, regex::Error::NoError, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -422,9 +422,11 @@ TEST_CASE(named_capture_group)
     EXPECT_EQ(re.search(haystack, result, PosixFlags::Multiline), true);
     EXPECT_EQ(result.count, 2u);
     EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
-    EXPECT_EQ(result.named_capture_group_matches.at(0).ensure("Test").view, "255");
+    EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "255");
+    EXPECT_EQ(result.capture_group_matches.at(0).at(0).capture_group_name, "Test");
     EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
-    EXPECT_EQ(result.named_capture_group_matches.at(1).ensure("Test").view, "0");
+    EXPECT_EQ(result.capture_group_matches.at(1).at(0).view, "0");
+    EXPECT_EQ(result.capture_group_matches.at(1).at(0).capture_group_name, "Test");
 }
 
 TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
@@ -443,9 +445,11 @@ TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
     EXPECT_EQ(re.search(haystack, result, ECMAScriptFlags::Multiline), true);
     EXPECT_EQ(result.count, 2u);
     EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
-    EXPECT_EQ(result.named_capture_group_matches.at(0).ensure("$Test$").view, "255");
+    EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "255");
+    EXPECT_EQ(result.capture_group_matches.at(0).at(0).capture_group_name, "$Test$");
     EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
-    EXPECT_EQ(result.named_capture_group_matches.at(1).ensure("$Test$").view, "0");
+    EXPECT_EQ(result.capture_group_matches.at(1).at(0).view, "0");
+    EXPECT_EQ(result.capture_group_matches.at(1).at(0).capture_group_name, "$Test$");
 }
 
 TEST_CASE(a_star)

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -499,6 +499,10 @@ TEST_CASE(ECMA262_parse)
         { "\\/" },                                         // #4189
         { ",/=-:" },                                       // #4243
         { "\\x" },                                         // Even invalid escapes are allowed if ~unicode.
+        { "\\x1" },                                        // Even invalid escapes are allowed if ~unicode.
+        { "\\x1", regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
+        { "\\x11" },
+        { "\\x11", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
         { "\\", regex::Error::InvalidTrailingEscape },
         { "(?", regex::Error::InvalidCaptureGroup },
         { "\\u1234", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -503,6 +503,8 @@ TEST_CASE(ECMA262_parse)
         { "(?", regex::Error::InvalidCaptureGroup },
         { "\\u1234", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
         { "[\\u1234]", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
+        { "\\u1", regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
+        { "[\\u1]", regex::Error::InvalidPattern, regex::ECMAScriptFlags::Unicode },
         { ",(?", regex::Error::InvalidCaptureGroup }, // #4583
         { "{1}", regex::Error::InvalidPattern },
         { "{1,2}", regex::Error::InvalidPattern },

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -525,6 +525,18 @@ TEST_CASE(ECMA262_parse)
         { "\\\\p{1}", regex::Error::NoError, ECMAScriptFlags::Unicode },
         { "\\\\p{AsCiI}", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
         { "\\\\p{ASCII}", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\c", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "\\c", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "[\\c]", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "[\\c]", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\c`", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "\\c`", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "[\\c`]", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "[\\c`]", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
+        { "\\A", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "\\A", regex::Error::InvalidCharacterClass, ECMAScriptFlags::Unicode },
+        { "[\\A]", regex::Error::NoError, ECMAScriptFlags::BrowserExtended },
+        { "[\\A]", regex::Error::InvalidPattern, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {
@@ -579,6 +591,7 @@ TEST_CASE(ECMA262_match)
         { "\\05", "\5", true, ECMAScriptFlags::BrowserExtended },
         { "\\455", "\45""5", true, ECMAScriptFlags::BrowserExtended },
         { "\\314", "\314", true, ECMAScriptFlags::BrowserExtended },
+        { "\\c", "\\c", true, ECMAScriptFlags::BrowserExtended },
         { "\\cf", "\06", true, ECMAScriptFlags::BrowserExtended },
         { "\\c1", "\\c1", true, ECMAScriptFlags::BrowserExtended },
         { "[\\c1]", "\x11", true, ECMAScriptFlags::BrowserExtended },

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -202,7 +202,7 @@ OpCode& ByteCode::get_opcode(MatchState& state) const
     return opcode;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, MatchState& state) const
 {
     if (state.string_position > input.view.length() || state.instruction_position >= m_bytecode->size())
         return ExecutionResult::Succeeded;
@@ -210,20 +210,20 @@ ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, Matc
     return ExecutionResult::Failed;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Save::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Save::execute(MatchInput const& input, MatchState& state) const
 {
     save_string_position(input, state);
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(MatchInput const& input, MatchState& state) const
 {
     if (!restore_string_position(input, state))
         return ExecutionResult::Failed;
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const&, MatchState& state) const
 {
     if (count() > state.string_position)
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -232,7 +232,7 @@ ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const&, MatchSta
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input, MatchState&, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input, MatchState&) const
 {
     VERIFY(count() > 0);
 
@@ -240,25 +240,25 @@ ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input,
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(MatchInput const&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(MatchInput const&, MatchState& state) const
 {
     state.instruction_position += offset();
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkJump::execute(MatchInput const&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ForkJump::execute(MatchInput const&, MatchState& state) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     return ExecutionResult::Fork_PrioHigh;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkStay::execute(MatchInput const&, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ForkStay::execute(MatchInput const&, MatchState& state) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     return ExecutionResult::Fork_PrioLow;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input, MatchState& state) const
 {
     if (0 == state.string_position && (input.regex_options & AllFlags::MatchNotBeginOfLine))
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -271,7 +271,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& input, MatchState& state) const
 {
     auto isword = [](auto ch) { return is_ascii_alphanumeric(ch) || ch == '_'; };
     auto is_word_boundary = [&] {
@@ -305,7 +305,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& in
     VERIFY_NOT_REACHED();
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, MatchState& state) const
 {
     if (state.string_position == input.view.length() && (input.regex_options & AllFlags::MatchNotEndOfLine))
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -317,7 +317,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, 
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     if (input.match_index < state.capture_group_matches.size()) {
         auto& group = state.capture_group_matches[input.match_index];
@@ -327,7 +327,7 @@ ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     if (input.match_index >= state.capture_group_matches.size()) {
         state.capture_group_matches.ensure_capacity(input.match_index);
@@ -347,7 +347,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput co
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     auto& match = state.capture_group_matches.at(input.match_index).at(id());
     auto start_position = match.left_column;
@@ -372,7 +372,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput c
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     auto& match = state.capture_group_matches.at(input.match_index).at(id());
     auto start_position = match.left_column;
@@ -397,7 +397,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchIn
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, MatchState& state, MatchOutput&) const
+ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, MatchState& state) const
 {
     bool inverse { false };
     bool temporary_inverse { false };

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -175,6 +175,9 @@ void ByteCode::ensure_opcodes_initialized()
         case OpCodeId::SaveRightNamedCaptureGroup:
             s_opcodes[i] = make<OpCode_SaveRightNamedCaptureGroup>();
             break;
+        case OpCodeId::Repeat:
+            s_opcodes[i] = make<OpCode_Repeat>();
+            break;
         }
     }
     s_opcodes_initialized = true;
@@ -850,4 +853,23 @@ Vector<String> const OpCode_Compare::variable_arguments_to_string(Optional<Match
     }
     return result;
 }
+
+ALWAYS_INLINE ExecutionResult OpCode_Repeat::execute(MatchInput const&, MatchState& state) const
+{
+    VERIFY(count() > 0);
+
+    if (id() >= state.repetition_marks.size())
+        state.repetition_marks.resize(id() + 1);
+    auto& repetition_mark = state.repetition_marks.at(id());
+
+    if (repetition_mark == count() - 1) {
+        repetition_mark = 0;
+    } else {
+        state.instruction_position -= offset() + size();
+        ++repetition_mark;
+    }
+
+    return ExecutionResult::Continue;
+}
+
 }

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -471,7 +471,7 @@ public:
 
     virtual OpCodeId opcode_id() const = 0;
     virtual size_t size() const = 0;
-    virtual ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const = 0;
+    virtual ExecutionResult execute(MatchInput const& input, MatchState& state) const = 0;
 
     ALWAYS_INLINE ByteCodeValueType argument(size_t offset) const
     {
@@ -508,7 +508,7 @@ protected:
 
 class OpCode_Exit final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Exit; }
     ALWAYS_INLINE size_t size() const override { return 1; }
     String const arguments_string() const override { return ""; }
@@ -516,7 +516,7 @@ public:
 
 class OpCode_FailForks final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t count() const { return argument(0); }
@@ -525,7 +525,7 @@ public:
 
 class OpCode_Save final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Save; }
     ALWAYS_INLINE size_t size() const override { return 1; }
     String const arguments_string() const override { return ""; }
@@ -533,7 +533,7 @@ public:
 
 class OpCode_Restore final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Restore; }
     ALWAYS_INLINE size_t size() const override { return 1; }
     String const arguments_string() const override { return ""; }
@@ -541,7 +541,7 @@ public:
 
 class OpCode_GoBack final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::GoBack; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t count() const { return argument(0); }
@@ -550,7 +550,7 @@ public:
 
 class OpCode_Jump final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Jump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
@@ -562,7 +562,7 @@ public:
 
 class OpCode_ForkJump final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkJump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
@@ -574,7 +574,7 @@ public:
 
 class OpCode_ForkStay final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkStay; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
@@ -586,7 +586,7 @@ public:
 
 class OpCode_CheckBegin final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBegin; }
     ALWAYS_INLINE size_t size() const override { return 1; }
     String const arguments_string() const override { return ""; }
@@ -594,7 +594,7 @@ public:
 
 class OpCode_CheckEnd final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckEnd; }
     ALWAYS_INLINE size_t size() const override { return 1; }
     String const arguments_string() const override { return ""; }
@@ -602,7 +602,7 @@ public:
 
 class OpCode_CheckBoundary final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBoundary; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t arguments_count() const { return 1; }
@@ -612,7 +612,7 @@ public:
 
 class OpCode_ClearCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ClearCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
@@ -621,7 +621,7 @@ public:
 
 class OpCode_SaveLeftCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
@@ -630,7 +630,7 @@ public:
 
 class OpCode_SaveRightCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
@@ -639,7 +639,7 @@ public:
 
 class OpCode_SaveRightNamedCaptureGroup final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 4; }
     ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
@@ -653,7 +653,7 @@ public:
 
 class OpCode_Compare final : public OpCode {
 public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state, MatchOutput& output) const override;
+    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Compare; }
     ALWAYS_INLINE size_t size() const override { return arguments_size() + 3; }
     ALWAYS_INLINE size_t arguments_count() const { return argument(0); }

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -507,13 +507,6 @@ struct MatchState {
     Vector<Vector<Match>> capture_group_matches;
 };
 
-struct MatchOutput {
-    size_t operations;
-    Vector<Match> matches;
-    Vector<Vector<Match>> capture_group_matches;
-    Vector<HashMap<String, Match>> named_capture_group_matches;
-};
-
 }
 
 using regex::RegexStringView;

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -442,8 +442,17 @@ public:
     }
 
     Match(String const string_, size_t const line_, size_t const column_, size_t const global_offset_)
-        : string(string_)
+        : string(move(string_))
         , view(string.value().view())
+        , line(line_)
+        , column(column_)
+        , global_offset(global_offset_)
+    {
+    }
+
+    Match(RegexStringView const view_, StringView capture_group_name_, size_t const line_, size_t const column_, size_t const global_offset_)
+        : view(view_)
+        , capture_group_name(capture_group_name_)
         , line(line_)
         , column(column_)
         , global_offset(global_offset_)
@@ -454,6 +463,7 @@ public:
     void reset()
     {
         view = view.typed_null_view();
+        capture_group_name.clear();
         line = 0;
         column = 0;
         global_offset = 0;
@@ -461,6 +471,7 @@ public:
     }
 
     RegexStringView view { nullptr };
+    Optional<StringView> capture_group_name {};
     size_t line { 0 };
     size_t column { 0 };
     size_t global_offset { 0 };
@@ -494,8 +505,6 @@ struct MatchState {
     size_t fork_at_position { 0 };
     Vector<Match> matches;
     Vector<Vector<Match>> capture_group_matches;
-    Vector<HashMap<String, Match>> named_capture_group_matches;
-    size_t recursion_level { 0 };
 };
 
 struct MatchOutput {

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -505,6 +505,7 @@ struct MatchState {
     size_t fork_at_position { 0 };
     Vector<Match> matches;
     Vector<Vector<Match>> capture_group_matches;
+    Vector<u64> repetition_marks;
 };
 
 }

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -206,6 +206,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             state.string_position = view_index;
             state.string_position_in_code_units = view_index;
             state.instruction_position = 0;
+            state.repetition_marks.clear();
 
             auto success = execute(input, state, temp_operations);
             // This success is acceptable only if it doesn't read anything from the input (input length is 0).
@@ -238,6 +239,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             state.string_position = view_index;
             state.string_position_in_code_units = view_index;
             state.instruction_position = 0;
+            state.repetition_marks.clear();
 
             auto success = execute(input, state, operations);
             if (!success.has_value())

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -391,7 +391,7 @@ private:
         Node* previous { nullptr };
     };
 
-    UniformBumpAllocator<Node, true, 8 * MiB> m_allocator;
+    UniformBumpAllocator<Node, true, 2 * MiB> m_allocator;
     Node* m_first { nullptr };
     Node* m_last { nullptr };
 };

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -64,7 +64,7 @@ public:
     }
 
 private:
-    Optional<bool> execute(MatchInput const& input, MatchState& state, MatchOutput& output) const;
+    Optional<bool> execute(MatchInput const& input, MatchState& state, size_t& operations) const;
 
     Regex<Parser> const* m_pattern;
     typename ParserTraits<Parser>::OptionsType const m_regex_options;

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -31,7 +31,6 @@ struct RegexResult final {
     size_t count { 0 };
     Vector<Match> matches;
     Vector<Vector<Match>> capture_group_matches;
-    Vector<HashMap<String, Match>> named_capture_group_matches;
     size_t n_operations { 0 };
     size_t n_capture_groups { 0 };
     size_t n_named_capture_groups { 0 };

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1290,6 +1290,9 @@ bool ECMA262Parser::parse_atom(ByteCode& stack, size_t& match_length_minimum, bo
     }
 
     if (match(TokenType::RightBracket) || match(TokenType::RightCurly) || match(TokenType::LeftCurly)) {
+        if (unicode)
+            return set_error(Error::InvalidPattern);
+
         if (m_should_use_browser_extended_grammar) {
             auto token = consume();
             match_length_minimum += 1;

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1450,7 +1450,7 @@ bool ECMA262Parser::parse_atom_escape(ByteCode& stack, size_t& match_length_mini
 
     // HexEscape
     if (try_skip("x")) {
-        if (auto hex_escape = read_digits(ReadDigitsInitialZeroState::Allow, true, 2); hex_escape.has_value()) {
+        if (auto hex_escape = read_digits(ReadDigitsInitialZeroState::Allow, true, 2, 2); hex_escape.has_value()) {
             match_length_minimum += 1;
             stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)hex_escape.value() } });
             return true;
@@ -1802,7 +1802,7 @@ bool ECMA262Parser::parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&
 
             // HexEscape
             if (try_skip("x")) {
-                if (auto hex_escape = read_digits(ReadDigitsInitialZeroState::Allow, true, 2); hex_escape.has_value()) {
+                if (auto hex_escape = read_digits(ReadDigitsInitialZeroState::Allow, true, 2, 2); hex_escape.has_value()) {
                     return { CharClassRangeElement { .code_point = hex_escape.value(), .is_character_class = false } };
                 } else if (!unicode) {
                     // '\x' is allowed in non-unicode mode, just matches 'x'.

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -102,6 +102,7 @@ protected:
         size_t capture_groups_count { 0 };
         size_t named_capture_groups_count { 0 };
         size_t match_length_minimum { 0 };
+        size_t repetition_mark_count { 0 };
         AllOptions regex_options;
         HashMap<int, size_t> capture_group_minimum_lengths;
         HashMap<FlyString, NamedCaptureGroup> named_capture_groups;
@@ -232,7 +233,7 @@ private:
     bool parse_assertion(ByteCode&, size_t&, bool unicode, bool named);
     bool parse_atom(ByteCode&, size_t&, bool unicode, bool named);
     bool parse_quantifier(ByteCode&, size_t&, bool unicode, bool named);
-    bool parse_interval_quantifier(Optional<size_t>& repeat_min, Optional<size_t>& repeat_max);
+    bool parse_interval_quantifier(Optional<u64>& repeat_min, Optional<u64>& repeat_max);
     bool parse_atom_escape(ByteCode&, size_t&, bool unicode, bool named);
     bool parse_character_class(ByteCode&, size_t&, bool unicode, bool named);
     bool parse_capture_group(ByteCode&, size_t&, bool unicode, bool named);

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -88,6 +88,11 @@ protected:
     ALWAYS_INLINE bool done() const;
     ALWAYS_INLINE bool set_error(Error error);
 
+    struct NamedCaptureGroup {
+        size_t group_index { 0 };
+        size_t minimum_length { 0 };
+    };
+
     struct ParserState {
         Lexer& lexer;
         Token current_token;
@@ -99,8 +104,7 @@ protected:
         size_t match_length_minimum { 0 };
         AllOptions regex_options;
         HashMap<int, size_t> capture_group_minimum_lengths;
-        HashMap<FlyString, size_t> named_capture_group_minimum_lengths;
-        HashMap<size_t, FlyString> named_capture_groups;
+        HashMap<FlyString, NamedCaptureGroup> named_capture_groups;
 
         explicit ParserState(Lexer& lexer)
             : lexer(lexer)
@@ -258,8 +262,7 @@ private:
     // ECMA-262 basically requires that we clear the inner captures of a capture group before trying to match it,
     // by requiring that (...)+ only contain the matches for the last iteration.
     // To do that, we have to keep track of which capture groups are "in scope", so we can clear them as needed.
-    using CaptureGroup = Variant<size_t, String>;
-    Vector<Vector<CaptureGroup>> m_capture_groups_in_scope;
+    Vector<Vector<size_t>> m_capture_groups_in_scope;
 };
 
 using PosixExtended = PosixExtendedParser;

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -210,8 +210,8 @@ private:
         Allow,
         Disallow,
     };
-    StringView read_digits_as_string(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1);
-    Optional<unsigned> read_digits(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1);
+    StringView read_digits_as_string(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1, int min_count = -1);
+    Optional<unsigned> read_digits(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1, int min_count = -1);
     StringView read_capture_group_specifier(bool take_starting_angle_bracket = false);
 
     struct Script {


### PR DESCRIPTION
Most of these commits are correctness fixes, tested by test262 (and now have tests in LibRegex).

The last commit (the REPEAT operation) addresses the following test262 test: `test262/test/built-ins/RegExp/quantifier-integer-limit.js`.

This test essentially creates regexes with `2^53 - 1` repetitions. We were previously trying to loop that many times, injecting the repeated byte code stack each iteration. We now have a REPEAT operation to defer this loop from the parser to runtime (which will have the chance to bail early on match failures).

(This is a draft due to an issue Ali pointed out on discord)