### PR TITLE
PixelPaint: Add Guides to .pp file format

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
     PenTool.cpp
     PickerTool.cpp
     PixelPaintWindowGML.h
+    ProjectLoader.cpp
     RectangleTool.cpp
     RectangleSelectTool.cpp
     Mask.cpp

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -231,23 +231,6 @@ void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
     }
 }
 
-Result<void, String> Image::write_to_fd_and_close(int fd) const
-{
-    StringBuilder builder;
-    JsonObjectSerializer json(builder);
-    serialize_as_json(json);
-    json.finish();
-
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
-    if (!file->write(builder.string_view()))
-        return String { file->error_string() };
-    return {};
-}
-
 Result<void, String> Image::write_to_file(const String& file_path) const
 {
     StringBuilder builder;

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -68,7 +68,6 @@ public:
     void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
 
     void serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
-    Result<void, String> write_to_fd_and_close(int fd) const;
     Result<void, String> write_to_file(String const& file_path) const;
     Result<void, String> export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel);
     Result<void, String> export_png_to_fd_and_close(int fd, bool preserve_alpha_channel);

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 #pragma once
 
 #include <AK/HashTable.h>
+#include <AK/JsonObjectSerializer.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
@@ -47,6 +49,7 @@ public:
     static Result<NonnullRefPtr<Image>, String> try_create_from_fd_and_close(int fd, String const& file_path);
     static Result<NonnullRefPtr<Image>, String> try_create_from_path(String const& file_path);
     static RefPtr<Image> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
+    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_json(JsonObject const&);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
     RefPtr<Gfx::Bitmap> try_compose_bitmap(Gfx::BitmapFormat format) const;
@@ -63,6 +66,8 @@ public:
     void restore_snapshot(Image const&);
 
     void paint_into(GUI::Painter&, Gfx::IntRect const& dest_rect) const;
