### PR TITLE
Meta+LibC: Don't allow text relocations in SerenityOS libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,8 @@ else()
     add_compile_options(-Wdouble-promotion)
 endif()
 
+add_link_options(LINKER:-z,text)
+
 if("${SERENITY_ARCH}" STREQUAL "i686")
     add_compile_options(-march=i686)
 else()

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -437,8 +437,9 @@ add_compile_definitions(KERNEL)
 #       It's needed because CLion doesn't understand the way we switch compilers mid-build.
 add_compile_definitions(__serenity__)
 
+add_link_options(LINKER:-z,notext)
+
 if (USE_CLANG_TOOLCHAIN)
-    add_link_options(LINKER:-z,notext)
     add_link_options(LINKER:--build-id=none)
 endif()
 

--- a/Userland/Libraries/LibC/arch/i386/setjmp.S
+++ b/Userland/Libraries/LibC/arch/i386/setjmp.S
@@ -31,7 +31,7 @@ sigsetjmp:
     push %eax
     push $0                 // Set argument set
     push $0                 // Set argument how
-    call sigprocmask
+    call sigprocmask@plt
     add $12, %esp
 
 .Lsaveregs:

--- a/Userland/Libraries/LibC/arch/x86_64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/x86_64/setjmp.S
@@ -25,7 +25,7 @@ sigsetjmp:
     mov $0, %rdi            // Set argument how
     mov $0, %rsi            // Set argument set
     lea 64(%rdi), %rdx      // Set argument oldset
-    call sigprocmask
+    call sigprocmask@plt
     mov %r12, %rdi          // Restore sigjmp_buf argument
 
 .Lsaveregs:


### PR DESCRIPTION
The `-z,text` linker flag causes the linker to reject shared libraries
and PIE executables that have textrels. Our code mostly did not use
these except in one place in LibC, which is changed in this commit.
This makes GNU ld match LLD's behavior, which has this option enabled by
default.

TEXTRELs pose a security risk, as performing these relocations require
executable pages to be written to by the dynamic linker. This can
significantly weaken W^X hardening mitigations.

Note that after this change, TEXTRELs can still be used in ports, as the
dynamic loader code is not changed. There are also uses of it in the
kernel, removing which are outside the scope of this PR. To allow those,
`-z,notext` is added.