### PR TITLE
Text Editor: Fixes modified indicator behavior after saving

### DIFF
--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -62,7 +62,7 @@ void UndoStack::push(NonnullOwnPtr<Command> command)
     if (m_clean_index.has_value() && m_clean_index.value() > m_stack.size())
         m_clean_index = {};
 
-    if (!m_stack.is_empty()) {
+    if (!m_stack.is_empty() && is_current_modified()) {
         if (m_stack.last().merge_with(*command))
             return;
     }


### PR DESCRIPTION
Pior to this change when the user added text after having saved the file
the Text Editor wouldn't enable the modified flag, unless this new text
was a new line.

This happened because the `UndoStack` was merging the `Command` added by
the new text with the old text, and when `is_current_modified()`
was called, the `m_stack_index` would not have been incremented, and
it would return false.

This problem was described in the issue https://github.com/SerenityOS/serenity/issues/8902
The problem was really the same described by @Mandar12 , but i thought this solution is
simpler.

In this change was added a condition to verify if the modified tag is
active, and the merge is only done if the document is already modified.

There is also a small behavior change after this. When the user types something, saves and then types
another thing and executes and undo, the undo only will revert the text before the changes.
I tested some editors and this is the behavior in them too, and personally i think it makes
more sense.

This is my first contribution, and i'm not a native english speaker, so if you have some feedback
I would be very happy to hear :)