### PR TITLE
Audio: Volume behavior revamp, per-client-volume, fixes

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -38,8 +38,8 @@ public:
             update();
         };
 
-        m_audio_client->on_main_mix_volume_change = [this](int volume) {
-            m_audio_volume = volume;
+        m_audio_client->on_main_mix_volume_change = [this](double volume) {
+            m_audio_volume = static_cast<int>(volume * 100);
             if (!m_audio_muted)
                 update();
         };
@@ -87,14 +87,14 @@ public:
         };
 
         m_slider = m_root_container->add<GUI::VerticalSlider>();
-        m_slider->set_max(20);
-        int non_log_volume = sqrt(100 * m_audio_volume);
-        m_slider->set_value(-(non_log_volume / 5.0f) + 20);
+        m_slider->set_max(100);
+        m_slider->set_page_step(5);
+        m_slider->set_step(5);
+        m_slider->set_value(m_slider->max() - m_audio_volume);
         m_slider->set_knob_size_mode(GUI::Slider::KnobSizeMode::Proportional);
         m_slider->on_change = [&](int value) {
-            int volume = clamp((20 - value) * 5, 0, 100);
-            double volume_log = ((volume / 100.0) * (volume / 100.0)) * 100.0;
-            m_audio_client->set_main_mix_volume(static_cast<i32>(volume_log));
+            double volume = clamp(static_cast<double>(m_slider->max() - value) / m_slider->max(), 0.0, 1.0);
+            m_audio_client->set_main_mix_volume(volume);
             update();
         };
 
@@ -131,8 +131,7 @@ private:
     {
         if (m_audio_muted)
             return;
-        int new_slider_value = m_slider->value() + event.wheel_delta() / 4;
-        m_slider->set_value(new_slider_value);
+        m_slider->dispatch_event(event);
         update();
     }
 

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -30,7 +30,8 @@ constexpr int buffer_size = sample_count * sizeof(Sample);
 
 constexpr double sample_rate = 44100;
 
-constexpr double volume_factor = 1800;
+// Headroom for the synth
+constexpr double volume_factor = 0.1;
 
 enum Switch {
     Off,

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -95,8 +95,8 @@ void Track::fill_sample(Sample& sample)
         default:
             VERIFY_NOT_REACHED();
         }
-        new_sample.left += note_sample.left * m_power[note] * volume_factor * (static_cast<double>(volume()) / volume_max);
-        new_sample.right += note_sample.right * m_power[note] * volume_factor * (static_cast<double>(volume()) / volume_max);
+        new_sample.left += note_sample.left * m_power[note] * NumericLimits<i16>::max() * volume_factor * (static_cast<double>(volume()) / volume_max);
+        new_sample.right += note_sample.right * m_power[note] * NumericLimits<i16>::max() * volume_factor * (static_cast<double>(volume()) / volume_max);
     }
 
     auto new_sample_dsp = LibDSP::Signal(LibDSP::Sample { new_sample.left / NumericLimits<i16>::max(), new_sample.right / NumericLimits<i16>::max() });
@@ -104,6 +104,9 @@ void Track::fill_sample(Sample& sample)
 
     new_sample.left = delayed_sample.left * NumericLimits<i16>::max();
     new_sample.right = delayed_sample.right * NumericLimits<i16>::max();
+
+    new_sample.left = clamp(new_sample.left, NumericLimits<i16>::min(), NumericLimits<i16>::max());
+    new_sample.right = clamp(new_sample.right, NumericLimits<i16>::min(), NumericLimits<i16>::max());
 
     sample.left += new_sample.left;
     sample.right += new_sample.right;

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -47,7 +47,7 @@ public:
     virtual void set_volume(double volume)
     {
         m_player_state.volume = volume;
-        client_connection().set_main_mix_volume((double)(volume * 100));
+        client_connection().set_self_volume(volume);
     }
     virtual void set_loaded_file_samplerate(int samplerate) { m_player_state.loaded_file_samplerate = samplerate; }
     virtual void set_looping_file(bool loop)

--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -78,7 +78,7 @@ struct Frame {
         return *this;
     }
 
