### PR TITLE
LibJS+LibUnicode: Implement `Intl.Locale.prototype.{maximize,minimize}`

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -281,6 +281,7 @@ namespace JS {
     P(log10)                                 \
     P(map)                                   \
     P(max)                                   \
+    P(maximize)                              \
     P(mergeFields)                           \
     P(message)                               \
     P(microsecond)                           \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -289,6 +289,7 @@ namespace JS {
     P(millisecond)                           \
     P(milliseconds)                          \
     P(min)                                   \
+    P(minimize)                              \
     P(minute)                                \
     P(minutes)                               \
     P(month)                                 \

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -4,15 +4,57 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/Locale.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
+
+Locale* Locale::create(GlobalObject& global_object, Unicode::LocaleID const& locale_id)
+{
+    return global_object.heap().allocate<Locale>(global_object, locale_id, *global_object.intl_locale_prototype());
+}
 
 // 14 Locale Objects, https://tc39.es/ecma402/#locale-objects
 Locale::Locale(Object& prototype)
     : Object(prototype)
 {
+}
+
+Locale::Locale(Unicode::LocaleID const& locale_id, Object& prototype)
+    : Object(prototype)
+{
+    set_locale(locale_id.to_string());
+
+    auto join_keyword_types = [](auto const& types) {
+        StringBuilder builder;
+        builder.join('-', types);
+        return builder.build();
+    };
+
+    for (auto const& extension : locale_id.extensions) {
+        if (!extension.has<Unicode::LocaleExtension>())
+            continue;
+
+        for (auto const& keyword : extension.get<Unicode::LocaleExtension>().keywords) {
+            if (keyword.key == "ca"sv) {
+                set_calendar(join_keyword_types(keyword.types));
+            } else if (keyword.key == "co"sv) {
+                set_collation(join_keyword_types(keyword.types));
+            } else if (keyword.key == "hc"sv) {
+                set_hour_cycle(join_keyword_types(keyword.types));
+            } else if (keyword.key == "kf"sv) {
+                set_case_first(join_keyword_types(keyword.types));
+            } else if (keyword.key == "kn"sv) {
+                set_numeric(keyword.types.is_empty());
+            } else if (keyword.key == "nu"sv) {
+                set_numbering_system(join_keyword_types(keyword.types));
+            }
+        }
+
+        break;
+    }
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Value.h>
+#include <LibUnicode/Forward.h>
 
 namespace JS::Intl {
 
@@ -17,7 +18,10 @@ class Locale final : public Object {
     JS_OBJECT(Locale, Object);
 
 public:
+    static Locale* create(GlobalObject&, Unicode::LocaleID const&);
+
     Locale(Object& prototype);
+    Locale(Unicode::LocaleID const&, Object& prototype);
     virtual ~Locale() override = default;
 
     String const& locale() const { return m_locale; }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -53,7 +53,7 @@ private:
     Optional<String> m_collation;        // [[Collation]]
     Optional<String> m_hour_cycle;       // [[HourCycle]]
     Optional<String> m_numbering_system; // [[NumberingSystem]]
-    bool m_numeric;                      // [[Numeric]]
+    bool m_numeric { false };            // [[Numeric]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -42,6 +42,7 @@ void LocalePrototype::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.maximize, maximize, 0, attr);
+    define_native_function(vm.names.minimize, minimize, 0, attr);
     define_native_function(vm.names.toString, to_string, 0, attr);
 
     // 14.3.2 Intl.Locale.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.Locale.prototype-@@tostringtag
@@ -76,6 +77,26 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::maximize)
         locale->language_id = maximal.release_value();
 
     // 4. Return ! Construct(%Locale%, maximal).
+    return Locale::create(global_object, *locale);
+}
+
+// 14.3.4 Intl.Locale.prototype.minimize ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
+JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::minimize)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto* locale_object = typed_this(global_object);
+    if (!locale_object)
+        return {};
+
+    auto locale = Unicode::parse_unicode_locale_id(locale_object->locale());
+    VERIFY(locale.has_value());
+
+    // 3. Let minimal be the result of the Remove Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set minimal to loc.[[Locale]].
+    if (auto minimal = Unicode::remove_likely_subtags(locale->language_id); minimal.has_value())
+        locale->language_id = minimal.release_value();
+
+    // 4. Return ! Construct(%Locale%, minimal).
     return Locale::create(global_object, *locale);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -19,6 +19,7 @@ public:
     virtual ~LocalePrototype() override = default;
 
 private:
+    JS_DECLARE_NATIVE_FUNCTION(maximize);
     JS_DECLARE_NATIVE_FUNCTION(to_string);
 
     JS_DECLARE_NATIVE_GETTER(base_name);

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(maximize);
+    JS_DECLARE_NATIVE_FUNCTION(minimize);
     JS_DECLARE_NATIVE_FUNCTION(to_string);
 
     JS_DECLARE_NATIVE_GETTER(base_name);

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.maximize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.maximize.js
@@ -1,0 +1,32 @@
+test("length is 0", () => {
+    expect(Intl.Locale.prototype.maximize).toHaveLength(0);
+});
+
+test("normal behavior", () => {
+    expect(new Intl.Locale("en").maximize().toString()).toBe("en-Latn-US");
+
+    expect(new Intl.Locale("en-Latn").maximize().toString()).toBe("en-Latn-US");
+    expect(new Intl.Locale("en-Shaw").maximize().toString()).toBe("en-Shaw-GB");
+    expect(new Intl.Locale("en-Arab").maximize().toString()).toBe("en-Arab-US");
+
+    expect(new Intl.Locale("en-US").maximize().toString()).toBe("en-Latn-US");
+    expect(new Intl.Locale("en-GB").maximize().toString()).toBe("en-Latn-GB");
+    expect(new Intl.Locale("en-FR").maximize().toString()).toBe("en-Latn-FR");
+
+    expect(new Intl.Locale("it-Kana-CA").maximize().toString()).toBe("it-Kana-CA");
+
+    expect(new Intl.Locale("und").maximize().toString()).toBe("en-Latn-US");
+    expect(new Intl.Locale("und-Thai").maximize().toString()).toBe("th-Thai-TH");
+    expect(new Intl.Locale("und-419").maximize().toString()).toBe("es-Latn-419");
+    expect(new Intl.Locale("und-150").maximize().toString()).toBe("ru-Cyrl-RU");
+    expect(new Intl.Locale("und-AT").maximize().toString()).toBe("de-Latn-AT");
+    expect(new Intl.Locale("und-Cyrl-RO").maximize().toString()).toBe("bg-Cyrl-RO");
+    expect(new Intl.Locale("und-AQ").maximize().toString()).toBe("und-Latn-AQ");
+});
+
+test("keywords are preserved", () => {
+    expect(new Intl.Locale("en-u-ca-abc").maximize().toString()).toBe("en-Latn-US-u-ca-abc");
+    expect(new Intl.Locale("en", { calendar: "abc" }).maximize().toString()).toBe(
+        "en-Latn-US-u-ca-abc"
+    );
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.minimize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.minimize.js
@@ -1,0 +1,34 @@
+test("length is 0", () => {
+    expect(Intl.Locale.prototype.minimize).toHaveLength(0);
+});
+
+test("normal behavior", () => {
+    expect(new Intl.Locale("en").minimize().toString()).toBe("en");
+
+    expect(new Intl.Locale("en-Latn").minimize().toString()).toBe("en");
+    expect(new Intl.Locale("ar-Arab").minimize().toString()).toBe("ar");
+    expect(new Intl.Locale("en-US").minimize().toString()).toBe("en");
+    expect(new Intl.Locale("en-GB").minimize().toString()).toBe("en-GB");
+
+    expect(new Intl.Locale("en-Latn-US").minimize().toString()).toBe("en");
+    expect(new Intl.Locale("en-Shaw-GB").minimize().toString()).toBe("en-Shaw");
+    expect(new Intl.Locale("en-Arab-US").minimize().toString()).toBe("en-Arab");
+    expect(new Intl.Locale("en-Latn-GB").minimize().toString()).toBe("en-GB");
+    expect(new Intl.Locale("en-Latn-FR").minimize().toString()).toBe("en-FR");
+
+    expect(new Intl.Locale("it-Kana-CA").minimize().toString()).toBe("it-Kana-CA");
+
+    expect(new Intl.Locale("th-Thai-TH").minimize().toString()).toBe("th");
+    expect(new Intl.Locale("es-Latn-419").minimize().toString()).toBe("es-419");
+    expect(new Intl.Locale("ru-Cyrl-RU").minimize().toString()).toBe("ru");
+    expect(new Intl.Locale("de-Latn-AT").minimize().toString()).toBe("de-AT");
+    expect(new Intl.Locale("bg-Cyrl-RO").minimize().toString()).toBe("bg-RO");
+    expect(new Intl.Locale("und-Latn-AQ").minimize().toString()).toBe("und-AQ");
+});
+
+test("keywords are preserved", () => {
+    expect(new Intl.Locale("en-Latn-US-u-ca-abc").minimize().toString()).toBe("en-u-ca-abc");
+    expect(new Intl.Locale("en-Latn-US", { calendar: "abc" }).minimize().toString()).toBe(
+        "en-u-ca-abc"
+    );
+});

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -834,6 +834,15 @@ Optional<StringView> resolve_subdivision_alias(StringView subdivision)
 #endif
 }
 
+Optional<LanguageID> add_likely_subtags([[maybe_unused]] LanguageID const& language_id)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::add_likely_subtags(language_id);
+#else
+    return {};
+#endif
+}
+
 String resolve_most_likely_territory([[maybe_unused]] LanguageID const& language_id, StringView territory_alias)
 {
     auto aliases = territory_alias.split_view(' ');

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -843,6 +843,52 @@ Optional<LanguageID> add_likely_subtags([[maybe_unused]] LanguageID const& langu
 #endif
 }
 
+Optional<LanguageID> remove_likely_subtags([[maybe_unused]] LanguageID const& language_id)
+{
+#if ENABLE_UNICODE_DATA
+    // https://www.unicode.org/reports/tr35/#Likely_Subtags
+    auto return_language_and_variants = [](auto language, auto variants) {
+        language.variants = move(variants);
+        return language;
+    };
+
+    // 1. First get max = AddLikelySubtags(inputLocale). If an error is signaled, return it.
+    auto maximized = add_likely_subtags(language_id);
+    if (!maximized.has_value())
+        return {};
+
+    // 2. Remove the variants from max.
+    auto variants = move(maximized->variants);
+
+    // 3. Get the components of the max (languagemax, scriptmax, regionmax).
+    auto language_max = maximized->language;
+    auto script_max = maximized->script;
+    auto region_max = maximized->region;
+
+    // 4. Then for trial in {languagemax, languagemax_regionmax, languagemax_scriptmax}:
+    //    If AddLikelySubtags(trial) = max, then return trial + variants.
+    auto run_trial = [&](Optional<String> language, Optional<String> script, Optional<String> region) -> Optional<LanguageID> {
+        LanguageID trial { .language = move(language), .script = move(script), .region = move(region) };
+
+        if (add_likely_subtags(trial) == maximized)
+            return return_language_and_variants(move(trial), move(variants));
+        return {};
+    };
+
+    if (auto trial = run_trial(language_max, {}, {}); trial.has_value())
+        return trial;
+    if (auto trial = run_trial(language_max, {}, region_max); trial.has_value())
+        return trial;
+    if (auto trial = run_trial(language_max, script_max, {}); trial.has_value())
+        return trial;
+
+    // 5. If you do not get a match, return max + variants.
+    return return_language_and_variants(maximized.release_value(), move(variants));
+#else
+    return {};
+#endif
+}
+
 String resolve_most_likely_territory([[maybe_unused]] LanguageID const& language_id, StringView territory_alias)
 {
     auto aliases = territory_alias.split_view(' ');

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/AllOf.h>
-#include <AK/CharacterTypes.h>
 #include <AK/GenericLexer.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
@@ -16,42 +15,6 @@
 #endif
 
 namespace Unicode {
-
-bool is_unicode_language_subtag(StringView subtag)
-{
-    // unicode_language_subtag = alpha{2,3} | alpha{5,8}
-    if ((subtag.length() < 2) || (subtag.length() == 4) || (subtag.length() > 8))
-        return false;
-    return all_of(subtag, is_ascii_alpha);
-}
-
-bool is_unicode_script_subtag(StringView subtag)
-{
-    // unicode_script_subtag = alpha{4}
-    if (subtag.length() != 4)
-        return false;
-    return all_of(subtag, is_ascii_alpha);
-}
-
-bool is_unicode_region_subtag(StringView subtag)
-{
-    // unicode_region_subtag = (alpha{2} | digit{3})
-    if (subtag.length() == 2)
-        return all_of(subtag, is_ascii_alpha);
-    if (subtag.length() == 3)
-        return all_of(subtag, is_ascii_digit);
-    return false;
-}
-
-bool is_unicode_variant_subtag(StringView subtag)
-{
-    // unicode_variant_subtag = (alphanum{5,8} | digit alphanum{3})
-    if ((subtag.length() >= 5) && (subtag.length() <= 8))
-        return all_of(subtag, is_ascii_alphanumeric);
-    if (subtag.length() == 4)
-        return is_ascii_digit(subtag[0]) && all_of(subtag.substring_view(1), is_ascii_alphanumeric);
-    return false;
-}
 
 static bool is_key(StringView key)
 {

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -18,6 +18,7 @@ namespace Unicode {
 
 struct LanguageID {
     String to_string() const;
+    bool operator==(LanguageID const&) const = default;
 
     bool is_root { false };
     Optional<String> language {};
@@ -131,6 +132,7 @@ Optional<StringView> resolve_variant_alias(StringView variant);
 Optional<StringView> resolve_subdivision_alias(StringView subdivision);
 
 Optional<LanguageID> add_likely_subtags(LanguageID const& language_id);
+Optional<LanguageID> remove_likely_subtags(LanguageID const& language_id);
 String resolve_most_likely_territory(LanguageID const& language_id, StringView territory_alias);
 
 }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/CharacterTypes.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -73,10 +74,42 @@ struct LocaleID {
 
 // Note: These methods only verify that the provided strings match the EBNF grammar of the
 // Unicode identifier subtag (i.e. no validation is done that the tags actually exist).
-bool is_unicode_language_subtag(StringView);
-bool is_unicode_script_subtag(StringView);
-bool is_unicode_region_subtag(StringView);
-bool is_unicode_variant_subtag(StringView);
+constexpr bool is_unicode_language_subtag(StringView subtag)
+{
+    // unicode_language_subtag = alpha{2,3} | alpha{5,8}
+    if ((subtag.length() < 2) || (subtag.length() == 4) || (subtag.length() > 8))
+        return false;
+    return all_of(subtag, is_ascii_alpha);
+}
+
+constexpr bool is_unicode_script_subtag(StringView subtag)
+{
+    // unicode_script_subtag = alpha{4}
+    if (subtag.length() != 4)
+        return false;
+    return all_of(subtag, is_ascii_alpha);
+}
+
+constexpr bool is_unicode_region_subtag(StringView subtag)
+{
+    // unicode_region_subtag = (alpha{2} | digit{3})
+    if (subtag.length() == 2)
+        return all_of(subtag, is_ascii_alpha);
+    if (subtag.length() == 3)
+        return all_of(subtag, is_ascii_digit);
+    return false;
+}
+
+constexpr bool is_unicode_variant_subtag(StringView subtag)
+{
+    // unicode_variant_subtag = (alphanum{5,8} | digit alphanum{3})
+    if ((subtag.length() >= 5) && (subtag.length() <= 8))
+        return all_of(subtag, is_ascii_alphanumeric);
+    if (subtag.length() == 4)
+        return is_ascii_digit(subtag[0]) && all_of(subtag.substring_view(1), is_ascii_alphanumeric);
+    return false;
+}
+
 bool is_type_identifier(StringView);
 
 Optional<LanguageID> parse_unicode_language_id(StringView);

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -130,6 +130,7 @@ Optional<StringView> resolve_script_tag_alias(StringView script_tag);
 Optional<StringView> resolve_variant_alias(StringView variant);
 Optional<StringView> resolve_subdivision_alias(StringView subdivision);
 
+Optional<LanguageID> add_likely_subtags(LanguageID const& language_id);
 String resolve_most_likely_territory(LanguageID const& language_id, StringView territory_alias);
 
 }


### PR DESCRIPTION
These prototypes depend on the entire [likely-subtags](https://github.com/unicode-org/cldr-json/blob/master/cldr-json/cldr-core/supplemental/likelySubtags.json) dataset, which the UnicodeData.cpp generator wasn't able to handle (the compiler raised warnings about the size of the generated data, and took a long time to complete).

So, first, this PR changes the way the likely-subtags data is generated. The generated code previously included a static method that would create a giant  hash map of likely-subtag data once at runtime. Now the data is all in a `constexpr` array. The main change that enabled this was parsing the data into canonicalized locales at code generation time, so that we can output structures of (basically) `StringView`s.

Second, we are then able to generate the TR35 Add/Remove Likely Subtags methods in order to implement `Intl.Locale.prototype.{maximize,minimize}`.