### PR TITLE
PixelPaint: Refactor Brush/Pen/Eraser, add a "Fit Image to View" action

### DIFF
--- a/Userland/Applications/PixelPaint/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/BrushTool.cpp
@@ -34,6 +34,14 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
     if (layer_event.button() != GUI::MouseButton::Left && layer_event.button() != GUI::MouseButton::Right)
         return;
 
+    if (layer_event.shift() && m_has_clicked) {
+        draw_line(layer->bitmap(), m_editor->color_for(layer_event), m_last_position, layer_event.position());
+        auto modified_rect = Gfx::IntRect::from_two_points(m_last_position, layer_event.position()).inflated(m_size * 2, m_size * 2);
+        layer->did_modify_bitmap(modified_rect);
+        m_last_position = layer_event.position();
+        return;
+    }
+
     const int first_draw_opacity = 10;
 
     for (int i = 0; i < first_draw_opacity; ++i)
@@ -41,6 +49,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
 
     layer->did_modify_bitmap(Gfx::IntRect::centered_on(layer_event.position(), Gfx::IntSize { m_size * 2, m_size * 2 }));
     m_last_position = layer_event.position();
+    m_has_clicked = true;
 }
 
 void BrushTool::on_mousemove(Layer* layer, MouseEvent& event)

--- a/Userland/Applications/PixelPaint/BrushTool.h
+++ b/Userland/Applications/PixelPaint/BrushTool.h
@@ -26,6 +26,7 @@ private:
     int m_size { 20 };
     int m_hardness { 80 };
     bool m_was_drawing { false };
+    bool m_has_clicked { false };
     Gfx::IntPoint m_last_position;
 
     void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end);

--- a/Userland/Applications/PixelPaint/BrushTool.h
+++ b/Userland/Applications/PixelPaint/BrushTool.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Ben Jilks <benjyjilks@gmail.com>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,7 +11,7 @@
 
 namespace PixelPaint {
 
-class BrushTool final : public Tool {
+class BrushTool : public Tool {
 public:
     BrushTool();
     virtual ~BrushTool() override;
@@ -21,6 +22,17 @@ public:
     virtual GUI::Widget* get_properties_widget() override;
     virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
 
+    void set_size(int size) { m_size = size; }
+    int size() const { return m_size; }
+
+    void set_hardness(int hardness) { m_hardness = hardness; }
+    int hardness() const { return m_hardness; }
+
+protected:
+    virtual Color color_for(GUI::MouseEvent const& event);
+    virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point);
+    virtual void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end);
+
 private:
     RefPtr<GUI::Widget> m_properties_widget;
     int m_size { 20 };
@@ -28,9 +40,6 @@ private:
     bool m_was_drawing { false };
     bool m_has_clicked { false };
     Gfx::IntPoint m_last_position;
-
-    void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end);
-    void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point);
 };
 
 }

--- a/Userland/Applications/PixelPaint/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/EraseTool.cpp
@@ -14,6 +14,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/RadioButton.h>
 #include <LibGUI/ValueSlider.h>
 #include <LibGfx/Bitmap.h>
 
@@ -36,10 +37,26 @@ Color EraseTool::color_for(GUI::MouseEvent const&)
 
 void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point)
 {
-    int radius = size() / 2;
-    Gfx::IntRect rect { point.x() - radius, point.y() - radius, size(), size() };
-    GUI::Painter painter(bitmap);
-    painter.clear_rect(rect, color);
+    if (m_draw_mode == DrawMode::Pencil) {
+        int radius = size() / 2;
+        Gfx::IntRect rect { point.x() - radius, point.y() - radius, size(), size() };
+        GUI::Painter painter(bitmap);
+        painter.clear_rect(rect, color);
+    } else {
+        for (int y = point.y() - size(); y < point.y() + size(); y++) {
+            for (int x = point.x() - size(); x < point.x() + size(); x++) {
+                auto distance = point.distance_from({ x, y });
+                if (x < 0 || x >= bitmap.width() || y < 0 || y >= bitmap.height())
+                    continue;
+                if (distance >= size())
+                    continue;
+                auto old_color = bitmap.get_pixel(x, y);
+                auto falloff = (1.0 - double { distance / size() }) * (1.0 / (100 - hardness()));
+                auto new_color = old_color.interpolate(color, falloff);
+                bitmap.set_pixel(x, y, new_color);
+            }
+        }
+    }
 }
 
 GUI::Widget* EraseTool::get_properties_widget()
