### PR TITLE
HackStudio: Invalidate the project model after deleting a file

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -485,6 +485,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()
                 }
             }
         }
+        m_project->model().invalidate();
     });
     delete_action->set_enabled(false);
     return delete_action;


### PR DESCRIPTION
Prior this change, deleting a file crashed the app.