### PR TITLE
TextEditor: Stop calling `window->set_modified(false)` on file save

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -289,8 +289,6 @@ MainWidget::MainWidget()
             GUI::MessageBox::show(window(), "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
             return;
         }
-        // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
-        window()->set_modified(false);
 
         set_path(*response.chosen_file);
         dbgln("Wrote document to {}", *response.chosen_file);
@@ -310,11 +308,6 @@ MainWidget::MainWidget()
 
             if (!m_editor->write_to_file_and_close(fd)) {
                 GUI::MessageBox::show(window(), "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
-            } else {
-                // FIXME: It would be cool if this would propagate from GUI::TextDocument somehow.
-                window()->set_modified(false);
-
-                update_title();
             }
             return;
         }


### PR DESCRIPTION
We use `TextEditor::on_modified_change()` to update the modified window flag, which it also works on file saves, so we don’t have to unset it there anymore!

It isn’t really what the FIXME note asked about – `GUI::TextDocument` only sends us notifications about the changes, but overall I don’t think it’s that bad, given that the whole window update logic is now in one function. :^)