### PR TITLE
PixelPaint: Fix broken opening of files from Shell

### DIFF
--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -69,7 +69,7 @@ Result<void, String> ProjectLoader::try_load_from_path(StringView path)
     if (file_or_error.is_error())
         return String::formatted("Unable to open file because: {}", file_or_error.release_error());
 
-    return try_load_from_fd_and_close(file_or_error.release_value()->fd(), path);
+    return try_load_from_fd_and_close(file_or_error.release_value()->leak_fd(), path);
 }
 
 }


### PR DESCRIPTION
Opening files (including .pp) in PixelPaint by calling `pp <path to file>` is broken right now due to me handling a closed fd around. This PR fixes that. I have no idea how that slipped past me since it was my path I took when testing the functionality.
Anyway, calling `leak_fd()` keeps it open and we close it later manually.