### PR TITLE
Games: Remove unveiling /tmp/portal/config

### DIFF
--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -49,11 +49,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (unveil("/tmp/portal/config", "rw") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
     if (unveil(nullptr, nullptr) < 0) {
         perror("unveil");
         return 1;

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -38,11 +38,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (unveil("/tmp/portal/config", "rw") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
     if (unveil("/bin/ChessEngine", "x") < 0) {
         perror("unveil");
         return 1;

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -38,11 +38,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (unveil("/tmp/portal/config", "rw") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
     if (unveil(nullptr, nullptr) < 0) {
         perror("unveil");
         return 1;


### PR DESCRIPTION
Config::pledge_domains is applied before, hence /tmp/portal/config
can and should be veiled.

This is also mentioned in the comments of "OS hacking: Centralizing program configuration (with a system configuration server)" on Youtube.