### PR TITLE
PixelPaint: Add and use new common mechanism for all tools to share keyboard shortcuts for properties :^)

### DIFF
--- a/Userland/Applications/PixelPaint/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/BrushTool.cpp
@@ -141,6 +141,7 @@ GUI::Widget* BrushTool::get_properties_widget()
         size_slider.on_change = [&](int value) {
             m_size = value;
         };
+        set_primary_slider(&size_slider);
 
         auto& hardness_container = m_properties_widget->add<GUI::Widget>();
         hardness_container.set_fixed_height(20);
@@ -157,6 +158,7 @@ GUI::Widget* BrushTool::get_properties_widget()
         hardness_slider.on_change = [&](int value) {
             m_hardness = value;
         };
+        set_secondary_slider(&hardness_slider);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/BucketTool.cpp
@@ -109,6 +109,7 @@ GUI::Widget* BucketTool::get_properties_widget()
         threshold_slider.on_change = [&](int value) {
             m_threshold = value;
         };
+        set_primary_slider(&threshold_slider);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -106,6 +106,7 @@ void EllipseTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
 void EllipseTool::on_keydown(GUI::KeyEvent& event)
 {
+    Tool::on_keydown(event);
     if (event.key() == Key_Escape && m_drawing_button != GUI::MouseButton::None) {
         m_drawing_button = GUI::MouseButton::None;
         m_editor->update();
@@ -134,6 +135,7 @@ GUI::Widget* EllipseTool::get_properties_widget()
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
         };
+        set_primary_slider(&thickness_slider);
 
         auto& mode_container = m_properties_widget->add<GUI::Widget>();
         mode_container.set_fixed_height(46);

--- a/Userland/Applications/PixelPaint/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/EraseTool.cpp
@@ -102,6 +102,7 @@ GUI::Widget* EraseTool::get_properties_widget()
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
         };
+        set_primary_slider(&thickness_slider);
 
         auto& checkbox_container = m_properties_widget->add<GUI::Widget>();
         checkbox_container.set_fixed_height(20);

--- a/Userland/Applications/PixelPaint/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/GuideTool.cpp
@@ -206,6 +206,7 @@ GUI::Widget* GuideTool::get_properties_widget()
         snapping_slider.on_change = [&](int value) {
             m_snap_size = value;
         };
