### PR TITLE
LibJS: Implement Temporal.Calendar.prototype.monthDayFromFields() + Temporal.PlainDate.prototype.toPlainMonthDay()

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -276,6 +276,7 @@ namespace JS {
     P(minutes)                               \
     P(month)                                 \
     P(monthCode)                             \
+    P(monthDayFromFields)                    \
     P(months)                                \
     P(monthsInYear)                          \
     P(multiline)                             \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -392,6 +392,7 @@ namespace JS {
     P(toLowerCase)                           \
     P(toPlainDate)                           \
     P(toPlainDateTime)                       \
+    P(toPlainMonthDay)                       \
     P(toPlainTime)                           \
     P(toPlainYearMonth)                      \
     P(toString)                              \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -417,7 +417,7 @@ PlainDate* date_from_fields(GlobalObject& global_object, Object& calendar, Objec
     return static_cast<PlainDate*>(date_object);
 }
 
-// 12.1.25 YearMonthFromFields ( calendar, fields [ , options ] ),
+// 12.1.25 YearMonthFromFields ( calendar, fields [ , options ] ), https://tc39.es/proposal-temporal/#sec-temporal-yearmonthfromfields
 PlainYearMonth* year_month_from_fields(GlobalObject& global_object, Object& calendar, Object& fields, Object* options)
 {
     auto& vm = global_object.vm();

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -447,6 +447,36 @@ PlainYearMonth* year_month_from_fields(GlobalObject& global_object, Object& cale
     return static_cast<PlainYearMonth*>(year_month_object);
 }
 
+// 12.1.26 MonthDayFromFields ( calendar, fields [ , options ] ), https://tc39.es/proposal-temporal/#sec-temporal-monthdayfromfields
+PlainMonthDay* month_day_from_fields(GlobalObject& global_object, Object& calendar, Object& fields, Object* options)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Assert: Type(calendar) is Object.
+    // 2. Assert: Type(fields) is Object.
+    // 3. If options is not present, then
+    //     a. Set options to undefined.
+    // 4. Else,
+    //     a. Assert: Type(options) is Object.
+
+    // 5. Let monthDay be ? Invoke(calendar, "monthDayFromFields", « fields, options »).
+    auto month_day = Value(&calendar).invoke(global_object, vm.names.monthDayFromFields, &fields, options ?: js_undefined());
+    if (vm.exception())
+        return {};
+
+    // 6. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
+    auto* month_day_object = month_day.to_object(global_object);
+    if (!month_day_object)
+        return {};
+    if (!is<PlainMonthDay>(month_day_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Temporal.PlainMonthDay");
+        return {};
+    }
+
+    // 7. Return monthDay.
+    return static_cast<PlainMonthDay*>(month_day_object);
+}
+
 // 12.1.28 CalendarEquals ( one, two ), https://tc39.es/proposal-temporal/#sec-temporal-calendarequals
 bool calendar_equals(GlobalObject& global_object, Object& one, Object& two)
 {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -9,6 +9,7 @@
 
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>
+#include <LibJS/Runtime/Temporal/PlainMonthDay.h>
 #include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -62,6 +63,7 @@ String build_iso_month_code(u8 month);
 double resolve_iso_month(GlobalObject&, Object& fields);
 Optional<ISODate> iso_date_from_fields(GlobalObject&, Object& fields, Object& options);
 Optional<ISOYearMonth> iso_year_month_from_fields(GlobalObject&, Object& fields, Object& options);
+Optional<ISOMonthDay> iso_month_day_from_fields(GlobalObject&, Object& fields, Object& options);
 i32 iso_year(Object& temporal_object);
 u8 iso_month(Object& temporal_object);
 String iso_month_code(Object& temporal_object);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -51,6 +51,7 @@ Object* to_temporal_calendar_with_iso_default(GlobalObject&, Value);
 Object* get_temporal_calendar_with_iso_default(GlobalObject&, Object&);
 PlainDate* date_from_fields(GlobalObject&, Object& calendar, Object& fields, Object& options);
 PlainYearMonth* year_month_from_fields(GlobalObject&, Object& calendar, Object& fields, Object* options = nullptr);
+PlainMonthDay* month_day_from_fields(GlobalObject& global_object, Object& calendar, Object& fields, Object* options = nullptr);
 bool calendar_equals(GlobalObject&, Object& one, Object& two);
 Object* consolidate_calendars(GlobalObject&, Object& one, Object& two);
 bool is_iso_leap_year(i32 year);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -35,6 +35,7 @@ void CalendarPrototype::initialize(GlobalObject& global_object)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.dateFromFields, date_from_fields, 2, attr);
     define_native_function(vm.names.yearMonthFromFields, year_month_from_fields, 2, attr);
+    define_native_function(vm.names.monthDayFromFields, month_day_from_fields, 2, attr);
     define_native_function(vm.names.year, year, 1, attr);
     define_native_function(vm.names.month, month, 1, attr);
     define_native_function(vm.names.monthCode, month_code, 1, attr);
@@ -140,6 +141,40 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::year_month_from_fields)
 
     // 7. Return ? CreateTemporalYearMonth(result.[[Year]], result.[[Month]], calendar, result.[[ReferenceISODay]]).
     return create_temporal_year_month(global_object, result->year, result->month, *calendar, result->reference_iso_day);
+}
+
+// 12.4.6 Temporal.Calendar.prototype.monthDayFromFields ( fields, options ), https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.monthdayfromfields
+// NOTE: This is the minimum monthDayFromFields implementation for engines without ECMA-402.
+JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::month_day_from_fields)
+{
+    // 1. Let calendar be the this value.
+    // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+    auto* calendar = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Assert: calendar.[[Identifier]] is "iso8601".
+    VERIFY(calendar->identifier() == "iso8601"sv);
+
+    // 4. If Type(fields) is not Object, throw a TypeError exception.
+    auto fields = vm.argument(0);
+    if (!fields.is_object()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObject, fields.to_string_without_side_effects());
+        return {};
+    }
+
+    // 5. Set options to ? GetOptionsObject(options).
+    auto* options = get_options_object(global_object, vm.argument(1));
+    if (vm.exception())
+        return {};
+
+    // 6. Let result be ? ISOMonthDayFromFields(fields, options).
+    auto result = iso_month_day_from_fields(global_object, fields.as_object(), *options);
+    if (vm.exception())
+        return {};
+
+    // 7. Return ? CreateTemporalMonthDay(result.[[Month]], result.[[Day]], calendar, result.[[ReferenceISOYear]]).
+    return create_temporal_month_day(global_object, result->month, result->day, *calendar, result->reference_iso_year);
 }
 
 // 12.4.9 Temporal.Calendar.prototype.year ( temporalDateLike ), https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.year

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
@@ -22,6 +22,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(id_getter);
     JS_DECLARE_NATIVE_FUNCTION(date_from_fields);
     JS_DECLARE_NATIVE_FUNCTION(year_month_from_fields);
