### PR TITLE
SystemMonitor: Don't fail if we don't have ports installed

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -139,7 +139,8 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (unveil("/usr/local/bin", "r") < 0) {
+    // This directory only exists if ports are installed
+    if (unveil("/usr/local/bin", "r") < 0 && errno != ENOENT) {
         perror("unveil");
         return 1;
     }


### PR DESCRIPTION
In #9373, /usr/local/bin was added to the unveiled directories to make
symbolization work on ports. This directory only exists if at least one
port is installed, so unveil would fail with ENOENT if we had none.