### PR TITLE
PixelPaint: Fix Undo and Redo

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -550,20 +550,45 @@ void Image::did_change_rect()
         client->image_did_change_rect(rect());
 }
 
-ImageUndoCommand::ImageUndoCommand(Image& image)
-    : m_snapshot(image.take_snapshot())
+ImageUndoCommand::ImageUndoCommand(Image& image, RefPtr<Image>& image_snapshot)
+    : m_snapshot_before(nullptr)
+    , m_snapshot_after(nullptr)
     , m_image(image)
+    , m_image_snapshot(image_snapshot)
+{
+}
+
+ImageUndoCommand::ImageUndoCommand(Image& image, RefPtr<Image>& image_snapshot, RefPtr<Image>& snapshot_before, RefPtr<Image>& snapshot_after)
+    : m_snapshot_before(snapshot_before)
+    , m_snapshot_after(snapshot_after)
+    , m_image(image)
+    , m_image_snapshot(image_snapshot)
 {
 }
 
 void ImageUndoCommand::undo()
 {
-    m_image.restore_snapshot(*m_snapshot);
+    if (m_snapshot_before.ptr()) {
+        m_image.restore_snapshot(*m_snapshot_before);
+        m_image_snapshot = m_snapshot_before;
+    }
 }
 
 void ImageUndoCommand::redo()
 {
-    undo();
+    if (m_snapshot_after.ptr()) {
+        m_image.restore_snapshot(*m_snapshot_after);
+        m_image_snapshot = m_snapshot_after;
+    }
+}
+
+
+void ImageUndoCommand::set_snapshot_before(RefPtr<Image>& snapshot_before) {
+    m_snapshot_before = snapshot_before;
+}
+
+void ImageUndoCommand::set_snapshot_after(RefPtr<Image>& snapshot_after) {
+    m_snapshot_after = snapshot_after;
 }
 
 void Image::set_title(String title)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -118,14 +118,20 @@ private:
 
 class ImageUndoCommand : public GUI::Command {
 public:
-    ImageUndoCommand(Image& image);
+    ImageUndoCommand(Image& image, RefPtr<Image>& image_snapshot);
+    ImageUndoCommand(Image& image, RefPtr<Image>& image_snapshot, RefPtr<Image>& snapshot_before, RefPtr<Image>& snapshot_after);
 
     virtual void undo() override;
     virtual void redo() override;
 
+    void set_snapshot_before(RefPtr<Image>& snapshot_before);
+    void set_snapshot_after(RefPtr<Image>& snapshot_after);
+
 private:
-    RefPtr<Image> m_snapshot;
+    RefPtr<Image> m_snapshot_before;
+    RefPtr<Image> m_snapshot_after;
     Image& m_image;
+    RefPtr<Image>& m_image_snapshot;
 };
 
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -118,6 +118,9 @@ private:
 
     NonnullRefPtr<Image> m_image;
     RefPtr<Layer> m_active_layer;
+
+    RefPtr<Image> m_image_snapshot;
+    OwnPtr<ImageUndoCommand> m_image_undo_command;
     OwnPtr<GUI::UndoStack> m_undo_stack;
 
     NonnullRefPtrVector<Guide> m_guides;


### PR DESCRIPTION
Undo and redo seem to be broken in PixelPaint. To reproduce the weird behavior it had, do the following:
- Open PixelPaint
- Undo to clear the undo stack
- Select the background layer and draw
- Now undo-ing doesn't give the desired effect.

This PR attempts to fix this bug.