### PR TITLE
Kernel/VFS: Restrict special unveil rule for Loader.so

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -764,7 +764,7 @@ KResult VirtualFileSystem::validate_path_against_process_veil(StringView path, i
 {
     if (Process::current().veil_state() == VeilState::None)
         return KSuccess;
-    if (path == "/usr/lib/Loader.so")
+    if (options == O_EXEC && path == "/usr/lib/Loader.so")
         return KSuccess;
 
     VERIFY(path.starts_with('/'));


### PR DESCRIPTION
/usr/lib/Loader.so is always completely unveiled.