### PR TITLE
FlappyBug: Flap less aggressively

### DIFF
--- a/Userland/Games/FlappyBug/Game.h
+++ b/Userland/Games/FlappyBug/Game.h
@@ -65,7 +65,7 @@ private:
 
         void flap()
         {
-            const float flap_strength = 15.0f;
+            const float flap_strength = 10.0f;
             velocity = -flap_strength;
         }
 


### PR DESCRIPTION
_In my opinion_ :smile: 

The current flap strength makes the game a lot more difficult than other
flappy games. Decrease the flap strength to make it a little easier to get
higher scores.

Before this change I could only get past 3 or 4 obstacles, now I can get 15
or 20 in, which seems more on par with other flappy games.