### PR TITLE
PixelPaint: Fix layer dragging bug

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -277,7 +277,9 @@ size_t LayerListWidget::hole_index_during_move() const
     VERIFY(is_moving_gadget());
     auto& moving_gadget = m_gadgets[m_moving_gadget_index.value()];
     int center_y_of_moving_gadget = moving_gadget.rect.translated(0, moving_gadget.movement_delta.y()).center().y();
-    return center_y_of_moving_gadget / vertical_step;
+
+    int top_of_gadgets = max(0, height() - m_total_gadget_height);
+    return (center_y_of_moving_gadget - top_of_gadgets) / vertical_step;
 }
 
 void LayerListWidget::select_bottom_layer()
@@ -316,8 +318,8 @@ void LayerListWidget::cycle_through_selection(int delta)
 
 void LayerListWidget::relayout_gadgets()
 {
-    auto total_gadget_height = static_cast<int>(m_gadgets.size()) * vertical_step + 6;
-    int y = max(0, height() - total_gadget_height);
+    m_total_gadget_height = static_cast<int>(m_gadgets.size()) * vertical_step + 6;
+    int y = max(0, height() - m_total_gadget_height);
 
     Optional<size_t> hole_index;
     if (is_moving_gadget())
@@ -334,8 +336,8 @@ void LayerListWidget::relayout_gadgets()
         ++index;
     }
 
-    set_content_size({ widget_inner_rect().width(), total_gadget_height });
-    vertical_scrollbar().set_range(0, max(total_gadget_height - height(), 0));
+    set_content_size({ widget_inner_rect().width(), m_total_gadget_height });
+    vertical_scrollbar().set_range(0, max(m_total_gadget_height - height(), 0));
     update();
 }
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -73,6 +73,7 @@ private:
     Gfx::IntPoint m_moving_event_origin;
 
     size_t m_selected_gadget_index { 0 };
+    int m_total_gadget_height { 0 };
 };
 
 }


### PR DESCRIPTION
A previous commit I made broke layer dragging (oops) since the hole_index
was always being computed with respect to the top of the layer list
widget, however we were now drawing layers from the bottom. When
you didn't have enough layers to fill up the full height, dragging
them around would be weird.

This patch computes the hole index correctly using the same offset
we start drawing from, and fixes the behaviour. This commit should
have been squashed with 0c56f06, but I didn't catch the mistake in time  :(