### PR TITLE
GifLoader: Marginally faster, significantly less crashy

### DIFF
--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -335,6 +335,9 @@ static bool decode_frame(GIFLoadingContext& context, size_t frame_index)
             copy_frame_buffer(*context.frame_buffer, *context.prev_frame_buffer);
         }
 
+        if (image.lzw_min_code_size > 8)
+            return false;
+
         LZWDecoder decoder(image.lzw_encoded_bytes, image.lzw_min_code_size);
 
         // Add GIF-specific control codes

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -228,9 +228,9 @@ public:
 private:
     void init_code_table()
     {
-        m_code_table.clear();
+        m_code_table.ensure_capacity(m_table_capacity);
         for (u16 i = 0; i < m_table_capacity; ++i) {
-            m_code_table.append({ (u8)i });
+            m_code_table.unchecked_append({ (u8)i });
         }
         m_original_code_table = m_code_table;
     }


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29034

A little bit of history:
- End of May 2021 I was working on the GifLoader.
- I found and fixed the two issues in this commit.
- I ran the fuzzer locally.
- Somehow, this triggered/revealed at least two different hardware faults, and I didn't have a home computer anymore.
- After an odyssee, I now have a new home computer.
- I'm (irrationaly) scared to run the GIF fuzzer now, and will not attempt to run it. :S