### PR TITLE
LibWasm: Yet another bag of fixes 

### DIFF
--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -245,7 +245,10 @@ def genarg(spec):
                     return str(struct.unpack('>i', struct.pack('>Q', int(x, 16))[4:])[0])
 
                 # cast back to i64 to get the correct sign
-                return str(struct.unpack('>q', struct.pack('>Q', int(x, 16)))[0])
+                return str(struct.unpack('>q', struct.pack('>Q', int(x, 16)))[0]) + 'n'
+            if spec['type'] == 'i64':
+                # Make a bigint instead, since `double' cannot fit all i64 values.
+                return x + 'n'
             return x
 
         if x == 'nan':
@@ -304,8 +307,8 @@ def genresult(ident, entry):
 
     if entry['kind'] == 'return':
         return (
-            f'let {ident}_result = {expectation};\n    ' +
-            (f'expect({ident}_result).toBe({genarg(entry["result"])})\n    ' if entry["result"] is not None else '')
+                f'let {ident}_result = {expectation};\n    ' +
+                (f'expect({ident}_result).toBe({genarg(entry["result"])})\n    ' if entry["result"] is not None else '')
         )
 
     if entry['kind'] == 'trap':

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -184,6 +184,8 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::get_export)
             if (auto v = value.get_pointer<Wasm::GlobalAddress>()) {
                 return m_machine.store().get(*v)->value().value().visit(
                     [&](const auto& value) -> JS::Value { return JS::Value(static_cast<double>(value)); },
+                    [&](i32 value) { return JS::Value(static_cast<double>(value)); },
+                    [&](i64 value) -> JS::Value { return JS::js_bigint(vm, Crypto::SignedBigInteger::create_from(value)); },
                     [&](const Wasm::Reference& reference) -> JS::Value {
                         return reference.ref().visit(
                             [&](const Wasm::Reference::Null&) -> JS::Value { return JS::js_null(); },
@@ -224,25 +226,33 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
     }
     size_t index = 1;
     for (auto& param : type->parameters()) {
-        auto value = vm.argument(index++).to_double(global_object);
+        auto argument = vm.argument(index++);
+        double double_value = 0;
+        if (!argument.is_bigint())
+            double_value = argument.to_double(global_object);
         switch (param.kind()) {
         case Wasm::ValueType::Kind::I32:
-            arguments.append(Wasm::Value(param, static_cast<u64>(value)));
+            arguments.append(Wasm::Value(param, static_cast<u64>(double_value)));
             break;
         case Wasm::ValueType::Kind::I64:
-            arguments.append(Wasm::Value(param, static_cast<u64>(value)));
+            if (argument.is_bigint()) {
+                auto value = argument.to_bigint_int64(global_object);
+                arguments.append(Wasm::Value(param, bit_cast<u64>(value)));
+            } else {
+                arguments.append(Wasm::Value(param, static_cast<u64>(double_value)));
+            }
             break;
         case Wasm::ValueType::Kind::F32:
-            arguments.append(Wasm::Value(static_cast<float>(value)));
+            arguments.append(Wasm::Value(static_cast<float>(double_value)));
             break;
         case Wasm::ValueType::Kind::F64:
-            arguments.append(Wasm::Value(static_cast<double>(value)));
+            arguments.append(Wasm::Value(static_cast<double>(double_value)));
             break;
         case Wasm::ValueType::Kind::FunctionReference:
-            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Func { static_cast<u64>(value) } }));
+            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Func { static_cast<u64>(double_value) } }));
             break;
         case Wasm::ValueType::Kind::ExternReference:
-            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Func { static_cast<u64>(value) } }));
+            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Func { static_cast<u64>(double_value) } }));
             break;
         case Wasm::ValueType::Kind::NullFunctionReference:
             arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Null { Wasm::ValueType(Wasm::ValueType::Kind::FunctionReference) } }));
