### PR TITLE
Everywhere: Fix format-vulnerabilities

### DIFF
--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -24,7 +24,7 @@ RefPtr<SQL::SQLResult> execute(NonnullRefPtr<SQL::Database> database, String con
     auto statement = parser.next_statement();
     EXPECT(!parser.has_errors());
     if (parser.has_errors()) {
-        outln(parser.errors()[0].to_string());
+        outln("{}", parser.errors()[0].to_string());
     }
     SQL::AST::ExecutionContext context { database };
     auto result = statement->execute(context);

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -201,7 +201,7 @@ void ArgsParser::print_usage(FILE* file, const char* argv0)
 
     if (m_general_help != nullptr && m_general_help[0] != '\0') {
         outln(file, "\nDescription:");
-        outln(file, m_general_help);
+        outln(file, "{}", m_general_help);
     }
 
     if (!m_options.is_empty())

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    outln(final_path);
+    outln("{}", final_path);
     free(final_path);
     return 0;
 }

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -191,7 +191,7 @@ int main()
     sql_client->on_next_result = [&](int, Vector<String> const& row) {
         StringBuilder builder;
         builder.join(", ", row);
-        outln(builder.build());
+        outln("{}", builder.build());
     };
 
     sql_client->on_results_exhausted = [&](int, int total_rows) {


### PR DESCRIPTION
Command used:

    grep -Pirn '(out|warn)ln\((?!["\)]|format,|stderr,|stdout,|output, ")' AK Kernel/ Tests/ Userland/

(Plus some manual reviewing.)

Let's pick ArgsParser as an example:

    outln(file, m_general_help);

This will fail at runtime if the general help happens to contain braces.

Even if this transformation turns out to be unnecessary in a place or two, this way the code is "more obviously" correct.