### PR TITLE
Meta+Kernel: Lint MutexProtected.h

### DIFF
--- a/Kernel/Locking/MutexProtected.h
+++ b/Kernel/Locking/MutexProtected.h
@@ -38,8 +38,7 @@ private:
         ALWAYS_INLINE U const& get() const { return &m_value; }
         ALWAYS_INLINE U& get() requires(!IsConst<U>) { return &m_value; }
 
-    private:
-        U& m_value;
+    private : U& m_value;
         MutexLocker m_locker;
     };
 


### PR DESCRIPTION
Running `Meta/lint-clang-format.sh` locally, lints this file. 