### PR TITLE
LibC: Define RLIM_NLIMITS constant

### DIFF
--- a/Userland/Libraries/LibC/sys/resource.h
+++ b/Userland/Libraries/LibC/sys/resource.h
@@ -44,6 +44,8 @@ int getrusage(int who, struct rusage* usage);
 #define RLIMIT_STACK 6
 #define RLIMIT_AS 7
 
+#define RLIM_NLIMITS 8
+
 #define RLIM_INFINITY SIZE_MAX
 
 typedef size_t rlim_t;


### PR DESCRIPTION
This is required by programs that want to either iterate over all
resources, or check that a resource identifier is valid before passing
it down (e.g., python's resource module).