### PR TITLE
LibJS+LibUnicode: Parse, validate, and canonicalize Unicode locale extensions

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -99,6 +99,8 @@ constexpr T ceil_div(T a, U b)
 template<typename T, typename U>
 inline void swap(T& a, U& b)
 {
+    if (&a == &b)
+        return;
     U tmp = move((U&)a);
     a = (T &&) move(b);
     b = move(tmp);

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -51,6 +51,7 @@ set(AK_TEST_SOURCES
     TestSourceLocation.cpp
     TestSpan.cpp
     TestStack.cpp
+    TestStdLibExtras.cpp
     TestString.cpp
     TestStringUtils.cpp
     TestStringView.cpp

--- a/Tests/AK/TestStdLibExtras.cpp
+++ b/Tests/AK/TestStdLibExtras.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestSuite.h>
+
+#include <AK/Optional.h>
+#include <AK/StdLibExtras.h>
+#include <AK/StringView.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+
+TEST_CASE(swap)
+{
+    int i = 4;
+    int j = 6;
+
+    swap(i, j);
+
+    EXPECT_EQ(i, 6);
+    EXPECT_EQ(j, 4);
+}
+
+TEST_CASE(swap_same_value)
+{
+
+    int i = 4;
+    swap(i, i);
+    EXPECT_EQ(i, 4);
+}
+
+TEST_CASE(swap_same_complex_object)
+{
+    struct Type1 {
+        StringView foo;
+    };
+    struct Type2 {
+        Optional<Type1> foo;
+        Vector<Type1> bar;
+    };
+
+    Variant<Type1, Type2> value1 { Type1 { "hello"sv } };
+    Variant<Type1, Type2> value2 { Type2 { {}, { { "goodbye"sv } } } };
+
+    swap(value1, value2);
+
+    EXPECT(value1.has<Type2>());
+    EXPECT(value2.has<Type1>());
+
+    swap(value1, value1);
+
+    EXPECT(value1.has<Type2>());
+    EXPECT(value2.has<Type1>());
+}

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -323,8 +323,15 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("en-z-bbb-0-aaa"sv, "en-0-aaa-z-bbb"sv);
     test("EN-Z-BBB-0-AAA"sv, "en-0-aaa-z-bbb"sv);
 
+    test("en-x-aa"sv, "en-x-aa"sv);
+    test("EN-X-AA"sv, "en-x-aa"sv);
+    test("en-x-bbb-aa"sv, "en-x-bbb-aa"sv);
+    test("EN-X-BBB-AA"sv, "en-x-bbb-aa"sv);
+
     test("en-u-aa-t-en"sv, "en-t-en-u-aa"sv);
     test("EN-U-AA-T-EN"sv, "en-t-en-u-aa"sv);
     test("en-z-bbb-u-aa-t-en-0-aaa"sv, "en-0-aaa-t-en-u-aa-z-bbb"sv);
     test("EN-Z-BBB-U-AA-T-EN-0-AAA"sv, "en-0-aaa-t-en-u-aa-z-bbb"sv);
+    test("en-z-bbb-u-aa-t-en-0-aaa-x-ccc"sv, "en-0-aaa-t-en-u-aa-z-bbb-x-ccc"sv);
+    test("EN-Z-BBB-U-AA-T-EN-0-AAA-X-CCC"sv, "en-0-aaa-t-en-u-aa-z-bbb-x-ccc"sv);
 }

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -212,6 +212,40 @@ TEST_CASE(parse_unicode_locale_id_with_transformed_extension)
     pass("en-t-en-k0-aaa"sv, { Unicode::LanguageID { false, "en"sv }, { { "k0"sv, { "aaa"sv } } } });
 }
 
