### PR TITLE
AK+Kernel+Userland+Documentation: Add AK::AssertSize, start documenting patterns

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -475,6 +475,21 @@ using AddRvalueReference = typename __AddReference<T>::RvalueType;
 template<class T>
 requires(IsEnum<T>) using UnderlyingType = __underlying_type(T);
 
+template<typename T, unsigned ExpectedSize, unsigned ActualSize>
+struct __AssertSize : TrueType {
+    static_assert(ActualSize == ExpectedSize,
+        "actual size does not match expected size");
+
+    consteval explicit operator bool() const { return value; }
+};
+
+// Note: This type is useful, as the sizes will be visible in the
+//       compiler error messages, as they will be part of the
+//       template parameters. This is not possible with a
+//       static_assert on the sizeof a type.
+template<typename T, unsigned ExpectedSize>
+using AssertSize = __AssertSize<T, ExpectedSize, sizeof(T)>;
+
 template<typename T>
 inline constexpr bool IsTrivial = __is_trivial(T);
 
@@ -543,6 +558,7 @@ inline constexpr bool IsSpecializationOf<U<Us...>, U> = true;
 using AK::Detail::AddConst;
 using AK::Detail::AddLvalueReference;
 using AK::Detail::AddRvalueReference;
+using AK::Detail::AssertSize;
 using AK::Detail::CommonType;
 using AK::Detail::Conditional;
 using AK::Detail::CopyConst;

--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -1,0 +1,82 @@
+# SerenityOS patterns
+
+## Introduction
+
+Over time numerous reoccurring patterns have emerged from or were adopted by
+the serenity code base. This document aims to track and describe them so they
+can be propagated further and keep the code base consistent. 
+
+## Intrusive Lists
+
+[Intrusive lists](https://www.data-structures-in-practice.com/intrusive-linked-lists/) are common in the Kernel and in some specific cases
+are used in the SerenityOS userland. A data structure is said to be
+"intrusive" when each element holds the metadata that tracks the
+element's membership in the data structure. In the case of a list, this
+means that every element in an intrusive linked list has a node embedded
+inside of it. The main advantage of intrusive
+data structures is you don't need to worry about handling out of memory (OOM)
+on insertion into the data structure. This means error handling code is
+much simpler than say, using a `Vector` in environments that need to be durable
+to OOM.
+
+The common pattern for declaring an intrusive list is to add the storage
+for the intrusive list node as a private member. A public type alias is
+then used to expose the list type to anyone who might need to create it.
+Here is an example from the `Region` class in the Kernel:
+
+```cpp
+class Region final
+    : public Weakable<Region> {
+
+public:
+
+... snip ...
+
+private:
+    bool m_syscall_region : 1 { false };
+
+    IntrusiveListNode<Region> m_memory_manager_list_node;
+    IntrusiveListNode<Region> m_vmobject_list_node;
+
+public:
+    using ListInMemoryManager = IntrusiveList<Region, RawPtr<Region>, &Region::m_memory_manager_list_node>;
+    using ListInVMObject = IntrusiveList<Region, RawPtr<Region>, &Region::m_vmobject_list_node>;
+};
+```
+
+You can then use the list by referencing the public type alias like so:
+
+```cpp
+class MemoryManager {
+
+... snip ...
+
+    Region::ListInMemoryManager m_kernel_regions;
+    Vector<UsedMemoryRange> m_used_memory_ranges;
+    Vector<PhysicalMemoryRange> m_physical_memory_ranges;
+    Vector<ContiguousReservedMemoryRange> m_reserved_memory_ranges;
+};
+```
+
+## Static Assertions of the size of a type
+
+It's a universal pattern to use `static_assert` to validate the size of a
+type matches the author's expectations. Unfortunately when these assertions
+fail they don't give you the values that actually caused the failure. This
+forces one to go investigate by printing out the size, or checking it in a
+debugger, etc. 
+
+For this reason `AK::AssertSize` was added. It exploits the fact that the
+compiler will emit template argument values for compiler errors to provide
+debugging information. Instead of getting no information you'll get the actual
+type sizes in your compiler error output.
+
+Example Usage:
+
+```cpp
+#include <AK/StdLibExtras.h>
+
+struct Empty { };
+
+static_assert(AssertSize<Empty, 1>());
+```

--- a/Kernel/Arch/x86/DescriptorTable.h
+++ b/Kernel/Arch/x86/DescriptorTable.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <Kernel/VirtualAddress.h>
 
@@ -100,7 +101,7 @@ union [[gnu::packed]] Descriptor {
     }
 };
 
