### PR TITLE
WebServer: Add 'Content-Type' header for error responses

### DIFF
--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -288,6 +288,7 @@ void Client::send_error_response(unsigned code, HTTP::HttpRequest const& request
         builder.append(header);
         builder.append("\r\n");
     }
+    builder.append("Content-Type: text/html; charset=UTF-8\r\n");
 
     builder.append("\r\n");
     builder.append("<!DOCTYPE html><html><body><h1>");


### PR DESCRIPTION
Previously when the WebServer sent an error page the browser would
show the raw HTML since we forgot to send the 'Content-Type' header