### PR TITLE
Meta: Create memory disk before mounting it on FreeBSD

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -98,9 +98,6 @@ if [ $USE_EXISTING -ne 1 ]; then
         VND=$(vnconfig _disk_image)
         (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e "$VND"
         newfs_ext2fs -D $INODE_SIZE -n $INODE_COUNT "/dev/r${VND}i" || die "could not create filesystem"
-    elif [ "$(uname -s)" = "FreeBSD" ]; then
-        MD=$(mdconfig _disk_image)
-        mke2fs -q -I $INODE_SIZE -N $INODE_COUNT _disk_image || die "could not create filesystem"
     else
         if [ -x /sbin/mke2fs ]; then
             /sbin/mke2fs -q -I $INODE_SIZE -N $INODE_COUNT _disk_image || die "could not create filesystem"
@@ -119,6 +116,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
 elif [ "$(uname -s)" = "OpenBSD" ]; then
   mount_cmd="mount -t ext2fs "/dev/${VND}i" mnt/"
 elif [ "$(uname -s)" = "FreeBSD" ]; then
+  MD=$(mdconfig _disk_image)
   mount_cmd="fuse-ext2 -o rw+,direct_io "/dev/${MD}" mnt/"
 else
   mount_cmd="mount _disk_image mnt/"


### PR DESCRIPTION
On FreeBSD, there was a case where the `build-image-qemu.sh`
script would decide to mount an existing disk image, but without
creating the memory disk device and recording its `/dev` file name.

With this commit, we create the memory disk device just before it
is used to mount the disk image.