### PR TITLE
LibGL: Add a bunch more functions to get glquake to run

### DIFF
--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     GLTexture.cpp
     GLUtils.cpp
     GLVert.cpp
+    GLVertexArrays.cpp
     SoftwareGLContext.cpp
     SoftwareRasterizer.cpp
     DepthBuffer.cpp

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -359,6 +359,7 @@ GLAPI void glEnableClientState(GLenum cap);
 GLAPI void glDisableClientState(GLenum cap);
 GLAPI void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
+GLAPI void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -263,6 +263,7 @@ typedef char GLchar;
 typedef char GLbyte;
 typedef unsigned char GLuchar;
 typedef unsigned char GLubyte;
+typedef unsigned char GLboolean;
 typedef short GLshort;
 typedef unsigned short GLushort;
 typedef int GLint;
@@ -352,6 +353,7 @@ GLAPI void glTexParameterf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glBindTexture(GLenum target, GLuint texture);
 GLAPI void glActiveTexture(GLenum texture);
 GLAPI void glGetFloatv(GLenum pname, GLfloat* params);
+GLAPI void glDepthMask(GLboolean flag);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -361,6 +361,7 @@ GLAPI void glDisableClientState(GLenum cap);
 GLAPI void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
+GLAPI void glDrawArrays(GLenum mode, GLint first, GLsizei count);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -354,6 +354,8 @@ GLAPI void glBindTexture(GLenum target, GLuint texture);
 GLAPI void glActiveTexture(GLenum texture);
 GLAPI void glGetFloatv(GLenum pname, GLfloat* params);
 GLAPI void glDepthMask(GLboolean flag);
+GLAPI void glEnableClientState(GLenum cap);
+GLAPI void glDisableClientState(GLenum cap);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -358,6 +358,7 @@ GLAPI void glDepthMask(GLboolean flag);
 GLAPI void glEnableClientState(GLenum cap);
 GLAPI void glDisableClientState(GLenum cap);
 GLAPI void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
+GLAPI void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -349,6 +349,7 @@ GLAPI void glReadBuffer(GLenum mode);
 GLAPI void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels);
 GLAPI void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* data);
 GLAPI void glTexCoord2f(GLfloat s, GLfloat t);
