### PR TITLE
LibCore+Userland: Implement Core::deferred_invoke

### DIFF
--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -3,6 +3,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCoreArgsParser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCoreFileWatcher.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCoreIODevice.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/TestLibCoreDeferredInvoke.cpp
 )
 
 foreach(source ${TEST_SOURCES})

--- a/Tests/LibCore/TestLibCoreDeferredInvoke.cpp
+++ b/Tests/LibCore/TestLibCoreDeferredInvoke.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(deferred_invoke)
+{
+    Core::EventLoop event_loop;
+    auto reaper = Core::Timer::create_single_shot(250, [] {
+        warnln("I waited for the deferred_invoke to happen, but it never did!");
+        VERIFY_NOT_REACHED();
+    });
+
+    Core::deferred_invoke([&event_loop] {
+        event_loop.quit(0);
+    });
+
+    event_loop.exec();
+}

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -434,7 +434,7 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
     };
 
     new_tab.on_tab_close_request = [this](auto& tab) {
-        m_tab_widget->deferred_invoke([this, &tab](auto&) {
+        m_tab_widget->deferred_invoke([this, &tab] {
             m_tab_widget->remove_tab(tab);
             m_tab_widget->set_bar_visible(!is_fullscreen() && m_tab_widget->children().size() > 1);
             if (m_tab_widget->children().is_empty())
@@ -443,7 +443,7 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
     };
 
     new_tab.on_tab_close_other_request = [this](auto& tab) {
-        m_tab_widget->deferred_invoke([this, &tab](auto&) {
+        m_tab_widget->deferred_invoke([this, &tab] {
             m_tab_widget->remove_all_tabs_except(tab);
             VERIFY(m_tab_widget->children().size() == 1);
             m_tab_widget->set_bar_visible(false);

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -500,7 +500,7 @@ void FontEditorWidget::initialize(const String& path, RefPtr<Gfx::BitmapFont>&& 
     m_fixed_width_checkbox->set_checked(m_edited_font->is_fixed_width());
 
     m_glyph_map_widget->set_selected_glyph('A');
-    deferred_invoke([this](auto&) {
+    deferred_invoke([this] {
         m_glyph_map_widget->set_focus(true);
         m_glyph_map_widget->scroll_to_glyph(m_glyph_map_widget->selected_glyph());
         window()->set_modified(false);

--- a/Userland/Applications/FontEditor/NewFontDialog.cpp
+++ b/Userland/Applications/FontEditor/NewFontDialog.cpp
@@ -196,7 +196,7 @@ NewFontDialog::NewFontDialog(GUI::Window* parent_window)
 
     m_glyph_width_spinbox->on_change = [&](int value) {
         preview_editor.set_preview_size(value, m_glyph_height_spinbox->value());
-        deferred_invoke([&](auto&) {
+        deferred_invoke([&] {
             m_glyph_editor_container->set_fixed_height(1 + preview_editor.height() + preview_editor.frame_thickness() * 2);
         });
     };
@@ -204,7 +204,7 @@ NewFontDialog::NewFontDialog(GUI::Window* parent_window)
         preview_editor.set_preview_size(m_glyph_width_spinbox->value(), value);
         m_mean_line_spinbox->set_max(max(value - 2, 0));
         m_baseline_spinbox->set_max(max(value - 2, 0));
-        deferred_invoke([&](auto&) {
+        deferred_invoke([&] {
             m_glyph_editor_container->set_fixed_height(1 + preview_editor.height() + preview_editor.frame_thickness() * 2);
         });
     };

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
         auto url = URL::create_with_file_protocol(path);
         page_view.load_html(html, url);
 
-        app->deferred_invoke([&, path](auto&) {
+        app->deferred_invoke([&, path] {
             auto tree_view_index = model->index_from_path(path);
             if (tree_view_index.has_value()) {
                 tree_view.expand_tree(tree_view_index.value().parent());

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -729,7 +729,7 @@ int main(int argc, char** argv)
             layer_properties_widget.set_layer(nullptr);
         }
 
-        tab_widget.deferred_invoke([&](auto&) {
+        tab_widget.deferred_invoke([&] {
             tab_widget.remove_tab(image_editor);
         });
     };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -779,32 +779,29 @@ void HackStudioWidget::initialize_debugger()
             }
             dbgln("Debugger stopped at source position: {}:{}", source_position.value().file_path, source_position.value().line_number);
 
-            Core::EventLoop::main().post_event(
-                *window(),
-                make<Core::DeferredInvocationEvent>(
-                    [this, source_position, &regs](auto&) {
-                        m_current_editor_in_execution = get_editor_of_file(source_position.value().file_path);
-                        if (m_current_editor_in_execution)
-                            m_current_editor_in_execution->editor().set_execution_position(source_position.value().line_number - 1);
-                        m_debug_info_widget->update_state(*Debugger::the().session(), regs);
-                        m_debug_info_widget->set_debug_actions_enabled(true);
-                        m_disassembly_widget->update_state(*Debugger::the().session(), regs);
-                        HackStudioWidget::reveal_action_tab(*m_debug_info_widget);
-                    }));
+            deferred_invoke([this, source_position, &regs] {
+                m_current_editor_in_execution = get_editor_of_file(source_position.value().file_path);
+                if (m_current_editor_in_execution)
+                    m_current_editor_in_execution->editor().set_execution_position(source_position.value().line_number - 1);
+                m_debug_info_widget->update_state(*Debugger::the().session(), regs);
+                m_debug_info_widget->set_debug_actions_enabled(true);
+                m_disassembly_widget->update_state(*Debugger::the().session(), regs);
+                HackStudioWidget::reveal_action_tab(*m_debug_info_widget);
+            });
             Core::EventLoop::wake();
 
             return Debugger::HasControlPassedToUser::Yes;
         },
         [this]() {
-            Core::EventLoop::main().post_event(*window(), make<Core::DeferredInvocationEvent>([this](auto&) {
+            deferred_invoke([this] {
                 m_debug_info_widget->set_debug_actions_enabled(false);
                 if (m_current_editor_in_execution)
                     m_current_editor_in_execution->editor().clear_execution_position();
-            }));
+            });
             Core::EventLoop::wake();
         },
         [this]() {
-            Core::EventLoop::main().post_event(*window(), make<Core::DeferredInvocationEvent>([this](auto&) {
+            deferred_invoke([this] {
                 m_debug_info_widget->set_debug_actions_enabled(false);
                 if (m_current_editor_in_execution)
                     m_current_editor_in_execution->editor().clear_execution_position();
@@ -820,7 +817,7 @@ void HackStudioWidget::initialize_debugger()
 
                 HackStudioWidget::hide_action_tabs();
                 GUI::MessageBox::show(window(), "Program Exited", "Debugger", GUI::MessageBox::Type::Information);
-            }));
+            });
             Core::EventLoop::wake();
         });
 }

--- a/Userland/Libraries/LibCore/DeferredInvocationContext.h
+++ b/Userland/Libraries/LibCore/DeferredInvocationContext.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018-2020, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Object.h>
+
+namespace Core {
+
+class DeferredInvocationContext final : public Core::Object {
+    C_OBJECT(DeferredInvocationContext)
+private:
+    DeferredInvocationContext() { }
+};
+
+}

--- a/Userland/Libraries/LibCore/Event.h
+++ b/Userland/Libraries/LibCore/Event.h
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/WeakPtr.h>
+#include <LibCore/DeferredInvocationContext.h>
 #include <LibCore/Forward.h>
 
 namespace Core {
@@ -50,14 +51,16 @@ class DeferredInvocationEvent : public Event {
     friend class EventLoop;
 
 public:
-    DeferredInvocationEvent(Function<void(Object&)> invokee)
+    DeferredInvocationEvent(NonnullRefPtr<DeferredInvocationContext> context, Function<void()> invokee)
         : Event(Event::Type::DeferredInvoke)
+        , m_context(move(context))
         , m_invokee(move(invokee))
     {
     }
 
 private:
-    Function<void(Object&)> m_invokee;
+    NonnullRefPtr<DeferredInvocationContext> m_context;
+    Function<void()> m_invokee;
 };
 
 class TimerEvent final : public Event {

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -394,7 +394,7 @@ void EventLoop::pump(WaitMode mode)
             }
         } else if (event.type() == Event::Type::DeferredInvoke) {
             dbgln_if(DEFERRED_INVOKE_DEBUG, "DeferredInvoke: receiver = {}", *receiver);
-            static_cast<DeferredInvocationEvent&>(event).m_invokee(*receiver);
+            static_cast<DeferredInvocationEvent&>(event).m_invokee();
         } else {
             NonnullRefPtr<Object> protector(*receiver);
             receiver->dispatch_event(event);

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -11,9 +11,12 @@
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
+#include <LibCore/DeferredInvocationContext.h>
+#include <LibCore/Event.h>
 #include <LibCore/Forward.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -76,6 +79,12 @@ public:
 
     static bool has_been_instantiated();
 
+    void deferred_invoke(Function<void()> invokee)
+    {
+        auto context = DeferredInvocationContext::construct();
+        post_event(context, make<Core::DeferredInvocationEvent>(context, move(invokee)));
+    }
+
 private:
     void wait_for_event(WaitMode);
     Optional<Time> get_next_timer_expiration();
@@ -105,5 +114,10 @@ private:
     struct Private;
     NonnullOwnPtr<Private> m_private;
 };
+
+inline void deferred_invoke(Function<void()> invokee)
+{
+    EventLoop::current().deferred_invoke(move(invokee));
+}
 
 }

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -15,6 +15,7 @@ class ConfigFile;
 class CustomEvent;
 class DateTime;
 class DirIterator;
+class DeferredInvocationContext;
 class ElapsedTimer;
 class Event;
 class EventLoop;

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -164,7 +164,12 @@ void Object::dump_tree(int indent)
 
 void Object::deferred_invoke(Function<void(Object&)> invokee)
 {
-    Core::EventLoop::current().post_event(*this, make<Core::DeferredInvocationEvent>(move(invokee)));
+    deferred_invoke([invokee = move(invokee), this] { invokee(*this); });
+}
+
+void Object::deferred_invoke(Function<void()> invokee)
+{
+    Core::deferred_invoke([invokee = move(invokee), strong_this = NonnullRefPtr(*this)] { invokee(); });
 }
 
 void Object::save_to(JsonObject& json)

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -162,11 +162,6 @@ void Object::dump_tree(int indent)
     });
 }
 
-void Object::deferred_invoke(Function<void(Object&)> invokee)
-{
-    deferred_invoke([invokee = move(invokee), this] { invokee(*this); });
-}
-
 void Object::deferred_invoke(Function<void()> invokee)
 {
     Core::deferred_invoke([invokee = move(invokee), strong_this = NonnullRefPtr(*this)] { invokee(); });

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -129,7 +129,6 @@ public:
 
     void dump_tree(int indent = 0);
 
-    void deferred_invoke(Function<void(Object&)>);
     void deferred_invoke(Function<void()>);
 
     void save_to(JsonObject&);

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -130,6 +130,7 @@ public:
     void dump_tree(int indent = 0);
 
     void deferred_invoke(Function<void(Object&)>);
+    void deferred_invoke(Function<void()>);
 
     void save_to(JsonObject&);
 

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -110,7 +110,7 @@ ComboBox::ComboBox()
     };
 
     m_list_view->on_activation = [this](auto& index) {
-        deferred_invoke([this, index](auto&) {
+        deferred_invoke([this, index] {
             selection_updated(index);
             if (on_change)
                 on_change(m_editor->text(), index);

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -105,7 +105,7 @@ void TabWidget::set_active_widget(Widget* widget)
         if (active_widget_had_focus)
             m_active_widget->set_focus(true);
         m_active_widget->set_visible(true);
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             if (on_change)
                 on_change(*m_active_widget);
         });
@@ -360,7 +360,7 @@ void TabWidget::mousedown_event(MouseEvent& event)
             set_active_widget(m_tabs[i].widget);
         } else if (event.button() == MouseButton::Middle) {
             auto* widget = m_tabs[i].widget;
-            deferred_invoke([this, widget](auto&) {
+            deferred_invoke([this, widget] {
                 if (on_middle_click && widget)
                     on_middle_click(*widget);
             });
@@ -381,7 +381,7 @@ void TabWidget::mouseup_event(MouseEvent& event)
 
     if (close_button_rect.contains(event.position())) {
         auto* widget = m_tabs[m_pressed_close_button_index.value()].widget;
-        deferred_invoke([this, widget](auto&) {
+        deferred_invoke([this, widget] {
             if (on_tab_close_click && widget)
                 on_tab_close_click(*widget);
         });
@@ -537,7 +537,7 @@ void TabWidget::context_menu_event(ContextMenuEvent& context_menu_event)
         if (!button_rect.contains(context_menu_event.position()))
             continue;
         auto* widget = m_tabs[i].widget;
-        deferred_invoke([this, widget, context_menu_event](auto&) {
+        deferred_invoke([this, widget, context_menu_event] {
             if (on_context_menu_request && widget)
                 on_context_menu_request(*widget, context_menu_event);
         });

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1469,7 +1469,7 @@ void TextEditor::did_change()
     m_needs_rehighlight = true;
     if (!m_has_pending_change_notification) {
         m_has_pending_change_notification = true;
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             m_has_pending_change_notification = false;
             if (on_change)
                 on_change();

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -679,7 +679,7 @@ void Window::update(const Gfx::IntRect& a_rect)
     }
 
     if (m_pending_paint_event_rects.is_empty()) {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             auto rects = move(m_pending_paint_event_rects);
             if (rects.is_empty())
                 return;
@@ -1010,7 +1010,7 @@ void Window::schedule_relayout()
     if (m_layout_pending)
         return;
     m_layout_pending = true;
-    deferred_invoke([this](auto&) {
+    deferred_invoke([this] {
         if (main_widget())
             main_widget()->do_layout();
         update();

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -357,7 +357,7 @@ void WindowServerConnection::display_link_notification()
         return;
 
     m_display_link_notification_pending = true;
-    deferred_invoke([this](auto&) {
+    deferred_invoke([this] {
         DisplayLink::notify({});
         m_display_link_notification_pending = false;
     });

--- a/Userland/Libraries/LibGemini/GeminiJob.cpp
+++ b/Userland/Libraries/LibGemini/GeminiJob.cpp
@@ -25,15 +25,15 @@ void GeminiJob::start()
     };
     m_socket->on_tls_error = [this](TLS::AlertDescription error) {
         if (error == TLS::AlertDescription::HandshakeFailure) {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 return did_fail(Core::NetworkJob::Error::ProtocolFailed);
             });
         } else if (error == TLS::AlertDescription::DecryptError) {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 return did_fail(Core::NetworkJob::Error::ConnectionFailed);
             });
         } else {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 return did_fail(Core::NetworkJob::Error::TransmissionFailed);
             });
         }
@@ -47,7 +47,7 @@ void GeminiJob::start()
     };
     bool success = ((TLS::TLSv12&)*m_socket).connect(m_request.url().host(), m_request.url().port());
     if (!success) {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             return did_fail(Core::NetworkJob::Error::ConnectionFailed);
         });
     }

--- a/Userland/Libraries/LibHTTP/HttpJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpJob.cpp
@@ -22,13 +22,13 @@ void HttpJob::start()
     };
     m_socket->on_error = [this] {
         dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_error callback");
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             did_fail(Core::NetworkJob::Error::ConnectionFailed);
         });
     };
     bool success = m_socket->connect(m_request.url().host(), m_request.url().port());
     if (!success) {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             return did_fail(Core::NetworkJob::Error::ConnectionFailed);
         });
     }

--- a/Userland/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpsJob.cpp
@@ -25,15 +25,15 @@ void HttpsJob::start()
     };
     m_socket->on_tls_error = [&](TLS::AlertDescription error) {
         if (error == TLS::AlertDescription::HandshakeFailure) {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 return did_fail(Core::NetworkJob::Error::ProtocolFailed);
             });
         } else if (error == TLS::AlertDescription::DecryptError) {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 return did_fail(Core::NetworkJob::Error::ConnectionFailed);
             });
         } else {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 return did_fail(Core::NetworkJob::Error::TransmissionFailed);
             });
         }
@@ -48,7 +48,7 @@ void HttpsJob::start()
     };
     bool success = ((TLS::TLSv12&)*m_socket).connect(m_request.url().host(), m_request.url().port());
     if (!success) {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             return did_fail(Core::NetworkJob::Error::ConnectionFailed);
         });
     }

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -196,7 +196,7 @@ protected:
             }
             if (nread == 0) {
                 if (bytes.is_empty()) {
-                    deferred_invoke([this](auto&) { shutdown(); });
+                    deferred_invoke([this] { shutdown(); });
                     return false;
                 }
                 break;
@@ -241,7 +241,7 @@ protected:
         }
 
         if (!m_unprocessed_messages.is_empty()) {
-            deferred_invoke([this](auto&) {
+            deferred_invoke([this] {
                 handle_messages();
             });
         }

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -607,7 +607,7 @@ void Editor::resized()
         if (set_origin(false)) {
             handle_resize_event(false);
         } else {
-            deferred_invoke([this](auto&) { handle_resize_event(true); });
+            deferred_invoke([this] { handle_resize_event(true); });
             m_has_origin_reset_scheduled = true;
         }
     }
@@ -618,7 +618,7 @@ void Editor::handle_resize_event(bool reset_origin)
     m_has_origin_reset_scheduled = false;
     if (reset_origin && !set_origin(false)) {
         m_has_origin_reset_scheduled = true;
-        return deferred_invoke([this](auto&) { handle_resize_event(true); });
+        return deferred_invoke([this] { handle_resize_event(true); });
     }
 
     set_origin(m_origin_row, 1);
@@ -722,7 +722,7 @@ auto Editor::get_line(const String& prompt) -> Result<String, Editor::Error>
 
     m_notifier->on_ready_to_read = [&] { try_update_once(); };
     if (!m_incomplete_data.is_empty())
-        deferred_invoke([&](auto&) { try_update_once(); });
+        deferred_invoke([&] { try_update_once(); });
 
     if (loop.exec() == Retry)
         return get_line(prompt);
@@ -1166,7 +1166,7 @@ void Editor::handle_read_event()
     }
 
     if (!m_incomplete_data.is_empty() && !m_finish)
-        deferred_invoke([&](auto&) { try_update_once(); });
+        deferred_invoke([&] { try_update_once(); });
 }
 
 void Editor::cleanup_suggestions()

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -265,7 +265,7 @@ void Editor::enter_search()
             search_editor.finish();
             m_reset_buffer_on_search_end = true;
             search_editor.end_search();
-            search_editor.deferred_invoke([&search_editor](auto&) { search_editor.really_quit_event_loop(); });
+            search_editor.deferred_invoke([&search_editor] { search_editor.really_quit_event_loop(); });
             return false;
         });
 

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -41,7 +41,7 @@ void TLSv12::write_packet(ByteBuffer& packet)
     if (m_context.connection_status > ConnectionStatus::Disconnected) {
         if (!m_has_scheduled_write_flush) {
             dbgln_if(TLS_DEBUG, "Scheduling write of {}", m_context.tls_buffer.size());
-            deferred_invoke([this](auto&) { write_into_socket(); });
+            deferred_invoke([this] { write_into_socket(); });
             m_has_scheduled_write_flush = true;
         } else {
             // multiple packet are available, let's flush some out

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -97,7 +97,7 @@ bool TLSv12::common_connect(const struct sockaddr* saddr, socklen_t length)
         auto packet = build_hello();
         write_packet(packet);
 
-        deferred_invoke([&](auto&) {
+        deferred_invoke([&] {
             m_handshake_timeout_timer = Core::Timer::create_single_shot(
                 m_max_wait_time_for_handshake_in_seconds * 1000, [&] {
                     auto timeout_diff = Core::DateTime::now().timestamp() - m_context.handshake_initiation_timestamp;
@@ -141,7 +141,7 @@ void TLSv12::read_from_socket()
     auto notify_client_for_app_data = [&] {
         if (m_context.application_buffer.size() > 0) {
             if (!did_schedule_read) {
-                deferred_invoke([&](auto&) { read_from_socket(); });
+                deferred_invoke([&] { read_from_socket(); });
                 did_schedule_read = true;
             }
             if (on_tls_ready_to_read)

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -66,10 +66,10 @@ private:
         enqueue_work([this] {
             m_result = m_action(*this);
             if (m_on_complete) {
-                Core::EventLoop::current().post_event(*this, make<Core::DeferredInvocationEvent>([this](auto&) {
+                deferred_invoke([this] {
                     m_on_complete(m_result.release_value());
-                    this->remove_from_parent();
-                }));
+                    remove_from_parent();
+                });
                 Core::EventLoop::wake();
             } else {
                 this->remove_from_parent();

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -106,7 +106,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
 
     if (url.protocol() == "about") {
         dbgln_if(SPAM_DEBUG, "Loading about: URL {}", url);
-        deferred_invoke([success_callback = move(success_callback)](auto&) {
+        deferred_invoke([success_callback = move(success_callback)] {
             success_callback(String::empty().to_byte_buffer(), {}, {});
         });
         return;
@@ -124,7 +124,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
         else
             data = url.data_payload().to_byte_buffer();
 
-        deferred_invoke([data = move(data), success_callback = move(success_callback)](auto&) {
+        deferred_invoke([data = move(data), success_callback = move(success_callback)] {
             success_callback(data, {}, {});
         });
         return;
@@ -141,7 +141,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
         }
 
         auto data = f->read_all();
-        deferred_invoke([data = move(data), success_callback = move(success_callback)](auto&) {
+        deferred_invoke([data = move(data), success_callback = move(success_callback)] {
             success_callback(data, {}, {});
         });
         return;
@@ -171,7 +171,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
                     error_callback("HTTP load failed", {});
                 return;
             }
-            deferred_invoke([protocol_request](auto&) {
+            deferred_invoke([protocol_request] {
                 // Clear circular reference of `protocol_request` captured by copy
                 const_cast<Protocol::Request&>(*protocol_request).on_buffered_request_finish = nullptr;
             });

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -64,7 +64,7 @@ void OutOfProcessWebView::create_client()
 
     m_client_state.client = WebContentClient::construct(*this);
     m_client_state.client->on_web_content_process_crash = [this] {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             handle_web_content_process_crash();
         });
     };

--- a/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.cpp
@@ -36,7 +36,7 @@ void TCPWebSocketConnectionImpl::connect(ConnectionInfo const& connection)
     };
     bool success = m_socket->connect(connection.url().host(), connection.url().port());
     if (!success) {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             on_connection_error();
         });
     }

--- a/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.cpp
@@ -44,7 +44,7 @@ void TLSv12WebSocketConnectionImpl::connect(ConnectionInfo const& connection)
     };
     bool success = m_socket->connect(connection.url().host(), connection.url().port());
     if (!success) {
-        deferred_invoke([this](auto&) {
+        deferred_invoke([this] {
             on_connection_error();
         });
     }

--- a/Userland/Services/SQLServer/DatabaseConnection.cpp
+++ b/Userland/Services/SQLServer/DatabaseConnection.cpp
@@ -38,7 +38,7 @@ DatabaseConnection::DatabaseConnection(String database_name, int client_id)
 
     dbgln_if(SQLSERVER_DEBUG, "DatabaseConnection {} initiating connection with database '{}'", connection_id(), m_database_name);
     s_connections.set(m_connection_id, *this);
-    deferred_invoke([&](Object&) {
+    deferred_invoke([&] {
         m_database = SQL::Database::construct(String::formatted("/home/anon/sql/{}.db", m_database_name));
         m_accept_statements = true;
         auto client_connection = ClientConnection::client_connection_for(m_client_id);
@@ -53,7 +53,7 @@ void DatabaseConnection::disconnect()
 {
     dbgln_if(SQLSERVER_DEBUG, "DatabaseConnection::disconnect(connection_id {}, database '{}'", connection_id(), m_database_name);
     m_accept_statements = false;
-    deferred_invoke([&](Object&) {
+    deferred_invoke([&] {
         m_database = nullptr;
         s_connections.remove(m_connection_id);
         auto client_connection = ClientConnection::client_connection_for(client_id());

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -60,7 +60,7 @@ void SQLStatement::execute()
         return;
     }
 
-    deferred_invoke([&](Object&) {
+    deferred_invoke([&] {
         auto maybe_error = parse();
         if (maybe_error.has_value()) {
             report_error(maybe_error.value());
@@ -107,7 +107,7 @@ void SQLStatement::next()
     if (m_index < m_result->results().size()) {
         auto& tuple = m_result->results()[m_index++];
         client_connection->async_next_result(statement_id(), tuple.to_string_vector());
-        deferred_invoke([&](Object&) {
+        deferred_invoke([&] {
             next();
         });
     } else {

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -36,10 +36,7 @@ Client::Client(NonnullRefPtr<Core::TCPSocket> socket, Core::Object* parent)
 
 void Client::die()
 {
-    deferred_invoke([this](auto& object) {
-        NonnullRefPtr protector { object };
-        remove_from_parent();
-    });
+    deferred_invoke([this] { remove_from_parent(); });
 }
 
 void Client::start()

--- a/Userland/Services/WebSocket/ClientConnection.cpp
+++ b/Userland/Services/WebSocket/ClientConnection.cpp
@@ -126,7 +126,7 @@ void ClientConnection::did_error(i32 connection_id, i32 message)
 void ClientConnection::did_close(i32 connection_id, u16 code, String reason, bool was_clean)
 {
     async_closed(connection_id, code, reason, was_clean);
-    deferred_invoke([this, connection_id](auto&) {
+    deferred_invoke([this, connection_id] {
         m_connections.remove(connection_id);
     });
 }

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -79,7 +79,7 @@ ClientConnection::~ClientConnection()
 
 void ClientConnection::die()
 {
-    deferred_invoke([this](auto&) {
+    deferred_invoke([this] {
         s_connections->remove(client_id());
     });
 }

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -28,7 +28,7 @@ WMClientConnection::~WMClientConnection()
 
 void WMClientConnection::die()
 {
-    deferred_invoke([this](auto&) {
+    deferred_invoke([this] {
         s_connections.remove(client_id());
     });
 }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -764,7 +764,7 @@ void Window::request_update(const Gfx::IntRect& rect, bool ignore_occlusion)
     if (rect.is_empty())
         return;
     if (m_pending_paint_rects.is_empty()) {
-        deferred_invoke([this, ignore_occlusion](auto&) {
+        deferred_invoke([this, ignore_occlusion] {
             client()->post_paint_message(*this, ignore_occlusion);
         });
     }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -958,7 +958,7 @@ void Shell::run_tail(const AST::Command& invoking_command, const AST::NodeWithAc
 void Shell::run_tail(RefPtr<Job> job)
 {
     if (auto cmd = job->command_ptr()) {
-        deferred_invoke([=, this](auto&) {
+        deferred_invoke([=, this] {
             for (auto& next_in_chain : cmd->next_chain) {
                 run_tail(*cmd, next_in_chain, job->exit_code());
             }


### PR DESCRIPTION
This commit is a step towards reviving #6513.

**LibCore+Userland: Implement Core::deferred_invoke**

`Core::deferred_invoke` is a way of executing an action after previously
queued events have been processed. It removes the requirement of
having/being a `Core::Object` subclass in order to defer invocation
through `Core::Object::deferred_invoke`.

`Core::Object::deferred_invoke` now delegates to `Core::deferred_invoke`.
The version with the `Object&` argument is still present but will be
removed in the following commits.

This commit additionally fixes a new places where the
`DeferredInvocationEvent` was dispatched to the event loop directly, and
replaces them with the `Core::deferred_invoke` equivalent.

**Userland: Migrate to argument-less deferred_invoke**

Only one place used this argument and it was to hold on to a strong ref
for the object. Since we already do that now, there's no need to keep
this argument around since this can be easily captured.

This commit contains no changes.

**LibCore: Remove deferred_invoke overload with Object& parameter**

This is not necessary because the user can just use this, which is
referenced until the deferred invocation is complete.

**Tests: Add tests for Core::deferred_invoke**