### PR TITLE
Kernel/USB: Add initial support for USB hubs

### DIFF
--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArraySerializer.h>
+#include <AK/JsonObjectSerializer.h>
+#include <Kernel/Bus/USB/SysFSUSB.h>
+#include <Kernel/KBufferBuilder.h>
+
+namespace Kernel::USB {
+
+static SysFSUSBBusDirectory* s_procfs_usb_bus_directory;
+
+SysFSUSBDeviceInformation::SysFSUSBDeviceInformation(USB::Device& device)
+    : SysFSComponent(String::number(device.address()))
+    , m_device(device)
+{
+}
+
+SysFSUSBDeviceInformation::~SysFSUSBDeviceInformation()
+{
+}
+
+KResultOr<size_t> SysFSUSBDeviceInformation::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, FileDescription*) const
+{
+    KBufferBuilder builder;
+    JsonArraySerializer array { builder };
+
+    auto obj = array.add_object();
+    obj.add("usb_spec_compliance_bcd", m_device->device_descriptor().usb_spec_compliance_bcd);
+    obj.add("device_class", m_device->device_descriptor().device_class);
+    obj.add("device_sub_class", m_device->device_descriptor().device_sub_class);
+    obj.add("device_protocol", m_device->device_descriptor().device_protocol);
+    obj.add("max_packet_size", m_device->device_descriptor().max_packet_size);
+    obj.add("vendor_id", m_device->device_descriptor().vendor_id);
+    obj.add("product_id", m_device->device_descriptor().product_id);
+    obj.add("device_release_bcd", m_device->device_descriptor().device_release_bcd);
+    obj.add("manufacturer_id_descriptor_index", m_device->device_descriptor().manufacturer_id_descriptor_index);
+    obj.add("product_string_descriptor_index", m_device->device_descriptor().product_string_descriptor_index);
+    obj.add("serial_number_descriptor_index", m_device->device_descriptor().serial_number_descriptor_index);
+    obj.add("num_configurations", m_device->device_descriptor().num_configurations);
+    obj.finish();
+    array.finish();
+
+    auto data = builder.build();
+    if (!data)
+        return ENOMEM;
+
+    ssize_t nread = min(static_cast<off_t>(data->size() - offset), static_cast<off_t>(count));
+    if (!buffer.write(data->data() + offset, nread))
+        return EFAULT;
+
+    return nread;
+}
+
+KResult SysFSUSBBusDirectory::traverse_as_directory(unsigned fsid, Function<bool(FileSystem::DirectoryEntryView const&)> callback) const
+{
+    ScopedSpinLock lock(m_lock);
+    // Note: if the parent directory is null, it means something bad happened as this should not happen for the USB directory.
+    VERIFY(m_parent_directory);
+    callback({ ".", { fsid, component_index() }, 0 });
+    callback({ "..", { fsid, m_parent_directory->component_index() }, 0 });
+
+    for (auto& device_node : m_device_nodes) {
+        InodeIdentifier identifier = { fsid, device_node.component_index() };
+        callback({ device_node.name(), identifier, 0 });
+    }
+    return KSuccess;
+}
+
+RefPtr<SysFSComponent> SysFSUSBBusDirectory::lookup(StringView name)
+{
+    ScopedSpinLock lock(m_lock);
+    for (auto& device_node : m_device_nodes) {
+        if (device_node.name() == name) {
+            return device_node;
+        }
+    }
+    return {};
+}
+
+RefPtr<SysFSUSBDeviceInformation> SysFSUSBBusDirectory::device_node_for(USB::Device& device)
+{
+    RefPtr<USB::Device> checked_device = device;
+    for (auto& device_node : m_device_nodes) {
+        if (device_node.device().ptr() == checked_device.ptr())
+            return device_node;
+    }
+    return {};
+}
+
+void SysFSUSBBusDirectory::plug(USB::Device& new_device)
+{
+    ScopedSpinLock lock(m_lock);
+    auto device_node = device_node_for(new_device);
+    VERIFY(!device_node);
+    m_device_nodes.append(SysFSUSBDeviceInformation::create(new_device));
+}
+
+void SysFSUSBBusDirectory::unplug(USB::Device& deleted_device)
+{
+    ScopedSpinLock lock(m_lock);
+    auto device_node = device_node_for(deleted_device);
+    VERIFY(device_node);
+    device_node->m_list_node.remove();
+}
+
+UNMAP_AFTER_INIT SysFSUSBBusDirectory::SysFSUSBBusDirectory(SysFSBusDirectory& buses_directory)
+    : SysFSDirectory("usb"sv, buses_directory)
+{
+}
+
+UNMAP_AFTER_INIT void SysFSUSBBusDirectory::initialize()
+{
+    auto directory = adopt_ref(*new SysFSUSBBusDirectory(SysFSComponentRegistry::the().buses_directory()));
+    SysFSComponentRegistry::the().register_new_bus_directory(directory);
+    s_procfs_usb_bus_directory = directory;
+}
+
+NonnullRefPtr<SysFSUSBDeviceInformation> SysFSUSBDeviceInformation::create(USB::Device& device)
+{
+    return adopt_ref(*new SysFSUSBDeviceInformation(device));
+}
+
+}

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -107,6 +107,12 @@ void SysFSUSBBusDirectory::unplug(USB::Device& deleted_device)
     device_node->m_list_node.remove();
 }
 
+SysFSUSBBusDirectory& SysFSUSBBusDirectory::the()
+{
+    VERIFY(s_procfs_usb_bus_directory);
+    return *s_procfs_usb_bus_directory;
+}
+
 UNMAP_AFTER_INIT SysFSUSBBusDirectory::SysFSUSBBusDirectory(SysFSBusDirectory& buses_directory)
     : SysFSDirectory("usb"sv, buses_directory)
 {

--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -34,6 +34,8 @@ protected:
 class SysFSUSBBusDirectory final : public SysFSDirectory {
 public:
     static void initialize();
+    static SysFSUSBBusDirectory& the();
+
     void plug(USB::Device&);
     void unplug(USB::Device&);
 

--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/USB/USBDevice.h>
+#include <Kernel/FileSystem/SysFS.h>
+
+namespace Kernel::USB {
+
+class SysFSUSBDeviceInformation : public SysFSComponent {
+    friend class SysFSUSBBusDirectory;
+
+public:
+    virtual ~SysFSUSBDeviceInformation() override;
+
+    static NonnullRefPtr<SysFSUSBDeviceInformation> create(USB::Device&);
+
+    RefPtr<USB::Device> device() const { return m_device; }
+
+protected:
+    explicit SysFSUSBDeviceInformation(USB::Device& device);
+
+    virtual KResultOr<size_t> read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, FileDescription*) const override;
+
+    IntrusiveListNode<SysFSUSBDeviceInformation, RefPtr<SysFSUSBDeviceInformation>> m_list_node;
+
+    NonnullRefPtr<USB::Device> m_device;
+};
+
+class SysFSUSBBusDirectory final : public SysFSDirectory {
+public:
+    static void initialize();
+    void plug(USB::Device&);
+    void unplug(USB::Device&);
+
+    virtual KResult traverse_as_directory(unsigned, Function<bool(FileSystem::DirectoryEntryView const&)>) const override;
+    virtual RefPtr<SysFSComponent> lookup(StringView name) override;
+
+private:
+    explicit SysFSUSBBusDirectory(SysFSBusDirectory&);
+
+    RefPtr<SysFSUSBDeviceInformation> device_node_for(USB::Device& device);
+
+    IntrusiveList<SysFSUSBDeviceInformation, RefPtr<SysFSUSBDeviceInformation>, &SysFSUSBDeviceInformation::m_list_node> m_device_nodes;
+    mutable SpinLock<u8> m_lock;
+};
+
+}

--- a/Kernel/Bus/USB/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCIController.cpp
@@ -254,27 +254,6 @@ UNMAP_AFTER_INIT UHCIController::~UHCIController()
 {
 }
 
-RefPtr<USB::Device> const UHCIController::get_device_at_port(USB::Device::PortNumber port)
-{
-    if (!m_devices.at(to_underlying(port)))
-        return nullptr;
-
-    return m_devices.at(to_underlying(port));
-}
-
-RefPtr<USB::Device> const UHCIController::get_device_from_address(u8 device_address)
-{
-    for (auto const& device : m_devices) {
-        if (!device)
-            continue;
-
-        if (device->address() == device_address)
-            return device;
-    }
-
-    return nullptr;
-}
-
 KResult UHCIController::reset()
 {
     if (auto stop_result = stop(); stop_result.is_error())

--- a/Kernel/Bus/USB/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCIController.cpp
@@ -62,6 +62,7 @@ static constexpr u16 UHCI_PORTSC_RESUME_DETECT = 0x40;
 static constexpr u16 UHCI_PORTSC_LOW_SPEED_DEVICE = 0x0100;
 static constexpr u16 UHCI_PORTSC_PORT_RESET = 0x0200;
 static constexpr u16 UHCI_PORTSC_SUSPEND = 0x1000;
+static constexpr u16 UCHI_PORTSC_NON_WRITE_CLEAR_BIT_MASK = 0x1FF5; // This is used to mask out the Write Clear bits making sure we don't accidentally clear them.
 
 // *BSD and a few other drivers seem to use this number
 static constexpr u8 UHCI_NUMBER_OF_ISOCHRONOUS_TDS = 128;
@@ -486,6 +487,16 @@ KResult UHCIController::start()
             break;
     }
     dbgln("UHCI: Started");
+
+    auto root_hub_or_error = UHCIRootHub::try_create(*this);
+    if (root_hub_or_error.is_error())
+        return root_hub_or_error.error();
+
+    m_root_hub = root_hub_or_error.release_value();
+    auto result = m_root_hub->setup({});
+    if (result.is_error())
+        return result;
+
     return KSuccess;
 }
 
