### PR TITLE
Userland+LibGUI: Margins constructor changes

### DIFF
--- a/Base/res/devel/templates/serenity-application/main.cpp
+++ b/Base/res/devel/templates/serenity-application/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
     main_widget.set_fill_with_background_color(true);
 
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 16, 16, 16, 16 });
+    layout.set_margins(16);
 
     auto& button = main_widget.add<GUI::Button>("Click me!");
     button.on_click = [&](auto) {

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -56,7 +56,7 @@ public:
         m_root_container = m_slider_window->set_main_widget<GUI::Label>();
         m_root_container->set_fill_with_background_color(true);
         m_root_container->set_layout<GUI::VerticalBoxLayout>();
-        m_root_container->layout()->set_margins({ 0, 4, 0, 4 });
+        m_root_container->layout()->set_margins({ 4, 0, 4, 0 });
         m_root_container->layout()->set_spacing(0);
         m_root_container->set_frame_thickness(2);
         m_root_container->set_frame_shape(Gfx::FrameShape::Container);

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -56,7 +56,7 @@ public:
         m_root_container = m_slider_window->set_main_widget<GUI::Label>();
         m_root_container->set_fill_with_background_color(true);
         m_root_container->set_layout<GUI::VerticalBoxLayout>();
-        m_root_container->layout()->set_margins({ 4, 0, 4, 0 });
+        m_root_container->layout()->set_margins({ 4, 0 });
         m_root_container->layout()->set_spacing(0);
         m_root_container->set_frame_thickness(2);
         m_root_container->set_frame_shape(Gfx::FrameShape::Container);

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -39,7 +39,7 @@ public:
     {
         auto& layout = set_layout<GUI::HorizontalBoxLayout>();
         layout.set_spacing(12);
-        layout.set_margins({ 4, 4, 4, 4 });
+        layout.set_margins(4);
 
         m_image = add<GUI::ImageWidget>();
 
@@ -221,12 +221,12 @@ int main(int argc, char** argv)
     container.set_fill_with_background_color(true);
     container.set_frame_shadow(Gfx::FrameShadow::Raised);
     auto& layout = container.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 8, 8, 0, 8 });
+    layout.set_margins({ 8, 8, 0 });
 
     auto& text_box = container.add<GUI::TextBox>();
     auto& results_container = container.add<GUI::Widget>();
     auto& results_layout = results_container.set_layout<GUI::VerticalBoxLayout>();
-    results_layout.set_margins({ 10, 0, 10, 0 });
+    results_layout.set_margins({ 10, 0 });
 
     auto mark_selected_item = [&]() {
         for (size_t i = 0; i < app_state.visible_result_count; ++i) {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -221,12 +221,12 @@ int main(int argc, char** argv)
     container.set_fill_with_background_color(true);
     container.set_frame_shadow(Gfx::FrameShadow::Raised);
     auto& layout = container.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 8, 8, 8, 0 });
+    layout.set_margins({ 8, 8, 0, 8 });
 
     auto& text_box = container.add<GUI::TextBox>();
     auto& results_container = container.add<GUI::Widget>();
     auto& results_layout = results_container.set_layout<GUI::VerticalBoxLayout>();
-    results_layout.set_margins({ 0, 10, 0, 10 });
+    results_layout.set_margins({ 10, 0, 10, 0 });
 
     auto mark_selected_item = [&]() {
         for (size_t i = 0; i < app_state.visible_result_count; ++i) {

--- a/Userland/Applications/Browser/BrowserWindow.gml
+++ b/Userland/Applications/Browser/BrowserWindow.gml
@@ -12,7 +12,7 @@
 
     @GUI::TabWidget {
         name: "tab_widget"
-        container_margins: [0, 0, 0, 0]
+        container_margins: [0]
         uniform_tabs: true
         text_alignment: "CenterLeft"
     }

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -61,7 +61,7 @@ DownloadWidget::DownloadWidget(const URL& url)
 
     set_fill_with_background_color(true);
     auto& layout = set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    layout.set_margins(4);
 
     auto& animation_container = add<GUI::Widget>();
     animation_container.set_fixed_height(32);

--- a/Userland/Applications/Browser/EditBookmark.gml
+++ b/Userland/Applications/Browser/EditBookmark.gml
@@ -4,7 +4,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
 

--- a/Userland/Applications/Calculator/CalculatorWindow.gml
+++ b/Userland/Applications/Calculator/CalculatorWindow.gml
@@ -13,7 +13,7 @@
 
         @GUI::Widget {
             layout: @GUI::VerticalBoxLayout {
-                margins: [8, 8, 8, 8]
+                margins: [8]
             }
 
             @GUI::TextBox {

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -39,7 +39,7 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     auto& top_container = widget.add<GUI::Widget>();
     top_container.set_layout<GUI::VerticalBoxLayout>();
     top_container.set_fixed_height(45);
-    top_container.layout()->set_margins({ 4, 4, 4, 4 });
+    top_container.layout()->set_margins(4);
 
     auto& add_label = top_container.add<GUI::Label>("Add title & date:");
     add_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -52,7 +52,7 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     auto& middle_container = widget.add<GUI::Widget>();
     middle_container.set_layout<GUI::HorizontalBoxLayout>();
     middle_container.set_fixed_height(25);
-    middle_container.layout()->set_margins({ 4, 4, 4, 4 });
+    middle_container.layout()->set_margins(4);
 
     auto& starting_month_combo = middle_container.add<GUI::ComboBox>();
     starting_month_combo.set_only_allow_values_from_model(true);

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [5, 5, 5, 5]
+        margins: [5]
     }
 
     @GUI::Widget {

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -225,7 +225,7 @@ int main(int argc, char** argv)
 
     auto& backtrace_tab = tab_widget.add_tab<GUI::Widget>("Backtrace");
     backtrace_tab.set_layout<GUI::VerticalBoxLayout>();
-    backtrace_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    backtrace_tab.layout()->set_margins(4);
 
     auto& backtrace_label = backtrace_tab.add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:");
     backtrace_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -236,7 +236,7 @@ int main(int argc, char** argv)
     for (auto& backtrace : thread_backtraces) {
         auto& backtrace_text_editor = backtrace_tab_widget.add_tab<GUI::TextEditor>(backtrace.title);
         backtrace_text_editor.set_layout<GUI::VerticalBoxLayout>();
-        backtrace_text_editor.layout()->set_margins({ 4, 4, 4, 4 });
+        backtrace_text_editor.layout()->set_margins(4);
         backtrace_text_editor.set_text(backtrace.text);
         backtrace_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
         backtrace_text_editor.set_should_hide_unnecessary_scrollbars(true);
@@ -244,7 +244,7 @@ int main(int argc, char** argv)
 
     auto& cpu_registers_tab = tab_widget.add_tab<GUI::Widget>("CPU Registers");
     cpu_registers_tab.set_layout<GUI::VerticalBoxLayout>();
-    cpu_registers_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    cpu_registers_tab.layout()->set_margins(4);
 
     auto& cpu_registers_label = cpu_registers_tab.add<GUI::Label>("The CPU register state for each thread alive during the crash is listed below:");
     cpu_registers_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -255,7 +255,7 @@ int main(int argc, char** argv)
     for (auto& cpu_registers : thread_cpu_registers) {
         auto& cpu_registers_text_editor = cpu_registers_tab_widget.add_tab<GUI::TextEditor>(cpu_registers.title);
         cpu_registers_text_editor.set_layout<GUI::VerticalBoxLayout>();
-        cpu_registers_text_editor.layout()->set_margins({ 4, 4, 4, 4 });
+        cpu_registers_text_editor.layout()->set_margins(4);
         cpu_registers_text_editor.set_text(cpu_registers.text);
         cpu_registers_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
         cpu_registers_text_editor.set_should_hide_unnecessary_scrollbars(true);
@@ -263,7 +263,7 @@ int main(int argc, char** argv)
 
     auto& environment_tab = tab_widget.add_tab<GUI::Widget>("Environment");
     environment_tab.set_layout<GUI::VerticalBoxLayout>();
-    environment_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    environment_tab.layout()->set_margins(4);
 
     auto& environment_text_editor = environment_tab.add<GUI::TextEditor>();
     environment_text_editor.set_text(String::join("\n", environment));

--- a/Userland/Applications/DisplaySettings/BackgroundSettings.gml
+++ b/Userland/Applications/DisplaySettings/BackgroundSettings.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [8, 8, 8, 8]
+        margins: [8]
     }
 
     @DisplaySettings::MonitorWidget {

--- a/Userland/Applications/DisplaySettings/DesktopSettings.gml
+++ b/Userland/Applications/DisplaySettings/DesktopSettings.gml
@@ -7,7 +7,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 24, 16, 6]
+            margins: [24, 16, 6, 16]
         }
 
         title: "Workspaces"

--- a/Userland/Applications/DisplaySettings/DesktopSettings.gml
+++ b/Userland/Applications/DisplaySettings/DesktopSettings.gml
@@ -2,12 +2,12 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [8, 8, 8, 8]
+        margins: [8]
     }
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [24, 16, 6, 16]
+            margins: [24, 16, 6]
         }
 
         title: "Workspaces"
@@ -17,7 +17,7 @@
             fixed_height: 32
 
             layout: @GUI::HorizontalBoxLayout {
-                margins: [6, 6, 6, 6]
+                margins: [6]
             }
 
             @GUI::Label {
@@ -57,7 +57,7 @@
             }
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [6, 6, 6, 6]
+                    margins: [6]
                 }
                 @GUI::Label {
                     text: "Use the Ctrl+Alt+Arrow hotkeys to move between workspaces."

--- a/Userland/Applications/DisplaySettings/FontSettings.gml
+++ b/Userland/Applications/DisplaySettings/FontSettings.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [8, 8, 8, 8]
+        margins: [8]
         spacing: 8
     }
 

--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [8, 8, 8, 8]
+        margins: [8]
     }
 
     @DisplaySettings::MonitorWidget {
@@ -34,7 +34,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [24, 16, 6, 16]
+            margins: [24, 16, 6]
         }
 
         title: "Screen settings"

