### PR TITLE
Everywhere: Pass AK::Format TypeErasedFormatParams by reference

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -500,7 +500,7 @@ void FormatBuilder::put_hexdump(ReadonlyBytes bytes, size_t width, char fill)
         put_char_view(bytes.size());
 }
 
-void vformat(StringBuilder& builder, StringView fmtstr, TypeErasedFormatParams params)
+void vformat(StringBuilder& builder, StringView fmtstr, TypeErasedFormatParams& params)
 {
     FormatBuilder fmtbuilder { builder };
     FormatParser parser { fmtstr };
@@ -608,7 +608,7 @@ void Formatter<StringView>::format(FormatBuilder& builder, StringView value)
         builder.put_string(value, m_align, m_width.value(), m_precision.value(), m_fill);
 }
 
-void Formatter<FormatString>::vformat(FormatBuilder& builder, StringView fmtstr, TypeErasedFormatParams params)
+void Formatter<FormatString>::vformat(FormatBuilder& builder, StringView fmtstr, TypeErasedFormatParams& params)
 {
     return Formatter<String>::format(builder, String::vformatted(fmtstr, params));
 }
@@ -754,7 +754,7 @@ void Formatter<float>::format(FormatBuilder& builder, float value)
 #endif
 
 #ifndef KERNEL
-void vout(FILE* file, StringView fmtstr, TypeErasedFormatParams params, bool newline)
+void vout(FILE* file, StringView fmtstr, TypeErasedFormatParams& params, bool newline)
 {
     StringBuilder builder;
     vformat(builder, fmtstr, params);
@@ -778,7 +778,7 @@ void set_debug_enabled(bool value)
     is_debug_enabled = value;
 }
 
-void vdbgln(StringView fmtstr, TypeErasedFormatParams params)
+void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
 {
     if (!is_debug_enabled)
         return;
@@ -817,7 +817,7 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams params)
 }
 
 #ifdef KERNEL
-void vdmesgln(StringView fmtstr, TypeErasedFormatParams params)
+void vdmesgln(StringView fmtstr, TypeErasedFormatParams& params)
 {
     StringBuilder builder;
 
@@ -837,7 +837,7 @@ void vdmesgln(StringView fmtstr, TypeErasedFormatParams params)
     kernelputstr(string.characters_without_null_termination(), string.length());
 }
 
-void v_critical_dmesgln(StringView fmtstr, TypeErasedFormatParams params)
+void v_critical_dmesgln(StringView fmtstr, TypeErasedFormatParams& params)
 {
     // FIXME: Try to avoid memory allocations further to prevent faulting
     // at OOM conditions.

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -466,16 +466,24 @@ struct Formatter<std::nullptr_t> : Formatter<FlatPtr> {
     }
 };
 
-void vformat(StringBuilder&, StringView fmtstr, TypeErasedFormatParams);
+void vformat(StringBuilder&, StringView fmtstr, TypeErasedFormatParams&);
 
 #ifndef KERNEL
-void vout(FILE*, StringView fmtstr, TypeErasedFormatParams, bool newline = false);
+void vout(FILE*, StringView fmtstr, TypeErasedFormatParams&, bool newline = false);
 
 template<typename... Parameters>
-void out(FILE* file, CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters) { vout(file, fmtstr.view(), VariadicFormatParams { parameters... }); }
+void out(FILE* file, CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters)
+{
+    VariadicFormatParams variadic_format_params { parameters... };
+    vout(file, fmtstr.view(), variadic_format_params);
+}
 
 template<typename... Parameters>
-void outln(FILE* file, CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters) { vout(file, fmtstr.view(), VariadicFormatParams { parameters... }, true); }
+void outln(FILE* file, CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters)
+{
+    VariadicFormatParams variadic_format_params { parameters... };
+    vout(file, fmtstr.view(), variadic_format_params, true);
+}
 
 inline void outln(FILE* file) { fputc('\n', file); }
 
@@ -512,12 +520,13 @@ inline void warnln() { outln(stderr); }
 
 #endif
 
