### PR TITLE
Kernel: Fix OOB read in sys$dbgputstr(..) during fuzzing

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -284,7 +284,7 @@ public:
     }
 
     int replace(const String& needle, const String& replacement, bool all_occurrences = false);
-    size_t count(const String& needle) const;
+    [[nodiscard]] size_t count(const String& needle) const;
     [[nodiscard]] String reverse() const;
 
     template<typename... Ts>

--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -16,19 +16,19 @@ class KString {
     AK_MAKE_NONMOVABLE(KString);
 
 public:
-    static OwnPtr<KString> try_create_uninitialized(size_t, char*&);
-    static NonnullOwnPtr<KString> must_create_uninitialized(size_t, char*&);
-    static OwnPtr<KString> try_create(StringView const&);
-    static NonnullOwnPtr<KString> must_create(StringView const&);
+    [[nodiscard]] static OwnPtr<KString> try_create_uninitialized(size_t, char*&);
+    [[nodiscard]] static NonnullOwnPtr<KString> must_create_uninitialized(size_t, char*&);
+    [[nodiscard]] static OwnPtr<KString> try_create(StringView const&);
+    [[nodiscard]] static NonnullOwnPtr<KString> must_create(StringView const&);
 
     void operator delete(void*);
 
-    OwnPtr<KString> try_clone() const;
+    [[nodiscard]] OwnPtr<KString> try_clone() const;
 
-    bool is_empty() const { return m_length == 0; }
-    size_t length() const { return m_length; }
-    char const* characters() const { return m_characters; }
-    StringView view() const { return { characters(), length() }; }
+    [[nodiscard]] bool is_empty() const { return m_length == 0; }
+    [[nodiscard]] size_t length() const { return m_length; }
+    [[nodiscard]] char const* characters() const { return m_characters; }
+    [[nodiscard]] StringView view() const { return { characters(), length() }; }
 
 private:
     explicit KString(size_t length)

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -592,7 +592,8 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
         if (!copy_from_user(&route, user_route))
             return EFAULT;
 
-        auto ifname_or_error = try_copy_kstring_from_user(route.rt_dev, IFNAMSIZ);
+        Userspace<const char*> user_rt_dev((FlatPtr)route.rt_dev);
+        auto ifname_or_error = try_copy_kstring_from_user(user_rt_dev, IFNAMSIZ);
         if (ifname_or_error.is_error())
             return ifname_or_error.error();
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -498,7 +498,7 @@ Custody& Process::current_directory()
     return *m_cwd;
 }
 
-KResultOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(char const* user_path, size_t path_length) const
+KResultOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(Userspace<char const*> user_path, size_t path_length) const
 {
     if (path_length == 0)
         return EINVAL;
@@ -512,7 +512,8 @@ KResultOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(char const*
 
 KResultOr<NonnullOwnPtr<KString>> Process::get_syscall_path_argument(Syscall::StringArgument const& path) const
 {
-    return get_syscall_path_argument(path.characters, path.length);
+    Userspace<char const*> path_characters((FlatPtr)path.characters);
+    return get_syscall_path_argument(path_characters, path.length);
 }
 
 bool Process::dump_core()

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -539,11 +539,7 @@ private:
 
     KResultOr<siginfo_t> do_waitid(idtype_t idtype, int id, int options);
 
-    KResultOr<NonnullOwnPtr<KString>> get_syscall_path_argument(const char* user_path, size_t path_length) const;
-    KResultOr<NonnullOwnPtr<KString>> get_syscall_path_argument(Userspace<const char*> user_path, size_t path_length) const
-    {
-        return get_syscall_path_argument(user_path.unsafe_userspace_ptr(), path_length);
-    }
+    KResultOr<NonnullOwnPtr<KString>> get_syscall_path_argument(Userspace<const char*> user_path, size_t path_length) const;
     KResultOr<NonnullOwnPtr<KString>> get_syscall_path_argument(const Syscall::StringArgument&) const;
 
     bool has_tracee_thread(ProcessID tracer_pid);
@@ -963,7 +959,8 @@ inline static String copy_string_from_user(const Kernel::Syscall::StringArgument
 
 inline static KResultOr<NonnullOwnPtr<KString>> try_copy_kstring_from_user(const Kernel::Syscall::StringArgument& string)
 {
-    return try_copy_kstring_from_user(string.characters, string.length);
+    Userspace<char const*> characters((FlatPtr)string.characters);
+    return try_copy_kstring_from_user(characters, string.length);
 }
 
 template<>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -264,7 +264,7 @@ public:
     KResultOr<FlatPtr> sys$inode_watcher_add_watch(Userspace<const Syscall::SC_inode_watcher_add_watch_params*> user_params);
     KResultOr<FlatPtr> sys$inode_watcher_remove_watch(int fd, int wd);
     KResultOr<FlatPtr> sys$dbgputch(u8);
-    KResultOr<FlatPtr> sys$dbgputstr(Userspace<const u8*>, size_t);
+    KResultOr<FlatPtr> sys$dbgputstr(Userspace<const char*>, size_t);
     KResultOr<FlatPtr> sys$dump_backtrace();
     KResultOr<FlatPtr> sys$gettid();
     KResultOr<FlatPtr> sys$setsid();

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -42,16 +42,16 @@ String copy_string_from_user(Userspace<const char*> user_str, size_t user_str_si
     return copy_string_from_user(user_str.unsafe_userspace_ptr(), user_str_size);
 }
 
-Kernel::KResultOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(const char* user_str, size_t user_str_size)
+Kernel::KResultOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(Userspace<const char*> user_str, size_t user_str_size)
 {
     bool is_user = Kernel::Memory::is_user_range(VirtualAddress(user_str), user_str_size);
     if (!is_user)
         return EFAULT;
     Kernel::SmapDisabler disabler;
     void* fault_at;
-    ssize_t length = Kernel::safe_strnlen(user_str, user_str_size, fault_at);
+    ssize_t length = Kernel::safe_strnlen(user_str.unsafe_userspace_ptr(), user_str_size, fault_at);
     if (length < 0) {
-        dbgln("copy_kstring_from_user({:p}, {}) failed at {} (strnlen)", static_cast<const void*>(user_str), user_str_size, VirtualAddress { fault_at });
+        dbgln("copy_kstring_from_user({:p}, {}) failed at {} (strnlen)", static_cast<const void*>(user_str.unsafe_userspace_ptr()), user_str_size, VirtualAddress { fault_at });
         return EFAULT;
     }
     char* buffer;
@@ -64,16 +64,11 @@ Kernel::KResultOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(con
     if (length == 0)
         return new_string.release_nonnull();
 
-    if (!Kernel::safe_memcpy(buffer, user_str, (size_t)length, fault_at)) {
-        dbgln("copy_kstring_from_user({:p}, {}) failed at {} (memcpy)", static_cast<const void*>(user_str), user_str_size, VirtualAddress { fault_at });
+    if (!Kernel::safe_memcpy(buffer, user_str.unsafe_userspace_ptr(), (size_t)length, fault_at)) {
+        dbgln("copy_kstring_from_user({:p}, {}) failed at {} (memcpy)", static_cast<const void*>(user_str.unsafe_userspace_ptr()), user_str_size, VirtualAddress { fault_at });
         return EFAULT;
     }
     return new_string.release_nonnull();
-}
-
-Kernel::KResultOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(Userspace<const char*> user_str, size_t user_str_size)
-{
-    return try_copy_kstring_from_user(user_str.unsafe_userspace_ptr(), user_str_size);
 }
 
 [[nodiscard]] Optional<Time> copy_time_from_user(const timespec* ts_user)

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -20,7 +20,6 @@ struct StringArgument;
 
 [[nodiscard]] String copy_string_from_user(const char*, size_t);
 [[nodiscard]] String copy_string_from_user(Userspace<const char*>, size_t);
-[[nodiscard]] Kernel::KResultOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(const char*, size_t);
 [[nodiscard]] Kernel::KResultOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(Userspace<const char*>, size_t);
 [[nodiscard]] Optional<Time> copy_time_from_user(const timespec*);
 [[nodiscard]] Optional<Time> copy_time_from_user(const timeval*);

--- a/Kernel/Syscalls/debug.cpp
+++ b/Kernel/Syscalls/debug.cpp
@@ -42,8 +42,9 @@ KResultOr<FlatPtr> Process::sys$dbgputstr(Userspace<const char*> characters, siz
     auto result = try_copy_kstring_from_user(characters, size);
     if (result.is_error())
         return result.error();
-    dbgputstr(result.value()->characters(), size);
-    return size;
+    auto string = result.release_value();
+    dbgputstr(string->view());
+    return string->length();
 }
 
 }

--- a/Kernel/Syscalls/debug.cpp
+++ b/Kernel/Syscalls/debug.cpp
@@ -25,7 +25,7 @@ KResultOr<FlatPtr> Process::sys$dbgputch(u8 ch)
     return 0;
 }
 
-KResultOr<FlatPtr> Process::sys$dbgputstr(Userspace<const u8*> characters, size_t size)
+KResultOr<FlatPtr> Process::sys$dbgputstr(Userspace<const char*> characters, size_t size)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     if (size == 0)
@@ -39,7 +39,7 @@ KResultOr<FlatPtr> Process::sys$dbgputstr(Userspace<const u8*> characters, size_
         return size;
     }
 
-    auto result = try_copy_kstring_from_user(reinterpret_cast<char const*>(characters.unsafe_userspace_ptr()), size);
+    auto result = try_copy_kstring_from_user(characters, size);
     if (result.is_error())
         return result.error();
     dbgputstr(result.value()->characters(), size);

--- a/Kernel/Syscalls/inode_watcher.cpp
+++ b/Kernel/Syscalls/inode_watcher.cpp
@@ -58,7 +58,7 @@ KResultOr<FlatPtr> Process::sys$inode_watcher_add_watch(Userspace<const Syscall:
         return EBADF;
     auto inode_watcher = description->inode_watcher();
 
-    auto path = get_syscall_path_argument(params.user_path.characters, params.user_path.length);
+    auto path = get_syscall_path_argument(params.user_path);
     if (path.is_error())
         return path.error();
 

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/PrintfImplementation.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <Kernel/ConsoleDevice.h>
 #include <Kernel/Devices/PCISerialDevice.h>
@@ -163,6 +164,11 @@ extern "C" void dbgputstr(const char* characters, size_t length)
     ScopedSpinLock lock(s_log_lock);
     for (size_t i = 0; i < length; ++i)
         internal_dbgputch(characters[i]);
+}
+
+void dbgputstr(StringView view)
+{
+    ::dbgputstr(view.characters_without_null_termination(), view.length());
 }
 
 extern "C" void kernelputstr(const char* characters, size_t length)

--- a/Kernel/kstdio.h
+++ b/Kernel/kstdio.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Types.h>
 
 extern "C" {
@@ -17,3 +18,5 @@ int snprintf(char* buf, size_t, const char* fmt, ...) __attribute__((format(prin
 void set_serial_debug(bool on_or_off);
 int get_serial_debug();
 }
+
+void dbgputstr(StringView view);


### PR DESCRIPTION
This PR primarily fixes an OOB read, but also attempts to tidy up some minor issues with
string handling in the kernel so we can attempt to avoid these types of issues in the future:

- **Kernel: Fix OOB read in sys$dbgputstr(..) during fuzzing**

    The implementation uses try_copy_kstring_from_user to allocate a kernel
    string using, but does not use the length of the resulting string.
    The size parameter to the syscall is untrusted, as try copy kstring will
    attempt to perform a `safe_strlen(..)` on the user mode string and use
    that value for the allocated length of the KString instead. The bug is
    that we are printing the kstring, but with the usermode size argument.

    During fuzzing this resulted in us walking off the end of the allocated
    KString buffer printing garbage (or any kernel data!), until we stumbled
    in to the KSym region and hit a fatal page fault.

    This is technically a kernel information disclosure, but (un)fortunately
    the disclosure only happens to the Bochs debug port, and or the serial
    port if serial debugging is enabled. As far as I can tell it's not
    actually possible for an untrusted attacker to use this to do something
    nefarious, as they would need access to the host. If they have host
    access then they can already do much worse things :^).

- **Kernel: Remove char versions of path argument / kstring copy methods**

    The only two paths for copying strings in the kernel should be going
    through the existing Userspace<char const*>, or StringArgument methods.

    Lets enforce this by removing the option for using the raw cstring APIs
    that were previously available.

- **Kernel: Fix sys$dbgputstr(...) to take a char instead of u8**

    We always attempt to print this as a string, and it's defined as such in
    LibC, so fix the signature to match.

- **Kernel: Introduce a StringView overload of dbgputstr(..)**

- **Kernel: Annotate KString methods as [[nodiscard]]**

- **AK: Annotate String.count as [[nodiscard]]**