--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -18,7 +18,7 @@
     @GUI::Widget {
         shrink_to_fit: true
         layout: @GUI::HorizontalBoxLayout {
-            margins: [16, 8, 8, 6]
+            margins: [8, 8, 6, 16]
         }
 
         @GUI::Label {
@@ -34,7 +34,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 24, 16, 6]
+            margins: [24, 16, 6, 16]
         }
 
         title: "Screen settings"

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    main_widget.layout()->set_margins(4);
     main_widget.layout()->set_spacing(6);
 
     auto& tab_widget = main_widget.add<GUI::TabWidget>();

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -134,7 +134,7 @@ DirectoryView::DirectoryView(Mode mode)
     , m_sorting_model(GUI::SortingProxyModel::create(m_model))
 {
     set_active_widget(nullptr);
-    set_content_margins({ 2, 2, 2, 2 });
+    set_content_margins(2);
 
     setup_actions();
 

--- a/Userland/Applications/FileManager/FileOperationProgress.gml
+++ b/Userland/Applications/FileManager/FileOperationProgress.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::Widget {

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -32,7 +32,7 @@ PropertiesWindow::PropertiesWindow(String const& path, bool disable_rename, Wind
 
     auto& main_widget = set_main_widget<GUI::Widget>();
     main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    main_widget.layout()->set_margins(4);
     main_widget.set_fill_with_background_color(true);
 
     set_rect({ 0, 0, 360, 420 });

--- a/Userland/Applications/FileManager/PropertiesWindowGeneralTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowGeneralTab.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [12, 8, 12, 8]
+        margins: [8, 12, 8, 12]
         spacing: 10
     }
 

--- a/Userland/Applications/FileManager/PropertiesWindowGeneralTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowGeneralTab.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [8, 12, 8, 12]
+        margins: [8, 12]
         spacing: 10
     }
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -443,12 +443,12 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     auto& toolbar_container = *widget.find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& main_toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("main_toolbar");
     auto& location_toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("location_toolbar");
-    location_toolbar.layout()->set_margins({ 6, 3, 6, 3 });
+    location_toolbar.layout()->set_margins({ 3, 6, 3, 6 });
 
     auto& location_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("location_textbox");
 
     auto& breadcrumb_toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("breadcrumb_toolbar");
-    breadcrumb_toolbar.layout()->set_margins({ 6, 0, 6, 0 });
+    breadcrumb_toolbar.layout()->set_margins({ 0, 6, 0, 6 });
     auto& breadcrumbbar = *widget.find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
 
     auto& splitter = *widget.find_descendant_of_type_named<GUI::HorizontalSplitter>("splitter");

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -443,12 +443,12 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     auto& toolbar_container = *widget.find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");
     auto& main_toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("main_toolbar");
     auto& location_toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("location_toolbar");
-    location_toolbar.layout()->set_margins({ 3, 6, 3, 6 });
+    location_toolbar.layout()->set_margins({ 3, 6 });
 
     auto& location_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("location_textbox");
 
     auto& breadcrumb_toolbar = *widget.find_descendant_of_type_named<GUI::Toolbar>("breadcrumb_toolbar");
-    breadcrumb_toolbar.layout()->set_margins({ 0, 6, 0, 6 });
+    breadcrumb_toolbar.layout()->set_margins({ 0, 6 });
     auto& breadcrumbbar = *widget.find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
 
     auto& splitter = *widget.find_descendant_of_type_named<GUI::HorizontalSplitter>("splitter");

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -60,12 +60,12 @@ static RefPtr<GUI::Window> create_font_preview_window(FontEditorWidget& editor)
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_margins({ 2, 2, 2, 2 });
+    main_widget.layout()->set_margins(2);
     main_widget.layout()->set_spacing(4);
 
     auto& preview_box = main_widget.add<GUI::GroupBox>();
     preview_box.set_layout<GUI::VerticalBoxLayout>();
-    preview_box.layout()->set_margins({ 8, 8, 8, 8 });
+    preview_box.layout()->set_margins(8);
 
     auto& preview_label = preview_box.add<GUI::Label>();
     preview_label.set_font(editor.edited_font());

--- a/Userland/Applications/FontEditor/NewFontDialogPage1.gml
+++ b/Userland/Applications/FontEditor/NewFontDialogPage1.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::Widget {

--- a/Userland/Applications/FontEditor/NewFontDialogPage2.gml
+++ b/Userland/Applications/FontEditor/NewFontDialogPage2.gml
@@ -11,7 +11,7 @@
             title: "Metadata"
             fixed_width: 200
             layout: @GUI::VerticalBoxLayout {
-                margins: [8, 16, 8, 8]
+                margins: [16, 8, 8, 8]
             }
 
             @GUI::Widget {
@@ -125,7 +125,7 @@
             @GUI::Widget {
                 name: "glyph_editor_container"
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [0, 5, 0, 0]
+                    margins: [5, 0, 0, 0]
                 }
             }
 

--- a/Userland/Applications/FontEditor/NewFontDialogPage2.gml
+++ b/Userland/Applications/FontEditor/NewFontDialogPage2.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::Widget {
@@ -11,7 +11,7 @@
             title: "Metadata"
             fixed_width: 200
             layout: @GUI::VerticalBoxLayout {
-                margins: [16, 8, 8, 8]
+                margins: [16, 8, 8]
             }
 
             @GUI::Widget {
@@ -125,7 +125,7 @@
             @GUI::Widget {
                 name: "glyph_editor_container"
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [5, 0, 0, 0]
+                    margins: [5, 0, 0]
                 }
             }
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -96,11 +96,11 @@ int main(int argc, char* argv[])
     auto& left_tab_bar = splitter.add<GUI::TabWidget>();
     auto& tree_view_container = left_tab_bar.add_tab<GUI::Widget>("Browse");
     tree_view_container.set_layout<GUI::VerticalBoxLayout>();
-    tree_view_container.layout()->set_margins({ 4, 4, 4, 4 });
+    tree_view_container.layout()->set_margins(4);
     auto& tree_view = tree_view_container.add<GUI::TreeView>();
     auto& search_view = left_tab_bar.add_tab<GUI::Widget>("Search");
     search_view.set_layout<GUI::VerticalBoxLayout>();
-    search_view.layout()->set_margins({ 4, 4, 4, 4 });
+    search_view.layout()->set_margins(4);
     auto& search_box = search_view.add<GUI::TextBox>();
     auto& search_list_view = search_view.add<GUI::ListView>();
     search_box.set_fixed_height(20);

--- a/Userland/Applications/HexEditor/FindDialog.gml
+++ b/Userland/Applications/HexEditor/FindDialog.gml
@@ -6,7 +6,7 @@
 
     layout: @GUI::VerticalBoxLayout {
         spacing: 2
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::Widget {

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.gml
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.gml
@@ -6,13 +6,13 @@
 
     layout: @GUI::VerticalBoxLayout {
         spacing: 2
-        margins: [0, 0, 0, 0]
+        margins: [0]
     }
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {
             spacing: 2
-            margins: [2, 2, 2, 2]
+            margins: [2]
         }
 
         @GUI::Label {
@@ -41,7 +41,7 @@
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {
             spacing: 2
-            margins: [2, 2, 2, 2]
+            margins: [2]
         }
 
         @GUI::Label {

--- a/Userland/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Userland/Applications/IRCClient/IRCAppWindow.cpp
@@ -298,7 +298,7 @@ void IRCAppWindow::setup_widgets()
 
     auto& outer_container = widget.add<GUI::Widget>();
     outer_container.set_layout<GUI::VerticalBoxLayout>();
-    outer_container.layout()->set_margins({ 0, 2, 2, 2 });
+    outer_container.layout()->set_margins({ 0, 2, 2 });
 
     auto& horizontal_container = outer_container.add<GUI::HorizontalSplitter>();
 

--- a/Userland/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Userland/Applications/IRCClient/IRCAppWindow.cpp
@@ -298,7 +298,7 @@ void IRCAppWindow::setup_widgets()
 
     auto& outer_container = widget.add<GUI::Widget>();
     outer_container.set_layout<GUI::VerticalBoxLayout>();
-    outer_container.layout()->set_margins({ 2, 0, 2, 2 });
+    outer_container.layout()->set_margins({ 0, 2, 2, 2 });
 
     auto& horizontal_container = outer_container.add<GUI::HorizontalSplitter>();
 

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -28,7 +28,7 @@ void KeyboardMapperWidget::create_frame()
 {
     set_fill_with_background_color(true);
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_margins(4);
 
     auto& main_widget = add<GUI::Widget>();
     main_widget.set_relative_rect(0, 0, 200, 200);

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
     root_widget.set_layout<GUI::VerticalBoxLayout>();
     root_widget.set_fill_with_background_color(true);
     root_widget.layout()->set_spacing(0);
-    root_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    root_widget.layout()->set_margins(4);
 
     auto& character_map_file_selection_container = root_widget.add<GUI::Widget>();
     character_map_file_selection_container.set_layout<GUI::HorizontalBoxLayout>();
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
     bottom_widget.set_layout<GUI::HorizontalBoxLayout>();
     bottom_widget.layout()->add_spacer();
     bottom_widget.set_fixed_height(30);
-    bottom_widget.set_content_margins({ 4, 0, 4, 0 });
+    bottom_widget.set_content_margins({ 4, 0 });
 
     auto& ok_button = bottom_widget.add<GUI::Button>();
     ok_button.set_text("OK");

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
     bottom_widget.set_layout<GUI::HorizontalBoxLayout>();
     bottom_widget.layout()->add_spacer();
     bottom_widget.set_fixed_height(30);
-    bottom_widget.set_content_margins({ 0, 4, 0, 4 });
+    bottom_widget.set_content_margins({ 4, 0, 4, 0 });
 
     auto& ok_button = bottom_widget.add<GUI::Button>();
     ok_button.set_text("OK");

--- a/Userland/Applications/MailSettings/MailSettingsWindow.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWindow.cpp
@@ -66,7 +66,7 @@ MailSettingsWindow::MailSettingsWindow()
     auto& main_widget = set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    main_widget.layout()->set_margins(4);
     main_widget.layout()->set_spacing(6);
 
     auto& tab_widget = main_widget.add<GUI::TabWidget>();

--- a/Userland/Applications/MailSettings/MailSettingsWindow.gml
+++ b/Userland/Applications/MailSettings/MailSettingsWindow.gml
@@ -11,7 +11,7 @@
         fixed_height: 170
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 16, 8, 8]
+            margins: [16, 8, 8, 8]
             spacing: 2
         }
 
@@ -101,7 +101,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 16, 8, 8]
+            margins: [16, 8, 8, 8]
             spacing: 2
         }
 

--- a/Userland/Applications/MailSettings/MailSettingsWindow.gml
+++ b/Userland/Applications/MailSettings/MailSettingsWindow.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [10, 10, 10, 10]
+        margins: [10]
         spacing: 5
     }
 
@@ -11,7 +11,7 @@
         fixed_height: 170
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8, 8]
+            margins: [16, 8, 8]
             spacing: 2
         }
 
@@ -101,7 +101,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8, 8]
+            margins: [16, 8, 8]
             spacing: 2
         }
 

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.cpp
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.cpp
@@ -44,7 +44,7 @@ MouseSettingsWindow::MouseSettingsWindow()
     auto& main_widget = set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    main_widget.layout()->set_margins(4);
     main_widget.layout()->set_spacing(6);
 
     auto& tab_widget = main_widget.add<GUI::TabWidget>();

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.gml
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.gml
@@ -11,7 +11,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 16, 8, 8]
+            margins: [16, 8, 8, 8]
             spacing: 2
         }
 
@@ -60,7 +60,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 16, 8, 8]
+            margins: [16, 8, 8, 8]
             spacing: 2
         }
 
@@ -114,7 +114,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 16, 8, 8]
+            margins: [16, 8, 8, 8]
             spacing: 2
         }
 

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.gml
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [10, 10, 10, 10]
+        margins: [10]
         spacing: 5
     }
 
@@ -11,7 +11,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8, 8]
+            margins: [16, 8, 8]
             spacing: 2
         }
 
@@ -60,7 +60,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8, 8]
+            margins: [16, 8, 8]
             spacing: 2
         }
 
@@ -83,7 +83,7 @@
 
         @GUI::Widget {
             layout: @GUI::HorizontalBoxLayout {
-                margins: [8, 8, 8, 8]
+                margins: [8]
                 spacing: 8
             }
 
@@ -114,7 +114,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8, 8]
+            margins: [16, 8, 8]
             spacing: 2
         }
 
