### PR TITLE
AK: Enable IntrusiveList self reference to be optimized out when empty

### DIFF
--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -187,7 +187,7 @@ private:
     IntrusiveListStorage<T, Container>* m_storage = nullptr;
     IntrusiveListNode<T, Container>* m_next = nullptr;
     IntrusiveListNode<T, Container>* m_prev = nullptr;
-    SelfReferenceIfNeeded<Container, IsRaw> m_self;
+    [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
 }


### PR DESCRIPTION
If a member is an empty class, the standard normally states that it needs
to have a size of at least 1 byte in order to guarantee that the
addresses of distinct objects of the same type are always distinct.

However as of c++20, we can use [[no_unique_address]] to instruct the
compiler that if the member has an empty type, it may optimize it to
occupy no space.

Reference:
- https://en.cppreference.com/w/cpp/language/attributes/no_unique_address
- https://en.cppreference.com/w/cpp/language/ebo