### PR TITLE
Ports: Build fixes for various ports

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -4,14 +4,16 @@ set -eu
 SCRIPT="$(dirname "${0}")"
 export SERENITY_ARCH="${SERENITY_ARCH:-i686}"
 
-HOST_CC="${CC:=cc}"
-HOST_CXX="${CXX:=c++}"
-HOST_AR="${AR:=ar}"
-HOST_RANLIB="${RANLIB:=ranlib}"
-HOST_PATH="${PATH:=}"
-HOST_PKG_CONFIG_DIR="${PKG_CONFIG_DIR:=}"
-HOST_PKG_CONFIG_SYSROOT_DIR="${PKG_CONFIG_SYSROOT_DIR:=}"
-HOST_PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:=}"
+if [ -z "${HOST_CC:=}" ]; then
+    export HOST_CC="${CC:=cc}"
+    export HOST_CXX="${CXX:=c++}"
+    export HOST_AR="${AR:=ar}"
+    export HOST_RANLIB="${RANLIB:=ranlib}"
+    export HOST_PATH="${PATH:=}"
+    export HOST_PKG_CONFIG_DIR="${PKG_CONFIG_DIR:=}"
+    export HOST_PKG_CONFIG_SYSROOT_DIR="${PKG_CONFIG_SYSROOT_DIR:=}"
+    export HOST_PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:=}"
+fi
 
 DESTDIR="/"
 

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -4,5 +4,11 @@ version=7.78.0
 useconfigure=true
 files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2 98530b317dc95ccb324bbe4f834f07bb642fbc393b794ddf3434f246a71ea44a"
 auth_type=sha256
-depends="openssl zlib"
-configopts="--disable-ntlm-wb --with-openssl=${SERENITY_INSTALL_ROOT}/usr/local"
+depends="openssl zlib zstd"
+configopts="--disable-ntlm-wb --with-openssl=${SERENITY_INSTALL_ROOT}/usr/local --disable-symbol-hiding"
+
+install() {
+    run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
+    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libcurl.so -Wl,-soname,libcurl.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libcurl.a -Wl,--no-whole-archive -lzstd
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libcurl.la
+}

--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -20,5 +20,5 @@ build() {
 
 install() {
     run make $installopts
-    run ln -s gcc "${SERENITY_INSTALL_ROOT}/usr/local/bin/cc"
+    run ln -sf gcc "${SERENITY_INSTALL_ROOT}/usr/local/bin/cc"
 }

--- a/Userland/Libraries/LibC/net/if.h
+++ b/Userland/Libraries/LibC/net/if.h
@@ -46,6 +46,14 @@ struct ifreq {
 #define ifr_hwaddr ifr_ifru.ifru_hwaddr       // MAC address
 };
 
+struct ifconf {
+    int ifc_len;
+    union {
+        void* ifc_buf;
+        struct ifreq* ifc_req;
+    };
+};
+
 unsigned int if_nametoindex(const char* ifname);
 char* if_indextoname(unsigned int ifindex, char* ifname);
 


### PR DESCRIPTION
**LibC: Add struct ifconf in net/if.h**

This fixes building the scummvm port.

**Ports: Make sure HOST_\* variables are set correctly for nested builds**

When building a port as a dependency for another port the HOST_* variables were previously initialized with values referring to the SerenityOS toolchain.

Fixes #9168.

**Ports: Make sure re-installing the gcc port doesn't fail**

Re-installing the gcc port would previously fail because we failed to overwrite the symlink.

**Ports: Build a shared library for curl**

This fixes building the git port.