### PR TITLE
PixelPaint: Add rulers

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -85,21 +85,6 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
         painter.draw_rect(enclosing_int_rect(image_rect_to_editor_rect(m_active_layer->relative_rect())).inflated(2, 2), Color::Black);
     }
 
-    if (m_show_guides) {
-        for (auto& guide : m_guides) {
-            if (guide.orientation() == Guide::Orientation::Horizontal) {
-                int y_coordinate = (int)image_position_to_editor_position({ 0.0f, guide.offset() }).y();
-                painter.draw_line({ 0, y_coordinate }, { rect().width(), y_coordinate }, Color::Cyan, 1, Gfx::Painter::LineStyle::Dashed, Color::LightGray);
-            } else if (guide.orientation() == Guide::Orientation::Vertical) {
-                int x_coordinate = (int)image_position_to_editor_position({ guide.offset(), 0.0f }).x();
-                painter.draw_line({ x_coordinate, 0 }, { x_coordinate, rect().height() }, Color::Cyan, 1, Gfx::Painter::LineStyle::Dashed, Color::LightGray);
-            }
-        }
-    }
-
-    if (!m_selection.is_empty())
-        m_selection.paint(painter);
-
     const float pixel_grid_threshold = 15.0f;
     if (m_show_pixel_grid && m_scale > pixel_grid_threshold) {
         auto grid_rect = m_editor_image_rect.intersected(event.rect());
@@ -117,6 +102,21 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
             painter.draw_line(start_point, end_point, Color::LightGray);
         }
     }
+
+    if (m_show_guides) {
+        for (auto& guide : m_guides) {
+            if (guide.orientation() == Guide::Orientation::Horizontal) {
+                int y_coordinate = (int)image_position_to_editor_position({ 0.0f, guide.offset() }).y();
+                painter.draw_line({ 0, y_coordinate }, { rect().width(), y_coordinate }, Color::Cyan, 1, Gfx::Painter::LineStyle::Dashed, Color::LightGray);
+            } else if (guide.orientation() == Guide::Orientation::Vertical) {
+                int x_coordinate = (int)image_position_to_editor_position({ guide.offset(), 0.0f }).x();
+                painter.draw_line({ x_coordinate, 0 }, { x_coordinate, rect().height() }, Color::Cyan, 1, Gfx::Painter::LineStyle::Dashed, Color::LightGray);
+            }
+        }
+    }
+
+    if (!m_selection.is_empty())
+        m_selection.paint(painter);
 }
 
 Gfx::FloatRect ImageEditor::layer_rect_to_editor_rect(Layer const& layer, Gfx::IntRect const& layer_rect) const

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -130,6 +130,8 @@ private:
     void relayout();
 
     int calculate_ruler_step_size() const;
+    Gfx::IntRect mouse_indicator_rect_x() const;
+    Gfx::IntRect mouse_indicator_rect_y() const;
 
     NonnullRefPtr<Image> m_image;
     RefPtr<Layer> m_active_layer;
@@ -150,8 +152,10 @@ private:
     Gfx::FloatPoint m_pan_origin;
     Gfx::FloatPoint m_saved_pan_origin;
     Gfx::IntPoint m_click_position;
+    Gfx::IntPoint m_mouse_position;
 
     int m_ruler_thickness { 20 };
+    int m_mouse_indicator_triangle_size { 5 };
 
     Gfx::StandardCursor m_active_cursor { Gfx::StandardCursor::None };
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -95,6 +95,10 @@ public:
     void set_guide_visibility(bool show_guides);
     Function<void(bool)> on_set_guide_visibility;
 
+    bool ruler_visibility() { return m_show_rulers; }
+    void set_ruler_visibility(bool);
+    Function<void(bool)> on_set_ruler_visibility;
+
     bool pixel_grid_visibility() const { return m_show_pixel_grid; }
     void set_pixel_grid_visibility(bool show_pixel_grid);
 
@@ -125,12 +129,15 @@ private:
     void clamped_scale(float);
     void relayout();
 
+    int calculate_ruler_step_size() const;
+
     NonnullRefPtr<Image> m_image;
     RefPtr<Layer> m_active_layer;
     OwnPtr<GUI::UndoStack> m_undo_stack;
 
     NonnullRefPtrVector<Guide> m_guides;
     bool m_show_guides { true };
+    bool m_show_rulers { true };
     bool m_show_pixel_grid { true };
 
     Tool* m_active_tool { nullptr };
@@ -143,6 +150,8 @@ private:
     Gfx::FloatPoint m_pan_origin;
     Gfx::FloatPoint m_saved_pan_origin;
     Gfx::IntPoint m_click_position;
+
+    int m_ruler_thickness { 20 };
 
     Gfx::StandardCursor m_active_cursor { Gfx::StandardCursor::None };
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -80,6 +80,7 @@ MainWidget::MainWidget()
             }
         });
         m_show_guides_action->set_checked(image_editor.guide_visibility());
+        m_show_rulers_action->set_checked(image_editor.ruler_visibility());
     };
 }
 
@@ -366,6 +367,15 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         });
     show_pixel_grid_action->set_checked(true);
     view_menu.add_action(*show_pixel_grid_action);
+
+    m_show_rulers_action = GUI::Action::create_checkable(
+        "Show Rulers", { Mod_Ctrl, Key_R }, [&](auto& action) {
+            if (auto* editor = current_image_editor()) {
+                editor->set_ruler_visibility(action.is_checked());
+            }
+        });
+    m_show_rulers_action->set_checked(true);
+    view_menu.add_action(*m_show_rulers_action);
 
     auto& tool_menu = window.add_menu("&Tool");
     m_toolbox->for_each_tool([&](auto& tool) {
@@ -774,6 +784,10 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
 
     image_editor.on_set_guide_visibility = [&](bool show_guides) {
         m_show_guides_action->set_checked(show_guides);
+    };
+
+    image_editor.on_set_ruler_visibility = [&](bool show_rulers) {
+        m_show_rulers_action->set_checked(show_rulers);
     };
 
     // NOTE: We invoke the above hook directly here to make sure the tab title is set up.

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -70,6 +70,7 @@ private:
     RefPtr<GUI::Action> m_reset_zoom_action;
     RefPtr<GUI::Action> m_add_guide_action;
     RefPtr<GUI::Action> m_show_guides_action;
+    RefPtr<GUI::Action> m_show_rulers_action;
 };
 
 }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -668,11 +668,9 @@ void Painter::draw_bitmap(const IntPoint& p, const GlyphBitmap& bitmap, Color co
 
 void Painter::draw_triangle(const IntPoint& a, const IntPoint& b, const IntPoint& c, Color color)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    IntPoint p0(a);
-    IntPoint p1(b);
-    IntPoint p2(c);
+    IntPoint p0(to_physical(a));
+    IntPoint p1(to_physical(b));
+    IntPoint p2(to_physical(c));
 
     // sort points from top to bottom
     if (p0.y() > p1.y())


### PR DESCRIPTION
Adds rulers to PixelPaint.

Would appreciate feedback - especially for these points:
- The ruler system is currently embedded inside the `ImageEditor` widget. It would be nice to be able to switch from pixel based rulers to percent based rulers via a right-click menu, but then it would need to be a separate widget. Should I refactor it to a `Ruler` class?
- Colors - Any palette colors that would be preferred?
- Is the translation + scale applied correctly in `Painter::draw_triangle`?

![image](https://user-images.githubusercontent.com/13297896/132138774-16e5f6b3-b344-4399-baa8-f0bef9e13195.png)

Closes #9827