### PR TITLE
WindowManager: Add Alt+F4 shortcut for windows

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1628,6 +1628,12 @@ void WindowManager::process_key_event(KeyEvent& event)
             }
         }
     }
+
+    if (event.type() == Event::KeyDown && event.modifiers() == Mod_Alt && event.key() == Key_F4 && active_input_window->type() != WindowType::Desktop) {
+        active_input_window->request_close();
+        return;
+    }
+
     active_input_window->dispatch_event(event);
 }
 


### PR DESCRIPTION
Previously, every window had to hadle the shortcut by itself.
This was done by adding the `CommonActions::make_quit_action()` to menu, but that meant that every application that didn't add it (mostly because they don't have a menu bar, like Settings windows or Assistant) didn't react on this shortcut at all.