### PR TITLE
Kernel: Define INADDR_BROADCAST constant

### DIFF
--- a/Kernel/API/POSIX/netinet/in.h
+++ b/Kernel/API/POSIX/netinet/in.h
@@ -18,6 +18,7 @@ typedef uint32_t in_addr_t;
 #define INADDR_ANY ((in_addr_t)0)
 #define INADDR_NONE ((in_addr_t)-1)
 #define INADDR_LOOPBACK 0x7f000001
+#define INADDR_BROADCAST 0xffffffff
 
 #define IN_LOOPBACKNET 127
 


### PR DESCRIPTION
This is required by some programs, notably python's socket module, which
fails to compile without this definition.