@@ -137,7 +137,7 @@
 
         @GUI::Widget {
             layout: @GUI::HorizontalBoxLayout {
-                margins: [8, 8, 8, 8]
+                margins: [8]
                 spacing: 8
             }
 

--- a/Userland/Applications/PDFViewer/SidebarWidget.cpp
+++ b/Userland/Applications/PDFViewer/SidebarWidget.cpp
@@ -18,14 +18,14 @@ SidebarWidget::SidebarWidget()
 
     auto& outline_container = tab_bar.add_tab<GUI::Widget>("Outline");
     outline_container.set_layout<GUI::VerticalBoxLayout>();
-    outline_container.layout()->set_margins({ 4, 4, 4, 4 });
+    outline_container.layout()->set_margins(4);
 
     m_outline_tree_view = outline_container.add<GUI::TreeView>();
     m_outline_tree_view->set_activates_on_selection(true);
 
     auto& thumbnails_container = tab_bar.add_tab<GUI::Widget>("Thumbnails");
     thumbnails_container.set_layout<GUI::VerticalBoxLayout>();
-    thumbnails_container.layout()->set_margins({ 4, 4, 4, 4 });
+    thumbnails_container.layout()->set_margins(4);
 
     // FIXME: Add thumbnail previews
 }

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -24,7 +24,7 @@ MainWidget::MainWidget(TrackManager& track_manager, AudioPlayerLoop& loop)
 {
     set_layout<GUI::VerticalBoxLayout>();
     layout()->set_spacing(2);
-    layout()->set_margins({ 2, 2, 2, 2 });
+    layout()->set_margins(2);
     set_fill_with_background_color(true);
 
     m_wave_widget = add<WaveWidget>(track_manager);

--- a/Userland/Applications/Piano/SamplerWidget.cpp
+++ b/Userland/Applications/Piano/SamplerWidget.cpp
@@ -72,7 +72,7 @@ SamplerWidget::SamplerWidget(TrackManager& track_manager)
     : m_track_manager(track_manager)
 {
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 10, 10, 10, 10 });
+    layout()->set_margins(10);
     layout()->set_spacing(10);
     set_fill_with_background_color(true);
 

