### PR TITLE
LibGUI: Set correct value on click with set `jump_to_cursor()` in Slider

### DIFF
--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -93,9 +93,9 @@ void Slider::mousedown_event(MouseEvent& event)
         if (jump_to_cursor()) {
             float normalized_mouse_offset = 0.0f;
             if (orientation() == Orientation::Vertical) {
-                normalized_mouse_offset = static_cast<float>(mouse_offset) / static_cast<float>(height());
+                normalized_mouse_offset = static_cast<float>(mouse_offset - track_margin()) / static_cast<float>(inner_rect().height());
             } else {
-                normalized_mouse_offset = static_cast<float>(mouse_offset) / static_cast<float>(width());
+                normalized_mouse_offset = static_cast<float>(mouse_offset - track_margin()) / static_cast<float>(inner_rect().width());
             }
 
             int new_value = static_cast<int>(min() + ((max() - min()) * normalized_mouse_offset));

--- a/Userland/Libraries/LibGUI/Slider.h
+++ b/Userland/Libraries/LibGUI/Slider.h
@@ -25,6 +25,7 @@ public:
     KnobSizeMode knob_size_mode() const { return m_knob_size_mode; }
 
     int track_size() const { return 2; }
+    int track_margin() const { return 10; }
     int knob_fixed_primary_size() const { return 8; }
     int knob_secondary_size() const { return 20; }
 
@@ -34,8 +35,8 @@ public:
     Gfx::IntRect inner_rect() const
     {
         if (orientation() == Orientation::Horizontal)
-            return rect().shrunken(20, 0);
-        return rect().shrunken(0, 20);
+            return rect().shrunken(track_margin() * 2, 0);
+        return rect().shrunken(0, track_margin() * 2);
     }
 
 protected:


### PR DESCRIPTION
- **LibGUI: Add `track_margin()` to Sliders**

  Less magic numbers! :^)

- **LibGUI: Set correct value on click with set `jump_to_cursor()` in Slider**

  Prior this change, clicking on a slider with set `jump_to_cursor()` flag didn’t exactly match the knob to the mouse position, and therefore the slider values were a bit off in the corners.
  The calculation used the whole widget size to set new values, which isn’t correct as the track slider has margins on both ends.

  I noticed this while seeking in the Sound Player.