+TEST_CASE(parse_unicode_locale_id_with_other_extension)
+{
+    auto fail = [](StringView locale) {
+        auto locale_id = Unicode::parse_unicode_locale_id(locale);
+        EXPECT(!locale_id.has_value());
+    };
+    auto pass = [](StringView locale, Unicode::OtherExtension const& expected_extension) {
+        auto locale_id = Unicode::parse_unicode_locale_id(locale);
+        VERIFY(locale_id.has_value());
+        EXPECT_EQ(locale_id->extensions.size(), 1u);
+
+        auto const& actual_extension = locale_id->extensions[0].get<Unicode::OtherExtension>();
+        EXPECT_EQ(actual_extension.key, expected_extension.key);
+        EXPECT_EQ(actual_extension.values, expected_extension.values);
+    };
+
+    fail("en-z"sv);
+    fail("en-0"sv);
+    fail("en-z-"sv);
+    fail("en-0-"sv);
+    fail("en-z-a"sv);
+    fail("en-0-a"sv);
+    fail("en-z-aaaaaaaaa"sv);
+    fail("en-0-aaaaaaaaa"sv);
+    fail("en-z-aaa-"sv);
+    fail("en-0-aaa-"sv);
+    fail("en-z-aaa-a"sv);
+    fail("en-0-aaa-a"sv);
+
+    pass("en-z-aa", { 'z', { "aa"sv } });
+    pass("en-z-aa-bbb", { 'z', { "aa"sv, "bbb"sv } });
+    pass("en-z-aa-bbb-cccccccc", { 'z', { "aa"sv, "bbb"sv, "cccccccc"sv } });
+}
+
 TEST_CASE(canonicalize_unicode_locale_id)
 {
     auto test = [](StringView locale, StringView expected_canonical_locale) {

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -277,7 +277,7 @@ TEST_CASE(canonicalize_unicode_locale_id)
         VERIFY(locale_id.has_value());
 
         auto canonical_locale = Unicode::canonicalize_unicode_locale_id(*locale_id);
-        EXPECT_EQ(canonical_locale, expected_canonical_locale);
+        EXPECT_EQ(*canonical_locale, expected_canonical_locale);
     };
 
     test("aaa"sv, "aaa"sv);
@@ -287,4 +287,44 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("aaa-bBBB-cC"sv, "aaa-Bbbb-CC"sv);
     test("aaa-bbbb-cc-1234"sv, "aaa-Bbbb-CC-1234"sv);
     test("aaa-bbbb-cc-ABCDE"sv, "aaa-Bbbb-CC-abcde"sv);
+
+    test("en-u-aa"sv, "en-u-aa"sv);
+    test("EN-U-AA"sv, "en-u-aa"sv);
+    test("en-u-aa-bbb"sv, "en-u-aa-bbb"sv);
+    test("EN-U-AA-BBB"sv, "en-u-aa-bbb"sv);
+    test("en-u-aa-ccc-bbb"sv, "en-u-aa-ccc-bbb"sv);
+    test("EN-U-AA-CCC-BBB"sv, "en-u-aa-ccc-bbb"sv);
+    test("en-u-ddd-bbb-ccc"sv, "en-u-bbb-ccc-ddd"sv);
+    test("EN-U-DDD-BBB-CCC"sv, "en-u-bbb-ccc-ddd"sv);
+    test("en-u-2k-aaa-1k-bbb"sv, "en-u-1k-bbb-2k-aaa"sv);
+    test("EN-U-2K-AAA-1K-BBB"sv, "en-u-1k-bbb-2k-aaa"sv);
+    test("en-u-ccc-bbb-2k-aaa-1k-bbb"sv, "en-u-bbb-ccc-1k-bbb-2k-aaa"sv);
+    test("EN-U-CCC-BBB-2K-AAA-1K-BBB"sv, "en-u-bbb-ccc-1k-bbb-2k-aaa"sv);
+    test("en-u-1k-true"sv, "en-u-1k"sv);
+    test("EN-U-1K-TRUE"sv, "en-u-1k"sv);
+
+    test("en-t-en"sv, "en-t-en"sv);
+    test("EN-T-EN"sv, "en-t-en"sv);
+    test("en-latn-t-en-latn"sv, "en-Latn-t-en-latn"sv);
+    test("EN-LATN-T-EN-LATN"sv, "en-Latn-t-en-latn"sv);
+    test("en-us-t-en-us"sv, "en-US-t-en-us"sv);
+    test("EN-US-T-EN-US"sv, "en-US-t-en-us"sv);
+    test("en-latn-us-t-en-latn-us"sv, "en-Latn-US-t-en-latn-us"sv);
+    test("EN-LATN-US-T-EN-LATN-US"sv, "en-Latn-US-t-en-latn-us"sv);
+    test("en-t-en-k2-bbb-k1-aaa"sv, "en-t-en-k1-aaa-k2-bbb"sv);
+    test("EN-T-EN-K2-BBB-K1-AAA"sv, "en-t-en-k1-aaa-k2-bbb"sv);
+    test("en-t-k1-true"sv, "en-t-k1-true"sv);
+    test("EN-T-K1-TRUE"sv, "en-t-k1-true"sv);
+
+    test("en-0-aaa"sv, "en-0-aaa"sv);
+    test("EN-0-AAA"sv, "en-0-aaa"sv);
+    test("en-0-bbb-aaa"sv, "en-0-bbb-aaa"sv);
+    test("EN-0-BBB-AAA"sv, "en-0-bbb-aaa"sv);
+    test("en-z-bbb-0-aaa"sv, "en-0-aaa-z-bbb"sv);
+    test("EN-Z-BBB-0-AAA"sv, "en-0-aaa-z-bbb"sv);
+
+    test("en-u-aa-t-en"sv, "en-t-en-u-aa"sv);
+    test("EN-U-AA-T-EN"sv, "en-t-en-u-aa"sv);
+    test("en-z-bbb-u-aa-t-en-0-aaa"sv, "en-0-aaa-t-en-u-aa-z-bbb"sv);
+    test("EN-Z-BBB-U-AA-T-EN-0-AAA"sv, "en-0-aaa-t-en-u-aa-z-bbb"sv);
 }

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -246,6 +246,30 @@ TEST_CASE(parse_unicode_locale_id_with_other_extension)
     pass("en-z-aa-bbb-cccccccc", { 'z', { "aa"sv, "bbb"sv, "cccccccc"sv } });
 }
 
