### PR TITLE
Meta: Don't allow overlap in sonar cube file classification

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -1,8 +1,12 @@
 name: Sonar Cloud Static Analysis
 on:
+  # Automatically run at the end of every day.
   schedule:
-    # At the end of every day
     - cron: '0 0 * * *'
+
+  # Run if this file is changed in a pull request (to get immediate feedback).
+  pull_request:
+    paths: [".github/workflows/sonar-cloud-static-analysis.yml"]
 
 jobs:
   build:
@@ -52,8 +56,8 @@ jobs:
           echo "sonar.cfamily.compile-commands=${{ github.workspace }}/Build/compile_commands.json" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.threads=2" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.host.url=${{ env.SONAR_SERVER_URL }}" >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.sources=." >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.tests=${{ github.workspace }}/Tests,${{ github.workspace }}/Base/res,${{ github.workspace }}/Base/www" >> ${{ github.workspace }}/sonar-project.properties
+          echo "sonar.sources=AK,Build,Userland,Kernel,Meta" >> ${{ github.workspace }}/sonar-project.properties
+          echo "sonar.tests=Tests" >> ${{ github.workspace }}/sonar-project.properties
 
       # === OS SETUP ===
       # TODO: Is there someway to share these steps with the cmake.yml?


### PR DESCRIPTION
Test files were getting analyzed twice, which the tool does
not like, and causes it to exit with a fatal error.

Also make the workflow run in PRs anytime the file is edited,
so that we can get immediate feedback without waiting till the
next day.