### PR TITLE
LibWeb: Various font-finding improvements

### DIFF
--- a/Base/res/html/misc/fonts.html
+++ b/Base/res/html/misc/fonts.html
@@ -1,32 +1,58 @@
 <!doctype html>
 <html>
     <head>
-        <title>CSS test</title>
+        <title>CSS Fonts test</title>
         <style type="text/css">
-            #monospace { font: 20px monospace; }
-            #a { font: 12pt/14pt sans-serif; }
-            #b { font: 80% cursive; }
-            #b2 { font: bold 80% cursive; }
-            #c { font: x-large/110% fantasy, serif; }
-            #d { font: 2em SerenitySans; }
-            #d2 { font: 400 2em SerenitySans; }
-            #e { font: bold italic large Helvetica, sans-serif; }
-            #f { font: normal small-caps 120%/120% monospace; }
-            #g { font: condensed oblique 12pt "Helvetica Neue", serif; }
-            #h { font: condensed oblique 25deg 12pt "Helvetica Neue", serif; }
+            h2 {
+                font-family: sans-serif;
+            }
+            section {
+                border: 1px solid black;
+                border-radius: 8px;
+                padding: 1em;
+                margin: 1em;
+            }
         </style>
     </head>
     <body>
-        <div id="monospace">font: 20px monospace;</div>
-        <div id="a">font: 12pt/14pt sans-serif;</div>
-        <div id="b">font: 80% cursive;</div>
-        <div id="b2">font: bold 80% cursive;</div>
-        <div id="c">font: x-large/110% fantasy, serif;</div>
-        <div id="d">font: 2em SerenitySans;</div>
-        <div id="d2">font: 400 2em SerenitySans;</div>
-        <div id="e">font: bold italic large Helvetica, sans-serif;</div>
-        <div id="f">font: normal small-caps 120%/120% monospace;</div>
-        <div id="g">font: condensed oblique 12pt "Helvetica Neue", serif;</div>
-        <div id="h">font: condensed oblique 25deg 12pt "Helvetica Neue", serif;</div>
+        <h2>General tests</h2>
+        <section>
+            <p style="font: 20px monospace;">font: 20px monospace;</p>
+            <p style="font: 12pt/14pt sans-serif;">font: 12pt/14pt sans-serif;</p>
+            <p style="font: 80% cursive;">font: 80% cursive;</p>
+            <p style="font: bold 80% cursive;">font: bold 80% cursive;</p>
+            <p style="font: x-large/110% fantasy, serif;">font: x-large/110% fantasy, serif;</p>
+            <p style="font: 400 2em SerenitySans;">font: 400 2em SerenitySans;</p>
+            <p style="font: 400 200% SerenitySans;">font: 400 200% SerenitySans;</p>
+            <p style="font: 400 x-large SerenitySans;">font: 400 x-large SerenitySans;</p>
+            <p style="font: smaller SerenitySans;">font: smaller SerenitySans;</p>
+            <p style="font: normal smaller SerenitySans;">font: normal smaller SerenitySans;</p>
+            <p style="font: bold italic large Helvetica, sans-serif;">font: bold italic large Helvetica, sans-serif;</p>
+            <p style="font: normal small-caps 120%/120% monospace;">font: normal small-caps 120%/120% monospace;</p>
+            <p style="font: condensed oblique 12pt 'Helvetica Neue', serif;">font: condensed oblique 12pt "Helvetica Neue", serif;</p>
+            <p style="font: condensed oblique 25deg 12pt 'Helvetica Neue', serif;">font: condensed oblique 25deg 12pt "Helvetica Neue", serif;</p>
+        </section>
+
+        <h2>Calc() values</h2>
+        <section>
+            <p style="font-family: 'Liberation Serif', cursive; font-size: calc(120% + 10px);">font-family: 'Liberation Serif', cursive; font-size: calc(120% + 10px);</p>
+            <p style="font: calc(120% + 10px) 'Liberation Serif', cursive;">font: calc(120% + 10px) 'Liberation Serif', cursive;</p>
+            <p style="font-family: 'Liberation Serif', cursive; font-weight: calc(200 * 4);">font-family: 'Liberation Serif', cursive; font-weight: calc(200 * 4);</p>
+            <p style="font: calc(200*4) 20px 'Liberation Serif', cursive;">font: calc(200 * 4) 20px 'Liberation Serif', cursive;</p>
+        </section>
+
+        <h2>Fallback</h2>
+        <section>
+            <p style="font: 16pt 'fake font', not-real-font, 'SerenitySans', monospace;">font: 16pt 'fake font', not-real-font, 'SerenitySans', monospace;</p>
+            <p style="font-family: 'fake font', not-real-font, 'SerenitySans', monospace;">font-family: 'fake font', not-real-font, 'SerenitySans', monospace;</p>
+        </section>
+
+        <h2>Fonts with multiple faces</h2>
+        <section>
+            <p style="font: 20px 'Liberation Serif';">font: 20px 'Liberation Serif';</p>
+            <p style="font: italic 20px 'Liberation Serif';">font: italic 20px 'Liberation Serif';</p>
+            <p style="font: bold 20px 'Liberation Serif';">font: bold 20px 'Liberation Serif';</p>
+            <p style="font: bold italic 20px 'Liberation Serif';">font: bold italic 20px 'Liberation Serif';</p>
+        </section>
     </body>
 </html>

