### PR TITLE
PixelPaint: Push the snapshot of the image before the action to the undo stack

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -19,6 +19,7 @@ namespace PixelPaint {
 
 ImageEditor::ImageEditor(NonnullRefPtr<Image> image)
     : m_image(move(image))
+    , m_prev_image_undo_command(nullptr)
     , m_undo_stack(make<GUI::UndoStack>())
     , m_selection(*this)
 {
@@ -35,7 +36,8 @@ ImageEditor::~ImageEditor()
 
 void ImageEditor::did_complete_action()
 {
-    m_undo_stack->push(make<ImageUndoCommand>(*m_image));
+    if (m_prev_image_undo_command.ptr())
+        m_undo_stack->push(m_prev_image_undo_command.release_nonnull());
 }
 
 bool ImageEditor::undo()
@@ -193,6 +195,8 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
             set_active_layer(other_layer);
         }
     }
+
+    m_prev_image_undo_command = make<ImageUndoCommand>(*m_image);
 
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
     auto image_event = event_with_pan_and_scale_applied(event);

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -116,6 +116,7 @@ private:
     void relayout();
 
     NonnullRefPtr<Image> m_image;
+    OwnPtr<ImageUndoCommand> m_prev_image_undo_command;
     RefPtr<Layer> m_active_layer;
     OwnPtr<GUI::UndoStack> m_undo_stack;
 


### PR DESCRIPTION
…instead of the one after the action.

This fixes the weird behavior of undo on PixelPaint. To reproduce this weird behavior, do the following:
- Open PixelPaint
- Undo to clear the undo stack
- Select the background layer and draw
- Now undo-ing doesn't give the desired effect.