@@ -580,6 +591,12 @@ KResultOr<size_t> UHCIController::submit_control_transfer(Transfer& transfer)
 {
     Pipe& pipe = transfer.pipe(); // Short circuit the pipe related to this transfer
     bool direction_in = (transfer.request().request_type & USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST) == USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST;
+
+    dbgln_if(UHCI_DEBUG, "UHCI: Received control transfer for address {}. Root Hub is at address {}.", pipe.device_address(), m_root_hub->device_address());
+
+    // Short-circuit the root hub.
+    if (pipe.device_address() == m_root_hub->device_address())
+        return m_root_hub->handle_control_transfer(transfer);
 
     TransferDescriptor* setup_td = create_transfer_descriptor(pipe, PacketID::SETUP, sizeof(USBRequestData));
     if (!setup_td)
@@ -683,88 +700,9 @@ void UHCIController::spawn_port_proc()
 
     Process::create_kernel_process(usb_hotplug_thread, "UHCIHotplug", [&] {
         for (;;) {
-            for (int port = 0; port < UHCI_ROOT_PORT_COUNT; port++) {
-                u16 port_data = 0;
+            if (m_root_hub)
+                m_root_hub->check_for_port_updates();
 
-                if (port == 1) {
-                    // Let's see what's happening on port 1
-                    // Current status
-                    port_data = read_portsc1();
-                    if (port_data & UHCI_PORTSC_CONNECT_STATUS_CHANGED) {
-                        if (port_data & UHCI_PORTSC_CURRRENT_CONNECT_STATUS) {
-                            dmesgln("UHCI: Device attach detected on Root Port 1!");
-
-                            // Reset the port
-                            port_data = read_portsc1();
-                            write_portsc1(port_data | UHCI_PORTSC_PORT_RESET);
-                            IO::delay(500);
-
-                            write_portsc1(port_data & ~UHCI_PORTSC_PORT_RESET);
-                            IO::delay(500);
-
-                            write_portsc1(port_data & (~UHCI_PORTSC_PORT_ENABLE_CHANGED | ~UHCI_PORTSC_CONNECT_STATUS_CHANGED));
-
-                            port_data = read_portsc1();
-                            write_portsc1(port_data | UHCI_PORTSC_PORT_ENABLED);
-                            dbgln("port should be enabled now: {:#04x}\n", read_portsc1());
-
-                            USB::Device::DeviceSpeed speed = (port_data & UHCI_PORTSC_LOW_SPEED_DEVICE) ? USB::Device::DeviceSpeed::LowSpeed : USB::Device::DeviceSpeed::FullSpeed;
-                            auto device = USB::Device::try_create(*this, USB::Device::PortNumber::Port1, speed);
-
-                            if (device.is_error())
-                                dmesgln("UHCI: Device creation failed on port 1 ({})", device.error());
-
-                            m_devices.at(0) = device.value();
-                            VERIFY(s_procfs_usb_bus_directory);
-                            s_procfs_usb_bus_directory->plug(device.value());
-                        } else {
-                            // FIXME: Clean up (and properly) the RefPtr to the device in m_devices
-                            VERIFY(s_procfs_usb_bus_directory);
-                            VERIFY(m_devices.at(0));
-                            dmesgln("UHCI: Device detach detected on Root Port 1");
-                            s_procfs_usb_bus_directory->unplug(*m_devices.at(0));
-                        }
-                    }
-                } else {
-                    port_data = read_portsc2();
-                    if (port_data & UHCI_PORTSC_CONNECT_STATUS_CHANGED) {
-                        if (port_data & UHCI_PORTSC_CURRRENT_CONNECT_STATUS) {
-                            dmesgln("UHCI: Device attach detected on Root Port 2");
-
-                            // Reset the port
-                            port_data = read_portsc2();
-                            write_portsc2(port_data | UHCI_PORTSC_PORT_RESET);
-                            for (size_t i = 0; i < 50000; ++i)
-                                IO::in8(0x80);
-
-                            write_portsc2(port_data & ~UHCI_PORTSC_PORT_RESET);
-                            for (size_t i = 0; i < 100000; ++i)
-                                IO::in8(0x80);
-
-                            write_portsc2(port_data & (~UHCI_PORTSC_PORT_ENABLE_CHANGED | ~UHCI_PORTSC_CONNECT_STATUS_CHANGED));
-
-                            port_data = read_portsc2();
-                            write_portsc2(port_data | UHCI_PORTSC_PORT_ENABLED);
-                            dbgln("port should be enabled now: {:#04x}\n", read_portsc2());
-                            USB::Device::DeviceSpeed speed = (port_data & UHCI_PORTSC_LOW_SPEED_DEVICE) ? USB::Device::DeviceSpeed::LowSpeed : USB::Device::DeviceSpeed::FullSpeed;
-                            auto device = USB::Device::try_create(*this, USB::Device::PortNumber::Port2, speed);
-
-                            if (device.is_error())
-                                dmesgln("UHCI: Device creation failed on port 2 ({})", device.error());
-
-                            m_devices.at(1) = device.value();
-                            VERIFY(s_procfs_usb_bus_directory);
-                            s_procfs_usb_bus_directory->plug(device.value());
-                        } else {
-                            // FIXME: Clean up (and properly) the RefPtr to the device in m_devices
-                            VERIFY(s_procfs_usb_bus_directory);
-                            VERIFY(m_devices.at(1));
-                            dmesgln("UHCI: Device detach detected on Root Port 2");
-                            s_procfs_usb_bus_directory->unplug(*m_devices.at(1));
-                        }
-                    }
-                }
-            }
             (void)Thread::current()->sleep(Time::from_seconds(1));
         }
     });
@@ -786,6 +724,175 @@ bool UHCIController::handle_irq(const RegisterState&)
     // Write back USBSTS to clear bits
     write_usbsts(status);
     return true;
+}
+
+void UHCIController::get_port_status(Badge<UHCIRootHub>, u8 port, HubStatus& hub_port_status)
+{
+    // The check is done by UHCIRootHub.
+    VERIFY(port < NUMBER_OF_ROOT_PORTS);
+
+    u16 status = port == 0 ? read_portsc1() : read_portsc2();
+
+    if (status & UHCI_PORTSC_CURRRENT_CONNECT_STATUS)
+        hub_port_status.status |= PORT_STATUS_CURRENT_CONNECT_STATUS;
+
+    if (status & UHCI_PORTSC_CONNECT_STATUS_CHANGED)
+        hub_port_status.change |= PORT_STATUS_CONNECT_STATUS_CHANGED;
+
+    if (status & UHCI_PORTSC_PORT_ENABLED)
+        hub_port_status.status |= PORT_STATUS_PORT_ENABLED;
+
+    if (status & UHCI_PORTSC_PORT_ENABLE_CHANGED)
+        hub_port_status.change |= PORT_STATUS_PORT_ENABLED_CHANGED;
+
+    if (status & UHCI_PORTSC_LOW_SPEED_DEVICE)
+        hub_port_status.status |= PORT_STATUS_LOW_SPEED_DEVICE_ATTACHED;
+
+    if (status & UHCI_PORTSC_PORT_RESET)
+        hub_port_status.status |= PORT_STATUS_RESET;
+
+    if (m_port_reset_change_statuses & (1 << port))
+        hub_port_status.change |= PORT_STATUS_RESET_CHANGED;
+
+    if (status & UHCI_PORTSC_SUSPEND)
+        hub_port_status.status |= PORT_STATUS_SUSPEND;
+
+    if (m_port_suspend_change_statuses & (1 << port))
+        hub_port_status.change |= PORT_STATUS_SUSPEND_CHANGED;
+
+    // UHCI ports are always powered.
+    hub_port_status.status |= PORT_STATUS_PORT_POWER;
+
+    dbgln_if(UHCI_DEBUG, "UHCI: get_port_status status=0x{:04x} change=0x{:04x}", hub_port_status.status, hub_port_status.change);
+}
+
+void UHCIController::reset_port(u8 port)
+{
+    // We still have to reset the port manually because UHCI does not automatically enable the port after reset.
+    // Additionally, the USB 2.0 specification says the SetPortFeature(PORT_ENABLE) request is not specified and that the _ideal_ behaviour is to return a Request Error.
+    // Source: USB 2.0 Specification Section 11.24.2.7.1.2
+    // This means the hub code cannot rely on using it.
+
+    // The check is done by UHCIRootHub and set_port_feature.
+    VERIFY(port < NUMBER_OF_ROOT_PORTS);
+
+    u16 port_data = port == 0 ? read_portsc1() : read_portsc2();
+    port_data &= UCHI_PORTSC_NON_WRITE_CLEAR_BIT_MASK;
+    port_data |= UHCI_PORTSC_PORT_RESET;
+    if (port == 0)
+        write_portsc1(port_data);
+    else
+        write_portsc2(port_data);
+
+    // Wait at least 50 ms for the port to reset.
+    // This is T DRSTR in the USB 2.0 Specification Page 186 Table 7-13.
+    constexpr u16 reset_delay = 50 * 1000;
+    IO::delay(reset_delay);
+
+    port_data &= ~UHCI_PORTSC_PORT_RESET;
+    if (port == 0)
+        write_portsc1(port_data);
+    else
+        write_portsc2(port_data);
+
+    // Wait 10 ms for the port to recover.
+    // This is T RSTRCY in the USB 2.0 Specification Page 188 Table 7-14.
+    constexpr u16 reset_recovery_delay = 10 * 1000;
+    IO::delay(reset_recovery_delay);
+
+    port_data = port == 0 ? read_portsc1() : read_portsc2();
+    port_data |= UHCI_PORTSC_PORT_ENABLED;
+    if (port == 0)
+        write_portsc1(port_data);
+    else
+        write_portsc2(port_data);
+
+    dbgln_if(UHCI_DEBUG, "UHCI: Port should be enabled now: {:#04x}", port == 0 ? read_portsc1() : read_portsc2());
+    m_port_reset_change_statuses |= (1 << port);
+}
+
+KResult UHCIController::set_port_feature(Badge<UHCIRootHub>, u8 port, HubFeatureSelector feature_selector)
+{
+    // The check is done by UHCIRootHub.
+    VERIFY(port < NUMBER_OF_ROOT_PORTS);
+
+    dbgln_if(UHCI_DEBUG, "UHCI: set_port_feature: port={} feature_selector={}", port, (u8)feature_selector);
+
+    switch (feature_selector) {
+    case HubFeatureSelector::PORT_POWER:
+        // Ignore the request. UHCI ports are always powered.
+        break;
+    case HubFeatureSelector::PORT_RESET:
+        reset_port(port);
+        break;
+    case HubFeatureSelector::PORT_SUSPEND: {
+        u16 port_data = port == 0 ? read_portsc1() : read_portsc2();
+        port_data &= UCHI_PORTSC_NON_WRITE_CLEAR_BIT_MASK;
+        port_data |= UHCI_PORTSC_SUSPEND;
+
+        if (port == 0)
+            write_portsc1(port_data);
+        else
+            write_portsc2(port_data);
+
+        m_port_suspend_change_statuses |= (1 << port);
+        break;
+    }
+    default:
+        dbgln("UHCI: Unknown feature selector in set_port_feature: {}", (u8)feature_selector);
+        return EINVAL;
+    }
+
+    return KSuccess;
+}
+
+KResult UHCIController::clear_port_feature(Badge<UHCIRootHub>, u8 port, HubFeatureSelector feature_selector)
+{
+    // The check is done by UHCIRootHub.
+    VERIFY(port < NUMBER_OF_ROOT_PORTS);
+
+    dbgln_if(UHCI_DEBUG, "UHCI: clear_port_feature: port={} feature_selector={}", port, (u8)feature_selector);
+
+    u16 port_data = port == 0 ? read_portsc1() : read_portsc2();
+    port_data &= UCHI_PORTSC_NON_WRITE_CLEAR_BIT_MASK;
+
+    switch (feature_selector) {
+    case HubFeatureSelector::PORT_ENABLE:
+        port_data &= ~UHCI_PORTSC_PORT_ENABLED;
+        break;
+    case HubFeatureSelector::PORT_SUSPEND:
+        port_data &= ~UHCI_PORTSC_SUSPEND;
+        break;
+    case HubFeatureSelector::PORT_POWER:
+        // Ignore the request. UHCI ports are always powered.
+        break;
+    case HubFeatureSelector::C_PORT_CONNECTION:
+        // This field is Write Clear.
+        port_data |= UHCI_PORTSC_CONNECT_STATUS_CHANGED;
+        break;
+    case HubFeatureSelector::C_PORT_RESET:
+        m_port_reset_change_statuses &= ~(1 << port);
+        break;
+    case HubFeatureSelector::C_PORT_ENABLE:
+        // This field is Write Clear.
+        port_data |= UHCI_PORTSC_PORT_ENABLE_CHANGED;
+        break;
+    case HubFeatureSelector::C_PORT_SUSPEND:
+        m_port_suspend_change_statuses &= ~(1 << port);
+        break;
+    default:
+        dbgln("UHCI: Unknown feature selector in clear_port_feature: {}", (u8)feature_selector);
+        return EINVAL;
+    }
+
+    dbgln_if(UHCI_DEBUG, "UHCI: clear_port_feature: writing 0x{:04x} to portsc{}.", port_data, port + 1);
+
+    if (port == 0)
+        write_portsc1(port_data);
+    else
+        write_portsc2(port_data);
+
+    return KSuccess;
 }
 
 }

