### PR TITLE
Kernel/ProcFS: Propagate errors correctly when they occur

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -486,7 +486,7 @@ KResultOr<size_t> ProcFSProcessPropertyInode::read_bytes(off_t offset, size_t co
         if (!process)
             return KResult(ESRCH);
         if (auto result = try_to_acquire_data(*process, builder); result.is_error())
-            return result.error();
+            return result;
         auto data_buffer = builder.build();
         if (!data_buffer)
             return KResult(EFAULT);


### PR DESCRIPTION
Calling error() on KResult is a mistake I introduced in 7ba991dc371, so
instead of doing that, which triggers an assertion if an error occured,
in Inode::read_entire method with VERIFY(nread <= sizeof(buffer)), we
really should just return the KResult and not to call error() on it.