### PR TITLE
AK: The none_of function implementation

### DIFF
--- a/AK/NoneOf.h
+++ b/AK/NoneOf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Find.h>
+#include <AK/Iterator.h>
+
+namespace AK {
+
+template<typename TEndIterator, IteratorPairWith<TEndIterator> TIterator>
+constexpr bool none_of(
+    TIterator const& begin,
+    TEndIterator const& end,
+    auto const& predicate)
+{
+    return find_if(begin, end, predicate) == end;
+}
+
+template<IterableContainer Container>
+constexpr bool none_of(Container&& container, auto const& predicate)
+{
+    return none_of(container.begin(), container.end(), predicate);
+}
+
+}
+
+using AK::none_of;


### PR DESCRIPTION
I've added the none_of function
to comply with the set of standard set of algorithm functions:
std::all_of, std::any_of, std::none_of