### PR TITLE
Meta: Explicitly configure source directory in debug-kernel.sh

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -28,6 +28,7 @@ fi
 exec $SERENITY_KERNEL_DEBUGGER \
     -ex "file $(dirname "$0")/../Build/${SERENITY_ARCH:-i686}/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
+    -ex "directory $(dirname "$0")/../Build/${SERENITY_ARCH:-i686}/" \
     -ex "add-symbol-file $(dirname "$0")/../Build/${SERENITY_ARCH:-i686}/Kernel/Kernel -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \


### PR DESCRIPTION
Previously debug-kernel.sh wouldn't detect source if you launched the
script from the wrong path. By explicitly setting the name, source will
be loaded by gdb in all situations.