### PR TITLE
LibRegex: Make infinite repetitions short-circuit on empty matches :infinity::infinity::infinity:

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -852,6 +852,21 @@ TEST_CASE(extremely_long_fork_chain)
     EXPECT_EQ(result.success, true);
 }
 
+TEST_CASE(theoretically_infinite_loop)
+{
+    Array patterns {
+        "(a*)*"sv,  // Infinitely matching empty substrings, the outer loop should short-circuit.
+        "(a*?)*"sv, // Infinitely matching empty substrings, the outer loop should short-circuit.
+        "(a*)*?"sv, // Should match exactly nothing.
+        "(?:)*?"sv, // Should not generate an infinite fork loop.
+    };
+    for (auto& pattern : patterns) {
+        Regex<ECMA262> re(pattern);
+        auto result = re.match("");
+        EXPECT_EQ(result.success, true);
+    }
+}
+
 static auto g_lots_of_a_s = String::repeated('a', 10'000'000);
 
 BENCHMARK_CASE(fork_performance)

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -848,7 +848,7 @@ TEST_CASE(case_insensitive_match)
 TEST_CASE(extremely_long_fork_chain)
 {
     Regex<ECMA262> re("(?:aa)*");
-    auto result = re.match(String::repeated('a', 100'000));
+    auto result = re.match(String::repeated('a', 1000));
     EXPECT_EQ(result.success, true);
 }
 

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -46,6 +46,22 @@ char const* execution_result_name(ExecutionResult result)
     }
 }
 
+char const* opcode_id_name(OpCodeId opcode)
+{
+    switch (opcode) {
+#define __ENUMERATE_OPCODE(x) \
+    case OpCodeId::x:         \
+        return #x;
+
+        ENUMERATE_OPCODES
+
+#undef __ENUMERATE_OPCODE
+    default:
+        VERIFY_NOT_REACHED();
+        return "<Unknown>";
+    }
+}
+
 char const* boundary_check_type_name(BoundaryCheckType ty)
 {
     switch (ty) {
@@ -144,60 +160,14 @@ void ByteCode::ensure_opcodes_initialized()
         return;
     for (u32 i = (u32)OpCodeId::First; i <= (u32)OpCodeId::Last; ++i) {
         switch ((OpCodeId)i) {
-        case OpCodeId::Exit:
-            s_opcodes[i] = make<OpCode_Exit>();
-            break;
-        case OpCodeId::Jump:
-            s_opcodes[i] = make<OpCode_Jump>();
-            break;
-        case OpCodeId::Compare:
-            s_opcodes[i] = make<OpCode_Compare>();
-            break;
-        case OpCodeId::CheckEnd:
-            s_opcodes[i] = make<OpCode_CheckEnd>();
-            break;
-        case OpCodeId::CheckBoundary:
-            s_opcodes[i] = make<OpCode_CheckBoundary>();
-            break;
-        case OpCodeId::ForkJump:
-            s_opcodes[i] = make<OpCode_ForkJump>();
-            break;
-        case OpCodeId::ForkStay:
-            s_opcodes[i] = make<OpCode_ForkStay>();
-            break;
-        case OpCodeId::FailForks:
-            s_opcodes[i] = make<OpCode_FailForks>();
-            break;
-        case OpCodeId::Save:
-            s_opcodes[i] = make<OpCode_Save>();
-            break;
-        case OpCodeId::Restore:
-            s_opcodes[i] = make<OpCode_Restore>();
-            break;
-        case OpCodeId::GoBack:
-            s_opcodes[i] = make<OpCode_GoBack>();
-            break;
-        case OpCodeId::CheckBegin:
-            s_opcodes[i] = make<OpCode_CheckBegin>();
-            break;
-        case OpCodeId::ClearCaptureGroup:
-            s_opcodes[i] = make<OpCode_ClearCaptureGroup>();
-            break;
-        case OpCodeId::SaveLeftCaptureGroup:
-            s_opcodes[i] = make<OpCode_SaveLeftCaptureGroup>();
-            break;
-        case OpCodeId::SaveRightCaptureGroup:
-            s_opcodes[i] = make<OpCode_SaveRightCaptureGroup>();
-            break;
-        case OpCodeId::SaveRightNamedCaptureGroup:
-            s_opcodes[i] = make<OpCode_SaveRightNamedCaptureGroup>();
-            break;
-        case OpCodeId::Repeat:
-            s_opcodes[i] = make<OpCode_Repeat>();
-            break;
-        case OpCodeId::ResetRepeat:
-            s_opcodes[i] = make<OpCode_ResetRepeat>();
-            break;
+#define __ENUMERATE_OPCODE(OpCode)              \
+    case OpCodeId::OpCode:                      \
+        s_opcodes[i] = make<OpCode_##OpCode>(); \
+        break;
+
+            ENUMERATE_OPCODES
+
+#undef __ENUMERATE_OPCODE
         }
     }
     s_opcodes_initialized = true;
@@ -898,6 +868,36 @@ ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, Mat
         state.repetition_marks.resize(id() + 1);
 
     state.repetition_marks.at(id()) = 0;
+    return ExecutionResult::Continue;
+}
+
+ALWAYS_INLINE ExecutionResult OpCode_Checkpoint::execute(MatchInput const&, MatchState& state) const
+{
+    state.checkpoints.set(state.instruction_position, state.string_position);
+    return ExecutionResult::Continue;
+}
+
+ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const&, MatchState& state) const
+{
+    auto current_position = state.string_position;
+    auto checkpoint_ip = state.instruction_position + size() + checkpoint();
+    if (state.checkpoints.get(checkpoint_ip).value_or(current_position) != current_position) {
+        auto form = this->form();
+
+        if (form == OpCodeId::Jump) {
+            state.instruction_position += offset();
+            return ExecutionResult::Continue;
+        }
+
+        state.fork_at_position = state.instruction_position + size() + offset();
+
+        if (form == OpCodeId::ForkJump)
+            return ExecutionResult::Fork_PrioHigh;
+
+        if (form == OpCodeId::ForkStay)
+            return ExecutionResult::Fork_PrioLow;
+    }
+
     return ExecutionResult::Continue;
 }
 

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -524,6 +524,7 @@ struct MatchState {
     Vector<Match> matches;
     Vector<Vector<Match>> capture_group_matches;
     Vector<u64> repetition_marks;
+    HashMap<u64, u64> checkpoints;
 };
 
 }


### PR DESCRIPTION
This makes (addmittedly weird) patterns like `(a*)*` work correctly
without going into an infinite fork loop.

:infinity::infinity::infinity::infinity::infinity::infinity::infinity:

Starring: I hate offset math!