### PR TITLE
LibCore: Show version and help before parsing positional arguments

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -108,7 +108,23 @@ bool ArgsParser::parse(int argc, char* const* argv, FailureBehavior failure_beha
         }
     }
 
-    // We're done processing options, now let's parse positional arguments.
+    // We're done processing options.
+    // Now let's show version or help if requested.
+
+    if (m_show_version) {
+        print_version(stdout);
+        if (failure_behavior == FailureBehavior::Exit || failure_behavior == FailureBehavior::PrintUsageAndExit)
+            exit(0);
+        return false;
+    }
+    if (m_show_help) {
+        print_usage(stdout, argv[0]);
+        if (failure_behavior == FailureBehavior::Exit || failure_behavior == FailureBehavior::PrintUsageAndExit)
+            exit(0);
+        return false;
+    }
+
+    // Now let's parse positional arguments.
 
     int values_left = argc - optind;
     Vector<int, 16> num_values_for_arg;
@@ -151,21 +167,6 @@ bool ArgsParser::parse(int argc, char* const* argv, FailureBehavior failure_beha
                 return false;
             }
         }
-    }
-
-    // We're done parsing! :)
-    // Now let's show version or help if requested.
-    if (m_show_version) {
-        print_version(stdout);
-        if (failure_behavior == FailureBehavior::Exit || failure_behavior == FailureBehavior::PrintUsageAndExit)
-            exit(0);
-        return false;
-    }
-    if (m_show_help) {
-        print_usage(stdout, argv[0]);
-        if (failure_behavior == FailureBehavior::Exit || failure_behavior == FailureBehavior::PrintUsageAndExit)
-            exit(0);
-        return false;
     }
 
     return true;


### PR DESCRIPTION
This allows `--version` and `--help` to work properly even if we do not supply the required positional arguments to a command.