### PR TITLE
Everywhere: Enable maybe_uninitialized warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,6 @@ add_compile_options(-Wno-unused-private-field)
 add_compile_options(-Wno-unused-const-variable)
 add_compile_options(-Wno-unused-command-line-argument)
 add_compile_options(-Wwrite-strings)
-add_compile_options(-Wno-maybe-uninitialized)
 
 add_compile_options(-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.)
 add_compile_options(-fno-exceptions)

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -214,7 +214,7 @@ bool CardStack::is_allowed_to_push(const Card& card, size_t stack_size, Movement
                 return false;
             return top_card.type() == card.type() && m_stack.size() == card.value();
         } else if (m_type == Normal) {
-            bool color_match;
+            bool color_match = true;
             switch (movement_rule) {
             case Alternating:
                 color_match = card.color() != top_card.color();
@@ -223,7 +223,6 @@ bool CardStack::is_allowed_to_push(const Card& card, size_t stack_size, Movement
                 color_match = card.color() == top_card.color();
                 break;
             case Any:
-                color_match = true;
                 break;
             }
 

--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
 
         *(MACAddress*)&arp_req.arp_ha.sa_data[0] = hw_address.value();
 
-        int rc;
+        int rc = 0;
         if (flag_set)
             rc = ioctl(fd, SIOCSARP, &arp_req);
         if (flag_delete)

--- a/Userland/Utilities/crash.cpp
+++ b/Userland/Utilities/crash.cpp
@@ -23,8 +23,12 @@ using Test::Crash;
 
 #ifdef __clang__
 #    pragma clang optimize off
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wmaybe-uninitialized"
 #else
 #    pragma GCC optimize("O0")
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
 int main(int argc, char** argv)
@@ -290,3 +294,9 @@ int main(int argc, char** argv)
 
     return 0;
 }
+
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#else
+#    pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Problem:
- Disabling the `maybe_uninitialized` compiler warning can lead to
  defects.

Solution:
- Enable warning.
- Initialize variable used in switch statement. This is a redundant
  store because all the cases of the `enum` are covered in the switch
  statement. Optimizer *should* catch this.
- Initialize variable which is potentially uninitialized in `arp`.
- Specific places which are intended to read from uninitialized memory
  are wrapped in pragmas to disable the warning.