### PR TITLE
HexEditor: Use LibConfig instead of Core::ConfigFile

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -20,4 +20,4 @@ set(SOURCES
 )
 
 serenity_app(HexEditor ICON app-hex-editor)
-target_link_libraries(HexEditor LibGUI)
+target_link_libraries(HexEditor LibGUI LibConfig)

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -33,8 +33,6 @@ private:
 
     virtual void drop_event(GUI::DropEvent&) override;
 
-    RefPtr<Core::ConfigFile> m_config;
-
     RefPtr<HexEditor> m_editor;
     String m_path;
     String m_name;

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "HexEditorWidget.h"
+#include <LibConfig/Client.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
 #include <stdio.h>
@@ -18,6 +19,8 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
+
+    Config::pledge_domains("HexEditor");
 
     if (pledge("stdio recvfd sendfd rpath cpath wpath thread", nullptr) < 0) {
         perror("pledge");


### PR DESCRIPTION
This also allows us to get rid of the `RefPtr<Core::ConfigFile>` stored inside the `HexEditorWidget`, pretty neat :^)