### PR TITLE
AK+Everywhere: Make (most) ByteBuffer APIs OOM-safe

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -87,7 +87,8 @@ ByteBuffer decode_base64(const StringView& input)
             output.append(out2);
     }
 
-    return ByteBuffer::copy(output.data(), output.size());
+    // FIXME: Handle OOM failure.
+    return ByteBuffer::copy(output).release_value();
 }
 
 String encode_base64(ReadonlyBytes input)

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -20,7 +20,11 @@ Optional<ByteBuffer> decode_hex(const StringView& input)
     if ((input.length() % 2) != 0)
         return {};
 
-    auto output = ByteBuffer::create_zeroed(input.length() / 2);
+    auto output_result = ByteBuffer::create_zeroed(input.length() / 2);
+    if (!output_result.has_value())
+        return {};
+
+    auto& output = output_result.value();
 
     for (size_t i = 0; i < input.length() / 2; ++i) {
         const auto c1 = decode_hex_digit(input[i * 2]);
@@ -34,7 +38,7 @@ Optional<ByteBuffer> decode_hex(const StringView& input)
         output[i] = (c1 << 4) + c2;
     }
 
-    return output;
+    return output_result;
 }
 
 String encode_hex(const ReadonlyBytes input)

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -224,7 +224,7 @@ public:
         size_t nwritten = 0;
         while (bytes.size() - nwritten > 0) {
             if ((m_write_offset + nwritten) % chunk_size == 0)
-                m_chunks.append(ByteBuffer::create_uninitialized(chunk_size));
+                m_chunks.append(ByteBuffer::create_uninitialized(chunk_size).release_value()); // FIXME: Handle possible OOM situation.
 
             nwritten += bytes.slice(nwritten).copy_trimmed_to(m_chunks.last().bytes().slice((m_write_offset + nwritten) % chunk_size));
         }
@@ -241,7 +241,8 @@ public:
 
     ByteBuffer copy_into_contiguous_buffer() const
     {
-        auto buffer = ByteBuffer::create_uninitialized(size());
+        // FIXME: Handle possible OOM situation.
+        auto buffer = ByteBuffer::create_uninitialized(size()).release_value();
 
         const auto nread = read_without_consuming(buffer);
         VERIFY(nread == buffer.size());

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -176,7 +176,8 @@ ByteBuffer String::to_byte_buffer() const
 {
     if (!m_impl)
         return {};
-    return ByteBuffer::copy(reinterpret_cast<const u8*>(characters()), length());
+    // FIXME: Handle OOM failure.
+    return ByteBuffer::copy(bytes()).release_value();
 }
 
 template<typename T>

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -69,7 +69,8 @@ void StringBuilder::appendvf(char const* fmt, va_list ap)
 
 ByteBuffer StringBuilder::to_byte_buffer() const
 {
-    return ByteBuffer::copy(data(), length());
+    // FIXME: Handle OOM failure.
+    return ByteBuffer::copy(data(), length()).release_value();
 }
 
 String StringBuilder::to_string() const

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -64,7 +64,7 @@ public:
     }
 
 private:
-    void will_append(size_t);
+    bool will_append(size_t);
     u8* data() { return m_buffer.data(); }
     u8 const* data() const { return m_buffer.data(); }
 

--- a/Kernel/Coredump.h
+++ b/Kernel/Coredump.h
@@ -29,11 +29,11 @@ private:
     [[nodiscard]] KResult write_regions();
     [[nodiscard]] KResult write_notes_segment(ByteBuffer&);
 
-    ByteBuffer create_notes_segment_data() const;
-    ByteBuffer create_notes_process_data() const;
-    ByteBuffer create_notes_threads_data() const;
-    ByteBuffer create_notes_regions_data() const;
-    ByteBuffer create_notes_metadata_data() const;
+    KResultOr<ByteBuffer> create_notes_segment_data() const;
+    KResultOr<ByteBuffer> create_notes_process_data() const;
+    KResultOr<ByteBuffer> create_notes_threads_data() const;
+    KResultOr<ByteBuffer> create_notes_regions_data() const;
+    KResultOr<ByteBuffer> create_notes_metadata_data() const;
 
     NonnullRefPtr<Process> m_process;
     NonnullRefPtr<FileDescription> m_fd;

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -33,8 +33,12 @@ void NetworkAdapter::send_packet(ReadonlyBytes packet)
 void NetworkAdapter::send(const MACAddress& destination, const ARPPacket& packet)
 {
     size_t size_in_bytes = sizeof(EthernetFrameHeader) + sizeof(ARPPacket);
-    auto buffer = NetworkByteBuffer::create_zeroed(size_in_bytes);
-    auto* eth = (EthernetFrameHeader*)buffer.data();
+    auto buffer_result = NetworkByteBuffer::create_zeroed(size_in_bytes);
+    if (!buffer_result.has_value()) {
+        dbgln("Dropping ARP packet targeted at {} as there is not enough memory to buffer it", packet.target_hardware_address().to_string());
+        return;
+    }
+    auto* eth = (EthernetFrameHeader*)buffer_result->data();
     eth->set_source(mac_address());
     eth->set_destination(destination);
     eth->set_ether_type(EtherType::ARP);

--- a/Kernel/Storage/IDEChannel.cpp
+++ b/Kernel/Storage/IDEChannel.cpp
@@ -379,8 +379,9 @@ UNMAP_AFTER_INIT void IDEChannel::detect_disks()
             }
         }
 
-        ByteBuffer wbuf = ByteBuffer::create_uninitialized(512);
-        ByteBuffer bbuf = ByteBuffer::create_uninitialized(512);
+        // FIXME: Handle possible OOM situation here.
+        ByteBuffer wbuf = ByteBuffer::create_uninitialized(512).release_value();
+        ByteBuffer bbuf = ByteBuffer::create_uninitialized(512).release_value();
         u8* b = bbuf.data();
         u16* w = (u16*)wbuf.data();
 

--- a/Kernel/Storage/Partition/MBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/MBRPartitionTable.cpp
@@ -47,7 +47,7 @@ bool MBRPartitionTable::read_boot_record()
 MBRPartitionTable::MBRPartitionTable(const StorageDevice& device, u32 start_lba)
     : PartitionTable(device)
     , m_start_lba(start_lba)
-    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()))
+    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()).release_value()) // FIXME: Do something sensible if this fails because of OOM.
 {
     if (!read_boot_record() || !initialize())
         return;
@@ -68,7 +68,7 @@ MBRPartitionTable::MBRPartitionTable(const StorageDevice& device, u32 start_lba)
 MBRPartitionTable::MBRPartitionTable(const StorageDevice& device)
     : PartitionTable(device)
     , m_start_lba(0)
-    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()))
+    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()).release_value()) // FIXME: Do something sensible if this fails because of OOM.
 {
     if (!read_boot_record() || contains_ebr() || is_protective_mbr() || !initialize())
         return;

--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto flac_data = ByteBuffer::copy(data, size);
+    auto flac_data = ByteBuffer::copy(data, size).release_value();
     auto flac = make<Audio::FlacLoaderPlugin>(flac_data);
 
     if (!flac->sniff())

--- a/Meta/Lagom/Fuzzers/FuzzIMAPParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzIMAPParser.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto parser = IMAP::Parser();
-    parser.parse(ByteBuffer::copy(data, size), true);
-    parser.parse(ByteBuffer::copy(data, size), false);
+    parser.parse(ByteBuffer::copy(data, size).release_value(), true);
+    parser.parse(ByteBuffer::copy(data, size).release_value(), false);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzMD5.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMD5.cpp
@@ -10,7 +10,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto buffer = ByteBuffer::copy(data, size);
-    Crypto::Hash::MD5::hash(buffer);
+    Crypto::Hash::MD5::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRSAKeyParsing.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRSAKeyParsing.cpp
@@ -10,7 +10,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    ByteBuffer rsa_data = ByteBuffer::copy(data, size);
-    Crypto::PK::RSA::parse_rsa_key(rsa_data);
+    Crypto::PK::RSA::parse_rsa_key({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA1.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA1.cpp
@@ -10,7 +10,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto buffer = ByteBuffer::copy(data, size);
-    Crypto::Hash::SHA1::hash(buffer);
+    Crypto::Hash::SHA1::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA256.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA256.cpp
@@ -10,7 +10,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto buffer = ByteBuffer::copy(data, size);
-    Crypto::Hash::SHA256::hash(buffer);
+    Crypto::Hash::SHA256::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA384.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA384.cpp
@@ -10,7 +10,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto buffer = ByteBuffer::copy(data, size);
-    Crypto::Hash::SHA384::hash(buffer);
+    Crypto::Hash::SHA384::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA512.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA512.cpp
@@ -10,7 +10,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto buffer = ByteBuffer::copy(data, size);
-    Crypto::Hash::SHA512::hash(buffer);
+    Crypto::Hash::SHA512::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -10,7 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto wav_data = ByteBuffer::copy(data, size);
+    auto wav_data = ByteBuffer::copy(data, size).release_value();
     auto wav = make<Audio::WavLoaderPlugin>(wav_data);
 
     if (!wav->sniff())

--- a/Meta/Lagom/Fuzzers/FuzzZip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzZip.cpp
@@ -10,8 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    ByteBuffer zip_data = ByteBuffer::copy(data, size);
-    auto zip_file = Archive::Zip::try_create(zip_data);
+    auto zip_file = Archive::Zip::try_create({ data, size });
     if (!zip_file.has_value())
         return 0;
 

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -206,8 +206,7 @@ int main(int, char**)
         VERIFY(read(REPRL_CRFD, &script_size, 8) == 8);
         VERIFY(script_size < REPRL_MAX_DATA_SIZE);
         ByteBuffer data_buffer;
-        if (data_buffer.size() < script_size)
-            data_buffer.resize(script_size - data_buffer.size());
+        data_buffer.resize(script_size);
         VERIFY(data_buffer.size() >= script_size);
         memcpy(data_buffer.data(), reprl_input, script_size);
 

--- a/Tests/AK/TestByteBuffer.cpp
+++ b/Tests/AK/TestByteBuffer.cpp
@@ -10,10 +10,10 @@
 
 TEST_CASE(equality_operator)
 {
-    ByteBuffer a = ByteBuffer::copy("Hello, world", 7);
-    ByteBuffer b = ByteBuffer::copy("Hello, friend", 7);
+    ByteBuffer a = ByteBuffer::copy("Hello, world", 7).release_value();
+    ByteBuffer b = ByteBuffer::copy("Hello, friend", 7).release_value();
     // `a` and `b` are both "Hello, ".
-    ByteBuffer c = ByteBuffer::copy("asdf", 4);
+    ByteBuffer c = ByteBuffer::copy("asdf", 4).release_value();
     ByteBuffer d;
     EXPECT_EQ(a == a, true);
     EXPECT_EQ(a == b, true);

--- a/Tests/Kernel/stress-writeread.cpp
+++ b/Tests/Kernel/stress-writeread.cpp
@@ -84,7 +84,12 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(target, "Target device/file path", "target");
     args_parser.parse(argc, argv);
 
-    auto buffer = AK::ByteBuffer::create_zeroed(block_size);
+    auto buffer_result = AK::ByteBuffer::create_zeroed(block_size);
+    if (!buffer_result.has_value()) {
+        warnln("Failed to allocate a buffer of {} bytes", block_size);
+        return EXIT_FAILURE;
+    }
+    auto buffer = buffer_result.release_value();
 
     int fd = open(target, O_CREAT | O_RDWR, 0666);
     if (fd < 0) {

--- a/Tests/LibC/TestSnprintf.cpp
+++ b/Tests/LibC/TestSnprintf.cpp
@@ -53,7 +53,7 @@ static bool test_single(const Testcase& testcase)
     }
 
     // Setup
-    ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE);
+    ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE).release_value();
     fill_with_random(actual.data(), actual.size());
     ByteBuffer expected = actual;
     VERIFY(actual.offset_pointer(0) != expected.offset_pointer(0));

--- a/Tests/LibC/TestStrlcpy.cpp
+++ b/Tests/LibC/TestStrlcpy.cpp
@@ -55,7 +55,7 @@ static bool test_single(const Testcase& testcase)
     }
 
     // Setup
-    ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE);
+    ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE).release_value();
     fill_with_random(actual.data(), actual.size());
     ByteBuffer expected = actual;
     VERIFY(actual.offset_pointer(0) != expected.offset_pointer(0));

