### PR TITLE
Solitaire: Fix 3 card draw from reversing after an undo

### DIFF
--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -438,7 +438,7 @@ void Game::draw_cards()
         NonnullRefPtrVector<Card> cards_drawn;
         for (size_t i = 0; (i < cards_to_draw) && !stock.is_empty(); ++i) {
             auto card = stock.pop();
-            cards_drawn.append(card);
+            cards_drawn.prepend(card);
             play.push(move(card));
         }
 


### PR DESCRIPTION
Fixes #9820 