### PR TITLE
USB: Get configuration descriptors during enumeration

### DIFF
--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -178,6 +178,19 @@ KResult Device::enumerate_device()
     dbgln_if(USB_DEBUG, "USB Device: Set address to {}", m_address);
 
     memcpy(&m_device_descriptor, &dev_descriptor, sizeof(USBDeviceDescriptor));
+
+    // Get all configuration descriptors
+    for (auto configuration = 0; configuration < m_device_descriptor.num_configurations; configuration++) {
+        auto configuration_descriptor_or_error = get_descriptor<USBConfigurationDescriptor>(configuration);
+
+        if (configuration_descriptor_or_error.is_error()) {
+            dbgln("USBD: Failed to get configuration descriptor {} for device address {}", configuration, m_address);
+            return configuration_descriptor_or_error.error();
+        }
+
+        m_configurations.append(configuration_descriptor_or_error.release_value());
+    }
+
     return KSuccess;
 }
 

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -45,6 +45,10 @@ public:
     USBController& controller() { return *m_controller; }
     USBController const& controller() const { return *m_controller; }
 
+    // Fetch a descriptor from the remote device
+    template<typename T>
+    KResultOr<T> get_descriptor(size_t index);
+
 protected:
     Device(NonnullRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe);
 

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -61,6 +61,8 @@ protected:
     u16 m_product_id { 0 };                  // This device's product ID assigned by the USB group
     USBDeviceDescriptor m_device_descriptor; // Device Descriptor obtained from USB Device
 
+    Vector<USBConfigurationDescriptor> m_configurations; // List of configuration descriptors on this device
+
     NonnullRefPtr<USBController> m_controller;
     NonnullOwnPtr<Pipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration
 


### PR DESCRIPTION
Few commits here. Firstly a `template` function that can be extended to get us a descriptor from the device. This function is then used during enumeration to fetch the configurations from the device and store them for later use.