### PR TITLE
AK: Add Statistics helper

### DIFF
--- a/AK/Statistics.h
+++ b/AK/Statistics.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <AK/QuickSort.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Vector.h>
+
+namespace AK {
+
+template<typename T = float>
+requires(IsArithmetic<T>) class Statistics {
+public:
+    Statistics() = default;
+    ~Statistics() = default;
+
+    void add(T const& value)
+    {
+        // FIXME: Check for an overflow
+        m_sum += value;
+        m_values.append(value);
+    }
+
+    T const sum() const { return m_sum; }
+    float average() const { return (float)sum() / size(); }
+
+    // FIXME: Implement a better algorithm
+    T const median()
+    {
+        quick_sort(m_values);
+        return m_values.at(size() / 2);
+    }
+
+    float standard_deviation() const { return sqrt(variance()); }
+    float variance() const
+    {
+        float summation = 0;
+        float avg = average();
+        for (T number : values()) {
+            float difference = (float)number - avg;
+            summation += (difference * difference);
+        }
+        summation = summation / size();
+        return summation;
+    }
+
+    Vector<T> const& values() const { return m_values; }
+    size_t size() const { return m_values.size(); }
+
+private:
+    Vector<T> m_values;
+    T m_sum {};
+};
+
+}

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -9,6 +9,7 @@
 #include "Shell/Formatter.h"
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
+#include <AK/Statistics.h>
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
@@ -929,8 +930,7 @@ int Shell::builtin_time(int argc, const char** argv)
 
     auto commands = expand_aliases({ move(command) });
 
-    Vector<int> iteration_times;
-    iteration_times.ensure_capacity(number_of_iterations);
+    AK::Statistics iteration_times;
 
     int exit_code = 1;
     for (int i = 0; i < number_of_iterations; ++i) {
@@ -940,25 +940,21 @@ int Shell::builtin_time(int argc, const char** argv)
             block_on_job(job);
             exit_code = job.exit_code();
         }
-        iteration_times.unchecked_append(timer.elapsed());
+        iteration_times.add(timer.elapsed());
     }
 
     if (number_of_iterations == 1) {
-        warnln("Time: {} ms", iteration_times.first());
+        warnln("Time: {} ms", iteration_times.values().first());
     } else {
-        float total_time = 0;
-        for (auto time : iteration_times)
-            total_time += static_cast<float>(time);
-        float average = total_time / number_of_iterations;
-
-        float total_time_excluding_first = total_time - static_cast<float>(iteration_times.first());
-        float average_excluding_first = total_time_excluding_first / (number_of_iterations - 1);
+        AK::Statistics iteration_times_excluding_first;
+        for (size_t i = 1; i < iteration_times.size(); i++)
+            iteration_times_excluding_first.add(iteration_times.values()[i]);
 
         warnln("Timing report:");
         warnln("==============");
         warnln("Command:         {}", String::join(' ', args));
-        warnln("Average time:    {} ms", average);
-        warnln("Excluding first: {} ms", average_excluding_first);
+        warnln("Average time:    {:.2} ms (median: {}, stddev: {:.2})", iteration_times.average(), iteration_times.median(), iteration_times.standard_deviation());
+        warnln("Excluding first: {:.2} ms (median: {}, stddev: {:.2})", iteration_times_excluding_first.average(), iteration_times_excluding_first.median(), iteration_times_excluding_first.standard_deviation());
     }
 
     return exit_code;


### PR DESCRIPTION
This adds the AK::Statistics helper which provides basic statistical tools to us.
This helper then gets used in the time command to gather some more information.

![image](https://user-images.githubusercontent.com/6002167/130522704-31cf3980-ce6f-4041-a996-2f6297e88c15.png)
