### PR TITLE
LibGL: Implement compatible `glGetx` functions

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -64,6 +64,8 @@ extern "C" {
 
 // Alpha blending
 #define GL_BLEND 0x0BE2
+#define GL_BLEND_SRC_ALPHA 0x0302
+#define GL_BLEND_DST_ALPHA 0x0304
 
 // Utility
 #define GL_VENDOR 0x1F00
@@ -358,6 +360,7 @@ GLAPI void glBindTexture(GLenum target, GLuint texture);
 GLAPI void glActiveTexture(GLenum texture);
 GLAPI void glGetFloatv(GLenum pname, GLfloat* params);
 GLAPI void glGetBooleanv(GLenum pname, GLboolean* data);
+GLAPI void glGetIntegerv(GLenum pname, GLint* data);
 GLAPI void glDepthMask(GLboolean flag);
 GLAPI void glEnableClientState(GLenum cap);
 GLAPI void glDisableClientState(GLenum cap);

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -357,6 +357,7 @@ GLAPI void glTexParameterf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glBindTexture(GLenum target, GLuint texture);
 GLAPI void glActiveTexture(GLenum texture);
 GLAPI void glGetFloatv(GLenum pname, GLfloat* params);
+GLAPI void glGetBooleanv(GLenum pname, GLboolean* data);
 GLAPI void glDepthMask(GLboolean flag);
 GLAPI void glEnableClientState(GLenum cap);
 GLAPI void glDisableClientState(GLenum cap);

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -72,6 +72,7 @@ public:
     virtual void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) = 0;
     virtual void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void* indices) = 0;
     virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) = 0;
+    virtual void gl_get_booleanv(GLenum pname, GLboolean* data) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -73,6 +73,7 @@ public:
     virtual void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void* indices) = 0;
     virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) = 0;
     virtual void gl_get_booleanv(GLenum pname, GLboolean* data) = 0;
+    virtual void gl_get_integerv(GLenum pname, GLint* data) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -100,6 +100,11 @@ void glGetBooleanv(GLenum pname, GLboolean* data)
     g_gl_context->gl_get_booleanv(pname, data);
 }
 
+void glGetIntegerv(GLenum pname, GLint* data)
+{
+    g_gl_context->gl_get_integerv(pname, data);
+}
+
 void glDepthMask(GLboolean flag)
 {
     g_gl_context->gl_depth_mask(flag);

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -95,6 +95,11 @@ void glGetFloatv(GLenum pname, GLfloat* params)
     g_gl_context->gl_get_floatv(pname, params);
 }
 
+void glGetBooleanv(GLenum pname, GLboolean* data)
+{
+    g_gl_context->gl_get_booleanv(pname, data);
+}
+
 void glDepthMask(GLboolean flag)
 {
     g_gl_context->gl_depth_mask(flag);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1392,6 +1392,30 @@ void SoftwareGLContext::gl_get_floatv(GLenum pname, GLfloat* params)
     }
 }
 
+void SoftwareGLContext::gl_get_booleanv(GLenum pname, GLboolean* data)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    switch (pname) {
+    case GL_BLEND:
+        *data = m_blend_enabled ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_ALPHA_TEST:
+        *data = m_alpha_test_func ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_DEPTH_TEST:
+        *data = m_depth_test_enabled ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_CULL_FACE:
+        *data = m_cull_faces ? GL_TRUE : GL_FALSE;
+        break;
+    default:
+        // According to the Khronos docs, we always return GL_INVALID_ENUM if we encounter a non-accepted value
+        // for `pname`
+        RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
+    }
+}
+
 void SoftwareGLContext::gl_depth_mask(GLboolean flag)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_depth_mask, flag);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1416,6 +1416,24 @@ void SoftwareGLContext::gl_get_booleanv(GLenum pname, GLboolean* data)
     }
 }
 
+void SoftwareGLContext::gl_get_integerv(GLenum pname, GLint* data)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    switch (pname) {
+    case GL_BLEND_SRC_ALPHA:
+        *data = m_blend_source_factor;
+        break;
+    case GL_BLEND_DST_ALPHA:
+        *data = m_blend_destination_factor;
+        break;
+    default:
+        // According to the Khronos docs, we always return GL_INVALID_ENUM if we encounter a non-accepted value
+        // for `pname`
+        RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
+    }
+}
+
 void SoftwareGLContext::gl_depth_mask(GLboolean flag)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_depth_mask, flag);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -83,6 +83,7 @@ public:
     virtual void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void* indices) override;
     virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
     virtual void gl_get_booleanv(GLenum pname, GLboolean* data) override;
+    virtual void gl_get_integerv(GLenum pname, GLint* data) override;
     virtual void present() override;
 
 private:

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -82,6 +82,7 @@ public:
     virtual void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) override;
     virtual void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void* indices) override;
     virtual void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
+    virtual void gl_get_booleanv(GLenum pname, GLboolean* data) override;
     virtual void present() override;
 
 private:


### PR DESCRIPTION
This implements a few more of the `glGet` function group that we support with the data we currently store in the context. 