### PR TITLE
LibJS: Fix incorrect Lexer VERIFY when parsing Unicode characters

### DIFF
--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -201,7 +201,7 @@ void Lexer::consume()
             char_size = 4;
         }
 
-        VERIFY(char_size > 1);
+        VERIFY(char_size >= 1);
         --char_size;
 
         m_position += char_size;


### PR DESCRIPTION
This bug was discovered via OSS fuzz, it's possible to fall through
to this assert with a char_size == 1, so we need to account for that
in the VERIFY(..).

Repro test case can be found in the OSS fuzz bug:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37296