+TEST_CASE(parse_unicode_locale_id_with_private_use_extension)
+{
+    auto fail = [](StringView locale) {
+        auto locale_id = Unicode::parse_unicode_locale_id(locale);
+        EXPECT(!locale_id.has_value());
+    };
+    auto pass = [](StringView locale, Vector<StringView> const& expected_extension) {
+        auto locale_id = Unicode::parse_unicode_locale_id(locale);
+        VERIFY(locale_id.has_value());
+        EXPECT_EQ(locale_id->private_use_extensions, expected_extension);
+    };
+
+    fail("en-x"sv);
+    fail("en-x-"sv);
+    fail("en-x-aaaaaaaaa"sv);
+    fail("en-x-aaa-"sv);
+    fail("en-x-aaa-aaaaaaaaa"sv);
+
+    pass("en-x-a", { "a"sv });
+    pass("en-x-aaaaaaaa", { "aaaaaaaa"sv });
+    pass("en-x-aaa-bbb", { "aaa"sv, "bbb"sv });
+    pass("en-x-aaa-x-bbb", { "aaa"sv, "x"sv, "bbb"sv });
+}
+
 TEST_CASE(canonicalize_unicode_locale_id)
 {
     auto test = [](StringView locale, StringView expected_canonical_locale) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
@@ -45,6 +45,29 @@ describe("errors", () => {
             Intl.getCanonicalLocales([true]);
         }).toThrowWithMessage(TypeError, "true is neither an object nor a string");
     });
