### PR TITLE
Fix and forbid making StringView from temporary ByteBuffers

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -50,6 +50,7 @@ public:
 
     explicit StringView(ByteBuffer&&) = delete;
     explicit StringView(String&&) = delete;
+    explicit StringView(FlyString&&) = delete;
 
     [[nodiscard]] constexpr bool is_null() const { return !m_characters; }
     [[nodiscard]] constexpr bool is_empty() const { return m_length == 0; }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -48,6 +48,7 @@ public:
     StringView(const String&);
     StringView(const FlyString&);
 
+    explicit StringView(ByteBuffer&&) = delete;
     explicit StringView(String&&) = delete;
 
     [[nodiscard]] constexpr bool is_null() const { return !m_characters; }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -115,9 +115,10 @@ RefPtr<Core::MimeData> SheetModel::mime_data(const GUI::ModelSelection& selectio
     VERIFY(cursor);
 
     Position cursor_position { (size_t)cursor->column(), (size_t)cursor->row() };
+    auto mime_data_buffer = mime_data->data("text/x-spreadsheet-data");
     auto new_data = String::formatted("{}\n{}",
         cursor_position.to_url(m_sheet).to_string(),
-        StringView(mime_data->data("text/x-spreadsheet-data")));
+        StringView(mime_data_buffer));
     mime_data->set_data("text/x-spreadsheet-data", new_data.to_byte_buffer());
 
     return mime_data;

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -26,7 +26,8 @@ ProcessModel::ProcessModel()
 
     auto file = Core::File::construct("/proc/cpuinfo");
     if (file->open(Core::OpenMode::ReadOnly)) {
-        auto json = JsonValue::from_string({ file->read_all() });
+        auto buffer = file->read_all();
+        auto json = JsonValue::from_string({ buffer });
         auto cpuinfo_array = json.value().as_array();
         cpuinfo_array.for_each([&](auto& value) {
             auto& cpu_object = value.as_object();

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -88,7 +88,8 @@ void Configuration::dump_stack()
     {
         DuplexMemoryStream memory_stream;
         Printer { memory_stream }.print(vs...);
-        dbgln(format.view(), StringView(memory_stream.copy_into_contiguous_buffer()).trim_whitespace());
+        ByteBuffer buffer = memory_stream.copy_into_contiguous_buffer();
+        dbgln(format.view(), StringView(buffer).trim_whitespace());
     };
     for (auto const& entry : stack().entries()) {
         entry.visit(

--- a/Userland/Utilities/nproc.cpp
+++ b/Userland/Utilities/nproc.cpp
@@ -22,7 +22,8 @@ int main()
         return 1;
     }
 
-    auto json = JsonValue::from_string({ file->read_all() });
+    auto buffer = file->read_all();
+    auto json = JsonValue::from_string({ buffer });
     auto cpuinfo_array = json.value().as_array();
     outln("{}", cpuinfo_array.size());
 

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -399,7 +399,8 @@ int main(int argc, char* argv[])
                                 first = false;
                             else
                                 argument_builder.append(", "sv);
-                            argument_builder.append(StringView(stream.copy_into_contiguous_buffer()).trim_whitespace());
+                            ByteBuffer buffer = stream.copy_into_contiguous_buffer();
+                            argument_builder.append(StringView(buffer).trim_whitespace());
                         }
                         dbgln("[wasm runtime] Stub function {} was called with the following arguments: {}", name, argument_builder.to_string());
                         Vector<Wasm::Value> result;


### PR DESCRIPTION
Similar reasoning as #9812: A StringView only has a pointer to the data, but doesn't actually keep it alive. If the ByteBuffer goes out of scope, then the StringView uses data after it has been free'd.

Personally, I find these are entirely too many commits, but [@IdanHo and everyone else](https://discord.com/channels/830522505605283862/830522505605283866/886001778775187456) insists that this is the way to go. Alrighty then!