### PR TITLE
LibWeb: Add constructors for Text, DocumentFragment and Comment

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Comment.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/DOM/Comment.h>
+#include <LibWeb/DOM/Window.h>
 #include <LibWeb/Layout/TextNode.h>
 
 namespace Web::DOM {
@@ -16,6 +17,12 @@ Comment::Comment(Document& document, const String& data)
 
 Comment::~Comment()
 {
+}
+
+// https://dom.spec.whatwg.org/#dom-comment-comment
+NonnullRefPtr<Comment> Comment::create_with_global_object(Bindings::WindowObject& window, String const& data)
+{
+    return make_ref_counted<Comment>(window.impl().document(), data);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Comment.h
+++ b/Userland/Libraries/LibWeb/DOM/Comment.h
@@ -19,6 +19,8 @@ public:
     virtual ~Comment() override;
 
     virtual FlyString node_name() const override { return "#comment"; }
+
+    static NonnullRefPtr<Comment> create_with_global_object(Bindings::WindowObject& window, String const& data);
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Comment.idl
+++ b/Userland/Libraries/LibWeb/DOM/Comment.idl
@@ -1,3 +1,3 @@
 interface Comment : CharacterData {
-
+    constructor(optional DOMString data = "");
 };

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2020, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2020-2021, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/DOM/DocumentFragment.h>
+#include <LibWeb/DOM/Window.h>
 
 namespace Web::DOM {
 
@@ -15,6 +16,12 @@ DocumentFragment::DocumentFragment(Document& document)
 
 DocumentFragment::~DocumentFragment()
 {
+}
+
+// https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment
+NonnullRefPtr<DocumentFragment> DocumentFragment::create_with_global_object(Bindings::WindowObject& window)
+{
+    return make_ref_counted<DocumentFragment>(window.impl().document());
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.h
@@ -19,6 +19,8 @@ class DocumentFragment
 public:
     using WrapperType = Bindings::DocumentFragmentWrapper;
 
+    static NonnullRefPtr<DocumentFragment> create_with_global_object(Bindings::WindowObject& window);
+
     explicit DocumentFragment(Document& document);
     virtual ~DocumentFragment() override;
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -1,5 +1,7 @@
 interface DocumentFragment : Node {
 
+    constructor();
+
     Element? getElementById(DOMString id);
 
     // FIXME: These should all come from a ParentNode mixin

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/DOM/Window.h>
 #include <LibWeb/Layout/TextNode.h>
 
 namespace Web::DOM {
@@ -21,6 +22,12 @@ Text::~Text()
 RefPtr<Layout::Node> Text::create_layout_node()
 {
     return adopt_ref(*new Layout::TextNode(document(), *this));
+}
+
+// https://dom.spec.whatwg.org/#dom-text-text
+NonnullRefPtr<Text> Text::create_with_global_object(Bindings::WindowObject& window, String const& data)
+{
+    return make_ref_counted<Text>(window.impl().document(), data);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -19,6 +19,8 @@ public:
     explicit Text(Document&, const String&);
     virtual ~Text() override;
 
+    static NonnullRefPtr<Text> create_with_global_object(Bindings::WindowObject& window, String const& data);
+
     // ^Node
     virtual FlyString node_name() const override { return "#text"; }
     virtual bool is_editable() const override { return m_always_editable || CharacterData::is_editable(); }

--- a/Userland/Libraries/LibWeb/DOM/Text.idl
+++ b/Userland/Libraries/LibWeb/DOM/Text.idl
@@ -1,3 +1,3 @@
 interface Text : CharacterData {
-
+    constructor(optional DOMString data = "");
 };


### PR DESCRIPTION
These three nodes are the only nodes in the DOM spec with constructors.