### PR TITLE
Config CLI: Handle missing config values correctly

### DIFF
--- a/Userland/Utilities/config.cpp
+++ b/Userland/Utilities/config.cpp
@@ -29,8 +29,9 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    auto value = Config::read_string(domain, group, key);
-    outln("{}", value);
-
+    auto value_or_error = Config::Client::the().read_string_value(domain, group, key);
+    if (!value_or_error.has_value())
+        return 1;
+    outln("{}", value_or_error.value());
     return 0;
 }


### PR DESCRIPTION
If the domain/group/key doesn't exist in the config, exit with
non-zero status and don't print out anything.

Previously the CLI would print a single empty line if the config
value was not found with LibConfig. Now, we use the proper
`Config::Client::the().read_string()` API which can return an
`Optional` type indicating failure.`

This behaviour is more consistent with the `ini` utility, which
also doesn't print out an empty line when an entry is not found.