### PR TITLE
LibGfx: Fix BiDi regressions

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1456,14 +1456,14 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
     }
 
     for (size_t i = 0; i < lines.size(); ++i) {
-        auto& line = lines[i];
+        auto line = Utf8View { lines[i] };
 
         IntRect line_rect { bounding_rect.x(), bounding_rect.y() + static_cast<int>(i) * line_height, bounding_rect.width(), line_height };
         line_rect.intersect(rect);
 
         TextDirection line_direction = get_text_direction(line);
-        if (text_contains_bidirectional_text(Utf8View { line }, line_direction)) { // Slow Path: The line contains mixed BiDi classes
-            auto directional_runs = split_text_into_directional_runs(Utf8View { line }, line_direction);
+        if (text_contains_bidirectional_text(line, line_direction)) { // Slow Path: The line contains mixed BiDi classes
+            auto directional_runs = split_text_into_directional_runs(line, line_direction);
             auto current_dx = line_direction == TextDirection::LTR ? 0 : line_rect.width();
             for (auto& directional_run : directional_runs) {
                 auto run_width = font.width(directional_run.text());
@@ -1476,14 +1476,14 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
                 // compatible with draw_text_line.
                 StringBuilder builder;
                 builder.append(directional_run.text());
-                auto text = Utf8View { builder.to_string() };
+                auto line_text = Utf8View { builder.to_string() };
 
-                draw_text_line(run_rect, text, font, alignment, directional_run.direction(), draw_glyph);
+                draw_text_line(run_rect, line_text, font, alignment, directional_run.direction(), draw_glyph);
                 if (line_direction == TextDirection::LTR)
                     current_dx += run_width;
             }
         } else {
-            draw_text_line(line_rect, Utf8View { line }, font, alignment, line_direction, draw_glyph);
+            draw_text_line(line_rect, line, font, alignment, line_direction, draw_glyph);
         }
     }
 }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1476,7 +1476,7 @@ void Painter::do_draw_text(IntRect const& rect, Utf8View const& text, Font const
                 // compatible with draw_text_line.
                 StringBuilder builder;
                 builder.append(directional_run.text());
-                auto line_text = Utf8View { builder.to_string() };
+                auto line_text = Utf8View { builder.string_view() };
 
                 draw_text_line(run_rect, line_text, font, alignment, directional_run.direction(), draw_glyph);
                 if (line_direction == TextDirection::LTR)


### PR DESCRIPTION
Fixes a couple of small regressions in LibGfx BiDi rendering that were introduced in e11940fd01c6c45ccaf4994cb588becd10c154f8. (`https://google.co.il/` now renders correctly again)