### PR TITLE
PixelPaint: Add `Crop to Selection` Action

### DIFF
--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -101,12 +101,13 @@ public:
 
     void flip(Gfx::Orientation orientation);
     void rotate(Gfx::RotationDirection direction);
+    void crop(Gfx::IntRect const& rect);
 
 private:
     explicit Image(Gfx::IntSize const&);
 
     void did_change(Gfx::IntRect const& modified_rect = {});
-    void did_change_rect();
+    void did_change_rect(Gfx::IntRect const& modified_rect = {});
     void did_modify_layer_stack();
 
     String m_path;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -375,6 +375,17 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 return;
             editor->image().rotate(Gfx::RotationDirection::Clockwise);
         }));
+    image_menu.add_separator();
+    image_menu.add_action(GUI::Action::create(
+        "&Crop To Selection", [&](auto&) {
+            auto* editor = current_image_editor();
+            // FIXME: disable this action if there is no selection
+            if (!editor || editor->selection().is_empty())
+                return;
+            auto crop_rect = editor->selection().bounding_rect();
+            editor->image().crop(crop_rect);
+            editor->selection().clear();
+        }));
 
     auto& layer_menu = window.add_menu("&Layer");
     layer_menu.add_action(GUI::Action::create(


### PR DESCRIPTION
I'm not super familiar with how the UndoStack works, so I haven't gotten this to behave nicely with that, however this doesn't break anything else that already works, so I figure it's good enough to make a commit and hopefully someone else who can figure out how to add the undo functionality can fix it :^)

Another yak on the stack is having a hook on selection changes so we can detect if there's no selection and disable the action, but I think that's beyond the scope of this commit