### PR TITLE
LibGUI: Don't add the root folder to the common locations #9244

### DIFF
--- a/Base/home/anon/.config/CommonLocations.json
+++ b/Base/home/anon/.config/CommonLocations.json
@@ -1,5 +1,4 @@
 [
-    { "name": "Root", "path": "/" },
     { "name": "Home", "path": "/home/anon" },
     { "name": "Documents", "path": "/home/anon/Documents" },
     { "name": "Desktop", "path": "/home/anon/Desktop" },

--- a/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
+++ b/Userland/Libraries/LibGUI/CommonLocationsProvider.cpp
@@ -30,7 +30,6 @@ static void initialize_if_needed()
     }
 
     // Fallback : If the user doesn't have custom locations, use some default ones.
-    s_common_locations.append({ "Root", "/" });
     s_common_locations.append({ "Home", Core::StandardPaths::home_directory() });
     s_common_locations.append({ "Downloads", Core::StandardPaths::downloads_directory() });
     s_initialized = true;


### PR DESCRIPTION
The common locations from the file picker include the root folder
which has not been unveiled.