### PR TITLE
LibWeb: Fix inverted-if typo in flex_shrink_factor()

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -361,7 +361,7 @@ Optional<float> StyleProperties::flex_shrink_factor() const
     auto value = property(CSS::PropertyID::FlexShrink);
     if (!value.has_value())
         return {};
-    if (!value.value()->is_numeric()) {
+    if (value.value()->is_numeric()) {
         auto numeric = verify_cast<CSS::NumericStyleValue>(value.value().ptr());
         return numeric->value();
     }


### PR DESCRIPTION
I messed this up when I changed it before, which was causing a crash.