### PR TITLE
PixelPaint: Always change cursor when active tool is set

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -318,6 +318,7 @@ void ImageEditor::set_active_tool(Tool* tool)
         m_active_tool->setup(*this);
         m_active_tool->on_tool_activation();
         m_active_cursor = m_active_tool->cursor();
+        set_override_cursor(m_active_cursor);
     }
 }
 


### PR DESCRIPTION
Previously, if you used one of the keyboard shortcuts to select a
different tool, it didn't change the cursor to the corresponding
one till you clicked somewhere / did something else to trigger an
update. This was pretty jarring since there's no indication as to
whether the tool change was successful or not.

This patch just calls `set_override_cursor()` when a valid active
tool is set to immediately update it.