### PR TITLE
LibJS+LibUnicode: A couple of fixes to locale and `Intl`

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -305,7 +305,7 @@ static void parse_locale_scripts(String locale_path, UnicodeLocaleData& locale_d
     });
 }
 
-static void parse_locale_list_patters(String misc_path, UnicodeLocaleData& locale_data, Locale& locale)
+static void parse_locale_list_patterns(String misc_path, UnicodeLocaleData& locale_data, Locale& locale)
 {
     LexicalPath list_patterns_path(move(misc_path));
     list_patterns_path = list_patterns_path.append("listPatterns.json"sv);
@@ -449,7 +449,7 @@ static void parse_all_locales(String core_path, String locale_names_path, String
             continue;
 
         auto& locale = locale_data.locales.ensure(*language);
-        parse_locale_list_patters(misc_path, locale_data, locale);
+        parse_locale_list_patterns(misc_path, locale_data, locale);
     }
 
     while (numbers_iterator.has_next()) {

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -138,7 +138,7 @@ TEST_CASE(parse_unicode_locale_id_with_unicode_locale_extension)
             auto const& expected_keyword = expected_extension.keywords[i];
 
             EXPECT_EQ(actual_keyword.key, expected_keyword.key);
-            EXPECT_EQ(actual_keyword.types, expected_keyword.types);
+            EXPECT_EQ(actual_keyword.value, expected_keyword.value);
         }
     };
 
@@ -153,15 +153,15 @@ TEST_CASE(parse_unicode_locale_id_with_unicode_locale_extension)
     fail("en-u-xxxxx-"sv);
     fail("en-u-xxxxxxxxx"sv);
 
-    pass("en-u-xx"sv, { {}, { { "xx"sv, {} } } });
+    pass("en-u-xx"sv, { {}, { { "xx"sv, ""sv } } });
     pass("en-u-xx-yyyy"sv, { {}, { { "xx"sv, { "yyyy"sv } } } });
-    pass("en-u-xx-yyyy-zzzz"sv, { {}, { { "xx"sv, { "yyyy"sv, "zzzz"sv } } } });
-    pass("en-u-xx-yyyy-zzzz-aa"sv, { {}, { { "xx"sv, { "yyyy"sv, "zzzz"sv } }, { "aa"sv, {} } } });
+    pass("en-u-xx-yyyy-zzzz"sv, { {}, { { "xx"sv, "yyyy-zzzz"sv } } });
+    pass("en-u-xx-yyyy-zzzz-aa"sv, { {}, { { "xx"sv, "yyyy-zzzz"sv }, { "aa"sv, ""sv } } });
     pass("en-u-xxx"sv, { { "xxx"sv }, {} });
     pass("en-u-fff-gggg"sv, { { "fff"sv, "gggg"sv }, {} });
-    pass("en-u-fff-xx"sv, { { "fff"sv }, { { "xx"sv, {} } } });
-    pass("en-u-fff-xx-yyyy"sv, { { "fff"sv }, { { "xx"sv, { "yyyy"sv } } } });
-    pass("en-u-fff-gggg-xx-yyyy"sv, { { "fff"sv, "gggg"sv }, { { "xx"sv, { "yyyy"sv } } } });
+    pass("en-u-fff-xx"sv, { { "fff"sv }, { { "xx"sv, ""sv } } });
+    pass("en-u-fff-xx-yyyy"sv, { { "fff"sv }, { { "xx"sv, "yyyy"sv } } });
+    pass("en-u-fff-gggg-xx-yyyy"sv, { { "fff"sv, "gggg"sv }, { { "xx"sv, "yyyy"sv } } });
 }
 
 TEST_CASE(parse_unicode_locale_id_with_transformed_extension)
@@ -192,7 +192,7 @@ TEST_CASE(parse_unicode_locale_id_with_transformed_extension)
             auto const& expected_field = expected_extension.fields[i];
 
             EXPECT_EQ(actual_field.key, expected_field.key);
-            EXPECT_EQ(actual_field.values, expected_field.values);
+            EXPECT_EQ(actual_field.value, expected_field.value);
         }
     };
 
