### PR TITLE
LibRegex: Avoid keeping track of checkpoints across forks

### DIFF
--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -871,17 +871,17 @@ ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, Mat
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Checkpoint::execute(MatchInput const&, MatchState& state) const
+ALWAYS_INLINE ExecutionResult OpCode_Checkpoint::execute(MatchInput const& input, MatchState& state) const
 {
-    state.checkpoints.set(state.instruction_position, state.string_position);
+    input.checkpoints.set(state.instruction_position, state.string_position);
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const&, MatchState& state) const
+ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const& input, MatchState& state) const
 {
     auto current_position = state.string_position;
     auto checkpoint_ip = state.instruction_position + size() + checkpoint();
-    if (state.checkpoints.get(checkpoint_ip).value_or(current_position) != current_position) {
+    if (input.checkpoints.get(checkpoint_ip).value_or(current_position) != current_position) {
         auto form = this->form();
 
         if (form == OpCodeId::Jump) {

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -513,6 +513,7 @@ struct MatchInput {
     mutable size_t fail_counter { 0 };
     mutable Vector<size_t> saved_positions;
     mutable Vector<size_t> saved_code_unit_positions;
+    mutable HashMap<u64, u64> checkpoints;
 };
 
 struct MatchState {
@@ -524,7 +525,6 @@ struct MatchState {
     Vector<Match> matches;
     Vector<Vector<Match>> capture_group_matches;
     Vector<u64> repetition_marks;
-    HashMap<u64, u64> checkpoints;
 };
 
 }


### PR DESCRIPTION
Doing so would increase memory consumption by quite a bit, since many
useless copies of the checkpoints hashmap would be created and later
thrown away.

Fixes the LibJS Test262 regression caused by 63523d3.