### PR TITLE
HexEditor: Use FileSystemAccessClient, add unveils :^)

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -20,4 +20,4 @@ set(SOURCES
 )
 
 serenity_app(HexEditor ICON app-hex-editor)
-target_link_libraries(HexEditor LibGUI LibConfig)
+target_link_libraries(HexEditor LibGUI LibConfig LibFileSystemAccessClient)

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,10 +8,12 @@
 #include "HexEditor.h"
 #include "SearchResultsModel.h"
 #include <AK/Debug.h>
+#include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGUI/TextEditor.h>
@@ -91,6 +94,13 @@ bool HexEditor::write_to_file(const String& path)
         return false;
     }
 
+    return write_to_file(fd);
+}
+
+bool HexEditor::write_to_file(int fd)
+{
+    ScopeGuard fd_guard = [fd] { close(fd); };
+
     int rc = ftruncate(fd, m_buffer.size());
     if (rc < 0) {
         perror("ftruncate");
@@ -109,7 +119,6 @@ bool HexEditor::write_to_file(const String& path)
         update();
     }
 
-    close(fd);
     return true;
 }
 

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,6 +35,7 @@ public:
     void set_buffer(const ByteBuffer&);
     void fill_selection(u8 fill_byte);
     bool write_to_file(const String& path);
+    bool write_to_file(int fd);
 
     void select_all();
     bool has_selection() const { return !(m_selection_start == -1 || m_selection_end == -1 || (m_selection_end - m_selection_start) < 0 || m_buffer.is_empty()); }

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,7 +22,7 @@ class HexEditorWidget final : public GUI::Widget {
     C_OBJECT(HexEditorWidget)
 public:
     virtual ~HexEditorWidget() override;
-    void open_file(const String& path);
+    void open_file(int fd, String const& path);
     void initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 #include <LibConfig/Client.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
+#include <LibGUI/MessageBox.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -21,11 +23,6 @@ int main(int argc, char** argv)
     auto app = GUI::Application::construct(argc, argv);
 
     Config::pledge_domains("HexEditor");
-
-    if (pledge("stdio recvfd sendfd rpath cpath wpath thread", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
 
     auto app_icon = GUI::Icon::default_icon("app-hex-editor");
 
@@ -41,12 +38,49 @@ int main(int argc, char** argv)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
+    String file_to_edit = (argc > 1) ? Core::File::absolute_path(argv[1]) : "";
+
+    if (!file_to_edit.is_empty()) {
+        if (Core::File::exists(file_to_edit)) {
+            dbgln("unveil for: {}", file_to_edit);
+            if (unveil(file_to_edit.characters(), "r") < 0) {
+                perror("unveil");
+                return 1;
+            }
+        } else {
+            file_to_edit = {};
+        }
+    }
+
+    if (unveil("/res", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/tmp/portal/filesystemaccess", "rw") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil(nullptr, nullptr) < 0) {
+        perror("unveil");
+        return 1;
+    }
+
     hex_editor_widget.initialize_menubar(*window);
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    if (argc >= 2)
-        hex_editor_widget.open_file(argv[1]);
+    if (!file_to_edit.is_empty()) {
+        auto file = Core::File::open(file_to_edit, Core::OpenMode::ReadOnly);
+
+        if (file.is_error()) {
+            GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", file_to_edit, file.error()));
+            return 1;
+        }
+
+        hex_editor_widget.open_file(file.value()->leak_fd(), file_to_edit);
+    }
 
     return app->exec();
 }


### PR DESCRIPTION
Most of the code here is based off the implementation of how
TextEditor uses FileSystemAccessClient.