--- a/Userland/Libraries/LibGfx/Typeface.cpp
+++ b/Userland/Libraries/LibGfx/Typeface.cpp
@@ -38,7 +38,7 @@ void Typeface::set_ttf_font(RefPtr<TTF::Font> font)
     m_ttf_font = font;
 }
 
-RefPtr<Font> Typeface::get_font(unsigned size)
+RefPtr<Font> Typeface::get_font(unsigned size) const
 {
     for (auto font : m_bitmap_fonts) {
         if (font->presentation_size() == size)

--- a/Userland/Libraries/LibGfx/Typeface.h
+++ b/Userland/Libraries/LibGfx/Typeface.h
@@ -35,7 +35,7 @@ public:
     void add_bitmap_font(RefPtr<BitmapFont>);
     void set_ttf_font(RefPtr<TTF::Font>);
 
-    RefPtr<Font> get_font(unsigned size);
+    RefPtr<Font> get_font(unsigned size) const;
 
 private:
     String m_family;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2400,14 +2400,13 @@ RefPtr<StyleValue> Parser::parse_font_value(ParsingContext const& context, Vecto
             font_families = maybe_font_families.release_nonnull();
             break;
         }
-
         return nullptr;
     }
 
     // Since normal is the default value for all the properties that can have it, we don't have to actually
     // set anything to normal here. It'll be set when we create the FontStyleValue below.
     // We just need to make sure we were not given more normals than will fit.
-    int unset_value_count = (font_style ? 1 : 0) + (font_weight ? 1 : 0);
+    int unset_value_count = (font_style ? 0 : 1) + (font_weight ? 0 : 1);
     if (unset_value_count < normal_count)
         return nullptr;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -102,7 +102,6 @@ void StyleProperties::load_font(Layout::Node const& node) const
     auto family = family_parts[0];
 
     auto monospace = false;
-    auto bold = false;
 
     if (family.is_one_of("monospace", "ui-monospace")) {
         monospace = true;
@@ -111,37 +110,38 @@ void StyleProperties::load_font(Layout::Node const& node) const
         family = "Katica";
     }
 
-    int weight = 400;
+    int weight = Gfx::FontWeight::Regular;
     if (font_weight->is_identifier()) {
         switch (static_cast<const IdentifierStyleValue&>(*font_weight).id()) {
         case CSS::ValueID::Normal:
-            weight = 400;
+            weight = Gfx::FontWeight::Regular;
             break;
         case CSS::ValueID::Bold:
-            weight = 700;
+            weight = Gfx::FontWeight::Bold;
             break;
         case CSS::ValueID::Lighter:
             // FIXME: This should be relative to the parent.
-            weight = 400;
+            weight = Gfx::FontWeight::Regular;
             break;
         case CSS::ValueID::Bolder:
             // FIXME: This should be relative to the parent.
-            weight = 700;
+            weight = Gfx::FontWeight::Bold;
             break;
         default:
             break;
         }
-    } else if (font_weight->is_length()) {
-        // FIXME: This isn't really a length, it's a numeric value..
-        int font_weight_integer = font_weight->to_length().raw_value();
-        if (font_weight_integer <= 400)
-            weight = 400;
-        if (font_weight_integer <= 700)
-            weight = 700;
-        weight = 900;
+    } else if (font_weight->is_numeric()) {
+        int font_weight_integer = roundf(static_cast<NumericStyleValue const&>(*font_weight).value());
+        if (font_weight_integer <= Gfx::FontWeight::Regular)
+            weight = Gfx::FontWeight::Regular;
+        else if (font_weight_integer <= Gfx::FontWeight::Bold)
+            weight = Gfx::FontWeight::Bold;
+        else
+            weight = Gfx::FontWeight::Black;
     }
+    // FIXME: calc() for font-weight
 
-    bold = weight > 400;
+    bool bold = weight > Gfx::FontWeight::Regular;
 
     int size = 10;
     auto parent_font_size = node.parent() == nullptr ? size : node.parent()->font_size();

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -64,10 +64,10 @@ public:
     Optional<CSS::Repeat> background_repeat_y() const;
     Optional<CSS::BoxShadowData> box_shadow() const;
 
-    const Gfx::Font& font() const
+    const Gfx::Font& font(Layout::Node const& node) const
     {
         if (!m_font)
-            load_font();
+            load_font(node);
         return *m_font;
     }
 
@@ -83,7 +83,7 @@ private:
     HashMap<unsigned, NonnullRefPtr<StyleValue>> m_property_values;
     Optional<CSS::Overflow> overflow(CSS::PropertyID) const;
 
-    void load_font() const;
+    void load_font(Layout::Node const&) const;
     RefPtr<Gfx::Font> font_fallback(bool monospace, bool bold) const;
 
     mutable RefPtr<Gfx::Font> m_font;

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -474,7 +474,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         if (value.is_font()) {
             auto& font_shorthand = static_cast<CSS::FontStyleValue const&>(value);
             style.set_property(CSS::PropertyID::FontSize, font_shorthand.font_size());
-            set_property_expanding_shorthands(style, CSS::PropertyID::FontFamily, *font_shorthand.font_families(), document);
+            style.set_property(CSS::PropertyID::FontFamily, font_shorthand.font_families());
             style.set_property(CSS::PropertyID::FontStyle, font_shorthand.font_style());
             style.set_property(CSS::PropertyID::FontWeight, font_shorthand.font_weight());
             style.set_property(CSS::PropertyID::LineHeight, font_shorthand.line_height());
@@ -483,28 +483,11 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         }
         if (value.is_builtin()) {
             style.set_property(CSS::PropertyID::FontSize, value);
-            // FIXME: Support multiple font-families
             style.set_property(CSS::PropertyID::FontFamily, value);
             style.set_property(CSS::PropertyID::FontStyle, value);
             style.set_property(CSS::PropertyID::FontWeight, value);
             style.set_property(CSS::PropertyID::LineHeight, value);
             // FIXME: Implement font-stretch and font-variant
-            return;
-        }
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::FontFamily) {
-        if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value).values();
-            // FIXME: Support multiple font-families
-            if (!values_list.is_empty()) {
-                style.set_property(CSS::PropertyID::FontFamily, values_list.first());
-            }
-            return;
-        }
-        if (value.is_builtin() || value.is_string() || value.is_identifier()) {
-            style.set_property(CSS::PropertyID::FontFamily, value);
             return;
         }
         return;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -223,9 +223,13 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     m_line_height = specified_style.line_height(*this);
 
     {
-        // FIXME: This doesn't work right for relative font-sizes
-        auto length = specified_style.length_or_fallback(CSS::PropertyID::FontSize, CSS::Length(10, CSS::Length::Type::Px));
-        m_font_size = length.raw_value();
+        constexpr int default_font_size = 10;
+        auto parent_font_size = parent() == nullptr ? default_font_size : parent()->font_size();
+        auto length = specified_style.length_or_fallback(CSS::PropertyID::FontSize, CSS::Length(default_font_size, CSS::Length::Type::Px));
+        // FIXME: em sizes return 0 here, for some reason
+        m_font_size = length.resolved_or_zero(*this, parent_font_size).to_px(*this);
+        if (m_font_size == 0)
+            m_font_size = default_font_size;
     }
 
     auto bgimage = specified_style.property(CSS::PropertyID::BackgroundImage);

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -219,7 +219,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
 {
     auto& computed_values = static_cast<CSS::MutableComputedValues&>(m_computed_values);
 
-    m_font = specified_style.font();
+    m_font = specified_style.font(*this);
     m_line_height = specified_style.line_height(*this);
 
     {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/129628763-3c3d861b-a134-448f-ad87-ee8a12ecc67a.png)
There's a few smaller commits, but here are the main features:

- **Handle non-px font sizes:** This was stubbed out before, now we support all size units, with the notable exception of "em", which always returns 0 for some reason. So, we check for 0 and substitute a default size for that.
- **Fix font-weight:** This was old code from before `NumericStyleValue` existed, so it only handled `Length`s, which meant it always used the default value. Also the logic would have returned 900 every time if it had been called.
- **Implement font-family fallback:** The big one! We now iterate through the provided list of font-families, and return the first match, if any. Also fixed vector fonts, which never matched before.

Also, we now properly distinguish between generic font-family identifiers (eg `sans-serif`) and string font names that happen to be the same as those identifiers (eg, `"sans-serif"`). Probably nobody on the web relies on this but it's in the spec. :^)