### PR TITLE
Kernel: Make Process::current() return a Process& instead of Process*

### DIFF
--- a/Kernel/Arch/x86/common/CPU.cpp
+++ b/Kernel/Arch/x86/common/CPU.cpp
@@ -22,9 +22,8 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
 {
     // Switch back to the current process's page tables if there are any.
     // Otherwise stack walking will be a disaster.
-    auto process = Process::current();
-    if (process)
-        MM.enter_process_paging_scope(*process);
+    if (Process::has_current())
+        MM.enter_process_paging_scope(Process::current());
 
     PANIC("Aborted");
 }

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -214,14 +214,14 @@ static void dump(const RegisterState& regs)
 
 void handle_crash(RegisterState const& regs, char const* description, int signal, bool out_of_memory)
 {
-    auto process = Process::current();
-    if (!process) {
+    if (!Process::has_current())
         PANIC("{} with !current", description);
-    }
+
+    auto& process = Process::current();
 
     // If a process crashed while inspecting another process,
     // make sure we switch back to the right page tables.
-    MM.enter_process_paging_scope(*process);
+    MM.enter_process_paging_scope(process);
 
     dmesgln("CRASH: CPU #{} {} in ring {}", Processor::id(), description, (regs.cs & 3));
     dump(regs);
@@ -230,7 +230,7 @@ void handle_crash(RegisterState const& regs, char const* description, int signal
         PANIC("Crash in ring 0");
     }
 
-    process->crash(signal, regs.ip(), out_of_memory);
+    process.crash(signal, regs.ip(), out_of_memory);
 }
 
 EH_ENTRY_NO_CODE(6, illegal_instruction);

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -685,7 +685,7 @@ void Processor::flush_tlb_local(VirtualAddress vaddr, size_t page_count)
 
 void Processor::flush_tlb(Memory::PageDirectory const* page_directory, VirtualAddress vaddr, size_t page_count)
 {
-    if (s_smp_enabled && (!Memory::is_user_address(vaddr) || Process::current()->thread_count() > 1))
+    if (s_smp_enabled && (!Memory::is_user_address(vaddr) || Process::current().thread_count() > 1))
         smp_broadcast_flush_tlb(page_directory, vaddr, page_count);
     else
         flush_tlb_local(vaddr, page_count);

--- a/Kernel/Devices/AsyncDeviceRequest.cpp
+++ b/Kernel/Devices/AsyncDeviceRequest.cpp
@@ -11,7 +11,7 @@ namespace Kernel {
 
 AsyncDeviceRequest::AsyncDeviceRequest(Device& device)
     : m_device(device)
-    , m_process(*Process::current())
+    , m_process(Process::current())
 {
 }
 

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -129,7 +129,7 @@ private:
     {
         if (buffer.is_kernel_buffer())
             return true;
-        return m_process == Process::current();
+        return m_process == &Process::current();
     }
 
     [[nodiscard]] static bool is_completed_result(RequestResult result)

--- a/Kernel/Devices/KCOVDevice.cpp
+++ b/Kernel/Devices/KCOVDevice.cpp
@@ -48,8 +48,7 @@ void KCOVDevice::free_thread()
 
 void KCOVDevice::free_process()
 {
-    auto process = Process::current();
-    auto pid = process->pid();
+    auto pid = Process::current().pid();
 
     auto maybe_kcov_instance = proc_instance->get(pid);
     if (!maybe_kcov_instance.has_value())
@@ -64,8 +63,7 @@ void KCOVDevice::free_process()
 
 KResultOr<NonnullRefPtr<FileDescription>> KCOVDevice::open(int options)
 {
-    auto process = Process::current();
-    auto pid = process->pid();
+    auto pid = Process::current().pid();
     if (proc_instance->get(pid).has_value())
         return EBUSY; // This process already open()ed the kcov device
     auto kcov_instance = new KCOVInstance(pid);

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -129,7 +129,7 @@ KResultOr<size_t> FIFO::read(FileDescription& fd, u64, UserOrKernelBuffer& buffe
 KResultOr<size_t> FIFO::write(FileDescription& fd, u64, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_readers) {
-        Thread::current()->send_signal(SIGPIPE, Process::current());
+        Thread::current()->send_signal(SIGPIPE, &Process::current());
         return EPIPE;
     }
     if (!fd.is_blocking() && m_buffer->space_for_writing() == 0)

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -68,7 +68,7 @@ KResult InodeFile::ioctl(FileDescription& description, unsigned request, Userspa
 
     switch (request) {
     case FIBMAP: {
-        if (!Process::current()->is_superuser())
+        if (!Process::current().is_superuser())
             return EPERM;
 
         auto user_block_number = static_ptr_cast<int*>(arg);

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -109,7 +109,7 @@ private:
             obj.add("bytes_in", socket.bytes_in());
             obj.add("packets_out", socket.packets_out());
             obj.add("bytes_out", socket.bytes_out());
-            if (Process::current()->is_superuser() || Process::current()->uid() == socket.origin_uid()) {
+            if (Process::current().is_superuser() || Process::current().uid() == socket.origin_uid()) {
                 obj.add("origin_pid", socket.origin_pid());
                 obj.add("origin_uid", socket.origin_uid());
                 obj.add("origin_gid", socket.origin_gid());
@@ -159,7 +159,7 @@ private:
             obj.add("local_port", socket.local_port());
             obj.add("peer_address", socket.peer_address().to_string());
             obj.add("peer_port", socket.peer_port());
-            if (Process::current()->is_superuser() || Process::current()->uid() == socket.origin_uid()) {
+            if (Process::current().is_superuser() || Process::current().uid() == socket.origin_uid()) {
                 obj.add("origin_pid", socket.origin_pid());
                 obj.add("origin_uid", socket.origin_uid());
                 obj.add("origin_gid", socket.origin_gid());
@@ -336,7 +336,7 @@ private:
     ProcFSSelfProcessDirectory();
     virtual bool acquire_link(KBufferBuilder& builder) override
     {
-        builder.appendff("{}", Process::current()->pid().value());
+        builder.appendff("{}", Process::current().pid().value());
         return true;
     }
 };
@@ -737,7 +737,7 @@ private:
 
     virtual bool output(KBufferBuilder& builder) override
     {
-        if (!Process::current()->is_superuser())
+        if (!Process::current().is_superuser())
             return false;
         builder.append(String::number(kernel_load_base));
         return true;

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -53,7 +53,7 @@ KResult AddressSpace::unmap_mmap_range(VirtualAddress addr, size_t size)
         if (!whole_region->is_mmap())
             return EPERM;
 
-        PerformanceManager::add_unmap_perf_event(*Process::current(), whole_region->range());
+        PerformanceManager::add_unmap_perf_event(Process::current(), whole_region->range());
 
         deallocate_region(*whole_region);
         return KSuccess;
@@ -83,7 +83,7 @@ KResult AddressSpace::unmap_mmap_range(VirtualAddress addr, size_t size)
             new_region->map(page_directory());
         }
 
-        PerformanceManager::add_unmap_perf_event(*Process::current(), range_to_unmap);
+        PerformanceManager::add_unmap_perf_event(Process::current(), range_to_unmap);
 
         return KSuccess;
     }
@@ -133,7 +133,7 @@ KResult AddressSpace::unmap_mmap_range(VirtualAddress addr, size_t size)
         new_region->map(page_directory());
     }
 
-    PerformanceManager::add_unmap_perf_event(*Process::current(), range_to_unmap);
+    PerformanceManager::add_unmap_perf_event(Process::current(), range_to_unmap);
 
     return KSuccess;
 }

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -52,7 +52,7 @@ Region::~Region()
 
 KResultOr<NonnullOwnPtr<Region>> Region::try_clone()
 {
-    VERIFY(Process::current());
+    VERIFY(Process::has_current());
 
     if (m_shared) {
         VERIFY(!m_stack);

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -118,9 +118,9 @@ KResult IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_t addr
         return set_so_error(EINVAL);
 
     auto requested_local_port = ntohs(address.sin_port);
-    if (!Process::current()->is_superuser()) {
+    if (!Process::current().is_superuser()) {
         if (requested_local_port > 0 && requested_local_port < 1024) {
-            dbgln("UID {} attempted to bind {} to port {}", Process::current()->uid(), class_name(), requested_local_port);
+            dbgln("UID {} attempted to bind {} to port {}", Process::current().uid(), class_name(), requested_local_port);
             return set_so_error(EACCES);
         }
     }
@@ -603,7 +603,7 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
 
         switch (request) {
         case SIOCADDRT:
-            if (!Process::current()->is_superuser())
+            if (!Process::current().is_superuser())
                 return EPERM;
             if (route.rt_gateway.sa_family != AF_INET)
                 return EAFNOSUPPORT;
@@ -628,7 +628,7 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
 
         switch (request) {
         case SIOCSARP:
-            if (!Process::current()->is_superuser())
+            if (!Process::current().is_superuser())
                 return EPERM;
             if (arp_req.arp_pa.sa_family != AF_INET)
                 return EAFNOSUPPORT;
@@ -636,7 +636,7 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
             return KSuccess;
 
         case SIOCDARP:
-            if (!Process::current()->is_superuser())
+            if (!Process::current().is_superuser())
                 return EPERM;
             if (arp_req.arp_pa.sa_family != AF_INET)
                 return EAFNOSUPPORT;
@@ -663,7 +663,7 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
 
         switch (request) {
         case SIOCSIFADDR:
-            if (!Process::current()->is_superuser())
+            if (!Process::current().is_superuser())
                 return EPERM;
             if (ifr.ifr_addr.sa_family != AF_INET)
                 return EAFNOSUPPORT;
@@ -671,7 +671,7 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
             return KSuccess;
 
         case SIOCSIFNETMASK:
-            if (!Process::current()->is_superuser())
+            if (!Process::current().is_superuser())
                 return EPERM;
             if (ifr.ifr_addr.sa_family != AF_INET)
                 return EAFNOSUPPORT;

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -34,7 +34,7 @@ Socket::Socket(int domain, int type, int protocol)
     , m_type(type)
     , m_protocol(protocol)
 {
-    auto& process = *Process::current();
+    auto& process = Process::current();
     m_origin = { process.pid().value(), process.uid(), process.gid() };
 }
 
@@ -57,7 +57,7 @@ RefPtr<Socket> Socket::accept()
     dbgln_if(SOCKET_DEBUG, "Socket({}) de-queueing connection", this);
     auto client = m_pending.take_first();
     VERIFY(!client->is_connected());
-    auto& process = *Process::current();
+    auto& process = Process::current();
     client->m_acceptor = { process.pid().value(), process.uid(), process.gid() };
     client->m_connected = true;
     client->m_role = Role::Accepted;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -390,7 +390,7 @@ void create_signal_trampoline()
 void Process::crash(int signal, FlatPtr ip, bool out_of_memory)
 {
     VERIFY(!is_dead());
-    VERIFY(Process::current() == this);
+    VERIFY(&Process::current() == this);
 
     if (out_of_memory) {
         dbgln("\033[31;1mOut of memory\033[m, killing: {}", *this);
@@ -721,7 +721,7 @@ void Process::terminate_due_to_signal(u8 signal)
 {
     VERIFY_INTERRUPTS_DISABLED();
     VERIFY(signal < 32);
-    VERIFY(Process::current() == this);
+    VERIFY(&Process::current() == this);
     dbgln("Terminating {} due to signal {}", *this, signal);
     {
         ProtectedDataMutationScope scope { *this };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -145,10 +145,16 @@ public:
 public:
     class ProcessProcFSTraits;
 
-    inline static Process* current()
+    inline static Process& current()
     {
         auto current_thread = Processor::current_thread();
-        return current_thread ? &current_thread->process() : nullptr;
+        VERIFY(current_thread);
+        return current_thread->process();
+    }
+
+    inline static bool has_current()
+    {
+        return Processor::current_thread();
     }
 
     template<typename EntryFunction>
@@ -948,25 +954,25 @@ inline ProcessID Thread::pid() const
     return m_process->pid();
 }
 
-#define REQUIRE_NO_PROMISES                        \
-    do {                                           \
-        if (Process::current()->has_promises()) {  \
-            dbgln("Has made a promise");           \
-            Process::current()->crash(SIGABRT, 0); \
-            VERIFY_NOT_REACHED();                  \
-        }                                          \
+#define REQUIRE_NO_PROMISES                       \
+    do {                                          \
+        if (Process::current().has_promises()) {  \
+            dbgln("Has made a promise");          \
+            Process::current().crash(SIGABRT, 0); \
+            VERIFY_NOT_REACHED();                 \
+        }                                         \
     } while (0)
 
-#define REQUIRE_PROMISE(promise)                                     \
-    do {                                                             \
-        if (Process::current()->has_promises()                       \
-            && !Process::current()->has_promised(Pledge::promise)) { \
-            dbgln("Has not pledged {}", #promise);                   \
-            (void)Process::current()->try_set_coredump_property(     \
-                "pledge_violation"sv, #promise);                     \
-            Process::current()->crash(SIGABRT, 0);                   \
-            VERIFY_NOT_REACHED();                                    \
-        }                                                            \
+#define REQUIRE_PROMISE(promise)                                    \
+    do {                                                            \
+        if (Process::current().has_promises()                       \
+            && !Process::current().has_promised(Pledge::promise)) { \
+            dbgln("Has not pledged {}", #promise);                  \
+            (void)Process::current().try_set_coredump_property(     \
+                "pledge_violation"sv, #promise);                    \
+            Process::current().crash(SIGABRT, 0);                   \
+            VERIFY_NOT_REACHED();                                   \
+        }                                                           \
     } while (0)
 }
 

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -24,7 +24,7 @@ KResultOr<size_t> Process::procfs_get_thread_stack(ThreadID thread_id, KBufferBu
     auto thread = Thread::from_tid(thread_id);
     if (!thread)
         return KResult(ESRCH);
-    bool show_kernel_addresses = Process::current()->is_superuser();
+    bool show_kernel_addresses = Process::current().is_superuser();
     bool kernel_address_added = false;
     for (auto address : Processor::capture_stack_trace(*thread, 1024)) {
         if (!show_kernel_addresses && !Memory::is_user_address(VirtualAddress { address })) {
@@ -213,7 +213,7 @@ KResult Process::procfs_get_virtual_memory_stats(KBufferBuilder& builder) const
     {
         ScopedSpinLock lock(address_space().get_lock());
         for (auto& region : address_space().regions()) {
-            if (!region->is_user() && !Process::current()->is_superuser())
+            if (!region->is_user() && !Process::current().is_superuser())
                 continue;
             auto region_object = array.add_object();
             region_object.add("readable", region->is_readable());

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -47,7 +47,7 @@ KResultOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
     case F_GETLK:
         return description->get_flock(Userspace<flock*>(arg));
     case F_SETLK:
-        return description->apply_flock(*Process::current(), Userspace<const flock*>(arg));
+        return description->apply_flock(Process::current(), Userspace<const flock*>(arg));
     default:
         return EINVAL;
     }

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -20,7 +20,7 @@ static KResultOr<u32> handle_ptrace(const Kernel::Syscall::SC_ptrace_params& par
 {
     ScopedSpinLock scheduler_lock(g_scheduler_lock);
     if (params.request == PT_TRACE_ME) {
-        if (Process::current()->tracer())
+        if (Process::current().tracer())
             return EBUSY;
 
         caller.set_wait_for_tracer_at_next_execve(true);

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -172,12 +172,8 @@ KResultOr<FlatPtr> Process::sys$kill_thread(pid_t tid, int signal)
     if (!thread || thread->pid() != pid())
         return ESRCH;
 
-    auto process = Process::current();
-    if (!process)
-        return ESRCH;
-
     if (signal != 0)
-        thread->send_signal(signal, process);
+        thread->send_signal(signal, &Process::current());
 
     return 0;
 }

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -41,9 +41,9 @@ MasterPTY::MasterPTY(unsigned index, NonnullOwnPtr<DoubleBuffer> buffer)
     , m_buffer(move(buffer))
 {
     m_pts_name = String::formatted("/dev/pts/{}", m_index);
-    auto process = Process::current();
-    set_uid(process->uid());
-    set_gid(process->gid());
+    auto& process = Process::current();
+    set_uid(process.uid());
+    set_gid(process.gid());
 
     m_buffer->set_unblock_callback([this]() {
         if (m_slave)

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -39,9 +39,9 @@ SlavePTY::SlavePTY(MasterPTY& master, unsigned index)
     , m_index(index)
 {
     m_tty_name = String::formatted("/dev/pts/{}", m_index);
-    auto process = Process::current();
-    set_uid(process->uid());
-    set_gid(process->gid());
+    auto& process = Process::current();
+    set_uid(process.uid());
+    set_gid(process.gid());
     set_size(80, 25);
 
     SlavePTY::all_instances().with([&](auto& list) { list.append(*this); });

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -43,9 +43,9 @@ void TTY::set_default_termios()
 
 KResultOr<size_t> TTY::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
-    if (Process::current()->pgid() != pgid()) {
+    if (Process::current().pgid() != pgid()) {
         // FIXME: Should we propagate this error path somehow?
-        [[maybe_unused]] auto rc = Process::current()->send_signal(SIGTTIN, nullptr);
+        [[maybe_unused]] auto rc = Process::current().send_signal(SIGTTIN, nullptr);
         return EINTR;
     }
     if (m_input_buffer.size() < static_cast<size_t>(size))
@@ -82,8 +82,8 @@ KResultOr<size_t> TTY::read(FileDescription&, u64, UserOrKernelBuffer& buffer, s
 
 KResultOr<size_t> TTY::write(FileDescription&, u64, const UserOrKernelBuffer& buffer, size_t size)
 {
-    if (m_termios.c_lflag & TOSTOP && Process::current()->pgid() != pgid()) {
-        [[maybe_unused]] auto rc = Process::current()->send_signal(SIGTTOU, nullptr);
+    if (m_termios.c_lflag & TOSTOP && Process::current().pgid() != pgid()) {
+        [[maybe_unused]] auto rc = Process::current().send_signal(SIGTTOU, nullptr);
         return EINTR;
     }
 
@@ -457,7 +457,7 @@ KResult TTY::set_termios(const termios& t)
 KResult TTY::ioctl(FileDescription&, unsigned request, Userspace<void*> arg)
 {
     REQUIRE_PROMISE(tty);
-    auto& current_process = *Process::current();
+    auto& current_process = Process::current();
     Userspace<termios*> user_termios;
     Userspace<winsize*> user_winsize;
 

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -599,7 +599,7 @@ Thread::WaitBlocker::WaitBlocker(int wait_options, idtype_t id_type, pid_t id, K
     switch (id_type) {
     case P_PID: {
         m_waitee = Process::from_pid(m_waitee_id);
-        if (!m_waitee || m_waitee->ppid() != Process::current()->pid()) {
+        if (!m_waitee || m_waitee->ppid() != Process::current().pid()) {
             m_result = ECHILD;
             m_error = true;
         }
@@ -622,7 +622,7 @@ Thread::WaitBlocker::WaitBlocker(int wait_options, idtype_t id_type, pid_t id, K
     // NOTE: unblock may be called within set_block_condition, in which
     // case it means that we already have a match without having to block.
     // In that case set_block_condition will return false.
-    if (m_error || !set_block_condition(Process::current()->wait_block_condition()))
+    if (m_error || !set_block_condition(Process::current().wait_block_condition()))
         m_should_block = false;
 }
 
@@ -630,7 +630,7 @@ void Thread::WaitBlocker::not_blocking(bool timeout_in_past)
 {
     VERIFY(timeout_in_past || !m_should_block);
     if (!m_error)
-        Process::current()->wait_block_condition().try_unblock(*this);
+        Process::current().wait_block_condition().try_unblock(*this);
 }
 
 void Thread::WaitBlocker::was_unblocked(bool)
@@ -643,7 +643,7 @@ void Thread::WaitBlocker::was_unblocked(bool)
     }
 
     if (try_unblock)
-        Process::current()->wait_block_condition().try_unblock(*this);
+        Process::current().wait_block_condition().try_unblock(*this);
 
     // If we were interrupted by SIGCHLD (which gets special handling
     // here) we're not going to return with EINTR. But we're going to

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -262,7 +262,7 @@ void init_stage2(void*)
     // This is a little bit of a hack. We can't register our process at the time we're
     // creating it, but we need to be registered otherwise finalization won't be happy.
     // The colonel process gets away without having to do this because it never exits.
-    Process::register_new(*Process::current());
+    Process::register_new(Process::current());
 
     WorkQueue::initialize();
 
@@ -352,14 +352,14 @@ void init_stage2(void*)
 
     if (boot_profiling) {
         dbgln("Starting full system boot profiling");
-        MutexLocker mutex_locker(Process::current()->big_lock());
-        auto result = Process::current()->sys$profiling_enable(-1, ~0ull);
+        MutexLocker mutex_locker(Process::current().big_lock());
+        auto result = Process::current().sys$profiling_enable(-1, ~0ull);
         VERIFY(!result.is_error());
     }
 
     NetworkTask::spawn();
 
-    Process::current()->sys$exit(0);
+    Process::current().sys$exit(0);
     VERIFY_NOT_REACHED();
 }
 


### PR DESCRIPTION
This has several benefits:
1) We no longer just blindly derefence a null pointer in various places
2) We will get nicer runtime error messages if the current process does turn out to be null in the call location
3) GCC no longer complains about possible nullptr dereferences when compiling without KUBSAN