### PR TITLE
LibJS: Remove read buffer overflow in Lexer::consume

### DIFF
--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -141,7 +141,7 @@ Lexer::Lexer(StringView source, StringView filename, size_t line_number, size_t 
 void Lexer::consume()
 {
     auto did_reach_eof = [this] {
-        if (m_position != m_source.length())
+        if (m_position < m_source.length())
             return false;
         m_eof = true;
         m_current_char = '\0';


### PR DESCRIPTION
The position is added to manually in the line terminator and Unicode
character cases. While it checks for EOF after doing so, the EOF check
used `!=` instead of `<`, meaning if the position went _over_ the
source length, it wouldn't think it was EOF and would cause read buffer
overflows.

For example, `0xea` followed by `0xfd` would cause this.