--- a/Kernel/Bus/USB/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCIController.cpp
@@ -579,7 +579,7 @@ void UHCIController::free_descriptor_chain(TransferDescriptor* first_descriptor)
 KResultOr<size_t> UHCIController::submit_control_transfer(Transfer& transfer)
 {
     Pipe& pipe = transfer.pipe(); // Short circuit the pipe related to this transfer
-    bool direction_in = (transfer.request().request_type & USB_DEVICE_REQUEST_DEVICE_TO_HOST) == USB_DEVICE_REQUEST_DEVICE_TO_HOST;
+    bool direction_in = (transfer.request().request_type & USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST) == USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST;
 
     TransferDescriptor* setup_td = create_transfer_descriptor(pipe, PacketID::SETUP, sizeof(USBRequestData));
     if (!setup_td)

--- a/Kernel/Bus/USB/UHCIController.h
+++ b/Kernel/Bus/USB/UHCIController.h
@@ -42,9 +42,6 @@ public:
 
     virtual KResultOr<size_t> submit_control_transfer(Transfer& transfer) override;
 
-    virtual RefPtr<USB::Device> const get_device_at_port(USB::Device::PortNumber) override;
-    virtual RefPtr<USB::Device> const get_device_from_address(u8 device_address) override;
-
     void get_port_status(Badge<UHCIRootHub>, u8, HubStatus&);
     KResult set_port_feature(Badge<UHCIRootHub>, u8, HubFeatureSelector);
     KResult clear_port_feature(Badge<UHCIRootHub>, u8, HubFeatureSelector);
@@ -109,8 +106,6 @@ private:
 
     // Bitfield containing whether a given port should signal a change in suspend or not.
     u8 m_port_suspend_change_statuses { 0 };
-
-    Array<RefPtr<USB::Device>, NUMBER_OF_ROOT_PORTS> m_devices; // Devices connected to the root ports (of which there are two)
 };
 
 }

