### PR TITLE
LibVT: Add movemouse support for triple click

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -869,8 +869,21 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
         m_auto_scroll_direction = AutoScrollDirection::None;
 
     VT::Position old_selection_end = m_selection.end();
-    m_selection.set_end(position);
-    if (old_selection_end != m_selection.end()) {
+    VT::Position old_selection_start = m_selection.start();
+
+    if (m_triple_click_timer.is_valid()) {
+        int start_column = 0;
+        int end_column = m_terminal.columns() - 1;
+
+        if (position.row() < m_left_mousedown_position_buffer.row())
+            m_selection.set({ position.row(), start_column }, { m_left_mousedown_position_buffer.row(), end_column });
+        else
+            m_selection.set({ m_left_mousedown_position_buffer.row(), start_column }, { position.row(), end_column });
+    } else {
+        m_selection.set_end(position);
+    }
+
+    if (old_selection_end != m_selection.end() || old_selection_start != m_selection.start()) {
         update_copy_action();
         update();
     }

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -783,8 +783,9 @@ void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Left) {
         m_left_mousedown_position = event.position();
+        m_left_mousedown_position_buffer = buffer_position_at(m_left_mousedown_position);
 
-        auto attribute = m_terminal.attribute_at(buffer_position_at(event.position()));
+        auto attribute = m_terminal.attribute_at(m_left_mousedown_position_buffer);
         if (!(event.modifiers() & Mod_Shift) && !attribute.href.is_empty()) {
             m_active_href = attribute.href;
             m_active_href_id = attribute.href_id;
@@ -798,10 +799,9 @@ void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
             int start_column = 0;
             int end_column = m_terminal.columns() - 1;
 
-            auto position = buffer_position_at(event.position());
-            m_selection.set({ position.row(), start_column }, { position.row(), end_column });
+            m_selection.set({ m_left_mousedown_position_buffer.row(), start_column }, { m_left_mousedown_position_buffer.row(), end_column });
         } else {
-            m_selection.set(buffer_position_at(event.position()), {});
+            m_selection.set(m_left_mousedown_position_buffer, {});
         }
         if (m_alt_key_held)
             m_rectangle_selection = true;

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -218,6 +218,7 @@ private:
     Core::ElapsedTimer m_triple_click_timer;
 
     Gfx::IntPoint m_left_mousedown_position;
+    VT::Position m_left_mousedown_position_buffer;
 };
 
 }


### PR DESCRIPTION
When moving the mouse after a triple click, the selected buffer does not
maintain the whole line selection. This patch will allow triple click
highlighting to hold the whole line selection.