### PR TITLE
Ports: More build fixes

### DIFF
--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -9,4 +9,5 @@ auth_type="sha256"
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install
     run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.so -Wl,-soname,libiconv.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.a -Wl,--no-whole-archive
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.la
 }

--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -4,7 +4,7 @@ useconfigure="true"
 version="2.9.12"
 files="ftp://xmlsoft.org/libxml2/libxml2-${version}.tar.gz libxml2-${version}.tar.gz c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
 auth_type=sha256
-depends="libiconv"
+depends="libiconv xz"
 configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local --without-python"
 
 install() {
@@ -12,5 +12,5 @@ install() {
     run make install
 
     # Link shared library
-    run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.so -Wl,-soname,libxml2.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.a -Wl,--no-whole-archive
+    run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.so -Wl,-soname,libxml2.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.a -Wl,--no-whole-archive -llzma
 }

--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -13,4 +13,5 @@ install() {
 
     # Link shared library
     run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.so -Wl,-soname,libxml2.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.a -Wl,--no-whole-archive -llzma
+    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.la
 }

--- a/Ports/nano/patches/fnmatch.patch
+++ b/Ports/nano/patches/fnmatch.patch
@@ -1,0 +1,14 @@
+diff -Naur nano-5.8/lib/fnmatch_loop.c nano-5.8.serenity/lib/fnmatch_loop.c
+--- nano-5.8/lib/fnmatch_loop.c	2020-06-26 21:57:10.000000000 +0200
++++ nano-5.8.serenity/lib/fnmatch_loop.c	2021-05-08 05:06:59.944736766 +0200
+@@ -19,6 +19,10 @@
+ # include <stdint.h>
+ #endif
+ 
++#ifdef __serenity__
++# define FNM_EXTMATCH 9000
++#endif
++
+ struct STRUCT
+ {
+   const CHAR *pattern;

--- a/Ports/wget/patches/fnmatch.patch
+++ b/Ports/wget/patches/fnmatch.patch
@@ -1,0 +1,14 @@
+diff -Naur wget-1.21.1/lib/fnmatch_loop.c wget-1.21.1.serenity/lib/fnmatch_loop.c
+--- wget-1.21.1/lib/fnmatch_loop.c	2020-06-26 21:57:10.000000000 +0200
++++ wget-1.21.1.serenity/lib/fnmatch_loop.c	2021-05-08 05:06:59.944736766 +0200
+@@ -19,6 +19,10 @@
+ # include <stdint.h>
+ #endif
+ 
++#ifdef __serenity__
++# define FNM_EXTMATCH 9000
++#endif
++
+ struct STRUCT
+ {
+   const CHAR *pattern;


### PR DESCRIPTION
**Ports: Make sure to remove the .la file after building libiconv**

Otherwise libtool gets confused and tries to link against files that don't exist.

**Ports: Add missing dependency for libxml2**

When xz was previously built we'd end up with a shared library for libxml2 that depends on xz features but isn't linked against liblzma.

**Ports: Make sure to remove the .la file after building libxml2**

Otherwise libtool gets confused and tries to link against files that don't exist.

**Ports: Fix building the nano port**

**Ports: Fix building the wget port**