--- a/Kernel/Bus/USB/UHCIRootHub.cpp
+++ b/Kernel/Bus/USB/UHCIRootHub.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/USB/UHCIController.h>
+#include <Kernel/Bus/USB/UHCIRootHub.h>
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBConstants.h>
+#include <Kernel/Bus/USB/USBEndpoint.h>
+#include <Kernel/Bus/USB/USBHub.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+
+namespace Kernel::USB {
+
+static USBDeviceDescriptor uhci_root_hub_device_descriptor = {
+    sizeof(USBDeviceDescriptor), // 18 bytes long
+    DESCRIPTOR_TYPE_DEVICE,
+    0x0110, // USB 1.1
+    (u8)USB_CLASS_HUB,
+    0,      // Hubs use subclass 0
+    0,      // Full Speed Hub
+    64,     // Max packet size
+    0x0,    // Vendor ID
+    0x0,    // Product ID
+    0x0110, // Product version (can be anything, currently matching usb_spec_compliance_bcd)
+    0,      // Index of manufacturer string. FIXME: There is currently no support for string descriptors.
+    0,      // Index of product string. FIXME: There is currently no support for string descriptors.
+    0,      // Index of serial string. FIXME: There is currently no support for string descriptors.
+    1,      // One configuration descriptor
+};
+
+static USBConfigurationDescriptor uhci_root_hub_configuration_descriptor = {
+    sizeof(USBConfigurationDescriptor), // 9 bytes long
+    DESCRIPTOR_TYPE_CONFIGURATION,
+    sizeof(USBConfigurationDescriptor) + sizeof(USBInterfaceDescriptor) + sizeof(USBEndpointDescriptor) + sizeof(USBHubDescriptor), // Combined length of configuration, interface, endpoint and hub descriptors.
+    1,                                                                                                                              // One interface descriptor
+    1,                                                                                                                              // Configuration #1
+    0,                                                                                                                              // Index of configuration string. FIXME: There is currently no support for string descriptors.
+    (1 << 7) | (1 << 6),                                                                                                            // Bit 6 is set to indicate that the root hub is self powered. Bit 7 must always be 1.
+    0,                                                                                                                              // 0 mA required from the bus (self-powered)
+};
+
+static USBInterfaceDescriptor uhci_root_hub_interface_descriptor = {
+    sizeof(USBInterfaceDescriptor), // 9 bytes long
+    DESCRIPTOR_TYPE_INTERFACE,
+    0, // Interface #0
+    0, // Alternate setting
+    1, // One endpoint
+    (u8)USB_CLASS_HUB,
+    0, // Hubs use subclass 0
+    0, // Full Speed Hub
+    0, // Index of interface string. FIXME: There is currently no support for string descriptors
+};
+
+static USBEndpointDescriptor uhci_root_hub_endpoint_descriptor = {
+    sizeof(USBEndpointDescriptor), // 7 bytes long
+    DESCRIPTOR_TYPE_ENDPOINT,
+    USBEndpoint::ENDPOINT_ADDRESS_DIRECTION_IN | 1,           // IN Endpoint #1
+    USBEndpoint::ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_INTERRUPT, // Interrupt endpoint
+    2,                                                        // Max Packet Size FIXME: I'm not sure what this is supposed to be as it is implementation defined. 2 is the number of bytes Get Port Status returns.
+    0xFF,                                                     // Max possible interval
+};
+
+// NOTE: UHCI does not provide us anything for the Root Hub's Hub Descriptor.
+static USBHubDescriptor uhci_root_hub_hub_descriptor = {
+    sizeof(USBHubDescriptor), // 7 bytes long. FIXME: Add the size of the VLAs at the end once they're supported.
+    DESCRIPTOR_TYPE_HUB,
+    UHCIController::NUMBER_OF_ROOT_PORTS, // 2 ports
+    0x0,                                  // Ganged power switching, not a compound device, global over-current protection.
+    0x0,                                  // UHCI ports are always powered, so there's no time from power on to power good.
+    0x0,                                  // Self-powered
+};
+
+KResultOr<NonnullOwnPtr<UHCIRootHub>> UHCIRootHub::try_create(NonnullRefPtr<UHCIController> uhci_controller)
+{
+    auto root_hub = adopt_own_if_nonnull(new (nothrow) UHCIRootHub(uhci_controller));
+    if (!root_hub)
+        return ENOMEM;
+
+    return root_hub.release_nonnull();
+}
+
+UHCIRootHub::UHCIRootHub(NonnullRefPtr<UHCIController> uhci_controller)
+    : m_uhci_controller(uhci_controller)
+{
+}
+
+KResult UHCIRootHub::setup(Badge<UHCIController>)
+{
+    auto hub_or_error = Hub::try_create_root_hub(m_uhci_controller, Device::DeviceSpeed::FullSpeed);
+    if (hub_or_error.is_error())
+        return hub_or_error.error();
+
+    m_hub = hub_or_error.release_value();
+
+    // NOTE: The root hub will be on the default address at this point.
+    // The root hub must be the first device to be created, otherwise the HCD will intercept all default address transfers as though they're targeted at the root hub.
+    auto result = m_hub->enumerate_device();
+    if (result.is_error())
+        return result;
+
+    // NOTE: The root hub is no longer on the default address.
+    result = m_hub->enumerate_and_power_on_hub();
+    if (result.is_error())
+        return result;
+
+    return KSuccess;
+}
+
+KResultOr<size_t> UHCIRootHub::handle_control_transfer(Transfer& transfer)
+{
+    auto& request = transfer.request();
+    auto* request_data = transfer.buffer().as_ptr() + sizeof(USBRequestData);
+
+    if constexpr (UHCI_DEBUG) {
+        dbgln("UHCIRootHub: Received control transfer.");
+        dbgln("UHCIRootHub: Request Type: 0x{:02x}", request.request_type);
+        dbgln("UHCIRootHub: Request: 0x{:02x}", request.request);
+        dbgln("UHCIRootHub: Value: 0x{:04x}", request.value);
+        dbgln("UHCIRootHub: Index: 0x{:04x}", request.index);
+        dbgln("UHCIRootHub: Length: 0x{:04x}", request.length);
+    }
+
+    size_t length = 0;
+
+    switch (request.request) {
+    case HubRequest::GET_STATUS: {
+        if (request.index > UHCIController::NUMBER_OF_ROOT_PORTS)
+            return EINVAL;
+
+        length = min(transfer.transfer_data_size(), sizeof(HubStatus));
+        VERIFY(length <= sizeof(HubStatus));
+        HubStatus hub_status {};
+
+        if (request.index == 0) {
+            // If index == 0, the actual request is Get Hub Status
+            // UHCI does not provide "Local Power Source" or "Over-current" and their corresponding change flags.
+            // The members of hub_status are initialized to 0, so we can memcpy it straight away.
+            memcpy(request_data, (void*)&hub_status, length);
+            break;
+        }
+
+        // If index != 0, the actual request is Get Port Status
+        m_uhci_controller->get_port_status({}, request.index - 1, hub_status);
+        memcpy(request_data, (void*)&hub_status, length);
+        break;
+    }
+    case HubRequest::GET_DESCRIPTOR: {
+        u8 descriptor_type = request.value >> 8;
+        switch (descriptor_type) {
+        case DESCRIPTOR_TYPE_DEVICE:
+            length = min(transfer.transfer_data_size(), sizeof(USBDeviceDescriptor));
+            VERIFY(length <= sizeof(USBDeviceDescriptor));
+            memcpy(request_data, (void*)&uhci_root_hub_device_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_CONFIGURATION:
+            length = min(transfer.transfer_data_size(), sizeof(USBConfigurationDescriptor));
+            VERIFY(length <= sizeof(USBConfigurationDescriptor));
+            memcpy(request_data, (void*)&uhci_root_hub_configuration_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_INTERFACE:
+            length = min(transfer.transfer_data_size(), sizeof(USBInterfaceDescriptor));
+            VERIFY(length <= sizeof(USBInterfaceDescriptor));
+            memcpy(request_data, (void*)&uhci_root_hub_interface_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_ENDPOINT:
+            length = min(transfer.transfer_data_size(), sizeof(USBEndpointDescriptor));
+            VERIFY(length <= sizeof(USBEndpointDescriptor));
+            memcpy(request_data, (void*)&uhci_root_hub_endpoint_descriptor, length);
+            break;
+        case DESCRIPTOR_TYPE_HUB:
+            length = min(transfer.transfer_data_size(), sizeof(USBHubDescriptor));
+            VERIFY(length <= sizeof(USBHubDescriptor));
+            memcpy(request_data, (void*)&uhci_root_hub_hub_descriptor, length);
+            break;
+        default:
+            return EINVAL;
+        }
+        break;
+    }
+    case USB_REQUEST_SET_ADDRESS:
+        dbgln_if(UHCI_DEBUG, "UHCIRootHub: Attempt to set address to {}, ignoring.", request.value);
+        if (request.value > USB_MAX_ADDRESS)
+            return EINVAL;
+        // Ignore SET_ADDRESS requests. USBDevice sets its internal address to the new allocated address that it just sent to us.
+        // The internal address is used to check if the request is directed at the root hub or not.
+        break;
+    case HubRequest::SET_FEATURE: {
+        if (request.index == 0) {
+            // If index == 0, the actual request is Set Hub Feature.
+            // UHCI does not provide "Local Power Source" or "Over-current" and their corresponding change flags.
+            // Therefore, ignore the request, but return an error if the value is not "Local Power Source" or "Over-current"
+            switch (request.value) {
+            case HubFeatureSelector::C_HUB_LOCAL_POWER:
+            case HubFeatureSelector::C_HUB_OVER_CURRENT:
+                break;
+            default:
+                return EINVAL;
+            }
+
+            break;
+        }
+
+        // If index != 0, the actual request is Set Port Feature.
+        u8 port = request.index & 0xFF;
+        if (port > UHCIController::NUMBER_OF_ROOT_PORTS)
+            return EINVAL;
+
+        auto feature_selector = (HubFeatureSelector)request.value;
+        auto result = m_uhci_controller->set_port_feature({}, port - 1, feature_selector);
+        if (result.is_error())
+            return result.error();
+        break;
+    }
+    case HubRequest::CLEAR_FEATURE: {
+        if (request.index == 0) {
+            // If index == 0, the actual request is Clear Hub Feature.
+            // UHCI does not provide "Local Power Source" or "Over-current" and their corresponding change flags.
+            // Therefore, ignore the request, but return an error if the value is not "Local Power Source" or "Over-current"
+            switch (request.value) {
+            case HubFeatureSelector::C_HUB_LOCAL_POWER:
+            case HubFeatureSelector::C_HUB_OVER_CURRENT:
+                break;
+            default:
+                return EINVAL;
+            }
+
+            break;
+        }
+
+        // If index != 0, the actual request is Clear Port Feature.
+        u8 port = request.index & 0xFF;
+        if (port > UHCIController::NUMBER_OF_ROOT_PORTS)
+            return EINVAL;
+
+        auto feature_selector = (HubFeatureSelector)request.value;
+        auto result = m_uhci_controller->clear_port_feature({}, port - 1, feature_selector);
+        if (result.is_error())
+            return result.error();
+        break;
+    }
+    default:
+        return EINVAL;
+    }
+
+    transfer.set_complete();
+    return length;
+}
+
+}

--- a/Kernel/Bus/USB/UHCIRootHub.h
+++ b/Kernel/Bus/USB/UHCIRootHub.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
+#include <Kernel/Bus/USB/USBHub.h>
+#include <Kernel/Bus/USB/USBTransfer.h>
+#include <Kernel/KResult.h>
+
+namespace Kernel::USB {
+
+class UHCIController;
+
+class UHCIRootHub {
+public:
+    static KResultOr<NonnullOwnPtr<UHCIRootHub>> try_create(NonnullRefPtr<UHCIController>);
+
+    UHCIRootHub(NonnullRefPtr<UHCIController>);
+    ~UHCIRootHub() = default;
+
+    KResult setup(Badge<UHCIController>);
+
+    u8 device_address() const { return m_hub->address(); }
+
+    KResultOr<size_t> handle_control_transfer(Transfer& transfer);
+
+    void check_for_port_updates() { m_hub->check_for_port_updates(); }
+
+private:
+    NonnullRefPtr<UHCIController> m_uhci_controller;
+    RefPtr<Hub> m_hub;
+};
+
+}

--- a/Kernel/Bus/USB/USBClasses.h
+++ b/Kernel/Bus/USB/USBClasses.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel::USB {
+
+// https://www.usb.org/defined-class-codes
+static constexpr u8 USB_CLASS_AUDIO = 0x01;
+static constexpr u8 USB_CLASS_COMMUNICATIONS_AND_CDC_CONTROL = 0x02;
+static constexpr u8 USB_CLASS_HID = 0x03;
+static constexpr u8 USB_CLASS_PHYSICAL = 0x05;
+static constexpr u8 USB_CLASS_IMAGE = 0x06;
+static constexpr u8 USB_CLASS_PRINTER = 0x07;
+static constexpr u8 USB_CLASS_MASS_STORAGE = 0x08;
+static constexpr u8 USB_CLASS_HUB = 0x09;
+static constexpr u8 USB_CLASS_CDC_DATE = 0x0A;
+static constexpr u8 USB_CLASS_SMART_CARD = 0x0B;
+static constexpr u8 USB_CLASS_CONTENT_SECURITY = 0x0D;
+static constexpr u8 USB_CLASS_VIDEO = 0x0E;
+static constexpr u8 USB_CLASS_PERSONAL_HEALTHCARE = 0x0F;
+static constexpr u8 USB_CLASS_AUDIO_VIDEO = 0x10;
+static constexpr u8 USB_CLASS_BILLBOARD = 0x11;
+static constexpr u8 USB_CLASS_TYPE_C_BRIDGE = 0x12;
+static constexpr u8 USB_CLASS_DIAGNOSTIC = 0xDC;
+static constexpr u8 USB_CLASS_WIRELESS_CONTROLLER = 0xE0;
+static constexpr u8 USB_CLASS_MISCELLANEOUS = 0xEF;
+static constexpr u8 USB_CLASS_APPLICATION_SPECIFIC = 0xFE;
+static constexpr u8 USB_CLASS_VENDOR_SPECIFIC = 0xFF;
+
+}

--- a/Kernel/Bus/USB/USBConstants.h
+++ b/Kernel/Bus/USB/USBConstants.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel::USB {
+
+// USB 2.0 Specification Section 9.4.6
+static constexpr u8 USB_MAX_ADDRESS = 127;
+
+}

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -25,9 +25,6 @@ public:
 
     virtual KResultOr<size_t> submit_control_transfer(Transfer&) = 0;
 
-    virtual RefPtr<USB::Device> const get_device_at_port(USB::Device::PortNumber) = 0;
-    virtual RefPtr<USB::Device> const get_device_from_address(u8) = 0;
-
     u8 allocate_address();
 
 private:

--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -39,6 +39,7 @@ struct [[gnu::packed]] USBDeviceDescriptor {
     u8 serial_number_descriptor_index;
     u8 num_configurations;
 };
+static_assert(sizeof(USBDeviceDescriptor) == 18);
 
 //
 //  Configuration Descriptor

--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -94,11 +94,25 @@ struct [[gnu::packed]] USBEndpointDescriptor {
     u8 poll_interval_in_frames;
 };
 
+//
+//  USB 1.1/2.0 Hub Descriptor
+//  ==============
+//
+struct [[gnu::packed]] USBHubDescriptor {
+    USBDescriptorCommon descriptor_header;
+    u8 number_of_downstream_ports;
+    u16 hub_characteristics;
+    u8 power_on_to_power_good_time;
+    u8 hub_controller_current;
+    // NOTE: This does not contain DeviceRemovable or PortPwrCtrlMask because a struct cannot have two VLAs in a row.
+};
+
 static constexpr u8 DESCRIPTOR_TYPE_DEVICE = 0x01;
 static constexpr u8 DESCRIPTOR_TYPE_CONFIGURATION = 0x02;
 static constexpr u8 DESCRIPTOR_TYPE_STRING = 0x03;
 static constexpr u8 DESCRIPTOR_TYPE_INTERFACE = 0x04;
 static constexpr u8 DESCRIPTOR_TYPE_ENDPOINT = 0x05;
 static constexpr u8 DESCRIPTOR_TYPE_DEVICE_QUALIFIER = 0x06;
+static constexpr u8 DESCRIPTOR_TYPE_HUB = 0x29;
 
 }

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -16,7 +16,7 @@
 
 namespace Kernel::USB {
 
-KResultOr<NonnullRefPtr<Device>> Device::try_create(USBController const& controller, PortNumber port, DeviceSpeed speed)
+KResultOr<NonnullRefPtr<Device>> Device::try_create(USBController const& controller, u8 port, DeviceSpeed speed)
 {
     auto pipe_or_error = Pipe::try_create_pipe(controller, Pipe::Type::Control, Pipe::Direction::Bidirectional, 0, 8, 0);
     if (pipe_or_error.is_error())
@@ -33,7 +33,7 @@ KResultOr<NonnullRefPtr<Device>> Device::try_create(USBController const& control
     return device.release_nonnull();
 }
 
-Device::Device(USBController const& controller, PortNumber port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe)
+Device::Device(USBController const& controller, u8 port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe)
     : m_device_port(port)
     , m_device_speed(speed)
     , m_address(0)
@@ -42,7 +42,7 @@ Device::Device(USBController const& controller, PortNumber port, DeviceSpeed spe
 {
 }
 
-Device::Device(NonnullRefPtr<USBController> controller, u8 address, PortNumber port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe)
+Device::Device(NonnullRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe)
     : m_device_port(port)
     , m_device_speed(speed)
     , m_address(address)

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -26,7 +26,7 @@ KResultOr<NonnullRefPtr<Device>> Device::try_create(USBController const& control
     if (!device)
         return ENOMEM;
 
-    auto enumerate_result = device->enumerate();
+    auto enumerate_result = device->enumerate_device();
     if (enumerate_result.is_error())
         return enumerate_result;
 
@@ -42,20 +42,58 @@ Device::Device(USBController const& controller, PortNumber port, DeviceSpeed spe
 {
 }
 
-KResult Device::enumerate()
+Device::Device(NonnullRefPtr<USBController> controller, u8 address, PortNumber port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe)
+    : m_device_port(port)
+    , m_device_speed(speed)
+    , m_address(address)
+    , m_controller(controller)
+    , m_default_pipe(move(default_pipe))
+{
+}
+
+Device::Device(Device const& device, NonnullOwnPtr<Pipe> default_pipe)
+    : m_device_port(device.port())
+    , m_device_speed(device.speed())
+    , m_address(device.address())
+    , m_device_descriptor(device.device_descriptor())
+    , m_controller(device.controller())
+    , m_default_pipe(move(default_pipe))
+{
+}
+
+Device::~Device()
+{
+}
+
+KResult Device::enumerate_device()
 {
     USBDeviceDescriptor dev_descriptor {};
 
     // Send 8-bytes to get at least the `max_packet_size` from the device
-    auto transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, 8, &dev_descriptor);
+    constexpr u8 short_device_descriptor_length = 8;
+    auto transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, short_device_descriptor_length, &dev_descriptor);
 
     if (transfer_length_or_error.is_error())
         return transfer_length_or_error.error();
 
     auto transfer_length = transfer_length_or_error.release_value();
 
-    // FIXME: This shouldn't crash! Do some correct error handling on me please!
-    VERIFY(transfer_length > 0);
+    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
+    if (transfer_length < short_device_descriptor_length) {
+        dbgln("USB Device: Not enough bytes for short device descriptor. Expected {}, got {}.", short_device_descriptor_length, transfer_length);
+        return EIO;
+    }
+
+    if constexpr (USB_DEBUG) {
+        dbgln("USB Short Device Descriptor:");
+        dbgln("Descriptor length: {}", dev_descriptor.descriptor_header.length);
+        dbgln("Descriptor type: {}", dev_descriptor.descriptor_header.descriptor_type);
+
+        dbgln("Device Class: {:02x}", dev_descriptor.device_class);
+        dbgln("Device Sub-Class: {:02x}", dev_descriptor.device_sub_class);
+        dbgln("Device Protocol: {:02x}", dev_descriptor.device_protocol);
+        dbgln("Max Packet Size: {:02x} bytes", dev_descriptor.max_packet_size);
+    }
 
     // Ensure that this is actually a valid device descriptor...
     VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
@@ -68,8 +106,11 @@ KResult Device::enumerate()
 
     transfer_length = transfer_length_or_error.release_value();
 
-    // FIXME: This shouldn't crash! Do some correct error handling on me please!
-    VERIFY(transfer_length > 0);
+    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
+    if (transfer_length < sizeof(USBDeviceDescriptor)) {
+        dbgln("USB Device: Unexpected device descriptor length. Expected {}, got {}.", sizeof(USBDeviceDescriptor), transfer_length);
+        return EIO;
+    }
 
     // Ensure that this is actually a valid device descriptor...
     VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
@@ -83,24 +124,23 @@ KResult Device::enumerate()
         dbgln("Number of configurations: {:02x}", dev_descriptor.num_configurations);
     }
 
-    m_address = m_controller->allocate_address();
+    auto new_address = m_controller->allocate_address();
 
     // Attempt to set devices address on the bus
-    transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE, USB_REQUEST_SET_ADDRESS, m_address, 0, 0, nullptr);
+    transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE, USB_REQUEST_SET_ADDRESS, new_address, 0, 0, nullptr);
 
     if (transfer_length_or_error.is_error())
         return transfer_length_or_error.error();
 
-    transfer_length = transfer_length_or_error.release_value();
+    // This has to be set after we send out the "Set Address" request because it might be sent to the root hub.
+    // The root hub uses the address to intercept requests to itself.
+    m_address = new_address;
+    m_default_pipe->set_device_address(new_address);
 
-    VERIFY(transfer_length > 0);
+    dbgln_if(USB_DEBUG, "USB Device: Set address to {}", m_address);
 
     memcpy(&m_device_descriptor, &dev_descriptor, sizeof(USBDeviceDescriptor));
     return KSuccess;
-}
-
-Device::~Device()
-{
 }
 
 }

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -46,9 +46,8 @@ KResult Device::enumerate()
 {
     USBDeviceDescriptor dev_descriptor {};
 
-    // FIXME: 0x100 is a magic number for now, as I'm not quite sure how these are constructed....
     // Send 8-bytes to get at least the `max_packet_size` from the device
-    auto transfer_length_or_error = m_default_pipe->control_transfer(USB_DEVICE_REQUEST_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, 0x100, 0, 8, &dev_descriptor);
+    auto transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, 8, &dev_descriptor);
 
     if (transfer_length_or_error.is_error())
         return transfer_length_or_error.error();
@@ -62,7 +61,7 @@ KResult Device::enumerate()
     VERIFY(dev_descriptor.descriptor_header.descriptor_type == DESCRIPTOR_TYPE_DEVICE);
     m_default_pipe->set_max_packet_size(dev_descriptor.max_packet_size);
 
-    transfer_length_or_error = m_default_pipe->control_transfer(USB_DEVICE_REQUEST_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, 0x100, 0, sizeof(USBDeviceDescriptor), &dev_descriptor);
+    transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_DEVICE << 8), 0, sizeof(USBDeviceDescriptor), &dev_descriptor);
 
     if (transfer_length_or_error.is_error())
         return transfer_length_or_error.error();
