### PR TITLE
Breakout: Improve collision response between ball and paddle

### DIFF
--- a/Userland/Games/Breakout/Game.cpp
+++ b/Userland/Games/Breakout/Game.cpp
@@ -266,8 +266,10 @@ void Game::tick()
     update(enclosing_int_rect(new_ball.rect()));
 
     if (new_ball.rect().intersects(m_paddle.rect)) {
-        new_ball.position.set_y(m_ball.y());
-        new_ball.velocity.set_y(new_ball.velocity.y() * -1);
+        if (m_ball.y() < new_ball.y()) {
+            new_ball.position.set_y(m_ball.y());
+        }
+        new_ball.velocity.set_y(fabs(new_ball.velocity.y()) * -1);
 
         float distance_to_middle_of_paddle = new_ball.x() - m_paddle.rect.center().x();
         float relative_impact_point = distance_to_middle_of_paddle / m_paddle.rect.width();


### PR DESCRIPTION
When the ball hits the side of the paddle, it would get stuck because the paddle moves faster than the ball.
This commit forces the post-collision vertical velocity of the ball to be going up and makes sure that new ball's y-position is higher than in the previous frame.

Before:
![broken](https://user-images.githubusercontent.com/271548/132876114-2b61feac-9b0c-46c4-bdd9-4aa711ac9e9c.gif)

After:
![fix](https://user-images.githubusercontent.com/271548/132876138-96f0d416-accd-41fc-b978-7e0a1cbfda2e.gif)

This is not a real physical behavior, but the alternative would make the ball bounce on the side and fall on the floor which is arguably less nice for the user.