### PR TITLE
Kernel: Make all Spinlocks use u8 for storage, remove template

### DIFF
--- a/Documentation/Kernel/AHCILocking.md
+++ b/Documentation/Kernel/AHCILocking.md
@@ -18,7 +18,7 @@ return true;
 
 This lock doesn't disable interrupts at all, and if it is already in use, the scheduler will simply yield away from that section until it tries to lock it again.
 
-### Hard lock - `SpinLock<u8>`
+### Hard lock - `Spinlock`
 
 A hard lock is essentially a lock that is used in critical sections in the kernel. We use it with a `ScopedSpinLock` class, to create a scoped locking of that lock:
 

--- a/Kernel/Bus/PCI/MMIOAccess.h
+++ b/Kernel/Bus/PCI/MMIOAccess.h
@@ -44,7 +44,7 @@ private:
     PhysicalAddress determine_memory_mapped_bus_region(u32 segment, u8 bus) const;
     void map_bus_region(u32, u8);
     VirtualAddress get_device_configuration_space(Address address);
-    Spinlock<u8> m_access_lock;
+    Spinlock m_access_lock;
     u8 m_mapped_bus { 0 };
     OwnPtr<Memory::Region> m_mapped_region;
 

--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -55,7 +55,7 @@ private:
     RefPtr<SysFSUSBDeviceInformation> device_node_for(USB::Device& device);
 
     IntrusiveList<SysFSUSBDeviceInformation, RefPtr<SysFSUSBDeviceInformation>, &SysFSUSBDeviceInformation::m_list_node> m_device_nodes;
-    mutable Spinlock<u8> m_lock;
+    mutable Spinlock m_lock;
 };
 
 }

--- a/Kernel/Bus/VirtIO/Queue.h
+++ b/Kernel/Bus/VirtIO/Queue.h
@@ -47,7 +47,7 @@ public:
     QueueChain pop_used_buffer_chain(size_t& used);
     void discard_used_buffers();
 
-    Spinlock<u8>& lock() { return m_lock; }
+    Spinlock& lock() { return m_lock; }
 
     bool should_notify() const;
 
@@ -94,7 +94,7 @@ private:
     OwnPtr<QueueDriver> m_driver { nullptr };
     OwnPtr<QueueDevice> m_device { nullptr };
     OwnPtr<Memory::Region> m_queue_region;
-    Spinlock<u8> m_lock;
+    Spinlock m_lock;
 
     friend class QueueChain;
 };

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -61,7 +61,7 @@ public:
 
     [[nodiscard]] RequestWaitResult wait(Time* = nullptr);
 
-    void do_start(SpinlockLocker<Spinlock<u8>>&& requests_lock)
+    void do_start(SpinlockLocker<Spinlock>&& requests_lock)
     {
         if (is_completed_result(m_result))
             return;
@@ -150,7 +150,7 @@ private:
     WaitQueue m_queue;
     NonnullRefPtr<Process> m_process;
     void* m_private { nullptr };
-    mutable Spinlock<u8> m_lock;
+    mutable Spinlock m_lock;
 };
 
 }

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -72,7 +72,7 @@ private:
     UserID m_uid { 0 };
     GroupID m_gid { 0 };
 
-    Spinlock<u8> m_requests_lock;
+    Spinlock m_requests_lock;
     DoublyLinkedList<RefPtr<AsyncDeviceRequest>> m_requests;
 };
 

--- a/Kernel/Devices/HID/I8042Controller.h
+++ b/Kernel/Devices/HID/I8042Controller.h
@@ -105,7 +105,7 @@ private:
     void do_wait_then_write(u8 port, u8 data);
     u8 do_wait_then_read(u8 port);
 
-    Spinlock<u8> m_lock;
+    Spinlock m_lock;
     bool m_first_port_available { false };
     bool m_second_port_available { false };
     bool m_is_dual_channel { false };

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -51,7 +51,7 @@ public:
 
 protected:
     KeyboardDevice();
-    mutable Spinlock<u8> m_queue_lock;
+    mutable Spinlock m_queue_lock;
     CircularQueue<Event, 16> m_queue;
     // ^CharacterDevice
     virtual StringView class_name() const override { return "KeyboardDevice"; }

--- a/Kernel/Devices/HID/MouseDevice.h
+++ b/Kernel/Devices/HID/MouseDevice.h
@@ -41,7 +41,7 @@ protected:
     // ^CharacterDevice
     virtual StringView class_name() const override { return "MouseDevice"; }
 
