### PR TITLE
Kernel: Make makedev()/minor()/major() static (again)

### DIFF
--- a/Kernel/API/POSIX/sys/types.h
+++ b/Kernel/API/POSIX/sys/types.h
@@ -92,9 +92,9 @@ typedef struct __pthread_condattr_t {
     int clockid; // clockid_t
 } pthread_condattr_t;
 
-inline dev_t makedev(unsigned major, unsigned minor) { return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u); }
-inline unsigned int major(dev_t dev) { return (dev & 0xfff00u) >> 8u; }
-inline unsigned int minor(dev_t dev) { return (dev & 0xffu) | ((dev >> 12u) & 0xfff00u); }
+static inline dev_t makedev(unsigned major, unsigned minor) { return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u); }
+static inline unsigned int major(dev_t dev) { return (dev & 0xfff00u) >> 8u; }
+static inline unsigned int minor(dev_t dev) { return (dev & 0xffu) | ((dev >> 12u) & 0xfff00u); }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This was originally done in 7274037 and for some reason reverted in 740140a.

This avoids "multiple definitions" link errors and fixes the libuv port.