### PR TITLE
Kernel: Avoid enumerating all the fds to find a specific one in procfs

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -428,6 +428,29 @@ RefPtr<Process> Process::from_pid(ProcessID pid)
     });
 }
 
+const Process::FileDescriptionAndFlags* Process::FileDescriptions::get_if_valid(size_t i) const
+{
+    ScopedSpinLock lock(m_fds_lock);
+    if (m_fds_metadatas.size() <= i)
+        return nullptr;
+
+    if (auto& metadata = m_fds_metadatas[i]; metadata.is_valid())
+        return &metadata;
+
+    return nullptr;
+}
+Process::FileDescriptionAndFlags* Process::FileDescriptions::get_if_valid(size_t i)
+{
+    ScopedSpinLock lock(m_fds_lock);
+    if (m_fds_metadatas.size() <= i)
+        return nullptr;
+
+    if (auto& metadata = m_fds_metadatas[i]; metadata.is_valid())
+        return &metadata;
+
+    return nullptr;
+}
+
 const Process::FileDescriptionAndFlags& Process::FileDescriptions::at(size_t i) const
 {
     ScopedSpinLock lock(m_fds_lock);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -643,6 +643,9 @@ public:
         const FileDescriptionAndFlags& at(size_t i) const;
         FileDescriptionAndFlags& at(size_t i);
 
+        FileDescriptionAndFlags const* get_if_valid(size_t i) const;
+        FileDescriptionAndFlags* get_if_valid(size_t i);
+
         void enumerate(Function<void(const FileDescriptionAndFlags&)>) const;
         void change_each(Function<void(FileDescriptionAndFlags&)>);
 


### PR DESCRIPTION
*distant screams of iterating over the entire universe*
~~Note: This may blow up, I have not tested it locally yet (still building)~~ seems alright with some light testing