### PR TITLE
Fix CatDog double context menu, and underlying architecture

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -52,7 +52,6 @@ public:
 
         set_shrink_to_fit(true);
         set_fill_with_background_color(true);
-        set_global_cursor_tracking(true);
         set_greedy_for_hits(true);
     }
 

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -244,6 +244,7 @@ int main(int argc, char** argv)
     text_box.on_return_pressed = [&]() {
         if (!app_state.selected_index.has_value())
             return;
+        lockfile.release();
         app_state.results[app_state.selected_index.value()].activate();
         GUI::Application::the()->quit();
     };

--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -20,16 +20,6 @@ MagnifierWidget::~MagnifierWidget()
 {
 }
 
-void MagnifierWidget::track_cursor_globally()
-{
-    VERIFY(window());
-    auto window_id = window()->window_id();
-    VERIFY(window_id >= 0);
-
-    set_global_cursor_tracking(true);
-    GUI::WindowServerConnection::the().async_set_global_cursor_tracking(window_id, true);
-}
-
 void MagnifierWidget::set_scale_factor(int scale_factor)
 {
     VERIFY(scale_factor == 2 || scale_factor == 4);

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -14,7 +14,6 @@ class MagnifierWidget final : public GUI::Frame {
 public:
     virtual ~MagnifierWidget();
     void set_scale_factor(int scale_factor);
-    void track_cursor_globally();
 
 private:
     MagnifierWidget();

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -79,7 +79,5 @@ int main(int argc, char** argv)
 
     window->show();
 
-    magnifier.track_cursor_globally();
-
     return app->exec();
 }

--- a/Userland/Demos/CatDog/CatDog.cpp
+++ b/Userland/Demos/CatDog/CatDog.cpp
@@ -7,7 +7,6 @@
 #include "CatDog.h"
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
-#include <LibGUI/WindowServerConnection.h>
 
 void CatDog::timer_event(Core::TimerEvent&)
 {
@@ -105,13 +104,14 @@ void CatDog::paint_event(GUI::PaintEvent& event)
     painter.blit(Gfx::IntPoint(0, 0), *m_curr_bmp, m_curr_bmp->rect());
 }
 
-void CatDog::mousemove_event(GUI::MouseEvent& event)
+void CatDog::track_mouse_move(Gfx::IntPoint const& point)
 {
     if (!m_roaming)
         return;
-    if (m_temp_pos == event.position())
+    Gfx::IntPoint relative_point = point - window()->position();
+    if (m_temp_pos == relative_point)
         return;
-    m_temp_pos = event.position();
+    m_temp_pos = relative_point;
     m_timer.start();
     if (m_sleeping) {
         m_curr_bmp = m_alert;
@@ -126,16 +126,6 @@ void CatDog::mousedown_event(GUI::MouseEvent& event)
         return;
     if (on_click)
         on_click();
-}
-
-void CatDog::track_cursor_globally()
-{
-    VERIFY(window());
-    auto window_id = window()->window_id();
-    VERIFY(window_id >= 0);
-
-    set_global_cursor_tracking(true);
-    GUI::WindowServerConnection::the().async_set_global_cursor_tracking(window_id, true);
 }
 
 void CatDog::context_menu_event(GUI::ContextMenuEvent& event)

--- a/Userland/Demos/CatDog/CatDog.h
+++ b/Userland/Demos/CatDog/CatDog.h
@@ -6,22 +6,23 @@
 
 #include <LibCore/ElapsedTimer.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MouseTracker.h>
 #include <LibGUI/Widget.h>
 #include <unistd.h>
 
 #pragma once
 
-class CatDog final : public GUI::Widget {
+class CatDog final : public GUI::Widget
+    , GUI::MouseTracker {
     C_OBJECT(CatDog);
 
 public:
     virtual void timer_event(Core::TimerEvent&) override;
     virtual void paint_event(GUI::PaintEvent& event) override;
-    virtual void mousemove_event(GUI::MouseEvent& event) override;
+    virtual void track_mouse_move(Gfx::IntPoint const& point) override;
     virtual void mousedown_event(GUI::MouseEvent& event) override;
     virtual void context_menu_event(GUI::ContextMenuEvent& event) override;
 
-    void track_cursor_globally();
     void start_the_timer() { m_timer.start(); }
 
     Function<void()> on_click;

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -59,7 +59,6 @@ int main(int argc, char** argv)
     context_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
 
     window->show();
-    catdog_widget.track_cursor_globally();
     catdog_widget.start_timer(250, Core::TimerShouldFireWhenNotVisible::Yes);
     catdog_widget.start_the_timer(); // timer for "mouse sleep detection"
 

--- a/Userland/Demos/Eyes/EyesWidget.cpp
+++ b/Userland/Demos/Eyes/EyesWidget.cpp
@@ -8,26 +8,15 @@
 #include <AK/Math.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
-#include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Palette.h>
 
 EyesWidget::~EyesWidget()
 {
 }
 
-void EyesWidget::track_cursor_globally()
+void EyesWidget::track_mouse_move(Gfx::IntPoint const& point)
 {
-    VERIFY(window());
-    auto window_id = window()->window_id();
-    VERIFY(window_id >= 0);
-
-    set_global_cursor_tracking(true);
-    GUI::WindowServerConnection::the().async_set_global_cursor_tracking(window_id, true);
-}
-
-void EyesWidget::mousemove_event(GUI::MouseEvent& event)
-{
-    m_mouse_position = event.position();
+    m_mouse_position = point - window()->position();
     update();
 }
 

--- a/Userland/Demos/Eyes/EyesWidget.h
+++ b/Userland/Demos/Eyes/EyesWidget.h
@@ -6,15 +6,15 @@
 
 #pragma once
 
+#include <LibGUI/MouseTracker.h>
 #include <LibGUI/Widget.h>
-#include <LibGfx/Point.h>
 
-class EyesWidget final : public GUI::Widget {
+class EyesWidget final : public GUI::Widget
+    , GUI::MouseTracker {
     C_OBJECT(EyesWidget)
 
 public:
     virtual ~EyesWidget();
-    void track_cursor_globally();
 
 private:
     EyesWidget(int num_eyes, int full_rows, int extra)
@@ -25,8 +25,8 @@ private:
         m_eyes_in_row = m_full_rows > 0 ? (num_eyes - m_extra_columns) / m_full_rows : m_extra_columns;
     }
 
-    virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void track_mouse_move(Gfx::IntPoint const&) override;
 
     void render_eyeball(int row, int column, GUI::Painter&) const;
     Gfx::IntPoint pupil_center(Gfx::IntRect& eyeball_bounds) const;

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
     window->resize(75 * (full_rows > 0 ? max_in_row : extra_columns), 100 * (full_rows + (extra_columns > 0 ? 1 : 0)));
     window->set_has_alpha_channel(true);
 
-    auto& eyes = window->set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns);
+    window->set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns);
 
     auto& file_menu = window->add_menu("&File");
     file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
@@ -85,7 +85,6 @@ int main(int argc, char* argv[])
     help_menu.add_action(GUI::CommonActions::make_about_action("Eyes Demo", app_icon, window));
 
     window->show();
-    eyes.track_cursor_globally();
 
     return app->exec();
 }

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SOURCES
     Model.cpp
     ModelIndex.cpp
     ModelSelection.cpp
+    MouseTracker.cpp
     MultiView.cpp
     Notification.cpp
     OpacitySlider.cpp

--- a/Userland/Libraries/LibGUI/MouseTracker.cpp
+++ b/Userland/Libraries/LibGUI/MouseTracker.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/MouseTracker.h>
+#include <LibGUI/WindowServerConnection.h>
+
+namespace GUI {
+
+MouseTracker::List MouseTracker::s_trackers;
+
+MouseTracker::MouseTracker()
+{
+    if (s_trackers.is_empty()) {
+        WindowServerConnection::the().async_set_global_mouse_tracking(true);
+    }
+    s_trackers.append(*this);
+}
+MouseTracker::~MouseTracker()
+{
+    m_list_node.remove();
+    if (s_trackers.is_empty()) {
+        WindowServerConnection::the().async_set_global_mouse_tracking(false);
+    }
+}
+
+void MouseTracker::track_mouse_move(Badge<WindowServerConnection>, Gfx::IntPoint const& point)
+{
+    for (auto& tracker : s_trackers) {
+        tracker.track_mouse_move(point);
+    }
+}
+
+}

--- a/Userland/Libraries/LibGUI/MouseTracker.h
+++ b/Userland/Libraries/LibGUI/MouseTracker.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/Function.h>
+#include <AK/IntrusiveList.h>
+#include <LibGUI/Forward.h>
+#include <LibGfx/Point.h>
+
+namespace GUI {
+
+class MouseTracker {
+public:
+    MouseTracker();
+    virtual ~MouseTracker();
+
+    static void track_mouse_move(Badge<WindowServerConnection>, Gfx::IntPoint const&);
+
+protected:
+    virtual void track_mouse_move(Gfx::IntPoint const&) = 0;
+
+private:
+    IntrusiveListNode<MouseTracker> m_list_node;
+    using List = IntrusiveList<MouseTracker, RawPtr<MouseTracker>, &MouseTracker::m_list_node>;
+    static List s_trackers;
+};
+
+}

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -757,22 +757,6 @@ void Widget::set_font_fixed_width(bool fixed_width)
         set_font(Gfx::FontDatabase::the().get(Gfx::FontDatabase::the().default_font().family(), m_font->presentation_size(), m_font->weight()));
 }
 
-void Widget::set_global_cursor_tracking(bool enabled)
-{
-    auto* win = window();
-    if (!win)
-        return;
-    win->set_global_cursor_tracking_widget(enabled ? this : nullptr);
-}
-
-bool Widget::global_cursor_tracking() const
-{
-    auto* win = window();
-    if (!win)
-        return false;
-    return win->global_cursor_tracking_widget() == this;
-}
-
 void Widget::set_min_size(const Gfx::IntSize& size)
 {
     if (m_min_size == size)

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -223,9 +223,6 @@ public:
     void set_font_weight(unsigned);
     void set_font_fixed_width(bool);
 
-    void set_global_cursor_tracking(bool);
-    bool global_cursor_tracking() const;
-
     void notify_layout_changed(Badge<Layout>);
     void invalidate_layout();
 

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -347,13 +347,6 @@ void Window::handle_drop_event(DropEvent& event)
 
 void Window::handle_mouse_event(MouseEvent& event)
 {
-    if (m_global_cursor_tracking_widget) {
-        auto window_relative_rect = m_global_cursor_tracking_widget->window_relative_rect();
-        Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
-        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
-        m_global_cursor_tracking_widget->dispatch_event(local_event, this);
-        return;
-    }
     if (m_automatic_cursor_tracking_widget) {
         auto window_relative_rect = m_automatic_cursor_tracking_widget->window_relative_rect();
         Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
@@ -371,8 +364,7 @@ void Window::handle_mouse_event(MouseEvent& event)
     set_hovered_widget(result.widget);
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)
         m_automatic_cursor_tracking_widget = *result.widget;
-    if (result.widget != m_global_cursor_tracking_widget.ptr())
-        result.widget->dispatch_event(local_event, this);
+    result.widget->dispatch_event(local_event, this);
 
     if (!m_pending_paint_event_rects.is_empty()) {
         MultiPaintEvent paint_event(move(m_pending_paint_event_rects), size());
@@ -755,13 +747,6 @@ void Window::set_focused_widget(Widget* widget, FocusSource source)
     }
 }
 
-void Window::set_global_cursor_tracking_widget(Widget* widget)
-{
-    if (widget == m_global_cursor_tracking_widget)
-        return;
-    m_global_cursor_tracking_widget = widget;
-}
-
 void Window::set_automatic_cursor_tracking_widget(Widget* widget)
 {
     if (widget == m_automatic_cursor_tracking_widget)
@@ -1138,8 +1123,6 @@ void Window::did_remove_widget(Badge<Widget>, Widget& widget)
         m_focused_widget = nullptr;
     if (m_hovered_widget == &widget)
         m_hovered_widget = nullptr;
-    if (m_global_cursor_tracking_widget == &widget)
-        m_global_cursor_tracking_widget = nullptr;
     if (m_automatic_cursor_tracking_widget == &widget)
         m_automatic_cursor_tracking_widget = nullptr;
 }

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -146,10 +146,6 @@ public:
     void update();
     void update(const Gfx::IntRect&);
 
-    void set_global_cursor_tracking_widget(Widget*);
-    Widget* global_cursor_tracking_widget() { return m_global_cursor_tracking_widget.ptr(); }
-    const Widget* global_cursor_tracking_widget() const { return m_global_cursor_tracking_widget.ptr(); }
-
     void set_automatic_cursor_tracking_widget(Widget*);
     Widget* automatic_cursor_tracking_widget() { return m_automatic_cursor_tracking_widget.ptr(); }
     const Widget* automatic_cursor_tracking_widget() const { return m_automatic_cursor_tracking_widget.ptr(); }
@@ -253,7 +249,6 @@ private:
     float m_alpha_hit_threshold { 0.0f };
     RefPtr<Widget> m_main_widget;
     WeakPtr<Widget> m_focused_widget;
-    WeakPtr<Widget> m_global_cursor_tracking_widget;
     WeakPtr<Widget> m_automatic_cursor_tracking_widget;
     WeakPtr<Widget> m_hovered_widget;
     Gfx::IntRect m_rect_when_windowless;

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -16,6 +16,7 @@
 #include <LibGUI/EmojiInputDialog.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MouseTracker.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Bitmap.h>
@@ -368,6 +369,11 @@ void WindowServerConnection::display_link_notification()
         DisplayLink::notify({});
         m_display_link_notification_pending = false;
     });
