### PR TITLE
Kernel: Initialize and expose SerialDevice(s) properly

### DIFF
--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -18,24 +18,30 @@ namespace Kernel {
 
 UNMAP_AFTER_INIT NonnullRefPtr<SerialDevice> SerialDevice::must_create(size_t com_number)
 {
-    SerialDevice* device = nullptr;
+    // FIXME: This way of blindly doing release_value is really not a good thing, find
+    // a way to propagate errors back.
+    RefPtr<SerialDevice> serial_device;
     switch (com_number) {
-    case 0:
-        device = new SerialDevice(IOAddress(SERIAL_COM1_ADDR), 64);
+    case 0: {
+        serial_device = try_create_device<SerialDevice>(IOAddress(SERIAL_COM1_ADDR), 64).release_value();
         break;
-    case 1:
-        device = new SerialDevice(IOAddress(SERIAL_COM2_ADDR), 65);
+    }
+    case 1: {
+        serial_device = try_create_device<SerialDevice>(IOAddress(SERIAL_COM2_ADDR), 65).release_value();
         break;
-    case 2:
-        device = new SerialDevice(IOAddress(SERIAL_COM3_ADDR), 66);
+    }
+    case 2: {
+        serial_device = try_create_device<SerialDevice>(IOAddress(SERIAL_COM3_ADDR), 66).release_value();
         break;
-    case 3:
-        device = new SerialDevice(IOAddress(SERIAL_COM4_ADDR), 67);
+    }
+    case 3: {
+        serial_device = try_create_device<SerialDevice>(IOAddress(SERIAL_COM4_ADDR), 67).release_value();
         break;
+    }
     default:
         break;
     }
-    return adopt_ref_if_nonnull(device).release_nonnull();
+    return serial_device.release_nonnull();
 }
 
 UNMAP_AFTER_INIT SerialDevice::SerialDevice(IOAddress base_addr, unsigned minor)

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -102,10 +102,12 @@ public:
         DataReady = 0x01 << 0
     };
 
+    // FIXME: We expose this constructor to make try_create_device helper to work
+    SerialDevice(IOAddress base_addr, unsigned minor);
+
 private:
     friend class PCISerialDevice;
 
-    SerialDevice(IOAddress base_addr, unsigned minor);
 
     // ^CharacterDevice
     virtual StringView class_name() const override { return "SerialDevice"; }


### PR DESCRIPTION
I forgot that we need to also initialize SerialDevice and also to ensure
it creates a sysfs node properly. Although I had a better fix for this,
it keeps the CI happy, so for now it's more than enough :)