### PR TITLE
Kernel: Don't VERIFY_NOT_REACHED in LocalSocket::has_attached_peer()

### DIFF
--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -297,7 +297,7 @@ bool LocalSocket::has_attached_peer(const FileDescription& description) const
         return m_connect_side_fd != nullptr;
     if (role == Role::Connected)
         return m_accept_side_fd_open;
-    VERIFY_NOT_REACHED();
+    return false;
 }
 
 bool LocalSocket::can_write(const FileDescription& description, size_t) const


### PR DESCRIPTION
It's possible to trigger this assertion by calling `sendmsg` on a listening socket. For example:
```c++
#include <fcntl.h>
#include <sys/socket.h>
#include <sys/uio.h>

int main()
{
    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
    listen(fd, 4);
    struct iovec iov{};
    struct msghdr msg{
        .msg_name = nullptr,
        .msg_namelen = 0,
        .msg_iov = &iov,
        .msg_iovlen = 1,
        .msg_control = nullptr,
        .msg_controllen = 0,
        .msg_flags = 0,
    };
    sendmsg(fd, &msg, 0);
}
```
This is because `sendto` calls `has_attached_peer` before checking the result of `send_buffer_for`. The issue doesn't affect `write` since `can_write` returns false on a listening socket.