### PR TITLE
Kernel: Don't link Prekernel against libsupc++

### DIFF
--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -39,7 +39,7 @@ set_target_properties(${PREKERNEL_TARGET} PROPERTIES LINK_DEPENDS ${CMAKE_CURREN
 if (USE_CLANG_TOOLCHAIN)
     target_link_libraries(${PREKERNEL_TARGET} clang_rt.builtins-${SERENITY_CLANG_ARCH} c++abi)
 else()
-    target_link_libraries(${PREKERNEL_TARGET} gcc supc++)
+    target_link_libraries(${PREKERNEL_TARGET} gcc)
 endif()
 
 if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")


### PR DESCRIPTION
It isn't needed.

Also, we stopped linking Kernel against it in 67f0c0d5f074. libsupc++
depends on symbols like free() or realloc() which we removed from
Kernel/StdLib.cpp after 67f0c0d5f074 and which don't exist in Prekernel
either.

(It also happens to make the aarc64 link fail in less obvious ways.)