### PR TITLE
LibJS: Fix Temporal.PlainTime.prototype.equals test

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.prototype.equals.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainTime/PlainTime.prototype.equals.js
@@ -6,7 +6,8 @@ describe("correct behavior", () => {
     test("basic functionality", () => {
         const firstPlainTime = new Temporal.PlainTime(1, 1, 1, 1, 1, 1);
         const secondPlainTime = new Temporal.PlainTime(0, 1, 1, 1, 1, 1);
-        expect(firstPlainTime.equals(firstPlainTime));
-        expect(!secondPlainTime.equals(secondPlainTime));
+        expect(firstPlainTime.equals(firstPlainTime)).toBeTrue();
+        expect(secondPlainTime.equals(secondPlainTime)).toBeTrue();
+        expect(secondPlainTime.equals(firstPlainTime)).toBeFalse();
     });
 });


### PR DESCRIPTION
The two plain times weren't being compared to each other.