### PR TITLE
Kernel/SysFS: Ensure data stability when reading from Inodes

### DIFF
--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -8,6 +8,8 @@
 
 #include <Kernel/Bus/USB/USBDevice.h>
 #include <Kernel/FileSystem/SysFS.h>
+#include <Kernel/KBufferBuilder.h>
+#include <Kernel/Locking/Mutex.h>
 
 namespace Kernel::USB {
 
@@ -29,6 +31,11 @@ protected:
     IntrusiveListNode<SysFSUSBDeviceInformation, RefPtr<SysFSUSBDeviceInformation>> m_list_node;
 
     NonnullRefPtr<USB::Device> m_device;
+
+private:
+    bool output(KBufferBuilder& builder);
+    virtual KResult refresh_data(FileDescription& description) const override;
+    mutable Mutex m_lock { "SysFSUSBDeviceInformation" };
 };
 
 class SysFSUSBBusDirectory final : public SysFSDirectory {

--- a/Kernel/FileSystem/SysFS.cpp
+++ b/Kernel/FileSystem/SysFS.cpp
@@ -96,6 +96,22 @@ SysFSInode::SysFSInode(SysFS const& fs, SysFSComponent const& component)
 {
 }
 
+void SysFSInode::did_seek(FileDescription& description, off_t new_offset)
+{
+    if (new_offset != 0)
+        return;
+    auto result = m_associated_component->refresh_data(description);
+    if (result.is_error()) {
+        // Subsequent calls to read will return EIO!
+        dbgln("SysFS: Could not refresh contents: {}", result.error());
+    }
+}
+
+KResult SysFSInode::attach(FileDescription& description)
+{
+    return m_associated_component->refresh_data(description);
+}
+
 KResultOr<size_t> SysFSInode::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, FileDescription* fd) const
 {
     return m_associated_component->read_bytes(offset, count, buffer, fd);

--- a/Kernel/FileSystem/SysFS.h
+++ b/Kernel/FileSystem/SysFS.h
@@ -96,6 +96,9 @@ protected:
     virtual KResult chown(UserID, GroupID) override;
     virtual KResult truncate(u64) override;
 
+    virtual KResult attach(FileDescription& description) override final;
+    virtual void did_seek(FileDescription&, off_t) override final;
+
     NonnullRefPtr<SysFSComponent> m_associated_component;
 };
 

--- a/Kernel/FileSystem/SysFSComponent.h
+++ b/Kernel/FileSystem/SysFSComponent.h
@@ -12,11 +12,16 @@
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/File.h>
+#include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/Forward.h>
 #include <Kernel/KResult.h>
 
 namespace Kernel {
+
+struct SysFSInodeData : public FileDescriptionData {
+    OwnPtr<KBuffer> buffer;
+};
 
 class SysFSComponent : public RefCounted<SysFSComponent> {
 public:
@@ -25,6 +30,7 @@ public:
     virtual KResult traverse_as_directory(unsigned, Function<bool(FileSystem::DirectoryEntryView const&)>) const { VERIFY_NOT_REACHED(); }
     virtual RefPtr<SysFSComponent> lookup(StringView) { VERIFY_NOT_REACHED(); };
     virtual KResultOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const&, FileDescription*) { return EROFS; }
+    virtual KResult refresh_data(FileDescription&) const { return KSuccess; }
 
     virtual NonnullRefPtr<SysFSInode> to_inode(SysFS const&) const;
 


### PR DESCRIPTION
Like with the ProcFS, description data can change at anytime, so it's
wise to ensure that when the userland reads from an Inode, data is
consistent unless the userland indicated it wants to refresh the data
(by seeking to offset 0, or re-attaching the Inode).
Otherwise, if the data changes, it can cause silent corruption in output
which can lead to random crashes.