### PR TITLE
HackStudio: Add "Go Back" and "Go Forward" navigation actions 

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -236,7 +236,7 @@ Vector<String> HackStudioWidget::selected_file_paths() const
     return files;
 }
 
-bool HackStudioWidget::open_file(const String& full_filename)
+bool HackStudioWidget::open_file(const String& full_filename, size_t line, size_t column)
 {
     String filename = full_filename;
     if (full_filename.starts_with(project().root_path())) {
@@ -298,6 +298,7 @@ bool HackStudioWidget::open_file(const String& full_filename)
 
     current_editor().on_cursor_change = [this] { update_statusbar(); };
     current_editor_wrapper().on_change = [this] { update_gml_preview(); };
+    current_editor().set_cursor(line, column);
     update_gml_preview();
 
     return true;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -41,7 +41,9 @@ public:
     void update_actions();
     Project& project();
     GUI::TextEditor& current_editor();
+    GUI::TextEditor const& current_editor() const;
     EditorWrapper& current_editor_wrapper();
+    EditorWrapper const& current_editor_wrapper() const;
     void set_current_editor_wrapper(RefPtr<EditorWrapper>);
 
     const String& active_file() const { return m_current_editor_wrapper->filename(); }
@@ -93,6 +95,7 @@ private:
     NonnullRefPtr<GUI::Action> create_build_action();
     NonnullRefPtr<GUI::Action> create_run_action();
     NonnullRefPtr<GUI::Action> create_stop_action();
+    void create_location_history_actions();
 
     void add_new_editor(GUI::Widget& parent);
     RefPtr<EditorWrapper> get_editor_of_file(const String& filename);
@@ -128,6 +131,16 @@ private:
     void update_gml_preview();
     void update_tree_view();
     void update_window_title();
+    void on_cursor_change();
+
+    struct ProjectLocation {
+        String filename;
+        size_t line { 0 };
+        size_t column { 0 };
+    };
+
+    ProjectLocation current_project_location() const;
+    void update_history_actions();
 
     NonnullRefPtrVector<EditorWrapper> m_all_editor_wrappers;
     RefPtr<EditorWrapper> m_current_editor_wrapper;
@@ -137,6 +150,12 @@ private:
     Vector<String> m_open_files_vector; // NOTE: This contains the keys from m_open_files and m_file_watchers
 
     OwnPtr<Project> m_project;
+
+    Vector<ProjectLocation> m_locations_history;
+    // This index is the boundary between the "Go Back" and "Go Forward" locations.
+    // It always points at one past the current location in the list.
+    size_t m_locations_history_end_index { 0 };
+    bool m_locations_history_disabled { false };
 
     RefPtr<GUI::TreeView> m_project_tree_view;
     RefPtr<GUI::ListView> m_open_files_view;
@@ -181,6 +200,8 @@ private:
     RefPtr<GUI::Action> m_debug_action;
     RefPtr<GUI::Action> m_build_action;
     RefPtr<GUI::Action> m_run_action;
+    RefPtr<GUI::Action> m_locations_history_back_action;
+    RefPtr<GUI::Action> m_locations_history_forward_action;
 
     GUI::ActionGroup m_wrapping_mode_actions;
     RefPtr<GUI::Action> m_no_wrapping_action;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -34,7 +34,8 @@ class HackStudioWidget : public GUI::Widget {
 
 public:
     virtual ~HackStudioWidget() override;
-    bool open_file(const String& filename);
+
+    bool open_file(String const& filename, size_t line = 0, size_t column = 0);
     void close_file_in_all_editors(String const& filename);
 
     void update_actions();

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -132,8 +132,7 @@ void open_file(const String& filename)
 
 void open_file(const String& filename, size_t line, size_t column)
 {
-    s_hack_studio_widget->open_file(filename);
-    s_hack_studio_widget->current_editor_wrapper().editor().set_cursor({ line, column });
+    s_hack_studio_widget->open_file(filename, line, column);
 }
 
 RefPtr<EditorWrapper> current_editor_wrapper()


### PR DESCRIPTION
These actions allow the user to move backwards & forwards between previous project locations they were at.
It's something I find myself using quite a lot in CLion & was missing in HackStudio.