+GLAPI void glTexCoord4fv(const GLfloat* v);
 GLAPI void glTexParameteri(GLenum target, GLenum pname, GLint param);
 GLAPI void glTexParameterf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glBindTexture(GLenum target, GLuint texture);

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -141,6 +141,7 @@ extern "C" {
 #define GL_INT 0x1404
 #define GL_UNSIGNED_INT 0x1405
 #define GL_FLOAT 0x1406
+#define GL_DOUBLE 0x140A
 
 // Format enums
 #define GL_COLOR_INDEX 0x1900
@@ -356,6 +357,7 @@ GLAPI void glGetFloatv(GLenum pname, GLfloat* params);
 GLAPI void glDepthMask(GLboolean flag);
 GLAPI void glEnableClientState(GLenum cap);
 GLAPI void glDisableClientState(GLenum cap);
+GLAPI void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -362,6 +362,7 @@ GLAPI void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* 
 GLAPI void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glDrawArrays(GLenum mode, GLint first, GLsizei count);
+GLAPI void glDrawElements(GLenum mode, GLsizei count, GLenum type, const void* indices);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -15,6 +15,13 @@ extern "C" {
 #    define GLAPI extern
 #endif
 
+#define GL_VERSION_1_0
+#define GL_VERSION_1_1
+#define GL_VERSION_1_2
+#define GL_VERSION_1_3
+#define GL_VERSION_1_4
+#define GL_VERSION_1_5
+
 // OpenGL related `defines`
 #define GL_TRUE 1
 #define GL_FALSE 0
@@ -46,7 +53,9 @@ extern "C" {
 
 // Enable capabilities
 #define GL_CULL_FACE 0x0B44
+#define GL_FOG 0x0B60
 #define GL_DEPTH_TEST 0x0B71
+#define GL_POLYGON_OFFSET_FILL 0x8037
 
 // Alpha testing
 #define GL_ALPHA_TEST 0x0BC0
@@ -60,6 +69,11 @@ extern "C" {
 #define GL_VENDOR 0x1F00
 #define GL_RENDERER 0x1F01
 #define GL_VERSION 0x1F02
+#define GL_EXTENSIONS 0x1F03
+
+// Get parameters
+#define GL_MAX_TEXTURE_SIZE 0x0D33
+#define GL_MAX_TEXTURE_UNITS 0x84E2
 
 // Blend factors
 #define GL_ZERO 0
@@ -112,6 +126,9 @@ extern "C" {
 #define GL_GENERATE_MIPMAP_HINT 0x8192
 #define GL_TEXTURE_COMPRESSION_HINT 0x84EF
 
+// Read pixels
+#define GL_UNPACK_ROW_LENGTH 0x0CF2
+
 // Listing enums
 #define GL_COMPILE 0x1300
 #define GL_COMPILE_AND_EXECUTE 0x1301
@@ -149,6 +166,9 @@ extern "C" {
 #define GL_CONSTANT_ALPHA 0x8003
 #define GL_ONE_MINUS_CONSTANT_ALPHA 0x8004
 
+// Polygon modes
+#define GL_FILL 0x1B02
+
 // Pixel formats
 #define GL_RGB 0x1907
 #define GL_RGBA 0x1908
@@ -157,6 +177,9 @@ extern "C" {
 
 // Source pixel data format
 #define GL_UNSIGNED_BYTE 0x1401
+
+// Stencil buffer operations
+#define GL_REPLACE 0x1E01
 
 // Texture targets
 #define GL_TEXTURE_2D 0x0DE1
@@ -196,6 +219,10 @@ extern "C" {
 #define GL_TEXTURE31 0x84DF
 
 // Texture Environment and Parameters
+#define GL_MODULATE 0x2100
+#define GL_TEXTURE_ENV_MODE 0x2200
+#define GL_DECAL 0x2102
+#define GL_TEXTURE_ENV 0x2300
 #define GL_NEAREST 0x2600
 #define GL_LINEAR 0x2601
 #define GL_NEAREST_MIPMAP_NEAREST 0x2700
@@ -212,6 +239,18 @@ extern "C" {
 #define GL_CLAMP_TO_BORDER 0x812D
 #define GL_CLAMP_TO_EDGE 0x812F
 
+// Client state capabilities
+#define GL_VERTEX_ARRAY 0x8074
+#define GL_COLOR_ARRAY 0x8076
+#define GL_TEXTURE_COORD_ARRAY 0x8078
+
+// Fog parameters
+#define GL_EXP 0x0800
+#define GL_EXP2 0x0801
+#define GL_FOG_MODE 0x0B65
+#define GL_FOG_COLOR 0x0B66
+#define GL_FOG_DENSITY 0x0B62
+
 // OpenGL State & GLGet
 #define GL_MODELVIEW_MATRIX 0x0BA6
 
@@ -221,6 +260,7 @@ extern "C" {
 // Defines types used by all OpenGL applications
 // https://www.khronos.org/opengl/wiki/OpenGL_Type
 typedef char GLchar;
+typedef char GLbyte;
 typedef unsigned char GLuchar;
 typedef unsigned char GLubyte;
 typedef short GLshort;

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -70,6 +70,7 @@ public:
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) = 0;
+    virtual void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void* indices) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -66,6 +66,7 @@ public:
     virtual void gl_depth_mask(GLboolean flag) = 0;
     virtual void gl_enable_client_state(GLenum cap) = 0;
     virtual void gl_disable_client_state(GLenum cap) = 0;
+    virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -64,6 +64,8 @@ public:
     virtual void gl_active_texture(GLenum texture) = 0;
     virtual void gl_get_floatv(GLenum pname, GLfloat* params) = 0;
     virtual void gl_depth_mask(GLboolean flag) = 0;
+    virtual void gl_enable_client_state(GLenum cap) = 0;
+    virtual void gl_disable_client_state(GLenum cap) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -63,6 +63,7 @@ public:
     virtual void gl_bind_texture(GLenum target, GLuint texture) = 0;
     virtual void gl_active_texture(GLenum texture) = 0;
     virtual void gl_get_floatv(GLenum pname, GLfloat* params) = 0;
+    virtual void gl_depth_mask(GLboolean flag) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -69,6 +69,7 @@ public:
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
+    virtual void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -68,6 +68,7 @@ public:
     virtual void gl_disable_client_state(GLenum cap) = 0;
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
+    virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -67,6 +67,7 @@ public:
     virtual void gl_enable_client_state(GLenum cap) = 0;
     virtual void gl_disable_client_state(GLenum cap) = 0;
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
+    virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -94,3 +94,13 @@ void glDepthMask(GLboolean flag)
 {
     g_gl_context->gl_depth_mask(flag);
 }
+
+void glEnableClientState(GLenum cap)
+{
+    g_gl_context->gl_enable_client_state(cap);
+}
+
+void glDisableClientState(GLenum cap)
+{
+    g_gl_context->gl_disable_client_state(cap);
+}

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -89,3 +89,8 @@ void glGetFloatv(GLenum pname, GLfloat* params)
 {
     g_gl_context->gl_get_floatv(pname, params);
 }
+
+void glDepthMask(GLboolean flag)
+{
+    g_gl_context->gl_depth_mask(flag);
+}

--- a/Userland/Libraries/LibGL/GLVert.cpp
+++ b/Userland/Libraries/LibGL/GLVert.cpp
@@ -145,6 +145,11 @@ void glTexCoord2f(GLfloat s, GLfloat t)
     g_gl_context->gl_tex_coord(s, t, 0.0f, 0.0f);
 }
 
+void glTexCoord4fv(const GLfloat* v)
+{
+    g_gl_context->gl_tex_coord(v[0], v[1], v[2], v[3]);
+}
+
 void glRotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
 {
     g_gl_context->gl_rotate(angle, x, y, z);

--- a/Userland/Libraries/LibGL/GLVertexArrays.cpp
+++ b/Userland/Libraries/LibGL/GLVertexArrays.cpp
@@ -28,3 +28,8 @@ void glDrawArrays(GLenum mode, GLint first, GLsizei count)
 {
     g_gl_context->gl_draw_arrays(mode, first, count);
 }
+
+void glDrawElements(GLenum mode, GLsizei count, GLenum type, const void* indices)
+{
+    g_gl_context->gl_draw_elements(mode, count, type, indices);
+}

--- a/Userland/Libraries/LibGL/GLVertexArrays.cpp
+++ b/Userland/Libraries/LibGL/GLVertexArrays.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GL/gl.h"
+#include "GLContext.h"
+
+extern GL::GLContext* g_gl_context;
+
+void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
+{
+    g_gl_context->gl_vertex_pointer(size, type, stride, pointer);
+}

--- a/Userland/Libraries/LibGL/GLVertexArrays.cpp
+++ b/Userland/Libraries/LibGL/GLVertexArrays.cpp
@@ -23,3 +23,8 @@ void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* poin
 {
     g_gl_context->gl_tex_coord_pointer(size, type, stride, pointer);
 }
+
+void glDrawArrays(GLenum mode, GLint first, GLsizei count)
+{
+    g_gl_context->gl_draw_arrays(mode, first, count);
+}

--- a/Userland/Libraries/LibGL/GLVertexArrays.cpp
+++ b/Userland/Libraries/LibGL/GLVertexArrays.cpp
@@ -18,3 +18,8 @@ void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer
 {
     g_gl_context->gl_color_pointer(size, type, stride, pointer);
 }
+
+void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
+{
+    g_gl_context->gl_tex_coord_pointer(size, type, stride, pointer);
+}

--- a/Userland/Libraries/LibGL/GLVertexArrays.cpp
+++ b/Userland/Libraries/LibGL/GLVertexArrays.cpp
@@ -13,3 +13,8 @@ void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointe
 {
     g_gl_context->gl_vertex_pointer(size, type, stride, pointer);
 }
+
+void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
+{
+    g_gl_context->gl_color_pointer(size, type, stride, pointer);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1485,6 +1485,22 @@ void SoftwareGLContext::gl_color_pointer(GLint size, GLenum type, GLsizei stride
     m_client_color_pointer.pointer = pointer;
 }
 
+void SoftwareGLContext::gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    RETURN_WITH_ERROR_IF(!(size == 1 || size == 2 || size == 3 || size == 4), GL_INVALID_VALUE);
+
+    RETURN_WITH_ERROR_IF(!(type == GL_SHORT || type == GL_INT || type == GL_FLOAT || type == GL_DOUBLE), GL_INVALID_ENUM);
+
+    RETURN_WITH_ERROR_IF(stride < 0, GL_INVALID_VALUE);
+
+    m_client_tex_coord_pointer.size = size;
+    m_client_tex_coord_pointer.type = type;
+    m_client_tex_coord_pointer.stride = stride;
+    m_client_tex_coord_pointer.pointer = pointer;
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1447,6 +1447,20 @@ void SoftwareGLContext::gl_disable_client_state(GLenum cap)
     }
 }
 
+void SoftwareGLContext::gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    RETURN_WITH_ERROR_IF(!(size == 1 || size == 2 || size == 4), GL_INVALID_VALUE);
+    RETURN_WITH_ERROR_IF(!(type == GL_SHORT || type == GL_INT || type == GL_FLOAT || type == GL_DOUBLE), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(stride < 0, GL_INVALID_VALUE);
+
+    m_client_vertex_pointer.size = size;
+    m_client_vertex_pointer.type = type;
+    m_client_vertex_pointer.stride = stride;
+    m_client_vertex_pointer.pointer = pointer;
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1461,6 +1461,30 @@ void SoftwareGLContext::gl_vertex_pointer(GLint size, GLenum type, GLsizei strid
     m_client_vertex_pointer.pointer = pointer;
 }
 
+void SoftwareGLContext::gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    RETURN_WITH_ERROR_IF(!(size == 3 || size == 4), GL_INVALID_VALUE);
+
+    RETURN_WITH_ERROR_IF(!(type == GL_BYTE
+                             || type == GL_UNSIGNED_BYTE
+                             || type == GL_SHORT
+                             || type == GL_UNSIGNED_SHORT
+                             || type == GL_INT
+                             || type == GL_UNSIGNED_INT
+                             || type == GL_FLOAT
+                             || type == GL_DOUBLE),
+        GL_INVALID_ENUM);
+
+    RETURN_WITH_ERROR_IF(stride < 0, GL_INVALID_VALUE);
+
+    m_client_color_pointer.size = size;
+    m_client_color_pointer.type = type;
+    m_client_color_pointer.stride = stride;
+    m_client_color_pointer.pointer = pointer;
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1403,6 +1403,50 @@ void SoftwareGLContext::gl_depth_mask(GLboolean flag)
     m_rasterizer.set_options(options);
 }
 
+void SoftwareGLContext::gl_enable_client_state(GLenum cap)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    switch (cap) {
+    case GL_VERTEX_ARRAY:
+        m_client_side_vertex_array_enabled = true;
+        break;
+
+    case GL_COLOR_ARRAY:
+        m_client_side_color_array_enabled = true;
+        break;
+
+    case GL_TEXTURE_COORD_ARRAY:
+        m_client_side_texture_coord_array_enabled = true;
+        break;
+
+    default:
+        RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
+    }
+}
+
+void SoftwareGLContext::gl_disable_client_state(GLenum cap)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    switch (cap) {
+    case GL_VERTEX_ARRAY:
+        m_client_side_vertex_array_enabled = false;
+        break;
+
+    case GL_COLOR_ARRAY:
+        m_client_side_color_array_enabled = false;
+        break;
+
+    case GL_TEXTURE_COORD_ARRAY:
+        m_client_side_texture_coord_array_enabled = false;
+        break;
+
+    default:
+        RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
+    }
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1392,6 +1392,17 @@ void SoftwareGLContext::gl_get_floatv(GLenum pname, GLfloat* params)
     }
 }
 
+void SoftwareGLContext::gl_depth_mask(GLboolean flag)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_depth_mask, flag);
+
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    auto options = m_rasterizer.options();
+    options.enable_depth_write = (flag != GL_FALSE);
+    m_rasterizer.set_options(options);
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -73,6 +73,7 @@ public:
     virtual void gl_bind_texture(GLenum target, GLuint texture) override;
     virtual void gl_active_texture(GLenum texture) override;
     virtual void gl_get_floatv(GLenum pname, GLfloat* params) override;
+    virtual void gl_depth_mask(GLboolean flag) override;
 
     virtual void present() override;
 
@@ -196,7 +197,8 @@ private:
             decltype(&SoftwareGLContext::gl_alpha_func),
             decltype(&SoftwareGLContext::gl_hint),
             decltype(&SoftwareGLContext::gl_read_buffer),
-            decltype(&SoftwareGLContext::gl_tex_parameter)>;
+            decltype(&SoftwareGLContext::gl_tex_parameter),
+            decltype(&SoftwareGLContext::gl_depth_mask)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -78,6 +78,7 @@ public:
     virtual void gl_disable_client_state(GLenum cap) override;
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
+    virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
 
     virtual void present() override;
 
@@ -235,6 +236,7 @@ private:
 
     VertexAttribPointer m_client_vertex_pointer;
     VertexAttribPointer m_client_color_pointer;
+    VertexAttribPointer m_client_tex_coord_pointer;
 };
 
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -76,6 +76,7 @@ public:
     virtual void gl_depth_mask(GLboolean flag) override;
     virtual void gl_enable_client_state(GLenum cap) override;
     virtual void gl_disable_client_state(GLenum cap) override;
+    virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
 
     virtual void present() override;
 
@@ -223,6 +224,15 @@ private:
         GLenum mode { GL_COMPILE };
     };
     Optional<CurrentListing> m_current_listing_index;
+
+    struct VertexAttribPointer {
+        GLint size { 4 };
+        GLenum type { GL_FLOAT };
+        GLsizei stride { 0 };
+        const void* pointer { 0 };
+    };
+
+    VertexAttribPointer m_client_vertex_pointer;
 };
 
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -77,6 +77,7 @@ public:
     virtual void gl_enable_client_state(GLenum cap) override;
     virtual void gl_disable_client_state(GLenum cap) override;
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
+    virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
 
     virtual void present() override;
 
