### PR TITLE
LibWeb: Implement JS scrolling API

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -71,6 +72,9 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(inner_height_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(parent_getter);
+
+    JS_DECLARE_NATIVE_GETTER(scroll_x_getter);
+    JS_DECLARE_NATIVE_GETTER(scroll_y_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(alert);
     JS_DECLARE_NATIVE_FUNCTION(confirm);

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -75,6 +75,8 @@ private:
 
     JS_DECLARE_NATIVE_GETTER(scroll_x_getter);
     JS_DECLARE_NATIVE_GETTER(scroll_y_getter);
+    JS_DECLARE_NATIVE_FUNCTION(scroll);
+    JS_DECLARE_NATIVE_FUNCTION(scroll_by);
 
     JS_DECLARE_NATIVE_FUNCTION(alert);
     JS_DECLARE_NATIVE_FUNCTION(confirm);

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -241,6 +241,12 @@ void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClien
     vertical_scrollbar().set_value(vertical_scrollbar().value() + y_delta);
 }
 
+void OutOfProcessWebView::notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint const& scroll_position)
+{
+    horizontal_scrollbar().set_value(scroll_position.x());
+    vertical_scrollbar().set_value(scroll_position.y());
+}
+
 void OutOfProcessWebView::notify_server_did_request_scroll_into_view(Badge<WebContentClient>, const Gfx::IntRect& rect)
 {
     scroll_into_view(rect, true, true);

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -235,9 +235,10 @@ void OutOfProcessWebView::notify_server_did_change_title(Badge<WebContentClient>
         on_title_change(title);
 }
 
-void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClient>, int wheel_delta)
+void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)
 {
-    vertical_scrollbar().set_value(vertical_scrollbar().value() + wheel_delta * 20);
+    horizontal_scrollbar().set_value(horizontal_scrollbar().value() + x_delta);
+    vertical_scrollbar().set_value(vertical_scrollbar().value() + y_delta);
 }
 
 void OutOfProcessWebView::notify_server_did_request_scroll_into_view(Badge<WebContentClient>, const Gfx::IntRect& rect)

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -58,6 +58,7 @@ public:
     void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor);
     void notify_server_did_change_title(Badge<WebContentClient>, const String&);
     void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32);
+    void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint const&);
     void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, const Gfx::IntRect&);
     void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, const Gfx::IntPoint&, const String&);
     void notify_server_did_leave_tooltip_area(Badge<WebContentClient>);

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -57,7 +57,7 @@ public:
     void notify_server_did_change_selection(Badge<WebContentClient>);
     void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor);
     void notify_server_did_change_title(Badge<WebContentClient>, const String&);
-    void notify_server_did_request_scroll(Badge<WebContentClient>, int);
+    void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32);
     void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, const Gfx::IntRect&);
     void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, const Gfx::IntPoint&, const String&);
     void notify_server_did_leave_tooltip_area(Badge<WebContentClient>);

--- a/Userland/Libraries/LibWeb/Page/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/Page/BrowsingContext.h
@@ -52,6 +52,7 @@ public:
 
     void set_needs_display(Gfx::IntRect const&);
 
+    Gfx::IntPoint const& viewport_scroll_offset() const { return m_viewport_scroll_offset; }
     void set_viewport_scroll_offset(Gfx::IntPoint const&);
     Gfx::IntRect viewport_rect() const { return { m_viewport_scroll_offset, m_size }; }
     void set_viewport_rect(Gfx::IntRect const&);

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -125,7 +125,7 @@ bool EventHandler::handle_mousewheel(const Gfx::IntPoint& position, unsigned int
     }
 
     if (auto* page = m_frame.page()) {
-        page->client().page_did_request_scroll(wheel_delta);
+        page->client().page_did_request_scroll(0, wheel_delta * 20);
         return true;
     }
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -85,7 +85,7 @@ public:
     virtual void page_did_invalidate(const Gfx::IntRect&) { }
     virtual void page_did_change_favicon(const Gfx::Bitmap&) { }
     virtual void page_did_layout() { }
-    virtual void page_did_request_scroll(int) { }
+    virtual void page_did_request_scroll(i32, i32) { }
     virtual void page_did_request_scroll_into_view(const Gfx::IntRect&) { }
     virtual void page_did_request_alert(const String&) { }
     virtual bool page_did_request_confirm(const String&) { return false; }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -86,6 +86,7 @@ public:
     virtual void page_did_change_favicon(const Gfx::Bitmap&) { }
     virtual void page_did_layout() { }
     virtual void page_did_request_scroll(i32, i32) { }
+    virtual void page_did_request_scroll_to(Gfx::IntPoint const&) { }
     virtual void page_did_request_scroll_into_view(const Gfx::IntRect&) { }
     virtual void page_did_request_alert(const String&) { }
     virtual bool page_did_request_confirm(const String&) { return false; }

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -73,6 +73,11 @@ void WebContentClient::did_request_scroll(i32 x_delta, i32 y_delta)
     m_view.notify_server_did_request_scroll({}, x_delta, y_delta);
 }
 
+void WebContentClient::did_request_scroll_to(Gfx::IntPoint const& scroll_position)
+{
+    m_view.notify_server_did_request_scroll_to({}, scroll_position);
+}
+
 void WebContentClient::did_request_scroll_into_view(Gfx::IntRect const& rect)
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidRequestScrollIntoView! rect={}", rect);

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -68,9 +68,9 @@ void WebContentClient::did_change_title(String const& title)
     m_view.notify_server_did_change_title({}, title);
 }
 
