### PR TITLE
HackStudio: Update the window title after changing an active editor and changing a file name 

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -629,6 +629,8 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
         auto new_project_file = m_project->get_file(save_path.value());
         m_open_files.set(save_path.value(), *new_project_file);
         m_open_files_vector.append(save_path.value());
+
+        update_window_title();
     });
 }
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -288,7 +288,6 @@ bool HackStudioWidget::open_file(const String& full_filename)
     if (filename.starts_with(m_project->root_path()))
         relative_file_path = filename.substring(m_project->root_path().length() + 1);
 
-    window()->set_title(String::formatted("{} - {} - Hack Studio", relative_file_path, m_project->name()));
     m_project_tree_view->update();
 
     current_editor_wrapper().set_filename(filename);
@@ -826,6 +825,7 @@ Project& HackStudioWidget::project()
 void HackStudioWidget::set_current_editor_wrapper(RefPtr<EditorWrapper> editor_wrapper)
 {
     m_current_editor_wrapper = editor_wrapper;
+    update_window_title();
 }
 
 void HackStudioWidget::configure_project_tree_view()
@@ -1192,6 +1192,11 @@ void HackStudioWidget::update_gml_preview()
 {
     auto gml_content = current_editor_wrapper().filename().ends_with(".gml") ? current_editor_wrapper().editor().text() : "";
     m_gml_preview_widget->load_gml(gml_content);
+}
+
+void HackStudioWidget::update_window_title()
+{
+    window()->set_title(String::formatted("{} - {} - Hack Studio", m_current_editor_wrapper->filename_label().text(), m_project->name()));
 }
 
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -122,6 +122,7 @@ private:
     bool any_document_is_dirty() const;
 
     void update_gml_preview();
+    void update_window_title();
 
     NonnullRefPtrVector<EditorWrapper> m_all_editor_wrappers;
     RefPtr<EditorWrapper> m_current_editor_wrapper;


### PR DESCRIPTION
- **HackStudio: Update the window title after changing an active editor**

  Prior this change, the window title was updated only when a new file has been opened, which means that it wasn't updated when user selected an already opened file in the split view.

  This change updates the title whenever the active editor changes.
  In addition, this title update logic has now its own function as it'll also be used in the next commit. :)

- **HackStudio: Update the window title after changing a file name**

  This is a very similar fix as the previous commit, but here it's due to my oversight when I was adding an 'Save as..' feature.