### PR TITLE
Browser: DOM Inspector improvements

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -220,6 +220,9 @@ void BrowserWindow::build_menus()
                     tab.m_dom_inspector_window->set_title("DOM inspector");
                     tab.m_dom_inspector_window->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspector-object.png"));
                     tab.m_dom_inspector_window->set_main_widget<InspectorWidget>();
+                    tab.m_dom_inspector_window->on_close = [&]() {
+                        tab.m_page_view->document()->set_inspected_node(nullptr);
+                    };
                 }
                 auto* inspector_widget = static_cast<InspectorWidget*>(tab.m_dom_inspector_window->main_widget());
                 inspector_widget->set_document(tab.m_page_view->document());

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -212,28 +212,17 @@ void BrowserWindow::build_menus()
 
     m_inspect_dom_tree_action = GUI::Action::create(
         "Inspect &DOM Tree", { Mod_None, Key_F12 }, [this](auto&) {
-            auto& tab = active_tab();
-            if (tab.m_type == Tab::Type::InProcessWebView) {
-                if (!tab.m_dom_inspector_window) {
-                    tab.m_dom_inspector_window = GUI::Window::construct(this);
-                    tab.m_dom_inspector_window->resize(300, 500);
-                    tab.m_dom_inspector_window->set_title("DOM inspector");
-                    tab.m_dom_inspector_window->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspector-object.png"));
-                    tab.m_dom_inspector_window->set_main_widget<InspectorWidget>();
-                    tab.m_dom_inspector_window->on_close = [&]() {
-                        tab.m_page_view->document()->set_inspected_node(nullptr);
-                    };
-                }
-                auto* inspector_widget = static_cast<InspectorWidget*>(tab.m_dom_inspector_window->main_widget());
-                inspector_widget->set_document(tab.m_page_view->document());
-                tab.m_dom_inspector_window->show();
-                tab.m_dom_inspector_window->move_to_front();
-            } else {
-                tab.m_web_content_view->inspect_dom_tree();
-            }
+            active_tab().show_inspector_window(Tab::InspectorTarget::Document);
         },
         this);
     m_inspect_dom_tree_action->set_status_tip("Open DOM inspector window for this page");
+
+    m_inspect_dom_node_action = GUI::Action::create(
+        "&Inspect Element", [this](auto&) {
+            active_tab().show_inspector_window(Tab::InspectorTarget::HoveredElement);
+        },
+        this);
+    m_inspect_dom_node_action->set_status_tip("Open DOM inspector for this element");
 
     auto& inspect_menu = add_menu("&Inspect");
     inspect_menu.add_action(*m_view_source_action);

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "BookmarksBarWidget.h"
+#include "Tab.h"
 #include "WindowActions.h"
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Window.h>
@@ -34,6 +35,7 @@ public:
     GUI::Action& select_all_action() { return *m_select_all_action; }
     GUI::Action& view_source_action() { return *m_view_source_action; }
     GUI::Action& inspect_dom_tree_action() { return *m_inspect_dom_tree_action; }
+    GUI::Action& inspect_dom_node_action() { return *m_inspect_dom_node_action; }
 
 private:
     explicit BrowserWindow(CookieJar&, URL);
@@ -49,6 +51,7 @@ private:
     RefPtr<GUI::Action> m_select_all_action;
     RefPtr<GUI::Action> m_view_source_action;
     RefPtr<GUI::Action> m_inspect_dom_tree_action;
+    RefPtr<GUI::Action> m_inspect_dom_node_action;
 
     CookieJar& m_cookie_jar;
     WindowActions m_window_actions;

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -26,6 +26,7 @@ void InspectorWidget::set_inspected_node(GUI::ModelIndex const index)
         return;
     }
     auto* node = static_cast<Web::DOM::Node*>(index.internal_data());