@@ -233,6 +234,7 @@ private:
     };
 
     VertexAttribPointer m_client_vertex_pointer;
+    VertexAttribPointer m_client_color_pointer;
 };
 
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -79,6 +79,7 @@ public:
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
+    virtual void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) override;
 
     virtual void present() override;
 
@@ -208,7 +209,8 @@ private:
             decltype(&SoftwareGLContext::gl_hint),
             decltype(&SoftwareGLContext::gl_read_buffer),
             decltype(&SoftwareGLContext::gl_tex_parameter),
-            decltype(&SoftwareGLContext::gl_depth_mask)>;
+            decltype(&SoftwareGLContext::gl_depth_mask),
+            decltype(&SoftwareGLContext::gl_draw_arrays)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;
@@ -233,6 +235,8 @@ private:
         GLsizei stride { 0 };
         const void* pointer { 0 };
     };
+
+    static void read_from_vertex_attribute_pointer(VertexAttribPointer const&, int index, float* elements, bool normalize);
 
     VertexAttribPointer m_client_vertex_pointer;
     VertexAttribPointer m_client_color_pointer;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -80,6 +80,7 @@ public:
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) override;
+    virtual void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void* indices) override;
 
     virtual void present() override;
 
@@ -210,7 +211,8 @@ private:
             decltype(&SoftwareGLContext::gl_read_buffer),
             decltype(&SoftwareGLContext::gl_tex_parameter),
             decltype(&SoftwareGLContext::gl_depth_mask),
