### PR TITLE
Base: Fix Markdown issues in man pages (many-commits version)

### DIFF
--- a/Base/usr/share/man/man1/checksum.md
+++ b/Base/usr/share/man/man1/checksum.md
@@ -13,10 +13,3 @@ checksum - helper program for calculating checksums
 
 This program calculates and print specified checksum of files. It cannot be run directly, only
 as `md5sum`, `sha1sum`, `sha256sum` or `sha512sum`.
-
-## See also
-
-* [`md5sum`(1)](md5sum.md)
-* [`sha1sum`(1)](sha1sum.md)
-* [`sha256sum`(1)](sha256sum.md)
-* [`sha512sum`(1)](sha512sum.md)

--- a/Base/usr/share/man/man1/chmod.md
+++ b/Base/usr/share/man/man1/chmod.md
@@ -44,6 +44,5 @@ $ chmod g=r script.sh
 
 ## See also
 
-* [`chgrp`(1)](chmod.md)
+* [`chgrp`(1)](chgrp.md)
 * [`chown`(1)](chown.md)
-* [`chmod`(2)](../man2/chmod.md)

--- a/Base/usr/share/man/man1/chown.md
+++ b/Base/usr/share/man/man1/chown.md
@@ -27,6 +27,5 @@ $ chown anon:anon file
 
 ## See also
 
-* [`chgrp`(1)](chmod.md)
-* [`chown`(1)](chown.md)
-* [`chmod`(2)](../man2/chmod.md)
+* [`chgrp`(1)](chgrp.md)
+* [`chmod`(1)](chmod.md)

--- a/Base/usr/share/man/man1/less.md
+++ b/Base/usr/share/man/man1/less.md
@@ -74,5 +74,5 @@ All other characters are treated normally.
 
 ## See Also
 
-* [more(1)](more.md) For a simpler pager that less implements.
-* [man(1)](man.md) For serenity's manual pager, that uses less.
+* [`more`(1)](more.md) For a simpler pager that less implements.
+* [`man`(1)](man.md) For serenity's manual pager, that uses less.

--- a/Base/usr/share/man/man1/less.md
+++ b/Base/usr/share/man/man1/less.md
@@ -68,7 +68,7 @@ character. For instance, `\\%l` would render as `%l`.
 
 All other characters are treated normally.
 
-#### examples
+#### Examples
 
 `less`'s current default prompt: `'?f%f :.(line %l)?e (END):.'`
 

--- a/Base/usr/share/man/man1/less.md
+++ b/Base/usr/share/man/man1/less.md
@@ -19,7 +19,7 @@ but largely incompatible with
 
 ## Options
 
