### PR TITLE
SoundPlayer: Simplify Bars Visualization drawing logic a bit

### DIFF
--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -41,10 +41,9 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     for (double& d : groups)
         d = 0.;
 
-    int bins_per_group = ceil_div((m_sample_count - 1) / 2, group_count) * freq_bin;
-
+    int bins_per_group = ceil_div((m_sample_count - 1) / 2, group_count);
     for (int i = 1; i < m_sample_count / 2; i++) {
-        groups[(i * freq_bin) / bins_per_group] += AK::fabs(m_sample_buffer.data()[i].real());
+        groups[i / bins_per_group] += AK::fabs(m_sample_buffer.data()[i].real());
     }
     for (int i = 0; i < group_count; i++)
         groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(AK::pow(AK::E<double>, (double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -28,7 +28,7 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     fft(m_sample_buffer, false);
     double max = AK::sqrt(m_sample_count * 2.);
 
-    double freq_bin = m_samplerate / m_sample_count;
+    double freq_bin = m_samplerate / (double)m_sample_count;
 
     constexpr int group_count = 60;
     Vector<double, group_count> groups;


### PR DESCRIPTION
While trying to find a fix for a choppy (flac) playback in the Sound Player, I found that you cannot make the buffer size too big, because it'll just crash. :p

- **SoundPlayer: Simplify Bars Visualization drawing logic a bit**

  The `freq_bin` in `bins_per_group` was multiplied only to be divided later, which could even result in a crash if you set higher buffer size (like 1000ms) in PlaybackManager, due to rounding errors I presume.

- **SoundPlayer: Convert to double before calculating**

  `freq_bin` was converted to double after it was calculated, so there was a much higher probability it could be 0 instead of some comma number, which meant that the bars always stayed on top.


