### PR TITLE
LibGUI+Browser: Address bar focus behaviour + bookmarking keyboard shortcut

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -173,14 +173,14 @@ Tab::Tab(BrowserWindow& window, Type type)
     m_bookmark_button->set_fixed_size(22, 22);
 
     m_bookmark_button->on_click = [this](auto) {
-        auto url = this->url().to_string();
-        if (BookmarksBarWidget::the().contains_bookmark(url)) {
-            BookmarksBarWidget::the().remove_bookmark(url);
-        } else {
-            BookmarksBarWidget::the().add_bookmark(url, m_title);
-        }
-        update_bookmark_button(url);
+        bookmark_current_url();
     };
+
+    auto bookmark_action = GUI::Action::create(
+        "Bookmark current URL", { Mod_Ctrl, Key_D }, [this](auto&) {
+            bookmark_current_url();
+        },
+        this);
 
     hooks().on_load_start = [this](auto& url) {
         m_location_box->set_icon(nullptr);
@@ -408,6 +408,17 @@ void Tab::update_actions()
         return;
     window.go_back_action().set_enabled(m_history.can_go_back());
     window.go_forward_action().set_enabled(m_history.can_go_forward());
+}
+
+void Tab::bookmark_current_url()
+{
+    auto url = this->url().to_string();
+    if (BookmarksBarWidget::the().contains_bookmark(url)) {
+        BookmarksBarWidget::the().remove_bookmark(url);
+    } else {
+        BookmarksBarWidget::the().add_bookmark(url, m_title);
+    }
+    update_bookmark_button(url);
 }
 
 void Tab::update_bookmark_button(const String& url)

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -142,7 +142,7 @@ Tab::Tab(BrowserWindow& window, Type type)
     toolbar.add_action(window.go_home_action());
     toolbar.add_action(window.reload_action());
 