--- a/Userland/Applications/PixelPaint/CreateNewGuideDialog.gml
+++ b/Userland/Applications/PixelPaint/CreateNewGuideDialog.gml
@@ -14,7 +14,7 @@
             shrink_to_fit: true
             
             layout: @GUI::HorizontalBoxLayout {
-                margins: [10,20,10,10]
+                margins: [20,10,10,10]
             }
 
             @GUI::RadioButton {

--- a/Userland/Applications/PixelPaint/CreateNewGuideDialog.gml
+++ b/Userland/Applications/PixelPaint/CreateNewGuideDialog.gml
@@ -6,7 +6,7 @@
 
     @GUI::Widget {
         layout: @GUI::VerticalBoxLayout {
-            margins: [4,4,4,4]
+            margins: [4]
         }
 
         @GUI::GroupBox {
@@ -14,7 +14,7 @@
             shrink_to_fit: true
             
             layout: @GUI::HorizontalBoxLayout {
-                margins: [20,10,10,10]
+                margins: [20, 10, 10]
             }
 
             @GUI::RadioButton {
@@ -31,7 +31,7 @@
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {
-            margins: [4,4,4,4]
+            margins: [4]
         }
         shrink_to_fit: true
 
@@ -50,7 +50,7 @@
         max_height: 24
 
         layout: @GUI::HorizontalBoxLayout {
-            margins: [4,4,4,4]
+            margins: [4]
         }
 
         @GUI::Widget {

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -23,7 +23,7 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     main_widget.set_fill_with_background_color(true);
 
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    layout.set_margins(4);
 
     auto& name_label = main_widget.add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -24,7 +24,7 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize const& suggested_size, G
     main_widget.set_fill_with_background_color(true);
 
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    layout.set_margins(4);
 
     auto& name_label = main_widget.add<GUI::Label>("Name:");
     name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/PixelPaint/FilterParams.h
+++ b/Userland/Applications/PixelPaint/FilterParams.h
@@ -50,7 +50,7 @@ private:
         main_widget.set_frame_shadow(Gfx::FrameShadow::Raised);
         main_widget.set_fill_with_background_color(true);
         auto& layout = main_widget.template set_layout<GUI::VerticalBoxLayout>();
-        layout.set_margins({ 4, 4, 4, 4 });
+        layout.set_margins(4);
 
         size_t index = 0;
         size_t columns = N;

--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
@@ -25,7 +25,7 @@ LayerPropertiesWidget::LayerPropertiesWidget()
     auto& group_box = add<GUI::GroupBox>("Layer properties");
     auto& layout = group_box.set_layout<GUI::VerticalBoxLayout>();
 
-    layout.set_margins({ 10, 20, 10, 10 });
+    layout.set_margins({ 20, 10, 10, 10 });
 
     auto& name_container = group_box.add<GUI::Widget>();
     name_container.set_fixed_height(20);

--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
@@ -25,7 +25,7 @@ LayerPropertiesWidget::LayerPropertiesWidget()
     auto& group_box = add<GUI::GroupBox>("Layer properties");
     auto& layout = group_box.set_layout<GUI::VerticalBoxLayout>();
 
-    layout.set_margins({ 20, 10, 10, 10 });
+    layout.set_margins({ 20, 10, 10 });
 
     auto& name_container = group_box.add<GUI::Widget>();
     name_container.set_fixed_height(20);

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -51,7 +51,7 @@
             @GUI::GroupBox {
                 title: "Layers"
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [6, 16, 6, 6]
+                    margins: [16, 6, 6, 6]
                 }
 
                 @PixelPaint::LayerListWidget {

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -51,7 +51,7 @@
             @GUI::GroupBox {
                 title: "Layers"
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [16, 6, 6, 6]
+                    margins: [16, 6, 6]
                 }
 
                 @PixelPaint::LayerListWidget {

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
@@ -19,7 +19,7 @@ ToolPropertiesWidget::ToolPropertiesWidget()
 
     m_group_box = add<GUI::GroupBox>("Tool properties");
     auto& layout = m_group_box->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 20, 10, 10, 10 });
+    layout.set_margins({ 20, 10, 10 });
     m_tool_widget_stack = m_group_box->add<GUI::StackWidget>();
     m_blank_widget = m_tool_widget_stack->add<GUI::Widget>();
 }

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
@@ -19,7 +19,7 @@ ToolPropertiesWidget::ToolPropertiesWidget()
 
     m_group_box = add<GUI::GroupBox>("Tool properties");
     auto& layout = m_group_box->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 10, 20, 10, 10 });
+    layout.set_margins({ 20, 10, 10, 10 });
     m_tool_widget_stack = m_group_box->add<GUI::StackWidget>();
     m_blank_widget = m_tool_widget_stack->add<GUI::Widget>();
 }

--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -35,7 +35,7 @@ ToolboxWidget::ToolboxWidget()
 
     set_layout<GUI::VerticalBoxLayout>();
     layout()->set_spacing(0);
-    layout()->set_margins({ 2, 2, 2, 2 });
+    layout()->set_margins(2);
 
     m_action_group.set_exclusive(true);
     m_action_group.set_unchecking_allowed(false);

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
 
     auto& toolbox = *main_widget.find_descendant_of_type_named<PixelPaint::ToolboxWidget>("toolbox");
     auto& tab_widget = *main_widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
-    tab_widget.set_container_margins({ 4, 4, 5, 5 });
+    tab_widget.set_container_margins({ 4, 5, 5, 4 });
     tab_widget.set_close_button_enabled(true);
 
     auto& palette_widget = *main_widget.find_descendant_of_type_named<PixelPaint::PaletteWidget>("palette_widget");

--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::Widget {
@@ -24,7 +24,7 @@
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {
-            margins: [4, 4, 4, 4]
+            margins: [4]
         }
 
         @GUI::Label {

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -199,7 +199,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
         {
             auto& horizontal_alignment_selection_container = alignment_tab.add<GUI::Widget>();
             horizontal_alignment_selection_container.set_layout<GUI::HorizontalBoxLayout>();
-            horizontal_alignment_selection_container.layout()->set_margins({ 0, 4, 0, 0 });
+            horizontal_alignment_selection_container.layout()->set_margins({ 4, 0, 0, 0 });
             horizontal_alignment_selection_container.set_fixed_height(22);
 
             auto& horizontal_alignment_label = horizontal_alignment_selection_container.add<GUI::Label>();
@@ -273,7 +273,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
                 // FIXME: Somehow allow unsetting these.
                 auto& foreground_container = static_formatting_container.add<GUI::Widget>();
                 foreground_container.set_layout<GUI::HorizontalBoxLayout>();
-                foreground_container.layout()->set_margins({ 0, 4, 0, 0 });
+                foreground_container.layout()->set_margins({ 4, 0, 0, 0 });
                 foreground_container.set_shrink_to_fit(true);
 
                 auto& foreground_label = foreground_container.add<GUI::Label>();
@@ -293,7 +293,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
                 // FIXME: Somehow allow unsetting these.
                 auto& background_container = static_formatting_container.add<GUI::Widget>();
                 background_container.set_layout<GUI::HorizontalBoxLayout>();
-                background_container.layout()->set_margins({ 0, 4, 0, 0 });
+                background_container.layout()->set_margins({ 4, 0, 0, 0 });
                 background_container.set_shrink_to_fit(true);
 
                 auto& background_label = background_container.add<GUI::Label>();

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -46,7 +46,7 @@ CellTypeDialog::CellTypeDialog(const Vector<Position>& positions, Sheet& sheet, 
     resize(285, 360);
 
     auto& main_widget = set_main_widget<GUI::Widget>();
-    main_widget.set_layout<GUI::VerticalBoxLayout>().set_margins({ 4, 4, 4, 4 });
+    main_widget.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
     main_widget.set_fill_with_background_color(true);
 
     auto& tab_widget = main_widget.add<GUI::TabWidget>();
@@ -130,7 +130,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
     }
 
     auto& type_tab = tabs.add_tab<GUI::Widget>("Type");
-    type_tab.set_layout<GUI::HorizontalBoxLayout>().set_margins({ 4, 4, 4, 4 });
+    type_tab.set_layout<GUI::HorizontalBoxLayout>().set_margins(4);
     {
         auto& left_side = type_tab.add<GUI::Widget>();
         left_side.set_layout<GUI::VerticalBoxLayout>();
@@ -192,14 +192,14 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
     }
 
     auto& alignment_tab = tabs.add_tab<GUI::Widget>("Alignment");
-    alignment_tab.set_layout<GUI::VerticalBoxLayout>().set_margins({ 4, 4, 4, 4 });
+    alignment_tab.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
     {
         // FIXME: Frame?
         // Horizontal alignment
         {
             auto& horizontal_alignment_selection_container = alignment_tab.add<GUI::Widget>();
             horizontal_alignment_selection_container.set_layout<GUI::HorizontalBoxLayout>();
-            horizontal_alignment_selection_container.layout()->set_margins({ 4, 0, 0, 0 });
+            horizontal_alignment_selection_container.layout()->set_margins({ 4, 0, 0 });
             horizontal_alignment_selection_container.set_fixed_height(22);
 
             auto& horizontal_alignment_label = horizontal_alignment_selection_container.add<GUI::Label>();
@@ -231,7 +231,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
         {
             auto& vertical_alignment_container = alignment_tab.add<GUI::Widget>();
             vertical_alignment_container.set_layout<GUI::HorizontalBoxLayout>();
-            vertical_alignment_container.layout()->set_margins({ 0, 4, 0, 0 });
+            vertical_alignment_container.layout()->set_margins({ 4, 0, 0 });
             vertical_alignment_container.set_fixed_height(22);
 
             auto& vertical_alignment_label = vertical_alignment_container.add<GUI::Label>();
@@ -261,7 +261,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
     }
 
     auto& colors_tab = tabs.add_tab<GUI::Widget>("Color");
-    colors_tab.set_layout<GUI::VerticalBoxLayout>().set_margins({ 4, 4, 4, 4 });
+    colors_tab.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
     {
         // Static formatting
         {
@@ -273,7 +273,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
                 // FIXME: Somehow allow unsetting these.
                 auto& foreground_container = static_formatting_container.add<GUI::Widget>();
                 foreground_container.set_layout<GUI::HorizontalBoxLayout>();
-                foreground_container.layout()->set_margins({ 4, 0, 0, 0 });
+                foreground_container.layout()->set_margins({ 4, 0, 0 });
                 foreground_container.set_shrink_to_fit(true);
 
                 auto& foreground_label = foreground_container.add<GUI::Label>();
@@ -293,7 +293,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
                 // FIXME: Somehow allow unsetting these.
                 auto& background_container = static_formatting_container.add<GUI::Widget>();
                 background_container.set_layout<GUI::HorizontalBoxLayout>();
-                background_container.layout()->set_margins({ 4, 0, 0, 0 });
+                background_container.layout()->set_margins({ 4, 0, 0 });
                 background_container.set_shrink_to_fit(true);
 
                 auto& background_label = background_container.add<GUI::Label>();

--- a/Userland/Applications/Spreadsheet/CondFormatting.gml
+++ b/Userland/Applications/Spreadsheet/CondFormatting.gml
@@ -3,7 +3,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
         spacing: 4
     }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -151,7 +151,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
     : m_sheet(sheet)
     , m_sheet_model(SheetModel::create(*m_sheet))
 {
-    set_layout<GUI::VerticalBoxLayout>().set_margins({ 2, 2, 2, 2 });
+    set_layout<GUI::VerticalBoxLayout>().set_margins(2);
     m_table_view = add<InfinitelyScrollableTableView>();
     m_table_view->set_grid_style(GUI::TableView::GridStyle::Both);
     m_table_view->set_selection_behavior(GUI::AbstractView::SelectionBehavior::SelectItems);

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -26,7 +26,7 @@ SpreadsheetWidget::SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets, bool s
     : m_workbook(make<Workbook>(move(sheets)))
 {
     set_fill_with_background_color(true);
-    set_layout<GUI::VerticalBoxLayout>().set_margins({ 2, 2, 2, 2 });
+    set_layout<GUI::VerticalBoxLayout>().set_margins(2);
     auto& container = add<GUI::VerticalSplitter>();
 
     auto& top_bar = container.add<GUI::Frame>();
@@ -71,7 +71,7 @@ SpreadsheetWidget::SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets, bool s
     m_inline_documentation_window->set_resizable(false);
     auto& inline_widget = m_inline_documentation_window->set_main_widget<GUI::Frame>();
     inline_widget.set_fill_with_background_color(true);
-    inline_widget.set_layout<GUI::VerticalBoxLayout>().set_margins({ 4, 4, 4, 4 });
+    inline_widget.set_layout<GUI::VerticalBoxLayout>().set_margins(4);
     inline_widget.set_frame_shape(Gfx::FrameShape::Box);
     m_inline_documentation_label = inline_widget.add<GUI::Label>();
     m_inline_documentation_label->set_fill_with_background_color(true);

--- a/Userland/Applications/Spreadsheet/csv_export.gml
+++ b/Userland/Applications/Spreadsheet/csv_export.gml
@@ -19,7 +19,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [10, 20, 10, 10]
+                        margins: [20, 10, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -70,7 +70,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [10, 20, 10, 10]
+                        margins: [20, 10, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -152,7 +152,7 @@
 
             layout: @GUI::VerticalBoxLayout {
                 // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                margins: [10, 20, 10, 10]
+                margins: [20, 10, 10, 10]
             }
 
             @GUI::TextEditor {

--- a/Userland/Applications/Spreadsheet/csv_export.gml
+++ b/Userland/Applications/Spreadsheet/csv_export.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::HorizontalSplitter {
@@ -19,7 +19,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10, 10]
+                        margins: [20, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -70,7 +70,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10, 10]
+                        margins: [20, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -152,7 +152,7 @@
 
             layout: @GUI::VerticalBoxLayout {
                 // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                margins: [20, 10, 10, 10]
+                margins: [20, 10, 10]
             }
 
             @GUI::TextEditor {

--- a/Userland/Applications/Spreadsheet/csv_import.gml
+++ b/Userland/Applications/Spreadsheet/csv_import.gml
@@ -19,7 +19,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [10, 20, 10, 10]
+                        margins: [20, 10, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -70,7 +70,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [10, 20, 10, 10]
+                        margins: [20, 10, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -133,7 +133,7 @@
                 fixed_height: 40
 
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [6, 6, 6, 0]
+                    margins: [6, 6, 0, 6]
                 }
 
                 @GUI::Widget {
@@ -165,7 +165,7 @@
 
             layout: @GUI::VerticalBoxLayout {
                 // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                margins: [10, 20, 10, 10]
+                margins: [20, 10, 10, 10]
             }
 
             @GUI::StackWidget {

--- a/Userland/Applications/Spreadsheet/csv_import.gml
+++ b/Userland/Applications/Spreadsheet/csv_import.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::HorizontalSplitter {
@@ -19,7 +19,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10, 10]
+                        margins: [20, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -70,7 +70,7 @@
 
                     layout: @GUI::VerticalBoxLayout {
                         // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10, 10]
+                        margins: [20, 10, 10]
                     }
 
                     @GUI::RadioButton {
@@ -133,7 +133,7 @@
                 fixed_height: 40
 
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [6, 6, 0, 6]
+                    margins: [6, 6, 0]
                 }
 
                 @GUI::Widget {
@@ -165,7 +165,7 @@
 
             layout: @GUI::VerticalBoxLayout {
                 // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                margins: [20, 10, 10, 10]
+                margins: [20, 10, 10]
             }
 
             @GUI::StackWidget {

--- a/Userland/Applications/Spreadsheet/select_format_page.gml
+++ b/Userland/Applications/Spreadsheet/select_format_page.gml
@@ -2,7 +2,7 @@
     name: "select_format"
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::Label {

--- a/Userland/Applications/SystemMonitor/InterruptsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/InterruptsWidget.cpp
@@ -15,7 +15,7 @@ InterruptsWidget::InterruptsWidget()
 {
     on_first_show = [this](auto&) {
         set_layout<GUI::VerticalBoxLayout>();
-        layout()->set_margins({ 4, 4, 4, 4 });
+        layout()->set_margins(4);
 
         Vector<GUI::JsonArrayModel::FieldSpec> interrupts_field;
         interrupts_field.empend("interrupt_line", "Line", Gfx::TextAlignment::CenterRight);

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -31,7 +31,7 @@ MemoryStatsWidget::MemoryStatsWidget(GraphWidget& graph)
     set_fixed_height(110);
 
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 8, 0, 0, 0 });
+    layout()->set_margins({ 8, 0, 0 });
     layout()->set_spacing(3);
 
     auto build_widgets_for_label = [this](const String& description) -> RefPtr<GUI::Label> {

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -31,7 +31,7 @@ MemoryStatsWidget::MemoryStatsWidget(GraphWidget& graph)
     set_fixed_height(110);
 
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 0, 8, 0, 0 });
+    layout()->set_margins({ 8, 0, 0, 0 });
     layout()->set_spacing(3);
 
     auto build_widgets_for_label = [this](const String& description) -> RefPtr<GUI::Label> {

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -16,7 +16,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 {
     on_first_show = [this](auto&) {
         set_layout<GUI::VerticalBoxLayout>();
-        layout()->set_margins({ 4, 4, 4, 4 });
+        layout()->set_margins(4);
         set_fill_with_background_color(true);
 
         m_network_connected_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/network-connected.png");
@@ -32,7 +32,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
         auto& adapters_group_box = add<GUI::GroupBox>("Adapters");
         adapters_group_box.set_layout<GUI::VerticalBoxLayout>();
-        adapters_group_box.layout()->set_margins({ 16, 6, 6, 6 });
+        adapters_group_box.layout()->set_margins({ 16, 6, 6 });
         adapters_group_box.set_fixed_height(120);
 
         m_adapter_table_view = adapters_group_box.add<GUI::TableView>();
@@ -69,7 +69,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
         auto& tcp_sockets_group_box = add<GUI::GroupBox>("TCP Sockets");
         tcp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
-        tcp_sockets_group_box.layout()->set_margins({ 16, 6, 6, 6 });
+        tcp_sockets_group_box.layout()->set_margins({ 16, 6, 6 });
 
         m_tcp_socket_table_view = tcp_sockets_group_box.add<GUI::TableView>();
 
@@ -90,7 +90,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
         auto& udp_sockets_group_box = add<GUI::GroupBox>("UDP Sockets");
         udp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
-        udp_sockets_group_box.layout()->set_margins({ 16, 6, 6, 6 });
+        udp_sockets_group_box.layout()->set_margins({ 16, 6, 6 });
 
         m_udp_socket_table_view = udp_sockets_group_box.add<GUI::TableView>();
 

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -32,7 +32,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
         auto& adapters_group_box = add<GUI::GroupBox>("Adapters");
         adapters_group_box.set_layout<GUI::VerticalBoxLayout>();
-        adapters_group_box.layout()->set_margins({ 6, 16, 6, 6 });
+        adapters_group_box.layout()->set_margins({ 16, 6, 6, 6 });
         adapters_group_box.set_fixed_height(120);
 
         m_adapter_table_view = adapters_group_box.add<GUI::TableView>();
@@ -69,7 +69,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
         auto& tcp_sockets_group_box = add<GUI::GroupBox>("TCP Sockets");
         tcp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
-        tcp_sockets_group_box.layout()->set_margins({ 6, 16, 6, 6 });
+        tcp_sockets_group_box.layout()->set_margins({ 16, 6, 6, 6 });
 
         m_tcp_socket_table_view = tcp_sockets_group_box.add<GUI::TableView>();
 
@@ -90,7 +90,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
         auto& udp_sockets_group_box = add<GUI::GroupBox>("UDP Sockets");
         udp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
-        udp_sockets_group_box.layout()->set_margins({ 6, 16, 6, 6 });
+        udp_sockets_group_box.layout()->set_margins({ 16, 6, 6, 6 });
 
         m_udp_socket_table_view = udp_sockets_group_box.add<GUI::TableView>();
 

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -13,7 +13,7 @@
 ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_margins(4);
     m_table_view = add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_fds_fields;

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -47,7 +47,7 @@ public:
 ProcessMemoryMapWidget::ProcessMemoryMapWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_margins(4);
     m_table_view = add<GUI::TableView>();
     Vector<GUI::JsonArrayModel::FieldSpec> pid_vm_fields;
     pid_vm_fields.empend(

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -84,7 +84,7 @@ private:
 ProcessStateWidget::ProcessStateWidget(pid_t pid)
 {
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_margins(4);
     m_table_view = add<GUI::TableView>();
     m_table_view->set_model(adopt_ref(*new ProcessStateModel(ProcessModel::the(), pid)));
     m_table_view->column_header().set_visible(false);

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
@@ -13,7 +13,7 @@
 ProcessUnveiledPathsWidget::ProcessUnveiledPathsWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_margins(4);
     m_table_view = add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_unveil_fields;

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -14,7 +14,7 @@
 ThreadStackWidget::ThreadStackWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_margins(4);
     m_stack_editor = add<GUI::TextEditor>();
     m_stack_editor->set_mode(GUI::TextEditor::ReadOnly);
     m_stack_editor->set_text("Symbolicating...");

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -179,7 +179,7 @@ int main(int argc, char** argv)
 
     auto& tabwidget_container = main_widget.add<GUI::Widget>();
     tabwidget_container.set_layout<GUI::VerticalBoxLayout>();
-    tabwidget_container.layout()->set_margins({ 0, 4, 4, 4 });
+    tabwidget_container.layout()->set_margins({ 0, 4, 4 });
     auto& tabwidget = tabwidget_container.add<GUI::TabWidget>();
 
     statusbar = main_widget.add<GUI::Statusbar>(3);
@@ -214,7 +214,7 @@ int main(int argc, char** argv)
     tabwidget.add_widget("Interrupts", interrupts_widget);
 
     process_table_container.set_layout<GUI::VerticalBoxLayout>();
-    process_table_container.layout()->set_margins({ 4, 4, 4, 4 });
+    process_table_container.layout()->set_margins(4);
     process_table_container.layout()->set_spacing(0);
 
     auto& process_table_view = process_table_container.add<GUI::TableView>();
@@ -434,7 +434,7 @@ NonnullRefPtr<GUI::Window> build_process_window(pid_t pid)
     auto& hero_container = main_widget.add<GUI::Widget>();
     hero_container.set_shrink_to_fit(true);
     hero_container.set_layout<GUI::HorizontalBoxLayout>();
-    hero_container.layout()->set_margins({ 4, 4, 4, 4 });
+    hero_container.layout()->set_margins(4);
     hero_container.layout()->set_spacing(8);
 
     auto& icon_label = hero_container.add<GUI::Label>();
@@ -493,7 +493,7 @@ NonnullRefPtr<GUI::Widget> build_file_systems_tab()
 
     fs_widget->on_first_show = [](GUI::LazyWidget& self) {
         self.set_layout<GUI::VerticalBoxLayout>();
-        self.layout()->set_margins({ 4, 4, 4, 4 });
+        self.layout()->set_margins(4);
         auto& fs_table_view = self.add<GUI::TableView>();
 
         Vector<GUI::JsonArrayModel::FieldSpec> df_fields;
@@ -589,7 +589,7 @@ NonnullRefPtr<GUI::Widget> build_pci_devices_tab()
 
     pci_widget->on_first_show = [](GUI::LazyWidget& self) {
         self.set_layout<GUI::VerticalBoxLayout>();
-        self.layout()->set_margins({ 4, 4, 4, 4 });
+        self.layout()->set_margins(4);
         auto& pci_table_view = self.add<GUI::TableView>();
 
         auto db = PCIDB::Database::open();
@@ -648,7 +648,7 @@ NonnullRefPtr<GUI::Widget> build_devices_tab()
 
     devices_widget->on_first_show = [](GUI::LazyWidget& self) {
         self.set_layout<GUI::VerticalBoxLayout>();
-        self.layout()->set_margins({ 4, 4, 4, 4 });
+        self.layout()->set_margins(4);
 
         auto& devices_table_view = self.add<GUI::TableView>();
         devices_table_view.set_model(GUI::SortingProxyModel::create(DevicesModel::create()));
@@ -665,11 +665,11 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
     graphs_container->set_fill_with_background_color(true);
     graphs_container->set_background_role(ColorRole::Button);
     graphs_container->set_layout<GUI::VerticalBoxLayout>();
-    graphs_container->layout()->set_margins({ 4, 4, 4, 4 });
+    graphs_container->layout()->set_margins(4);
 
     auto& cpu_graph_group_box = graphs_container->add<GUI::GroupBox>("CPU usage");
     cpu_graph_group_box.set_layout<GUI::HorizontalBoxLayout>();
-    cpu_graph_group_box.layout()->set_margins({ 16, 6, 6, 6 });
+    cpu_graph_group_box.layout()->set_margins({ 16, 6, 6 });
     cpu_graph_group_box.set_fixed_height(120);
     Vector<GraphWidget&> cpu_graphs;
     for (size_t i = 0; i < ProcessModel::the().cpus().size(); i++) {
@@ -701,7 +701,7 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
 
     auto& memory_graph_group_box = graphs_container->add<GUI::GroupBox>("Memory usage");
     memory_graph_group_box.set_layout<GUI::VerticalBoxLayout>();
-    memory_graph_group_box.layout()->set_margins({ 16, 6, 6, 6 });
+    memory_graph_group_box.layout()->set_margins({ 16, 6, 6 });
     memory_graph_group_box.set_fixed_height(120);
     auto& memory_graph = memory_graph_group_box.add<GraphWidget>();
     memory_graph.set_stack_values(true);
@@ -734,7 +734,7 @@ NonnullRefPtr<GUI::Widget> build_processors_tab()
 
     processors_widget->on_first_show = [](GUI::LazyWidget& self) {
         self.set_layout<GUI::VerticalBoxLayout>();
-        self.layout()->set_margins({ 4, 4, 4, 4 });
+        self.layout()->set_margins(4);
 
         Vector<GUI::JsonArrayModel::FieldSpec> processors_field;
         processors_field.empend("processor", "Processor", Gfx::TextAlignment::CenterRight);

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -179,7 +179,7 @@ int main(int argc, char** argv)
 
     auto& tabwidget_container = main_widget.add<GUI::Widget>();
     tabwidget_container.set_layout<GUI::VerticalBoxLayout>();
-    tabwidget_container.layout()->set_margins({ 4, 0, 4, 4 });
+    tabwidget_container.layout()->set_margins({ 0, 4, 4, 4 });
     auto& tabwidget = tabwidget_container.add<GUI::TabWidget>();
 
     statusbar = main_widget.add<GUI::Statusbar>(3);
@@ -669,7 +669,7 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
 
     auto& cpu_graph_group_box = graphs_container->add<GUI::GroupBox>("CPU usage");
     cpu_graph_group_box.set_layout<GUI::HorizontalBoxLayout>();
-    cpu_graph_group_box.layout()->set_margins({ 6, 16, 6, 6 });
+    cpu_graph_group_box.layout()->set_margins({ 16, 6, 6, 6 });
     cpu_graph_group_box.set_fixed_height(120);
     Vector<GraphWidget&> cpu_graphs;
     for (size_t i = 0; i < ProcessModel::the().cpus().size(); i++) {
@@ -701,7 +701,7 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
 
     auto& memory_graph_group_box = graphs_container->add<GUI::GroupBox>("Memory usage");
     memory_graph_group_box.set_layout<GUI::VerticalBoxLayout>();
-    memory_graph_group_box.layout()->set_margins({ 6, 16, 6, 6 });
+    memory_graph_group_box.layout()->set_margins({ 16, 6, 6, 6 });
     memory_graph_group_box.set_fixed_height(120);
     auto& memory_graph = memory_graph_group_box.add<GraphWidget>();
     memory_graph.set_stack_values(true);

--- a/Userland/Applications/Terminal/TerminalSettingsWindow.gml
+++ b/Userland/Applications/Terminal/TerminalSettingsWindow.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::GroupBox {
@@ -10,7 +10,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6, 6]
+            margins: [16, 6, 6]
         }
 
         @GUI::RadioButton {
@@ -34,7 +34,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6, 6]
+            margins: [16, 6, 6]
         }
 
         @GUI::OpacitySlider {
@@ -50,7 +50,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6, 6]
+            margins: [16, 6, 6]
         }
 
         @GUI::SpinBox {
@@ -66,7 +66,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6, 6]
+            margins: [16, 6, 6]
         }
 
         @GUI::ComboBox {

--- a/Userland/Applications/Terminal/TerminalSettingsWindow.gml
+++ b/Userland/Applications/Terminal/TerminalSettingsWindow.gml
@@ -10,7 +10,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [6, 16, 6, 6]
+            margins: [16, 6, 6, 6]
         }
 
         @GUI::RadioButton {
@@ -34,7 +34,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [6, 16, 6, 6]
+            margins: [16, 6, 6, 6]
         }
 
         @GUI::OpacitySlider {
@@ -50,7 +50,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [6, 16, 6, 6]
+            margins: [16, 6, 6, 6]
         }
 
         @GUI::SpinBox {
@@ -66,7 +66,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [6, 16, 6, 6]
+            margins: [16, 6, 6, 6]
         }
 
         @GUI::ComboBox {

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -190,11 +190,11 @@ static RefPtr<GUI::Window> create_find_window(VT::TerminalWidget& terminal)
     search.set_fill_with_background_color(true);
     search.set_background_role(ColorRole::Button);
     search.set_layout<GUI::VerticalBoxLayout>();
-    search.layout()->set_margins({ 4, 4, 4, 4 });
+    search.layout()->set_margins(4);
 
     auto& find = search.add<GUI::Widget>();
     find.set_layout<GUI::HorizontalBoxLayout>();
-    find.layout()->set_margins({ 4, 4, 4, 4 });
+    find.layout()->set_margins(4);
     find.set_fixed_height(30);
 
     auto& find_textbox = find.add<GUI::TextBox>();

--- a/Userland/Applications/TextEditor/TextEditorWindow.gml
+++ b/Userland/Applications/TextEditor/TextEditorWindow.gml
@@ -36,7 +36,7 @@
 
         layout: @GUI::VerticalBoxLayout {
             spacing: 2
-            margins: [5, 5, 5, 5]
+            margins: [5]
         }
 
         @GUI::Widget {

--- a/Userland/Applications/Welcome/WelcomeWindow.gml
+++ b/Userland/Applications/Welcome/WelcomeWindow.gml
@@ -17,7 +17,7 @@
             min_width: 340
             min_height: 160
             layout: @GUI::HorizontalBoxLayout {
-                margins: [0, 0, 16, 0]
+                margins: [0, 16, 0, 0]
             }
 
             @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/DemoWizardPage1.gml
+++ b/Userland/Demos/WidgetGallery/DemoWizardPage1.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::Label {

--- a/Userland/Demos/WidgetGallery/DemoWizardPage2.gml
+++ b/Userland/Demos/WidgetGallery/DemoWizardPage2.gml
@@ -1,6 +1,6 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {
-        margins: [20, 20, 20, 20]
+        margins: [20]
     }
 
     @GUI::Label {

--- a/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
@@ -20,7 +20,7 @@
                 shadow: "Sunken"
                 thickness: 1
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [4, 3, 4, 3]
+                    margins: [3, 4, 3, 4]
                 }
 
                 @GUI::Label {
@@ -37,7 +37,7 @@
 
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [4, 0, 4, 0]
+                    margins: [0, 4, 0, 4]
                 }
 
                 @GUI::Label {
@@ -85,7 +85,7 @@
     @GUI::Widget {
         fixed_height: 125
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 3, 8, 3]
+            margins: [3, 8, 3, 8]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
@@ -1,13 +1,13 @@
 @GUI::Widget {
     name: "basics_tab"
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::GroupBox {
         fixed_height: 95
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::HorizontalSplitter {
@@ -20,7 +20,7 @@
                 shadow: "Sunken"
                 thickness: 1
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [3, 4, 3, 4]
+                    margins: [3, 4]
                 }
 
                 @GUI::Label {
@@ -37,7 +37,7 @@
 
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [0, 4, 0, 4]
+                    margins: [0, 4]
                 }
 
                 @GUI::Label {
@@ -85,7 +85,7 @@
     @GUI::Widget {
         fixed_height: 125
         layout: @GUI::VerticalBoxLayout {
-            margins: [3, 8, 3, 8]
+            margins: [3, 8]
         }
 
         @GUI::Widget {
@@ -237,7 +237,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/CursorsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/CursorsTab.gml
@@ -1,12 +1,12 @@
 @GUI::Widget {
     name: "cursors_tab"
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::TableView {

--- a/Userland/Demos/WidgetGallery/GalleryGML/IconsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/IconsTab.gml
@@ -1,12 +1,12 @@
 @GUI::Widget {
     name: "icons_tab"
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::TableView {

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -1,13 +1,13 @@
 @GUI::Widget {
     name: "sliders_tab"
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::GroupBox {
         fixed_height: 129
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::OpacitySlider {
@@ -24,7 +24,7 @@
             max_width: 394
             max_height: 79
             layout: @GUI::VerticalBoxLayout {
-                margins: [1, 1, 1, 1]
+                margins: [1]
             }
 
             @GUI::ImageWidget {
@@ -36,7 +36,7 @@
     @GUI::Widget {
         fixed_height: 88
         layout: @GUI::VerticalBoxLayout {
-            margins: [0, 8, 0, 8]
+            margins: [0, 8]
         }
 
         @GUI::Widget {
@@ -72,7 +72,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::HorizontalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::VerticalProgressbar {
@@ -120,7 +120,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -36,7 +36,7 @@
     @GUI::Widget {
         fixed_height: 88
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 0, 8, 0]
+            margins: [0, 8, 0, 8]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/Window.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/Window.gml
@@ -1,7 +1,7 @@
 @GUI::Widget {
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::TabWidget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/WizardsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/WizardsTab.gml
@@ -1,12 +1,12 @@
 @GUI::Widget {
     name: "wizards_tab"
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8, 8, 8, 8]
+            margins: [8]
         }
 
         @GUI::Button {

--- a/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.cpp
@@ -77,7 +77,7 @@ void EvaluateExpressionDialog::build(Window* parent_window)
     auto& button_container_inner = button_container_outer.add<GUI::Widget>();
     button_container_inner.set_layout<GUI::HorizontalBoxLayout>();
     button_container_inner.layout()->set_spacing(6);
-    button_container_inner.layout()->set_margins({ 4, 4, 0, 4 });
+    button_container_inner.layout()->set_margins({ 4, 0, 4, 4 });
     button_container_inner.layout()->add_spacer();
 
     m_evaluate_button = button_container_inner.add<GUI::Button>();

--- a/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.cpp
@@ -48,7 +48,7 @@ void EvaluateExpressionDialog::build(Window* parent_window)
     widget.set_layout<GUI::VerticalBoxLayout>();
     widget.set_fill_with_background_color(true);
 
-    widget.layout()->set_margins({ 6, 6, 6, 6 });
+    widget.layout()->set_margins(6);
     widget.layout()->set_spacing(6);
 
     m_text_editor = widget.add<GUI::TextBox>();
@@ -77,7 +77,7 @@ void EvaluateExpressionDialog::build(Window* parent_window)
     auto& button_container_inner = button_container_outer.add<GUI::Widget>();
     button_container_inner.set_layout<GUI::HorizontalBoxLayout>();
     button_container_inner.layout()->set_spacing(6);
-    button_container_inner.layout()->set_margins({ 4, 0, 4, 4 });
+    button_container_inner.layout()->set_margins({ 4, 0, 4 });
     button_container_inner.layout()->add_spacer();
 
     m_evaluate_button = button_container_inner.add<GUI::Button>();

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.gml
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::VerticalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
     }
 
     @GUI::Label {

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -24,7 +24,7 @@ EditorWrapper::EditorWrapper()
     label_wrapper.set_fixed_height(14);
     label_wrapper.set_fill_with_background_color(true);
     label_wrapper.set_layout<GUI::HorizontalBoxLayout>();
-    label_wrapper.layout()->set_margins({ 0, 2, 0, 2 });
+    label_wrapper.layout()->set_margins({ 0, 2 });
 
     m_filename_label = label_wrapper.add<GUI::Label>("(Untitled)");
     m_filename_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -24,7 +24,7 @@ EditorWrapper::EditorWrapper()
     label_wrapper.set_fixed_height(14);
     label_wrapper.set_fill_with_background_color(true);
     label_wrapper.set_layout<GUI::HorizontalBoxLayout>();
-    label_wrapper.layout()->set_margins({ 2, 0, 2, 0 });
+    label_wrapper.layout()->set_margins({ 0, 2, 0, 2 });
 
     m_filename_label = label_wrapper.add<GUI::Label>("(Untitled)");
     m_filename_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -107,7 +107,7 @@ HackStudioWidget::HackStudioWidget(const String& path_to_project)
 
     m_editors_splitter = m_right_hand_stack->add<GUI::VerticalSplitter>();
     m_editors_splitter->layout()->set_spacing(5);
-    m_editors_splitter->layout()->set_margins({ 3, 0, 0, 0 });
+    m_editors_splitter->layout()->set_margins({ 3, 0, 0 });
     add_new_editor(*m_editors_splitter);
 
     m_switch_to_next_editor = create_switch_to_next_editor_action();
@@ -958,14 +958,14 @@ void HackStudioWidget::create_project_tab(GUI::Widget& parent)
 
     auto& tree_view_container = m_project_tab->add_tab<GUI::Widget>("Files");
     tree_view_container.set_layout<GUI::VerticalBoxLayout>();
-    tree_view_container.layout()->set_margins({ 2, 2, 2, 2 });
+    tree_view_container.layout()->set_margins(2);
 
     m_project_tree_view = tree_view_container.add<GUI::TreeView>();
     configure_project_tree_view();
 
     auto& class_view_container = m_project_tab->add_tab<GUI::Widget>("Classes");
     class_view_container.set_layout<GUI::VerticalBoxLayout>();
-    class_view_container.layout()->set_margins({ 2, 2, 2, 2 });
+    class_view_container.layout()->set_margins(2);
 
     m_class_view = class_view_container.add<ClassViewWidget>();
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -107,7 +107,7 @@ HackStudioWidget::HackStudioWidget(const String& path_to_project)
 
     m_editors_splitter = m_right_hand_stack->add<GUI::VerticalSplitter>();
     m_editors_splitter->layout()->set_spacing(5);
-    m_editors_splitter->layout()->set_margins({ 0, 3, 0, 0 });
+    m_editors_splitter->layout()->set_margins({ 3, 0, 0, 0 });
     add_new_editor(*m_editors_splitter);
 
     m_switch_to_next_editor = create_switch_to_next_editor_action();

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
 
     auto& tree_tab = tab_widget.add_tab<GUI::Widget>("Call Tree");
     tree_tab.set_layout<GUI::VerticalBoxLayout>();
-    tree_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    tree_tab.layout()->set_margins(4);
     auto& bottom_splitter = tree_tab.add<GUI::VerticalSplitter>();
 
     auto& tree_view = bottom_splitter.add<GUI::TreeView>();
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
 
     auto& samples_tab = tab_widget.add_tab<GUI::Widget>("Samples");
     samples_tab.set_layout<GUI::VerticalBoxLayout>();
-    samples_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    samples_tab.layout()->set_margins(4);
 
     auto& samples_splitter = samples_tab.add<GUI::HorizontalSplitter>();
     auto& samples_table_view = samples_splitter.add<GUI::TableView>();
@@ -178,7 +178,7 @@ int main(int argc, char** argv)
 
     auto& signposts_tab = tab_widget.add_tab<GUI::Widget>("Signposts");
     signposts_tab.set_layout<GUI::VerticalBoxLayout>();
-    signposts_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    signposts_tab.layout()->set_margins(4);
 
     auto& signposts_splitter = signposts_tab.add<GUI::HorizontalSplitter>();
     auto& signposts_table_view = signposts_splitter.add<GUI::TableView>();
@@ -262,7 +262,7 @@ static bool prompt_to_stop_profiling(pid_t pid, const String& process_name)
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);
     auto& layout = widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 0, 0, 16, 0 });
+    layout.set_margins({ 0, 0, 16 });
 
     auto& timer_label = widget.add<GUI::Label>("...");
     Core::ElapsedTimer clock;

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -262,7 +262,7 @@ static bool prompt_to_stop_profiling(pid_t pid, const String& process_name)
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);
     auto& layout = widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins(GUI::Margins(0, 0, 0, 16));
+    layout.set_margins({ 0, 0, 16, 0 });
 
     auto& timer_label = widget.add<GUI::Label>("...");
     Core::ElapsedTimer clock;

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -28,7 +28,7 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     main_widget.set_fill_with_background_color(true);
 
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    layout.set_margins(4);
 
     auto& board_size_box = main_widget.add<GUI::Widget>();
     auto& input_layout = board_size_box.set_layout<GUI::HorizontalBoxLayout>();

--- a/Userland/Games/Breakout/LevelSelectDialog.cpp
+++ b/Userland/Games/Breakout/LevelSelectDialog.cpp
@@ -41,7 +41,7 @@ void LevelSelectDialog::build()
     main_widget.set_fill_with_background_color(true);
 
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    layout.set_margins(4);
 
     main_widget.add<GUI::Label>("Choose a level").set_text_alignment(Gfx::TextAlignment::Center);
 

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
     main_widget.set_fill_with_background_color(true);
 
     auto& main_toolbar = *main_widget.find_descendant_of_type_named<GUI::Toolbar>("toolbar");
-    main_toolbar.layout()->set_margins({ 0, 6, 0, 6 });
+    main_toolbar.layout()->set_margins({ 0, 6 });
 
     auto& board_widget_container = *main_widget.find_descendant_of_type_named<GUI::Widget>("board_widget_container");
     auto& board_layout = board_widget_container.set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
     main_widget.set_fill_with_background_color(true);
 
     auto& main_toolbar = *main_widget.find_descendant_of_type_named<GUI::Toolbar>("toolbar");
-    main_toolbar.layout()->set_margins({ 6, 0, 6, 0 });
+    main_toolbar.layout()->set_margins({ 0, 6, 0, 6 });
 
     auto& board_widget_container = *main_widget.find_descendant_of_type_named<GUI::Widget>("board_widget_container");
     auto& board_layout = board_widget_container.set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -128,7 +128,7 @@ void Game::show_score_card(bool game_over)
     auto& score_widget = score_dialog->set_main_widget<GUI::Widget>();
     score_widget.set_fill_with_background_color(true);
     auto& layout = score_widget.set_layout<GUI::HorizontalBoxLayout>();
-    layout.set_margins({ 10, 10, 10, 10 });
+    layout.set_margins(10);
     layout.set_spacing(15);
 
     auto& card_container = score_widget.add<GUI::Widget>();

--- a/Userland/Games/Hearts/SettingsDialog.cpp
+++ b/Userland/Games/Hearts/SettingsDialog.cpp
@@ -23,7 +23,7 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, String player_name)
     main_widget.set_fill_with_background_color(true);
 
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 4, 4, 4, 4 });
+    layout.set_margins(4);
 
     auto& name_box = main_widget.add<GUI::Widget>();
     auto& input_layout = name_box.set_layout<GUI::HorizontalBoxLayout>();

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -43,7 +43,7 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
     auto& left_container = content_container.add<Widget>();
     left_container.set_fixed_width(60);
     left_container.set_layout<VerticalBoxLayout>();
-    left_container.layout()->set_margins({ 12, 0, 0, 0 });
+    left_container.layout()->set_margins({ 12, 0, 0 });
 
     if (icon) {
         auto& icon_wrapper = left_container.add<Widget>();
@@ -62,7 +62,7 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
         auto& label = right_container.add<Label>(text);
         label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         label.set_fixed_height(14);
-        label.set_content_margins({ 0, 8, 0, 0 });
+        label.set_content_margins({ 0, 8, 0 });
         if (bold)
             label.set_font(Gfx::FontDatabase::default_font().bold_variant());
     };

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -43,7 +43,7 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
     auto& left_container = content_container.add<Widget>();
     left_container.set_fixed_width(60);
     left_container.set_layout<VerticalBoxLayout>();
-    left_container.layout()->set_margins({ 0, 12, 0, 0 });
+    left_container.layout()->set_margins({ 12, 0, 0, 0 });
 
     if (icon) {
         auto& icon_wrapper = left_container.add<Widget>();
@@ -56,13 +56,13 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
 
     auto& right_container = content_container.add<Widget>();
     right_container.set_layout<VerticalBoxLayout>();
-    right_container.layout()->set_margins({ 0, 12, 4, 4 });
+    right_container.layout()->set_margins({ 12, 4, 4, 0 });
 
     auto make_label = [&](const StringView& text, bool bold = false) {
         auto& label = right_container.add<Label>(text);
         label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         label.set_fixed_height(14);
-        label.set_content_margins({ 0, 0, 8, 0 });
+        label.set_content_margins({ 0, 8, 0, 0 });
         if (bold)
             label.set_font(Gfx::FontDatabase::default_font().bold_variant());
     };

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -240,7 +240,7 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     // Right Side
     auto& vertical_container = horizontal_container.add<Widget>();
     vertical_container.set_layout<VerticalBoxLayout>();
-    vertical_container.layout()->set_margins({ 8, 0, 0, 0 });
+    vertical_container.layout()->set_margins({ 0, 0, 0, 8 });
     vertical_container.set_fixed_width(128);
 
     auto& preview_container = vertical_container.add<Frame>();

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -154,21 +154,21 @@ void ColorPicker::build_ui()
 {
     auto& root_container = set_main_widget<Widget>();
     root_container.set_layout<VerticalBoxLayout>();
-    root_container.layout()->set_margins({ 4, 4, 4, 4 });
+    root_container.layout()->set_margins(4);
     root_container.set_fill_with_background_color(true);
 
     auto& tab_widget = root_container.add<GUI::TabWidget>();
 
     auto& tab_palette = tab_widget.add_tab<Widget>("Palette");
     tab_palette.set_layout<VerticalBoxLayout>();
-    tab_palette.layout()->set_margins({ 4, 4, 4, 4 });
+    tab_palette.layout()->set_margins(4);
     tab_palette.layout()->set_spacing(4);
 
     build_ui_palette(tab_palette);
 
     auto& tab_custom_color = tab_widget.add_tab<Widget>("Custom Color");
     tab_custom_color.set_layout<VerticalBoxLayout>();
-    tab_custom_color.layout()->set_margins({ 4, 4, 4, 4 });
+    tab_custom_color.layout()->set_margins(4);
     tab_custom_color.layout()->set_spacing(4);
 
     build_ui_custom(tab_custom_color);
@@ -245,7 +245,7 @@ void ColorPicker::build_ui_custom(Widget& root_container)
 
     auto& preview_container = vertical_container.add<Frame>();
     preview_container.set_layout<VerticalBoxLayout>();
-    preview_container.layout()->set_margins({ 2, 2, 2, 2 });
+    preview_container.layout()->set_margins(2);
     preview_container.layout()->set_spacing(0);
     preview_container.set_fixed_height(128);
 

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -45,7 +45,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     main_widget.set_frame_shadow(Gfx::FrameShadow::Raised);
     main_widget.set_fill_with_background_color(true);
     auto& main_layout = main_widget.set_layout<VerticalBoxLayout>();
-    main_layout.set_margins({ 1, 1, 1, 1 });
+    main_layout.set_margins(1);
     main_layout.set_spacing(0);
 
     auto code_points = supported_emoji_code_points();

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -2,14 +2,14 @@
     fill_with_background_color: true
 
     layout: @GUI::HorizontalBoxLayout {
-        margins: [4, 4, 4, 4]
+        margins: [4]
         spacing: 3
     }
 
     @GUI::Widget {
         shrink_to_fit: true
         layout: @GUI::VerticalBoxLayout {
-            margins: [0, 4, 0, 4]
+            margins: [0, 4]
         }
 
         @GUI::Label {
@@ -24,7 +24,7 @@
             fill_with_background_color: true
 
             layout: @GUI::VerticalBoxLayout {
-                margins: [2, 2, 2, 2]
+                margins: [2]
                 spacing: 0
             }
         }

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -9,7 +9,7 @@
     @GUI::Widget {
         shrink_to_fit: true
         layout: @GUI::VerticalBoxLayout {
-            margins: [4, 0, 4, 0]
+            margins: [0, 4, 0, 4]
         }
 
         @GUI::Label {

--- a/Userland/Libraries/LibGUI/Frame.cpp
+++ b/Userland/Libraries/LibGUI/Frame.cpp
@@ -42,7 +42,7 @@ void Frame::set_frame_thickness(int thickness)
     if (m_thickness == thickness)
         return;
     m_thickness = thickness;
-    set_content_margins({ thickness, thickness, thickness, thickness });
+    set_content_margins(thickness);
 }
 
 void Frame::paint_event(PaintEvent& event)

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -83,7 +83,7 @@ void InputBox::build(InputType input_type)
     auto& button_container_inner = button_container_outer.add<Widget>();
     button_container_inner.set_layout<HorizontalBoxLayout>();
     button_container_inner.layout()->set_spacing(6);
-    button_container_inner.layout()->set_margins({ 4, 4, 0, 4 });
+    button_container_inner.layout()->set_margins({ 4, 0, 4, 4 });
     button_container_inner.layout()->add_spacer();
 
     m_ok_button = button_container_inner.add<Button>();

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -52,7 +52,7 @@ void InputBox::build(InputType input_type)
     widget.set_layout<VerticalBoxLayout>();
     widget.set_fill_with_background_color(true);
 
-    widget.layout()->set_margins({ 6, 6, 6, 6 });
+    widget.layout()->set_margins(6);
     widget.layout()->set_spacing(6);
 
     auto& label_editor_container = widget.add<Widget>();

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -11,26 +11,26 @@ namespace GUI {
 class Margins {
 public:
     Margins() { }
-    Margins(int left, int top, int right, int bottom)
-        : m_left(left)
-        , m_top(top)
+    Margins(int top, int right, int bottom, int left)
+        : m_top(top)
         , m_right(right)
         , m_bottom(bottom)
+        , m_left(left)
     {
     }
     ~Margins() { }
 
     bool is_null() const { return !m_left && !m_top && !m_right && !m_bottom; }
 
-    int left() const { return m_left; }
     int top() const { return m_top; }
     int right() const { return m_right; }
     int bottom() const { return m_bottom; }
+    int left() const { return m_left; }
 
-    void set_left(int value) { m_left = value; }
     void set_top(int value) { m_top = value; }
     void set_right(int value) { m_right = value; }
     void set_bottom(int value) { m_bottom = value; }
+    void set_left(int value) { m_left = value; }
 
     bool operator==(const Margins& other) const
     {
@@ -41,10 +41,10 @@ public:
     }
 
 private:
-    int m_left { 0 };
     int m_top { 0 };
     int m_right { 0 };
     int m_bottom { 0 };
+    int m_left { 0 };
 };
 
 }

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -11,6 +11,27 @@ namespace GUI {
 class Margins {
 public:
     Margins() { }
+    Margins(int all)
+        : m_top(all)
+        , m_right(all)
+        , m_bottom(all)
+        , m_left(all)
+    {
+    }
+    Margins(int vertical, int horizontal)
+        : m_top(vertical)
+        , m_right(horizontal)
+        , m_bottom(vertical)
+        , m_left(horizontal)
+    {
+    }
+    Margins(int top, int horizontal, int bottom)
+        : m_top(top)
+        , m_right(horizontal)
+        , m_bottom(bottom)
+        , m_left(horizontal)
+    {
+    }
     Margins(int top, int right, int bottom, int left)
         : m_top(top)
         , m_right(right)
@@ -49,8 +70,8 @@ private:
 
 }
 
-#define REGISTER_MARGINS_PROPERTY(property_name, getter, setter)   \
-    register_property(                                             \
+#define REGISTER_MARGINS_PROPERTY(property_name, getter, setter) \
+    register_property(                                           \
         property_name, [this]() {                                  \
             auto m = getter();                                     \
             JsonObject margins_object;                             \
@@ -58,13 +79,23 @@ private:
             margins_object.set("right", m.right());                \
             margins_object.set("top", m.top());                    \
             margins_object.set("bottom", m.bottom());              \
-            return margins_object; },                               \
-        [this](auto& value) {                                      \
-            if (!value.is_array() || value.as_array().size() != 4) \
-                return false;                                      \
-            int m[4];                                              \
-            for (size_t i = 0; i < 4; ++i)                         \
-                m[i] = value.as_array().at(i).to_i32();            \
-            setter({ m[0], m[1], m[2], m[3] });                    \
-            return true;                                           \
+            return margins_object; },                             \
+        [this](auto& value) {                                    \
+            if (!value.is_array())                               \
+                return false;                                    \
+            auto size = value.as_array().size();                 \
+            if (size == 0 || size > 4)                           \
+                return false;                                    \
+            int m[4];                                            \
+            for (size_t i = 0; i < size; ++i)                    \
+                m[i] = value.as_array().at(i).to_i32();          \
+            if (size == 1)                                       \
+                setter({ m[0] });                                \
+            else if (size == 2)                                  \
+                setter({ m[0], m[1] });                          \
+            else if (size == 3)                                  \
+                setter({ m[0], m[1], m[2] });                    \
+            else                                                 \
+                setter({ m[0], m[1], m[2], m[3] });              \
+            return true;                                         \
         });

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -89,7 +89,7 @@ void MessageBox::build()
     widget.set_layout<VerticalBoxLayout>();
     widget.set_fill_with_background_color(true);
 
-    widget.layout()->set_margins({ 8, 8, 8, 8 });
+    widget.layout()->set_margins(8);
     widget.layout()->set_spacing(6);
 
     auto& message_container = widget.add<Widget>();

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -102,7 +102,7 @@ void MessageBox::build()
         if (icon()) {
             icon_width = icon()->width();
             if (icon_width > 0)
-                message_container.layout()->set_margins({ 8, 0, 0, 0 });
+                message_container.layout()->set_margins({ 0, 0, 0, 8 });
         }
     }
 

--- a/Userland/Libraries/LibGUI/MultiView.cpp
+++ b/Userland/Libraries/LibGUI/MultiView.cpp
@@ -20,7 +20,7 @@ namespace GUI {
 MultiView::MultiView()
 {
     set_active_widget(nullptr);
-    set_content_margins({ 2, 2, 2, 2 });
+    set_content_margins(2);
     m_icon_view = add<IconView>();
     m_table_view = add<TableView>();
     m_columns_view = add<ColumnsView>();

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.gml
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.gml
@@ -2,7 +2,7 @@
     fill_with_background_color: true
 
     layout: @GUI::HorizontalBoxLayout {
-        margins: [8, 8, 8, 8]
+        margins: [8]
         spacing: 8
     }
 

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -48,8 +48,8 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     auto& button_container = widget.add<GUI::Widget>();
     button_container.set_fixed_height(30);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container.set_content_margins({ 0, 4, 0, 4 });
-    button_container.layout()->set_margins({ 0, 0, 4, 0 });
+    button_container.set_content_margins({ 4, 0, 4, 0 });
+    button_container.layout()->set_margins({ 0, 4, 0, 0 });
     button_container.layout()->add_spacer();
 
     auto& select_button = button_container.add<GUI::Button>(m_button_label);

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -48,8 +48,8 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     auto& button_container = widget.add<GUI::Widget>();
     button_container.set_fixed_height(30);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container.set_content_margins({ 4, 0, 4, 0 });
-    button_container.layout()->set_margins({ 0, 4, 0, 0 });
+    button_container.set_content_margins({ 4, 0 });
+    button_container.layout()->set_margins({ 0, 4, 0 });
     button_container.layout()->add_spacer();
 
     auto& select_button = button_container.add<GUI::Button>(m_button_label);

--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -21,7 +21,7 @@ Statusbar::Statusbar(int label_count)
 {
     set_fixed_height(18);
     set_layout<HorizontalBoxLayout>();
-    layout()->set_margins({ 0, 0, 0, 0 });
+    layout()->set_margins(0);
     layout()->set_spacing(2);
 
     m_corner = add<ResizeCorner>();

--- a/Userland/Libraries/LibGUI/ToolbarContainer.cpp
+++ b/Userland/Libraries/LibGUI/ToolbarContainer.cpp
@@ -25,7 +25,7 @@ ToolbarContainer::ToolbarContainer(Gfx::Orientation orientation)
 
     auto& layout = set_layout<VerticalBoxLayout>();
     layout.set_spacing(2);
-    layout.set_margins({ 2, 2, 2, 2 });
+    layout.set_margins(2);
 
     set_shrink_to_fit(true);
 }

--- a/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.cpp
@@ -25,7 +25,7 @@ CoverWizardPage::CoverWizardPage()
 
     m_content_widget = add<Widget>();
     m_content_widget->set_layout<VerticalBoxLayout>();
-    m_content_widget->layout()->set_margins({ 20, 20, 20, 20 });
+    m_content_widget->layout()->set_margins(20);
 
     m_header_label = m_content_widget->add<Label>();
     m_header_label->set_font(Gfx::FontDatabase::the().get("Pebbleton", 14, 700));

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -41,7 +41,7 @@ WizardDialog::WizardDialog(Window* parent_window)
     auto& nav_container_widget = main_widget.add<Widget>();
     nav_container_widget.set_layout<HorizontalBoxLayout>();
     nav_container_widget.set_fixed_height(42);
-    nav_container_widget.layout()->set_margins({ 0, 10, 0, 10 });
+    nav_container_widget.layout()->set_margins({ 0, 10 });
     nav_container_widget.layout()->set_spacing(0);
     nav_container_widget.layout()->add_spacer();
 

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -41,7 +41,7 @@ WizardDialog::WizardDialog(Window* parent_window)
     auto& nav_container_widget = main_widget.add<Widget>();
     nav_container_widget.set_layout<HorizontalBoxLayout>();
     nav_container_widget.set_fixed_height(42);
-    nav_container_widget.layout()->set_margins({ 10, 0, 10, 0 });
+    nav_container_widget.layout()->set_margins({ 0, 10, 0, 10 });
     nav_container_widget.layout()->set_spacing(0);
     nav_container_widget.layout()->add_spacer();
 

--- a/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
@@ -26,7 +26,7 @@ WizardPage::WizardPage(const String& title_text, const String& subtitle_text)
     header_widget.set_fixed_height(58);
 
     header_widget.set_layout<VerticalBoxLayout>();
-    header_widget.layout()->set_margins({ 30, 15, 30, 0 });
+    header_widget.layout()->set_margins({ 15, 30, 0, 30 });
     m_title_label = header_widget.add<Label>(title_text);
     m_title_label->set_font(Gfx::FontDatabase::default_font().bold_variant());
     m_title_label->set_fixed_height(m_title_label->font().glyph_height() + 2);

--- a/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
@@ -26,7 +26,7 @@ WizardPage::WizardPage(const String& title_text, const String& subtitle_text)
     header_widget.set_fixed_height(58);
 
     header_widget.set_layout<VerticalBoxLayout>();
-    header_widget.layout()->set_margins({ 15, 30, 0, 30 });
+    header_widget.layout()->set_margins({ 15, 30, 0 });
     m_title_label = header_widget.add<Label>(title_text);
     m_title_label->set_font(Gfx::FontDatabase::default_font().bold_variant());
     m_title_label->set_fixed_height(m_title_label->font().glyph_height() + 2);
@@ -41,7 +41,7 @@ WizardPage::WizardPage(const String& title_text, const String& subtitle_text)
 
     m_body_widget = add<Widget>();
     m_body_widget->set_layout<VerticalBoxLayout>();
-    m_body_widget->layout()->set_margins({ 20, 20, 20, 20 });
+    m_body_widget->layout()->set_margins(20);
 }
 
 void WizardPage::set_page_title(const String& text)

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -69,7 +69,7 @@ NotificationWindow::NotificationWindow(i32 client_id, const String& text, const 
 
     widget.set_fill_with_background_color(true);
     widget.set_layout<GUI::HorizontalBoxLayout>();
-    widget.layout()->set_margins({ 8, 8, 8, 8 });
+    widget.layout()->set_margins(8);
     widget.layout()->set_spacing(6);
 
     m_image = &widget.add<GUI::ImageWidget>();

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -47,7 +47,7 @@ ClockWidget::ClockWidget()
     auto& root_container = m_calendar_window->set_main_widget<GUI::Label>();
     root_container.set_fill_with_background_color(true);
     root_container.set_layout<GUI::VerticalBoxLayout>();
-    root_container.layout()->set_margins({ 0, 2, 0, 2 });
+    root_container.layout()->set_margins({ 2, 0, 2, 0 });
     root_container.layout()->set_spacing(0);
     root_container.set_frame_thickness(2);
     root_container.set_frame_shape(Gfx::FrameShape::Container);
@@ -56,7 +56,7 @@ ClockWidget::ClockWidget()
     auto& navigation_container = root_container.add<GUI::Widget>();
     navigation_container.set_fixed_height(24);
     navigation_container.set_layout<GUI::HorizontalBoxLayout>();
-    navigation_container.layout()->set_margins({ 2, 2, 3, 2 });
+    navigation_container.layout()->set_margins({ 2, 3, 2, 2 });
 
     m_prev_date = navigation_container.add<GUI::Button>();
     m_prev_date->set_button_style(Gfx::ButtonStyle::Coolbar);
@@ -120,7 +120,7 @@ ClockWidget::ClockWidget()
 
     auto& calendar_container = root_container.add<GUI::Widget>();
     calendar_container.set_layout<GUI::HorizontalBoxLayout>();
-    calendar_container.layout()->set_margins({ 4, 4, 5, 4 });
+    calendar_container.layout()->set_margins({ 4, 5, 4, 4 });
 
     m_calendar = calendar_container.add<GUI::Calendar>();
     m_selected_calendar_button->set_text(m_calendar->formatted_date());
@@ -139,7 +139,7 @@ ClockWidget::ClockWidget()
     auto& settings_container = root_container.add<GUI::Widget>();
     settings_container.set_fixed_height(24);
     settings_container.set_layout<GUI::HorizontalBoxLayout>();
-    settings_container.layout()->set_margins({ 2, 2, 3, 2 });
+    settings_container.layout()->set_margins({ 2, 3, 2, 2 });
     settings_container.layout()->add_spacer();
 
     m_jump_to_button = settings_container.add<GUI::Button>();

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -47,7 +47,7 @@ ClockWidget::ClockWidget()
     auto& root_container = m_calendar_window->set_main_widget<GUI::Label>();
     root_container.set_fill_with_background_color(true);
     root_container.set_layout<GUI::VerticalBoxLayout>();
-    root_container.layout()->set_margins({ 2, 0, 2, 0 });
+    root_container.layout()->set_margins({ 2, 0 });
     root_container.layout()->set_spacing(0);
     root_container.set_frame_thickness(2);
     root_container.set_frame_shape(Gfx::FrameShape::Container);

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -56,7 +56,7 @@ ShutdownDialog::ShutdownDialog()
     auto& left_container = content_container.add<GUI::Widget>();
     left_container.set_fixed_width(60);
     left_container.set_layout<GUI::VerticalBoxLayout>();
-    left_container.layout()->set_margins({ 12, 0, 0, 0 });
+    left_container.layout()->set_margins({ 12, 0, 0 });
 
     auto& icon_wrapper = left_container.add<GUI::Widget>();
     icon_wrapper.set_fixed_size(32, 48);

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -56,7 +56,7 @@ ShutdownDialog::ShutdownDialog()
     auto& left_container = content_container.add<GUI::Widget>();
     left_container.set_fixed_width(60);
     left_container.set_layout<GUI::VerticalBoxLayout>();
-    left_container.layout()->set_margins({ 0, 12, 0, 0 });
+    left_container.layout()->set_margins({ 12, 0, 0, 0 });
 
     auto& icon_wrapper = left_container.add<GUI::Widget>();
     icon_wrapper.set_fixed_size(32, 48);
@@ -67,7 +67,7 @@ ShutdownDialog::ShutdownDialog()
 
     auto& right_container = content_container.add<GUI::Widget>();
     right_container.set_layout<GUI::VerticalBoxLayout>();
-    right_container.layout()->set_margins({ 0, 12, 12, 8 });
+    right_container.layout()->set_margins({ 12, 12, 8, 0 });
 
     auto& label = right_container.add<GUI::Label>("What would you like to do?");
     label.set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -62,7 +62,7 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
 
     auto& main_widget = set_main_widget<TaskbarWidget>();
     main_widget.set_layout<GUI::HorizontalBoxLayout>();
-    main_widget.layout()->set_margins({ 3, 3, 1, 1 });
+    main_widget.layout()->set_margins({ 3, 1, 1, 3 });
 
     m_start_button = GUI::Button::construct("Serenity");
     set_start_button_font(Gfx::FontDatabase::default_font().bold_variant());


### PR DESCRIPTION
No functional changes in this PR.

**Userland+LibGUI: Make Margins arguments match CSS ordering**

Previously the argument order for Margins was (left, top, right,
bottom). To make it more familiar and closer to how CSS does it, the
argument order is now (top, right, bottom, left).

**Userland+LibGUI: Add shorthand versions of the Margins constructor**

This allows for typing [8] instead of [8, 8, 8, 8] to specify the same
margin on all edges, for example. The constructors follow CSS' style of
specifying margins. The added constructors are:

- `Margins(int all)`: Sets the same margin on all edges.
- `Margins(int vertical, int horizontal)`: Sets the first argument to top
  and bottom margins, and the second argument to left and right margins.
- `Margins(int top, int vertical, int bottom)`: Sets the first argument to
  the top margin, the second argument to the left and right margins,
  and the third argument to the bottom margin.