@@ -87,7 +86,7 @@ KResult Device::enumerate()
     m_address = m_controller->allocate_address();
 
     // Attempt to set devices address on the bus
-    transfer_length_or_error = m_default_pipe->control_transfer(USB_DEVICE_REQUEST_HOST_TO_DEVICE, USB_REQUEST_SET_ADDRESS, m_address, 0, 0, nullptr);
+    transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE, USB_REQUEST_SET_ADDRESS, m_address, 0, 0, nullptr);
 
     if (transfer_length_or_error.is_error())
         return transfer_length_or_error.error();

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -21,26 +21,21 @@ class USBController;
 // https://www.ftdichip.com/Support/Documents/TechnicalNotes/TN_113_Simplified%20Description%20of%20USB%20Device%20Enumeration.pdf
 class Device : public RefCounted<Device> {
 public:
-    enum class PortNumber : u8 {
-        Port1 = 0,
-        Port2
-    };
-
     enum class DeviceSpeed : u8 {
         FullSpeed = 0,
         LowSpeed
     };
 
 public:
-    static KResultOr<NonnullRefPtr<Device>> try_create(USBController const&, PortNumber, DeviceSpeed);
+    static KResultOr<NonnullRefPtr<Device>> try_create(USBController const&, u8, DeviceSpeed);
 
-    Device(USBController const&, PortNumber, DeviceSpeed, NonnullOwnPtr<Pipe> default_pipe);
+    Device(USBController const&, u8, DeviceSpeed, NonnullOwnPtr<Pipe> default_pipe);
     Device(Device const& device, NonnullOwnPtr<Pipe> default_pipe);
     virtual ~Device();
 
     KResult enumerate_device();
 
-    PortNumber port() const { return m_device_port; }
+    u8 port() const { return m_device_port; }
     DeviceSpeed speed() const { return m_device_speed; }
 
     u8 address() const { return m_address; }
@@ -51,9 +46,9 @@ public:
     USBController const& controller() const { return *m_controller; }
 
 protected:
-    Device(NonnullRefPtr<USBController> controller, u8 address, PortNumber port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe);
+    Device(NonnullRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe);
 
-    PortNumber m_device_port;   // What port is this device attached to
+    u8 m_device_port { 0 };     // What port is this device attached to. NOTE: This is 1-based.
     DeviceSpeed m_device_speed; // What speed is this device running at
     u8 m_address { 0 };         // USB address assigned to this device
 

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -35,9 +35,10 @@ public:
     static KResultOr<NonnullRefPtr<Device>> try_create(USBController const&, PortNumber, DeviceSpeed);
 
     Device(USBController const&, PortNumber, DeviceSpeed, NonnullOwnPtr<Pipe> default_pipe);
-    ~Device();
+    Device(Device const& device, NonnullOwnPtr<Pipe> default_pipe);
+    virtual ~Device();
 
-    KResult enumerate();
+    KResult enumerate_device();
 
     PortNumber port() const { return m_device_port; }
     DeviceSpeed speed() const { return m_device_speed; }
@@ -46,7 +47,12 @@ public:
 
     const USBDeviceDescriptor& device_descriptor() const { return m_device_descriptor; }
 
-private:
+    USBController& controller() { return *m_controller; }
+    USBController const& controller() const { return *m_controller; }
+
+protected:
+    Device(NonnullRefPtr<USBController> controller, u8 address, PortNumber port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe);
+
     PortNumber m_device_port;   // What port is this device attached to
     DeviceSpeed m_device_speed; // What speed is this device running at
     u8 m_address { 0 };         // USB address assigned to this device
@@ -58,5 +64,11 @@ private:
 
     NonnullRefPtr<USBController> m_controller;
     NonnullOwnPtr<Pipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration
+
+private:
+    IntrusiveListNode<Device, NonnullRefPtr<Device>> m_hub_child_node;
+
+public:
+    using List = IntrusiveList<Device, NonnullRefPtr<Device>, &Device::m_hub_child_node>;
 };
 }

