### PR TITLE
LibJS+LibUnicode: Implement `Intl.ListFormat`

### DIFF
--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -46,6 +46,9 @@ set(CLDR_CORE_PATH ${CLDR_PATH}/${CLDR_CORE_SOURCE})
 set(CLDR_LOCALES_SOURCE cldr-localenames-modern)
 set(CLDR_LOCALES_PATH ${CLDR_PATH}/${CLDR_LOCALES_SOURCE})
 
+set(CLDR_MISC_SOURCE cldr-misc-modern)
+set(CLDR_MISC_PATH ${CLDR_PATH}/${CLDR_MISC_SOURCE})
+
 set(CLDR_NUMBERS_SOURCE cldr-numbers-modern)
 set(CLDR_NUMBERS_PATH ${CLDR_PATH}/${CLDR_NUMBERS_SOURCE})
 
@@ -117,6 +120,13 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
             message(FATAL_ERROR "Failed to unzip ${CLDR_LOCALES_SOURCE} from ${CLDR_ZIP_PATH} with status ${unzip_result}")
         endif()
     endif()
+    if(EXISTS ${CLDR_ZIP_PATH} AND NOT EXISTS ${CLDR_MISC_PATH})
+        message(STATUS "Extracting CLDR ${CLDR_MISC_SOURCE} from ${CLDR_ZIP_PATH}...")
+        execute_process(COMMAND unzip -q ${CLDR_ZIP_PATH} "${CLDR_MISC_SOURCE}/**" -d ${CLDR_PATH} RESULT_VARIABLE unzip_result)
+        if (NOT unzip_result EQUAL 0)
+            message(FATAL_ERROR "Failed to unzip ${CLDR_MISC_SOURCE} from ${CLDR_ZIP_PATH} with status ${unzip_result}")
+        endif()
+    endif()
     if(EXISTS ${CLDR_ZIP_PATH} AND NOT EXISTS ${CLDR_NUMBERS_PATH})
         message(STATUS "Extracting CLDR ${CLDR_NUMBERS_SOURCE} from ${CLDR_ZIP_PATH}...")
         execute_process(COMMAND unzip -q ${CLDR_ZIP_PATH} "${CLDR_NUMBERS_SOURCE}/**" -d ${CLDR_PATH} RESULT_VARIABLE unzip_result)
@@ -153,9 +163,9 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_LOCALE_HEADER} ${UNICODE_LOCALE_IMPLEMENTATION}
-        COMMAND $<TARGET_FILE:GenerateUnicodeLocale> -h ${UNICODE_LOCALE_HEADER} -c ${UNICODE_LOCALE_IMPLEMENTATION} -r ${CLDR_CORE_PATH} -l ${CLDR_LOCALES_PATH} -n ${CLDR_NUMBERS_PATH}
+        COMMAND $<TARGET_FILE:GenerateUnicodeLocale> -h ${UNICODE_LOCALE_HEADER} -c ${UNICODE_LOCALE_IMPLEMENTATION} -r ${CLDR_CORE_PATH} -l ${CLDR_LOCALES_PATH} -m ${CLDR_MISC_PATH} -n ${CLDR_NUMBERS_PATH}
         VERBATIM
-        DEPENDS GenerateUnicodeLocale ${CLDR_CORE_PATH} ${CLDR_LOCALES_PATH} ${CLDR_NUMBERS_PATH}
+        DEPENDS GenerateUnicodeLocale ${CLDR_CORE_PATH} ${CLDR_LOCALES_PATH} ${CLDR_MISC_PATH} ${CLDR_NUMBERS_PATH}
     )
     add_custom_target(generate_${UNICODE_META_TARGET_PREFIX}UnicodeLocale DEPENDS ${UNICODE_LOCALE_HEADER} ${UNICODE_LOCALE_IMPLEMENTATION})
     add_dependencies(all_generated generate_${UNICODE_META_TARGET_PREFIX}UnicodeLocale)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -937,6 +937,7 @@ int main(int argc, char** argv)
     char const* generated_implementation_path = nullptr;
     char const* core_path = nullptr;
     char const* locale_names_path = nullptr;
+    char const* misc_path = nullptr;
     char const* numbers_path = nullptr;
 
     Core::ArgsParser args_parser;
