### PR TITLE
Meta: Fix yaml syntax of Sonar Cube Workflow

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -2,7 +2,7 @@ name: Sonar Cloud Static Analysis
 on:
   schedule:
     # At the end of every day
-    cron: "0 0 * * *"
+    - cron: '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
I fat fingered this last minute when converting from the trigger
I was using for development/testing to the cron schedule for use
in the main repo.