--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -113,7 +113,7 @@ TEST_CASE(deflate_decompress_zeroes)
 
 TEST_CASE(deflate_round_trip_store)
 {
-    auto original = ByteBuffer::create_uninitialized(1024);
+    auto original = ByteBuffer::create_uninitialized(1024).release_value();
     fill_with_random(original.data(), 1024);
     auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::STORE);
     EXPECT(compressed.has_value());
@@ -124,7 +124,7 @@ TEST_CASE(deflate_round_trip_store)
 
 TEST_CASE(deflate_round_trip_compress)
 {
-    auto original = ByteBuffer::create_zeroed(2048);
+    auto original = ByteBuffer::create_zeroed(2048).release_value();
     fill_with_random(original.data(), 1024); // we pre-filled the second half with 0s to make sure we test back references as well
     // Since the different levels just change how much time is spent looking for better matches, just use fast here to reduce test time
     auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST);
@@ -137,7 +137,7 @@ TEST_CASE(deflate_round_trip_compress)
 TEST_CASE(deflate_round_trip_compress_large)
 {
     auto size = Compress::DeflateCompressor::block_size * 2;
-    auto original = ByteBuffer::create_uninitialized(size); // Compress a buffer larger than the maximum block size to test the sliding window mechanism
+    auto original = ByteBuffer::create_uninitialized(size).release_value(); // Compress a buffer larger than the maximum block size to test the sliding window mechanism
     fill_with_random(original.data(), size);
     // Since the different levels just change how much time is spent looking for better matches, just use fast here to reduce test time
     auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST);

--- a/Tests/LibCompress/TestGzip.cpp
+++ b/Tests/LibCompress/TestGzip.cpp
@@ -87,7 +87,7 @@ TEST_CASE(gzip_decompress_repeat_around_buffer)
 
 TEST_CASE(gzip_round_trip)
 {
-    auto original = ByteBuffer::create_uninitialized(1024);
+    auto original = ByteBuffer::create_uninitialized(1024).release_value();
     fill_with_random(original.data(), 1024);
     auto compressed = Compress::GzipCompressor::compress_all(original);
     EXPECT(compressed.has_value());

--- a/Tests/LibCrypto/TestAES.cpp
+++ b/Tests/LibCrypto/TestAES.cpp
@@ -12,7 +12,7 @@
 
 static ByteBuffer operator""_b(const char* string, size_t length)
 {
-    return ByteBuffer::copy(string, length);
+    return ByteBuffer::copy(string, length).release_value();
 }
 
 TEST_CASE(test_AES_CBC_name)
@@ -23,8 +23,8 @@ TEST_CASE(test_AES_CBC_name)
 
 static auto test_aes_cbc_encrypt = [](auto& cipher, auto& result) {
     auto in = "This is a test! This is another test!"_b;
-    auto out = cipher.create_aligned_buffer(in.size());
-    auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size());
+    auto out = cipher.create_aligned_buffer(in.size()).release_value();
+    auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size()).release_value();
     auto out_span = out.bytes();
     cipher.encrypt(in, out_span, iv);
     EXPECT_EQ(out.size(), sizeof(result));
@@ -84,9 +84,9 @@ TEST_CASE(test_AES_CBC_encrypt_with_unsigned_256bit_key)
 
 static auto test_aes_cbc_decrypt = [](auto& cipher, auto& result, auto result_len) {
     auto true_value = "This is a test! This is another test!";
-    auto in = ByteBuffer::copy(result, result_len);
-    auto out = cipher.create_aligned_buffer(in.size());
-    auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size());
+    auto in = ByteBuffer::copy(result, result_len).release_value();
+    auto out = cipher.create_aligned_buffer(in.size()).release_value();
+    auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size()).release_value();
     auto out_span = out.bytes();
     cipher.decrypt(in, out_span, iv);
     EXPECT_EQ(out_span.size(), strlen(true_value));
@@ -142,7 +142,7 @@ TEST_CASE(test_AES_CTR_name)
 static auto test_aes_ctr_encrypt = [](auto key, auto ivec, auto in, auto out_expected) {
     // nonce is already included in ivec.
     Crypto::Cipher::AESCipher::CTRMode cipher(key, 8 * key.size(), Crypto::Cipher::Intent::Encryption);
-    ByteBuffer out_actual = ByteBuffer::create_zeroed(in.size());
+    ByteBuffer out_actual = ByteBuffer::create_zeroed(in.size()).release_value();
     Bytes out_span = out_actual.bytes();
     cipher.encrypt(in, out_span, ivec);
     EXPECT_EQ(out_expected.size(), out_actual.size());
@@ -309,7 +309,7 @@ TEST_CASE(test_AES_CTR_256bit_encrypt_36bytes_with_high_counter)
 static auto test_aes_ctr_decrypt = [](auto key, auto ivec, auto in, auto out_expected) {
     // nonce is already included in ivec.
     Crypto::Cipher::AESCipher::CTRMode cipher(key, 8 * key.size(), Crypto::Cipher::Intent::Decryption);
-    ByteBuffer out_actual = ByteBuffer::create_zeroed(in.size());
+    ByteBuffer out_actual = ByteBuffer::create_zeroed(in.size()).release_value();
     auto out_span = out_actual.bytes();
     cipher.decrypt(in, out_span, ivec);
     EXPECT_EQ(out_expected.size(), out_span.size());
@@ -347,7 +347,7 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_empty)
     Crypto::Cipher::AESCipher::GCMMode cipher("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, 128, Crypto::Cipher::Intent::Encryption);
     u8 result_tag[] { 0x58, 0xe2, 0xfc, 0xce, 0xfa, 0x7e, 0x30, 0x61, 0x36, 0x7f, 0x1d, 0x57, 0xa4, 0xe7, 0x45, 0x5a };
     Bytes out;
-    auto tag = ByteBuffer::create_uninitialized(16);
+    auto tag = ByteBuffer::create_uninitialized(16).release_value();
     cipher.encrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, tag);
     EXPECT(memcmp(result_tag, tag.data(), tag.size()) == 0);
 }
