### PR TITLE
DisplaySettings: Add context menu for wallpapers

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
@@ -11,6 +11,7 @@
 #include <LibCore/Timer.h>
 #include <LibGUI/ColorInput.h>
 #include <LibGUI/ComboBox.h>
+#include <LibGUI/Menu.h>
 #include <LibGUI/RadioButton.h>
 
 namespace DisplaySettings {
@@ -35,6 +36,9 @@ private:
     RefPtr<GUI::IconView> m_wallpaper_view;
     RefPtr<GUI::ComboBox> m_mode_combo;
     RefPtr<GUI::ColorInput> m_color_input;
+    RefPtr<GUI::Menu> m_context_menu;
+    RefPtr<GUI::Action> m_show_in_file_manager_action;
+    RefPtr<GUI::Action> m_copy_action;
 };
 
 }

--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -23,4 +23,4 @@ set(SOURCES
 )
 
 serenity_app(DisplaySettings ICON app-display-settings)
-target_link_libraries(DisplaySettings LibGUI LibConfig)
+target_link_libraries(DisplaySettings LibDesktop LibGUI LibConfig)

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -31,11 +31,6 @@ int main(int argc, char** argv)
     auto app = GUI::Application::construct(argc, argv);
     Config::pledge_domains("WindowManager");
 
-    if (pledge("stdio thread recvfd sendfd rpath cpath wpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
-
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 
     auto window = GUI::Window::construct();


### PR DESCRIPTION
This adds a 'Show in File Manager' action and copy path action to file context menu for quicker navigation. :^)

![preview](https://user-images.githubusercontent.com/16520278/132053350-63d9039f-6016-4bd8-a212-30e41c3c217f.png)