### PR TITLE
Kernel/VirtIO: Defer initialization of device out of the constructor

### DIFF
--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -17,10 +17,9 @@ UNMAP_AFTER_INIT NonnullRefPtr<Console> Console::must_create(PCI::Address addres
     return adopt_ref_if_nonnull(new Console(address)).release_nonnull();
 }
 
-UNMAP_AFTER_INIT Console::Console(PCI::Address address)
-    : VirtIO::Device(address)
-    , m_device_id(next_device_id++)
+UNMAP_AFTER_INIT void Console::initialize()
 {
+    Device::initialize();
     if (auto cfg = get_config(ConfigurationType::Device)) {
         bool success = negotiate_features([&](u64 supported_features) {
             u64 negotiated = 0;
@@ -56,6 +55,12 @@ UNMAP_AFTER_INIT Console::Console(PCI::Address address)
                 m_ports.append(make_ref_counted<VirtIO::ConsolePort>(0u, *this));
         }
     }
+}
+
+UNMAP_AFTER_INIT Console::Console(PCI::Address address)
+    : VirtIO::Device(address)
+    , m_device_id(next_device_id++)
+{
 }
 
 bool Console::handle_device_config_change()

--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -28,6 +28,8 @@ public:
         return m_device_id;
     }
 
+    virtual void initialize() override;
+
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"; }
     explicit Console(PCI::Address);

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -90,6 +90,8 @@ class Device
 public:
     virtual ~Device() override = default;
 
+    virtual void initialize();
+
 protected:
     virtual StringView class_name() const = 0;
     explicit Device(PCI::Address);

--- a/Kernel/Bus/VirtIO/RNG.cpp
+++ b/Kernel/Bus/VirtIO/RNG.cpp
@@ -14,9 +14,9 @@ UNMAP_AFTER_INIT NonnullRefPtr<RNG> RNG::must_create(PCI::Address address)
     return adopt_ref_if_nonnull(new RNG(address)).release_nonnull();
 }
 
-UNMAP_AFTER_INIT RNG::RNG(PCI::Address address)
-    : VirtIO::Device(address)
+UNMAP_AFTER_INIT void RNG::initialize()
 {
+    Device::initialize();
     bool success = negotiate_features([&](auto) {
         return 0;
     });
@@ -33,9 +33,14 @@ UNMAP_AFTER_INIT RNG::RNG(PCI::Address address)
     }
 }
 
+UNMAP_AFTER_INIT RNG::RNG(PCI::Address address)
+    : VirtIO::Device(address)
+{
+}
+
 bool RNG::handle_device_config_change()
 {
-    VERIFY_NOT_REACHED(); // Device has no config
+    return false; // Device has no config
 }
 
 void RNG::handle_queue_update(u16 queue_index)

--- a/Kernel/Bus/VirtIO/RNG.h
+++ b/Kernel/Bus/VirtIO/RNG.h
@@ -23,6 +23,8 @@ public:
     virtual StringView purpose() const override { return class_name(); }
     virtual ~RNG() override = default;
 
+    virtual void initialize() override;
+
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"; }
     explicit RNG(PCI::Address);

--- a/Kernel/Graphics/VirtIOGPU/GPU.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU.cpp
@@ -15,10 +15,9 @@
 
 namespace Kernel::Graphics::VirtIOGPU {
 
-GPU::GPU(PCI::Address address)
-    : VirtIO::Device(address)
-    , m_scratch_space(MM.allocate_contiguous_kernel_region(32 * PAGE_SIZE, "VirtGPU Scratch Space", Memory::Region::Access::ReadWrite))
+void GPU::initialize()
 {
+    Device::initialize();
     VERIFY(!!m_scratch_space);
     if (auto cfg = get_config(VirtIO::ConfigurationType::Device)) {
         m_device_configuration = cfg;
@@ -45,6 +44,12 @@ GPU::GPU(PCI::Address address)
     } else {
         VERIFY_NOT_REACHED();
     }
+}
+
+GPU::GPU(PCI::Address address)
+    : VirtIO::Device(address)
+    , m_scratch_space(MM.allocate_contiguous_kernel_region(32 * PAGE_SIZE, "VirtGPU Scratch Space", Memory::Region::Access::ReadWrite))
+{
 }
 
 GPU::~GPU()

--- a/Kernel/Graphics/VirtIOGPU/GPU.h
+++ b/Kernel/Graphics/VirtIOGPU/GPU.h
@@ -57,6 +57,8 @@ public:
         return IterationDecision::Continue;
     }
 
+    virtual void initialize() override;
+
     RefPtr<Console> default_console()
     {
         if (m_default_scanout.has_value())

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -22,6 +22,7 @@ GraphicsAdapter::GraphicsAdapter(PCI::Address base_address)
     : PCI::Device(base_address)
 {
     m_gpu_device = adopt_ref(*new GPU(base_address)).leak_ref();
+    m_gpu_device->initialize();
 }
 
 void GraphicsAdapter::initialize_framebuffer_devices()


### PR DESCRIPTION
This ensures we safely handle interrupts (which can call virtual
functions), so they don't happen in the constructor - this pattern can
lead to a crash, if we are still in the constructor context because
not all methods are available for usage (some are pure virtual,
so it's possible to call __cxa_pure_virtual).

Also, under some conditions like adding a PCI device via PCI-passthrough
mechanism in QEMU, it became exposed to the eye that the code asserts on
RNG::handle_device_config_change(). That device has no configuration but
if the hypervisor still misbehaves and tries to configure it, we should
simply return false to indicate nothing happened.