### PR TITLE
LibGUI: add ctrl delete support

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -333,7 +333,6 @@ MainWidget::MainWidget()
     m_toolbar->add_action(m_editor->cut_action());
     m_toolbar->add_action(m_editor->copy_action());
     m_toolbar->add_action(m_editor->paste_action());
-    m_toolbar->add_action(m_editor->delete_action());
 
     m_toolbar->add_separator();
 
@@ -390,7 +389,6 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     edit_menu.add_action(m_editor->cut_action());
     edit_menu.add_action(m_editor->copy_action());
     edit_menu.add_action(m_editor->paste_action());
-    edit_menu.add_action(m_editor->delete_action());
     edit_menu.add_separator();
     edit_menu.add_action(*m_vim_emulation_setting_action);
     edit_menu.add_separator();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -847,13 +847,22 @@ void TextEditor::keydown_event(KeyEvent& event)
 
         if (m_cursor.column() < current_line().length()) {
             // Delete within line
-            TextRange erased_range(m_cursor, { m_cursor.line(), m_cursor.column() + 1 });
+            int erase_count = 1;
+            if (event.modifiers() == Mod_Ctrl) {
+                auto word_break_pos = document().first_word_break_after(m_cursor);
+                erase_count = word_break_pos.column() - m_cursor.column();
+            }
+            TextRange erased_range(m_cursor, { m_cursor.line(), m_cursor.column() + erase_count });
             execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
             return;
         }
         if (m_cursor.column() == current_line().length() && m_cursor.line() != line_count() - 1) {
             // Delete at end of line; merge with next line
-            TextRange erased_range(m_cursor, { m_cursor.line() + 1, 0 });
+            size_t erase_count = 0;
+            if (event.modifiers() == Mod_Ctrl) {
+                erase_count = document().first_word_break_after({ m_cursor.line() + 1, 0 }).column();
+            }
+            TextRange erased_range(m_cursor, { m_cursor.line() + 1, erase_count });
             execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
             return;
         }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -162,7 +162,6 @@ public:
     Action& cut_action() { return *m_cut_action; }
     Action& copy_action() { return *m_copy_action; }
     Action& paste_action() { return *m_paste_action; }
-    Action& delete_action() { return *m_delete_action; }
     Action& go_to_line_action() { return *m_go_to_line_action; }
     Action& select_all_action() { return *m_select_all_action; }
 
@@ -352,7 +351,6 @@ private:
     RefPtr<Action> m_cut_action;
     RefPtr<Action> m_copy_action;
     RefPtr<Action> m_paste_action;
-    RefPtr<Action> m_delete_action;
     RefPtr<Action> m_go_to_line_action;
     RefPtr<Action> m_select_all_action;
     Core::ElapsedTimer m_triple_click_timer;


### PR DESCRIPTION
Allow deleting the word after the cursor using Ctrl+Delete in a similar to how Ctrl+Backspace deletes the word before the cursor.

In order to support this, I had to migrate the handling of the delete key from an action to keydown_event so I could look at key modifiers. This did mean removing the delete button and menu entry from TextEditor, but that was kinda a weird design choice anyway.