### PR TITLE
SQLServer: Use m_client_id instead of client_id in callback

### DIFF
--- a/Userland/Services/SQLServer/DatabaseConnection.cpp
+++ b/Userland/Services/SQLServer/DatabaseConnection.cpp
@@ -41,7 +41,7 @@ DatabaseConnection::DatabaseConnection(String database_name, int client_id)
     deferred_invoke([&](Object&) {
         m_database = SQL::Database::construct(String::formatted("/home/anon/sql/{}.db", m_database_name));
         m_accept_statements = true;
-        auto client_connection = ClientConnection::client_connection_for(client_id);
+        auto client_connection = ClientConnection::client_connection_for(m_client_id);
         if (client_connection)
             client_connection->async_connected(m_connection_id);
         else


### PR DESCRIPTION
This is a fix for the SQL utility. Currently, if the SQLSERVER_DEBUG symbol is defined, then the sql utility will load properly and everything works; however, without it, the sql utility will just hang there without connecting to the SQLServer. This problem was also discussed in #8906.

I'm not even sure if this is the correct explanation of what's going on as I'm still learning C++, but this is my best understanding of what's going on. In the DatabaseConnection constructor, there's a `deferred_invoke` callback that references the `client_id`. But depending on when the callback occurs, the reference of the `client_id` can change. This created a problem when connecting to SQLServer using the SQL utility because depending on when the callback was invoked, the `client_id` could change. 

`m_client_id` is set in the constructor and that reference will not change depending on when the callback is invoked. If SQLSERVER_DEBUG is defined, then the value that `client_id` references will be correct at the time of the callback being invoked. If SQLSERVER_DEBUG is not defined, then the value of the `client_id` will have changed by the time the callback is invoked.

This PR fixes the problem by using the DatabasesConnection's m_client_id.

For investigating this, I added some debug statements (they've been removed from this PR) to illustrate the problem. If SQLSERVER_DEBUG is defined, here are the values of client_id and m_client_id:

![client_id_in_lambda_with_debug](https://user-images.githubusercontent.com/19653787/130331488-82d5e5d8-abf8-4787-bd63-e38063e01530.png)

And here are the values of client_id and m_client_id without SQLSERVER_DEBUG defined.

![client_id_in_lambda_no_debug](https://user-images.githubusercontent.com/19653787/130331498-ef8e6c90-0a9a-4516-974a-be5840b3873c.png)