### PR TITLE
Kernel: Handle allocation failure in aligned `new` and `kfree_aligned`

### DIFF
--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -302,6 +302,8 @@ size_t kmalloc_good_size(size_t size)
 {
     VERIFY(alignment <= 4096);
     void* ptr = kmalloc(size + alignment + sizeof(ptrdiff_t));
+    if (ptr == nullptr)
+        return nullptr;
     size_t max_addr = (size_t)ptr + alignment;
     void* aligned_ptr = (void*)(max_addr - (max_addr % alignment));
     ((ptrdiff_t*)aligned_ptr)[-1] = (ptrdiff_t)((u8*)aligned_ptr - (u8*)ptr);

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -93,6 +93,8 @@ template<size_t ALIGNMENT>
 
 inline void kfree_aligned(void* ptr)
 {
+    if (ptr == nullptr)
+        return;
     kfree((u8*)ptr - ((const ptrdiff_t*)ptr)[-1]);
 }
 


### PR DESCRIPTION
Now that the regular `kmalloc` is allowed to return nullptr, we should make `kfree_aligned` and aligned `new` work correctly too.