### PR TITLE
PixelPaint: Shift-key for squares and circles

### DIFF
--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -88,7 +88,11 @@ void EllipseTool::on_mousemove(Layer*, MouseEvent& event)
 
     m_draw_mode = event.layer_event().alt() ? DrawMode::FromCenter : DrawMode::FromCorner;
 
-    m_ellipse_end_position = event.layer_event().position();
+    if (event.layer_event().shift())
+        m_ellipse_end_position = m_ellipse_start_position.end_point_for_square_aspect_ratio(event.layer_event().position());
+    else
+        m_ellipse_end_position = event.layer_event().position();
+
     m_editor->update();
 }
 

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -93,7 +93,11 @@ void RectangleTool::on_mousemove(Layer* layer, MouseEvent& event)
 
     m_draw_mode = event.layer_event().alt() ? DrawMode::FromCenter : DrawMode::FromCorner;
 
-    m_rectangle_end_position = event.layer_event().position();
+    if (event.layer_event().shift())
+        m_rectangle_end_position = m_rectangle_start_position.end_point_for_square_aspect_ratio(event.layer_event().position());
+    else
+        m_rectangle_end_position = event.layer_event().position();
+
     m_editor->update();
 }
 

--- a/Userland/Libraries/LibGfx/Point.cpp
+++ b/Userland/Libraries/LibGfx/Point.cpp
@@ -19,6 +19,17 @@ void Point<T>::constrain(Rect<T> const& rect)
     m_y = AK::clamp<T>(y(), rect.top(), rect.bottom());
 }
 
+template<typename T>
+[[nodiscard]] Point<T> Point<T>::end_point_for_square_aspect_ratio(Point<T> const& previous_end_point) const
+{
+    const T dx = previous_end_point.x() - x();
+    const T dy = previous_end_point.y() - y();
+    const T x_sign = dx >= 0 ? 1 : -1;
+    const T y_sign = dy >= 0 ? 1 : -1;
+    const T abs_size = AK::max(AK::abs(dx), AK::abs(dy));
+    return { x() + x_sign * abs_size, y() + y_sign * abs_size };
+}
+
 template<>
 String IntPoint::to_string() const
 {

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -231,6 +231,8 @@ public:
         return { AK::abs(dx_relative_to(other)), AK::abs(dy_relative_to(other)) };
     }
 
+    [[nodiscard]] Point end_point_for_square_aspect_ratio(Point const&) const;
+
     template<typename U>
     [[nodiscard]] Point<U> to_type() const
     {


### PR DESCRIPTION
PR adds method for changing point's one coordinate (X or Y) to make X and Y difference with other point's X and Y equal to the maximum difference. In short: it makes abs(X2 - X1) == abs(Y2 - Y1). 

Method is used in Rectangle Tool for making squares and Ellipse Tool for making circles 
