### PR TITLE
PixelPaint: Add actions to flip/rotate entire image

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -553,6 +554,18 @@ void Image::set_path(String path)
 {
     m_path = move(path);
     set_title(LexicalPath::basename(m_path));
+}
+
+void Image::flip(Gfx::Orientation orientation)
+{
+    for (auto& layer : m_layers) {
+        auto flipped = layer.bitmap().flipped(orientation);
+        VERIFY(flipped);
+        layer.set_bitmap(*flipped);
+        layer.did_modify_bitmap(rect());
+    }
+
+    did_change();
 }
 
 }

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -527,6 +527,12 @@ void Image::did_change(Gfx::IntRect const& a_modified_rect)
         client->image_did_change(modified_rect);
 }
 
+void Image::did_change_rect()
+{
+    for (auto* client : m_clients)
+        client->image_did_change_rect(rect());
+}
+
 ImageUndoCommand::ImageUndoCommand(Image& image)
     : m_snapshot(image.take_snapshot())
     , m_image(image)
@@ -566,6 +572,19 @@ void Image::flip(Gfx::Orientation orientation)
     }
 
     did_change();
+}
+
+void Image::rotate(Gfx::RotationDirection direction)
+{
+    for (auto& layer : m_layers) {
+        auto rotated = layer.bitmap().rotated(direction);
+        VERIFY(rotated);
+        layer.set_bitmap(*rotated);
+        layer.did_modify_bitmap(rect());
+    }
+
+    m_size = { m_size.height(), m_size.width() };
+    did_change_rect();
 }
 
 }

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -16,6 +16,7 @@
 #include <LibCore/File.h>
 #include <LibGUI/Command.h>
 #include <LibGUI/Forward.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
@@ -32,6 +33,7 @@ public:
     virtual void image_did_modify_layer_bitmap(size_t) { }
     virtual void image_did_modify_layer_stack() { }
     virtual void image_did_change(Gfx::IntRect const&) { }
+    virtual void image_did_change_rect(Gfx::IntRect const&) { }
     virtual void image_select_layer(Layer*) { }
     virtual void image_did_change_title(String const&) { }
 
@@ -91,6 +93,7 @@ public:
     void set_title(String);
 
     void flip(Gfx::Orientation orientation);
+    void rotate(Gfx::RotationDirection direction);
 
 private:
     explicit Image(Gfx::IntSize const&);
@@ -100,6 +103,7 @@ private:
     static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_file(Core::File& file, String const& file_path);
 
     void did_change(Gfx::IntRect const& modified_rect = {});
+    void did_change_rect();
     void did_modify_layer_stack();
 
     String m_path;

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -88,6 +89,8 @@ public:
 
     String const& title() const { return m_title; }
     void set_title(String);
+
+    void flip(Gfx::Orientation orientation);
 
 private:
     explicit Image(Gfx::IntSize const&);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -453,6 +453,12 @@ void ImageEditor::image_did_change(Gfx::IntRect const& modified_image_rect)
     update(m_editor_image_rect.intersected(enclosing_int_rect(image_rect_to_editor_rect(modified_image_rect))));
 }
 
+void ImageEditor::image_did_change_rect(Gfx::IntRect const& new_image_rect)
+{
+    m_editor_image_rect = enclosing_int_rect(image_rect_to_editor_rect(new_image_rect));
+    update(m_editor_image_rect);
+}
+
 void ImageEditor::image_did_change_title(String const& path)
 {
     if (on_image_title_change)

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -106,6 +106,7 @@ private:
     virtual void leave_event(Core::Event&) override;
 
     virtual void image_did_change(Gfx::IntRect const&) override;
+    virtual void image_did_change_rect(Gfx::IntRect const&) override;
     virtual void image_select_layer(Layer*) override;
     virtual void image_did_change_title(String const&) override;
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -424,6 +424,22 @@ int main(int argc, char** argv)
             editor->image().flip(Gfx::Orientation::Horizontal);
         },
         window));
+    image_menu.add_action(GUI::Action::create(
+        "Rotate &Left", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            editor->image().rotate(Gfx::RotationDirection::CounterClockwise);
+        },
+        window));
+    image_menu.add_action(GUI::Action::create(
+        "Rotate &Right", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            editor->image().rotate(Gfx::RotationDirection::Clockwise);
+        },
+        window));
 
     auto& layer_menu = window->add_menu("&Layer");
     layer_menu.add_action(GUI::Action::create(

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -405,6 +406,24 @@ int main(int argc, char** argv)
             tool_menu.add_action(*tool.action());
         return IterationDecision::Continue;
     });
+
+    auto& image_menu = window->add_menu("&Image");
+    image_menu.add_action(GUI::Action::create(
+        "Flip &Vertically", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            editor->image().flip(Gfx::Orientation::Vertical);
+        },
+        window));
+    image_menu.add_action(GUI::Action::create(
+        "Flip &Horizontally", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            editor->image().flip(Gfx::Orientation::Horizontal);
+        },
+        window));
 
     auto& layer_menu = window->add_menu("&Layer");
     layer_menu.add_action(GUI::Action::create(


### PR DESCRIPTION
We can now rotate and flip the image :^) Added these items in a separate `Image` menu for actions that modify the whole image, where it doesn't necessary make sense to cram them in the `Layer` menu (this just bloats the context menus for layers too).