### PR TITLE
LibMarkdown: New inline parser and better inline support

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -371,6 +371,8 @@ String escape_html_entities(const StringView& html)
             builder.append("&gt;");
         else if (html[i] == '&')
             builder.append("&amp;");
+        else if (html[i] == '"')
+            builder.append("&quot;");
         else
             builder.append(html[i]);
     }

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -14,9 +14,9 @@ namespace Markdown {
 
 class CodeBlock final : public Block {
 public:
-    CodeBlock(Text&& style_spec, const String& code)
+    CodeBlock(const String& language, const String& code)
         : m_code(move(code))
-        , m_style_spec(move(style_spec))
+        , m_language(language)
     {
     }
     virtual ~CodeBlock() override { }
@@ -26,11 +26,8 @@ public:
     static OwnPtr<CodeBlock> parse(Vector<StringView>::ConstIterator& lines);
 
 private:
-    String style_language() const;
-    Text::Style style() const;
-
     String m_code;
-    Text m_style_spec;
+    String m_language;
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -14,9 +14,10 @@ namespace Markdown {
 
 class CodeBlock final : public Block {
 public:
-    CodeBlock(const String& language, const String& code)
+    CodeBlock(String const& language, String const& style, String const& code)
         : m_code(move(code))
         , m_language(language)
+        , m_style(style)
     {
     }
     virtual ~CodeBlock() override { }
@@ -28,6 +29,7 @@ public:
 private:
     String m_code;
     String m_language;
+    String m_style;
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/Document.cpp
+++ b/Userland/Libraries/LibMarkdown/Document.cpp
@@ -92,6 +92,7 @@ OwnPtr<Document> Document::parse(const StringView& str)
 
         if ((*lines).is_empty()) {
             ++lines;
+
             flush_paragraph();
             continue;
         }
@@ -108,8 +109,9 @@ OwnPtr<Document> Document::parse(const StringView& str)
             continue;
         }
 
+        if (!paragraph_text.is_empty())
+            paragraph_text.append("\n");
         paragraph_text.append(*lines++);
-        paragraph_text.append("\n");
     }
 
     flush_paragraph();

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -53,10 +53,7 @@ OwnPtr<Heading> Heading::parse(Vector<StringView>::ConstIterator& lines)
 
     StringView title_view = line.substring_view(level + 1, line.length() - level - 1);
     auto text = Text::parse(title_view);
-    if (!text.has_value())
-        return {};
-
-    auto heading = make<Heading>(move(text.value()), level);
+    auto heading = make<Heading>(move(text), level);
 
     ++lines;
     return heading;

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -59,10 +59,7 @@ OwnPtr<List> List::parse(Vector<StringView>::ConstIterator& lines)
             return true;
 
         auto text = Text::parse(item_builder.string_view());
-        if (!text.has_value())
-            return false;
-
-        items.append(move(text.value()));
+        items.append(move(text));
 
         item_builder.clear();
         return true;

--- a/Userland/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Userland/Libraries/LibMarkdown/Paragraph.cpp
@@ -13,13 +13,7 @@ String Paragraph::render_to_html() const
 {
     StringBuilder builder;
     builder.append("<p>");
-    bool first = true;
-    for (auto& line : m_lines) {
-        if (!first)
-            builder.append('\n');
-        first = false;
-        builder.append(line.text().render_to_html().trim(" \t"));
-    }
+    builder.append(m_text.render_to_html());
     builder.append("</p>\n");
     return builder.build();
 }
@@ -27,26 +21,9 @@ String Paragraph::render_to_html() const
 String Paragraph::render_for_terminal(size_t) const
 {
     StringBuilder builder;
-    bool first = true;
-    for (auto& line : m_lines) {
-        if (!first)
-            builder.append(' ');
-        first = false;
-        builder.append(line.text().render_for_terminal());
-    }
+    builder.append(m_text.render_for_terminal());
     builder.append("\n\n");
     return builder.build();
 }
 
-OwnPtr<Paragraph::Line> Paragraph::Line::parse(Vector<StringView>::ConstIterator& lines)
-{
-    if (lines.is_end())
-        return {};
-
-    auto text = Text::parse(*lines++);
-    if (!text.has_value())
-        return {};
-
-    return make<Paragraph::Line>(text.release_value());
-}
 }

--- a/Userland/Libraries/LibMarkdown/Paragraph.h
+++ b/Userland/Libraries/LibMarkdown/Paragraph.h
@@ -15,22 +15,8 @@ namespace Markdown {
 
 class Paragraph final : public Block {
 public:
-    class Line {
-    public:
-        explicit Line(Text&& text)
-            : m_text(move(text))
-        {
-        }
-
-        static OwnPtr<Line> parse(Vector<StringView>::ConstIterator& lines);
-        const Text& text() const { return m_text; }
-
-    private:
-        Text m_text;
-    };
-
-    Paragraph(NonnullOwnPtrVector<Line>&& lines)
-        : m_lines(move(lines))
+    Paragraph(Text text)
+        : m_text(move(text))
     {
     }
 
@@ -40,7 +26,7 @@ public:
     virtual String render_for_terminal(size_t view_width = 0) const override;
 
 private:
-    NonnullOwnPtrVector<Line> m_lines;
+    Text m_text;
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -79,13 +79,19 @@ void Text::TextNode::render_to_html(StringBuilder& builder) const
 
 void Text::TextNode::render_for_terminal(StringBuilder& builder) const
 {
-    String text_copy = text;
-    text_copy.replace("\n", " ");
-    builder.append(text_copy);
+    if (collapsible && (text == "\n" || text.is_whitespace())) {
+        builder.append(" ");
+    } else {
+        builder.append(text);
+    }
 }
 
 size_t Text::TextNode::terminal_length() const
 {
+    if (collapsible && text.is_whitespace()) {
+        return 1;
+    }
+
     return text.length();
 }
 
@@ -445,7 +451,7 @@ NonnullOwnPtr<Text::Node> Text::parse_code(Vector<Token>::ConstIterator& tokens)
         }
 
         is_all_whitespace = is_all_whitespace && iterator->data.is_whitespace();
-        code->children.append(make<TextNode>((*iterator == "\n") ? " " : iterator->data));
+        code->children.append(make<TextNode>((*iterator == "\n") ? " " : iterator->data, false));
     }
 
     return make<TextNode>(opening.data);

--- a/Userland/Libraries/LibMarkdown/Text.h
+++ b/Userland/Libraries/LibMarkdown/Text.h
@@ -55,6 +55,13 @@ public:
         virtual size_t terminal_length() const override;
     };
 
