### PR TITLE
FileManager: Update the tree view on model update

### DIFF
--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -12,6 +12,7 @@ compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h prope
 set(SOURCES
     DesktopWidget.cpp
     DirectoryView.cpp
+    DirectoryTreeView.cpp
     FileManagerWindowGML.h
     FileOperationProgress.gml
     FileOperationProgressWidget.cpp

--- a/Userland/Applications/FileManager/DirectoryTreeView.cpp
+++ b/Userland/Applications/FileManager/DirectoryTreeView.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "DirectoryTreeView.h"
+#include <LibGUI/FileSystemModel.h>
+
+namespace FileManager {
+
+void DirectoryTreeView::model_did_update(unsigned flags)
+{
+    TreeView::model_did_update(flags);
+
+    auto file_system_model = dynamic_cast<GUI::FileSystemModel*>(model());
+
+    auto current_path = m_directory_view->path();
+
+    struct stat st;
+    // If the directory no longer exists, we find a parent that does.
+    while (stat(current_path.characters(), &st) != 0) {
+        m_directory_view->open_parent_directory();
+        current_path = m_directory_view->path();
+        if (current_path == file_system_model->root_path()) {
+            break;
+        }
+    }
+
+    // Reselect the existing folder in the tree.
+    auto new_index = file_system_model->index(current_path, GUI::FileSystemModel::Column::Name);
+    if (new_index.is_valid()) {
+        expand_all_parents_of(new_index);
+        set_cursor(new_index, GUI::AbstractView::SelectionUpdate::Set, true);
+    }
+
+    m_directory_view->refresh();
+}
+
+}

--- a/Userland/Applications/FileManager/DirectoryTreeView.h
+++ b/Userland/Applications/FileManager/DirectoryTreeView.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "DirectoryView.h"
+#include <LibGUI/TreeView.h>
+
+namespace FileManager {
+
+class DirectoryTreeView final
+    : public GUI::TreeView {
+    C_OBJECT(DirectoryTreeView)
+
+public:
+    void set_view(RefPtr<DirectoryView> directory_view) { m_directory_view = directory_view; }
+
+private:
+    // ^GUI::ModelClient
+    virtual void model_did_update(unsigned) override;
+
+    RefPtr<DirectoryView> m_directory_view;
+};
+
+}

--- a/Userland/Applications/FileManager/FileManagerWindow.gml
+++ b/Userland/Applications/FileManager/FileManagerWindow.gml
@@ -40,12 +40,6 @@
     @GUI::HorizontalSplitter {
         name: "splitter"
         first_resizee_minimum_size: 80
-
-        @GUI::TreeView {
-            name: "tree_view"
-            fixed_width: 175
-        }
-
     }
 
     @GUI::Statusbar {


### PR DESCRIPTION
The tree view clears the metadata it uses for expanding the current
directory each time the model is updated. This is causing the tree
view to collapse on operations that have model updates outside of
the FileManager process such as paste events.