### PR TITLE
LibJS: Add class fields and other small fixes

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -933,6 +933,30 @@ private:
     bool m_is_static;
 };
 
+class ClassField final : public ASTNode {
+public:
+    ClassField(SourceRange source_range, NonnullRefPtr<Expression> key, RefPtr<Expression> init, bool is_static)
+        : ASTNode(source_range)
+        , m_key(move(key))
+        , m_initializer(move(init))
+        , m_is_static(is_static)
+    {
+    }
+
+    Expression const& key() const { return *m_key; }
+    bool is_static() const { return m_is_static; }
+    RefPtr<Expression> const& initializer() const { return m_initializer; }
+    RefPtr<Expression>& initializer() { return m_initializer; }
+
+    virtual Value execute(Interpreter&, GlobalObject&) const override;
+    virtual void dump(int indent) const override;
+
+private:
+    NonnullRefPtr<Expression> m_key;
+    RefPtr<Expression> m_initializer;
+    bool m_is_static;
+};
+
 class SuperExpression final : public Expression {
 public:
     explicit SuperExpression(SourceRange source_range)
@@ -948,12 +972,13 @@ public:
 
 class ClassExpression final : public Expression {
 public:
-    ClassExpression(SourceRange source_range, String name, RefPtr<FunctionExpression> constructor, RefPtr<Expression> super_class, NonnullRefPtrVector<ClassMethod> methods)
+    ClassExpression(SourceRange source_range, String name, RefPtr<FunctionExpression> constructor, RefPtr<Expression> super_class, NonnullRefPtrVector<ClassMethod> methods, NonnullRefPtrVector<ClassField> fields)
         : Expression(source_range)
         , m_name(move(name))
         , m_constructor(move(constructor))
         , m_super_class(move(super_class))
         , m_methods(move(methods))
+        , m_fields(move(fields))
     {
     }
 
@@ -968,6 +993,7 @@ private:
     RefPtr<FunctionExpression> m_constructor;
     RefPtr<Expression> m_super_class;
     NonnullRefPtrVector<ClassMethod> m_methods;
+    NonnullRefPtrVector<ClassField> m_fields;
 };
 
 class ClassDeclaration final : public Declaration {

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -258,6 +258,7 @@ private:
         bool in_break_context { false };
         bool in_continue_context { false };
         bool string_legacy_octal_escape_sequence_in_scope { false };
+        bool in_class_field_initializer { false };
 
         ParserState(Lexer, Program::Type);
     };

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -58,7 +58,7 @@ public:
 
     NonnullRefPtr<Statement> parse_statement(AllowLabelledFunction allow_labelled_function = AllowLabelledFunction::No);
     NonnullRefPtr<BlockStatement> parse_block_statement();
-    NonnullRefPtr<BlockStatement> parse_block_statement(bool& is_strict, bool error_on_binding = false);
+    NonnullRefPtr<BlockStatement> parse_block_statement(bool& is_strict, bool function_with_non_simple_parameter_list = false);
     NonnullRefPtr<ReturnStatement> parse_return_statement();
     NonnullRefPtr<VariableDeclaration> parse_variable_declaration(bool for_loop_variable_declaration = false);
     NonnullRefPtr<Statement> parse_for_statement();
@@ -180,6 +180,8 @@ private:
     void discard_saved_state();
     Position position() const;
 
+    Token next_token();
+
     void check_identifier_name_for_assignment_validity(StringView, bool force_strict = false);
 
     bool try_parse_arrow_function_expression_failed_at_position(const Position&) const;
@@ -245,7 +247,7 @@ private:
 
         Vector<Vector<FunctionNode::Parameter>&> function_parameters;
 
-        HashTable<StringView> labels_in_scope;
+        HashMap<StringView, bool> labels_in_scope;
         bool strict_mode { false };
         bool allow_super_property_lookup { false };
         bool allow_super_constructor_call { false };

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -63,6 +63,17 @@ public:
     // This is for IsSimpleParameterList (static semantics)
     bool has_simple_parameter_list() const { return m_has_simple_parameter_list; }
 
+    // [[Fields]]
+    struct InstanceField {
+        StringOrSymbol name;
+        FunctionObject* initializer { nullptr };
+
+        void define_field(VM& vm, Object& receiver) const;
+    };
+
+    Vector<InstanceField> const& fields() const { return m_fields; }
+    void add_field(StringOrSymbol property_key, FunctionObject* initializer);
+
 protected:
     virtual void visit_edges(Visitor&) override;
 
@@ -79,6 +90,7 @@ private:
     ConstructorKind m_constructor_kind = ConstructorKind::Base;
     ThisMode m_this_mode { ThisMode::Global };
     bool m_has_simple_parameter_list { false };
+    Vector<InstanceField> m_fields;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -267,6 +267,8 @@ public:
     Function<void(const Promise&)> on_promise_unhandled_rejection;
     Function<void(const Promise&)> on_promise_rejection_handled;
 
+    void initialize_instance_elements(Object& object, FunctionObject& constructor);
+
 private:
     VM();
 

--- a/Userland/Libraries/LibJS/Tests/classes/class-public-fields.js
+++ b/Userland/Libraries/LibJS/Tests/classes/class-public-fields.js
@@ -1,0 +1,87 @@
+test("basic functionality", () => {
+    class A {
+        number = 3;
+
+        string = "foo";
+
+        uninitialized;
+    }
+
+    const a = new A();
+    expect(a.number).toBe(3);
+    expect(a.string).toBe("foo");
+    expect(a.uninitialized).toBeUndefined();
+});
+
+test("extended name syntax", () => {
+    class A {
+        "field with space" = 1;
+
+        12 = "twelve";
+
+        [`he${"llo"}`] = 3;
+    }
+
+    const a = new A();
+    expect(a["field with space"]).toBe(1);
+    expect(a[12]).toBe("twelve");
+    expect(a.hello).toBe(3);
+});
+
+test("initializer has correct this value", () => {
+    class A {
+        this_val = this;
+
+        this_name = this.this_val;
+    }
+
+    const a = new A();
+    expect(a.this_val).toBe(a);
+    expect(a.this_name).toBe(a);
+});
+
+test("static fields", () => {
+    class A {
+        static simple = 1;
+        simple = 2;
+
+        static "with space" = 3;
+
+        static 24 = "two dozen";
+
+        static [`he${"llo"}`] = "friends";
+
+        static this_val = this;
+        static this_name = this.name;
+        static this_val2 = this.this_val;
+    }
+
+    expect(A.simple).toBe(1);
+    expect(A["with space"]).toBe(3);
+    expect(A[24]).toBe("two dozen");
+    expect(A.hello).toBe("friends");
+
+    expect(A.this_val).toBe(A);
+    expect(A.this_name).toBe("A");
+    expect(A.this_val2).toBe(A);
+
+    const a = new A();
+    expect(a.simple).toBe(2);
+});
+
+test("with super class", () => {
+    class A {
+        super_field = 3;
+    }
+
+    class B extends A {
+        references_super_field = super.super_field;
+        arrow_ref_super = () => (super.super_field = 4);
+    }
+
+    const b = new B();
+    expect(b.super_field).toBe(3);
+    expect(b.references_super_field).toBeUndefined();
+    b.arrow_ref_super();
+    expect(b.super_field).toBe(4);
+});


### PR DESCRIPTION
Was working on some class fixes and implemented fields, thought just private fields was ecma 2022 spec but public fields is as well. Whoops.
Example:
```javascript
class A {
  value = 3

  static also_possible = true;
}

new A().value === 3
```

We still do a small number of things wrong like `NamedEvaluation` things but that is a more general issue so I just left that.