### PR TITLE
LibJS: Prevent stack overflow if Proxy handler's __proto__ is the Proxy

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1946,7 +1946,7 @@ static size_t flatten_into_array(GlobalObject& global_object, Object& new_array,
 
         if (depth > 0 && value.is_array(global_object)) {
             if (vm.did_reach_stack_space_limit()) {
-                vm.throw_exception<Error>(global_object, "Call stack size limit exceeded");
+                vm.throw_exception<Error>(global_object, ErrorType::CallStackSizeExceeded);
                 return {};
             }
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -15,6 +15,7 @@
     M(BigIntFromNonIntegral, "Cannot convert non-integral number to BigInt")                                                            \
     M(BigIntInvalidValue, "Invalid value for BigInt: {}")                                                                               \
     M(BindingNotInitialized, "Binding {} is not initialized")                                                                           \
+    M(CallStackSizeExceeded, "Call stack size limit exceeded")                                                                          \
     M(ClassConstructorWithoutNew, "Class constructor {} must be called with 'new'")                                                     \
     M(ClassExtendsValueNotAConstructorOrNull, "Class extends value {} is not a constructor or null")                                    \
     M(ClassExtendsValueInvalidPrototype, "Class extends value has an invalid prototype {}")                                             \

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -116,7 +116,7 @@ public:
         VERIFY(!exception());
         // Ensure we got some stack space left, so the next function call doesn't kill us.
         if (did_reach_stack_space_limit())
-            throw_exception<Error>(global_object, "Call stack size limit exceeded");
+            throw_exception<Error>(global_object, ErrorType::CallStackSizeExceeded);
         else
             m_execution_context_stack.append(&context);
     }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -107,8 +107,11 @@ public:
 
     bool did_reach_stack_space_limit() const
     {
-        // Note: the 32 kiB used to be 16 kiB, but that turned out to not be enough with ASAN enabled.
+#ifdef HAS_ADDRESS_SANITIZER
         return m_stack_info.size_free() < 32 * KiB;
+#else
+        return m_stack_info.size_free() < 16 * KiB;
+#endif
     }
 
     void push_execution_context(ExecutionContext& context, GlobalObject& global_object)

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
@@ -107,3 +107,12 @@ describe("[[Get]] invariants", () => {
         );
     });
 });
+
+test("Proxy handler that has the Proxy itself as its prototype", () => {
+    const handler = {};
+    const proxy = new Proxy({}, handler);
+    handler.__proto__ = proxy;
+    expect(() => {
+        proxy.foo;
+    }).toThrowWithMessage(Error, "Call stack size limit exceeded");
+});


### PR DESCRIPTION
...and two small related tweaks.