### PR TITLE
Kernel+LibC: Various POSIX fixes from my attempt to port X11

### DIFF
--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -38,6 +38,10 @@ public:
     bool is_empty() const { return m_empty; }
 
     size_t space_for_writing() const { return m_space_for_writing; }
+    size_t immediately_readable() const
+    {
+        return (m_read_buffer->size - m_read_buffer_index) + m_write_buffer->size;
+    }
 
     void set_unblock_callback(Function<void()> callback)
     {

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -64,8 +64,6 @@ KResultOr<size_t> InodeFile::write(FileDescription& description, u64 offset, con
 
 KResult InodeFile::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
 {
-    (void)description;
-
     switch (request) {
     case FIBMAP: {
         if (!Process::current().is_superuser())
@@ -84,6 +82,13 @@ KResult InodeFile::ioctl(FileDescription& description, unsigned request, Userspa
             return block_address.error();
 
         if (!copy_to_user(user_block_number, &block_address.value()))
+            return EFAULT;
+
+        return KSuccess;
+    }
+    case FIONREAD: {
+        int remaining_bytes = inode().size() - description.offset();
+        if (!copy_to_user(Userspace<int*>(arg), &remaining_bytes))
             return EFAULT;
 
         return KSuccess;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -770,6 +770,14 @@ KResult IPv4Socket::ioctl(FileDescription&, unsigned request, Userspace<void*> a
     case SIOCSARP:
     case SIOCDARP:
         return ioctl_arp();
+
+    case FIONREAD: {
+        int readable = m_receive_buffer->immediately_readable();
+        if (!copy_to_user(Userspace<int*>(arg), &readable))
+            return EFAULT;
+
+        return KSuccess;
+    }
     }
 
     return EINVAL;

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -399,9 +399,9 @@ KResult LocalSocket::getsockopt(FileDescription& description, int level, int opt
 
     switch (option) {
     case SO_SNDBUF:
-        TODO();
+        return ENOTSUP;
     case SO_RCVBUF:
-        TODO();
+        return ENOTSUP;
     case SO_PEERCRED: {
         if (size < sizeof(ucred))
             return EINVAL;

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -16,6 +16,7 @@
 #include <Kernel/StdLib.h>
 #include <Kernel/UnixTypes.h>
 #include <LibC/errno_numbers.h>
+#include <LibC/sys/ioctl_numbers.h>
 
 namespace Kernel {
 
@@ -429,6 +430,21 @@ KResult LocalSocket::getsockopt(FileDescription& description, int level, int opt
     default:
         return Socket::getsockopt(description, level, option, value, value_size);
     }
+}
+
+KResult LocalSocket::ioctl(FileDescription& description, unsigned request, Userspace<void*> arg)
+{
+    switch (request) {
+    case FIONREAD: {
+        int readable = receive_buffer_for(description)->immediately_readable();
+        if (!copy_to_user(Userspace<int*>(arg), &readable))
+            return EFAULT;
+
+        return KSuccess;
+    }
+    }
+
+    return ENOTTY;
 }
 
 KResult LocalSocket::chmod(FileDescription&, mode_t mode)

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -47,6 +47,7 @@ public:
     virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
     virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, Time&) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
+    virtual KResult ioctl(FileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual KResult chown(FileDescription&, uid_t, gid_t) override;
     virtual KResult chmod(FileDescription&, mode_t) override;
 

--- a/Userland/Libraries/LibC/arpa/inet.h
+++ b/Userland/Libraries/LibC/arpa/inet.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <endian.h>
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <sys/cdefs.h>
@@ -26,33 +25,5 @@ static inline int inet_aton(const char* cp, struct in_addr* inp)
 }
 
 char* inet_ntoa(struct in_addr);
-
-static inline uint16_t htons(uint16_t value)
-{
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap16(value);
-#else
-    return value;
-#endif
-}
-
-static inline uint16_t ntohs(uint16_t value)
-{
-    return htons(value);
-}
-
-static inline uint32_t htonl(uint32_t value)
-{
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap32(value);
-#else
-    return value;
-#endif
-}
-
-static inline uint32_t ntohl(uint32_t value)
-{
-    return htonl(value);
-}
 
 __END_DECLS

--- a/Userland/Libraries/LibC/fd_set.h
+++ b/Userland/Libraries/LibC/fd_set.h
@@ -8,12 +8,12 @@
 
 #define FD_SETSIZE 1024
 #define FD_ZERO(set) memset((set), 0, sizeof(fd_set));
-#define FD_CLR(fd, set) ((set)->bits[(fd / 8)] &= ~(1 << (fd) % 8))
-#define FD_SET(fd, set) ((set)->bits[(fd / 8)] |= (1 << (fd) % 8))
-#define FD_ISSET(fd, set) ((set)->bits[(fd / 8)] & (1 << (fd) % 8))
+#define FD_CLR(fd, set) ((set)->fds_bits[(fd / 8)] &= ~(1 << (fd) % 8))
+#define FD_SET(fd, set) ((set)->fds_bits[(fd / 8)] |= (1 << (fd) % 8))
+#define FD_ISSET(fd, set) ((set)->fds_bits[(fd / 8)] & (1 << (fd) % 8))
 
 struct __fd_set {
-    unsigned char bits[FD_SETSIZE / 8];
+    unsigned char fds_bits[FD_SETSIZE / 8];
 };
 
 typedef struct __fd_set fd_set;

--- a/Userland/Libraries/LibC/limits.h
+++ b/Userland/Libraries/LibC/limits.h
@@ -80,6 +80,8 @@
 
 #define SSIZE_MAX 2147483647
 
+#define LINK_MAX 4096
+
 #ifdef __USE_POSIX
 #    include <bits/posix1_lim.h>
 #endif

--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -7,9 +7,44 @@
 #pragma once
 
 #include <Kernel/API/POSIX/netinet/in.h>
+#include <endian.h>
 
 __BEGIN_DECLS
 
 in_addr_t inet_addr(char const*);
+
+static inline uint16_t htons(uint16_t value)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap16(value);
+#else
+    return value;
+#endif
+}
+
+static inline uint16_t ntohs(uint16_t value)
+{
+    return htons(value);
+}
+
+static inline uint32_t htonl(uint32_t value)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap32(value);
+#else
+    return value;
+#endif
+}
+
+static inline uint32_t ntohl(uint32_t value)
+{
+    return htonl(value);
+}
+
+#define IN6_IS_ADDR_LOOPBACK(addr) \
+    (addr->s6_addr[0] == 0 && addr->s6_addr[1] == 0 && addr->s6_addr[2] == 0 && addr->s6_addr[3] == 0 && addr->s6_addr[4] == 0 && addr->s6_addr[5] == 0 && addr->s6_addr[6] == 0 && addr->s6_addr[7] == 0 && addr->s6_addr[8] == 0 && addr->s6_addr[9] == 0 && addr->s6_addr[10] == 0 && addr->s6_addr[11] == 0 && addr->s6_addr[12] == 0 && addr->s6_addr[13] == 0 && addr->s6_addr[14] == 0 && addr->s6_addr[15] == 1)
+
+#define IN6_IS_ADDR_V4MAPPED(addr) \
+    (addr->s6_addr[0] == 0 && addr->s6_addr[1] == 0 && addr->s6_addr[2] == 0 && addr->s6_addr[3] == 0 && addr->s6_addr[4] == 0 && addr->s6_addr[5] == 0 && addr->s6_addr[6] == 0 && addr->s6_addr[7] == 0 && addr->s6_addr[8] == 0xff && addr->s6_addr[9] == 0xff && addr->s6_addr[10] == 0xff && addr->s6_addr[11] == 0xff)
 
 __END_DECLS

--- a/Userland/Libraries/LibC/sys/ioctl.h
+++ b/Userland/Libraries/LibC/sys/ioctl.h
@@ -11,8 +11,6 @@
 
 __BEGIN_DECLS
 
-#define FIONREAD 0x541B
-
 int ioctl(int fd, unsigned request, ...);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -83,6 +83,7 @@ enum IOCtlNumber {
     SIOCDARP,
     FIBMAP,
     FIONBIO,
+    FIONREAD,
     KCOV_SETBUFSIZE,
     KCOV_ENABLE,
     KCOV_DISABLE,
@@ -126,3 +127,4 @@ enum IOCtlNumber {
 #define SIOCDARP SIOCDARP
 #define FIBMAP FIBMAP
 #define FIONBIO FIONBIO
+#define FIONREAD FIONREAD

--- a/Userland/Libraries/LibC/sys/poll.h
+++ b/Userland/Libraries/LibC/sys/poll.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <poll.h>

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -619,7 +619,7 @@ int mknod(const char* pathname, mode_t mode, dev_t dev)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-long fpathconf([[maybe_unused]] int fd, [[maybe_unused]] int name)
+long fpathconf([[maybe_unused]] int fd, int name)
 {
     switch (name) {
     case _PC_NAME_MAX:
@@ -628,6 +628,8 @@ long fpathconf([[maybe_unused]] int fd, [[maybe_unused]] int name)
         return PATH_MAX;
     case _PC_VDISABLE:
         return _POSIX_VDISABLE;
+    case _PC_LINK_MAX:
+        return LINK_MAX;
     }
 
     VERIFY_NOT_REACHED();
@@ -642,6 +644,8 @@ long pathconf([[maybe_unused]] const char* path, int name)
         return PATH_MAX;
     case _PC_PIPE_BUF:
         return PIPE_BUF;
+    case _PC_LINK_MAX:
+        return LINK_MAX;
     }
 
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -121,7 +121,8 @@ enum {
     _PC_NAME_MAX,
     _PC_PATH_MAX,
     _PC_PIPE_BUF,
-    _PC_VDISABLE
+    _PC_VDISABLE,
+    _PC_LINK_MAX
 };
 
 #define _POSIX_MONOTONIC_CLOCK 200112L


### PR DESCRIPTION
I was writing an X server for serenity, but since that isn't wanted, here are the the POSIX changes in LibC and Kernel to get the X11 client libraries to compile. Hopefully this will save people some time while porting.

The biggest change in this PR is support for the FIONREAD ioctl for regular files and IPv4 Sockets.