+    class BreakNode : public Node {
+    public:
+        virtual void render_to_html(StringBuilder& builder) const override;
+        virtual void render_for_terminal(StringBuilder& builder) const override;
+        virtual size_t terminal_length() const override;
+    };
+
     class TextNode : public Node {
     public:
         String text;
@@ -128,6 +135,10 @@ private:
             VERIFY(is_run);
             return data.length();
         }
+        bool is_space() const
+        {
+            return data[0] == ' ';
+        }
         bool operator==(StringView const& str) const { return str == data; }
     };
 
@@ -137,6 +148,8 @@ private:
     static bool can_close_for(Token const& opening, Token const& closing);
 
     static NonnullOwnPtr<MultiNode> parse_sequence(Vector<Token>::ConstIterator& tokens, bool in_link);
+    static NonnullOwnPtr<Node> parse_break(Vector<Token>::ConstIterator& tokens);
+    static NonnullOwnPtr<Node> parse_newline(Vector<Token>::ConstIterator& tokens);
     static NonnullOwnPtr<Node> parse_emph(Vector<Token>::ConstIterator& tokens, bool in_link);
     static NonnullOwnPtr<Node> parse_code(Vector<Token>::ConstIterator& tokens);
     static NonnullOwnPtr<Node> parse_link(Vector<Token>::ConstIterator& tokens);

--- a/Userland/Libraries/LibMarkdown/Text.h
+++ b/Userland/Libraries/LibMarkdown/Text.h
@@ -65,9 +65,17 @@ public:
     class TextNode : public Node {
     public:
         String text;
+        bool collapsible;
 
         TextNode(StringView const& text)
             : text(text)
+            , collapsible(true)
+        {
+        }
+
+        TextNode(StringView const& text, bool collapsible)
+            : text(text)
+            , collapsible(collapsible)
         {
         }
 

--- a/Userland/Libraries/LibMarkdown/Text.h
+++ b/Userland/Libraries/LibMarkdown/Text.h
@@ -111,6 +111,8 @@ private:
         // definition, see the CommonMark spec.
         bool left_flanking;
         bool right_flanking;
+        bool punct_before;
+        bool punct_after;
         // is_run indicates that this token is a 'delimiter run'. A delimiter
         // run occurs when several of the same sytactical character ('`', '_',
         // or '*') occur in a row.


### PR DESCRIPTION
This week I rewrote the inline text parser in LibMarkdown, mostly to fail gracefully when parsing spans that aren't closed, without too much backtracking. With these changes our TestCommonmark pass rate went from 87/652 to 227/652.

## What it has
- **Will still render properly when failing to parse spans**.
- Spans that cross newlines now work.
- Delimiter runs and flanking.
- Multi-backtick code blocks.
- Line breaks.
- Correct whitespace handling.

## What it lacks
- Proper logic for delimiter runs more than 2 characters long.
- Proper handling of escapes in code.
- ~~Support for serenity's codeblock styling markdown extension (I can re-add that if people want).~~
- Inline HTML.
- Autolinks.
- Ref links.

## 