-* `-P`, `--prompt`: Set the prompt format string. See [Prompts](#Prompts) for more details.
+* `-P`, `--prompt`: Set the prompt format string. See [Prompts](#prompts) for more details.
 * `-X`, `--no-init`: Don't switch to the xterm alternate buffer on startup.
 * `-e`, `--quit-at-eof`: Immediately exit less when the last line of the document is reached.
 * `-m`, `--emulate-more`: Apply `-Xe`, set the prompt to `--More--`, and disable

--- a/Base/usr/share/man/man1/man.md
+++ b/Base/usr/share/man/man1/man.md
@@ -53,4 +53,4 @@ this man page should be located at `/usr/share/man/man1/man.md`.
 
 ## See Also
 
-* [less(1)](less.md) For the terminal pager that `man` uses by default
+* [`less`(1)](less.md) For the terminal pager that `man` uses by default

--- a/Base/usr/share/man/man1/md5sum.md
+++ b/Base/usr/share/man/man1/md5sum.md
@@ -1,0 +1,1 @@
+checksum.md

--- a/Base/usr/share/man/man1/more.md
+++ b/Base/usr/share/man/man1/more.md
@@ -11,7 +11,7 @@ $ more
 ## Description
 
 `more` reads data from standard input and prints it to standard output, screen by screen.
-`more` is a symlink for [`less(1)`](less.md), which has a more emulation mode.
+`more` is a symlink for [`less`(1)](less.md), which has a more emulation mode.
 
 ## Examples
 
@@ -23,4 +23,4 @@ $ more
 
 ## See Also
 
-* [less(1)](less.md) For the more advanced terminal pager that implements more.
+* [`less`(1)](less.md) For the more advanced terminal pager that implements more.

--- a/Base/usr/share/man/man1/sha1sum.md
+++ b/Base/usr/share/man/man1/sha1sum.md
@@ -1,0 +1,1 @@
+checksum.md

--- a/Base/usr/share/man/man1/sha256sum.md
+++ b/Base/usr/share/man/man1/sha256sum.md
@@ -1,0 +1,1 @@
+checksum.md

--- a/Base/usr/share/man/man1/sha512sum.md
+++ b/Base/usr/share/man/man1/sha512sum.md
@@ -1,0 +1,1 @@
+checksum.md

--- a/Base/usr/share/man/man2/pledge.md
+++ b/Base/usr/share/man/man2/pledge.md
@@ -20,7 +20,7 @@ Note that `pledge()` can be called repeatedly to remove previously-pledged promi
 
 `promises` are applied to the current process, and will also be inherited by children created by [`fork`(2)](fork.md).
 
-`execpromises` are applied if/when a new process image is created with [`exec(2)`](exec.md).
+`execpromises` are applied if/when a new process image is created with [`exec`(2)](exec.md).
 
 If `promises` or `execpromises` is null, the corresponding value is unchanged.
 
@@ -35,26 +35,26 @@ If the process later attempts to use any system functionality it has previously 
 * `id`: Ability to change UID/GID
 * `tty`: TTY related functionality
 * `proc`: Process and scheduling related functionality
-* `exec`: The [`exec(2)`](exec.md) syscall
+* `exec`: The [`exec`(2)](exec.md) syscall
 * `unix`: UNIX local domain sockets
 * `inet`: IPv4 domain sockets
-* `accept`: May use [`accept(2)`](accept.md) to accept incoming socket connections on already listening sockets (\*)
+* `accept`: May use [`accept`(2)](accept.md) to accept incoming socket connections on already listening sockets (\*)
 * `rpath`: "Read" filesystem access
 * `wpath`: "Write" filesystem access
 * `cpath`: "Create" filesystem access
 * `dpath`: Creating new device files
 * `chown`: Changing file owner/group
 * `fattr`: Changing file attributes/permissions
-* `chroot`: The [`chroot(2)`](chroot.md) syscall (\*)
-* `video`: May use [`ioctl(2)`](ioctl.md) and [`mmap(2)`](mmap.md) on framebuffer video devices
+* `chroot`: The [`chroot`(2)](chroot.md) syscall (\*)
+* `video`: May use [`ioctl`(2)](ioctl.md) and [`mmap`(2)](mmap.md) on framebuffer video devices
 * `settime`: Changing the system time and date
 * `setkeymap`: Changing the system keyboard layout (\*)
 * `sigaction`: Change signal handlers and dispositions (\*)
 * `sendfd`: Send file descriptors over a local socket
 * `recvfd`: Receive file descriptors over a local socket
-* `ptrace`: The [`ptrace(2)`](ptrace.md) syscall (\*)
-* `prot_exec`: [`mmap(2)`](mmap.md) and [`mprotect(2)`](mprotect.md) with `PROT_EXEC`
-* `map_fixed`: [`mmap(2)`](mmap.md) with `MAP_FIXED` (\*)
+* `ptrace`: The [`ptrace`(2)](ptrace.md) syscall (\*)
+* `prot_exec`: [`mmap`(2)](mmap.md) and [`mprotect`(2)](mprotect.md) with `PROT_EXEC`
+* `map_fixed`: [`mmap`(2)](mmap.md) with `MAP_FIXED` (\*)
 
 Promises marked with an asterisk (\*) are SerenityOS specific extensions not supported by the original OpenBSD `pledge()`.
 

--- a/Base/usr/share/man/man3/getopt.md
+++ b/Base/usr/share/man/man3/getopt.md
@@ -27,7 +27,7 @@ int getopt_long(int argc, char** argv, const char* short_options, const struct o
 ## Description
 
 `getopt()` and `getopt_long()` parse options according to the syntax specified
-in [`getopt`(5)](../getopt.md). `getopt()` only supports short options;
+in [`getopt`(5)](../man5/getopt.md). `getopt()` only supports short options;
 `getopt_long()` supports both short and long options.
 
 One invocation of either function extracts at most one option from command line

--- a/Base/usr/share/man/man4/mem.md
+++ b/Base/usr/share/man/man4/mem.md
@@ -7,8 +7,8 @@ mem - physical system memory
 `/dev/mem` is a character device file that is used by other programs to examine
 the physical memory.
 
-Trying to [`mmap`(2)](../mmap.md) a physical range results either with success,
-or with an error. When invoking [`mmap`(2)](../mmap.md) on bad memory range,
+Trying to [`mmap`(2)](../man2/mmap.md) a physical range results either with success,
+or with an error. When invoking [`mmap`(2)](../man2/mmap.md) on bad memory range,
 the kernel will write a message about it to the kernel log.
 
 By default, the kernel limits the areas which can be accessed. The allowed areas
@@ -21,11 +21,11 @@ mknod /dev/mem c 1 1
 chmod 660 /dev/mem
 ```
 
-## Returned error values after [`mmap`(2)](../mmap.md)
+## Returned error values after [`mmap`(2)](../man2/mmap.md)
 
 * `EINVAL`: An access violation was detected.
 * `ENOMEM`: The requested range would wrap around, creating an access violation.
 
 ## See also
 
-* [`mmap`(2)](../mmap.md)
+* [`mmap`(2)](../man2/mmap.md)

--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -57,7 +57,7 @@ Note that heredocs _must_ be listed in the same order as they are used after a s
 
 ##### Variable Reference
 Any sequence of _Identifier_ characters, or a _Special Variable_ following a `$`.
-Variables may be followed by a _Slice_ (see [Slice](#Slice))
+Variables may be followed by a _Slice_ (see [Slice](#slice))
 
 ##### Slice
 Variables may be sliced into, which will allow the user to select a subset of entries in the contents of the variable.

--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -74,9 +74,9 @@ Date:   Mon Jan 20 22:12:04 2020 +0100
 Kernel: Add a basic implementation of unveil()
 ```
 
-### syscall call-from verification
+### Syscall call-from verification
 
-[syscall call-from verification](https://marc.info/?l=openbsd-tech&m=157488907117170&w=2) is
+[Syscall call-from verification](https://marc.info/?l=openbsd-tech&m=157488907117170&w=2) is
 a mitigation which originated from OpenBSD.
 In short the kernel checks that all syscalls originate
 from the address of the system's libc. This makes attacks


### PR DESCRIPTION
Inspired by #9892, I wrote a tool to detect bad links in our markdown files. Turns out, only the man pages have any problems whatsoever, but I did check the entire codebase. I did not check external links.

The tool itself cannot be merged yet, as it depends on #9928, and I'm not sure yet how to integrate it into the build system properly, and don't want to touch it right now until the "super build" has landed.

This PR fixes the broken links in multiple commits. This PR is otherwise identical to #9964.