### PR TITLE
AK: On macOS host builds, fix inclusion of unistd.h in Platform.h

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -83,9 +83,17 @@
 #endif
 
 #ifndef __serenity__
+// On macOS (at least Mojave), Apple's version of this header is not wrapped
+// in extern "C".
+#    ifdef AK_OS_MACOS
+extern "C" {
+#    endif
 #    include <unistd.h>
 #    undef PAGE_SIZE
 #    define PAGE_SIZE sysconf(_SC_PAGESIZE)
+#    ifdef AK_OS_MACOS
+};
+#    endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
During the build process on macOS, multiple versions of <unistd.h> were
being included (Apple's version and GCC's version). It appears that
all other places #include the version from GCC, but in Platform.h the Apple
header was being used. GCC's <unistd.h> is wrapped in `extern "C"`, while Apple's
is not. This causes a conflicting declaration, so we can just not #include
Apple's version.

Issue has been observed on macOS Mojave but ~~likely is found on Catalina, too~~ (see below).

See https://github.com/microsoft/vcpkg/issues/11320 for a similar issue.