### PR TITLE
LibRegex: Allow null bytes in pattern

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -660,6 +660,7 @@ TEST_CASE(ECMA262_match)
         { "[\\0]"sv, "\0"sv, true, ECMAScriptFlags::BrowserExtended },
         { "[\\0]"sv, "\0"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::BrowserExtended) },
         { "[\\01]"sv, "\1"sv, true, ECMAScriptFlags::BrowserExtended },
+        { "(\0|a)"sv, "a"sv, true }, // #9686, Should allow null bytes in pattern
     };
     // clang-format on
 

--- a/Userland/Libraries/LibRegex/RegexLexer.cpp
+++ b/Userland/Libraries/LibRegex/RegexLexer.cpp
@@ -109,7 +109,7 @@ Token Lexer::next()
         }
     };
 
-    while (m_index <= m_input.length()) {
+    while (m_index < m_input.length()) {
         auto ch = peek();
         if (ch == '(')
             return emit_token(TokenType::LeftParen);
@@ -174,9 +174,6 @@ Token Lexer::next()
                 return commit_token(TokenType::EscapeSequence);
             }
         }
-
-        if (ch == '\0')
-            break;
 
         return emit_token(TokenType::Char);
     }


### PR DESCRIPTION
That check was rather pointless as the input is a StringView which knows
its own bounds.
Fixes #9686.