### PR TITLE
LibGUI: Always resize the mapping rows when sorting

### DIFF
--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -163,8 +163,11 @@ ModelIndex SortingProxyModel::parent_index(const ModelIndex& proxy_index) const
 
 void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sort_order)
 {
+    int row_count = source().row_count(mapping.source_parent);
+    mapping.source_rows.resize(row_count);
+    mapping.proxy_rows.resize(row_count);
+
     if (column == -1) {
-        int row_count = source().row_count(mapping.source_parent);
         for (int i = 0; i < row_count; ++i) {
             mapping.source_rows[i] = i;
             mapping.proxy_rows[i] = i;
@@ -173,10 +176,6 @@ void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sor
     }
 
     auto old_source_rows = mapping.source_rows;
-
-    int row_count = source().row_count(mapping.source_parent);
-    mapping.source_rows.resize(row_count);
-    mapping.proxy_rows.resize(row_count);
 
     for (int i = 0; i < row_count; ++i)
         mapping.source_rows[i] = i;


### PR DESCRIPTION
Prior this change, creating a file or directory on Desktop crashed the desktop instance of FileManager.

Closes: #9560