-    m_location_box = toolbar.add<GUI::TextBox>();
+    m_location_box = toolbar.add<GUI::UrlBox>();
     m_location_box->set_placeholder("Address");
 
     m_location_box->on_return_pressed = [this] {
@@ -153,7 +153,7 @@ Tab::Tab(BrowserWindow& window, Type type)
 
         auto url = url_from_user_input(m_location_box->text());
         load(url);
-        view().set_focus(true);
+        view();
     };
 
     m_location_box->add_custom_context_menu_action(GUI::Action::create("Paste && Go", [this](auto&) {
@@ -312,8 +312,8 @@ Tab::Tab(BrowserWindow& window, Type type)
 
     auto focus_location_box_action = GUI::Action::create(
         "Focus location box", { Mod_Ctrl, Key_L }, Key_F6, [this](auto&) {
-            m_location_box->select_all();
             m_location_box->set_focus(true);
+            m_location_box->select_current_line();
         },
         this);
 
@@ -371,6 +371,8 @@ void Tab::load(const URL& url, LoadType load_type)
         m_page_view->load(url);
     else
         m_web_content_view->load(url);
+
+    m_location_box->set_focus(false);
 }
 
 URL Tab::url() const

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -77,6 +77,7 @@ private:
 
     Web::WebViewHooks& hooks();
     void update_actions();
+    void bookmark_current_url();
     void update_bookmark_button(const String& url);
     void start_download(const URL& url);
     void view_source(const URL& url, const String& source);

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -89,7 +89,7 @@ private:
     RefPtr<Web::InProcessWebView> m_page_view;
     RefPtr<Web::OutOfProcessWebView> m_web_content_view;
 
-    RefPtr<GUI::TextBox> m_location_box;
+    RefPtr<GUI::UrlBox> m_location_box;
     RefPtr<GUI::Button> m_bookmark_button;
     RefPtr<GUI::Window> m_dom_inspector_window;
     RefPtr<GUI::Window> m_console_window;

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -66,6 +66,7 @@ class Statusbar;
 class TabWidget;
 class TableView;
 class TextBox;
+class UrlBox;
 class TextDocument;
 class TextDocumentLine;
 struct TextDocumentSpan;

--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -8,6 +8,7 @@
 
 REGISTER_WIDGET(GUI, TextBox)
 REGISTER_WIDGET(GUI, PasswordBox)
+REGISTER_WIDGET(GUI, UrlBox)
 
 namespace GUI {
 
@@ -78,6 +79,40 @@ PasswordBox::PasswordBox()
 {
     set_substitution_code_point('*');
     set_text_is_secret(true);
+}
+
+UrlBox::UrlBox()
+    : TextBox()
+{
+    set_auto_focusable(false);
+}
+
+UrlBox::~UrlBox()
+{
+}
+
+void UrlBox::focusout_event(GUI::FocusEvent& event)
+{
+    set_focus_transition(true);
+
+    TextBox::focusout_event(event);
+}
+
+void UrlBox::mousedown_event(GUI::MouseEvent& event)
+{
+    if (is_displayonly())
+        return;
+
+    if (event.button() != MouseButton::Left)
+        return;
+
+    if (is_focus_transition()) {
+        TextBox::select_current_line();
+
+        set_focus_transition(false);
+    } else {
+        TextBox::mousedown_event(event);
+    }
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextBox.h
+++ b/Userland/Libraries/LibGUI/TextBox.h
@@ -43,4 +43,20 @@ public:
     PasswordBox();
 };
 
+class UrlBox : public TextBox {
+    C_OBJECT(UrlBox)
+public:
+    UrlBox();
+    virtual ~UrlBox() override;
+
+    void set_focus_transition(bool focus_transition) { m_focus_transition = focus_transition; }
+    bool is_focus_transition() const { return m_focus_transition; }
+
+private:
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void focusout_event(GUI::FocusEvent&) override;
+
+    bool m_focus_transition { true };
+};
+
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -256,10 +256,7 @@ void TextEditor::mousedown_event(MouseEvent& event)
 
     if (m_triple_click_timer.is_valid() && m_triple_click_timer.elapsed() < 250) {
         m_triple_click_timer = Core::ElapsedTimer();
-        m_selection = document().range_for_entire_line(m_cursor.line());
-        set_cursor(m_selection.end());
-        update();
-        did_update_selection();
+        select_current_line();
         return;
     }
 
@@ -308,6 +305,14 @@ void TextEditor::mousemove_event(MouseEvent& event)
         update();
         return;
     }
+}
+
+void TextEditor::select_current_line()
+{
+    m_selection = document().range_for_entire_line(m_cursor.line());
+    set_cursor(m_selection.end());
+    update();
+    did_update_selection();
 }
 
 void TextEditor::automatic_selection_scroll_timer_fired()

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -142,6 +142,7 @@ public:
     void delete_previous_char();
     void delete_from_line_start_to_cursor();
     void select_all();
+    void select_current_line();
     virtual void undo();
     virtual void redo();
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -114,6 +114,9 @@ public:
     String tooltip() const { return m_tooltip; }
     void set_tooltip(String);
 
+    bool is_auto_focusable() const { return m_auto_focusable; }
+    void set_auto_focusable(bool auto_focusable) { m_auto_focusable = auto_focusable; }
+
     bool is_enabled() const { return m_enabled; }
     void set_enabled(bool);
 
@@ -357,6 +360,7 @@ private:
     bool m_fill_with_background_color { false };
     bool m_visible { true };
     bool m_greedy_for_hits { false };
+    bool m_auto_focusable { true };
     bool m_enabled { true };
     bool m_updates_enabled { true };
     bool m_accepts_emoji_input { false };

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -947,6 +947,8 @@ Vector<Widget&> Window::focusable_widgets(FocusSource source) const
                 return IterationDecision::Continue;
             if (!child.is_enabled())
                 return IterationDecision::Continue;
+            if (!child.is_auto_focusable())
+                return IterationDecision::Continue;
             collect_focusable_widgets(child);
             return IterationDecision::Continue;
         });


### PR DESCRIPTION
Currently the browser address bar is a bit slow to use compared to Chrome/ Firebox bahaviour of autofocusing.

This changes the behaviour to select all and place the cursor at the end of the line when focused, subsequent bahaviour after initial focusing is as normal for a TextBox.

This also adds the ability to specify a widget as not autofocusable when Window::focus_a_widget_if_possible is called. This is so when the browser is loaded or a new page is loaded that the address bar doesn't automatically gain focus.