### PR TITLE
FileManager: Make context menus more consistent

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -368,6 +368,20 @@ int run_in_desktop_mode()
         }
     });
 
+    auto open_terminal_action = GUI::Action::create("Open in &Terminal", {}, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-terminal.png"), [&](auto&) {
+        auto paths = directory_view.selected_file_paths();
+        if (paths.is_empty()) {
+            spawn_terminal(directory_view.path());
+            return;
+        }
+
+        for (auto& path : paths) {
+            if (Core::File::is_directory(path)) {
+                spawn_terminal(path);
+            }
+        }
+    });
+
     auto display_properties_action = GUI::Action::create("&Display Settings", {}, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-display-settings.png"), [&](GUI::Action const&) {
         Desktop::Launcher::open(URL::create_with_file_protocol("/bin/DisplaySettings"));
     });
@@ -384,6 +398,7 @@ int run_in_desktop_mode()
     auto desktop_context_menu = GUI::Menu::construct("Directory View Directory");
 
     desktop_context_menu->add_action(file_manager_action);
+    desktop_context_menu->add_action(open_terminal_action);
     desktop_context_menu->add_separator();
     desktop_context_menu->add_action(cut_action);
     desktop_context_menu->add_action(copy_action);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -556,7 +556,6 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
     auto directory_context_menu = GUI::Menu::construct("Directory View Directory");
     auto directory_view_context_menu = GUI::Menu::construct("Directory View");
     auto tree_view_directory_context_menu = GUI::Menu::construct("Tree View Directory");
-    auto tree_view_context_menu = GUI::Menu::construct("Tree View");
 
     auto open_parent_directory_action = GUI::Action::create("Open &Parent Directory", { Mod_Alt, Key_Up }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-parent-directory.png"), [&](GUI::Action const&) {
         directory_view.open_parent_directory();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1032,15 +1032,15 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
 
     tree_view_directory_context_menu->add_action(open_in_new_window_action);
     tree_view_directory_context_menu->add_action(open_in_new_terminal_action);
+    tree_view_directory_context_menu->add_separator();
+    tree_view_directory_context_menu->add_action(mkdir_action);
+    tree_view_directory_context_menu->add_action(touch_action);
     tree_view_directory_context_menu->add_action(cut_action);
     tree_view_directory_context_menu->add_action(copy_action);
     tree_view_directory_context_menu->add_action(paste_action);
     tree_view_directory_context_menu->add_action(tree_view_delete_action);
     tree_view_directory_context_menu->add_separator();
     tree_view_directory_context_menu->add_action(properties_action);
-    tree_view_directory_context_menu->add_separator();
-    tree_view_directory_context_menu->add_action(mkdir_action);
-    tree_view_directory_context_menu->add_action(touch_action);
 
     RefPtr<GUI::Menu> file_context_menu;
     NonnullRefPtrVector<LauncherHandler> current_file_handlers;

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -392,6 +392,11 @@ int run_in_desktop_mode()
                 desktop_context_menu->popup(event.screen_position());
             } else {
                 file_context_menu = GUI::Menu::construct("Directory View File");
+
+                bool added_open_menu_items = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
+                if (added_open_menu_items)
+                    file_context_menu->add_separator();
+
                 file_context_menu->add_action(cut_action);
                 file_context_menu->add_action(copy_action);
                 file_context_menu->add_action(paste_action);
@@ -403,10 +408,6 @@ int run_in_desktop_mode()
                     file_context_menu->add_action(unzip_archive_action);
                     file_context_menu->add_separator();
                 }
-
-                bool added_open_menu_items = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
-                if (added_open_menu_items)
-                    file_context_menu->add_separator();
 
                 file_context_menu->add_action(properties_action);
                 file_context_menu->popup(event.screen_position(), file_context_menu_action_default_action);
@@ -1055,6 +1056,11 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
                 directory_context_menu->popup(event.screen_position());
             } else {
                 file_context_menu = GUI::Menu::construct("Directory View File");
+
+                bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
+                if (added_launch_file_handlers)
+                    file_context_menu->add_separator();
+
                 file_context_menu->add_action(cut_action);
                 file_context_menu->add_action(copy_action);
                 file_context_menu->add_action(paste_action);
@@ -1067,10 +1073,6 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
                     file_context_menu->add_action(unzip_archive_action);
                     file_context_menu->add_separator();
                 }
-
-                bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
-                if (added_launch_file_handlers)
-                    file_context_menu->add_separator();
 
                 file_context_menu->add_action(properties_action);
                 file_context_menu->popup(event.screen_position(), file_context_menu_action_default_action);


### PR DESCRIPTION
Before:
![context menus preview 27KiB](https://user-images.githubusercontent.com/16520278/131403519-bc9d2a48-fb6b-4739-8226-ac768c89772a.png)

This PR:
![context menus preview 28KiB](https://user-images.githubusercontent.com/16520278/131409262-c2183521-1996-4f7c-99c8-f1c00969cf65.png)

legend:
- green: added
- purple: moved
- yellow: edited text label to make the action more reusable

*“but what about the File Picker?”* you might ask
well, it has only “Show Dotfiles” when there’s nothing selected (which in my opinion isnt’s a good practice, as you don’t have an access to it when you have a dir with many files in list view), so there’s nothing to change! :^)

<details>
<summary>git log (it isn’t that long, just the description already is)</summary>

- **FileManager: Put file launch actions first**

  The default action (shown in bold) indicates what would you get by double-clicking on file.  Since it’s a default option, I think it deserves to be on top (together with alternative launch options). :^)

  Also they're not task actions like “Extract .zip here” or “Add to bookmarks”.

- **FileManager: Place mkdir and touch actions below openings in tree view**

  This way, the Properties action will always be everywhere on bottom.

- **FileManager: Add default ‘Open’ action in context menu for directories**

  This makes the directory context menu more similar to the file context menu.

- **FileManager: Add ‘Open in Terminal’ action for selected dirs on desktop**

  This is to be more similar to the context menu from the windowed instance of File Manager.

- **FileManager: Remove tree_view_directory_context_menu**

  It isn't used anywhere and the tree view shows only directories (and that is covered by the `tree_view_directory_context_menu`).

</details>
