### PR TITLE
Spreadsheet: Don't invalidate the model on set_data()

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -146,7 +146,7 @@ void SheetModel::set_data(const GUI::ModelIndex& index, const GUI::Variant& valu
 
     auto& cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
     cell.set_data(value.to_string());
-    invalidate();
+    did_update(UpdateFlag::DontInvalidateIndices);
 }
 
 void SheetModel::update()


### PR DESCRIPTION
No previous model index will be invalidated afterwards, so avoid
invalidating them.
Also fixes an issue where committing to an edit with the inline cell
editor makes the focused cell switch to A0.
Fixes #9677.