### PR TITLE
Ports: python3 socket module compilation fix

### DIFF
--- a/Ports/python3/patches/ReadMe.md
+++ b/Ports/python3/patches/ReadMe.md
@@ -4,6 +4,10 @@
 
 Ensures `HAVE_SIGSET_T` is defined, as we *do* have `sigset_t` but it's not detected properly due to some related functions being missing.
 
+## `include-sys-uio.patch`
+
+Ensures `struct iovec` is defined, required by the socket module.
+
 ## `define-py-force-utf8-locale.patch`
 
 Enforce UTF-8 as encoding by defining `_Py_FORCE_UTF8_LOCALE`.

--- a/Ports/python3/patches/include-sys-uio.patch
+++ b/Ports/python3/patches/include-sys-uio.patch
@@ -1,0 +1,11 @@
+--- Python-3.10.0rc1/Modules/socketmodule.c	2021-09-09 01:14:41.120232921 +0800
++++ Python-3.10.0rc1/Modules/socketmodule.c	2021-08-03 03:53:59.000000000 +0800
+@@ -171,7 +171,7 @@
+ # undef HAVE_GETHOSTBYNAME_R_6_ARG
+ #endif
+ 
+-#if defined(__OpenBSD__)
++#if defined(__OpenBSD__) || defined(__serenity__)
+ # include <sys/uio.h>
+ #endif
+ 


### PR DESCRIPTION
Now that #9906 has been merged this finally allows python's socket module to compile and become usable.