### PR TITLE
LibJS: Implement RegExp.prototype.compile

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -687,6 +687,8 @@ TEST_CASE(ECMA262_unicode_match)
         ECMAScriptFlags options {};
     };
     _test tests[] {
+        { "\xf0\x9d\x8c\x86"sv, "abcdef"sv, false, ECMAScriptFlags::Unicode },
+        { "[\xf0\x9d\x8c\x86]"sv, "abcdef"sv, false, ECMAScriptFlags::Unicode },
         { "\\ud83d"sv, "😀"sv, true },
         { "\\ud83d"sv, "😀"sv, false, ECMAScriptFlags::Unicode },
         { "\\ude00"sv, "😀"sv, true },

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -94,6 +94,7 @@ namespace JS {
     P(clz32)                                 \
     P(codePointAt)                           \
     P(compareExchange)                       \
+    P(compile)                               \
     P(concat)                                \
     P(configurable)                          \
     P(console)                               \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -61,6 +61,7 @@
     M(NotASymbol, "{} is not a symbol")                                                                                                 \
     M(NotIterable, "{} is not iterable")                                                                                                \
     M(NotObjectCoercible, "{} cannot be converted to an object")                                                                        \
+    M(NotUndefined, "{} is not undefined")                                                                                              \
     M(ObjectDefineOwnPropertyReturnedFalse, "Object's [[DefineOwnProperty]] method returned false")                                     \
     M(ObjectDeleteReturnedFalse, "Object's [[Delete]] method returned false")                                                           \
     M(ObjectFreezeFailed, "Could not freeze object")                                                                                    \

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -103,9 +103,19 @@ String parse_regex_pattern(StringView pattern, bool unicode)
     return builder.build();
 }
 
+RegExpObject* RegExpObject::create(GlobalObject& global_object)
+{
+    return global_object.heap().allocate<RegExpObject>(global_object, *global_object.regexp_prototype());
+}
+
 RegExpObject* RegExpObject::create(GlobalObject& global_object, Regex<ECMA262> regex, String pattern, String flags)
 {
     return global_object.heap().allocate<RegExpObject>(global_object, move(regex), move(pattern), move(flags), *global_object.regexp_prototype());
+}
+
+RegExpObject::RegExpObject(Object& prototype)
+    : Object(prototype)
+{
 }
 
 RegExpObject::RegExpObject(Regex<ECMA262> regex, String pattern, String flags, Object& prototype)
@@ -114,7 +124,7 @@ RegExpObject::RegExpObject(Regex<ECMA262> regex, String pattern, String flags, O
     , m_flags(move(flags))
     , m_regex(move(regex))
 {
-    VERIFY(m_regex.parser_result.error == regex::Error::NoError);
+    VERIFY(m_regex->parser_result.error == regex::Error::NoError);
 }
 
 RegExpObject::~RegExpObject()
@@ -128,8 +138,8 @@ void RegExpObject::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.lastIndex, Value(0), Attribute::Writable);
 }
 