-            decltype(&SoftwareGLContext::gl_draw_arrays)>;
+            decltype(&SoftwareGLContext::gl_draw_arrays),
+            decltype(&SoftwareGLContext::gl_draw_elements)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -74,6 +74,8 @@ public:
     virtual void gl_active_texture(GLenum texture) override;
     virtual void gl_get_floatv(GLenum pname, GLfloat* params) override;
     virtual void gl_depth_mask(GLboolean flag) override;
+    virtual void gl_enable_client_state(GLenum cap) override;
+    virtual void gl_disable_client_state(GLenum cap) override;
 
     virtual void present() override;
 
@@ -133,6 +135,11 @@ private:
     GLclampf m_alpha_test_ref_value = 0;
 
     GLenum m_current_read_buffer = GL_BACK;
+
+    // Client side arrays
+    bool m_client_side_vertex_array_enabled = false;
+    bool m_client_side_color_array_enabled = false;
+    bool m_client_side_texture_coord_array_enabled = false;
 
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -265,7 +265,9 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                             continue;
                         }
 
-                        *depth = z;
+                        if (options.enable_depth_write)
+                            *depth = z;
+
                         z_pass_count++;
                     }
                 }

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -21,6 +21,7 @@ namespace GL {
 struct RasterizerOptions {
     bool shade_smooth { true };
     bool enable_depth_test { false };
+    bool enable_depth_write { true };
     bool enable_alpha_test { false };
     GLenum alpha_test_func { GL_ALWAYS };
     float alpha_test_ref_value { 0 };


### PR DESCRIPTION
This implements more functions and defines for #7062 

* glDepthMask
* glEnableClientState
* gDisableClientState
* glVertexPointer
* glColorPointer
* glTexCoordPointer
* glTexCoord4fv
* glDrawArrays
* glDrawElements