-    mutable Spinlock<u8> m_queue_lock;
+    mutable Spinlock m_queue_lock;
     CircularQueue<MousePacket, 100> m_queue;
 };
 

--- a/Kernel/Devices/KCOVInstance.h
+++ b/Kernel/Devices/KCOVInstance.h
@@ -35,7 +35,7 @@ public:
     bool has_buffer() const { return m_buffer != nullptr; }
     void buffer_add_pc(u64 pc);
 
-    Spinlock<u8> lock;
+    Spinlock lock;
     enum {
         UNUSED = 0,
         OPENED = 1,

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -133,7 +133,7 @@ private:
     bool m_break_enable { false };
     u8 m_modem_control { 0 };
     bool m_last_put_char_was_carriage_return { false };
-    Spinlock<u8> m_serial_lock;
+    Spinlock m_serial_lock;
 };
 
 }

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -66,11 +66,11 @@ private:
 
     private:
         Plan9FS& m_fs;
-        mutable Spinlock<u8> m_lock;
+        mutable Spinlock m_lock;
     };
 
     struct ReceiveCompletion : public RefCounted<ReceiveCompletion> {
-        mutable Spinlock<u8> lock;
+        mutable Spinlock lock;
         bool completed { false };
         const u16 tag;
         OwnPtr<Message> message;
@@ -139,7 +139,7 @@ private:
     Plan9FSBlockerSet m_completion_blocker;
     HashMap<u16, NonnullRefPtr<ReceiveCompletion>> m_completions;
 
-    Spinlock<u8> m_thread_lock;
+    Spinlock m_thread_lock;
     RefPtr<Thread> m_thread;
     Atomic<bool> m_thread_running { false };
     Atomic<bool, AK::MemoryOrder::memory_order_relaxed> m_thread_shutdown { false };

--- a/Kernel/FileSystem/SysFSComponent.cpp
+++ b/Kernel/FileSystem/SysFSComponent.cpp
@@ -9,7 +9,7 @@
 
 namespace Kernel {
 
-static Spinlock<u8> s_index_lock;
+static Spinlock s_index_lock;
 static InodeIndex s_next_inode_index { 0 };
 
 static size_t allocate_inode_index()

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -84,7 +84,6 @@ class VirtualRange;
 class VirtualRangeAllocator;
 }
 
-template<typename BaseType>
 class Spinlock;
 template<typename LockType>
 class SpinlockLocker;

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -60,7 +60,7 @@ private:
     Memory::TypedMapping<BochsDisplayMMIORegisters volatile> m_registers;
     RefPtr<FramebufferDevice> m_framebuffer_device;
     RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
-    Spinlock<u8> m_console_mode_switch_lock;
+    Spinlock m_console_mode_switch_lock;
     bool m_console_enabled { false };
     bool m_io_required { false };
 };

--- a/Kernel/Graphics/Console/GenericFramebufferConsole.h
+++ b/Kernel/Graphics/Console/GenericFramebufferConsole.h
@@ -47,6 +47,6 @@ protected:
     virtual u8* framebuffer_data() = 0;
     void clear_glyph(size_t x, size_t y);
     size_t m_pitch;
-    mutable Spinlock<u8> m_lock;
+    mutable Spinlock m_lock;
 };
 }

--- a/Kernel/Graphics/Console/TextModeConsole.h
+++ b/Kernel/Graphics/Console/TextModeConsole.h
@@ -39,7 +39,7 @@ private:
 
     explicit TextModeConsole(const VGACompatibleAdapter&);
 
-    mutable Spinlock<u8> m_vga_lock;
+    mutable Spinlock m_vga_lock;
     u16 m_vga_start_row { 0 };
     u16 m_current_vga_start_address { 0 };
     u8* m_current_vga_window { nullptr };

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -53,7 +53,7 @@ private:
     size_t m_framebuffer_width { 0 };
     size_t m_framebuffer_height { 0 };
 
-    Spinlock<u8> m_activation_lock;
+    Spinlock m_activation_lock;
 
     RefPtr<Memory::AnonymousVMObject> m_real_framebuffer_vmobject;
     RefPtr<Memory::AnonymousVMObject> m_swapped_framebuffer_vmobject;

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -40,7 +40,7 @@ public:
     bool framebuffer_devices_allowed() const { return m_framebuffer_devices_allowed; }
     bool framebuffer_devices_exist() const;
 
