### PR TITLE
CI: Include a timestamp in the Azure ccache key

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -6,6 +6,10 @@ parameters:
   ccache_version: 1 # Increment this number if CI has trouble with ccache.
 
 steps:
+  - script: |
+      echo "##vso[task.setvariable variable=timestamp]$(date -u +"%Y%m%d%H%M_%S")"
+    displayName: 'Stamps'
+
   - ${{ if ne(parameters.arch, 'Lagom') }}:
     - ${{ if eq(parameters.toolchain, 'clang') }}:
       - task: Cache@2
@@ -22,7 +26,9 @@ steps:
 
   - task: Cache@2
     inputs:
-      key: '"ccache" | "${{ parameters.os }}" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}"'
+      key: '"ccache" | "${{ parameters.os }}" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}" | "$(timestamp)"'
+      restoreKeys: |
+        "ccache" | "${{ parameters.os }}" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}"
       path: $(CCACHE_DIR)
     displayName: 'Compiler Cache'
 

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -74,6 +74,7 @@ jobs:
         fi
       displayName: 'Test'
       workingDirectory: $(Build.SourcesDirectory)/Build
+      timeoutInMinutes: 60
       env:
         SERENITY_QEMU_CPU: 'max,vmx=off'
         SERENITY_KERNEL_CMDLINE: 'boot_mode=self-test'


### PR DESCRIPTION
Caches on Azure are immutable - so if a cache changes, but its key does
not, then the cache is not updated. Include a timestamp in the ccache
key so that we always push an updated cache from the master branch. Then
use a subkey without the timestamp to pull the cache.

We use a similar trick on GitHub Actions.