@@ -265,6 +275,8 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
     JS::Value return_value;
     result.values().first().value().visit(
         [&](const auto& value) { return_value = JS::Value(static_cast<double>(value)); },
+        [&](i32 value) { return_value = JS::Value(static_cast<double>(value)); },
+        [&](i64 value) { return_value = JS::Value(JS::js_bigint(vm, Crypto::SignedBigInteger::create_from(value))); },
         [&](const Wasm::Reference& reference) {
             reference.ref().visit(
                 [&](const Wasm::Reference::Null&) { return_value = JS::js_null(); },

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -104,6 +104,11 @@ TESTJS_GLOBAL_FUNCTION(parse_webassembly_module, parseWebAssemblyModule)
     }
     auto& array = static_cast<JS::Uint8Array&>(*object);
     InputMemoryStream stream { array.data() };
+    ScopeGuard handle_stream_error {
+        [&] {
+            stream.handle_any_error();
+        }
+    };
     auto result = Wasm::Module::parse(stream);
     if (result.is_error()) {
         vm.throw_exception<JS::SyntaxError>(global_object, Wasm::parse_error_to_string(result.error()));

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -824,7 +824,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::f32_trunc.value():
         return unary_operation<float, float, Operators::Truncate>(configuration);
     case Instructions::f32_nearest.value():
-        return unary_operation<float, float, Operators::Round>(configuration);
+        return unary_operation<float, float, Operators::NearbyIntegral>(configuration);
     case Instructions::f32_sqrt.value():
         return unary_operation<float, float, Operators::SquareRoot>(configuration);
     case Instructions::f32_add.value():
@@ -852,7 +852,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::f64_trunc.value():
         return unary_operation<double, double, Operators::Truncate>(configuration);
     case Instructions::f64_nearest.value():
-        return unary_operation<double, double, Operators::Round>(configuration);
+        return unary_operation<double, double, Operators::NearbyIntegral>(configuration);
     case Instructions::f64_sqrt.value():
         return unary_operation<double, double, Operators::SquareRoot>(configuration);
     case Instructions::f64_add.value():

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -259,7 +259,7 @@ struct Floor {
 };
 struct Truncate {
     template<typename Lhs>
-    auto operator()(Lhs lhs) const
+    Result<Lhs, StringView> operator()(Lhs lhs) const
     {
         if constexpr (IsSame<Lhs, float>)
             return truncf(lhs);
@@ -327,10 +327,13 @@ struct CheckedTruncate {
         else
             VERIFY_NOT_REACHED();
 
-        if (NumericLimits<ResultT>::min() <= truncated && static_cast<double>(NumericLimits<ResultT>::max()) >= static_cast<double>(truncated))
-            return static_cast<ResultT>(truncated);
+        // FIXME: This function assumes that all values of ResultT are representable in Lhs
+        //        the assumption comes from the fact that this was used exclusively by LibJS,
+        //        which only considers values that are all representable in 'double'.
+        if (!AK::is_within_range<ResultT>(truncated))
+            return "Truncation out of range"sv;
 
-        return "Truncation out of range"sv;
+        return static_cast<ResultT>(truncated);
     }
 
     static StringView name() { return "truncate.checked"; }
@@ -424,6 +427,9 @@ struct SaturatingTruncate {
             return NumericLimits<ResultT>::max();
         }
 
+        // FIXME: This assumes that all values in ResultT are representable in 'double'.
+        //        that assumption is not correct, which makes this function yield incorrect values
+        //        for 'edge' values of type i64.
         constexpr auto convert = [](auto truncated_value) {
             if (truncated_value < NumericLimits<ResultT>::min())
                 return NumericLimits<ResultT>::min();

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -271,14 +271,14 @@ struct Truncate {
 
     static StringView name() { return "truncate"; }
 };
-struct Round {
+struct NearbyIntegral {
     template<typename Lhs>
     auto operator()(Lhs lhs) const
     {
         if constexpr (IsSame<Lhs, float>)
-            return roundf(lhs);
+            return nearbyintf(lhs);
         else if constexpr (IsSame<Lhs, double>)
-            return round(lhs);
+            return nearbyint(lhs);
         else
             VERIFY_NOT_REACHED();
     }


### PR DESCRIPTION
This is mostly improving the spec test suite support (with this, the only unimplemented assertion types are "invalid" and "malformed", which can't be implemented until we have a WAST parser).
This also fixes some other bugs encountered on the way.