### PR TITLE
AK+Everywhere: Reduce the number of template parameters of IntrusiveFoo

### DIFF
--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -13,29 +13,34 @@
 #include <AK/Noncopyable.h>
 #include <AK/StdLibExtras.h>
 
-namespace AK {
+namespace AK::Detail {
 
-namespace Detail {
 template<typename T, typename Container = RawPtr<T>>
 class IntrusiveListNode;
-}
+
+struct ExtractIntrusiveListTypes {
+    template<typename V, typename Container, typename T>
+    static V value(IntrusiveListNode<V, Container> T::*x);
+    template<typename V, typename Container, typename T>
+    static Container container(IntrusiveListNode<V, Container> T::*x);
+};
 
 template<typename T, typename Container = RawPtr<T>>
-using IntrusiveListNode = Detail::IntrusiveListNode<T, typename Detail::SubstituteIntrusiveContainerType<T, Container>::Type>;
+using SubstitutedIntrusiveListNode = IntrusiveListNode<T, typename Detail::SubstituteIntrusiveContainerType<T, Container>::Type>;
 
 template<typename T, typename Container>
 class IntrusiveListStorage {
 private:
-    friend class Detail::IntrusiveListNode<T, Container>;
+    friend class IntrusiveListNode<T, Container>;
 
-    template<class T_, typename Container_, IntrusiveListNode<T_, Container_> T_::*member>
+    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
     friend class IntrusiveList;
 
-    IntrusiveListNode<T, Container>* m_first { nullptr };
-    IntrusiveListNode<T, Container>* m_last { nullptr };
+    SubstitutedIntrusiveListNode<T, Container>* m_first { nullptr };
+    SubstitutedIntrusiveListNode<T, Container>* m_last { nullptr };
 };
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 class IntrusiveList {
     AK_MAKE_NONCOPYABLE(IntrusiveList);
     AK_MAKE_NONMOVABLE(IntrusiveList);
@@ -144,11 +149,9 @@ private:
     static T* prev(T* current);
     static const T* next(const T* current);
     static const T* prev(const T* current);
-    static T* node_to_value(IntrusiveListNode<T, Container>& node);
+    static T* node_to_value(SubstitutedIntrusiveListNode<T, Container>& node);
     IntrusiveListStorage<T, Container> m_storage;
 };
-
-namespace Detail {
 
 template<typename T, typename Container>
 class IntrusiveListNode {
@@ -159,23 +162,21 @@ public:
 
     static constexpr bool IsRaw = IsPointer<Container>;
 
-    // Note: For some reason, clang does not consider `member` as declared here, and as declared above (`IntrusiveListNode<T, Container> T::*`)
+    // Note: For some reason, clang does not consider `member` as declared here, and as declared above (`SubstitutedIntrusiveListNode<T, Container> T::*`)
     //       to be of equal types. so for now, just make the members public on clang.
 #ifndef __clang__
 private:
-    template<class T_, typename Container_, IntrusiveListNode<T_, Container_> T_::*member>
-    friend class ::AK::IntrusiveList;
+    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
+    friend class ::AK::Detail::IntrusiveList;
 #endif
 
     IntrusiveListStorage<T, Container>* m_storage = nullptr;
-    IntrusiveListNode<T, Container>* m_next = nullptr;
-    IntrusiveListNode<T, Container>* m_prev = nullptr;
+    SubstitutedIntrusiveListNode<T, Container>* m_next = nullptr;
+    SubstitutedIntrusiveListNode<T, Container>* m_prev = nullptr;
     [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
-}
-
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, Container, member>::Iterator::erase()
 {
     auto old = m_value;
@@ -184,26 +185,26 @@ inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, 
     return *this;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline IntrusiveList<T, Container, member>::~IntrusiveList()
 {
     clear();
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline void IntrusiveList<T, Container, member>::clear()
 {
     while (m_storage.m_first)
         m_storage.m_first->remove();
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline bool IntrusiveList<T, Container, member>::is_empty() const
 {
     return m_storage.m_first == nullptr;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline size_t IntrusiveList<T, Container, member>::size_slow() const
 {
     size_t size = 0;
@@ -214,7 +215,7 @@ inline size_t IntrusiveList<T, Container, member>::size_slow() const
     return size;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline void IntrusiveList<T, Container, member>::append(T& n)
 {
     remove(n);
@@ -233,7 +234,7 @@ inline void IntrusiveList<T, Container, member>::append(T& n)
         m_storage.m_first = &nnode;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline void IntrusiveList<T, Container, member>::prepend(T& n)
 {
     remove(n);
@@ -252,7 +253,7 @@ inline void IntrusiveList<T, Container, member>::prepend(T& n)
         m_storage.m_last = &nnode;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline void IntrusiveList<T, Container, member>::insert_before(T& bn, T& n)
 {
     remove(n);
@@ -274,7 +275,7 @@ inline void IntrusiveList<T, Container, member>::insert_before(T& bn, T& n)
         new_node.m_self.reference = &n;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline void IntrusiveList<T, Container, member>::remove(T& n)
 {
     auto& nnode = n.*member;
@@ -282,20 +283,20 @@ inline void IntrusiveList<T, Container, member>::remove(T& n)
         nnode.remove();
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline bool IntrusiveList<T, Container, member>::contains(const T& n) const
 {
     auto& nnode = n.*member;
     return nnode.m_storage == &m_storage;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline Container IntrusiveList<T, Container, member>::first() const
 {
     return m_storage.m_first ? node_to_value(*m_storage.m_first) : nullptr;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline Container IntrusiveList<T, Container, member>::take_first()
 {
     if (Container ptr = first()) {
@@ -305,7 +306,7 @@ inline Container IntrusiveList<T, Container, member>::take_first()
     return nullptr;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline Container IntrusiveList<T, Container, member>::take_last()
 {
     if (Container ptr = last()) {
@@ -315,13 +316,13 @@ inline Container IntrusiveList<T, Container, member>::take_last()
     return nullptr;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline Container IntrusiveList<T, Container, member>::last() const
 {
     return m_storage.m_last ? node_to_value(*m_storage.m_last) : nullptr;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline const T* IntrusiveList<T, Container, member>::next(const T* current)
 {
     auto& nextnode = (current->*member).m_next;
@@ -329,7 +330,7 @@ inline const T* IntrusiveList<T, Container, member>::next(const T* current)
     return nextstruct;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline const T* IntrusiveList<T, Container, member>::prev(const T* current)
 {
     auto& prevnode = (current->*member).m_prev;
@@ -337,7 +338,7 @@ inline const T* IntrusiveList<T, Container, member>::prev(const T* current)
     return prevstruct;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline T* IntrusiveList<T, Container, member>::next(T* current)
 {
     auto& nextnode = (current->*member).m_next;
@@ -345,7 +346,7 @@ inline T* IntrusiveList<T, Container, member>::next(T* current)
     return nextstruct;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline T* IntrusiveList<T, Container, member>::prev(T* current)
 {
     auto& prevnode = (current->*member).m_prev;
@@ -353,26 +354,26 @@ inline T* IntrusiveList<T, Container, member>::prev(T* current)
     return prevstruct;
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline typename IntrusiveList<T, Container, member>::Iterator IntrusiveList<T, Container, member>::begin()
 {
     return m_storage.m_first ? Iterator(node_to_value(*m_storage.m_first)) : Iterator();
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline typename IntrusiveList<T, Container, member>::ReverseIterator IntrusiveList<T, Container, member>::rbegin()
 {
     return m_storage.m_last ? ReverseIterator(node_to_value(*m_storage.m_last)) : ReverseIterator();
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
 inline typename IntrusiveList<T, Container, member>::ConstIterator IntrusiveList<T, Container, member>::begin() const
 {
     return m_storage.m_first ? ConstIterator(node_to_value(*m_storage.m_first)) : ConstIterator();
 }
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
-inline T* IntrusiveList<T, Container, member>::node_to_value(IntrusiveListNode<T, Container>& node)
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+inline T* IntrusiveList<T, Container, member>::node_to_value(SubstitutedIntrusiveListNode<T, Container>& node)
 {
     // Note: Since this might seem odd, here's an explanation on what this function actually does:
     //       `node` is a reference that resides in some part of the actual value (of type T), the
@@ -382,8 +383,6 @@ inline T* IntrusiveList<T, Container, member>::node_to_value(IntrusiveListNode<T
     //       of the value (of type T) holding that member.
     return bit_cast<T*>(bit_cast<unsigned char*>(&node) - bit_cast<unsigned char*>(member));
 }
-
-namespace Detail {
 
 template<typename T, typename Container>
 inline IntrusiveListNode<T, Container>::~IntrusiveListNode()
@@ -416,13 +415,11 @@ inline bool IntrusiveListNode<T, Container>::is_in_list() const
     return m_storage != nullptr;
 }
 
-}
-
 // Specialise IntrusiveList for NonnullRefPtr
 // By default, intrusive lists cannot contain null entries anyway, so switch to RefPtr
 // and just make the user-facing functions deref the pointers.
 
-template<class T, IntrusiveListNode<T, NonnullRefPtr<T>> T::*member>
+template<class T, SubstitutedIntrusiveListNode<T, NonnullRefPtr<T>> T::*member>
 class IntrusiveList<T, NonnullRefPtr<T>, member> : public IntrusiveList<T, RefPtr<T>, member> {
 public:
     [[nodiscard]] NonnullRefPtr<T> first() const { return *IntrusiveList<T, RefPtr<T>, member>::first(); }
@@ -431,6 +428,19 @@ public:
     [[nodiscard]] NonnullRefPtr<T> take_first() { return *IntrusiveList<T, RefPtr<T>, member>::take_first(); }
     [[nodiscard]] NonnullRefPtr<T> take_last() { return *IntrusiveList<T, RefPtr<T>, member>::take_last(); }
 };
+
+}
+
+namespace AK {
+
+template<typename T, typename Container = RawPtr<T>>
+using IntrusiveListNode = Detail::SubstitutedIntrusiveListNode<T, Container>;
+
+template<auto member>
+using IntrusiveList = Detail::IntrusiveList<
+    decltype(Detail::ExtractIntrusiveListTypes::value(member)),
+    decltype(Detail::ExtractIntrusiveListTypes::container(member)),
+    member>;
 
 }
 

--- a/AK/IntrusiveListRelaxedConst.h
+++ b/AK/IntrusiveListRelaxedConst.h
@@ -9,6 +9,7 @@
 #include <AK/IntrusiveList.h>
 
 namespace AK {
+namespace Detail {
 
 template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
 class IntrusiveListRelaxedConst : public IntrusiveList<T, Container, member> {
@@ -23,6 +24,14 @@ public:
     Iterator begin() const { return const_cast<IntrusiveListRelaxedConst*>(this)->IntrusiveList<T, Container, member>::begin(); }
     Iterator end() const { return Iterator {}; }
 };
+
+}
+
+template<auto member>
+using IntrusiveListRelaxedConst = Detail::IntrusiveListRelaxedConst<
+    decltype(Detail::ExtractIntrusiveListTypes::value(member)),
+    decltype(Detail::ExtractIntrusiveListTypes::container(member)),
+    member>;
 
 }
 

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -9,17 +9,24 @@
 #include <AK/IntrusiveDetails.h>
 #include <AK/RedBlackTree.h>
 
-namespace AK {
+namespace AK::Detail {
 
-namespace Detail {
 template<Integral K, typename V, typename Container = RawPtr<V>>
 class IntrusiveRedBlackTreeNode;
-}
+
+struct ExtractIntrusiveRedBlackTreeTypes {
+    template<typename K, typename V, typename Container, typename T>
+    static K key(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    template<typename K, typename V, typename Container, typename T>
+    static V value(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    template<typename K, typename V, typename Container, typename T>
+    static Container container(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+};
 
 template<Integral K, typename V, typename Container = RawPtr<V>>
-using IntrusiveRedBlackTreeNode = Detail::IntrusiveRedBlackTreeNode<K, V, typename Detail::SubstituteIntrusiveContainerType<V, Container>::Type>;
+using SubstitutedIntrusiveRedBlackTreeNode = IntrusiveRedBlackTreeNode<K, V, typename Detail::SubstituteIntrusiveContainerType<V, Container>::Type>;
 
-template<Integral K, typename V, typename Container, IntrusiveRedBlackTreeNode<K, V, Container> V::*member>
+template<Integral K, typename V, typename Container, SubstitutedIntrusiveRedBlackTreeNode<K, V, Container> V::*member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
 
 public:
@@ -30,7 +37,7 @@ public:
     }
 
     using BaseTree = BaseRedBlackTree<K>;
-    using TreeNode = IntrusiveRedBlackTreeNode<K, V, Container>;
+    using TreeNode = SubstitutedIntrusiveRedBlackTreeNode<K, V, Container>;
 
     Container find(K key)
     {
@@ -161,8 +168,6 @@ private:
     }
 };
 
-namespace Detail {
-
 template<Integral K, typename V, typename Container>
 class IntrusiveRedBlackTreeNode : public BaseRedBlackTree<K>::Node {
 public:
@@ -185,25 +190,37 @@ public:
 
 #ifndef __clang__
 private:
-    template<Integral TK, typename TV, typename TContainer, IntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::*member>
-    friend class ::AK::IntrusiveRedBlackTree;
+    template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::*member>
+    friend class ::AK::Detail::IntrusiveRedBlackTree;
 #endif
 
     bool m_in_tree { false };
     [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
-}
-
 // Specialise IntrusiveRedBlackTree for NonnullRefPtr
 // By default, red black trees cannot contain null entries anyway, so switch to RefPtr
 // and just make the user-facing functions deref the pointers.
-template<Integral K, typename V, IntrusiveRedBlackTreeNode<K, V, NonnullRefPtr<V>> V::*member>
+template<Integral K, typename V, SubstitutedIntrusiveRedBlackTreeNode<K, V, NonnullRefPtr<V>> V::*member>
 class IntrusiveRedBlackTree<K, V, NonnullRefPtr<V>, member> : public IntrusiveRedBlackTree<K, V, RefPtr<V>, member> {
 public:
     [[nodiscard]] NonnullRefPtr<V> find(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find(key).release_nonnull(); }
     [[nodiscard]] NonnullRefPtr<V> find_largest_not_above(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find_largest_not_above(key).release_nonnull(); }
 };
+
+}
+
+namespace AK {
+
+template<Integral K, typename V, typename Container = RawPtr<K>>
+using IntrusiveRedBlackTreeNode = Detail::SubstitutedIntrusiveRedBlackTreeNode<K, V, Container>;
+
+template<auto member>
+using IntrusiveRedBlackTree = Detail::IntrusiveRedBlackTree<
+    decltype(Detail::ExtractIntrusiveRedBlackTreeTypes::key(member)),
+    decltype(Detail::ExtractIntrusiveRedBlackTreeTypes::value(member)),
+    decltype(Detail::ExtractIntrusiveRedBlackTreeTypes::container(member)),
+    member>;
 
 }
 

--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -76,7 +76,7 @@ private:
         IntrusiveListNode<QueueSegment> node;
     };
 
-    IntrusiveList<QueueSegment, RawPtr<QueueSegment>, &QueueSegment::node> m_segments;
+    IntrusiveList<&QueueSegment::node> m_segments;
     size_t m_index_into_first { 0 };
     size_t m_size { 0 };
 };

--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -39,8 +39,8 @@ private:
     IntrusiveListNode<Region> m_vmobject_list_node;
 
 public:
-    using ListInMemoryManager = IntrusiveList<Region, RawPtr<Region>, &Region::m_memory_manager_list_node>;
-    using ListInVMObject = IntrusiveList<Region, RawPtr<Region>, &Region::m_vmobject_list_node>;
+    using ListInMemoryManager = IntrusiveList<&Region::m_memory_manager_list_node>;
+    using ListInVMObject = IntrusiveList<&Region::m_vmobject_list_node>;
 };
 ```
 

--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -54,7 +54,7 @@ private:
 
     RefPtr<SysFSUSBDeviceInformation> device_node_for(USB::Device& device);
 
-    IntrusiveList<SysFSUSBDeviceInformation, RefPtr<SysFSUSBDeviceInformation>, &SysFSUSBDeviceInformation::m_list_node> m_device_nodes;
+    IntrusiveList<&SysFSUSBDeviceInformation::m_list_node> m_device_nodes;
     mutable Spinlock m_lock;
 };
 

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -33,7 +33,7 @@ private:
     IntrusiveListNode<USBController, NonnullRefPtr<USBController>> m_controller_list_node;
 
 public:
-    using List = IntrusiveList<USBController, NonnullRefPtr<USBController>, &USBController::m_controller_list_node>;
+    using List = IntrusiveList<&USBController::m_controller_list_node>;
 };
 
 }

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -64,6 +64,6 @@ private:
     IntrusiveListNode<Device, NonnullRefPtr<Device>> m_hub_child_node;
 
 public:
-    using List = IntrusiveList<Device, NonnullRefPtr<Device>, &Device::m_hub_child_node>;
+    using List = IntrusiveList<&Device::m_hub_child_node>;
 };
 }

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -143,7 +143,7 @@ private:
     RequestResult m_result { Pending };
     IntrusiveListNode<AsyncDeviceRequest, RefPtr<AsyncDeviceRequest>> m_list_node;
 
-    using AsyncDeviceSubRequestList = IntrusiveList<AsyncDeviceRequest, RefPtr<AsyncDeviceRequest>, &AsyncDeviceRequest::m_list_node>;
+    using AsyncDeviceSubRequestList = IntrusiveList<&AsyncDeviceRequest::m_list_node>;
 
     AsyncDeviceSubRequestList m_sub_requests_pending;
     AsyncDeviceSubRequestList m_sub_requests_complete;

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -97,8 +97,8 @@ public:
 private:
     BlockBasedFileSystem& m_fs;
     mutable HashMap<BlockBasedFileSystem::BlockIndex, CacheEntry*> m_hash;
-    mutable IntrusiveList<CacheEntry, RawPtr<CacheEntry>, &CacheEntry::list_node> m_clean_list;
-    mutable IntrusiveList<CacheEntry, RawPtr<CacheEntry>, &CacheEntry::list_node> m_dirty_list;
+    mutable IntrusiveList<&CacheEntry::list_node> m_clean_list;
+    mutable IntrusiveList<&CacheEntry::list_node> m_dirty_list;
     NonnullOwnPtr<KBuffer> m_cached_block_data;
     NonnullOwnPtr<KBuffer> m_entries;
     bool m_dirty { false };

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -50,7 +50,7 @@ private:
     mutable IntrusiveListNode<Custody> m_all_custodies_list_node;
 
 public:
-    using AllCustodiesList = IntrusiveList<Custody, RawPtr<Custody>, &Custody::m_all_custodies_list_node>;
+    using AllCustodiesList = IntrusiveList<&Custody::m_all_custodies_list_node>;
 };
 
 }

--- a/Kernel/FileSystem/DevTmpFS.h
+++ b/Kernel/FileSystem/DevTmpFS.h
@@ -143,7 +143,7 @@ protected:
     DevTmpFSDirectoryInode(DevTmpFS&, NonnullOwnPtr<KString> name);
     // ^Inode
     OwnPtr<KString> m_name;
-    IntrusiveList<DevTmpFSInode, NonnullRefPtr<DevTmpFSInode>, &DevTmpFSInode::m_list_node> m_nodes;
+    IntrusiveList<&DevTmpFSInode::m_list_node> m_nodes;
 
 private:
     explicit DevTmpFSDirectoryInode(DevTmpFS&);

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -134,7 +134,7 @@ private:
     Vector<Flock> m_flocks;
 
 public:
-    using AllInstancesList = IntrusiveList<Inode, RawPtr<Inode>, &Inode::m_inode_list_node>;
+    using AllInstancesList = IntrusiveList<&Inode::m_inode_list_node>;
     static SpinlockProtected<Inode::AllInstancesList>& all_instances();
 };
 

--- a/Kernel/FileSystem/SysFS.h
+++ b/Kernel/FileSystem/SysFS.h
@@ -81,7 +81,7 @@ private:
 };
 
 class SysFSComponentRegistry {
-    using DevicesList = MutexProtected<IntrusiveList<SysFSDeviceComponent, NonnullRefPtr<SysFSDeviceComponent>, &SysFSDeviceComponent::m_list_node>>;
+    using DevicesList = MutexProtected<IntrusiveList<&SysFSDeviceComponent::m_list_node>>;
 
 public:
     static SysFSComponentRegistry& the();

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -79,7 +79,7 @@ private:
         NonnullOwnPtr<KString> name;
         NonnullRefPtr<TmpFSInode> inode;
         IntrusiveListNode<Child> list_node {};
-        using List = IntrusiveList<Child, RawPtr<Child>, &Child::list_node>;
+        using List = IntrusiveList<&Child::list_node>;
     };
 
     Child* find_child_by_name(StringView);

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -68,6 +68,6 @@ private:
     IntrusiveListNode<GenericInterruptHandler> m_list_node;
 
 public:
-    using List = IntrusiveList<GenericInterruptHandler, RawPtr<GenericInterruptHandler>, &GenericInterruptHandler::m_list_node>;
+    using List = IntrusiveList<&GenericInterruptHandler::m_list_node>;
 };
 }

--- a/Kernel/Locking/Mutex.h
+++ b/Kernel/Locking/Mutex.h
@@ -69,7 +69,7 @@ public:
     }
 
 private:
-    using BlockedThreadList = IntrusiveList<Thread, RawPtr<Thread>, &Thread::m_blocked_threads_list_node>;
+    using BlockedThreadList = IntrusiveList<&Thread::m_blocked_threads_list_node>;
 
     ALWAYS_INLINE BlockedThreadList& thread_list_for_mode(Mode mode)
     {

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -17,9 +17,9 @@ extern u8 end_of_kernel_image[];
 
 namespace Kernel::Memory {
 
-static Singleton<IntrusiveRedBlackTree<FlatPtr, PageDirectory, RawPtr<PageDirectory>, &PageDirectory::m_tree_node>> s_cr3_map;
+static Singleton<IntrusiveRedBlackTree<&PageDirectory::m_tree_node>> s_cr3_map;
 
-static IntrusiveRedBlackTree<FlatPtr, PageDirectory, RawPtr<PageDirectory>, &PageDirectory::m_tree_node>& cr3_map()
+static IntrusiveRedBlackTree<&PageDirectory::m_tree_node>& cr3_map()
 {
     VERIFY_INTERRUPTS_DISABLED();
     return *s_cr3_map;

--- a/Kernel/Memory/PhysicalZone.h
+++ b/Kernel/Memory/PhysicalZone.h
@@ -89,7 +89,7 @@ private:
     IntrusiveListNode<PhysicalZone> m_list_node;
 
 public:
-    using List = IntrusiveList<PhysicalZone, RawPtr<PhysicalZone>, &PhysicalZone::m_list_node>;
+    using List = IntrusiveList<&PhysicalZone::m_list_node>;
 };
 
 }

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -217,8 +217,8 @@ private:
     IntrusiveListNode<Region> m_vmobject_list_node;
 
 public:
-    using ListInMemoryManager = IntrusiveList<Region, RawPtr<Region>, &Region::m_memory_manager_list_node>;
-    using ListInVMObject = IntrusiveList<Region, RawPtr<Region>, &Region::m_vmobject_list_node>;
+    using ListInMemoryManager = IntrusiveList<&Region::m_memory_manager_list_node>;
+    using ListInVMObject = IntrusiveList<&Region::m_vmobject_list_node>;
 };
 
 AK_ENUM_BITWISE_OPERATORS(Region::Access)

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -73,7 +73,7 @@ private:
     Region::ListInVMObject m_regions;
 
 public:
-    using AllInstancesList = IntrusiveList<VMObject, RawPtr<VMObject>, &VMObject::m_list_node>;
+    using AllInstancesList = IntrusiveList<&VMObject::m_list_node>;
     static SpinlockProtected<VMObject::AllInstancesList>& all_instances();
 };
 

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -133,7 +133,7 @@ private:
     IntrusiveListNode<IPv4Socket> m_list_node;
 
 public:
-    using List = IntrusiveList<IPv4Socket, RawPtr<IPv4Socket>, &IPv4Socket::m_list_node>;
+    using List = IntrusiveList<&IPv4Socket::m_list_node>;
 
     static MutexProtected<IPv4Socket::List>& all_sockets();
 };

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -105,7 +105,7 @@ private:
     IntrusiveListNode<LocalSocket> m_list_node;
 
 public:
-    using List = IntrusiveList<LocalSocket, RawPtr<LocalSocket>, &LocalSocket::m_list_node>;
+    using List = IntrusiveList<&LocalSocket::m_list_node>;
 };
 
 }

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -111,7 +111,7 @@ private:
     // FIXME: Make this configurable
     static constexpr size_t max_packet_buffers = 1024;
 
-    using PacketList = IntrusiveList<PacketWithTimestamp, RefPtr<PacketWithTimestamp>, &PacketWithTimestamp::packet_node>;
+    using PacketList = IntrusiveList<&PacketWithTimestamp::packet_node>;
 
     PacketList m_packet_queue;
     size_t m_packet_queue_size { 0 };

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -225,7 +225,7 @@ private:
     IntrusiveListNode<TCPSocket> m_retransmit_list_node;
 
 public:
-    using RetransmitList = IntrusiveList<TCPSocket, RawPtr<TCPSocket>, &TCPSocket::m_retransmit_list_node>;
+    using RetransmitList = IntrusiveList<&TCPSocket::m_retransmit_list_node>;
     static MutexProtected<TCPSocket::RetransmitList>& sockets_for_retransmit();
 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -807,7 +807,7 @@ private:
     u8 m_protected_values_padding[PAGE_SIZE - sizeof(ProtectedValues)];
 
 public:
-    using List = IntrusiveListRelaxedConst<Process, RawPtr<Process>, &Process::m_list_node>;
+    using List = IntrusiveListRelaxedConst<&Process::m_list_node>;
 };
 
 // Note: Process object should be 2 pages of 4096 bytes each.

--- a/Kernel/ProcessGroup.h
+++ b/Kernel/ProcessGroup.h
@@ -40,7 +40,7 @@ private:
     ProcessGroupID m_pgid;
 
 public:
-    using List = IntrusiveList<ProcessGroup, RawPtr<ProcessGroup>, &ProcessGroup::m_list_node>;
+    using List = IntrusiveList<&ProcessGroup::m_list_node>;
 };
 
 SpinlockProtected<ProcessGroup::List>& process_groups();

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -38,7 +38,7 @@ Atomic<bool> g_finalizer_has_work { false };
 READONLY_AFTER_INIT static Process* s_colonel_process;
 
 struct ThreadReadyQueue {
-    IntrusiveList<Thread, RawPtr<Thread>, &Thread::m_ready_queue_node> thread_list;
+    IntrusiveList<&Thread::m_ready_queue_node> thread_list;
 };
 
 struct ThreadReadyQueues {

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -51,7 +51,7 @@ private:
     String m_boot_argument;
     WeakPtr<BlockDevice> m_boot_block_device;
     NonnullRefPtrVector<StorageController> m_controllers;
-    IntrusiveList<StorageDevice, RefPtr<StorageDevice>, &StorageDevice::m_list_node> m_storage_devices;
+    IntrusiveList<&StorageDevice::m_list_node> m_storage_devices;
 };
 
 }

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -49,7 +49,7 @@ private:
     mutable IntrusiveListNode<SlavePTY> m_list_node;
 
 public:
-    using List = IntrusiveList<SlavePTY, RawPtr<SlavePTY>, &SlavePTY::m_list_node>;
+    using List = IntrusiveList<&SlavePTY::m_list_node>;
     static SpinlockProtected<SlavePTY::List>& all_instances();
 };
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1372,8 +1372,8 @@ private:
     mutable IntrusiveListNode<Thread> m_global_thread_list_node;
 
 public:
-    using ListInProcess = IntrusiveList<Thread, RawPtr<Thread>, &Thread::m_process_thread_list_node>;
-    using GlobalList = IntrusiveList<Thread, RawPtr<Thread>, &Thread::m_global_thread_list_node>;
+    using ListInProcess = IntrusiveList<&Thread::m_process_thread_list_node>;
+    using GlobalList = IntrusiveList<&Thread::m_global_thread_list_node>;
 
     static SpinlockProtected<GlobalList>& all_instances();
 };

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -77,7 +77,7 @@ private:
 
 public:
     IntrusiveListNode<Timer> m_list_node;
-    using List = IntrusiveList<Timer, RawPtr<Timer>, &Timer::m_list_node>;
+    using List = IntrusiveList<&Timer::m_list_node>;
 };
 
 class TimerQueue {

--- a/Kernel/WorkQueue.h
+++ b/Kernel/WorkQueue.h
@@ -51,7 +51,7 @@ private:
 
     RefPtr<Thread> m_thread;
     WaitQueue m_wait_queue;
-    IntrusiveList<WorkItem, RawPtr<WorkItem>, &WorkItem::m_node> m_items;
+    IntrusiveList<&WorkItem::m_node> m_items;
     Spinlock m_lock;
 };
 

--- a/Tests/AK/TestIntrusiveList.cpp
+++ b/Tests/AK/TestIntrusiveList.cpp
@@ -15,7 +15,7 @@ public:
     IntrusiveTestItem() = default;
     IntrusiveListNode<IntrusiveTestItem> m_list_node;
 };
-using IntrusiveTestList = IntrusiveList<IntrusiveTestItem, RawPtr<IntrusiveTestItem>, &IntrusiveTestItem::m_list_node>;
+using IntrusiveTestList = IntrusiveList<&IntrusiveTestItem::m_list_node>;
 
 TEST_CASE(construct)
 {
@@ -91,7 +91,7 @@ public:
     IntrusiveRefPtrItem() = default;
     IntrusiveListNode<IntrusiveRefPtrItem, RefPtr<IntrusiveRefPtrItem>> m_list_node;
 };
-using IntrusiveRefPtrList = IntrusiveList<IntrusiveRefPtrItem, RefPtr<IntrusiveRefPtrItem>, &IntrusiveRefPtrItem::m_list_node>;
+using IntrusiveRefPtrList = IntrusiveList<&IntrusiveRefPtrItem::m_list_node>;
 
 TEST_CASE(intrusive_ref_ptr_no_ref_leaks)
 {
@@ -138,7 +138,7 @@ public:
     IntrusiveNonnullRefPtrItem() = default;
     IntrusiveListNode<IntrusiveNonnullRefPtrItem, NonnullRefPtr<IntrusiveNonnullRefPtrItem>> m_list_node;
 };
-using IntrusiveNonnullRefPtrList = IntrusiveList<IntrusiveNonnullRefPtrItem, NonnullRefPtr<IntrusiveNonnullRefPtrItem>, &IntrusiveNonnullRefPtrItem::m_list_node>;
+using IntrusiveNonnullRefPtrList = IntrusiveList<&IntrusiveNonnullRefPtrItem::m_list_node>;
 
 TEST_CASE(intrusive_nonnull_ref_ptr_intrusive)
 {

--- a/Tests/AK/TestIntrusiveRedBlackTree.cpp
+++ b/Tests/AK/TestIntrusiveRedBlackTree.cpp
@@ -20,7 +20,7 @@ public:
     IntrusiveRedBlackTreeNode<int, IntrusiveTest, RawPtr<IntrusiveTest>> m_tree_node;
     int m_some_value;
 };
-using IntrusiveRBTree = IntrusiveRedBlackTree<int, IntrusiveTest, RawPtr<IntrusiveTest>, &IntrusiveTest::m_tree_node>;
+using IntrusiveRBTree = IntrusiveRedBlackTree<&IntrusiveTest::m_tree_node>;
 
 TEST_CASE(construct)
 {
@@ -123,7 +123,7 @@ public:
 
     IntrusiveRedBlackTreeNode<int, IntrusiveRefPtrTest, RefPtr<IntrusiveRefPtrTest>> m_tree_node;
 };
-using IntrusiveRefPtrRBTree = IntrusiveRedBlackTree<int, IntrusiveRefPtrTest, RefPtr<IntrusiveRefPtrTest>, &IntrusiveRefPtrTest::m_tree_node>;
+using IntrusiveRefPtrRBTree = IntrusiveRedBlackTree<&IntrusiveRefPtrTest::m_tree_node>;
 
 TEST_CASE(intrusive_ref_ptr_no_ref_leaks)
 {
@@ -173,7 +173,7 @@ public:
 
     IntrusiveRedBlackTreeNode<int, IntrusiveNonnullRefPtrTest, NonnullRefPtr<IntrusiveNonnullRefPtrTest>> m_tree_node;
 };
-using IntrusiveNonnullRefPtrRBTree = IntrusiveRedBlackTree<int, IntrusiveNonnullRefPtrTest, NonnullRefPtr<IntrusiveNonnullRefPtrTest>, &IntrusiveNonnullRefPtrTest::m_tree_node>;
+using IntrusiveNonnullRefPtrRBTree = IntrusiveRedBlackTree<&IntrusiveNonnullRefPtrTest::m_tree_node>;
 
 TEST_CASE(intrusive_nonnull_ref_ptr_intrusive)
 {

--- a/Userland/Libraries/LibC/mallocdefs.h
+++ b/Userland/Libraries/LibC/mallocdefs.h
@@ -75,5 +75,5 @@ struct ChunkedBlock : public CommonHeader {
     size_t used_chunks() const { return chunk_capacity() - m_free_chunks; }
     size_t chunk_capacity() const { return (block_size - sizeof(ChunkedBlock)) / m_size; }
 
-    using List = IntrusiveList<ChunkedBlock, RawPtr<ChunkedBlock>, &ChunkedBlock::m_list_node>;
+    using List = IntrusiveList<&ChunkedBlock::m_list_node>;
 };

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -14,9 +14,9 @@
 
 namespace Core {
 
-IntrusiveList<Object, RawPtr<Object>, &Object::m_all_objects_list_node>& Object::all_objects()
+IntrusiveList<&Object::m_all_objects_list_node>& Object::all_objects()
 {
-    static IntrusiveList<Object, RawPtr<Object>, &Object::m_all_objects_list_node> objects;
+    static IntrusiveList<&Object::m_all_objects_list_node> objects;
     return objects;
 }
 

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -137,7 +137,7 @@ public:
     JsonValue property(String const& name) const;
     const HashMap<String, NonnullOwnPtr<Property>>& properties() const { return m_properties; }
 
-    static IntrusiveList<Object, RawPtr<Object>, &Object::m_all_objects_list_node>& all_objects();
+    static IntrusiveList<&Object::m_all_objects_list_node>& all_objects();
 
     void dispatch_event(Core::Event&, Object* stay_within = nullptr);
 

--- a/Userland/Libraries/LibGUI/MouseTracker.h
+++ b/Userland/Libraries/LibGUI/MouseTracker.h
@@ -26,7 +26,7 @@ protected:
 
 private:
     IntrusiveListNode<MouseTracker> m_list_node;
-    using List = IntrusiveList<MouseTracker, RawPtr<MouseTracker>, &MouseTracker::m_list_node>;
+    using List = IntrusiveList<&MouseTracker::m_list_node>;
     static List s_trackers;
 };
 

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -43,7 +43,7 @@ public:
 private:
     const size_t m_cell_size;
 
-    using BlockList = IntrusiveList<HeapBlock, RawPtr<HeapBlock>, &HeapBlock::m_list_node>;
+    using BlockList = IntrusiveList<&HeapBlock::m_list_node>;
     BlockList m_full_blocks;
     BlockList m_usable_blocks;
 };

--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -35,7 +35,7 @@ private:
     IntrusiveListNode<HandleImpl> m_list_node;
 
 public:
-    using List = IntrusiveList<HandleImpl, RawPtr<HandleImpl>, &HandleImpl::m_list_node>;
+    using List = IntrusiveList<&HandleImpl::m_list_node>;
 };
 
 template<class T>

--- a/Userland/Libraries/LibJS/Runtime/MarkedValueList.h
+++ b/Userland/Libraries/LibJS/Runtime/MarkedValueList.h
@@ -39,7 +39,7 @@ private:
     IntrusiveListNode<MarkedValueList> m_list_node;
 
 public:
-    using List = IntrusiveList<MarkedValueList, RawPtr<MarkedValueList>, &MarkedValueList::m_list_node>;
+    using List = IntrusiveList<&MarkedValueList::m_list_node>;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakContainer.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakContainer.h
@@ -27,7 +27,7 @@ private:
     IntrusiveListNode<WeakContainer> m_list_node;
 
 public:
-    using List = IntrusiveList<WeakContainer, RawPtr<WeakContainer>, &WeakContainer::m_list_node>;
+    using List = IntrusiveList<&WeakContainer::m_list_node>;
 };
 
 }

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -220,7 +220,7 @@ private:
     bool m_invalidated_cursor { false };
     bool m_overlay_rects_changed { false };
 
-    IntrusiveList<Overlay, RawPtr<Overlay>, &Overlay::m_list_node> m_overlay_list;
+    IntrusiveList<&Overlay::m_list_node> m_overlay_list;
     Gfx::DisjointRectSet m_overlay_rects;
     Gfx::DisjointRectSet m_dirty_screen_rects;
     Gfx::DisjointRectSet m_opaque_wallpaper_rects;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -469,7 +469,7 @@ private:
     RefPtr<Animation> m_animation;
 
 public:
-    using List = IntrusiveList<Window, RawPtr<Window>, &Window::m_list_node>;
+    using List = IntrusiveList<&Window::m_list_node>;
 };
 
 }


### PR DESCRIPTION
Do you hate specifying the types on `IntrusiveFoo`? Me too! so let's just not!
`IntrusiveRedBlackTree<K, V, Container, &Foo::some_node>` -> `IntrusiveRedBlackTree<&Foo::some_node>`!

~~Just need to tweak the documentation a bit before~~ this is ready :)