### PR TITLE
LibJS+LibUnicode: Implement subtag alias and likely subtag substitution

### DIFF
--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -40,6 +40,9 @@ set(CLDR_PATH ${CMAKE_BINARY_DIR}/CLDR)
 set(CLDR_ZIP_URL https://github.com/unicode-org/cldr-json/releases/download/39.0.0/cldr-39.0.0-json-modern.zip)
 set(CLDR_ZIP_PATH ${CLDR_PATH}/cldr.zip)
 
+set(CLDR_CORE_SOURCE cldr-core)
+set(CLDR_CORE_PATH ${CLDR_PATH}/${CLDR_CORE_SOURCE})
+
 set(CLDR_LOCALES_SOURCE cldr-localenames-modern)
 set(CLDR_LOCALES_PATH ${CLDR_PATH}/${CLDR_LOCALES_SOURCE})
 
@@ -100,6 +103,13 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
         message(STATUS "Downloading CLDR database from ${CLDR_ZIP_URL}...")
         file(DOWNLOAD ${CLDR_ZIP_URL} ${CLDR_ZIP_PATH} INACTIVITY_TIMEOUT 10)
     endif()
+    if(EXISTS ${CLDR_ZIP_PATH} AND NOT EXISTS ${CLDR_CORE_PATH})
+        message(STATUS "Extracting CLDR ${CLDR_CORE_SOURCE} from ${CLDR_ZIP_PATH}...")
+        execute_process(COMMAND unzip -q ${CLDR_ZIP_PATH} "${CLDR_CORE_SOURCE}/**" -d ${CLDR_PATH} RESULT_VARIABLE unzip_result)
+        if (NOT unzip_result EQUAL 0)
+            message(FATAL_ERROR "Failed to unzip ${CLDR_CORE_SOURCE} from ${CLDR_ZIP_PATH} with status ${unzip_result}")
+        endif()
+    endif()
     if(EXISTS ${CLDR_ZIP_PATH} AND NOT EXISTS ${CLDR_LOCALES_PATH})
         message(STATUS "Extracting CLDR ${CLDR_LOCALES_SOURCE} from ${CLDR_ZIP_PATH}...")
         execute_process(COMMAND unzip -q ${CLDR_ZIP_PATH} "${CLDR_LOCALES_SOURCE}/**" -d ${CLDR_PATH} RESULT_VARIABLE unzip_result)
@@ -143,9 +153,9 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_LOCALE_HEADER} ${UNICODE_LOCALE_IMPLEMENTATION}
-        COMMAND $<TARGET_FILE:GenerateUnicodeLocale> -h ${UNICODE_LOCALE_HEADER} -c ${UNICODE_LOCALE_IMPLEMENTATION} -l ${CLDR_LOCALES_PATH} -n ${CLDR_NUMBERS_PATH}
+        COMMAND $<TARGET_FILE:GenerateUnicodeLocale> -h ${UNICODE_LOCALE_HEADER} -c ${UNICODE_LOCALE_IMPLEMENTATION} -r ${CLDR_CORE_PATH} -l ${CLDR_LOCALES_PATH} -n ${CLDR_NUMBERS_PATH}
         VERBATIM
