### PR TITLE
Inspector: Fix Inspector window will nolonger close after inspecting itself

### DIFF
--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -88,7 +88,11 @@ int main(int argc, char** argv)
 
     if (pid == getpid()) {
         GUI::MessageBox::show(window, "Cannot inspect Inspector itself!", "Error", GUI::MessageBox::Type::Error);
-        return 1;
+        if (gui_mode) {
+            goto choose_pid;
+        } else {
+            return 1;
+        }
     }
 
     RemoteProcess remote_process(pid);


### PR DESCRIPTION
When trying to inspect the Inspector window, it closed after showing the error message.

This PR should change this behavior, so that it will switch back to the program selection after the error message.