### PR TITLE
AK: Stop publishing detail namespaced functions

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -111,4 +111,3 @@ constexpr static auto iota_array(T const offset = {})
 
 using AK::Array;
 using AK::iota_array;
-using AK::Detail::integer_sequence_generate_array;


### PR DESCRIPTION
Problem:
- `AK::Detail::integer_sequence_generate_array` is published via a
  `using` directive in the `Array.h` header, but this is a `Detail`
  function.

Solution:
- Remove the `using` declaration.