### PR TITLE
FileSystemAccessServer+Everywhere: Allow requesting read-only files without a prompt, transition some applications to LibFSAC fully.

### DIFF
--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -7,6 +7,7 @@
 
 #include "HexEditorWidget.h"
 #include <LibConfig/Client.h>
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
@@ -38,20 +39,6 @@ int main(int argc, char** argv)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
-    String file_to_edit = (argc > 1) ? Core::File::absolute_path(argv[1]) : "";
-
-    if (!file_to_edit.is_empty()) {
-        if (Core::File::exists(file_to_edit)) {
-            dbgln("unveil for: {}", file_to_edit);
-            if (unveil(file_to_edit.characters(), "r") < 0) {
-                perror("unveil");
-                return 1;
-            }
-        } else {
-            file_to_edit = {};
-        }
-    }
-
     if (unveil("/res", "r") < 0) {
         perror("unveil");
         return 1;
@@ -71,15 +58,16 @@ int main(int argc, char** argv)
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    if (!file_to_edit.is_empty()) {
-        auto file = Core::File::open(file_to_edit, Core::OpenMode::ReadOnly);
+    if (argc > 1) {
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), argv[1]);
 
-        if (file.is_error()) {
-            GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", file_to_edit, file.error()));
+        if (response.error != 0) {
+            if (response.error != -1)
+                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
             return 1;
         }
 
-        hex_editor_widget.open_file(file.value()->leak_fd(), file_to_edit);
+        hex_editor_widget.open_file(*response.fd, *response.chosen_file);
     }
 
     return app->exec();

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     if (argc >= 2) {
-        auto response = FileSystemAccessClient::Client::the().request_file(window->window_id(), argv[1], Core::OpenMode::ReadOnly);
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), argv[1]);
 
         if (response.error != 0) {
             if (response.error != -1)

--- a/Userland/Applications/TextEditor/FileArgument.cpp
+++ b/Userland/Applications/TextEditor/FileArgument.cpp
@@ -15,12 +15,6 @@ FileArgument::FileArgument(String file_argument)
     m_line = {};
     m_column = {};
 
-    if (Core::File::exists(file_argument)) {
-        // A file exists with the full specified name, don't attempt to parse it.
-        m_filename = move(file_argument);
-        return;
-    }
-
     // A file doesn't exist with the full specified name, maybe the user entered line/column coordinates?
     Regex<PosixExtended> re("^(.+?)(:([0-9]+):?([0-9]+)?)?$");
     RegexResult result = match(file_argument, re, PosixFlags::Global | PosixFlags::Multiline | PosixFlags::Ungreedy);

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -22,6 +22,23 @@ Client& Client::the()
     return *s_the;
 }
 
+Result Client::request_file_read_only_approved(i32 parent_window_id, String const& path)
+{
+    m_promise = Core::Promise<Result>::construct();
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
+
+    return m_promise->await();
+}
+
 Result Client::request_file(i32 parent_window_id, String const& path, Core::OpenMode mode)
 {
     m_promise = Core::Promise<Result>::construct();

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -8,6 +8,8 @@
 // clang-format off
 #include <LibGUI/WindowServerConnection.h>
 // clang-format on
+#include <AK/LexicalPath.h>
+#include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Window.h>
 
@@ -34,7 +36,12 @@ Result Client::request_file_read_only_approved(i32 parent_window_id, String cons
         GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
+    if (path.starts_with('/')) {
+        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
+    } else {
+        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
+        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, full_path);
+    }
 
     return m_promise->await();
 }
@@ -51,7 +58,12 @@ Result Client::request_file(i32 parent_window_id, String const& path, Core::Open
         GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_request_file(parent_window_server_client_id, parent_window_id, path, mode);
+    if (path.starts_with('/')) {
+        async_request_file(parent_window_server_client_id, parent_window_id, path, mode);
+    } else {
+        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
+        async_request_file(parent_window_server_client_id, parent_window_id, full_path, mode);
+    }
 
     return m_promise->await();
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -27,6 +27,7 @@ class Client final
     C_OBJECT(Client)
 
 public:
+    Result request_file_read_only_approved(i32 parent_window_id, String const& path);
     Result request_file(i32 parent_window_id, String const& path, Core::OpenMode mode);
     Result open_file(i32 parent_window_id, String const& window_title = {}, StringView const& path = Core::StandardPaths::home_directory());
     Result save_file(i32 parent_window_id, String const& name, String const ext);

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.h
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.h
@@ -26,12 +26,19 @@ public:
     virtual void die() override;
 
 private:
+    virtual void request_file_read_only_approved(i32, i32, String const&) override;
     virtual void request_file(i32, i32, String const&, Core::OpenMode const&) override;
     virtual void prompt_open_file(i32, i32, String const&, String const&, Core::OpenMode const&) override;
     virtual void prompt_save_file(i32, i32, String const&, String const&, String const&, Core::OpenMode const&) override;
 
     void prompt_helper(Optional<String> const&, Core::OpenMode const&);
     RefPtr<GUI::Window> create_dummy_child_window(i32, i32);
+
+    enum class ShouldPrompt {
+        No,
+        Yes
+    };
+    void request_file_handler(i32, i32, String const&, Core::OpenMode const&, ShouldPrompt);
 
     virtual Messages::FileSystemAccessServer::ExposeWindowServerClientIdResponse expose_window_server_client_id() override;
 

--- a/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
+++ b/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
@@ -3,6 +3,7 @@
 
 endpoint FileSystemAccessServer
 {
+    request_file_read_only_approved(i32 window_server_client_id, i32 window_id, String path) =|
     request_file(i32 window_server_client_id, i32 window_id, String path, Core::OpenMode requested_access) =|
     prompt_open_file(i32 window_server_client_id, i32 window_id, String window_title, String path_to_view, Core::OpenMode requested_access) =|
     prompt_save_file(i32 window_server_client_id, i32 window_id,String title, String ext, String path_to_view, Core::OpenMode requested_access) =|


### PR DESCRIPTION
There were a few applications that were almost - but not fully - ported to use the FileSystemAccessServer. In most cases, the initial file specified through the command line was still manually unveiled, and read using `Core::File`, after which we would leak the fd to keep the reading interface similar.

There were a few issues with just naively plugging in LibFileSystemAccessClient:

1. You would get a prompt asking to provide read access to the file. This might be behaviour we want, but after using the system for some time with this, it became really annoying having to have an extra step between running the command in the terminal and having the file open. It made the system feel less snappy, somehow.

2. We needed to specify the absolute path to the files, otherwise the FileSystemAccessServer would just crash. This is easier to get around by just appending the relative path with the current working directory, but is annoying to do manually.

This PR fixes both these issues. In addition, it ports over TextEditor, HexEditor and PDFViewer to fully use LibFileSystemAccessClient. The user-facing experience is the same as earlier (yay!), but now we don't `unveil()` anything in the file system that isn't needed.