### PR TITLE
AK+Kernel: Move KResult.h to Kernel/API for userspace access

### DIFF
--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -9,7 +9,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>
 #ifdef KERNEL
-#    include <Kernel/KResult.h>
+#    include <Kernel/API/KResult.h>
 #endif
 
 namespace AK {

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -14,9 +14,9 @@
 #include <AK/Traits.h>
 #include <AK/Types.h>
 #ifdef KERNEL
+#    include <Kernel/API/KResult.h>
 #    include <Kernel/Arch/x86/Processor.h>
 #    include <Kernel/Arch/x86/ScopedCritical.h>
-#    include <Kernel/KResult.h>
 #endif
 
 namespace AK {

--- a/Kernel/API/KResult.h
+++ b/Kernel/API/KResult.h
@@ -173,8 +173,12 @@ private:
 
 }
 
+using Kernel::KResult;
+using Kernel::KResultOr;
+using Kernel::KSuccess;
+
 template<>
-struct AK::Formatter<Kernel::KResult> : Formatter<FormatString> {
+struct AK::Formatter<KResult> : Formatter<FormatString> {
     void format(FormatBuilder& builder, Kernel::KResult value)
     {
         if (value.is_error())

--- a/Kernel/Bus/USB/UHCI/UHCIRootHub.h
+++ b/Kernel/Bus/USB/UHCI/UHCIRootHub.h
@@ -8,9 +8,9 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Bus/USB/USBHub.h>
 #include <Kernel/Bus/USB/USBTransfer.h>
-#include <Kernel/KResult.h>
 
 namespace Kernel::USB {
 

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <AK/RefCounted.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Bus/USB/USBDevice.h>
 #include <Kernel/Bus/USB/USBTransfer.h>
-#include <Kernel/KResult.h>
 
 namespace Kernel::USB {
 

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -12,9 +12,9 @@
 #include <AK/RefPtr.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/API/KeyCode.h>
 #include <Kernel/API/MousePacket.h>
-#include <Kernel/KResult.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/UnixTypes.h>
 #include <LibKeyboard/CharacterMap.h>

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -10,9 +10,9 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Heap/SlabAllocator.h>
-#include <Kernel/KResult.h>
 #include <Kernel/KString.h>
 
 namespace Kernel {

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -11,8 +11,8 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Weakable.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Forward.h>
-#include <Kernel/KResult.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/UserOrKernelBuffer.h>
 #include <Kernel/VirtualAddress.h>

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -9,9 +9,9 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/StringView.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/Forward.h>
-#include <Kernel/KResult.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/UserOrKernelBuffer.h>

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "ISO9660FileSystem.h"
-#include "Kernel/FileSystem/BlockBasedFileSystem.h"
 #include <AK/CharacterTypes.h>
 #include <AK/Endian.h>
 #include <AK/HashFunctions.h>
@@ -15,9 +14,9 @@
 #include <AK/StringHash.h>
 #include <AK/StringView.h>
 #include <Kernel/Debug.h>
+#include <Kernel/FileSystem/BlockBasedFileSystem.h>
 #include <Kernel/Forward.h>
 #include <Kernel/KBuffer.h>
-#include <Kernel/KResult.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/UserOrKernelBuffer.h>
 

--- a/Kernel/FileSystem/ISO9660FileSystem.h
+++ b/Kernel/FileSystem/ISO9660FileSystem.h
@@ -12,10 +12,10 @@
 #include <AK/RecursionDecision.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/BlockBasedFileSystem.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/KBuffer.h>
-#include <Kernel/KResult.h>
 
 namespace Kernel {
 

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -12,12 +12,12 @@
 #include <AK/IntrusiveList.h>
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/FIFO.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/FileSystem/InodeMetadata.h>
 #include <Kernel/Forward.h>
-#include <Kernel/KResult.h>
 #include <Kernel/Library/ListedRefCounted.h>
 #include <Kernel/Locking/Mutex.h>
 

--- a/Kernel/FileSystem/InodeMetadata.h
+++ b/Kernel/FileSystem/InodeMetadata.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/Span.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
-#include <Kernel/KResult.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {

--- a/Kernel/FileSystem/SysFSComponent.h
+++ b/Kernel/FileSystem/SysFSComponent.h
@@ -11,11 +11,11 @@
 #include <AK/RefPtr.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/Forward.h>
-#include <Kernel/KResult.h>
 
 namespace Kernel {
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -13,13 +13,13 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/FileSystem/InodeMetadata.h>
 #include <Kernel/FileSystem/Mount.h>
 #include <Kernel/FileSystem/UnveilNode.h>
 #include <Kernel/Forward.h>
-#include <Kernel/KResult.h>
 #include <Kernel/Locking/MutexProtected.h>
 
 namespace Kernel {

--- a/Kernel/Memory/VirtualRange.h
+++ b/Kernel/Memory/VirtualRange.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <Kernel/KResult.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/VirtualAddress.h>
 
 namespace Kernel::Memory {

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -10,8 +10,8 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Time.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/FileSystem/File.h>
-#include <Kernel/KResult.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/UnixTypes.h>

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -10,7 +10,7 @@
 #include <AK/HashMap.h>
 #include <AK/SinglyLinkedList.h>
 #include <AK/WeakPtr.h>
-#include <Kernel/KResult.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Locking/MutexProtected.h>
 #include <Kernel/Net/IPv4Socket.h>
 

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <Kernel/KResult.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Locking/MutexProtected.h>
 #include <Kernel/Net/IPv4Socket.h>
 

--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <Kernel/API/KResult.h>
 #include <Kernel/KBuffer.h>
-#include <Kernel/KResult.h>
 
 namespace Kernel {
 

--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -11,12 +11,12 @@
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Arch/x86/CPU.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/KBufferBuilder.h>
-#include <Kernel/KResult.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -10,7 +10,7 @@
 #include <AK/Forward.h>
 #include <AK/Time.h>
 #include <AK/Userspace.h>
-#include <Kernel/KResult.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/KString.h>
 #include <Kernel/UnixTypes.h>
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -19,12 +19,12 @@
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/Arch/x86/RegisterState.h>
 #include <Kernel/Arch/x86/SafeMem.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/Forward.h>
-#include <Kernel/KResult.h>
 #include <Kernel/KString.h>
 #include <Kernel/Library/ListedRefCounted.h>
 #include <Kernel/Locking/LockLocation.h>

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -11,9 +11,9 @@
 #include <AK/RefPtr.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
+#include <Kernel/API/KResult.h>
 #include <Kernel/API/TimePage.h>
 #include <Kernel/Arch/x86/RegisterState.h>
-#include <Kernel/KResult.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {


### PR DESCRIPTION
This commit moves the KResult and KResultOr objects to Kernel/API to
signify that they may now be freely used by userspace code at points
where a syscall-related error result is to be expected. It also exposes
KResult and KResultOr to the global namespace to make it nicer to use
for userspace code.