### PR TITLE
AK+LibRegex: Disable construction of views from temporary Strings

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -48,6 +48,8 @@ public:
     StringView(const String&);
     StringView(const FlyString&);
 
+    explicit StringView(String&&) = delete;
+
     [[nodiscard]] constexpr bool is_null() const { return !m_characters; }
     [[nodiscard]] constexpr bool is_empty() const { return m_length == 0; }
 

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -58,6 +58,8 @@ public:
     explicit Utf8View(const char*);
     ~Utf8View() = default;
 
+    explicit Utf8View(String&&) = delete;
+
     const StringView& as_string() const { return m_string; }
 
     Utf8CodePointIterator begin() const;

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -54,6 +54,8 @@ public:
     {
     }
 
+    explicit RegexStringView(String&&) = delete;
+
     StringView const& string_view() const
     {
         return m_view.get<StringView>();


### PR DESCRIPTION
The only existing instance of this issue was fixed in #9805. (Suggested by @awesomekling :^)