### PR TITLE
LibCore: Make --version print same version as in LibGUI's About dialogs

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -9,10 +9,9 @@
 #include <LibCore/ArgsParser.h>
 #include <getopt.h>
 #include <limits.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
-
-static constexpr bool isnan(double __x) { return __builtin_isnan(__x); }
 
 static Optional<double> convert_to_double(const char* s)
 {

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -7,6 +7,7 @@
 #include <AK/Format.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/ConfigFile.h>
 #include <getopt.h>
 #include <limits.h>
 #include <math.h>
@@ -155,7 +156,7 @@ bool ArgsParser::parse(int argc, char* const* argv, FailureBehavior failure_beha
     // We're done parsing! :)
     // Now let's show version or help if requested.
     if (m_show_version) {
-        outln(stdout, "git");
+        print_version(stdout);
         if (failure_behavior == FailureBehavior::Exit || failure_behavior == FailureBehavior::PrintUsageAndExit)
             exit(0);
         return false;
@@ -239,6 +240,20 @@ void ArgsParser::print_usage(FILE* file, const char* argv0)
             out(file, "\t{}", arg.help_string);
         outln(file);
     }
+}
+
+void ArgsParser::print_version(FILE* file)
+{
+    auto version_config = Core::ConfigFile::open("/res/version.ini");
+    auto major_version = version_config->read_entry("Version", "Major", "0");
+    auto minor_version = version_config->read_entry("Version", "Minor", "0");
+
+    StringBuilder builder;
+    builder.appendff("{}.{}", major_version, minor_version);
+    if (auto git_version = version_config->read_entry("Version", "Git", ""); git_version != "")
+        builder.appendff(".g{}", git_version);
+
+    outln(file, builder.to_string());
 }
 
 void ArgsParser::add_option(Option&& option)

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -58,6 +58,7 @@ public:
     void set_general_help(const char* help_string) { m_general_help = help_string; };
     void set_stop_on_first_non_option(bool stop_on_first_non_option) { m_stop_on_first_non_option = stop_on_first_non_option; }
     void print_usage(FILE*, const char* argv0);
+    void print_version(FILE*);
 
     void add_option(Option&&);
     void add_option(bool& value, const char* help_string, const char* long_name, char short_name);

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -95,19 +95,11 @@ String AboutDialog::version_string() const
     auto version_config = Core::ConfigFile::open("/res/version.ini");
     auto major_version = version_config->read_entry("Version", "Major", "0");
     auto minor_version = version_config->read_entry("Version", "Minor", "0");
-    auto git_version = version_config->read_entry("Version", "Git", "");
 
     StringBuilder builder;
-    builder.append("Version ");
-    builder.append(major_version);
-    builder.append('.');
-    builder.append(minor_version);
-
-    if (git_version != "") {
-        builder.append(".g");
-        builder.append(git_version);
-    }
-
+    builder.appendff("Version {}.{}", major_version, minor_version);
+    if (auto git_version = version_config->read_entry("Version", "Git", ""); git_version != "")
+        builder.appendff(".g{}", git_version);
     return builder.to_string();
 }
 


### PR DESCRIPTION
Making every binary's behavior depend on the current git hash seems a
bit questionable to me, but we should be self-consistent about this.