### PR TITLE
LibGL: Implement missing features and bug fixes for glquake

### DIFF
--- a/Userland/Applications/3DFileViewer/Mesh.cpp
+++ b/Userland/Applications/3DFileViewer/Mesh.cpp
@@ -69,6 +69,9 @@ void Mesh::draw(float uv_scale)
         glBegin(GL_TRIANGLES);
         glColor4f(color.x(), color.y(), color.z(), color.w());
 
+        if (is_textured())
+            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index0).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index0).v) * uv_scale);
+
         // Vertex 1
         glVertex3f(
             m_vertex_list.at(m_triangle_list[i].a).x,
@@ -76,7 +79,7 @@ void Mesh::draw(float uv_scale)
             m_vertex_list.at(m_triangle_list[i].a).z);
 
         if (is_textured())
-            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index0).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index0).v) * uv_scale);
+            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index1).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index1).v) * uv_scale);
 
         // Vertex 2
         glVertex3f(
@@ -85,16 +88,13 @@ void Mesh::draw(float uv_scale)
             m_vertex_list.at(m_triangle_list[i].b).z);
 
         if (is_textured())
-            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index1).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index1).v) * uv_scale);
+            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index2).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index2).v) * uv_scale);
 
         // Vertex 3
         glVertex3f(
             m_vertex_list.at(m_triangle_list[i].c).x,
             m_vertex_list.at(m_triangle_list[i].c).y,
             m_vertex_list.at(m_triangle_list[i].c).z);
-
-        if (is_textured())
-            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index2).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index2).v) * uv_scale);
 
         glEnd();
     }

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -225,7 +225,7 @@ bool GLContextWidget::load(const String& filename)
     if (texture_image) {
         // Upload texture data to the GL
         glBindTexture(GL_TEXTURE_2D, tex);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, texture_image->width(), texture_image->height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, texture_image->scanline(0));
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, texture_image->width(), texture_image->height(), 0, GL_BGRA, GL_UNSIGNED_BYTE, texture_image->scanline(0));
     } else {
         dbgln("3DFileViewer: Couldn't load texture for {}", filename);
     }

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -60,7 +60,7 @@ private:
         start_timer(20);
 
         GL::make_context_current(m_context);
-        glFrontFace(GL_CW);
+        glFrontFace(GL_CCW);
         glEnable(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
 

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -97,7 +97,7 @@ private:
     float m_angle_y = 0.0;
     float m_angle_z = 0.0;
     Gfx::IntPoint m_last_mouse;
-    float m_rotation_speed = 1.f;
+    float m_rotation_speed = 60.f;
     bool m_show_frame_rate = false;
     int m_cycles = 0;
     int m_accumulated_time = 0;
@@ -124,8 +124,8 @@ void GLContextWidget::mousemove_event(GUI::MouseEvent& event)
         int delta_x = m_last_mouse.x() - event.x();
         int delta_y = m_last_mouse.y() - event.y();
 
-        m_angle_x -= delta_y / 100.0f;
-        m_angle_y -= delta_x / 100.0f;
+        m_angle_x -= delta_y / 2.0f;
+        m_angle_y -= delta_x / 2.0f;
     }
 
     m_last_mouse = event.position();
@@ -315,13 +315,13 @@ int main(int argc, char** argv)
         widget.set_rotation_speed(0.f);
     });
     auto slow_rotation_action = GUI::Action::create_checkable("&Slow", [&widget](auto&) {
-        widget.set_rotation_speed(0.5f);
+        widget.set_rotation_speed(30.f);
     });
     auto normal_rotation_action = GUI::Action::create_checkable("&Normal", [&widget](auto&) {
-        widget.set_rotation_speed(1.f);
+        widget.set_rotation_speed(60.f);
     });
     auto fast_rotation_action = GUI::Action::create_checkable("&Fast", [&widget](auto&) {
-        widget.set_rotation_speed(1.5f);
+        widget.set_rotation_speed(90.f);
     });
 
     rotation_speed_actions.add_action(*no_rotation_action);

