### PR TITLE
Tests: Reduce the execution time of the LibC TestQSort test

### DIFF
--- a/Tests/LibC/TestQsort.cpp
+++ b/Tests/LibC/TestQsort.cpp
@@ -12,7 +12,7 @@
 #include <AK/Vector.h>
 #include <stdlib.h>
 
-const size_t NUM_RUNS = 100;
+const size_t NUM_RUNS = 10;
 
 struct SortableObject {
     int m_key;


### PR DESCRIPTION
Executing 100 times vs 10 times doesn't increase test coverage
substantial, this API is stable and more iterations is just a
waste of time.

Without KVM this test is a clear outlier in runtime during CI:

```
START  LibC/TestQsort (106/172)
PASS   LibC/TestQsort (41.233692s)
```