### PR TITLE
Kernel/VirtIO: Determine names without PCI access in IRQ context

### DIFF
--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -396,25 +396,25 @@ bool Device::handle_irq(const RegisterState&)
 {
     u8 isr_type = isr_status();
     if ((isr_type & (QUEUE_INTERRUPT | DEVICE_CONFIG_INTERRUPT)) == 0) {
-        dbgln_if(VIRTIO_DEBUG, "{}: Handling interrupt with unknown type: {}", VirtIO::determine_device_class(pci_address()), isr_type);
+        dbgln_if(VIRTIO_DEBUG, "{}: Handling interrupt with unknown type: {}", class_name(), isr_type);
         return false;
     }
     if (isr_type & DEVICE_CONFIG_INTERRUPT) {
-        dbgln_if(VIRTIO_DEBUG, "{}: VirtIO Device config interrupt!", VirtIO::determine_device_class(pci_address()));
+        dbgln_if(VIRTIO_DEBUG, "{}: VirtIO Device config interrupt!", class_name());
         if (!handle_device_config_change()) {
             set_status_bit(DEVICE_STATUS_FAILED);
-            dbgln("{}: Failed to handle device config change!", VirtIO::determine_device_class(pci_address()));
+            dbgln("{}: Failed to handle device config change!", class_name());
         }
     }
     if (isr_type & QUEUE_INTERRUPT) {
-        dbgln_if(VIRTIO_DEBUG, "{}: VirtIO Queue interrupt!", VirtIO::determine_device_class(pci_address()));
+        dbgln_if(VIRTIO_DEBUG, "{}: VirtIO Queue interrupt!", class_name());
         for (size_t i = 0; i < m_queues.size(); i++) {
             if (get_queue(i).new_data_available()) {
                 handle_queue_update(i);
                 return true;
             }
         }
-        dbgln_if(VIRTIO_DEBUG, "{}: Got queue interrupt but all queues are up to date!", VirtIO::determine_device_class(pci_address()));
+        dbgln_if(VIRTIO_DEBUG, "{}: Got queue interrupt but all queues are up to date!", class_name());
     }
     return true;
 }

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -93,7 +93,7 @@ public:
     virtual void initialize();
 
 protected:
-    virtual StringView class_name() const = 0;
+    virtual StringView class_name() const { return "VirtIO::Device"; }
     explicit Device(PCI::Address);
     struct MappedMMIO {
         OwnPtr<Memory::Region> base;


### PR DESCRIPTION
This is a fix so the VirtIO code doesn't lead to assertion because we
try to determine the name based on the PCI values of the VirtIO device,
because trying to read from the PCI configuration space requires to
acquire a Mutex, which fails in an IRQ context.

To ensure we never encounter a situation when we call a pure virtual
function in an IRQ context, let's make class_name() method to be a
non-pure virtual function, so it can be still called at anytime.

Fixes a bug that was exposed by #9873.