### PR TITLE
AK+Kernel: StringView hash map Traits should not set peek type to String

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -228,7 +228,7 @@ private:
 };
 
 template<>
-struct Traits<StringView> : public GenericTraits<String> {
+struct Traits<StringView> : public GenericTraits<StringView> {
     static unsigned hash(const StringView& s) { return s.hash(); }
 };
 

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -80,7 +80,7 @@ UNMAP_AFTER_INIT CommandLine::CommandLine(const String& cmdline_from_bootloader)
     add_arguments(args);
 }
 
-Optional<String> CommandLine::lookup(const StringView& key) const
+Optional<StringView> CommandLine::lookup(const StringView& key) const
 {
     return m_params.get(key);
 }
@@ -132,7 +132,7 @@ UNMAP_AFTER_INIT bool CommandLine::is_force_pio() const
     return contains("force_pio"sv);
 }
 
-UNMAP_AFTER_INIT String CommandLine::root_device() const
+UNMAP_AFTER_INIT StringView CommandLine::root_device() const
 {
     return lookup("root"sv).value_or("/dev/hda"sv);
 }
@@ -220,14 +220,14 @@ UNMAP_AFTER_INIT bool CommandLine::is_no_framebuffer_devices_mode() const
     return mode == BootMode::NoFramebufferDevices || mode == BootMode::SelfTest;
 }
 
-String CommandLine::userspace_init() const
+StringView CommandLine::userspace_init() const
 {
     return lookup("init"sv).value_or("/bin/SystemServer"sv);
 }
 
 Vector<String> CommandLine::userspace_init_args() const
 {
-    auto init_args = lookup("init_args"sv).value_or(""sv).split(',');
+    auto init_args = lookup("init_args"sv).value_or(""sv).to_string().split(';');
     if (!init_args.is_empty())
         init_args.prepend(userspace_init());
 

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -55,7 +55,7 @@ public:
     };
 
     [[nodiscard]] const String& string() const { return m_string; }
-    Optional<String> lookup(const StringView& key) const;
+    Optional<StringView> lookup(const StringView& key) const;
     [[nodiscard]] bool contains(const StringView& key) const;
 
     [[nodiscard]] bool is_boot_profiling_enabled() const;
@@ -76,9 +76,9 @@ public:
     [[nodiscard]] bool disable_usb() const;
     [[nodiscard]] bool disable_virtio() const;
     [[nodiscard]] AHCIResetMode ahci_reset_mode() const;
-    [[nodiscard]] String userspace_init() const;
+    [[nodiscard]] StringView userspace_init() const;
     [[nodiscard]] Vector<String> userspace_init_args() const;
-    [[nodiscard]] String root_device() const;
+    [[nodiscard]] StringView root_device() const;
     [[nodiscard]] size_t switch_to_tty() const;
 
 private:


### PR DESCRIPTION
This typo / bug in the Traits<T> implementation for StringView caused
AK::HashMap methods to return a `String` when looking up values out of
a hash map of type HashTable<StringView,StringView>.

This change fixes the typo, and fixes the only consumer, the kernel
Commandline class.