-    ALWAYS_INLINE Frame log_multiplied(double const volume_change)
+    ALWAYS_INLINE Frame log_multiplied(double const volume_change) const
     {
         Frame new_frame { left, right };
         new_frame.log_multiply(volume_change);

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -54,4 +54,10 @@ void ClientConnection::main_mix_volume_changed(double volume)
         on_main_mix_volume_change(volume);
 }
 
+void ClientConnection::client_volume_changed(double volume)
+{
+    if (on_client_volume_change)
+        on_client_volume_change(volume);
+}
+
 }

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -48,7 +48,7 @@ void ClientConnection::muted_state_changed(bool muted)
         on_muted_state_change(muted);
 }
 
-void ClientConnection::main_mix_volume_changed(i32 volume)
+void ClientConnection::main_mix_volume_changed(double volume)
 {
     if (on_main_mix_volume_change)
         on_main_mix_volume_change(volume);

--- a/Userland/Libraries/LibAudio/ClientConnection.h
+++ b/Userland/Libraries/LibAudio/ClientConnection.h
@@ -27,12 +27,12 @@ public:
 
     Function<void(i32 buffer_id)> on_finish_playing_buffer;
     Function<void(bool muted)> on_muted_state_change;
-    Function<void(int volume)> on_main_mix_volume_change;
+    Function<void(double volume)> on_main_mix_volume_change;
 
 private:
     virtual void finished_playing_buffer(i32) override;
     virtual void muted_state_changed(bool) override;
-    virtual void main_mix_volume_changed(i32) override;
+    virtual void main_mix_volume_changed(double) override;
 };
 
 }

--- a/Userland/Libraries/LibAudio/ClientConnection.h
+++ b/Userland/Libraries/LibAudio/ClientConnection.h
@@ -28,11 +28,13 @@ public:
     Function<void(i32 buffer_id)> on_finish_playing_buffer;
     Function<void(bool muted)> on_muted_state_change;
     Function<void(double volume)> on_main_mix_volume_change;
+    Function<void(double volume)> on_client_volume_change;
 
 private:
     virtual void finished_playing_buffer(i32) override;
     virtual void muted_state_changed(bool) override;
     virtual void main_mix_volume_changed(double) override;
+    virtual void client_volume_changed(double) override;
 };
 
 }

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -39,9 +39,8 @@ Signal Delay::process_impl(Signal const& input_signal)
 
     Sample const& in = input_signal.get<Sample>();
     Sample out;
-    // FIXME: Once we have log scaling, change these to use it instead
-    out += in.scaled(static_cast<double>(m_dry_gain));
-    out += m_delay_buffer[m_delay_index].scaled(m_delay_decay);
+    out += in.log_multiplied(static_cast<double>(m_dry_gain));
+    out += m_delay_buffer[m_delay_index].log_multiplied(m_delay_decay);
 
     // This is also convenient for disabling the delay effect by setting the buffer size to 0
     if (m_delay_buffer.size() >= 1)

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -78,6 +78,12 @@ bool Decoder::decode(float& value)
     return !m_stream.handle_any_error();
 }
 