--- a/Kernel/Bus/USB/USBEndpoint.h
+++ b/Kernel/Bus/USB/USBEndpoint.h
@@ -56,7 +56,7 @@ private:
     USBEndpoint(/* TODO */);
     USBEndpointDescriptor m_descriptor;
 
-    USBPipe m_pipe;
+    Pipe m_pipe;
 };
 
 }

--- a/Kernel/Bus/USB/USBEndpoint.h
+++ b/Kernel/Bus/USB/USBEndpoint.h
@@ -27,8 +27,11 @@ namespace Kernel::USB {
 // while the keyboard part would only generate data once we push a key (hence an interrupt transfer).
 // Each of these data sources would be a _different_ endpoint on the device that we read from.
 class USBEndpoint {
+public:
     static constexpr u8 ENDPOINT_ADDRESS_NUMBER_MASK = 0x0f;
     static constexpr u8 ENDPOINT_ADDRESS_DIRECTION_MASK = 0x80;
+    static constexpr u8 ENDPOINT_ADDRESS_DIRECTION_OUT = 0x00;
+    static constexpr u8 ENDPOINT_ADDRESS_DIRECTION_IN = 0x80;
 
     static constexpr u8 ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_MASK = 0x03;
     static constexpr u8 ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_CONTROL = 0x00;
@@ -39,7 +42,6 @@ class USBEndpoint {
     static constexpr u8 ENDPOINT_ATTRIBUTES_ISO_MODE_SYNC_TYPE = 0x0c;
     static constexpr u8 ENDPOINT_ATTRIBUTES_ISO_MODE_USAGE_TYPE = 0x30;
 
-public:
     const USBEndpointDescriptor& descriptor() const { return m_descriptor; }
 
     bool is_control() const { return (m_descriptor.endpoint_attributes_bitmap & ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_MASK) == ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_CONTROL; }

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Bus/USB/USBHub.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+#include <Kernel/StdLib.h>
+
+namespace Kernel::USB {
+
+KResultOr<NonnullRefPtr<Hub>> Hub::try_create_root_hub(NonnullRefPtr<USBController> controller, DeviceSpeed device_speed)
+{
+    auto pipe_or_error = Pipe::try_create_pipe(controller, Pipe::Type::Control, Pipe::Direction::Bidirectional, 0, 8, 0);
+    if (pipe_or_error.is_error())
+        return pipe_or_error.error();
+
+    auto hub = AK::try_create<Hub>(controller, device_speed, pipe_or_error.release_value());
+    if (!hub)
+        return ENOMEM;
+
+    // NOTE: Enumeration does not happen here, as the controller must know what the device address is at all times during enumeration to intercept requests.
+
+    return hub.release_nonnull();
+}
+
+KResultOr<NonnullRefPtr<Hub>> Hub::try_create_from_device(Device const& device)
+{
+    auto pipe_or_error = Pipe::try_create_pipe(device.controller(), Pipe::Type::Control, Pipe::Direction::Bidirectional, 0, device.device_descriptor().max_packet_size, device.address());
+    if (pipe_or_error.is_error())
+        return pipe_or_error.error();
+
+    auto hub = AK::try_create<Hub>(device, pipe_or_error.release_value());
+    if (!hub)
+        return ENOMEM;
+
+    auto result = hub->enumerate_and_power_on_hub();
+    if (result.is_error())
+        return result;
+
+    return hub.release_nonnull();
+}
+
+Hub::Hub(NonnullRefPtr<USBController> controller, DeviceSpeed device_speed, NonnullOwnPtr<Pipe> default_pipe)
+    : Device(move(controller), PortNumber::Port1, device_speed, move(default_pipe))
+{
+}
+
+Hub::Hub(Device const& device, NonnullOwnPtr<Pipe> default_pipe)
+    : Device(device, move(default_pipe))
+{
+}
+
+KResult Hub::enumerate_and_power_on_hub()
+{
+    // USBDevice::enumerate_device must be called before this.
+    VERIFY(m_address > 0);
+
+    if (m_device_descriptor.device_class != USB_CLASS_HUB) {
+        dbgln("USB Hub: Trying to enumerate and power on a device that says it isn't a hub.");
+        return EINVAL;
+    }
+
+    dbgln_if(USB_DEBUG, "USB Hub: Enumerating and powering on for address {}", m_address);
+
+    USBHubDescriptor descriptor {};
+
+    // Get the first hub descriptor. All hubs are required to have a hub descriptor at index 0. USB 2.0 Specification Section 11.24.2.5.
+    auto transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST | USB_REQUEST_TYPE_CLASS, HubRequest::GET_DESCRIPTOR, (DESCRIPTOR_TYPE_HUB << 8), 0, sizeof(USBHubDescriptor), &descriptor);
+    if (transfer_length_or_error.is_error())
+        return transfer_length_or_error.error();
+
+    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
+    if (transfer_length_or_error.value() < sizeof(USBHubDescriptor)) {
+        dbgln("USB Hub: Unexpected hub descriptor size. Expected {}, got {}", sizeof(USBHubDescriptor), transfer_length_or_error.value());
+        return EIO;
+    }
+
+    if constexpr (USB_DEBUG) {
+        dbgln("USB Hub Descriptor for {:04x}:{:04x}", m_vendor_id, m_product_id);
+        dbgln("Number of Downstream Ports: {}", descriptor.number_of_downstream_ports);
+        dbgln("Hub Characteristics: 0x{:04x}", descriptor.hub_characteristics);
+        dbgln("Power On to Power Good Time: {} ms ({} * 2ms)", descriptor.power_on_to_power_good_time * 2, descriptor.power_on_to_power_good_time);
+        dbgln("Hub Controller Current: {} mA", descriptor.hub_controller_current);
+    }
+
+    // FIXME: Queue the status change interrupt
+
+    // Enable all the ports
+    for (u8 port_index = 0; port_index < descriptor.number_of_downstream_ports; ++port_index) {
+        auto result = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE | USB_REQUEST_TYPE_CLASS | USB_REQUEST_RECIPIENT_OTHER, HubRequest::SET_FEATURE, HubFeatureSelector::PORT_POWER, port_index + 1, 0, nullptr);
+        if (result.is_error())
+            dbgln("USB: Failed to power on port {} on hub at address {}.", port_index + 1, m_address);
+    }
+
+    // Wait for the ports to power up. power_on_to_power_good_time is in units of 2 ms and we want in us, so multiply by 2000.
+    IO::delay(descriptor.power_on_to_power_good_time * 2000);
+
+    memcpy(&m_hub_descriptor, &descriptor, sizeof(USBHubDescriptor));
+
+    return KSuccess;
+}
+
+// USB 2.0 Specification Section 11.24.2.7
+KResult Hub::get_port_status(u8 port, HubStatus& hub_status)
+{
+    // Ports are 1-based.
+    if (port == 0 || port > m_hub_descriptor.number_of_downstream_ports)
+        return EINVAL;
+
+    auto transfer_length_or_error = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST | USB_REQUEST_TYPE_CLASS | USB_REQUEST_RECIPIENT_OTHER, HubRequest::GET_STATUS, 0, port, sizeof(HubStatus), &hub_status);
+    if (transfer_length_or_error.is_error())
+        return transfer_length_or_error.error();
+
+    // FIXME: This be "not equal to" instead of "less than", but control transfers report a higher transfer length than expected.
+    if (transfer_length_or_error.value() < sizeof(HubStatus)) {
+        dbgln("USB Hub: Unexpected hub status size. Expected {}, got {}.", sizeof(HubStatus), transfer_length_or_error.value());
+        return EIO;
+    }
+
+    return KSuccess;
+}
+
+// USB 2.0 Specification Section 11.24.2.2
+KResult Hub::clear_port_feature(u8 port, HubFeatureSelector feature_selector)
+{
+    // Ports are 1-based.
+    if (port == 0 || port > m_hub_descriptor.number_of_downstream_ports)
+        return EINVAL;
+
+    auto result = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE | USB_REQUEST_TYPE_CLASS | USB_REQUEST_RECIPIENT_OTHER, HubRequest::CLEAR_FEATURE, feature_selector, port, 0, nullptr);
+    if (result.is_error())
+        return result.error();
+
+    return KSuccess;
+}
+
+// USB 2.0 Specification Section 11.24.2.13
+KResult Hub::set_port_feature(u8 port, HubFeatureSelector feature_selector)
+{
+    // Ports are 1-based.
+    if (port == 0 || port > m_hub_descriptor.number_of_downstream_ports)
+        return EINVAL;
+
+    auto result = m_default_pipe->control_transfer(USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE | USB_REQUEST_TYPE_CLASS | USB_REQUEST_RECIPIENT_OTHER, HubRequest::SET_FEATURE, feature_selector, port, 0, nullptr);
+    if (result.is_error())
+        return result.error();
+
+    return KSuccess;
+}
+
+void Hub::check_for_port_updates()
+{
+    for (u8 port_number = 1; port_number < m_hub_descriptor.number_of_downstream_ports + 1; ++port_number) {
+        dbgln_if(USB_DEBUG, "USB Hub: Checking for port updates on port {}...", port_number);
+
+        HubStatus port_status {};
+        auto result = get_port_status(port_number, port_status);
+        if (result.is_error()) {
+            dbgln("USB Hub: Error occurred when getting status for port {}: {}. Checking next port instead.", port_number, result.error());
+            continue;
+        }
+
+        if (port_status.change & PORT_STATUS_CONNECT_STATUS_CHANGED) {
+            // Clear the connection status change notification.
+            result = clear_port_feature(port_number, HubFeatureSelector::C_PORT_CONNECTION);
+            if (result.is_error()) {
+                dbgln("USB Hub: Error occurred when clearing port connection change for port {}: {}.", port_number, result.error());
+                return;
+            }
+
+            if (port_status.status & PORT_STATUS_CURRENT_CONNECT_STATUS) {
+                dbgln("USB Hub: Device attached to port {}!", port_number);
+
+                // Debounce the port. USB 2.0 Specification Page 150
+                // Debounce interval is 100 ms (100000 us). USB 2.0 Specification Page 188 Table 7-14.
+                constexpr u32 debounce_interval = 100 * 1000;
+
+                // We must check if the device disconnected every so often. If it disconnects, we must reset the debounce timer.
+                // This doesn't seem to be specified. Let's check every 10ms (10000 us).
+                constexpr u32 debounce_disconnect_check_interval = 10 * 1000;
+
+                u32 debounce_timer = 0;
+
+                dbgln_if(USB_DEBUG, "USB Hub: Debouncing...");
+
+                // FIXME: Timeout
+                while (debounce_timer < debounce_interval) {
+                    IO::delay(debounce_disconnect_check_interval);
+                    debounce_timer += debounce_disconnect_check_interval;
+
+                    result = get_port_status(port_number, port_status);
+                    if (result.is_error()) {
+                        dbgln("USB Hub: Error occurred when getting status while debouncing port {}: {}.", port_number, result.error());
+                        return;
+                    }
+
+                    if (!(port_status.change & PORT_STATUS_CONNECT_STATUS_CHANGED))
+                        continue;
+
+                    dbgln_if(USB_DEBUG, "USB Hub: Connection status changed while debouncing, resetting debounce timer.");
+                    debounce_timer = 0;
+                    result = clear_port_feature(port_number, HubFeatureSelector::C_PORT_CONNECTION);
+                    if (result.is_error()) {
+                        dbgln("USB Hub: Error occurred when clearing port connection change while debouncing port {}: {}.", port_number, result.error());
+                        return;
+                    }
+                }
+
+                // Reset the port
+                dbgln_if(USB_DEBUG, "USB Hub: Debounce finished. Driving reset...");
+                result = set_port_feature(port_number, HubFeatureSelector::PORT_RESET);
+                if (result.is_error()) {
+                    dbgln("USB Hub: Error occurred when resetting port {}: {}.", port_number, result.error());
+                    return;
+                }
+
+                // FIXME: Timeout
+                for (;;) {
+                    // Wait at least 10 ms for the port to reset.
+                    // This is T DRST in the USB 2.0 Specification Page 186 Table 7-13.
+                    constexpr u16 reset_delay = 10 * 1000;
+                    IO::delay(reset_delay);
+
+                    result = get_port_status(port_number, port_status);
+                    if (result.is_error()) {
+                        dbgln("USB Hub: Error occurred when getting status while resetting port {}: {}.", port_number, result.error());
+                        return;
+                    }
+
+                    if (port_status.change & PORT_STATUS_RESET_CHANGED)
+                        break;
+                }
+
+                // Stop asserting reset. This also causes the port to become enabled.
+                result = clear_port_feature(port_number, HubFeatureSelector::C_PORT_RESET);
+                if (result.is_error()) {
+                    dbgln("USB Hub: Error occurred when resetting port {}: {}.", port_number, result.error());
+                    return;
+                }
+
+                // Wait 10 ms for the port to recover.
+                // This is T RSTRCY in the USB 2.0 Specification Page 188 Table 7-14.
+                constexpr u16 reset_recovery_delay = 10 * 1000;
+                IO::delay(reset_recovery_delay);
+
+                dbgln_if(USB_DEBUG, "USB Hub: Reset complete!");
+
+                // The port is ready to go. This is where we start communicating with the device to set up a driver for it.
+
+                result = get_port_status(port_number, port_status);
+                if (result.is_error()) {
+                    dbgln("USB Hub: Error occurred when getting status for port {} after reset: {}.", port_number, result.error());
+                    return;
+                }
+
+                // FIXME: Check for high speed.
+                auto speed = port_status.status & PORT_STATUS_LOW_SPEED_DEVICE_ATTACHED ? USB::Device::DeviceSpeed::LowSpeed : USB::Device::DeviceSpeed::FullSpeed;
+
+                // FIXME: This only assumes two ports.
+                auto device_or_error = USB::Device::try_create(m_controller, port_number == 1 ? PortNumber::Port1 : PortNumber::Port2, speed);
+                if (device_or_error.is_error()) {
+                    dbgln("USB Hub: Failed to create device for port {}: {}", port_number, device_or_error.error());
+                    return;
+                }
+
+                auto device = device_or_error.release_value();
+
+                dbgln_if(USB_DEBUG, "USB Hub: Created device with address {}!", device->address());
+
+                if (device->device_descriptor().device_class == USB_CLASS_HUB) {
+                    auto hub_or_error = Hub::try_create_from_device(*device);
+                    if (hub_or_error.is_error()) {
+                        dbgln("USB Hub: Failed to upgrade device to hub for port {}: {}", port_number, device_or_error.error());
+                        return;
+                    }
+
+                    dbgln_if(USB_DEBUG, "USB Hub: Upgraded device at address {} to hub!", device->address());
+
+                    m_children.append(hub_or_error.release_value());
+                } else {
+                    m_children.append(device);
+                }
+
+            } else {
+                dbgln("USB Hub: Device detached on port {}!", port_number);
+
+                Device* device_to_remove = nullptr;
+                for (auto& child : m_children) {
+                    // FIXME: This kinda sucks.
+                    if (port_number - 1 == (u8)child.port()) {
+                        device_to_remove = &child;
+                        break;
+                    }
+                }
+
+                if (device_to_remove)
+                    m_children.remove(*device_to_remove);
+                else
+                    dbgln_if(USB_DEBUG, "USB Hub: No child set up on port {}, ignoring detachment.", port_number);
+            }
+        }
+    }
+
+    for (auto& child : m_children) {
+        if (child.device_descriptor().device_class == USB_CLASS_HUB) {
+            auto& hub_child = static_cast<Hub&>(child);
+            dbgln_if(USB_DEBUG, "USB Hub: Checking for port updates on child hub at address {}...", child.address());
+            hub_child.check_for_port_updates();
+        }
+    }
+}
+
+}

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -45,7 +45,7 @@ KResultOr<NonnullRefPtr<Hub>> Hub::try_create_from_device(Device const& device)
 }
 
 Hub::Hub(NonnullRefPtr<USBController> controller, DeviceSpeed device_speed, NonnullOwnPtr<Pipe> default_pipe)
