### PR TITLE
Kernel: Created const defines for pci class id,etc for IDE and SATA controllers

### DIFF
--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -52,6 +52,12 @@ namespace Kernel {
 #define PCI_CAPABILITY_VENDOR_SPECIFIC 0x9
 #define PCI_CAPABILITY_MSIX 0x11
 
+// Taken from https://pcisig.com/sites/default/files/files/PCI_Code-ID_r_1_11__v24_Jan_2019.pdf
+#define PCI_MASS_STORAGE_CLASS_ID 0x1
+#define PCI_IDE_CTRL_SUBCLASS_ID 0x1
+#define PCI_SATA_CTRL_SUBCLASS_ID 0x6
+#define PCI_AHCI_IF_PROGIF 0x1
+
 namespace PCI {
 struct ID {
     u16 vendor_id { 0 };

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -48,13 +48,13 @@ UNMAP_AFTER_INIT NonnullRefPtrVector<StorageController> StorageManagement::enume
     if (!kernel_command_line().disable_physical_storage()) {
         if (kernel_command_line().is_ide_enabled()) {
             PCI::enumerate([&](const PCI::Address& address, PCI::ID) {
-                if (PCI::get_class(address) == 0x1 && PCI::get_subclass(address) == 0x1) {
+                if (PCI::get_class(address) == PCI_MASS_STORAGE_CLASS_ID && PCI::get_subclass(address) == PCI_IDE_CTRL_SUBCLASS_ID) {
                     controllers.append(IDEController::initialize(address, force_pio));
                 }
             });
         }
         PCI::enumerate([&](const PCI::Address& address, PCI::ID) {
-            if (PCI::get_class(address) == 0x1 && PCI::get_subclass(address) == 0x6 && PCI::get_programming_interface(address) == 0x1) {
+            if (PCI::get_class(address) == PCI_MASS_STORAGE_CLASS_ID && PCI::get_subclass(address) == PCI_SATA_CTRL_SUBCLASS_ID && PCI::get_programming_interface(address) == PCI_AHCI_IF_PROGIF) {
                 controllers.append(AHCIController::initialize(address));
             }
         });


### PR DESCRIPTION
Minor change to create const defines for PCI class ID, sub-class id, and programming interface for IDE and SATA controller used in storage management to improve readability. 