### PR TITLE
Meta: Update Win32 WSL2 Build Instructions

### DIFF
--- a/Documentation/BuildInstructionsWindows.md
+++ b/Documentation/BuildInstructionsWindows.md
@@ -11,6 +11,14 @@ Once installed, you will need to make sure the distribution you want to use (and
 - `wsl --set-version <distro> <version>` is used to convert a distro to another version, and<br/>
 - `wsl --set-default-version 2` will set the default version for all new distros (if desired.)<br/>
 
+## Dependencies
+
+Fresh installations of WSL2 need these packages to perform a fresh build properly:
+
+```bash
+$ sudo apt install unzip build-essential ninja-build g++-10 libmpc-dev libgmp3-dev git cmake
+```
+
 ## Note on filesystems
 
 WSL2 filesystem performance for IO heavy tasks (such as compiling a large C++ project) on the host Windows filesystem is


### PR DESCRIPTION
It took me a couple days to figure out why it wouldn't build but I was missing the `unzip` dependency and it was manifesting itself in odd ways during the Configuration step.

This PR updates the documentation to briefly mention what is needed by fresh WSL installations.

Coming from a primarily Windows background, this would have been helpful to me.

Once I got it up and running though it was a blast! :D