### PR TITLE
Add a "View" menu to Mandelbrot

### DIFF
--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -407,6 +407,31 @@ int main(int argc, char** argv)
         }));
     file_menu.add_separator();
     file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
+
+    auto zoom_in_action = GUI::CommonActions::make_zoom_in_action(
+        [&](auto&) {
+            mandelbrot.zoom(Mandelbrot::Zoom::In, mandelbrot.relative_rect().center());
+        },
+        window);
+
+    auto reset_zoom_action = GUI::CommonActions::make_reset_zoom_action(
+        [&](auto&) {
+            // FIXME: Ideally, this would only reset zoom. Currently, it resets pan too.
+            mandelbrot.reset();
+        },
+        window);
+
+    auto zoom_out_action = GUI::CommonActions::make_zoom_out_action(
+        [&](auto&) {
+            mandelbrot.zoom(Mandelbrot::Zoom::Out, mandelbrot.relative_rect().center());
+        },
+        window);
+
+    auto& view_menu = window->add_menu("&View");
+    view_menu.add_action(zoom_in_action);
+    view_menu.add_action(reset_zoom_action);
+    view_menu.add_action(zoom_out_action);
+
     window->show();
 
     auto app_icon = GUI::Icon::default_icon("app-mandelbrot");

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -215,6 +215,8 @@ class Mandelbrot : public GUI::Frame {
     };
     void zoom(Zoom in_out, const Gfx::IntPoint& center);
 
+    void reset();
+
 private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent& event) override;
@@ -257,6 +259,12 @@ void Mandelbrot::zoom(Zoom in_out, const Gfx::IntPoint& center)
     zoomed_rect.set_y((zooming_in ? 1 : -1) * leftover_height * cursor_y_percentage);
 
     m_set.zoom(zoomed_rect);
+    update();
+}
+
+void Mandelbrot::reset()
+{
+    m_set.reset();
     update();
 }
 
@@ -330,8 +338,7 @@ void Mandelbrot::mouseup_event(GUI::MouseEvent& event)
         m_panning = false;
         update();
     } else if (event.button() == GUI::MouseButton::Right) {
-        m_set.reset();
-        update();
+        reset();
     }
 
     return GUI::Widget::mouseup_event(event);

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -209,6 +209,12 @@ class Mandelbrot : public GUI::Frame {
 
     void export_image(String const& export_path);
 
+    enum class Zoom {
+        In,
+        Out,
+    };
+    void zoom(Zoom in_out, const Gfx::IntPoint& center);
+
 private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent& event) override;
@@ -226,6 +232,33 @@ private:
 
     MandelbrotSet m_set;
 };
+
+void Mandelbrot::zoom(Zoom in_out, const Gfx::IntPoint& center)
+{
+    static constexpr double zoom_in_multiplier = 0.8;
+    static constexpr double zoom_out_multiplier = 1.25;
+
+    bool zooming_in = in_out == Zoom::In;
+    double multiplier = zooming_in ? zoom_in_multiplier : zoom_out_multiplier;
+
+    auto relative_rect = this->relative_rect();
+    Gfx::IntRect zoomed_rect = relative_rect;
+
+    zoomed_rect.set_width(zoomed_rect.width() * multiplier);
+    zoomed_rect.set_height(zoomed_rect.height() * multiplier);
+
+    auto leftover_width = abs(relative_rect.width() - zoomed_rect.width());
+    auto leftover_height = abs(relative_rect.height() - zoomed_rect.height());
+
+    double cursor_x_percentage = static_cast<double>(center.x()) / relative_rect.width();
+    double cursor_y_percentage = static_cast<double>(center.y()) / relative_rect.height();
+
+    zoomed_rect.set_x((zooming_in ? 1 : -1) * leftover_width * cursor_x_percentage);
+    zoomed_rect.set_y((zooming_in ? 1 : -1) * leftover_height * cursor_y_percentage);
+
+    m_set.zoom(zoomed_rect);
+    update();
+}
 
 void Mandelbrot::paint_event(GUI::PaintEvent& event)
 {
@@ -306,29 +339,7 @@ void Mandelbrot::mouseup_event(GUI::MouseEvent& event)
 
 void Mandelbrot::mousewheel_event(GUI::MouseEvent& event)
 {
-    static constexpr double zoom_in_multiplier = 0.8;
-    static constexpr double zoom_out_multiplier = 1.25;
-
-    bool zooming_in = event.wheel_delta() < 0;
-    double multiplier = zooming_in ? zoom_in_multiplier : zoom_out_multiplier;
-
-    auto relative_rect = this->relative_rect();
-    Gfx::IntRect zoomed_rect = relative_rect;
-
-    zoomed_rect.set_width(zoomed_rect.width() * multiplier);
-    zoomed_rect.set_height(zoomed_rect.height() * multiplier);
-
-    auto leftover_width = abs(relative_rect.width() - zoomed_rect.width());
-    auto leftover_height = abs(relative_rect.height() - zoomed_rect.height());
-
-    double cursor_x_percentage = static_cast<double>(event.position().x()) / relative_rect.width();
-    double cursor_y_percentage = static_cast<double>(event.position().y()) / relative_rect.height();
-
-    zoomed_rect.set_x((zooming_in ? 1 : -1) * leftover_width * cursor_x_percentage);
-    zoomed_rect.set_y((zooming_in ? 1 : -1) * leftover_height * cursor_y_percentage);
-
-    m_set.zoom(zoomed_rect);
-    update();
+    zoom(event.wheel_delta() < 0 ? Zoom::In : Zoom::Out, event.position());
 }
 
 void Mandelbrot::resize_event(GUI::ResizeEvent& event)


### PR DESCRIPTION
It uses the standard actions, so ctrl-=/ctrl--/ctrl-0 can now be used for zooming, just like in ImageViewer.