### PR TITLE
LibC: Add ensure_pledge and ensure_unveil APIs

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -201,10 +201,7 @@ private:
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd rpath wpath cpath unix", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath wpath cpath unix", nullptr);
 
     auto app = GUI::Application::construct(argc, argv);
     Config::pledge_domains({ "Audio", "AudioApplet" });
@@ -226,17 +223,10 @@ int main(int argc, char** argv)
         window->resize(44, 16);
     }
 
-    if (unveil("/res", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
+    ensure_unveil("/res", "r");
+    ensure_unveil(nullptr, nullptr);
 
-    unveil(nullptr, nullptr);
-
-    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath", nullptr);
 
     return app->exec();
 }

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -16,27 +16,14 @@
 
 int main(int argc, char* argv[])
 {
-    if (pledge("stdio recvfd sendfd rpath unix", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath unix", nullptr);
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath", nullptr);
 
-    if (unveil("/res", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil(nullptr, nullptr) < 0) {
-        perror("unveil");
-        return 1;
-    }
+    ensure_unveil("/res", "r");
+    ensure_unveil(nullptr, nullptr);
 
     auto app_icon = GUI::Icon::default_icon("edit-copy");
 

--- a/Userland/Applets/DesktopPicker/main.cpp
+++ b/Userland/Applets/DesktopPicker/main.cpp
@@ -14,20 +14,14 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd rpath unix", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath unix", nullptr);
 
     auto app = GUI::Application::construct(argc, argv);
 
     // We need to obtain the WM connection here as well before the pledge shortening.
     GUI::WindowManagerServerConnection::the();
 
-    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath", nullptr);
 
     auto window = DesktopStatusWindow::construct();
     window->set_title("DesktopPicker");

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -158,37 +158,15 @@ private:
 
 int main(int argc, char* argv[])
 {
-    if (pledge("stdio recvfd sendfd rpath unix proc exec", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd rpath unix proc exec", nullptr);
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (unveil("/res", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil("/tmp/portal/notify", "rw") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil("/proc/net/adapters", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil("/bin/SystemMonitor", "x") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil(nullptr, nullptr) < 0) {
-        perror("unveil");
-        return 1;
-    }
+    ensure_unveil("/res", "r");
+    ensure_unveil("/tmp/portal/notify", "rw");
+    ensure_unveil("/proc/net/adapters", "r");
+    ensure_unveil("/bin/SystemMonitor", "x");
+    ensure_unveil(nullptr, nullptr);
 
     bool display_notifications = false;
     const char* name = nullptr;

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -186,17 +186,11 @@ private:
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd proc exec rpath unix", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd proc exec rpath unix", nullptr);
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio recvfd sendfd proc exec rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    ensure_pledge("stdio recvfd sendfd proc exec rpath", nullptr);
 
     const char* cpu = nullptr;
     const char* memory = nullptr;
@@ -238,32 +232,13 @@ int main(int argc, char** argv)
     if (memory)
         create_applet(GraphType::Memory, memory);
 
-    if (unveil("/res", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
+    ensure_unveil("/res", "r");
     // FIXME: This is required by Core::ProcessStatisticsReader.
     //        It would be good if we didn't depend on that.
-    if (unveil("/etc/passwd", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil("/proc/all", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil("/proc/memstat", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil("/bin/SystemMonitor", "x") < 0) {
-        perror("unveil");
-        return 1;
-    }
+    ensure_unveil("/etc/passwd", "r");
+    ensure_unveil("/proc/all", "r");
+    ensure_unveil("/proc/memstat", "r");
+    ensure_unveil("/bin/SystemMonitor", "x");
 
     unveil(nullptr, nullptr);
 

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -777,6 +777,14 @@ int pledge(const char* promises, const char* execpromises)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+void ensure_pledge(const char* promises, const char* execpromises)
+{
+    if (pledge(promises, execpromises) < 0) {
+        perror("pledge");
+        exit(1);
+    }
+}
+
 int unveil(const char* path, const char* permissions)
 {
     Syscall::SC_unveil_params params {
@@ -785,6 +793,14 @@ int unveil(const char* path, const char* permissions)
     };
     int rc = syscall(SC_unveil, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+void ensure_unveil(const char* path, const char* permissions)
+{
+    if (unveil(path, permissions) < 0) {
+        perror("unveil");
+        exit(1);
+    }
 }
 
 char* getpass(const char* prompt)

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -113,7 +113,9 @@ int reboot();
 int mount(int source_fd, const char* target, const char* fs_type, int flags);
 int umount(const char* mountpoint);
 int pledge(const char* promises, const char* execpromises);
+void ensure_pledge(const char* promises, const char* execpromises);
 int unveil(const char* path, const char* permissions);
+void ensure_unveil(const char* path, const char* permissions);
 char* getpass(const char* prompt);
 int pause();
 


### PR DESCRIPTION
Every time in the code base we do a `pledge()` or `unveil()` call,
it looks something like this:

```cpp
if (unveil("...", "...") < 0) {
    perror("unveil");
    return 1;
}
```
which to be seems like a bit of an eyesore, especially since many
applications need to make repeated calls to unveil(). These new
APIs allow you to just call :

```cpp
ensure_unveil("...", "...");
```

The program will only continue past that point if the unveil was
successful, otherwise it exits with a status of 1.

---

For now, I've also updated all the Applets to use these new APIs,
and in my opinion it looks much cleaner and nice on the eyes. If
this is something that you all don't mind adding, I can do make
these changes throughout the codebase incrementally.
