### PR TITLE
Kernel: Remove g_scheduler_lock

### DIFF
--- a/Kernel/Arch/aarch64/Spinlock.h
+++ b/Kernel/Arch/aarch64/Spinlock.h
@@ -70,6 +70,11 @@ public:
         return false;
     }
 
+    [[nodiscard]] ALWAYS_INLINE u32 own_recursions() const
+    {
+        return 0;
+    }
+
     ALWAYS_INLINE void initialize()
     {
     }

--- a/Kernel/Arch/x86/Spinlock.h
+++ b/Kernel/Arch/x86/Spinlock.h
@@ -120,6 +120,15 @@ public:
         return m_lock.load(AK::memory_order_relaxed) == FlatPtr(&Processor::current());
     }
 
+    [[nodiscard]] ALWAYS_INLINE u32 own_recursions() const
+    {
+        if (is_locked_by_current_processor()) {
+            atomic_thread_fence(AK::MemoryOrder::memory_order_acquire);
+            return m_recursions;
+        }
+        return 0;
+    }
+
     ALWAYS_INLINE void initialize()
     {
         m_lock.store(0, AK::memory_order_relaxed);

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -489,15 +489,6 @@ extern "C" void handle_interrupt(TrapFrame*) __attribute__((used));
 
 extern "C" UNMAP_AFTER_INIT void pre_init_finished(void)
 {
-    VERIFY(g_scheduler_lock.is_locked_by_current_processor());
-
-    // Because init_finished() will wait on the other APs, we need
-    // to release the scheduler lock so that the other APs can also get
-    // to this point
-
-    // The target flags will get restored upon leaving the trap
-    u32 prev_flags = cpu_flags();
-    Scheduler::leave_on_first_switch(prev_flags);
 }
 
 extern "C" UNMAP_AFTER_INIT void post_init_finished(void)

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -62,7 +62,7 @@ StringView Processor::platform_string()
 FlatPtr Processor::init_context(Thread& thread, bool leave_crit)
 {
     VERIFY(is_kernel_mode());
-    VERIFY(g_scheduler_lock.is_locked());
+    VERIFY(thread.get_lock().is_locked_by_current_processor());
     if (leave_crit) {
         // Leave the critical section we set up in in Process::exec,
         // but because we still have the scheduler lock we should end up with 1
@@ -164,13 +164,17 @@ FlatPtr Processor::init_context(Thread& thread, bool leave_crit)
 
 void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
 {
-    VERIFY(!m_in_irq);
-    VERIFY(m_in_critical == 1);
+    VERIFY(!current_in_irq());
     VERIFY(is_kernel_mode());
+    VERIFY(from_thread->get_lock().is_locked_by_current_processor());
+    VERIFY(from_thread->get_lock().own_recursions() == 1);
+    VERIFY(to_thread->get_lock().is_locked_by_current_processor());
+    VERIFY(to_thread->get_lock().own_recursions() == 1);
 
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context --> switching out of: {} {}", VirtualAddress(from_thread), *from_thread);
+    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context --> switching out of: {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 
     // m_in_critical is restored in enter_thread_context
+    VERIFY(m_in_critical == 2); // we're holding the lock for from_thread and to_thread
     from_thread->save_critical(m_in_critical);
 
     // clang-format off
@@ -245,6 +249,7 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
 UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_thread)
 {
     VERIFY(initial_thread.process().is_kernel_process());
+    VERIFY(initial_thread.is_idle_thread());
 
     auto& regs = initial_thread.regs();
     m_tss.iomapbase = sizeof(m_tss);

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -527,7 +527,6 @@ private:
             });
         };
 
-        SpinlockLocker lock(g_scheduler_lock);
         {
             {
                 auto array = json.add_array("processes");

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -520,9 +520,6 @@ UNMAP_AFTER_INIT void APIC::init_finished(u32 cpu)
     // This method is called once the boot stack is no longer needed
     VERIFY(cpu > 0);
     VERIFY(cpu < m_processor_enabled_cnt);
-    // Since we're waiting on other APs here, we shouldn't have the
-    // scheduler lock
-    VERIFY(!g_scheduler_lock.is_locked_by_current_processor());
 
     // Notify the BSP that we are done initializing. It will unmap the startup data at P8000
     m_apic_ap_count.fetch_add(1, AK::MemoryOrder::memory_order_acq_rel);

--- a/Kernel/Locking/Spinlock.h
+++ b/Kernel/Locking/Spinlock.h
@@ -12,7 +12,6 @@
 #include <Kernel/Locking/LockRank.h>
 
 namespace Kernel {
-
 template<typename LockType>
 class [[nodiscard]] SpinlockLocker {
     AK_MAKE_NONCOPYABLE(SpinlockLocker);

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -412,7 +412,6 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region)
     VERIFY_INTERRUPTS_DISABLED();
     VERIFY(vmobject().is_inode());
     VERIFY(!s_mm_lock.is_locked_by_current_processor());
-    VERIFY(!g_scheduler_lock.is_locked_by_current_processor());
 
     auto& inode_vmobject = static_cast<InodeVMObject&>(vmobject());
 

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -22,7 +22,6 @@ struct RegisterState;
 extern Thread* g_finalizer;
 extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
-extern RecursiveSpinlock g_scheduler_lock;
 
 struct TotalTimeScheduled {
     u64 total { 0 };
@@ -39,8 +38,8 @@ public:
     static bool pick_next();
     static bool yield();
     static bool context_switch(Thread*);
-    static void enter_current(Thread& prev_thread, bool is_first);
-    static void leave_on_first_switch(u32 flags);
+    static void enter_current(Thread&, Thread&, bool);
+    static void leave_context_switch(Thread&, Thread&, bool);
     static void prepare_after_exec();
     static void prepare_for_idle_loop();
     static Process* colonel();

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -242,8 +242,6 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     } else {
         VERIFY(!current_thread->is_promise_violation_pending());
     }
-
-    VERIFY(!g_scheduler_lock.is_locked_by_current_processor());
 }
 
 }

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -114,9 +114,11 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
 
     PerformanceManager::add_process_created_event(*child);
 
-    SpinlockLocker lock(g_scheduler_lock);
-    child_first_thread->set_affinity(Thread::current()->affinity());
-    child_first_thread->set_state(Thread::State::Runnable);
+    {
+        SpinlockLocker lock(child_first_thread->get_lock());
+        child_first_thread->set_affinity(Thread::current()->affinity());
+        child_first_thread->set_state(Thread::State::Runnable);
+    }
 
     auto child_pid = child->pid().value();
 

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -18,7 +18,6 @@ namespace Kernel {
 
 static ErrorOr<FlatPtr> handle_ptrace(const Kernel::Syscall::SC_ptrace_params& params, Process& caller)
 {
-    SpinlockLocker scheduler_lock(g_scheduler_lock);
     if (params.request == PT_TRACE_ME) {
         if (Process::current().tracer())
             return EBUSY;
@@ -70,8 +69,6 @@ static ErrorOr<FlatPtr> handle_ptrace(const Kernel::Syscall::SC_ptrace_params& p
 
     if (peer->state() == Thread::State::Running)
         return EBUSY;
-
-    scheduler_lock.unlock();
 
     switch (params.request) {
     case PT_CONTINUE:

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -65,9 +65,11 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<con
 
     PerformanceManager::add_thread_created_event(*thread);
 
-    SpinlockLocker lock(g_scheduler_lock);
-    thread->set_priority(requested_thread_priority);
-    thread->set_state(Thread::State::Runnable);
+    {
+        SpinlockLocker lock(thread->get_lock());
+        thread->set_priority(requested_thread_priority);
+        thread->set_state(Thread::State::Runnable);
+    }
     return thread->tid().value();
 }
 

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -763,7 +763,6 @@ bool Thread::WaitBlocker::unblock(Process& process, UnblockFlags flags, u8 signa
     } else {
         siginfo_t siginfo {};
         {
-            SpinlockLocker lock(g_scheduler_lock);
             // We need to gather the information before we release the scheduler lock!
             siginfo.si_signo = SIGCHLD;
             siginfo.si_pid = process.pid().value();


### PR DESCRIPTION
This solves some deadlocks due to multiple locks having to be acquired
at the same time. Also, this allows the system to use a lot more of its
resources because for most things only a thread's m_lock needs to be
acquired. E.g. all processors can switch contexts simultaneously as
they only need to hold the previous and next thread's lock.