### PR TITLE
UserspaceEmulator+LibELF: Fix `ue` profiling, optimize LibELF symbol lookup.

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -476,7 +476,7 @@ void Emulator::emit_profile_sample(AK::OutputStream& output)
     gettimeofday(&tv, nullptr);
     builder.appendff(R"~(, {{"type": "sample", "pid": {}, "tid": {}, "timestamp": {}, "lost_samples": 0, "stack": [)~", getpid(), gettid(), tv.tv_sec * 1000 + tv.tv_usec / 1000);
     builder.join(',', raw_backtrace());
-    builder.append("]}");
+    builder.append("]}\n");
     output.write_or_error(builder.string_view().bytes());
 }
 
@@ -486,6 +486,7 @@ void Emulator::emit_profile_event(AK::OutputStream& output, StringView event_nam
     timeval tv {};
     gettimeofday(&tv, nullptr);
     builder.appendff(R"~(, {{"type": "{}", "pid": {}, "tid": {}, "timestamp": {}, "lost_samples": 0, "stack": [], {}}})~", event_name, getpid(), gettid(), tv.tv_sec * 1000 + tv.tv_usec / 1000, contents);
+    builder.append('\n');
     output.write_or_error(builder.string_view().bytes());
 }
 

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv, char** env)
     rc = emulator.exec();
 
     if (dump_profile)
-        emulator.profile_stream().write_or_error(R"(]})"sv.bytes());
+        emulator.profile_stream().write_or_error(R"(], "strings": []})"sv.bytes());
 
     return rc;
 }


### PR DESCRIPTION
 LibELF: Apply some minor optimizations to symbol lookup

Optimizations:

- Make sure `DT_SYMTAB` is a string view literal, instead of string.

- DynamicObject::HashSection::lookup_sysv_symbol should be using
  raw_name() from symbol comparison to avoid needlessly calling
  `strlen`, when the StrinView::operator= walks the cstring without
  calling `strlen` first.

- DynamicObject::HashSection::lookup_gnu_symbol shouldn't create a
  symbol unless we know the hashes match first.

In order to test these changes I enabled Undefined behavior sanitizer
which creates a huge amount of relocations, and then ran the browser
with the help argument 100 times. The browser is a fairly big app with
a few different libraries being loaded, so it seemed liked a good
target.

Command: `time -n 100 br --help`

Before:
```
Timing report:
==============
Command:         br --help
Average time:    3897.679931 ms
Excluding first: 3901.242431 ms
```

After:
```
Timing report:
==============
Command:         br --help
Average time:    3612.860107 ms
Excluding first: 3613.54541  ms
```