### PR TITLE
LibGUI+SystemMonitor: Enable searching on the processes list

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -45,12 +45,12 @@ ProcessModel::~ProcessModel()
 {
 }
 
-int ProcessModel::row_count(const GUI::ModelIndex&) const
+int ProcessModel::row_count(GUI::ModelIndex const&) const
 {
     return m_tids.size();
 }
 
-int ProcessModel::column_count(const GUI::ModelIndex&) const
+int ProcessModel::column_count(GUI::ModelIndex const&) const
 {
     return Column::__Count;
 }
@@ -128,7 +128,7 @@ static String pretty_byte_size(size_t size)
     return String::formatted("{}K", size / 1024);
 }
 
-GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     VERIFY(is_within_range(index));
 
@@ -313,7 +313,7 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
-Vector<GUI::ModelIndex> ProcessModel::matches(const StringView& searching, unsigned flags, const GUI::ModelIndex&)
+Vector<GUI::ModelIndex> ProcessModel::matches(StringView const& searching, unsigned flags, GUI::ModelIndex const&)
 {
     Vector<GUI::ModelIndex> found_indices;
 

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -313,6 +313,24 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
+Vector<GUI::ModelIndex, 1> ProcessModel::matches(const StringView& searching, unsigned flags, const GUI::ModelIndex&)
+{
+    Vector<GUI::ModelIndex, 1> found_indices;
+
+    for (auto& thread : m_threads) {
+        if (string_matches(thread.value->current_state.name, searching, flags)) {
+            auto maybe_tid_index = m_tids.find_first_index(thread.key);
+            if (!maybe_tid_index.has_value())
+                continue;
+            found_indices.append(create_index(maybe_tid_index.value(), Column::Name));
+            if (flags & FirstMatchOnly)
+                break;
+        }
+    }
+
+    return found_indices;
+}
+
 void ProcessModel::update()
 {
     auto previous_tid_count = m_tids.size();

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -313,9 +313,9 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, GUI::ModelRole rol
     return {};
 }
 
-Vector<GUI::ModelIndex, 1> ProcessModel::matches(const StringView& searching, unsigned flags, const GUI::ModelIndex&)
+Vector<GUI::ModelIndex> ProcessModel::matches(const StringView& searching, unsigned flags, const GUI::ModelIndex&)
 {
-    Vector<GUI::ModelIndex, 1> found_indices;
+    Vector<GUI::ModelIndex> found_indices;
 
     for (auto& thread : m_threads) {
         if (string_matches(thread.value->current_state.name, searching, flags)) {

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -60,6 +60,8 @@ public:
     virtual int column_count(const GUI::ModelIndex&) const override;
     virtual String column_name(int column) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual bool is_searchable() const override { return true; }
+    virtual Vector<GUI::ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const GUI::ModelIndex& = GUI::ModelIndex()) override;
     virtual bool is_column_sortable(int column_index) const override { return column_index != Column::Icon; }
     void update();
 

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -61,7 +61,7 @@ public:
     virtual String column_name(int column) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
     virtual bool is_searchable() const override { return true; }
-    virtual Vector<GUI::ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const GUI::ModelIndex& = GUI::ModelIndex()) override;
+    virtual Vector<GUI::ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const GUI::ModelIndex& = GUI::ModelIndex()) override;
     virtual bool is_column_sortable(int column_index) const override { return column_index != Column::Icon; }
     void update();
 

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -56,12 +56,12 @@ public:
     static NonnullRefPtr<ProcessModel> create() { return adopt_ref(*new ProcessModel); }
     virtual ~ProcessModel() override;
 
-    virtual int row_count(const GUI::ModelIndex&) const override;
-    virtual int column_count(const GUI::ModelIndex&) const override;
+    virtual int row_count(GUI::ModelIndex const&) const override;
+    virtual int column_count(GUI::ModelIndex const&) const override;
     virtual String column_name(int column) const override;
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_searchable() const override { return true; }
-    virtual Vector<GUI::ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const GUI::ModelIndex& = GUI::ModelIndex()) override;
+    virtual Vector<GUI::ModelIndex> matches(StringView const&, unsigned = MatchesFlag::AllMatching, GUI::ModelIndex const& = GUI::ModelIndex()) override;
     virtual bool is_column_sortable(int column_index) const override { return column_index != Column::Icon; }
     void update();
 
@@ -76,10 +76,10 @@ public:
         }
     };
 
-    Function<void(const NonnullOwnPtrVector<CpuInfo>&)> on_cpu_info_change;
+    Function<void(NonnullOwnPtrVector<CpuInfo> const&)> on_cpu_info_change;
     Function<void(int process_count, int thread_count)> on_state_update;
 
-    const NonnullOwnPtrVector<CpuInfo>& cpus() const { return m_cpus; }
+    NonnullOwnPtrVector<CpuInfo> const& cpus() const { return m_cpus; }
 
 private:
     ProcessModel();

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -682,7 +682,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index
     else
         text_color = index.data(ModelRole::ForegroundColor).to_color(palette().color(foreground_role()));
     if (is_highlighting_searching(index)) {
-        Utf8View searching_text(searching());
+        Utf8View searching_text(m_searching);
         auto searching_length = searching_text.length();
         if (searching_length > search_highlighting_offset)
             searching_length -= search_highlighting_offset;

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -72,6 +72,10 @@ void AbstractView::model_did_update(unsigned int flags)
         if (!model()->is_within_range(m_drop_candidate_index))
             m_drop_candidate_index = {};
         selection().remove_matching([this](auto& index) { return !model()->is_within_range(index); });
+
+        auto index = find_next_search_match(m_highlighted_search.view());
+        if (index.is_valid())
+            highlight_search(index);
     }
     m_selection_start_index = {};
 }

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -666,11 +666,6 @@ void AbstractView::set_searchable(bool searchable)
         cancel_searching();
 }
 
