### PR TITLE
ak: Add basic Rational type with tests

### DIFF
--- a/AK/Rational.h
+++ b/AK/Rational.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Traits.h>
+#include <math.h>
+
+namespace AK {
+
+template<typename T>
+class Rational {
+public:
+    Rational()
+        : m_numerator(0)
+        , m_denominator(1)
+    {
+    }
+
+    Rational(T const numerator, T const denominator)
+        : m_numerator(numerator)
+        , m_denominator(denominator)
+    {
+        static_assert(IsIntegral<T> == true);
+    }
+
+    // FIXME: Create function to create type from double
+
+    T numerator() const
+    {
+        return m_numerator;
+    }
+
+    T denominator() const
+    {
+        return m_denominator;
+    }
+
+    double to_double() const
+    {
+        if (m_denominator == 0) {
+            return NAN;
+        }
+        return static_cast<double>(m_numerator) / m_denominator;
+    }
+
+    String to_string() const
+    {
+        return String::formatted("{}/{}", m_numerator, m_denominator);
+    }
+
+    // FIXME: Create calculation functions e.g. addition
+
+    // FIXME: Create a reduction function using GCD
+
+private:
+    T m_numerator;
+    T m_denominator;
+};
+
+}
+
+using AK::Rational;

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -45,6 +45,7 @@ set(AK_TEST_SOURCES
     TestQueue.cpp
     TestQuickSort.cpp
     TestRedBlackTree.cpp
+    TestRational.cpp
     TestRefPtr.cpp
     TestSinglyLinkedList.cpp
     TestSourceGenerator.cpp

--- a/Tests/AK/TestRational.cpp
+++ b/Tests/AK/TestRational.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <AK/Rational.h>
+
+TEST_CASE(rational_construct_is_zero)
+{
+    Rational<u32> item;
+    EXPECT_EQ(item.numerator(), 0U);
+    EXPECT_EQ(item.denominator(), 1U);
+    EXPECT_APPROXIMATE(item.to_double(), 0);
+}
+
+TEST_CASE(rational_0_over_0_todouble_isnan)
+{
+    Rational<u32> item(0, 0);
+    const auto result = item.to_double();
+    EXPECT(result != result);
+}
+
+
+TEST_CASE(rational_3_over_2_todouble_is_1p5)
+{
+    Rational<u32> item(3, 2);
+    EXPECT_APPROXIMATE(item.to_double(), 1.5);
+}
+
+TEST_CASE(rational_1_over_1_to_string)
+{
+    Rational<u32> item(1, 1);
+    EXPECT_EQ(item.to_string(), String("1/1"));
+}
+


### PR DESCRIPTION
Type is used frequently in container-formats + codecs to prevent rounding errors

Atm it's initial use is to contain the num/denom values and ways to present them