### PR TITLE
LibGL: Implement `glPolygonMode`

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -170,6 +170,8 @@ extern "C" {
 #define GL_ONE_MINUS_CONSTANT_ALPHA 0x8004
 
 // Polygon modes
+#define GL_POINT 0x1B00
+#define GL_LINE 0x1B01
 #define GL_FILL 0x1B02
 
 // Pixel formats
@@ -371,6 +373,7 @@ GLAPI void glDrawArrays(GLenum mode, GLint first, GLsizei count);
 GLAPI void glDrawElements(GLenum mode, GLsizei count, GLenum type, const void* indices);
 GLAPI void glDepthRange(GLdouble nearVal, GLdouble farVal);
 GLAPI void glDepthFunc(GLenum func);
+GLAPI void glPolygonMode(GLenum face, GLenum mode);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -76,6 +76,7 @@ public:
     virtual void gl_get_integerv(GLenum pname, GLint* data) = 0;
     virtual void gl_depth_range(GLdouble min, GLdouble max) = 0;
     virtual void gl_depth_func(GLenum func) = 0;
+    virtual void gl_polygon_mode(GLenum face, GLenum mode) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -129,3 +129,8 @@ void glDepthFunc(GLenum func)
 {
     g_gl_context->gl_depth_func(func);
 }
+
+void glPolygonMode(GLenum face, GLenum mode)
+{
+    g_gl_context->gl_polygon_mode(face, mode);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1733,6 +1733,18 @@ void SoftwareGLContext::gl_color_mask(GLboolean red, GLboolean green, GLboolean 
     m_rasterizer.set_options(options);
 }
 
+void SoftwareGLContext::gl_polygon_mode(GLenum face, GLenum mode)
+{
+    RETURN_WITH_ERROR_IF(!(face == GL_BACK || face == GL_FRONT || face == GL_FRONT_AND_BACK), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(!(mode == GL_POINT || mode == GL_LINE || mode == GL_FILL), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    auto options = m_rasterizer.options();
+    options.polygon_mode = mode;
+
+    m_rasterizer.set_options(options);
+}
+
 void SoftwareGLContext::present()
 {
     m_rasterizer.blit_to(*m_frontbuffer);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -86,6 +86,7 @@ public:
     virtual void gl_get_integerv(GLenum pname, GLint* data) override;
     virtual void gl_depth_range(GLdouble min, GLdouble max) override;
     virtual void gl_depth_func(GLenum func) override;
+    virtual void gl_polygon_mode(GLenum face, GLenum mode) override;
     virtual void present() override;
 
 private:

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -32,6 +32,7 @@ struct RasterizerOptions {
     float depth_min { 0 };
     float depth_max { 1 };
     GLenum depth_func { GL_LESS };
+    GLenum polygon_mode { GL_FILL };
 };
 
 class SoftwareRasterizer final {


### PR DESCRIPTION
Currently just sets the renderer option for what polygon mode we
want the rasterizer to draw in. GLQuake only uses `GL_FRONT_AND_BACK`
with `GL_FILL` )which implies both back and front facing triangles
are to be filled completely by the rasterizer), so keeping this as
a small stub is perfectly fine for now.