### PR TITLE
FileOperation: Deduplicate destination file names on copy

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -174,11 +174,6 @@ void do_paste(String const& target_directory, GUI::Window* window)
             dbgln("Cannot paste URI {}", uri_as_string);
             continue;
         }
-
-        auto new_path = String::formatted("{}/{}", target_directory, url.basename());
-        if (url.path() == new_path)
-            continue;
-
         source_paths.append(url.path());
     }
 


### PR DESCRIPTION
When there is a file with the same name in the destination directory,
FileManager overwrites that file without any warning. With this change,
such a file will be automatically renamed to "emoji-2.txt", for example.

Also, currently there is a check in FileManager that makes copy and
paste of a file in the same directory no-op. This change removes that
check, because it is no longer a problem.