### PR TITLE
FontEditor: Add the ability to copy the selected character as text

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.h
+++ b/Userland/Applications/FontEditor/FontEditor.h
@@ -56,6 +56,7 @@ private:
     RefPtr<GUI::Action> m_copy_action;
     RefPtr<GUI::Action> m_paste_action;
     RefPtr<GUI::Action> m_delete_action;
+    RefPtr<GUI::Action> m_copy_character_action;
 
     RefPtr<GUI::Action> m_undo_action;
     RefPtr<GUI::Action> m_redo_action;


### PR DESCRIPTION
This pull request adds a feature that lets the user copy a selected Unicode character to the clipboard.

Note:
The Unicode character is copied regardless of its size. Pasting it into other applications can lead to an error.

A possible improvement to the user experience could be a different icon for the new copy function, in order to not confuse the user with the same icons for different functions. Do to the lack of design skills, I could not implement this improvement, myself.

This is a resubmit of https://github.com/SerenityOS/serenity/pull/9531 where I messed something up, that I wasn't able to fix.