### PR TITLE
Kernel/SysFS: Prepend to the custody cache instead of append

### DIFF
--- a/Kernel/FileSystem/Custody.cpp
+++ b/Kernel/FileSystem/Custody.cpp
@@ -40,7 +40,7 @@ KResultOr<NonnullRefPtr<Custody>> Custody::try_create(Custody* parent, StringVie
         if (!custody)
             return ENOMEM;
 
-        all_custodies.append(*custody);
+        all_custodies.prepend(*custody);
         return custody.release_nonnull();
     });
 }


### PR DESCRIPTION
Usage patterns mean we are more likely to need a Custody we just cached.
Because lookup walks the list from the beginning, prepending new items
instead of appending means they will be found quicker.

This reduces the number of items in the cache we need to walk by 50% for
boot and application startups.