### PR TITLE
Kernel: Fix shift sometimes staying pressed after releasing the key

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -61,7 +61,8 @@ protected:
     bool m_caps_lock_on { false };
     bool m_num_lock_on { false };
     bool m_has_e0_prefix { false };
-    bool m_both_shift_keys_pressed { false };
+    bool m_left_shift_pressed { false };
+    bool m_right_shift_pressed { false };
 
     void key_state_changed(u8 raw, bool pressed);
 };

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -53,13 +53,12 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         update_modifier(Mod_Super, pressed);
         break;
     case 0x2a:
+        m_left_shift_pressed = pressed;
+        update_modifier(Mod_Shift, m_left_shift_pressed || m_right_shift_pressed);
+        break;
     case 0x36:
-        if (m_both_shift_keys_pressed)
-            m_both_shift_keys_pressed = false;
-        else if ((m_modifiers & Mod_Shift) != 0 && pressed)
-            m_both_shift_keys_pressed = true;
-        else
-            update_modifier(Mod_Shift, pressed);
+        m_right_shift_pressed = pressed;
+        update_modifier(Mod_Shift, m_left_shift_pressed || m_right_shift_pressed);
         break;
     }
     switch (ch) {


### PR DESCRIPTION
Previous implementation sometimes didn't release the key after pressing
and holding shift due to repeating key updates when holding keys. This
meant repeating updates would set/unset `m_both_shift_keys_pressed`
repeatedly, sometimes resulting in shift still being considered pressed
even after you released it.

Simplify left and right shift key pressed logic by tracking both key
states separately and always updating modifiers based on them.