+    m_inspected_node = node;
     m_document->set_inspected_node(node);
     if (node && node->is_element()) {
         auto& element = verify_cast<Web::DOM::Element>(*node);
@@ -70,6 +71,7 @@ InspectorWidget::~InspectorWidget()
 
 void InspectorWidget::set_document(Web::DOM::Document* document)
 {
+    document->set_inspected_node(m_inspected_node);
     if (m_document == document)
         return;
     m_document = document;

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -28,6 +28,8 @@ void InspectorWidget::set_inspected_node(GUI::ModelIndex const index)
     auto* node = static_cast<Web::DOM::Node*>(index.internal_data());
     m_inspected_node = node;
     m_document->set_inspected_node(node);
+    m_dom_tree_view->set_cursor(index, GUI::AbstractView::SelectionUpdate::Set);
+    m_dom_tree_view->expand_all_parents_of(index);
     if (node && node->is_element()) {
         auto& element = verify_cast<Web::DOM::Element>(*node);
         if (element.specified_css_values()) {
@@ -38,6 +40,17 @@ void InspectorWidget::set_inspected_node(GUI::ModelIndex const index)
         m_style_table_view->set_model(nullptr);
         m_computed_style_table_view->set_model(nullptr);
     }
+}
+
+void InspectorWidget::set_inspected_node(Web::DOM::Node* requested_node)
+{
+    dbgln("Inspected node: {:p}", requested_node);
+    if (requested_node == nullptr) {
+        set_inspected_node(GUI::ModelIndex {});
+        return;
+    }
+
+    set_inspected_node(static_cast<Web::DOMTreeModel*>(m_dom_tree_view->model())->index_for_node(requested_node));
 }
 
 InspectorWidget::InspectorWidget()

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -18,6 +18,7 @@ public:
 
     void set_document(Web::DOM::Document*);
     void set_dom_json(String);
+    void set_inspected_node(Web::DOM::Node*);
 
 private:
     InspectorWidget();

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -29,6 +29,8 @@ private:
     RefPtr<GUI::TableView> m_style_table_view;
     RefPtr<GUI::TableView> m_computed_style_table_view;
 
+    RefPtr<Web::DOM::Node> m_inspected_node;
+
     // One of these will be available, depending on if we're
     // in-process (m_document) or out-of-process (m_dom_json)
     RefPtr<Web::DOM::Document> m_document;

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -64,6 +64,12 @@ public:
     Function<void(const URL&, const Web::Cookie::ParsedCookie& cookie, Web::Cookie::Source source)> on_set_cookie;
     Function<void()> on_dump_cookies;
 
+    enum class InspectorTarget {
+        Document,
+        HoveredElement
+    };
+    void show_inspector_window(InspectorTarget);
+
     const String& title() const { return m_title; }
     const Gfx::Bitmap* icon() const { return m_icon; }
 

--- a/Userland/Libraries/LibWeb/DOMTreeModel.cpp
+++ b/Userland/Libraries/LibWeb/DOMTreeModel.cpp
@@ -131,4 +131,20 @@ GUI::Variant DOMTreeModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
+GUI::ModelIndex DOMTreeModel::index_for_node(DOM::Node* node) const
+{
+    if (!node)
+        return {};
+
+    DOM::Node* parent = node->parent();
+    if (!parent)
+        return {};
+
+    auto maybe_row = parent->index_of_child(*node);
+    if (maybe_row.has_value())
+        return create_index(maybe_row.value(), 0, node);
+
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOMTreeModel.h
+++ b/Userland/Libraries/LibWeb/DOMTreeModel.h
@@ -26,6 +26,8 @@ public:
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
 
+    GUI::ModelIndex index_for_node(DOM::Node*) const;
+
 private:
     explicit DOMTreeModel(DOM::Document&);
 

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Painter.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Layout/BlockBox.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
@@ -45,6 +46,22 @@ void InlineNode::paint_fragment(PaintContext& context, const LineBoxFragment& fr
 
     if (phase == PaintPhase::Background) {
         painter.fill_rect(enclosing_int_rect(fragment.absolute_rect()), computed_values().background_color());
+    }
+}
+
+void InlineNode::paint(PaintContext& context, PaintPhase phase)
+{
+    auto& painter = context.painter();
+
+    if (phase == PaintPhase::Foreground && document().inspected_node() == dom_node()) {
+        // FIXME: This paints a double-thick border between adjacent fragments, where ideally there
+        //        would be none. Once we implement non-rectangular outlines for the `outline` CSS
+        //        property, we can use that here instead.
+        containing_block()->for_each_fragment([&](auto& fragment) {
+            if (is_inclusive_ancestor_of(fragment.layout_node()))
+                painter.draw_rect(enclosing_int_rect(fragment.absolute_rect()), Color::Magenta);
+            return IterationDecision::Continue;
+        });
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.h
@@ -15,6 +15,7 @@ public:
     InlineNode(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~InlineNode() override;
 
+    virtual void paint(PaintContext&, PaintPhase) override;
     virtual void paint_fragment(PaintContext&, const LineBoxFragment&, PaintPhase) const override;
 
     virtual void split_into_lines(InlineFormattingContext&, LayoutMode) override;


### PR DESCRIPTION
*Note: this only applies when Browser is in single-process mode. The multi-process DOM Inspector is a whole other pile of yaks.*

- **Browser: Hide inspected-element outline when DOM Inspector is closed**
  It bugged me that it would hang around after closing the window, so now it doesn't.
- **LibWeb: Add DOMTreeModel::index_for_node()**
- **Browser: Add "Inspect Element" to context menu :^)**
  Not being able to right-click and inspect an element was really bothering me, so now you can! Yay!
- **LibWeb: Paint inspection outline for InlineNodes :^)**
  I believe these were the only nodes that didn't get an outline before. Now they do!

Fixes #8936