### PR TITLE
AK: Make declaration of std::move and std::forward optional

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -20,6 +20,7 @@ constexpr auto round_up_to_power_of_two(T value, U power_of_two) requires(IsInte
 // Disabling formatting for that doesn't help either.
 //
 // clang-format off
+#ifndef AK_DONT_REPLACE_STD
 namespace std {
 
 // NOTE: These are in the "std" namespace since some compilers and static analyzers rely on it.
@@ -44,6 +45,7 @@ constexpr T&& move(T& arg)
 }
 
 }
+#endif
 // clang-format on
 
 using std::forward;


### PR DESCRIPTION
This introduces a new define AK_DONT_REPLACE_STD that disables importing
AK::move and AK::forward into the std namespace. Some ports include both
STL and AK headers which causes conflicts when trying to resolve move
or forward. The port can #define AK_DONT_REPLACE_STD before including AK
headers in that case.