@@ -225,9 +225,9 @@ TEST_CASE(parse_unicode_locale_id_with_transformed_extension)
     pass("en-t-en-us-posix"sv, { Unicode::LanguageID { false, "en"sv, {}, "us"sv, { "posix"sv } }, {} });
     pass("en-t-en-latn-us-posix"sv, { Unicode::LanguageID { false, "en"sv, "latn"sv, "us"sv, { "posix"sv } }, {} });
     pass("en-t-k0-aaa"sv, { {}, { { "k0"sv, { "aaa"sv } } } });
-    pass("en-t-k0-aaa-bbbb"sv, { {}, { { "k0"sv, { "aaa"sv, "bbbb" } } } });
-    pass("en-t-k0-aaa-k1-bbbb"sv, { {}, { { "k0"sv, { "aaa"sv } }, { "k1"sv, { "bbbb"sv } } } });
-    pass("en-t-en-k0-aaa"sv, { Unicode::LanguageID { false, "en"sv }, { { "k0"sv, { "aaa"sv } } } });
+    pass("en-t-k0-aaa-bbbb"sv, { {}, { { "k0"sv, "aaa-bbbb"sv } } });
+    pass("en-t-k0-aaa-k1-bbbb"sv, { {}, { { "k0"sv, { "aaa"sv } }, { "k1"sv, "bbbb"sv } } });
+    pass("en-t-en-k0-aaa"sv, { Unicode::LanguageID { false, "en"sv }, { { "k0"sv, "aaa"sv } } });
 }
 
 TEST_CASE(parse_unicode_locale_id_with_other_extension)
@@ -243,7 +243,7 @@ TEST_CASE(parse_unicode_locale_id_with_other_extension)
 
         auto const& actual_extension = locale_id->extensions[0].get<Unicode::OtherExtension>();
         EXPECT_EQ(actual_extension.key, expected_extension.key);
-        EXPECT_EQ(actual_extension.values, expected_extension.values);
+        EXPECT_EQ(actual_extension.value, expected_extension.value);
     };
 
     fail("en-z"sv);
@@ -259,9 +259,9 @@ TEST_CASE(parse_unicode_locale_id_with_other_extension)
     fail("en-z-aaa-a"sv);
     fail("en-0-aaa-a"sv);
 
-    pass("en-z-aa", { 'z', { "aa"sv } });
-    pass("en-z-aa-bbb", { 'z', { "aa"sv, "bbb"sv } });
-    pass("en-z-aa-bbb-cccccccc", { 'z', { "aa"sv, "bbb"sv, "cccccccc"sv } });
+    pass("en-z-aa", { 'z', "aa"sv });
+    pass("en-z-aa-bbb", { 'z', "aa-bbb"sv });
+    pass("en-z-aa-bbb-cccccccc", { 'z', "aa-bbb-cccccccc"sv });
 }
 
 TEST_CASE(parse_unicode_locale_id_with_private_use_extension)
@@ -320,8 +320,12 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("EN-U-CCC-BBB-2K-AAA-1K-BBB"sv, "en-u-bbb-ccc-1k-bbb-2k-aaa"sv);
     test("en-u-1k-true"sv, "en-u-1k"sv);
     test("EN-U-1K-TRUE"sv, "en-u-1k"sv);
+    test("en-u-1k-true-abcd"sv, "en-u-1k-true-abcd"sv);
+    test("EN-U-1K-TRUE-ABCD"sv, "en-u-1k-true-abcd"sv);
     test("en-u-kb-yes"sv, "en-u-kb"sv);
     test("EN-U-KB-YES"sv, "en-u-kb"sv);
+    test("en-u-kb-yes-abcd"sv, "en-u-kb-yes-abcd"sv);
+    test("EN-U-KB-YES-ABCD"sv, "en-u-kb-yes-abcd"sv);
     test("en-u-ka-yes"sv, "en-u-ka-yes"sv);
     test("EN-U-KA-YES"sv, "en-u-ka-yes"sv);
     test("en-u-1k-names"sv, "en-u-1k-names"sv);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -114,7 +114,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatConstructor::supported_locales_of)
     auto locales = vm.argument(0);
     auto options = vm.argument(1);
 
-    // 1. Let availableLocales be %DisplayNames%.[[AvailableLocales]].
+    // 1. Let availableLocales be %ListFormat%.[[AvailableLocales]].
 
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = canonicalize_locale_list(global_object, locales);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -345,7 +345,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format_to_parts)
     return format_list_to_parts(global_object, *list_format, string_list);
 }
 
