### PR TITLE
LibCpp+HackStudio: Handle circular imports & fix "navigate to include"

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -565,11 +565,9 @@ void Editor::flush_file_content_to_langauge_server()
 
 void Editor::on_navigatable_link_click(const GUI::TextDocumentSpan& span)
 {
-    auto adjusted_range = span.range;
-    adjusted_range.end().set_column(adjusted_range.end().column() + 1);
-    auto span_text = document().text_in_range(adjusted_range);
+    auto span_text = document().text_in_range(span.range);
     auto header_path = span_text.substring(1, span_text.length() - 2);
-    dbgln_if(EDITOR_DEBUG, "Ctrl+click: {} \"{}\"", adjusted_range, header_path);
+    dbgln_if(EDITOR_DEBUG, "Ctrl+click: {} \"{}\"", span.range, header_path);
     navigate_to_include_if_available(header_path);
 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/HashTable.h>
 #include <AK/OwnPtr.h>
+#include <AK/ScopeGuard.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCpp/AST.h>
@@ -44,6 +45,11 @@ const CppComprehensionEngine::DocumentData* CppComprehensionEngine::get_document
 
 OwnPtr<CppComprehensionEngine::DocumentData> CppComprehensionEngine::create_document_data_for(const String& file)
 {
+    if (m_unfinished_documents.contains(file)) {
+        return {};
+    }
+    m_unfinished_documents.set(file);
+    ScopeGuard mark_finished([&file, this]() { m_unfinished_documents.remove(file); });
     auto document = filedb().get_or_create_from_filesystem(file);
     if (!document)
         return {};

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
@@ -140,6 +140,11 @@ private:
     void for_each_included_document_recursive(const DocumentData&, Func) const;
 
     HashMap<String, OwnPtr<DocumentData>> m_documents;
+
+    // A document's path will be in this set if we're currently processing it.
+    // A document is added to this set when we start processing it (e.g because it was #included) and removed when we're done.
+    // We use this to prevent circular #includes from looping indefinitely.
+    HashTable<String> m_unfinished_documents;
 };
 
 template<typename Func>


### PR DESCRIPTION
\- There's a circular #include between `Kernel/API/POSIX/sys/types.h` and `LibC/sys/types.h`, which previously caused the c++ language server to crash.

\- Fixes an off-by-one error in span calculation in the "navigate to include" feature of HackStudio.
