### PR TITLE
Kernel/Devices: Remove unnecessary virtual method and include

### DIFF
--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -41,7 +41,6 @@ public:
     virtual String device_name() const = 0;
 
     virtual bool is_device() const override { return true; }
-    virtual bool is_disk_device() const { return false; }
 
     static void for_each(Function<void(Device&)>);
     static Device* get_device(unsigned major, unsigned minor);

--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Singleton.h>
 #include <AK/StringView.h>
 #include <Kernel/FileSystem/DevFS.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>


### PR DESCRIPTION
In preparation for #9399, let's ensure we put all the cosmetic changes before applying hotplug support.