### PR TITLE
LibGUI: Show an error message box in the FilePicker on no permissions

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -27,6 +27,7 @@
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 #include <string.h>
+#include <unistd.h>
 
 namespace GUI {
 
@@ -291,6 +292,13 @@ void FilePicker::on_file_return()
 
 void FilePicker::set_path(const String& path)
 {
+    if (access(path.characters(), R_OK | X_OK) == -1) {
+        GUI::MessageBox::show(this, String::formatted("Could not open '{}':\n{}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
+        for (auto location_button : m_common_location_buttons)
+            location_button.button.set_checked(m_model->root_path() == location_button.path);
+        return;
+    }
+
     auto new_path = LexicalPath(path).string();
     m_location_textbox->set_icon(FileIconProvider::icon_for_path(new_path).bitmap_for_size(16));
     m_model->set_root_path(new_path);


### PR DESCRIPTION
The first attempt in #9037 used a special label as a view, if it wanted to communicate any kind of error, but that sure did look a bit ugly.

Here we are just showing a message box right before setting the new path as:
- the contents of the previous directory will be visible in background, which I find pretty nice, and
- I don't have to deal with adding a path history vector to reopen the previous directory (which might not even exist then). :^)

https://user-images.githubusercontent.com/16520278/131733853-fdd8395f-e0de-457b-a7e5-b0329bb14739.mp4

---

Note that I’m keeping the older error label too, in case of something really bad happened in the model itself. But I’m not sure if that’s needed.

