### PR TITLE
Kernel/VirtIO: Determine VirtIO device class based on PCI device ID

### DIFF
--- a/Kernel/Bus/PCI/IDs.h
+++ b/Kernel/Bus/PCI/IDs.h
@@ -19,6 +19,8 @@ enum VendorID {
 };
 
 enum DeviceID {
+    VirtIONetAdapter = 0x1000,
+    VirtIOBlockDevice = 0x1001,
     VirtIOConsole = 0x1003,
     VirtIOEntropy = 0x1005,
     VirtIOGPU = 0x1050,


### PR DESCRIPTION
According to the VirtIO 1.0 specification:
"Non-transitional devices SHOULD have a PCI Device ID in the range
0x1040 to 0x107f. Non-transitional devices SHOULD have a PCI Revision ID
of 1 or higher. Non-transitional devices SHOULD have a PCI Subsystem
Device ID of 0x40 or higher."

It also says that:
"Transitional devices MUST have a PCI Revision ID of 0. Transitional
devices MUST have the PCI Subsystem Device ID matching the Virtio
Device ID, as indicated in section 5. Transitional devices MUST have the
Transitional PCI Device ID in the range 0x1000 to 0x103f."

So, for legacy devices, we know that revision ID in the PCI header won't
be 1, so we probe for PCI_SUBSYSTEM_ID value.
Instead of using the subsystem device ID, we can probe the DEVICE_ID
value directly in case it's not a legacy device.
This should cover all possibilities for identifying VirtIO devices, both
per the specification of 0.9.5, and future revisions from 1.0 onwards.

Fixes #9780 (I broke this, therefore I need to fix it).