### PR TITLE
PixelPaint: Panning with space and mouse wheel changes

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -501,4 +501,13 @@ void ImageEditor::image_select_layer(Layer* layer)
 {
     set_active_layer(layer);
 }
+
+void ImageEditor::window_did_lose_focus()
+{
+    m_middle_mouse_down = false;
+    m_space_down = false;
+    m_active_cursor = m_active_tool ? m_active_tool->cursor() : Gfx::StandardCursor::None;
+    set_override_cursor(m_active_cursor);
+}
+
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -239,8 +239,18 @@ void ImageEditor::mouseup_event(GUI::MouseEvent& event)
 
 void ImageEditor::mousewheel_event(GUI::MouseEvent& event)
 {
-    auto scale_delta = -event.wheel_delta() * 0.1f;
-    scale_centered_on_position(event.position(), scale_delta);
+    if (event.modifiers() == Mod_None) {
+        auto translate_delta = event.wheel_delta() * 5;
+        m_pan_origin.translate_by(0, translate_delta / m_scale);
+        relayout();
+    } else if (event.modifiers() == Mod_Shift) {
+        auto translate_delta = event.wheel_delta() * 5;
+        m_pan_origin.translate_by(translate_delta / m_scale, 0);
+        relayout();
+    } else if (event.modifiers() == Mod_Ctrl) {
+        auto scale_delta = -event.wheel_delta() * 0.1f;
+        scale_centered_on_position(event.position(), scale_delta);
+    }
 }
 
 void ImageEditor::context_menu_event(GUI::ContextMenuEvent& event)

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -132,6 +132,8 @@ private:
     Gfx::FloatPoint m_pan_origin;
     Gfx::FloatPoint m_saved_pan_origin;
     Gfx::IntPoint m_click_position;
+    bool m_space_down { false };
+    bool m_middle_mouse_down { false };
 
     Gfx::StandardCursor m_active_cursor { Gfx::StandardCursor::None };
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -89,6 +89,8 @@ public:
     void set_guide_visibility(bool show_guides);
     Function<void(bool)> on_set_guide_visibility;
 
+    void window_did_lose_focus();
+
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -112,6 +112,13 @@ int main(int argc, char** argv)
         return verify_cast<PixelPaint::ImageEditor>(tab_widget.active_widget());
     };
 
+    window->on_active_window_change = [current_image_editor](bool is_active_window) {
+        if (!is_active_window) {
+            if (auto* editor = current_image_editor())
+                editor->window_did_lose_focus();
+        }
+    };
+
     Function<PixelPaint::ImageEditor&(NonnullRefPtr<PixelPaint::Image>)> create_new_editor;
 
     auto& layer_list_widget = *main_widget.find_descendant_of_type_named<PixelPaint::LayerListWidget>("layer_list_widget");

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -583,6 +583,8 @@ void Window::leave_event(Core::Event&)
 
 void Window::handle_entered_event(Core::Event& event)
 {
+    if (m_automatic_cursor_tracking_widget)
+        set_hovered_widget(m_automatic_cursor_tracking_widget);
     enter_event(event);
 }
 


### PR DESCRIPTION
Adds the ability to pan while holding space and dragging the mouse.
I also changed how mouse wheel behaves while holding shift or ctrl.

Also fixed a bug with the cursor not restoring correctly when dragging the mouse out and back in the window.