### PR TITLE
AK: Use POSIX specified types for Time::to_timespec and to_timeval

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -170,12 +170,12 @@ i64 Time::to_nanoseconds() const
 timespec Time::to_timespec() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
-    return { static_cast<i64>(m_seconds), static_cast<i32>(m_nanoseconds) };
+    return { static_cast<time_t>(m_seconds), static_cast<long>(m_nanoseconds) };
 }
 timeval Time::to_timeval() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
-    return { static_cast<i64>(m_seconds), static_cast<i32>(m_nanoseconds) / 1000 };
+    return { static_cast<time_t>(m_seconds), static_cast<suseconds_t>(m_nanoseconds) / 1000 };
 }
 
 Time Time::operator+(const Time& other) const


### PR DESCRIPTION
Hello, I wasn't able to build Serenity on 32bit host (Debian 11)

After some help on discord, I implemented the following changes in Time.cpp and it builds now.

Use POSIX specified types for Time::to_timeespec and to_timeval

The previous implementation assumed 64-bit time_t and 32-bit long,
which is not true on some 32-bit systems

This was the error I initially ran into:
`[18/4025] Building CXX object Meta/Lag...iles/LagomCore.dir/__/__/AK/Time.cpp.o
FAILED: Meta/Lagom/CMakeFiles/LagomCore.dir/__/__/AK/Time.cpp.o 
/usr/bin/ccache /usr/bin/g++ -DLagomCore_EXPORTS -I../../Userland/Libraries -I../../. -I. -I../../Meta/Lagom/../.. -I../../Meta/Lagom/../../Userland -I../../Meta/Lagom/../../Userland/Libraries -IMeta/Lagom -fPIC -fsized-deallocation -Wno-literal-suffix -Wno-unknown-warning-option -Wno-deprecated-copy -O2 -Wall -Wextra -Werror -fPIC -g -Wno-expansion-to-defined -std=c++2a -MD -MT Meta/Lagom/CMakeFiles/LagomCore.dir/__/__/AK/Time.cpp.o -MF Meta/Lagom/CMakeFiles/LagomCore.dir/__/__/AK/Time.cpp.o.d -o Meta/Lagom/CMakeFiles/LagomCore.dir/__/__/AK/Time.cpp.o -c ../../AK/Time.cpp
../../AK/Time.cpp: In member function ‘timespec AK::Time::to_timespec() const’:
../../AK/Time.cpp:173:14: error: narrowing conversion of ‘(i64)((const AK::Time*)this)->AK::Time::m_seconds’ from ‘i64’ {aka ‘long long int’} to ‘__time_t’ {aka ‘long int’} [-Werror=narrowing]
  173 |     return { static_cast<i64>(m_seconds), static_cast<i32>(m_nanoseconds) };
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../../AK/Time.cpp: In member function ‘timeval AK::Time::to_timeval() const’:
../../AK/Time.cpp:178:14: error: narrowing conversion of ‘(i64)((const AK::Time*)this)->AK::Time::m_seconds’ from ‘i64’ {aka ‘long long int’} to ‘__time_t’ {aka ‘long int’} [-Werror=narrowing]
  178 |     return { static_cast<i64>(m_seconds), static_cast<i32>(m_nanoseconds) / 1000 };
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
[20/4025] Building CXX object Meta/Lag...gomCore.dir/__/__/AK/StringUtils.cpp.o
ninja: build stopped: subcommand failed.`