### PR TITLE
Kernel: Process goodies

### DIFF
--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -16,6 +16,7 @@
 #ifdef KERNEL
 #    include <Kernel/Arch/x86/Processor.h>
 #    include <Kernel/Arch/x86/ScopedCritical.h>
+#    include <Kernel/KResult.h>
 #endif
 
 namespace AK {
@@ -498,9 +499,24 @@ inline RefPtr<T> try_create(Args&&... args)
     return adopt_ref_if_nonnull(new (nothrow) T { forward<Args>(args)... });
 }
 
+#ifdef KERNEL
+template<typename T>
+inline Kernel::KResultOr<NonnullRefPtr<T>> adopt_nonnull_ref_or_enomem(T* object)
+{
+    auto result = adopt_ref_if_nonnull(object);
+    if (!result)
+        return ENOMEM;
+    return result.release_nonnull();
+}
+#endif
+
 }
 
 using AK::adopt_ref_if_nonnull;
 using AK::RefPtr;
 using AK::static_ptr_cast;
 using AK::try_create;
+
+#ifdef KERNEL
+using AK::adopt_nonnull_ref_or_enomem;
+#endif

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -179,6 +179,7 @@ set(KERNEL_SOURCES
     ProcessExposed.cpp
     ProcessSpecificExposed.cpp
     ProcessGroup.cpp
+    ProcessProcFSTraits.cpp
     RTC.cpp
     Random.cpp
     Scheduler.cpp

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -274,13 +274,15 @@ InodeMetadata ProcFSProcessDirectoryInode::metadata() const
     auto process = Process::from_pid(associated_pid());
     if (!process)
         return {};
+
+    auto traits = process->procfs_traits();
     InodeMetadata metadata;
-    metadata.inode = { fsid(), process->component_index() };
-    metadata.mode = S_IFDIR | process->required_mode();
-    metadata.uid = process->owner_user();
-    metadata.gid = process->owner_group();
+    metadata.inode = { fsid(), traits->component_index() };
+    metadata.mode = S_IFDIR | traits->required_mode();
+    metadata.uid = traits->owner_user();
+    metadata.gid = traits->owner_group();
     metadata.size = 0;
-    metadata.mtime = process->modified_time();
+    metadata.mtime = traits->modified_time();
     return metadata;
 }
 
@@ -295,7 +297,7 @@ KResult ProcFSProcessDirectoryInode::traverse_as_directory(Function<bool(FileSys
     auto process = Process::from_pid(associated_pid());
     if (!process)
         return EINVAL;
-    return process->traverse_as_directory(procfs().fsid(), move(callback));
+    return process->procfs_traits()->traverse_as_directory(procfs().fsid(), move(callback));
 }
 
 KResultOr<NonnullRefPtr<Inode>> ProcFSProcessDirectoryInode::lookup(StringView name)
@@ -400,13 +402,15 @@ InodeMetadata ProcFSProcessSubDirectoryInode::metadata() const
     auto process = Process::from_pid(associated_pid());
     if (!process)
         return {};
+
+    auto traits = process->procfs_traits();
     InodeMetadata metadata;
-    metadata.inode = { fsid(), process->component_index() };
-    metadata.mode = S_IFDIR | process->required_mode();
-    metadata.uid = process->owner_user();
-    metadata.gid = process->owner_group();
+    metadata.inode = { fsid(), traits->component_index() };
+    metadata.mode = S_IFDIR | traits->required_mode();
+    metadata.uid = traits->owner_user();
+    metadata.gid = traits->owner_group();
     metadata.size = 0;
-    metadata.mtime = process->modified_time();
+    metadata.mtime = traits->modified_time();
     return metadata;
 }
 
@@ -522,13 +526,15 @@ InodeMetadata ProcFSProcessPropertyInode::metadata() const
     auto process = Process::from_pid(associated_pid());
     if (!process)
         return {};
+
+    auto traits = process->procfs_traits();
     InodeMetadata metadata;
