### PR TITLE
LibGL: Implement `glColor3fv`

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -243,6 +243,7 @@ GLAPI void glClear(GLbitfield mask);
 GLAPI void glClearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
 GLAPI void glClearDepth(GLdouble depth);
 GLAPI void glColor3f(GLfloat r, GLfloat g, GLfloat b);
+GLAPI void glColor3fv(const GLfloat* v);
 GLAPI void glColor4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
 GLAPI void glColor4fv(const GLfloat* v);
 GLAPI void glColor4ub(GLubyte r, GLubyte g, GLubyte b, GLubyte a);

--- a/Userland/Libraries/LibGL/GLColor.cpp
+++ b/Userland/Libraries/LibGL/GLColor.cpp
@@ -14,6 +14,10 @@ void glColor3f(GLfloat r, GLfloat g, GLfloat b)
 {
     g_gl_context->gl_color(r, g, b, 1.0);
 }
+void glColor3fv(const GLfloat* v)
+{
+    g_gl_context->gl_color(v[0], v[1], v[2], 1.0);
+}
 
 void glColor4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a)
 {


### PR DESCRIPTION
One more OpenGL call to cross off the checklist to Quake compatibility! #7062 

cc @sunverwerth @alimpfard 