-// 3.4.5 Intl.ListFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.resolvedoptions
+// 13.4.5 Intl.ListFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
 {
     // 1. Let lf be the this value.

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/Locale.h>
 #include <LibUnicode/Locale.h>
@@ -27,29 +26,23 @@ Locale::Locale(Unicode::LocaleID const& locale_id, Object& prototype)
 {
     set_locale(locale_id.to_string());
 
-    auto join_keyword_types = [](auto const& types) {
-        StringBuilder builder;
-        builder.join('-', types);
-        return builder.build();
-    };
-
     for (auto const& extension : locale_id.extensions) {
         if (!extension.has<Unicode::LocaleExtension>())
             continue;
 
         for (auto const& keyword : extension.get<Unicode::LocaleExtension>().keywords) {
             if (keyword.key == "ca"sv) {
-                set_calendar(join_keyword_types(keyword.types));
+                set_calendar(keyword.value);
             } else if (keyword.key == "co"sv) {
-                set_collation(join_keyword_types(keyword.types));
+                set_collation(keyword.value);
             } else if (keyword.key == "hc"sv) {
-                set_hour_cycle(join_keyword_types(keyword.types));
+                set_hour_cycle(keyword.value);
             } else if (keyword.key == "kf"sv) {
-                set_case_first(join_keyword_types(keyword.types));
+                set_case_first(keyword.value);
             } else if (keyword.key == "kn"sv) {
-                set_numeric(keyword.types.is_empty());
+                set_numeric(keyword.value.is_empty());
             } else if (keyword.key == "nu"sv) {
-                set_numbering_system(join_keyword_types(keyword.types));
+                set_numbering_system(keyword.value);
             }
         }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Optional.h>
 #include <AK/String.h>
-#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
@@ -193,9 +192,7 @@ static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKey
             entry = &(*it);
 
             // ii. Let value be entry.[[Value]].
-            StringBuilder builder;
-            builder.join('-', entry->types);
-            value = builder.build();
+            value = entry->value;
         }
         // c. Else,
         //     i. Let entry be empty.
@@ -213,12 +210,12 @@ static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKey
             // iii. If entry is not empty, then
             if (entry != nullptr) {
                 // 1. Set entry.[[Value]] to value.
-                entry->types = value->split('-');
+                entry->value = *value;
             }
             // iv. Else,
             else {
                 // 1. Append the Record { [[Key]]: key, [[Value]]: value } to keywords.
-                keywords.append({ key, value->split('-') });
+                keywords.append({ key, *value });
             }
         }
 

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -468,8 +468,7 @@ static void perform_hard_coded_key_value_substitutions(String& key, String& valu
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/timezone.xml
     // https://github.com/unicode-org/cldr-staging/blob/master/production/common/bcp47/transform.xml
     //
-    // There doesn't seem to be a counterpart in the JSON export. Since there aren't many such
-    // aliases, until an XML parser is implemented, those aliases are implemented here.
+    // There isn't yet a counterpart in the JSON export. See: https://unicode-org.atlassian.net/browse/CLDR-14571
     if ((key == "ca"sv) && (value == "islamicc"sv)) {
         value = "islamic-civil"sv;
     } else if (key.is_one_of("kb"sv, "kc"sv, "kh"sv, "kk"sv, "kn"sv) && (value == "yes"sv)) {

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -29,7 +29,7 @@ struct LanguageID {
 
 struct Keyword {
     String key {};
-    Vector<String> types {};
+    String value {};
 };
 
 struct LocaleExtension {
@@ -38,8 +38,8 @@ struct LocaleExtension {
 };
 
 struct TransformedField {
-    String key;
-    Vector<String> values {};
+    String key {};
+    String value {};
 };
 
 struct TransformedExtension {
@@ -49,7 +49,7 @@ struct TransformedExtension {
 
 struct OtherExtension {
     char key {};
-    Vector<String> values {};
+    String value {};
 };
 
 using Extension = Variant<LocaleExtension, TransformedExtension, OtherExtension>;


### PR DESCRIPTION
Long story short, I started implementing `Intl.Collator`, but found that [the data needed for collation](https://github.com/unicode-org/cldr-staging/tree/master/production/common/collation) is not yet available in the JSON export of CLDR. I couldn't find anything that indicates this data will be exported soon, so it'll likely need to wait until we have something like LibXML to parse this data.

This PR contains just a couple fixes for things I came across while implementing `Intl.Collator`.