### PR TITLE
LibC: Add FNM_NOMATCH to fnmatch.h

### DIFF
--- a/Userland/Libraries/LibC/fnmatch.h
+++ b/Userland/Libraries/LibC/fnmatch.h
@@ -8,6 +8,7 @@
 
 #include <sys/types.h>
 
+#define FNM_NOMATCH 1
 #define FNM_PATHNAME 1
 #define FNM_NOESCAPE 2
 #define FNM_PERIOD 4


### PR DESCRIPTION
Adding FNM_NOMATCH fixes the currently broken curl port.