@@ -944,6 +945,7 @@ int main(int argc, char** argv)
     args_parser.add_option(generated_implementation_path, "Path to the Unicode locale implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
     args_parser.add_option(core_path, "Path to cldr-core directory", "core-path", 'r', "core-path");
     args_parser.add_option(locale_names_path, "Path to cldr-localenames directory", "locale-names-path", 'l', "locale-names-path");
+    args_parser.add_option(misc_path, "Path to cldr-misc directory", "misc-path", 'm', "misc-path");
     args_parser.add_option(numbers_path, "Path to cldr-numbers directory", "numbers-path", 'n', "numbers-path");
     args_parser.parse(argc, argv);
 

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -77,6 +77,9 @@ set(SOURCES
     Runtime/Intl/DisplayNamesConstructor.cpp
     Runtime/Intl/DisplayNamesPrototype.cpp
     Runtime/Intl/Intl.cpp
+    Runtime/Intl/ListFormat.cpp
+    Runtime/Intl/ListFormatConstructor.cpp
+    Runtime/Intl/ListFormatPrototype.cpp
     Runtime/Intl/Locale.cpp
     Runtime/Intl/LocaleConstructor.cpp
     Runtime/Intl/LocalePrototype.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -78,6 +78,7 @@
 
 #define JS_ENUMERATE_INTL_OBJECTS                                                               \
     __JS_ENUMERATE(DisplayNames, display_names, DisplayNamesPrototype, DisplayNamesConstructor) \
+    __JS_ENUMERATE(ListFormat, list_format, ListFormatPrototype, ListFormatConstructor)         \
     __JS_ENUMERATE(Locale, locale, LocalePrototype, LocaleConstructor)
 
 #define JS_ENUMERATE_TEMPORAL_OBJECTS                                                                    \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -168,6 +168,7 @@ namespace JS {
     P(fontsize)                              \
     P(forEach)                               \
     P(format)                                \
+    P(formatToParts)                         \
     P(fractionalSecondDigits)                \
     P(freeze)                                \
     P(from)                                  \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -167,6 +167,7 @@ namespace JS {
     P(fontcolor)                             \
     P(fontsize)                              \
     P(forEach)                               \
+    P(format)                                \
     P(fractionalSecondDigits)                \
     P(freeze)                                \
     P(from)                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -62,6 +62,7 @@
     M(NotAnObject, "{} is not an object")                                                                                               \
     M(NotAnObjectOrNull, "{} is neither an object nor null")                                                                            \
     M(NotAnObjectOrString, "{} is neither an object nor a string")                                                                      \
+    M(NotAString, "{} is not a string")                                                                                                 \
     M(NotASymbol, "{} is not a symbol")                                                                                                 \
     M(NotIterable, "{} is not iterable")                                                                                                \
     M(NotObjectCoercible, "{} cannot be converted to an object")                                                                        \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -44,6 +44,8 @@
 #include <LibJS/Runtime/Intl/DisplayNamesConstructor.h>
 #include <LibJS/Runtime/Intl/DisplayNamesPrototype.h>
 #include <LibJS/Runtime/Intl/Intl.h>
+#include <LibJS/Runtime/Intl/ListFormatConstructor.h>
+#include <LibJS/Runtime/Intl/ListFormatPrototype.h>
 #include <LibJS/Runtime/Intl/LocaleConstructor.h>
 #include <LibJS/Runtime/Intl/LocalePrototype.h>
 #include <LibJS/Runtime/IteratorPrototype.h>

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -26,6 +26,11 @@ struct LocaleResult {
     String locale;
 };
 
+struct PatternPartition {
+    StringView type;
+    StringView value;
+};
+
 Optional<Unicode::LocaleID> is_structurally_valid_language_tag(StringView locale);
 String canonicalize_unicode_locale_id(Unicode::LocaleID& locale);
 Vector<String> canonicalize_locale_list(GlobalObject&, Value locales);
@@ -35,6 +40,7 @@ Vector<String> lookup_supported_locales(Vector<String> const& requested_locales)
 Array* supported_locales(GlobalObject&, Vector<String> const& requested_locales, Value options);
 Object* coerce_options_to_object(GlobalObject& global_object, Value options);
 Value get_option(GlobalObject& global_object, Value options, PropertyName const& property, Value::Type type, Vector<StringView> const& values, Fallback fallback);
+Vector<PatternPartition> partition_pattern(StringView pattern);
 String insert_unicode_extension_and_canonicalize(Unicode::LocaleID locale_id, Unicode::LocaleExtension extension);
 LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, Vector<StringView> relevant_extension_keys);
 Value canonical_code_for_display_names(GlobalObject&, DisplayNames::Type type, StringView code);

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DisplayNamesConstructor.h>
 #include <LibJS/Runtime/Intl/Intl.h>
+#include <LibJS/Runtime/Intl/ListFormatConstructor.h>
 #include <LibJS/Runtime/Intl/LocaleConstructor.h>
 
 namespace JS::Intl {
@@ -30,6 +31,7 @@ void Intl::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_direct_property(vm.names.DisplayNames, global_object.intl_display_names_constructor(), attr);
+    define_direct_property(vm.names.ListFormat, global_object.intl_list_format_constructor(), attr);
     define_direct_property(vm.names.Locale, global_object.intl_locale_constructor(), attr);
 
     define_native_function(vm.names.getCanonicalLocales, get_canonical_locales, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Intl/ListFormat.h>
+
+namespace JS::Intl {
+
+// 13 ListFomat Objects, https://tc39.es/ecma402/#listformat-objects
+ListFormat::ListFormat(Object& prototype)
+    : Object(prototype)
+{
+}
+
+void ListFormat::set_type(StringView type)
+{
+    if (type == "conjunction"sv) {
+        m_type = Type::Conjunction;
+    } else if (type == "disjunction"sv) {
+        m_type = Type::Disjunction;
+    } else if (type == "unit"sv) {
+        m_type = Type::Unit;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+}
+
+StringView ListFormat::type_string() const
+{
+    switch (m_type) {
+    case Type::Conjunction:
+        return "conjunction"sv;
+    case Type::Disjunction:
+        return "disjunction"sv;
+    case Type::Unit:
+        return "unit"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void ListFormat::set_style(StringView style)
+{
+    if (style == "narrow"sv) {
+        m_style = Style::Narrow;
+    } else if (style == "short"sv) {
+        m_style = Style::Short;
+    } else if (style == "long"sv) {
+        m_style = Style::Long;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+}
+
+StringView ListFormat::style_string() const
+{
+    switch (m_style) {
+    case Style::Narrow:
+        return "narrow"sv;
+    case Style::Short:
+        return "short"sv;
+    case Style::Long:
+        return "long"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace JS::Intl {
+
+class ListFormat final : public Object {
+    JS_OBJECT(ListFormat, Object);
+
+public:
+    enum class Type {
+        Invalid,
+        Conjunction,
+        Disjunction,
+        Unit,
+    };
+
+    enum class Style {
+        Invalid,
+        Narrow,
+        Short,
+        Long,
+    };
+
+    ListFormat(Object& prototype);
+    virtual ~ListFormat() override = default;
+
+    String const& locale() const { return m_locale; }
+    void set_locale(String locale) { m_locale = move(locale); }
+
+    Type type() const { return m_type; }
+    void set_type(StringView type);
+    StringView type_string() const;
+
+    Style style() const { return m_style; }
+    void set_style(StringView style);
+    StringView style_string() const;
+
+private:
+    String m_locale;                  // [[Locale]]
+    Type m_type { Type::Invalid };    // [[Type]]
+    Style m_style { Style::Invalid }; // [[Style]]
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/ListFormat.h>
+#include <LibJS/Runtime/Intl/ListFormatConstructor.h>
+
+namespace JS::Intl {
+
+// 13.2 The Intl.ListFormat Constructor, https://tc39.es/ecma402/#sec-intl-listformat-constructor
+ListFormatConstructor::ListFormatConstructor(GlobalObject& global_object)
+    : NativeFunction(vm().names.ListFormat.as_string(), *global_object.function_prototype())
+{
+}
+
+void ListFormatConstructor::initialize(GlobalObject& global_object)
+{
+    NativeFunction::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 13.3.1 Intl.ListFormat.prototype, https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype
+    define_direct_property(vm.names.prototype, global_object.intl_list_format_prototype(), 0);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
+}
+
+// 13.2.1 Intl.ListFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat
+Value ListFormatConstructor::call()
+{
+    // 1. If NewTarget is undefined, throw a TypeError exception.
+    vm().throw_exception<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.ListFormat");
+    return {};
+}
+
+// 13.2.1 Intl.ListFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat
+Value ListFormatConstructor::construct(FunctionObject& new_target)
+{
+    auto& vm = this->vm();
+    auto& global_object = this->global_object();
+
+    // 2. Let listFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%ListFormat.prototype%", « [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] »).
+    auto* list_format = ordinary_create_from_constructor<ListFormat>(global_object, new_target, &GlobalObject::intl_list_format_prototype);
+    if (vm.exception())
+        return {};
+
+    return list_format;
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/ListFormat.h>
@@ -27,6 +28,10 @@ void ListFormatConstructor::initialize(GlobalObject& global_object)
 
     // 13.3.1 Intl.ListFormat.prototype, https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype
     define_direct_property(vm.names.prototype, global_object.intl_list_format_prototype(), 0);
+
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.supportedLocalesOf, supported_locales_of, 1, attr);
+
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
@@ -101,6 +106,23 @@ Value ListFormatConstructor::construct(FunctionObject& new_target)
 
     // 19. Return listFormat.
     return list_format;
+}
+
+// 13.3.2 Intl.ListFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat.supportedLocalesOf
+JS_DEFINE_NATIVE_FUNCTION(ListFormatConstructor::supported_locales_of)
+{
+    auto locales = vm.argument(0);
+    auto options = vm.argument(1);
+
+    // 1. Let availableLocales be %DisplayNames%.[[AvailableLocales]].
+
+    // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = canonicalize_locale_list(global_object, locales);
+    if (vm.exception())
+        return {};
+
+    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
+    return supported_locales(global_object, requested_locales, options);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS::Intl {
+
+class ListFormatConstructor final : public NativeFunction {
+    JS_OBJECT(ListFormatConstructor, NativeFunction);
+
+public:
+    explicit ListFormatConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~ListFormatConstructor() override = default;
+
+    virtual Value call() override;
+    virtual Value construct(FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
@@ -23,6 +23,8 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
+
+    JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -4,10 +4,247 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
+#include <AK/StringBuilder.h>
+#include <AK/TypeCasts.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/Intl/ListFormatPrototype.h>
+#include <LibJS/Runtime/IteratorOperations.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
+
+static ListFormat* typed_this(GlobalObject& global_object)
+{
+    auto& vm = global_object.vm();
+
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return nullptr;
+
+    if (!is<ListFormat>(this_object)) {
+        vm.throw_exception<TypeError>(global_object, ErrorType::NotA, "Intl.ListFormat");
+        return nullptr;
+    }
+
+    return static_cast<ListFormat*>(this_object);
+}
+
+using Placeables = HashMap<StringView, Variant<PatternPartition, Vector<PatternPartition>>>;
+
+// 13.1.1 DeconstructPattern ( pattern, placeables ), https://tc39.es/ecma402/#sec-deconstructpattern
+static Vector<PatternPartition> deconstruct_pattern(StringView pattern, Placeables placeables)
+{
+    // 1. Let patternParts be PartitionPattern(pattern).
+    auto pattern_parts = partition_pattern(pattern);
+
+    // 2. Let result be a new empty List.
+    Vector<PatternPartition> result {};
+
+    // 3. For each Record { [[Type]], [[Value]] } patternPart of patternParts, do
+    for (auto const& pattern_part : pattern_parts) {
+        // a. Let part be patternPart.[[Type]].
+        auto part = pattern_part.type;
+
+        // b. If part is "literal", then
+        if (part == "literal"sv) {
+            // i. Append Record { [[Type]]: "literal", [[Value]]: patternPart.[[Value]] } to result.
+            result.append({ part, pattern_part.value });
+        }
+        // c. Else,
+        else {
+            // i. Assert: placeables has a field [[<part>]].
+            // ii. Let subst be placeables.[[<part>]].
+            auto subst = placeables.get(part);
+            VERIFY(subst.has_value());
+
+            subst.release_value().visit(
+                // iii. If Type(subst) is List, then
+                [&](Vector<PatternPartition>& partition) {
+                    // 1. For each element s of subst, do
+                    for (auto& element : partition) {
+                        // a. Append s to result.
+                        result.append(move(element));
+                    }
+                },
+                // iv. Else,
+                [&](PatternPartition& partition) {
+                    // 1. Append subst to result.
+                    result.append(move(partition));
+                });
+        }
+    }
+
+    // 4. Return result.
+    return result;
+}
+
+// 13.1.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist
+static Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, Vector<String> const& list)
+{
+    auto list_patterns = Unicode::get_locale_list_patterns(list_format.locale(), list_format.type_string(), list_format.style_string());
+    if (!list_patterns.has_value())
+        return {};
+
+    // 1. Let size be the number of elements of list.
+    auto size = list.size();
+
+    // 2. If size is 0, then
+    if (size == 0) {
+        // a. Return a new empty List.
+        return {};
+    }
+
+    // 3. If size is 2, then
+    if (size == 2) {
+        // a. Let n be an index into listFormat.[[Templates]] based on listFormat.[[Locale]], list[0], and list[1].
+        // b. Let pattern be listFormat.[[Templates]][n].[[Pair]].
+        auto pattern = list_patterns->pair;
+
+        // c. Let first be a new Record { [[Type]]: "element", [[Value]]: list[0] }.
+        PatternPartition first { "element"sv, list[0] };
+
+        // d. Let second be a new Record { [[Type]]: "element", [[Value]]: list[1] }.
+        PatternPartition second { "element"sv, list[1] };
+
+        // e. Let placeables be a new Record { [[0]]: first, [[1]]: second }.
+        Placeables placeables;
+        placeables.set("0"sv, move(first));
+        placeables.set("1"sv, move(second));
+
+        // f. Return DeconstructPattern(pattern, placeables).
+        return deconstruct_pattern(pattern, move(placeables));
+    }
+
+    // 4. Let last be a new Record { [[Type]]: "element", [[Value]]: list[size - 1] }.
+    PatternPartition last { "element"sv, list[size - 1] };
+
+    // 5. Let parts be « last ».
+    Vector<PatternPartition> parts { move(last) };
+
+    // The spec does not say to do this, but because size_t is unsigned, we need to take care not to wrap around 0.
+    if (size == 1)
+        return parts;
+
+    // 6. Let i be size - 2.
+    size_t i = size - 2;
+
+    // 7. Repeat, while i ≥ 0,
+    do {
+        // a. Let head be a new Record { [[Type]]: "element", [[Value]]: list[i] }.
+        PatternPartition head { "element"sv, list[i] };
+
+        // b. Let n be an implementation-defined index into listFormat.[[Templates]] based on listFormat.[[Locale]], head, and parts.
+        StringView pattern;
+
+        // c. If i is 0, then
+        if (i == 0) {
+            // i. Let pattern be listFormat.[[Templates]][n].[[Start]].
+            pattern = list_patterns->start;
+        }
+        // d. Else if i is less than size - 2, then
+        else if (i < (size - 2)) {
+            // i. Let pattern be listFormat.[[Templates]][n].[[Middle]].
+            pattern = list_patterns->middle;
+        }
+        // e. Else,
+        else {
+            // i. Let pattern be listFormat.[[Templates]][n].[[End]].
+            pattern = list_patterns->end;
+        }
+
+        // f. Let placeables be a new Record { [[0]]: head, [[1]]: parts }.
+        Placeables placeables;
+        placeables.set("0"sv, move(head));
+        placeables.set("1"sv, move(parts));
+
+        // g. Set parts to DeconstructPattern(pattern, placeables).
+        parts = deconstruct_pattern(pattern, move(placeables));
+
+        // h. Decrement i by 1.
+    } while (i-- != 0);
+
+    // 8. Return parts.
+    return parts;
+}
+
+// 13.1.3 FormatList ( listFormat, list )
+static String format_list(ListFormat const& list_format, Vector<String> const& list)
+{
+    // 1. Let parts be CreatePartsFromList(listFormat, list).
+    auto parts = create_parts_from_list(list_format, list);
+
+    // 2. Let result be an empty String.
+    StringBuilder result;
+
+    // 3. For each Record { [[Type]], [[Value]] } part in parts, do
+    for (auto const& part : parts) {
+        // a. Set result to the string-concatenation of result and part.[[Value]].
+        result.append(part.value);
+    }
+
+    // 4. Return result.
+    return result.build();
+}
+
+// 13.1.5 StringListFromIterable ( iterable ), https://tc39.es/ecma402/#sec-createstringlistfromiterable
+static Vector<String> string_list_from_iterable(GlobalObject& global_object, Value iterable)
+{
+    auto& vm = global_object.vm();
+
+    // 1. If iterable is undefined, then
+    if (iterable.is_undefined()) {
+        // a. Return a new empty List.
+        return {};
+    }
+
+    // 2. Let iteratorRecord be ? GetIterator(iterable).
+    auto* iterator_record = get_iterator(global_object, iterable);
+    if (vm.exception())
+        return {};
+
+    // 3. Let list be a new empty List.
+    Vector<String> list;
+
+    // 4. Let next be true.
+    Object* next = nullptr;
+
+    // 5. Repeat, while next is not false,
+    do {
+        // a. Set next to ? IteratorStep(iteratorRecord).
+        next = iterator_step(global_object, *iterator_record);
+        if (vm.exception())
+            return {};
+
+        // b. If next is not false, then
+        if (next != nullptr) {
+            // i. Let nextValue be ? IteratorValue(next).
+            auto next_value = iterator_value(global_object, *next);
+            if (vm.exception())
+                return {};
+
+            // ii. If Type(nextValue) is not String, then
+            if (!next_value.is_string()) {
+                // 1. Let error be ThrowCompletion(a newly created TypeError object).
+                vm.throw_exception<TypeError>(global_object, ErrorType::NotAString, next_value);
+
+                // 2. Return ? IteratorClose(iteratorRecord, error).
+                iterator_close(*iterator_record);
+                return {};
+            }
+
+            // iii. Append nextValue to the end of the List list.
+            list.append(next_value.as_string().string());
+        }
+    } while (next != nullptr);
+
+    // 6. Return list.
+    return list;
+}
 
 // 13.4 Properties of the Intl.ListFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
 ListFormatPrototype::ListFormatPrototype(GlobalObject& global_object)
@@ -23,6 +260,30 @@ void ListFormatPrototype::initialize(GlobalObject& global_object)
 
     // 13.4.2 Intl.ListFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype-toStringTag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.ListFormat"), Attribute::Configurable);
+
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.format, format, 1, attr);
+}
+
+// 13.4.3 Intl.ListFormat.prototype.format ( list ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.format
+JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format)
+{
+    auto list = vm.argument(0);
+
+    // 1. Let lf be the this value.
+    // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
+    auto* list_format = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let stringList be ? StringListFromIterable(list).
+    auto string_list = string_list_from_iterable(global_object, list);
+    if (vm.exception())
+        return {};
+
+    // 4. Return FormatList(lf, stringList).
+    auto formatted = format_list(*list_format, string_list);
+    return js_string(vm, move(formatted));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -301,6 +301,7 @@ void ListFormatPrototype::initialize(GlobalObject& global_object)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.format, format, 1, attr);
     define_native_function(vm.names.formatToParts, format_to_parts, 1, attr);
+    define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
 // 13.4.3 Intl.ListFormat.prototype.format ( list ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.format
@@ -342,6 +343,31 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format_to_parts)
 
     // 4. Return FormatListToParts(lf, stringList).
     return format_list_to_parts(global_object, *list_format, string_list);
+}
+
+// 3.4.5 Intl.ListFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.resolvedoptions
+JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
+{
+    // 1. Let lf be the this value.
+    // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
+    auto* list_format = typed_this(global_object);
+    if (vm.exception())
+        return {};
+
+    // 3. Let options be ! OrdinaryObjectCreate(%Object.prototype%).
+    auto* options = Object::create(global_object, global_object.object_prototype());
+
+    // 4. For each row of Table 9, except the header row, in table order, do
+    //     a. Let p be the Property value of the current row.
+    //     b. Let v be the value of lf's internal slot whose name is the Internal Slot value of the current row.
+    //     c. Assert: v is not undefined.
+    //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
+    options->create_data_property_or_throw(vm.names.locale, js_string(vm, list_format->locale()));
+    options->create_data_property_or_throw(vm.names.type, js_string(vm, list_format->type_string()));
+    options->create_data_property_or_throw(vm.names.style, js_string(vm, list_format->style_string()));
+
+    // 5. Return options.
+    return options;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/ListFormatPrototype.h>
+
+namespace JS::Intl {
+
+// 13.4 Properties of the Intl.ListFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
+ListFormatPrototype::ListFormatPrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void ListFormatPrototype::initialize(GlobalObject& global_object)
+{
+    Object::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 13.4.2 Intl.ListFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype-toStringTag
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.ListFormat"), Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -21,6 +21,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
+    JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
+
+namespace JS::Intl {
+
+class ListFormatPrototype final : public Object {
+    JS_OBJECT(ListFormatPrototype, Object);
+
+public:
+    explicit ListFormatPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~ListFormatPrototype() override = default;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -17,6 +17,9 @@ public:
     explicit ListFormatPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~ListFormatPrototype() override = default;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(format);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(format);
+    JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.@@toStringTag.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.@@toStringTag.js
@@ -1,0 +1,3 @@
+test("basic functionality", () => {
+    expect(Intl.ListFormat.prototype[Symbol.toStringTag]).toBe("Intl.ListFormat");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.js
@@ -1,0 +1,13 @@
+describe("errors", () => {
+    test("called without new", () => {
+        expect(() => {
+            Intl.ListFormat();
+        }).toThrowWithMessage(TypeError, "Intl.ListFormat constructor must be called with 'new'");
+    });
+});
+
+describe("normal behavior", () => {
+    test("length is 0", () => {
+        expect(Intl.ListFormat).toHaveLength(0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.js
@@ -4,10 +4,58 @@ describe("errors", () => {
             Intl.ListFormat();
         }).toThrowWithMessage(TypeError, "Intl.ListFormat constructor must be called with 'new'");
     });
+
+    test("options is an invalid type", () => {
+        expect(() => {
+            new Intl.ListFormat("en", true);
+        }).toThrowWithMessage(TypeError, "Options is not an object");
+    });
+
+    test("type option is invalid ", () => {
+        expect(() => {
+            new Intl.ListFormat("en", { type: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option type");
+    });
+
+    test("style option is invalid ", () => {
+        expect(() => {
+            new Intl.ListFormat("en", { style: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option style");
+    });
+
+    test("matcher option is invalid ", () => {
+        expect(() => {
+            new Intl.ListFormat("en", { localeMatcher: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option localeMatcher");
+    });
 });
 
 describe("normal behavior", () => {
     test("length is 0", () => {
         expect(Intl.ListFormat).toHaveLength(0);
+    });
+
+    test("all valid types", () => {
+        ["conjunction", "disjunction", "unit"].forEach(type => {
+            expect(() => {
+                new Intl.ListFormat("en", { type: type });
+            }).not.toThrow();
+        });
+    });
+
+    test("all valid styles", () => {
+        ["long", "short", "narrow"].forEach(style => {
+            expect(() => {
+                new Intl.ListFormat("en", { style: style });
+            }).not.toThrow();
+        });
+    });
+
+    test("all valid matchers", () => {
+        ["lookup", "best fit"].forEach(matcher => {
+            expect(() => {
+                new Intl.ListFormat("en", { localeMatcher: matcher });
+            }).not.toThrow();
+        });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.prototype.format.js
@@ -1,0 +1,186 @@
+describe("errors", () => {
+    function SomeError() {}
+
+    test("called on non-ListFormat object", () => {
+        expect(() => {
+            Intl.ListFormat.prototype.format([]);
+        }).toThrowWithMessage(TypeError, "Not a Intl.ListFormat object");
+    });
+
+    test("called with non-string iterable", () => {
+        expect(() => {
+            new Intl.ListFormat().format([1]);
+        }).toThrowWithMessage(TypeError, "1 is not a string");
+    });
+
+    test("called with iterable that throws immediately", () => {
+        let iterable = {
+            [Symbol.iterator]() {
+                throw new SomeError();
+            },
+        };
+
+        expect(() => {
+            new Intl.ListFormat().format(iterable);
+        }).toThrow(SomeError);
+    });
+
+    test("called with iterable that throws on step", () => {
+        let iterable = {
+            [Symbol.iterator]() {
+                return this;
+            },
+            next() {
+                throw new SomeError();
+            },
+        };
+
+        expect(() => {
+            new Intl.ListFormat().format(iterable);
+        }).toThrow(SomeError);
+    });
+
+    test("called with iterable that throws on value resolution", () => {
+        let iterable = {
+            [Symbol.iterator]() {
+                return this;
+            },
+            next() {
+                return {
+                    done: false,
+                    get value() {
+                        throw new SomeError();
+                    },
+                };
+            },
+        };
+
+        expect(() => {
+            new Intl.ListFormat().format(iterable);
+        }).toThrow(SomeError);
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Intl.ListFormat.prototype.format).toHaveLength(1);
+    });
+
+    test("undefined list returns empty string", () => {
+        expect(new Intl.ListFormat().format(undefined)).toBe("");
+    });
+});
+
+describe("type=conjunction", () => {
+    test("style=long", () => {
+        let en = new Intl.ListFormat("en", { type: "conjunction", style: "long" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a and b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, and c");
+
+        let es = new Intl.ListFormat("es-419", { type: "conjunction", style: "long" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a y b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b y c");
+    });
+
+    test("style=short", () => {
+        let en = new Intl.ListFormat("en", { type: "conjunction", style: "short" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a & b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, & c");
+
+        let es = new Intl.ListFormat("es-419", { type: "conjunction", style: "short" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a y b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b y c");
+    });
+
+    test("style=narrow", () => {
+        let en = new Intl.ListFormat("en", { type: "conjunction", style: "narrow" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a, b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, c");
+
+        let es = new Intl.ListFormat("es-419", { type: "conjunction", style: "narrow" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a y b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b y c");
+    });
+});
+
+describe("type=disjunction", () => {
+    test("style=long", () => {
+        let en = new Intl.ListFormat("en", { type: "disjunction", style: "long" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a or b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, or c");
+
+        let es = new Intl.ListFormat("es-419", { type: "disjunction", style: "long" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a o b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b o c");
+    });
+
+    test("style=short", () => {
+        let en = new Intl.ListFormat("en", { type: "disjunction", style: "short" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a or b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, or c");
+
+        let es = new Intl.ListFormat("es-419", { type: "disjunction", style: "short" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a o b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b o c");
+    });
+
+    test("style=narrow", () => {
+        let en = new Intl.ListFormat("en", { type: "disjunction", style: "narrow" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a or b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, or c");
+
+        let es = new Intl.ListFormat("es-419", { type: "disjunction", style: "narrow" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a o b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b o c");
+    });
+});
+
+describe("type=unit", () => {
+    test("style=long", () => {
+        let en = new Intl.ListFormat("en", { type: "unit", style: "long" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a, b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, c");
+
+        let es = new Intl.ListFormat("es-419", { type: "unit", style: "long" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a y b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b y c");
+    });
+
+    test("style=short", () => {
+        let en = new Intl.ListFormat("en", { type: "unit", style: "short" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a, b");
+        expect(en.format(["a", "b", "c"])).toBe("a, b, c");
+
+        let es = new Intl.ListFormat("es-419", { type: "unit", style: "short" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a y b");
+        expect(es.format(["a", "b", "c"])).toBe("a, b, c");
+    });
+
+    test("style=narrow", () => {
+        let en = new Intl.ListFormat("en", { type: "unit", style: "narrow" });
+        expect(en.format(["a"])).toBe("a");
+        expect(en.format(["a", "b"])).toBe("a b");
+        expect(en.format(["a", "b", "c"])).toBe("a b c");
+
+        let es = new Intl.ListFormat("es-419", { type: "unit", style: "narrow" });
+        expect(es.format(["a"])).toBe("a");
+        expect(es.format(["a", "b"])).toBe("a b");
+        expect(es.format(["a", "b", "c"])).toBe("a b c");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.prototype.formatToParts.js
@@ -1,0 +1,231 @@
+describe("errors", () => {
+    function SomeError() {}
+
+    test("called on non-ListFormat object", () => {
+        expect(() => {
+            Intl.ListFormat.prototype.formatToParts([]);
+        }).toThrowWithMessage(TypeError, "Not a Intl.ListFormat object");
+    });
+
+    test("called with non-string iterable", () => {
+        expect(() => {
+            new Intl.ListFormat().formatToParts([1]);
+        }).toThrowWithMessage(TypeError, "1 is not a string");
+    });
+
+    test("called with iterable that throws immediately", () => {
+        let iterable = {
+            [Symbol.iterator]() {
+                throw new SomeError();
+            },
+        };
+
+        expect(() => {
+            new Intl.ListFormat().formatToParts(iterable);
+        }).toThrow(SomeError);
+    });
+
+    test("called with iterable that throws on step", () => {
+        let iterable = {
+            [Symbol.iterator]() {
+                return this;
+            },
+            next() {
+                throw new SomeError();
+            },
+        };
+
+        expect(() => {
+            new Intl.ListFormat().formatToParts(iterable);
+        }).toThrow(SomeError);
+    });
+
+    test("called with iterable that throws on value resolution", () => {
+        let iterable = {
+            [Symbol.iterator]() {
+                return this;
+            },
+            next() {
+                return {
+                    done: false,
+                    get value() {
+                        throw new SomeError();
+                    },
+                };
+            },
+        };
+
+        expect(() => {
+            new Intl.ListFormat().formatToParts(iterable);
+        }).toThrow(SomeError);
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Intl.ListFormat.prototype.formatToParts).toHaveLength(1);
+    });
+
+    test("undefined list returns empty string", () => {
+        expect(new Intl.ListFormat().formatToParts(undefined)).toEqual([]);
+    });
+});
+
+describe("type=conjunction", () => {
+    test("style=long", () => {
+        let en = new Intl.ListFormat("en", { type: "conjunction", style: "long" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " and " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", and " },
+            { type: "element", value: "c" },
+        ]);
+    });
+
+    test("style=short", () => {
+        let en = new Intl.ListFormat("en", { type: "conjunction", style: "short" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " & " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", & " },
+            { type: "element", value: "c" },
+        ]);
+    });
+
+    test("style=narrow", () => {
+        let en = new Intl.ListFormat("en", { type: "conjunction", style: "narrow" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "c" },
+        ]);
+    });
+});
+
+describe("type=disjunction", () => {
+    test("style=long", () => {
+        let en = new Intl.ListFormat("en", { type: "disjunction", style: "long" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " or " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", or " },
+            { type: "element", value: "c" },
+        ]);
+    });
+
+    test("style=short", () => {
+        let en = new Intl.ListFormat("en", { type: "disjunction", style: "short" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " or " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", or " },
+            { type: "element", value: "c" },
+        ]);
+    });
+
+    test("style=narrow", () => {
+        let en = new Intl.ListFormat("en", { type: "disjunction", style: "narrow" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " or " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", or " },
+            { type: "element", value: "c" },
+        ]);
+    });
+});
+
+describe("type=unit", () => {
+    test("style=long", () => {
+        let en = new Intl.ListFormat("en", { type: "unit", style: "long" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "c" },
+        ]);
+    });
+
+    test("style=short", () => {
+        let en = new Intl.ListFormat("en", { type: "unit", style: "short" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "b" },
+            { type: "literal", value: ", " },
+            { type: "element", value: "c" },
+        ]);
+    });
+
+    test("style=narrow", () => {
+        let en = new Intl.ListFormat("en", { type: "unit", style: "narrow" });
+        expect(en.formatToParts(["a"])).toEqual([{ type: "element", value: "a" }]);
+        expect(en.formatToParts(["a", "b"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " " },
+            { type: "element", value: "b" },
+        ]);
+        expect(en.formatToParts(["a", "b", "c"])).toEqual([
+            { type: "element", value: "a" },
+            { type: "literal", value: " " },
+            { type: "element", value: "b" },
+            { type: "literal", value: " " },
+            { type: "element", value: "c" },
+        ]);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.prototype.resolvedOptions.js
@@ -1,0 +1,38 @@
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Intl.ListFormat.prototype.resolvedOptions).toHaveLength(0);
+    });
+
+    test("all valid types", () => {
+        ["conjunction", "disjunction", "unit"].forEach(type => {
+            const en = new Intl.ListFormat("en", { type: type });
+            expect(en.resolvedOptions()).toEqual({
+                locale: "en",
+                type: type,
+                style: "long",
+            });
+        });
+    });
+
+    test("all valid styles", () => {
+        ["long", "short", "narrow"].forEach(style => {
+            const en = new Intl.ListFormat("en", { style: style });
+            expect(en.resolvedOptions()).toEqual({
+                locale: "en",
+                type: "conjunction",
+                style: style,
+            });
+        });
+    });
+
+    test("locales with extensions", () => {
+        const en = new Intl.ListFormat("en-t-en");
+        expect(en.resolvedOptions().locale).toBe("en");
+
+        const es419 = new Intl.ListFormat("es-419-u-1k-aaa");
+        expect(es419.resolvedOptions().locale).toBe("es-419");
+
+        const zhHant = new Intl.ListFormat(["zh-Hant-x-aaa"]);
+        expect(zhHant.resolvedOptions().locale).toBe("zh-Hant");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.supportedLocalesOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/ListFormat/ListFormat.supportedLocalesOf.js
@@ -1,0 +1,43 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Intl.ListFormat.supportedLocalesOf).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        // prettier-ignore
+        const values = [
+            [[], []],
+            [undefined, []],
+            ["en", ["en"]],
+            [new Intl.Locale("en"), ["en"]],
+            [["en"], ["en"]],
+            [["en", "en-gb", "en-us"], ["en", "en-GB", "en-US"]],
+            [["en", "de", "fr"], ["en", "de", "fr"]],
+            [["en-foobar"], ["en-foobar"]],
+            [["en-foobar-u-abc"], ["en-foobar-u-abc"]],
+            [["aa", "zz"], []],
+            [["en", "aa", "zz"], ["en"]],
+        ];
+        for (const [input, expected] of values) {
+            expect(Intl.ListFormat.supportedLocalesOf(input)).toEqual(expected);
+            // "best fit" (implementation defined) just uses the same implementation as "lookup" at the moment
+            expect(
+                Intl.ListFormat.supportedLocalesOf(input, { localeMatcher: "best fit" })
+            ).toEqual(Intl.ListFormat.supportedLocalesOf(input, { localeMatcher: "lookup" }));
+        }
+    });
+});
+
+describe("errors", () => {
+    test("invalid value for localeMatcher option", () => {
+        expect(() => {
+            Intl.ListFormat.supportedLocalesOf([], { localeMatcher: "foo" });
+        }).toThrowWithMessage(RangeError, "foo is not a valid value for option localeMatcher");
+    });
+
+    test("invalid language tag", () => {
+        expect(() => {
+            Intl.ListFormat.supportedLocalesOf(["aaaaaaaaa"]);
+        }).toThrowWithMessage(RangeError, "aaaaaaaaa is not a structurally valid language tag");
+    });
+});

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -13,6 +13,8 @@ namespace Unicode {
 enum class Condition : u8;
 enum class GeneralCategory : u8;
 enum class Language : u8;
+enum class ListPatternStyle : u8;
+enum class ListPatternType : u8;
 enum class Locale : u16;
 enum class Property : u8;
 enum class Script : u8;
@@ -21,6 +23,7 @@ enum class WordBreakProperty : u8;
 
 struct Keyword;
 struct LanguageID;
+struct ListPatterns;
 struct LocaleExtension;
 struct LocaleID;
 struct OtherExtension;

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -798,6 +798,15 @@ Optional<StringView> get_locale_currency_mapping([[maybe_unused]] StringView loc
 #endif
 }
 
+Optional<ListPatterns> get_locale_list_patterns([[maybe_unused]] StringView locale, [[maybe_unused]] StringView type, [[maybe_unused]] StringView style)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_locale_list_pattern_mapping(locale, type, style);
+#else
+    return {};
+#endif
+}
+
 Optional<StringView> resolve_language_alias(StringView language)
 {
 #if ENABLE_UNICODE_DATA

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -78,6 +78,13 @@ struct LocaleID {
     Vector<String> private_use_extensions {};
 };
 
+struct ListPatterns {
+    StringView start;
+    StringView middle;
+    StringView end;
+    StringView pair;
+};
+
 // Note: These methods only verify that the provided strings match the EBNF grammar of the
 // Unicode identifier subtag (i.e. no validation is done that the tags actually exist).
 constexpr bool is_unicode_language_subtag(StringView subtag)
@@ -130,6 +137,7 @@ Optional<StringView> get_locale_language_mapping(StringView locale, StringView l
 Optional<StringView> get_locale_territory_mapping(StringView locale, StringView territory);
 Optional<StringView> get_locale_script_mapping(StringView locale, StringView script);
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency);
+Optional<ListPatterns> get_locale_list_patterns(StringView locale, StringView type, StringView style);
 
 Optional<StringView> resolve_language_alias(StringView language);
 Optional<StringView> resolve_territory_alias(StringView territory);

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -30,6 +30,7 @@
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
+#include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Map.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -549,6 +550,18 @@ static void print_intl_locale(JS::Object const& object, HashTable<JS::Object*>& 
     print_value(JS::Value(locale.numeric()), seen_objects);
 }
 
+static void print_intl_list_format(JS::Object const& object, HashTable<JS::Object*>& seen_objects)
+{
+    auto& list_format = static_cast<JS::Intl::ListFormat const&>(object);
+    print_type("Intl.ListFormat");
+    out("\n  locale: ");
+    print_value(js_string(object.vm(), list_format.locale()), seen_objects);
+    out("\n  type: ");
+    print_value(js_string(object.vm(), list_format.type_string()), seen_objects);
+    out("\n  style: ");
+    print_value(js_string(object.vm(), list_format.style_string()), seen_objects);
+}
+
 static void print_primitive_wrapper_object(FlyString const& name, JS::Object const& object, HashTable<JS::Object*>& seen_objects)
 {
     // BooleanObject, NumberObject, StringObject
@@ -626,6 +639,8 @@ static void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
             return print_intl_display_names(object, seen_objects);
         if (is<JS::Intl::Locale>(object))
             return print_intl_locale(object, seen_objects);
+        if (is<JS::Intl::ListFormat>(object))
+            return print_intl_list_format(object, seen_objects);
         return print_object(object, seen_objects);
     }
 


### PR DESCRIPTION
This extracts and parses the `cldr-misc/**/listPatterns.json` data from the CLDR and generates an array of formatting list patterns per locale. For example, in en-US, the list `["a", "b", "c"]` formatted to a string should become `"a, b, and c"`.

tl;dr:
```
test/intl402/ListFormat    81/81    (100.00%) [ ✅ 81 ] 
```