### PR TITLE
Various tweaks to the clang build script

### DIFF
--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -76,7 +76,18 @@ BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils"
 buildstep() {
     NAME=$1
     shift
-    "$@" 2>&1 | sed $'s|^|\x1b[34m['"${NAME}"$']\x1b[39m |'
+    "$@" 2>&1 | sed $'s|^|\e[34m['"${NAME}"$']\e[39m |'
+}
+
+buildstep_ninja() {
+    # When ninja writes to a pipe, it strips ANSI escape codes and prints one line per buildstep.
+    # Instead, use NINJA_STATUS so that we get colored output from LLVM's build and fewer lines of output when running in a tty.
+    # ANSI escape codes in NINJA_STATUS are slightly janky (ninja thinks that "\e[34m" needs 5 output characters instead of 5, so
+    # it's middle elision is slightly off; also it would happily elide the "\e39m" which messes up the output if the terminal is too
+    # narrow), but it's still working better than the alternative.
+    NAME=$1
+    shift
+    env NINJA_STATUS=$'\e[34m['"${NAME}"$']\e[39m [%f/%t] ' "$@"
 }
 
 # === DEPENDENCIES ===
@@ -263,7 +274,7 @@ pushd "$DIR/Build/clang/$ARCH"
             -DLLVM_INSTALL_UTILS=OFF \
             ${dev:+"-DLLVM_CCACHE_BUILD=ON"} || exit 1
 
-        buildstep "llvm+clang/build" ninja -j "$MAKEJOBS" || exit 1
+        buildstep_ninja "llvm+clang/build" ninja -j "$MAKEJOBS" || exit 1
         buildstep "llvm+clang/install" ninja install || exit 1
     popd
 
@@ -298,7 +309,7 @@ pushd "$DIR/Build/clang/$ARCH"
             -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
             -DCOMPILER_RT_BUILD_XRAY=OFF || exit 1
 
-        buildstep "compiler-rt/build" ninja -j "$MAKEJOBS" || exit 1
+        buildstep_ninja "compiler-rt/build" ninja -j "$MAKEJOBS" || exit 1
         buildstep "compiler-rt/install" ninja install || exit 1
     popd
 
@@ -319,7 +330,7 @@ pushd "$DIR/Build/clang/$ARCH"
             -DLIBUNWIND_TARGET_TRIPLE="$LLVM_TARGET" \
             -DLIBUNWIND_SYSROOT="$SYSROOT" || exit 1
 
-        buildstep "libunwind/build" ninja -j "$MAKEJOBS" || exit 1
+        buildstep_ninja "libunwind/build" ninja -j "$MAKEJOBS" || exit 1
         buildstep "libunwind/install" ninja install || exit 1
     popd
 
@@ -343,7 +354,7 @@ pushd "$DIR/Build/clang/$ARCH"
             -DLIBCXXABI_ENABLE_ASSERTIONS=OFF \
             -DLIBCXXABI_BAREMETAL=ON || exit 1
 
-        buildstep "libcxxabi/build" ninja -j "$MAKEJOBS" || exit 1
+        buildstep_ninja "libcxxabi/build" ninja -j "$MAKEJOBS" || exit 1
         buildstep "libcxxabi/install" ninja install || exit 1
     popd
 

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -253,7 +253,7 @@ pushd "$DIR/Build/clang/$ARCH"
             -DCMAKE_BUILD_TYPE="MinSizeRel" \
             -DCMAKE_INSTALL_PREFIX="$PREFIX" \
             -DLLVM_DEFAULT_TARGET_TRIPLE="$LLVM_TARGET" \
-            -DLLVM_TARGETS_TO_BUILD=X86 \
+            '-DLLVM_TARGETS_TO_BUILD=X86;AArch64' \
             -DLLVM_ENABLE_BINDINGS=OFF \
             -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF \
             -DLLVM_ENABLE_PROJECTS="clang;lld" \

--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -259,7 +259,6 @@ pushd "$DIR/Build/clang/$ARCH"
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
             -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -DLLVM_INCLUDE_TESTS=OFF \
-            -DLLVM_LLVM_BUILD_LLVM_DYLIB=ON \
             -DLLVM_LINK_LLVM_DYLIB=ON \
             -DLLVM_INSTALL_UTILS=OFF \
             ${dev:+"-DLLVM_CCACHE_BUILD=ON"} || exit 1

--- a/Toolchain/Patches/llvm.patch
+++ b/Toolchain/Patches/llvm.patch
@@ -2,6 +2,15 @@ diff --git a/clang/lib/Basic/Targets.cpp b/clang/lib/Basic/Targets.cpp
 index 90a67d03b..ad21af415 100644
 --- a/clang/lib/Basic/Targets.cpp
 +++ b/clang/lib/Basic/Targets.cpp
+@@ -148,6 +148,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
+       return new NetBSDTargetInfo<AArch64leTargetInfo>(Triple, Opts);
+     case llvm::Triple::OpenBSD:
+       return new OpenBSDTargetInfo<AArch64leTargetInfo>(Triple, Opts);
++    case llvm::Triple::Serenity:
++      return new SerenityTargetInfo<AArch64leTargetInfo>(Triple, Opts);
+     case llvm::Triple::Win32:
+       switch (Triple.getEnvironment()) {
+       case llvm::Triple::GNU:
 @@ -527,6 +527,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
        return new MCUX86_32TargetInfo(Triple, Opts);
      case llvm::Triple::Hurd:


### PR DESCRIPTION
- Make serenity clang support aarch64
- Fix a CMake warning about `LLVM_LLVM_BUILD_LLVM_DYLIB`
- Make build script produce less output and colored diagnostics when called from a TTY

@BertalanD