### PR TITLE
Meta: Disable printing frame args when debugging the kernel with gdb

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -31,6 +31,7 @@ exec $SERENITY_KERNEL_DEBUGGER \
     -ex "add-symbol-file $(dirname "$0")/../Build/${SERENITY_ARCH:-i686}/Kernel/Kernel -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
+    -ex "set print frame-arguments none" \
     -ex "target remote ${gdb_host}:1234" \
     -ex "source $(dirname "$0")/serenity_gdb.py" \
     -ex "layout asm" \


### PR DESCRIPTION
The function arguments almost always optimized away, so you never get
much value out of showing these in the default back trace view, it just
adds a bunch of extra stuff that you need to visual wade through.
So lets disable showing them.