### PR TITLE
LibWeb: Add initial support for AbortController and AbortSignal

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
@@ -1223,6 +1223,7 @@ void generate_prototype_implementation(IDL::Interface const& interface)
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/@prototype_class@.h>
 #include <LibWeb/Bindings/@wrapper_class@.h>
+#include <LibWeb/Bindings/AbortSignalWrapper.h>
 #include <LibWeb/Bindings/CSSStyleDeclarationWrapper.h>
 #include <LibWeb/Bindings/CSSStyleSheetWrapper.h>
 #include <LibWeb/Bindings/CanvasRenderingContext2DWrapper.h>

--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -8,6 +8,10 @@
 
 // FIXME: Find a way to generate all of this
 
+#include <LibWeb/Bindings/AbortControllerConstructor.h>
+#include <LibWeb/Bindings/AbortControllerPrototype.h>
+#include <LibWeb/Bindings/AbortSignalConstructor.h>
+#include <LibWeb/Bindings/AbortSignalPrototype.h>
 #include <LibWeb/Bindings/CSSStyleSheetConstructor.h>
 #include <LibWeb/Bindings/CSSStyleSheetPrototype.h>
 #include <LibWeb/Bindings/CanvasRenderingContext2DConstructor.h>
@@ -239,6 +243,8 @@
 
 #define ADD_WINDOW_OBJECT_INTERFACES                       \
     auto& vm = this->vm();                                 \
