### PR TITLE
PixelPaint: Sync Guide visibility and revert too tight update rect on Selection

### DIFF
--- a/Userland/Applications/PixelPaint/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/GuideTool.cpp
@@ -57,6 +57,8 @@ void GuideTool::on_mousedown(Layer&, GUI::MouseEvent& mouse_event, GUI::MouseEve
     if (mouse_event.button() != GUI::MouseButton::Left)
         return;
 
+    m_editor->set_guide_visibility(true);
+
     RefPtr<Guide> new_guide;
     if (image_event.position().x() < 0 || image_event.position().x() > editor()->image().size().width()) {
         new_guide = Guide::construct(Guide::Orientation::Vertical, image_event.position().x());
@@ -129,6 +131,11 @@ void GuideTool::on_mousemove(Layer&, GUI::MouseEvent&, GUI::MouseEvent& image_ev
 
 void GuideTool::on_context_menu(Layer&, GUI::ContextMenuEvent& event)
 {
+    if (!m_editor)
+        return;
+
+    m_editor->set_guide_visibility(true);
+
     if (!m_context_menu) {
         m_context_menu = GUI::Menu::construct();
         m_context_menu->add_action(GUI::Action::create(
@@ -146,6 +153,12 @@ void GuideTool::on_context_menu(Layer&, GUI::ContextMenuEvent& event)
     auto image_position = editor()->editor_position_to_image_position(event.position());
     m_context_menu_guide = closest_guide({ (int)image_position.x(), (int)image_position.y() });
     m_context_menu->popup(event.screen_position());
+}
+
+void GuideTool::on_tool_activation()
+{
+    if (m_editor)
+        m_editor->set_guide_visibility(true);
 }
 
 GUI::Widget* GuideTool::get_properties_widget()

--- a/Userland/Applications/PixelPaint/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/GuideTool.cpp
@@ -152,7 +152,8 @@ void GuideTool::on_context_menu(Layer&, GUI::ContextMenuEvent& event)
 
     auto image_position = editor()->editor_position_to_image_position(event.position());
     m_context_menu_guide = closest_guide({ (int)image_position.x(), (int)image_position.y() });
-    m_context_menu->popup(event.screen_position());
+    if (m_context_menu_guide)
+        m_context_menu->popup(event.screen_position());
 }
 
 void GuideTool::on_tool_activation()

--- a/Userland/Applications/PixelPaint/GuideTool.h
+++ b/Userland/Applications/PixelPaint/GuideTool.h
@@ -23,6 +23,8 @@ public:
     virtual void on_mouseup(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent& image_event) override;
     virtual void on_context_menu(Layer&, GUI::ContextMenuEvent&) override;
 
+    virtual void on_tool_activation() override;
+
     virtual GUI::Widget* get_properties_widget() override;
     virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -316,8 +316,22 @@ void ImageEditor::set_active_tool(Tool* tool)
 
     if (m_active_tool) {
         m_active_tool->setup(*this);
+        m_active_tool->on_tool_activation();
         m_active_cursor = m_active_tool->cursor();
     }
+}
+
+void ImageEditor::set_guide_visibility(bool show_guides)
+{
+    if (m_show_guides == show_guides)
+        return;
+
+    m_show_guides = show_guides;
+
+    if (on_set_guide_visibility)
+        on_set_guide_visibility(m_show_guides);
+
+    update();
 }
 
 void ImageEditor::layers_did_change()

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -85,7 +85,9 @@ public:
     Gfx::FloatPoint editor_position_to_image_position(Gfx::IntPoint const&) const;
 
     NonnullRefPtrVector<Guide> const& guides() const { return m_guides; }
-    void toggle_guide_visibility() { m_show_guides = !m_show_guides; }
+    bool guide_visibility() { return m_show_guides; }
+    void set_guide_visibility(bool show_guides);
+    Function<void(bool)> on_set_guide_visibility;
 
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);

--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -24,7 +24,7 @@ Selection::Selection(ImageEditor& editor)
         ++m_marching_ants_offset;
         m_marching_ants_offset %= (marching_ant_length * 2);
         if (!is_empty() || m_in_interactive_selection)
-            m_editor.update(m_editor.image_rect_to_editor_rect(bounding_rect().inflated(10, 10)).to_type<int>());
+            m_editor.update();
     });
     m_marching_ants_timer->start();
 }

--- a/Userland/Applications/PixelPaint/Tool.h
+++ b/Userland/Applications/PixelPaint/Tool.h
@@ -27,6 +27,7 @@ public:
     virtual void on_second_paint(Layer const&, GUI::PaintEvent&) { }
     virtual void on_keydown(GUI::KeyEvent&) { }
     virtual void on_keyup(GUI::KeyEvent&) { }
+    virtual void on_tool_activation() { }
     virtual GUI::Widget* get_properties_widget() { return nullptr; }
     virtual Gfx::StandardCursor cursor() { return Gfx::StandardCursor::None; }
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -399,9 +399,9 @@ int main(int argc, char** argv)
         window);
 
     auto show_guides_action = GUI::Action::create_checkable(
-        "Show Guides", [&](auto&) {
+        "Show Guides", [&](auto& action) {
             if (auto* editor = current_image_editor()) {
-                editor->toggle_guide_visibility();
+                editor->set_guide_visibility(action.is_checked());
             }
         },
         window);
@@ -706,6 +706,10 @@ int main(int argc, char** argv)
             statusbar.set_override_text({});
         };
 
+        image_editor.on_set_guide_visibility = [&](bool show_guides) {
+            show_guides_action->set_checked(show_guides);
+        };
+
         // NOTE: We invoke the above hook directly here to make sure the tab title is set up.
         image_editor.on_image_title_change(image->title());
 
@@ -742,6 +746,7 @@ int main(int argc, char** argv)
                 image_editor.set_active_tool(&tool);
             }
         });
+        show_guides_action->set_checked(image_editor.guide_visibility());
     };
 
     if (Core::File::exists(file_to_edit_full_path)) {


### PR DESCRIPTION
**PixelPaint: Revert update rect tightening for Selection**
Tightening of the update rect when firing the marching ants timer unfortunately meant that only finalized selections would be 
redrawn, and any new selection drawn outside of the update rect would not update.

**PixelPaint: Show Guides on GuideTool activation**
This adds `on_tool_activation()` to Tool which GuideTool can use to show guides, if they're hidden, when it's activated. Also show guides on mousedown since there's no use in drawing invisible guides. Also make sure that the guide visibility state remains updated when changing between tabs.

**PixelPaint: Disable context menu for GuideTool when no guide is found**
Previously the context menu would popup even when `closest_guide()` returned nullptr, making the Delete action do nothing.