-    Spinlock<u8>& main_vga_lock() { return m_main_vga_lock; }
+    Spinlock& main_vga_lock() { return m_main_vga_lock; }
     RefPtr<Graphics::Console> console() const { return m_console; }
 
     void deactivate_graphical_mode();
@@ -56,7 +56,7 @@ private:
     unsigned m_current_minor_number { 0 };
     const bool m_framebuffer_devices_allowed;
 
-    Spinlock<u8> m_main_vga_lock;
+    Spinlock m_main_vga_lock;
 };
 
 }

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -161,9 +161,9 @@ private:
 
     Optional<PLLSettings> create_pll_settings(u64 target_frequency, u64 reference_clock, const PLLMaxSettings&);
 
-    Spinlock<u8> m_control_lock;
-    Spinlock<u8> m_modeset_lock;
-    mutable Spinlock<u8> m_registers_lock;
+    Spinlock m_control_lock;
+    Spinlock m_modeset_lock;
+    mutable Spinlock m_registers_lock;
 
     Graphics::VideoInfoBlock m_crt_edid;
     const PhysicalAddress m_registers;

--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -200,7 +200,7 @@ void Mutex::unlock()
     }
 }
 
-void Mutex::block(Thread& current_thread, Mode mode, SpinlockLocker<Spinlock<u8>>& lock, u32 requested_locks)
+void Mutex::block(Thread& current_thread, Mode mode, SpinlockLocker<Spinlock>& lock, u32 requested_locks)
 {
     if constexpr (LOCK_IN_CRITICAL_DEBUG)
         VERIFY_INTERRUPTS_ENABLED();

--- a/Kernel/Locking/Mutex.h
+++ b/Kernel/Locking/Mutex.h
@@ -77,7 +77,7 @@ private:
         return mode == Mode::Exclusive ? m_blocked_threads_list_exclusive : m_blocked_threads_list_shared;
     }
 
-    void block(Thread&, Mode, SpinlockLocker<Spinlock<u8>>&, u32);
+    void block(Thread&, Mode, SpinlockLocker<Spinlock>&, u32);
     void unblock_waiters(Mode);
 
     StringView m_name;
@@ -98,7 +98,7 @@ private:
     BlockedThreadList m_blocked_threads_list_exclusive;
     BlockedThreadList m_blocked_threads_list_shared;
 
-    mutable Spinlock<u8> m_lock;
+    mutable Spinlock m_lock;
 };
 
 class MutexLocker {

--- a/Kernel/Locking/Spinlock.h
+++ b/Kernel/Locking/Spinlock.h
@@ -13,7 +13,6 @@
 
 namespace Kernel {
 
-template<typename BaseType = u32>
 class Spinlock {
     AK_MAKE_NONCOPYABLE(Spinlock);
     AK_MAKE_NONMOVABLE(Spinlock);
@@ -54,7 +53,7 @@ public:
     }
 
 private:
-    Atomic<BaseType> m_lock { 0 };
+    Atomic<u8> m_lock { 0 };
 };
 
 class RecursiveSpinlock {

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -76,7 +76,7 @@ private:
         void uncommit_one();
 
     public:
-        Spinlock<u8> m_lock;
+        Spinlock m_lock;
         CommittedPhysicalPageSet m_committed_pages;
     };
 

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -93,7 +93,7 @@ struct PhysicalMemoryRange {
 struct MemoryManagerData {
     static ProcessorSpecificDataID processor_specific_data_id() { return ProcessorSpecificDataID::MemoryManager; }
 
-    Spinlock<u8> m_quickmap_in_use;
+    Spinlock m_quickmap_in_use;
     u32 m_quickmap_prev_flags;
 
     PhysicalAddress m_last_quickmap_pd;

--- a/Kernel/Memory/RingBuffer.h
+++ b/Kernel/Memory/RingBuffer.h
@@ -23,7 +23,7 @@ public:
     void reclaim_space(PhysicalAddress chunk_start, size_t chunk_size);
     PhysicalAddress start_of_used() const;
 
-    Spinlock<u8>& lock() { return m_lock; }
+    Spinlock& lock() { return m_lock; }
     size_t used_bytes() const { return m_num_used_bytes; }
     PhysicalAddress start_of_region() const { return m_region->physical_page(0)->paddr(); }
     VirtualAddress vaddr() const { return m_region->vaddr(); }
@@ -31,7 +31,7 @@ public:
 
 private:
     OwnPtr<Memory::Region> m_region;
-    Spinlock<u8> m_lock;
+    Spinlock m_lock;
     size_t m_start_of_used {};
     size_t m_num_used_bytes {};
     size_t m_capacity_in_bytes {};

--- a/Kernel/Memory/VirtualRangeAllocator.h
+++ b/Kernel/Memory/VirtualRangeAllocator.h
@@ -35,7 +35,7 @@ private:
 
     RedBlackTree<FlatPtr, VirtualRange> m_available_ranges;
     VirtualRange m_total_range;
-    mutable Spinlock<u8> m_lock;
+    mutable Spinlock m_lock;
 };
 
 }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -679,7 +679,7 @@ public:
     private:
         FileDescriptions() = default;
         static constexpr size_t m_max_open_file_descriptors { FD_SETSIZE };
-        mutable Spinlock<u8> m_fds_lock;
+        mutable Spinlock m_fds_lock;
         Vector<FileDescriptionAndFlags> m_fds_metadatas;
     };
 