+}
+
+void WindowServerConnection::track_mouse_move(Gfx::IntPoint const& mouse_position)
+{
+    MouseTracker::track_mouse_move({}, mouse_position);
 }
 
 void WindowServerConnection::ping()

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -55,6 +55,7 @@ private:
     virtual void update_system_fonts(String const&, String const&) override;
     virtual void window_state_changed(i32, bool, bool) override;
     virtual void display_link_notification() override;
+    virtual void track_mouse_move(Gfx::IntPoint const&) override;
     virtual void ping() override;
 
     bool m_display_link_notification_pending { false };

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -653,16 +653,6 @@ void ClientConnection::set_window_backing_store(i32 window_id, [[maybe_unused]] 
         window.invalidate(false);
 }
 
-void ClientConnection::set_global_cursor_tracking(i32 window_id, bool enabled)
-{
-    auto it = m_windows.find(window_id);
-    if (it == m_windows.end()) {
-        did_misbehave("SetGlobalCursorTracking: Bad window ID");
-        return;
-    }
-    it->value->set_global_cursor_tracking_enabled(enabled);
-}
-
 void ClientConnection::set_global_mouse_tracking(bool enabled)
 {
     m_does_global_mouse_tracking = enabled;

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -663,6 +663,11 @@ void ClientConnection::set_global_cursor_tracking(i32 window_id, bool enabled)
     it->value->set_global_cursor_tracking_enabled(enabled);
 }
 
