### PR TITLE
Kernel/ACPI: Return Optional container after table search

### DIFF
--- a/Kernel/ACPI/Definitions.h
+++ b/Kernel/ACPI/Definitions.h
@@ -330,7 +330,7 @@ class Parser;
 
 namespace StaticParsing {
 Optional<PhysicalAddress> find_rsdp();
-PhysicalAddress find_table(PhysicalAddress rsdp, const StringView& signature);
+Optional<PhysicalAddress> find_table(PhysicalAddress rsdp, const StringView& signature);
 }
 
 }

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -103,8 +103,8 @@ void Parser::set_the(Parser& parser)
 }
 
 static bool match_table_signature(PhysicalAddress table_header, const StringView& signature);
-static PhysicalAddress search_table_in_xsdt(PhysicalAddress xsdt, const StringView& signature);
-static PhysicalAddress search_table_in_rsdt(PhysicalAddress rsdt, const StringView& signature);
+static Optional<PhysicalAddress> search_table_in_xsdt(PhysicalAddress xsdt, const StringView& signature);
+static Optional<PhysicalAddress> search_table_in_rsdt(PhysicalAddress rsdt, const StringView& signature);
 static bool validate_table(const Structures::SDTHeader&, size_t length);
 
 UNMAP_AFTER_INIT void Parser::locate_static_data()
@@ -115,7 +115,7 @@ UNMAP_AFTER_INIT void Parser::locate_static_data()
     init_facs();
 }
 
