### PR TITLE
Kernel: Fix Clang not initializing `s_bsp_processor` correctly

### DIFF
--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -119,8 +119,8 @@ class Processor {
     u32 m_gdt_length;
 
     u32 m_cpu;
-    FlatPtr m_in_irq {};
-    volatile u32 m_in_critical {};
+    FlatPtr m_in_irq;
+    volatile u32 m_in_critical;
     static Atomic<u32> s_idle_cpu_mask;
 
     TSS m_tss;
@@ -137,7 +137,7 @@ class Processor {
 
     bool m_invoke_scheduler_async;
     bool m_scheduler_initialized;
-    bool m_in_scheduler { true };
+    bool m_in_scheduler;
     Atomic<bool> m_halt_requested;
 
     DeferredCallEntry* m_pending_deferred_calls; // in reverse order

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -305,6 +305,7 @@ UNMAP_AFTER_INIT void Processor::early_initialize(u32 cpu)
 
     m_invoke_scheduler_async = false;
     m_scheduler_initialized = false;
+    m_in_scheduler = true;
 
     m_message_queue = nullptr;
     m_idle_thread = nullptr;


### PR DESCRIPTION
Initializing the variable this way fixes a kernel panic in Clang where
the object was zero-initialized, so the `m_in_scheduler` contained the
wrong value. GCC got it right, but we're better off making this change,
as leaving uninitialized fields in constant-initialized objects can
cause other weird situations like this. Also, initializing only a single
field to a non-zero value isn't worth the cost of no longer fitting in
`.bss`.

Another two variables suffer from the same problem, even though their
values are supposed to be zero. Removing these causes the
`_GLOBAL_sub_I_` function to no longer be generated and the (not
handled) `.init_array` section to be omitted.