### PR TITLE
LibCore: Store ObjectRegistration names as StringViews

### DIFF
--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -250,15 +250,15 @@ void Object::set_event_filter(Function<bool(Core::Event&)> filter)
     m_event_filter = move(filter);
 }
 
-static HashMap<String, ObjectClassRegistration*>& object_classes()
+static HashMap<StringView, ObjectClassRegistration*>& object_classes()
 {
-    static HashMap<String, ObjectClassRegistration*>* map;
+    static HashMap<StringView, ObjectClassRegistration*>* map;
     if (!map)
-        map = new HashMap<String, ObjectClassRegistration*>;
+        map = new HashMap<StringView, ObjectClassRegistration*>;
     return *map;
 }
 
-ObjectClassRegistration::ObjectClassRegistration(const String& class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class)
+ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class)
     : m_class_name(class_name)
     , m_factory(move(factory))
     , m_parent_class(parent_class)
@@ -286,7 +286,7 @@ void ObjectClassRegistration::for_each(Function<void(const ObjectClassRegistrati
     }
 }
 
-const ObjectClassRegistration* ObjectClassRegistration::find(const String& class_name)
+const ObjectClassRegistration* ObjectClassRegistration::find(StringView class_name)
 {
     return object_classes().get(class_name).value_or(nullptr);
 }

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -32,7 +32,7 @@ class ObjectClassRegistration {
     AK_MAKE_NONMOVABLE(ObjectClassRegistration);
 
 public:
-    ObjectClassRegistration(const String& class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
+    ObjectClassRegistration(StringView class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
     ~ObjectClassRegistration();
 
     String class_name() const { return m_class_name; }
@@ -41,10 +41,10 @@ public:
     bool is_derived_from(const ObjectClassRegistration& base_class) const;
 
     static void for_each(Function<void(const ObjectClassRegistration&)>);
-    static const ObjectClassRegistration* find(const String& class_name);
+    static const ObjectClassRegistration* find(StringView class_name);
 
 private:
-    String m_class_name;
+    StringView m_class_name;
     Function<NonnullRefPtr<Object>()> m_factory;
     ObjectClassRegistration* m_parent_class { nullptr };
 };


### PR DESCRIPTION
We don't need to be allocating Strings for these names during static
initialization. The C-string literals will be stored in the .rodata ELF
section, so they're not going anywhere. We can just wrap the .rodata
storage for the class names in StringViews and use those in Object
registration and lookup APIs.