### PR TITLE
LibTLS: Implement DHE_RSA key exchange and enable relevent cipher suites

### DIFF
--- a/Userland/Libraries/LibTLS/CipherSuite.h
+++ b/Userland/Libraries/LibTLS/CipherSuite.h
@@ -12,6 +12,7 @@ enum class CipherSuite {
     Invalid = 0,
 
     // Weak cipher suites, but we support them
+
     // RFC 5246 - Original TLS v1.2 ciphers
     RSA_WITH_AES_128_CBC_SHA = 0x002F,
     RSA_WITH_AES_256_CBC_SHA = 0x0035,
@@ -22,7 +23,14 @@ enum class CipherSuite {
     RSA_WITH_AES_128_GCM_SHA256 = 0x009C,
     RSA_WITH_AES_256_GCM_SHA384 = 0x009D,
 
+    // Secure cipher suites, but not recommended
+
+    // RFC 5288 - DH, DHE and RSA for AES-GCM
+    DHE_RSA_WITH_AES_128_GCM_SHA256 = 0x009E,
+    DHE_RSA_WITH_AES_256_GCM_SHA384 = 0x009F,
+
     // All recommended cipher suites (according to https://ciphersuite.info/cs/)
+
     // RFC 5288 - DH, DHE and RSA for AES-GCM
     DHE_DSS_WITH_AES_128_GCM_SHA256 = 0x00A2,
     DHE_DSS_WITH_AES_256_GCM_SHA384 = 0x00A3,

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -300,6 +300,12 @@ struct Context {
     size_t send_retries { 0 };
 
     time_t handshake_initiation_timestamp { 0 };
+
+    struct {
+        ByteBuffer p;
+        ByteBuffer g;
+        ByteBuffer Ys;
+    } server_diffie_hellman_params;
 };
 
 class TLSv12 : public Core::Socket {
@@ -397,6 +403,7 @@ private:
     ByteBuffer build_change_cipher_spec();
     ByteBuffer build_verify_request();
     void build_rsa_pre_master_secret(PacketBuilder&);
+    void build_dhe_rsa_pre_master_secret(PacketBuilder&);
 
     bool flush();
     void write_into_socket();
@@ -408,6 +415,7 @@ private:
     ssize_t handle_handshake_finished(ReadonlyBytes, WritePacketStage&);
     ssize_t handle_certificate(ReadonlyBytes);
     ssize_t handle_server_key_exchange(ReadonlyBytes);
+    ssize_t handle_dhe_rsa_server_key_exchange(ReadonlyBytes);
     ssize_t handle_server_hello_done(ReadonlyBytes);
     ssize_t handle_certificate_verify(ReadonlyBytes);
     ssize_t handle_handshake_payload(ReadonlyBytes);

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -164,13 +164,15 @@ enum ClientVerificationStaus {
 // 4 bytes of fixed IV, 8 random (nonce) bytes, 4 bytes for counter
 // GCM specifically asks us to transmit only the nonce, the counter is zero
 // and the fixed IV is derived from the premaster key.
-#define ENUMERATE_CIPHERS(C)                                                                                                                    \
-    C(true, CipherSuite::RSA_WITH_AES_128_CBC_SHA, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_128_CBC, Crypto::Hash::SHA1, 16, false)      \
-    C(true, CipherSuite::RSA_WITH_AES_256_CBC_SHA, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_256_CBC, Crypto::Hash::SHA1, 16, false)      \
-    C(true, CipherSuite::RSA_WITH_AES_128_CBC_SHA256, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_128_CBC, Crypto::Hash::SHA256, 16, false) \
-    C(true, CipherSuite::RSA_WITH_AES_256_CBC_SHA256, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_256_CBC, Crypto::Hash::SHA256, 16, false) \
-    C(true, CipherSuite::RSA_WITH_AES_128_GCM_SHA256, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_128_GCM, Crypto::Hash::SHA256, 8, true)   \
-    C(true, CipherSuite::RSA_WITH_AES_256_GCM_SHA384, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_256_GCM, Crypto::Hash::SHA384, 8, true)
+#define ENUMERATE_CIPHERS(C)                                                                                                                          \
+    C(true, CipherSuite::RSA_WITH_AES_128_CBC_SHA, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_128_CBC, Crypto::Hash::SHA1, 16, false)            \
+    C(true, CipherSuite::RSA_WITH_AES_256_CBC_SHA, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_256_CBC, Crypto::Hash::SHA1, 16, false)            \
+    C(true, CipherSuite::RSA_WITH_AES_128_CBC_SHA256, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_128_CBC, Crypto::Hash::SHA256, 16, false)       \
+    C(true, CipherSuite::RSA_WITH_AES_256_CBC_SHA256, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_256_CBC, Crypto::Hash::SHA256, 16, false)       \
+    C(true, CipherSuite::RSA_WITH_AES_128_GCM_SHA256, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_128_GCM, Crypto::Hash::SHA256, 8, true)         \
+    C(true, CipherSuite::RSA_WITH_AES_256_GCM_SHA384, KeyExchangeAlgorithm::RSA, CipherAlgorithm::AES_256_GCM, Crypto::Hash::SHA384, 8, true)         \
+    C(true, CipherSuite::DHE_RSA_WITH_AES_128_GCM_SHA256, KeyExchangeAlgorithm::DHE_RSA, CipherAlgorithm::AES_128_GCM, Crypto::Hash::SHA256, 8, true) \
+    C(true, CipherSuite::DHE_RSA_WITH_AES_256_GCM_SHA384, KeyExchangeAlgorithm::DHE_RSA, CipherAlgorithm::AES_256_GCM, Crypto::Hash::SHA384, 8, true)
 
 constexpr KeyExchangeAlgorithm get_key_exchange_algorithm(CipherSuite suite)
 {


### PR DESCRIPTION
This PR adds to LibTLS support for the DHE_RSA key exchange and enables the following cipher suites:

- DHE_RSA_WITH_AES_128_GCM_SHA256
- DHE_RSA_WITH_AES_256_GCM_SHA384

The DHE_RSA key exchange, unlike the only currently supported key exchange RSA, provides forward secrecy and grants us access to sites which do not support the RSA key exchange, but do support DHE_RSA (eg. my personal site [https://sambowman.tech](https://sambowman.tech) which is served by [kubernetes/nginx-ingress](https://github.com/kubernetes/ingress-nginx) using the [default cipher suites](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#ssl-ciphers)).

It is worth noting that this does not yet validate the signature of the server provided Diffie-Hellman parameters. This could allow a man-in-the-middle attack to occur, but seeing as we currently don't even validate certificates beyond checking their names (a similarly severe vulnerability), I think this an acceptable compromise for now.

As an aside, this is my first contribution to Serenity! After sporadically playing around with the system for several months, I finally found the time to take initiative and fix something that bugged me. Any and all feedback is welcome and appreciated! :^)