### PR TITLE
LibAudio: Playback of FLACs with non-44100-Hz sample rate

### DIFF
--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -91,7 +91,7 @@ String sample_format_name(PcmSampleFormat format);
 template<typename SampleType>
 class ResampleHelper {
 public:
-    ResampleHelper(double source, double target);
+    ResampleHelper(u32 source, u32 target);
 
     // To be used as follows:
     // while the resampler doesn't need a new sample, read_sample(current) and store the resulting samples.
@@ -103,9 +103,12 @@ public:
     bool read_sample(SampleType& next_l, SampleType& next_r);
     Vector<SampleType> resample(Vector<SampleType> to_resample);
 
+    void reset();
+
 private:
-    const double m_ratio;
-    double m_current_ratio { 0 };
+    const u32 m_source;
+    const u32 m_target;
+    u32 m_current_ratio { 0 };
     SampleType m_last_sample_l;
     SampleType m_last_sample_r;
 };

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -124,7 +124,7 @@ private:
     bool m_valid { false };
     RefPtr<Core::File> m_file;
     String m_error_string;
-    OwnPtr<ResampleHelper<double>> m_resampler;
+    OwnPtr<ResampleHelper<i32>> m_resampler;
 
     // Data obtained directly from the FLAC metadata: many values have specific bit counts
     u32 m_sample_rate { 0 };         // 20 bit

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -42,6 +42,10 @@ int main(int argc, char** argv)
             out("{}/{}", loader->loaded_samples(), loader->total_samples());
             fflush(stdout);
             audio_client->enqueue(*samples);
+        } else if (loader->has_error()) {
+            outln();
+            outln("Error: {}", loader->error_string());
+            break;
         } else if (should_loop) {
             loader->reset();
         } else if (audio_client->get_remaining_samples()) {


### PR DESCRIPTION
FLAC files with a sample rate other than 44100 Hz can now be properly played back.

An additional fix that came up while debugging the resampler was that `aplay` didn't respect loader errors. So this is fixed in the third commit.