@@ -65,6 +82,23 @@ GUI::Widget* EraseTool::get_properties_widget()
         };
         set_primary_slider(&size_slider);
 
+        auto& hardness_container = m_properties_widget->add<GUI::Widget>();
+        hardness_container.set_fixed_height(20);
+        hardness_container.set_layout<GUI::HorizontalBoxLayout>();
+
+        auto& hardness_label = hardness_container.add<GUI::Label>("Hardness:");
+        hardness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        hardness_label.set_fixed_size(80, 20);
+
+        auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
+        hardness_slider.set_range(1, 99);
+        hardness_slider.set_value(hardness());
+
+        hardness_slider.on_change = [&](int value) {
+            set_hardness(value);
+        };
+        set_secondary_slider(&hardness_slider);
+
         auto& secondary_color_container = m_properties_widget->add<GUI::Widget>();
         secondary_color_container.set_fixed_height(20);
         secondary_color_container.set_layout<GUI::HorizontalBoxLayout>();
@@ -75,6 +109,29 @@ GUI::Widget* EraseTool::get_properties_widget()
         use_secondary_color_checkbox.on_checked = [&](bool checked) {
             m_use_secondary_color = checked;
         };
+
+        auto& mode_container = m_properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(46);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Draw Mode:");
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(80, 20);
+
+        auto& mode_radio_container = mode_container.add<GUI::Widget>();
+        mode_radio_container.set_layout<GUI::VerticalBoxLayout>();
+        auto& pencil_mode_radio = mode_radio_container.add<GUI::RadioButton>("Pencil");
+        auto& brush_mode_radio = mode_radio_container.add<GUI::RadioButton>("Brush");
+
+        pencil_mode_radio.on_checked = [&](bool) {
+            m_draw_mode = DrawMode::Pencil;
+            hardness_slider.set_enabled(false);
+        };
+        brush_mode_radio.on_checked = [&](bool) {
+            m_draw_mode = DrawMode::Brush;
+            hardness_slider.set_enabled(true);
+        };
+
+        pencil_mode_radio.set_checked(true);
     }
 
     return m_properties_widget.ptr();

--- a/Userland/Applications/PixelPaint/EraseTool.h
+++ b/Userland/Applications/PixelPaint/EraseTool.h
@@ -1,35 +1,34 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Tool.h"
+#include "BrushTool.h"
 #include <LibGUI/ActionGroup.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
 
 namespace PixelPaint {
 
-class EraseTool final : public Tool {
+class EraseTool final : public BrushTool {
 public:
     EraseTool();
     virtual ~EraseTool() override;
 
-    virtual void on_mousedown(Layer*, MouseEvent& event) override;
-    virtual void on_mousemove(Layer*, MouseEvent& event) override;
-    virtual void on_mouseup(Layer*, MouseEvent& event) override;
     virtual GUI::Widget* get_properties_widget() override;
 
+protected:
+    virtual Color color_for(GUI::MouseEvent const& event) override;
+    virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point) override;
+
 private:
-    Gfx::Color get_color() const;
-    Gfx::IntRect build_rect(Gfx::IntPoint const& pos, Gfx::IntRect const& widget_rect);
     RefPtr<GUI::Widget> m_properties_widget;
 
     bool m_use_secondary_color { false };
-    int m_thickness { 1 };
 };
 
 }

