### PR TITLE
HackStudio: Fixes to my 'Save as...' feature

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -653,7 +653,14 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
         }
 
         String const relative_file_path = LexicalPath::relative_path(save_path.value(), m_project->root_path());
-        current_editor_wrapper().set_filename(relative_file_path);
+        if (current_editor_wrapper().filename().is_null()) {
+            current_editor_wrapper().set_filename(relative_file_path);
+        } else {
+            for (auto& editor_wrapper : m_all_editor_wrappers) {
+                if (editor_wrapper.filename() == old_filename)
+                    editor_wrapper.set_filename(relative_file_path);
+            }
+        }
         current_editor_wrapper().save();
 
         auto new_project_file = m_project->get_file(relative_file_path);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -652,12 +652,13 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
             return;
         }
 
-        current_editor_wrapper().set_filename(save_path.value());
+        String const relative_file_path = LexicalPath::relative_path(save_path.value(), m_project->root_path());
+        current_editor_wrapper().set_filename(relative_file_path);
         current_editor_wrapper().save();
 
-        auto new_project_file = m_project->get_file(save_path.value());
-        m_open_files.set(save_path.value(), *new_project_file);
-        m_open_files_vector.append(save_path.value());
+        auto new_project_file = m_project->get_file(relative_file_path);
+        m_open_files.set(relative_file_path, *new_project_file);
+        m_open_files_vector.append(relative_file_path);
 
         update_window_title();
     });


### PR DESCRIPTION
When I was adding the 'Save as...' feature in #9360, I was too excited it started working that I didn't really test it as much and opened that PR right away (ughhh).
For now, that's the current list of fixes I'm pretty certain of.

---

- **HackStudio: Convert selected path to a relative path on 'Save as...'**

  This makes the editor title a bit more consistent with the other files and removes duplicating the file name in the file history when reopening that file.

- **HackStudio: Update every editor with matching filename on 'Save as...'**

  Prior this change, if user had more than two copies of one file opened in a split view, then only the active editor was renamed, when the others had the same file contents changed.

  This change will set a new file name for every file.

  The `is_null()` check is for uncreated files, as they shouldn't be treated as the same single file.