### PR TITLE
Kernel/Userland: Expose usb device address and use it in `lsusb`

### DIFF
--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -29,6 +29,7 @@ KResultOr<size_t> SysFSUSBDeviceInformation::read_bytes(off_t offset, size_t cou
     JsonArraySerializer array { builder };
 
     auto obj = array.add_object();
+    obj.add("device_address", m_device->address());
     obj.add("usb_spec_compliance_bcd", m_device->device_descriptor().usb_spec_compliance_bcd);
     obj.add("device_class", m_device->device_descriptor().device_class);
     obj.add("device_sub_class", m_device->device_descriptor().device_sub_class);

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -53,7 +53,6 @@ int main(int argc, char** argv)
         auto full_path = LexicalPath(usb_devices.next_full_path());
 
         auto proc_usb_device = Core::File::construct(full_path.string());
-        auto bus_id = proc_usb_device->filename().split('/').last();
         if (!proc_usb_device->open(Core::OpenMode::ReadOnly)) {
             warnln("Failed to open {}: {}", proc_usb_device->name(), proc_usb_device->error_string());
             continue;
@@ -63,9 +62,10 @@ int main(int argc, char** argv)
         auto json = JsonValue::from_string(contents);
         VERIFY(json.has_value());
 
-        json.value().as_array().for_each([bus_id, usb_db](auto& value) {
+        json.value().as_array().for_each([usb_db](auto& value) {
             auto& device_descriptor = value.as_object();
 
+            auto device_address = device_descriptor.get("device_address").to_u32();
             auto vendor_id = device_descriptor.get("vendor_id").to_u32();
             auto product_id = device_descriptor.get("product_id").to_u32();
 
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
             if (device_string.is_empty())
                 device_string = "Unknown Device";
 
-            outln("Device {}: ID {:04x}:{:04x} {} {}", bus_id, vendor_id, product_id, vendor_string, device_string);
+            outln("Device {}: ID {:04x}:{:04x} {} {}", device_address, vendor_id, product_id, vendor_string, device_string);
         });
     }
 


### PR DESCRIPTION
We now expose the `USBDevice`'s address in the SysFS object. This means
that device addresses are no longer determined by the name of the file
in the `/bus/usb/` directory. This was an incorrect way of determining
device address, as a standard PC can have multiple USB controllers
(and hence multiple buses) that can have overlapping device IDs.