### PR TITLE
HackStudio:  Add language detection from file basename

### DIFF
--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -22,8 +22,13 @@ CodeDocument::CodeDocument(const String& file_path, Client* client)
     : TextDocument(client)
     , m_file_path(file_path)
 {
-    m_language = language_from_file_extension(LexicalPath::extension(file_path));
-    m_language_name = language_name_from_file_extension(LexicalPath::extension(file_path));
+    m_language = language_from_file_name(LexicalPath::basename(file_path));
+    if (m_language != Language::Unknown) {
+        m_language_name = language_name_from_file_name(LexicalPath::basename(file_path));
+    } else {
+        m_language = language_from_file_extension(LexicalPath::extension(file_path));
+        m_language_name = language_name_from_file_extension(LexicalPath::extension(file_path));
+    }
 }
 
 CodeDocument::CodeDocument(Client* client)

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -26,13 +26,15 @@ Language language_from_file_extension(const String& extension)
         return Language::Shell;
     if (extension == "sql")
         return Language::SQL;
+    if (extension == "mk")
+        return Language::Makefile;
 
     return Language::Unknown;
 }
 
 Language language_from_file_name(const String& name)
 {
-    if (name == "Makefile")
+    if (name == "makefile" || name == "Makefile" || name == "GNUmakefile")
         return Language::Makefile;
     if (name == "CMakeLists.txt")
         return Language::CMake;
@@ -74,13 +76,15 @@ String language_name_from_file_extension(const String& extension)
         return "SQL";
     if (extension == "txt")
         return "Plaintext";
+    if (extension == "mk")
+        return "Makefile";
 
     return "Unknown";
 }
 
 String language_name_from_file_name(const String& name)
 {
-    if (name == "Makefile")
+    if (name == "makefile" || name == "Makefile" || name == "GNUmakefile")
         return "Makefile";
     if (name == "CMakeLists.txt")
         return "CMake";

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -30,6 +30,16 @@ Language language_from_file_extension(const String& extension)
     return Language::Unknown;
 }
 
+Language language_from_file_name(const String& name)
+{
+    if (name == "Makefile")
+        return Language::Makefile;
+    if (name == "CMakeLists.txt")
+        return Language::CMake;
+
+    return Language::Unknown;
+}
+
 Language language_from_name(const String& name)
 {
     if (name == "Cpp")
@@ -64,6 +74,16 @@ String language_name_from_file_extension(const String& extension)
         return "SQL";
     if (extension == "txt")
         return "Plaintext";
+
+    return "Unknown";
+}
+
+String language_name_from_file_name(const String& name)
+{
+    if (name == "Makefile")
+        return "Makefile";
+    if (name == "CMakeLists.txt")
+        return "CMake";
 
     return "Unknown";
 }

--- a/Userland/DevTools/HackStudio/Language.h
+++ b/Userland/DevTools/HackStudio/Language.h
@@ -18,10 +18,14 @@ enum class Language {
     Ini,
     Shell,
     SQL,
+    Makefile,
+    CMake,
 };
 
 Language language_from_file_extension(const String&);
+Language language_from_file_name(const String&);
 Language language_from_name(const String&);
 String language_name_from_file_extension(const String&);
+String language_name_from_file_name(const String&);
 
 }


### PR DESCRIPTION
Allows HackStudio to determine languages from filenames such as 'Makefile' and 'CMakeLists.txt'.