### PR TITLE
SoundPlayer: Don't try to dereference null-pointer buffers

### DIFF
--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -118,10 +118,11 @@ void PlaybackManager::next_buffer()
 
     if (audio_server_remaining_samples < m_device_samples_per_buffer) {
         m_current_buffer = m_loader->get_more_samples(m_source_buffer_size_bytes);
-        VERIFY(m_resampler.has_value());
-        m_resampler->reset();
-        m_current_buffer = Audio::resample_buffer(m_resampler.value(), *m_current_buffer);
-        if (m_current_buffer)
+        if (m_current_buffer) {
+            VERIFY(m_resampler.has_value());
+            m_resampler->reset();
+            m_current_buffer = Audio::resample_buffer(m_resampler.value(), *m_current_buffer);
             m_connection->enqueue(*m_current_buffer);
+        }
     }
 }


### PR DESCRIPTION
d049626f402f50720a1ccc4452676a56e22debbd tried to resample the buffer before checking if it points to a valid location.
This caused a crash, generally at the end of the file.