### PR TITLE
Implement [max,min]_element

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -8,6 +8,7 @@
 
 #include <AK/Iterator.h>
 #include <AK/MaxElement.h>
+#include <AK/MinElement.h>
 #include <AK/Span.h>
 
 namespace AK {

--- a/AK/Array.h
+++ b/AK/Array.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Iterator.h>
+#include <AK/MaxElement.h>
 #include <AK/Span.h>
 
 namespace AK {
@@ -64,16 +65,6 @@ struct Array {
             __data[idx] = value;
 
         return Size;
-    }
-
-    [[nodiscard]] constexpr T max() requires(requires(T x, T y) { x < y; })
-    {
-        static_assert(Size > 0, "No values to max() over");
-
-        T value = __data[0];
-        for (size_t i = 1; i < Size; ++i)
-            value = AK::max(__data[i], value);
-        return value;
     }
 
     [[nodiscard]] constexpr T min() requires(requires(T x, T y) { x > y; })

--- a/AK/Iterator.h
+++ b/AK/Iterator.h
@@ -58,7 +58,7 @@ public:
     constexpr auto operator->() const { return &m_container[m_index]; }
     constexpr auto operator->() { return &m_container[m_index]; }
 
-    SimpleIterator& operator=(const SimpleIterator& other)
+    constexpr SimpleIterator& operator=(const SimpleIterator& other)
     {
         m_index = other.m_index;
         return *this;

--- a/AK/MaxElement.h
+++ b/AK/MaxElement.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Iterator.h>
+
+namespace AK {
+
+template<typename TEndIterator, IteratorPairWith<TEndIterator> TIterator>
+constexpr auto max_element(
+    TIterator const& begin,
+    TEndIterator const& end,
+    auto const& comp)
+{
+    if (begin == end) {
+        return end;
+    }
+
+    TIterator largest = begin;
+    for (TIterator cur = begin + 1; cur != end; ++cur) {
+        if (comp(*largest, *cur)) {
+            largest = cur;
+        }
+    }
+    return largest;
+}
+
+template<typename TEndIterator, IteratorPairWith<TEndIterator> TIterator>
+constexpr auto max_element(
+    TIterator const& begin,
+    TEndIterator const& end)
+{
+    constexpr auto less = [](auto const& a, auto const& b) {
+        return a < b;
+    };
+    return max_element(begin, end, less);
+}
+
+template<IterableContainer Container>
+constexpr auto max_element(Container&& container, auto const& comp)
+{
+    return max_element(container.begin(), container.end(), comp);
+}
+
+template<IterableContainer Container>
+constexpr auto max_element(Container&& container)
+{
+    return max_element(container.begin(), container.end());
+}
+
+}
+
+using AK::max_element;

--- a/AK/MinElement.h
+++ b/AK/MinElement.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Iterator.h>
+
+namespace AK {
+
+template<typename TEndIterator, IteratorPairWith<TEndIterator> TIterator>
+constexpr auto min_element(
+    TIterator const& begin,
+    TEndIterator const& end,
+    auto const& comp)
+{
+    if (begin == end) {
+        return end;
+    }
+
+    TIterator smallest = begin;
+    for (TIterator cur = begin + 1; cur != end; ++cur) {
+        if (comp(*cur, *smallest)) {
+            smallest = cur;
+        }
+    }
+    return smallest;
+}
+
+template<typename TEndIterator, IteratorPairWith<TEndIterator> TIterator>
+constexpr auto min_element(
+    TIterator const& begin,
+    TEndIterator const& end)
+{
+    constexpr auto less = [](auto const& a, auto const& b) {
+        return a < b;
+    };
+    return min_element(begin, end, less);
+}
+
+template<IterableContainer Container>
+constexpr auto min_element(Container&& container, auto const& comp)
+{
+    return min_element(container.begin(), container.end(), comp);
+}
+
+template<IterableContainer Container>
+constexpr auto min_element(Container&& container)
+{
+    return min_element(container.begin(), container.end());
+}
+
+}
+
+using AK::min_element;

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/BitCast.h>
+#include <AK/MaxElement.h>
 #include <AK/StdLibExtras.h>
 #include <AK/TypeList.h>
 
@@ -392,8 +393,8 @@ public:
     }
 
 private:
-    static constexpr auto data_size = integer_sequence_generate_array<size_t>(0, IntegerSequence<size_t, sizeof(Ts)...>()).max();
-    static constexpr auto data_alignment = integer_sequence_generate_array<size_t>(0, IntegerSequence<size_t, alignof(Ts)...>()).max();
+    static constexpr auto data_size = *max_element(integer_sequence_generate_array<size_t>(0, IntegerSequence<size_t, sizeof(Ts)...>()));
+    static constexpr auto data_alignment = *max_element(integer_sequence_generate_array<size_t>(0, IntegerSequence<size_t, alignof(Ts)...>()));
     using Helper = Detail::Variant<IndexType, 0, Ts...>;
     using VisitHelper = Detail::VisitImpl<IndexType, Ts...>;
 

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -36,6 +36,7 @@ set(AK_TEST_SOURCES
     TestLEB128.cpp
     TestLexicalPath.cpp
     TestMACAddress.cpp
+    TestMaxElement.cpp
     TestMemMem.cpp
     TestMemoryStream.cpp
     TestNeverDestroyed.cpp

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -39,6 +39,7 @@ set(AK_TEST_SOURCES
     TestMaxElement.cpp
     TestMemMem.cpp
     TestMemoryStream.cpp
+    TestMinElement.cpp
     TestNeverDestroyed.cpp
     TestNonnullRefPtr.cpp
     TestNumberFormat.cpp

--- a/Tests/AK/TestMaxElement.cpp
+++ b/Tests/AK/TestMaxElement.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Array.h>
+#include <AK/MaxElement.h>
+
+TEST_CASE(should_return_end_for_empty_container)
+{
+    constexpr AK::Array<int, 0> v {};
+    EXPECT_EQ(v.end(), AK::max_element(v));
+    static_assert(v.end() == AK::max_element(v));
+}
+
+TEST_CASE(should_return_begin_for_1_element_in_container)
+{
+    constexpr AK::Array v { 42 };
+    EXPECT_EQ(v.begin(), AK::max_element(v));
+    static_assert(v.begin() == AK::max_element(v));
+}
+
+TEST_CASE(should_return_begin_for_same_elements_in_container)
+{
+    constexpr AK::Array v { 42, 42 };
+    EXPECT_EQ(v.begin(), AK::max_element(v));
+    static_assert(v.begin() == AK::max_element(v));
+}
+
+TEST_CASE(should_return_largest_element_first)
+{
+    constexpr AK::Array v { 42, 5, 17 };
+    EXPECT_EQ(v.begin(), AK::max_element(v));
+    static_assert(v.begin() == AK::max_element(v));
+}
+
+TEST_CASE(should_return_largest_element_last)
+{
+    constexpr AK::Array v { 1, 2, 3 };
+    EXPECT_EQ(3, *AK::max_element(v));
+    static_assert(3 == *AK::max_element(v));
+}
+
+TEST_CASE(should_return_largest_element_middle)
+{
+    constexpr AK::Array v { 1, 42, 3 };
+    EXPECT_EQ(42, *AK::max_element(v));
+    static_assert(42 == *AK::max_element(v));
+}

--- a/Tests/AK/TestMinElement.cpp
+++ b/Tests/AK/TestMinElement.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Array.h>
+#include <AK/MinElement.h>
+
+TEST_CASE(should_return_end_for_empty_container)
+{
+    constexpr AK::Array<int, 0> v {};
+    EXPECT_EQ(v.end(), AK::min_element(v));
+    static_assert(v.end() == AK::min_element(v));
+}
+
+TEST_CASE(should_return_begin_for_1_element_in_container)
+{
+    constexpr AK::Array v { 42 };
+    EXPECT_EQ(v.begin(), AK::min_element(v));
+    static_assert(v.begin() == AK::min_element(v));
+}
+
+TEST_CASE(should_return_begin_for_same_elements_in_container)
+{
+    constexpr AK::Array v { 42, 42 };
+    EXPECT_EQ(v.begin(), AK::min_element(v));
+    static_assert(v.begin() == AK::min_element(v));
+}
+
+TEST_CASE(should_return_largest_element_first)
+{
+    constexpr AK::Array v { 5, 17, 42 };
+    EXPECT_EQ(v.begin(), AK::min_element(v));
+    static_assert(v.begin() == AK::min_element(v));
+}
+
+TEST_CASE(should_return_largest_element_last)
+{
+    constexpr AK::Array v { 3, 2, 1 };
+    EXPECT_EQ(1, *AK::min_element(v));
+    static_assert(1 == *AK::min_element(v));
+}
+
+TEST_CASE(should_return_largest_element_middle)
+{
+    constexpr AK::Array v { 42, 1, 3 };
+    EXPECT_EQ(1, *AK::min_element(v));
+    static_assert(1 == *AK::min_element(v));
+}


### PR DESCRIPTION
Problem:                                                              
- There are raw loops which are intended to find the min/max
  element within a container. These raw loops are error prone
  and more time consuming and difficult to read than a single 
  line expressing `[min,max]_element`.                                                      
- `[min,max]()` is coupled to `AK::Array` by being
  implemented inside of it.
                                                                      
Solution:                                                             
- Implement `[min,max]_element` providing both the ability
  to search an entire container and an iterator range within a
  container.          
- Remove `AK::Array::[min,max]()` in favor of the generic                   
  `AK::[min,max]_element()`                                                 
- Test implementation at run-time and compile-time.                   
- `constexpr` decorate SimpleIterator<>::operator=()` to make this    
  work.                                                               