+    JS_DECLARE_NATIVE_FUNCTION(month_day_from_fields);
     JS_DECLARE_NATIVE_FUNCTION(year);
     JS_DECLARE_NATIVE_FUNCTION(month);
     JS_DECLARE_NATIVE_FUNCTION(month_code);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/PlainDate.h>
 #include <LibJS/Runtime/Temporal/PlainDatePrototype.h>
+#include <LibJS/Runtime/Temporal/PlainMonthDay.h>
 #include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 
 namespace JS::Temporal {
@@ -46,6 +47,7 @@ void PlainDatePrototype::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.toPlainYearMonth, to_plain_year_month, 0, attr);
+    define_native_function(vm.names.toPlainMonthDay, to_plain_month_day, 0, attr);
     define_native_function(vm.names.getISOFields, get_iso_fields, 0, attr);
     define_native_function(vm.names.withCalendar, with_calendar, 1, attr);
     define_native_function(vm.names.equals, equals, 1, attr);
@@ -294,6 +296,32 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_plain_year_month)
 
     // 6. Return ? YearMonthFromFields(calendar, fields).
     return year_month_from_fields(global_object, calendar, *fields);
+}
+
+// 3.3.17 Temporal.PlainDate.prototype.toPlainMonthDay ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday
+JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_plain_month_day)
+{
+    // 1. Let temporalDate be the this value.
+    // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
+    auto* temporal_date = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let calendar be temporalDate.[[Calendar]].
+    auto& calendar = temporal_date->calendar();
+
+    // 4. Let fieldNames be ? CalendarFields(calendar, « "day", "monthCode" »).
+    auto field_names = calendar_fields(global_object, calendar, { "day"sv, "monthCode"sv });
+    if (vm.exception())
+        return {};
+
+    // 5. Let fields be ? PrepareTemporalFields(temporalDate, fieldNames, «»).
+    auto* fields = prepare_temporal_fields(global_object, *temporal_date, field_names, {});
+    if (vm.exception())
+        return {};
+
+    // 6. Return ? MonthDayFromFields(calendar, fields).
+    return month_day_from_fields(global_object, calendar, *fields);
 }
 
 // 3.3.18 Temporal.PlainDate.prototype.getISOFields ( ), https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.getisofields

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
@@ -33,6 +33,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(months_in_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(in_leap_year_getter);
     JS_DECLARE_NATIVE_FUNCTION(to_plain_year_month);
+    JS_DECLARE_NATIVE_FUNCTION(to_plain_month_day);
     JS_DECLARE_NATIVE_FUNCTION(get_iso_fields);
     JS_DECLARE_NATIVE_FUNCTION(with_calendar);
     JS_DECLARE_NATIVE_FUNCTION(equals);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
@@ -33,6 +33,12 @@ private:
     Object& m_calendar;   // [[Calendar]]
 };
 