@@ -357,8 +357,8 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_zeros)
     Crypto::Cipher::AESCipher::GCMMode cipher("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, 128, Crypto::Cipher::Intent::Encryption);
     u8 result_tag[] { 0xab, 0x6e, 0x47, 0xd4, 0x2c, 0xec, 0x13, 0xbd, 0xf5, 0x3a, 0x67, 0xb2, 0x12, 0x57, 0xbd, 0xdf };
     u8 result_ct[] { 0x03, 0x88, 0xda, 0xce, 0x60, 0xb6, 0xa3, 0x92, 0xf3, 0x28, 0xc2, 0xb9, 0x71, 0xb2, 0xfe, 0x78 };
-    auto tag = ByteBuffer::create_uninitialized(16);
-    auto out = ByteBuffer::create_uninitialized(16);
+    auto tag = ByteBuffer::create_uninitialized(16).release_value();
+    auto out = ByteBuffer::create_uninitialized(16).release_value();
     auto out_bytes = out.bytes();
     cipher.encrypt("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, tag);
     EXPECT(memcmp(result_ct, out.data(), out.size()) == 0);
@@ -370,8 +370,8 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_multiple_blocks_with_iv)
     Crypto::Cipher::AESCipher::GCMMode cipher("\xfe\xff\xe9\x92\x86\x65\x73\x1c\x6d\x6a\x8f\x94\x67\x30\x83\x08"_b, 128, Crypto::Cipher::Intent::Encryption);
     u8 result_tag[] { 0x4d, 0x5c, 0x2a, 0xf3, 0x27, 0xcd, 0x64, 0xa6, 0x2c, 0xf3, 0x5a, 0xbd, 0x2b, 0xa6, 0xfa, 0xb4 };
     u8 result_ct[] { 0x42, 0x83, 0x1e, 0xc2, 0x21, 0x77, 0x74, 0x24, 0x4b, 0x72, 0x21, 0xb7, 0x84, 0xd0, 0xd4, 0x9c, 0xe3, 0xaa, 0x21, 0x2f, 0x2c, 0x02, 0xa4, 0xe0, 0x35, 0xc1, 0x7e, 0x23, 0x29, 0xac, 0xa1, 0x2e, 0x21, 0xd5, 0x14, 0xb2, 0x54, 0x66, 0x93, 0x1c, 0x7d, 0x8f, 0x6a, 0x5a, 0xac, 0x84, 0xaa, 0x05, 0x1b, 0xa3, 0x0b, 0x39, 0x6a, 0x0a, 0xac, 0x97, 0x3d, 0x58, 0xe0, 0x91, 0x47, 0x3f, 0x59, 0x85 };
-    auto tag = ByteBuffer::create_uninitialized(16);
-    auto out = ByteBuffer::create_uninitialized(64);
+    auto tag = ByteBuffer::create_uninitialized(16).release_value();
+    auto out = ByteBuffer::create_uninitialized(64).release_value();
     auto out_bytes = out.bytes();
     cipher.encrypt(
         "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b.bytes(),
@@ -388,8 +388,8 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_with_aad)
     Crypto::Cipher::AESCipher::GCMMode cipher("\xfe\xff\xe9\x92\x86\x65\x73\x1c\x6d\x6a\x8f\x94\x67\x30\x83\x08"_b, 128, Crypto::Cipher::Intent::Encryption);
     u8 result_tag[] { 0x4d, 0x5c, 0x2a, 0xf3, 0x27, 0xcd, 0x64, 0xa6, 0x2c, 0xf3, 0x5a, 0xbd, 0x2b, 0xa6, 0xfa, 0xb4 };
     u8 result_ct[] { 0x42, 0x83, 0x1e, 0xc2, 0x21, 0x77, 0x74, 0x24, 0x4b, 0x72, 0x21, 0xb7, 0x84, 0xd0, 0xd4, 0x9c, 0xe3, 0xaa, 0x21, 0x2f, 0x2c, 0x02, 0xa4, 0xe0, 0x35, 0xc1, 0x7e, 0x23, 0x29, 0xac, 0xa1, 0x2e, 0x21, 0xd5, 0x14, 0xb2, 0x54, 0x66, 0x93, 0x1c, 0x7d, 0x8f, 0x6a, 0x5a, 0xac, 0x84, 0xaa, 0x05, 0x1b, 0xa3, 0x0b, 0x39, 0x6a, 0x0a, 0xac, 0x97, 0x3d, 0x58, 0xe0, 0x91, 0x47, 0x3f, 0x59, 0x85 };
-    auto tag = ByteBuffer::create_uninitialized(16);
-    auto out = ByteBuffer::create_uninitialized(64);
+    auto tag = ByteBuffer::create_uninitialized(16).release_value();
+    auto out = ByteBuffer::create_uninitialized(64).release_value();
     auto out_bytes = out.bytes();
     cipher.encrypt(
         "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b.bytes(),
@@ -417,7 +417,7 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_zeros)
     u8 input_tag[] { 0xab, 0x6e, 0x47, 0xd4, 0x2c, 0xec, 0x13, 0xbd, 0xf5, 0x3a, 0x67, 0xb2, 0x12, 0x57, 0xbd, 0xdf };
     u8 input_ct[] { 0x03, 0x88, 0xda, 0xce, 0x60, 0xb6, 0xa3, 0x92, 0xf3, 0x28, 0xc2, 0xb9, 0x71, 0xb2, 0xfe, 0x78 };
     u8 result_pt[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    auto out = ByteBuffer::create_uninitialized(16);
+    auto out = ByteBuffer::create_uninitialized(16).release_value();
     auto out_bytes = out.bytes();
     auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
     EXPECT_EQ(consistency, Crypto::VerificationConsistency::Consistent);
@@ -430,7 +430,7 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_multiple_blocks_with_iv)
     u8 input_tag[] { 0xab, 0x6e, 0x47, 0xd4, 0x2c, 0xec, 0x13, 0xbd, 0xf5, 0x3a, 0x67, 0xb2, 0x12, 0x57, 0xbd, 0xdf };
     u8 input_ct[] { 0x03, 0x88, 0xda, 0xce, 0x60, 0xb6, 0xa3, 0x92, 0xf3, 0x28, 0xc2, 0xb9, 0x71, 0xb2, 0xfe, 0x78 };
     u8 result_pt[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    auto out = ByteBuffer::create_uninitialized(16);
+    auto out = ByteBuffer::create_uninitialized(16).release_value();
     auto out_bytes = out.bytes();
     auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
     EXPECT_EQ(consistency, Crypto::VerificationConsistency::Consistent);
@@ -443,7 +443,7 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_multiple_blocks_with_aad)
     u8 input_tag[] { 0x93, 0xae, 0x16, 0x97, 0x49, 0xa3, 0xbf, 0x39, 0x4f, 0x61, 0xb7, 0xc1, 0xb1, 0x2, 0x4f, 0x60 };
     u8 input_ct[] { 0x42, 0x83, 0x1e, 0xc2, 0x21, 0x77, 0x74, 0x24, 0x4b, 0x72, 0x21, 0xb7, 0x84, 0xd0, 0xd4, 0x9c, 0xe3, 0xaa, 0x21, 0x2f, 0x2c, 0x02, 0xa4, 0xe0, 0x35, 0xc1, 0x7e, 0x23, 0x29, 0xac, 0xa1, 0x2e, 0x21, 0xd5, 0x14, 0xb2, 0x54, 0x66, 0x93, 0x1c, 0x7d, 0x8f, 0x6a, 0x5a, 0xac, 0x84, 0xaa, 0x05, 0x1b, 0xa3, 0x0b, 0x39, 0x6a, 0x0a, 0xac, 0x97, 0x3d, 0x58, 0xe0, 0x91, 0x47, 0x3f, 0x59, 0x85 };
     u8 result_pt[] { 0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5, 0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a, 0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda, 0x2e, 0x4c, 0x30, 0x3d, 0x8a, 0x31, 0x8a, 0x72, 0x1c, 0x3c, 0x0c, 0x95, 0x95, 0x68, 0x09, 0x53, 0x2f, 0xcf, 0x0e, 0x24, 0x49, 0xa6, 0xb5, 0x25, 0xb1, 0x6a, 0xed, 0xf5, 0xaa, 0x0d, 0xe6, 0x57, 0xba, 0x63, 0x7b, 0x39, 0x1a, 0xaf, 0xd2, 0x55 };
-    auto out = ByteBuffer::create_uninitialized(64);
+    auto out = ByteBuffer::create_uninitialized(64).release_value();
     auto out_bytes = out.bytes();
     auto consistency = cipher.decrypt(
         { input_ct, 64 },

--- a/Tests/LibCrypto/TestRSA.cpp
+++ b/Tests/LibCrypto/TestRSA.cpp
@@ -12,7 +12,7 @@
 
 static ByteBuffer operator""_b(const char* string, size_t length)
 {
-    return ByteBuffer::copy(string, length);
+    return ByteBuffer::copy(string, length).release_value();
 }
 
 TEST_CASE(test_RSA_raw_encrypt)

--- a/Tests/LibIMAP/TestQuotedPrintable.cpp
+++ b/Tests/LibIMAP/TestQuotedPrintable.cpp
@@ -17,7 +17,7 @@ TEST_CASE(test_decode)
 
     auto decode_equal_byte_buffer = [](const char* input, const char* expected, size_t expected_length) {
         auto decoded = IMAP::decode_quoted_printable(StringView(input));
-        EXPECT(decoded == ByteBuffer::copy(expected, expected_length));
+        EXPECT(decoded == *ByteBuffer::copy(expected, expected_length));
     };
 
     decode_equal("hello world", "hello world");

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -95,7 +95,10 @@ TEST_CASE(test_TLS_hello_handshake)
             loop.quit(1);
         } else {
             //            print_buffer(data.value(), 16);
-            contents.append(data.value().data(), data.value().size());
+            if (!contents.try_append(data.value().data(), data.value().size())) {
+                FAIL("Allocation failure");
+                loop.quit(1);
+            }
         }
     };
     tls->on_tls_finished = [&] {

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -18,7 +18,7 @@ constexpr const char* DEFAULT_SERVER { "www.google.com" };
 
 static ByteBuffer operator""_b(const char* string, size_t length)
 {
-    return ByteBuffer::copy(string, length);
+    return ByteBuffer::copy(string, length).release_value();
 }
 
 Vector<Certificate> load_certificates();
@@ -69,7 +69,7 @@ TEST_CASE(test_TLS_hello_handshake)
     RefPtr<TLS::TLSv12> tls = TLS::TLSv12::construct(nullptr);
     tls->set_root_certificates(s_root_ca_certificates);
     bool sent_request = false;
-    ByteBuffer contents = ByteBuffer::create_uninitialized(0);
+    ByteBuffer contents;
     tls->on_tls_ready_to_write = [&](TLS::TLSv12& tls) {
         if (sent_request)
             return;

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -65,7 +65,8 @@ static bool handle_disassemble_command(const String& command, void* first_instru
         auto value = g_debug_session->peek(reinterpret_cast<u32*>(first_instruction) + i);
         if (!value.has_value())
             break;
-        code.append(&value, sizeof(u32));
+        if (!code.try_append(&value, sizeof(u32)))
+            break;
     }
 
     X86::SimpleInstructionStream stream(code.data(), code.size());

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -80,8 +80,7 @@ void GlyphEditorWidget::copy_glyph()
     metadata.set("width", String::number(bitmap.width()));
     metadata.set("height", String::number(bitmap.height()));
 
-    auto data = ByteBuffer::copy(&bits[0], bitmap.width() * bitmap.height());
-    GUI::Clipboard::the().set_data(data, "glyph/x-fonteditor", metadata);
+    GUI::Clipboard::the().set_data(ReadonlyBytes(&bits[0], bitmap.width() * bitmap.height()), "glyph/x-fonteditor", metadata);
 }
 
 void GlyphEditorWidget::paste_glyph()

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -75,7 +75,12 @@ HexEditorWidget::HexEditorWidget()
             auto file_size = value.to_int();
             if (file_size.has_value() && file_size.value() > 0) {
                 m_document_dirty = false;
-                m_editor->set_buffer(ByteBuffer::create_zeroed(file_size.value()));
+                auto buffer_result = ByteBuffer::create_zeroed(file_size.value());
+                if (!buffer_result.has_value()) {
+                    GUI::MessageBox::show(window(), "Entered file size is too large.", "Error", GUI::MessageBox::Type::Error);
+                    return;
+                }
+                m_editor->set_buffer(buffer_result.release_value());
                 set_path({});
                 update_title();
             } else {

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -242,8 +242,7 @@ void ViewWidget::load_from_file(const String& path)
     // Spawn a new ImageDecoder service process and connect to it.
     auto client = ImageDecoderClient::Client::construct();
 
-    // FIXME: Find a way to avoid the memory copying here.
-    auto decoded_image_or_error = client->decode_image(ByteBuffer::copy(mapped_file.bytes()));
+    auto decoded_image_or_error = client->decode_image(mapped_file.bytes());
     if (!decoded_image_or_error.has_value()) {
         show_error();
         return;

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -56,7 +56,7 @@ void Image::paint_into(GUI::Painter& painter, Gfx::IntRect const& dest_rect) con
     }
 }
 
-RefPtr<Gfx::Bitmap> Image::try_decode_bitmap(ByteBuffer const& bitmap_data)
+RefPtr<Gfx::Bitmap> Image::try_decode_bitmap(ReadonlyBytes const& bitmap_data)
 {
     // Spawn a new ImageDecoder service process and connect to it.
     auto client = ImageDecoderClient::Client::construct();

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -50,7 +50,7 @@ public:
     static Result<NonnullRefPtr<Image>, String> try_create_from_pixel_paint_json(JsonObject const&);
     static RefPtr<Image> try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap>);
 
-    static RefPtr<Gfx::Bitmap> try_decode_bitmap(const ByteBuffer& bitmap_data);
+    static RefPtr<Gfx::Bitmap> try_decode_bitmap(const ReadonlyBytes& bitmap_data);
 
     // This generates a new Bitmap with the final image (all layers composed according to their attributes.)
     RefPtr<Gfx::Bitmap> try_compose_bitmap(Gfx::BitmapFormat format) const;

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -35,7 +35,7 @@ Result<void, String> ProjectLoader::try_load_from_fd_and_close(int fd, StringVie
 
         auto& mapped_file = *file_or_error.value();
         // FIXME: Find a way to avoid the memory copy here.
-        auto bitmap = Image::try_decode_bitmap(ByteBuffer::copy(mapped_file.bytes()));
+        auto bitmap = Image::try_decode_bitmap(mapped_file.bytes());
         if (!bitmap)
             return String { "Unable to decode image"sv };
         auto image = Image::try_create_from_bitmap(bitmap.release_nonnull());

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -35,7 +35,7 @@ CSVExportDialogPage::CSVExportDialogPage(const Sheet& sheet)
     m_headers.extend(m_data.take_first());
 
     auto temp_template = String::formatted("{}/spreadsheet-csv-export.{}.XXXXXX", Core::StandardPaths::tempfile_directory(), getpid());
-    auto temp_path = ByteBuffer::create_uninitialized(temp_template.length() + 1);
+    auto temp_path = ByteBuffer::create_uninitialized(temp_template.length() + 1).release_value();
     auto buf = reinterpret_cast<char*>(temp_path.data());
     auto copy_ok = temp_template.copy_characters_to_buffer(buf, temp_path.size());
     VERIFY(copy_ok);

--- a/Userland/Applications/Spreadsheet/Readers/Test/TestXSV.cpp
+++ b/Userland/Applications/Spreadsheet/Readers/Test/TestXSV.cpp
@@ -85,7 +85,7 @@ BENCHMARK_CASE(fairly_big_data)
 {
     constexpr auto num_rows = 100000u;
     constexpr auto line = "well,hello,friends,1,2,3,4,5,6,7,8,pizza,guacamole\n"sv;
-    auto buf = ByteBuffer::create_uninitialized((line.length() * num_rows) + 1);
+    auto buf = ByteBuffer::create_uninitialized((line.length() * num_rows) + 1).release_value();
     buf[buf.size() - 1] = '\0';
 
     for (size_t row = 0; row <= num_rows; ++row) {

--- a/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
+++ b/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
@@ -18,7 +18,7 @@ TEST_CASE(can_write)
         { 7, 8, 9 },
     };
 
-    auto buffer = ByteBuffer::create_uninitialized(1024);
+    auto buffer = ByteBuffer::create_uninitialized(1024).release_value();
     OutputMemoryStream stream { buffer };
 
     Writer::CSV csv(stream, data);
@@ -39,7 +39,7 @@ TEST_CASE(can_write_with_header)
         { 7, 8, 9 },
     };
 
-    auto buffer = ByteBuffer::create_uninitialized(1024);
+    auto buffer = ByteBuffer::create_uninitialized(1024).release_value();
     OutputMemoryStream stream { buffer };
 
     Writer::CSV csv(stream, data, { "A", "B\"", "C" });
@@ -60,7 +60,7 @@ TEST_CASE(can_write_with_different_behaviours)
         { "We\"ll", "Hello,", "   Friends" },
     };
 
-    auto buffer = ByteBuffer::create_uninitialized(1024);
+    auto buffer = ByteBuffer::create_uninitialized(1024).release_value();
     OutputMemoryStream stream { buffer };
 
     Writer::CSV csv(stream, data, { "A", "B\"", "C" }, Writer::WriterBehaviour::QuoteOnlyInFieldStart | Writer::WriterBehaviour::WriteHeaders);

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -63,17 +63,17 @@ void SoftMMU::ensure_split_at(X86::LogicalAddress address)
     // a previous page, and that it belongs to the same region.
     auto* old_region = verify_cast<MmapRegion>(m_page_to_region_map[page_index]);
 
-    //dbgln("splitting at {:p}", address.offset());
-    //dbgln("    old region: {:p}-{:p}", old_region->base(), old_region->end() - 1);
+    // dbgln("splitting at {:p}", address.offset());
+    // dbgln("    old region: {:p}-{:p}", old_region->base(), old_region->end() - 1);
 
     NonnullOwnPtr<MmapRegion> new_region = old_region->split_at(VirtualAddress(offset));
-    //dbgln("    new region: {:p}-{:p}", new_region->base(), new_region->end() - 1);
-    //dbgln(" up old region: {:p}-{:p}", old_region->base(), old_region->end() - 1);
+    // dbgln("    new region: {:p}-{:p}", new_region->base(), new_region->end() - 1);
+    // dbgln(" up old region: {:p}-{:p}", old_region->base(), old_region->end() - 1);
 
     size_t first_page_in_region = new_region->base() / PAGE_SIZE;
     size_t last_page_in_region = (new_region->base() + new_region->size() - 1) / PAGE_SIZE;
 
-    //dbgln("  @ remapping pages {} thru {}", first_page_in_region, last_page_in_region);
+    // dbgln("  @ remapping pages {} thru {}", first_page_in_region, last_page_in_region);
 
     for (size_t page = first_page_in_region; page <= last_page_in_region; ++page) {
         VERIFY(m_page_to_region_map[page] == old_region);
@@ -321,7 +321,7 @@ void SoftMMU::copy_from_vm(void* destination, const FlatPtr source, size_t size)
 
 ByteBuffer SoftMMU::copy_buffer_from_vm(const FlatPtr source, size_t size)
 {
-    auto buffer = ByteBuffer::create_uninitialized(size);
+    auto buffer = ByteBuffer::create_uninitialized(size).release_value(); // FIXME: Handle possible OOM situation.
     copy_from_vm(buffer.data(), source, size);
     return buffer;
 }

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -69,7 +69,10 @@ RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_i
         bytes_to_read, m_num_channels, m_sample_rate,
         pcm_bits_per_sample(m_sample_format), sample_format_name(m_sample_format));
 
-    ByteBuffer sample_data = ByteBuffer::create_zeroed(bytes_to_read);
+    auto sample_data_result = ByteBuffer::create_zeroed(bytes_to_read);
+    if (!sample_data_result.has_value())
+        return nullptr;
+    auto sample_data = sample_data_result.release_value();
     m_stream->read_or_error(sample_data.bytes());
     if (m_stream->handle_any_error()) {
         return nullptr;
@@ -244,17 +247,17 @@ bool WavLoaderPlugin::parse_header()
     while (true) {
         search_byte = read_u8();
         CHECK_OK("Reading byte searching for data");
-        if (search_byte != 0x64) //D
+        if (search_byte != 0x64) // D
             continue;
 
         search_byte = read_u8();
         CHECK_OK("Reading next byte searching for data");
-        if (search_byte != 0x61) //A
+        if (search_byte != 0x61) // A
             continue;
 
         u16 search_remaining = read_u16();
         CHECK_OK("Reading remaining bytes searching for data");
-        if (search_remaining != 0x6174) //TA
+        if (search_remaining != 0x6174) // TA
             continue;
 
         data_sz = read_u32();

--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -282,7 +282,7 @@ hostent* gethostbyaddr(const void* addr, socklen_t addr_size, int type)
 
 struct servent* getservent()
 {
-    //If the services file is not open, attempt to open it and return null if it fails.
+    // If the services file is not open, attempt to open it and return null if it fails.
     if (!services_file) {
         services_file = fopen(services_path, "r");
 
@@ -424,7 +424,7 @@ void endservent()
 // false if failure occurs.
 static bool fill_getserv_buffers(const char* line, ssize_t read)
 {
-    //Splitting the line by tab delimiter and filling the servent buffers name, port, and protocol members.
+    // Splitting the line by tab delimiter and filling the servent buffers name, port, and protocol members.
     String string_line = String(line, read);
     string_line.replace(" ", "\t", true);
     auto split_line = string_line.split('\t');
@@ -465,7 +465,8 @@ static bool fill_getserv_buffers(const char* line, ssize_t read)
                 break;
             }
             auto alias = split_line[i].to_byte_buffer();
-            alias.append("\0", sizeof(char));
+            if (!alias.try_append("\0", sizeof(char)))
+                return false;
             __getserv_alias_list_buffer.append(move(alias));
         }
     }
@@ -635,7 +636,8 @@ static bool fill_getproto_buffers(const char* line, ssize_t read)
             if (split_line[i].starts_with('#'))
                 break;
             auto alias = split_line[i].to_byte_buffer();
-            alias.append("\0", sizeof(char));
+            if (!alias.try_append("\0", sizeof(char)))
+                return false;
             __getproto_alias_list_buffer.append(move(alias));
         }
     }

--- a/Userland/Libraries/LibCore/UDPServer.cpp
+++ b/Userland/Libraries/LibCore/UDPServer.cpp
@@ -63,7 +63,8 @@ bool UDPServer::bind(const IPv4Address& address, u16 port)
 
 ByteBuffer UDPServer::receive(size_t size, sockaddr_in& in)
 {
-    auto buf = ByteBuffer::create_uninitialized(size);
+    // FIXME: Handle possible OOM situation.
+    auto buf = ByteBuffer::create_uninitialized(size).release_value();
     socklen_t in_len = sizeof(in);
     ssize_t rlen = ::recvfrom(m_fd, buf.data(), size, 0, (sockaddr*)&in, &in_len);
     if (rlen < 0) {

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -51,9 +51,9 @@ public:
     HashMap<String, String> metadata() const;
 
 private:
-    Reader(ReadonlyBytes);
+    Reader(ByteBuffer);
 
-    static ByteBuffer decompress_coredump(const ReadonlyBytes&);
+    static Optional<ByteBuffer> decompress_coredump(const ReadonlyBytes&);
 
     class NotesEntryIterator {
     public:

--- a/Userland/Libraries/LibCrypto/ASN1/PEM.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/PEM.cpp
@@ -35,7 +35,10 @@ ByteBuffer decode_pem(ReadonlyBytes data)
                 break;
             }
             auto b64decoded = decode_base64(lexer.consume_line().trim_whitespace(TrimMode::Right));
-            decoded.append(b64decoded.data(), b64decoded.size());
+            if (!decoded.try_append(b64decoded.data(), b64decoded.size())) {
+                dbgln("Failed to decode PEM, likely OOM condition");
+                return {};
+            }
             break;
         }
         case Ended:

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
@@ -66,8 +66,14 @@ public:
 
     void encrypt(const ReadonlyBytes& in, Bytes out, const ReadonlyBytes& iv_in, const ReadonlyBytes& aad, Bytes tag)
     {
-        auto iv_buf = ByteBuffer::copy(iv_in.data(), iv_in.size());
-        auto iv = iv_buf.bytes();
+        auto iv_buf_result = ByteBuffer::copy(iv_in);
+        // Not enough memory to figure out :shrug:
+        if (!iv_buf_result.has_value()) {
+            dbgln("GCM::encrypt: Not enough memory to allocate {} bytes for IV", iv_in.size());
+            return;
+        }
+
+        auto iv = iv_buf_result->bytes();
 
         // Increment the IV for block 0
         CTR<T>::increment(iv);
@@ -90,8 +96,12 @@ public:
 
     VerificationConsistency decrypt(ReadonlyBytes in, Bytes out, ReadonlyBytes iv_in, ReadonlyBytes aad, ReadonlyBytes tag)
     {
-        auto iv_buf = ByteBuffer::copy(iv_in.data(), iv_in.size());
-        auto iv = iv_buf.bytes();
+        auto iv_buf_result = ByteBuffer::copy(iv_in);
+        // Not enough memory to figure out :shrug:
+        if (!iv_buf_result.has_value())
+            return VerificationConsistency::Inconsistent;
+
+        auto iv = iv_buf_result->bytes();
 
         // Increment the IV for block 0
         CTR<T>::increment(iv);

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
@@ -26,7 +26,7 @@ public:
 
     const T& cipher() const { return m_cipher; }
 
-    ByteBuffer create_aligned_buffer(size_t input_size) const
+    Optional<ByteBuffer> create_aligned_buffer(size_t input_size) const
     {
         size_t remainder = (input_size + T::block_size()) % T::block_size();
         if (remainder == 0)

--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -83,18 +83,18 @@ public:
 
     Manager()
     {
-        m_pre_init_buffer = ByteBuffer::create_zeroed(0);
+        m_pre_init_buffer = ByteBuffer();
     }
 
     Manager(const Manager& other) // NOT a copy constructor!
     {
-        m_pre_init_buffer = ByteBuffer::create_zeroed(0); // will not be used
+        m_pre_init_buffer = ByteBuffer(); // will not be used
         initialize(other.m_kind);
     }
 
     Manager(HashKind kind)
     {
-        m_pre_init_buffer = ByteBuffer::create_zeroed(0);
+        m_pre_init_buffer = ByteBuffer();
         initialize(kind);
     }
 

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -165,7 +165,7 @@ UnsignedBigInteger random_number(const UnsignedBigInteger& min, const UnsignedBi
     UnsignedBigInteger base;
     auto size = range.trimmed_length() * sizeof(u32) + 2;
     // "+2" is intentional (see below).
-    auto buffer = ByteBuffer::create_uninitialized(size);
+    auto buffer = ByteBuffer::create_uninitialized(size).release_value(); // FIXME: Handle possible OOM situation.
     auto* buf = buffer.data();
 
     fill_with_random(buf, size);

--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
@@ -151,7 +151,10 @@ public:
         for (size_t counter = 0; counter < length / HashFunction::DigestSize - 1; ++counter) {
             hash_fn.update(seed);
             hash_fn.update((u8*)&counter, 4);
-            T.append(hash_fn.digest().data, HashFunction::DigestSize);
+            if (!T.try_append(hash_fn.digest().data, HashFunction::DigestSize)) {
+                dbgln("EMSA_PSS: MGF1 digest failed, not enough space");
+                return;
+            }
         }
         out.overwrite(0, T.data(), length);
     }

--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
@@ -147,7 +147,7 @@ public:
     void MGF1(ReadonlyBytes seed, size_t length, Bytes out)
     {
         auto& hash_fn = this->hasher();
-        ByteBuffer T = ByteBuffer::create_zeroed(0);
+        ByteBuffer T;
         for (size_t counter = 0; counter < length / HashFunction::DigestSize - 1; ++counter) {
             hash_fn.update(seed);
             hash_fn.update((u8*)&counter, 4);

--- a/Userland/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Userland/Libraries/LibCrypto/PK/RSA.cpp
@@ -198,7 +198,12 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         // Now just read it as a PKCS#1 DER.
         auto data = data_result.release_value();
         // FIXME: This is pretty awkward, maybe just generate a zero'd out ByteBuffer from the parser instead?
-        auto padded_data = ByteBuffer::create_zeroed(data.size_in_bytes());
+        auto padded_data_result = ByteBuffer::create_zeroed(data.size_in_bytes());
+        if (!padded_data_result.has_value()) {
+            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 key parse failed: Not enough memory");
+            return keypair;
+        }
+        auto padded_data = padded_data_result.release_value();
         padded_data.overwrite(0, data.data(), data.size_in_bytes());
 
         return parse_rsa_key(padded_data.bytes());

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -169,7 +169,13 @@ static void allocate_tls()
         return;
 
     auto page_aligned_size = align_up_to(s_total_tls_size, PAGE_SIZE);
-    ByteBuffer initial_tls_data = ByteBuffer::create_zeroed(page_aligned_size);
+    auto initial_tls_data_result = ByteBuffer::create_zeroed(page_aligned_size);
+    if (!initial_tls_data_result.has_value()) {
+        dbgln("Failed to allocate initial TLS data");
+        VERIFY_NOT_REACHED();
+    }
+
+    auto& initial_tls_data = initial_tls_data_result.value();
 
     // Initialize TLS data
     for (const auto& entry : s_loaders) {

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -56,9 +56,12 @@ Clipboard::DataAndType Clipboard::data_and_type() const
     if (!response.data().is_valid())
         return {};
     auto data = ByteBuffer::copy(response.data().data<void>(), response.data().size());
+    if (!data.has_value())
+        return {};
+
     auto type = response.mime_type();
     auto metadata = response.metadata().entries();
-    return { data, type, metadata };
+    return { data.release_value(), type, metadata };
 }
 
 RefPtr<Gfx::Bitmap> Clipboard::bitmap() const

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -946,7 +946,12 @@ static bool uncompress_bmp_rle_data(BMPLoadingContext& context, ByteBuffer& buff
         dbgln("Suspiciously large amount of RLE data");
         return false;
     }
-    buffer = ByteBuffer::create_zeroed(buffer_size);
+    auto buffer_result = ByteBuffer::create_zeroed(buffer_size);
+    if (!buffer_result.has_value()) {
+        dbgln("Not enough memory for buffer allocation");
+        return false;
+    }
+    buffer = buffer_result.release_value();
 
     // Avoid as many if statements as possible by pulling out
     // compression-dependent actions into separate lambdas

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -45,7 +45,11 @@ private:
 static ByteBuffer write_pixel_data(const RefPtr<Bitmap> bitmap, int pixel_row_data_size, int bytes_per_pixel, bool include_alpha_channel)
 {
     int image_size = pixel_row_data_size * bitmap->height();
-    auto buffer = ByteBuffer::create_uninitialized(image_size);
+    auto buffer_result = ByteBuffer::create_uninitialized(image_size);
+    if (!buffer_result.has_value())
+        return {};
+
+    auto buffer = buffer_result.release_value();
 
     int current_row = 0;
     for (int y = bitmap->physical_height() - 1; y >= 0; --y) {
@@ -95,7 +99,11 @@ ByteBuffer BMPWriter::dump(const RefPtr<Bitmap> bitmap, DibHeader dib_header)
 
     int pixel_row_data_size = (m_bytes_per_pixel * 8 * bitmap->width() + 31) / 32 * 4;
     int image_size = pixel_row_data_size * bitmap->height();
-    auto buffer = ByteBuffer::create_uninitialized(pixel_data_offset);
+    auto buffer_result = ByteBuffer::create_uninitialized(pixel_data_offset);
+    if (!buffer_result.has_value())
+        return {};
+
+    auto buffer = buffer_result.release_value();
 
     auto pixel_data = write_pixel_data(bitmap, pixel_row_data_size, m_bytes_per_pixel, m_include_alpha_channel);
     pixel_data = compress_pixel_data(pixel_data, m_compression);

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -135,7 +135,8 @@ ByteBuffer BMPWriter::dump(const RefPtr<Bitmap> bitmap, DibHeader dib_header)
         }
     }
 
-    buffer.append(pixel_data.data(), pixel_data.size());
+    if (!buffer.try_append(pixel_data.data(), pixel_data.size()))
+        dbgln("Failed to write {} bytes of pixel data to buffer", pixel_data.size());
     return buffer;
 }
 

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -247,7 +247,8 @@ RefPtr<Bitmap> Bitmap::try_create_from_serialized_byte_buffer(ByteBuffer&& buffe
 
 ByteBuffer Bitmap::serialize_to_byte_buffer() const
 {
-    auto buffer = ByteBuffer::create_uninitialized(sizeof(size_t) + 4 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes());
+    // FIXME: Somehow handle possible OOM situation here.
+    auto buffer = ByteBuffer::create_uninitialized(sizeof(size_t) + 4 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes()).release_value();
     OutputMemoryStream stream { buffer };
 
     auto write = [&]<typename T>(T value) {

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -221,7 +221,8 @@ ByteBuffer PNGWriter::encode(Gfx::Bitmap const& bitmap)
     writer.add_IHDR_chunk(bitmap.width(), bitmap.height(), 8, 6, 0, 0, 0);
     writer.add_IDAT_chunk(bitmap);
     writer.add_IEND_chunk();
-    return ByteBuffer::copy(writer.m_data);
+    // FIXME: Handle OOM failure.
+    return ByteBuffer::copy(writer.m_data).release_value();
 }
 
 }

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -72,9 +72,7 @@ PNGChunk::PNGChunk(String type)
 
 void PNGChunk::store_type()
 {
-    for (auto character : type()) {
-        m_data.append(&character, sizeof(character));
-    }
+    m_data.append(type().bytes());
 }
 
 void PNGChunk::store_data_length()

--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -47,7 +47,6 @@ public:
     void set_method(Method method) { m_method = method; }
 
     ByteBuffer const& body() const { return m_body; }
-    void set_body(ReadonlyBytes body) { m_body = ByteBuffer::copy(body); }
     void set_body(ByteBuffer&& body) { m_body = move(body); }
 
     String method_name() const;

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -231,13 +231,17 @@ protected:
             // Sometimes we might receive a partial message. That's okay, just stash away
             // the unprocessed bytes and we'll prepend them to the next incoming message
             // in the next run of this function.
-            auto remaining_bytes = ByteBuffer::copy(bytes.data() + index, bytes.size() - index);
+            auto remaining_bytes_result = ByteBuffer::copy(bytes.span().slice(index));
+            if (!remaining_bytes_result.has_value()) {
+                dbgln("{}::drain_messages_from_peer: Failed to allocate buffer", *this);
+                return false;
+            }
             if (!m_unprocessed_bytes.is_empty()) {
                 dbgln("{}::drain_messages_from_peer: Already have unprocessed bytes", *this);
                 shutdown();
                 return false;
             }
-            m_unprocessed_bytes = remaining_bytes;
+            m_unprocessed_bytes = remaining_bytes_result.release_value();
         }
 
         if (!m_unprocessed_messages.is_empty()) {

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -110,10 +110,14 @@ bool Decoder::decode(ByteBuffer& value)
         return true;
     }
     if (length == 0) {
-        value = ByteBuffer::create_uninitialized(0);
+        value = {};
         return true;
     }
-    value = ByteBuffer::create_uninitialized(length);
+    if (auto buffer_result = ByteBuffer::create_uninitialized(length); buffer_result.has_value())
+        value = buffer_result.release_value();
+    else
+        return false;
+
     m_stream >> value.bytes();
     return !m_stream.handle_any_error();
 }

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -20,7 +20,7 @@ void Client::die()
         on_death();
 }
 
-Optional<DecodedImage> Client::decode_image(const ByteBuffer& encoded_data)
+Optional<DecodedImage> Client::decode_image(const ReadonlyBytes& encoded_data)
 {
     if (encoded_data.is_empty())
         return {};

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -30,7 +30,7 @@ class Client final
     C_OBJECT(Client);
 
 public:
-    Optional<DecodedImage> decode_image(const ByteBuffer&);
+    Optional<DecodedImage> decode_image(const ReadonlyBytes&);
 
     Function<void()> on_death;
 

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2106,6 +2106,8 @@ Value ArrayExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
     InterpreterNodeScope node_scope { interpreter, *this };
 
     auto* array = Array::create(global_object, 0);
+    array->indexed_properties();
+    size_t index = 0;
     for (auto& element : m_elements) {
         auto value = Value();
         if (element) {
@@ -2115,7 +2117,7 @@ Value ArrayExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
 
             if (is<SpreadExpression>(*element)) {
                 get_iterator_values(global_object, value, [&](Value iterator_value) {
-                    array->indexed_properties().append(iterator_value);
+                    array->indexed_properties().put(index++, iterator_value, default_attributes);
                     return IterationDecision::Continue;
                 });
                 if (interpreter.exception())
@@ -2123,7 +2125,7 @@ Value ArrayExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
                 continue;
             }
         }
-        array->indexed_properties().append(value);
+        array->indexed_properties().put(index++, value, default_attributes);
     }
     return array;
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -11,7 +11,12 @@ namespace JS {
 
 ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, size_t byte_size)
 {
-    return global_object.heap().allocate<ArrayBuffer>(global_object, byte_size, *global_object.array_buffer_prototype());
+    auto buffer = ByteBuffer::create_zeroed(byte_size);
+    if (!buffer.has_value()) {
+        global_object.vm().throw_exception<RangeError>(global_object, ErrorType::NotEnoughMemoryToAllocate, byte_size);
+        return nullptr;
+    }
+    return global_object.heap().allocate<ArrayBuffer>(global_object, buffer.release_value(), *global_object.array_buffer_prototype());
 }
 
 ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer* buffer)
@@ -19,9 +24,9 @@ ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer* buffer
     return global_object.heap().allocate<ArrayBuffer>(global_object, buffer, *global_object.array_buffer_prototype());
 }
 
-ArrayBuffer::ArrayBuffer(size_t byte_size, Object& prototype)
+ArrayBuffer::ArrayBuffer(ByteBuffer buffer, Object& prototype)
     : Object(prototype)
-    , m_buffer(ByteBuffer::create_zeroed(byte_size).release_value()) // FIXME: Handle this possible OOM failure.
+    , m_buffer(move(buffer))
     , m_detach_key(js_undefined())
 {
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -21,7 +21,7 @@ ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, ByteBuffer* buffer
 
 ArrayBuffer::ArrayBuffer(size_t byte_size, Object& prototype)
     : Object(prototype)
-    , m_buffer(ByteBuffer::create_zeroed(byte_size))
+    , m_buffer(ByteBuffer::create_zeroed(byte_size).release_value()) // FIXME: Handle this possible OOM failure.
     , m_detach_key(js_undefined())
 {
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -125,7 +125,7 @@ template<typename T>
 static ByteBuffer numeric_to_raw_bytes(GlobalObject& global_object, Value value, bool is_little_endian)
 {
     using UnderlyingBufferDataType = Conditional<IsSame<ClampedU8, T>, u8, T>;
-    ByteBuffer raw_bytes = ByteBuffer::create_uninitialized(sizeof(UnderlyingBufferDataType));
+    ByteBuffer raw_bytes = ByteBuffer::create_uninitialized(sizeof(UnderlyingBufferDataType)).release_value(); // FIXME: Handle possible OOM situation.
     auto flip_if_needed = [&]() {
         if (is_little_endian)
             return;

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -27,7 +27,7 @@ public:
     static ArrayBuffer* create(GlobalObject&, size_t);
     static ArrayBuffer* create(GlobalObject&, ByteBuffer*);
 
-    ArrayBuffer(size_t, Object& prototype);
+    ArrayBuffer(ByteBuffer buffer, Object& prototype);
     ArrayBuffer(ByteBuffer* buffer, Object& prototype);
     virtual ~ArrayBuffer() override;
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -60,7 +60,11 @@ Value ArrayBufferConstructor::construct(FunctionObject&)
         }
         return {};
     }
-    return ArrayBuffer::create(global_object(), byte_length);
+    auto array_buffer = ArrayBuffer::create(global_object(), byte_length);
+    if (!array_buffer)
+        return {};
+
+    return array_buffer;
 }
 
 // 25.1.4.1 ArrayBuffer.isView ( arg ), https://tc39.es/ecma262/#sec-arraybuffer.isview

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -213,7 +213,8 @@
     M(BadArgCountOne, "{}() needs one argument")                                                                                        \
     M(BadArgCountAtLeastOne, "{}() needs at least one argument")                                                                        \
     M(BadArgCountMany, "{}() needs {} arguments")                                                                                       \
-    M(FixmeAddAnErrorString, "FIXME: Add a string for this error.")
+    M(FixmeAddAnErrorString, "FIXME: Add a string for this error.")                                                                     \
+    M(NotEnoughMemoryToAllocate, "Not enough memory to allocate {} bytes")
 
 namespace JS {
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -182,6 +182,9 @@ static void initialize_typed_array_from_array_like(GlobalObject& global_object, 
     }
     auto byte_length = element_size * length;
     auto array_buffer = ArrayBuffer::create(global_object, byte_length);
+    if (!array_buffer)
+        return;
+
     typed_array.set_viewed_array_buffer(array_buffer);
     typed_array.set_byte_length(byte_length);
     typed_array.set_byte_offset(0);
@@ -215,6 +218,9 @@ static void initialize_typed_array_from_list(GlobalObject& global_object, TypedA
     }
     auto byte_length = element_size * list.size();
     auto array_buffer = ArrayBuffer::create(global_object, byte_length);
+    if (!array_buffer)
+        return;
+
     typed_array.set_viewed_array_buffer(array_buffer);
     typed_array.set_byte_length(byte_length);
     typed_array.set_byte_offset(0);

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -185,7 +185,7 @@ Editor::Editor(Configuration configuration)
     : m_configuration(move(configuration))
 {
     m_always_refresh = m_configuration.refresh_behaviour == Configuration::RefreshBehaviour::Eager;
-    m_pending_chars = ByteBuffer::create_uninitialized(0);
+    m_pending_chars = {};
     get_terminal_size();
     m_suggestion_display = make<XtermSuggestionDisplay>(m_num_lines, m_num_columns);
 }

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -370,7 +370,8 @@ void Editor::insert(const u32 cp)
     StringBuilder builder;
     builder.append(Utf32View(&cp, 1));
     auto str = builder.build();
-    m_pending_chars.append(str.characters(), str.length());
+    if (!m_pending_chars.try_append(str.characters(), str.length()))
+        return;
 
     readjust_anchored_styles(m_cursor, ModificationKind::Insertion);
 

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -44,7 +44,11 @@ Optional<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes const& bytes)
 
     // FIXME: Integrate this padding into AK/Hex?
 
-    auto output = ByteBuffer::create_zeroed(bytes.size() / 2 + 1);
+    auto output_result = ByteBuffer::create_zeroed(bytes.size() / 2 + 1);
+    if (!output_result.has_value())
+        return output_result;
+
+    auto output = output_result.release_value();
 
     for (size_t i = 0; i < bytes.size() / 2; ++i) {
         const auto c1 = decode_hex_digit(static_cast<char>(bytes[i * 2]));
@@ -61,7 +65,7 @@ Optional<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes const& bytes)
     // Process last byte with a padded zero
     output[output.size() - 1] = decode_hex_digit(static_cast<char>(bytes[bytes.size() - 1])) * 16;
 
-    return output;
+    return { move(output) };
 };
 
 Optional<ByteBuffer> Filter::decode_ascii85(ReadonlyBytes const& bytes)

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -263,8 +263,10 @@ bool Parser::initialize_hint_tables()
         auto total_size = primary_size + overflow_size;
 
         possible_merged_stream_buffer = ByteBuffer::create_uninitialized(total_size);
-        possible_merged_stream_buffer.append(primary_hint_stream->bytes());
-        possible_merged_stream_buffer.append(overflow_hint_stream->bytes());
+        auto ok = possible_merged_stream_buffer.try_append(primary_hint_stream->bytes());
+        ok = ok && possible_merged_stream_buffer.try_append(overflow_hint_stream->bytes());
+        if (!ok)
+            return false;
         hint_stream_bytes = possible_merged_stream_buffer.bytes();
     } else {
         hint_stream_bytes = primary_hint_stream->bytes();

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -262,7 +262,10 @@ bool Parser::initialize_hint_tables()
         auto overflow_size = overflow_hint_stream->bytes().size();
         auto total_size = primary_size + overflow_size;
 
-        possible_merged_stream_buffer = ByteBuffer::create_uninitialized(total_size);
+        auto buffer_result = ByteBuffer::create_uninitialized(total_size);
+        if (!buffer_result.has_value())
+            return false;
+        possible_merged_stream_buffer = buffer_result.release_value();
         auto ok = possible_merged_stream_buffer.try_append(primary_hint_stream->bytes());
         ok = ok && possible_merged_stream_buffer.try_append(overflow_hint_stream->bytes());
         if (!ok)

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -22,7 +22,11 @@ RefPtr<Request> RequestClient::start_request(String const& method, URL const& ur
     for (auto& it : request_headers)
         header_dictionary.add(it.key, it.value);
 
-    auto response = IPCProxy::start_request(method, url, header_dictionary, ByteBuffer::copy(request_body));
+    auto body_result = ByteBuffer::copy(request_body);
+    if (!body_result.has_value())
+        return nullptr;
+
+    auto response = IPCProxy::start_request(method, url, header_dictionary, body_result.release_value());
     auto request_id = response.request_id();
     if (request_id < 0 || !response.response_fd().has_value())
         return nullptr;

--- a/Userland/Libraries/LibProtocol/WebSocket.cpp
+++ b/Userland/Libraries/LibProtocol/WebSocket.cpp
@@ -27,7 +27,9 @@ void WebSocket::send(ByteBuffer binary_or_text_message, bool is_text)
 
 void WebSocket::send(StringView text_message)
 {
-    send(ByteBuffer::copy(text_message.bytes()), true);
+    auto data_result = ByteBuffer::copy(text_message.bytes());
+    VERIFY(data_result.has_value());
+    send(data_result.release_value(), true);
 }
 
 void WebSocket::close(u16 code, String reason)

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -75,7 +75,8 @@ bool Heap::write_block(u32 block, ByteBuffer& buffer)
     VERIFY(buffer.size() <= BLOCKSIZE);
     auto sz = buffer.size();
     if (sz < BLOCKSIZE) {
-        buffer.resize(BLOCKSIZE);
+        if (!buffer.try_resize(BLOCKSIZE))
+            return false;
         memset(buffer.offset_pointer((int)sz), 0, BLOCKSIZE - sz);
     }
     dbgln_if(SQL_DEBUG, "{:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -203,7 +203,8 @@ void Heap::update_zero_block()
         }
     }
 
-    auto buffer = ByteBuffer::create_zeroed(BLOCKSIZE);
+    // FIXME: Handle an OOM failure here.
+    auto buffer = ByteBuffer::create_zeroed(BLOCKSIZE).release_value();
     buffer.overwrite(0, FILE_ID, strlen(FILE_ID));
     buffer.overwrite(VERSION_OFFSET, &m_version, sizeof(u32));
     buffer.overwrite(SCHEMAS_ROOT_OFFSET, &m_schemas_root, sizeof(u32));

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -151,7 +151,7 @@ ByteBuffer TLSv12::build_handshake_finished()
 
     u8 out[verify_data_length];
     auto outbuffer = Bytes { out, verify_data_length };
-    auto dummy = ByteBuffer::create_zeroed(0);
+    ByteBuffer dummy;
 
     auto digest = m_context.handshake_hash.digest();
     auto hashbuf = ReadonlyBytes { digest.immutable_data(), m_context.handshake_hash.digest_size() };

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -119,7 +119,10 @@ bool TLSv12::compute_master_secret_from_pre_master_secret(size_t length)
         return false;
     }
 
-    m_context.master_key.resize(length);
+    if (!m_context.master_key.try_resize(length)) {
+        dbgln("Couldn't allocate enough space for the master key :(");
+        return false;
+    }
 
     pseudorandom_function(
         m_context.master_key,

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -240,15 +240,30 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
 {
     auto dh_p_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(3)));
     auto dh_p = buffer.slice(5, dh_p_length);
-    m_context.server_diffie_hellman_params.p = ByteBuffer::copy(dh_p.data(), dh_p.size());
+    auto p_result = ByteBuffer::copy(dh_p);
+    if (!p_result.has_value()) {
+        dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
+        return 0;
+    }
+    m_context.server_diffie_hellman_params.p = p_result.release_value();
 
     auto dh_g_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(5 + dh_p_length)));
     auto dh_g = buffer.slice(7 + dh_p_length, dh_g_length);