+
+    void serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
     Result<void, String> write_to_fd_and_close(int fd) const;
     Result<void, String> write_to_file(String const& file_path) const;
     Result<void, String> export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel);

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -46,10 +46,10 @@ protected:
 class Image : public RefCounted<Image> {
 public:
     static RefPtr<Image> try_create_with_size(Gfx::IntSize const&);
-    static Result<NonnullRefPtr<Image>, String> try_create_from_fd_and_close(int fd, String const& file_path);
-    static Result<NonnullRefPtr<Image>, String> try_create_from_path(String const& file_path);
-    static RefPtr<Image> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
     static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_json(JsonObject const&);
+    static RefPtr<Image> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
+
+    static RefPtr<Gfx::Bitmap> try_decode_bitmap(const ByteBuffer& bitmap_data);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
     RefPtr<Gfx::Bitmap> try_compose_bitmap(Gfx::BitmapFormat format) const;
@@ -102,10 +102,6 @@ public:
 
 private:
     explicit Image(Gfx::IntSize const&);
-
-    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_fd(int fd, String const& file_path);
-    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_path(String const& file_path);
-    static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_file(Core::File& file, String const& file_path);
 
     void did_change(Gfx::IntRect const& modified_rect = {});
     void did_change_rect();

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -469,4 +469,22 @@ void ImageEditor::image_select_layer(Layer* layer)
 {
     set_active_layer(layer);
 }
+
+Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
+{
+    StringBuilder builder;
+    JsonObjectSerializer json(builder);
+    m_image->serialize_as_json(json);
+    json.finish();
+
+    auto file = Core::File::construct();
+    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
+    if (file->has_error())
+        return String { file->error_string() };
+
+    if (!file->write(builder.string_view()))
+        return String { file->error_string() };
+    return {};
+}
+
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -475,6 +476,17 @@ Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
     StringBuilder builder;
     JsonObjectSerializer json(builder);
     m_image->serialize_as_json(json);
+    auto json_guides = json.add_array("guides");
+    for (const auto& guide : m_guides) {
+        auto json_guide = json_guides.add_object();
+        json_guide.add("offset"sv, (double)guide.offset());
+        if (guide.orientation() == Guide::Orientation::Vertical)
+            json_guide.add("orientation", "vertical");
+        else if (guide.orientation() == Guide::Orientation::Horizontal)
+            json_guide.add("orientation", "horizontal");
+        json_guide.finish();
+    }
+    json_guides.finish();
     json.finish();
 
     auto file = Core::File::construct();

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -84,6 +84,8 @@ public:
     Gfx::FloatPoint image_position_to_editor_position(Gfx::IntPoint const&) const;
     Gfx::FloatPoint editor_position_to_image_position(Gfx::IntPoint const&) const;
 
+    Result<void, String> save_project_to_fd_and_close(int fd) const;
+
     NonnullRefPtrVector<Guide> const& guides() const { return m_guides; }
     bool guide_visibility() { return m_show_guides; }
     void set_guide_visibility(bool show_guides);

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ProjectLoader.h"
+#include "Image.h"
+#include "Layer.h"
+#include <AK/JsonObject.h>
+#include <AK/MappedFile.h>
+#include <AK/Result.h>
+#include <AK/String.h>
+#include <LibCore/File.h>
+#include <LibImageDecoderClient/Client.h>
+
+namespace PixelPaint {
+
+Result<void, String> ProjectLoader::try_load_from_fd_and_close(int fd, StringView path)
+{
+    auto file = Core::File::construct();
+    file->open(fd, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
+    if (file->has_error())
+        return String { file->error_string() };
+
+    auto contents = file->read_all();
+
+    auto json_or_error = JsonValue::from_string(contents);
+    if (!json_or_error.has_value()) {
+        m_is_raw_image = true;
+
+        auto file_or_error = MappedFile::map_from_fd_and_close(fd, path);
+        if (file_or_error.is_error())
+            return String::formatted("Unable to mmap file {}", file_or_error.error().string());
+
+        auto& mapped_file = *file_or_error.value();
+        // FIXME: Find a way to avoid the memory copy here.
+        auto bitmap = Image::try_decode_bitmap(ByteBuffer::copy(mapped_file.bytes()));
+        if (!bitmap)
+            return String { "Unable to decode image"sv };
+        auto image = Image::try_create_from_bitmap(bitmap.release_nonnull());
+        if (!image)
+            return String { "Unable to allocate Image"sv };
+
+        image->set_path(path);
+        m_image = image;
+        return {};
+    }
+
+    close(fd);
+    auto& json = json_or_error.value().as_object();
+    auto image_or_error = Image::try_create_from_pixel_paint_json(json);
+
+    if (image_or_error.is_error())
+        return image_or_error.release_error();
+
+    auto image = image_or_error.release_value();
+    image->set_path(path);
+
+    if (json.has("guides"))
+        m_json_metadata = json.get("guides").as_array();
+
+    m_image = image;
+    return {};
+}
+Result<void, String> ProjectLoader::try_load_from_path(StringView path)
+{
+    auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
+    if (file_or_error.is_error())
+        return String::formatted("Unable to open file because: {}", file_or_error.release_error());
+
+    return try_load_from_fd_and_close(file_or_error.release_value()->fd(), path);
+}
+
+}

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Image.h"
+#include <AK/JsonArray.h>
+#include <AK/Result.h>
+#include <AK/StringView.h>
+
+namespace PixelPaint {
+
+class ProjectLoader {
+public:
+    ProjectLoader() = default;
+    ~ProjectLoader() = default;
+
+    Result<void, String> try_load_from_fd_and_close(int fd, StringView path);
+    Result<void, String> try_load_from_path(StringView path);
+
+    bool is_raw_image() const { return m_is_raw_image; }
+    bool has_image() const { return !m_image.is_null(); }
+    RefPtr<Image> release_image() const { return move(m_image); }
+    JsonArray const& json_metadata() const { return m_json_metadata; }
+
+private:
+    RefPtr<Image> m_image { nullptr };
+    bool m_is_raw_image { false };
+    JsonArray m_json_metadata {};
+};
+
+}

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
         auto save_result = FileSystemAccessClient::Client::the().save_file(window->window_id(), "untitled", "pp");
         if (save_result.error != 0)
             return;
-        auto result = editor->image().write_to_fd_and_close(*save_result.fd);
+        auto result = editor->save_project_to_fd_and_close(*save_result.fd);
         if (result.is_error()) {
             GUI::MessageBox::show_error(window, String::formatted("Could not save {}: {}", *save_result.chosen_file, result.error()));
             return;

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -765,6 +765,32 @@ int main(int argc, char** argv)
         if (image->layer_count())
             image_editor.set_active_layer(&image->layer(0));
 
+        if (!loader.is_raw_image()) {
+            loader.json_metadata().for_each([&](JsonValue const& value) {
+                if (!value.is_object())
+                    return;
+                auto& json_object = value.as_object();
+                auto orientation_value = json_object.get("orientation"sv);
+                if (!orientation_value.is_string())
+                    return;
+
+                auto offset_value = json_object.get("offset"sv);
+                if (!offset_value.is_number())
+                    return;
+
+                auto orientation_string = orientation_value.as_string();
+                PixelPaint::Guide::Orientation orientation;
+                if (orientation_string == "horizontal"sv)
+                    orientation = PixelPaint::Guide::Orientation::Horizontal;
+                else if (orientation_string == "vertical"sv)
+                    orientation = PixelPaint::Guide::Orientation::Vertical;
+                else
+                    return;
+
+                image_editor.add_guide(PixelPaint::Guide::construct(orientation, offset_value.to_number<float>()));
+            });
+        }
+
         tab_widget.set_active_widget(&image_editor);
         image_editor.set_focus(true);
         return image_editor;


### PR DESCRIPTION
Up until now Guides haven't been saved alongside the Image/Layer data in .pp files.
After shifting a bit of code around, saving them works.
Loading works :tm: too.