### PR TITLE
HackStudio: Reuse `TextDocument::is_modified()`

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -42,13 +42,8 @@ EditorWrapper::EditorWrapper()
         open_file(path);
     };
 
-    m_editor->on_change = [this] {
-        if (this->on_change)
-            this->on_change();
-        bool was_dirty = m_document_dirty;
-        m_document_dirty = true;
-        if (!was_dirty)
-            update_title();
+    m_editor->on_modified_change = [this](bool) {
+        update_title();
     };
 }
 
@@ -91,8 +86,6 @@ void EditorWrapper::set_filename(const String& filename)
 void EditorWrapper::save()
 {
     editor().write_to_file(filename());
-    m_document_dirty = false;
-    update_title();
     update_diff();
     editor().update();
 }
@@ -128,7 +121,7 @@ void EditorWrapper::update_title()
     else
         title.append(m_filename);
 
-    if (m_document_dirty)
+    if (editor().document().is_modified())
         title.append(" (*)");
     m_filename_label->set_text(title.to_string());
 }

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -42,7 +42,6 @@ public:
     void set_debug_mode(bool);
     void set_filename(const String&);
     const String& filename() const { return m_filename; }
-    bool document_dirty() const { return m_document_dirty; }
 
     Optional<LexicalPath> const& project_root() const { return m_project_root; }
     void set_project_root(LexicalPath const& project_root);
@@ -64,7 +63,6 @@ private:
     String m_filename;
     RefPtr<GUI::Label> m_filename_label;
     RefPtr<Editor> m_editor;
-    bool m_document_dirty { false };
 
     Optional<LexicalPath> m_project_root;
     RefPtr<GitRepo> m_git_repo;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1253,7 +1253,7 @@ HackStudioWidget::ContinueDecision HackStudioWidget::warn_unsaved_changes(const 
 
     if (result == GUI::MessageBox::ExecYes) {
         for (auto& editor_wrapper : m_all_editor_wrappers) {
-            if (editor_wrapper.document_dirty()) {
+            if (editor_wrapper.editor().document().is_modified()) {
                 editor_wrapper.save();
             }
         }
@@ -1264,12 +1264,9 @@ HackStudioWidget::ContinueDecision HackStudioWidget::warn_unsaved_changes(const 
 
 bool HackStudioWidget::any_document_is_dirty() const
 {
-    for (auto& editor_wrapper : m_all_editor_wrappers) {
-        if (editor_wrapper.document_dirty()) {
-            return true;
-        }
-    }
-    return false;
+    return any_of(m_all_editor_wrappers, [](auto& editor_wrapper) {
+        return editor_wrapper.editor().document().is_modified();
+    });
 }
 
 void HackStudioWidget::update_gml_preview()


### PR DESCRIPTION
Previously, the modification tag in the editor file label was unset only after a file was saved.

This commit will also unset the tag if you undo the stack (for example by hitting <kbd>Ctrl</kbd>+<kbd>Z</kbd>) to the last saved state.