### PR TITLE
CI: Increase ccache size limit for serenity builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,12 +109,12 @@ jobs:
       - name: Show ccache stats before build and configure
         run: |
           # We only have 5 GiB of cache available *in total*. Beyond that, GitHub deletes caches.
-          # Currently, we use about 130 MB for the two toolchains (i686 & x86_64), and four ccache caches:
-          # Two with ALL_DEBUG (i686 & x86_64) and two with NORMAL_DEBUG (i686 & x86_64).
-          # Therefore, using 1.25 GB or more per cache causes disaster.
+          # Currently, we use about 130 MB for the two toolchains (i686 & x86_64), and three ccache caches:
+          # One with ALL_DEBUG (i686) and two with NORMAL_DEBUG (i686 & x86_64).
+          # Therefore, using 1.6 GB or more per cache causes disaster.
           # Building from scratch fills the ccache cache from 0 to about 0.7 GB, and after compression it comes out to
-          # about 0.25 GB, so 1.5 GB (0.5GB after compression) should be plenty, all while comfortly fitting in the cache.
-          ccache -M 1500M
+          # about 0.25 GB, so 3 GB (1GB after compression) should be plenty, all while comfortably fitting in the cache.
+          ccache -M 3000M
           ccache -s
       - name: Create build directory
         run: |


### PR DESCRIPTION
Now that we only have 3 ccached builds on CI we can comfortably increase the ccache size limit to get some free speed-up in CI.