--- a/Userland/Applications/PixelPaint/EraseTool.h
+++ b/Userland/Applications/PixelPaint/EraseTool.h
@@ -28,6 +28,11 @@ protected:
 private:
     RefPtr<GUI::Widget> m_properties_widget;
 
+    enum class DrawMode {
+        Pencil,
+        Brush,
+    };
+    DrawMode m_draw_mode { DrawMode::Brush };
     bool m_use_secondary_color { false };
 };
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -425,6 +425,18 @@ void ImageEditor::scale_by(float scale_delta)
     }
 }
 
+void ImageEditor::fit_image_to_view()
+{
+    const float border_ratio = 0.95f;
+    auto image_size = image().size();
+    auto height_ratio = rect().height() / (float)image_size.height();
+    auto width_ratio = rect().width() / (float)image_size.width();
+    m_scale = border_ratio * min(height_ratio, width_ratio);
+
+    m_pan_origin = Gfx::FloatPoint(0, 0);
+    relayout();
+}
+
 void ImageEditor::reset_scale_and_position()
 {
     if (m_scale != 1.0f)

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -52,6 +52,7 @@ public:
 
     float scale() const { return m_scale; }
     void scale_centered_on_position(Gfx::IntPoint const&, float);
+    void fit_image_to_view();
     void reset_scale_and_position();
     void scale_by(float);
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -342,6 +342,11 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     view_menu.add_action(*m_zoom_in_action);
     view_menu.add_action(*m_zoom_out_action);
     view_menu.add_action(*m_reset_zoom_action);
+    view_menu.add_action(GUI::Action::create(
+        "&Fit Image To View", [&](auto&) {
+            if (auto* editor = current_image_editor())
+                editor->fit_image_to_view();
+        }));
     view_menu.add_separator();
     view_menu.add_action(*m_add_guide_action);
     view_menu.add_action(*m_show_guides_action);

--- a/Userland/Applications/PixelPaint/PenTool.h
+++ b/Userland/Applications/PixelPaint/PenTool.h
@@ -1,32 +1,31 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Tool.h"
+#include "BrushTool.h"
 #include <LibGUI/ActionGroup.h>
 #include <LibGfx/Point.h>
 
 namespace PixelPaint {
 
-class PenTool final : public Tool {
+class PenTool final : public BrushTool {
 public:
     PenTool();
     virtual ~PenTool() override;
 
-    virtual void on_mousedown(Layer*, MouseEvent&) override;
-    virtual void on_mousemove(Layer*, MouseEvent&) override;
-    virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+
+protected:
+    virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point) override;
+    virtual void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end) override;
 
 private:
-    Gfx::IntPoint m_last_drawing_event_position { -1, -1 };
     RefPtr<GUI::Widget> m_properties_widget;
-    int m_thickness { 1 };
 };
 
 }


### PR DESCRIPTION
This PR is mostly a rework of how the {Brush,Pen,Erase}Tool are implemented, re-using code and new functionality amongst all of them. The last commit is sort of a drive-by addition, but the lack of this action was really bothering me while working on the brushes and trying to zoom in/out and pan using a laptop trackpad, so I added it in anyway. Rough breakdown of changes:

1. EraseTool/PenTool now re-use all the event handling code from BrushTool by deriving from it, and now only need to specify the changes required in how to draw the resulting line/point. As a nice bonus, this finally makes `EraseTool` feel really smooth (on my laggy machine at least, since we didn't draw lines between the current and previous position earlier)

2. With the point above, now all 3 tools can draw lines between 2 points by Shift+Clicking. I think it's a nice to have.

3. Add a "Fit Image To View" action, that basically makes the image fill up the editor. The "Reset Zoom" action we currently have only sets the scale to 1, but if the editor is much bigger / smaller then this isn't ideal. Especially on laptops where I don't have the ability to pan properly :^(   (Drive-by commit, didn't really feel like making a separate PR for this relatively minor change, but I can split it out if you think it's necessary)