### PR TITLE
HackStudio: Remove an old file from the vectors in ‘Save as...’ action

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -262,7 +262,7 @@ bool HackStudioWidget::open_file(const String& full_filename, size_t line, size_
     if (auto it = m_open_files.find(filename); it != m_open_files.end()) {
         new_project_file = it->value;
     } else {
-        new_project_file = m_project->get_file(filename);
+        new_project_file = m_project->create_file(filename);
         m_open_files.set(filename, *new_project_file);
         m_open_files_vector.append(filename);
 
@@ -699,7 +699,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
         }
         current_editor_wrapper().save();
 
-        auto new_project_file = m_project->get_file(relative_file_path);
+        auto new_project_file = m_project->create_file(relative_file_path);
         m_open_files.set(relative_file_path, *new_project_file);
         m_open_files_vector.append(relative_file_path);
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -701,7 +701,10 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
 
         auto new_project_file = m_project->create_file(relative_file_path);
         m_open_files.set(relative_file_path, *new_project_file);
+        m_open_files.remove(old_filename);
+
         m_open_files_vector.append(relative_file_path);
+        m_open_files_vector.remove_all_matching([&old_filename](auto const& element) { return element == old_filename; });
 
         update_window_title();
 

--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -48,13 +48,7 @@ void Project::for_each_text_file(Function<void(const ProjectFile&)> callback) co
 NonnullRefPtr<ProjectFile> Project::get_file(const String& path) const
 {
     auto full_path = to_absolute_path(path);
-    for (auto& file : m_files) {
-        if (file.name() == full_path)
-            return file;
-    }
-    auto file = ProjectFile::construct_with_name(full_path);
-    m_files.append(file);
-    return file;
+    return ProjectFile::construct_with_name(full_path);
 }
 
 String Project::to_absolute_path(const String& path) const

--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -40,12 +40,12 @@ static void traverse_model(const GUI::FileSystemModel& model, const GUI::ModelIn
 void Project::for_each_text_file(Function<void(const ProjectFile&)> callback) const
 {
     traverse_model(model(), {}, [&](auto& index) {
-        auto file = get_file(model().full_path(index));
+        auto file = create_file(model().full_path(index));
         callback(*file);
     });
 }
 
-NonnullRefPtr<ProjectFile> Project::get_file(const String& path) const
+NonnullRefPtr<ProjectFile> Project::create_file(const String& path) const
 {
     auto full_path = to_absolute_path(path);
     return ProjectFile::construct_with_name(full_path);

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -26,7 +26,7 @@ public:
     String name() const { return LexicalPath::basename(m_root_path); }
     String root_path() const { return m_root_path; }
 
-    NonnullRefPtr<ProjectFile> get_file(const String& path) const;
+    NonnullRefPtr<ProjectFile> create_file(const String& path) const;
 
     void for_each_text_file(Function<void(const ProjectFile&)>) const;
 

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -36,7 +36,6 @@ private:
     String to_absolute_path(const String&) const;
 
     RefPtr<GUI::FileSystemModel> m_model;
-    mutable NonnullRefPtrVector<ProjectFile> m_files;
 
     String m_root_path;
 };


### PR DESCRIPTION
this is the second part (and hopefully the end) of my fixes to the ‘Save as...’ action from #9360 (part one and the explanation: #9404).

- **HackStudio: Remove storing a vector of opened files in Project class**

  It looks to me like this has the same purpose as `m_open_files` in the HackStudioWidget, so removing it shouldn’t change anything.

- **HackStudio: Rename `Project::get_file()` to `Project::create_file()`**

  The function no longer looks for the already opened files, so let's emphasize that by renaming it to `create_file`. :^)

- **HackStudio: Remove an old file from the vectors in ‘Save as...’ action**

  If you saved a file under a different name and then went back to the first file, then you had the same TextDocument buffer, and therefore the same changes to the file as in the new one.

