### PR TITLE
WindowServer: Add message to notify clients of applet area resize

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -82,7 +82,6 @@ public:
                 window()->resize(44, 16);
                 m_percent_box->set_tooltip("Hide percent");
             }
-            reposition_slider_window();
             GUI::Application::the()->hide_tooltip();
 
             m_config->write_bool_entry("Applet", "ShowPercent", m_show_percent);
@@ -154,6 +153,11 @@ private:
             auto volume_text = m_audio_muted ? "mute" : String::formatted("{}%", m_audio_volume);
             painter.draw_text({ 16, 3, 24, 16 }, volume_text, Gfx::FontDatabase::default_fixed_width_font(), Gfx::TextAlignment::TopLeft, palette().window_text());
         }
+    }
+
+    virtual void applet_area_rect_change_event(GUI::AppletAreaRectChangeEvent&) override
+    {
+        reposition_slider_window();
     }
 
     void open()

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -56,6 +56,7 @@ public:
         ScreenRectsChange,
         ActionEnter,
         ActionLeave,
+        AppletAreaRectChange,
 
         __Begin_WM_Events,
         WM_WindowRemoved,
@@ -449,6 +450,20 @@ public:
 private:
     Vector<Gfx::IntRect, 4> m_rects;
     size_t m_main_screen_index;
+};
+
+class AppletAreaRectChangeEvent final : public Event {
+public:
+    explicit AppletAreaRectChangeEvent(Gfx::IntRect rect)
+        : Event(Type::AppletAreaRectChange)
+        , m_rect(rect)
+    {
+    }
+
+    Gfx::IntRect rect() const { return m_rect; }
+
+private:
+    Gfx::IntRect const m_rect;
 };
 
 class FocusEvent final : public Event {

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -13,6 +13,7 @@ class AbstractTableView;
 class AbstractView;
 class Action;
 class ActionGroup;
+class AppletAreaRectChangeEvent;
 class Application;
 class AutocompleteBox;
 class AutocompleteProvider;

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -305,6 +305,8 @@ void Widget::event(Core::Event& event)
         return change_event(static_cast<Event&>(event));
     case Event::ContextMenu:
         return context_menu_event(static_cast<ContextMenuEvent&>(event));
+    case Event::AppletAreaRectChange:
+        return applet_area_rect_change_event(static_cast<AppletAreaRectChangeEvent&>(event));
     default:
         return Core::Object::event(event);
     }
@@ -576,6 +578,10 @@ void Widget::fonts_change_event(FontsChangeEvent&)
 }
 
 void Widget::screen_rects_change_event(ScreenRectsChangeEvent&)
+{
+}
+
+void Widget::applet_area_rect_change_event(AppletAreaRectChangeEvent&)
 {
 }
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -319,6 +319,7 @@ protected:
     virtual void theme_change_event(ThemeChangeEvent&);
     virtual void fonts_change_event(FontsChangeEvent&);
     virtual void screen_rects_change_event(ScreenRectsChangeEvent&);
+    virtual void applet_area_rect_change_event(AppletAreaRectChangeEvent&);
 
     virtual void did_begin_inspection() override;
     virtual void did_end_inspection() override;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -554,6 +554,22 @@ void Window::handle_screen_rects_change_event(ScreenRectsChangeEvent& event)
     screen_rects_change_event(event);
 }
 
+void Window::handle_applet_area_rect_change_event(AppletAreaRectChangeEvent& event)
+{
+    if (!m_main_widget)
+        return;
+    auto dispatch_applet_area_rect_change = [&](auto& widget, auto recursive) {
+        widget.dispatch_event(event, this);
+        widget.for_each_child_widget([&](auto& widget) -> IterationDecision {
+            widget.dispatch_event(event, this);
+            recursive(widget, recursive);
+            return IterationDecision::Continue;
+        });
+    };
+    dispatch_applet_area_rect_change(*m_main_widget.ptr(), dispatch_applet_area_rect_change);
+    applet_area_rect_change_event(event);
+}
+
 void Window::handle_drag_move_event(DragEvent& event)
 {
     if (!m_main_widget)
@@ -643,6 +659,9 @@ void Window::event(Core::Event& event)
 
     if (event.type() == Event::ScreenRectsChange)
         return handle_screen_rects_change_event(static_cast<ScreenRectsChangeEvent&>(event));
+
+    if (event.type() == Event::AppletAreaRectChange)
+        return handle_applet_area_rect_change_event(static_cast<AppletAreaRectChangeEvent&>(event));
 
     Core::Object::event(event);
 }
