### PR TITLE
LibWeb: Respond to 'initial', 'inherit' and 'unset' in StyleProperties

### DIFF
--- a/Base/res/html/misc/cascade-keywords.html
+++ b/Base/res/html/misc/cascade-keywords.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <title>Initial</title>
+    <style>
+        span {
+            background: lime;
+        }
+        .initial {
+            font-weight: initial;
+        }
+        .inherit {
+            font-weight: inherit;
+        }
+        .unset {
+            font-weight: unset;
+        }
+    </style>
+</head>
+<body>
+<p>
+    This is some text. <b>This text is bold, <span class="initial">but this is not, since it's set to initial,</span> and this is bold again.</b>
+</p>
+<p>
+    This is some text. <b>This text is bold, <span class="inherit">and so is this, because it's set to inherit,</span> and this is bold again.</b>
+</p>
+<p>
+    This is some text. <b>This text is bold, <span class="unset">and so is this, because it's set to unset and font-weight is inherited,</span> and this is bold again.</b>
+</p>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -119,6 +119,7 @@
             <li><a href="link-over-zindex-block.html">link elements with background box placed with z-index</a></li>
             <li><a href="percent-css.html">Percentage values</a></li>
             <li><a href="position-absolute-top-left.html">position: absolute; for top and left</a></li>
