### PR TITLE
LibJS+LibUnicode: Implement (most of) `Intl.Locale`

### DIFF
--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -69,6 +69,24 @@ TEST_CASE(is_unicode_variant_subtag)
     EXPECT(!Unicode::is_unicode_variant_subtag("a234"sv));
 }
 
+TEST_CASE(is_type_identifier)
+{
+    EXPECT(Unicode::is_type_identifier("aaaa"sv));
+    EXPECT(Unicode::is_type_identifier("aaaa-bbbb"sv));
+    EXPECT(Unicode::is_type_identifier("aaaa-bbbb-cccc"sv));
+
+    EXPECT(Unicode::is_type_identifier("1aaa"sv));
+    EXPECT(Unicode::is_type_identifier("12aa"sv));
+    EXPECT(Unicode::is_type_identifier("123a"sv));
+    EXPECT(Unicode::is_type_identifier("1234"sv));
+
+    EXPECT(!Unicode::is_type_identifier(""sv));
+    EXPECT(!Unicode::is_type_identifier("a"sv));
+    EXPECT(!Unicode::is_type_identifier("aa"sv));
+    EXPECT(!Unicode::is_type_identifier("aaaaaaaaa"sv));
+    EXPECT(!Unicode::is_type_identifier("aaaa-"sv));
+}
+
 TEST_CASE(parse_unicode_locale_id)
 {
     auto fail = [](StringView locale) {

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -77,6 +77,9 @@ set(SOURCES
     Runtime/Intl/DisplayNamesConstructor.cpp
     Runtime/Intl/DisplayNamesPrototype.cpp
     Runtime/Intl/Intl.cpp
+    Runtime/Intl/Locale.cpp
+    Runtime/Intl/LocaleConstructor.cpp
+    Runtime/Intl/LocalePrototype.cpp
     Runtime/IteratorOperations.cpp
     Runtime/IteratorPrototype.cpp
     Runtime/JSONObject.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -76,8 +76,9 @@
     __JS_ENUMERATE(Float32Array, float32_array, Float32ArrayPrototype, Float32ArrayConstructor, float)                          \
     __JS_ENUMERATE(Float64Array, float64_array, Float64ArrayPrototype, Float64ArrayConstructor, double)
 
-#define JS_ENUMERATE_INTL_OBJECTS \
-    __JS_ENUMERATE(DisplayNames, display_names, DisplayNamesPrototype, DisplayNamesConstructor)
+#define JS_ENUMERATE_INTL_OBJECTS                                                               \
+    __JS_ENUMERATE(DisplayNames, display_names, DisplayNamesPrototype, DisplayNamesConstructor) \
+    __JS_ENUMERATE(Locale, locale, LocalePrototype, LocaleConstructor)
 
 #define JS_ENUMERATE_TEMPORAL_OBJECTS                                                                    \
     __JS_ENUMERATE(Calendar, calendar, CalendarPrototype, CalendarConstructor)                           \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -71,6 +71,7 @@ namespace JS {
     P(atan)                                  \
     P(atan2)                                 \
     P(atanh)                                 \
+    P(baseName)                              \
     P(big)                                   \
     P(bind)                                  \
     P(blank)                                 \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -84,6 +84,7 @@ namespace JS {
     P(call)                                  \
     P(callee)                                \
     P(caller)                                \
+    P(caseFirst)                             \
     P(cause)                                 \
     P(cbrt)                                  \
     P(ceil)                                  \
@@ -93,6 +94,7 @@ namespace JS {
     P(clear)                                 \
     P(clz32)                                 \
     P(codePointAt)                           \
+    P(collation)                             \
     P(compareExchange)                       \
     P(compile)                               \
     P(concat)                                \
@@ -224,6 +226,7 @@ namespace JS {
     P(hasOwn)                                \
     P(hasOwnProperty)                        \
     P(hour)                                  \
+    P(hourCycle)                             \
     P(hours)                                 \
     P(hypot)                                 \
     P(id)                                    \
@@ -262,6 +265,7 @@ namespace JS {
     P(join)                                  \
     P(keyFor)                                \
     P(keys)                                  \
+    P(language)                              \
     P(lastIndex)                             \
     P(lastIndexOf)                           \
     P(length)                                \
@@ -297,6 +301,8 @@ namespace JS {
     P(negated)                               \
     P(next)                                  \
     P(now)                                   \
+    P(numberingSystem)                       \
+    P(numeric)                               \
     P(of)                                    \
     P(offset)                                \
     P(offsetNanoseconds)                     \
@@ -325,6 +331,7 @@ namespace JS {
     P(reason)                                \
     P(reduce)                                \
     P(reduceRight)                           \
+    P(region)                                \
     P(reject)                                \
     P(repeat)                                \
     P(resolve)                               \
@@ -335,6 +342,7 @@ namespace JS {
     P(round)                                 \
     P(roundingIncrement)                     \
     P(roundingMode)                          \
+    P(script)                                \
     P(seal)                                  \
     P(second)                                \
     P(seconds)                               \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -31,7 +31,6 @@
     M(InOperatorWithObject, "'in' operator must be used on an object")                                                                  \
     M(InstanceOfOperatorBadPrototype, "'prototype' property of {} is not an object")                                                    \
     M(IntlInvalidLanguageTag, "{} is not a structurally valid language tag")                                                            \
-    M(IntlInvalidCode, "'{}' is not a valid value for option type {}")                                                                  \
     M(InvalidAssignToConst, "Invalid assignment to const variable")                                                                     \
     M(InvalidCodePoint, "Invalid code point {}, must be an integer no less than 0 and no greater than 0x10FFFF")                        \
     M(InvalidFormat, "Invalid {} format")                                                                                               \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -44,6 +44,8 @@
 #include <LibJS/Runtime/Intl/DisplayNamesConstructor.h>
 #include <LibJS/Runtime/Intl/DisplayNamesPrototype.h>
 #include <LibJS/Runtime/Intl/Intl.h>
+#include <LibJS/Runtime/Intl/LocaleConstructor.h>
+#include <LibJS/Runtime/Intl/LocalePrototype.h>
 #include <LibJS/Runtime/IteratorPrototype.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/MapConstructor.h>

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -445,7 +445,7 @@ Value canonical_code_for_display_names(GlobalObject& global_object, DisplayNames
     if (type == DisplayNames::Type::Language) {
         // a. If code does not match the unicode_language_id production, throw a RangeError exception.
         if (!Unicode::parse_unicode_language_id(code).has_value()) {
-            vm.throw_exception<RangeError>(global_object, ErrorType::IntlInvalidCode, code, "language"sv);
+            vm.throw_exception<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "language"sv);
             return {};
         }
 
@@ -466,7 +466,7 @@ Value canonical_code_for_display_names(GlobalObject& global_object, DisplayNames
     if (type == DisplayNames::Type::Region) {
         // a. If code does not match the unicode_region_subtag production, throw a RangeError exception.
         if (!Unicode::is_unicode_region_subtag(code)) {
-            vm.throw_exception<RangeError>(global_object, ErrorType::IntlInvalidCode, code, "region"sv);
+            vm.throw_exception<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "region"sv);
             return {};
         }
 
@@ -479,7 +479,7 @@ Value canonical_code_for_display_names(GlobalObject& global_object, DisplayNames
     if (type == DisplayNames::Type::Script) {
         // a. If code does not match the unicode_script_subtag production, throw a RangeError exception.
         if (!Unicode::is_unicode_script_subtag(code)) {
-            vm.throw_exception<RangeError>(global_object, ErrorType::IntlInvalidCode, code, "script"sv);
+            vm.throw_exception<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "script"sv);
             return {};
         }
 
@@ -493,7 +493,7 @@ Value canonical_code_for_display_names(GlobalObject& global_object, DisplayNames
 
     // 5. If ! IsWellFormedCurrencyCode(code) is false, throw a RangeError exception.
     if (!is_well_formed_currency_code(code)) {
-        vm.throw_exception<RangeError>(global_object, ErrorType::IntlInvalidCode, code, "currency"sv);
+        vm.throw_exception<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "currency"sv);
         return {};
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -26,7 +26,7 @@ static Optional<Unicode::LocaleID> is_structurally_valid_language_tag(StringView
         quick_sort(variants);
 
         for (size_t i = 0; i < variants.size() - 1; ++i) {
-            if (variants[i] == variants[i + 1])
+            if (variants[i].equals_ignoring_case(variants[i + 1]))
                 return true;
         }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -12,6 +12,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
 #include <LibJS/Runtime/Value.h>
+#include <LibUnicode/Forward.h>
 
 namespace JS::Intl {
 
@@ -25,8 +26,12 @@ struct LocaleResult {
     String locale;
 };
 
+Optional<Unicode::LocaleID> is_structurally_valid_language_tag(StringView locale);
+String canonicalize_unicode_locale_id(Unicode::LocaleID& locale);
 Vector<String> canonicalize_locale_list(GlobalObject&, Value locales);
+Object* coerce_options_to_object(GlobalObject& global_object, Value options);
 Value get_option(GlobalObject& global_object, Value options, PropertyName const& property, Value::Type type, Vector<StringView> const& values, Fallback fallback);
+String insert_unicode_extension_and_canonicalize(Unicode::LocaleID locale_id, Unicode::LocaleExtension extension);
 LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, Vector<StringView> relevant_extension_keys);
 Value canonical_code_for_display_names(GlobalObject&, DisplayNames::Type type, StringView code);
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DisplayNamesConstructor.h>
 #include <LibJS/Runtime/Intl/Intl.h>
+#include <LibJS/Runtime/Intl/LocaleConstructor.h>
 
 namespace JS::Intl {
 
@@ -29,6 +30,7 @@ void Intl::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_direct_property(vm.names.DisplayNames, global_object.intl_display_names_constructor(), attr);
+    define_direct_property(vm.names.Locale, global_object.intl_locale_constructor(), attr);
 
     define_native_function(vm.names.getCanonicalLocales, get_canonical_locales, 1, attr);
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/Locale.h>
+
+namespace JS::Intl {
+
+// 14 Locale Objects, https://tc39.es/ecma402/#locale-objects
+Locale::Locale(Object& prototype)
+    : Object(prototype)
+{
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS::Intl {
+
+class Locale final : public Object {
+    JS_OBJECT(Locale, Object);
+
+public:
+    Locale(Object& prototype);
+    virtual ~Locale() override = default;
+
+    String const& locale() const { return m_locale; }
+    void set_locale(String locale) { m_locale = move(locale); }
+
+    bool has_calendar() const { return m_calendar.has_value(); }
+    String const& calendar() const { return m_calendar.value(); }
+    void set_calendar(String calendar) { m_calendar = move(calendar); }
+
+    bool has_case_first() const { return m_case_first.has_value(); }
+    String const& case_first() const { return m_case_first.value(); }
+    void set_case_first(String case_first) { m_case_first = move(case_first); }
+
+    bool has_collation() const { return m_collation.has_value(); }
+    String const& collation() const { return m_collation.value(); }
+    void set_collation(String collation) { m_collation = move(collation); }
+
+    bool has_hour_cycle() const { return m_hour_cycle.has_value(); }
+    String const& hour_cycle() const { return m_hour_cycle.value(); }
+    void set_hour_cycle(String hour_cycle) { m_hour_cycle = move(hour_cycle); }
+
+    bool has_numbering_system() const { return m_numbering_system.has_value(); }
+    String const& numbering_system() const { return m_numbering_system.value(); }
+    void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }
+
+    bool numeric() const { return m_numeric; }
+    void set_numeric(bool numeric) { m_numeric = numeric; }
+
+private:
+    String m_locale;                     // [[Locale]]
+    Optional<String> m_calendar;         // [[Calendar]]
+    Optional<String> m_case_first;       // [[CaseFirst]]
+    Optional<String> m_collation;        // [[Collation]]
+    Optional<String> m_hour_cycle;       // [[HourCycle]]
+    Optional<String> m_numbering_system; // [[NumberingSystem]]
+    bool m_numeric;                      // [[Numeric]]
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/Locale.h>
+#include <LibJS/Runtime/Intl/LocaleConstructor.h>
+
+namespace JS::Intl {
+
+// 14.1 The Intl.Locale Constructor, https://tc39.es/ecma402/#sec-intl-locale-constructor
+LocaleConstructor::LocaleConstructor(GlobalObject& global_object)
+    : NativeFunction(vm().names.Locale.as_string(), *global_object.function_prototype())
+{
+}
+
+void LocaleConstructor::initialize(GlobalObject& global_object)
+{
+    NativeFunction::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 14.2.1 Intl.Locale.prototype, https://tc39.es/ecma402/#sec-Intl.Locale.prototype
+    define_direct_property(vm.names.prototype, global_object.intl_locale_prototype(), 0);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
+}
+
+// 14.1.3 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
+Value LocaleConstructor::call()
+{
+    // 1. If NewTarget is undefined, throw a TypeError exception.
+    vm().throw_exception<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.Locale");
+    return {};
+}
+
+// 14.1.3 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
+Value LocaleConstructor::construct(FunctionObject& new_target)
+{
+    auto& vm = this->vm();
+    auto& global_object = this->global_object();
+
+    // 6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, "%Locale.prototype%", internalSlotsList).
+    auto* locale = ordinary_create_from_constructor<Locale>(global_object, new_target, &GlobalObject::intl_locale_prototype);
+    if (vm.exception())
+        return {};
+
+    return locale;
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -4,12 +4,247 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Intl/LocaleConstructor.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
+
+struct LocaleAndKeys {
+    String locale;
+    Optional<String> ca;
+    Optional<String> co;
+    Optional<String> hc;
+    Optional<String> kf;
+    Optional<String> kn;
+    Optional<String> nu;
+};
+
+static Vector<StringView> const& locale_relevant_extension_keys()
+{
+    // 14.2.2 Internal slots, https://tc39.es/ecma402/#sec-intl.locale-internal-slots
+    // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "co", "hc", "kf", "kn", "nu" ».
+    // If %Collator%.[[RelevantExtensionKeys]] does not contain "kf", then remove "kf" from %Locale%.[[RelevantExtensionKeys]].
+    // If %Collator%.[[RelevantExtensionKeys]] does not contain "kn", then remove "kn" from %Locale%.[[RelevantExtensionKeys]].
+
+    // FIXME: We do not yet have an Intl.Collator object. For now, we behave as if "kf" and "kn" exist, as test262 depends on it.
+    static Vector<StringView> relevant_extension_keys { "ca"sv, "co"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
+    return relevant_extension_keys;
+}
+
+// Note: This is not an AO in the spec. This just serves to abstract very similar steps in ApplyOptionsToTag and the Intl.Locale constructor.
+static Optional<String> get_string_option(GlobalObject& global_object, Object const& options, PropertyName const& property, Function<bool(StringView)> validator, Vector<StringView> const& values = {})
+{
+    auto& vm = global_object.vm();
+
+    auto option = get_option(global_object, &options, property, Value::Type::String, values, Empty {});
+    if (vm.exception())
+        return {};
+    if (option.is_undefined())
+        return {};
+
+    if (validator && !validator(option.as_string().string())) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::OptionIsNotValidValue, option, property);
+        return {};
+    }
+
+    return option.as_string().string();
+}
+
+// 14.1.1 ApplyOptionsToTag ( tag, options ), https://tc39.es/ecma402/#sec-apply-options-to-tag
+static Optional<String> apply_options_to_tag(GlobalObject& global_object, StringView tag, Object const& options)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Assert: Type(tag) is String.
+    // 2. Assert: Type(options) is Object.
+
+    // 3. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+    auto locale_id = is_structurally_valid_language_tag(tag);
+    if (!locale_id.has_value()) {
+        vm.throw_exception<RangeError>(global_object, ErrorType::IntlInvalidLanguageTag, tag);
+        return {};
+    }
+
+    // 4. Let language be ? GetOption(options, "language", "string", undefined, undefined).
+    // 5. If language is not undefined, then
+    //     a. If language does not match the unicode_language_subtag production, throw a RangeError exception.
+    auto language = get_string_option(global_object, options, vm.names.language, Unicode::is_unicode_language_subtag);
+    if (vm.exception())
+        return {};
+
+    // 6. Let script be ? GetOption(options, "script", "string", undefined, undefined).
+    // 7. If script is not undefined, then
+    //     a. If script does not match the unicode_script_subtag production, throw a RangeError exception.
+    auto script = get_string_option(global_object, options, vm.names.script, Unicode::is_unicode_script_subtag);
+    if (vm.exception())
+        return {};
+
+    // 8. Let region be ? GetOption(options, "region", "string", undefined, undefined).
+    // 9. If region is not undefined, then
+    //     a. If region does not match the unicode_region_subtag production, throw a RangeError exception.
+    auto region = get_string_option(global_object, options, vm.names.region, Unicode::is_unicode_region_subtag);
+    if (vm.exception())
+        return {};
+
+    // 10. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    auto canonicalized_tag = JS::Intl::canonicalize_unicode_locale_id(*locale_id);
+
+    // 11. Assert: tag matches the unicode_locale_id production.
+    locale_id = Unicode::parse_unicode_locale_id(canonicalized_tag);
+    VERIFY(locale_id.has_value());
+
+    // 12. Let languageId be the substring of tag corresponding to the unicode_language_id production.
+    auto& language_id = locale_id->language_id;
+
+    // 13. If language is not undefined, then
+    if (language.has_value()) {
+        // a. Set languageId to languageId with the substring corresponding to the unicode_language_subtag production replaced by the string language.
+        language_id.language = language.release_value();
+    }
+
+    // 14. If script is not undefined, then
+    if (script.has_value()) {
+        // a. If languageId does not contain a unicode_script_subtag production, then
+        //     i. Set languageId to the string-concatenation of the unicode_language_subtag production of languageId, "-", script, and the rest of languageId.
+        // b. Else,
+        //     i. Set languageId to languageId with the substring corresponding to the unicode_script_subtag production replaced by the string script.
+        language_id.script = script.release_value();
+    }
+
+    // 15. If region is not undefined, then
+    if (region.has_value()) {
+        // a. If languageId does not contain a unicode_region_subtag production, then
+        //     i. Set languageId to the string-concatenation of the unicode_language_subtag production of languageId, the substring corresponding to "-"` and the `unicode_script_subtag` production if present, `"-", region, and the rest of languageId.
+        // b. Else,
+        //     i. Set languageId to languageId with the substring corresponding to the unicode_region_subtag production replaced by the string region.
+        language_id.region = region.release_value();
+    }
+
+    // 16. Set tag to tag with the substring corresponding to the unicode_language_id production replaced by the string languageId.
+    // 17. Return CanonicalizeUnicodeLocaleId(tag).
+    return JS::Intl::canonicalize_unicode_locale_id(*locale_id);
+}
+
+// 14.1.2 ApplyUnicodeExtensionToTag ( tag, options, relevantExtensionKeys ), https://tc39.es/ecma402/#sec-apply-unicode-extension-to-tag
+static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKeys options, Vector<StringView> const& relevant_extension_keys)
+{
+    // 1. Assert: Type(tag) is String.
+    // 2. Assert: tag matches the unicode_locale_id production.
+    auto locale_id = Unicode::parse_unicode_locale_id(tag);
+    VERIFY(locale_id.has_value());
+
+    Vector<String> attributes;
+    Vector<Unicode::Keyword> keywords;
+
+    // 3. If tag contains a substring that is a Unicode locale extension sequence, then
+    for (auto& extension : locale_id->extensions) {
+        if (!extension.has<Unicode::LocaleExtension>())
+            continue;
+
+        // a. Let extension be the String value consisting of the substring of the Unicode locale extension sequence within tag.
+        // b. Let components be ! UnicodeExtensionComponents(extension).
+        auto& components = extension.get<Unicode::LocaleExtension>();
+        // c. Let attributes be components.[[Attributes]].
+        attributes = move(components.attributes);
+        // d. Let keywords be components.[[Keywords]].
+        keywords = move(components.keywords);
+
+        break;
+    }
+    // 4. Else,
+    //     a. Let attributes be a new empty List.
+    //     b. Let keywords be a new empty List.
+
+    auto field_from_key = [](LocaleAndKeys& value, StringView key) -> Optional<String>& {
+        if (key == "ca"sv)
+            return value.ca;
+        if (key == "co"sv)
+            return value.co;
+        if (key == "hc"sv)
+            return value.hc;
+        if (key == "kf"sv)
+            return value.kf;
+        if (key == "kn"sv)
+            return value.kn;
+        if (key == "nu"sv)
+            return value.nu;
+        VERIFY_NOT_REACHED();
+    };
+
+    // 5. Let result be a new Record.
+    LocaleAndKeys result {};
+
+    // 6. For each element key of relevantExtensionKeys, do
+    for (auto const& key : relevant_extension_keys) {
+        // a. Let value be undefined.
+        Optional<String> value {};
+
+        Unicode::Keyword* entry = nullptr;
+        // b. If keywords contains an element whose [[Key]] is the same as key, then
+        if (auto it = keywords.find_if([&](auto const& k) { return key == k.key; }); it != keywords.end()) {
+            // i. Let entry be the element of keywords whose [[Key]] is the same as key.
+            entry = &(*it);
+
+            // ii. Let value be entry.[[Value]].
+            StringBuilder builder;
+            builder.join('-', entry->types);
+            value = builder.build();
+        }
+        // c. Else,
+        //     i. Let entry be empty.
+
+        // d. Assert: options has a field [[<key>]].
+        // e. Let optionsValue be options.[[<key>]].
+        auto options_value = field_from_key(options, key);
+
+        // f. If optionsValue is not undefined, then
+        if (options_value.has_value()) {
+            // i. Assert: Type(optionsValue) is String.
+            // ii. Let value be optionsValue.
+            value = options_value.release_value();
+
+            // iii. If entry is not empty, then
+            if (entry != nullptr) {
+                // 1. Set entry.[[Value]] to value.
+                entry->types = value->split('-');
+            }
+            // iv. Else,
+            else {
+                // 1. Append the Record { [[Key]]: key, [[Value]]: value } to keywords.
+                keywords.append({ key, value->split('-') });
+            }
+        }
+
+        // g. Set result.[[<key>]] to value.
+        field_from_key(result, key) = move(value);
+    }
+
+    // 7. Let locale be the String value that is tag with any Unicode locale extension sequences removed.
+    locale_id->remove_extension_type<Unicode::LocaleExtension>();
+    auto locale = locale_id->to_string();
+
+    // 8. Let newExtension be a Unicode BCP 47 U Extension based on attributes and keywords.
+    Unicode::LocaleExtension new_extension { move(attributes), move(keywords) };
+
+    // 9. If newExtension is not the empty String, then
+    if (!new_extension.attributes.is_empty() || !new_extension.keywords.is_empty()) {
+        // a. Let locale be ! InsertUnicodeExtensionAndCanonicalize(locale, newExtension).
+        locale = insert_unicode_extension_and_canonicalize(locale_id.release_value(), move(new_extension));
+    }
+
+    // 10. Set result.[[locale]] to locale.
+    result.locale = move(locale);
+
+    // 11. Return result.
+    return result;
+}
 
 // 14.1 The Intl.Locale Constructor, https://tc39.es/ecma402/#sec-intl-locale-constructor
 LocaleConstructor::LocaleConstructor(GlobalObject& global_object)
@@ -42,11 +277,143 @@ Value LocaleConstructor::construct(FunctionObject& new_target)
     auto& vm = this->vm();
     auto& global_object = this->global_object();
 
+    auto tag = vm.argument(0);
+    auto options = vm.argument(1);
+
+    // 2. Let relevantExtensionKeys be %Locale%.[[RelevantExtensionKeys]].
+    auto const& relevant_extension_keys = locale_relevant_extension_keys();
+
+    // 3. Let internalSlotsList be « [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[NumberingSystem]] ».
+    // 4. If relevantExtensionKeys contains "kf", then
+    //     a. Append [[CaseFirst]] as the last element of internalSlotsList.
+    // 5. If relevantExtensionKeys contains "kn", then
+    //     a. Append [[Numeric]] as the last element of internalSlotsList.
+
     // 6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, "%Locale.prototype%", internalSlotsList).
     auto* locale = ordinary_create_from_constructor<Locale>(global_object, new_target, &GlobalObject::intl_locale_prototype);
     if (vm.exception())
         return {};
 
+    // 7. If Type(tag) is not String or Object, throw a TypeError exception.
+    if (!tag.is_string() && !tag.is_object()) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOrString, "tag"sv);
+        return {};
+    }
+
+    // 8. If Type(tag) is Object and tag has an [[InitializedLocale]] internal slot, then
+    if (tag.is_object() && is<Locale>(tag.as_object())) {
+        // a. Let tag be tag.[[Locale]].
+        auto const& tag_object = static_cast<Locale const&>(tag.as_object());
+        tag = js_string(vm, tag_object.locale());
+    }
+    // 9. Else,
+    else {
+        // a. Let tag be ? ToString(tag).
+        tag = tag.to_primitive_string(global_object);
+        if (vm.exception())
+            return {};
+    }
+
+    // 10. Set options to ? CoerceOptionsToObject(options).
+    options = coerce_options_to_object(global_object, options);
+    if (vm.exception())
+        return {};
+
+    // 11. Set tag to ? ApplyOptionsToTag(tag, options).
+    auto canonicalized_tag = apply_options_to_tag(global_object, tag.as_string().string(), options.as_object());
+    if (vm.exception())
+        return {};
+
+    // 12. Let opt be a new Record.
+    LocaleAndKeys opt {};
+
+    // 13. Let calendar be ? GetOption(options, "calendar", "string", undefined, undefined).
+    // 14. If calendar is not undefined, then
+    //     a. If calendar does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+    // 15. Set opt.[[ca]] to calendar.
+    opt.ca = get_string_option(global_object, options.as_object(), vm.names.calendar, Unicode::is_type_identifier);
+    if (vm.exception())
+        return {};
+
+    // 16. Let collation be ? GetOption(options, "collation", "string", undefined, undefined).
+    // 17. If collation is not undefined, then
+    //     a. If collation does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+    // 18. Set opt.[[co]] to collation.
+    opt.co = get_string_option(global_object, options.as_object(), vm.names.collation, Unicode::is_type_identifier);
+    if (vm.exception())
+        return {};
+
+    // 19. Let hc be ? GetOption(options, "hourCycle", "string", « "h11", "h12", "h23", "h24" », undefined).
+    // 20. Set opt.[[hc]] to hc.
+    opt.hc = get_string_option(global_object, options.as_object(), vm.names.hourCycle, nullptr, { "h11"sv, "h12"sv, "h23"sv, "h24"sv });
+    if (vm.exception())
+        return {};
+
+    // 21. Let kf be ? GetOption(options, "caseFirst", "string", « "upper", "lower", "false" », undefined).
+    // 22. Set opt.[[kf]] to kf.
+    opt.kf = get_string_option(global_object, options.as_object(), vm.names.caseFirst, nullptr, { "upper"sv, "lower"sv, "false"sv });
+    if (vm.exception())
+        return {};
+
+    // 23. Let kn be ? GetOption(options, "numeric", "boolean", undefined, undefined).
+    auto kn = get_option(global_object, options, vm.names.numeric, Value::Type::Boolean, {}, Empty {});
+    if (vm.exception())
+        return {};
+
+    // 24. If kn is not undefined, set kn to ! ToString(kn).
+    // 25. Set opt.[[kn]] to kn.
+    if (!kn.is_undefined())
+        opt.kn = kn.to_string(global_object);
+
+    // 26. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    // 27. If numberingSystem is not undefined, then
+    //     a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+    // 28. Set opt.[[nu]] to numberingSystem.
+    opt.nu = get_string_option(global_object, options.as_object(), vm.names.numberingSystem, Unicode::is_type_identifier);
+    if (vm.exception())
+        return {};
+
+    // 29. Let r be ! ApplyUnicodeExtensionToTag(tag, opt, relevantExtensionKeys).
+    auto result = apply_unicode_extension_to_tag(*canonicalized_tag, move(opt), relevant_extension_keys);
+
+    // 30. Set locale.[[Locale]] to r.[[locale]].
+    locale->set_locale(move(result.locale));
+    // 31. Set locale.[[Calendar]] to r.[[ca]].
+    if (result.ca.has_value())
+        locale->set_calendar(result.ca.release_value());
+    // 32. Set locale.[[Collation]] to r.[[co]].
+    if (result.co.has_value())
+        locale->set_collation(result.co.release_value());
+    // 33. Set locale.[[HourCycle]] to r.[[hc]].
+    if (result.hc.has_value())
+        locale->set_hour_cycle(result.hc.release_value());
+
+    // 34. If relevantExtensionKeys contains "kf", then
+    if (relevant_extension_keys.contains_slow("kf"sv)) {
+        // a. Set locale.[[CaseFirst]] to r.[[kf]].
+        if (result.kf.has_value())
+            locale->set_case_first(result.kf.release_value());
+    }
+
+    // 35. If relevantExtensionKeys contains "kn", then
+    if (relevant_extension_keys.contains_slow("kn"sv)) {
+        // a. If ! SameValue(r.[[kn]], "true") is true or r.[[kn]] is the empty String, then
+        if (result.kn.has_value() && (same_value(js_string(vm, *result.kn), js_string(vm, "true")) || result.kn->is_empty())) {
+            // i. Set locale.[[Numeric]] to true.
+            locale->set_numeric(true);
+        }
+        // b. Else,
+        else {
+            // i. Set locale.[[Numeric]] to false.
+            locale->set_numeric(false);
+        }
+    }
+
+    // 36. Set locale.[[NumberingSystem]] to r.[[nu]].
+    if (result.nu.has_value())
+        locale->set_numbering_system(result.nu.release_value());
+
+    // 37. Return locale.
     return locale;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS::Intl {
+
+class LocaleConstructor final : public NativeFunction {
+    JS_OBJECT(LocaleConstructor, NativeFunction);
+
+public:
+    explicit LocaleConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~LocaleConstructor() override = default;
+
+    virtual Value call() override;
+    virtual Value construct(FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -53,6 +53,7 @@ void LocalePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.hourCycle, hour_cycle, {}, Attribute::Configurable);
     define_native_accessor(vm.names.numberingSystem, numbering_system, {}, Attribute::Configurable);
     define_native_accessor(vm.names.numeric, numeric, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.language, language, {}, Attribute::Configurable);
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -121,6 +122,25 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::numeric)
 
     // 3. Return loc.[[Numeric]].
     return Value(locale_object->numeric());
+}
+
+// 14.3.13 get Intl.Locale.prototype.language, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.language
+JS_DEFINE_NATIVE_GETTER(LocalePrototype::language)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    // 3. Let locale be loc.[[Locale]].
+    auto locale = Unicode::parse_unicode_locale_id(locale_object->locale());
+
+    // 4. Assert: locale matches the unicode_locale_id production.
+    VERIFY(locale.has_value());
+
+    // 5. Return the substring of locale corresponding to the unicode_language_subtag production of the unicode_language_id.
+    return js_string(vm, *locale->language_id.language);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -55,6 +55,7 @@ void LocalePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.numeric, numeric, {}, Attribute::Configurable);
     define_native_accessor(vm.names.language, language, {}, Attribute::Configurable);
     define_native_accessor(vm.names.script, script, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.region, region, {}, Attribute::Configurable);
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -165,6 +166,29 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::script)
 
     // 6. Return the substring of locale corresponding to the unicode_script_subtag production of the unicode_language_id.
     return js_string(vm, *locale->language_id.script);
+}
+
+// 14.3.15 get Intl.Locale.prototype.region, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region
+JS_DEFINE_NATIVE_GETTER(LocalePrototype::region)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    // 3. Let locale be loc.[[Locale]].
+    auto locale = Unicode::parse_unicode_locale_id(locale_object->locale());
+
+    // 4. Assert: locale matches the unicode_locale_id production.
+    VERIFY(locale.has_value());
+
+    // 5. If the unicode_language_id production of locale does not contain the ["-" unicode_region_subtag] sequence, return undefined.
+    if (!locale->language_id.region.has_value())
+        return js_undefined();
+
+    // 6. Return the substring of locale corresponding to the unicode_region_subtag production of the unicode_language_id.
+    return js_string(vm, *locale->language_id.region);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/TypeCasts.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/LocalePrototype.h>
+
+namespace JS::Intl {
+
+// 14.3 Properties of the Intl.Locale Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-locale-prototype-object
+LocalePrototype::LocalePrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void LocalePrototype::initialize(GlobalObject& global_object)
+{
+    Object::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 14.3.2 Intl.Locale.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.Locale.prototype-@@tostringtag
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.Locale"), Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Intl/LocalePrototype.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
@@ -44,6 +45,8 @@ void LocalePrototype::initialize(GlobalObject& global_object)
 
     // 14.3.2 Intl.Locale.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.Locale.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.Locale"), Attribute::Configurable);
+
+    define_native_accessor(vm.names.baseName, base_name, {}, Attribute::Configurable);
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -57,6 +60,23 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::to_string)
 
     // 3. Return loc.[[Locale]].
     return js_string(vm, locale_object->locale());
+}
+
+// 14.3.6 get Intl.Locale.prototype.baseName, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.baseName
+JS_DEFINE_NATIVE_GETTER(LocalePrototype::base_name)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    // 3. Let locale be loc.[[Locale]].
+    auto locale = Unicode::parse_unicode_locale_id(locale_object->locale());
+    VERIFY(locale.has_value());
+
+    // 4. Return the substring of locale corresponding to the unicode_language_id production.
+    return js_string(vm, locale->language_id.to_string());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -6,9 +6,26 @@
 
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Intl/LocalePrototype.h>
 
 namespace JS::Intl {
+
+static Locale* typed_this(GlobalObject& global_object)
+{
+    auto& vm = global_object.vm();
+
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return nullptr;
+
+    if (!is<Locale>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Intl.Locale");
+        return nullptr;
+    }
+
+    return static_cast<Locale*>(this_object);
+}
 
 // 14.3 Properties of the Intl.Locale Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-locale-prototype-object
 LocalePrototype::LocalePrototype(GlobalObject& global_object)
@@ -22,8 +39,24 @@ void LocalePrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.toString, to_string, 0, attr);
+
     // 14.3.2 Intl.Locale.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.Locale.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.Locale"), Attribute::Configurable);
+}
+
+// 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
+JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::to_string)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    // 3. Return loc.[[Locale]].
+    return js_string(vm, locale_object->locale());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -54,6 +54,7 @@ void LocalePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.numberingSystem, numbering_system, {}, Attribute::Configurable);
     define_native_accessor(vm.names.numeric, numeric, {}, Attribute::Configurable);
     define_native_accessor(vm.names.language, language, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.script, script, {}, Attribute::Configurable);
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -141,6 +142,29 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::language)
 
     // 5. Return the substring of locale corresponding to the unicode_language_subtag production of the unicode_language_id.
     return js_string(vm, *locale->language_id.language);
+}
+
+// 14.3.14 get Intl.Locale.prototype.script, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script
+JS_DEFINE_NATIVE_GETTER(LocalePrototype::script)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    // 3. Let locale be loc.[[Locale]].
+    auto locale = Unicode::parse_unicode_locale_id(locale_object->locale());
+
+    // 4. Assert: locale matches the unicode_locale_id production.
+    VERIFY(locale.has_value());
+
+    // 5. If the unicode_language_id production of locale does not contain the ["-" unicode_script_subtag] sequence, return undefined.
+    if (!locale->language_id.script.has_value())
+        return js_undefined();
+
+    // 6. Return the substring of locale corresponding to the unicode_script_subtag production of the unicode_language_id.
+    return js_string(vm, *locale->language_id.script);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -52,6 +52,7 @@ void LocalePrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.collation, collation, {}, Attribute::Configurable);
     define_native_accessor(vm.names.hourCycle, hour_cycle, {}, Attribute::Configurable);
     define_native_accessor(vm.names.numberingSystem, numbering_system, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.numeric, numeric, {}, Attribute::Configurable);
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -108,5 +109,18 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::base_name)
     }
 JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES
 #undef __JS_ENUMERATE
+
+// 14.3.11 get Intl.Locale.prototype.numeric, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric
+JS_DEFINE_NATIVE_GETTER(LocalePrototype::numeric)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    // 3. Return loc.[[Numeric]].
+    return Value(locale_object->numeric());
+}
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -47,6 +47,11 @@ void LocalePrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.Locale"), Attribute::Configurable);
 
     define_native_accessor(vm.names.baseName, base_name, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.calendar, calendar, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.caseFirst, case_first, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.collation, collation, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.hourCycle, hour_cycle, {}, Attribute::Configurable);
+    define_native_accessor(vm.names.numberingSystem, numbering_system, {}, Attribute::Configurable);
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -78,5 +83,30 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::base_name)
     // 4. Return the substring of locale corresponding to the unicode_language_id production.
     return js_string(vm, locale->language_id.to_string());
 }
+
+#define JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES \
+    __JS_ENUMERATE(calendar)                   \
+    __JS_ENUMERATE(case_first)                 \
+    __JS_ENUMERATE(collation)                  \
+    __JS_ENUMERATE(hour_cycle)                 \
+    __JS_ENUMERATE(numbering_system)
+
+// 14.3.7 get Intl.Locale.prototype.calendar, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar
+// 14.3.8 get Intl.Locale.prototype.caseFirst, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.caseFirst
+// 14.3.9 get Intl.Locale.prototype.collation, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation
+// 14.3.10 get Intl.Locale.prototype.hourCycle, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle
+// 14.3.12 get Intl.Locale.prototype.numberingSystem, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem
+#define __JS_ENUMERATE(keyword)                          \
+    JS_DEFINE_NATIVE_GETTER(LocalePrototype::keyword)    \
+    {                                                    \
+        auto* locale_object = typed_this(global_object); \
+        if (!locale_object)                              \
+            return {};                                   \
+        if (!locale_object->has_##keyword())             \
+            return js_undefined();                       \
+        return js_string(vm, locale_object->keyword());  \
+    }
+JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES
+#undef __JS_ENUMERATE
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
+
+namespace JS::Intl {
+
+class LocalePrototype final : public Object {
+    JS_OBJECT(LocalePrototype, Object);
+
+public:
+    explicit LocalePrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~LocalePrototype() override = default;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -27,6 +27,7 @@ private:
     JS_DECLARE_NATIVE_GETTER(collation);
     JS_DECLARE_NATIVE_GETTER(hour_cycle);
     JS_DECLARE_NATIVE_GETTER(numbering_system);
+    JS_DECLARE_NATIVE_GETTER(numeric);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -30,6 +30,7 @@ private:
     JS_DECLARE_NATIVE_GETTER(numeric);
     JS_DECLARE_NATIVE_GETTER(language);
     JS_DECLARE_NATIVE_GETTER(script);
+    JS_DECLARE_NATIVE_GETTER(region);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -17,6 +17,9 @@ public:
     explicit LocalePrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~LocalePrototype() override = default;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(to_string);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -20,6 +20,8 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);
+
+    JS_DECLARE_NATIVE_GETTER(base_name);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -28,6 +28,7 @@ private:
     JS_DECLARE_NATIVE_GETTER(hour_cycle);
     JS_DECLARE_NATIVE_GETTER(numbering_system);
     JS_DECLARE_NATIVE_GETTER(numeric);
+    JS_DECLARE_NATIVE_GETTER(language);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -22,6 +22,11 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);
 
     JS_DECLARE_NATIVE_GETTER(base_name);
+    JS_DECLARE_NATIVE_GETTER(calendar);
+    JS_DECLARE_NATIVE_GETTER(case_first);
+    JS_DECLARE_NATIVE_GETTER(collation);
+    JS_DECLARE_NATIVE_GETTER(hour_cycle);
+    JS_DECLARE_NATIVE_GETTER(numbering_system);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -29,6 +29,7 @@ private:
     JS_DECLARE_NATIVE_GETTER(numbering_system);
     JS_DECLARE_NATIVE_GETTER(numeric);
     JS_DECLARE_NATIVE_GETTER(language);
+    JS_DECLARE_NATIVE_GETTER(script);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
@@ -2,25 +2,25 @@ describe("errors", () => {
     test("invalid language", () => {
         expect(() => {
             new Intl.DisplayNames("en", { type: "language" }).of("hello!");
-        }).toThrowWithMessage(RangeError, "'hello!' is not a valid value for option type language");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option language");
     });
 
     test("invalid region", () => {
         expect(() => {
             new Intl.DisplayNames("en", { type: "region" }).of("hello!");
-        }).toThrowWithMessage(RangeError, "'hello!' is not a valid value for option type region");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option region");
     });
 
     test("invalid script", () => {
         expect(() => {
             new Intl.DisplayNames("en", { type: "script" }).of("hello!");
-        }).toThrowWithMessage(RangeError, "'hello!' is not a valid value for option type script");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option script");
     });
 
     test("invalid currency", () => {
         expect(() => {
             new Intl.DisplayNames("en", { type: "currency" }).of("hello!");
-        }).toThrowWithMessage(RangeError, "'hello!' is not a valid value for option type currency");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option currency");
     });
 });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
@@ -115,4 +115,12 @@ describe("normal behavior", () => {
             "en-US-u-1k-aaa-2k-ccc",
         ]);
     });
+
+    test("canonicalize locale objects", () => {
+        const en = new Intl.Locale("en", { script: "Latn" });
+        expect(Intl.getCanonicalLocales(en)).toEqual(["en-Latn"]);
+
+        const es = new Intl.Locale("es", { region: "419" });
+        expect(Intl.getCanonicalLocales([en, es])).toEqual(["en-Latn", "es-419"]);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.getCanonicalLocales.js
@@ -19,6 +19,13 @@ describe("errors", () => {
 
     test("duplicate variant subtags", () => {
         expect(() => {
+            Intl.getCanonicalLocales("en-posix-POSIX");
+        }).toThrowWithMessage(
+            RangeError,
+            "en-posix-POSIX is not a structurally valid language tag"
+        );
+
+        expect(() => {
             Intl.getCanonicalLocales("en-POSIX-POSIX");
         }).toThrowWithMessage(
             RangeError,

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.@@toStringTag.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.@@toStringTag.js
@@ -1,0 +1,3 @@
+test("basic functionality", () => {
+    expect(Intl.Locale.prototype[Symbol.toStringTag]).toBe("Intl.Locale");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.js
@@ -4,10 +4,168 @@ describe("errors", () => {
             Intl.Locale();
         }).toThrowWithMessage(TypeError, "Intl.Locale constructor must be called with 'new'");
     });
+
+    test("tag is neither object nor string", () => {
+        expect(() => {
+            new Intl.Locale(1);
+        }).toThrowWithMessage(TypeError, "tag is neither an object nor a string");
+    });
+
+    test("structurally invalid tag", () => {
+        expect(() => {
+            new Intl.Locale("root");
+        }).toThrowWithMessage(RangeError, "root is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.Locale("en-");
+        }).toThrowWithMessage(RangeError, "en- is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.Locale("Latn");
+        }).toThrowWithMessage(RangeError, "Latn is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.Locale("en-u-aa-U-aa");
+        }).toThrowWithMessage(RangeError, "en-u-aa-U-aa is not a structurally valid language tag");
+    });
+
+    test("locale option fields are not valid Unicode TR35 subtags", () => {
+        expect(() => {
+            new Intl.Locale("en", { language: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option language");
+
+        expect(() => {
+            new Intl.Locale("en", { script: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option script");
+
+        expect(() => {
+            new Intl.Locale("en", { region: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option region");
+    });
+
+    test("keyword option fields are not valid Unicode TR35 types", () => {
+        expect(() => {
+            new Intl.Locale("en", { calendar: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option calendar");
+
+        expect(() => {
+            new Intl.Locale("en", { collation: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option collation");
+
+        expect(() => {
+            new Intl.Locale("en", { hourCycle: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option hourCycle");
+
+        expect(() => {
+            new Intl.Locale("en", { caseFirst: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option caseFirst");
+    });
 });
 
 describe("normal behavior", () => {
     test("length is 1", () => {
         expect(Intl.Locale).toHaveLength(1);
+    });
+
+    test("locale option fields create subtags", () => {
+        const sr = new Intl.Locale("sr", { script: "Latn" });
+        expect(sr.toString()).toBe("sr-Latn");
+
+        const en = new Intl.Locale("en", { region: "US" });
+        expect(en.toString()).toBe("en-US");
+    });
+
+    test("locale option fields replace subtags", () => {
+        const es = new Intl.Locale("en", { language: "es" });
+        expect(es.toString()).toBe("es");
+
+        const sr = new Intl.Locale("sr-Latn", { script: "Cyrl" });
+        expect(sr.toString()).toBe("sr-Cyrl");
+
+        const en = new Intl.Locale("en-US", { region: "GB" });
+        expect(en.toString()).toBe("en-GB");
+    });
+
+    test("construction from another locale", () => {
+        const en1 = new Intl.Locale("en", { region: "US" });
+        const en2 = new Intl.Locale(en1, { script: "Latn" });
+        expect(en2.toString()).toBe("en-Latn-US");
+    });
+
+    test("locale is canonicalized", () => {
+        const en = new Intl.Locale("EN", { script: "lAtN", region: "us" });
+        expect(en.toString()).toBe("en-Latn-US");
+    });
+
+    test("calendar extension", () => {
+        const en1 = new Intl.Locale("en-u-ca-abc");
+        expect(en1.toString()).toBe("en-u-ca-abc");
+
+        const en2 = new Intl.Locale("en", { calendar: "abc" });
+        expect(en2.toString()).toBe("en-u-ca-abc");
+
+        const en3 = new Intl.Locale("en-u-ca-abc", { calendar: "def" });
+        expect(en3.toString()).toBe("en-u-ca-def");
+    });
+
+    test("collation extension", () => {
+        const en1 = new Intl.Locale("en-u-co-abc");
+        expect(en1.toString()).toBe("en-u-co-abc");
+
+        const en2 = new Intl.Locale("en", { collation: "abc" });
+        expect(en2.toString()).toBe("en-u-co-abc");
+
+        const en3 = new Intl.Locale("en-u-co-abc", { collation: "def" });
+        expect(en3.toString()).toBe("en-u-co-def");
+    });
+
+    test("hour-cycle extension", () => {
+        const en1 = new Intl.Locale("en-u-hc-h11");
+        expect(en1.toString()).toBe("en-u-hc-h11");
+
+        const en2 = new Intl.Locale("en", { hourCycle: "h12" });
+        expect(en2.toString()).toBe("en-u-hc-h12");
+
+        const en3 = new Intl.Locale("en-u-hc-h23", { hourCycle: "h24" });
+        expect(en3.toString()).toBe("en-u-hc-h24");
+    });
+
+    test("case-first extension", () => {
+        const en1 = new Intl.Locale("en-u-kf-upper");
+        expect(en1.toString()).toBe("en-u-kf-upper");
+
+        const en2 = new Intl.Locale("en", { caseFirst: "lower" });
+        expect(en2.toString()).toBe("en-u-kf-lower");
+
+        const en3 = new Intl.Locale("en-u-kf-upper", { caseFirst: "false" });
+        expect(en3.toString()).toBe("en-u-kf-false");
+    });
+
+    test("numeric extension", () => {
+        // Note: "true" values are removed from Unicode locale extensions during canonicalization.
+        const en1 = new Intl.Locale("en-u-kn-true");
+        expect(en1.toString()).toBe("en-u-kn");
+
+        const en2 = new Intl.Locale("en", { numeric: false });
+        expect(en2.toString()).toBe("en-u-kn-false");
+
+        const en3 = new Intl.Locale("en-u-kn-false", { numeric: 1 });
+        expect(en3.toString()).toBe("en-u-kn");
+    });
+
+    test("numbering-system extension", () => {
+        const en1 = new Intl.Locale("en-u-nu-abc");
+        expect(en1.toString()).toBe("en-u-nu-abc");
+
+        const en2 = new Intl.Locale("en", { numberingSystem: "abc" });
+        expect(en2.toString()).toBe("en-u-nu-abc");
+
+        const en3 = new Intl.Locale("en-u-nu-abc", { numberingSystem: "def" });
+        expect(en3.toString()).toBe("en-u-nu-def");
+    });
+
+    test("unicode extension inserted before private use extension", () => {
+        const en1 = new Intl.Locale("en-x-abcd", { calendar: "abc" });
+        expect(en1.toString()).toBe("en-u-ca-abc-x-abcd");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.js
@@ -1,0 +1,13 @@
+describe("errors", () => {
+    test("called without new", () => {
+        expect(() => {
+            Intl.Locale();
+        }).toThrowWithMessage(TypeError, "Intl.Locale constructor must be called with 'new'");
+    });
+});
+
+describe("normal behavior", () => {
+    test("length is 1", () => {
+        expect(Intl.Locale).toHaveLength(1);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.baseName.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.baseName.js
@@ -1,0 +1,21 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.baseName;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").baseName).toBe("en");
+        expect(new Intl.Locale("en-Latn").baseName).toBe("en-Latn");
+        expect(new Intl.Locale("en-GB").baseName).toBe("en-GB");
+        expect(new Intl.Locale("en", { script: "Latn" }).baseName).toBe("en-Latn");
+        expect(new Intl.Locale("en", { region: "GB" }).baseName).toBe("en-GB");
+
+        expect(new Intl.Locale("en-u-ca-abc").baseName).toBe("en");
+        expect(new Intl.Locale("en", { calendar: "abc" }).baseName).toBe("en");
+        expect(new Intl.Locale("en-x-abcd").baseName).toBe("en");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.calendar.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.calendar.js
@@ -1,0 +1,16 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.calendar;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").calendar).toBeUndefined();
+        expect(new Intl.Locale("en-u-ca-abc").calendar).toBe("abc");
+        expect(new Intl.Locale("en", { calendar: "abc" }).calendar).toBe("abc");
+        expect(new Intl.Locale("en-u-ca-abc", { calendar: "def" }).calendar).toBe("def");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.caseFirst.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.caseFirst.js
@@ -1,0 +1,16 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.caseFirst;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").caseFirst).toBeUndefined();
+        expect(new Intl.Locale("en-u-kf-upper").caseFirst).toBe("upper");
+        expect(new Intl.Locale("en", { caseFirst: "lower" }).caseFirst).toBe("lower");
+        expect(new Intl.Locale("en-u-kf-upper", { caseFirst: "false" }).caseFirst).toBe("false");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.collation.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.collation.js
@@ -1,0 +1,16 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.collation;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").collation).toBeUndefined();
+        expect(new Intl.Locale("en-u-co-abc").collation).toBe("abc");
+        expect(new Intl.Locale("en", { collation: "abc" }).collation).toBe("abc");
+        expect(new Intl.Locale("en-u-co-abc", { collation: "def" }).collation).toBe("def");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.hourCycle.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.hourCycle.js
@@ -1,0 +1,16 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.hourCycle;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").hourCycle).toBeUndefined();
+        expect(new Intl.Locale("en-u-hc-h11").hourCycle).toBe("h11");
+        expect(new Intl.Locale("en", { hourCycle: "h12" }).hourCycle).toBe("h12");
+        expect(new Intl.Locale("en-u-hc-h23", { hourCycle: "h24" }).hourCycle).toBe("h24");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.language.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.language.js
@@ -1,0 +1,21 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.language;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").language).toBe("en");
+        expect(new Intl.Locale("en-Latn").language).toBe("en");
+        expect(new Intl.Locale("en-GB").language).toBe("en");
+        expect(new Intl.Locale("en", { script: "Latn" }).language).toBe("en");
+        expect(new Intl.Locale("en", { region: "GB" }).language).toBe("en");
+
+        expect(new Intl.Locale("en-u-ca-abc").language).toBe("en");
+        expect(new Intl.Locale("en", { calendar: "abc" }).language).toBe("en");
+        expect(new Intl.Locale("en-x-abcd").language).toBe("en");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.numberingSystem.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.numberingSystem.js
@@ -1,0 +1,18 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.numberingSystem;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").numberingSystem).toBeUndefined();
+        expect(new Intl.Locale("en-u-nu-abc").numberingSystem).toBe("abc");
+        expect(new Intl.Locale("en", { numberingSystem: "abc" }).numberingSystem).toBe("abc");
+        expect(new Intl.Locale("en-u-nu-abc", { numberingSystem: "def" }).numberingSystem).toBe(
+            "def"
+        );
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.numeric.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.numeric.js
@@ -1,0 +1,16 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.numeric;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").numeric).toBeFalse();
+        expect(new Intl.Locale("en-u-kn-true").numeric).toBeTrue();
+        expect(new Intl.Locale("en", { numeric: false }).numeric).toBeFalse();
+        expect(new Intl.Locale("en-u-kn-false", { numeric: true }).numeric).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.region.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.region.js
@@ -1,0 +1,21 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.region;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").region).toBeUndefined();
+        expect(new Intl.Locale("en-Latn").region).toBeUndefined();
+        expect(new Intl.Locale("en-GB").region).toBe("GB");
+        expect(new Intl.Locale("en", { script: "Latn" }).region).toBeUndefined();
+        expect(new Intl.Locale("en", { region: "GB" }).region).toBe("GB");
+
+        expect(new Intl.Locale("en-u-ca-abc").region).toBeUndefined();
+        expect(new Intl.Locale("en", { calendar: "abc" }).region).toBeUndefined();
+        expect(new Intl.Locale("en-x-abcd").region).toBeUndefined();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.script.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.script.js
@@ -1,0 +1,21 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.script;
+        }).toThrowWithMessage(TypeError, "Not a Intl.Locale object");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").script).toBeUndefined();
+        expect(new Intl.Locale("en-Latn").script).toBe("Latn");
+        expect(new Intl.Locale("en-GB").script).toBeUndefined();
+        expect(new Intl.Locale("en", { script: "Latn" }).script).toBe("Latn");
+        expect(new Intl.Locale("en", { region: "GB" }).script).toBeUndefined();
+
+        expect(new Intl.Locale("en-u-ca-abc").script).toBeUndefined();
+        expect(new Intl.Locale("en", { calendar: "abc" }).script).toBeUndefined();
+        expect(new Intl.Locale("en-x-abcd").script).toBeUndefined();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.toString.js
@@ -1,3 +1,28 @@
 test("length is 0", () => {
     expect(Intl.Locale.prototype.toString).toHaveLength(0);
 });
+
+test("normal behavior", () => {
+    const en1 = new Intl.Locale("en");
+    expect(en1.toString()).toBe("en");
+
+    const en2 = new Intl.Locale("en-Latn");
+    expect(en2.toString()).toBe("en-Latn");
+
+    const en3 = new Intl.Locale("en-US");
+    expect(en3.toString()).toBe("en-US");
+
+    const en4 = new Intl.Locale("en", { language: "es" });
+    expect(en4.toString()).toBe("es");
+
+    const en5 = new Intl.Locale("en", { script: "Latn" });
+    expect(en5.toString()).toBe("en-Latn");
+
+    const en6 = new Intl.Locale("en", { script: "Latn", region: "US" });
+    expect(en6.toString()).toBe("en-Latn-US");
+});
+
+test("string is canonicalized behavior", () => {
+    const en = new Intl.Locale("EN", { script: "lAtN", region: "us" });
+    expect(en.toString()).toBe("en-Latn-US");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.toString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.toString.js
@@ -1,0 +1,3 @@
+test("length is 0", () => {
+    expect(Intl.Locale.prototype.toString).toHaveLength(0);
+});

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -19,8 +19,14 @@ enum class Script : u8;
 enum class Territory : u8;
 enum class WordBreakProperty : u8;
 
+struct Keyword;
 struct LanguageID;
+struct LocaleExtension;
+struct LocaleID;
+struct OtherExtension;
 struct SpecialCasing;
+struct TransformedExtension;
+struct TransformedField;
 struct UnicodeData;
 
 }

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -114,6 +114,22 @@ static Optional<StringView> consume_next_segment(GenericLexer& lexer, bool with_
     return segment;
 }
 
+bool is_type_identifier(StringView identifier)
+{
+    // type = alphanum{3,8} (sep alphanum{3,8})*
+    GenericLexer lexer { identifier };
+
+    while (true) {
+        auto type = consume_next_segment(lexer, lexer.tell() > 0);
+        if (!type.has_value())
+            break;
+        if (!is_single_type(*type))
+            return false;
+    }
+
+    return lexer.is_eof() && (lexer.tell() > 0);
+}
+
 static Optional<LanguageID> parse_unicode_language_id(GenericLexer& lexer)
 {
     // https://unicode.org/reports/tr35/#Unicode_language_identifier

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -62,6 +62,7 @@ bool is_unicode_language_subtag(StringView);
 bool is_unicode_script_subtag(StringView);
 bool is_unicode_region_subtag(StringView);
 bool is_unicode_variant_subtag(StringView);
+bool is_type_identifier(StringView);
 
 Optional<LanguageID> parse_unicode_language_id(StringView);
 Optional<LocaleID> parse_unicode_locale_id(StringView);

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -16,6 +16,8 @@
 namespace Unicode {
 
 struct LanguageID {
+    String to_string() const;
+
     bool is_root { false };
     Optional<String> language {};
     Optional<String> script {};
@@ -51,6 +53,19 @@ struct OtherExtension {
 using Extension = Variant<LocaleExtension, TransformedExtension, OtherExtension>;
 
 struct LocaleID {
+    String to_string() const;
+
+    template<typename ExtensionType>
+    void remove_extension_type()
+    {
+        auto tmp_extensions = move(extensions);
+
+        for (auto& extension : tmp_extensions) {
+            if (!extension.has<ExtensionType>())
+                extensions.append(move(extension));
+        }
+    }
+
     LanguageID language_id {};
     Vector<Extension> extensions {};
     Vector<String> private_use_extensions {};

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -30,6 +30,7 @@
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
+#include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Map.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/NumberObject.h>
@@ -518,6 +519,36 @@ static void print_intl_display_names(JS::Object const& object, HashTable<JS::Obj
     print_value(js_string(object.vm(), display_names.fallback_string()), seen_objects);
 }
 
+static void print_intl_locale(JS::Object const& object, HashTable<JS::Object*>& seen_objects)
+{
+    auto& locale = static_cast<JS::Intl::Locale const&>(object);
+    print_type("Intl.Locale");
+    out("\n  locale: ");
+    print_value(js_string(object.vm(), locale.locale()), seen_objects);
+    if (locale.has_calendar()) {
+        out("\n  calendar: ");
+        print_value(js_string(object.vm(), locale.calendar()), seen_objects);
+    }
+    if (locale.has_case_first()) {
+        out("\n  caseFirst: ");
+        print_value(js_string(object.vm(), locale.case_first()), seen_objects);
+    }
+    if (locale.has_collation()) {
+        out("\n  collation: ");
+        print_value(js_string(object.vm(), locale.collation()), seen_objects);
+    }
+    if (locale.has_hour_cycle()) {
+        out("\n  hourCycle: ");
+        print_value(js_string(object.vm(), locale.hour_cycle()), seen_objects);
+    }
+    if (locale.has_numbering_system()) {
+        out("\n  numberingSystem: ");
+        print_value(js_string(object.vm(), locale.numbering_system()), seen_objects);
+    }
+    out("\n  numeric: ");
+    print_value(JS::Value(locale.numeric()), seen_objects);
+}
+
 static void print_primitive_wrapper_object(FlyString const& name, JS::Object const& object, HashTable<JS::Object*>& seen_objects)
 {
     // BooleanObject, NumberObject, StringObject
@@ -593,6 +624,8 @@ static void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
             return print_temporal_zoned_date_time(object, seen_objects);
         if (is<JS::Intl::DisplayNames>(object))
             return print_intl_display_names(object, seen_objects);
+        if (is<JS::Intl::Locale>(object))
+            return print_intl_locale(object, seen_objects);
         return print_object(object, seen_objects);
     }
 


### PR DESCRIPTION
This implements everything in the main ECMA-402 spec for `Intl.Locale` except `Intl.Locale.prototype.maximize` and `Intl.Locale.prototype.minimize`. Those will require some code-size reduction in the locale generator since they will need all of the [likely subtags](https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-core/supplemental/likelySubtags.json) data set, which is just too large for the generator as-is. It also looks like there's a bunch of proposal methods tested by test262 that aren't included here.