### PR TITLE
LibJS: Prevent stack overflow in flatten_into_array()

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1945,6 +1945,11 @@ static size_t flatten_into_array(GlobalObject& global_object, Object& new_array,
         }
 
         if (depth > 0 && value.is_array(global_object)) {
+            if (vm.did_reach_stack_space_limit()) {
+                vm.throw_exception<Error>(global_object, "Call stack size limit exceeded");
+                return {};
+            }
+
             auto length = length_of_array_like(global_object, value.as_object());
             if (vm.exception())
                 return {};

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -105,12 +105,17 @@ public:
         return *m_single_ascii_character_strings[character];
     }
 
+    bool did_reach_stack_space_limit() const
+    {
+        // Note: the 32 kiB used to be 16 kiB, but that turned out to not be enough with ASAN enabled.
+        return m_stack_info.size_free() < 32 * KiB;
+    }
+
     void push_execution_context(ExecutionContext& context, GlobalObject& global_object)
     {
         VERIFY(!exception());
         // Ensure we got some stack space left, so the next function call doesn't kill us.
-        // Note: the 32 kiB used to be 16 kiB, but that turned out to not be enough with ASAN enabled.
-        if (m_stack_info.size_free() < 32 * KiB)
+        if (did_reach_stack_space_limit())
             throw_exception<Error>(global_object, "Call stack size limit exceeded");
         else
             m_execution_context_stack.append(&context);

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flat.js
@@ -2,6 +2,16 @@ test("length is 0", () => {
     expect(Array.prototype.flat).toHaveLength(0);
 });
 
+describe("error", () => {
+    test("Issue #9317, stack overflow in flatten_into_array from flat call", () => {
+        var a = [];
+        a[0] = a;
+        expect(() => {
+            a.flat(3893232121);
+        }).toThrowWithMessage(Error, "Call stack size limit exceeded");
+    });
+});
+
 describe("normal behavior", () => {
     test("basic functionality", () => {
         var array1 = [1, 2, [3, 4]];


### PR DESCRIPTION
This fixes #9317. It adds a new exception type similar to node's exception that's thrown when the call stack limit has been exceeded.

The issue with flatten_into_array was that it could cause a stack overflow if the depth was too large. The fix here was to add a check to make sure that there's enough space on the stack before the next flatten_into_array call. If there is not enough space on the stack, then an exception is thrown.
