### PR TITLE
LibCore+LibGUI: Have two version numbers in LibCore and allow applications to override the version in `AboutDialog`.

### DIFF
--- a/Userland/Applications/About/main.cpp
+++ b/Userland/Applications/About/main.cpp
@@ -32,6 +32,6 @@ int main(int argc, char** argv)
     unveil(nullptr, nullptr);
 
     auto app_icon = GUI::Icon::default_icon("ladyball");
-    GUI::AboutDialog::show("SerenityOS", app_icon.bitmap_for_size(32), nullptr, app_icon.bitmap_for_size(16));
+    GUI::AboutDialog::show("SerenityOS", app_icon.bitmap_for_size(32), nullptr, app_icon.bitmap_for_size(16), Core::Version::read_long_version_string());
     return app->exec();
 }

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -7,7 +7,7 @@
 #include <AK/Format.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/ConfigFile.h>
+#include <LibCore/Version.h>
 #include <getopt.h>
 #include <limits.h>
 #include <math.h>
@@ -245,16 +245,7 @@ void ArgsParser::print_usage(FILE* file, const char* argv0)
 
 void ArgsParser::print_version(FILE* file)
 {
-    auto version_config = Core::ConfigFile::open("/res/version.ini");
-    auto major_version = version_config->read_entry("Version", "Major", "0");
-    auto minor_version = version_config->read_entry("Version", "Minor", "0");
-
-    StringBuilder builder;
-    builder.appendff("{}.{}", major_version, minor_version);
-    if (auto git_version = version_config->read_entry("Version", "Git", ""); git_version != "")
-        builder.appendff(".g{}", git_version);
-
-    outln(file, builder.to_string());
+    outln(file, Core::Version::SERENITY_VERSION);
 }
 
 void ArgsParser::add_option(Option&& option)

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     Timer.cpp
     UDPServer.cpp
     UDPSocket.cpp
+    Version.cpp
 )
 
 serenity_lib(LibCore core)

--- a/Userland/Libraries/LibCore/Version.cpp
+++ b/Userland/Libraries/LibCore/Version.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ConfigFile.h>
+#include <LibCore/Version.h>
+
+namespace Core::Version {
+
+String read_long_version_string()
+{
+    auto version_config = Core::ConfigFile::open("/res/version.ini");
+    auto major_version = version_config->read_entry("Version", "Major", "0");
+    auto minor_version = version_config->read_entry("Version", "Minor", "0");
+
+    StringBuilder builder;
+    builder.appendff("Version {}.{}", major_version, minor_version);
+    if (auto git_version = version_config->read_entry("Version", "Git", ""); git_version != "")
+        builder.appendff(".g{}", git_version);
+    return builder.to_string();
+}
+
+}

--- a/Userland/Libraries/LibCore/Version.h
+++ b/Userland/Libraries/LibCore/Version.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace Core::Version {
+
+constexpr StringView SERENITY_VERSION = "Version 1.0"sv;
+
+}

--- a/Userland/Libraries/LibCore/Version.h
+++ b/Userland/Libraries/LibCore/Version.h
@@ -12,4 +12,6 @@ namespace Core::Version {
 
 constexpr StringView SERENITY_VERSION = "Version 1.0"sv;
 
+String read_long_version_string();
+
 }

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <AK/StringBuilder.h>
-#include <LibCore/ConfigFile.h>
+#include <LibCore/Version.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -92,15 +92,7 @@ AboutDialog::~AboutDialog()
 
 String AboutDialog::version_string() const
 {
-    auto version_config = Core::ConfigFile::open("/res/version.ini");
-    auto major_version = version_config->read_entry("Version", "Major", "0");
-    auto minor_version = version_config->read_entry("Version", "Minor", "0");
-
-    StringBuilder builder;
-    builder.appendff("Version {}.{}", major_version, minor_version);
-    if (auto git_version = version_config->read_entry("Version", "Git", ""); git_version != "")
-        builder.appendff(".g{}", git_version);
-    return builder.to_string();
+    return Core::Version::SERENITY_VERSION;
 }
 
 }

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/StringBuilder.h>
-#include <LibCore/Version.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -17,10 +16,11 @@
 
 namespace GUI {
 
-AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window* parent_window)
+AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window* parent_window, const StringView& version)
     : Dialog(parent_window)
     , m_name(name)
     , m_icon(icon)
+    , m_version_string(version)
 {
     resize(413, 204);
     set_title(String::formatted("About {}", m_name));
@@ -70,7 +70,7 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
     // If we are displaying a dialog for an application, insert 'SerenityOS' below the application name
     if (m_name != "SerenityOS")
         make_label("SerenityOS");
-    make_label(version_string());
+    make_label(m_version_string);
     make_label("Copyright \xC2\xA9 the SerenityOS developers, 2018-2021");
 
     right_container.layout()->add_spacer();
@@ -88,11 +88,6 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
 
 AboutDialog::~AboutDialog()
 {
-}
-
-String AboutDialog::version_string() const
-{
-    return Core::Version::SERENITY_VERSION;
 }
 
 }

--- a/Userland/Libraries/LibGUI/AboutDialog.h
+++ b/Userland/Libraries/LibGUI/AboutDialog.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibCore/Version.h>
 #include <LibGUI/Dialog.h>
 
 namespace GUI {
@@ -15,19 +16,19 @@ class AboutDialog final : public Dialog {
 public:
     virtual ~AboutDialog() override;
 
-    static void show(const StringView& name, const Gfx::Bitmap* icon = nullptr, Window* parent_window = nullptr, const Gfx::Bitmap* window_icon = nullptr)
+    static void show(const StringView& name, const Gfx::Bitmap* icon = nullptr, Window* parent_window = nullptr, const Gfx::Bitmap* window_icon = nullptr, const StringView& version = Core::Version::SERENITY_VERSION)
     {
-        auto dialog = AboutDialog::construct(name, icon, parent_window);
+        auto dialog = AboutDialog::construct(name, icon, parent_window, version);
         if (window_icon)
             dialog->set_icon(window_icon);
         dialog->exec();
     }
 
 private:
-    AboutDialog(const StringView& name, const Gfx::Bitmap* icon = nullptr, Window* parent_window = nullptr);
-    String version_string() const;
+    AboutDialog(const StringView& name, const Gfx::Bitmap* icon = nullptr, Window* parent_window = nullptr, const StringView& version = Core::Version::SERENITY_VERSION);
 
     String m_name;
     RefPtr<Gfx::Bitmap> m_icon;
+    String m_version_string;
 };
 }


### PR DESCRIPTION
This PR solves two problems with the `--version` argument with `ArgsParser`.

1. Some utilities did not have `rpath` pledged, so accessing `/res/version.ini` was prohibited.
2. Some utilities unveiled parts of the file system so the `version.ini` file was not accessible, which resulted in `ArgsParser` falling back to version `0.0`.

The solution is proposed by refactoring a version reading from `/res/version.ini` utility and have a constant `SERENITY_VERSION` and put both in a `Core::Version` namespace. Applications that use `ArgsParser` and `AboutDialog` will have `SERENITY_VERSION` by default with the option to override it in `AboutDialog`, which is used in `Userland/Applications/About`. 