### PR TITLE
AudioApplet: Fix initial mute state

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -219,8 +219,8 @@ int main(int argc, char** argv)
     window->set_window_type(GUI::WindowType::Applet);
 
     auto initial_volume = Config::read_i32("Audio", "Master", "Volume", 100);
-    auto initial_muted = Config::read_bool("Audio", "Master", "Muted", false);
-    window->set_main_widget<AudioWidget>(initial_volume, initial_muted);
+    auto initial_mute = Config::read_bool("Audio", "Master", "Mute", false);
+    window->set_main_widget<AudioWidget>(initial_volume, initial_mute);
     window->show();
 
     // This positioning code depends on the window actually existing.


### PR DESCRIPTION
During conversion from `Core::ConfigFile` to `LibConfig` in c646efaf49e2d79d7cbcabb561c62977f2f084d3, the requested key name has been changed from 'Mute' to 'Muted', resulting in using always the default value.

---

AudioServer saves the value to the `Mute` key right here:
https://github.com/SerenityOS/serenity/blob/e7e2ccc04c8f93ada63815ef4d06470f9dd62fa0/Userland/Services/AudioServer/Mixer.cpp#L141-L147