### PR TITLE
Terminal: Fix failed assertion in rewrap when narrowing window

### DIFF
--- a/Userland/Libraries/LibVT/Line.cpp
+++ b/Userland/Libraries/LibVT/Line.cpp
@@ -51,7 +51,7 @@ void Line::push_cells_into_next_line(size_t new_length, Line* next_line, bool cu
 
     // Push as many cells as _wouldn't_ fit into the next line.
     auto cells_to_preserve = !next_line->m_terminated_at.has_value() && next_line->is_empty() ? 0 : m_terminated_at.value_or(0);
-    auto preserved_cells = max(new_length, cells_to_preserve);
+    auto preserved_cells = min(max(new_length, cells_to_preserve), length());
     auto cells_to_push_into_next_line = length() - preserved_cells;
     if (!cells_to_push_into_next_line)
         return;


### PR DESCRIPTION
The terminal would consistently crash if you ran something like `find`
and then narrow the window to about a 12 character width. This bug would
also trigger at other times, but the above steps would consistently
reproduce it.

The problem was that `preserved_cells` would be larger then `length()`,
so `length() - preserved_cells` would underflow and become a value near
`NumericLimits<size_t>::max()`. Later the call to
`Span::slice_from_end()` would fail assertion that the given count was
less then the span length.

    Terminal(16:16): ASSERTION FAILED: count <= size()
    ../.././AK/Span.h:133
    [#0 Terminal(16:16)]: Terminating Terminal(16) due to signal 6

    [#0 FinalizerTask(4:4)]: Generating coredump for pid: 16
    CrashDaemon(21:21): New coredump file: /tmp/coredump/Terminal_16_1629562119
    SystemServer(6:6): Service Terminal has exited with exit code 6
    [#0 SyncTask(3:3)]: Ext2FS: Flushed 4 blocks to disk
    CrashDaemon(21:21): --- Backtrace for thread #0 (TID 16) ---
    CrashDaemon(21:21): 0x675cc1de: [libsystem.so] syscall2 +0xe (syscall.cpp:25 => syscall.cpp:24)
    CrashDaemon(21:21): 0x639a945f: [libc.so] raise +0x2f (syscall.h:35 => signal.cpp:21)
    CrashDaemon(21:21): 0x63992795: [libc.so] abort +0x29 (stdlib.cpp:230)
    CrashDaemon(21:21): 0x639932f6: [libc.so] __assertion_failed +0xd6 (assert.cpp:31)
    CrashDaemon(21:21): 0x332e34cf: [libvt.so] VT::Line::push_cells_into_next_line(unsigned long, VT::Line*, bool, VT::CursorPosition*) [clone .localalias] +0x79f (Span.h:133)
    CrashDaemon(21:21): 0x332ebfc5: [libvt.so] auto VT::Terminal::set_size(unsigned short, unsigned short)::{lambda(auto:1&, auto:2&)#1}::operator()<AK::NonnullOwnPtrVector<VT::Line, 0ul>, VT::CursorPosition>(AK::NonnullOwnPtrVector<VT::Line, 0ul>&, VT::CursorPosition&) const +0x1a5 (Terminal.cpp:1453)
    CrashDaemon(21:21): 0x332ec708: [libvt.so] VT::Terminal::set_size(unsigned short, unsigned short) [clone .localalias] +0x1f8 (Terminal.cpp:1499)
    CrashDaemon(21:21): 0x332f2f9c: [libvt.so] VT::TerminalWidget::relayout(Gfx::Size<int> const&) [clone .localalias] +0xfc (TerminalWidget.cpp:511)

This is fixed by adding a `min()` so that `preserved_cells` never
exceeds `length()`.