### PR TITLE
3DFileViewer+LibGfx: Use unveil & FileSystemAccessServer

### DIFF
--- a/Userland/Applications/3DFileViewer/CMakeLists.txt
+++ b/Userland/Applications/3DFileViewer/CMakeLists.txt
@@ -2,6 +2,7 @@ serenity_component(
     3DFileViewer
     RECOMMENDED
     TARGETS 3DFileViewer
+    DEPENDS FileSystemAccessServer
 )
 
 set(SOURCES
@@ -11,4 +12,4 @@ set(SOURCES
 )
 
 serenity_app(3DFileViewer ICON app-3d-file-viewer)
-target_link_libraries(3DFileViewer LibGUI LibGL)
+target_link_libraries(3DFileViewer LibGUI LibGL LibFileSystemAccessClient)

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -171,17 +171,14 @@ RefPtr<Gfx::Bitmap> load_bmp(String const& path)
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    auto bitmap = load_bmp_impl((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded BMP: {}", bitmap->size(), LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_bmp_from_memory((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), LexicalPath::canonicalized_path(path));
 }
 
-RefPtr<Gfx::Bitmap> load_bmp_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_bmp_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
     auto bitmap = load_bmp_impl(data, length);
     if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded BMP: <memory>", bitmap->size()));
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded BMP: {}", bitmap->size(), mmap_name));
     return bitmap;
 }
 

--- a/Userland/Libraries/LibGfx/BMPLoader.h
+++ b/Userland/Libraries/LibGfx/BMPLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_bmp(String const& path);
-RefPtr<Gfx::Bitmap> load_bmp_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_bmp_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct BMPLoadingContext;
 

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -94,6 +94,7 @@ public:
     [[nodiscard]] static RefPtr<Bitmap> try_create_shareable(BitmapFormat, const IntSize&, int intrinsic_scale = 1);
     [[nodiscard]] static RefPtr<Bitmap> try_create_wrapper(BitmapFormat, const IntSize&, int intrinsic_scale, size_t pitch, void*);
     [[nodiscard]] static RefPtr<Bitmap> try_load_from_file(String const& path, int scale_factor = 1);
+    [[nodiscard]] static RefPtr<Bitmap> try_load_from_fd_and_close(int fd, String const& path, int scale_factor = 1);
     [[nodiscard]] static RefPtr<Bitmap> try_create_with_anonymous_buffer(BitmapFormat, Core::AnonymousBuffer, const IntSize&, int intrinsic_scale, const Vector<RGBA32>& palette);
     [[nodiscard]] static RefPtr<Bitmap> try_create_from_serialized_byte_buffer(ByteBuffer&& buffer);
 

--- a/Userland/Libraries/LibGfx/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/DDSLoader.cpp
@@ -957,17 +957,14 @@ RefPtr<Gfx::Bitmap> load_dds(String const& path)
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    auto bitmap = load_dds_impl((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded DDS: {}", bitmap->size(), LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_dds_from_memory((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), LexicalPath::canonicalized_path(path));
 }
 
-RefPtr<Gfx::Bitmap> load_dds_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_dds_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
     auto bitmap = load_dds_impl(data, length);
     if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded DDS: <memory>", bitmap->size()));
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded DDS: {}", bitmap->size(), mmap_name));
     return bitmap;
 }
 

--- a/Userland/Libraries/LibGfx/DDSLoader.h
+++ b/Userland/Libraries/LibGfx/DDSLoader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
@@ -233,7 +234,7 @@ struct DDSHeaderDXT10 {
 };
 
 RefPtr<Gfx::Bitmap> load_dds(String const& path);
-RefPtr<Gfx::Bitmap> load_dds_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_dds_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct DDSLoadingContext;
 

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -87,19 +87,15 @@ RefPtr<Gfx::Bitmap> load_gif(String const& path)
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    GIFImageDecoderPlugin gif_decoder((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    auto bitmap = gif_decoder.bitmap();
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded GIF: {}", bitmap->size(), LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_gif_from_memory((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), LexicalPath::canonicalized_path(path));
 }
 
-RefPtr<Gfx::Bitmap> load_gif_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_gif_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
     GIFImageDecoderPlugin gif_decoder(data, length);
     auto bitmap = gif_decoder.bitmap();
     if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded GIF: <memory>", bitmap->size()));
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded GIF: {}", bitmap->size(), mmap_name));
     return bitmap;
 }
 

--- a/Userland/Libraries/LibGfx/GIFLoader.h
+++ b/Userland/Libraries/LibGfx/GIFLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_gif(String const& path);
-RefPtr<Gfx::Bitmap> load_gif_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_gif_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct GIFLoadingContext;
 

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -96,19 +96,15 @@ RefPtr<Gfx::Bitmap> load_ico(const StringView& path)
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    ICOImageDecoderPlugin decoder((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    auto bitmap = decoder.bitmap();
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded ICO: {}", bitmap->size(), LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_ico_from_memory((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), LexicalPath::canonicalized_path(path));
 }
 
-RefPtr<Gfx::Bitmap> load_ico_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_ico_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
     ICOImageDecoderPlugin decoder(data, length);
     auto bitmap = decoder.bitmap();
     if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded ICO: <memory>", bitmap->size()));
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded ICO: {}", bitmap->size(), mmap_name));
     return bitmap;
 }
 

--- a/Userland/Libraries/LibGfx/ICOLoader.h
+++ b/Userland/Libraries/LibGfx/ICOLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_ico(const StringView& path);
-RefPtr<Gfx::Bitmap> load_ico_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_ico_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct ICOLoadingContext;
 

--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -9,7 +9,6 @@
 #include <AK/Debug.h>
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
-#include <AK/MappedFile.h>
 #include <AK/Math.h>
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
@@ -1238,17 +1237,14 @@ RefPtr<Gfx::Bitmap> load_jpg(String const& path)
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    auto bitmap = load_jpg_impl((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded JPG: {}", bitmap->size(), LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_jpg_from_memory((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), path);
 }
 
-RefPtr<Gfx::Bitmap> load_jpg_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_jpg_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
     auto bitmap = load_jpg_impl(data, length);
     if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded jpg: <memory>", bitmap->size()));
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded jpg: {}", bitmap->size(), mmap_name));
     return bitmap;
 }
 

--- a/Userland/Libraries/LibGfx/JPGLoader.h
+++ b/Userland/Libraries/LibGfx/JPGLoader.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/MappedFile.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
@@ -14,7 +16,7 @@
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_jpg(String const& path);
-RefPtr<Gfx::Bitmap> load_jpg_from_memory(const u8* data, size_t length);
+RefPtr<Gfx::Bitmap> load_jpg_from_memory(u8 const* data, size_t length, String const& mmap_name = "<memory>");
 
 struct JPGLoadingContext;
 

--- a/Userland/Libraries/LibGfx/PBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PBMLoader.cpp
@@ -102,12 +102,9 @@ RefPtr<Gfx::Bitmap> load_pbm(const StringView& path)
     return load<PBMLoadingContext>(path);
 }
 
