### PR TITLE
LibVT: Quote the file paths on a DropEvent

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1100,7 +1100,7 @@ void TerminalWidget::drop_event(GUI::DropEvent& event)
                 send_non_user_input(" "sv.bytes());
 
             if (url.protocol() == "file")
-                send_non_user_input(url.path().bytes());
+                send_non_user_input(String::formatted("\"{}\"", url.path()).bytes());
             else
                 send_non_user_input(url.to_string().bytes());
 


### PR DESCRIPTION
Earlier, we would directly just paste the file path into the terminal,
however if the path had and spaces or special characters, they would
not be escaped properly. This patch just quotes the paths before
putting them on screen.