### PR TITLE
Kernel: Harden construction patterns against OOM conditions

### DIFF
--- a/Kernel/ACPI/Definitions.h
+++ b/Kernel/ACPI/Definitions.h
@@ -330,7 +330,7 @@ class Parser;
 
 namespace StaticParsing {
 Optional<PhysicalAddress> find_rsdp();
-PhysicalAddress find_table(PhysicalAddress rsdp, const StringView& signature);
+Optional<PhysicalAddress> find_table(PhysicalAddress rsdp, const StringView& signature);
 }
 
 }

--- a/Kernel/ACPI/Parser.h
+++ b/Kernel/ACPI/Parser.h
@@ -48,7 +48,7 @@ public:
         set_the(*new ParserType(rsdp));
     }
 
-    virtual PhysicalAddress find_table(const StringView& signature);
+    virtual Optional<PhysicalAddress> find_table(const StringView& signature);
 
     virtual void try_acpi_reboot();
     virtual bool can_reboot();

--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -12,14 +12,20 @@ namespace Kernel::VirtIO {
 
 unsigned Console::next_device_id = 0;
 
-UNMAP_AFTER_INIT NonnullRefPtr<Console> Console::must_create(PCI::Address address)
+UNMAP_AFTER_INIT RefPtr<Console> Console::try_create(PCI::Address address)
 {
-    return adopt_ref_if_nonnull(new Console(address)).release_nonnull();
+    auto console = adopt_ref_if_nonnull(new Console(address));
+    if (!console)
+        return {};
+    if (!console->initialize())
+        return {};
+    return console;
 }
 
-UNMAP_AFTER_INIT void Console::initialize()
+UNMAP_AFTER_INIT bool Console::initialize()
 {
-    Device::initialize();
+    if (auto result = Device::initialize(); !result)
+        return false;
     if (auto cfg = get_config(ConfigurationType::Device)) {
         bool success = negotiate_features([&](u64 supported_features) {
             u64 negotiated = 0;
@@ -55,6 +61,7 @@ UNMAP_AFTER_INIT void Console::initialize()
                 m_ports.append(make_ref_counted<VirtIO::ConsolePort>(0u, *this));
         }
     }
+    return true;
 }
 
 UNMAP_AFTER_INIT Console::Console(PCI::Address address)

--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -118,8 +118,8 @@ void Console::handle_queue_update(u16 queue_index)
 
 void Console::setup_multiport()
 {
-    m_control_receive_buffer = make<Memory::RingBuffer>("VirtIOConsole control receive queue", CONTROL_BUFFER_SIZE);
-    m_control_transmit_buffer = make<Memory::RingBuffer>("VirtIOConsole control transmit queue", CONTROL_BUFFER_SIZE);
+    m_control_receive_buffer = Memory::RingBuffer::try_create("VirtIOConsole control receive queue", CONTROL_BUFFER_SIZE).release_value();
+    m_control_transmit_buffer = Memory::RingBuffer::try_create("VirtIOConsole control transmit queue", CONTROL_BUFFER_SIZE).release_value();
 
     auto& queue = get_queue(CONTROL_RECEIVEQ);
     SpinlockLocker queue_lock(queue.lock());

--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -18,7 +18,7 @@ class Console
     friend VirtIO::ConsolePort;
 
 public:
-    static NonnullRefPtr<Console> must_create(PCI::Address address);
+    static RefPtr<Console> try_create(PCI::Address address);
     virtual ~Console() override = default;
 
     virtual StringView purpose() const override { return class_name(); }
@@ -28,7 +28,7 @@ public:
         return m_device_id;
     }
 
-    virtual void initialize() override;
+    virtual bool initialize() override;
 
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"; }

--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -32,7 +32,7 @@ public:
 
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"; }
-    explicit Console(PCI::Address);
+    Console(PCI::Address, NonnullOwnPtr<Memory::RingBuffer>&& control_transmit_buffer, NonnullOwnPtr<Memory::RingBuffer>&& control_receive_buffer);
     enum class ControlEvent : u16 {
         DeviceReady = 0,
         DeviceAdd = 1,
@@ -72,8 +72,8 @@ private:
 
     unsigned m_device_id;
 
-    OwnPtr<Memory::RingBuffer> m_control_transmit_buffer;
-    OwnPtr<Memory::RingBuffer> m_control_receive_buffer;
+    NonnullOwnPtr<Memory::RingBuffer> m_control_transmit_buffer;
+    NonnullOwnPtr<Memory::RingBuffer> m_control_receive_buffer;
 
     WaitQueue m_control_wait_queue;
 

--- a/Kernel/Bus/VirtIO/ConsolePort.cpp
+++ b/Kernel/Bus/VirtIO/ConsolePort.cpp
@@ -17,8 +17,8 @@ ConsolePort::ConsolePort(unsigned port, VirtIO::Console& console)
     , m_console(console)
     , m_port(port)
 {
-    m_receive_buffer = make<Memory::RingBuffer>("VirtIO::ConsolePort Receive", RINGBUFFER_SIZE);
-    m_transmit_buffer = make<Memory::RingBuffer>("VirtIO::ConsolePort Transmit", RINGBUFFER_SIZE);
+    m_receive_buffer = Memory::RingBuffer::try_create("VirtIO::ConsolePort Receive", RINGBUFFER_SIZE).release_value();
+    m_transmit_buffer = Memory::RingBuffer::try_create("VirtIO::ConsolePort Transmit", RINGBUFFER_SIZE).release_value();
     m_receive_queue = m_port == 0 ? 0 : m_port * 2 + 2;
     m_transmit_queue = m_port == 0 ? 1 : m_port * 2 + 3;
     init_receive_buffer();

--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -25,13 +25,17 @@ UNMAP_AFTER_INIT void detect()
             return;
         switch (id.device_id) {
         case PCI::DeviceID::VirtIOConsole: {
-            auto& console = Console::must_create(address).leak_ref();
-            console.initialize();
+            auto console = Console::try_create(address);
+            if (console) {
+                [[maybe_unused]] auto* unused = console.leak_ref();
+            }
             break;
         }
         case PCI::DeviceID::VirtIOEntropy: {
-            auto& rng = RNG::must_create(address).leak_ref();
-            rng.initialize();
+            auto rng = RNG::try_create(address);
+            if (rng) {
+                [[maybe_unused]] auto* unused = rng.leak_ref();
+            }
             break;
         }
         case PCI::DeviceID::VirtIOGPU: {
@@ -83,7 +87,7 @@ StringView determine_device_class(const PCI::Address& address)
     VERIFY_NOT_REACHED();
 }
 
-UNMAP_AFTER_INIT void Device::initialize()
+UNMAP_AFTER_INIT bool Device::initialize()
 {
     auto address = pci_address();
     enable_bus_mastering(pci_address());
@@ -98,7 +102,7 @@ UNMAP_AFTER_INIT void Device::initialize()
             auto raw_config_type = capability.read8(0x3);
             if (raw_config_type < static_cast<u8>(ConfigurationType::Common) || raw_config_type > static_cast<u8>(ConfigurationType::PCI)) {
                 dbgln("{}: Unknown capability configuration type: {}", VirtIO::determine_device_class(address), raw_config_type);
-                return;
+                return false;
             }
             cfg->cfg_type = static_cast<ConfigurationType>(raw_config_type);
             auto cap_length = capability.read8(0x2);
@@ -133,6 +137,7 @@ UNMAP_AFTER_INIT void Device::initialize()
     set_status_bit(DEVICE_STATUS_ACKNOWLEDGE);
 
     set_status_bit(DEVICE_STATUS_DRIVER);
+    return true;
 }
 
 UNMAP_AFTER_INIT VirtIO::Device::Device(PCI::Address address)

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -90,7 +90,7 @@ class Device
 public:
     virtual ~Device() override = default;
 
-    virtual void initialize();
+    virtual bool initialize();
 
 protected:
     virtual StringView class_name() const = 0;

--- a/Kernel/Bus/VirtIO/RNG.h
+++ b/Kernel/Bus/VirtIO/RNG.h
@@ -19,11 +19,11 @@ class RNG final
     : public RefCounted<RNG>
     , public VirtIO::Device {
 public:
-    static NonnullRefPtr<RNG> must_create(PCI::Address address);
+    static RefPtr<RNG> try_create(PCI::Address address);
     virtual StringView purpose() const override { return class_name(); }
     virtual ~RNG() override = default;
 
-    virtual void initialize() override;
+    virtual bool initialize() override;
 
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"; }

--- a/Kernel/Bus/VirtIO/RNG.h
+++ b/Kernel/Bus/VirtIO/RNG.h
@@ -27,12 +27,12 @@ public:
 
 private:
     virtual StringView class_name() const override { return "VirtIOConsole"; }
-    explicit RNG(PCI::Address);
+    RNG(PCI::Address, NonnullOwnPtr<Memory::Region>&&);
     virtual bool handle_device_config_change() override;
     virtual void handle_queue_update(u16 queue_index) override;
     void request_entropy_from_host();
 
-    OwnPtr<Memory::Region> m_entropy_buffer;
+    NonnullOwnPtr<Memory::Region> m_entropy_buffer;
     EntropySource m_entropy_source;
 };
 

--- a/Kernel/Graphics/VirtIOGPU/GPU.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU.cpp
@@ -19,9 +19,6 @@ bool GPU::initialize()
 {
     if (auto result = Device::initialize(); !result)
         return false;
-    m_scratch_space = MM.allocate_contiguous_kernel_region(32 * PAGE_SIZE, "VirtGPU Scratch Space", Memory::Region::Access::ReadWrite);
-    if (!m_scratch_space)
-        return false;
     if (auto cfg = get_config(VirtIO::ConfigurationType::Device)) {
         m_device_configuration = cfg;
         bool success = negotiate_features([&](u64 supported_features) {
@@ -54,7 +51,10 @@ bool GPU::initialize()
 
 UNMAP_AFTER_INIT RefPtr<GPU> GPU::try_create(Badge<VirtIOGPU::GraphicsAdapter>, PCI::Address address)
 {
-    auto gpu_device = adopt_ref_if_nonnull(new GPU(address));
+    auto scratch_region = MM.allocate_contiguous_kernel_region(32 * PAGE_SIZE, "VirtGPU Scratch Space", Memory::Region::Access::ReadWrite);
+    if (scratch_region.is_error())
+        return {};
+    auto gpu_device = adopt_ref_if_nonnull(new GPU(address, scratch_region.release_value()));
     if (!gpu_device)
         return {};
     if (!gpu_device->initialize())
@@ -62,13 +62,10 @@ UNMAP_AFTER_INIT RefPtr<GPU> GPU::try_create(Badge<VirtIOGPU::GraphicsAdapter>, 
     return gpu_device;
 }
 
-GPU::GPU(PCI::Address address)
+GPU::GPU(PCI::Address address, NonnullOwnPtr<Memory::Region>&& scratch_region)
     : VirtIO::Device(address)
+    , m_scratch_space(move(scratch_region))
 {
-    auto region_or_error = MM.allocate_contiguous_kernel_region(32 * PAGE_SIZE, "VirtGPU Scratch Space", Memory::Region::Access::ReadWrite);
-    if (region_or_error.is_error())
-        TODO();
-    m_scratch_space = region_or_error.release_value();
 }
 
 GPU::~GPU()

--- a/Kernel/Graphics/VirtIOGPU/GPU.h
+++ b/Kernel/Graphics/VirtIOGPU/GPU.h
@@ -80,7 +80,7 @@ public:
     void flush_dirty_rectangle(ScanoutID, Protocol::Rect const& dirty_rect, ResourceID);
 
 private:
-    explicit GPU(PCI::Address);
+    GPU(PCI::Address, NonnullOwnPtr<Memory::Region>&&);
     virtual StringView class_name() const override { return "VirtIOGPU"; }
 
     struct Scanout {
@@ -124,7 +124,7 @@ private:
     // Synchronous commands
     WaitQueue m_outstanding_request;
     Mutex m_operation_lock;
-    OwnPtr<Memory::Region> m_scratch_space;
+    NonnullOwnPtr<Memory::Region> m_scratch_space;
 };
 
 }

--- a/Kernel/Graphics/VirtIOGPU/GPU.h
+++ b/Kernel/Graphics/VirtIOGPU/GPU.h
@@ -34,13 +34,14 @@ class FrameBufferDevice;
 TYPEDEF_DISTINCT_ORDERED_ID(u32, ResourceID);
 TYPEDEF_DISTINCT_ORDERED_ID(u32, ScanoutID);
 
+class GraphicsAdapter;
 class GPU final
     : public VirtIO::Device
     , public RefCounted<GPU> {
     friend class FrameBufferDevice;
 
 public:
-    GPU(PCI::Address);
+    static RefPtr<GPU> try_create(Badge<GraphicsAdapter>, PCI::Address address);
     virtual ~GPU() override;
 
     void create_framebuffer_devices();
@@ -57,7 +58,7 @@ public:
         return IterationDecision::Continue;
     }
 
-    virtual void initialize() override;
+    virtual bool initialize() override;
 
     RefPtr<Console> default_console()
     {
@@ -79,6 +80,7 @@ public:
     void flush_dirty_rectangle(ScanoutID, Protocol::Rect const& dirty_rect, ResourceID);
 
 private:
+    explicit GPU(PCI::Address);
     virtual StringView class_name() const override { return "VirtIOGPU"; }
 
     struct Scanout {

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -18,11 +18,13 @@ class GraphicsAdapter final
     AK_MAKE_ETERNAL
 
 public:
-    static NonnullRefPtr<GraphicsAdapter> initialize(PCI::Address);
+    static RefPtr<GraphicsAdapter> initialize(PCI::Address);
 
     virtual bool framebuffer_devices_initialized() const override { return m_created_framebuffer_devices; }
 
 private:
+    bool initialize();
+
     explicit GraphicsAdapter(PCI::Address base_address);
 
     virtual void initialize_framebuffer_devices() override;

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -265,12 +265,12 @@ UNMAP_AFTER_INIT bool APIC::init_bsp()
         return false;
     }
     auto madt_address = ACPI::StaticParsing::find_table(rsdp.value(), "APIC");
-    if (madt_address.is_null()) {
+    if (!madt_address.has_value()) {
         dbgln("APIC: MADT table not found");
         return false;
     }
 
-    auto madt = Memory::map_typed<ACPI::Structures::MADT>(madt_address);
+    auto madt = Memory::map_typed<ACPI::Structures::MADT>(madt_address.value());
     size_t entry_index = 0;
     size_t entries_length = madt->h.length - sizeof(ACPI::Structures::MADT);
     auto* madt_entry = madt->entries;

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -115,7 +115,7 @@ UNMAP_AFTER_INIT PhysicalAddress InterruptManagement::search_for_madt()
     auto rsdp = ACPI::StaticParsing::find_rsdp();
     if (!rsdp.has_value())
         return {};
-    return ACPI::StaticParsing::find_table(rsdp.value(), "APIC");
+    return ACPI::StaticParsing::find_table(rsdp.value(), "APIC").value();
 }
 
 UNMAP_AFTER_INIT InterruptManagement::InterruptManagement()

--- a/Kernel/Memory/RingBuffer.h
+++ b/Kernel/Memory/RingBuffer.h
@@ -14,7 +14,7 @@ namespace Kernel::Memory {
 
 class RingBuffer {
 public:
-    RingBuffer(String region_name, size_t capacity);
+    static KResultOr<NonnullOwnPtr<RingBuffer>> try_create(String region_name, size_t capacity);
 
     bool has_space() const { return m_num_used_bytes < m_capacity_in_bytes; }
     bool copy_data_in(const UserOrKernelBuffer& buffer, size_t offset, size_t length, PhysicalAddress& start_of_copied_data, size_t& bytes_copied);
@@ -30,7 +30,8 @@ public:
     size_t bytes_till_end() const { return (m_capacity_in_bytes - ((m_start_of_used + m_num_used_bytes) % m_capacity_in_bytes)) % m_capacity_in_bytes; };
 
 private:
-    OwnPtr<Memory::Region> m_region;
+    RingBuffer(NonnullOwnPtr<Memory::Region>&&, size_t capacity);
+    NonnullOwnPtr<Memory::Region> m_region;
     Spinlock m_lock;
     size_t m_start_of_used {};
     size_t m_num_used_bytes {};

--- a/Kernel/Storage/AHCIController.h
+++ b/Kernel/Storage/AHCIController.h
@@ -25,7 +25,7 @@ class AHCIController final : public StorageController
     friend class AHCIPort;
     AK_MAKE_ETERNAL
 public:
-    UNMAP_AFTER_INIT static NonnullRefPtr<AHCIController> initialize(PCI::Address address);
+    UNMAP_AFTER_INIT static KResultOr<NonnullRefPtr<AHCIController>> try_create(PCI::Address address);
     virtual ~AHCIController() override;
 
     virtual RefPtr<StorageDevice> device(u32 index) const override;
@@ -41,8 +41,8 @@ private:
     void disable_global_interrupts() const;
     void enable_global_interrupts() const;
 
-    UNMAP_AFTER_INIT explicit AHCIController(PCI::Address address);
-    UNMAP_AFTER_INIT void initialize();
+    UNMAP_AFTER_INIT AHCIController(NonnullOwnPtr<Memory::Region>&& hba_region, PCI::Address address);
+    UNMAP_AFTER_INIT KResult initialize();
 
     AHCI::HBADefinedCapabilities capabilities() const;
     RefPtr<StorageDevice> device_by_port(u32 index) const;

--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -71,7 +71,7 @@ private:
 
     void start_request(AsyncBlockDeviceRequest&);
     void complete_current_request(AsyncDeviceRequest::RequestResult);
-    bool access_device(AsyncBlockDeviceRequest::RequestType, u64 lba, u8 block_count);
+    AsyncDeviceRequest::RequestResult access_device(AsyncBlockDeviceRequest::RequestType, u64 lba, u8 block_count);
     size_t calculate_descriptors_count(size_t block_count) const;
     [[nodiscard]] Optional<AsyncDeviceRequest::RequestResult> prepare_and_set_scatter_list(AsyncBlockDeviceRequest& request);
 

--- a/Kernel/Storage/AHCIPortHandler.h
+++ b/Kernel/Storage/AHCIPortHandler.h
@@ -32,7 +32,7 @@ class AHCIPortHandler final : public RefCounted<AHCIPortHandler>
     friend class SATADiskDevice;
 
 public:
-    UNMAP_AFTER_INIT static NonnullRefPtr<AHCIPortHandler> create(AHCIController&, u8 irq, AHCI::MaskedBitField taken_ports);
+    UNMAP_AFTER_INIT static KResultOr<NonnullRefPtr<AHCIPortHandler>> try_create(AHCIController&, u8 irq, AHCI::MaskedBitField taken_ports);
     virtual ~AHCIPortHandler() override;
 
     RefPtr<StorageDevice> device_at_port(size_t port_index) const;
@@ -45,7 +45,8 @@ public:
     bool is_responsible_for_port_index(u32 port_index) const { return m_taken_ports.is_set_at(port_index); }
 
 private:
-    UNMAP_AFTER_INIT AHCIPortHandler(AHCIController&, u8 irq, AHCI::MaskedBitField taken_ports);
+    KResult initialize();
+    UNMAP_AFTER_INIT AHCIPortHandler(AHCIController&, u8 irq, NonnullRefPtrVector<Memory::PhysicalPage>, AHCI::MaskedBitField taken_ports);
 
     //^ IRQHandler
     virtual bool handle_irq(const RegisterState&) override;

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -55,7 +55,10 @@ UNMAP_AFTER_INIT NonnullRefPtrVector<StorageController> StorageManagement::enume
         }
         PCI::enumerate([&](const PCI::Address& address, PCI::ID) {
             if (PCI::get_class(address) == PCI_MASS_STORAGE_CLASS_ID && PCI::get_subclass(address) == PCI_SATA_CTRL_SUBCLASS_ID && PCI::get_programming_interface(address) == PCI_AHCI_IF_PROGIF) {
-                controllers.append(AHCIController::initialize(address));
+                auto controller_or_error = AHCIController::try_create(address);
+                if (controller_or_error.is_error())
+                    VERIFY_NOT_REACHED();
+                controllers.append(controller_or_error.release_value());
             }
         });
     }

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -119,12 +119,12 @@ UNMAP_AFTER_INIT bool HPET::test_and_initialize()
 {
     VERIFY(!HPET::initialized());
     hpet_initialized = true;
-    auto hpet = ACPI::Parser::the()->find_table("HPET");
-    if (hpet.is_null())
+    auto hpet_table = ACPI::Parser::the()->find_table("HPET");
+    if (!hpet_table.has_value())
         return false;
-    dmesgln("HPET @ {}", hpet);
+    dmesgln("HPET @ {}", hpet_table.value());
 
-    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet);
+    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet_table.value());
 
     // Note: HPET is only usable from System Memory
     VERIFY(sdt->event_timer_block.address_space == (u8)ACPI::GenericAddressStructure::AddressSpace::SystemMemory);
@@ -141,11 +141,11 @@ UNMAP_AFTER_INIT bool HPET::test_and_initialize()
 
 UNMAP_AFTER_INIT bool HPET::check_for_exisiting_periodic_timers()
 {
-    auto hpet = ACPI::Parser::the()->find_table("HPET");
-    if (hpet.is_null())
+    auto hpet_table = ACPI::Parser::the()->find_table("HPET");
+    if (!hpet_table.has_value())
         return false;
 
-    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet);
+    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet_table.value());
     VERIFY(sdt->event_timer_block.address_space == 0);
     auto registers = Memory::map_typed<HPETRegistersBlock>(PhysicalAddress(sdt->event_timer_block.address));
 

--- a/Kernel/Time/HPET.h
+++ b/Kernel/Time/HPET.h
@@ -24,6 +24,7 @@ public:
     static bool test_and_initialize();
     static bool check_for_exisiting_periodic_timers();
     static HPET& the();
+    static PhysicalAddress find_acpi_hpet_registers_block(PhysicalAddress hpet_table);
 
     u64 frequency() const { return m_frequency; }
     u64 raw_counter_ticks_to_ns(u64) const;
@@ -60,12 +61,10 @@ private:
     void set_comparators_to_optimal_interrupt_state(size_t timers_count);
 
     u64 nanoseconds_to_raw_ticks() const;
-
-    PhysicalAddress find_acpi_hpet_registers_block();
-    explicit HPET(PhysicalAddress acpi_hpet);
+    HPET(NonnullOwnPtr<Memory::Region>&&, PhysicalAddress acpi_hpet, PhysicalAddress hpet_registers_block);
     PhysicalAddress m_physical_acpi_hpet_table;
-    PhysicalAddress m_physical_acpi_hpet_registers;
-    OwnPtr<Memory::Region> m_hpet_mmio_region;
+    PhysicalAddress m_physical_hpet_registers;
+    NonnullOwnPtr<Memory::Region> m_hpet_mmio_region;
 
     u64 m_main_counter_last_read { 0 };
     u64 m_main_counter_drift { 0 };


### PR DESCRIPTION
Relies on #9818 and #9871 (to some extent).
Fixes problems that were mentioned in https://github.com/SerenityOS/serenity/commit/75564b4a5f2b5452163571116ee9efaf5c3c65af.