### PR TITLE
Kernel/PCI: Assign a PCI address in the SysFS PCI device directories

### DIFF
--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -374,7 +374,8 @@ UNMAP_AFTER_INIT NonnullRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory:
 }
 
 UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(const SysFSDirectory& parent_directory, Address address)
-    : SysFSDirectory(String::formatted("{:04x}:{:04x}:{:02x}.{}", address.seg(), address.bus(), address.device(), address.function()), parent_directory)
+    : SysFSDirectory(String::formatted("{:04x}:{:02x}:{:02x}.{}", address.seg(), address.bus(), address.device(), address.function()), parent_directory)
+    , m_address(address)
 {
     m_components.append(PCIDeviceAttributeSysFSComponent::create("vendor", *this, PCI_VENDOR_ID, 2));
     m_components.append(PCIDeviceAttributeSysFSComponent::create("device_id", *this, PCI_DEVICE_ID, 2));


### PR DESCRIPTION
This is a bug that went unnoticed for a long time, so the exposed values
in SysFS PCI device directories were incorrect because the assigned PCI
address was simply the host bridge always.

Also, the bus typing should really be two hexadecimal digits and not 4
digits.