### PR TITLE
Documentation: Add genext2fs package for BuildInstructions

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -7,7 +7,7 @@ Make sure you have all the dependencies installed:
 ### Debian / Ubuntu
 
 ```console
-sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync
+sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync genext2fs
 ```
 
 #### GCC 10


### PR DESCRIPTION
I've had issues running Serenity (`Meta/serenity.sh run` under WSL), it gave permission error and requested `genext2fs` package to be installed. After installing this package everything worked well.