### PR TITLE
LibWeb: A bunch of fixes that are actually very related to text layouting and only tangentially related to the web

### DIFF
--- a/Userland/Libraries/LibGfx/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/BitmapFont.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/CharacterTypes.h>
 #include <AK/MappedFile.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
@@ -45,7 +46,13 @@ public:
     Glyph glyph(u32 code_point) const override;
     bool contains_glyph(u32 code_point) const override { return code_point < (u32)glyph_count() && m_glyph_widths[code_point] > 0; }
 
-    u8 glyph_width(size_t ch) const override { return m_fixed_width ? m_glyph_width : m_glyph_widths[ch]; }
+    u8 glyph_width(size_t ch) const override
+    {
+        if (is_ascii(ch) && !is_ascii_printable(ch))
+            return 0;
+
+        return m_fixed_width ? m_glyph_width : m_glyph_widths[ch];
+    }
     ALWAYS_INLINE int glyph_or_emoji_width(u32 code_point) const override
     {
         if (m_fixed_width)

--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/Utf8View.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LineBox.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
-#include <ctype.h>
 
 namespace Web::Layout {
 
@@ -40,16 +40,20 @@ void LineBox::trim_trailing_whitespace()
     if (m_fragments.is_empty())
         return;
 
-    auto last_text = m_fragments.last().text();
+    auto& last_fragment = m_fragments.last();
+    auto last_text = last_fragment.text();
     if (last_text.is_null())
         return;
-    auto& last_fragment = m_fragments.last();
 
-    int space_width = last_fragment.layout_node().font().glyph_width(' ');
-    while (last_fragment.length() && isspace(last_text[last_fragment.length() - 1])) {
+    while (last_fragment.length()) {
+        auto last_character = last_text[last_fragment.length() - 1];
+        if (!is_ascii_space(last_character))
+            break;
+
+        int last_character_width = last_fragment.layout_node().font().glyph_width(last_character);
         last_fragment.m_length -= 1;
-        last_fragment.set_width(last_fragment.width() - space_width);
-        m_width -= space_width;
+        last_fragment.set_width(last_fragment.width() - last_character_width);
+        m_width -= last_character_width;
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -41,7 +41,7 @@ public:
         Optional<Chunk> next();
 
     private:
-        Optional<Chunk> try_commit_chunk(Utf8View::Iterator const&, bool has_breaking_newline, bool must_commit = false);
+        Optional<Chunk> try_commit_chunk(Utf8View::Iterator const& start, Utf8View::Iterator const& end, bool has_breaking_newline, bool must_commit = false);
 
         const LayoutMode m_layout_mode;
         const bool m_wrap_lines;
@@ -49,7 +49,6 @@ public:
         bool m_last_was_space { false };
         bool m_last_was_newline { false };
         Utf8View m_utf8_view;
-        Utf8View::Iterator m_start_of_chunk;
         Utf8View::Iterator m_iterator;
     };
 

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -37,7 +37,7 @@ public:
 
     class ChunkIterator {
     public:
-        ChunkIterator(StringView const& text, LayoutMode, bool wrap_lines, bool wrap_breaks);
+        ChunkIterator(StringView const& text, LayoutMode, bool wrap_lines, bool respect_linebreaks);
         Optional<Chunk> next();
 
     private:
@@ -45,7 +45,7 @@ public:
 
         const LayoutMode m_layout_mode;
         const bool m_wrap_lines;
-        const bool m_wrap_breaks;
+        const bool m_respect_linebreaks;
         bool m_last_was_space { false };
         bool m_last_was_newline { false };
         Utf8View m_utf8_view;
@@ -60,7 +60,7 @@ private:
     virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
-    void split_into_lines_by_rules(InlineFormattingContext&, LayoutMode, bool do_collapse, bool do_wrap_lines, bool do_wrap_breaks);
+    void split_into_lines_by_rules(InlineFormattingContext&, LayoutMode, bool do_collapse, bool do_wrap_lines, bool do_respect_linebreaks);
     void paint_cursor_if_needed(PaintContext&, const LineBoxFragment&) const;
     void paint_text_decoration(Gfx::Painter&, LineBoxFragment const&) const;
 


### PR DESCRIPTION
All boogs fixed, no moar boogs.

![image](https://user-images.githubusercontent.com/77421532/131203058-a022b735-84c1-4b92-9b5e-bf1dea79c922.png)

Fixes #9415.

**LibWeb: Refactor TextNode::ChunkIterator**

This commit refactors the text chunking algorithm used in
TextNode::ChunkIterator. The m_start_of_chunk member parameter has been
replaced with a local variable that's anchored to the current iterator
at the start of every next() call, and the algorithm is made a little
more clear by explicitly separating what can and cannot peek into the
next character during iteration.

**LibWeb: Rename wrap_breaks to respect_linebreaks**

This more clearly expresses the purpose of this flag. Since only
CSS::WhiteSpace::Nowrap sets this value to false and it does not respect
linebreaks, this made the most sense as a flag name.

**LibGfx: Return 0 width for non-printable ASCII characters**

Non-printable characters should always have a width of 0. This is not
true for some characters like tab, but those can be exempted as the need
arises. Doing this here saves us from a bunch of checks in any place
that needs to figure out glyph widths for text which can contain
non-printable characters.

**LibWeb: Properly handle newlines at the end of LineBoxes**

This always subtracted the glyph width of a space, despite isspace
also accepting newlines and a few other characters. It now also uses
AK/CharacterTypes.h. :^)
