### PR TITLE
RequestServer: Exit early to avoid executing protocol destructors

### DIFF
--- a/Userland/Services/RequestServer/Protocol.cpp
+++ b/Userland/Services/RequestServer/Protocol.cpp
@@ -31,6 +31,7 @@ Protocol::Protocol(const String& name)
 
 Protocol::~Protocol()
 {
+    // FIXME: Do proper de-registration.
     VERIFY_NOT_REACHED();
 }
 

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -46,5 +46,10 @@ int main(int, char**)
     auto socket = Core::LocalSocket::take_over_accepted_socket_from_system_server();
     VERIFY(socket);
     IPC::new_client_connection<RequestServer::ClientConnection>(socket.release_nonnull(), 1);
-    return event_loop.exec();
+    auto result = event_loop.exec();
+
+    // FIXME: We exit instead of returning, so that protocol destructors don't get called.
+    //        The Protocol base class should probably do proper de-registration instead of
+    //        just VERIFY_NOT_REACHED().
+    exit(result);
 }


### PR DESCRIPTION
I broke this when I made the protocol objects be wrapped by smart
pointers to appease static analysis.

The Protocol base class currently VERIFY's that it's never called.
So to have the best of both worlds until someone actually fixes
the code to do proper de-registration, just call `exit(..)` so the
smart pointers never go out of scope.