### PR TITLE
Meta: Assume and find GNU du

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -30,13 +30,17 @@ PATH="$SCRIPT_DIR/../Toolchain/Local/qemu/bin:$PATH"
 # directory was changed to Toolchain/Local/qemu.
 PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
 
+# We depend on GNU coreutils du for the --apparent-size extension.
+# GNU coreutils is a build dependency.
+if type gdu > /dev/null 2>&1; then
+    GNUDU="gdu"
+else
+    GNUDU="du"
+fi
+
 disk_usage() {
     # shellcheck disable=SC2003
-if [ "$(uname -s)" = "Darwin" ]; then
-    expr "$(du -sk "$1" | cut -f1)"
-else
-    expr "$(du -sk --apparent-size "$1" | cut -f1)"
-fi
+    expr "$(${GNUDU} -sk --apparent-size "$1" | cut -f1)"
 }
 
 inode_usage() {


### PR DESCRIPTION
We want to use use the `du` option `--apparent-size` which is a
GNU coreutils extension. GNU coreutils is a build dependency so
we know it is available. With this commit we first try to pick up
`du` as `'gdu'`, and if that fails, try `'du'` instead.

This fixes an issue on FreeBSD where the script tried to use
`--apparent-size` with the installed `du`, which failed because it is
not the GNU `du`.