### PR TITLE
Solitaire: Add Auto-Collect gameplay option

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -260,6 +260,9 @@ void Game::mousedown_event(GUI::MouseEvent& event)
                         remember_flip_for_undo(top_card);
                     }
                 } else if (m_focused_cards.is_empty()) {
+                    if (is_auto_collecting() && attempt_to_move_card_to_foundations(to_check))
+                        break;
+
                     to_check.add_all_grabbed_cards(click_location, m_focused_cards);
                     m_mouse_down_location = click_location;
                     to_check.set_focused(true);

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -40,6 +40,9 @@ public:
     void setup(Mode);
     void perform_undo();
 
+    bool is_auto_collecting() const { return m_auto_collect; }
+    void set_auto_collect(bool collect) { m_auto_collect = collect; }
+
     Function<void(uint32_t)> on_score_update;
     Function<void()> on_game_start;
     Function<void(GameOverReason, uint32_t)> on_game_end;
@@ -208,6 +211,8 @@ private:
 
     uint32_t m_score { 0 };
     uint8_t m_passes_left_before_punishment { 0 };
+
+    bool m_auto_collect { false };
 };
 
 }

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -186,6 +186,15 @@ int main(int argc, char** argv)
     three_card_draw_action->set_status_tip("Draw three cards at a time");
     draw_setting_actions.add_action(three_card_draw_action);
 
+    game.set_auto_collect(Config::read_bool("Solitaire", "Settings", "AutoCollect", false));
+    auto toggle_auto_collect_action = GUI::Action::create_checkable("Auto-&Collect", [&](auto& action) {
+        auto checked = action.is_checked();
+        game.set_auto_collect(checked);
+        Config::write_bool("Solitaire", "Settings", "AutoCollect", checked);
+    });
+    toggle_auto_collect_action->set_checked(game.is_auto_collecting());
+    toggle_auto_collect_action->set_status_tip("Auto-collect to foundation piles");
+
     auto& game_menu = window->add_menu("&Game");
 
     game_menu.add_action(GUI::Action::create("&New Game", { Mod_None, Key_F2 }, [&](auto&) {
@@ -200,6 +209,8 @@ int main(int argc, char** argv)
     game_menu.add_separator();
     game_menu.add_action(single_card_draw_action);
     game_menu.add_action(three_card_draw_action);
+    game_menu.add_separator();
+    game_menu.add_action(toggle_auto_collect_action);
     game_menu.add_separator();
     game_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
 


### PR DESCRIPTION
Add the option for players to enable automatic collection of eligible cards to their foundation pile with a single click of that card.