### PR TITLE
Everywhere: Use the Optional<T>::operator==(T) operator in a few places

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -307,7 +307,7 @@ void LayerListWidget::relayout_gadgets()
     for (auto& gadget : m_gadgets) {
         if (gadget.is_moving)
             continue;
-        if (hole_index.has_value() && index == hole_index.value())
+        if (index == hole_index)
             y += vertical_step;
         gadget.rect = { 0, y, widget_inner_rect().width(), gadget_height };
         y += vertical_step;

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -218,7 +218,7 @@ void TabWidget::paint_event(PaintEvent& event)
     for (size_t i = 0; i < m_tabs.size(); ++i) {
         if (m_tabs[i].widget == m_active_widget)
             continue;
-        bool hovered = m_hovered_tab_index.has_value() && i == m_hovered_tab_index.value();
+        bool hovered = i == m_hovered_tab_index;
         auto button_rect = this->button_rect(i);
         Gfx::StylePainter::paint_tab_button(painter, button_rect, palette(), false, hovered, m_tabs[i].widget->is_enabled(), m_tab_position == TabPosition::Top, window()->is_active());
         auto tab_button_content_rect = button_rect.translated(4, m_tab_position == TabPosition::Top ? 1 : 0);
@@ -237,7 +237,7 @@ void TabWidget::paint_event(PaintEvent& event)
     for (size_t i = 0; i < m_tabs.size(); ++i) {
         if (m_tabs[i].widget != m_active_widget)
             continue;
-        bool hovered = m_hovered_tab_index.has_value() && i == m_hovered_tab_index.value();
+        bool hovered = i == m_hovered_tab_index;
         auto button_rect = this->button_rect(i);
         Gfx::StylePainter::paint_tab_button(painter, button_rect, palette(), true, hovered, m_tabs[i].widget->is_enabled(), m_tab_position == TabPosition::Top, window()->is_active());
         auto tab_button_content_rect = button_rect.translated(4, m_tab_position == TabPosition::Top ? 1 : 0);
@@ -270,8 +270,8 @@ void TabWidget::paint_event(PaintEvent& event)
         return;
 
     for (size_t i = 0; i < m_tabs.size(); ++i) {
-        bool hovered_close_button = m_hovered_close_button_index.has_value() && i == m_hovered_close_button_index.value();
-        bool pressed_close_button = m_pressed_close_button_index.has_value() && i == m_pressed_close_button_index.value();
+        bool hovered_close_button = i == m_hovered_close_button_index;
+        bool pressed_close_button = i == m_pressed_close_button_index;
         auto close_button_rect = this->close_button_rect(i);
 
         if (hovered_close_button)


### PR DESCRIPTION
Just updating a few instances in the code which doesn't use the `==` operator defined for Optional types. 

In general, I think `opt == x` looks much nicer than `opt.has_value() && opt.value() == x`, so I'm updating 
the remaining few instances I could find with some regex magic in my search.