### PR TITLE
PixelPaint: Add ability to draw shapes from center

### DIFF
--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -37,11 +37,11 @@ void EllipseTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start_p
         ellipse_intersecting_rect = Gfx::IntRect::from_two_points(start_position, end_position);
     }
 
-    switch (m_mode) {
-    case Mode::Outline:
+    switch (m_fill_mode) {
+    case FillMode::Outline:
         painter.draw_ellipse_intersecting(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), m_thickness);
         break;
-    case Mode::Fill:
+    case FillMode::Fill:
         painter.fill_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button));
         break;
     default:
@@ -148,10 +148,10 @@ GUI::Widget* EllipseTool::get_properties_widget()
         auto& fill_mode_radio = mode_radio_container.add<GUI::RadioButton>("Fill");
 
         outline_mode_radio.on_checked = [&](bool) {
-            m_mode = Mode::Outline;
+            m_fill_mode = FillMode::Outline;
         };
         fill_mode_radio.on_checked = [&](bool) {
-            m_mode = Mode::Fill;
+            m_fill_mode = FillMode::Fill;
         };
 
         outline_mode_radio.set_checked(true);

--- a/Userland/Applications/PixelPaint/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/EllipseTool.h
@@ -27,7 +27,7 @@ public:
     virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
-    enum class Mode {
+    enum class FillMode {
         Outline,
         Fill,
     };
@@ -44,7 +44,7 @@ private:
     Gfx::IntPoint m_ellipse_start_position;
     Gfx::IntPoint m_ellipse_end_position;
     int m_thickness { 1 };
-    Mode m_mode { Mode::Outline };
+    FillMode m_fill_mode { FillMode::Outline };
     DrawMode m_draw_mode { DrawMode::FromCorner };
 };
 

--- a/Userland/Applications/PixelPaint/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/EllipseTool.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -31,7 +32,12 @@ private:
         Fill,
     };
 
-    void draw_using(GUI::Painter&, Gfx::IntRect const&);
+    enum class DrawMode {
+        FromCenter,
+        FromCorner,
+    };
+
+    void draw_using(GUI::Painter&, Gfx::IntPoint const& start_position, Gfx::IntPoint const& end_position);
 
     RefPtr<GUI::Widget> m_properties_widget;
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
@@ -39,6 +45,7 @@ private:
     Gfx::IntPoint m_ellipse_end_position;
     int m_thickness { 1 };
     Mode m_mode { Mode::Outline };
+    DrawMode m_draw_mode { DrawMode::FromCorner };
 };
 
 }

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -36,14 +36,14 @@ void RectangleTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start
         rect = Gfx::IntRect::from_two_points(start_position, end_position);
     }
 
-    switch (m_mode) {
-    case Mode::Fill:
+    switch (m_fill_mode) {
+    case FillMode::Fill:
         painter.fill_rect(rect, m_editor->color_for(m_drawing_button));
         break;
-    case Mode::Outline:
+    case FillMode::Outline:
         painter.draw_rect(rect, m_editor->color_for(m_drawing_button));
         break;
-    case Mode::Gradient:
+    case FillMode::Gradient:
         painter.fill_rect_with_gradient(rect, m_editor->primary_color(), m_editor->secondary_color());
         break;
     default:
@@ -138,13 +138,13 @@ GUI::Widget* RectangleTool::get_properties_widget()
         auto& gradient_mode_radio = mode_radio_container.add<GUI::RadioButton>("Gradient");
 
         outline_mode_radio.on_checked = [&](bool) {
-            m_mode = Mode::Outline;
+            m_fill_mode = FillMode::Outline;
         };
         fill_mode_radio.on_checked = [&](bool) {
-            m_mode = Mode::Fill;
+            m_fill_mode = FillMode::Fill;
         };
         gradient_mode_radio.on_checked = [&](bool) {
-            m_mode = Mode::Gradient;
+            m_fill_mode = FillMode::Gradient;
         };
 
         outline_mode_radio.set_checked(true);

--- a/Userland/Applications/PixelPaint/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/RectangleTool.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -32,13 +33,19 @@ private:
         Gradient,
     };
 
-    void draw_using(GUI::Painter&, Gfx::IntRect const&);
+    enum class DrawMode {
+        FromCenter,
+        FromCorner,
+    };
+
+    void draw_using(GUI::Painter&, Gfx::IntPoint const& start_position, Gfx::IntPoint const& end_position);
 
     RefPtr<GUI::Widget> m_properties_widget;
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
     Gfx::IntPoint m_rectangle_start_position;
     Gfx::IntPoint m_rectangle_end_position;
     Mode m_mode { Mode::Outline };
+    DrawMode m_draw_mode { DrawMode::FromCorner };
 };
 
 }

--- a/Userland/Applications/PixelPaint/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/RectangleTool.h
@@ -27,7 +27,7 @@ public:
     virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
-    enum class Mode {
+    enum class FillMode {
         Outline,
         Fill,
         Gradient,
@@ -44,7 +44,7 @@ private:
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
     Gfx::IntPoint m_rectangle_start_position;
     Gfx::IntPoint m_rectangle_end_position;
-    Mode m_mode { Mode::Outline };
+    FillMode m_fill_mode { FillMode::Outline };
     DrawMode m_draw_mode { DrawMode::FromCorner };
 };
 


### PR DESCRIPTION
Previously, when using`EllipseTool` or `RectangleTool`, you could only draw shapes by defining the two corners of the bounding boxes (based on the start/end position of the mouse). Now, you can press `alt` when drawing either of the shapes to interpret the start position of the mouse as the center of the object. 

This is useful if you want to draw a sphere / rectangle centered around a point, since there's no visual indication of the center to be able to move it to the right place. The `alt` convention is from other image editing software I have used.

Perhaps this should also be implemented for `RectangleSelectionTool`, but there's already a mechanism right now to move by center so I didn't do so right now. If anyone thinks it would be a good addition I'm more than happy to add it.

PS: This is my first commit here, so please let me know if I'm doing something wrong. Still trying to get my editing workflow to a good place :^)