@@ -780,7 +780,7 @@ private:
     OwnPtr<PerformanceEventBuffer> m_perf_event_buffer;
 
     FutexQueues m_futex_queues;
-    Spinlock<u8> m_futex_lock;
+    Spinlock m_futex_lock;
 
     // This member is used in the implementation of ptrace's PT_TRACEME flag.
     // If it is set to true, the process will stop at the next execve syscall

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -15,7 +15,7 @@
 
 namespace Kernel {
 
-static Spinlock<u8> s_index_lock;
+static Spinlock s_index_lock;
 static InodeIndex s_next_inode_index = 0;
 
 namespace SegmentedProcFSIndex {

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -81,7 +81,7 @@ public:
         return is_seeded() || m_p0_len >= reseed_threshold;
     }
 
-    Spinlock<u8>& get_lock() { return m_lock; }
+    Spinlock& get_lock() { return m_lock; }
 
 private:
     void reseed()
@@ -107,7 +107,7 @@ private:
     size_t m_p0_len { 0 };
     ByteBuffer m_key;
     HashType m_pools[pool_count];
-    Spinlock<u8> m_lock;
+    Spinlock m_lock;
 };
 
 class KernelRng : public Lockable<FortunaPRNG<Crypto::Cipher::AESCipher, Crypto::Hash::SHA256, 256>> {
@@ -121,7 +121,7 @@ public:
 
     void wake_if_ready();
 
-    Spinlock<u8>& get_lock() { return resource().get_lock(); }
+    Spinlock& get_lock() { return resource().get_lock(); }
 
 private:
     WaitQueue m_seed_queue;

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -238,7 +238,7 @@ bool AHCIPort::initialize_without_reset()
     return initialize(lock);
 }
 
-bool AHCIPort::initialize(SpinlockLocker<Spinlock<u8>>& main_lock)
+bool AHCIPort::initialize(SpinlockLocker<Spinlock>& main_lock)
 {
     VERIFY(m_lock.is_locked());
     dbgln_if(AHCI_DEBUG, "AHCI Port {}: Initialization. Signature = {:#08x}", representative_port_index(), static_cast<u32>(m_port_registers.sig));
@@ -591,7 +591,7 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
     return true;
 }
 
-bool AHCIPort::identify_device(SpinlockLocker<Spinlock<u8>>& main_lock)
+bool AHCIPort::identify_device(SpinlockLocker<Spinlock>& main_lock)
 {
     VERIFY(m_lock.is_locked());
     VERIFY(is_operable());
@@ -740,7 +740,7 @@ void AHCIPort::stop_fis_receiving() const
     m_port_registers.cmd = m_port_registers.cmd & 0xFFFFFFEF;
 }
 
-bool AHCIPort::initiate_sata_reset(SpinlockLocker<Spinlock<u8>>& main_lock)
+bool AHCIPort::initiate_sata_reset(SpinlockLocker<Spinlock>& main_lock)
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());

--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -51,7 +51,7 @@ public:
 
 private:
     bool is_phy_enabled() const { return (m_port_registers.ssts & 0xf) == 3; }
-    bool initialize(SpinlockLocker<Spinlock<u8>>&);
+    bool initialize(SpinlockLocker<Spinlock>&);
 
     UNMAP_AFTER_INIT AHCIPort(const AHCIPortHandler&, volatile AHCI::PortRegisters&, u32 port_index);
 
@@ -62,7 +62,7 @@ private:
     const char* try_disambiguate_sata_status();
     void try_disambiguate_sata_error();
 
