### PR TITLE
LibJS: Add type range checks to the Date make_day AO

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -48,7 +48,7 @@ inline bool is_leap_year(int year)
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 }
 
-inline unsigned days_in_year(int year)
+inline int days_in_year(int year)
 {
     return 365 + is_leap_year(year);
 }

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -18,7 +18,7 @@ DateTime DateTime::now()
     return from_timestamp(time(nullptr));
 }
 
-DateTime DateTime::create(unsigned year, unsigned month, unsigned day, unsigned hour, unsigned minute, unsigned second)
+DateTime DateTime::create(int year, int month, int day, int hour, int minute, int second)
 {
     DateTime dt;
     dt.set_time(year, month, day, hour, minute, second);
@@ -60,15 +60,15 @@ bool DateTime::is_leap_year() const
     return ::is_leap_year(m_year);
 }
 
-void DateTime::set_time(unsigned year, unsigned month, unsigned day, unsigned hour, unsigned minute, unsigned second)
+void DateTime::set_time(int year, int month, int day, int hour, int minute, int second)
 {
     struct tm tm = {};
-    tm.tm_sec = (int)second;
-    tm.tm_min = (int)minute;
-    tm.tm_hour = (int)hour;
-    tm.tm_mday = (int)day;
-    tm.tm_mon = (int)month - 1;
-    tm.tm_year = (int)year - 1900;
+    tm.tm_sec = second;
+    tm.tm_min = minute;
+    tm.tm_hour = hour;
+    tm.tm_mday = day;
+    tm.tm_mon = month - 1;
+    tm.tm_year = year - 1900;
     tm.tm_isdst = -1;
     // mktime() doesn't read tm.tm_wday and tm.tm_yday, no need to fill them in.
 

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -29,10 +29,10 @@ public:
     unsigned day_of_year() const;
     bool is_leap_year() const;
 
-    void set_time(unsigned year, unsigned month = 1, unsigned day = 0, unsigned hour = 0, unsigned minute = 0, unsigned second = 0);
+    void set_time(int year, int month = 1, int day = 0, int hour = 0, int minute = 0, int second = 0);
     String to_string(const String& format = "%Y-%m-%d %H:%M:%S") const;
 
-    static DateTime create(unsigned year, unsigned month = 1, unsigned day = 0, unsigned hour = 0, unsigned minute = 0, unsigned second = 0);
+    static DateTime create(int year, int month = 1, int day = 0, int hour = 0, int minute = 0, int second = 0);
     static DateTime now();
     static DateTime from_timestamp(time_t);
     static Optional<DateTime> parse(const String& format, const String& string);
@@ -41,12 +41,12 @@ public:
 
 private:
     time_t m_timestamp { 0 };
-    unsigned m_year { 0 };
-    unsigned m_month { 0 };
-    unsigned m_day { 0 };
-    unsigned m_hour { 0 };
-    unsigned m_minute { 0 };
-    unsigned m_second { 0 };
+    int m_year { 0 };
+    int m_month { 0 };
+    int m_day { 0 };
+    int m_hour { 0 };
+    int m_minute { 0 };
+    int m_second { 0 };
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -339,9 +339,11 @@ Value make_day(GlobalObject& global_object, Value year, Value month, Value date)
     // NOTE: This calculation has no side-effects and is unused, so we omit it
 
     // 8. Find a finite time value t such that YearFromTime(t) is ym and MonthFromTime(t) is mn and DateFromTime(t) is 1𝔽; but if this is not possible (because some argument is out of range), return NaN.
-    auto t = Core::DateTime::create(y, m + 1, 0).timestamp() * 1000;
+    if (!AK::is_within_range<int>(y) || !AK::is_within_range<int>(m + 1))
+        return js_nan();
+    auto t = Core::DateTime::create(static_cast<int>(y), static_cast<int>(m + 1), 0).timestamp() * 1000;
     // 9. Return Day(t) + dt - 1𝔽.
-    return Value(day(t) + dt - 1);
+    return Value(day(static_cast<double>(t)) + dt - 1);
 }
 
 // 21.4.1.13 MakeDate ( day, time ), https://tc39.es/ecma262/#sec-makedate


### PR DESCRIPTION
This should fix the failing UBSAN check in clang CI. (At least the LibJS instance of it)