### PR TITLE
LibGfx: Increase bit-width of variables used in do_draw_scaled_bitmap

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1088,16 +1088,17 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, const IntRe
     }
 
     bool has_opacity = opacity != 1.0f;
-    int hscale = (src_rect.width() * (1 << 16)) / dst_rect.width();
-    int vscale = (src_rect.height() * (1 << 16)) / dst_rect.height();
-    int src_left = src_rect.left() * (1 << 16);
-    int src_top = src_rect.top() * (1 << 16);
+    i64 shift = (i64)1 << 32;
+    i64 hscale = (src_rect.width() * shift) / dst_rect.width();
+    i64 vscale = (src_rect.height() * shift) / dst_rect.height();
+    i64 src_left = src_rect.left() * shift;
+    i64 src_top = src_rect.top() * shift;
 
     for (int y = clipped_rect.top(); y <= clipped_rect.bottom(); ++y) {
         auto* scanline = (Color*)target.scanline(y);
         for (int x = clipped_rect.left(); x <= clipped_rect.right(); ++x) {
-            auto scaled_x = ((x - dst_rect.x()) * hscale + src_left) >> 16;
-            auto scaled_y = ((y - dst_rect.y()) * vscale + src_top) >> 16;
+            auto scaled_x = ((x - dst_rect.x()) * hscale + src_left) >> 32;
+            auto scaled_y = ((y - dst_rect.y()) * vscale + src_top) >> 32;
             auto src_pixel = get_pixel(source, scaled_x, scaled_y);
             if (has_opacity)
                 src_pixel.set_alpha(src_pixel.alpha() * opacity);


### PR DESCRIPTION
When the src_rect is sufficiently large (when, say, PixelPaint is zoomed in x100), the precision provided by the "shift everything 16 to the left and handle it as ints" strategy is no longer enough. This patch changes the used types to "i64" which are guaranteed to be at least 64 bits wide and the shifting is increased to 32 bits.
On the 32-bit-arch a long long int doesn't fit in a single register anymore but I think it's okay to trust the compiler to do clever stuff around this issue.
This bitshifting is probably done to avoid having floating points all over this function which is slower than just multiplying and adding integers.

I don't know whether it's actually worth it to not just bathe in floats here, but the optimization was here before, so it seems to have merit.

Closes #9889 