### PR TITLE
Kernel: Don't use {:p} when printing out invalid userspace stack pointer

### DIFF
--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -646,7 +646,7 @@ void MemoryManager::validate_syscall_preconditions(AddressSpace& space, Register
     {
         VirtualAddress userspace_sp = VirtualAddress { regs.userspace_sp() };
         if (!MM.validate_user_stack_no_lock(space, userspace_sp)) {
-            dbgln("Invalid stack pointer: {:p}", userspace_sp);
+            dbgln("Invalid stack pointer: {}", userspace_sp);
             unlock_and_handle_crash("Bad stack on syscall entry", SIGSTKFLT);
         }
     }


### PR DESCRIPTION
`userspace_esp` is a virtual address and thus using `{:p}` on it is
invalid and will cause an assertion failure.

I ran into this while testing #9772.