+void ClientConnection::set_global_mouse_tracking(bool enabled)
+{
+    m_does_global_mouse_tracking = enabled;
+}
+
 void ClientConnection::set_window_cursor(i32 window_id, i32 cursor_type)
 {
     auto it = m_windows.find(window_id);

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -113,7 +113,6 @@ private:
     virtual Messages::WindowServer::GetAppletRectOnScreenResponse get_applet_rect_on_screen(i32) override;
     virtual void invalidate_rect(i32, Vector<Gfx::IntRect> const&, bool) override;
     virtual void did_finish_painting(i32, Vector<Gfx::IntRect> const&) override;
-    virtual void set_global_cursor_tracking(i32, bool) override;
     virtual void set_global_mouse_tracking(bool) override;
     virtual void set_window_opacity(i32, float) override;
     virtual void set_window_backing_store(i32, i32, i32, IPC::File const&, i32, bool, Gfx::IntSize const&, bool) override;

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -38,6 +38,7 @@ public:
     ~ClientConnection() override;
 
     bool is_unresponsive() const { return m_unresponsive; }
+    bool does_global_mouse_tracking() const { return m_does_global_mouse_tracking; }
 
     static ClientConnection* from_client_id(int client_id);
     static void for_each_client(Function<void(ClientConnection&)>);
@@ -113,6 +114,7 @@ private:
     virtual void invalidate_rect(i32, Vector<Gfx::IntRect> const&, bool) override;
     virtual void did_finish_painting(i32, Vector<Gfx::IntRect> const&) override;
     virtual void set_global_cursor_tracking(i32, bool) override;
+    virtual void set_global_mouse_tracking(bool) override;
     virtual void set_window_opacity(i32, float) override;
     virtual void set_window_backing_store(i32, i32, i32, IPC::File const&, i32, bool, Gfx::IntSize const&, bool) override;
     virtual void set_window_has_alpha_channel(i32, bool) override;
@@ -179,6 +181,7 @@ private:
     bool m_has_display_link { false };
     bool m_show_screen_number { false };
     bool m_unresponsive { false };
+    bool m_does_global_mouse_tracking { false };
 
     // Need this to get private client connection stuff
     friend WMClientConnection;

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -44,5 +44,7 @@ endpoint WindowClient
 
     display_link_notification() =|
 
+    track_mouse_move(Gfx::IntPoint mouse_position) =|
+
     ping() =|
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1200,14 +1200,17 @@ void WindowManager::process_mouse_event(MouseEvent& event)
     if (process_ongoing_drag(event))
         return;
 
-    // 2. Send the mouse event to all windows with global cursor tracking enabled.
-    // The active input tracking window is excluded here because we're sending the event to it
-    // in the next step.
+    // 2. Send the mouse event to all clients with global cursor tracking enabled.
     auto& window_stack = current_window_stack();
     for_each_visible_window_from_front_to_back([&](Window& window) {
         if (window.global_cursor_tracking() && &window != window_stack.active_input_tracking_window())
             deliver_mouse_event(window, event, false);
         return IterationDecision::Continue;
+    });
+    ClientConnection::for_each_client([&](ClientConnection& conn) {
+        if (conn.does_global_mouse_tracking()) {
+            conn.async_track_mouse_move(event.position());
+        }
     });
 
     // 3. If there's an active input tracking window, all mouse events go there.

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1201,12 +1201,6 @@ void WindowManager::process_mouse_event(MouseEvent& event)
         return;
 
     // 2. Send the mouse event to all clients with global cursor tracking enabled.
-    auto& window_stack = current_window_stack();
-    for_each_visible_window_from_front_to_back([&](Window& window) {
-        if (window.global_cursor_tracking() && &window != window_stack.active_input_tracking_window())
-            deliver_mouse_event(window, event, false);
-        return IterationDecision::Continue;
-    });
     ClientConnection::for_each_client([&](ClientConnection& conn) {
         if (conn.does_global_mouse_tracking()) {
             conn.async_track_mouse_move(event.position());

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -75,6 +75,7 @@ endpoint WindowServer
     did_finish_painting(i32 window_id, Vector<Gfx::IntRect> rects) =|
 
     set_global_cursor_tracking(i32 window_id, bool enabled) =|
+    set_global_mouse_tracking(bool enabled) =|
     set_window_opacity(i32 window_id, float opacity) =|
 
     set_window_alpha_hit_threshold(i32 window_id, float threshold) =|

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -74,7 +74,6 @@ endpoint WindowServer
     invalidate_rect(i32 window_id, Vector<Gfx::IntRect> rects, bool ignore_occlusion) =|
     did_finish_painting(i32 window_id, Vector<Gfx::IntRect> rects) =|
 
-    set_global_cursor_tracking(i32 window_id, bool enabled) =|
     set_global_mouse_tracking(bool enabled) =|
     set_window_opacity(i32 window_id, float opacity) =|
 


### PR DESCRIPTION
Alternative title: How to shave a yak in five easy steps.

## 1. Observe a small bug

Right-clicking CatDog sometimes results in this:

![catdogyak](https://user-images.githubusercontent.com/2690845/132407029-3648cfee-13b3-42f0-a8b4-eb28b4bfa58f.png)

Hmm, this doesn't look right.

What happened here is that CatDog fails the hit test in WindowManager (because the mouse is over a transparent pixel), so the event is delivered to the window behind it (here: FileManager in desktop mode). However, the way that cursor tracking (used to) work, CatDog *still* received an Event anyway, and CatDog's custom logic considered an event to be a hit if it lies in the window rect. Here it does that, so CatDog thinks the Event it has received is a genuine event, and not just some tracking notification.

## 2. Find a yak

So the old way of tracking has the disadvantage that the client can be easily confused which events are "genuine" and which are just for tracking.

Therefore, let's overthrow the underlying architecture!

## 3. Fix the CatDog bug itself

Now that the architecture supports a saner way of being notified, just use it.

Here's CatDog enjoying the company of the other mouse-tracking applications in Serenity:

![Bildschirmfoto_2021-09-07_22-17-00](https://user-images.githubusercontent.com/2690845/132407612-ee85550d-2ce2-4635-9dad-d839b85485cb.png)

EDIT: I fixed the todo in the meantime, and I fixed a typo in the above text.