+bool Decoder::decode(double& value)
+{
+    m_stream >> value;
+    return !m_stream.handle_any_error();
+}
+
 bool Decoder::decode(String& value)
 {
     i32 length = 0;

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -41,6 +41,7 @@ public:
     bool decode(i32&);
     bool decode(i64&);
     bool decode(float&);
+    bool decode(double&);
     bool decode(String&);
     bool decode(ByteBuffer&);
     bool decode(URL&);

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -1,9 +1,11 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BitCast.h>
 #include <AK/ByteBuffer.h>
 #include <AK/String.h>
 #include <AK/URL.h>
@@ -98,12 +100,14 @@ Encoder& Encoder::operator<<(i64 value)
 
 Encoder& Encoder::operator<<(float value)
 {
-    union bits {
-        float as_float;
-        u32 as_u32;
-    } u;
-    u.as_float = value;
-    return *this << u.as_u32;
+    u32 as_u32 = bit_cast<u32>(value);
+    return *this << as_u32;
+}
+
+Encoder& Encoder::operator<<(double value)
+{
+    u64 as_u64 = bit_cast<u64>(value);
+    return *this << as_u64;
 }
 
 Encoder& Encoder::operator<<(char const* value)

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -37,6 +37,7 @@ public:
     Encoder& operator<<(i32);
     Encoder& operator<<(i64);
     Encoder& operator<<(float);
+    Encoder& operator<<(double);
     Encoder& operator<<(char const*);
     Encoder& operator<<(StringView const&);
     Encoder& operator<<(String const&);

--- a/Userland/Libraries/LibThreading/ConditionVariable.h
+++ b/Userland/Libraries/LibThreading/ConditionVariable.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <LibThreading/Mutex.h>
+#include <pthread.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+namespace Threading {
+
+// A signaling condition variable that wraps over the pthread_cond_* APIs.
+class ConditionVariable {
+    friend class Mutex;
+
+public:
+    ConditionVariable(Mutex& to_wait_on)
+        : m_to_wait_on(to_wait_on)
+    {
+        auto result = pthread_cond_init(&m_condition, nullptr);
+        VERIFY(result == 0);
+    }
+
+    ALWAYS_INLINE ~ConditionVariable()
+    {
+        auto result = pthread_cond_destroy(&m_condition);
+        VERIFY(result == 0);
+    }
+
+    // As with pthread APIs, the mutex must be locked or undefined behavior ensues.
+    ALWAYS_INLINE void wait()
+    {
+        auto result = pthread_cond_wait(&m_condition, &m_to_wait_on.m_mutex);
+        VERIFY(result == 0);
+    }
+    ALWAYS_INLINE void wait_while(Function<bool()> condition)
+    {
+        while (condition())
+            wait();
+    }
+    // Release at least one of the threads waiting on this variable.
+    ALWAYS_INLINE void signal()
+    {
+        auto result = pthread_cond_signal(&m_condition);
+        VERIFY(result == 0);
+    }
+    // Release all of the threads waiting on this variable.
+    ALWAYS_INLINE void broadcast()
+    {
+        auto result = pthread_cond_broadcast(&m_condition);
+        VERIFY(result == 0);
+    }
+
+private:
+    pthread_cond_t m_condition;
+    Mutex& m_to_wait_on;
+};
+
+}

--- a/Userland/Libraries/LibThreading/Mutex.h
+++ b/Userland/Libraries/LibThreading/Mutex.h
@@ -13,6 +13,8 @@
 namespace Threading {
 
 class Mutex {
+    friend class ConditionVariable;
+
 public:
     Mutex()
     {

--- a/Userland/Services/AudioServer/AudioClient.ipc
+++ b/Userland/Services/AudioServer/AudioClient.ipc
@@ -4,5 +4,5 @@ endpoint AudioClient
 {
     finished_playing_buffer(i32 buffer_id) =|
     muted_state_changed(bool muted) =|
-    main_mix_volume_changed(i32 volume) =|
+    main_mix_volume_changed(double volume) =|
 }

--- a/Userland/Services/AudioServer/AudioClient.ipc
+++ b/Userland/Services/AudioServer/AudioClient.ipc
@@ -5,4 +5,5 @@ endpoint AudioClient
     finished_playing_buffer(i32 buffer_id) =|
     muted_state_changed(bool muted) =|
     main_mix_volume_changed(double volume) =|
+    client_volume_changed(double volume) =|
 }

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -5,8 +5,8 @@ endpoint AudioServer
     // Mixer functions
     set_muted(bool muted) => ()
     get_muted() => (bool muted)
-    get_main_mix_volume() => (i32 volume)
-    set_main_mix_volume(i32 volume) => ()
+    get_main_mix_volume() => (double volume)
+    set_main_mix_volume(double volume) => ()
 
     // Audio device
     set_sample_rate(u16 sample_rate) => ()

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -7,6 +7,8 @@ endpoint AudioServer
     get_muted() => (bool muted)
     get_main_mix_volume() => (double volume)
     set_main_mix_volume(double volume) => ()
+    get_self_volume() => (double volume)
+    set_self_volume(double volume) => ()
 
     // Audio device
     set_sample_rate(u16 sample_rate) => ()

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -38,7 +38,7 @@ void ClientConnection::die()
     s_connections.remove(client_id());
 }
 
-void ClientConnection::did_finish_playing_buffer(Badge<BufferQueue>, int buffer_id)
+void ClientConnection::did_finish_playing_buffer(Badge<ClientAudioStream>, int buffer_id)
 {
     async_finished_playing_buffer(buffer_id);
 }

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -48,7 +48,7 @@ void ClientConnection::did_change_muted_state(Badge<Mixer>, bool muted)
     async_muted_state_changed(muted);
 }
 