+        set_primary_slider(&snapping_slider);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -105,6 +105,7 @@ void LineTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
 void LineTool::on_keydown(GUI::KeyEvent& event)
 {
+    Tool::on_keydown(event);
     if (event.key() == Key_Escape && m_drawing_button != GUI::MouseButton::None) {
         m_drawing_button = GUI::MouseButton::None;
         m_editor->update();
@@ -133,6 +134,7 @@ GUI::Widget* LineTool::get_properties_widget()
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
         };
+        set_primary_slider(&thickness_slider);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/PenTool.cpp
@@ -96,6 +96,7 @@ GUI::Widget* PenTool::get_properties_widget()
         thickness_slider.on_change = [&](int value) {
             m_thickness = value;
         };
+        set_primary_slider(&thickness_slider);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleSelectTool.cpp
@@ -110,6 +110,7 @@ void RectangleSelectTool::on_mouseup(Layer*, MouseEvent& event)
 
 void RectangleSelectTool::on_keydown(GUI::KeyEvent& key_event)
 {
+    Tool::on_keydown(key_event);
     if (key_event.key() == KeyCode::Key_Space)
         m_moving_mode = MovingMode::MovingOrigin;
     else if (key_event.key() == KeyCode::Key_Control)
@@ -164,6 +165,7 @@ GUI::Widget* RectangleSelectTool::get_properties_widget()
     feather_slider.on_change = [&](int value) {
         m_edge_feathering = (float)value / (float)feather_slider_max;
     };
+    set_primary_slider(&feather_slider);
 
     auto& mode_container = m_properties_widget->add<GUI::Widget>();
     mode_container.set_fixed_height(20);

--- a/Userland/Applications/PixelPaint/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/SprayTool.cpp
@@ -116,6 +116,7 @@ GUI::Widget* SprayTool::get_properties_widget()
         size_slider.on_change = [&](int value) {
             m_thickness = value;
         };
+        set_primary_slider(&size_slider);
 
         auto& density_container = m_properties_widget->add<GUI::Widget>();
         density_container.set_fixed_height(20);
@@ -132,6 +133,7 @@ GUI::Widget* SprayTool::get_properties_widget()
         density_slider.on_change = [&](int value) {
             m_density = value;
         };
+        set_secondary_slider(&density_slider);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tool.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -26,6 +27,30 @@ void Tool::setup(ImageEditor& editor)
 void Tool::set_action(GUI::Action* action)
 {
     m_action = action;
+}
+
+void Tool::on_keydown(GUI::KeyEvent& event)
+{
+    switch (event.key()) {
+    case KeyCode::Key_LeftBracket:
+        if (m_primary_slider)
+            m_primary_slider->set_value(m_primary_slider->value() - 1);
+        break;
+    case KeyCode::Key_RightBracket:
+        if (m_primary_slider)
+            m_primary_slider->set_value(m_primary_slider->value() + 1);
+        break;
+    case KeyCode::Key_LeftBrace:
+        if (m_secondary_slider)
+            m_secondary_slider->set_value(m_secondary_slider->value() - 1);
+        break;
+    case KeyCode::Key_RightBrace:
+        if (m_secondary_slider)
+            m_secondary_slider->set_value(m_secondary_slider->value() + 1);
+        break;
+    default:
+        break;
+    }
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tool.h
+++ b/Userland/Applications/PixelPaint/Tool.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 
 #include <LibGUI/Event.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/StandardCursor.h>
 
 namespace PixelPaint {
@@ -54,7 +56,7 @@ public:
     virtual void on_context_menu(Layer*, GUI::ContextMenuEvent&) { }
     virtual void on_tool_button_contextmenu(GUI::ContextMenuEvent&) { }
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) { }
-    virtual void on_keydown(GUI::KeyEvent&) { }
+    virtual void on_keydown(GUI::KeyEvent&);
     virtual void on_keyup(GUI::KeyEvent&) { }
     virtual void on_tool_activation() { }
     virtual GUI::Widget* get_properties_widget() { return nullptr; }
@@ -73,6 +75,12 @@ protected:
     Tool();
     WeakPtr<ImageEditor> m_editor;
     RefPtr<GUI::Action> m_action;
+
+    void set_primary_slider(GUI::ValueSlider* primary) { m_primary_slider = primary; }
+    void set_secondary_slider(GUI::ValueSlider* secondary) { m_secondary_slider = secondary; }
+
+    GUI::ValueSlider* m_primary_slider { nullptr };
+    GUI::ValueSlider* m_secondary_slider { nullptr };
 };
 
 }

--- a/Userland/Applications/PixelPaint/ZoomTool.cpp
+++ b/Userland/Applications/PixelPaint/ZoomTool.cpp
@@ -51,6 +51,7 @@ GUI::Widget* ZoomTool::get_properties_widget()
         sensitivity_slider.on_change = [&](int value) {
             m_sensitivity = (double)value / 100.0;
         };
+        set_primary_slider(&sensitivity_slider);
     }
 
     return m_properties_widget.ptr();


### PR DESCRIPTION
GIMP / Photoshop allow you to change the brush / eraser / etc size using `[` and `]`, and I really missed that. In the spirit of making everything work really coherently, instead of just adding `keydown` handlers for each tool, this PR adds a mechanism for each tool to be able to register a "primary" and "secondary" slider which will be modified using common shortcuts. (Shift + `[` and `]` for secondary).

All the tools that have some sliders to adjust have been hooked up with this now. Other than inconsistent ranges for the sliders (problem for another PR), this feels super nice after spending some time using it.