-// 22.2.3.2.4 RegExpCreate ( P, F ), https://tc39.es/ecma262/#sec-regexpcreate
-RegExpObject* regexp_create(GlobalObject& global_object, Value pattern, Value flags)
+// 22.2.3.2.2 RegExpInitialize ( obj, pattern, flags ), https://tc39.es/ecma262/#sec-regexpinitialize
+RegExpObject* RegExpObject::regexp_initialize(GlobalObject& global_object, Value pattern, Value flags)
 {
     auto& vm = global_object.vm();
 
@@ -169,11 +179,22 @@ RegExpObject* regexp_create(GlobalObject& global_object, Value pattern, Value fl
         return {};
     }
 
-    auto* object = RegExpObject::create(global_object, move(regex), move(original_pattern), move(f));
-    object->set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
+    m_pattern = move(original_pattern);
+    m_flags = move(f);
+    m_regex = move(regex);
+
+    set(vm.names.lastIndex, Value(0), Object::ShouldThrowExceptions::Yes);
     if (vm.exception())
         return {};
-    return object;
+
+    return this;
+}
+
+// 22.2.3.2.4 RegExpCreate ( P, F ), https://tc39.es/ecma262/#sec-regexpcreate
+RegExpObject* regexp_create(GlobalObject& global_object, Value pattern, Value flags)
+{
+    auto* regexp_object = RegExpObject::create(global_object);
+    return regexp_object->regexp_initialize(global_object, pattern, flags);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/Result.h>
 #include <LibJS/AST.h>
 #include <LibJS/Runtime/Object.h>
@@ -26,21 +27,26 @@ public:
     // FIXME: Enable 'BrowserExtended' only if in a browser context.
     static constexpr regex::RegexOptions<ECMAScriptFlags> default_flags { (regex::ECMAScriptFlags)regex::AllFlags::Global | (regex::ECMAScriptFlags)regex::AllFlags::SkipTrimEmptyMatches | regex::ECMAScriptFlags::BrowserExtended };
 
+    static RegExpObject* create(GlobalObject&);
     static RegExpObject* create(GlobalObject&, Regex<ECMA262> regex, String pattern, String flags);
 
+    RegExpObject(Object& prototype);
     RegExpObject(Regex<ECMA262> regex, String pattern, String flags, Object& prototype);
+
+    RegExpObject* regexp_initialize(GlobalObject&, Value pattern, Value flags);
+
     virtual void initialize(GlobalObject&) override;
     virtual ~RegExpObject() override;
 
     const String& pattern() const { return m_pattern; }
     const String& flags() const { return m_flags; }
-    const Regex<ECMA262>& regex() { return m_regex; }
-    const Regex<ECMA262>& regex() const { return m_regex; }
+    const Regex<ECMA262>& regex() { return *m_regex; }
+    const Regex<ECMA262>& regex() const { return *m_regex; }
 
 private:
     String m_pattern;
     String m_flags;
-    Regex<ECMA262> m_regex;
+    Optional<Regex<ECMA262>> m_regex;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -34,6 +34,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(symbol_replace);
     JS_DECLARE_NATIVE_FUNCTION(symbol_search);
     JS_DECLARE_NATIVE_FUNCTION(symbol_split);
+    JS_DECLARE_NATIVE_FUNCTION(compile);
 
 #define __JS_ENUMERATE(_, flag_name, ...) \
     JS_DECLARE_NATIVE_GETTER(flag_name);

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.compile.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.compile.js
@@ -1,0 +1,17 @@
+test("basic functionality", () => {
+    let re = /foo/;
+    expect(re.compile.length).toBe(2);
+
+    re.compile("bar");
+    expect(re.test("foo")).toBeFalse();
+    expect(re.test("bar")).toBeTrue();
+
+    expect(re.unicode).toBeFalse();
+    re.compile("bar", "u");
+    expect(re.unicode).toBeTrue();
+
+    re.compile(/baz/g);
+    expect(re.global).toBeTrue();
+    expect(re.test("bar")).toBeFalse();
+    expect(re.test("baz")).toBeTrue();
+});

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -145,9 +145,9 @@ ALWAYS_INLINE bool Parser::lookahead_any(StringView str)
     return false;
 }
 
-ALWAYS_INLINE char Parser::skip()
+ALWAYS_INLINE unsigned char Parser::skip()
 {
-    char ch;
+    unsigned char ch;
     if (m_parser_state.current_token.value().length() == 1) {
         ch = m_parser_state.current_token.value()[0];
     } else {
@@ -1287,7 +1287,7 @@ bool ECMA262Parser::parse_atom(ByteCode& stack, size_t& match_length_minimum, bo
         // Also part of AtomEscape.
         auto token = consume();
         match_length_minimum += 1;
-        stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)token.value()[1] } });
+        stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (u8)token.value()[1] } });
         return true;
     }
     if (try_skip("\\")) {
@@ -1326,7 +1326,7 @@ bool ECMA262Parser::parse_atom(ByteCode& stack, size_t& match_length_minimum, bo
         if (m_should_use_browser_extended_grammar) {
             auto token = consume();
             match_length_minimum += 1;
-            stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)token.value()[0] } });
+            stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (u8)token.value()[0] } });
             return true;
         } else {
             return false;
@@ -1336,7 +1336,7 @@ bool ECMA262Parser::parse_atom(ByteCode& stack, size_t& match_length_minimum, bo
     if (match_ordinary_characters()) {
         auto token = consume().value();
         match_length_minimum += 1;
-        stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)token[0] } });
+        stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (u8)token[0] } });
         return true;
     }
 
@@ -1594,7 +1594,7 @@ bool ECMA262Parser::parse_atom_escape(ByteCode& stack, size_t& match_length_mini
             // Allow all SourceCharacter's as escapes here.
             auto token = consume();
             match_length_minimum += 1;
-            stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)token.value()[0] } });
+            stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (u8)token.value()[0] } });
             return true;
         }
 

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -84,7 +84,7 @@ protected:
     ALWAYS_INLINE Optional<u32> consume_escaped_code_point(bool unicode);
     ALWAYS_INLINE bool try_skip(StringView);
     ALWAYS_INLINE bool lookahead_any(StringView);
-    ALWAYS_INLINE char skip();
+    ALWAYS_INLINE unsigned char skip();
     ALWAYS_INLINE void back(size_t = 1);
     ALWAYS_INLINE void reset();
     ALWAYS_INLINE bool done() const;


### PR DESCRIPTION
This contains a fly-by fix in LibRegex to handle sign extensions when casting from `char` to `u64`. There are tests in the `annexB/built-ins/RegExp/prototype/compile` folder that rely on that fix.