+    ADD_WINDOW_OBJECT_INTERFACE(AbortController)           \
+    ADD_WINDOW_OBJECT_INTERFACE(AbortSignal)               \
     ADD_WINDOW_OBJECT_INTERFACE(CanvasRenderingContext2D)  \
     ADD_WINDOW_OBJECT_INTERFACE(CharacterData)             \
     ADD_WINDOW_OBJECT_INTERFACE(CloseEvent)                \

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -38,6 +38,8 @@ set(SOURCES
     CSS/ValueID.cpp
     CSS/ValueID.h
     Cookie/ParsedCookie.cpp
+    DOM/AbortController.cpp
+    DOM/AbortSignal.cpp
     DOM/CharacterData.cpp
     DOM/CharacterData.idl
     DOM/Comment.cpp
@@ -299,6 +301,8 @@ libweb_js_wrapper(CSS/CSSStyleSheet)
 libweb_js_wrapper(CSS/Screen)
 libweb_js_wrapper(CSS/StyleSheet)
 libweb_js_wrapper(CSS/StyleSheetList)
+libweb_js_wrapper(DOM/AbortController)
+libweb_js_wrapper(DOM/AbortSignal)
 libweb_js_wrapper(DOM/CharacterData)
 libweb_js_wrapper(DOM/Comment)
 libweb_js_wrapper(DOM/Document)

--- a/Userland/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/AbortController.h>
+#include <LibWeb/DOM/AbortSignal.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#dom-abortcontroller-abortcontroller
+AbortController::AbortController(Document& document)
+    : m_signal(AbortSignal::create(document))
+{
+}
+
+AbortController::~AbortController()
+{
+}
+
+// https://dom.spec.whatwg.org/#dom-abortcontroller-abort
+void AbortController::abort()
+{
+    m_signal->signal_abort();
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AbortController.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/Weakable.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/DOM/AbortSignal.h>
+#include <LibWeb/DOM/Window.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#abortcontroller
+class AbortController final
+    : public RefCounted<AbortController>
+    , public Weakable<AbortController>
+    , public Bindings::Wrappable {
+public:
+    using WrapperType = Bindings::AbortControllerWrapper;
+
+    static NonnullRefPtr<AbortController> create(Document& document)
+    {
+        return adopt_ref(*new AbortController(document));
+    }
+
+    static NonnullRefPtr<AbortController> create_with_global_object(Bindings::WindowObject& window_object)
+    {
+        return AbortController::create(window_object.impl().document());
+    }
+
+    virtual ~AbortController() override;
+
+    // https://dom.spec.whatwg.org/#dom-abortcontroller-signal
+    NonnullRefPtr<AbortSignal> signal() const { return m_signal; }
+
+    void abort();
+
+private:
+    AbortController(Document& document);
+
+    // https://dom.spec.whatwg.org/#abortcontroller-signal
+    NonnullRefPtr<AbortSignal> m_signal;
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AbortController.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.idl
@@ -1,0 +1,8 @@
+[Exposed=(Window,Worker)]
+interface AbortController {
+    constructor();
+
+    [SameObject] readonly attribute AbortSignal signal;
+
+    undefined abort();
+};

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Bindings/AbortSignalWrapper.h>
+#include <LibWeb/DOM/AbortSignal.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/EventDispatcher.h>
+
+namespace Web::DOM {
+
+AbortSignal::AbortSignal(Document& document)
+    : EventTarget(static_cast<Bindings::ScriptExecutionContext&>(document))
+{
+}
+
+AbortSignal::~AbortSignal()
+{
+}
+
+bool AbortSignal::dispatch_event(NonnullRefPtr<Event> event)
+{
+    return EventDispatcher::dispatch(*this, event);
+}
+
+JS::Object* AbortSignal::create_wrapper(JS::GlobalObject& global_object)
+{
+    return wrap(global_object, *this);
+}
+
+// https://dom.spec.whatwg.org/#abortsignal-add
+void AbortSignal::add_abort_algorithm(Function<void()> abort_algorithm)
+{
+    if (m_aborted)
+        return;
+
+    m_abort_algorithms.append(move(abort_algorithm));
+}
+
+// https://dom.spec.whatwg.org/#abortsignal-signal-abort
+void AbortSignal::signal_abort()
+{
+    if (m_aborted)
+        return;
+
+    m_aborted = true;
+
+    for (auto& algorithm : m_abort_algorithms)
+        algorithm();
+
+    m_abort_algorithms.clear();
+
+    dispatch_event(Event::create(HTML::EventNames::abort));
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/Weakable.h>
+#include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/DOM/Window.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#abortsignal
+class AbortSignal final
+    : public RefCounted<AbortSignal>
+    , public Weakable<AbortSignal>
+    , public EventTarget
+    , public Bindings::Wrappable {
+public:
+    using WrapperType = Bindings::AbortSignalWrapper;
+
+    using RefCounted::ref;
+    using RefCounted::unref;
+
+    static NonnullRefPtr<AbortSignal> create(Document& document)
+    {
+        return adopt_ref(*new AbortSignal(document));
+    }
+
+    static NonnullRefPtr<AbortSignal> create_with_global_object(Bindings::WindowObject& window_object)
+    {
+        return AbortSignal::create(window_object.impl().document());
+    }
+
+    virtual ~AbortSignal() override;
+
+    void add_abort_algorithm(Function<void()>);
+
+    // https://dom.spec.whatwg.org/#dom-abortsignal-aborted
+    bool aborted() const { return m_aborted; }
+
+    void signal_abort();
+
+    // ^EventTarget
+    virtual void ref_event_target() override { ref(); }
+    virtual void unref_event_target() override { unref(); }
+    virtual bool dispatch_event(NonnullRefPtr<Event>) override;
+    virtual JS::Object* create_wrapper(JS::GlobalObject&) override;
+
+private:
+    AbortSignal(Document& document);
+
+    // https://dom.spec.whatwg.org/#abortsignal-aborted-flag
+    bool m_aborted { false };
+
+    // https://dom.spec.whatwg.org/#abortsignal-abort-algorithms
+    // FIXME: This should be a set.
+    Vector<Function<void()>> m_abort_algorithms;
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
@@ -1,0 +1,8 @@
+[Exposed=(Window,Worker)]
+interface AbortSignal : EventTarget {
+    // FIXME: [NewObject] static AbortSignal abort();
+
+    readonly attribute boolean aborted;
+
+    // FIXME: attribute EventHandler onabort;
+};

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -32,6 +32,8 @@ enum class Display;
 }
 
 namespace Web::DOM {
+class AbortController;
+class AbortSignal;
 class CharacterData;
 class Comment;
 class Document;
@@ -203,6 +205,8 @@ class XMLHttpRequestEventTarget;
 }
 
 namespace Web::Bindings {
+class AbortControllerWrapper;
+class AbortSignalWrapper;
 class CSSStyleDeclarationWrapper;
 class CSSStyleSheetWrapper;
 class CanvasRenderingContext2DWrapper;

--- a/Userland/Libraries/LibWeb/Tests/DOM/AbortController.js
+++ b/Userland/Libraries/LibWeb/Tests/DOM/AbortController.js
@@ -1,0 +1,20 @@
+describe("AbortController", () => {
+    loadLocalPage("/res/html/misc/blank.html");
+
+    afterInitialPageLoad(page => {
+        test("Basic functionality", () => {
+            const abortController = new page.AbortController();
+            let timesCallbackCalled = 0;
+            abortController.signal.addEventListener("abort", () => {
+                timesCallbackCalled++;
+            });
+
+            abortController.abort();
+            expect(abortController.signal.aborted).toBeTrue();
+
+            abortController.abort();
+            expect(timesCallbackCalled).toBe(1);
+        });
+    });
+    waitForPageToLoad();
+});


### PR DESCRIPTION
The DOM specification says that the primary use case for these is to
give Promises abort semantics. It is also a prerequisite for Fetch,
as it is used to make Fetch abortable.