### PR TITLE
WidgetGallery: Add GUI::ValueSlider widget

### DIFF
--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -10,8 +10,28 @@
             margins: [8]
         }
 
-        @GUI::OpacitySlider {
-            name: "opacity_slider"
+        @GUI::GroupBox {
+            max_height: 30
+
+            layout: @GUI::HorizontalBoxLayout {
+                margins: [8]
+            }
+
+            @GUI::OpacitySlider {
+                name: "opacity_slider"
+                tooltip: "Opacity Slider"
+            }
+
+            @GUI::VerticalSeparator {
+            }
+
+            @GUI::ValueSlider {
+                name: "opacity_value_slider"
+                min: 0
+                max: 100
+                value: 100
+                tooltip: "Value Slider"
+            }
         }
 
         @GUI::HorizontalSeparator {

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -25,6 +25,7 @@
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/TableView.h>
+#include <LibGUI/ValueSlider.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 
@@ -217,6 +218,15 @@ GalleryWidget::GalleryWidget()
 
     m_opacity_slider->on_change = [&](auto percent) {
         m_opacity_imagewidget->set_opacity_percent(percent);
+        m_opacity_value_slider->set_value(percent);
+    };
+
+    m_opacity_value_slider = sliders_tab.find_descendant_of_type_named<GUI::ValueSlider>("opacity_value_slider");
+    m_opacity_value_slider->set_range(0, 100);
+
+    m_opacity_value_slider->on_change = [&](auto percent) {
+        m_opacity_imagewidget->set_opacity_percent(percent);
+        m_opacity_slider->set_value(percent);
     };
 
     auto& wizards_tab = tab_widget.add_tab<GUI::Widget>("Wizards");

--- a/Userland/Demos/WidgetGallery/GalleryWidget.h
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.h
@@ -58,6 +58,7 @@ private:
     RefPtr<GUI::TableView> m_icons_tableview;
     RefPtr<GUI::TableView> m_cursors_tableview;
     RefPtr<GUI::OpacitySlider> m_opacity_slider;
+    RefPtr<GUI::ValueSlider> m_opacity_value_slider;
     RefPtr<GUI::ImageWidget> m_opacity_imagewidget;
 
     Vector<String> m_frame_shapes;


### PR DESCRIPTION
This was a cool slider and was missing from the gallery completely.
Vertical mode for this isn't enabled, and it looked awfully crammed
in the bottom along with the other horizontal sliders, so for now
I've just added this to the top, and it controls the opacity of the
image along with the opacity slider.

![image](https://user-images.githubusercontent.com/9910883/132936466-00d4e47f-8eb4-4e0c-99a4-5a725296922b.png)