-        DEPENDS GenerateUnicodeLocale ${CLDR_LOCALES_PATH} ${CLDR_NUMBERS_PATH}
+        DEPENDS GenerateUnicodeLocale ${CLDR_CORE_PATH} ${CLDR_LOCALES_PATH} ${CLDR_NUMBERS_PATH}
     )
     add_custom_target(generate_${UNICODE_META_TARGET_PREFIX}UnicodeLocale DEPENDS ${UNICODE_LOCALE_HEADER} ${UNICODE_LOCALE_IMPLEMENTATION})
     add_dependencies(all_generated generate_${UNICODE_META_TARGET_PREFIX}UnicodeLocale)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -487,12 +487,14 @@ int main(int argc, char** argv)
 {
     char const* generated_header_path = nullptr;
     char const* generated_implementation_path = nullptr;
+    char const* core_path = nullptr;
     char const* locale_names_path = nullptr;
     char const* numbers_path = nullptr;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(generated_header_path, "Path to the Unicode locale header file to generate", "generated-header-path", 'h', "generated-header-path");
     args_parser.add_option(generated_implementation_path, "Path to the Unicode locale implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
+    args_parser.add_option(core_path, "Path to cldr-core directory", "core-path", 'r', "core-path");
     args_parser.add_option(locale_names_path, "Path to cldr-localenames directory", "locale-names-path", 'l', "locale-names-path");
     args_parser.add_option(numbers_path, "Path to cldr-numbers directory", "numbers-path", 'n', "numbers-path");
     args_parser.parse(argc, argv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -394,6 +394,14 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-SU"sv, "en-RU"sv);
     test("en-810"sv, "en-RU"sv);
     test("EN-810"sv, "en-RU"sv);
+    test("hy-su"sv, "hy-AM"sv);
+    test("HY-SU"sv, "hy-AM"sv);
+    test("hy-810"sv, "hy-AM"sv);
+    test("HY-810"sv, "hy-AM"sv);
+    test("und-Armn-su"sv, "und-Armn-AM"sv);
+    test("UND-ARMN-SU"sv, "und-Armn-AM"sv);
+    test("und-Armn-810"sv, "und-Armn-AM"sv);
+    test("UND-ARMN-810"sv, "und-Armn-AM"sv);
 
     // Script subtag aliases.
     test("en-qaai"sv, "en-Zinh"sv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -306,6 +306,8 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-KB-YES"sv, "en-u-kb"sv);
     test("en-u-ka-yes"sv, "en-u-ka-yes"sv);
     test("EN-U-KA-YES"sv, "en-u-ka-yes"sv);
+    test("en-u-1k-names"sv, "en-u-1k-names"sv);
+    test("EN-U-1K-NAMES"sv, "en-u-1k-names"sv);
 
     test("en-t-en"sv, "en-t-en"sv);
     test("EN-T-EN"sv, "en-t-en"sv);
@@ -321,6 +323,10 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-T-K1-TRUE"sv, "en-t-k1-true"sv);
     test("en-t-k1-yes"sv, "en-t-k1-yes"sv);
     test("EN-T-K1-YES"sv, "en-t-k1-yes"sv);
+    test("en-t-m0-names"sv, "en-t-m0-prprname"sv);
+    test("EN-T-M0-NAMES"sv, "en-t-m0-prprname"sv);
+    test("en-t-k1-names"sv, "en-t-k1-names"sv);
+    test("EN-T-K1-NAMES"sv, "en-t-k1-names"sv);
 
     test("en-0-aaa"sv, "en-0-aaa"sv);
     test("EN-0-AAA"sv, "en-0-aaa"sv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -410,4 +410,20 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-RG-CN12"sv, "en-u-rg-cntj"sv);
     test("en-u-aa-cn11"sv, "en-u-aa-cn11"sv);
     test("EN-U-AA-CN11"sv, "en-u-aa-cn11"sv);
+
+    // Complex aliases.
+    test("en-lojban"sv, "en"sv);
+    test("EN-LOJBAN"sv, "en"sv);
+    test("art-lojban"sv, "jbo"sv);
+    test("ART-LOJBAN"sv, "jbo"sv);
+    test("cel-gaulish"sv, "xtg"sv);
+    test("CEL-GAULISH"sv, "xtg"sv);
+    test("zh-guoyu"sv, "zh"sv);
+    test("ZH-GUOYU"sv, "zh"sv);
+    test("zh-hakka"sv, "hak"sv);
+    test("ZH-HAKKA"sv, "hak"sv);
+    test("zh-xiang"sv, "hsn"sv);
+    test("ZH-XIANG"sv, "hsn"sv);
+    test("ja-latn-hepburn-heploc"sv, "ja-Latn-alalc97"sv);
+    test("JA-LATN-HEPBURN-HEPLOC"sv, "ja-Latn-alalc97"sv);
 }

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -312,6 +312,10 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-KS-PRIMARY"sv, "en-u-ks-level1"sv);
     test("en-u-ka-primary"sv, "en-u-ka-primary"sv);
     test("EN-U-KA-PRIMARY"sv, "en-u-ka-primary"sv);
+    test("en-u-ms-imperial"sv, "en-u-ms-uksystem"sv);
+    test("EN-U-MS-IMPERIAL"sv, "en-u-ms-uksystem"sv);
+    test("en-u-ma-imperial"sv, "en-u-ma-imperial"sv);
+    test("EN-U-MA-IMPERIAL"sv, "en-u-ma-imperial"sv);
 
     test("en-t-en"sv, "en-t-en"sv);
     test("EN-T-EN"sv, "en-t-en"sv);
@@ -333,6 +337,8 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-T-K1-NAMES"sv, "en-t-k1-names"sv);
     test("en-t-k1-primary"sv, "en-t-k1-primary"sv);
     test("EN-T-K1-PRIMARY"sv, "en-t-k1-primary"sv);
+    test("en-t-k1-imperial"sv, "en-t-k1-imperial"sv);
+    test("EN-T-K1-IMPERIAL"sv, "en-t-k1-imperial"sv);
 
     test("en-0-aaa"sv, "en-0-aaa"sv);
     test("EN-0-AAA"sv, "en-0-aaa"sv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -320,6 +320,14 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-TZ-HONGKONG"sv, "en-u-tz-hkhkg"sv);
     test("en-u-ta-hongkong"sv, "en-u-ta-hongkong"sv);
     test("EN-U-TA-HONGKONG"sv, "en-u-ta-hongkong"sv);
+    test("en-u-ca-ethiopic-amete-alem"sv, "en-u-ca-ethioaa"sv);
+    test("EN-U-CA-ETHIOPIC-AMETE-ALEM"sv, "en-u-ca-ethioaa"sv);
+    test("en-u-ca-alem-ethiopic-amete"sv, "en-u-ca-alem-ethiopic-amete"sv);
+    test("EN-U-CA-ALEM-ETHIOPIC-AMETE"sv, "en-u-ca-alem-ethiopic-amete"sv);
+    test("en-u-ca-ethiopic-amete-xxx-alem"sv, "en-u-ca-ethiopic-amete-xxx-alem"sv);
+    test("EN-U-CA-ETHIOPIC-AMETE-XXX-ALEM"sv, "en-u-ca-ethiopic-amete-xxx-alem"sv);
+    test("en-u-cb-ethiopic-amete-alem"sv, "en-u-cb-ethiopic-amete-alem"sv);
+    test("EN-U-CB-ETHIOPIC-AMETE-ALEM"sv, "en-u-cb-ethiopic-amete-alem"sv);
 
     test("en-t-en"sv, "en-t-en"sv);
     test("EN-T-EN"sv, "en-t-en"sv);
@@ -345,6 +353,8 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-T-K1-IMPERIAL"sv, "en-t-k1-imperial"sv);
     test("en-t-k1-hongkong"sv, "en-t-k1-hongkong"sv);
     test("EN-T-K1-HONGKONG"sv, "en-t-k1-hongkong"sv);
+    test("en-t-k1-ethiopic-amete-alem"sv, "en-t-k1-ethiopic-amete-alem"sv);
+    test("EN-T-K1-ETHIOPIC-AMETE-ALEM"sv, "en-t-k1-ethiopic-amete-alem"sv);
 
     test("en-0-aaa"sv, "en-0-aaa"sv);
     test("EN-0-AAA"sv, "en-0-aaa"sv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -302,6 +302,10 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-CCC-BBB-2K-AAA-1K-BBB"sv, "en-u-bbb-ccc-1k-bbb-2k-aaa"sv);
     test("en-u-1k-true"sv, "en-u-1k"sv);
     test("EN-U-1K-TRUE"sv, "en-u-1k"sv);
+    test("en-u-kb-yes"sv, "en-u-kb"sv);
+    test("EN-U-KB-YES"sv, "en-u-kb"sv);
+    test("en-u-ka-yes"sv, "en-u-ka-yes"sv);
+    test("EN-U-KA-YES"sv, "en-u-ka-yes"sv);
 
     test("en-t-en"sv, "en-t-en"sv);
     test("EN-T-EN"sv, "en-t-en"sv);
@@ -315,6 +319,8 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-T-EN-K2-BBB-K1-AAA"sv, "en-t-en-k1-aaa-k2-bbb"sv);
     test("en-t-k1-true"sv, "en-t-k1-true"sv);
     test("EN-T-K1-TRUE"sv, "en-t-k1-true"sv);
+    test("en-t-k1-yes"sv, "en-t-k1-yes"sv);
+    test("EN-T-K1-YES"sv, "en-t-k1-yes"sv);
 
     test("en-0-aaa"sv, "en-0-aaa"sv);
     test("EN-0-AAA"sv, "en-0-aaa"sv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -75,7 +75,7 @@ TEST_CASE(parse_unicode_locale_id)
         auto locale_id = Unicode::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
-    auto pass = [](StringView locale, Optional<StringView> expected_language, Optional<StringView> expected_script, Optional<StringView> expected_region, Vector<StringView> expected_variants) {
+    auto pass = [](StringView locale, Optional<StringView> expected_language, Optional<StringView> expected_script, Optional<StringView> expected_region, Vector<String> expected_variants) {
         auto locale_id = Unicode::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
 
@@ -252,7 +252,7 @@ TEST_CASE(parse_unicode_locale_id_with_private_use_extension)
         auto locale_id = Unicode::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
-    auto pass = [](StringView locale, Vector<StringView> const& expected_extension) {
+    auto pass = [](StringView locale, Vector<String> const& expected_extension) {
         auto locale_id = Unicode::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
         EXPECT_EQ(locale_id->private_use_extensions, expected_extension);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -316,6 +316,10 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-MS-IMPERIAL"sv, "en-u-ms-uksystem"sv);
     test("en-u-ma-imperial"sv, "en-u-ma-imperial"sv);
     test("EN-U-MA-IMPERIAL"sv, "en-u-ma-imperial"sv);
+    test("en-u-tz-hongkong"sv, "en-u-tz-hkhkg"sv);
+    test("EN-U-TZ-HONGKONG"sv, "en-u-tz-hkhkg"sv);
+    test("en-u-ta-hongkong"sv, "en-u-ta-hongkong"sv);
+    test("EN-U-TA-HONGKONG"sv, "en-u-ta-hongkong"sv);
 
     test("en-t-en"sv, "en-t-en"sv);
     test("EN-T-EN"sv, "en-t-en"sv);
@@ -339,6 +343,8 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-T-K1-PRIMARY"sv, "en-t-k1-primary"sv);
     test("en-t-k1-imperial"sv, "en-t-k1-imperial"sv);
     test("EN-T-K1-IMPERIAL"sv, "en-t-k1-imperial"sv);
+    test("en-t-k1-hongkong"sv, "en-t-k1-hongkong"sv);
+    test("EN-T-K1-HONGKONG"sv, "en-t-k1-hongkong"sv);
 
     test("en-0-aaa"sv, "en-0-aaa"sv);
     test("EN-0-AAA"sv, "en-0-aaa"sv);

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -334,4 +334,40 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-Z-BBB-U-AA-T-EN-0-AAA"sv, "en-0-aaa-t-en-u-aa-z-bbb"sv);
     test("en-z-bbb-u-aa-t-en-0-aaa-x-ccc"sv, "en-0-aaa-t-en-u-aa-z-bbb-x-ccc"sv);
     test("EN-Z-BBB-U-AA-T-EN-0-AAA-X-CCC"sv, "en-0-aaa-t-en-u-aa-z-bbb-x-ccc"sv);
+
+    // Language subtag aliases.
+    test("sh"sv, "sr-Latn"sv);
+    test("SH"sv, "sr-Latn"sv);
+    test("sh-cyrl"sv, "sr-Cyrl"sv);
+    test("SH-CYRL"sv, "sr-Cyrl"sv);
+    test("cnr"sv, "sr-ME"sv);
+    test("CNR"sv, "sr-ME"sv);
+    test("cnr-ba"sv, "sr-BA"sv);
+    test("CNR-BA"sv, "sr-BA"sv);
+
+    // Territory subtag aliases.
+    test("ru-su"sv, "ru-RU"sv);
+    test("RU-SU"sv, "ru-RU"sv);
+    test("ru-810"sv, "ru-RU"sv);
+    test("RU-810"sv, "ru-RU"sv);
+    test("en-su"sv, "en-RU"sv);
+    test("EN-SU"sv, "en-RU"sv);
+    test("en-810"sv, "en-RU"sv);
+    test("EN-810"sv, "en-RU"sv);
+
+    // Script subtag aliases.
+    test("en-qaai"sv, "en-Zinh"sv);
+    test("EN-QAAI"sv, "en-Zinh"sv);
+
+    // Variant subtag aliases.
+    test("en-polytoni"sv, "en-polyton"sv);
+    test("EN-POLYTONI"sv, "en-polyton"sv);
+
+    // Subdivision subtag aliases.
+    test("en-u-sd-cn11"sv, "en-u-sd-cnbj"sv);
+    test("EN-U-SD-CN11"sv, "en-u-sd-cnbj"sv);
+    test("en-u-rg-cn12"sv, "en-u-rg-cntj"sv);
+    test("EN-U-RG-CN12"sv, "en-u-rg-cntj"sv);
+    test("en-u-aa-cn11"sv, "en-u-aa-cn11"sv);
+    test("EN-U-AA-CN11"sv, "en-u-aa-cn11"sv);
 }

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -308,6 +308,10 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-KA-YES"sv, "en-u-ka-yes"sv);
     test("en-u-1k-names"sv, "en-u-1k-names"sv);
     test("EN-U-1K-NAMES"sv, "en-u-1k-names"sv);
+    test("en-u-ks-primary"sv, "en-u-ks-level1"sv);
+    test("EN-U-KS-PRIMARY"sv, "en-u-ks-level1"sv);
+    test("en-u-ka-primary"sv, "en-u-ka-primary"sv);
+    test("EN-U-KA-PRIMARY"sv, "en-u-ka-primary"sv);
 
     test("en-t-en"sv, "en-t-en"sv);
     test("EN-T-EN"sv, "en-t-en"sv);
@@ -327,6 +331,8 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-T-M0-NAMES"sv, "en-t-m0-prprname"sv);
     test("en-t-k1-names"sv, "en-t-k1-names"sv);
     test("EN-T-K1-NAMES"sv, "en-t-k1-names"sv);
+    test("en-t-k1-primary"sv, "en-t-k1-primary"sv);
+    test("EN-T-K1-PRIMARY"sv, "en-t-k1-primary"sv);
 
     test("en-0-aaa"sv, "en-0-aaa"sv);
     test("EN-0-AAA"sv, "en-0-aaa"sv);

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -19,7 +19,7 @@ namespace JS::Intl {
 // 6.2.2 IsStructurallyValidLanguageTag ( locale ), https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag
 static Optional<Unicode::LocaleID> is_structurally_valid_language_tag(StringView locale)
 {
-    auto contains_duplicate_variant = [](Vector<StringView>& variants) {
+    auto contains_duplicate_variant = [](auto& variants) {
         if (variants.is_empty())
             return false;
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.resolvedOptions.js
@@ -28,4 +28,15 @@ describe("correct behavior", () => {
             fallback: "code",
         });
     });
+
+    test("locales with extensions", () => {
+        const en = new Intl.DisplayNames("en-t-en", { type: "language" });
+        expect(en.resolvedOptions().locale).toBe("en");
+
+        const es419 = new Intl.DisplayNames("es-419-u-1k-aaa", { type: "language" });
+        expect(es419.resolvedOptions().locale).toBe("es-419");
+
+        const zhHant = new Intl.DisplayNames(["zh-Hant-x-aaa"], { type: "language" });
+        expect(zhHant.resolvedOptions().locale).toBe("zh-Hant");
+    });
 });

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -19,6 +19,7 @@ enum class Script : u8;
 enum class Territory : u8;
 enum class WordBreakProperty : u8;
 
+struct LanguageID;
 struct SpecialCasing;
 struct UnicodeData;
 

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -568,6 +568,10 @@ static void transform_unicode_locale_id_to_canonical_syntax(LocaleID& locale_id)
         for (auto& variant : language_id.variants)
             variant = variant.to_lowercase();
 
+#if ENABLE_UNICODE_DATA
+        Detail::resolve_complex_language_aliases(language_id);
+#endif
+
         if (auto alias = resolve_language_alias(*language_id.language); alias.has_value()) {
             auto language_alias = parse_unicode_language_id(*alias);
             VERIFY(language_alias.has_value());

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -860,4 +860,19 @@ Optional<StringView> resolve_subdivision_alias(StringView subdivision)
 #endif
 }
 
+String resolve_most_likely_territory([[maybe_unused]] LanguageID const& language_id, StringView territory_alias)
+{
+    auto aliases = territory_alias.split_view(' ');
+
+#if ENABLE_UNICODE_DATA
+    if (aliases.size() > 1) {
+        auto territory = Detail::resolve_most_likely_territory(language_id);
+        if (territory.has_value() && aliases.contains_slow(*territory))
+            return territory.release_value();
+    }
+#endif
+
+    return aliases[0].to_string();
+}
+
 }

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -400,7 +400,7 @@ static Optional<Extension> parse_extension(GenericLexer& lexer)
     return {};
 }
 
-static Vector<StringView> parse_private_use_extensions(GenericLexer& lexer)
+static Vector<String> parse_private_use_extensions(GenericLexer& lexer)
 {
     // https://unicode.org/reports/tr35/#pu_extensions
     //
@@ -411,8 +411,8 @@ static Vector<StringView> parse_private_use_extensions(GenericLexer& lexer)
     if (!header.has_value())
         return {};
 
-    auto parse_values = [&]() -> Vector<StringView> {
-        Vector<StringView> extensions;
+    auto parse_values = [&]() -> Vector<String> {
+        Vector<String> extensions;
 
         while (true) {
             auto segment = consume_next_segment(lexer);
@@ -491,18 +491,18 @@ Optional<String> canonicalize_unicode_locale_id(LocaleID& locale_id)
         Title,
     };
 
-    auto append_sep_and_string = [&](Optional<StringView> const& string, Case case_ = Case::Lower) {
+    auto append_sep_and_string = [&](Optional<String> const& string, Case case_ = Case::Lower) {
         if (!string.has_value())
             return;
         switch (case_) {
         case Case::Upper:
-            builder.appendff("-{}", string->to_uppercase_string());
+            builder.appendff("-{}", string->to_uppercase());
             break;
         case Case::Lower:
-            builder.appendff("-{}", string->to_lowercase_string());
+            builder.appendff("-{}", string->to_lowercase());
             break;
         case Case::Title:
-            builder.appendff("-{}", string->to_titlecase_string());
+            builder.appendff("-{}", string->to_titlecase());
             break;
         }
     };
@@ -510,7 +510,7 @@ Optional<String> canonicalize_unicode_locale_id(LocaleID& locale_id)
     if (!locale_id.language_id.language.has_value())
         return {};
 
-    builder.append(locale_id.language_id.language->to_lowercase_string());
+    builder.append(locale_id.language_id.language->to_lowercase());
     append_sep_and_string(locale_id.language_id.script, Case::Title);
     append_sep_and_string(locale_id.language_id.region, Case::Upper);
 

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -591,13 +591,8 @@ static void transform_unicode_locale_id_to_canonical_syntax(LocaleID& locale_id)
         }
 
         if (language_id.region.has_value()) {
-            if (auto alias = resolve_territory_alias(*language_id.region); alias.has_value()) {
-                auto aliases = alias->split_view(' ');
-
-                // FIXME: Territory subtag aliases should also consult the CLDR likelySubtags.json file.
-                //        For now, implement the spec's recommendation of using just the first alias.
-                language_id.region = aliases[0].to_string();
-            }
+            if (auto alias = resolve_territory_alias(*language_id.region); alias.has_value())
+                language_id.region = resolve_most_likely_territory(language_id, *alias);
         }
 
         quick_sort(language_id.variants);

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -484,6 +484,7 @@ static void perform_hard_coded_key_value_substitutions(String& key, String& valu
 {
     // FIXME: In the XML export of CLDR, there are some aliases defined in the following files:
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/collation.xml
+    // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/measure.xml
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/transform.xml
     //
     // There doesn't seem to be a counterpart in the JSON export. Since there aren't many such
@@ -499,6 +500,8 @@ static void perform_hard_coded_key_value_substitutions(String& key, String& valu
         // but those are semantically incorrect values (they are too long), so they can be skipped.
     } else if ((key == "m0"sv) && (value == "names"sv)) {
         value = "prprname"sv;
+    } else if ((key == "ms"sv) && (value == "imperial"sv)) {
+        value = "uksystem"sv;
     }
 }
 

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -488,10 +488,18 @@ static void perform_hard_coded_key_value_substitutions(String& key, String& valu
     //
     // There doesn't seem to be a counterpart in the JSON export. Since there aren't many such
     // aliases, until an XML parser is implemented, those aliases are implemented here.
-    if (key.is_one_of("kb"sv, "kc"sv, "kh"sv, "kk"sv, "kn"sv) && (value == "yes"sv))
+    if (key.is_one_of("kb"sv, "kc"sv, "kh"sv, "kk"sv, "kn"sv) && (value == "yes"sv)) {
         value = "true"sv;
-    else if ((key == "m0"sv) && (value == "names"sv))
+    } else if (key == "ks"sv) {
+        if (value == "primary"sv)
+            value = "level1"sv;
+        else if (value == "tertiary"sv)
+            value = "level3"sv;
+        // Note: There are also aliases for "secondary", "quaternary", "quarternary", and "identical",
+        // but those are semantically incorrect values (they are too long), so they can be skipped.
+    } else if ((key == "m0"sv) && (value == "names"sv)) {
         value = "prprname"sv;
+    }
 }
 
 static void transform_unicode_locale_id_to_canonical_syntax(LocaleID& locale_id)

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -482,13 +482,16 @@ Optional<LocaleID> parse_unicode_locale_id(StringView locale)
 
 static void perform_hard_coded_key_value_substitutions(String& key, String& value)
 {
-    // FIXME: In the XML export of CLDR, there are some aliases defined in the following file:
+    // FIXME: In the XML export of CLDR, there are some aliases defined in the following files:
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/collation.xml
+    // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/transform.xml
     //
     // There doesn't seem to be a counterpart in the JSON export. Since there aren't many such
     // aliases, until an XML parser is implemented, those aliases are implemented here.
     if (key.is_one_of("kb"sv, "kc"sv, "kh"sv, "kk"sv, "kn"sv) && (value == "yes"sv))
         value = "true"sv;
+    else if ((key == "m0"sv) && (value == "names"sv))
+        value = "prprname"sv;
 }
 
 static void transform_unicode_locale_id_to_canonical_syntax(LocaleID& locale_id)

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -485,6 +485,7 @@ static void perform_hard_coded_key_value_substitutions(String& key, String& valu
     // FIXME: In the XML export of CLDR, there are some aliases defined in the following files:
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/collation.xml
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/measure.xml
+    // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/timezone.xml
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/transform.xml
     //
     // There doesn't seem to be a counterpart in the JSON export. Since there aren't many such
@@ -502,6 +503,40 @@ static void perform_hard_coded_key_value_substitutions(String& key, String& valu
         value = "prprname"sv;
     } else if ((key == "ms"sv) && (value == "imperial"sv)) {
         value = "uksystem"sv;
+    } else if (key == "tz"sv) {
+        // Formatter disabled because this block is easier to read / check against timezone.xml as one-liners.
+        // clang-format off
+        if (value == "aqams"sv) value = "nzakl"sv;
+        else if (value == "cnckg"sv) value = "cnsha"sv;
+        else if (value == "cnhrb"sv) value = "cnsha"sv;
+        else if (value == "cnkhg"sv) value = "cnurc"sv;
+        else if (value == "cuba"sv) value = "cuhav"sv;
+        else if (value == "egypt"sv) value = "egcai"sv;
+        else if (value == "eire"sv) value = "iedub"sv;
+        else if (value == "est"sv) value = "utcw05"sv;
+        else if (value == "gmt0"sv) value = "gmt"sv;
+        else if (value == "hongkong"sv) value = "hkhkg"sv;
+        else if (value == "hst"sv) value = "utcw10"sv;
+        else if (value == "iceland"sv) value = "isrey"sv;
+        else if (value == "iran"sv) value = "irthr"sv;
+        else if (value == "israel"sv) value = "jeruslm"sv;
+        else if (value == "jamaica"sv) value = "jmkin"sv;
+        else if (value == "japan"sv) value = "jptyo"sv;
+        else if (value == "kwajalein"sv) value = "mhkwa"sv;
+        else if (value == "libya"sv) value = "lytip"sv;
+        else if (value == "mst"sv) value = "utcw07"sv;
+        else if (value == "navajo"sv) value = "usden"sv;
+        else if (value == "poland"sv) value = "plwaw"sv;
+        else if (value == "portugal"sv) value = "ptlis"sv;
+        else if (value == "prc"sv) value = "cnsha"sv;
+        else if (value == "roc"sv) value = "twtpe"sv;
+        else if (value == "rok"sv) value = "krsel"sv;
+        else if (value == "singapore"sv) value = "sgsin"sv;
+        else if (value == "turkey"sv) value = "trist"sv;
+        else if (value == "uct"sv) value = "utc"sv;
+        else if (value == "usnavajo"sv) value = "usden"sv;
+        else if (value == "zulu"sv) value = "utc"sv;
+        // clang-format on
     }
 }
 

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -640,4 +640,49 @@ Optional<StringView> get_locale_currency_mapping([[maybe_unused]] StringView loc
 #endif
 }
 
+Optional<StringView> resolve_language_alias(StringView language)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::resolve_language_alias(language);
+#else
+    return language;
+#endif
+}
+
+Optional<StringView> resolve_territory_alias(StringView territory)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::resolve_territory_alias(territory);
+#else
+    return territory;
+#endif
+}
+
+Optional<StringView> resolve_script_tag_alias(StringView script_tag)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::resolve_script_tag_alias(script_tag);
+#else
+    return script_tag;
+#endif
+}
+
+Optional<StringView> resolve_variant_alias(StringView variant)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::resolve_variant_alias(variant);
+#else
+    return variant;
+#endif
+}
+
+Optional<StringView> resolve_subdivision_alias(StringView subdivision)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::resolve_subdivision_alias(subdivision);
+#else
+    return subdivision;
+#endif
+}
+
 }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -81,4 +81,6 @@ Optional<StringView> resolve_script_tag_alias(StringView script_tag);
 Optional<StringView> resolve_variant_alias(StringView variant);
 Optional<StringView> resolve_subdivision_alias(StringView subdivision);
 
+String resolve_most_likely_territory(LanguageID const& language_id, StringView territory_alias);
+
 }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -75,4 +75,10 @@ Optional<StringView> get_locale_territory_mapping(StringView locale, StringView 
 Optional<StringView> get_locale_script_mapping(StringView locale, StringView script);
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency);
 
+Optional<StringView> resolve_language_alias(StringView language);
+Optional<StringView> resolve_territory_alias(StringView territory);
+Optional<StringView> resolve_script_tag_alias(StringView script_tag);
+Optional<StringView> resolve_variant_alias(StringView variant);
+Optional<StringView> resolve_subdivision_alias(StringView subdivision);
+
 }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -17,25 +17,25 @@ namespace Unicode {
 
 struct LanguageID {
     bool is_root { false };
-    Optional<StringView> language {};
-    Optional<StringView> script {};
-    Optional<StringView> region {};
-    Vector<StringView> variants {};
+    Optional<String> language {};
+    Optional<String> script {};
+    Optional<String> region {};
+    Vector<String> variants {};
 };
 
 struct Keyword {
-    StringView key {};
-    Vector<StringView> types {};
+    String key {};
+    Vector<String> types {};
 };
 
 struct LocaleExtension {
-    Vector<StringView> attributes {};
+    Vector<String> attributes {};
     Vector<Keyword> keywords {};
 };
 
 struct TransformedField {
-    StringView key;
-    Vector<StringView> values {};
+    String key;
+    Vector<String> values {};
 };
 
 struct TransformedExtension {
@@ -45,7 +45,7 @@ struct TransformedExtension {
 
 struct OtherExtension {
     char key {};
-    Vector<StringView> values {};
+    Vector<String> values {};
 };
 
 using Extension = Variant<LocaleExtension, TransformedExtension, OtherExtension>;
@@ -53,7 +53,7 @@ using Extension = Variant<LocaleExtension, TransformedExtension, OtherExtension>
 struct LocaleID {
     LanguageID language_id {};
     Vector<Extension> extensions {};
-    Vector<StringView> private_use_extensions {};
+    Vector<String> private_use_extensions {};
 };
 
 // Note: These methods only verify that the provided strings match the EBNF grammar of the


### PR DESCRIPTION
Unicode TR35 has rules dictating how subtags within a locale should be replaced if they match some aliasing rule. Most of these are "simple" rules (meaning matching is done on single subtags). However some are "complex" rules (where matching is done on multiple subtags) - those rules are handled separately here. Further, some territory subtag aliases contain multiple possible substitutions. For these, we consult the likely subtag CLDR data to decide which territory alias should be used.

~~Fixes about 10 test262 tests. The following tests should also be fixed once #9707 is fixed:
test262/test/intl402/Intl/getCanonicalLocales/canonicalized-tags.js
test262/test/intl402/Intl/getCanonicalLocales/preferred-variant.js
test262/test/intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js
test262/test/intl402/Intl/getCanonicalLocales/transformed-ext-valid.js
test262/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-calendar.js~~

Fixes about 15 test262 tests :)