-RefPtr<Gfx::Bitmap> load_pbm_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_pbm_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
-    auto bitmap = load_impl<PBMLoadingContext>(data, length);
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded PBM: <memory>", bitmap->size()));
-    return bitmap;
+    return load_from_memory<PBMLoadingContext>(data, length, mmap_name);
 }
 
 PBMImageDecoderPlugin::PBMImageDecoderPlugin(const u8* data, size_t size)

--- a/Userland/Libraries/LibGfx/PBMLoader.h
+++ b/Userland/Libraries/LibGfx/PBMLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_pbm(const StringView& path);
-RefPtr<Gfx::Bitmap> load_pbm_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_pbm_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct PBMLoadingContext;
 

--- a/Userland/Libraries/LibGfx/PGMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PGMLoader.cpp
@@ -104,12 +104,9 @@ RefPtr<Gfx::Bitmap> load_pgm(const StringView& path)
     return load<PGMLoadingContext>(path);
 }
 
-RefPtr<Gfx::Bitmap> load_pgm_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_pgm_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
-    auto bitmap = load_impl<PGMLoadingContext>(data, length);
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded PGM: <memory>", bitmap->size()));
-    return bitmap;
+    return load_from_memory<PGMLoadingContext>(data, length, mmap_name);
 }
 
 PGMImageDecoderPlugin::PGMImageDecoderPlugin(const u8* data, size_t size)

