### PR TITLE
LibGUI: Adjust BreadcrumbButton width on resize

### DIFF
--- a/Userland/Libraries/LibGUI/Breadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.h
@@ -19,6 +19,7 @@ public:
     void clear_segments();
     void append_segment(String text, Gfx::Bitmap const* icon = nullptr, String data = {}, String tooltip = {});
     void remove_end_segments(size_t segment_index);
+    void relayout();
 
     size_t segment_count() const { return m_segments.size(); }
     String segment_data(size_t index) const { return m_segments[index].data; }
@@ -35,10 +36,14 @@ public:
 private:
     Breadcrumbbar();
 
+    virtual void resize_event(ResizeEvent&) override;
+
     struct Segment {
         RefPtr<const Gfx::Bitmap> icon;
         String text;
         String data;
+        int width { 0 };
+        int shrunken_width { 0 };
         WeakPtr<GUI::Button> button;
     };
 


### PR DESCRIPTION
This commit relayouts the BreadcrumbButtons on resize to a shrunken state if they don't fit.
It also caps the button width to 100px to avoid overflowing the widget.

This approach is much simpler than calculating variable button sizes and showing parts of the folder names when they don't fit. The shrunken size is adjusted to show just the icon, or '...' when no icon is loaded. The selected folder in the bar will always be shown full size.

Fixes #9658

![Screenshot_20210831_181553](https://user-images.githubusercontent.com/69970419/131540397-821adf42-46b6-452e-801f-32e21f577a61.png)
