### PR TITLE
AK: Add OOM safe interface to HashTable/Map

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -57,6 +57,9 @@ public:
 
     HashSetResult set(const K& key, const V& value) { return m_table.set({ key, value }); }
     HashSetResult set(const K& key, V&& value) { return m_table.set({ key, move(value) }); }
+    HashSetResult try_set(const K& key, const V& value) { return m_table.try_set({ key, value }); }
+    HashSetResult try_set(const K& key, V&& value) { return m_table.try_set({ key, move(value) }); }
+
     bool remove(const K& key)
     {
         auto it = find(key);
@@ -96,6 +99,7 @@ public:
     }
 
     void ensure_capacity(size_t capacity) { m_table.ensure_capacity(capacity); }
+    bool try_ensure_capacity(size_t capacity) { return m_table.try_ensure_capacity(capacity); }
 
     Optional<typename Traits<V>::PeekType> get(const K& key) const requires(!IsPointer<typename Traits<V>::PeekType>)
     {

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -378,7 +378,7 @@ private:
         }
     }
 
-    [[nodiscard]] static size_t size_in_bytes(size_t capacity)
+    [[nodiscard]] static constexpr size_t size_in_bytes(size_t capacity)
     {
         if constexpr (IsOrdered) {
             return sizeof(BucketType) * capacity;


### PR DESCRIPTION
Work towards OOM safety in the Kernel.

This adds a new HashSetResult only returned by try_set, to signal
allocation failure during setting.