-static_assert(sizeof(Descriptor) == 8);
+static_assert(AssertSize<Descriptor, 8>());
 
 enum class IDTEntryType {
     TaskGate32 = 0b0101,
@@ -174,6 +175,6 @@ struct [[gnu::packed]] IDTEntry
 };
 // clang-format on
 
-static_assert(sizeof(IDTEntry) == 2 * sizeof(void*));
+static_assert(AssertSize<IDTEntry, 2 * sizeof(void*)>());
 
 }

--- a/Kernel/Arch/x86/PageDirectory.h
+++ b/Kernel/Arch/x86/PageDirectory.h
@@ -132,8 +132,8 @@ private:
     u64 m_raw;
 };
 
-static_assert(sizeof(PageDirectoryEntry) == 8);
-static_assert(sizeof(PageTableEntry) == 8);
+static_assert(AssertSize<PageDirectoryEntry, 8>());
+static_assert(AssertSize<PageTableEntry, 8>());
 
 class PageDirectoryPointerTable {
 public:

--- a/Kernel/Arch/x86/RegisterState.h
+++ b/Kernel/Arch/x86/RegisterState.h
@@ -121,7 +121,7 @@ struct [[gnu::packed]] RegisterState {
 #else
 #    define REGISTER_STATE_SIZE (22 * 8)
 #endif
-static_assert(REGISTER_STATE_SIZE == sizeof(RegisterState));
+static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
 
 inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, const RegisterState& kernel_regs)
 {

--- a/Kernel/Arch/x86/TrapFrame.h
+++ b/Kernel/Arch/x86/TrapFrame.h
@@ -32,7 +32,7 @@ struct TrapFrame {
 #    define TRAP_FRAME_SIZE (3 * 8)
 #endif
 
-static_assert(TRAP_FRAME_SIZE == sizeof(TrapFrame));
+static_assert(AssertSize<TrapFrame, TRAP_FRAME_SIZE>());
 
 extern "C" void enter_trap_no_irq(TrapFrame* trap) __attribute__((used));
 extern "C" void enter_trap(TrapFrame*) __attribute__((used));

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorTypes.h
@@ -244,7 +244,7 @@ private:
     bool m_in_use;                                   // Has this TD been allocated (and therefore in use)?
 };
 
-static_assert(sizeof(TransferDescriptor) == 32); // Transfer Descriptor is always 8 Dwords
+static_assert(AssertSize<TransferDescriptor, 32>()); // Transfer Descriptor is always 8 Dwords
 
 //
 // Queue Head
@@ -361,5 +361,5 @@ private:
     bool m_in_use { false };                          // Is this QH currently in use?
 };
 
-static_assert(sizeof(QueueHead) == 32); // Queue Head is always 8 Dwords
+static_assert(AssertSize<QueueHead, 32>()); // Queue Head is always 8 Dwords
 }

--- a/Kernel/Bus/USB/USBHub.h
+++ b/Kernel/Bus/USB/USBHub.h
@@ -53,7 +53,7 @@ struct [[gnu::packed]] HubStatus {
     u16 status { 0 };
     u16 change { 0 };
 };
