### PR TITLE
Documentation: Add unzip package to BuildInstructions

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -7,7 +7,7 @@ Make sure you have all the dependencies installed:
 ### Debian / Ubuntu
 
 ```console
-sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync genext2fs
+sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync genext2fs unzip
 ```
 
 #### GCC 10


### PR DESCRIPTION
`Meta/serenity.sh build` was failing for me on WSL Ubuntu with this error:

```
serenity build
-- Extracting CLDR cldr-localenames-modern from /home/miha/Projects/personal/serenity/Build/i686/CLDR/cldr.zip...
CMake Error at Meta/CMake/unicode_data.cmake:107 (message):
  Failed to unzip cldr-localenames-modern from
  /home/miha/Projects/personal/serenity/Build/i686/CLDR/cldr.zip with status
  No such file or directory
Call Stack (most recent call first):
  Userland/Libraries/LibUnicode/CMakeLists.txt:1 (include)


-- Configuring incomplete, errors occurred!
See also "/home/miha/Projects/personal/serenity/Build/i686/CMakeFiles/CMakeOutput.log".
See also "/home/miha/Projects/personal/serenity/Build/i686/CMakeFiles/CMakeError.log".
```

It turns out `unzip` was missing.