### PR TITLE
Kernel: Add nothrow so heap allocations will not try to throw exceptions

### DIFF
--- a/Kernel/ACPI/Parser.h
+++ b/Kernel/ACPI/Parser.h
@@ -45,7 +45,7 @@ public:
     template<typename ParserType>
     static void initialize(PhysicalAddress rsdp)
     {
-        set_the(*new ParserType(rsdp));
+        set_the(*new (nothrow) ParserType(rsdp));
     }
 
     virtual Optional<PhysicalAddress> find_table(const StringView& signature);

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -441,7 +441,7 @@ class ProcessorSpecific {
 public:
     static void initialize()
     {
-        Processor::current().set_specific(T::processor_specific_data_id(), new T);
+        Processor::current().set_specific(T::processor_specific_data_id(), new (nothrow) T);
     }
     static T& get()
     {

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -514,7 +514,7 @@ GenericInterruptHandler& get_interrupt_handler(u8 interrupt_number)
 
 static void revert_to_unused_handler(u8 interrupt_number)
 {
-    auto handler = new UnhandledInterruptHandler(interrupt_number);
+    auto handler = new (nothrow) UnhandledInterruptHandler(interrupt_number);
     handler->register_interrupt_handler();
 }
 
@@ -808,7 +808,7 @@ UNMAP_AFTER_INIT void idt_init()
     register_interrupt_handler(0xff, interrupt_255_asm_entry);
 
     for (u8 i = 0; i < GENERIC_INTERRUPT_HANDLERS_COUNT; ++i) {
-        auto* handler = new UnhandledInterruptHandler(i);
+        auto* handler = new (nothrow) UnhandledInterruptHandler(i);
         handler->register_interrupt_handler();
     }
 

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -358,7 +358,7 @@ UNMAP_AFTER_INIT void Processor::initialize(u32 cpu)
             detect_hypervisor();
     }
 
-    m_info = new ProcessorInfo(*this);
+    m_info = new (nothrow) ProcessorInfo(*this);
 
     {
         // We need to prevent races between APs starting up at the same time
@@ -790,8 +790,8 @@ UNMAP_AFTER_INIT void Processor::smp_enable()
     size_t msg_pool_size = Processor::count() * 100u;
     size_t msg_entries_cnt = Processor::count();
 
-    auto msgs = new ProcessorMessage[msg_pool_size];
-    auto msg_entries = new ProcessorMessageEntry[msg_pool_size * msg_entries_cnt];
+    auto msgs = new (nothrow) ProcessorMessage[msg_pool_size];
+    auto msg_entries = new (nothrow) ProcessorMessageEntry[msg_pool_size * msg_entries_cnt];
     size_t msg_entry_i = 0;
     for (size_t i = 0; i < msg_pool_size; i++, msg_entry_i += msg_entries_cnt) {
         auto& msg = msgs[i];
@@ -1063,7 +1063,8 @@ DeferredCallEntry* Processor::deferred_call_get_free()
         return entry;
     }
 
-    auto* entry = new DeferredCallEntry;
+    auto* entry = new (nothrow) DeferredCallEntry;
+    VERIFY(entry);
     new (entry->handler_storage) DeferredCallEntry::HandlerFunction;
     entry->was_allocated = true;
     return entry;

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -41,7 +41,8 @@ UNMAP_AFTER_INIT bool Access::initialize_for_memory_access(PhysicalAddress mcfg_
         return false;
 
     InterruptDisabler disabler;
-    auto* access = new Access(Access::AccessType::Memory);
+    auto* access = new (nothrow) Access(Access::AccessType::Memory);
+    VERIFY(access);
     if (!access->scan_pci_domains(mcfg_table))
         return false;
     access->rescan_hardware();
@@ -85,7 +86,8 @@ UNMAP_AFTER_INIT bool Access::initialize_for_io_access()
     if (Access::is_initialized()) {
         return false;
     }
-    auto* access = new Access(Access::AccessType::IO);
+    auto* access = new (nothrow) Access(Access::AccessType::IO);
+    VERIFY(access);
     access->rescan_hardware();
     dbgln_if(PCI_DEBUG, "PCI: IO access initialised.");
     return true;

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -156,14 +156,14 @@ UNMAP_AFTER_INIT SysFSUSBBusDirectory::SysFSUSBBusDirectory(SysFSBusDirectory& b
 
 UNMAP_AFTER_INIT void SysFSUSBBusDirectory::initialize()
 {
-    auto directory = adopt_ref(*new SysFSUSBBusDirectory(SysFSComponentRegistry::the().buses_directory()));
+    auto directory = adopt_ref(*new (nothrow) SysFSUSBBusDirectory(SysFSComponentRegistry::the().buses_directory()));
     SysFSComponentRegistry::the().register_new_bus_directory(directory);
     s_procfs_usb_bus_directory = directory;
 }
 
 NonnullRefPtr<SysFSUSBDeviceInformation> SysFSUSBDeviceInformation::create(USB::Device& device)
 {
-    return adopt_ref(*new SysFSUSBDeviceInformation(device));
+    return adopt_ref(*new (nothrow) SysFSUSBDeviceInformation(device));
 }
 
 }

--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -15,7 +15,7 @@ unsigned Console::next_device_id = 0;
 
 UNMAP_AFTER_INIT NonnullRefPtr<Console> Console::must_create(PCI::Address address)
 {
-    return adopt_ref_if_nonnull(new Console(address)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) Console(address)).release_nonnull();
 }
 
 UNMAP_AFTER_INIT void Console::initialize()

--- a/Kernel/Bus/VirtIO/RNG.cpp
+++ b/Kernel/Bus/VirtIO/RNG.cpp
@@ -11,7 +11,7 @@ namespace Kernel::VirtIO {
 
 UNMAP_AFTER_INIT NonnullRefPtr<RNG> RNG::must_create(PCI::Address address)
 {
-    return adopt_ref_if_nonnull(new RNG(address)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) RNG(address)).release_nonnull();
 }
 
 UNMAP_AFTER_INIT void RNG::initialize()

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -36,7 +36,8 @@ const CommandLine& kernel_command_line()
 UNMAP_AFTER_INIT void CommandLine::initialize()
 {
     VERIFY(!s_the);
-    s_the = new CommandLine(s_cmd_line);
+    s_the = new (nothrow) CommandLine(s_cmd_line);
+    VERIFY(s_the);
     dmesgln("Kernel Commandline: {}", kernel_command_line().string());
     // Validate the boot mode the user passed in.
     (void)s_the->boot_mode(Validate::Yes);

--- a/Kernel/ConsoleDevice.cpp
+++ b/Kernel/ConsoleDevice.cpp
@@ -20,6 +20,7 @@ static Kernel::Spinlock g_console_lock;
 UNMAP_AFTER_INIT void ConsoleDevice::initialize()
 {
     s_the.ensure_instance();
+    s_the->after_inserting();
 }
 
 ConsoleDevice& ConsoleDevice::the()

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -22,7 +22,7 @@ MutexProtected<HashMap<u32, Device*>>& Device::all_devices()
 
 NonnullRefPtr<SysFSDeviceComponent> SysFSDeviceComponent::must_create(Device const& device)
 {
-    return adopt_ref_if_nonnull(new SysFSDeviceComponent(device)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSDeviceComponent(device)).release_nonnull();
 }
 SysFSDeviceComponent::SysFSDeviceComponent(Device const& device)
     : SysFSComponent(String::formatted("{}:{}", device.major(), device.minor()))
@@ -33,7 +33,7 @@ SysFSDeviceComponent::SysFSDeviceComponent(Device const& device)
 
 UNMAP_AFTER_INIT NonnullRefPtr<SysFSDevicesDirectory> SysFSDevicesDirectory::must_create(SysFSRootDirectory const& root_directory)
 {
-    auto devices_directory = adopt_ref_if_nonnull(new SysFSDevicesDirectory(root_directory)).release_nonnull();
+    auto devices_directory = adopt_ref_if_nonnull(new (nothrow) SysFSDevicesDirectory(root_directory)).release_nonnull();
     devices_directory->m_components.append(SysFSBlockDevicesDirectory::must_create(*devices_directory));
     devices_directory->m_components.append(SysFSCharacterDevicesDirectory::must_create(*devices_directory));
     return devices_directory;
@@ -45,7 +45,7 @@ SysFSDevicesDirectory::SysFSDevicesDirectory(SysFSRootDirectory const& root_dire
 
 NonnullRefPtr<SysFSBlockDevicesDirectory> SysFSBlockDevicesDirectory::must_create(SysFSDevicesDirectory const& devices_directory)
 {
-    return adopt_ref_if_nonnull(new SysFSBlockDevicesDirectory(devices_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSBlockDevicesDirectory(devices_directory)).release_nonnull();
 }
 SysFSBlockDevicesDirectory::SysFSBlockDevicesDirectory(SysFSDevicesDirectory const& devices_directory)
     : SysFSDirectory("block"sv, devices_directory)
@@ -81,7 +81,7 @@ RefPtr<SysFSComponent> SysFSBlockDevicesDirectory::lookup(StringView name)
 
 NonnullRefPtr<SysFSCharacterDevicesDirectory> SysFSCharacterDevicesDirectory::must_create(SysFSDevicesDirectory const& devices_directory)
 {
-    return adopt_ref_if_nonnull(new SysFSCharacterDevicesDirectory(devices_directory)).release_nonnull();
+    return adopt_ref_if_nonnull(new (nothrow) SysFSCharacterDevicesDirectory(devices_directory)).release_nonnull();
 }
 SysFSCharacterDevicesDirectory::SysFSCharacterDevicesDirectory(SysFSDevicesDirectory const& devices_directory)
     : SysFSDirectory("char"sv, devices_directory)

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -46,7 +46,8 @@ public:
     GroupID gid() const { return m_gid; }
 
     virtual bool is_device() const override { return true; }
-    virtual void before_removing();
+    virtual void before_removing() override;
+    virtual void after_inserting();
 
     static void for_each(Function<void(Device&)>);
     static Device* get_device(unsigned major, unsigned minor);
@@ -82,7 +83,7 @@ private:
 
     Spinlock m_requests_lock;
     DoublyLinkedList<RefPtr<AsyncDeviceRequest>> m_requests;
-    WeakPtr<SysFSDeviceComponent> m_sysfs_component;
+    RefPtr<SysFSDeviceComponent> m_sysfs_component;
 };
 
 }

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -13,7 +13,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<FullDevice> FullDevice::must_create()
 {
-    auto device = adopt_ref(*new FullDevice);
+    auto device = adopt_ref(*new (nothrow) FullDevice);
     device->after_inserting();
     return device;
 }

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -13,7 +13,9 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<FullDevice> FullDevice::must_create()
 {
-    return adopt_ref(*new FullDevice);
+    auto device = adopt_ref(*new FullDevice);
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT FullDevice::FullDevice()

--- a/Kernel/Devices/HID/HIDManagement.cpp
+++ b/Kernel/Devices/HID/HIDManagement.cpp
@@ -110,10 +110,17 @@ UNMAP_AFTER_INIT void HIDManagement::enumerate()
         return;
     m_i8042_controller = I8042Controller::initialize();
     m_i8042_controller->detect_devices();
-    if (m_i8042_controller->mouse())
-        m_hid_devices.append(m_i8042_controller->mouse().release_nonnull());
-    if (m_i8042_controller->keyboard())
-        m_hid_devices.append(m_i8042_controller->keyboard().release_nonnull());
+    if (m_i8042_controller->mouse()) {
+        auto mouse_device = m_i8042_controller->mouse().release_nonnull();
+        mouse_device->after_inserting();
+        m_hid_devices.append(mouse_device);
+    }
+
+    if (m_i8042_controller->keyboard()) {
+        auto keyboard_device = m_i8042_controller->keyboard().release_nonnull();
+        keyboard_device->after_inserting();
+        m_hid_devices.append(keyboard_device);
+    }
 }
 
 UNMAP_AFTER_INIT void HIDManagement::initialize()

--- a/Kernel/Devices/HID/I8042Controller.cpp
+++ b/Kernel/Devices/HID/I8042Controller.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<I8042Controller> I8042Controller::initialize()
 {
-    return adopt_ref(*new I8042Controller());
+    return adopt_ref(*new (nothrow) I8042Controller());
 }
 
 RefPtr<MouseDevice> I8042Controller::mouse() const

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -83,7 +83,7 @@ bool PS2KeyboardDevice::handle_irq(const RegisterState&)
 
 UNMAP_AFTER_INIT RefPtr<PS2KeyboardDevice> PS2KeyboardDevice::try_to_initialize(const I8042Controller& ps2_controller)
 {
-    auto device = adopt_ref(*new PS2KeyboardDevice(ps2_controller));
+    auto device = adopt_ref(*new (nothrow) PS2KeyboardDevice(ps2_controller));
     if (device->initialize())
         return device;
     return nullptr;

--- a/Kernel/Devices/HID/PS2MouseDevice.cpp
+++ b/Kernel/Devices/HID/PS2MouseDevice.cpp
@@ -174,7 +174,7 @@ void PS2MouseDevice::set_sample_rate(u8 rate)
 
 UNMAP_AFTER_INIT RefPtr<PS2MouseDevice> PS2MouseDevice::try_to_initialize(const I8042Controller& ps2_controller)
 {
-    auto device = adopt_ref(*new PS2MouseDevice(ps2_controller));
+    auto device = adopt_ref(*new (nothrow) PS2MouseDevice(ps2_controller));
     if (device->initialize())
         return device;
     return nullptr;

--- a/Kernel/Devices/HID/VMWareMouseDevice.cpp
+++ b/Kernel/Devices/HID/VMWareMouseDevice.cpp
@@ -16,7 +16,7 @@ UNMAP_AFTER_INIT RefPtr<VMWareMouseDevice> VMWareMouseDevice::try_to_initialize(
         return {};
     if (!VMWareBackdoor::the()->vmmouse_is_absolute())
         return {};
-    auto device = adopt_ref(*new VMWareMouseDevice(ps2_controller));
+    auto device = adopt_ref(*new (nothrow) VMWareMouseDevice(ps2_controller));
     if (device->initialize())
         return device;
     return {};

--- a/Kernel/Devices/KCOVDevice.cpp
+++ b/Kernel/Devices/KCOVDevice.cpp
@@ -20,7 +20,7 @@ HashMap<ThreadID, KCOVInstance*>* KCOVDevice::thread_instance;
 
 UNMAP_AFTER_INIT NonnullRefPtr<KCOVDevice> KCOVDevice::must_create()
 {
-    auto device = adopt_ref(*new KCOVDevice);
+    auto device = adopt_ref(*new (nothrow) KCOVDevice);
     device->after_inserting();
     return device;
 }
@@ -28,8 +28,8 @@ UNMAP_AFTER_INIT NonnullRefPtr<KCOVDevice> KCOVDevice::must_create()
 UNMAP_AFTER_INIT KCOVDevice::KCOVDevice()
     : BlockDevice(30, 0)
 {
-    proc_instance = new HashMap<ProcessID, KCOVInstance*>();
-    thread_instance = new HashMap<ThreadID, KCOVInstance*>();
+    proc_instance = new (nothrow) HashMap<ProcessID, KCOVInstance*>();
+    thread_instance = new (nothrow) HashMap<ThreadID, KCOVInstance*>();
     dbgln("KCOVDevice created");
 }
 
@@ -68,7 +68,7 @@ KResultOr<NonnullRefPtr<OpenFileDescription>> KCOVDevice::open(int options)
     auto pid = Process::current().pid();
     if (proc_instance->get(pid).has_value())
         return EBUSY; // This process already open()ed the kcov device
-    auto kcov_instance = new KCOVInstance(pid);
+    auto kcov_instance = new (nothrow) KCOVInstance(pid);
     kcov_instance->set_state(KCOVInstance::OPENED);
     proc_instance->set(pid, kcov_instance);
 

--- a/Kernel/Devices/KCOVDevice.cpp
+++ b/Kernel/Devices/KCOVDevice.cpp
@@ -20,7 +20,9 @@ HashMap<ThreadID, KCOVInstance*>* KCOVDevice::thread_instance;
 
 UNMAP_AFTER_INIT NonnullRefPtr<KCOVDevice> KCOVDevice::must_create()
 {
-    return adopt_ref(*new KCOVDevice);
+    auto device = adopt_ref(*new KCOVDevice);
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT KCOVDevice::KCOVDevice()

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -15,7 +15,9 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<MemoryDevice> MemoryDevice::must_create()
 {
-    return adopt_ref(*new MemoryDevice);
+    auto device = adopt_ref(*new MemoryDevice);
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT MemoryDevice::MemoryDevice()

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<MemoryDevice> MemoryDevice::must_create()
 {
-    auto device = adopt_ref(*new MemoryDevice);
+    auto device = adopt_ref(*new (nothrow) MemoryDevice);
     device->after_inserting();
     return device;
 }

--- a/Kernel/Devices/NullDevice.cpp
+++ b/Kernel/Devices/NullDevice.cpp
@@ -15,6 +15,7 @@ static Singleton<NullDevice> s_the;
 UNMAP_AFTER_INIT void NullDevice::initialize()
 {
     s_the.ensure_instance();
+    s_the->after_inserting();
 }
 
 NullDevice& NullDevice::the()

--- a/Kernel/Devices/PCISerialDevice.cpp
+++ b/Kernel/Devices/PCISerialDevice.cpp
@@ -26,7 +26,7 @@ UNMAP_AFTER_INIT void PCISerialDevice::detect()
             auto bar_base = PCI::get_BAR(address, board_definition.pci_bar) & ~1;
             auto port_base = IOAddress(bar_base + board_definition.first_offset);
             for (size_t i = 0; i < board_definition.port_count; i++) {
-                auto serial_device = new SerialDevice(port_base.offset(board_definition.port_size * i), current_device_minor++);
+                auto serial_device = new (nothrow) SerialDevice(port_base.offset(board_definition.port_size * i), current_device_minor++);
                 if (board_definition.baud_rate != SerialDevice::Baud::Baud38400) // non-default baud
                     serial_device->set_baud(board_definition.baud_rate);
 

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<RandomDevice> RandomDevice::must_create()
 {
-    auto device = adopt_ref(*new RandomDevice);
+    auto device = adopt_ref(*new (nothrow) RandomDevice);
     device->after_inserting();
     return device;
 }

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -12,7 +12,9 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<RandomDevice> RandomDevice::must_create()
 {
-    return adopt_ref(*new RandomDevice);
+    auto device = adopt_ref(*new RandomDevice);
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT RandomDevice::RandomDevice()

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -89,6 +89,7 @@ UNMAP_AFTER_INIT void SB16::detect()
 UNMAP_AFTER_INIT void SB16::create()
 {
     s_the.ensure_instance();
+    s_the->after_inserting();
 }
 
 SB16& SB16::the()

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -21,16 +21,16 @@ UNMAP_AFTER_INIT NonnullRefPtr<SerialDevice> SerialDevice::must_create(size_t co
     SerialDevice* device = nullptr;
     switch (com_number) {
     case 0:
-        device = new SerialDevice(IOAddress(SERIAL_COM1_ADDR), 64);
+        device = new (nothrow) SerialDevice(IOAddress(SERIAL_COM1_ADDR), 64);
         break;
     case 1:
-        device = new SerialDevice(IOAddress(SERIAL_COM2_ADDR), 65);
+        device = new (nothrow) SerialDevice(IOAddress(SERIAL_COM2_ADDR), 65);
         break;
     case 2:
-        device = new SerialDevice(IOAddress(SERIAL_COM3_ADDR), 66);
+        device = new (nothrow) SerialDevice(IOAddress(SERIAL_COM3_ADDR), 66);
         break;
     case 3:
-        device = new SerialDevice(IOAddress(SERIAL_COM4_ADDR), 67);
+        device = new (nothrow) SerialDevice(IOAddress(SERIAL_COM4_ADDR), 67);
         break;
     default:
         break;

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -12,7 +12,9 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<ZeroDevice> ZeroDevice::must_create()
 {
-    return adopt_ref(*new ZeroDevice);
+    auto device = adopt_ref(*new ZeroDevice);
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT ZeroDevice::ZeroDevice()

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<ZeroDevice> ZeroDevice::must_create()
 {
-    auto device = adopt_ref(*new ZeroDevice);
+    auto device = adopt_ref(*new (nothrow) ZeroDevice);
     device->after_inserting();
     return device;
 }

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -24,6 +24,7 @@ bool File::unref() const
 {
     if (deref_base())
         return false;
+    const_cast<File&>(*this).before_removing();
     delete this;
     return true;
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -75,6 +75,7 @@ class File
     , public Weakable<File> {
 public:
     virtual bool unref() const;
+    virtual void before_removing() { }
     virtual ~File();
 
     virtual KResultOr<NonnullRefPtr<OpenFileDescription>> open(int options);

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -586,7 +586,7 @@ KResult Plan9FS::post_message_and_wait_for_a_reply(Message& message)
 {
     auto request_type = message.type();
     auto tag = message.tag();
-    auto completion = adopt_ref(*new ReceiveCompletion(tag));
+    auto completion = adopt_ref(*new (nothrow) ReceiveCompletion(tag));
     TRY(post_message(message, completion));
     if (Thread::current()->block<Plan9FS::Blocker>({}, *this, message, completion).was_interrupted())
         return EINTR;

--- a/Kernel/FileSystem/SysFS.h
+++ b/Kernel/FileSystem/SysFS.h
@@ -34,12 +34,12 @@ class SysFSDeviceComponent final
 public:
     static NonnullRefPtr<SysFSDeviceComponent> must_create(Device const&);
 
-    Device const& device() const { return *m_associated_device; }
+    bool is_block_device() { return m_block_device; }
 
 private:
     explicit SysFSDeviceComponent(Device const&);
     IntrusiveListNode<SysFSDeviceComponent, NonnullRefPtr<SysFSDeviceComponent>> m_list_node;
-    RefPtr<Device> m_associated_device;
+    bool m_block_device;
 };
 
 class SysFSDevicesDirectory final : public SysFSDirectory {

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -59,7 +59,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initi
 {
     PCI::ID id = PCI::get_id(address);
     VERIFY((id.vendor_id == PCI::VendorID::QEMUOld && id.device_id == 0x1111) || (id.vendor_id == PCI::VendorID::VirtualBox && id.device_id == 0xbeef));
-    return adopt_ref(*new BochsGraphicsAdapter(address));
+    return adopt_ref(*new (nothrow) BochsGraphicsAdapter(address));
 }
 
 UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::Address pci_address)

--- a/Kernel/Graphics/Console/ContiguousFramebufferConsole.cpp
+++ b/Kernel/Graphics/Console/ContiguousFramebufferConsole.cpp
@@ -11,7 +11,7 @@ namespace Kernel::Graphics {
 
 NonnullRefPtr<ContiguousFramebufferConsole> ContiguousFramebufferConsole::initialize(PhysicalAddress framebuffer_address, size_t width, size_t height, size_t pitch)
 {
-    return adopt_ref(*new ContiguousFramebufferConsole(framebuffer_address, width, height, pitch));
+    return adopt_ref(*new (nothrow) ContiguousFramebufferConsole(framebuffer_address, width, height, pitch));
 }
 
 ContiguousFramebufferConsole::ContiguousFramebufferConsole(PhysicalAddress framebuffer_address, size_t width, size_t height, size_t pitch)

--- a/Kernel/Graphics/Console/TextModeConsole.cpp
+++ b/Kernel/Graphics/Console/TextModeConsole.cpp
@@ -13,7 +13,7 @@ namespace Kernel::Graphics {
 
 UNMAP_AFTER_INIT NonnullRefPtr<TextModeConsole> TextModeConsole::initialize(const VGACompatibleAdapter& adapter)
 {
-    return adopt_ref(*new TextModeConsole(adapter));
+    return adopt_ref(*new (nothrow) TextModeConsole(adapter));
 }
 
 UNMAP_AFTER_INIT TextModeConsole::TextModeConsole(const VGACompatibleAdapter& adapter)

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -22,7 +22,7 @@ namespace Kernel {
 
 NonnullRefPtr<FramebufferDevice> FramebufferDevice::create(const GraphicsDevice& adapter, size_t output_port_index, PhysicalAddress paddr, size_t width, size_t height, size_t pitch)
 {
-    auto device = adopt_ref(*new FramebufferDevice(adapter, output_port_index, paddr, width, height, pitch));
+    auto device = adopt_ref(*new (nothrow) FramebufferDevice(adapter, output_port_index, paddr, width, height, pitch));
     device->after_inserting();
     return device;
 }

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -22,7 +22,9 @@ namespace Kernel {
 
 NonnullRefPtr<FramebufferDevice> FramebufferDevice::create(const GraphicsDevice& adapter, size_t output_port_index, PhysicalAddress paddr, size_t width, size_t height, size_t pitch)
 {
-    return adopt_ref(*new FramebufferDevice(adapter, output_port_index, paddr, width, height, pitch));
+    auto device = adopt_ref(*new FramebufferDevice(adapter, output_port_index, paddr, width, height, pitch));
+    device->after_inserting();
+    return device;
 }
 
 KResultOr<Memory::Region*> FramebufferDevice::mmap(Process& process, OpenFileDescription&, Memory::VirtualRange const& range, u64 offset, int prot, bool shared)

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -47,7 +47,7 @@ RefPtr<IntelNativeGraphicsAdapter> IntelNativeGraphicsAdapter::initialize(PCI::A
     VERIFY(id.vendor_id == 0x8086);
     if (!is_supported_model(id.device_id))
         return {};
-    return adopt_ref(*new IntelNativeGraphicsAdapter(address));
+    return adopt_ref(*new (nothrow) IntelNativeGraphicsAdapter(address));
 }
 
 static size_t compute_dac_multiplier(size_t pixel_clock_in_khz)

--- a/Kernel/Graphics/VGACompatibleAdapter.cpp
+++ b/Kernel/Graphics/VGACompatibleAdapter.cpp
@@ -15,12 +15,12 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<VGACompatibleAdapter> VGACompatibleAdapter::initialize_with_preset_resolution(PCI::Address address, PhysicalAddress m_framebuffer_address, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch)
 {
-    return adopt_ref(*new VGACompatibleAdapter(address, m_framebuffer_address, framebuffer_width, framebuffer_height, framebuffer_pitch));
+    return adopt_ref(*new (nothrow) VGACompatibleAdapter(address, m_framebuffer_address, framebuffer_width, framebuffer_height, framebuffer_pitch));
 }
 
 UNMAP_AFTER_INIT NonnullRefPtr<VGACompatibleAdapter> VGACompatibleAdapter::initialize(PCI::Address address)
 {
-    return adopt_ref(*new VGACompatibleAdapter(address));
+    return adopt_ref(*new (nothrow) VGACompatibleAdapter(address));
 }
 
 UNMAP_AFTER_INIT void VGACompatibleAdapter::initialize_framebuffer_devices()

--- a/Kernel/Graphics/VirtIOGPU/Console.cpp
+++ b/Kernel/Graphics/VirtIOGPU/Console.cpp
@@ -32,7 +32,7 @@ void DirtyRect::union_rect(size_t x, size_t y, size_t width, size_t height)
 
 NonnullRefPtr<Console> Console::initialize(RefPtr<FrameBufferDevice> const& framebuffer_device)
 {
-    return adopt_ref(*new Console(framebuffer_device));
+    return adopt_ref(*new (nothrow) Console(framebuffer_device));
 }
 
 Console::Console(RefPtr<FrameBufferDevice> const& framebuffer_device)
@@ -55,7 +55,7 @@ void Console::flush(size_t x, size_t y, size_t width, size_t height)
 
 void Console::enqueue_refresh_timer()
 {
-    NonnullRefPtr<Timer> refresh_timer = adopt_ref(*new Timer());
+    NonnullRefPtr<Timer> refresh_timer = adopt_ref(*new (nothrow) Timer());
     refresh_timer->setup(CLOCK_MONOTONIC, refresh_interval, [this]() {
         auto rect = m_dirty_rect;
         if (rect.is_dirty()) {

--- a/Kernel/Graphics/VirtIOGPU/GPU.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU.cpp
@@ -63,7 +63,7 @@ void GPU::create_framebuffer_devices()
 {
     for (size_t i = 0; i < min(m_num_scanouts, VIRTIO_GPU_MAX_SCANOUTS); i++) {
         auto& scanout = m_scanouts[i];
-        scanout.framebuffer = adopt_ref(*new VirtIOGPU::FrameBufferDevice(*this, i));
+        scanout.framebuffer = adopt_ref(*new (nothrow) VirtIOGPU::FrameBufferDevice(*this, i));
         scanout.framebuffer->after_inserting();
         scanout.console = Kernel::Graphics::VirtIOGPU::Console::initialize(scanout.framebuffer);
     }

--- a/Kernel/Graphics/VirtIOGPU/GPU.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU.cpp
@@ -64,6 +64,7 @@ void GPU::create_framebuffer_devices()
     for (size_t i = 0; i < min(m_num_scanouts, VIRTIO_GPU_MAX_SCANOUTS); i++) {
         auto& scanout = m_scanouts[i];
         scanout.framebuffer = adopt_ref(*new VirtIOGPU::FrameBufferDevice(*this, i));
+        scanout.framebuffer->after_inserting();
         scanout.console = Kernel::Graphics::VirtIOGPU::Console::initialize(scanout.framebuffer);
     }
 }

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -16,13 +16,13 @@ namespace Kernel::Graphics::VirtIOGPU {
 NonnullRefPtr<GraphicsAdapter> GraphicsAdapter::initialize(PCI::Address base_address)
 {
     VERIFY(PCI::get_id(base_address).vendor_id == PCI::VendorID::VirtIO);
-    return adopt_ref(*new GraphicsAdapter(base_address));
+    return adopt_ref(*new (nothrow) GraphicsAdapter(base_address));
 }
 
 GraphicsAdapter::GraphicsAdapter(PCI::Address base_address)
     : PCI::Device(base_address)
 {
-    m_gpu_device = adopt_ref(*new GPU(base_address)).leak_ref();
+    m_gpu_device = adopt_ref(*new (nothrow) GPU(base_address)).leak_ref();
     m_gpu_device->initialize();
 }
 

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -70,7 +70,7 @@ public:
 
     static void initialize(u8 interrupt_number)
     {
-        auto* handler = new APICIPIInterruptHandler(interrupt_number);
+        auto* handler = new (nothrow) APICIPIInterruptHandler(interrupt_number);
         handler->register_interrupt_handler();
     }
 
@@ -101,7 +101,7 @@ public:
 
     static void initialize(u8 interrupt_number)
     {
-        auto* handler = new APICErrInterruptHandler(interrupt_number);
+        auto* handler = new (nothrow) APICErrInterruptHandler(interrupt_number);
         handler->register_interrupt_handler();
     }
 

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -129,7 +129,7 @@ UNMAP_AFTER_INIT void InterruptManagement::switch_to_pic_mode()
     dmesgln("Interrupts: Switch to Legacy PIC mode");
     InterruptDisabler disabler;
     m_smp_enabled = false;
-    m_interrupt_controllers[0] = adopt_ref(*new PIC());
+    m_interrupt_controllers[0] = adopt_ref(*new (nothrow) PIC());
     SpuriousInterruptHandler::initialize(7);
     SpuriousInterruptHandler::initialize(15);
     for (auto& irq_controller : m_interrupt_controllers) {
@@ -187,7 +187,7 @@ UNMAP_AFTER_INIT void InterruptManagement::locate_apic_data()
 
     int irq_controller_count = 0;
     if (madt->flags & PCAT_COMPAT_FLAG) {
-        m_interrupt_controllers[0] = adopt_ref(*new PIC());
+        m_interrupt_controllers[0] = adopt_ref(*new (nothrow) PIC());
         irq_controller_count++;
     }
     size_t entry_index = 0;

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT void SharedIRQHandler::initialize(u8 interrupt_number)
 {
-    auto* handler = new SharedIRQHandler(interrupt_number);
+    auto* handler = new (nothrow) SharedIRQHandler(interrupt_number);
     handler->register_interrupt_handler();
     handler->disable_interrupt_vector();
 }

--- a/Kernel/Interrupts/SpuriousInterruptHandler.cpp
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT void SpuriousInterruptHandler::initialize(u8 interrupt_number)
 {
-    auto* handler = new SpuriousInterruptHandler(interrupt_number);
+    auto* handler = new (nothrow) SpuriousInterruptHandler(interrupt_number);
     handler->register_interrupt_handler();
 }
 

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -606,7 +606,7 @@ UNMAP_AFTER_INIT void MemoryManager::initialize(u32 cpu)
     ProcessorSpecific<MemoryManagerData>::initialize();
 
     if (cpu == 0) {
-        new MemoryManager;
+        new (nothrow) MemoryManager;
         kmalloc_enable_expand();
     }
 }

--- a/Kernel/Memory/PhysicalRegion.h
+++ b/Kernel/Memory/PhysicalRegion.h
@@ -20,7 +20,7 @@ class PhysicalRegion {
 public:
     static OwnPtr<PhysicalRegion> try_create(PhysicalAddress lower, PhysicalAddress upper)
     {
-        return adopt_own_if_nonnull(new PhysicalRegion { lower, upper });
+        return adopt_own_if_nonnull(new (nothrow) PhysicalRegion { lower, upper });
     }
 
     ~PhysicalRegion();

--- a/Kernel/Net/LoopbackAdapter.cpp
+++ b/Kernel/Net/LoopbackAdapter.cpp
@@ -13,7 +13,7 @@ static bool s_loopback_initialized = false;
 
 RefPtr<LoopbackAdapter> LoopbackAdapter::try_create()
 {
-    return adopt_ref_if_nonnull(new LoopbackAdapter());
+    return adopt_ref_if_nonnull(new (nothrow) LoopbackAdapter());
 }
 
 LoopbackAdapter::LoopbackAdapter()

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -57,7 +57,7 @@ bool NetworkTask::is_current()
 
 void NetworkTask_main(void*)
 {
-    delayed_ack_sockets = new HashTable<RefPtr<TCPSocket>>;
+    delayed_ack_sockets = new (nothrow) HashTable<RefPtr<TCPSocket>>;
 
     WaitQueue packet_wait_queue;
     int pending_packets = 0;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -72,7 +72,7 @@ ProcessID Process::allocate_pid()
 
 UNMAP_AFTER_INIT void Process::initialize()
 {
-    g_modules = new HashMap<String, OwnPtr<Module>>;
+    g_modules = new (nothrow) HashMap<String, OwnPtr<Module>>;
 
     next_pid.store(0, AK::MemoryOrder::memory_order_release);
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -174,7 +174,8 @@ public:
     template<typename EntryFunction>
     static RefPtr<Process> create_kernel_process(RefPtr<Thread>& first_thread, NonnullOwnPtr<KString> name, EntryFunction entry, u32 affinity = THREAD_AFFINITY_DEFAULT, RegisterProcess do_register = RegisterProcess::Yes)
     {
-        auto* entry_func = new EntryFunction(move(entry));
+        auto* entry_func = new (nothrow) EntryFunction(move(entry));
+        VERIFY(entry_func)
         return create_kernel_process(first_thread, move(name), &Process::kernel_process_trampoline<EntryFunction>, entry_func, affinity, do_register);
     }
 

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -410,7 +410,7 @@ UNMAP_AFTER_INIT void Scheduler::initialize()
     }
 
     RefPtr<Thread> idle_thread;
-    g_finalizer_wait_queue = new WaitQueue;
+    g_finalizer_wait_queue = new (nothrow) WaitQueue;
 
     g_finalizer_has_work.store(false, AK::MemoryOrder::memory_order_release);
     s_colonel_process = Process::create_kernel_process(idle_thread, KString::must_create("colonel"), idle_loop, nullptr, 1, Process::RegisterProcess::No).leak_ref();

--- a/Kernel/Storage/AHCIController.cpp
+++ b/Kernel/Storage/AHCIController.cpp
@@ -17,7 +17,7 @@ namespace Kernel {
 
 NonnullRefPtr<AHCIController> AHCIController::initialize(PCI::Address address)
 {
-    return adopt_ref(*new AHCIController(address));
+    return adopt_ref(*new (nothrow) AHCIController(address));
 }
 
 bool AHCIController::reset()

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -22,7 +22,7 @@ namespace Kernel {
 
 NonnullRefPtr<AHCIPort> AHCIPort::create(const AHCIPortHandler& handler, volatile AHCI::PortRegisters& registers, u32 port_index)
 {
-    return adopt_ref(*new AHCIPort(handler, registers, port_index));
+    return adopt_ref(*new (nothrow) AHCIPort(handler, registers, port_index));
 }
 
 AHCIPort::AHCIPort(const AHCIPortHandler& handler, volatile AHCI::PortRegisters& registers, u32 port_index)

--- a/Kernel/Storage/AHCIPortHandler.cpp
+++ b/Kernel/Storage/AHCIPortHandler.cpp
@@ -11,7 +11,7 @@ namespace Kernel {
 
 NonnullRefPtr<AHCIPortHandler> AHCIPortHandler::create(AHCIController& controller, u8 irq, AHCI::MaskedBitField taken_ports)
 {
-    return adopt_ref(*new AHCIPortHandler(controller, irq, taken_ports));
+    return adopt_ref(*new (nothrow) AHCIPortHandler(controller, irq, taken_ports));
 }
 
 AHCIPortHandler::AHCIPortHandler(AHCIController& controller, u8 irq, AHCI::MaskedBitField taken_ports)

--- a/Kernel/Storage/BMIDEChannel.cpp
+++ b/Kernel/Storage/BMIDEChannel.cpp
@@ -15,12 +15,12 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<BMIDEChannel> BMIDEChannel::create(const IDEController& ide_controller, IDEChannel::IOAddressGroup io_group, IDEChannel::ChannelType type)
 {
-    return adopt_ref(*new BMIDEChannel(ide_controller, io_group, type));
+    return adopt_ref(*new (nothrow) BMIDEChannel(ide_controller, io_group, type));
 }
 
 UNMAP_AFTER_INIT NonnullRefPtr<BMIDEChannel> BMIDEChannel::create(const IDEController& ide_controller, u8 irq, IDEChannel::IOAddressGroup io_group, IDEChannel::ChannelType type)
 {
-    return adopt_ref(*new BMIDEChannel(ide_controller, irq, io_group, type));
+    return adopt_ref(*new (nothrow) BMIDEChannel(ide_controller, irq, io_group, type));
 }
 
 UNMAP_AFTER_INIT BMIDEChannel::BMIDEChannel(const IDEController& controller, IDEChannel::IOAddressGroup io_group, IDEChannel::ChannelType type)

--- a/Kernel/Storage/IDEChannel.cpp
+++ b/Kernel/Storage/IDEChannel.cpp
@@ -24,12 +24,12 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<IDEChannel> IDEChannel::create(const IDEController& controller, IOAddressGroup io_group, ChannelType type)
 {
-    return adopt_ref(*new IDEChannel(controller, io_group, type));
+    return adopt_ref(*new (nothrow) IDEChannel(controller, io_group, type));
 }
 
 UNMAP_AFTER_INIT NonnullRefPtr<IDEChannel> IDEChannel::create(const IDEController& controller, u8 irq, IOAddressGroup io_group, ChannelType type)
 {
-    return adopt_ref(*new IDEChannel(controller, irq, io_group, type));
+    return adopt_ref(*new (nothrow) IDEChannel(controller, irq, io_group, type));
 }
 
 RefPtr<StorageDevice> IDEChannel::master_device() const

--- a/Kernel/Storage/IDEController.cpp
+++ b/Kernel/Storage/IDEController.cpp
@@ -18,7 +18,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<IDEController> IDEController::initialize(PCI::Address address, bool force_pio)
 {
-    return adopt_ref(*new IDEController(address, force_pio));
+    return adopt_ref(*new (nothrow) IDEController(address, force_pio));
 }
 
 bool IDEController::reset()

--- a/Kernel/Storage/PATADiskDevice.cpp
+++ b/Kernel/Storage/PATADiskDevice.cpp
@@ -15,7 +15,9 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 capabilities, u64 max_addressable_block)
 {
-    return adopt_ref(*new PATADiskDevice(controller, channel, type, interface_type, capabilities, max_addressable_block));
+    auto device = adopt_ref(*new PATADiskDevice(controller, channel, type, interface_type, capabilities, max_addressable_block));
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT PATADiskDevice::PATADiskDevice(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 capabilities, u64 max_addressable_block)

--- a/Kernel/Storage/PATADiskDevice.cpp
+++ b/Kernel/Storage/PATADiskDevice.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 capabilities, u64 max_addressable_block)
 {
-    auto device = adopt_ref(*new PATADiskDevice(controller, channel, type, interface_type, capabilities, max_addressable_block));
+    auto device = adopt_ref(*new (nothrow) PATADiskDevice(controller, channel, type, interface_type, capabilities, max_addressable_block));
     device->after_inserting();
     return device;
 }

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -12,7 +12,9 @@ namespace Kernel {
 
 NonnullRefPtr<DiskPartition> DiskPartition::create(BlockDevice& device, unsigned minor_number, DiskPartitionMetadata metadata)
 {
-    return adopt_ref(*new DiskPartition(device, minor_number, metadata));
+    auto partition = adopt_ref(*new DiskPartition(device, minor_number, metadata));
+    partition->after_inserting();
+    return partition;
 }
 
 DiskPartition::DiskPartition(BlockDevice& device, unsigned minor_number, DiskPartitionMetadata metadata)

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -12,7 +12,7 @@ namespace Kernel {
 
 NonnullRefPtr<DiskPartition> DiskPartition::create(BlockDevice& device, unsigned minor_number, DiskPartitionMetadata metadata)
 {
-    auto partition = adopt_ref(*new DiskPartition(device, minor_number, metadata));
+    auto partition = adopt_ref(*new (nothrow) DiskPartition(device, minor_number, metadata));
     partition->after_inserting();
     return partition;
 }

--- a/Kernel/Storage/RamdiskController.cpp
+++ b/Kernel/Storage/RamdiskController.cpp
@@ -13,7 +13,7 @@ namespace Kernel {
 
 NonnullRefPtr<RamdiskController> RamdiskController::initialize()
 {
-    return adopt_ref(*new RamdiskController());
+    return adopt_ref(*new (nothrow) RamdiskController());
 }
 
 bool RamdiskController::reset()

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -14,7 +14,9 @@ namespace Kernel {
 
 NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& controller, NonnullOwnPtr<Memory::Region>&& region, int major, int minor)
 {
-    return adopt_ref(*new RamdiskDevice(controller, move(region), major, minor));
+    auto device = adopt_ref(*new RamdiskDevice(controller, move(region), major, minor));
+    device->after_inserting();
+    return device;
 }
 
 RamdiskDevice::RamdiskDevice(const RamdiskController& controller, NonnullOwnPtr<Memory::Region>&& region, int major, int minor)

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -14,7 +14,7 @@ namespace Kernel {
 
 NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& controller, NonnullOwnPtr<Memory::Region>&& region, int major, int minor)
 {
-    auto device = adopt_ref(*new RamdiskDevice(controller, move(region), major, minor));
+    auto device = adopt_ref(*new (nothrow) RamdiskDevice(controller, move(region), major, minor));
     device->after_inserting();
     return device;
 }

--- a/Kernel/Storage/SATADiskDevice.cpp
+++ b/Kernel/Storage/SATADiskDevice.cpp
@@ -14,7 +14,9 @@ namespace Kernel {
 
 NonnullRefPtr<SATADiskDevice> SATADiskDevice::create(const AHCIController& controller, const AHCIPort& port, size_t sector_size, u64 max_addressable_block)
 {
-    return adopt_ref(*new SATADiskDevice(controller, port, sector_size, max_addressable_block));
+    auto device = adopt_ref(*new SATADiskDevice(controller, port, sector_size, max_addressable_block));
+    device->after_inserting();
+    return device;
 }
 
 SATADiskDevice::SATADiskDevice(const AHCIController& controller, const AHCIPort& port, size_t sector_size, u64 max_addressable_block)

--- a/Kernel/Storage/SATADiskDevice.cpp
+++ b/Kernel/Storage/SATADiskDevice.cpp
@@ -14,7 +14,7 @@ namespace Kernel {
 
 NonnullRefPtr<SATADiskDevice> SATADiskDevice::create(const AHCIController& controller, const AHCIPort& port, size_t sector_size, u64 max_addressable_block)
 {
-    auto device = adopt_ref(*new SATADiskDevice(controller, port, sector_size, max_addressable_block));
+    auto device = adopt_ref(*new (nothrow) SATADiskDevice(controller, port, sector_size, max_addressable_block));
     device->after_inserting();
     return device;
 }

--- a/Kernel/Syscalls/futex.cpp
+++ b/Kernel/Syscalls/futex.cpp
@@ -64,7 +64,7 @@ KResultOr<FlatPtr> Process::sys$futex(Userspace<const Syscall::SC_futex_params*>
             return it->value;
         if (create_if_not_found) {
             *did_create = true;
-            auto futex_queue = adopt_ref(*new FutexQueue);
+            auto futex_queue = adopt_ref(*new (nothrow) FutexQueue);
             auto result = queues->set(user_address, futex_queue);
             VERIFY(result == AK::HashSetResult::InsertedNewEntry);
             return futex_queue;

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -22,6 +22,8 @@ KResultOr<NonnullRefPtr<MasterPTY>> MasterPTY::try_create(unsigned int index)
     auto master_pty = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) MasterPTY(index, move(buffer))));
     auto slave_pty = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SlavePTY(*master_pty, index)));
     master_pty->m_slave = slave_pty;
+    master_pty->after_inserting();
+    slave_pty->after_inserting();
     return master_pty;
 }
 

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -35,6 +35,12 @@ UNMAP_AFTER_INIT PTYMultiplexer::~PTYMultiplexer()
 {
 }
 
+void PTYMultiplexer::initialize()
+{
+    the();
+    the().after_inserting();
+}
+
 KResultOr<NonnullRefPtr<OpenFileDescription>> PTYMultiplexer::open(int options)
 {
     return m_freelist.with_exclusive([&](auto& freelist) -> KResultOr<NonnullRefPtr<OpenFileDescription>> {

--- a/Kernel/TTY/PTYMultiplexer.h
+++ b/Kernel/TTY/PTYMultiplexer.h
@@ -20,10 +20,7 @@ public:
     PTYMultiplexer();
     virtual ~PTYMultiplexer() override;
 
-    static void initialize()
-    {
-        the();
-    }
+    static void initialize();
     static PTYMultiplexer& the();
 
     // ^CharacterDevice

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -28,8 +28,10 @@ bool SlavePTY::unref() const
         m_list_node.remove();
         return true;
     });
-    if (did_hit_zero)
+    if (did_hit_zero) {
+        const_cast<SlavePTY&>(*this).before_removing();
         delete this;
+    }
     return did_hit_zero;
 }
 

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -103,14 +103,14 @@ void VirtualConsole::set_graphical(bool graphical)
 
 UNMAP_AFTER_INIT NonnullRefPtr<VirtualConsole> VirtualConsole::create(size_t index)
 {
-    auto device = adopt_ref(*new VirtualConsole(index));
+    auto device = adopt_ref(*new (nothrow) VirtualConsole(index));
     device->after_inserting();
     return device;
 }
 
 UNMAP_AFTER_INIT NonnullRefPtr<VirtualConsole> VirtualConsole::create_with_preset_log(size_t index, const CircularQueue<char, 16384>& log)
 {
-    auto device = adopt_ref(*new VirtualConsole(index, log));
+    auto device = adopt_ref(*new (nothrow) VirtualConsole(index, log));
     device->after_inserting();
     return device;
 }

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -103,12 +103,16 @@ void VirtualConsole::set_graphical(bool graphical)
 
 UNMAP_AFTER_INIT NonnullRefPtr<VirtualConsole> VirtualConsole::create(size_t index)
 {
-    return adopt_ref(*new VirtualConsole(index));
+    auto device = adopt_ref(*new VirtualConsole(index));
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT NonnullRefPtr<VirtualConsole> VirtualConsole::create_with_preset_log(size_t index, const CircularQueue<char, 16384>& log)
 {
-    return adopt_ref(*new VirtualConsole(index, log));
+    auto device = adopt_ref(*new VirtualConsole(index, log));
+    device->after_inserting();
+    return device;
 }
 
 UNMAP_AFTER_INIT void VirtualConsole::initialize()

--- a/Kernel/Time/APICTimer.cpp
+++ b/Kernel/Time/APICTimer.cpp
@@ -17,7 +17,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT APICTimer* APICTimer::initialize(u8 interrupt_number, HardwareTimerBase& calibration_source)
 {
-    auto timer = adopt_ref(*new APICTimer(interrupt_number, nullptr));
+    auto timer = adopt_ref(*new (nothrow) APICTimer(interrupt_number, nullptr));
     timer->register_interrupt_handler();
     if (!timer->calibrate(calibration_source)) {
         return nullptr;

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -135,7 +135,7 @@ UNMAP_AFTER_INIT bool HPET::test_and_initialize()
             return false;
         }
     }
-    new HPET(PhysicalAddress(hpet_table.value()));
+    new (nothrow) HPET(PhysicalAddress(hpet_table.value()));
     return true;
 }
 

--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<HPETComparator> HPETComparator::create(u8 number, u8 irq, bool periodic_capable, bool is_64bit_capable)
 {
-    auto timer = adopt_ref(*new HPETComparator(number, irq, periodic_capable, is_64bit_capable));
+    auto timer = adopt_ref(*new (nothrow) HPETComparator(number, irq, periodic_capable, is_64bit_capable));
     timer->register_interrupt_handler();
     return timer;
 }

--- a/Kernel/Time/PIT.cpp
+++ b/Kernel/Time/PIT.cpp
@@ -18,7 +18,7 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<PIT> PIT::initialize(Function<void(const RegisterState&)> callback)
 {
-    return adopt_ref(*new PIT(move(callback)));
+    return adopt_ref(*new (nothrow) PIT(move(callback)));
 }
 
 [[maybe_unused]] inline static void reset_countdown(u16 timer_reload)

--- a/Kernel/Time/RTC.cpp
+++ b/Kernel/Time/RTC.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 
 NonnullRefPtr<RealTimeClock> RealTimeClock::create(Function<void(const RegisterState&)> callback)
 {
-    return adopt_ref(*new RealTimeClock(move(callback)));
+    return adopt_ref(*new (nothrow) RealTimeClock(move(callback)));
 }
 RealTimeClock::RealTimeClock(Function<void(const RegisterState&)> callback)
     : HardwareTimer(IRQ_TIMER, move(callback))

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -16,7 +16,7 @@ WorkQueue* g_io_work;
 
 UNMAP_AFTER_INIT void WorkQueue::initialize()
 {
-    g_io_work = new WorkQueue("IO WorkQueue");
+    g_io_work = new (nothrow) WorkQueue("IO WorkQueue");
 }
 
 UNMAP_AFTER_INIT WorkQueue::WorkQueue(StringView name)

--- a/Kernel/WorkQueue.h
+++ b/Kernel/WorkQueue.h
@@ -22,7 +22,7 @@ public:
 
     void queue(void (*function)(void*), void* data = nullptr, void (*free_data)(void*) = nullptr)
     {
-        auto* item = new WorkItem; // TODO: use a pool
+        auto* item = new (nothrow) WorkItem; // TODO: use a pool
         item->function = [function, data, free_data] {
             function(data);
             if (free_data)
@@ -34,7 +34,7 @@ public:
     template<typename Function>
     void queue(Function function)
     {
-        auto* item = new WorkItem; // TODO: use a pool
+        auto* item = new (nothrow) WorkItem; // TODO: use a pool
         item->function = Function(function);
         do_queue(item);
     }


### PR DESCRIPTION
Instead, they will return a null pointer, so we can handle it (either by
VERIFYing it if it's a raw pointer, or let adopt_ref to VERIFY it).

As a side note, I just found a bunch of these `new` allocations without `nothrow` request, so I thought
it might be a good idea to not do that anymore.

Relies on #9930.