-static_assert(sizeof(HubStatus) == 4);
+static_assert(AssertSize<HubStatus, 4>());
 
 static constexpr u16 HUB_STATUS_LOCAL_POWER_SOURCE = (1 << 0);
 static constexpr u16 HUB_STATUS_OVER_CURRENT = (1 << 1);

--- a/Kernel/Graphics/Definitions.h
+++ b/Kernel/Graphics/Definitions.h
@@ -80,6 +80,6 @@ struct [[gnu::packed]] VideoInfoBlock {
     u8 checksum;
 };
 
-static_assert(sizeof(VideoInfoBlock) == 128);
+static_assert(AssertSize<VideoInfoBlock, 128>());
 
 }

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -102,7 +102,7 @@ private:
     void* m_base { nullptr };
     void* m_end { nullptr };
 
-    static_assert(sizeof(FreeSlab) == templated_slab_size);
+    static_assert(AssertSize<FreeSlab, templated_slab_size>());
 };
 
 static SlabAllocator<16> s_slab_allocator_16;

--- a/Kernel/Locking/LockLocation.h
+++ b/Kernel/Locking/LockLocation.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #if LOCK_DEBUG
 #    include <AK/SourceLocation.h>
 #endif
@@ -25,6 +26,9 @@ using LockLocation = SourceLocation;
 #else
 struct LockLocation {
     static constexpr LockLocation current() { return {}; }
+
+private:
+    constexpr LockLocation() = default;
 };
 #endif
 

--- a/Kernel/Net/ICMP.h
+++ b/Kernel/Net/ICMP.h
@@ -40,7 +40,7 @@ private:
     // NOTE: The rest of the header is 4 bytes
 };
 
-static_assert(sizeof(ICMPHeader) == 4);
+static_assert(AssertSize<ICMPHeader, 4>());
 
 struct [[gnu::packed]] ICMPEchoPacket {
     ICMPHeader header;

--- a/Kernel/Net/IPv4.h
+++ b/Kernel/Net/IPv4.h
@@ -102,7 +102,7 @@ private:
     IPv4Address m_destination;
 };
 
-static_assert(sizeof(IPv4Packet) == 20);
+static_assert(AssertSize<IPv4Packet, 20>());
 
 inline NetworkOrdered<u16> internet_checksum(const void* ptr, size_t count)
 {

--- a/Kernel/Net/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/RTL8168NetworkAdapter.h
@@ -59,7 +59,7 @@ private:
         static constexpr u16 LargeSend = 0x800u;
     };
 
-    static_assert(sizeof(TXDescriptor) == 16u);
+    static_assert(AssertSize<TXDescriptor, 16u>());
 
     struct [[gnu::packed]] RXDescriptor {
         volatile u16 buffer_size; // top 2 bits are reserved
@@ -83,7 +83,7 @@ private:
         static constexpr u16 CRCError = 0x8;
     };
 
-    static_assert(sizeof(RXDescriptor) == 16u);
+    static_assert(AssertSize<RXDescriptor, 16u>());
 
     enum class ChipVersion : u8 {
         Unknown = 0,

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <Kernel/Net/IPv4.h>
 
 namespace Kernel {
@@ -36,7 +37,7 @@ private:
     NetworkOrdered<u16> m_value;
 };
 
-static_assert(sizeof(TCPOptionMSS) == 4);
+static_assert(AssertSize<TCPOptionMSS, 4>());
 
 class [[gnu::packed]] TCPPacket {
 public:
@@ -92,6 +93,6 @@ private:
     NetworkOrdered<u16> m_urgent;
 };
 
-static_assert(sizeof(TCPPacket) == 20);
+static_assert(AssertSize<TCPPacket, 20>());
 
 }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -811,7 +811,7 @@ public:
 // It's not expected that the Process object will expand further because the first
 // page is used for all unprotected values (which should be plenty of space for them).
 // The second page is being used exclusively for write-protected values.
