### PR TITLE
AK: Use explode_byte for pointer sanitization

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -51,10 +51,7 @@ public:
     {
         clear();
 #ifdef SANITIZE_PTRS
-        if constexpr (sizeof(T*) == 8)
-            m_ptr = (T*)(0xe3e3e3e3e3e3e3e3);
-        else
-            m_ptr = (T*)(0xe3e3e3e3);
+        m_ptr = (T*)(explode_byte(0xe3));
 #endif
     }
 

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -95,10 +95,7 @@ public:
     {
         assign(nullptr);
 #ifdef SANITIZE_PTRS
-        if constexpr (sizeof(T*) == 8)
-            m_bits.store(0xb0b0b0b0b0b0b0b0, AK::MemoryOrder::memory_order_relaxed);
-        else
-            m_bits.store(0xb0b0b0b0, AK::MemoryOrder::memory_order_relaxed);
+        m_bits.store(explode_byte(0xb0), AK::MemoryOrder::memory_order_relaxed);
 #endif
     }
 

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -43,10 +43,7 @@ public:
     {
         clear();
 #ifdef SANITIZE_PTRS
-        if constexpr (sizeof(T*) == 8)
-            m_ptr = (T*)(0xe1e1e1e1e1e1e1e1);
-        else
-            m_ptr = (T*)(0xe1e1e1e1);
+        m_ptr = (T*)(explode_byte(0xe1));
 #endif
     }
 

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -182,10 +182,7 @@ public:
     {
         clear();
 #ifdef SANITIZE_PTRS
-        if constexpr (sizeof(T*) == 8)
-            m_bits.store(0xe0e0e0e0e0e0e0e0, AK::MemoryOrder::memory_order_relaxed);
-        else
-            m_bits.store(0xe0e0e0e0, AK::MemoryOrder::memory_order_relaxed);
+        m_bits.store(explode_byte(0xe0), AK::MemoryOrder::memory_order_relaxed);
 #endif
     }
 


### PR DESCRIPTION
This cuts down on some `if constexpr (sizeof(T*) == ?)`