### PR TITLE
LibGUI+Settings: Use LibConfig where possible

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -22,6 +22,9 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
 
+// Including this after to avoid LibIPC errors
+#include <LibConfig/Client.h>
+
 namespace DisplaySettings {
 
 BackgroundSettingsWidget::BackgroundSettingsWidget()
@@ -86,9 +89,8 @@ void BackgroundSettingsWidget::create_frame()
 void BackgroundSettingsWidget::load_current_settings()
 {
     auto ws_config = Core::ConfigFile::open("/etc/WindowServer.ini");
-    auto wm_config = Core::ConfigFile::open_for_app("WindowManager");
 
-    auto selected_wallpaper = wm_config->read_entry("Background", "Wallpaper", "");
+    auto selected_wallpaper = Config::read_string("WindowManager", "Background", "Wallpaper", "");
     if (!selected_wallpaper.is_empty()) {
         auto index = static_cast<GUI::FileSystemModel*>(m_wallpaper_view->model())->index(selected_wallpaper, m_wallpaper_view->model_column());
         m_wallpaper_view->set_cursor(index, GUI::AbstractView::SelectionUpdate::Set);
@@ -118,8 +120,7 @@ void BackgroundSettingsWidget::load_current_settings()
 
 void BackgroundSettingsWidget::apply_settings()
 {
-    auto wm_config = Core::ConfigFile::open_for_app("WindowManager", Core::ConfigFile::AllowWriting::Yes);
-    wm_config->write_entry("Background", "Wallpaper", m_monitor_widget->wallpaper());
+    Config::write_string("WindowManager", "Background", "Wallpaper", m_monitor_widget->wallpaper());
 
     if (!m_monitor_widget->wallpaper().is_empty()) {
         GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper());

--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -23,4 +23,4 @@ set(SOURCES
 )
 
 serenity_app(DisplaySettings ICON app-display-settings)
-target_link_libraries(DisplaySettings LibGUI)
+target_link_libraries(DisplaySettings LibGUI LibConfig)

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -9,6 +9,7 @@
 #include "DesktopSettingsWidget.h"
 #include "FontSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
+#include <LibConfig/Client.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -28,6 +29,7 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
+    Config::pledge_domains("WindowManager");
 
     if (pledge("stdio thread recvfd sendfd rpath cpath wpath", nullptr) < 0) {
         perror("pledge");

--- a/Userland/Applications/KeyboardSettings/CMakeLists.txt
+++ b/Userland/Applications/KeyboardSettings/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_app(KeyboardSettings ICON app-keyboard-settings)
-target_link_libraries(KeyboardSettings LibGUI LibKeyboard)
+target_link_libraries(KeyboardSettings LibGUI LibKeyboard LibConfig)

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -7,7 +7,6 @@
 #include "CharacterMapFileListModel.h"
 #include <AK/JsonObject.h>
 #include <AK/QuickSort.h>
-#include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibGUI/Action.h>
@@ -24,6 +23,9 @@
 #include <LibKeyboard/CharacterMap.h>
 #include <spawn.h>
 
+// Including this after to avoid LibIPC errors
+#include <LibConfig/Client.h>
+
 int main(int argc, char** argv)
 {
     if (pledge("stdio rpath cpath wpath recvfd sendfd unix proc exec", nullptr) < 0) {
@@ -32,15 +34,10 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
+    Config::pledge_domains("KeyboardSettings");
 
     if (pledge("stdio rpath cpath wpath recvfd sendfd proc exec", nullptr) < 0) {
         perror("pledge");
-        return 1;
-    }
-
-    auto config = Core::ConfigFile::open_for_app("KeyboardSettings", Core::ConfigFile::AllowWriting::Yes);
-    if (unveil(config->filename().characters(), "rwc") < 0) {
-        perror("unveil");
         return 1;
     }
 
@@ -126,7 +123,7 @@ int main(int argc, char** argv)
     character_map_file_combo.set_selected_index(initial_keymap_index);
 
     auto& num_lock_checkbox = root_widget.add<GUI::CheckBox>("Enable Num Lock on login");
-    num_lock_checkbox.set_checked(config->read_bool_entry("StartupEnable", "NumLock", true));
+    num_lock_checkbox.set_checked(Config::read_bool("KeyboardSettings", "StartupEnable", "NumLock", true));
 
     root_widget.layout()->add_spacer();
 
@@ -143,8 +140,7 @@ int main(int argc, char** argv)
             exit(1);
         }
 
-        config->write_bool_entry("StartupEnable", "NumLock", num_lock_checkbox.is_checked());
-        config->sync();
+        Config::write_bool("KeyboardSettings", "StartupEnable", "NumLock", num_lock_checkbox.is_checked());
 
         if (quit)
             app->quit();

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -124,4 +124,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibGUI gui)
-target_link_libraries(LibGUI LibCore LibGfx LibIPC LibThreading LibRegex LibSyntax)
+target_link_libraries(LibGUI LibCore LibGfx LibIPC LibThreading LibRegex LibSyntax LibConfig)

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -5,10 +5,12 @@
  */
 
 #include <AK/Badge.h>
-#include <LibCore/ConfigFile.h>
 #include <LibGUI/Desktop.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <string.h>
+
+// Including this after to avoid LibIPC errors
+#include <LibConfig/Client.h>
 
 namespace GUI {
 
@@ -59,10 +61,8 @@ bool Desktop::set_wallpaper(const StringView& path, bool save_config)
     auto ret_val = WindowServerConnection::the().wait_for_specific_message<Messages::WindowClient::SetWallpaperFinished>()->success();
 
     if (ret_val && save_config) {
-        RefPtr<Core::ConfigFile> config = Core::ConfigFile::open_for_app("WindowManager", Core::ConfigFile::AllowWriting::Yes);
-        dbgln("Saving wallpaper path '{}' to config file at {}", path, config->filename());
-        config->write_entry("Background", "Wallpaper", path);
-        config->sync();
+        dbgln("Saving wallpaper path '{}' to ConfigServer", path);
+        Config::write_string("WindowManager", "Background", "Wallpaper", path);
     }
 
     return ret_val;


### PR DESCRIPTION
I think after this we've now ported almost every app that we can given some of the limitations of the ConfigServer. Upon doing a quick search through the code base, every other occurrence of `Core::ConfigFile::open_for_app(...)` cannot use the ConfigServer yet for one of the following reasons:

- Need to loop keys in the config file (TaskBarWindow, LaunchServer)
- No event loop, which I think is needed. (Utilities/run-tests, KeyboardPreferenceLoader)
- Application wants to flush to disk based on specific timings (AudioServer)

