### PR TITLE
LibWeb: Make Node::root return a reference and fix small mistake in EventDispatcher

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -35,15 +35,15 @@ static EventTarget* retarget(EventTarget* left, EventTarget* right)
             return left;
 
         auto* left_node = verify_cast<Node>(left);
-        auto* left_root = left_node->root();
+        auto& left_root = left_node->root();
         if (!is<ShadowRoot>(left_root))
             return left;
 
-        if (is<Node>(right) && left_root->is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*right)))
+        if (is<Node>(right) && left_root.is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*right)))
             return left;
 
-        auto* left_shadow_root = verify_cast<ShadowRoot>(left_root);
-        left = left_shadow_root->host();
+        auto& left_shadow_root = verify_cast<ShadowRoot>(left_root);
+        left = left_shadow_root.host();
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -202,7 +202,7 @@ bool EventDispatcher::dispatch(NonnullRefPtr<EventTarget> target, NonnullRefPtr<
             }
 
             if (is<Window>(parent)
-                || (is<Node>(parent) && verify_cast<Node>(*target).is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*parent)))) {
+                || (is<Node>(parent) && verify_cast<Node>(*target).root().is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*parent)))) {
                 if (is_activation_event && event->bubbles() && !activation_target && parent->activation_behaviour)
                     activation_target = parent;
 

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -113,14 +113,14 @@ public:
 
     String child_text_content() const;
 
-    Node* root();
-    const Node* root() const
+    Node& root();
+    const Node& root() const
     {
         return const_cast<Node*>(this)->root();
     }
 
-    Node* shadow_including_root();
-    const Node* shadow_including_root() const
+    Node& shadow_including_root();
+    const Node& shadow_including_root() const
     {
         return const_cast<Node*>(this)->shadow_including_root();
     }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -16,11 +16,12 @@ ShadowRoot::ShadowRoot(Document& document, Element& host)
     set_host(host);
 }
 
+// https://dom.spec.whatwg.org/#ref-for-get-the-parent%E2%91%A6
 EventTarget* ShadowRoot::get_parent(const Event& event)
 {
     if (!event.composed()) {
         auto& events_first_invocation_target = verify_cast<Node>(*event.path().first().invocation_target);
-        if (events_first_invocation_target.root() == this)
+        if (&events_first_invocation_target.root() == this)
             return nullptr;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -72,7 +72,7 @@ bool Node::establishes_stacking_context() const
 {
     if (!has_style())
         return false;
-    if (dom_node() == document().root())
+    if (dom_node() == &document().root())
         return true;
     auto position = computed_values().position();
     if (position == CSS::Position::Absolute || position == CSS::Position::Relative || position == CSS::Position::Fixed || position == CSS::Position::Sticky)


### PR DESCRIPTION
LibWeb: Make Node::root return a reference

The root of a node can never be null, as "the root of an object is
itself, if its parent is null, or else it is the root of its parent."

https://dom.spec.whatwg.org/#concept-tree-root

-----

LibWeb: Check target's root instead of target itself in EventDispatcher

This was accidentally missing ".root()": "or parent is a node and
target’s _root_ is a shadow-including inclusive ancestor of parent"

https://dom.spec.whatwg.org/#concept-event-dispatch Step 5.9.6