+            <li><a href="cascade-keywords.html">Cascade keywords (initial, inherit, unset)</a></li>
         </ul>
 
         <h2>JavaScript/WASM</h2>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1407,7 +1407,9 @@ RefPtr<StyleValue> Parser::parse_builtin_value(ParsingContext const&, StyleCompo
             return InheritStyleValue::the();
         if (ident.equals_ignoring_case("initial"))
             return InitialStyleValue::the();
-        // FIXME: Implement `unset` keyword
+        if (ident.equals_ignoring_case("unset"))
+            return UnsetStyleValue::the();
+        // FIXME: Implement `revert` and `revert-layer` keywords, from Cascade4 and Cascade5 respectively
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1404,9 +1404,9 @@ RefPtr<StyleValue> Parser::parse_builtin_value(ParsingContext const&, StyleCompo
     if (component_value.is(Token::Type::Ident)) {
         auto ident = component_value.token().ident();
         if (ident.equals_ignoring_case("inherit"))
-            return InheritStyleValue::create();
+            return InheritStyleValue::the();
         if (ident.equals_ignoring_case("initial"))
-            return InitialStyleValue::create();
+            return InitialStyleValue::the();
         // FIXME: Implement `unset` keyword
     }
 
@@ -2738,7 +2738,7 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(ParsingContext const& con
         decoration_style = IdentifierStyleValue::create(ValueID::Solid);
     // FIXME: Should default to 'currentcolor' special value: https://www.w3.org/TR/css-color-3/#currentcolor
     if (!decoration_color)
-        decoration_color = InitialStyleValue::create();
+        decoration_color = InitialStyleValue::the();
 
     return TextDecorationStyleValue::create(decoration_line.release_nonnull(), decoration_style.release_nonnull(), decoration_color.release_nonnull());
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -168,7 +168,8 @@ private:
     static Optional<Length> parse_length(ParsingContext const&, StyleComponentValueRule const&);
     static Optional<URL> parse_url_function(ParsingContext const&, StyleComponentValueRule const&);
 
-    static RefPtr<StyleValue> parse_builtin_or_dynamic_value(ParsingContext const&, StyleComponentValueRule const&);
+    static RefPtr<StyleValue> parse_builtin_value(ParsingContext const&, StyleComponentValueRule const&);
+    static RefPtr<StyleValue> parse_dynamic_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_length_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_numeric_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_identifier_value(ParsingContext const&, StyleComponentValueRule const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -72,11 +72,11 @@
     "inherited": false
   },
   "border-bottom-left-radius": {
-    "initial": 0,
+    "initial": "0",
     "inherited": false
   },
   "border-bottom-right-radius": {
-    "initial": 0,
+    "initial": "0",
     "inherited": false
   },
   "border-bottom-style": {
@@ -148,11 +148,11 @@
     "inherited": false
   },
   "border-top-left-radius": {
-    "initial": 0,
+    "initial": "0",
     "inherited": false
   },
   "border-top-right-radius": {
-    "initial": 0,
+    "initial": "0",
     "inherited": false
   },
   "border-top-style": {
@@ -230,11 +230,11 @@
   },
   "flex-grow": {
     "inherited": false,
-    "initial": 0
+    "initial": "0"
   },
   "flex-shrink": {
     "inherited": false,
-    "initial": 1
+    "initial": "1"
   },
   "flex-wrap": {
     "inherited": false,
@@ -354,7 +354,7 @@
   },
   "opacity": {
     "inherited": false,
-    "initial": 1
+    "initial": "1"
   },
   "overflow": {
     "longhands": [

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -71,6 +71,13 @@ Optional<NonnullRefPtr<StyleValue>> StyleProperties::property(CSS::PropertyID id
         return fetch_initial(id);
     if (value->is_inherit())
         return fetch_inherited(id);
+    if (value->is_unset()) {
+        if (is_inherited_property(id)) {
+            return fetch_inherited(id);
+        } else {
+            return fetch_initial(id);
+        }
+    }
 
     return value;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -219,6 +219,7 @@ public:
         Invalid,
         Inherit,
         Initial,
+        Unset,
         String,
         Length,
         Color,
@@ -245,6 +246,7 @@ public:
 
     bool is_inherit() const { return type() == Type::Inherit; }
     bool is_initial() const { return type() == Type::Initial; }
+    bool is_unset() const { return type() == Type::Unset; }
     bool is_color() const { return type() == Type::Color; }
     bool is_identifier() const { return type() == Type::Identifier || is_auto(); }
     bool is_image() const { return type() == Type::Image; }
@@ -266,11 +268,11 @@ public:
     bool is_overflow() const { return type() == Type::Overflow; }
     bool is_text_decoration() const { return type() == Type::TextDecoration; }
 
-    bool is_builtin() const { return is_inherit() || is_initial(); }
+    bool is_builtin() const { return is_inherit() || is_initial() || is_unset(); }
 
     bool is_builtin_or_dynamic() const
     {
-        return is_inherit() || is_initial() || is_custom_property() || is_calculated();
+        return is_builtin() || is_custom_property() || is_calculated();
     }
 
     virtual String to_string() const = 0;
@@ -564,6 +566,24 @@ public:
 private:
     InheritStyleValue()
         : StyleValue(Type::Inherit)
+    {
+    }
+};
+
+class UnsetStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<UnsetStyleValue> the()
+    {
+        static NonnullRefPtr<UnsetStyleValue> instance = adopt_ref(*new UnsetStyleValue);
+        return instance;
+    }
+    virtual ~UnsetStyleValue() override { }
+
+    String to_string() const override { return "unset"; }
+
+private:
+    UnsetStyleValue()
+        : StyleValue(Type::Unset)
     {
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -534,7 +534,11 @@ private:
 
 class InitialStyleValue final : public StyleValue {
 public:
-    static NonnullRefPtr<InitialStyleValue> create() { return adopt_ref(*new InitialStyleValue); }
+    static NonnullRefPtr<InitialStyleValue> the()
+    {
+        static NonnullRefPtr<InitialStyleValue> instance = adopt_ref(*new InitialStyleValue);
+        return instance;
+    }
     virtual ~InitialStyleValue() override { }
 
     String to_string() const override { return "initial"; }
@@ -548,7 +552,11 @@ private:
 
 class InheritStyleValue final : public StyleValue {
 public:
-    static NonnullRefPtr<InheritStyleValue> create() { return adopt_ref(*new InheritStyleValue); }
+    static NonnullRefPtr<InheritStyleValue> the()
+    {
+        static NonnullRefPtr<InheritStyleValue> instance = adopt_ref(*new InheritStyleValue);
+        return instance;
+    }
     virtual ~InheritStyleValue() override { }
 
     String to_string() const override { return "inherit"; }

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -47,6 +47,7 @@ int main(int argc, char** argv)
 
 #include <AK/StringView.h>
 #include <AK/Traits.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
@@ -73,6 +74,7 @@ PropertyID property_id_from_string(const StringView&);
 const char* string_from_property_id(PropertyID);
 bool is_inherited_property(PropertyID);
 bool is_pseudo_property(PropertyID);
+RefPtr<StyleValue> property_initial_value(PropertyID);
 
 } // namespace Web::CSS
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -27,6 +27,7 @@ class Selector;
 class StyleProperties;
 class StyleResolver;
 class StyleSheet;
+class StyleValue;
 enum class Display;
 }
 


### PR DESCRIPTION
This adds initial values to the generated `PropertyID.h/cpp` files, which are then used by `StyleProperties::property()`. `initial` looks up the initial value, as does `unset` for non-inherited properties. There's a stub for doing an inheritance lookup for the other cases, but actually implementing that (and the cascade in general) is a very big hairy yak, so trying to keep this simple for now.

Weirdly, this does cause a regression for Acid2 - the eyes disappear. My assumption is this is related to an em-sized box getting a size of 0, which is a problem I've seen before with ems, and I don't have a fix for.

We still have `InitialValues` which are set separately in code. Ideally that would disappear, and maybe most of `ComputedValues` could be generated from `Properties.json` too, but I don't have a plan for how to do that yet.

Also, there's a test page for the 3 builtin values now, but it's hard to test them in a way that proves they work. eg, setting `font-weight: initial` has the same effect as `font-weight: green` in our system at the moment, which is tricky.