### PR TITLE
LibCore: Set file offset in ConfigFile::sync

### DIFF
--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -164,6 +164,7 @@ bool ConfigFile::sync()
         return true;
 
     m_file->truncate(0);
+    m_file->seek(0);
 
     for (auto& it : m_groups) {
         m_file->write(String::formatted("[{}]\n", it.key));


### PR DESCRIPTION
When I changed an ini file using the ini utility. I noticed that the old content was overwritten by zeroes and the new content appended.