### PR TITLE
Kernel: Introduce initial lock rank tracking and verification

### DIFF
--- a/Kernel/Arch/x86/common/CPU.cpp
+++ b/Kernel/Arch/x86/common/CPU.cpp
@@ -20,6 +20,11 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
 
 [[noreturn]] void abort()
 {
+    // Avoid lock ranking checks on crashing paths, just try to get some debugging messages out.
+    auto thread = Thread::current();
+    if (thread)
+        thread->set_crashing();
+
     // Switch back to the current process's page tables if there are any.
     // Otherwise stack walking will be a disaster.
     if (Process::has_current())

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -161,6 +161,7 @@ set(KERNEL_SOURCES
     Memory/VirtualRange.cpp
     Memory/VirtualRangeAllocator.cpp
     MiniStdLib.cpp
+    Locking/LockRank.cpp
     Locking/Mutex.cpp
     Net/E1000ENetworkAdapter.cpp
     Net/E1000NetworkAdapter.cpp

--- a/Kernel/Locking/LockRank.cpp
+++ b/Kernel/Locking/LockRank.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Locking/LockRank.h>
+#include <Kernel/Thread.h>
+
+// Note: These stubs can't be in LockRank.h as that would create
+// a cyclic dependency in the header include graph of the Kernel.
+
+namespace Kernel {
+
+void track_lock_acquire(LockRank rank)
+{
+    auto thread = Thread::current();
+    if (thread && !thread->is_crashing())
+        thread->track_lock_acquire(rank);
+}
+
+void track_lock_release(LockRank rank)
+{
+    auto thread = Thread::current();
+    if (thread && !thread->is_crashing())
+        thread->track_lock_release(rank);
+}
+
+}

--- a/Kernel/Locking/LockRank.h
+++ b/Kernel/Locking/LockRank.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/EnumBits.h>
+
+namespace Kernel {
+// To catch bugs where locks are taken out of order, we annotate all locks
+// in the kernel with a rank. The rank describes the order in which locks
+// are allowed to be taken. If a lock is acquired, and it is of an incompatible
+// rank with the lock held by the executing thread then the system can detect
+// the lock order violation and respond appropriately (crash with error).
+//
+// A thread holding a lower ranked lock cannot acquire a lock of a greater or equal rank.
+enum class LockRank : int {
+    // Special marker for locks which haven't been annotated yet.
+    // Note: This should be removed once all locks are annotated.
+    None = 0x000,
+
+    // We need to be able to handle page faults from anywhere, so
+    // memory manager locks are our lowest rank lock.
+    MemoryManager = 0x001,
+
+    Interrupts = 0x002,
+
+    FileSystem = 0x004,
+
+    Thread = 0x008,
+
+    // Process locks are the lowest rank, as they normally are taken
+    // first thing when processing syscalls.
+    Process = 0x010,
+};
+
+AK_ENUM_BITWISE_OPERATORS(LockRank);
+
+void track_lock_acquire(LockRank);
+void track_lock_release(LockRank);
+}

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -47,7 +47,7 @@ namespace Kernel::Memory {
 // run. If we do, then Singleton would get re-initialized, causing
 // the memory manager to be initialized twice!
 static MemoryManager* s_the;
-RecursiveSpinlock s_mm_lock;
+RecursiveSpinlock s_mm_lock { LockRank::MemoryManager };
 
 MemoryManager& MemoryManager::the()
 {

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -61,7 +61,7 @@ void NetworkTask_main(void*)
     NetworkingManagement::the().for_each([&](auto& adapter) {
         dmesgln("NetworkTask: {} network adapter found: hw={}", adapter.class_name(), adapter.mac_address().to_string());
 
-        if (String(adapter.class_name()) == "LoopbackAdapter") {
+        if (adapter.class_name() == "LoopbackAdapter"sv) {
             adapter.set_ipv4_address({ 127, 0, 0, 1 });
             adapter.set_ipv4_netmask({ 255, 0, 0, 0 });
             adapter.set_ipv4_gateway({ 0, 0, 0, 0 });

--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -10,6 +10,7 @@
 #include <Kernel/IO.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
+#include <Kernel/Thread.h>
 
 namespace Kernel {
 
@@ -25,6 +26,11 @@ namespace Kernel {
 
 void __panic(const char* file, unsigned int line, const char* function)
 {
+    // Avoid lock ranking checks on crashing paths, just try to get some debugging messages out.
+    auto thread = Thread::current();
+    if (thread)
+        thread->set_crashing();
+
     critical_dmesgln("at {}:{} in {}", file, line, function);
     dump_backtrace(PrintToScreen::Yes);
     if (kernel_command_line().boot_mode() == BootMode::SelfTest)

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1276,7 +1276,7 @@ private:
     void relock_process(LockMode, u32);
     void reset_fpu_state();
 
-    mutable RecursiveSpinlock m_lock;
+    mutable RecursiveSpinlock m_lock { LockRank::Thread };
     mutable RecursiveSpinlock m_block_lock;
     NonnullRefPtr<Process> m_process;
     ThreadID m_tid { -1 };

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -29,6 +29,7 @@
 #include <Kernel/Library/ListedRefCounted.h>
 #include <Kernel/Locking/LockLocation.h>
 #include <Kernel/Locking/LockMode.h>
+#include <Kernel/Locking/LockRank.h>
 #include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/Memory/VirtualRange.h>
 #include <Kernel/Scheduler.h>
@@ -1083,6 +1084,9 @@ public:
     u32 saved_critical() const { return m_saved_critical; }
     void save_critical(u32 critical) { m_saved_critical = critical; }
 
+    void track_lock_acquire(LockRank rank);
+    void track_lock_release(LockRank rank);
+
     [[nodiscard]] bool is_active() const { return m_is_active; }
 
     [[nodiscard]] bool is_finalizable() const
@@ -1302,6 +1306,7 @@ private:
     Kernel::Mutex* m_blocking_lock { nullptr };
     u32 m_lock_requested_count { 0 };
     IntrusiveListNode<Thread> m_blocked_threads_list_node;
+    LockRank m_lock_rank_mask { LockRank::None };
 
 #if LOCK_DEBUG
     struct HoldingLockInfo {

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1186,6 +1186,9 @@ public:
     void set_idle_thread() { m_is_idle_thread = true; }
     bool is_idle_thread() const { return m_is_idle_thread; }
 
+    void set_crashing() { m_is_crashing = true; }
+    [[nodiscard]] bool is_crashing() const { return m_is_crashing; }
+
     ALWAYS_INLINE u32 enter_profiler()
     {
         return m_nested_profiler_calls.fetch_add(1, AK::MemoryOrder::memory_order_acq_rel);
@@ -1343,6 +1346,7 @@ private:
     bool m_initialized { false };
     bool m_in_block { false };
     bool m_is_idle_thread { false };
+    bool m_is_crashing { false };
     Atomic<bool> m_have_any_unmasked_pending_signals { false };
     Atomic<u32> m_nested_profiler_calls { 0 };
 


### PR DESCRIPTION
This PR adds a static lock hierarchy / ranking to the Kernel with
the goal of reducing / finding deadlocks when running with SMP enabled.

We have seen quite a few lock ordering deadlocks (locks taken in a
different order, on two different code paths). As we properly annotate
locks in the system, then these facilities will find these locking
protocol violations automatically

The `LockRank` enum documents the various locks in the system and their
rank. The implementation guarantees that a thread holding one or more
locks of a lower rank cannot acquire an additional lock with rank that
is greater or equal to any of the currently held locks.

`Mutex` support will come later, as well as fixing and ranking more locks. 