-void ClientConnection::did_change_main_mix_volume(Badge<Mixer>, int volume)
+void ClientConnection::did_change_main_mix_volume(Badge<Mixer>, double volume)
 {
     async_main_mix_volume_changed(volume);
 }
@@ -58,7 +58,7 @@ Messages::AudioServer::GetMainMixVolumeResponse ClientConnection::get_main_mix_v
     return m_mixer.main_volume();
 }
 
-void ClientConnection::set_main_mix_volume(i32 volume)
+void ClientConnection::set_main_mix_volume(double volume)
 {
     m_mixer.set_main_volume(volume);
 }

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -53,6 +53,11 @@ void ClientConnection::did_change_main_mix_volume(Badge<Mixer>, double volume)
     async_main_mix_volume_changed(volume);
 }
 
+void ClientConnection::did_change_client_volume(Badge<ClientAudioStream>, double volume)
+{
+    async_client_volume_changed(volume);
+}
+
 Messages::AudioServer::GetMainMixVolumeResponse ClientConnection::get_main_mix_volume()
 {
     return m_mixer.main_volume();
@@ -71,6 +76,17 @@ Messages::AudioServer::GetSampleRateResponse ClientConnection::get_sample_rate()
 void ClientConnection::set_sample_rate(u16 sample_rate)
 {
     m_mixer.audiodevice_set_sample_rate(sample_rate);
+}
+
+Messages::AudioServer::GetSelfVolumeResponse ClientConnection::get_self_volume()
+{
+    return m_queue->volume().target();
+}
+
+void ClientConnection::set_self_volume(double volume)
+{
+    if (m_queue)
+        m_queue->set_volume(volume);
 }
 
 Messages::AudioServer::EnqueueBufferResponse ClientConnection::enqueue_buffer(Core::AnonymousBuffer const& buffer, i32 buffer_id, int sample_count)

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -28,7 +28,7 @@ public:
 
     void did_finish_playing_buffer(Badge<BufferQueue>, int buffer_id);
     void did_change_muted_state(Badge<Mixer>, bool muted);
-    void did_change_main_mix_volume(Badge<Mixer>, int volume);
+    void did_change_main_mix_volume(Badge<Mixer>, double volume);
 
     virtual void die() override;
 
@@ -36,7 +36,7 @@ public:
 
 private:
     virtual Messages::AudioServer::GetMainMixVolumeResponse get_main_mix_volume() override;
-    virtual void set_main_mix_volume(i32) override;
+    virtual void set_main_mix_volume(double) override;
     virtual Messages::AudioServer::EnqueueBufferResponse enqueue_buffer(Core::AnonymousBuffer const&, i32, int) override;
     virtual Messages::AudioServer::GetRemainingSamplesResponse get_remaining_samples() override;
     virtual Messages::AudioServer::GetPlayedSamplesResponse get_played_samples() override;

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -17,7 +17,7 @@ class Buffer;
 
 namespace AudioServer {
 
-class BufferQueue;
+class ClientAudioStream;
 class Mixer;
 
 class ClientConnection final : public IPC::ClientConnection<AudioClientEndpoint, AudioServerEndpoint> {
@@ -49,7 +49,7 @@ private:
     virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
 
     Mixer& m_mixer;
-    RefPtr<BufferQueue> m_queue;
+    RefPtr<ClientAudioStream> m_queue;
 };
 
 }

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -26,7 +26,8 @@ public:
     explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id, Mixer& mixer);
     ~ClientConnection() override;
 