-    bool initiate_sata_reset(SpinlockLocker<Spinlock<u8>>&);
+    bool initiate_sata_reset(SpinlockLocker<Spinlock>&);
     void rebase();
     void recover_from_fatal_error();
     bool shutdown();
@@ -79,7 +79,7 @@ private:
 
     bool spin_until_ready() const;
 
-    bool identify_device(SpinlockLocker<Spinlock<u8>>&);
+    bool identify_device(SpinlockLocker<Spinlock>&);
 
     ALWAYS_INLINE void start_command_list_processing() const;
     ALWAYS_INLINE void mark_command_header_ready_to_process(u8 command_header_index) const;
@@ -101,7 +101,7 @@ private:
 
     EntropySource m_entropy_source;
     RefPtr<AsyncBlockDeviceRequest> m_current_request;
-    Spinlock<u8> m_hard_lock;
+    Spinlock m_hard_lock;
     Mutex m_lock { "AHCIPort" };
 
     mutable bool m_wait_for_completion { false };

--- a/Kernel/Storage/IDEChannel.h
+++ b/Kernel/Storage/IDEChannel.h
@@ -157,7 +157,7 @@ protected:
     RefPtr<AsyncBlockDeviceRequest> m_current_request;
     u64 m_current_request_block_index { 0 };
     bool m_current_request_flushing_cache { false };
-    Spinlock<u8> m_request_lock;
+    Spinlock m_request_lock;
     Mutex m_lock { "IDEChannel" };
 
     IOAddressGroup m_io_group;

--- a/Kernel/TTY/ConsoleManagement.h
+++ b/Kernel/TTY/ConsoleManagement.h
@@ -40,7 +40,7 @@ public:
 private:
     NonnullRefPtrVector<VirtualConsole, s_max_virtual_consoles> m_consoles;
     VirtualConsole* m_active_console { nullptr };
-    Spinlock<u8> m_lock;
+    Spinlock m_lock;
     RecursiveSpinlock m_tty_write_lock;
 };
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -155,7 +155,7 @@ Thread::~Thread()
     }
 }
 
-void Thread::block(Kernel::Mutex& lock, SpinlockLocker<Spinlock<u8>>& lock_lock, u32 lock_count)
+void Thread::block(Kernel::Mutex& lock, SpinlockLocker<Spinlock>& lock_lock, u32 lock_count)
 {
     VERIFY(!Processor::current_in_irq());
     VERIFY(this == Thread::current());

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -507,7 +507,7 @@ public:
             blockers_to_append.clear();
         }
 
-        mutable Spinlock<u8> m_lock;
+        mutable Spinlock m_lock;
 
     private:
         Vector<BlockerInfo, 4> m_blockers;
@@ -831,7 +831,7 @@ public:
         }
     }
 
-    void block(Kernel::Mutex&, SpinlockLocker<Spinlock<u8>>&, u32);
+    void block(Kernel::Mutex&, SpinlockLocker<Spinlock>&, u32);
 
     template<typename BlockerType, class... Args>
     [[nodiscard]] BlockResult block(const BlockTimeout& timeout, Args&&... args)
@@ -1307,7 +1307,7 @@ private:
         unsigned count;
     };
     Atomic<u32> m_holding_locks { 0 };
-    Spinlock<u8> m_holding_locks_lock;
+    Spinlock m_holding_locks_lock;
     Vector<HoldingLockInfo> m_holding_locks_list;
 #endif
 

--- a/Kernel/TimerQueue.cpp
+++ b/Kernel/TimerQueue.cpp
@@ -14,7 +14,7 @@
 namespace Kernel {
 
 static Singleton<TimerQueue> s_the;
-static Spinlock<u8> g_timerqueue_lock;
+static Spinlock g_timerqueue_lock;
 
 Time Timer::remaining() const
 {

--- a/Kernel/WorkQueue.h
+++ b/Kernel/WorkQueue.h
@@ -52,7 +52,7 @@ private:
     RefPtr<Thread> m_thread;
     WaitQueue m_wait_queue;
     IntrusiveList<WorkItem, RawPtr<WorkItem>, &WorkItem::m_node> m_items;
-    Spinlock<u8> m_lock;
+    Spinlock m_lock;
 };
 
 }


### PR DESCRIPTION
The default template argument one place, and it looks like it
was probably just an oversight. The rest of the Kernel code all
uses u8 as the type. So lets make that the default and remove
the unused template argument, as there doesn't seem to be a
reason to allow the size to be customizable.