### PR TITLE
CI: Add statement to ensure workflow runs only on serenity

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Static Analysis
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     env:
       # Latest scanner version is tracked on: https://sonarcloud.io/documentation/analysis/scan/sonarscanner/
       SONAR_SCANNER_VERSION: 4.6.1.2450


### PR DESCRIPTION
This statement ensures that the `Sonar Cloud Static Analysis` workflow
runs only for the official repository and not for the forks.