-UNMAP_AFTER_INIT PhysicalAddress Parser::find_table(const StringView& signature)
+UNMAP_AFTER_INIT Optional<PhysicalAddress> Parser::find_table(const StringView& signature)
 {
     dbgln_if(ACPI_DEBUG, "ACPI: Calling Find Table method!");
     for (auto p_sdt : m_sdt_pointers) {
@@ -131,7 +131,8 @@ UNMAP_AFTER_INIT PhysicalAddress Parser::find_table(const StringView& signature)
 
 UNMAP_AFTER_INIT void Parser::init_facs()
 {
-    m_facs = find_table("FACS");
+    if (auto facs = find_table("FACS"); facs.has_value())
+        m_facs = facs.value();
 }
 
 UNMAP_AFTER_INIT void Parser::init_fadt()
@@ -139,9 +140,7 @@ UNMAP_AFTER_INIT void Parser::init_fadt()
     dmesgln("ACPI: Initializing Fixed ACPI data");
     dmesgln("ACPI: Searching for the Fixed ACPI Data Table");
 
-    m_fadt = find_table("FACP");
-    VERIFY(!m_fadt.is_null());
-
+    m_fadt = find_table("FACP").value();
     auto sdt = Memory::map_typed<const volatile Structures::FADT>(m_fadt);
 
     dbgln_if(ACPI_DEBUG, "ACPI: FADT @ V{}, {}", &sdt, m_fadt);
@@ -379,7 +378,7 @@ UNMAP_AFTER_INIT Optional<PhysicalAddress> StaticParsing::find_rsdp()
     return map_bios().find_chunk_starting_with(signature, 16);
 }
 
-UNMAP_AFTER_INIT PhysicalAddress StaticParsing::find_table(PhysicalAddress rsdp_address, const StringView& signature)
+UNMAP_AFTER_INIT Optional<PhysicalAddress> StaticParsing::find_table(PhysicalAddress rsdp_address, const StringView& signature)
 {
     // FIXME: There's no validation of ACPI tables here. Use the checksum to validate the tables.
     VERIFY(signature.length() == 4);
@@ -397,7 +396,7 @@ UNMAP_AFTER_INIT PhysicalAddress StaticParsing::find_table(PhysicalAddress rsdp_
     VERIFY_NOT_REACHED();
 }
 
-UNMAP_AFTER_INIT static PhysicalAddress search_table_in_xsdt(PhysicalAddress xsdt_address, const StringView& signature)
+UNMAP_AFTER_INIT static Optional<PhysicalAddress> search_table_in_xsdt(PhysicalAddress xsdt_address, const StringView& signature)
 {
     // FIXME: There's no validation of ACPI tables here. Use the checksum to validate the tables.
     VERIFY(signature.length() == 4);
@@ -420,7 +419,7 @@ static bool match_table_signature(PhysicalAddress table_header, const StringView
     return !strncmp(table->h.sig, signature.characters_without_null_termination(), 4);
 }
 
-UNMAP_AFTER_INIT static PhysicalAddress search_table_in_rsdt(PhysicalAddress rsdt_address, const StringView& signature)
+UNMAP_AFTER_INIT static Optional<PhysicalAddress> search_table_in_rsdt(PhysicalAddress rsdt_address, const StringView& signature)
 {
     // FIXME: There's no validation of ACPI tables here. Use the checksum to validate the tables.
     VERIFY(signature.length() == 4);

--- a/Kernel/ACPI/Parser.h
+++ b/Kernel/ACPI/Parser.h
@@ -48,7 +48,7 @@ public:
         set_the(*new ParserType(rsdp));
     }
 
-    virtual PhysicalAddress find_table(const StringView& signature);
+    virtual Optional<PhysicalAddress> find_table(const StringView& signature);
 
     virtual void try_acpi_reboot();
     virtual bool can_reboot();

--- a/Kernel/Bus/PCI/Initializer.cpp
+++ b/Kernel/Bus/PCI/Initializer.cpp
@@ -21,7 +21,7 @@ static bool test_pci_io();
 
 UNMAP_AFTER_INIT static PCIAccessLevel detect_optimal_access_type(PCIAccessLevel boot_determined)
 {
-    if (!ACPI::is_enabled() || ACPI::Parser::the()->find_table("MCFG").is_null())
+    if (!ACPI::is_enabled() || !ACPI::Parser::the()->find_table("MCFG").has_value())
         return PCIAccessLevel::IOAddressing;
 
     if (boot_determined != PCIAccessLevel::IOAddressing)
@@ -39,7 +39,9 @@ UNMAP_AFTER_INIT void initialize()
 
     switch (detect_optimal_access_type(boot_determined)) {
     case PCIAccessLevel::MemoryAddressing: {
-        auto success = Access::initialize_for_memory_access(ACPI::Parser::the()->find_table("MCFG"));
+        auto mcfg = ACPI::Parser::the()->find_table("MCFG");
+        VERIFY(mcfg.has_value());
+        auto success = Access::initialize_for_memory_access(mcfg.value());
         VERIFY(success);
         break;
     }

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -265,12 +265,12 @@ UNMAP_AFTER_INIT bool APIC::init_bsp()
         return false;
     }
     auto madt_address = ACPI::StaticParsing::find_table(rsdp.value(), "APIC");
-    if (madt_address.is_null()) {
+    if (!madt_address.has_value()) {
         dbgln("APIC: MADT table not found");
         return false;
     }
 
-    auto madt = Memory::map_typed<ACPI::Structures::MADT>(madt_address);
+    auto madt = Memory::map_typed<ACPI::Structures::MADT>(madt_address.value());
     size_t entry_index = 0;
     size_t entries_length = madt->h.length - sizeof(ACPI::Structures::MADT);
     auto* madt_entry = madt->entries;

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -115,7 +115,7 @@ UNMAP_AFTER_INIT PhysicalAddress InterruptManagement::search_for_madt()
     auto rsdp = ACPI::StaticParsing::find_rsdp();
     if (!rsdp.has_value())
         return {};
-    return ACPI::StaticParsing::find_table(rsdp.value(), "APIC");
+    return ACPI::StaticParsing::find_table(rsdp.value(), "APIC").value();
 }
 
 UNMAP_AFTER_INIT InterruptManagement::InterruptManagement()

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -119,12 +119,12 @@ UNMAP_AFTER_INIT bool HPET::test_and_initialize()
 {
     VERIFY(!HPET::initialized());
     hpet_initialized = true;
-    auto hpet = ACPI::Parser::the()->find_table("HPET");
-    if (hpet.is_null())
+    auto hpet_table = ACPI::Parser::the()->find_table("HPET");
+    if (!hpet_table.has_value())
         return false;
-    dmesgln("HPET @ {}", hpet);
+    dmesgln("HPET @ {}", hpet_table.value());
 
-    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet);
+    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet_table.value());
 
     // Note: HPET is only usable from System Memory
     VERIFY(sdt->event_timer_block.address_space == (u8)ACPI::GenericAddressStructure::AddressSpace::SystemMemory);
@@ -135,17 +135,17 @@ UNMAP_AFTER_INIT bool HPET::test_and_initialize()
             return false;
         }
     }
-    new HPET(PhysicalAddress(hpet));
+    new HPET(PhysicalAddress(hpet_table.value()));
     return true;
 }
 
 UNMAP_AFTER_INIT bool HPET::check_for_exisiting_periodic_timers()
 {
-    auto hpet = ACPI::Parser::the()->find_table("HPET");
-    if (hpet.is_null())
+    auto hpet_table = ACPI::Parser::the()->find_table("HPET");
+    if (!hpet_table.has_value())
         return false;
 
-    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet);
+    auto sdt = Memory::map_typed<ACPI::Structures::HPET>(hpet_table.value());
     VERIFY(sdt->event_timer_block.address_space == 0);
     auto registers = Memory::map_typed<HPETRegistersBlock>(PhysicalAddress(sdt->event_timer_block.address));
 


### PR DESCRIPTION
This is a better pattern than returning a PhysicalAddress with a zero
value, so the code is more understandable now.