### PR TITLE
Add link to contributors overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Join our Discord server: [SerenityOS Discord](https://discord.gg/serenityos)
 * **Peter Elliott** - [Petelliott](https://github.com/Petelliott)
 * **Karol Kosek** - [krkk](https://github.com/krkk)
 
-(And many more!) The people listed above have landed more than 100 commits in the project. :^)
+([And many more!](https://github.com/SerenityOS/serenity/graphs/contributors)) The people listed above have landed more than 100 commits in the project. :^)
 
 ## License
 


### PR DESCRIPTION
Make it easier for people to view the list of all contributors by adding a link to the contributors page.