+
+    test("duplicate extension components", () => {
+        expect(() => {
+            Intl.getCanonicalLocales("en-u-aa-U-aa");
+        }).toThrowWithMessage(RangeError, "en-u-aa-U-aa is not a structurally valid language tag");
+
+        expect(() => {
+            Intl.getCanonicalLocales("en-t-aa-T-aa");
+        }).toThrowWithMessage(RangeError, "en-t-aa-T-aa is not a structurally valid language tag");
+
+        expect(() => {
+            Intl.getCanonicalLocales("en-z-aa-Z-aa");
+        }).toThrowWithMessage(RangeError, "en-z-aa-Z-aa is not a structurally valid language tag");
+    });
+
+    test("duplicate transformed extension variant subtags", () => {
+        expect(() => {
+            Intl.getCanonicalLocales("en-t-en-POSIX-POSIX");
+        }).toThrowWithMessage(
+            RangeError,
+            "en-t-en-POSIX-POSIX is not a structurally valid language tag"
+        );
+    });
 });
 
 describe("normal behavior", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
@@ -96,4 +96,16 @@ describe("normal behavior", () => {
         expect(Intl.getCanonicalLocales(true)).toEqual([]);
         expect(Intl.getCanonicalLocales(123)).toEqual([]);
     });
+
+    test("duplicate Unicode locale extension attributes", () => {
+        expect(Intl.getCanonicalLocales("en-us-u-aaa-aaa")).toEqual(["en-US-u-aaa"]);
+        expect(Intl.getCanonicalLocales("en-us-u-aaa-bbb-aaa")).toEqual(["en-US-u-aaa-bbb"]);
+    });
+
+    test("duplicate Unicode locale extension keywords", () => {
+        expect(Intl.getCanonicalLocales("en-us-u-1k-aaa-1k-bbb")).toEqual(["en-US-u-1k-aaa"]);
+        expect(Intl.getCanonicalLocales("en-us-u-1k-aaa-2k-ccc-1k-bbb")).toEqual([
+            "en-US-u-1k-aaa-2k-ccc",
+        ]);
+    });
 });

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -580,7 +580,11 @@ Optional<String> canonicalize_unicode_locale_id(LocaleID& locale_id)
             });
     }
 
-    // FIXME: Handle pu_extensions.
+    if (!locale_id.private_use_extensions.is_empty()) {
+        builder.append("-x"sv);
+        for (auto const& extension : locale_id.private_use_extensions)
+            append_sep_and_string(extension);
+    }
 
     return builder.build();
 }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
 
@@ -22,8 +23,21 @@ struct LanguageID {
     Vector<StringView> variants {};
 };
 
+struct Keyword {
+    StringView key {};
+    Vector<StringView> types {};
+};
+
+struct LocaleExtension {
+    Vector<StringView> attributes {};
+    Vector<Keyword> keywords {};
+};
+
+using Extension = Variant<LocaleExtension>;
+
 struct LocaleID {
     LanguageID language_id {};
+    Vector<Extension> extensions {};
 };
 
 // Note: These methods only verify that the provided strings match the EBNF grammar of the

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -53,6 +53,7 @@ using Extension = Variant<LocaleExtension, TransformedExtension, OtherExtension>
 struct LocaleID {
     LanguageID language_id {};
     Vector<Extension> extensions {};
+    Vector<StringView> private_use_extensions {};
 };
 
 // Note: These methods only verify that the provided strings match the EBNF grammar of the

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -33,7 +33,17 @@ struct LocaleExtension {
     Vector<Keyword> keywords {};
 };
 
-using Extension = Variant<LocaleExtension>;
+struct TransformedField {
+    StringView key;
+    Vector<StringView> values {};
+};
+
+struct TransformedExtension {
+    Optional<LanguageID> language {};
+    Vector<TransformedField> fields {};
+};
+
+using Extension = Variant<LocaleExtension, TransformedExtension>;
 
 struct LocaleID {
     LanguageID language_id {};

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -43,7 +43,12 @@ struct TransformedExtension {
     Vector<TransformedField> fields {};
 };
 
-using Extension = Variant<LocaleExtension, TransformedExtension>;
+struct OtherExtension {
+    char key {};
+    Vector<StringView> values {};
+};
+
+using Extension = Variant<LocaleExtension, TransformedExtension, OtherExtension>;
 
 struct LocaleID {
     LanguageID language_id {};


### PR DESCRIPTION
In the first round of `Intl` changes, I marked anything having to do with extensions and private use extensions with a FIXME. This PR begins to address those FIXMEs:
* LibUnicode: Parse Unicode locale, transformed, other, and private use extensions
* LibUnicode: Canonicalize the above extensions
* LibJS: Reject structurally invalid extensions
* LibJS: Perform additional canonicalization which Unicode TR35 does not perform

There's still a few FIXMEs to address in `Intl`'s abstract operations, but there's enough here to pass...5...new test262 tests :smiley: 