### PR TITLE
LibGL: Don't crash on invalid pname value in glGetFloatv

### DIFF
--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1323,7 +1323,7 @@ void SoftwareGLContext::gl_get_floatv(GLenum pname, GLfloat* params)
     default:
         // FIXME: Because glQuake only requires GL_MODELVIEW_MATRIX, that is the only parameter
         // that we currently support. More parameters should be supported.
-        TODO();
+        RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
     }
 }
 


### PR DESCRIPTION
This brings `glGetFloatv` more inline with the other `glGet`
functions. We should prevent crashing in the driver as much as
possible and instead let the application deal with the generated
GL error.