-void vdbgln(StringView fmtstr, TypeErasedFormatParams);
+void vdbgln(StringView fmtstr, TypeErasedFormatParams&);
 
 template<typename... Parameters>
 void dbgln(CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters)
 {
-    vdbgln(fmtstr.view(), VariadicFormatParams { parameters... });
+    VariadicFormatParams variadic_format_params { parameters... };
+    vdbgln(fmtstr.view(), variadic_format_params);
 }
 
 inline void dbgln() { dbgln(""); }
@@ -525,22 +534,24 @@ inline void dbgln() { dbgln(""); }
 void set_debug_enabled(bool);
 
 #ifdef KERNEL
-void vdmesgln(StringView fmtstr, TypeErasedFormatParams);
+void vdmesgln(StringView fmtstr, TypeErasedFormatParams&);
 
 template<typename... Parameters>
 void dmesgln(CheckedFormatString<Parameters...>&& fmt, const Parameters&... parameters)
 {
-    vdmesgln(fmt.view(), VariadicFormatParams { parameters... });
+    VariadicFormatParams variadic_format_params { parameters... };
+    vdmesgln(fmt.view(), variadic_format_params);
 }
 
-void v_critical_dmesgln(StringView fmtstr, TypeErasedFormatParams);
+void v_critical_dmesgln(StringView fmtstr, TypeErasedFormatParams&);
 
 // be very careful to not cause any allocations here, since we could be in
 // a very unstable situation
 template<typename... Parameters>
 void critical_dmesgln(CheckedFormatString<Parameters...>&& fmt, const Parameters&... parameters)
 {
-    v_critical_dmesgln(fmt.view(), VariadicFormatParams { parameters... });
+    VariadicFormatParams variadic_format_params { parameters... };
+    v_critical_dmesgln(fmt.view(), variadic_format_params);
 }
 #endif
 
@@ -584,9 +595,10 @@ struct Formatter<FormatString> : Formatter<String> {
     template<typename... Parameters>
     void format(FormatBuilder& builder, StringView fmtstr, const Parameters&... parameters)
     {
-        vformat(builder, fmtstr, VariadicFormatParams { parameters... });
+        VariadicFormatParams variadic_format_params { parameters... };
+        vformat(builder, fmtstr, variadic_format_params);
     }
-    void vformat(FormatBuilder& builder, StringView fmtstr, TypeErasedFormatParams params);
+    void vformat(FormatBuilder& builder, StringView fmtstr, TypeErasedFormatParams& params);
 };
 
 } // namespace AK

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -35,7 +35,8 @@ public:
     template<typename... Parameters>
     void appendff(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
     {
-        vformat(*this, fmtstr.view(), VariadicFormatParams { parameters... });
+        VariadicFormatParams variadic_format_params { parameters... };
+        vformat(*this, fmtstr.view(), variadic_format_params);
     }
 
     [[nodiscard]] String build() const;

--- a/Kernel/KBufferBuilder.h
+++ b/Kernel/KBufferBuilder.h
@@ -32,7 +32,8 @@ public:
     {
         // FIXME: This really not ideal, but vformat expects StringBuilder.
         StringBuilder builder;
-        vformat(builder, fmtstr.view(), AK::VariadicFormatParams { parameters... });
+        AK::VariadicFormatParams variadic_format_params { parameters... };
+        vformat(builder, fmtstr.view(), variadic_format_params);
         append_bytes(builder.string_view().bytes());
     }
 

--- a/Userland/DevTools/UserspaceEmulator/Report.h
+++ b/Userland/DevTools/UserspaceEmulator/Report.h
@@ -13,8 +13,10 @@ extern bool g_report_to_debug;
 template<typename... Ts>
 void reportln(const StringView& format, Ts... args)
 {
-    if (g_report_to_debug)
-        AK::vdbgln(format, AK::VariadicFormatParams { args... });
-    else
+    if (g_report_to_debug) {
+        AK::VariadicFormatParams variadic_format_params { args... };
+        AK::vdbgln(format, variadic_format_params);
+    } else {
         warnln(format, args...);
+    }
 }


### PR DESCRIPTION
This silences a overeager warning in sonar cloud, warning that
slicing could occur with `VariadicFormatParams` which derives from
`TypeErasedFormatParams`.

Reference:
https://sonarcloud.io/project/issues?id=SerenityOS_serenity&issues=AXuVPBO_k92xXUF3qWsm&open=AXuVPBO_k92xXUF3qWsm