### PR TITLE
LibWeb: Replace is_inherited_property() with generated code

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -293,6 +293,7 @@
     "initial": "normal"
   },
   "list-style": {
+    "inherited": true,
     "longhands": [
       "list-style-type",
       "list-style-position",
@@ -422,7 +423,8 @@
     "initial": "none"
   },
   "text-decoration-line": {
-    "inherited": false,
+    "__comment": "FIXME: This property is not supposed to be inherited, but we currently rely on inheritance to propagate decorations into line boxes.",
+    "inherited": true,
     "initial": "none"
   },
   "text-decoration-style": {

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -102,38 +102,6 @@ void StyleResolver::sort_matching_rules(Vector<MatchingRule>& matching_rules) co
     });
 }
 
-bool StyleResolver::is_inherited_property(CSS::PropertyID property_id)
-{
-    static HashTable<CSS::PropertyID> inherited_properties;
-    if (inherited_properties.is_empty()) {
-        inherited_properties.set(CSS::PropertyID::BorderCollapse);
-        inherited_properties.set(CSS::PropertyID::BorderSpacing);
-        inherited_properties.set(CSS::PropertyID::Color);
-        inherited_properties.set(CSS::PropertyID::FontFamily);
-        inherited_properties.set(CSS::PropertyID::FontSize);
-        inherited_properties.set(CSS::PropertyID::FontStyle);
-        inherited_properties.set(CSS::PropertyID::FontVariant);
-        inherited_properties.set(CSS::PropertyID::FontWeight);
-        inherited_properties.set(CSS::PropertyID::LetterSpacing);
-        inherited_properties.set(CSS::PropertyID::LineHeight);
-        inherited_properties.set(CSS::PropertyID::ListStyle);
-        inherited_properties.set(CSS::PropertyID::ListStyleImage);
-        inherited_properties.set(CSS::PropertyID::ListStylePosition);
-        inherited_properties.set(CSS::PropertyID::ListStyleType);
-        inherited_properties.set(CSS::PropertyID::TextAlign);
-        inherited_properties.set(CSS::PropertyID::TextIndent);
-        inherited_properties.set(CSS::PropertyID::TextTransform);
-        inherited_properties.set(CSS::PropertyID::Visibility);
-        inherited_properties.set(CSS::PropertyID::WhiteSpace);
-        inherited_properties.set(CSS::PropertyID::WordSpacing);
-
-        // FIXME: This property is not supposed to be inherited, but we currently
-        //        rely on inheritance to propagate decorations into line boxes.
-        inherited_properties.set(CSS::PropertyID::TextDecorationLine);
-    }
-    return inherited_properties.contains(property_id);
-}
-
 enum class Edge {
     Top,
     Right,

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.h
@@ -41,8 +41,6 @@ public:
     CustomPropertyResolutionTuple resolve_custom_property_with_specificity(DOM::Element&, String const&) const;
     Optional<StyleProperty> resolve_custom_property(DOM::Element&, String const&) const;
 
-    static bool is_inherited_property(CSS::PropertyID);
-
 private:
     template<typename Callback>
     void for_each_stylesheet(Callback) const;

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -71,6 +71,7 @@ enum class PropertyID {
 
 PropertyID property_id_from_string(const StringView&);
 const char* string_from_property_id(PropertyID);
+bool is_inherited_property(PropertyID);
 bool is_pseudo_property(PropertyID);
 
 } // namespace Web::CSS


### PR DESCRIPTION
We already include the inheritance for each property in Properties.json,
so made sense to use that instead of a list in StyleResolver.

Added `inherited: true` to a couple of properties to match the previous
code's behavior. One of those had a FIXME which I've moved to the JSON
file, which is hacky, but it works.