### PR TITLE
find(1) go brrrr

### DIFF
--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -218,8 +218,8 @@ KResult ProcFSExposedDirectory::traverse_as_directory(unsigned fsid, Function<bo
     auto parent_directory = m_parent_directory.strong_ref();
     if (parent_directory.is_null())
         return KResult(EINVAL);
-    callback({ ".", { fsid, component_index() }, 0 });
-    callback({ "..", { fsid, parent_directory->component_index() }, 0 });
+    callback({ ".", { fsid, component_index() }, DT_DIR });
+    callback({ "..", { fsid, parent_directory->component_index() }, DT_DIR });
 
     for (auto& component : m_components) {
         InodeIdentifier identifier = { fsid, component.component_index() };

--- a/Kernel/ProcessProcFSTraits.cpp
+++ b/Kernel/ProcessProcFSTraits.cpp
@@ -54,17 +54,17 @@ KResult Process::ProcessProcFSTraits::traverse_as_directory(unsigned fsid, Funct
     if (!process)
         return ESRCH;
 
-    callback({ ".", { fsid, SegmentedProcFSIndex::build_segmented_index_for_pid_directory(process->pid()) }, 0 });
-    callback({ "..", { fsid, ProcFSComponentRegistry::the().root_directory().component_index() }, 0 });
-    callback({ "fd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::FileDescriptions) }, 0 });
-    callback({ "stacks", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::Stacks) }, 0 });
-    callback({ "unveil", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Unveil) }, 0 });
-    callback({ "pledge", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Pledge) }, 0 });
-    callback({ "fds", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::FileDescriptions) }, 0 });
-    callback({ "exe", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::BinaryLink) }, 0 });
-    callback({ "cwd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::CurrentWorkDirectoryLink) }, 0 });
-    callback({ "perf_events", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::PerformanceEvents) }, 0 });
-    callback({ "vm", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::VirtualMemoryStats) }, 0 });
+    callback({ ".", { fsid, SegmentedProcFSIndex::build_segmented_index_for_pid_directory(process->pid()) }, DT_DIR });
+    callback({ "..", { fsid, ProcFSComponentRegistry::the().root_directory().component_index() }, DT_DIR });
+    callback({ "fd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::FileDescriptions) }, DT_DIR });
+    callback({ "stacks", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::Stacks) }, DT_DIR });
+    callback({ "unveil", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Unveil) }, DT_REG });
+    callback({ "pledge", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Pledge) }, DT_REG });
+    callback({ "fds", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::FileDescriptions) }, DT_DIR });
+    callback({ "exe", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::BinaryLink) }, DT_LNK });
+    callback({ "cwd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::CurrentWorkDirectoryLink) }, DT_LNK });
+    callback({ "perf_events", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::PerformanceEvents) }, DT_REG });
+    callback({ "vm", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::VirtualMemoryStats) }, DT_REG });
     return KSuccess;
 }
 

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -99,7 +99,7 @@ KResult Process::traverse_file_descriptions_directory(unsigned fsid, Function<bo
         }
         StringBuilder builder;
         builder.appendff("{}", count);
-        callback({ builder.string_view(), { fsid, SegmentedProcFSIndex::build_segmented_index_for_file_description(pid(), count) }, 0 });
+        callback({ builder.string_view(), { fsid, SegmentedProcFSIndex::build_segmented_index_for_file_description(pid(), count) }, DT_LNK });
         count++;
     });
     return KSuccess;


### PR DESCRIPTION
After [watching @awesomekling improve `find /` performance](https://www.youtube.com/watch?v=5yooYgMqs3Y) by doing kernel path resolution optimizations, I couldn't help but think of how we could make it substantially faster by just not doing that many path traversals in the first place.

The results speak for themselves :^)

![image](https://user-images.githubusercontent.com/10091584/129898389-17f3e68c-100d-4c24-815f-94776967e4e3.png)

Sorry for ruining such a cool kernel benchmark :rofl:

Please do test that I have not broken things!