### PR TITLE
shot: Get only cropped region from WindowServer

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -973,7 +973,8 @@ Messages::WindowServer::GetScreenBitmapResponse ClientConnection::get_screen_bit
         return bitmap.to_shareable_bitmap();
     }
     // TODO: Mixed scale setups at what scale? Lowest? Highest? Configurable?
-    if (auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, Screen::bounding_rect().size(), 1)) {
+    auto bitmap_size = rect.value_or(Screen::bounding_rect()).size();
+    if (auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, bitmap_size, 1)) {
         Gfx::Painter painter(*bitmap);
         Screen::for_each([&](auto& screen) {
             auto screen_rect = screen.rect();

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -131,17 +131,13 @@ int main(int argc, char** argv)
     if (screen >= 0)
         screen_index = (u32)screen;
     dbgln("getting screenshot...");
-    auto shared_bitmap = GUI::WindowServerConnection::the().get_screen_bitmap({}, screen_index);
+    auto shared_bitmap = GUI::WindowServerConnection::the().get_screen_bitmap(crop_region, screen_index);
     dbgln("got screenshot");
 
     RefPtr<Gfx::Bitmap> bitmap = shared_bitmap.bitmap();
     if (!bitmap) {
         warnln("Failed to grab screenshot");
         return 1;
-    }
-
-    if (select_region) {
-        bitmap = bitmap->cropped(crop_region);
     }
 
     if (output_to_clipboard) {


### PR DESCRIPTION
Previously, we were always getting the full screen(s) bitmap from the WindowServer and cropping it manually. The `get_screen_bitmap` function already took in a `crop_region`, so we are now utilizing that.

The first commit fixes a bug in `WindowServer` which didn't properly crop the image when a specific screen index was not provided.