-    void did_finish_playing_buffer(Badge<BufferQueue>, int buffer_id);
+    void did_finish_playing_buffer(Badge<ClientAudioStream>, int buffer_id);
+    void did_change_client_volume(Badge<ClientAudioStream>, double volume);
     void did_change_muted_state(Badge<Mixer>, bool muted);
     void did_change_main_mix_volume(Badge<Mixer>, double volume);
 
@@ -37,6 +38,8 @@ public:
 private:
     virtual Messages::AudioServer::GetMainMixVolumeResponse get_main_mix_volume() override;
     virtual void set_main_mix_volume(double) override;
+    virtual Messages::AudioServer::GetSelfVolumeResponse get_self_volume() override;
+    virtual void set_self_volume(double) override;
     virtual Messages::AudioServer::EnqueueBufferResponse enqueue_buffer(Core::AnonymousBuffer const&, i32, int) override;
     virtual Messages::AudioServer::GetRemainingSamplesResponse get_remaining_samples() override;
     virtual Messages::AudioServer::GetPlayedSamplesResponse get_played_samples() override;

--- a/Userland/Services/AudioServer/FadingProperty.h
+++ b/Userland/Services/AudioServer/FadingProperty.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Mixer.h"
+#include <compare>
+
+namespace AudioServer {
+
+// This is in buffer counts.
+// As each buffer is approx 1/40 of a second, this means about 1/4 of a second of fade time.
+constexpr int DEFAULT_FADE_TIME = 10;
+
+// A property of an audio system that needs to fade briefly whenever changed.
+template<typename T>
+class FadingProperty {
+public:
+    FadingProperty(T const value)
+        : FadingProperty(value, DEFAULT_FADE_TIME)
+    {
+    }
+    FadingProperty(T const value, int const fade_time)
+        : m_old_value(value)
+        , m_new_value(move(value))
+        , m_fade_time(fade_time)
+    {
+    }
+    virtual ~FadingProperty()
+    {
+        m_old_value.~T();
+        m_new_value.~T();
+    }
+
+    FadingProperty<T>& operator=(T const& new_value)
+    {
+        // The origin of the fade is wherever we're right now.
+        m_old_value = static_cast<T>(*this);
+        m_new_value = new_value;
+        m_current_fade = 0;
+        return *this;
+    }
+    FadingProperty<T>& operator=(FadingProperty<T> const&) = delete;
+
+    operator T() const
+    {
+        if (!is_fading())
+            return m_new_value;
+        return m_old_value * (1 - m_current_fade) + m_new_value * (m_current_fade);
+    }
+
+    auto operator<=>(FadingProperty<T> const& other) const
+    {
+        return static_cast<T>(this) <=> static_cast<T>(other);
+    }
+
+    auto operator<=>(T const& other) const
+    {
+        return static_cast<T>(*this) <=> other;
+    }
+
+    void advance_time()
+    {
+        m_current_fade += 1.0 / static_cast<double>(m_fade_time);
+        m_current_fade = clamp(m_current_fade, 0.0, 1.0);
+    }
+
+    bool is_fading() const
+    {
+        return m_current_fade < 1;
+    }
+
+    T target() const { return m_new_value; }
+
+private:
+    T m_old_value {};
+    T m_new_value {};
+    double m_current_fade { 0 };
+    int const m_fade_time;
+};
+
+}

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -49,9 +49,9 @@ Mixer::~Mixer()
 {
 }
 
-NonnullRefPtr<BufferQueue> Mixer::create_queue(ClientConnection& client)
+NonnullRefPtr<ClientAudioStream> Mixer::create_queue(ClientConnection& client)
 {
-    auto queue = adopt_ref(*new BufferQueue(client));
+    auto queue = adopt_ref(*new ClientAudioStream(client));
     pthread_mutex_lock(&m_pending_mutex);
     m_pending_mixing.append(*queue);
     m_added_queue = true;
@@ -191,12 +191,12 @@ void Mixer::request_setting_sync()
     }
 }
 
