### PR TITLE
HackStudio: Preserve the untitled filename text on file modification

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -26,7 +26,7 @@ EditorWrapper::EditorWrapper()
     label_wrapper.set_layout<GUI::HorizontalBoxLayout>();
     label_wrapper.layout()->set_margins({ 0, 2 });
 
-    m_filename_label = label_wrapper.add<GUI::Label>("(Untitled)");
+    m_filename_label = label_wrapper.add<GUI::Label>(untitled_label);
     m_filename_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
     m_filename_label->set_fixed_height(14);
 
@@ -123,7 +123,10 @@ void EditorWrapper::set_project_root(LexicalPath const& project_root)
 void EditorWrapper::update_title()
 {
     StringBuilder title;
-    title.append(m_filename);
+    if (m_filename.is_null())
+        title.append(untitled_label);
+    else
+        title.append(m_filename);
 
     if (m_document_dirty)
         title.append(" (*)");

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -55,6 +55,8 @@ public:
     Function<void()> on_change;
 
 private:
+    static constexpr auto untitled_label = "(Untitled)";
+
     EditorWrapper();
 
     void update_title();


### PR DESCRIPTION
Previously, the title of an unnamed file would just disappear from the editor label if you started typing.

![Peek 2021-09-06 21-312](https://user-images.githubusercontent.com/16520278/132581885-592eed3e-a320-4f57-acc6-f10b3a60d182.gif)
