### PR TITLE
Kernel: Allow kmalloc(..) / kmalloc_aligned(..) to return nullptr, handle OOM during clone of FileDescriptions 

### DIFF
--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -255,9 +255,6 @@ void* kmalloc(size_t size)
     }
 
     void* ptr = g_kmalloc_global->m_heap.allocate(size);
-    if (!ptr) {
-        PANIC("kmalloc: Out of memory (requested size: {})", size);
-    }
 
     Thread* current_thread = Thread::current();
     if (!current_thread)

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -75,14 +75,16 @@ void operator delete(void* ptr, size_t, std::align_val_t) noexcept;
 void operator delete[](void* ptrs) noexcept DISALLOW("All deletes in the kernel should have a known size.");
 void operator delete[](void* ptr, size_t) noexcept;
 
-[[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] void* kmalloc(size_t);
+[[gnu::malloc, gnu::alloc_size(1)]] void* kmalloc(size_t);
 
 template<size_t ALIGNMENT>
-[[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] inline void* kmalloc_aligned(size_t size)
+[[gnu::malloc, gnu::alloc_size(1)]] inline void* kmalloc_aligned(size_t size)
 {
     static_assert(ALIGNMENT > sizeof(ptrdiff_t));
     static_assert(ALIGNMENT <= 4096);
     void* ptr = kmalloc(size + ALIGNMENT + sizeof(ptrdiff_t));
+    if (ptr == nullptr)
+        return ptr;
     size_t max_addr = (size_t)ptr + ALIGNMENT;
     void* aligned_ptr = (void*)(max_addr - (max_addr % ALIGNMENT));
     ((ptrdiff_t*)aligned_ptr)[-1] = (ptrdiff_t)((u8*)aligned_ptr - (u8*)ptr);

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -25,7 +25,10 @@ KResultOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     child->m_root_directory_relative_to_global_root = m_root_directory_relative_to_global_root;
     child->m_veil_state = m_veil_state;
     child->m_unveiled_paths = m_unveiled_paths.deep_copy();
-    child->m_fds = m_fds;
+
+    if (auto result = child->m_fds.try_clone(m_fds); result.is_error())
+        return result.error();
+
     child->m_pg = m_pg;
 
     {


### PR DESCRIPTION
More progress towards #6369

FileDescriptions issue was found with `loop { CatDog& }` :smile_cat: 