--- a/Userland/Libraries/LibGL/Clipper.h
+++ b/Userland/Libraries/LibGL/Clipper.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibGL/GLStruct.h>
 #include <LibGfx/Vector4.h>
 
 namespace GL {
@@ -34,26 +35,24 @@ class Clipper final {
     };
 
     static constexpr FloatVector4 clip_plane_normals[] = {
-        { 1, 0, 0, 1 },  // Left Plane
-        { -1, 0, 0, 1 }, // Right Plane
-        { 0, -1, 0, 1 }, // Top Plane
-        { 0, 1, 0, 1 },  // Bottom plane
-        { 0, 0, -1, 1 }, // Near Plane
-        { 0, 0, 1, 1 }   // Far Plane
+        { 1, 0, 0, 0 },  // Left Plane
+        { -1, 0, 0, 0 }, // Right Plane
+        { 0, -1, 0, 0 }, // Top Plane
+        { 0, 1, 0, 0 },  // Bottom plane
+        { 0, 0, 1, 0 },  // Near Plane
+        { 0, 0, -1, 0 }  // Far Plane
     };
 
 public:
     Clipper() { }
 
-    void clip_triangle_against_frustum(Vector<FloatVector4>& input_vecs);
-    const Vector<FloatVector4, MAX_CLIPPED_VERTS>& clipped_verts() const;
+    void clip_triangle_against_frustum(Vector<GLVertex>& input_vecs);
 
 private:
     bool point_within_clip_plane(const FloatVector4& vertex, ClipPlane plane);
-    FloatVector4 clip_intersection_point(const FloatVector4& vec, const FloatVector4& prev_vec, ClipPlane plane_index);
-
-private:
-    Vector<FloatVector4, MAX_CLIPPED_VERTS> m_clipped_verts;
+    GLVertex clip_intersection_point(const GLVertex& vec, const GLVertex& prev_vec, ClipPlane plane_index);
+    Vector<GLVertex> list_a;
+    Vector<GLVertex> list_b;
 };
 
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -370,6 +370,7 @@ GLAPI void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void
 GLAPI void glDrawArrays(GLenum mode, GLint first, GLsizei count);
 GLAPI void glDrawElements(GLenum mode, GLsizei count, GLenum type, const void* indices);
 GLAPI void glDepthRange(GLdouble nearVal, GLdouble farVal);
+GLAPI void glDepthFunc(GLenum func);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -369,6 +369,7 @@ GLAPI void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* p
 GLAPI void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glDrawArrays(GLenum mode, GLint first, GLsizei count);
 GLAPI void glDrawElements(GLenum mode, GLsizei count, GLenum type, const void* indices);
+GLAPI void glDepthRange(GLdouble nearVal, GLdouble farVal);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -75,6 +75,7 @@ public:
     virtual void gl_get_booleanv(GLenum pname, GLboolean* data) = 0;
     virtual void gl_get_integerv(GLenum pname, GLint* data) = 0;
     virtual void gl_depth_range(GLdouble min, GLdouble max) = 0;
+    virtual void gl_depth_func(GLenum func) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -74,6 +74,7 @@ public:
     virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) = 0;
     virtual void gl_get_booleanv(GLenum pname, GLboolean* data) = 0;
     virtual void gl_get_integerv(GLenum pname, GLint* data) = 0;