-BufferQueue::BufferQueue(ClientConnection& client)
+ClientAudioStream::ClientAudioStream(ClientConnection& client)
     : m_client(client)
 {
 }
 
-void BufferQueue::enqueue(NonnullRefPtr<Audio::Buffer>&& buffer)
+void ClientAudioStream::enqueue(NonnullRefPtr<Audio::Buffer>&& buffer)
 {
     m_remaining_samples += buffer->sample_count();
     m_queue.enqueue(move(buffer));

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -88,6 +88,7 @@ void Mixer::mix()
                 continue;
             }
             ++active_queues;
+            queue->volume().advance_time();
 
             for (int i = 0; i < mixed_buffer_length; ++i) {
                 auto& mixed_sample = mixed_buffer[i];
@@ -95,6 +96,7 @@ void Mixer::mix()
                 if (!queue->get_next_sample(sample))
                     break;
                 sample.log_multiply(SAMPLE_HEADROOM);
+                sample.log_multiply(queue->volume());
                 mixed_sample += sample;
             }
         }

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -19,8 +19,10 @@
 #include <LibAudio/Buffer.h>
 #include <LibCore/File.h>
 #include <LibCore/Timer.h>
+#include <LibThreading/ConditionVariable.h>
 #include <LibThreading/Mutex.h>
 #include <LibThreading/Thread.h>
+#include <sys/types.h>
 
 namespace AudioServer {
 
@@ -125,9 +127,8 @@ private:
     void request_setting_sync();
 
     Vector<NonnullRefPtr<ClientAudioStream>> m_pending_mixing;
-    Atomic<bool> m_added_queue { false };
-    pthread_mutex_t m_pending_mutex;
-    pthread_cond_t m_pending_cond;
+    Threading::Mutex m_pending_mutex;
+    Threading::ConditionVariable m_mixing_necessary { m_pending_mutex };
 
     RefPtr<Core::File> m_device;
 

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -30,10 +30,10 @@ constexpr double SAMPLE_HEADROOM = 0.7;
 
 class ClientConnection;
 
-class BufferQueue : public RefCounted<BufferQueue> {
+class ClientAudioStream : public RefCounted<ClientAudioStream> {
 public:
-    explicit BufferQueue(ClientConnection&);
-    ~BufferQueue() { }
+    explicit ClientAudioStream(ClientConnection&);
+    ~ClientAudioStream() { }
 
     bool is_full() const { return m_queue.size() >= 3; }
     void enqueue(NonnullRefPtr<Audio::Buffer>&&);
@@ -109,7 +109,7 @@ public:
     Mixer(NonnullRefPtr<Core::ConfigFile> config);
     virtual ~Mixer() override;
 
-    NonnullRefPtr<BufferQueue> create_queue(ClientConnection&);
+    NonnullRefPtr<ClientAudioStream> create_queue(ClientConnection&);
 
     // To the outside world, we pretend that the target volume is already reached, even though it may be still fading.
     double main_volume() const { return m_main_volume.target(); }
@@ -124,7 +124,7 @@ public:
 private:
     void request_setting_sync();
 
-    Vector<NonnullRefPtr<BufferQueue>> m_pending_mixing;
+    Vector<NonnullRefPtr<ClientAudioStream>> m_pending_mixing;
     Atomic<bool> m_added_queue { false };
     pthread_mutex_t m_pending_mutex;
     pthread_cond_t m_pending_cond;


### PR DESCRIPTION
This is a collection of fixes/QOL/improvements to all parts of the audio subsystem:
- [x] Use a 0-1 volume instead of 0-100, which simplifies linear-log transformation logic and is more intuitive to program with
- [x] Logarithmic volume instead of the half-square-half-linear thing we had before
- [x] Fix deadlocks in AudioServer so that simultaneous audio playback actually works
- [x] Prevent clicks when changing volume quickly
- [x] Prevent clipping when mixing audio by reducing all client stream's volume (adding about 24dB of headroom)
- [x] Make Piano louder (old volume logic was dumb and written by me)
- [x] Each client can have its own volume (which is also logarithmic)