### PR TITLE
PixelPaint: Fix BucketTool out of memory crashes

### DIFF
--- a/Userland/Applications/PixelPaint/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/BucketTool.cpp
@@ -7,6 +7,7 @@
 #include "BucketTool.h"
 #include "ImageEditor.h"
 #include "Layer.h"
+#include <AK/HashTable.h>
 #include <AK/Queue.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
@@ -47,8 +48,12 @@ static void flood_fill(Gfx::Bitmap& bitmap, Gfx::IntPoint const& start_position,
 
     Queue<Gfx::IntPoint> queue;
     queue.enqueue(start_position);
+    HashTable<Gfx::IntPoint> visited;
     while (!queue.is_empty()) {
         auto position = queue.dequeue();
+        if (visited.contains(position))
+            continue;
+        visited.set(position);
 
         auto pixel_color = bitmap.get_pixel<Gfx::StorageFormat::BGRA8888>(position.x(), position.y());
         if (color_distance_squared(pixel_color, target_color) > threshold_normalized_squared)

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -267,3 +267,12 @@ bool encode(Encoder&, Gfx::IntPoint const&);
 bool decode(Decoder&, Gfx::IntPoint&);
 
 }
+
+template<typename T>
+struct AK::Traits<Gfx::Point<T>> : public AK::GenericTraits<Gfx::Point<T>> {
+    static constexpr bool is_trivial() { return false; }
+    static unsigned hash(Gfx::Point<T> const& point)
+    {
+        return pair_int_hash(AK::Traits<T>::hash(point.x()), AK::Traits<T>::hash(point.y()));
+    }
+};


### PR DESCRIPTION
The BFS implementation for BucketTool's flood-fill had sitations
which could result in infinite loop, causing OOM crashes due to
the queue growing unbounded. The way to fix this is to keep track
of the pixels we have already visited in the flood-fill algorithm
and ignore those if we ever encounter them again.

This PR makes `Point<T>` hashable, and then uses a hashtable to
keep track of the visited pixels so far in the flood-fill algorithm.

This also fixes the crashing issue from #9003. We still need a
better way to account for transparency, but that is beyond the scope
of this PR, and this issue still exists without any transparent pixels.
