### PR TITLE
AK: Add note about an internal compile error with Optional in GCC 10.3+

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -14,6 +14,14 @@
 
 namespace AK {
 
+// NOTE: If you're here because of an internal compiler error in GCC 10.3.0+,
+//       it's because of the following bug:
+//
+//       https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96745
+//
+//       Make sure you didn't accidentally make your destructor private before
+//       you start bug hunting. :^)
+
 template<typename T>
 class [[nodiscard]] Optional {
 public:


### PR DESCRIPTION
This bit me because I accidentally made the destructor for a class which
was wrapped in an Optional private. This causes none of the Optional
destructors to be able to be deduced, which when combined with concepts
causes an internal compile error in GCC 10.3.0+. This commit adds a note
here to make sure that future encounters of this bug does not surprise
people.