@@ -879,6 +898,10 @@ void Window::wm_event(WMEvent&)
 }
 
 void Window::screen_rects_change_event(ScreenRectsChangeEvent&)
+{
+}
+
+void Window::applet_area_rect_change_event(AppletAreaRectChangeEvent&)
 {
 }
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -207,6 +207,7 @@ protected:
     Window(Core::Object* parent = nullptr);
     virtual void wm_event(WMEvent&);
     virtual void screen_rects_change_event(ScreenRectsChangeEvent&);
+    virtual void applet_area_rect_change_event(AppletAreaRectChangeEvent&);
 
     virtual void enter_event(Core::Event&);
     virtual void leave_event(Core::Event&);
@@ -226,6 +227,7 @@ private:
     void handle_theme_change_event(ThemeChangeEvent&);
     void handle_fonts_change_event(FontsChangeEvent&);
     void handle_screen_rects_change_event(ScreenRectsChangeEvent&);
+    void handle_applet_area_rect_change_event(AppletAreaRectChangeEvent&);
     void handle_drag_move_event(DragEvent&);
     void handle_entered_event(Core::Event&);
     void handle_left_event(Core::Event&);

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -321,6 +321,13 @@ void WindowServerConnection::screen_rects_changed(Vector<Gfx::IntRect> const& re
     });
 }
 
+void WindowServerConnection::applet_area_rect_changed(Gfx::IntRect const& rect)
+{
+    Window::for_each_window({}, [&](auto& window) {
+        Core::EventLoop::current().post_event(window, make<AppletAreaRectChangeEvent>(rect));
+    });
+}
+
 void WindowServerConnection::set_wallpaper_finished(bool)
 {
     // This is handled manually by Desktop::set_wallpaper().

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -46,6 +46,7 @@ private:
     virtual void menu_item_left(i32, u32) override;
     virtual void menu_visibility_did_change(i32, bool) override;
     virtual void screen_rects_changed(Vector<Gfx::IntRect> const&, u32, u32, u32) override;
+    virtual void applet_area_rect_changed(Gfx::IntRect const&) override;
     virtual void set_wallpaper_finished(bool) override;
     virtual void drag_dropped(i32, Gfx::IntPoint const&, String const&, HashMap<String, ByteBuffer> const&) override;
     virtual void drag_accepted() override;

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -42,6 +42,10 @@ void WMClientConnection::set_applet_area_position(Gfx::IntPoint const& position)
     }
 
     AppletManager::the().set_position(position);
+
+    WindowServer::ClientConnection::for_each_client([](auto& connection) {
+        connection.post_message(Messages::WindowClient::AppletAreaRectChanged(AppletManager::the().window()->rect()));
+    });
 }
 
 void WMClientConnection::set_active_window(i32 client_id, i32 window_id)

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -30,6 +30,8 @@ endpoint WindowClient
 
     screen_rects_changed(Vector<Gfx::IntRect> rects, u32 main_screen_index, u32 virtual_desktop_rows, u32 virtual_desktop_columns) =|
 
+    applet_area_rect_changed(Gfx::IntRect rect) =|
+
     set_wallpaper_finished(bool success) =|
 
     drag_accepted() =|


### PR DESCRIPTION
Applets and windows would like to be able to know when the applet area has been resized. For example, applet area relayout happens asynchronously after an applet has been resized, so we cannot then rely on the applet area position synchronously after resizing. This adds a new message applet_area_rect_changed and associated Event AppletAreaRectChange, and the appropriate virtual functions.

This also allows the fixing of a bug involving the Audio applet positioning.