### PR TITLE
Documentation: Add missing dependencies for Nix

### DIFF
--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
     patch
     ccache
     rsync
+    unzip
 
     # Example Build-time Additional Dependencies
     pkgconfig
@@ -55,6 +56,7 @@ stdenv.mkDerivation {
     # Example Run-time Additional Dependencies
     openssl
     x11
+    qemu
     # glibc
   ];
   hardeningDisable = [ "format" "fortify" ];


### PR DESCRIPTION
I was building serenity on quite a fresh NixOS system and it turns out `unzip` and `qemu` were missing from this nix expression to compile and run serenity.