-bool AbstractView::is_highlighting_searching(const ModelIndex& index) const
-{
-    return index == m_highlighted_search_index;
-}
-
 void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index, bool is_selected, const Gfx::IntRect& text_rect, const StringView& item_text, const Gfx::Font& font, Gfx::TextAlignment alignment, Gfx::TextElision elision, size_t search_highlighting_offset)
 {
     if (m_edit_index == index)
@@ -681,7 +676,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index
         text_color = is_focused() ? palette().selection_text() : palette().inactive_selection_text();
     else
         text_color = index.data(ModelRole::ForegroundColor).to_color(palette().color(foreground_role()));
-    if (is_highlighting_searching(index)) {
+    if (index == m_highlighted_search_index) {
         Utf8View searching_text(m_searching);
         auto searching_length = searching_text.length();
         if (searching_length > search_highlighting_offset)

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -562,7 +562,7 @@ void AbstractView::keydown_event(KeyEvent& event)
 
     if (is_searchable()) {
         if (event.key() == KeyCode::Key_Backspace) {
-            if (is_searching()) {
+            if (!m_highlighted_search.is_null()) {
                 //if (event.modifiers() == Mod_Ctrl) {
                 // TODO: delete last word
                 //}
@@ -587,7 +587,7 @@ void AbstractView::keydown_event(KeyEvent& event)
                 return;
             }
         } else if (event.key() == KeyCode::Key_Escape) {
-            if (is_searching()) {
+            if (!m_highlighted_search.is_null()) {
                 stop_highlighted_search_timer();
 
                 event.accept();

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -566,7 +566,7 @@ void AbstractView::keydown_event(KeyEvent& event)
                 //if (event.modifiers() == Mod_Ctrl) {
                 // TODO: delete last word
                 //}
-                Utf8View view(m_searching);
+                Utf8View view(m_highlighted_search);
                 size_t n_code_points = view.length();
                 if (n_code_points > 1) {
                     n_code_points--;
@@ -595,7 +595,7 @@ void AbstractView::keydown_event(KeyEvent& event)
             }
         } else if (event.key() != KeyCode::Key_Tab && !event.ctrl() && !event.alt() && event.code_point() != 0) {
             StringBuilder sb;
-            sb.append(m_searching);
+            sb.append(m_highlighted_search);
             sb.append_code_point(event.code_point());
             do_search(sb.to_string());
             start_searching_timer();
@@ -610,7 +610,7 @@ void AbstractView::keydown_event(KeyEvent& event)
 
 void AbstractView::cancel_searching()
 {
-    m_searching = nullptr;
+    m_highlighted_search = nullptr;
     if (m_searching_timer)
         m_searching_timer->stop();
     if (m_highlighted_search_index.is_valid()) {
@@ -643,7 +643,7 @@ void AbstractView::do_search(String&& searching)
     if (!found_indices.is_empty() && found_indices[0].is_valid()) {
         auto& index = found_indices[0];
         m_highlighted_search_index = index;
-        m_searching = move(searching);
+        m_highlighted_search = move(searching);
         set_selection(index);
         scroll_into_view(index);
         update();
@@ -677,7 +677,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index
     else
         text_color = index.data(ModelRole::ForegroundColor).to_color(palette().color(foreground_role()));
     if (index == m_highlighted_search_index) {
-        Utf8View searching_text(m_searching);
+        Utf8View searching_text(m_highlighted_search);
         auto searching_length = searching_text.length();
         if (searching_length > search_highlighting_offset)
             searching_length -= search_highlighting_offset;

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -85,27 +85,27 @@ void AbstractView::clear_selection()
     m_selection.clear();
 }
 
-void AbstractView::set_selection(const ModelIndex& new_index)
+void AbstractView::set_selection(ModelIndex const& new_index)
 {
     m_selection.set(new_index);
 }
 
-void AbstractView::set_selection_start_index(const ModelIndex& new_index)
+void AbstractView::set_selection_start_index(ModelIndex const& new_index)
 {
     m_selection_start_index = new_index;
 }
 
-void AbstractView::add_selection(const ModelIndex& new_index)
+void AbstractView::add_selection(ModelIndex const& new_index)
 {
     m_selection.add(new_index);
 }
 
-void AbstractView::remove_selection(const ModelIndex& new_index)
+void AbstractView::remove_selection(ModelIndex const& new_index)
 {
     m_selection.remove(new_index);
 }
 
-void AbstractView::toggle_selection(const ModelIndex& new_index)
+void AbstractView::toggle_selection(ModelIndex const& new_index)
 {
     m_selection.toggle(new_index);
 }
@@ -130,7 +130,7 @@ void AbstractView::update_edit_widget_position()
     m_edit_widget->set_relative_rect(m_edit_widget_content_rect.translated(-horizontal_scrollbar().value(), -vertical_scrollbar().value()));
 }
 
-void AbstractView::begin_editing(const ModelIndex& index)
+void AbstractView::begin_editing(ModelIndex const& index)
 {
     VERIFY(is_editable());
     VERIFY(model());
@@ -182,7 +182,7 @@ void AbstractView::stop_editing()
         set_focus(true);
 }
 
-void AbstractView::activate(const ModelIndex& index)
+void AbstractView::activate(ModelIndex const& index)
 {
     if (on_activation)
         on_activation(index);
@@ -205,7 +205,7 @@ void AbstractView::notify_selection_changed(Badge<ModelSelection>)
         update();
 }
 
-NonnullRefPtr<Gfx::Font> AbstractView::font_for_index(const ModelIndex& index) const
+NonnullRefPtr<Gfx::Font> AbstractView::font_for_index(ModelIndex const& index) const
 {
     if (!model())
         return font();
@@ -249,7 +249,7 @@ void AbstractView::mousedown_event(MouseEvent& event)
     update();
 }
 
-void AbstractView::set_hovered_index(const ModelIndex& index)
+void AbstractView::set_hovered_index(ModelIndex const& index)
 {
     if (m_hovered_index == index)
         return;
@@ -682,7 +682,7 @@ void AbstractView::set_searchable(bool searchable)
         stop_highlighted_search_timer();
 }
 
-void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index, bool is_selected, const Gfx::IntRect& text_rect, const StringView& item_text, const Gfx::Font& font, Gfx::TextAlignment alignment, Gfx::TextElision elision, size_t search_highlighting_offset)
+void AbstractView::draw_item_text(Gfx::Painter& painter, ModelIndex const& index, bool is_selected, Gfx::IntRect const& text_rect, StringView const& item_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Gfx::TextElision elision, size_t search_highlighting_offset)
 {
     if (m_edit_index == index)
         return;
@@ -702,7 +702,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index
 
         // Highlight the text background first
         auto background_searching_length = searching_length;
-        painter.draw_text([&](const Gfx::IntRect& rect, u32) {
+        painter.draw_text([&](Gfx::IntRect const& rect, u32) {
             if (background_searching_length > 0) {
                 background_searching_length--;
                 painter.fill_rect(rect.inflated(0, 2), palette().highlight_searching());
@@ -714,7 +714,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, const ModelIndex& index
         auto text_searching_length = searching_length;
         auto highlight_text_color = palette().highlight_searching_text();
         searching_length = searching_text.length();
-        painter.draw_text([&](const Gfx::IntRect& rect, u32 code_point) {
+        painter.draw_text([&](Gfx::IntRect const& rect, u32 code_point) {
             if (text_searching_length > 0) {
                 text_searching_length--;
                 painter.draw_glyph_or_emoji(rect.location(), code_point, font, highlight_text_color);

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -164,7 +164,8 @@ protected:
 
     void stop_highlighted_search_timer();
     void start_highlighted_search_timer();
-    void do_search(String&&);
+    ModelIndex find_next_search_match(StringView const);
+    void highlight_search(ModelIndex const index);
 
     ModelIndex drop_candidate_index() const { return m_drop_candidate_index; }
 

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -166,7 +166,6 @@ protected:
     void cancel_searching();
     void start_searching_timer();
     void do_search(String&&);
-    bool is_highlighting_searching(const ModelIndex&) const;
 
     ModelIndex drop_candidate_index() const { return m_drop_candidate_index; }
 

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -162,7 +162,7 @@ protected:
     void activate_selected();
     void update_edit_widget_position();
 
-    bool is_searching() const { return !m_searching.is_null(); }
+    bool is_searching() const { return !m_highlighted_search.is_null(); }
     void cancel_searching();
     void start_searching_timer();
     void do_search(String&&);
@@ -192,7 +192,7 @@ private:
 
     RefPtr<Model> m_model;
     ModelSelection m_selection;
-    String m_searching;
+    String m_highlighted_search;
     RefPtr<Core::Timer> m_searching_timer;
     SelectionBehavior m_selection_behavior { SelectionBehavior::SelectItems };
     SelectionMode m_selection_mode { SelectionMode::SingleSelection };

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -163,8 +163,8 @@ protected:
     void update_edit_widget_position();
 
     bool is_searching() const { return !m_highlighted_search.is_null(); }
-    void cancel_searching();
-    void start_searching_timer();
+    void stop_highlighted_search_timer();
+    void start_highlighted_search_timer();
     void do_search(String&&);
 
     ModelIndex drop_candidate_index() const { return m_drop_candidate_index; }
@@ -193,7 +193,7 @@ private:
     RefPtr<Model> m_model;
     ModelSelection m_selection;
     String m_highlighted_search;
-    RefPtr<Core::Timer> m_searching_timer;
+    RefPtr<Core::Timer> m_highlighted_search_timer;
     SelectionBehavior m_selection_behavior { SelectionBehavior::SelectItems };
     SelectionMode m_selection_mode { SelectionMode::SingleSelection };
     unsigned m_edit_triggers { EditTrigger::DoubleClicked | EditTrigger::EditKeyPressed };

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -55,10 +55,10 @@ public:
 
     void set_model(RefPtr<Model>);
     Model* model() { return m_model.ptr(); }
-    const Model* model() const { return m_model.ptr(); }
+    Model const* model() const { return m_model.ptr(); }
 
     ModelSelection& selection() { return m_selection; }
-    const ModelSelection& selection() const { return m_selection; }
+    ModelSelection const& selection() const { return m_selection; }
     virtual void select_all() { }
 
     bool is_editable() const { return m_editable; }
@@ -86,37 +86,37 @@ public:
     virtual void model_did_update(unsigned flags) override;
     virtual void did_update_selection();
 
-    virtual Gfx::IntRect content_rect(const ModelIndex&) const { return {}; }
+    virtual Gfx::IntRect content_rect(ModelIndex const&) const { return {}; }
     virtual Gfx::IntRect editing_rect(ModelIndex const& index) const { return content_rect(index); }
     virtual Gfx::IntRect paint_invalidation_rect(ModelIndex const& index) const { return content_rect(index); }
 
-    virtual ModelIndex index_at_event_position(const Gfx::IntPoint&) const { return {}; }
-    void begin_editing(const ModelIndex&);
+    virtual ModelIndex index_at_event_position(Gfx::IntPoint const&) const { return {}; }
+    void begin_editing(ModelIndex const&);
     void stop_editing();
 
     void set_activates_on_selection(bool b) { m_activates_on_selection = b; }
     bool activates_on_selection() const { return m_activates_on_selection; }
 
     Function<void()> on_selection_change;
-    Function<void(const ModelIndex&)> on_activation;
-    Function<void(const ModelIndex&, const ContextMenuEvent&)> on_context_menu_request;
-    Function<void(const ModelIndex&, const DropEvent&)> on_drop;
+    Function<void(ModelIndex const&)> on_activation;
+    Function<void(ModelIndex const&, ContextMenuEvent const&)> on_context_menu_request;
+    Function<void(ModelIndex const&, DropEvent const&)> on_drop;
 
-    Function<OwnPtr<ModelEditingDelegate>(const ModelIndex&)> aid_create_editing_delegate;
+    Function<OwnPtr<ModelEditingDelegate>(ModelIndex const&)> aid_create_editing_delegate;
 
     void notify_selection_changed(Badge<ModelSelection>);
 
-    NonnullRefPtr<Gfx::Font> font_for_index(const ModelIndex&) const;
+    NonnullRefPtr<Gfx::Font> font_for_index(ModelIndex const&) const;
 
     void set_key_column_and_sort_order(int column, SortOrder);
 
     int key_column() const { return m_key_column; }
     SortOrder sort_order() const { return m_sort_order; }
 
-    virtual void scroll_into_view(const ModelIndex&, [[maybe_unused]] bool scroll_horizontally = true, [[maybe_unused]] bool scroll_vertically = true) { }
+    virtual void scroll_into_view(ModelIndex const&, [[maybe_unused]] bool scroll_horizontally = true, [[maybe_unused]] bool scroll_vertically = true) { }
 
-    const ModelIndex& cursor_index() const { return m_cursor_index; }
-    const ModelIndex& selection_start_index() const { return m_selection_start_index; }
+    ModelIndex const& cursor_index() const { return m_cursor_index; }
+    ModelIndex const& selection_start_index() const { return m_selection_start_index; }
     void set_cursor(ModelIndex, SelectionUpdate, bool scroll_cursor_into_view = true);
 
     bool is_tab_key_navigation_enabled() const { return m_tab_key_navigation_enabled; }
@@ -143,22 +143,22 @@ protected:
     virtual void focusin_event(FocusEvent&) override;
 
     virtual void clear_selection();
-    virtual void set_selection(const ModelIndex&);
-    virtual void set_selection_start_index(const ModelIndex&);
-    virtual void add_selection(const ModelIndex&);
-    virtual void remove_selection(const ModelIndex&);
-    virtual void toggle_selection(const ModelIndex&);
-    virtual void did_change_hovered_index([[maybe_unused]] const ModelIndex& old_index, [[maybe_unused]] const ModelIndex& new_index) { }
-    virtual void did_change_cursor_index([[maybe_unused]] const ModelIndex& old_index, [[maybe_unused]] const ModelIndex& new_index) { }
-    virtual void editing_widget_did_change([[maybe_unused]] const ModelIndex& index) { }
+    virtual void set_selection(ModelIndex const&);
+    virtual void set_selection_start_index(ModelIndex const&);
+    virtual void add_selection(ModelIndex const&);
+    virtual void remove_selection(ModelIndex const&);
+    virtual void toggle_selection(ModelIndex const&);
+    virtual void did_change_hovered_index([[maybe_unused]] ModelIndex const& old_index, [[maybe_unused]] ModelIndex const& new_index) { }
+    virtual void did_change_cursor_index([[maybe_unused]] ModelIndex const& old_index, [[maybe_unused]] ModelIndex const& new_index) { }
+    virtual void editing_widget_did_change([[maybe_unused]] ModelIndex const& index) { }
 
-    void draw_item_text(Gfx::Painter&, const ModelIndex&, bool, const Gfx::IntRect&, const StringView&, const Gfx::Font&, Gfx::TextAlignment, Gfx::TextElision, size_t search_highlighting_offset = 0);
+    void draw_item_text(Gfx::Painter&, ModelIndex const&, bool, Gfx::IntRect const&, StringView const&, Gfx::Font const&, Gfx::TextAlignment, Gfx::TextElision, size_t search_highlighting_offset = 0);
 
     void set_suppress_update_on_selection_change(bool value) { m_suppress_update_on_selection_change = value; }
 
     virtual void did_scroll() override;
-    void set_hovered_index(const ModelIndex&);
-    void activate(const ModelIndex&);
+    void set_hovered_index(ModelIndex const&);
+    void activate(ModelIndex const&);
     void activate_selected();
     void update_edit_widget_position();
 

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -163,7 +163,6 @@ protected:
     void update_edit_widget_position();
 
     bool is_searching() const { return !m_searching.is_null(); }
-    StringView searching() const { return m_searching; }
     void cancel_searching();
     void start_searching_timer();
     void do_search(String&&);

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -162,7 +162,6 @@ protected:
     void activate_selected();
     void update_edit_widget_position();
 
-    bool is_searching() const { return !m_highlighted_search.is_null(); }
     void stop_highlighted_search_timer();
     void start_highlighted_search_timer();
     void do_search(String&&);

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -64,8 +64,6 @@ public:
     bool is_editable() const { return m_editable; }
     void set_editable(bool editable) { m_editable = editable; }
 
-    bool is_searching() const { return !m_searching.is_null(); }
-
     bool is_searchable() const;
     void set_searchable(bool);
 
@@ -164,6 +162,7 @@ protected:
     void activate_selected();
     void update_edit_widget_position();
 
+    bool is_searching() const { return !m_searching.is_null(); }
     StringView searching() const { return m_searching; }
     void cancel_searching();
     void start_searching_timer();

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -37,7 +37,7 @@ ModelIndex FileSystemModel::Node::index(int column) const
     VERIFY_NOT_REACHED();
 }
 
-bool FileSystemModel::Node::fetch_data(const String& full_path, bool is_root)
+bool FileSystemModel::Node::fetch_data(String const& full_path, bool is_root)
 {
     struct stat st;
     int rc;
@@ -211,7 +211,7 @@ FileSystemModel::Node const* FileSystemModel::node_for_path(String const& path) 
         resolved_path = path;
     LexicalPath lexical_path(resolved_path);
 
-    const Node* node = m_root->m_parent_of_root ? &m_root->m_children.first() : m_root;
+    Node const* node = m_root->m_parent_of_root ? &m_root->m_children.first() : m_root;
     if (lexical_path.string() == "/")
         return node;
 
@@ -235,7 +235,7 @@ FileSystemModel::Node const* FileSystemModel::node_for_path(String const& path) 
     return nullptr;
 }
 
-String FileSystemModel::full_path(const ModelIndex& index) const
+String FileSystemModel::full_path(ModelIndex const& index) const
 {
     auto& node = this->node(index);
     const_cast<Node&>(node).reify_if_needed();
@@ -333,7 +333,7 @@ void FileSystemModel::Node::set_selected(bool selected)
     m_selected = selected;
 }
 
-void FileSystemModel::update_node_on_selection(const ModelIndex& index, const bool selected)
+void FileSystemModel::update_node_on_selection(ModelIndex const& index, bool const selected)
 {
     Node& node = const_cast<Node&>(this->node(index));
     node.set_selected(selected);
@@ -435,7 +435,7 @@ void FileSystemModel::handle_file_event(Core::FileWatcherEvent const& event)
     did_update(UpdateFlag::DontInvalidateIndices);
 }
 
-int FileSystemModel::row_count(const ModelIndex& index) const
+int FileSystemModel::row_count(ModelIndex const& index) const
 {
     Node& node = const_cast<Node&>(this->node(index));
     node.reify_if_needed();
@@ -444,7 +444,7 @@ int FileSystemModel::row_count(const ModelIndex& index) const
     return 0;
 }
 
-const FileSystemModel::Node& FileSystemModel::node(const ModelIndex& index) const
+FileSystemModel::Node const& FileSystemModel::node(ModelIndex const& index) const
 {
     if (!index.is_valid())
         return *m_root;
@@ -452,7 +452,7 @@ const FileSystemModel::Node& FileSystemModel::node(const ModelIndex& index) cons
     return *(Node*)index.internal_data();
 }
 
-ModelIndex FileSystemModel::index(int row, int column, const ModelIndex& parent) const
+ModelIndex FileSystemModel::index(int row, int column, ModelIndex const& parent) const
 {
     if (row < 0 || column < 0)
         return {};
@@ -463,7 +463,7 @@ ModelIndex FileSystemModel::index(int row, int column, const ModelIndex& parent)
     return create_index(row, column, &node.m_children[row]);
 }
 
-ModelIndex FileSystemModel::parent_index(const ModelIndex& index) const
+ModelIndex FileSystemModel::parent_index(ModelIndex const& index) const
 {
     if (!index.is_valid())
         return {};
@@ -475,7 +475,7 @@ ModelIndex FileSystemModel::parent_index(const ModelIndex& index) const
     return node.m_parent->index(index.column());
 }
 
-Variant FileSystemModel::data(const ModelIndex& index, ModelRole role) const
+Variant FileSystemModel::data(ModelIndex const& index, ModelRole role) const
 {
     VERIFY(index.is_valid());
 
@@ -574,7 +574,7 @@ Variant FileSystemModel::data(const ModelIndex& index, ModelRole role) const
     return {};
 }
 
-Icon FileSystemModel::icon_for(const Node& node) const
+Icon FileSystemModel::icon_for(Node const& node) const
 {
     if (node.full_path() == "/")
         return FileIconProvider::icon_for_path("/");
@@ -604,7 +604,7 @@ Icon FileSystemModel::icon_for(const Node& node) const
 
 static HashMap<String, RefPtr<Gfx::Bitmap>> s_thumbnail_cache;
 
-static RefPtr<Gfx::Bitmap> render_thumbnail(const StringView& path)
+static RefPtr<Gfx::Bitmap> render_thumbnail(StringView const& path)
 {
     auto png_bitmap = Gfx::Bitmap::try_load_from_file(path);
     if (!png_bitmap)
@@ -620,7 +620,7 @@ static RefPtr<Gfx::Bitmap> render_thumbnail(const StringView& path)
     return thumbnail;
 }
 
-bool FileSystemModel::fetch_thumbnail_for(const Node& node)
+bool FileSystemModel::fetch_thumbnail_for(Node const& node)
 {
     // See if we already have the thumbnail
     // we're looking for in the cache.
@@ -668,7 +668,7 @@ bool FileSystemModel::fetch_thumbnail_for(const Node& node)
     return false;
 }
 
-int FileSystemModel::column_count(const ModelIndex&) const
+int FileSystemModel::column_count(ModelIndex const&) const
 {
     return Column::__Count;
 }
@@ -698,7 +698,7 @@ String FileSystemModel::column_name(int column) const
     VERIFY_NOT_REACHED();
 }
 
-bool FileSystemModel::accepts_drag(const ModelIndex& index, const Vector<String>& mime_types) const
+bool FileSystemModel::accepts_drag(ModelIndex const& index, Vector<String> const& mime_types) const
 {
     if (!index.is_valid())
         return false;
@@ -718,14 +718,14 @@ void FileSystemModel::set_should_show_dotfiles(bool show)
     invalidate();
 }
 
-bool FileSystemModel::is_editable(const ModelIndex& index) const
+bool FileSystemModel::is_editable(ModelIndex const& index) const
 {
     if (!index.is_valid())
         return false;
     return index.column() == Column::Name;
 }
 
-void FileSystemModel::set_data(const ModelIndex& index, const Variant& data)
+void FileSystemModel::set_data(ModelIndex const& index, Variant const& data)
 {
     VERIFY(is_editable(index));
     Node& node = const_cast<Node&>(this->node(index));
@@ -738,7 +738,7 @@ void FileSystemModel::set_data(const ModelIndex& index, const Variant& data)
     }
 }
 
-Vector<ModelIndex> FileSystemModel::matches(const StringView& searching, unsigned flags, const ModelIndex& index)
+Vector<ModelIndex> FileSystemModel::matches(StringView const& searching, unsigned flags, ModelIndex const& index)
 {
     Node& node = const_cast<Node&>(this->node(index));
     node.reify_if_needed();

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -738,11 +738,11 @@ void FileSystemModel::set_data(const ModelIndex& index, const Variant& data)
     }
 }
 
-Vector<ModelIndex, 1> FileSystemModel::matches(const StringView& searching, unsigned flags, const ModelIndex& index)
+Vector<ModelIndex> FileSystemModel::matches(const StringView& searching, unsigned flags, const ModelIndex& index)
 {
     Node& node = const_cast<Node&>(this->node(index));
     node.reify_if_needed();
-    Vector<ModelIndex, 1> found_indices;
+    Vector<ModelIndex> found_indices;
     for (auto& child : node.m_children) {
         if (string_matches(child.name, searching, flags)) {
             const_cast<Node&>(child).reify_if_needed();

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -132,7 +132,7 @@ public:
     virtual bool is_editable(const ModelIndex&) const override;
     virtual bool is_searchable() const override { return true; }
     virtual void set_data(const ModelIndex&, const Variant&) override;
-    virtual Vector<ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
+    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
     virtual void invalidate() override;
 
     static String timestamp_string(time_t timestamp)

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -67,7 +67,7 @@ public:
 
         bool has_error() const { return m_error != 0; }
         int error() const { return m_error; }
-        const char* error_string() const { return strerror(m_error); }
+        char const* error_string() const { return strerror(m_error); }
 
         String full_path() const;
 
@@ -106,33 +106,33 @@ public:
 
     String root_path() const { return m_root_path; }
     void set_root_path(String);
-    String full_path(const ModelIndex&) const;
+    String full_path(ModelIndex const&) const;
     ModelIndex index(String path, int column) const;
 
-    void update_node_on_selection(const ModelIndex&, const bool);
+    void update_node_on_selection(ModelIndex const&, const bool);
     ModelIndex m_previously_selected_index {};
 
-    const Node& node(const ModelIndex& index) const;
+    Node const& node(ModelIndex const& index) const;
 
     Function<void(int done, int total)> on_thumbnail_progress;
     Function<void()> on_complete;
-    Function<void(int error, const char* error_string)> on_directory_change_error;
-    Function<void(int error, const char* error_string)> on_rename_error;
+    Function<void(int error, char const* error_string)> on_directory_change_error;
+    Function<void(int error, char const* error_string)> on_rename_error;
 
     virtual int tree_column() const override { return Column::Name; }
-    virtual int row_count(const ModelIndex& = ModelIndex()) const override;
-    virtual int column_count(const ModelIndex& = ModelIndex()) const override;
+    virtual int row_count(ModelIndex const& = ModelIndex()) const override;
+    virtual int column_count(ModelIndex const& = ModelIndex()) const override;
     virtual String column_name(int column) const override;
-    virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
-    virtual ModelIndex parent_index(const ModelIndex&) const override;
-    virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const override;
+    virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
+    virtual ModelIndex parent_index(ModelIndex const&) const override;
+    virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;
     virtual StringView drag_data_type() const override { return "text/uri-list"; }
-    virtual bool accepts_drag(const ModelIndex&, const Vector<String>& mime_types) const override;
+    virtual bool accepts_drag(ModelIndex const&, Vector<String> const& mime_types) const override;
     virtual bool is_column_sortable(int column_index) const override { return column_index != Column::Icon; }
-    virtual bool is_editable(const ModelIndex&) const override;
+    virtual bool is_editable(ModelIndex const&) const override;
     virtual bool is_searchable() const override { return true; }
-    virtual void set_data(const ModelIndex&, const Variant&) override;
-    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
+    virtual void set_data(ModelIndex const&, Variant const&) override;
+    virtual Vector<ModelIndex> matches(StringView const&, unsigned = MatchesFlag::AllMatching, ModelIndex const& = ModelIndex()) override;
     virtual void invalidate() override;
 
     static String timestamp_string(time_t timestamp)
@@ -154,8 +154,8 @@ private:
     HashMap<uid_t, String> m_user_names;
     HashMap<gid_t, String> m_group_names;
 
-    bool fetch_thumbnail_for(const Node& node);
-    GUI::Icon icon_for(const Node& node) const;
+    bool fetch_thumbnail_for(Node const& node);
+    GUI::Icon icon_for(Node const& node) const;
 
     void handle_file_event(Core::FileWatcherEvent const& event);
 

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -8,7 +8,7 @@
 
 namespace GUI {
 
-ModelIndex FilteringProxyModel::index(int row, int column, const ModelIndex& parent_index) const
+ModelIndex FilteringProxyModel::index(int row, int column, ModelIndex const& parent_index) const
 {
     int parent_row = parent_index.row();
     if (!parent_index.is_valid())
@@ -17,12 +17,12 @@ ModelIndex FilteringProxyModel::index(int row, int column, const ModelIndex& par
     return create_index(parent_row + row, column);
 }
 
-int FilteringProxyModel::row_count(const ModelIndex&) const
+int FilteringProxyModel::row_count(ModelIndex const&) const
 {
     return m_matching_indices.size();
 }
 
-int FilteringProxyModel::column_count(const ModelIndex& index) const
+int FilteringProxyModel::column_count(ModelIndex const& index) const
 {
     if (!index.is_valid())
         return {};
@@ -33,7 +33,7 @@ int FilteringProxyModel::column_count(const ModelIndex& index) const
     return m_model.column_count(m_matching_indices[index.row()]);
 }
 
-Variant FilteringProxyModel::data(const ModelIndex& index, ModelRole role) const
+Variant FilteringProxyModel::data(ModelIndex const& index, ModelRole role) const
 {
     if (!index.is_valid())
         return {};
@@ -79,7 +79,7 @@ void FilteringProxyModel::filter()
     add_matching(parent_index);
 }
 
-void FilteringProxyModel::set_filter_term(const StringView& term)
+void FilteringProxyModel::set_filter_term(StringView const& term)
 {
     if (m_filter_term == term)
         return;
@@ -87,7 +87,7 @@ void FilteringProxyModel::set_filter_term(const StringView& term)
     invalidate();
 }
 
-ModelIndex FilteringProxyModel::map(const ModelIndex& index) const
+ModelIndex FilteringProxyModel::map(ModelIndex const& index) const
 {
     if (!index.is_valid())
         return {};
@@ -104,7 +104,7 @@ bool FilteringProxyModel::is_searchable() const
     return m_model.is_searchable();
 }
 
-Vector<ModelIndex> FilteringProxyModel::matches(const StringView& searching, unsigned flags, const ModelIndex& index)
+Vector<ModelIndex> FilteringProxyModel::matches(StringView const& searching, unsigned flags, ModelIndex const& index)
 {
     auto found_indices = m_model.matches(searching, flags, index);
     for (size_t i = 0; i < found_indices.size(); i++)

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -104,7 +104,7 @@ bool FilteringProxyModel::is_searchable() const
     return m_model.is_searchable();
 }
 
-Vector<ModelIndex, 1> FilteringProxyModel::matches(const StringView& searching, unsigned flags, const ModelIndex& index)
+Vector<ModelIndex> FilteringProxyModel::matches(const StringView& searching, unsigned flags, const ModelIndex& index)
 {
     auto found_indices = m_model.matches(searching, flags, index);
     for (size_t i = 0; i < found_indices.size(); i++)

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -29,7 +29,7 @@ public:
     virtual void invalidate() override;
     virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const override;
     virtual bool is_searchable() const override;
-    virtual Vector<ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
+    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
 
     void set_filter_term(const StringView& term);
 

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -23,17 +23,17 @@ public:
 
     virtual ~FilteringProxyModel() override {};
 
-    virtual int row_count(const ModelIndex& = ModelIndex()) const override;
-    virtual int column_count(const ModelIndex& = ModelIndex()) const override;
-    virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
+    virtual int row_count(ModelIndex const& = ModelIndex()) const override;
+    virtual int column_count(ModelIndex const& = ModelIndex()) const override;
+    virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
-    virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const override;
+    virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;
     virtual bool is_searchable() const override;
-    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
+    virtual Vector<ModelIndex> matches(StringView const&, unsigned = MatchesFlag::AllMatching, ModelIndex const& = ModelIndex()) override;
 
-    void set_filter_term(const StringView& term);
+    void set_filter_term(StringView const& term);
 
-    ModelIndex map(const ModelIndex&) const;
+    ModelIndex map(ModelIndex const&) const;
 
 private:
     void filter();

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -78,9 +78,9 @@ public:
     }
 
     virtual bool is_searchable() const override { return true; }
-    virtual Vector<GUI::ModelIndex, 1> matches(StringView const& searching, unsigned flags, GUI::ModelIndex const&) override
+    virtual Vector<GUI::ModelIndex> matches(StringView const& searching, unsigned flags, GUI::ModelIndex const&) override
     {
-        Vector<GUI::ModelIndex, 1> found_indices;
+        Vector<GUI::ModelIndex> found_indices;
         if constexpr (IsTwoDimensional) {
             for (auto it = m_data.begin(); it != m_data.end(); ++it) {
                 for (auto it2d = (*it).begin(); it2d != (*it).end(); ++it2d) {

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -25,23 +25,23 @@ public:
     // Substitute 'void' for a dummy u8.
     using ColumnNamesT = Conditional<IsVoid<ColumnNameListType>, u8, ColumnNameListType>;
 
-    static NonnullRefPtr<ItemListModel> create(const Container& data, const ColumnNamesT& column_names, const Optional<size_t>& row_count = {}) requires(IsTwoDimensional)
+    static NonnullRefPtr<ItemListModel> create(Container const& data, ColumnNamesT const& column_names, Optional<size_t> const& row_count = {}) requires(IsTwoDimensional)
     {
         return adopt_ref(*new ItemListModel<T, Container, ColumnNameListType>(data, column_names, row_count));
     }
-    static NonnullRefPtr<ItemListModel> create(const Container& data, const Optional<size_t>& row_count = {}) requires(!IsTwoDimensional)
+    static NonnullRefPtr<ItemListModel> create(Container const& data, Optional<size_t> const& row_count = {}) requires(!IsTwoDimensional)
     {
         return adopt_ref(*new ItemListModel<T, Container>(data, row_count));
     }
 
     virtual ~ItemListModel() override { }
 
-    virtual int row_count(const ModelIndex&) const override
+    virtual int row_count(ModelIndex const&) const override
     {
         return m_provided_row_count.has_value() ? *m_provided_row_count : m_data.size();
     }
 
-    virtual int column_count(const ModelIndex& index) const override
+    virtual int column_count(ModelIndex const& index) const override
     {
         // if it's 2D (e.g. Vector<Vector<T>>)
         if constexpr (IsTwoDimensional) {
@@ -63,7 +63,7 @@ public:
         return "Data";
     }
 
-    virtual Variant data(const ModelIndex& index, ModelRole role) const override
+    virtual Variant data(ModelIndex const& index, ModelRole role) const override
     {
         if (role == ModelRole::TextAlignment)
             return Gfx::TextAlignment::CenterLeft;
@@ -109,20 +109,20 @@ public:
     }
 
 protected:
-    explicit ItemListModel(const Container& data, Optional<size_t> row_count = {}) requires(!IsTwoDimensional)
+    explicit ItemListModel(Container const& data, Optional<size_t> row_count = {}) requires(!IsTwoDimensional)
         : m_data(data)
         , m_provided_row_count(move(row_count))
     {
     }
 
-    explicit ItemListModel(const Container& data, const ColumnNamesT& column_names, Optional<size_t> row_count = {}) requires(IsTwoDimensional)
+    explicit ItemListModel(Container const& data, ColumnNamesT const& column_names, Optional<size_t> row_count = {}) requires(IsTwoDimensional)
         : m_data(data)
         , m_column_names(column_names)
         , m_provided_row_count(move(row_count))
     {
     }
 
-    const Container& m_data;
+    Container const& m_data;
     ColumnNamesT m_column_names;
     Optional<size_t> m_provided_row_count;
 };

--- a/Userland/Libraries/LibGUI/Model.cpp
+++ b/Userland/Libraries/LibGUI/Model.cpp
@@ -56,17 +56,17 @@ void Model::did_update(unsigned flags)
     });
 }
 
-ModelIndex Model::create_index(int row, int column, const void* data) const
+ModelIndex Model::create_index(int row, int column, void const* data) const
 {
     return ModelIndex(*this, row, column, const_cast<void*>(data));
 }
 
-ModelIndex Model::index(int row, int column, const ModelIndex&) const
+ModelIndex Model::index(int row, int column, ModelIndex const&) const
 {
     return create_index(row, column);
 }
 
-bool Model::accepts_drag(const ModelIndex&, const Vector<String>&) const
+bool Model::accepts_drag(ModelIndex const&, Vector<String> const&) const
 {
     return false;
 }
@@ -81,7 +81,7 @@ void Model::unregister_client(ModelClient& client)
     m_clients.remove(&client);
 }
 
-WeakPtr<PersistentHandle> Model::register_persistent_index(Badge<PersistentModelIndex>, const ModelIndex& index)
+WeakPtr<PersistentHandle> Model::register_persistent_index(Badge<PersistentModelIndex>, ModelIndex const& index)
 {
     if (!index.is_valid())
         return {};
@@ -100,7 +100,7 @@ WeakPtr<PersistentHandle> Model::register_persistent_index(Badge<PersistentModel
     return weak_handle;
 }
 
-RefPtr<Core::MimeData> Model::mime_data(const ModelSelection& selection) const
+RefPtr<Core::MimeData> Model::mime_data(ModelSelection const& selection) const
 {
     auto mime_data = Core::MimeData::construct();
     RefPtr<Gfx::Bitmap> bitmap;

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -62,20 +62,20 @@ public:
 
     virtual ~Model();
 
-    virtual int row_count(const ModelIndex& = ModelIndex()) const = 0;
-    virtual int column_count(const ModelIndex& = ModelIndex()) const = 0;
+    virtual int row_count(ModelIndex const& = ModelIndex()) const = 0;
+    virtual int column_count(ModelIndex const& = ModelIndex()) const = 0;
     virtual String column_name(int) const { return {}; }
-    virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const = 0;
-    virtual TriState data_matches(const ModelIndex&, const Variant&) const { return TriState::Unknown; }
+    virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const = 0;
+    virtual TriState data_matches(ModelIndex const&, Variant const&) const { return TriState::Unknown; }
     virtual void invalidate();
-    virtual ModelIndex parent_index(const ModelIndex&) const { return {}; }
-    virtual ModelIndex index(int row, int column = 0, const ModelIndex& parent = ModelIndex()) const;
-    virtual bool is_editable(const ModelIndex&) const { return false; }
+    virtual ModelIndex parent_index(ModelIndex const&) const { return {}; }
+    virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const;
+    virtual bool is_editable(ModelIndex const&) const { return false; }
     virtual bool is_searchable() const { return false; }
-    virtual void set_data(const ModelIndex&, const Variant&) { }
+    virtual void set_data(ModelIndex const&, Variant const&) { }
     virtual int tree_column() const { return 0; }
-    virtual bool accepts_drag(const ModelIndex&, const Vector<String>& mime_types) const;
-    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) { return {}; }
+    virtual bool accepts_drag(ModelIndex const&, Vector<String> const& mime_types) const;
+    virtual Vector<ModelIndex> matches(StringView const&, unsigned = MatchesFlag::AllMatching, ModelIndex const& = ModelIndex()) { return {}; }
 
     virtual bool is_column_sortable([[maybe_unused]] int column_index) const { return true; }
     virtual void sort([[maybe_unused]] int column, SortOrder) { }
@@ -87,7 +87,7 @@ public:
     }
 
     virtual StringView drag_data_type() const { return {}; }
-    virtual RefPtr<Core::MimeData> mime_data(const ModelSelection&) const;
+    virtual RefPtr<Core::MimeData> mime_data(ModelSelection const&) const;
 
     void register_view(Badge<AbstractView>, AbstractView&);
     void unregister_view(Badge<AbstractView>, AbstractView&);
@@ -104,7 +104,7 @@ protected:
     void for_each_client(Function<void(ModelClient&)>);
     void did_update(unsigned flags = UpdateFlag::InvalidateAllIndices);
 
-    static bool string_matches(const StringView& str, const StringView& needle, unsigned flags)
+    static bool string_matches(StringView const& str, StringView const& needle, unsigned flags)
     {
         auto case_sensitivity = (flags & CaseInsensitive) ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive;
         if (flags & MatchFull)
@@ -114,7 +114,7 @@ protected:
         return str.contains(needle, case_sensitivity);
     }
 
-    ModelIndex create_index(int row, int column, const void* data = nullptr) const;
+    ModelIndex create_index(int row, int column, void const* data = nullptr) const;
 
     void begin_insert_rows(ModelIndex const& parent, int first, int last);
     void begin_insert_columns(ModelIndex const& parent, int first, int last);

--- a/Userland/Libraries/LibGUI/Model.h
+++ b/Userland/Libraries/LibGUI/Model.h
@@ -75,7 +75,7 @@ public:
     virtual void set_data(const ModelIndex&, const Variant&) { }
     virtual int tree_column() const { return 0; }
     virtual bool accepts_drag(const ModelIndex&, const Vector<String>& mime_types) const;
-    virtual Vector<ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) { return {}; }
+    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) { return {}; }
 
     virtual bool is_column_sortable([[maybe_unused]] int column_index) const { return true; }
     virtual void sort([[maybe_unused]] int column, SortOrder) { }

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -49,22 +49,22 @@ void SortingProxyModel::model_did_update(unsigned flags)
     update_sort(flags);
 }
 
-bool SortingProxyModel::accepts_drag(const ModelIndex& proxy_index, const Vector<String>& mime_types) const
+bool SortingProxyModel::accepts_drag(ModelIndex const& proxy_index, Vector<String> const& mime_types) const
 {
     return source().accepts_drag(map_to_source(proxy_index), mime_types);
 }
 
-int SortingProxyModel::row_count(const ModelIndex& proxy_index) const
+int SortingProxyModel::row_count(ModelIndex const& proxy_index) const
 {
     return source().row_count(map_to_source(proxy_index));
 }
 
-int SortingProxyModel::column_count(const ModelIndex& proxy_index) const
+int SortingProxyModel::column_count(ModelIndex const& proxy_index) const
 {
     return source().column_count(map_to_source(proxy_index));
 }
 
-ModelIndex SortingProxyModel::map_to_source(const ModelIndex& proxy_index) const
+ModelIndex SortingProxyModel::map_to_source(ModelIndex const& proxy_index) const
 {
     if (!proxy_index.is_valid())
         return {};
@@ -84,7 +84,7 @@ ModelIndex SortingProxyModel::map_to_source(const ModelIndex& proxy_index) const
     return source().index(source_row, source_column, it->key);
 }
 
-ModelIndex SortingProxyModel::map_to_proxy(const ModelIndex& source_index) const
+ModelIndex SortingProxyModel::map_to_proxy(ModelIndex const& source_index) const
 {
     if (!source_index.is_valid())
         return {};
@@ -111,7 +111,7 @@ String SortingProxyModel::column_name(int column) const
     return source().column_name(column);
 }
 
-Variant SortingProxyModel::data(const ModelIndex& proxy_index, ModelRole role) const
+Variant SortingProxyModel::data(ModelIndex const& proxy_index, ModelRole role) const
 {
     return source().data(map_to_source(proxy_index), role);
 }
@@ -121,7 +121,7 @@ StringView SortingProxyModel::drag_data_type() const
     return source().drag_data_type();
 }
 
-bool SortingProxyModel::less_than(const ModelIndex& index1, const ModelIndex& index2) const
+bool SortingProxyModel::less_than(ModelIndex const& index1, ModelIndex const& index2) const
 {
     auto data1 = index1.data(m_sort_role);
     auto data2 = index2.data(m_sort_role);
@@ -130,7 +130,7 @@ bool SortingProxyModel::less_than(const ModelIndex& index1, const ModelIndex& in
     return data1 < data2;
 }
 
-ModelIndex SortingProxyModel::index(int row, int column, const ModelIndex& parent) const
+ModelIndex SortingProxyModel::index(int row, int column, ModelIndex const& parent) const
 {
     if (row < 0 || column < 0)
         return {};
@@ -146,7 +146,7 @@ ModelIndex SortingProxyModel::index(int row, int column, const ModelIndex& paren
     return create_index(row, column, &mapping);
 }
 
-ModelIndex SortingProxyModel::parent_index(const ModelIndex& proxy_index) const
+ModelIndex SortingProxyModel::parent_index(ModelIndex const& proxy_index) const
 {
     if (!proxy_index.is_valid())
         return {};
@@ -206,7 +206,7 @@ void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sor
         view.selection().change_from_model({}, [&](ModelSelection& selection) {
             Vector<ModelIndex> selected_indices_in_source;
             Vector<ModelIndex> stale_indices_in_selection;
-            selection.for_each_index([&](const ModelIndex& index) {
+            selection.for_each_index([&](ModelIndex const& index) {
                 if (index.parent() == mapping.source_parent) {
                     stale_indices_in_selection.append(index);
                     selected_indices_in_source.append(source().index(old_source_rows[index.row()], index.column(), mapping.source_parent));
@@ -243,7 +243,7 @@ void SortingProxyModel::sort(int column, SortOrder sort_order)
     did_update(UpdateFlag::DontInvalidateIndices);
 }
 
-SortingProxyModel::InternalMapIterator SortingProxyModel::build_mapping(const ModelIndex& source_parent)
+SortingProxyModel::InternalMapIterator SortingProxyModel::build_mapping(ModelIndex const& source_parent)
 {
     auto it = m_mappings.find(source_parent);
     if (it != m_mappings.end())
@@ -273,12 +273,12 @@ bool SortingProxyModel::is_column_sortable(int column_index) const
     return source().is_column_sortable(column_index);
 }
 
-bool SortingProxyModel::is_editable(const ModelIndex& proxy_index) const
+bool SortingProxyModel::is_editable(ModelIndex const& proxy_index) const
 {
     return source().is_editable(map_to_source(proxy_index));
 }
 
-void SortingProxyModel::set_data(const ModelIndex& proxy_index, const Variant& data)
+void SortingProxyModel::set_data(ModelIndex const& proxy_index, Variant const& data)
 {
     source().set_data(map_to_source(proxy_index), data);
 }
@@ -288,7 +288,7 @@ bool SortingProxyModel::is_searchable() const
     return source().is_searchable();
 }
 
-Vector<ModelIndex> SortingProxyModel::matches(const StringView& searching, unsigned flags, const ModelIndex& proxy_index)
+Vector<ModelIndex> SortingProxyModel::matches(StringView const& searching, unsigned flags, ModelIndex const& proxy_index)
 {
     auto found_indices = source().matches(searching, flags, map_to_source(proxy_index));
     for (size_t i = 0; i < found_indices.size(); i++)

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -288,7 +288,7 @@ bool SortingProxyModel::is_searchable() const
     return source().is_searchable();
 }
 
-Vector<ModelIndex, 1> SortingProxyModel::matches(const StringView& searching, unsigned flags, const ModelIndex& proxy_index)
+Vector<ModelIndex> SortingProxyModel::matches(const StringView& searching, unsigned flags, const ModelIndex& proxy_index)
 {
     auto found_indices = source().matches(searching, flags, map_to_source(proxy_index));
     for (size_t i = 0; i < found_indices.size(); i++)

--- a/Userland/Libraries/LibGUI/SortingProxyModel.h
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.h
@@ -17,26 +17,26 @@ public:
     static NonnullRefPtr<SortingProxyModel> create(NonnullRefPtr<Model> source) { return adopt_ref(*new SortingProxyModel(move(source))); }
     virtual ~SortingProxyModel() override;
 
-    virtual int row_count(const ModelIndex& = ModelIndex()) const override;
-    virtual int column_count(const ModelIndex& = ModelIndex()) const override;
+    virtual int row_count(ModelIndex const& = ModelIndex()) const override;
+    virtual int column_count(ModelIndex const& = ModelIndex()) const override;
     virtual String column_name(int) const override;
-    virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
+    virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual StringView drag_data_type() const override;
-    virtual ModelIndex parent_index(const ModelIndex&) const override;
-    virtual ModelIndex index(int row, int column, const ModelIndex& parent) const override;
-    virtual bool is_editable(const ModelIndex&) const override;
+    virtual ModelIndex parent_index(ModelIndex const&) const override;
+    virtual ModelIndex index(int row, int column, ModelIndex const& parent) const override;
+    virtual bool is_editable(ModelIndex const&) const override;
     virtual bool is_searchable() const override;
-    virtual void set_data(const ModelIndex&, const Variant&) override;
-    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
-    virtual bool accepts_drag(const ModelIndex&, const Vector<String>& mime_types) const override;
+    virtual void set_data(ModelIndex const&, Variant const&) override;
+    virtual Vector<ModelIndex> matches(StringView const&, unsigned = MatchesFlag::AllMatching, ModelIndex const& = ModelIndex()) override;
+    virtual bool accepts_drag(ModelIndex const&, Vector<String> const& mime_types) const override;
 
     virtual bool is_column_sortable(int column_index) const override;
 
-    virtual bool less_than(const ModelIndex&, const ModelIndex&) const;
+    virtual bool less_than(ModelIndex const&, ModelIndex const&) const;
 
-    ModelIndex map_to_source(const ModelIndex&) const;
-    ModelIndex map_to_proxy(const ModelIndex&) const;
+    ModelIndex map_to_source(ModelIndex const&) const;
+    ModelIndex map_to_proxy(ModelIndex const&) const;
 
     ModelRole sort_role() const { return m_sort_role; }
     void set_sort_role(ModelRole role) { m_sort_role = role; }
@@ -61,10 +61,10 @@ private:
     virtual void model_did_update(unsigned) override;
 
     Model& source() { return *m_source; }
-    const Model& source() const { return *m_source; }
+    Model const& source() const { return *m_source; }
 
     void update_sort(unsigned = UpdateFlag::DontInvalidateIndices);
-    InternalMapIterator build_mapping(const ModelIndex& proxy_index);
+    InternalMapIterator build_mapping(ModelIndex const& proxy_index);
 
     NonnullRefPtr<Model> m_source;
 

--- a/Userland/Libraries/LibGUI/SortingProxyModel.h
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.h
@@ -28,7 +28,7 @@ public:
     virtual bool is_editable(const ModelIndex&) const override;
     virtual bool is_searchable() const override;
     virtual void set_data(const ModelIndex&, const Variant&) override;
-    virtual Vector<ModelIndex, 1> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
+    virtual Vector<ModelIndex> matches(const StringView&, unsigned = MatchesFlag::AllMatching, const ModelIndex& = ModelIndex()) override;
     virtual bool accepts_drag(const ModelIndex&, const Vector<String>& mime_types) const override;
 
     virtual bool is_column_sortable(int column_index) const override;


### PR DESCRIPTION
This enables the System Monitor's ProcessModel to be searched in the same manner as FileSystemModel and ItemListModel.
The corresponding LibGUI change handles a case where the highlighting would get out of sync right after the SystemMonitor's timer updated the list and order of processes.