### PR TITLE
test-js: Fix the flaky js tests

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -191,9 +191,15 @@ public:
 void Heap::mark_live_cells(const HashTable<Cell*>& roots)
 {
     dbgln_if(HEAP_DEBUG, "mark_live_cells:");
+
     MarkingVisitor visitor;
     for (auto* root : roots)
         visitor.visit(root);
+
+    for (auto& inverse_root : m_uprooted_cells)
+        inverse_root->set_marked(false);
+
+    m_uprooted_cells.clear();
 }
 
 void Heap::sweep_dead_cells(bool print_report, const Core::ElapsedTimer& measurement_timer)
@@ -325,6 +331,11 @@ void Heap::undefer_gc(Badge<DeferGC>)
             collect_garbage();
         m_should_gc_when_deferral_ends = false;
     }
+}
+
+void Heap::uproot_cell(Cell* cell)
+{
+    m_uprooted_cells.append(cell);
 }
 
 }

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -83,6 +83,8 @@ public:
 
     BlockAllocator& block_allocator() { return m_block_allocator; }
 
+    void uproot_cell(Cell* cell);
+
 private:
     Cell* allocate_cell(size_t);
 
@@ -116,6 +118,8 @@ private:
     MarkedValueList::List m_marked_value_lists;
 
     WeakContainer::List m_weak_containers;
+
+    Vector<Cell*> m_uprooted_cells;
 
     BlockAllocator m_block_allocator;
 

--- a/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.cleanupSome.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/FinalizationRegistry/FinalizationRegistry.prototype.cleanupSome.js
@@ -3,11 +3,12 @@ test("length is 0", () => {
 });
 
 function registerInDifferentScope(registry) {
-    registry.register({}, {});
+    const target = {};
+    registry.register(target, {});
+    return target;
 }
 
-// Flaky test, investigate and fix :^)
-test.skip("basic functionality", () => {
+test("basic functionality", () => {
     var registry = new FinalizationRegistry(() => {});
 
     var count = 0;
@@ -19,7 +20,8 @@ test.skip("basic functionality", () => {
 
     expect(count).toBe(0);
 
-    registerInDifferentScope(registry);
+    const target = registerInDifferentScope(registry);
+    markAsGarbage("target");
     gc();
 
     registry.cleanupSome(increment);

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakMap/WeakMap.prototype.set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakMap/WeakMap.prototype.set.js
@@ -21,10 +21,13 @@ test("invalid values", () => {
 
 test("automatic removal of garbage-collected values", () => {
     const weakMap = new WeakMap();
-    {
-        expect(weakMap.set({ a: 1 }, 1)).toBe(weakMap);
-        expect(getWeakMapSize(weakMap)).toBe(1);
-    }
+    const key = { e: 3 };
+
+    expect(weakMap.set(key, 1)).toBe(weakMap);
+    expect(getWeakMapSize(weakMap)).toBe(1);
+
+    markAsGarbage("key");
     gc();
+
     expect(getWeakMapSize(weakMap)).toBe(0);
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/WeakSet/WeakSet.prototype.add.js
@@ -17,10 +17,13 @@ test("invalid values", () => {
 
 test("automatic removal of garbage-collected values", () => {
     const weakSet = new WeakSet();
-    {
-        expect(weakSet.add({ a: 1 })).toBe(weakSet);
-        expect(getWeakSetSize(weakSet)).toBe(1);
-    }
+    const item = { a: 1 };
+
+    expect(weakSet.add(item)).toBe(weakSet);
+    expect(getWeakSetSize(weakSet)).toBe(1);
+
+    markAsGarbage("item");
     gc();
+
     expect(getWeakSetSize(weakSet)).toBe(0);
 });


### PR DESCRIPTION
This fixes both the case that the values were GC'd too early and forces them to be GC'd when we want which should prevent the tests from being flaky again.