### PR TITLE
Kernel: Return KResult<Nonnull*Ptr<T>> in a bunch of places

### DIFF
--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -8,6 +8,9 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>
+#ifdef KERNEL
+#    include <Kernel/KResult.h>
+#endif
 
 namespace AK {
 
@@ -205,6 +208,17 @@ inline OwnPtr<T> adopt_own_if_nonnull(T* object)
     return {};
 }
 
+#ifdef KERNEL
+template<typename T>
+inline Kernel::KResultOr<NonnullOwnPtr<T>> adopt_nonnull_own_or_enomem(T* object)
+{
+    auto result = adopt_own_if_nonnull(object);
+    if (!result)
+        return ENOMEM;
+    return result.release_nonnull();
+}
+#endif
+
 template<typename T, class... Args>
 requires(IsConstructible<T, Args...>) inline OwnPtr<T> try_make(Args&&... args)
 {
@@ -232,3 +246,7 @@ struct Traits<OwnPtr<T>> : public GenericTraits<OwnPtr<T>> {
 using AK::adopt_own_if_nonnull;
 using AK::OwnPtr;
 using AK::try_make;
+
+#ifdef KERNEL
+using AK::adopt_nonnull_own_or_enomem;
+#endif

--- a/Kernel/Bus/USB/UHCIController.h
+++ b/Kernel/Bus/USB/UHCIController.h
@@ -69,7 +69,7 @@ private:
 
     virtual bool handle_irq(const RegisterState&) override;
 
-    void create_structures();
+    KResult create_structures();
     void setup_schedule();
     size_t poll_transfer_queue(QueueHead& transfer_queue);
 

--- a/Kernel/Devices/KCOVInstance.cpp
+++ b/Kernel/Devices/KCOVInstance.cpp
@@ -28,10 +28,11 @@ KResult KCOVInstance::buffer_allocate(size_t buffer_size_in_entries)
     // - we allocate one kernel region using that vmobject
     // - when an mmap call comes in, we allocate another userspace region,
     //   backed by the same vmobject
-    this->vmobject = Memory::AnonymousVMObject::try_create_with_size(
+    auto maybe_vmobject = Memory::AnonymousVMObject::try_create_with_size(
         this->m_buffer_size_in_bytes, AllocationStrategy::AllocateNow);
-    if (!this->vmobject)
-        return ENOMEM;
+    if (maybe_vmobject.is_error())
+        return maybe_vmobject.error();
+    this->vmobject = maybe_vmobject.release_value();
 
     this->m_kernel_region = MM.allocate_kernel_region_with_vmobject(
         *this->vmobject, this->m_buffer_size_in_bytes, String::formatted("kcov_{}", this->m_pid),

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -47,13 +47,14 @@ KResultOr<Memory::Region*> MemoryDevice::mmap(Process& process, FileDescription&
         return EINVAL;
     }
 
-    auto vmobject = Memory::AnonymousVMObject::try_create_for_physical_range(viewed_address, range.size());
-    if (!vmobject)
-        return ENOMEM;
+    auto maybe_vmobject = Memory::AnonymousVMObject::try_create_for_physical_range(viewed_address, range.size());
+    if (maybe_vmobject.is_error())
+        return maybe_vmobject.error();
+
     dbgln("MemoryDevice: Mapped physical memory at {} for range of {} bytes", viewed_address, range.size());
     return process.address_space().allocate_region_with_vmobject(
         range,
-        vmobject.release_nonnull(),
+        maybe_vmobject.release_value(),
         0,
         "Mapped Physical Memory",
         prot,

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -238,10 +238,11 @@ KResultOr<size_t> SB16::write(FileDescription&, u64, const UserOrKernelBuffer& d
         if (!page)
             return ENOMEM;
         auto nonnull_page = page.release_nonnull();
-        auto vmobject = Memory::AnonymousVMObject::try_create_with_physical_pages({ &nonnull_page, 1 });
-        if (!vmobject)
-            return ENOMEM;
-        m_dma_region = MM.allocate_kernel_region_with_vmobject(*vmobject, PAGE_SIZE, "SB16 DMA buffer", Memory::Region::Access::Write);
+        auto maybe_vmobject = Memory::AnonymousVMObject::try_create_with_physical_pages({ &nonnull_page, 1 });
+        if (maybe_vmobject.is_error())
+            return maybe_vmobject.error();
+
+        m_dma_region = MM.allocate_kernel_region_with_vmobject(maybe_vmobject.release_value(), PAGE_SIZE, "SB16 DMA buffer", Memory::Region::Access::Write);
         if (!m_dma_region)
             return ENOMEM;
     }

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -184,11 +184,7 @@ private:
 
 KResultOr<NonnullRefPtr<ISO9660FS>> ISO9660FS::try_create(FileDescription& description)
 {
-    auto result = adopt_ref_if_nonnull(new (nothrow) ISO9660FS(description));
-    if (!result) {
-        return ENOMEM;
-    }
-    return result.release_nonnull();
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ISO9660FS(description));
 }
 
 ISO9660FS::ISO9660FS(FileDescription& description)
@@ -635,11 +631,7 @@ ISO9660Inode::~ISO9660Inode()
 
 KResultOr<NonnullRefPtr<ISO9660Inode>> ISO9660Inode::try_create_from_directory_record(ISO9660FS& fs, ISO::DirectoryRecordHeader const& record, StringView const& name)
 {
-    auto result = adopt_ref_if_nonnull(new (nothrow) ISO9660Inode(fs, record, name));
-    if (!result) {
-        return ENOMEM;
-    }
-    return result.release_nonnull();
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ISO9660Inode(fs, record, name));
 }
 
 void ISO9660Inode::create_metadata()

--- a/Kernel/FileSystem/ISO9660FileSystem.h
+++ b/Kernel/FileSystem/ISO9660FileSystem.h
@@ -293,11 +293,7 @@ public:
 
         static KResultOr<NonnullRefPtr<DirectoryEntry>> try_create(u32 extent, u32 length, OwnPtr<KBuffer> blocks)
         {
-            auto result = adopt_ref_if_nonnull(new (nothrow) DirectoryEntry(extent, length, move(blocks)));
-            if (!result) {
-                return ENOMEM;
-            }
-            return result.release_nonnull();
+            return adopt_nonnull_ref_or_enomem(new (nothrow) DirectoryEntry(extent, length, move(blocks)));
         }
 
     private:

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -88,7 +88,8 @@ UNMAP_AFTER_INIT void BochsGraphicsAdapter::initialize_framebuffer_devices()
 {
     // FIXME: Find a better way to determine default resolution...
     m_framebuffer_device = FramebufferDevice::create(*this, 0, PhysicalAddress(PCI::get_BAR0(pci_address()) & 0xfffffff0), 1024, 768, 1024 * sizeof(u32));
-    m_framebuffer_device->initialize();
+    // FIXME: Would be nice to be able to return a KResult here.
+    VERIFY(!m_framebuffer_device->initialize().is_error());
 }
 
 GraphicsDevice::Type BochsGraphicsAdapter::type() const

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -34,7 +34,7 @@ public:
     size_t framebuffer_size_in_bytes() const;
 
     virtual ~FramebufferDevice() {};
-    void initialize();
+    KResult initialize();
 
 private:
     // ^File

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -639,6 +639,7 @@ void IntelNativeGraphicsAdapter::initialize_framebuffer_devices()
     VERIFY(m_framebuffer_height != 0);
     VERIFY(m_framebuffer_width != 0);
     m_framebuffer_device = FramebufferDevice::create(*this, 0, address, m_framebuffer_width, m_framebuffer_height, m_framebuffer_pitch);
-    m_framebuffer_device->initialize();
+    // FIXME: Would be nice to be able to return a KResult here.
+    VERIFY(!m_framebuffer_device->initialize().is_error());
 }
 }

--- a/Kernel/Graphics/VGACompatibleAdapter.cpp
+++ b/Kernel/Graphics/VGACompatibleAdapter.cpp
@@ -33,7 +33,8 @@ UNMAP_AFTER_INIT void VGACompatibleAdapter::initialize_framebuffer_devices()
     VERIFY(m_framebuffer_height != 0);
     VERIFY(m_framebuffer_pitch != 0);
     m_framebuffer_device = FramebufferDevice::create(*this, 0, m_framebuffer_address, m_framebuffer_width, m_framebuffer_height, m_framebuffer_pitch);
-    m_framebuffer_device->initialize();
+    // FIXME: Would be nice to be able to return KResult here.
+    VERIFY(!m_framebuffer_device->initialize().is_error());
 }
 
 UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address)

