### PR TITLE
Calculator: Fix conversion from double to KeypadValue

### DIFF
--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -107,7 +107,7 @@ KeypadValue::KeypadValue(double d)
     current_pow -= 1;
     while (d != 0) {
         m_value *= 10;
-        m_value += (u64)(d / AK::pow(10.0, (double)current_pow)) % 10;
+        m_value += (u64)(d / AK::pow(10.0, (double)current_pow) + 0.5) % 10;
         if (current_pow < 0)
             m_decimal_places += 1;
         current_pow -= 1;


### PR DESCRIPTION
When naively casting a double to an integer, we get a round-to-floor
behaviour. What we want here instead is round-to-closest to
be robust to some floating point rounding.

With this fix the result of `9/3` is 3 instead of 3.999.