-void WebContentClient::did_request_scroll(int wheel_delta)
+void WebContentClient::did_request_scroll(i32 x_delta, i32 y_delta)
 {
-    m_view.notify_server_did_request_scroll({}, wheel_delta);
+    m_view.notify_server_did_request_scroll({}, x_delta, y_delta);
 }
 
 void WebContentClient::did_request_scroll_into_view(Gfx::IntRect const& rect)

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -36,7 +36,7 @@ private:
     virtual void did_request_cursor_change(i32) override;
     virtual void did_layout(Gfx::IntSize const&) override;
     virtual void did_change_title(String const&) override;
-    virtual void did_request_scroll(int) override;
+    virtual void did_request_scroll(i32, i32) override;
     virtual void did_request_scroll_into_view(Gfx::IntRect const&) override;
     virtual void did_enter_tooltip_area(Gfx::IntPoint const&, String const&) override;
     virtual void did_leave_tooltip_area() override;

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -37,6 +37,7 @@ private:
     virtual void did_layout(Gfx::IntSize const&) override;
     virtual void did_change_title(String const&) override;
     virtual void did_request_scroll(i32, i32) override;
+    virtual void did_request_scroll_to(Gfx::IntPoint const&) override;
     virtual void did_request_scroll_into_view(Gfx::IntRect const&) override;
     virtual void did_enter_tooltip_area(Gfx::IntPoint const&, String const&) override;
     virtual void did_leave_tooltip_area() override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -104,9 +104,9 @@ void PageHost::page_did_change_title(const String& title)
     m_client.async_did_change_title(title);
 }
 
-void PageHost::page_did_request_scroll(int wheel_delta)
+void PageHost::page_did_request_scroll(i32 x_delta, i32 y_delta)
 {
-    m_client.async_did_request_scroll(wheel_delta);
+    m_client.async_did_request_scroll(x_delta, y_delta);
 }
 
 void PageHost::page_did_request_scroll_into_view(const Gfx::IntRect& rect)

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -109,6 +109,11 @@ void PageHost::page_did_request_scroll(i32 x_delta, i32 y_delta)
     m_client.async_did_request_scroll(x_delta, y_delta);
 }
 
+void PageHost::page_did_request_scroll_to(Gfx::IntPoint const& scroll_position)
+{
+    m_client.async_did_request_scroll_to(scroll_position);
+}
+
 void PageHost::page_did_request_scroll_into_view(const Gfx::IntRect& rect)
 {
     m_client.async_did_request_scroll_into_view(rect);

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -42,6 +42,7 @@ private:
     virtual void page_did_layout() override;
     virtual void page_did_change_title(const String&) override;
     virtual void page_did_request_scroll(i32, i32) override;
+    virtual void page_did_request_scroll_to(Gfx::IntPoint const&) override;
     virtual void page_did_request_scroll_into_view(const Gfx::IntRect&) override;
     virtual void page_did_enter_tooltip_area(const Gfx::IntPoint&, const String&) override;
     virtual void page_did_leave_tooltip_area() override;

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -41,7 +41,7 @@ private:
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;
     virtual void page_did_layout() override;
     virtual void page_did_change_title(const String&) override;
-    virtual void page_did_request_scroll(int) override;
+    virtual void page_did_request_scroll(i32, i32) override;
     virtual void page_did_request_scroll_into_view(const Gfx::IntRect&) override;
     virtual void page_did_enter_tooltip_area(const Gfx::IntPoint&, const String&) override;
     virtual void page_did_leave_tooltip_area() override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -13,6 +13,7 @@ endpoint WebContentClient
     did_layout(Gfx::IntSize content_size) =|
     did_change_title(String title) =|
     did_request_scroll(i32 x_delta, i32 y_delta) =|
+    did_request_scroll_to(Gfx::IntPoint scroll_position) =|
     did_request_scroll_into_view(Gfx::IntRect rect) =|
     did_enter_tooltip_area(Gfx::IntPoint content_position, String title) =|
     did_leave_tooltip_area() =|

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -12,7 +12,7 @@ endpoint WebContentClient
     did_request_cursor_change(i32 cursor_type) =|
     did_layout(Gfx::IntSize content_size) =|
     did_change_title(String title) =|
-    did_request_scroll(int wheel_delta) =|
+    did_request_scroll(i32 x_delta, i32 y_delta) =|
     did_request_scroll_into_view(Gfx::IntRect rect) =|
     did_enter_tooltip_area(Gfx::IntPoint content_position, String title) =|
     did_leave_tooltip_area() =|


### PR DESCRIPTION
This implements the following parts of the [Window DOM](https://www.w3.org/TR/cssom-view/#extensions-to-the-window-interface):

```c++
  // viewport scrolling
    [Replaceable] readonly attribute double scrollX;
    [Replaceable] readonly attribute double pageXOffset;
    [Replaceable] readonly attribute double scrollY;
    [Replaceable] readonly attribute double pageYOffset;
    undefined scroll(optional ScrollToOptions options = {});
    undefined scroll(unrestricted double x, unrestricted double y);
    undefined scrollTo(optional ScrollToOptions options = {});
    undefined scrollTo(unrestricted double x, unrestricted double y);
    undefined scrollBy(optional ScrollToOptions options = {});
    undefined scrollBy(unrestricted double x, unrestricted double y);
```

Not everything is to spec completely yet. I've documented that with `FIXME`s.

As this is my first go at implementing a JS API, probably I have done some things wrong, so any guidance or feedback is appreciated! :^)