### PR TITLE
Base: Associate obj files with 3DFileViewer

### DIFF
--- a/Base/res/apps/3DFileViewer.af
+++ b/Base/res/apps/3DFileViewer.af
@@ -2,3 +2,6 @@
 Name=3D File Viewer
 Executable=/bin/3DFileViewer
 Category=Graphics
+
+[Launcher]
+FileTypes=obj


### PR DESCRIPTION
With this change, a user can open .obj files from FileManager.