### PR TITLE
Games: Remove wpath and cpath pledges and pledge earlier in some cases

### DIFF
--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -25,7 +25,7 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath wpath cpath recvfd sendfd unix", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd unix", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
 
     Config::pledge_domains("2048");
 
-    if (pledge("stdio rpath recvfd sendfd wpath cpath", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -20,11 +20,12 @@
 
 int main(int argc, char** argv)
 {
-    auto app = GUI::Application::construct(argc, argv);
-    auto app_icon = GUI::Icon::default_icon("app-chess");
+    if (pledge("stdio rpath wpath cpath recvfd sendfd thread proc exec unix", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
 
-    auto window = GUI::Window::construct();
-    auto& widget = window->set_main_widget<ChessWidget>();
+    auto app = GUI::Application::construct(argc, argv);
 
     Config::pledge_domains("Chess");
 
@@ -32,6 +33,11 @@ int main(int argc, char** argv)
         perror("pledge");
         return 1;
     }
+
+    auto app_icon = GUI::Icon::default_icon("app-chess");
+
+    auto window = GUI::Window::construct();
+    auto& widget = window->set_main_widget<ChessWidget>();
 
     if (unveil("/res", "r") < 0) {
         perror("unveil");

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -16,7 +16,7 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath wpath cpath recvfd sendfd unix", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd unix", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -18,12 +18,34 @@
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/ToolbarContainer.h>
 #include <LibGUI/Window.h>
+#include <unistd.h>
 
 const char* click_tip = "Tip: click the board to toggle individual cells, or click+drag to toggle multiple cells";
 
 int main(int argc, char** argv)
 {
+    if (pledge("stdio rpath recvfd sendfd unix", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
     auto app = GUI::Application::construct(argc, argv);
+
+    if (pledge("stdio rpath recvfd sendfd", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    if (unveil("/res", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil(nullptr, nullptr) < 0) {
+        perror("unveil");
+        return 1;
+    }
+
     auto app_icon = GUI::Icon::default_icon("app-gameoflife");
 
     auto window = GUI::Window::construct();

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -21,7 +21,7 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath wpath cpath recvfd sendfd unix", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd unix", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
 
     Config::pledge_domains("Minesweeper");
 
-    if (pledge("stdio rpath wpath cpath recvfd sendfd", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -15,14 +15,14 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath wpath cpath recvfd sendfd unix", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd unix", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio rpath wpath cpath recvfd sendfd", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -19,7 +19,7 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath wpath cpath recvfd sendfd unix", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd unix", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
 
     Config::pledge_domains("Snake");
 
-    if (pledge("stdio rpath wpath cpath recvfd sendfd", nullptr) < 0) {
+    if (pledge("stdio rpath recvfd sendfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -23,12 +23,17 @@
 
 int main(int argc, char** argv)
 {
+    if (pledge("stdio recvfd sendfd rpath unix", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
     auto app = GUI::Application::construct(argc, argv);
     auto app_icon = GUI::Icon::default_icon("app-solitaire");
 
     Config::pledge_domains("Solitaire");
 
-    if (pledge("stdio recvfd sendfd rpath wpath cpath", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -38,12 +38,17 @@ static String format_seconds(uint64_t seconds_elapsed)
 
 int main(int argc, char** argv)
 {
+    if (pledge("stdio recvfd sendfd rpath unix", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
     auto app = GUI::Application::construct(argc, argv);
     auto app_icon = GUI::Icon::default_icon("app-spider");
 
     Config::pledge_domains("Spider");
 
-    if (pledge("stdio recvfd sendfd rpath wpath cpath", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
With the move to LibConfig, the wpath and cpath pledges are no longer
needed.

In the case of GameOfLife, this adds pledge and unveil :^)

This doesn't touch Hearts as it does not use LibConfig just yet (which will change with #9635)
It also does not touch Chess as they are required for import/export PGM.