+struct ISOMonthDay {
+    u8 month;
+    u8 day;
+    i32 reference_iso_year;
+};
+
 PlainMonthDay* create_temporal_month_day(GlobalObject&, u8 iso_month, u8 iso_day, Object& calendar, i32 reference_iso_year, FunctionObject* new_target = nullptr);
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Calendar/Calendar.prototype.monthDayFromFields.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Calendar/Calendar.prototype.monthDayFromFields.js
@@ -1,0 +1,60 @@
+describe("correct behavior", () => {
+    test("length is 2", () => {
+        expect(Temporal.Calendar.prototype.monthDayFromFields).toHaveLength(2);
+    });
+
+    test("basic functionality", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainMonthDay = calendar.monthDayFromFields({ year: 2021, month: 7, day: 6 });
+        expect(plainMonthDay.calendar).toBe(calendar);
+        expect(plainMonthDay.monthCode).toBe("M07");
+        expect(plainMonthDay.day).toBe(6);
+
+        const fields = plainMonthDay.getISOFields();
+        expect(fields.isoYear).toBe(1972); // No, this isn't a mistake
+    });
+
+    test("with monthCode", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainMonthDay = calendar.monthDayFromFields({ monthCode: "M07", day: 6 });
+        expect(plainMonthDay.calendar).toBe(calendar);
+        expect(plainMonthDay.monthCode).toBe("M07");
+        expect(plainMonthDay.day).toBe(6);
+
+        const fields = plainMonthDay.getISOFields();
+        expect(fields.isoYear).toBe(1972);
+    });
+});
+
+describe("errors", () => {
+    test("first argument must be an object", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        expect(() => {
+            calendar.monthDayFromFields(42);
+        }).toThrowWithMessage(TypeError, "42 is not an object");
+    });
+
+    test("month or monthCode field is required", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        expect(() => {
+            calendar.monthDayFromFields({ year: 2021 });
+        }).toThrowWithMessage(TypeError, "Required property month is missing or undefined");
+    });
+
+    test("day field is required", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        expect(() => {
+            calendar.monthDayFromFields({ year: 2021, month: 7 });
+        }).toThrowWithMessage(TypeError, "Required property day is missing or undefined");
+    });
+
+    test("monthCode or year field is required when month is given", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        expect(() => {
+            calendar.monthDayFromFields({ month: 7, day: 6 });
+        }).toThrowWithMessage(
+            TypeError,
+            "Required property monthCode or year is missing or undefined"
+        );
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.toPlainMonthDay.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.toPlainMonthDay.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Temporal.PlainDate.prototype.toPlainMonthDay).toHaveLength(0);
+    });
+
+    test("basic functionality", () => {
+        const plainDate = new Temporal.PlainDate(2021, 7, 6);
+        const plainMonthDay = plainDate.toPlainMonthDay();
+        expect(plainMonthDay.calendar).toBe(plainDate.calendar);
+        expect(plainMonthDay.monthCode).toBe("M07");
+        expect(plainMonthDay.day).toBe(6);
+        const fields = plainMonthDay.getISOFields();
+        expect(fields.isoYear).toBe(1972);
+    });
+});


### PR DESCRIPTION
Ticks two checkboxes in #8982.