### PR TITLE
GameOfLife: Don't enable rotate button if a pattern isn't selected

### DIFF
--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -28,6 +28,8 @@ BoardWidget::BoardWidget(size_t rows, size_t columns)
 
     on_pattern_selection = [this](auto* pattern) {
         m_selected_pattern = pattern;
+        if (on_pattern_selection_state_change)
+            on_pattern_selection_state_change();
     };
 
     setup_patterns();
@@ -245,6 +247,8 @@ void BoardWidget::place_pattern(size_t row, size_t column)
         y_offset++;
     }
     m_selected_pattern = nullptr;
+    if (on_pattern_selection_state_change)
+        on_pattern_selection_state_change();
     if (m_pattern_preview_timer->is_active())
         m_pattern_preview_timer->stop();
 }

--- a/Userland/Games/GameOfLife/BoardWidget.h
+++ b/Userland/Games/GameOfLife/BoardWidget.h
@@ -66,6 +66,7 @@ public:
 
     Function<void()> on_running_state_change;
     Function<void()> on_stall;
+    Function<void()> on_pattern_selection_state_change;
     Function<void(Board*, size_t row, size_t column)> on_cell_toggled;
 
 private:

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -127,9 +127,9 @@ int main(int argc, char** argv)
     main_toolbar.add_action(randomize_cells_action);
 
     auto rotate_pattern_action = GUI::Action::create("&Rotate pattern", { 0, Key_R }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/redo.png"), [&](auto&) {
-        if (board_widget.selected_pattern() != nullptr)
-            board_widget.selected_pattern()->rotate_clockwise();
+        board_widget.selected_pattern()->rotate_clockwise();
     });
+    rotate_pattern_action->set_enabled(false);
     main_toolbar.add_action(rotate_pattern_action);
 
     auto& game_menu = window->add_menu("&Game");
@@ -178,6 +178,10 @@ int main(int argc, char** argv)
 
     board_widget.on_cell_toggled = [&](auto, auto, auto) {
         statusbar.set_text(click_tip);
+    };
+
+    board_widget.on_pattern_selection_state_change = [&] {
+        rotate_pattern_action->set_enabled(board_widget.selected_pattern() != nullptr);
     };
 
     window->resize(500, 420);


### PR DESCRIPTION
Pattern rotation button is enabled all the time, regardless of the user selecting a pattern, which is confusing to new users.(it was to me at least :)). 

This is how it looks with the changes:
![S1](https://user-images.githubusercontent.com/30195912/131228612-6e947aee-e73b-471c-9108-1a9f572bcc69.png)

![S2](https://user-images.githubusercontent.com/30195912/131228614-fc1a7a87-169a-4115-8bfe-3ba73fe891ea.png)