-    metadata.inode = { fsid(), process->component_index() };
+    metadata.inode = { fsid(), traits->component_index() };
     metadata.mode = determine_procfs_process_inode_mode(m_parent_sub_directory_type, m_possible_data.property_type);
-    metadata.uid = process->owner_user();
-    metadata.gid = process->owner_group();
+    metadata.uid = traits->owner_user();
+    metadata.gid = traits->owner_group();
     metadata.size = 0;
-    metadata.mtime = process->modified_time();
+    metadata.mtime = traits->modified_time();
     return metadata;
 }
 KResult ProcFSProcessPropertyInode::traverse_as_directory(Function<bool(FileSystem::DirectoryEntryView const&)>) const

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -28,7 +28,7 @@ class ProcFS final : public FileSystem {
 
 public:
     virtual ~ProcFS() override;
-    static RefPtr<ProcFS> create();
+    static KResultOr<NonnullRefPtr<ProcFS>> try_create();
 
     virtual KResult initialize() override;
     virtual StringView class_name() const override { return "ProcFS"sv; }
@@ -38,7 +38,7 @@ public:
 private:
     ProcFS();
 
-    NonnullRefPtr<ProcFSDirectoryInode> m_root_inode;
+    RefPtr<ProcFSDirectoryInode> m_root_inode;
 };
 
 class ProcFSInode : public Inode {
@@ -69,7 +69,7 @@ class ProcFSGlobalInode : public ProcFSInode {
     friend class ProcFS;
 
 public:
-    static NonnullRefPtr<ProcFSGlobalInode> create(const ProcFS&, const ProcFSExposedComponent&);
+    static KResultOr<NonnullRefPtr<ProcFSGlobalInode>> try_create(const ProcFS&, const ProcFSExposedComponent&);
     virtual ~ProcFSGlobalInode() override {};
     StringView name() const;
 
@@ -92,7 +92,7 @@ class ProcFSLinkInode : public ProcFSGlobalInode {
     friend class ProcFS;
 
 public:
-    static NonnullRefPtr<ProcFSLinkInode> create(const ProcFS&, const ProcFSExposedComponent&);
+    static KResultOr<NonnullRefPtr<ProcFSLinkInode>> try_create(const ProcFS&, const ProcFSExposedComponent&);
 
 protected:
     ProcFSLinkInode(const ProcFS&, const ProcFSExposedComponent&);
@@ -103,7 +103,7 @@ class ProcFSDirectoryInode final : public ProcFSGlobalInode {
     friend class ProcFS;
 
 public:
-    static NonnullRefPtr<ProcFSDirectoryInode> create(const ProcFS&, const ProcFSExposedComponent&);
+    static KResultOr<NonnullRefPtr<ProcFSDirectoryInode>> try_create(const ProcFS&, const ProcFSExposedComponent&);
     virtual ~ProcFSDirectoryInode() override;
 
 protected:
@@ -132,7 +132,7 @@ class ProcFSProcessDirectoryInode final : public ProcFSProcessAssociatedInode {
     friend class ProcFS;
 
 public:
-    static NonnullRefPtr<ProcFSProcessDirectoryInode> create(const ProcFS&, ProcessID);
+    static KResultOr<NonnullRefPtr<ProcFSProcessDirectoryInode>> try_create(const ProcFS&, ProcessID);
 
 private:
     ProcFSProcessDirectoryInode(const ProcFS&, ProcessID);
@@ -149,7 +149,7 @@ class ProcFSProcessSubDirectoryInode final : public ProcFSProcessAssociatedInode
     friend class ProcFS;
 
 public:
-    static NonnullRefPtr<ProcFSProcessSubDirectoryInode> create(const ProcFS&, SegmentedProcFSIndex::ProcessSubDirectory, ProcessID);
+    static KResultOr<NonnullRefPtr<ProcFSProcessSubDirectoryInode>> try_create(const ProcFS&, SegmentedProcFSIndex::ProcessSubDirectory, ProcessID);
 
 private:
     ProcFSProcessSubDirectoryInode(const ProcFS&, SegmentedProcFSIndex::ProcessSubDirectory, ProcessID);
@@ -168,9 +168,9 @@ class ProcFSProcessPropertyInode final : public ProcFSProcessAssociatedInode {
     friend class ProcFS;
 
 public:
-    static NonnullRefPtr<ProcFSProcessPropertyInode> create_for_file_description_link(const ProcFS&, unsigned, ProcessID);
-    static NonnullRefPtr<ProcFSProcessPropertyInode> create_for_thread_stack(const ProcFS&, ThreadID, ProcessID);
-    static NonnullRefPtr<ProcFSProcessPropertyInode> create_for_pid_property(const ProcFS&, SegmentedProcFSIndex::MainProcessProperty, ProcessID);
+    static KResultOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_file_description_link(const ProcFS&, unsigned, ProcessID);
+    static KResultOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_thread_stack(const ProcFS&, ThreadID, ProcessID);
+    static KResultOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_pid_property(const ProcFS&, SegmentedProcFSIndex::MainProcessProperty, ProcessID);
 
 private:
     ProcFSProcessPropertyInode(const ProcFS&, SegmentedProcFSIndex::MainProcessProperty, ProcessID);

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -944,8 +944,9 @@ KResultOr<NonnullRefPtr<ProcFSExposedComponent>> ProcFSRootDirectory::lookup(Str
     auto actual_pid = pid.value();
 
     auto maybe_process = Process::from_pid(actual_pid);
-    if (maybe_process)
-        return maybe_process.release_nonnull();
+    if (maybe_process) {
+        return maybe_process->procfs_traits();
+    }
     return ENOENT;
 }
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -260,6 +260,11 @@ Process::Process(const String& name, uid_t uid, gid_t gid, ProcessID ppid, bool 
     m_protected_values.suid = uid;
     m_protected_values.sgid = gid;
 
+    auto maybe_procfs_traits = ProcessProcFSTraits::try_create({}, make_weak_ptr());
+    // NOTE: This can fail, but it should be very, *very* rare.
+    VERIFY(!maybe_procfs_traits.is_error());
+    m_procfs_traits = maybe_procfs_traits.release_value();
+
     dbgln_if(PROCESS_DEBUG, "Created new process {}({})", m_name, this->pid().value());
 }
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -85,7 +85,7 @@ typedef HashMap<FlatPtr, RefPtr<FutexQueue>> FutexQueues;
 struct LoadResult;
 
 class Process
-    : public RefCounted<Process>
+    : public AK::RefCountedBase
     , public Weakable<Process> {
 
     class ProtectedValues {
@@ -175,6 +175,8 @@ public:
     static RefPtr<Process> create_kernel_process(RefPtr<Thread>& first_thread, String&& name, void (*entry)(void*), void* entry_data = nullptr, u32 affinity = THREAD_AFFINITY_DEFAULT, RegisterProcess do_register = RegisterProcess::Yes);
     static RefPtr<Process> create_user_process(RefPtr<Thread>& first_thread, const String& path, uid_t, gid_t, ProcessID ppid, int& error, Vector<String>&& arguments = Vector<String>(), Vector<String>&& environment = Vector<String>(), TTY* = nullptr);
     static void register_new(Process&);
+
+    bool unref() const;
     ~Process();
 
     static NonnullRefPtrVector<Process> all_processes();

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -84,7 +84,7 @@ typedef HashMap<FlatPtr, RefPtr<FutexQueue>> FutexQueues;
 
 struct LoadResult;
 
-class Process
+class Process final
     : public AK::RefCountedBase
     , public Weakable<Process> {
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -551,7 +551,7 @@ private:
 public:
     // ^ProcFSExposedComponent stats
     virtual InodeIndex component_index() const override;
-    virtual NonnullRefPtr<Inode> to_inode(const ProcFS& procfs_instance) const override;
+    virtual KResultOr<NonnullRefPtr<Inode>> to_inode(const ProcFS& procfs_instance) const override;
     virtual KResult traverse_as_directory(unsigned, Function<bool(FileSystem::DirectoryEntryView const&)>) const override;
     virtual mode_t required_mode() const override { return 0555; }
     virtual uid_t owner_user() const override { return uid(); }
@@ -567,10 +567,10 @@ public:
     mode_t binary_link_required_mode() const;
     KResultOr<size_t> procfs_get_thread_stack(ThreadID thread_id, KBufferBuilder& builder) const;
     KResult traverse_stacks_directory(unsigned fsid, Function<bool(FileSystem::DirectoryEntryView const&)> callback) const;
-    RefPtr<Inode> lookup_stacks_directory(const ProcFS&, StringView name) const;
+    KResultOr<NonnullRefPtr<Inode>> lookup_stacks_directory(const ProcFS&, StringView name) const;
     KResultOr<size_t> procfs_get_file_description_link(unsigned fd, KBufferBuilder& builder) const;
     KResult traverse_file_descriptions_directory(unsigned fsid, Function<bool(FileSystem::DirectoryEntryView const&)> callback) const;
-    RefPtr<Inode> lookup_file_descriptions_directory(const ProcFS&, StringView name) const;
+    KResultOr<NonnullRefPtr<Inode>> lookup_file_descriptions_directory(const ProcFS&, StringView name) const;
 
 private:
     inline PerformanceEventBuffer* current_perf_events_buffer()

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -170,19 +170,31 @@ KResultOr<size_t> ProcFSExposedLink::read_bytes(off_t offset, size_t count, User
     return nread;
 }
 
-NonnullRefPtr<Inode> ProcFSExposedLink::to_inode(const ProcFS& procfs_instance) const
+KResultOr<NonnullRefPtr<Inode>> ProcFSExposedLink::to_inode(const ProcFS& procfs_instance) const
 {
-    return ProcFSLinkInode::create(procfs_instance, *this);
+    auto maybe_inode = ProcFSLinkInode::try_create(procfs_instance, *this);
+    if (maybe_inode.is_error())
+        return maybe_inode.error();
+
+    return maybe_inode.release_value();
 }
 
-NonnullRefPtr<Inode> ProcFSExposedComponent::to_inode(const ProcFS& procfs_instance) const
+KResultOr<NonnullRefPtr<Inode>> ProcFSExposedComponent::to_inode(const ProcFS& procfs_instance) const
 {
-    return ProcFSGlobalInode::create(procfs_instance, *this);
+    auto maybe_inode = ProcFSGlobalInode::try_create(procfs_instance, *this);
+    if (maybe_inode.is_error())
+        return maybe_inode.error();
+
+    return maybe_inode.release_value();
 }
 
-NonnullRefPtr<Inode> ProcFSExposedDirectory::to_inode(const ProcFS& procfs_instance) const
+KResultOr<NonnullRefPtr<Inode>> ProcFSExposedDirectory::to_inode(const ProcFS& procfs_instance) const
 {
-    return ProcFSDirectoryInode::create(procfs_instance, *this);
+    auto maybe_inode = ProcFSDirectoryInode::try_create(procfs_instance, *this);
+    if (maybe_inode.is_error())
+        return maybe_inode.error();
+
+    return maybe_inode.release_value();
 }
 
 void ProcFSExposedDirectory::add_component(const ProcFSExposedComponent&)
@@ -190,14 +202,14 @@ void ProcFSExposedDirectory::add_component(const ProcFSExposedComponent&)
     TODO();
 }
 
-RefPtr<ProcFSExposedComponent> ProcFSExposedDirectory::lookup(StringView name)
+KResultOr<NonnullRefPtr<ProcFSExposedComponent>> ProcFSExposedDirectory::lookup(StringView name)
 {
     for (auto& component : m_components) {
         if (component.name() == name) {
             return component;
         }
     }
-    return {};
+    return ENOENT;
 }
 
 KResult ProcFSExposedDirectory::traverse_as_directory(unsigned fsid, Function<bool(FileSystem::DirectoryEntryView const&)> callback) const

--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -69,7 +69,7 @@ public:
     StringView name() const { return m_name->view(); }
     virtual KResultOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, FileDescription*) const { VERIFY_NOT_REACHED(); }
     virtual KResult traverse_as_directory(unsigned, Function<bool(FileSystem::DirectoryEntryView const&)>) const { VERIFY_NOT_REACHED(); }
-    virtual RefPtr<ProcFSExposedComponent> lookup(StringView) { VERIFY_NOT_REACHED(); };
+    virtual KResultOr<NonnullRefPtr<ProcFSExposedComponent>> lookup(StringView) { VERIFY_NOT_REACHED(); };
     virtual KResultOr<size_t> write_bytes(off_t, size_t, const UserOrKernelBuffer&, FileDescription*) { return KResult(EROFS); }
     virtual size_t size() const { return 0; }
 
@@ -84,7 +84,7 @@ public:
         return KSuccess;
     }
 
-    virtual NonnullRefPtr<Inode> to_inode(const ProcFS& procfs_instance) const;
+    virtual KResultOr<NonnullRefPtr<Inode>> to_inode(const ProcFS& procfs_instance) const;
 
     virtual InodeIndex component_index() const { return m_component_index; }
 
@@ -106,7 +106,7 @@ class ProcFSExposedDirectory
 
 public:
     virtual KResult traverse_as_directory(unsigned, Function<bool(FileSystem::DirectoryEntryView const&)>) const override;
-    virtual RefPtr<ProcFSExposedComponent> lookup(StringView name) override;
+    virtual KResultOr<NonnullRefPtr<ProcFSExposedComponent>> lookup(StringView name) override;
     void add_component(const ProcFSExposedComponent&);
 
     virtual void prepare_for_deletion() override
@@ -117,7 +117,7 @@ public:
     }
     virtual mode_t required_mode() const override { return 0555; }
 
-    virtual NonnullRefPtr<Inode> to_inode(const ProcFS& procfs_instance) const override final;
+    virtual KResultOr<NonnullRefPtr<Inode>> to_inode(const ProcFS& procfs_instance) const override final;
 
 protected:
     explicit ProcFSExposedDirectory(StringView name);
@@ -128,7 +128,7 @@ protected:
 
 class ProcFSExposedLink : public ProcFSExposedComponent {
 public:
-    virtual NonnullRefPtr<Inode> to_inode(const ProcFS& procfs_instance) const override final;
+    virtual KResultOr<NonnullRefPtr<Inode>> to_inode(const ProcFS& procfs_instance) const override final;
 
     virtual KResultOr<size_t> read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, FileDescription* description) const override;
 
@@ -142,7 +142,7 @@ class ProcFSRootDirectory final : public ProcFSExposedDirectory {
     friend class ProcFSComponentRegistry;
 
 public:
-    virtual RefPtr<ProcFSExposedComponent> lookup(StringView name) override;
+    virtual KResultOr<NonnullRefPtr<ProcFSExposedComponent>> lookup(StringView name) override;
     static NonnullRefPtr<ProcFSRootDirectory> must_create();
     virtual ~ProcFSRootDirectory();
 

--- a/Kernel/ProcessProcFSTraits.cpp
+++ b/Kernel/ProcessProcFSTraits.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/ProcFS.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+uid_t Process::ProcessProcFSTraits::owner_user() const
+{
+    auto process = m_process.strong_ref();
+    if (!process)
+        return 0;
+
+    return process->uid();
+}
+
+gid_t Process::ProcessProcFSTraits::owner_group() const
+{
+    auto process = m_process.strong_ref();
+    if (!process)
+        return 0;
+
+    return process->gid();
+}
+
+InodeIndex Process::ProcessProcFSTraits::component_index() const
+{
+    auto process = m_process.strong_ref();
+    if (!process)
+        return {};
+
+    return SegmentedProcFSIndex::build_segmented_index_for_pid_directory(process->pid());
+}
+
+KResultOr<NonnullRefPtr<Inode>> Process::ProcessProcFSTraits::to_inode(const ProcFS& procfs_instance) const
+{
+    auto process = m_process.strong_ref();
+    if (!process)
+        return ESRCH;
+
+    auto maybe_inode = ProcFSProcessDirectoryInode::try_create(procfs_instance, process->pid());
+    if (maybe_inode.is_error())
+        return maybe_inode.error();
+    return maybe_inode.release_value();
+}
+
+KResult Process::ProcessProcFSTraits::traverse_as_directory(unsigned fsid, Function<bool(FileSystem::DirectoryEntryView const&)> callback) const
+{
+    auto process = m_process.strong_ref();
+    if (!process)
+        return ESRCH;
+
+    callback({ ".", { fsid, SegmentedProcFSIndex::build_segmented_index_for_pid_directory(process->pid()) }, 0 });
+    callback({ "..", { fsid, ProcFSComponentRegistry::the().root_directory().component_index() }, 0 });
+    callback({ "fd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::FileDescriptions) }, 0 });
+    callback({ "stacks", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::Stacks) }, 0 });
+    callback({ "unveil", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Unveil) }, 0 });
+    callback({ "pledge", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Pledge) }, 0 });
+    callback({ "fds", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::FileDescriptions) }, 0 });
+    callback({ "exe", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::BinaryLink) }, 0 });
+    callback({ "cwd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::CurrentWorkDirectoryLink) }, 0 });
+    callback({ "perf_events", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::PerformanceEvents) }, 0 });
+    callback({ "vm", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::VirtualMemoryStats) }, 0 });
+    callback({ "root", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::RootLink) }, 0 });
+    return KSuccess;
+}
+
+}

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -90,7 +90,10 @@ KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*>
 
         fs = Plan9FS::create(*description);
     } else if (fs_type == "proc"sv || fs_type == "ProcFS"sv) {
-        fs = ProcFS::create();
+        auto maybe_fs = ProcFS::try_create();
+        if (maybe_fs.is_error())
+            return maybe_fs.error();
+        fs = maybe_fs.release_value();
     } else if (fs_type == "devpts"sv || fs_type == "DevPtsFS"sv) {
         fs = DevPtsFS::create();
     } else if (fs_type == "dev"sv || fs_type == "DevFS"sv) {


### PR DESCRIPTION
The most important change here is the move to a custom `unref` implementation, which will reduce the time between a process starting to destruct and the process removing itself from the process list to 0.

**AK: Add adopt_nonnull_ref_or_enomem**

This gets rid of the `ENOMEM` boilerplate for handling memory allocation
failures in the kernel.

**Kernel: Handle allocation failure in ProcFS and friends**

There were many places in which allocation failure was noticed but
ignored.

**Kernel: Move ProcFS related overrides in Process to ProcessProcFSTraits**

This allows us to 1) let go of the Process when an inode is ref'ing for
ProcFSExposedComponent related reasons, and 2) change our ref/unref
implementation.

**Kernel: Handle removal of Process from list before unref**

This makes the following scenario impossible with an SMP setup:

1) CPU A enters unref() and decrements the link count to 0.
2) CPU B sees the process in the process list and ref()s it.
3) CPU A removes the process from the list and continues destructing.
4) CPU B is now holding a destructed Process object.

By holding the process list lock before doing anything with it, we
ensure that other CPUs can't find this process in the middle of it being
destructed.

**Kernel: Make Process final**

This silences a clangd diagnostic about Process holding virtual
functions but having a non-virtual destructor.
