### PR TITLE
LibTest+Utilities: Print a start message before each test in run-tests

### DIFF
--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -162,7 +162,7 @@ public:
     virtual ~TestRunner() = default;
 
 protected:
-    virtual void do_run_single_test(const String& test_path) override;
+    virtual void do_run_single_test(const String& test_path, size_t, size_t) override;
     virtual Vector<String> get_test_paths() const override;
     virtual JSFileResult run_file_test(const String& test_path);
     void print_file_result(const JSFileResult& file_result) const;
@@ -230,7 +230,7 @@ inline Optional<JsonValue> get_test_results(JS::Interpreter& interpreter)
     return json.value();
 }
 
-inline void TestRunner::do_run_single_test(const String& test_path)
+inline void TestRunner::do_run_single_test(const String& test_path, size_t, size_t)
 {
     auto file_result = run_file_test(test_path);
     if (!m_print_json)

--- a/Userland/Libraries/LibTest/TestRunner.h
+++ b/Userland/Libraries/LibTest/TestRunner.h
@@ -54,7 +54,7 @@ protected:
     void print_test_results_as_json() const;
 
     virtual Vector<String> get_test_paths() const = 0;
-    virtual void do_run_single_test(const String&) = 0;
+    virtual void do_run_single_test(const String&, size_t current_test_index, size_t num_tests) = 0;
     virtual const Vector<String>* get_failed_test_names() const { return nullptr; }
 
     String m_test_root;
@@ -115,7 +115,7 @@ inline void TestRunner::run(String test_glob)
         if (!path.matches(test_glob))
             continue;
         ++progress_counter;
-        do_run_single_test(path);
+        do_run_single_test(path, progress_counter, test_paths.size());
         if (m_print_progress)
             warn("\033]9;{};{};\033\\", progress_counter, test_paths.size());
     }

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -46,7 +46,7 @@ public:
     virtual ~TestRunner() = default;
 
 protected:
-    virtual void do_run_single_test(const String& test_path) override;
+    virtual void do_run_single_test(const String& test_path, size_t current_text_index, size_t num_tests) override;
     virtual Vector<String> get_test_paths() const override;
     virtual const Vector<String>* get_failed_test_names() const override { return &m_failed_test_names; }
 
@@ -94,10 +94,12 @@ bool TestRunner::should_skip_test(const LexicalPath& test_path)
     return false;
 }
 
-void TestRunner::do_run_single_test(const String& test_path)
+void TestRunner::do_run_single_test(const String& test_path, size_t current_test_index, size_t num_tests)
 {
     g_currently_running_test = test_path;
-
+    auto test_relative_path = LexicalPath::relative_path(test_path, m_test_root);
+    outln(" START  {} ({}/{})", test_relative_path, current_test_index, num_tests);
+    fflush(stdout); // we really want to see the start text in case the test hangs
     auto test_result = run_test_file(test_path);
 
     switch (test_result.result) {
@@ -128,11 +130,11 @@ void TestRunner::do_run_single_test(const String& test_path)
         print_modifiers({ Test::CLEAR });
     } else {
         print_modifiers({ Test::BG_GREEN, Test::FG_BLACK, Test::FG_BOLD });
-        out(" PASS ");
+        out(" PASS  ");
         print_modifiers({ Test::CLEAR });
     }
 
-    out(" {}", LexicalPath::relative_path(test_path, m_test_root));
+    out(" {}", test_relative_path);
 
     print_modifiers({ Test::CLEAR, Test::ITALIC, Test::FG_GRAY });
     if (test_result.time_taken < 1000) {


### PR DESCRIPTION
It can sometimes be difficult to tell from the debug.log and test stdout
which test was the last to run before the test runner hangs or exits the
QEMU instance unexpectedly.

Print out a start message before each test is executed, along with a
progress message indicating which test out of how many tests we're about
to run.