-    m_context.server_diffie_hellman_params.g = ByteBuffer::copy(dh_g.data(), dh_g.size());
+    auto g_result = ByteBuffer::copy(dh_g);
+    if (!g_result.has_value()) {
+        dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
+        return 0;
+    }
+    m_context.server_diffie_hellman_params.g = g_result.release_value();
 
     auto dh_Ys_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(7 + dh_p_length + dh_g_length)));
     auto dh_Ys = buffer.slice(9 + dh_p_length + dh_g_length, dh_Ys_length);
-    m_context.server_diffie_hellman_params.Ys = ByteBuffer::copy(dh_Ys.data(), dh_Ys.size());
+    auto Ys_result = ByteBuffer::copy(dh_Ys);
+    if (!Ys_result.has_value()) {
+        dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
+        return 0;
+    }
+    m_context.server_diffie_hellman_params.Ys = Ys_result.release_value();
 
     if constexpr (TLS_DEBUG) {
         dbgln("dh_p: {:hex-dump}", dh_p);

--- a/Userland/Libraries/LibTLS/TLSPacketBuilder.h
+++ b/Userland/Libraries/LibTLS/TLSPacketBuilder.h
@@ -36,7 +36,8 @@ public:
 
     PacketBuilder(MessageType type, Version version, size_t size_hint = 0xfdf)
     {
-        m_packet_data = ByteBuffer::create_uninitialized(size_hint + 16);
+        // FIXME: Handle possible OOM situation.
+        m_packet_data = ByteBuffer::create_uninitialized(size_hint + 16).release_value();
         m_current_length = 5;
         m_packet_data[0] = (u8)type;
         ByteReader::store(m_packet_data.offset_pointer(1), AK::convert_between_host_and_network_endian((u16)version));

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -35,7 +35,7 @@ void TLSv12::consume(ReadonlyBytes record)
 
     dbgln_if(TLS_DEBUG, "Consuming {} bytes", record.size());
 
-    if (!m_context.message_buffer.try_append(record.data(), record.size())) {
+    if (!m_context.message_buffer.try_append(record)) {
         dbgln("Not enough space in message buffer, dropping the record");
         return;
     }
@@ -306,7 +306,7 @@ TLSv12::TLSv12(Core::Object* parent, Options options)
 {
     m_context.options = move(options);
     m_context.is_server = false;
-    m_context.tls_buffer = ByteBuffer::create_uninitialized(0);
+    m_context.tls_buffer = {};
 #ifdef SOCK_NONBLOCK
     int fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
 #else

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -35,7 +35,10 @@ void TLSv12::consume(ReadonlyBytes record)
 
     dbgln_if(TLS_DEBUG, "Consuming {} bytes", record.size());
 
-    m_context.message_buffer.append(record.data(), record.size());
+    if (!m_context.message_buffer.try_append(record.data(), record.size())) {
+        dbgln("Not enough space in message buffer, dropping the record");
+        return;
+    }
 
     size_t index { 0 };
     size_t buffer_length = m_context.message_buffer.size();

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -349,7 +349,8 @@ public:
                 return false;
         }
         auto previous_size = m_size;
-        m_data.resize(new_size);
+        if (!m_data.try_resize(new_size))
+            return false;
         m_size = new_size;
         // The spec requires that we zero out everything on grow
         __builtin_memset(m_data.offset_pointer(previous_size), 0, size_to_grow);

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -744,7 +744,8 @@ ParseResult<CustomSection> CustomSection::parse(InputStream& stream)
         auto size = stream.read({ buf, 16 });
         if (size == 0)
             break;
-        data_buffer.append(buf, size);
+        if (!data_buffer.try_append(buf, size))
+            return with_eof_check(stream, ParseError::HugeAllocationRequested);
     }
 
     return CustomSection(name.release_value(), move(data_buffer));

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -738,7 +738,10 @@ ParseResult<CustomSection> CustomSection::parse(InputStream& stream)
     if (name.is_error())
         return name.error();
 
-    auto data_buffer = ByteBuffer::create_uninitialized(64);
+    ByteBuffer data_buffer;
+    if (!data_buffer.try_resize(64))
+        return ParseError::OutOfMemory;
+
     while (!stream.has_any_error() && !stream.unreliable_eof()) {
         char buf[16];
         auto size = stream.read({ buf, 16 });
@@ -1413,6 +1416,8 @@ String parse_error_to_string(ParseError error)
         return "The parser encountered an unimplemented feature";
     case ParseError::HugeAllocationRequested:
         return "Parsing caused an attempt to allocate a very big chunk of memory, likely malformed data";
+    case ParseError::OutOfMemory:
+        return "The parser hit an OOM condition";
     case ParseError::ExpectedFloatingImmediate:
         return "Expected a floating point immediate";
     case ParseError::ExpectedSignedImmediate:

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -36,6 +36,7 @@ enum class ParseError {
     InvalidTag,
     InvalidType,
     HugeAllocationRequested,
+    OutOfMemory,
     // FIXME: This should not exist!
     NotImplemented,
 };

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -68,7 +68,8 @@ static String mime_type_from_content_type(const String& content_type)
 void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap<String, String, CaseInsensitiveStringTraits>& headers, Optional<u32> status_code)
 {
     VERIFY(!m_loaded);
-    m_encoded_data = ByteBuffer::copy(data);
+    // FIXME: Handle OOM failure.
+    m_encoded_data = ByteBuffer::copy(data).release_value();
     m_response_headers = headers;
     m_status_code = move(status_code);
     m_loaded = true;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -212,7 +212,8 @@ DOM::ExceptionOr<void> XMLHttpRequest::send()
                 if (!weak_this)
                     return;
                 auto& xhr = const_cast<XMLHttpRequest&>(*weak_this);
-                auto response_data = ByteBuffer::copy(data);
+                // FIXME: Handle OOM failure.
+                auto response_data = ByteBuffer::copy(data).release_value();
                 // FIXME: There's currently no difference between transmitted and length.
                 u64 transmitted = response_data.size();
                 u64 length = response_data.size();

--- a/Userland/Libraries/LibWebSocket/Message.h
+++ b/Userland/Libraries/LibWebSocket/Message.h
@@ -15,7 +15,7 @@ class Message {
 public:
     explicit Message(String const& data)
         : m_is_text(true)
-        , m_data(ByteBuffer::copy(data.bytes()))
+        , m_data(ByteBuffer::copy(data.bytes()).release_value()) // FIXME: Handle possible OOM situation.
     {
     }
 

--- a/Userland/Services/DHCPClient/DHCPv4.h
+++ b/Userland/Services/DHCPClient/DHCPv4.h
@@ -239,7 +239,7 @@ private:
 class DHCPv4PacketBuilder {
 public:
     DHCPv4PacketBuilder()
-        : m_buffer(ByteBuffer::create_zeroed(sizeof(DHCPv4Packet)))
+        : m_buffer(ByteBuffer::create_zeroed(sizeof(DHCPv4Packet)).release_value()) // FIXME: Handle possible OOM failure.
     {
         auto* options = peek().options();
         // set the magic DHCP cookie value

--- a/Userland/Services/InspectorServer/InspectableProcess.cpp
+++ b/Userland/Services/InspectorServer/InspectableProcess.cpp
@@ -57,7 +57,10 @@ String InspectableProcess::wait_for_response()
         auto packet = m_socket->read(remaining_bytes);
         if (packet.size() == 0)
             break;
-        data.append(packet.data(), packet.size());
+        if (!data.try_append(packet.data(), packet.size())) {
+            dbgln("Failed to append {} bytes to data buffer", packet.size());
+            break;
+        }
         remaining_bytes -= packet.size();
     }
 

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -69,7 +69,11 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ClientConnection& clie
         request.set_method(HTTP::HttpRequest::Method::GET);
     request.set_url(url);
     request.set_headers(headers);
-    request.set_body(body);
+
+    auto allocated_body_result = ByteBuffer::copy(body);
+    if (!allocated_body_result.has_value())
+        return {};
+    request.set_body(allocated_body_result.release_value());
 
     auto output_stream = make<OutputFileStream>(pipe_result.value().write_fd);
     output_stream->make_unbuffered();

--- a/Userland/Services/SpiceAgent/ClipboardServerConnection.cpp
+++ b/Userland/Services/SpiceAgent/ClipboardServerConnection.cpp
@@ -38,8 +38,8 @@ RefPtr<Gfx::Bitmap> ClipboardServerConnection::get_bitmap()
     if (!format.has_value() || format.value() == 0)
         return nullptr;
 
-    auto data = ByteBuffer::copy(clipping.data().data<void>(), clipping.data().size());
-    auto clipping_bitmap = Gfx::Bitmap::try_create_wrapper((Gfx::BitmapFormat)format.value(), { (int)width.value(), (int)height.value() }, scale.value(), pitch.value(), data.data());
+    auto data = clipping.data().data<void>();
+    auto clipping_bitmap = Gfx::Bitmap::try_create_wrapper((Gfx::BitmapFormat)format.value(), { (int)width.value(), (int)height.value() }, scale.value(), pitch.value(), const_cast<void*>(data));
     auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { (int)width.value(), (int)height.value() }, scale.value());
 
     for (int y = 0; y < clipping_bitmap->physical_height(); ++y) {

--- a/Userland/Services/SpiceAgent/SpiceAgent.cpp
+++ b/Userland/Services/SpiceAgent/SpiceAgent.cpp
@@ -59,7 +59,7 @@ void SpiceAgent::on_message_received()
 {
     ChunkHeader header {};
     read_n(&header, sizeof(header));
-    auto buffer = ByteBuffer::create_uninitialized(header.size);
+    auto buffer = ByteBuffer::create_uninitialized(header.size).release_value(); // FIXME: Handle possible OOM situation.
     read_n(buffer.data(), buffer.size());
     auto* message = reinterpret_cast<Message*>(buffer.data());
     switch (message->type) {
@@ -75,15 +75,17 @@ void SpiceAgent::on_message_received()
         auto* request_message = reinterpret_cast<ClipboardRequest*>(message->data);
         auto clipboard = m_clipboard_connection.get_clipboard_data();
         auto& mime = clipboard.mime_type();
-        ByteBuffer byte_buffer;
+        ByteBuffer backing_byte_buffer;
+        ReadonlyBytes bytes;
         if (mime == "image/x-serenityos") {
             auto bitmap = m_clipboard_connection.get_bitmap();
-            byte_buffer = Gfx::PNGWriter::encode(*bitmap);
+            backing_byte_buffer = Gfx::PNGWriter::encode(*bitmap);
+            bytes = backing_byte_buffer;
         } else {
-            auto clip_data = clipboard.data();
-            byte_buffer = ByteBuffer::copy(clip_data.data<void>(), clip_data.size());
+            auto data = clipboard.data();
+            bytes = { data.data<void>(), data.size() };
         }
-        auto clipboard_buffer = Clipboard::make_buffer((ClipboardType)request_message->type, byte_buffer);
+        auto clipboard_buffer = Clipboard::make_buffer((ClipboardType)request_message->type, bytes);
         send_message(clipboard_buffer);
         break;
     }
@@ -116,7 +118,7 @@ void SpiceAgent::on_message_received()
     case (u32)MessageType::Clipboard: {
         auto* clipboard_message = reinterpret_cast<Clipboard*>(message->data);
         auto type = (ClipboardType)clipboard_message->type;
-        auto data_buffer = ByteBuffer::create_uninitialized(message->size - sizeof(u32));
+        auto data_buffer = ByteBuffer::create_uninitialized(message->size - sizeof(u32)).release_value(); // FIXME: Handle possible OOM situation.
 
         const auto total_bytes = message->size - sizeof(Clipboard);
         auto bytes_copied = header.size - sizeof(Message) - sizeof(Clipboard);
@@ -204,7 +206,7 @@ SpiceAgent::Message* SpiceAgent::initialize_headers(u8* data, size_t additional_
 ByteBuffer SpiceAgent::AnnounceCapabilities::make_buffer(bool request, const Vector<Capability>& capabilities)
 {
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + sizeof(AnnounceCapabilities);
-    auto buffer = ByteBuffer::create_uninitialized(required_size);
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, sizeof(AnnounceCapabilities), MessageType::AnnounceCapabilities);
@@ -226,7 +228,7 @@ ByteBuffer SpiceAgent::ClipboardGrab::make_buffer(const Vector<ClipboardType>& t
     VERIFY(types.size() > 0);
     size_t variable_data_size = sizeof(u32) * types.size();
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + variable_data_size;
-    auto buffer = ByteBuffer::create_uninitialized(required_size);
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, variable_data_size, MessageType::ClipboardGrab);
@@ -244,7 +246,7 @@ ByteBuffer SpiceAgent::Clipboard::make_buffer(ClipboardType type, ReadonlyBytes 
 {
     size_t data_size = sizeof(Clipboard) + contents.size();
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + data_size;
-    auto buffer = ByteBuffer::create_uninitialized(required_size);
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, data_size, MessageType::Clipboard);
@@ -262,7 +264,7 @@ ByteBuffer SpiceAgent::ClipboardRequest::make_buffer(ClipboardType type)
 {
     size_t data_size = sizeof(ClipboardRequest);
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + data_size;
-    auto buffer = ByteBuffer::create_uninitialized(required_size);
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, data_size, MessageType::ClipboardRequest);

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -150,7 +150,7 @@ void Client::send_command(Command command)
 
 void Client::send_commands(Vector<Command> commands)
 {
-    auto buffer = ByteBuffer::create_uninitialized(commands.size() * 3);
+    auto buffer = ByteBuffer::create_uninitialized(commands.size() * 3).release_value(); // FIXME: Handle possible OOM situation.
     OutputMemoryStream stream { buffer };
 
     for (auto& command : commands)

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1999,6 +1999,9 @@ void Shell::possibly_print_error() const
     case ShellError::OpenFailure:
         warnln("Shell: Open failed for {}", m_error_description);
         break;
+    case ShellError::OutOfMemory:
+        warnln("Shell: Hit an OOM situation");
+        break;
     case ShellError::InternalControlFlowBreak:
     case ShellError::InternalControlFlowContinue:
         return;

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -233,6 +233,7 @@ public:
         InvalidGlobError,
         InvalidSliceContentsError,
         OpenFailure,
+        OutOfMemory,
     };
 
     void raise_error(ShellError kind, String description, Optional<AST::Position> position = {})

--- a/Userland/Utilities/disk_benchmark.cpp
+++ b/Userland/Utilities/disk_benchmark.cpp
@@ -95,7 +95,11 @@ int main(int argc, char** argv)
             if (block_size > file_size)
                 continue;
 
-            auto buffer = ByteBuffer::create_uninitialized(block_size);
+            auto buffer_result = ByteBuffer::create_uninitialized(block_size);
+            if (!buffer_result.has_value()) {
+                warnln("Not enough memory to allocate space for block size = {}", block_size);
+                continue;
+            }
             Vector<Result> results;
 
             outln("Running: file_size={} block_size={}", file_size, block_size);
@@ -104,7 +108,7 @@ int main(int argc, char** argv)
             while (timer.elapsed() < time_per_benchmark * 1000) {
                 out(".");
                 fflush(stdout);
-                auto result = benchmark(filename, file_size, block_size, buffer, allow_cache);
+                auto result = benchmark(filename, file_size, block_size, *buffer_result, allow_cache);
                 if (!result.has_value())
                     return 1;
                 results.append(result.release_value());

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -319,7 +319,7 @@ static String get_key_sequence()
 
 static void cat_file(FILE* file)
 {
-    ByteBuffer buffer = ByteBuffer::create_uninitialized(4096);
+    Array<u8, 4096> buffer;
     while (!feof(file)) {
         size_t n = fread(buffer.data(), 1, buffer.size(), file);
         if (n == 0 && ferror(file)) {

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -68,8 +68,7 @@ int main(int argc, char** argv)
                 return 1;
             }
 
-            auto bytes = AK::ByteBuffer::copy(buf, nread);
-            socket->send(bytes.span());
+            socket->send({ buf, static_cast<size_t>(nread) });
         }
     }
 

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -122,7 +122,8 @@ private:
     {
         if (!m_condition()) {
         write_to_buffer:;
-            m_buffer.append(bytes.data(), bytes.size());
+            if (!m_buffer.try_append(bytes.data(), bytes.size()))
+                return 0;
             return bytes.size();
         }
 

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -165,8 +165,9 @@ static void tls(const char* message, size_t len)
             g_loop.quit(0);
         };
     }
-    write.append(message, len);
-    write.append("\r\n", 2);
+    auto ok = write.try_append(message, len);
+    ok = ok && write.try_append("\r\n", 2);
+    VERIFY(ok);
 }
 
 static void aes_cbc(const char* message, size_t len)
@@ -2037,7 +2038,10 @@ static void tls_test_client_hello()
             loop.quit(1);
         } else {
             //            print_buffer(data.value(), 16);
-            contents.append(data.value().data(), data.value().size());
+            if (!contents.try_append(data.value().data(), data.value().size())) {
+                FAIL(Allocation failed);
+                loop.quit(1);
+            }
         }
     };
     tls->on_tls_finished = [&] {


### PR DESCRIPTION
Unfortunately this isn't a very clean split patch, since all the ByteBuffer APIs are tangled together, so there's no simple way to split it up further - sowwy.
The only remaining APIs that cannot fail nicely are:
- `ByteBuffer::slice()` - Ideally this shouldn't even exist
- `ByteBuffer::operator+=` - Cannot fail in a nice way, so I didn't touch it, there aren't many users anyway.

Note that a lot of the users of these APIs (particularly in Userland) have no way of communicating failure, they've been marked with a `FIXME` and currently ignore the failing case.

This also fixes (by necessity) a possible nullptr deref bug in `ByteBuffer::try_ensure_capacity_slowpath()` that was introduced in 966880eb45330bcdfbf4e0d74ad6e11b4782716c when moving from `realloc()` to `malloc()`+copy.
