### PR TITLE
AK+LibJS+LibRegex: Allow Unicode escape sequences in identifiers and regex capture groups

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 Base/home/anon/Source/js
 Userland/Libraries/LibJS/Tests/eval-aliasing.js
-
+Userland/Libraries/LibJS/Tests/unicode-identifier-escape.js

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -26,6 +26,21 @@
 
 namespace AK {
 
+class FormatParser : public GenericLexer {
+public:
+    struct FormatSpecifier {
+        StringView flags;
+        size_t index;
+    };
+
+    explicit FormatParser(StringView input);
+
+    StringView consume_literal();
+    bool consume_number(size_t& value);
+    bool consume_specifier(FormatSpecifier& specifier);
+    bool consume_replacement_field(size_t& index);
+};
+
 namespace {
 
 static constexpr size_t use_next_index = NumericLimits<size_t>::max();

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -11,7 +11,6 @@
 #include <AK/AllOf.h>
 #include <AK/AnyOf.h>
 #include <AK/Array.h>
-#include <AK/GenericLexer.h>
 #include <AK/Optional.h>
 #include <AK/StringView.h>
 
@@ -119,21 +118,6 @@ struct TypeErasedParameter {
     const void* value;
     Type type;
     void (*formatter)(TypeErasedFormatParams&, FormatBuilder&, FormatParser&, const void* value);
-};
-
-class FormatParser : public GenericLexer {
-public:
-    struct FormatSpecifier {
-        StringView flags;
-        size_t index;
-    };
-
-    explicit FormatParser(StringView input);
-
-    StringView consume_literal();
-    bool consume_number(size_t& value);
-    bool consume_specifier(FormatSpecifier& specifier);
-    bool consume_replacement_field(size_t& index);
 };
 
 class FormatBuilder {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -17,6 +17,7 @@ class ByteBuffer;
 
 class Bitmap;
 using ByteBuffer = AK::Detail::ByteBuffer<32>;
+class GenericLexer;
 class IPv4Address;
 class JsonArray;
 class JsonObject;
@@ -139,6 +140,7 @@ using AK::DuplexMemoryStream;
 using AK::FixedArray;
 using AK::FlyString;
 using AK::Function;
+using AK::GenericLexer;
 using AK::HashMap;
 using AK::HashTable;
 using AK::InputBitStream;

--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -5,9 +5,11 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/CharacterTypes.h>
 #include <AK/GenericLexer.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/Utf16View.h>
 
 namespace AK {
 // Consume a number of characters
@@ -126,6 +128,76 @@ String GenericLexer::consume_and_unescape_string(char escape_char)
     for (size_t i = 0; i < view.length(); ++i)
         builder.append(consume_escaped_character(escape_char));
     return builder.to_string();
+}
+
+auto GenericLexer::consume_escaped_code_point(bool combine_surrogate_pairs) -> Result<u32, UnicodeEscapeError>
+{
+    if (!consume_specific("\\u"sv))
+        return UnicodeEscapeError::MalformedUnicodeEscape;
+
+    if (next_is('{'))
+        return decode_code_point();
+    return decode_single_or_paired_surrogate(combine_surrogate_pairs);
+}
+
+auto GenericLexer::decode_code_point() -> Result<u32, UnicodeEscapeError>
+{
+    bool starts_with_open_bracket = consume_specific('{');
+    VERIFY(starts_with_open_bracket);
+
+    u32 code_point = 0;
+
+    while (true) {
+        if (!next_is(is_ascii_hex_digit))
+            return UnicodeEscapeError::MalformedUnicodeEscape;
+
+        auto new_code_point = (code_point << 4u) | parse_ascii_hex_digit(consume());
+        if (new_code_point < code_point)
+            return UnicodeEscapeError::UnicodeEscapeOverflow;
+
+        code_point = new_code_point;
+        if (consume_specific('}'))
+            break;
+    }
+
+    if (is_unicode(code_point))
+        return code_point;
+    return UnicodeEscapeError::UnicodeEscapeOverflow;
+}
+
+auto GenericLexer::decode_single_or_paired_surrogate(bool combine_surrogate_pairs) -> Result<u32, UnicodeEscapeError>
+{
+    constexpr size_t surrogate_length = 4;
+
+    auto decode_one_surrogate = [&]() -> Optional<u16> {
+        u16 surrogate = 0;
+
+        for (size_t i = 0; i < surrogate_length; ++i) {
+            if (!next_is(is_ascii_hex_digit))
+                return {};
+
+            surrogate = (surrogate << 4u) | parse_ascii_hex_digit(consume());
+        }
+
+        return surrogate;
+    };
+
+    auto high_surrogate = decode_one_surrogate();
+    if (!high_surrogate.has_value())
+        return UnicodeEscapeError::MalformedUnicodeEscape;
+    if (!Utf16View::is_high_surrogate(*high_surrogate))
+        return *high_surrogate;
+    if (!combine_surrogate_pairs || !consume_specific("\\u"sv))
+        return *high_surrogate;
+
+    auto low_surrogate = decode_one_surrogate();
+    if (!low_surrogate.has_value())
+        return UnicodeEscapeError::MalformedUnicodeEscape;
+    if (Utf16View::is_low_surrogate(*low_surrogate))
+        return Utf16View::decode_surrogate_pair(*high_surrogate, *low_surrogate);
+
+    retreat(6);
+    return *high_surrogate;
 }
 
 }

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Result.h>
 #include <AK/StringView.h>
 
 namespace AK {
@@ -115,6 +116,13 @@ public:
     StringView consume_quoted_string(char escape_char = 0);
     String consume_and_unescape_string(char escape_char = '\\');
 
+    enum class UnicodeEscapeError {
+        MalformedUnicodeEscape,
+        UnicodeEscapeOverflow,
+    };
+
+    Result<u32, UnicodeEscapeError> consume_escaped_code_point(bool combine_surrogate_pairs = true);
+
     constexpr void ignore(size_t count = 1)
     {
         count = min(count, m_input.length() - m_index);
@@ -201,6 +209,10 @@ public:
 protected:
     StringView m_input;
     size_t m_index { 0 };
+
+private:
+    Result<u32, UnicodeEscapeError> decode_code_point();
+    Result<u32, UnicodeEscapeError> decode_single_or_paired_surrogate(bool combine_surrogate_pairs);
 };
 
 constexpr auto is_any_of(const StringView& values)

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericLexer.h>
 #include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/Debug.h>

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -698,6 +698,9 @@ TEST_CASE(ECMA262_unicode_match)
         { "\\ud83d\\ud83d"sv, "\xed\xa0\xbd\xed\xa0\xbd"sv, true, ECMAScriptFlags::Unicode },
         { "(?<=.{3})f"sv, "abcdef"sv, true, ECMAScriptFlags::Unicode },
         { "(?<=.{3})f"sv, "abc😀ef"sv, true, ECMAScriptFlags::Unicode },
+        { "(?<𝓑𝓻𝓸𝔀𝓷>brown)"sv, "brown"sv, true, ECMAScriptFlags::Unicode },
+        { "(?<\\u{1d4d1}\\u{1d4fb}\\u{1d4f8}\\u{1d500}\\u{1d4f7}>brown)"sv, "brown"sv, true, ECMAScriptFlags::Unicode },
+        { "(?<\\ud835\\udcd1\\ud835\\udcfb\\ud835\\udcf8\\ud835\\udd00\\ud835\\udcf7>brown)"sv, "brown"sv, true, ECMAScriptFlags::Unicode },
     };
 
     for (auto& test : tests) {

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -6,6 +6,7 @@
 
 #include "MailWidget.h"
 #include <AK/Base64.h>
+#include <AK/GenericLexer.h>
 #include <Applications/Mail/MailWindowGML.h>
 #include <LibCore/ConfigFile.h>
 #include <LibDesktop/Launcher.h>

--- a/Userland/Libraries/LibCrypto/ASN1/ASN1.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/ASN1.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericLexer.h>
 #include <LibCrypto/ASN1/ASN1.h>
 
 namespace Crypto::ASN1 {

--- a/Userland/Libraries/LibJS/Lexer.h
+++ b/Userland/Libraries/LibJS/Lexer.h
@@ -41,8 +41,9 @@ private:
     bool is_eof() const;
     bool is_line_terminator() const;
     bool is_whitespace() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
+    Optional<u32> is_unicode_escape(size_t& identifier_length) const;
+    Optional<u32> is_identifier_start(size_t& identifier_length) const;
+    Optional<u32> is_identifier_middle(size_t& identifier_length) const;
     bool is_line_comment_start(bool line_has_token_yet) const;
     bool is_block_comment_start() const;
     bool is_block_comment_end() const;
@@ -80,6 +81,10 @@ private:
     static HashMap<String, TokenType> s_three_char_tokens;
     static HashMap<String, TokenType> s_two_char_tokens;
     static HashMap<char, TokenType> s_single_char_tokens;
+
+    // Resolved identifiers must be kept alive for the duration of the parsing stage, otherwise
+    // the only references to these strings are deleted by the Token destructor.
+    Vector<FlyString> m_parsed_identifiers;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -141,7 +141,7 @@ static Value get_match_indices_array(GlobalObject& global_object, Utf16View cons
 }
 
 // 1.1.4.1.5 MakeIndicesArray ( S , indices, groupNames, hasGroups ), https://tc39.es/proposal-regexp-match-indices/#sec-makeindicesarray
-static Value make_indices_array(GlobalObject& global_object, Utf16View const& string, Vector<Optional<Match>> const& indices, HashMap<String, Match> const& group_names, bool has_groups)
+static Value make_indices_array(GlobalObject& global_object, Utf16View const& string, Vector<Optional<Match>> const& indices, HashMap<FlyString, Match> const& group_names, bool has_groups)
 {
     // Note: This implementation differs from the spec, but has the same behavior.
     //
@@ -268,7 +268,7 @@ static Value regexp_builtin_exec(GlobalObject& global_object, RegExpObject& rege
         return {};
 
     Vector<Optional<Match>> indices { Match::create(match) };
-    HashMap<String, Match> group_names;
+    HashMap<FlyString, Match> group_names;
 
     bool has_groups = result.n_named_capture_groups != 0;
     Object* groups_object = has_groups ? Object::create(global_object, nullptr) : nullptr;
@@ -285,7 +285,7 @@ static Value regexp_builtin_exec(GlobalObject& global_object, RegExpObject& rege
         array->create_data_property_or_throw(i + 1, capture_value);
 
         if (capture.capture_group_name.has_value()) {
-            auto group_name = capture.capture_group_name->to_string();
+            auto group_name = capture.capture_group_name.release_value();
             groups_object->create_data_property_or_throw(group_name, js_string(vm, capture.view.u16_view()));
             group_names.set(move(group_name), Match::create(capture));
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
@@ -55,3 +55,18 @@ test("UTF-16", () => {
     expect("😀😀".match(/\ud83d/g)).toEqual(["\ud83d", "\ud83d"]);
     expect("😀😀".match(/\ude00/g)).toEqual(["\ude00", "\ude00"]);
 });
+
+test("escaped code points", () => {
+    var string = "The quick brown fox jumped over the lazy dog's back";
+
+    var re = /(?<𝓑𝓻𝓸𝔀𝓷>brown)/u;
+    expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
+
+    re = /(?<\u{1d4d1}\u{1d4fb}\u{1d4f8}\u{1d500}\u{1d4f7}>brown)/u;
+    expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
+    expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
+
+    re = /(?<\ud835\udcd1\ud835\udcfb\ud835\udcf8\ud835\udd00\ud835\udcf7>brown)/u;
+    expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
+    expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
+});

--- a/Userland/Libraries/LibJS/Tests/unicode-identifier-escape.js
+++ b/Userland/Libraries/LibJS/Tests/unicode-identifier-escape.js
@@ -1,0 +1,19 @@
+test("basic escapes", () => {
+    var foo = {};
+    foo.brown = 12389;
+
+    expect(foo.brown).toBe(12389);
+    expect(foo.br\u006fwn).toBe(12389);
+    expect(foo.br\u{6f}wn).toBe(12389);
+    expect(foo.\u{62}\u{72}\u{6f}\u{77}\u{6e}).toBe(12389);
+});
+
+test("non-ascii escapes", () => {
+    var foo = {};
+    foo.𝓑𝓻𝓸𝔀𝓷 = 12389;
+
+    expect(foo.𝓑𝓻𝓸𝔀𝓷).toBe(12389);
+    expect(foo.𝓑𝓻\ud835\udcf8𝔀𝓷).toBe(12389);
+    expect(foo.𝓑𝓻\u{1d4f8}𝔀𝓷).toBe(12389);
+    expect(foo.\u{1d4d1}\u{1d4fb}\u{1d4f8}\u{1d500}\u{1d4f7}).toBe(12389);
+});

--- a/Userland/Libraries/LibJS/Token.cpp
+++ b/Userland/Libraries/LibJS/Token.cpp
@@ -56,7 +56,7 @@ double Token::double_value() const
 
     StringBuilder builder;
 
-    for (auto ch : m_value) {
+    for (auto ch : value()) {
         if (ch == '_')
             continue;
         builder.append(ch);
@@ -75,7 +75,7 @@ double Token::double_value() const
             return static_cast<double>(strtoul(value_string.characters() + 2, nullptr, 2));
         } else if (is_ascii_digit(value_string[1])) {
             // also octal, but syntax error in strict mode
-            if (!m_value.contains('8') && !m_value.contains('9'))
+            if (!value().contains('8') && !value().contains('9'))
                 return static_cast<double>(strtoul(value_string.characters() + 1, nullptr, 8));
         }
     }
@@ -95,7 +95,7 @@ String Token::string_value(StringValueStatus& status) const
     VERIFY(type() == TokenType::StringLiteral || type() == TokenType::TemplateLiteralString);
 
     auto is_template = type() == TokenType::TemplateLiteralString;
-    GenericLexer lexer(is_template ? m_value : m_value.substring_view(1, m_value.length() - 2));
+    GenericLexer lexer(is_template ? value() : value().substring_view(1, value().length() - 2));
 
     auto encoding_failure = [&status](StringValueStatus parse_status) -> String {
         status = parse_status;
@@ -195,7 +195,7 @@ String Token::string_value(StringValueStatus& status) const
 bool Token::bool_value() const
 {
     VERIFY(type() == TokenType::BoolLiteral);
-    return m_value == "true";
+    return value() == "true";
 }
 
 bool Token::is_identifier_name() const

--- a/Userland/Libraries/LibRegex/RegexLexer.h
+++ b/Userland/Libraries/LibRegex/RegexLexer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/GenericLexer.h>
 #include <AK/StringView.h>
 
 namespace regex {
@@ -63,27 +64,20 @@ private:
     StringView m_value { nullptr };
 };
 
-class Lexer {
+class Lexer : public GenericLexer {
 public:
-    Lexer() = default;
+    Lexer();
     explicit Lexer(StringView const source);
     Token next();
     void reset();
     void back(size_t offset);
-    void set_source(StringView const source) { m_source = source; }
-    bool try_skip(char);
-    char skip();
-    auto const& source() const { return m_source; }
+    char consume();
+    void set_source(StringView const source) { m_input = source; }
+    auto const& source() const { return m_input; }
 
 private:
-    ALWAYS_INLINE int peek(size_t offset = 0) const;
-    ALWAYS_INLINE void consume();
-
-    StringView m_source {};
-    size_t m_position { 0 };
     size_t m_previous_position { 0 };
     Token m_current_token { TokenType::Eof, 0, StringView(nullptr) };
-    int m_current_char { 0 };
 };
 
 }

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -487,7 +487,7 @@ public:
     }
 
     RegexStringView view { nullptr };
-    Optional<StringView> capture_group_name {};
+    Optional<FlyString> capture_group_name {};
     size_t line { 0 };
     size_t column { 0 };
     size_t global_offset { 0 };

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -12,6 +12,7 @@
 #include "RegexParser.h"
 
 #include <AK/Forward.h>
+#include <AK/GenericLexer.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/Types.h>

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -8,6 +8,7 @@
 #include "RegexParser.h"
 #include "RegexDebug.h"
 #include <AK/CharacterTypes.h>
+#include <AK/GenericLexer.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringUtils.h>

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -101,7 +101,7 @@ ALWAYS_INLINE bool Parser::try_skip(StringView str)
 
     size_t potentially_go_back { 0 };
     for (auto ch : str) {
-        if (!m_parser_state.lexer.try_skip(ch)) {
+        if (!m_parser_state.lexer.consume_specific(ch)) {
             m_parser_state.lexer.back(potentially_go_back);
             return false;
         }
@@ -129,7 +129,7 @@ ALWAYS_INLINE char Parser::skip()
         ch = m_parser_state.current_token.value()[0];
     } else {
         m_parser_state.lexer.back(m_parser_state.current_token.value().length());
-        ch = m_parser_state.lexer.skip();
+        ch = m_parser_state.lexer.consume();
     }
 
     m_parser_state.current_token = m_parser_state.lexer.next();

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -80,6 +80,7 @@ protected:
     ALWAYS_INLINE Token consume();
     ALWAYS_INLINE Token consume(TokenType type, Error error);
     ALWAYS_INLINE bool consume(String const&);
+    ALWAYS_INLINE Optional<u32> consume_escaped_code_point(bool unicode);
     ALWAYS_INLINE bool try_skip(StringView);
     ALWAYS_INLINE bool lookahead_any(StringView);
     ALWAYS_INLINE char skip();

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -53,6 +53,7 @@ public:
         size_t match_length_minimum;
         Error error;
         Token error_token;
+        Vector<FlyString> capture_groups;
     };
 
     explicit Parser(Lexer& lexer)
@@ -218,7 +219,7 @@ private:
     };
     StringView read_digits_as_string(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1, int min_count = -1);
     Optional<unsigned> read_digits(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, bool hex = false, int max_count = -1, int min_count = -1);
-    StringView read_capture_group_specifier(bool take_starting_angle_bracket = false);
+    FlyString read_capture_group_specifier(bool take_starting_angle_bracket = false);
 
     struct Script {
         Unicode::Script script {};

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Selector.h"
+#include <AK/GenericLexer.h>
 #include <AK/StringUtils.h>
 #include <ctype.h>
 

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -7,6 +7,7 @@
 #include "Parser.h"
 #include "Shell.h"
 #include <AK/AllOf.h>
+#include <AK/GenericLexer.h>
 #include <AK/ScopeGuard.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/TemporaryChange.h>

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -10,6 +10,7 @@
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/Function.h>
+#include <AK/GenericLexer.h>
 #include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
 #include <AK/ScopeGuard.h>

--- a/Userland/Utilities/tr.cpp
+++ b/Userland/Utilities/tr.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericLexer.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>


### PR DESCRIPTION
The purpose is to allow Unicode escape sequences in both JS identifiers and regex capture group names. For example, the following lines are equivalent:
```javascript
"brown".match(/(?<𝓑𝓻𝓸𝔀𝓷>brown)/u).groups.𝓑𝓻𝓸𝔀𝓷
"brown".match(/(?<\u{1d4d1}\u{1d4fb}\u{1d4f8}\u{1d500}\u{1d4f7}>brown)/u).groups.𝓑𝓻𝓸𝔀𝓷
"brown".match(/(?<𝓑𝓻𝓸𝔀𝓷>brown)/u).groups.\u{1d4d1}\u{1d4fb}\u{1d4f8}\u{1d500}\u{1d4f7}
"brown".match(/(?<\u{1d4d1}\u{1d4fb}\u{1d4f8}\u{1d500}\u{1d4f7}>brown)/u).groups.\u{1d4d1}\u{1d4fb}\u{1d4f8}\u{1d500}\u{1d4f7}
```

Before implementing that, this PR first moves parsing of Unicode escape sequences to `GenericLexer`. This was already implemented in both LibJS ad LibRegex in a few functions, so it was about time to generalize it.