-    : Device(move(controller), PortNumber::Port1, device_speed, move(default_pipe))
+    : Device(move(controller), 1 /* Port 1 */, device_speed, move(default_pipe))
 {
 }
 
@@ -260,8 +260,7 @@ void Hub::check_for_port_updates()
                 // FIXME: Check for high speed.
                 auto speed = port_status.status & PORT_STATUS_LOW_SPEED_DEVICE_ATTACHED ? USB::Device::DeviceSpeed::LowSpeed : USB::Device::DeviceSpeed::FullSpeed;
 
-                // FIXME: This only assumes two ports.
-                auto device_or_error = USB::Device::try_create(m_controller, port_number == 1 ? PortNumber::Port1 : PortNumber::Port2, speed);
+                auto device_or_error = USB::Device::try_create(m_controller, port_number, speed);
                 if (device_or_error.is_error()) {
                     dbgln("USB Hub: Failed to create device for port {}: {}", port_number, device_or_error.error());
                     return;
@@ -290,8 +289,7 @@ void Hub::check_for_port_updates()
 
                 Device* device_to_remove = nullptr;
                 for (auto& child : m_children) {
-                    // FIXME: This kinda sucks.
-                    if (port_number - 1 == (u8)child.port()) {
+                    if (port_number == child.port()) {
                         device_to_remove = &child;
                         break;
                     }

--- a/Kernel/Bus/USB/USBHub.h
+++ b/Kernel/Bus/USB/USBHub.h
@@ -102,6 +102,8 @@ private:
     USBHubDescriptor m_hub_descriptor;
 
     Device::List m_children;
+
+    void remove_children_from_sysfs();
 };
 
 }

--- a/Kernel/Bus/USB/USBHub.h
+++ b/Kernel/Bus/USB/USBHub.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/Types.h>
+#include <Kernel/Bus/USB/USBDevice.h>
+
+namespace Kernel::USB {
+
+// USB 2.0 Specification Page 421 Table 11-16
+enum HubRequest : u8 {
+    GET_STATUS = 0,
+    CLEAR_FEATURE = 1,
+    // 2 is reserved.
+    SET_FEATURE = 3,
+    // 4-5 are reserved.
+    GET_DESCRIPTOR = 6,
+    SET_DESCRIPTOR = 7,
+    CLEAR_TT_BUFFER = 8,
+    RESET_TT = 9,
+    GET_TT_STATE = 10,
+    STOP_TT = 11,
+};
+
+// USB 2.0 Specification Pages 421-422 Table 11-17
+enum HubFeatureSelector : u8 {
+    C_HUB_LOCAL_POWER = 0,
+    C_HUB_OVER_CURRENT = 1,
+    PORT_CONNECTION = 0,
+    PORT_ENABLE = 1,
+    PORT_SUSPEND = 2,
+    PORT_OVER_CURRENT = 3,
+    PORT_RESET = 4,
+    PORT_POWER = 8,
+    PORT_LOW_SPEED = 9,
+    C_PORT_CONNECTION = 16,
+    C_PORT_ENABLE = 17,
+    C_PORT_SUSPEND = 18,
+    C_PORT_OVER_CURRENT = 19,
+    C_PORT_RESET = 20,
+    PORT_TEST = 21,
+    PORT_INDICATOR = 22,
+};
+
+// USB 2.0 Specification Section 11.24.2.{6,7}
+// This is used to store both the hub status and port status, as they have the same layout.
+struct [[gnu::packed]] HubStatus {
+    u16 status { 0 };
+    u16 change { 0 };
+};
+static_assert(sizeof(HubStatus) == 4);
+
+static constexpr u16 HUB_STATUS_LOCAL_POWER_SOURCE = (1 << 0);
+static constexpr u16 HUB_STATUS_OVER_CURRENT = (1 << 1);
+
+static constexpr u16 HUB_STATUS_LOCAL_POWER_SOURCE_CHANGED = (1 << 0);
+static constexpr u16 HUB_STATUS_OVER_CURRENT_CHANGED = (1 << 1);
+
+static constexpr u16 PORT_STATUS_CURRENT_CONNECT_STATUS = (1 << 0);
+static constexpr u16 PORT_STATUS_PORT_ENABLED = (1 << 1);
+static constexpr u16 PORT_STATUS_SUSPEND = (1 << 2);
+static constexpr u16 PORT_STATUS_OVER_CURRENT = (1 << 3);
+static constexpr u16 PORT_STATUS_RESET = (1 << 4);
+static constexpr u16 PORT_STATUS_PORT_POWER = (1 << 8);
+static constexpr u16 PORT_STATUS_LOW_SPEED_DEVICE_ATTACHED = (1 << 9);
+static constexpr u16 PORT_STATUS_HIGH_SPEED_DEVICE_ATTACHED = (1 << 10);
+static constexpr u16 PORT_STATUS_PORT_STATUS_MODE = (1 << 11);
+static constexpr u16 PORT_STATUS_PORT_INDICATOR_CONTROL = (1 << 12);
+
+static constexpr u16 PORT_STATUS_CONNECT_STATUS_CHANGED = (1 << 0);
+static constexpr u16 PORT_STATUS_PORT_ENABLED_CHANGED = (1 << 1);
+static constexpr u16 PORT_STATUS_SUSPEND_CHANGED = (1 << 2);
+static constexpr u16 PORT_STATUS_OVER_CURRENT_INDICATOR_CHANGED = (1 << 3);
+static constexpr u16 PORT_STATUS_RESET_CHANGED = (1 << 4);
+
+class Hub : public Device {
+public:
+    static KResultOr<NonnullRefPtr<Hub>> try_create_root_hub(NonnullRefPtr<USBController>, DeviceSpeed);
+    static KResultOr<NonnullRefPtr<Hub>> try_create_from_device(Device const&);
+
+    // Root Hub constructor
+    Hub(NonnullRefPtr<USBController>, DeviceSpeed, NonnullOwnPtr<Pipe> default_pipe);
+    Hub(Device const&, NonnullOwnPtr<Pipe> default_pipe);
+    virtual ~Hub() override = default;
+
+    KResult enumerate_and_power_on_hub();
+
+    KResult get_port_status(u8, HubStatus&);
+    KResult clear_port_feature(u8, HubFeatureSelector);
+    KResult set_port_feature(u8, HubFeatureSelector);
+
+    KResult reset_port(u8);
+
+    void check_for_port_updates();
+
+private:
+    USBHubDescriptor m_hub_descriptor;
+
+    Device::List m_children;
+};
+
+}

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Singleton.h>
 #include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/USB/SysFSUSB.h>
 #include <Kernel/Bus/USB/UHCIController.h>
 #include <Kernel/Bus/USB/USBManagement.h>
 #include <Kernel/CommandLine.h>
@@ -14,6 +15,7 @@
 namespace Kernel::USB {
 
 static Singleton<USBManagement> s_the;
+READONLY_AFTER_INIT bool s_initialized_sys_fs_directory = false;
 
 UNMAP_AFTER_INIT USBManagement::USBManagement()
 {
@@ -64,6 +66,11 @@ bool USBManagement::initialized()
 
 UNMAP_AFTER_INIT void USBManagement::initialize()
 {
+    if (!s_initialized_sys_fs_directory) {
+        USB::SysFSUSBBusDirectory::initialize();
+        s_initialized_sys_fs_directory = true;
+    }
+
     s_the.ensure_instance();
 }
 

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -13,7 +13,7 @@ namespace Kernel::USB {
 
 KResultOr<NonnullOwnPtr<Pipe>> Pipe::try_create_pipe(USBController const& controller, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, i8 device_address, u8 poll_interval)
 {
-    auto pipe = adopt_own_if_nonnull(new (nothrow) Pipe(controller, type, direction, endpoint_address, max_packet_size, device_address, poll_interval));
+    auto pipe = adopt_own_if_nonnull(new (nothrow) Pipe(controller, type, direction, endpoint_address, max_packet_size, poll_interval, device_address));
     if (!pipe)
         return ENOMEM;
 

--- a/Kernel/Bus/USB/USBRequest.h
+++ b/Kernel/Bus/USB/USBRequest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,18 +10,21 @@
 #include <AK/Types.h>
 
 //
-// USB Request directions
+// bmRequestType fields
 //
-// As per Section 9.4 of the USB Specification, it is noted that Requeset Types that
-// Device to Host have bit 7 of `bmRequestType` set. These are here as a convenience,
-// as we construct the request at the call-site to make reading transfers easier.
+// As per Section 9.3 of the USB 2.0 Specification.
+// Note that while some of these values are zero, there are here for convenience.
+// This is because it makes reading the request type easier to read when constructing a USB request.
 //
-static constexpr u8 USB_DEVICE_REQUEST_DEVICE_TO_HOST = 0x80;
-static constexpr u8 USB_DEVICE_REQUEST_HOST_TO_DEVICE = 0x00;
-static constexpr u8 USB_INTERFACE_REQUEST_DEVICE_TO_HOST = 0x81;
-static constexpr u8 USB_INTERFACE_REQUEST_HOST_TO_DEVICE = 0x01;
-static constexpr u8 USB_ENDPOINT_REQUEST_DEVICE_TO_HOST = 0x82;
-static constexpr u8 USB_ENDPOINT_REQUEST_HOST_TO_DEVICE = 0x02;
+static constexpr u8 USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST = 0x80;
+static constexpr u8 USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE = 0x00;
+static constexpr u8 USB_REQUEST_TYPE_STANDARD = 0x00;
+static constexpr u8 USB_REQUEST_TYPE_CLASS = 0x20;
+static constexpr u8 USB_REQUEST_TYPE_VENDOR = 0x40;
+static constexpr u8 USB_REQUEST_RECIPIENT_DEVICE = 0x00;
+static constexpr u8 USB_REQUEST_RECIPIENT_INTERFACE = 0x01;
+static constexpr u8 USB_REQUEST_RECIPIENT_ENDPOINT = 0x02;
+static constexpr u8 USB_REQUEST_RECIPIENT_OTHER = 0x03;
 
 //
 // Standard USB request types

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -23,7 +23,7 @@ public:
 
 public:
     Transfer() = delete;
-    Transfer(Pipe& pipe, u16 len, Memory::AnonymousVMObject&);
+    Transfer(Pipe& pipe, u16 len, NonnullOwnPtr<Memory::Region>);
     ~Transfer();
 
     void set_setup_packet(const USBRequestData& request);
@@ -41,11 +41,11 @@ public:
     bool error_occurred() const { return m_error_occurred; }
 
 private:
-    Pipe& m_pipe;                         // Pipe that initiated this transfer
-    USBRequestData m_request;             // USB request
-    OwnPtr<Memory::Region> m_data_buffer; // DMA Data buffer for transaction
-    u16 m_transfer_data_size { 0 };       // Size of the transfer's data stage
-    bool m_complete { false };            // Has this transfer been completed?
-    bool m_error_occurred { false };      // Did an error occur during this transfer?
+    Pipe& m_pipe;                                // Pipe that initiated this transfer
+    USBRequestData m_request;                    // USB request
+    NonnullOwnPtr<Memory::Region> m_data_buffer; // DMA Data buffer for transaction
+    u16 m_transfer_data_size { 0 };              // Size of the transfer's data stage
+    bool m_complete { false };                   // Has this transfer been completed?
+    bool m_error_occurred { false };             // Did an error occur during this transfer?
 };
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -32,8 +32,10 @@ set(KERNEL_SOURCES
     Bus/PCI/Initializer.cpp
     Bus/PCI/WindowedMMIOAccess.cpp
     Bus/USB/UHCIController.cpp
+    Bus/USB/UHCIRootHub.cpp
     Bus/USB/USBController.cpp
     Bus/USB/USBDevice.cpp
+    Bus/USB/USBHub.cpp
     Bus/USB/USBManagement.cpp
     Bus/USB/USBPipe.cpp
     Bus/USB/USBTransfer.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -31,6 +31,7 @@ set(KERNEL_SOURCES
     Bus/PCI/MMIOAccess.cpp
     Bus/PCI/Initializer.cpp
     Bus/PCI/WindowedMMIOAccess.cpp
+    Bus/USB/SysFSUSB.cpp
     Bus/USB/UHCIController.cpp
     Bus/USB/UHCIRootHub.cpp
     Bus/USB/USBController.cpp


### PR DESCRIPTION
Here it is in action:

https://user-images.githubusercontent.com/25595356/129425962-bb6e9933-7e66-447d-aa56-66dbf6544e9b.mp4

QEMU UHCI only has 2 ports on its root hub, so it automatically attaches a hub with the device attached to it.

Currently, this is only done via polling every second instead of using the status change interrupt endpoint that every hub is required to have.
With this, we can implement the root hub as if it was a physical hub plugged into a USB port. This is because the USB specification requires the root hub to act like a normal hub.
This means that for each new controller, only a new root hub is required to be implemented that correctly responds to the hub requests.

Additionally, this refactors the USB SysFS to not be tied to the UHCI controller. This allows us to access it from the USB hub code, allowing it to work for any controller and any hub that is attached.

cc @Quaker762 
