### PR TITLE
LibWeb: Make Node.textContent more spec compliant

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -25,8 +25,6 @@ public:
 
     unsigned length() const { return m_data.length(); }
 
-    virtual String text_content() const override { return m_data; }
-
 protected:
     explicit CharacterData(Document&, NodeType, const String&);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -718,4 +718,31 @@ bool Node::is_shadow_including_inclusive_ancestor_of(Node const& other) const
     return other.is_shadow_including_inclusive_descendant_of(*this);
 }
 
+// https://dom.spec.whatwg.org/#concept-node-replace-all
+void Node::replace_all(RefPtr<Node> node)
+{
+    // FIXME: Let removedNodes be parent’s children. (Current unused so not included)
+    // FIXME: Let addedNodes be the empty set. (Currently unused so not included)
+    // FIXME: If node is a DocumentFragment node, then set addedNodes to node’s children.
+    // FIXME: Otherwise, if node is non-null, set addedNodes to « node ».
+
+    remove_all_children(true);
+
+    if (node)
+        insert_before(*node, nullptr, true);
+
+    // FIXME: If either addedNodes or removedNodes is not empty, then queue a tree mutation record for parent with addedNodes, removedNodes, null, and null.
+}
+
+// https://dom.spec.whatwg.org/#string-replace-all
+void Node::string_replace_all(String const& string)
+{
+    RefPtr<Node> node;
+
+    if (!string.is_empty())
+        node = make_ref_counted<Text>(document(), string);
+
+    replace_all(node);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -99,8 +99,9 @@ public:
 
     virtual FlyString node_name() const = 0;
 
-    virtual String text_content() const;
-    void set_text_content(const String&);
+    String descendant_text_content() const;
+    String text_content() const;
+    void set_text_content(String const&);
 
     Document& document() { return *m_document; }
     const Document& document() const { return *m_document; }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -182,6 +182,9 @@ public:
     i32 id() const { return m_id; }
     static Node* from_id(i32 node_id);
 
+    void replace_all(RefPtr<Node>);
+    void string_replace_all(String const&);
+
 protected:
     Node(Document&, NodeType);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -14,7 +14,11 @@ interface Node : EventTarget {
     readonly attribute Element? parentElement;
     readonly attribute boolean isConnected;
     readonly attribute Document? ownerDocument;
-    attribute DOMString textContent;
+
+    // FIXME: [LegacyNullToEmptyString] is not allowed on nullable types as per the Web IDL spec.
+    //        However, we only apply it to setters, so this works as a stop gap.
+    //        Replace this with something like a special cased [LegacyNullToEmptyString].
+    [LegacyNullToEmptyString] attribute DOMString? textContent;
 
     Node appendChild(Node node);
     [ImplementedAs=pre_insert] Node insertBefore(Node node, Node? child);


### PR DESCRIPTION
The current implementation felt a bit ad-hoc and notably allowed
textContent to operate on all node types. It also only returned the
child text content of the Node instead of the descendant text content.