### PR TITLE
PixelPaint: Fixes to LayerListWidget + Merge Layer Down action

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -481,6 +482,23 @@ void Image::merge_visible_layers()
             index++;
         }
     }
+}
+
+void Image::merge_active_layer_down(Layer& layer)
+{
+    if (m_layers.size() < 2)
+        return;
+    int layer_index = this->index_of(layer);
+    if (layer_index == 0) {
+        dbgln("Cannot merge layer down: layer is already at the bottom");
+        return; // FIXME: Notify user of error properly.
+    }
+
+    auto& layer_below = m_layers.at(layer_index - 1);
+    GUI::Painter painter(layer_below.bitmap());
+    painter.draw_scaled_bitmap(rect(), layer.bitmap(), layer.rect(), (float)layer.opacity_percent() / 100.0f);
+    remove_layer(layer);
+    select_layer(&layer_below);
 }
 
 void Image::select_layer(Layer* layer)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -74,6 +75,7 @@ public:
     void select_layer(Layer*);
     void flatten_all_layers();
     void merge_visible_layers();
+    void merge_active_layer_down(Layer& layer);
 
     void add_client(ImageClient&);
     void remove_client(ImageClient&);

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -316,7 +316,8 @@ void LayerListWidget::cycle_through_selection(int delta)
 
 void LayerListWidget::relayout_gadgets()
 {
-    int y = 0;
+    auto total_gadget_height = static_cast<int>(m_gadgets.size()) * vertical_step + 6;
+    int y = max(0, height() - total_gadget_height);
 
     Optional<size_t> hole_index;
     if (is_moving_gadget())
@@ -333,7 +334,6 @@ void LayerListWidget::relayout_gadgets()
         ++index;
     }
 
-    auto total_gadget_height = static_cast<int>(m_gadgets.size()) * vertical_step;
     set_content_size({ widget_inner_rect().width(), total_gadget_height });
     vertical_scrollbar().set_range(0, max(total_gadget_height - height(), 0));
     update();

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -62,13 +63,16 @@ private:
 
     Optional<size_t> gadget_at(Gfx::IntPoint const&);
 
+    size_t to_layer_index(size_t gadget_index) const;
+    size_t to_gadget_index(size_t layer_index) const;
+
     Vector<Gadget> m_gadgets;
     RefPtr<Image> m_image;
 
     Optional<size_t> m_moving_gadget_index;
     Gfx::IntPoint m_moving_event_origin;
 
-    size_t m_selected_layer_index { 0 };
+    size_t m_selected_gadget_index { 0 };
 };
 
 }

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -541,6 +541,19 @@ int main(int argc, char** argv)
         },
         window));
 
+    layer_menu.add_action(GUI::Action::create(
+        "M&erge Active Layer Down", { Mod_Ctrl, Key_E }, [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            auto active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+            editor->image().merge_active_layer_down(*active_layer);
+            editor->did_complete_action();
+        },
+        window));
+
     auto& filter_menu = window->add_menu("&Filter");
     auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");
 


### PR DESCRIPTION
1. Fix the order in which layers are displayed, with the layers in front now appearing on top. 

2. Add a "Merge Layer Down" action, which combines a layer with the one below it.

3. Draw layers justified to the bottom instead of the top, and fix the spacing for the LayerListWidget a little to not clip the bottom gadget. Look below.

Before:
<img width="205" alt="before" src="https://user-images.githubusercontent.com/9910883/131817377-ec9a8ef3-11fb-4a03-8382-a101838c6196.png">

After:
<img width="205" alt="after" src="https://user-images.githubusercontent.com/9910883/131915379-39c5bd54-ca18-41c0-ab69-236cb9e43cba.png">

