### PR TITLE
Userland: Guard set_jmp.h static_assert check to cpp impls only

### DIFF
--- a/Userland/Libraries/LibC/setjmp.h
+++ b/Userland/Libraries/LibC/setjmp.h
@@ -48,14 +48,21 @@ struct __jmp_buf {
 typedef struct __jmp_buf jmp_buf[1];
 typedef struct __jmp_buf sigjmp_buf[1];
 
-#ifdef __i386__
-static_assert(sizeof(struct __jmp_buf) == 32, "struct __jmp_buf unsynchronized with i386/setjmp.S");
-#elif __x86_64__
-static_assert(sizeof(struct __jmp_buf) == 72, "struct __jmp_buf unsynchronized with x86_64/setjmp.S");
-#elif __aarch64__
-static_assert(sizeof(struct __jmp_buf) == 184, "struct __jmp_buf unsynchronized with aarch64/setjmp.S");
-#else
-#    error
+
+/**
+ * Since setjmp.h may be included in ports / c-projects, we need to guard this
+ *
+ */
+#ifdef __cplusplus
+    #ifdef __i386__
+        static_assert(sizeof(struct __jmp_buf) == 32, "struct __jmp_buf unsynchronized with i386/setjmp.S");
+    #elif __x86_64__
+        static_assert(sizeof(struct __jmp_buf) == 72, "struct __jmp_buf unsynchronized with x86_64/setjmp.S");
+    #elif __aarch64__
+        static_assert(sizeof(struct __jmp_buf) == 184, "struct __jmp_buf unsynchronized with aarch64/setjmp.S");
+    #else
+        #error
+    #endif
 #endif
 
 /**


### PR DESCRIPTION
A few ports were broken with https://github.com/SerenityOS/serenity/commit/0248e6ae2796648f8446d1d35ce680d9c5c685bc.
