### PR TITLE
SystemMonitor: Make memory statistics dynamically formatted by size

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -710,20 +710,20 @@ NonnullRefPtr<GUI::Widget> build_performance_tab()
     memory_graph.set_stack_values(true);
     memory_graph.set_value_format(0, {
                                          .graph_color_role = ColorRole::SyntaxComment,
-                                         .text_formatter = [](int value) {
-                                             return String::formatted("Committed: {} KiB", value);
+                                         .text_formatter = [](int bytes) {
+                                             return String::formatted("Committed: {}", human_readable_size(bytes));
                                          },
                                      });
     memory_graph.set_value_format(1, {
                                          .graph_color_role = ColorRole::SyntaxPreprocessorStatement,
-                                         .text_formatter = [](int value) {
-                                             return String::formatted("Allocated: {} KiB", value);
+                                         .text_formatter = [](int bytes) {
+                                             return String::formatted("Allocated: {}", human_readable_size(bytes));
                                          },
                                      });
     memory_graph.set_value_format(2, {
                                          .graph_color_role = ColorRole::SyntaxPreprocessorValue,
-                                         .text_formatter = [](int value) {
-                                             return String::formatted("Kernel heap: {} KiB", value);
+                                         .text_formatter = [](int bytes) {
+                                             return String::formatted("Kernel heap: {}", human_readable_size(bytes));
                                          },
                                      });
 


### PR DESCRIPTION
Previously all memory values on the performance was formatted as KiB,
but with such formatting it can be quite hard to read large numbers
(as mentioned by Andreas on todays office hours livestream :^)).
This patch makes use of the human readable formatting utilies and
displays them in an easier to read format.

Before:
![2021-09-03_18-15](https://user-images.githubusercontent.com/13297896/132038765-4c53ce1b-537a-4802-b5a3-73ff5925310b.png)
After:
![2021-09-03_18-18](https://user-images.githubusercontent.com/13297896/132038771-ea7b1799-68df-43da-9cd1-cf29cc6dd99b.png)