### PR TITLE
HackStudio: Drop files to the selected editor

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -357,6 +357,7 @@ void Editor::drop_event(GUI::DropEvent& event)
             GUI::MessageBox::show(window(), "HackStudio can only open one file at a time!", "One at a time please!", GUI::MessageBox::Type::Error);
             return;
         }
+        set_current_editor_wrapper(static_cast<EditorWrapper*>(parent()));
         open_file(urls.first().path());
     }
 }


### PR DESCRIPTION
Previously, the files were opened in the current editor, instead of one that received a drop event.