### PR TITLE
ClipboardHistory: Use a config file to get number of history items

### DIFF
--- a/Userland/Applets/ClipboardHistory/CMakeLists.txt
+++ b/Userland/Applets/ClipboardHistory/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_app(ClipboardHistory.Applet ICON edit-copy)
-target_link_libraries(ClipboardHistory.Applet LibGUI LibCore LibGfx)
+target_link_libraries(ClipboardHistory.Applet LibGUI LibCore LibGfx LibConfig)

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -1,16 +1,23 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "ClipboardHistoryModel.h"
+#include <LibConfig/Client.h>
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
 
 NonnullRefPtr<ClipboardHistoryModel> ClipboardHistoryModel::create()
 {
     return adopt_ref(*new ClipboardHistoryModel());
+}
+
+ClipboardHistoryModel::ClipboardHistoryModel()
+    : m_history_limit(Config::read_i32("ClipboardHistory", "ClipboardHistory", "NumHistoryItems", 20))
+{
 }
 
 ClipboardHistoryModel::~ClipboardHistoryModel()

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -8,11 +8,13 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibConfig/Listener.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/Model.h>
 
 class ClipboardHistoryModel final : public GUI::Model
-    , public GUI::Clipboard::ClipboardClient {
+    , public GUI::Clipboard::ClipboardClient
+    , public Config::Listener {
 public:
     static NonnullRefPtr<ClipboardHistoryModel> create();
 
@@ -27,6 +29,9 @@ public:
 
     const GUI::Clipboard::DataAndType& item_at(int index) const { return m_history_items[index]; }
     void remove_item(int index);
+
+    // ^Config::Listener
+    virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override;
 
 private:
     ClipboardHistoryModel();

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,6 +29,7 @@ public:
     void remove_item(int index);
 
 private:
+    ClipboardHistoryModel();
     void add_item(const GUI::Clipboard::DataAndType& item);
 
     // ^GUI::Model
@@ -40,5 +42,5 @@ private:
     virtual void clipboard_content_did_change(const String&) override { add_item(GUI::Clipboard::the().data_and_type()); }
 
     Vector<GUI::Clipboard::DataAndType> m_history_items;
-    size_t m_history_limit { 20 };
+    size_t m_history_limit;
 };

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ClipboardHistoryModel.h"
+#include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/ImageWidget.h>
@@ -22,6 +23,8 @@ int main(int argc, char* argv[])
     }
 
     auto app = GUI::Application::construct(argc, argv);
+
+    Config::pledge_domains("ClipboardHistory");
 
     if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
         perror("pledge");

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char* argv[])
     auto app = GUI::Application::construct(argc, argv);
 
     Config::pledge_domains("ClipboardHistory");
+    Config::monitor_domain("ClipboardHistory");
 
     if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
         perror("pledge");


### PR DESCRIPTION
We now use LibConfig to read the number of items to store in clipboard history, and also use a listener to see if this config changes.

Note: Once we have the `config_i32_did_change` API, the listener here should be updated to use that. For now we are just attempting string-to-int conversion.