+    virtual void gl_depth_range(GLdouble min, GLdouble max) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLStruct.h
+++ b/Userland/Libraries/LibGL/GLStruct.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "GL/gl.h"
+#include <LibGfx/Vector2.h>
+#include <LibGfx/Vector4.h>
 
 namespace GL {
 
@@ -15,9 +17,9 @@ struct GLColor {
 };
 
 struct GLVertex {
-    GLfloat x, y, z, w;
-    GLfloat r, g, b, a;
-    GLfloat u, v;
+    FloatVector4 position;
+    FloatVector4 color;
+    FloatVector2 tex_coord;
 };
 
 struct GLTriangle {

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -124,3 +124,8 @@ void glDepthRange(GLdouble min, GLdouble max)
 {
     g_gl_context->gl_depth_range(min, max);
 }
+
+void glDepthFunc(GLenum func)
+{
+    g_gl_context->gl_depth_func(func);
+}

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -119,3 +119,8 @@ void glDisableClientState(GLenum cap)
 {
     g_gl_context->gl_disable_client_state(cap);
 }
+
+void glDepthRange(GLdouble min, GLdouble max)
+{
+    g_gl_context->gl_depth_range(min, max);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -504,7 +504,7 @@ void SoftwareGLContext::gl_rotate(GLdouble angle, GLdouble x, GLdouble y, GLdoub
 
     FloatVector3 axis = { (float)x, (float)y, (float)z };
     axis.normalize();
-    auto rotation_mat = Gfx::rotation_matrix(axis, static_cast<float>(angle));
+    auto rotation_mat = Gfx::rotation_matrix(axis, static_cast<float>(angle * M_PI * 2 / 360));
 
     if (m_current_matrix_mode == GL_MODELVIEW)
         m_model_view_matrix = m_model_view_matrix * rotation_mat;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1653,6 +1653,27 @@ void SoftwareGLContext::gl_depth_range(GLdouble min, GLdouble max)
     m_rasterizer.set_options(options);
 }
 
+void SoftwareGLContext::gl_depth_func(GLenum func)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_depth_func, func);
+
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    RETURN_WITH_ERROR_IF(!(func == GL_NEVER
+                             || func == GL_LESS
+                             || func == GL_EQUAL
+                             || func == GL_LEQUAL
+                             || func == GL_GREATER
+                             || func == GL_NOTEQUAL
+                             || func == GL_GEQUAL
+                             || func == GL_ALWAYS),
+        GL_INVALID_ENUM);
+
+    auto options = m_rasterizer.options();
+    options.depth_func = func;
+    m_rasterizer.set_options(options);
+}
+
 // General helper function to read arbitrary vertex attribute data into a float array
 void SoftwareGLContext::read_from_vertex_attribute_pointer(VertexAttribPointer const& attrib, int index, float* elements, bool normalize)
 {

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -555,19 +555,18 @@ void SoftwareGLContext::gl_vertex(GLdouble x, GLdouble y, GLdouble z, GLdouble w
 
     // FIXME: This is to suppress any -Wunused errors
     vertex.w = 0.0f;
-    vertex.u = 0.0f;
-    vertex.v = 0.0f;
+    vertex.u = m_current_vertex_tex_coord.x();
+    vertex.v = m_current_vertex_tex_coord.y();
 
     vertex_list.append(vertex);
 }
 
 // FIXME: We need to add `r` and `q` to our GLVertex?!
-void SoftwareGLContext::gl_tex_coord(GLfloat s, GLfloat t, GLfloat, GLfloat)
+void SoftwareGLContext::gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q)
 {
-    auto& vertex = vertex_list.last(); // Get the last created vertex
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_tex_coord, s, t, r, q);
 
-    vertex.u = s;
-    vertex.v = t;
+    m_current_vertex_tex_coord = { s, t, r, q };
 }
 
 void SoftwareGLContext::gl_viewport(GLint x, GLint y, GLsizei width, GLsizei height)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -246,13 +246,17 @@ void SoftwareGLContext::gl_end()
             continue;
 
         if (m_cull_faces) {
-            bool is_front = (m_front_face == GL_CCW ? area > 0 : area < 0);
+            bool is_front = (m_front_face == GL_CCW ? area < 0 : area > 0);
 
             if (is_front && (m_culled_sides == GL_FRONT || m_culled_sides == GL_FRONT_AND_BACK))
                 continue;
 
             if (!is_front && (m_culled_sides == GL_BACK || m_culled_sides == GL_FRONT_AND_BACK))
                 continue;
+        }
+
+        if (area > 0) {
+            swap(triangle.vertices[0], triangle.vertices[1]);
         }
 
         m_rasterizer.submit_triangle(triangle, m_texture_units);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1492,7 +1492,7 @@ void SoftwareGLContext::gl_vertex_pointer(GLint size, GLenum type, GLsizei strid
 {
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    RETURN_WITH_ERROR_IF(!(size == 1 || size == 2 || size == 4), GL_INVALID_VALUE);
+    RETURN_WITH_ERROR_IF(!(size == 2 || size == 3 || size == 4), GL_INVALID_VALUE);
     RETURN_WITH_ERROR_IF(!(type == GL_SHORT || type == GL_INT || type == GL_FLOAT || type == GL_DOUBLE), GL_INVALID_ENUM);
     RETURN_WITH_ERROR_IF(stride < 0, GL_INVALID_VALUE);
 

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -397,7 +397,9 @@ GLubyte* SoftwareGLContext::gl_get_string(GLenum name)
     case GL_RENDERER:
         return reinterpret_cast<GLubyte*>(const_cast<char*>("SerenityOS OpenGL"));
     case GL_VERSION:
-        return reinterpret_cast<GLubyte*>(const_cast<char*>("OpenGL 1.2 SerenityOS"));
+        return reinterpret_cast<GLubyte*>(const_cast<char*>("1.5"));
+    case GL_EXTENSIONS:
+        return reinterpret_cast<GLubyte*>(const_cast<char*>(""));
     default:
         dbgln_if(GL_DEBUG, "glGetString(): Unknown enum name!");
         break;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1641,6 +1641,18 @@ void SoftwareGLContext::gl_draw_elements(GLenum mode, GLsizei count, GLenum type
     glEnd();
 }
 
+void SoftwareGLContext::gl_depth_range(GLdouble min, GLdouble max)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_depth_range, min, max);
+
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    auto options = m_rasterizer.options();
+    options.depth_min = clamp(min, 0.f, 1.f);
+    options.depth_max = clamp(max, 0.f, 1.f);
+    m_rasterizer.set_options(options);
+}
+
 // General helper function to read arbitrary vertex attribute data into a float array
 void SoftwareGLContext::read_from_vertex_attribute_pointer(VertexAttribPointer const& attrib, int index, float* elements, bool normalize)
 {

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -84,6 +84,7 @@ public:
     virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
     virtual void gl_get_booleanv(GLenum pname, GLboolean* data) override;
     virtual void gl_get_integerv(GLenum pname, GLint* data) override;
+    virtual void gl_depth_range(GLdouble min, GLdouble max) override;
     virtual void present() override;
 
 private:
@@ -215,7 +216,8 @@ private:
             decltype(&SoftwareGLContext::gl_tex_parameter),
             decltype(&SoftwareGLContext::gl_depth_mask),
             decltype(&SoftwareGLContext::gl_draw_arrays),
-            decltype(&SoftwareGLContext::gl_draw_elements)>;
+            decltype(&SoftwareGLContext::gl_draw_elements),
+            decltype(&SoftwareGLContext::gl_depth_range)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -119,6 +119,7 @@ private:
     FloatVector4 m_clear_color = { 0.0f, 0.0f, 0.0f, 0.0f };
     double m_clear_depth = { 1.0 };
     FloatVector4 m_current_vertex_color = { 1.0f, 1.0f, 1.0f, 1.0f };
+    FloatVector4 m_current_vertex_tex_coord = { 0.0f, 0.0f, 0.0f, 0.0f };
 
     Vector<GLVertex, 96> vertex_list;
     Vector<GLTriangle, 32> triangle_list;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -85,6 +85,7 @@ public:
     virtual void gl_get_booleanv(GLenum pname, GLboolean* data) override;
     virtual void gl_get_integerv(GLenum pname, GLint* data) override;
     virtual void gl_depth_range(GLdouble min, GLdouble max) override;
+    virtual void gl_depth_func(GLenum func) override;
     virtual void present() override;
 
 private:

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -126,6 +126,7 @@ private:
     Vector<GLVertex, 96> vertex_list;
     Vector<GLTriangle, 32> triangle_list;
     Vector<GLTriangle, 32> processed_triangles;
+    Vector<GLVertex> m_clipped_vertices;
 
     GLenum m_error = GL_NO_ERROR;
     bool m_in_draw_state = false;

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -261,8 +261,36 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                         auto barycentric = FloatVector3(coords.x(), coords.y(), coords.z()) * one_over_area;
                         float z = interpolate(triangle.vertices[0].z, triangle.vertices[1].z, triangle.vertices[2].z, barycentric);
                         z = options.depth_min + (options.depth_max - options.depth_min) * (z + 1) / 2;
-                        
-                        if (z >= *depth) {
+
+                        bool pass = false;
+                        switch (options.depth_func) {
+                        case GL_ALWAYS:
+                            pass = true;
+                            break;
+                        case GL_NEVER:
+                            pass = false;
+                            break;
+                        case GL_GREATER:
+                            pass = z > *depth;
+                            break;
+                        case GL_GEQUAL:
+                            pass = z >= *depth;
+                            break;
+                        case GL_NOTEQUAL:
+                            pass = z != *depth;
+                            break;
+                        case GL_EQUAL:
+                            pass = z == *depth;
+                            break;
+                        case GL_LEQUAL:
+                            pass = z <= *depth;
+                            break;
+                        case GL_LESS:
+                            pass = z < *depth;
+                            break;
+                        }
+
+                        if (!pass) {
                             pixel_mask[y] ^= 1 << x;
                             continue;
                         }

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -77,7 +77,7 @@ static constexpr void setup_blend_factors(GLenum mode, FloatVector4& constant, f
         src_alpha = -1;
         break;
     case GL_DST_ALPHA:
-        dst_alpha = -1;
+        dst_alpha = 1;
         break;
     case GL_ONE_MINUS_DST_ALPHA:
         constant = { 1.0f, 1.0f, 1.0f, 1.0f };
@@ -139,7 +139,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             src_factor_dst_color);
 
         setup_blend_factors(
-            options.blend_source_factor,
+            options.blend_destination_factor,
             dst_constant,
             dst_factor_src_alpha,
             dst_factor_dst_alpha,

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -260,6 +260,8 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
 
                         auto barycentric = FloatVector3(coords.x(), coords.y(), coords.z()) * one_over_area;
                         float z = interpolate(triangle.vertices[0].z, triangle.vertices[1].z, triangle.vertices[2].z, barycentric);
+                        z = options.depth_min + (options.depth_max - options.depth_min) * (z + 1) / 2;
+                        
                         if (z >= *depth) {
                             pixel_mask[y] ^= 1 << x;
                             continue;

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -35,15 +35,15 @@ static Gfx::RGBA32 to_rgba32(const FloatVector4& v)
     u8 g = clamped.y() * 255;
     u8 b = clamped.z() * 255;
     u8 a = clamped.w() * 255;
-    return a << 24 | b << 16 | g << 8 | r;
+    return a << 24 | r << 16 | g << 8 | b;
 }
 
 static FloatVector4 to_vec4(Gfx::RGBA32 rgba)
 {
     return {
-        (rgba & 0xff) / 255.0f,
-        ((rgba >> 8) & 0xff) / 255.0f,
         ((rgba >> 16) & 0xff) / 255.0f,
+        ((rgba >> 8) & 0xff) / 255.0f,
+        (rgba & 0xff) / 255.0f,
         ((rgba >> 24) & 0xff) / 255.0f
     };
 }

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -308,6 +308,10 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                     continue;
             }
 
+            // We will not update the color buffer at all
+            if (!options.color_mask)
+                continue;
+
             // Draw the pixels according to the previously generated mask
             auto coords = b0;
             for (int y = 0; y < RASTERIZER_BLOCK_SIZE; y++, coords += step_y) {

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -29,6 +29,8 @@ struct RasterizerOptions {
     GLenum blend_source_factor { GL_ONE };
     GLenum blend_destination_factor { GL_ONE };
     u32 color_mask { 0xffffffff };
+    float depth_min { 0 };
+    float depth_max { 1 };
 };
 
 class SoftwareRasterizer final {

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -31,6 +31,7 @@ struct RasterizerOptions {
     u32 color_mask { 0xffffffff };
     float depth_min { 0 };
     float depth_max { 1 };
+    GLenum depth_func { GL_LESS };
 };
 
 class SoftwareRasterizer final {

--- a/Userland/Libraries/LibGL/Tex/MipMap.h
+++ b/Userland/Libraries/LibGL/Tex/MipMap.h
@@ -34,9 +34,9 @@ public:
         u32 texel = m_pixel_data.at(y * m_width + x);
 
         return {
-            (texel & 0xff) / 255.f,
-            ((texel >> 8) & 0xff) / 255.f,
             ((texel >> 16) & 0xff) / 255.f,
+            ((texel >> 8) & 0xff) / 255.f,
+            (texel & 0xff) / 255.f,
             ((texel >> 24) & 0xff) / 255.f
         };
     }

--- a/Userland/Libraries/LibGL/Tex/MipMap.h
+++ b/Userland/Libraries/LibGL/Tex/MipMap.h
@@ -42,8 +42,8 @@ public:
     }
 
 private:
-    GLsizei m_width;
-    GLsizei m_height;
+    GLsizei m_width { 0 };
+    GLsizei m_height { 0 };
     Vector<u32> m_pixel_data;
 };
 }

--- a/Userland/Libraries/LibGL/Tex/Sampler2D.cpp
+++ b/Userland/Libraries/LibGL/Tex/Sampler2D.cpp
@@ -57,6 +57,9 @@ FloatVector4 Sampler2D::sample(FloatVector2 const& uv) const
 
     MipMap const& mip = m_texture.mipmap(lod);
 
+    if (mip.width() < 1 || mip.height() < 1)
+        return { 1, 1, 1, 1 };
+
     float x = wrap(uv.x(), m_wrap_t_mode);
     float y = wrap(uv.y(), m_wrap_s_mode);
 

--- a/Userland/Libraries/LibGL/Tex/Sampler2D.cpp
+++ b/Userland/Libraries/LibGL/Tex/Sampler2D.cpp
@@ -68,7 +68,7 @@ FloatVector4 Sampler2D::sample(FloatVector2 const& uv) const
 
     // Sampling implemented according to https://www.khronos.org/registry/OpenGL/specs/gl/glspec121.pdf Chapter 3.8
     if (m_mag_filter == GL_NEAREST) {
-        return mip.texel(static_cast<unsigned>(x) % mip.width(), static_cast<unsigned>(y) % mip.height());
+        return mip.texel(static_cast<unsigned>(x), static_cast<unsigned>(y));
     } else if (m_mag_filter == GL_LINEAR) {
         // FIXME: Implement different sampling points for wrap modes other than GL_REPEAT
 
@@ -88,8 +88,11 @@ FloatVector4 Sampler2D::sample(FloatVector2 const& uv) const
 
         float frac_x = x - floorf(x);
         float frac_y = y - floorf(y);
+        float one_minus_frac_x = 1 - frac_x;
 
-        return t0 * (1 - frac_x) * (1 - frac_y) + t1 * frac_x * (1 - frac_y) + t2 * (1 - frac_x) * frac_y + t3 * frac_x * frac_y;
+        auto h1 = t0 * one_minus_frac_x + t1 * frac_x;
+        auto h2 = t2 * one_minus_frac_x + t3 * frac_x;
+        return h1 * (1 - frac_y) + h2 * frac_y;
     } else {
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibGL/Tex/Texture2D.cpp
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.cpp
@@ -18,17 +18,18 @@ void Texture2D::upload_texture_data(GLenum, GLint lod, GLint internal_format, GL
     // Considering we control this library, and `gl.h` itself, we don't need to add any
     // checks here to see if we support them; the program will simply fail to compile..
 
-    // Somebody passed us in nullptr...
-    // Apparently this allocates memory on the GPU (according to Khronos docs..)?
+    auto& mip = m_mipmaps[lod];
+    mip.set_width(width);
+    mip.set_height(height);
+
+    // No pixel data was supplied. Just allocate texture memory and leave it uninitialized.
     if (pixels == nullptr) {
-        dbgln("LibGL: pixels == nullptr when uploading texture data.");
-        VERIFY_NOT_REACHED();
+        mip.pixel_data().resize(width * height);
+        return;
     }
 
     m_internal_format = internal_format;
 
-    // Get reference to the mip
-    auto& mip = m_mipmaps[lod];
     const u8* pixel_byte_array = reinterpret_cast<const u8*>(pixels);
 
     mip.pixel_data().clear();
@@ -75,9 +76,6 @@ void Texture2D::upload_texture_data(GLenum, GLint lod, GLint internal_format, GL
     } else {
         VERIFY_NOT_REACHED();
     }
-
-    mip.set_width(width);
-    mip.set_height(height);
 }
 
 MipMap const& Texture2D::mipmap(unsigned lod) const


### PR DESCRIPTION
#7062 

Implement missing features needed by glquake.
Also fixes several bugs that occured while porting.

There are still some functions missing:

* glTexEnvf
* glPixelStorei
* glTexSubImage2D
* glDrawBuffer
* glPolygonMode
* glPolygonOffset
* glFogi
* glFogf
* glFogfv