-static_assert(sizeof(Process) == (PAGE_SIZE * 2));
+static_assert(AssertSize<Process, (PAGE_SIZE * 2)>());
 
 extern RecursiveSpinlock g_profiling_lock;
 

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -83,7 +83,7 @@ static_assert(__builtin_offsetof(HPETRegistersBlock, timers[1]) == 0x120);
 // Note: The HPET specification says it reserves the range of byte 0x160 to
 // 0x400 for comparators 3-31, but for implementing all 32 comparators the HPET
 // MMIO space has to be 1280 bytes and not 1024 bytes.
-static_assert(sizeof(HPETRegistersBlock) == 0x500);
+static_assert(AssertSize<HPETRegistersBlock, 0x500>());
 
 static u64 read_register_safe64(const HPETRegister& reg)
 {

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.h
@@ -28,7 +28,7 @@ union MMX {
     i16x4 v16u;
     i32x2 v32u;
 };
-static_assert(sizeof(MMX) == sizeof(u64));
+static_assert(AssertSize<MMX, sizeof(u64)>());
 
 class SoftFPU final {
 public:

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -29,7 +29,7 @@ struct [[gnu::packed]] FontFileHeader {
     u16 unused;
 };
 
-static_assert(sizeof(FontFileHeader) == 80);
+static_assert(AssertSize<FontFileHeader, 80>());
 
 NonnullRefPtr<Font> BitmapFont::clone() const
 {

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -23,7 +23,7 @@ struct ICONDIR {
     u16 must_be_1 = 0;
     u16 image_count = 0;
 };
-static_assert(sizeof(ICONDIR) == 6);
+static_assert(AssertSize<ICONDIR, 6>());
 
 struct ICONDIRENTRY {
     u8 width;
@@ -35,7 +35,7 @@ struct ICONDIRENTRY {
     u32 size;
     u32 offset;
 };
-static_assert(sizeof(ICONDIRENTRY) == 16);
+static_assert(AssertSize<ICONDIRENTRY, 16>());
 
 struct [[gnu::packed]] BMPFILEHEADER {
     u8 signature[2];

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -36,7 +36,7 @@ struct PNG_IHDR {
     u8 interlace_method { 0 };
 };
 
-static_assert(sizeof(PNG_IHDR) == 13);
+static_assert(AssertSize<PNG_IHDR, 13>());
 
 struct Scanline {
     u8 filter { 0 };
@@ -211,7 +211,7 @@ union [[gnu::packed]] Pixel {
         u8 a;
     };
 };
-static_assert(sizeof(Pixel) == 4);
+static_assert(AssertSize<Pixel, 4>());
 
 template<bool has_alpha, u8 filter_type>
 ALWAYS_INLINE static void unfilter_impl(Gfx::Bitmap& bitmap, int y, const void* dummy_scanline_data)

--- a/Userland/Utilities/ntpquery.cpp
+++ b/Userland/Utilities/ntpquery.cpp
@@ -46,7 +46,7 @@ struct [[gnu::packed]] NtpPacket {
     uint8_t version_number() const { return (li_vn_mode >> 3) & 7; }
     uint8_t mode() const { return li_vn_mode & 7; }
 };
-static_assert(sizeof(NtpPacket) == 48);
+static_assert(AssertSize<NtpPacket, 48>());
 
 // NTP measures time in seconds since 1900-01-01, POSIX in seconds since 1970-01-01.
 // 1900 wasn't a leap year, so there are 70/4 leap years between 1900 and 1970.


### PR DESCRIPTION
- **Documentation: Add Patterns.md**

    The purpose of this document is to track and describe the various
    patterns used through the SerenityOS code base.

- **AK: Add AssertSize utility template to provide rich type size assertions**

    This type is useful, as the sizes will be visible in the compiler error
    messages, as they will be part of the template parameters. This is not
    possible with a normal static_assert of the sizeof a type.

- **Kernel: Switch static_asserts of a type size to AK::AssertSize**

    This will provide better debug ability when the size comparison fails.

- **Userland: Switch static_assert of type sizes to AK::AssertSize**



