### PR TITLE
LibRegex: Fork before trying to match the repeated regexp

### DIFF
--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -102,6 +102,12 @@ static void advance_string_position(MatchState& state, RegexStringView const& vi
     }
 }
 
+static void advance_string_position(MatchState& state, RegexStringView const&, RegexStringView const& advance_by)
+{
+    state.string_position += advance_by.length();
+    state.string_position_in_code_units += advance_by.length_in_code_units();
+}
+
 static void reverse_string_position(MatchState& state, RegexStringView const& view, size_t amount)
 {
     VERIFY(state.string_position >= amount);
@@ -606,7 +612,7 @@ ALWAYS_INLINE bool OpCode_Compare::compare_string(MatchInput const& input, Match
         equals = subject.equals(str);
 
     if (equals)
-        state.string_position += str.length();
+        advance_string_position(state, input.view, str);
 
     return equals;
 }

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -189,6 +189,9 @@ void ByteCode::ensure_opcodes_initialized()
         case OpCodeId::Repeat:
             s_opcodes[i] = make<OpCode_Repeat>();
             break;
+        case OpCodeId::ResetRepeat:
+            s_opcodes[i] = make<OpCode_ResetRepeat>();
+            break;
         }
     }
     s_opcodes_initialized = true;
@@ -880,6 +883,15 @@ ALWAYS_INLINE ExecutionResult OpCode_Repeat::execute(MatchInput const&, MatchSta
         ++repetition_mark;
     }
 
+    return ExecutionResult::Continue;
+}
+
+ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, MatchState& state) const
+{
+    if (id() >= state.repetition_marks.size())
+        state.repetition_marks.resize(id() + 1);
+
+    state.repetition_marks.at(id()) = 0;
     return ExecutionResult::Continue;
 }
 

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -446,8 +446,9 @@ bool PosixBasicParser::parse_simple_re(ByteCode& bytecode, size_t& match_length_
         if (min_limit > s_maximum_repetition_count || (max_limit.has_value() && *max_limit > s_maximum_repetition_count))
             return set_error(Error::InvalidBraceContent);
 
-        auto repetition_mark_id = m_parser_state.repetition_mark_count++;
-        ByteCode::transform_bytecode_repetition_min_max(simple_re_bytecode, min_limit, max_limit, repetition_mark_id, true);
+        auto min_repetition_mark_id = m_parser_state.repetition_mark_count++;
+        auto max_repetition_mark_id = m_parser_state.repetition_mark_count++;
+        ByteCode::transform_bytecode_repetition_min_max(simple_re_bytecode, min_limit, max_limit, min_repetition_mark_id, max_repetition_mark_id, true);
         match_length_minimum += re_match_length_minimum * min_limit;
     } else {
         match_length_minimum += re_match_length_minimum;
@@ -620,8 +621,9 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& byteco
             maybe_maximum = value.value();
         }
 
-        auto repetition_mark_id = m_parser_state.repetition_mark_count++;
-        ByteCode::transform_bytecode_repetition_min_max(bytecode_to_repeat, minimum, maybe_maximum, repetition_mark_id);
+        auto min_repetition_mark_id = m_parser_state.repetition_mark_count++;
+        auto max_repetition_mark_id = m_parser_state.repetition_mark_count++;
+        ByteCode::transform_bytecode_repetition_min_max(bytecode_to_repeat, minimum, maybe_maximum, min_repetition_mark_id, max_repetition_mark_id);
 
         consume(TokenType::RightCurly, Error::MismatchingBrace);
         return !has_error();
@@ -1219,8 +1221,9 @@ bool ECMA262Parser::parse_quantifier(ByteCode& stack, size_t& match_length_minim
         match_length_minimum = 0;
         break;
     case Repetition::Explicit: {
-        auto repetition_mark_id = m_parser_state.repetition_mark_count++;
-        ByteCode::transform_bytecode_repetition_min_max(stack, repeat_min.value(), repeat_max, repetition_mark_id, !ungreedy);
+        auto min_repetition_mark_id = m_parser_state.repetition_mark_count++;
+        auto max_repetition_mark_id = m_parser_state.repetition_mark_count++;
+        ByteCode::transform_bytecode_repetition_min_max(stack, repeat_min.value(), repeat_max, min_repetition_mark_id, max_repetition_mark_id, !ungreedy);
         match_length_minimum *= repeat_min.value();
         break;
     }


### PR DESCRIPTION
Otherwise the last failing fork would have nowhere to return to.
Fixes #9707.

I decided against copying the test262 test into our own suite.