--- a/Userland/Libraries/LibGfx/PGMLoader.h
+++ b/Userland/Libraries/LibGfx/PGMLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_pgm(const StringView& path);
-RefPtr<Gfx::Bitmap> load_pgm_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_pgm_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct PGMLoadingContext;
 

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -174,17 +174,14 @@ RefPtr<Gfx::Bitmap> load_png(String const& path)
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    auto bitmap = load_png_impl((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded PNG: {}", bitmap->size(), LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_png_from_memory((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), LexicalPath::canonicalized_path(path));
 }
 
-RefPtr<Gfx::Bitmap> load_png_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_png_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
     auto bitmap = load_png_impl(data, length);
     if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded PNG: <memory>", bitmap->size()));
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded PNG: {}", bitmap->size(), mmap_name));
     return bitmap;
 }
 

--- a/Userland/Libraries/LibGfx/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/PNGLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_png(String const& path);
-RefPtr<Gfx::Bitmap> load_png_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_png_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct PNGLoadingContext;
 

--- a/Userland/Libraries/LibGfx/PPMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PPMLoader.cpp
@@ -106,12 +106,9 @@ RefPtr<Gfx::Bitmap> load_ppm(const StringView& path)
     return load<PPMLoadingContext>(path);
 }
 
-RefPtr<Gfx::Bitmap> load_ppm_from_memory(const u8* data, size_t length)
+RefPtr<Gfx::Bitmap> load_ppm_from_memory(u8 const* data, size_t length, String const& mmap_name)
 {
-    auto bitmap = load_impl<PPMLoadingContext>(data, length);
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded PPM: <memory>", bitmap->size()));
-    return bitmap;
+    return load_from_memory<PPMLoadingContext>(data, length, mmap_name);
 }
 
 PPMImageDecoderPlugin::PPMImageDecoderPlugin(const u8* data, size_t size)

--- a/Userland/Libraries/LibGfx/PPMLoader.h
+++ b/Userland/Libraries/LibGfx/PPMLoader.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
 namespace Gfx {
 
 RefPtr<Gfx::Bitmap> load_ppm(const StringView& path);
-RefPtr<Gfx::Bitmap> load_ppm_from_memory(const u8*, size_t);
+RefPtr<Gfx::Bitmap> load_ppm_from_memory(u8 const*, size_t, String const& mmap_name = "<memory>");
 
 struct PPMLoadingContext;
 

--- a/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
@@ -261,19 +261,23 @@ static RefPtr<Gfx::Bitmap> load_impl(const u8* data, size_t data_size)
     }
     return context.bitmap;
 }
+
+template<typename TContext>
+static RefPtr<Gfx::Bitmap> load_from_memory(u8 const* data, size_t length, String const& mmap_name)
+{
+    auto bitmap = load_impl<TContext>(data, length);
+    if (bitmap)
+        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded {}: {}", bitmap->size(), TContext::image_type, mmap_name));
+    return bitmap;
+}
+
 template<typename TContext>
 static RefPtr<Gfx::Bitmap> load(const StringView& path)
 {
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;
-    auto bitmap = load_impl<TContext>((const u8*)file_or_error.value()->data(), file_or_error.value()->size());
-    if (bitmap)
-        bitmap->set_mmap_name(String::formatted("Gfx::Bitmap [{}] - Decoded {}: {}",
-            bitmap->size(),
-            TContext::image_type,
-            LexicalPath::canonicalized_path(path)));
-    return bitmap;
+    return load_from_memory<TContext>((u8 const*)file_or_error.value()->data(), file_or_error.value()->size(), LexicalPath::canonicalized_path(path));
 }
 
 }


### PR DESCRIPTION
* **LibGfx: Add methods to load image from existing fd**

* **3DFileViewer: Use unveil and FileSystemAccessServer**
   This will restrict 3DFileViewer's access to the file system.

   3DFileViewer loads a texture based on the path of the model loaded, this
    will request access to the texture file before loading.