### PR TITLE
WindowServer+ColorPicker: Add ability to select a color on the screen 

### DIFF
--- a/Userland/Libraries/LibGUI/ColorPicker.h
+++ b/Userland/Libraries/LibGUI/ColorPicker.h
@@ -14,6 +14,7 @@ namespace GUI {
 class ColorButton;
 class ColorPreview;
 class CustomColorWidget;
+class ColorSelectOverlay;
 
 class ColorPicker final : public Dialog {
     C_OBJECT(ColorPicker)
@@ -40,6 +41,7 @@ private:
     Vector<ColorButton&> m_color_widgets;
     RefPtr<CustomColorWidget> m_custom_color;
     RefPtr<ColorPreview> m_preview_widget;
+    RefPtr<Button> m_selector_button;
     RefPtr<TextBox> m_html_text;
     RefPtr<SpinBox> m_red_spinbox;
     RefPtr<SpinBox> m_green_spinbox;

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -1053,6 +1053,16 @@ Messages::WindowServer::GetScreenBitmapAroundCursorResponse ClientConnection::ge
     return { {} };
 }
 
+Messages::WindowServer::GetColorUnderCursorResponse ClientConnection::get_color_under_cursor()
+{
+    // FIXME: Add a mechanism to get screen bitmap without cursor, so we don't have to do this
+    //        manual translation to avoid sampling the color on the actual cursor itself.
+    auto cursor_location = ScreenInput::the().cursor_location().translated(-1, -1);
+    auto& screen_with_cursor = ScreenInput::the().cursor_location_screen();
+    auto color = Compositor::the().color_at_position({}, screen_with_cursor, cursor_location);
+    return color;
+}
+
 Messages::WindowServer::IsWindowModifiedResponse ClientConnection::is_window_modified(i32 window_id)
 {
     auto it = m_windows.find(window_id);

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -168,6 +168,7 @@ private:
     virtual void add_window_stealing_for_client(i32, i32) override;
     virtual void remove_window_stealing_for_client(i32, i32) override;
     virtual void remove_window_stealing(i32) override;
+    virtual Messages::WindowServer::GetColorUnderCursorResponse get_color_under_cursor() override;
 
     Window* window_from_id(i32 window_id);
 

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -78,6 +78,11 @@ const Gfx::Bitmap& Compositor::front_bitmap_for_screenshot(Badge<ClientConnectio
     return *screen.compositor_screen_data().m_front_bitmap;
 }
 
+Gfx::Color Compositor::color_at_position(Badge<ClientConnection>, Screen& screen, Gfx::IntPoint const& position) const
+{
+    return screen.compositor_screen_data().m_front_bitmap->get_pixel(position);
+}
+
 void CompositorScreenData::init_bitmaps(Compositor& compositor, Screen& screen)
 {
     // Recreate the screen-number overlay as the Screen instances may have changed, or get rid of it if we no longer need it

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -176,6 +176,7 @@ public:
 
     const Gfx::Bitmap* cursor_bitmap_for_screenshot(Badge<ClientConnection>, Screen&) const;
     const Gfx::Bitmap& front_bitmap_for_screenshot(Badge<ClientConnection>, Screen&) const;
+    Gfx::Color color_at_position(Badge<ClientConnection>, Screen&, Gfx::IntPoint const&) const;
 
     void register_animation(Badge<Animation>, Animation&);
     void unregister_animation(Badge<Animation>, Animation&);

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -136,6 +136,7 @@ endpoint WindowServer
 
     get_screen_bitmap(Optional<Gfx::IntRect> rect, Optional<u32> screen_index) => (Gfx::ShareableBitmap bitmap)
     get_screen_bitmap_around_cursor(Gfx::IntSize size) => (Gfx::ShareableBitmap bitmap)
+    get_color_under_cursor() => (Gfx::Color color)
 
     pong() =|
 


### PR DESCRIPTION
This PR is a combination of all of @awesomekling's useful suggestions on #9742 from the office hours. 

In short, a new IPC endpoint / method in the compositor have been added that allow us to get the color directly under the cursor directly without having any intermediate bitmap allocations like earlier. Video demonstration is below (same as the last PR, no functionality has changed)

[Video Demonstration](https://youtu.be/6zreJ-uhDPw)

The flickering when you start the selection seems to be caused by a bug in the rendering of transparent windows. The details of why it has been implemented this way is described in the appropriate commit message.