### PR TITLE
LibGfx: Intersect the bounding box with the drawable area

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1455,6 +1455,8 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
         VERIFY_NOT_REACHED();
     }
 
+    bounding_rect.intersect(rect);
+
     for (size_t i = 0; i < lines.size(); ++i) {
         auto& line = lines[i];
 


### PR DESCRIPTION
Without this, the bounding rect can go beyond the bounds of the
user-supplied drawing rect and cause the text to overlap because of the
line_rect.intersect(rect) a few lines below.