### PR TITLE
LibWeb: Don't trim whitespace when checking for "module" type on scripts

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -126,12 +126,12 @@ void HTMLScriptElement::prepare_script()
         || (!has_type && !has_language)) {
         script_block_type = "text/javascript";
     } else if (has_type) {
-        script_block_type = attribute(HTML::AttributeNames::type).trim_whitespace();
+        script_block_type = attribute(HTML::AttributeNames::type);
     } else if (!attribute(HTML::AttributeNames::language).is_empty()) {
         script_block_type = String::formatted("text/{}", attribute(HTML::AttributeNames::language));
     }
 
-    if (is_javascript_mime_type_essence_match(script_block_type)) {
+    if (is_javascript_mime_type_essence_match(script_block_type.trim_whitespace())) {
         m_script_type = ScriptType::Classic;
     } else if (script_block_type.equals_ignoring_case("module")) {
         m_script_type = ScriptType::Module;


### PR DESCRIPTION
No major engine allows whitespace in the type when checking for "module".
This was also reflected in the relevant web platform test, but not in the spec.
The spec has been changed to match this behaviour: https://github.com/whatwg/html/commit/23c723e3e94103e495a6b67e60ffc8a1a164334b