### PR TITLE
LibGfx/Color: Change grayscale conversion + add new API to get a contrasting color

### DIFF
--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -221,9 +221,14 @@ public:
             alpha() * other.alpha() / 255);
     }
 
+    constexpr u8 luminosity() const
+    {
+        return (red() * 0.2126f + green() * 0.7152f + blue() * 0.0722f);
+    }
+
     constexpr Color to_grayscale() const
     {
-        int gray = (red() + green() + blue()) / 3;
+        auto gray = luminosity();
         return Color(gray, gray, gray, alpha());
     }
 

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -392,6 +392,11 @@ public:
         return Color(out_r, out_g, out_b);
     }
 
+    constexpr Color suggested_foreground_color() const
+    {
+        return luminosity() < 128 ? Color::White : Color::Black;
+    }
+
 private:
     constexpr explicit Color(RGBA32 rgba)
         : m_value(rgba)


### PR DESCRIPTION
Issue #9758 relevant to the first commit.

The second commit adds a new API to query for a suggested color to use as foreground text (right now black/white). There's a few places this might be useful, some that come to mind are the flame graph, the code in #9756, possibly Space Analyzer. A possible improvement would be to also analyze how alpha would come into play here, but I'm not yet exactly sure how to account for that.

(Sorry for the big rebuild)