--- a/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/FrameBufferDevice.h
@@ -56,7 +56,7 @@ private:
     Protocol::DisplayInfoResponse::Display const& display_info() const;
     Protocol::DisplayInfoResponse::Display& display_info();
 
-    void create_framebuffer();
+    KResult create_framebuffer();
     void create_buffer(Buffer&, size_t, size_t);
     void set_buffer(int);
 

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -277,11 +277,13 @@ UNMAP_AFTER_INIT bool APIC::init_bsp()
 
 UNMAP_AFTER_INIT static NonnullOwnPtr<Memory::Region> create_identity_mapped_region(PhysicalAddress paddr, size_t size)
 {
-    auto vmobject = Memory::AnonymousVMObject::try_create_for_physical_range(paddr, size);
-    VERIFY(vmobject);
+    auto maybe_vmobject = Memory::AnonymousVMObject::try_create_for_physical_range(paddr, size);
+    // FIXME: Would be nice to be able to return a KResultOr from here.
+    VERIFY(!maybe_vmobject.is_error());
+
     auto region = MM.allocate_kernel_region_with_vmobject(
         Memory::VirtualRange { VirtualAddress { static_cast<FlatPtr>(paddr.get()) }, size },
-        vmobject.release_nonnull(),
+        maybe_vmobject.release_value(),
         {},
         Memory::Region::Access::ReadWriteExecute);
     VERIFY(region);

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -170,10 +170,10 @@ KResultOr<Region*> AddressSpace::try_allocate_split_region(Region const& source_
 KResultOr<Region*> AddressSpace::allocate_region(VirtualRange const& range, StringView name, int prot, AllocationStrategy strategy)
 {
     VERIFY(range.is_valid());
-    auto vmobject = AnonymousVMObject::try_create_with_size(range.size(), strategy);
-    if (!vmobject)
-        return ENOMEM;
-    auto region = Region::try_create_user_accessible(range, vmobject.release_nonnull(), 0, KString::try_create(name), prot_to_region_access_flags(prot), Region::Cacheable::Yes, false);
+    auto maybe_vmobject = AnonymousVMObject::try_create_with_size(range.size(), strategy);
+    if (maybe_vmobject.is_error())
+        return maybe_vmobject.error();
+    auto region = Region::try_create_user_accessible(range, maybe_vmobject.release_value(), 0, KString::try_create(name), prot_to_region_access_flags(prot), Region::Cacheable::Yes, false);
     if (!region)
         return ENOMEM;
     if (!region->map(page_directory()))

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -18,12 +18,12 @@ class AnonymousVMObject final : public VMObject {
 public:
     virtual ~AnonymousVMObject() override;
 
-    static RefPtr<AnonymousVMObject> try_create_with_size(size_t, AllocationStrategy);
-    static RefPtr<AnonymousVMObject> try_create_for_physical_range(PhysicalAddress paddr, size_t size);
-    static RefPtr<AnonymousVMObject> try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalPage>>);
-    static RefPtr<AnonymousVMObject> try_create_purgeable_with_size(size_t, AllocationStrategy);
-    static RefPtr<AnonymousVMObject> try_create_physically_contiguous_with_size(size_t);
-    virtual RefPtr<VMObject> try_clone() override;
+    static KResultOr<NonnullRefPtr<AnonymousVMObject>> try_create_with_size(size_t, AllocationStrategy);
+    static KResultOr<NonnullRefPtr<AnonymousVMObject>> try_create_for_physical_range(PhysicalAddress paddr, size_t size);
+    static KResultOr<NonnullRefPtr<AnonymousVMObject>> try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalPage>>);
+    static KResultOr<NonnullRefPtr<AnonymousVMObject>> try_create_purgeable_with_size(size_t, AllocationStrategy);
+    static KResultOr<NonnullRefPtr<AnonymousVMObject>> try_create_physically_contiguous_with_size(size_t);
+    virtual KResultOr<NonnullRefPtr<VMObject>> try_clone() override;
 
     [[nodiscard]] NonnullRefPtr<PhysicalPage> allocate_committed_page(Badge<Region>);
     PageFaultResponse handle_cow_fault(size_t, VirtualAddress);

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -743,9 +743,12 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region(PhysicalAddress paddr, size
 
 OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(VirtualRange const& range, VMObject& vmobject, StringView name, Region::Access access, Region::Cacheable cacheable)
 {
-    auto region = Region::try_create_kernel_only(range, vmobject, 0, KString::try_create(name), access, cacheable);
-    if (region)
-        region->map(kernel_page_directory());
+    auto maybe_region = Region::try_create_kernel_only(range, vmobject, 0, KString::try_create(name), access, cacheable);
+    if (maybe_region.is_error())
+        return {};
+
+    auto region = maybe_region.release_value();
+    region->map(kernel_page_directory());
     return region;
 }
 

--- a/Kernel/Memory/PrivateInodeVMObject.cpp
+++ b/Kernel/Memory/PrivateInodeVMObject.cpp
@@ -14,9 +14,9 @@ RefPtr<PrivateInodeVMObject> PrivateInodeVMObject::try_create_with_inode(Inode& 
     return adopt_ref_if_nonnull(new (nothrow) PrivateInodeVMObject(inode, inode.size()));
 }
 
-RefPtr<VMObject> PrivateInodeVMObject::try_clone()
+KResultOr<NonnullRefPtr<VMObject>> PrivateInodeVMObject::try_clone()
 {
-    return adopt_ref_if_nonnull(new (nothrow) PrivateInodeVMObject(*this));
+    return adopt_nonnull_ref_or_enomem<VMObject>(new (nothrow) PrivateInodeVMObject(*this));
 }
 
 PrivateInodeVMObject::PrivateInodeVMObject(Inode& inode, size_t size)

--- a/Kernel/Memory/PrivateInodeVMObject.h
+++ b/Kernel/Memory/PrivateInodeVMObject.h
@@ -19,7 +19,7 @@ public:
     virtual ~PrivateInodeVMObject() override;
 
     static RefPtr<PrivateInodeVMObject> try_create_with_inode(Inode&);
-    virtual RefPtr<VMObject> try_clone() override;
+    virtual KResultOr<NonnullRefPtr<VMObject>> try_clone() override;
 
 private:
     virtual bool is_private_inode() const override { return true; }

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -75,14 +75,14 @@ OwnPtr<Region> Region::clone()
     if (vmobject().is_inode())
         VERIFY(vmobject().is_private_inode());
 
-    auto vmobject_clone = vmobject().try_clone();
-    if (!vmobject_clone)
+    auto maybe_vmobject_clone = vmobject().try_clone();
+    if (maybe_vmobject_clone.is_error())
         return {};
 
     // Set up a COW region. The parent (this) region becomes COW as well!
     remap();
     auto clone_region = Region::try_create_user_accessible(
-        m_range, vmobject_clone.release_nonnull(), m_offset_in_vmobject, m_name ? m_name->try_clone() : OwnPtr<KString> {}, access(), m_cacheable ? Cacheable::Yes : Cacheable::No, m_shared);
+        m_range, maybe_vmobject_clone.release_value(), m_offset_in_vmobject, m_name ? m_name->try_clone() : OwnPtr<KString> {}, access(), m_cacheable ? Cacheable::Yes : Cacheable::No, m_shared);
     if (!clone_region) {
         dbgln("Region::clone: Unable to allocate new Region for COW");
         return nullptr;

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -49,8 +49,8 @@ public:
         Yes,
     };
 
-    static OwnPtr<Region> try_create_user_accessible(VirtualRange const&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable, bool shared);
-    static OwnPtr<Region> try_create_kernel_only(VirtualRange const&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable = Cacheable::Yes);
+    static KResultOr<NonnullOwnPtr<Region>> try_create_user_accessible(VirtualRange const&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable, bool shared);
+    static KResultOr<NonnullOwnPtr<Region>> try_create_kernel_only(VirtualRange const&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, OwnPtr<KString> name, Region::Access access, Cacheable = Cacheable::Yes);
 
     ~Region();
 
@@ -90,7 +90,7 @@ public:
 
     PageFaultResponse handle_fault(PageFault const&);
 
-    OwnPtr<Region> clone();
+    KResultOr<NonnullOwnPtr<Region>> try_clone();
 
     bool contains(VirtualAddress vaddr) const
     {

--- a/Kernel/Memory/ScatterGatherList.cpp
+++ b/Kernel/Memory/ScatterGatherList.cpp
@@ -10,10 +10,12 @@ namespace Kernel::Memory {
 
 RefPtr<ScatterGatherList> ScatterGatherList::try_create(AsyncBlockDeviceRequest& request, Span<NonnullRefPtr<PhysicalPage>> allocated_pages, size_t device_block_size)
 {
-    auto vm_object = AnonymousVMObject::try_create_with_physical_pages(allocated_pages);
-    if (!vm_object)
+    auto maybe_vm_object = AnonymousVMObject::try_create_with_physical_pages(allocated_pages);
+    if (maybe_vm_object.is_error()) {
+        // FIXME: Would be nice to be able to return a KResultOr here.
         return {};
-    return adopt_ref_if_nonnull(new (nothrow) ScatterGatherList(vm_object.release_nonnull(), request, device_block_size));
+    }
+    return adopt_ref_if_nonnull(new (nothrow) ScatterGatherList(maybe_vm_object.release_value(), request, device_block_size));
 }
 
 ScatterGatherList::ScatterGatherList(NonnullRefPtr<AnonymousVMObject> vm_object, AsyncBlockDeviceRequest& request, size_t device_block_size)

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -21,9 +21,9 @@ RefPtr<SharedInodeVMObject> SharedInodeVMObject::try_create_with_inode(Inode& in
     return vmobject;
 }
 
-RefPtr<VMObject> SharedInodeVMObject::try_clone()
+KResultOr<NonnullRefPtr<VMObject>> SharedInodeVMObject::try_clone()
 {
-    return adopt_ref_if_nonnull(new (nothrow) SharedInodeVMObject(*this));
+    return adopt_nonnull_ref_or_enomem<VMObject>(new (nothrow) SharedInodeVMObject(*this));
 }
 
 SharedInodeVMObject::SharedInodeVMObject(Inode& inode, size_t size)

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -17,7 +17,7 @@ class SharedInodeVMObject final : public InodeVMObject {
 
 public:
     static RefPtr<SharedInodeVMObject> try_create_with_inode(Inode&);
-    virtual RefPtr<VMObject> try_clone() override;
+    virtual KResultOr<NonnullRefPtr<VMObject>> try_clone() override;
 
 private:
     virtual bool is_shared_inode() const override { return true; }

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -33,7 +33,7 @@ class VMObject : public RefCounted<VMObject>
 public:
     virtual ~VMObject();
 
-    virtual RefPtr<VMObject> try_clone() = 0;
+    virtual KResultOr<NonnullRefPtr<VMObject>> try_clone() = 0;
 
     virtual bool is_anonymous() const { return false; }
     virtual bool is_inode() const { return false; }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -714,11 +714,7 @@ public:
     public:
         static KResultOr<NonnullRefPtr<ProcessProcFSTraits>> try_create(Badge<Process>, WeakPtr<Process> process)
         {
-            auto result = adopt_ref_if_nonnull(new (nothrow) ProcessProcFSTraits(process));
-            if (!result)
-                return ENOMEM;
-
-            return result.release_nonnull();
+            return adopt_nonnull_ref_or_enomem(new (nothrow) ProcessProcFSTraits(process));
         }
 
         virtual InodeIndex component_index() const override;

--- a/Kernel/Syscalls/anon_create.cpp
+++ b/Kernel/Syscalls/anon_create.cpp
@@ -29,11 +29,11 @@ KResultOr<FlatPtr> Process::sys$anon_create(size_t size, int options)
     if (new_fd_or_error.is_error())
         return new_fd_or_error.error();
     auto new_fd = new_fd_or_error.release_value();
-    auto vmobject = Memory::AnonymousVMObject::try_create_purgeable_with_size(size, AllocationStrategy::Reserve);
-    if (!vmobject)
-        return ENOMEM;
+    auto maybe_vmobject = Memory::AnonymousVMObject::try_create_purgeable_with_size(size, AllocationStrategy::Reserve);
+    if (maybe_vmobject.is_error())
+        return maybe_vmobject.error();
 
-    auto anon_file = AnonymousFile::create(vmobject.release_nonnull());
+    auto anon_file = AnonymousFile::create(maybe_vmobject.release_value());
     if (!anon_file)
         return ENOMEM;
     auto description_or_error = FileDescription::create(*anon_file);


### PR DESCRIPTION
These commits contain no functional changes.

**AK: Add adopt_nonnull_own_or_enomem**

This is basically a complement to `adopt_nonnull_ref_or_enomem`, and
simplifies boilerplate for try_create functions which just return `ENOMEM`
or the object based on whether it was able to allocate.

**Kernel: Simplify OOM handling in ProcessProcFSTraits**

**Kernel: Simplify OOM handling in ISO9660FileSystem**

**Kernel: Make Kernel::VMObject allocation functions return KResultOr**

This makes for nicer handling of errors compared to checking whether a
RefPtr is null. Additionally, this will give way to return different
types of errors in the future.

**Kernel: Make Memory::Region allocation functions return KResultOr**

This makes for some nicer handling of errors compared to checking an
OwnPtr for null state.

