### PR TITLE
LibJS: Exclude FinalizationRegistries with queued cleanup jobs from GC

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -120,6 +120,9 @@ void VM::gather_roots(HashTable<Cell*>& roots)
 
     for (auto* job : m_promise_jobs)
         roots.set(job);
+
+    for (auto* finalization_registry : m_finalization_registry_cleanup_jobs)
+        roots.set(finalization_registry);
 }
 
 Symbol* VM::get_global_symbol(const String& description)


### PR DESCRIPTION
This is done by just adding them to the list of GC roots, which
prevents the VM from trying to run cleanup job of garbage collected
registries.