### PR TITLE
LibCore: Properly calculate the fire time of `EventLoopTimer`, so it is normalized

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -703,9 +703,7 @@ bool EventLoopTimer::has_expired(const timeval& now) const
 
 void EventLoopTimer::reload(const timeval& now)
 {
-    fire_time = now;
-    fire_time.tv_sec += interval / 1000;
-    fire_time.tv_usec += (interval % 1000) * 1000;
+    timeval_add(now, { interval / 1000, (interval % 1000) * 1000 }, fire_time);
 }
 
 Optional<struct timeval> EventLoop::get_next_timer_expiration()


### PR DESCRIPTION
Normalized means that the finer time unit (microseconds in this case)
does not exceed a full coarse unit (seconds in this case).

In Serenity's kernel, this is not currently an issue, as there is no checks for non-normalized `timespec`s and `timeval`s -- however on Lagom, this proves to be an issue as Linux kernels do check this. An example of this failing in practice is the `select` call inside of `wait_for_event`, which fails with `EINVAL` because of the non-normalized timeout.

Our kernel allowing non-normalized time is an issue of it's own, but that will require some test rewriting as a lot of them actually use these non-normalized times, which shouldn't be expected nor supported :^)