### PR TITLE
HackStudio: Added language detection based on filename

### DIFF
--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -22,8 +22,17 @@ CodeDocument::CodeDocument(const String& file_path, Client* client)
     : TextDocument(client)
     , m_file_path(file_path)
 {
-    m_language = language_from_file_extension(LexicalPath::extension(file_path));
-    m_language_name = language_name_from_file_extension(LexicalPath::extension(file_path));
+    // Check base name before extension to catch files like CMakeLists.txt
+    m_language = language_from_file_name(LexicalPath::basename(file_path));
+    if(m_language != Language::Unknown)
+    {
+        m_language_name = language_name_from_file_name(LexicalPath::basename(file_path));
+    }
+    else
+    {
+        m_language = language_from_file_extension(LexicalPath::extension(file_path));
+        m_language_name = language_name_from_file_extension(LexicalPath::extension(file_path));
+    }
 }
 
 CodeDocument::CodeDocument(Client* client)

--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -24,12 +24,9 @@ CodeDocument::CodeDocument(const String& file_path, Client* client)
 {
     // Check base name before extension to catch files like CMakeLists.txt
     m_language = language_from_file_name(LexicalPath::basename(file_path));
-    if(m_language != Language::Unknown)
-    {
+    if (m_language != Language::Unknown) {
         m_language_name = language_name_from_file_name(LexicalPath::basename(file_path));
-    }
-    else
-    {
+    } else {
         m_language = language_from_file_extension(LexicalPath::extension(file_path));
         m_language_name = language_name_from_file_extension(LexicalPath::extension(file_path));
     }

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -30,6 +30,16 @@ Language language_from_file_extension(const String& extension)
     return Language::Unknown;
 }
 
+Language language_from_file_name(const String& name)
+{
+    if (name == "Makefile")
+        return Language::Makefile;
+    if (name == "CMakeLists.txt")
+        return Language::CMake;
+
+    return Language::Unknown;
+}
+
 Language language_from_name(const String& name)
 {
     if (name == "Cpp")
@@ -64,6 +74,16 @@ String language_name_from_file_extension(const String& extension)
         return "SQL";
     if (extension == "txt")
         return "Plaintext";
+
+    return "Unknown";
+}
+
+String language_name_from_file_name(const String& name)
+{
+    if (name == "Makefile")
+        return "Makefile";
+    if (name == "CMakeLists.txt")
+        return "CMake";
 
     return "Unknown";
 }

--- a/Userland/DevTools/HackStudio/Language.h
+++ b/Userland/DevTools/HackStudio/Language.h
@@ -18,10 +18,14 @@ enum class Language {
     Ini,
     Shell,
     SQL,
+    Makefile,
+    CMake,
 };
 
 Language language_from_file_extension(const String&);
+Language language_from_file_name(const String&);
 Language language_from_name(const String&);
 String language_name_from_file_extension(const String&);
+String language_name_from_file_name(const String&);
 
 }


### PR DESCRIPTION
Added feature to HackStudio to allow language detection based on a file's base name. 

When constructing a `CodeDocument`, we now check for common filenames such as 'Makefile' and 'CMakeLists.txt' before checking for an extension.

This PR defines `Language::Makefile` and `Language::CMake`.

Empty CMakeLists.txt: 
![CMakeInHS](https://user-images.githubusercontent.com/34384005/129450599-5a077e6d-195d-4bd8-bcad-0616751f5085.png)