### PR TITLE
LibGUI: Make Ctrl+Shift+Right select text

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -78,7 +78,12 @@ bool EditingEngine::on_key(const KeyEvent& event)
             }
         }
         if (event.ctrl()) {
+            m_editor->update_selection(event.shift());
             move_to_next_span(event);
+            if (event.shift() && m_editor->selection()->start().is_valid()) {
+                m_editor->selection()->set_end(m_editor->cursor());
+                m_editor->did_update_selection();
+            }
             return true;
         }
         m_editor->update_selection(event.shift());


### PR DESCRIPTION
Ctrl+Shift+Left would add the word before the cursor to the selection,
but for some reason Ctrl+Shift+Right didn't add the word after the
cursor to the selection.