### PR TITLE
PixelPaint: Show a pixel grid when zoomed in :^)

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -98,6 +98,24 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
 
     if (!m_selection.is_empty())
         m_selection.paint(painter);
+
+    const float pixel_grid_threshold = 15.0f;
+    if (m_scale > pixel_grid_threshold) {
+        auto grid_rect = m_editor_image_rect.intersected(event.rect());
+        auto image_rect = enclosing_int_rect(editor_rect_to_image_rect(grid_rect)).inflated(1, 1);
+
+        for (auto i = image_rect.left(); i < image_rect.right(); i++) {
+            auto start_point = image_position_to_editor_position({ i, image_rect.top() }).to_type<int>();
+            auto end_point = image_position_to_editor_position({ i, image_rect.bottom() }).to_type<int>();
+            painter.draw_line(start_point, end_point, Color::LightGray);
+        }
+
+        for (auto i = image_rect.top(); i < image_rect.bottom(); i++) {
+            auto start_point = image_position_to_editor_position({ image_rect.left(), i }).to_type<int>();
+            auto end_point = image_position_to_editor_position({ image_rect.right(), i }).to_type<int>();
+            painter.draw_line(start_point, end_point, Color::LightGray);
+        }
+    }
 }
 
 Gfx::FloatRect ImageEditor::layer_rect_to_editor_rect(Layer const& layer, Gfx::IntRect const& layer_rect) const

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -100,7 +101,7 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
         m_selection.paint(painter);
 
     const float pixel_grid_threshold = 15.0f;
-    if (m_scale > pixel_grid_threshold) {
+    if (m_show_pixel_grid && m_scale > pixel_grid_threshold) {
         auto grid_rect = m_editor_image_rect.intersected(event.rect());
         auto image_rect = enclosing_int_rect(editor_rect_to_image_rect(grid_rect)).inflated(1, 1);
 
@@ -351,6 +352,14 @@ void ImageEditor::set_guide_visibility(bool show_guides)
     if (on_set_guide_visibility)
         on_set_guide_visibility(m_show_guides);
 
+    update();
+}
+
+void ImageEditor::set_pixel_grid_visibility(bool show_pixel_grid)
+{
+    if (m_show_pixel_grid == show_pixel_grid)
+        return;
+    m_show_pixel_grid = show_pixel_grid;
     update();
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -94,6 +95,9 @@ public:
     void set_guide_visibility(bool show_guides);
     Function<void(bool)> on_set_guide_visibility;
 
+    bool pixel_grid_visibility() const { return m_show_pixel_grid; }
+    void set_pixel_grid_visibility(bool show_pixel_grid);
+
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
 
@@ -127,6 +131,7 @@ private:
 
     NonnullRefPtrVector<Guide> m_guides;
     bool m_show_guides { true };
+    bool m_show_pixel_grid { true };
 
     Tool* m_active_tool { nullptr };
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -357,6 +357,15 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             if (auto* editor = current_image_editor())
                 editor->clear_guides();
         }));
+    view_menu.add_separator();
+
+    auto show_pixel_grid_action = GUI::Action::create_checkable(
+        "Show Pixel Grid", [&](auto& action) {
+            if (auto* editor = current_image_editor())
+                editor->set_pixel_grid_visibility(action.is_checked());
+        });
+    show_pixel_grid_action->set_checked(true);
+    view_menu.add_action(*show_pixel_grid_action);
 
     auto& tool_menu = window.add_menu("&Tool");
     m_toolbox->for_each_tool([&](auto& tool) {


### PR DESCRIPTION
This is something I always need when making some pixel art / graphics, so I've added this feature. Preview:

https://user-images.githubusercontent.com/9910883/132934683-cdf1f948-bf88-478a-8436-bc8fdca45925.mp4

Special mention to @TobyAsE for fixing the bug that allows this to work nicely :^)