### PR TITLE
LibJS: Create a class to provide common methods for object prototypes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -7,7 +7,6 @@
 
 #include <AK/Function.h>
 #include <LibJS/Runtime/AbstractOperations.h>
-#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/ArrayBufferConstructor.h>
 #include <LibJS/Runtime/ArrayBufferPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -15,7 +14,7 @@
 namespace JS {
 
 ArrayBufferPrototype::ArrayBufferPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -35,21 +34,10 @@ ArrayBufferPrototype::~ArrayBufferPrototype()
 {
 }
 
-static ArrayBuffer* array_buffer_object_from(VM& vm, GlobalObject& global_object)
-{
-    // ArrayBuffer.prototype.* deliberately don't coerce |this| value to object.
-    auto this_value = vm.this_value(global_object);
-    if (!this_value.is_object() || !is<ArrayBuffer>(this_value.as_object())) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "ArrayBuffer");
-        return nullptr;
-    }
-    return static_cast<ArrayBuffer*>(&this_value.as_object());
-}
-
 // 25.1.5.3 ArrayBuffer.prototype.slice ( start, end ), https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
 JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
 {
-    auto array_buffer_object = array_buffer_object_from(vm, global_object);
+    auto array_buffer_object = typed_this_value(global_object);
     if (!array_buffer_object)
         return {};
 
@@ -126,7 +114,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
 // 25.1.5.1 get ArrayBuffer.prototype.byteLength, https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
 JS_DEFINE_NATIVE_GETTER(ArrayBufferPrototype::byte_length_getter)
 {
-    auto array_buffer_object = array_buffer_object_from(vm, global_object);
+    auto array_buffer_object = typed_this_value(global_object);
     if (!array_buffer_object)
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class ArrayBufferPrototype final : public Object {
-    JS_OBJECT(ArrayBufferPrototype, Object);
+class ArrayBufferPrototype final : public PrototypeObject<ArrayBufferPrototype, ArrayBuffer> {
+    JS_PROTOTYPE_OBJECT(ArrayBufferPrototype, ArrayBuffer, ArrayBuffer);
 
 public:
     explicit ArrayBufferPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/ArrayIterator.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class ArrayIteratorPrototype final : public Object {
-    JS_OBJECT(ArrayIteratorPrototype, Object)
+class ArrayIteratorPrototype final : public PrototypeObject<ArrayIteratorPrototype, ArrayIterator> {
+    JS_PROTOTYPE_OBJECT(ArrayIteratorPrototype, ArrayIterator, ArrayIterator);
 
 public:
     ArrayIteratorPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 DataViewPrototype::DataViewPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -54,22 +54,12 @@ DataViewPrototype::~DataViewPrototype()
 {
 }
 
-static DataView* typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto this_value = vm.this_value(global_object);
-    if (!this_value.is_object() || !is<DataView>(this_value.as_object())) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, vm.names.DataView);
-        return nullptr;
-    }
-    return static_cast<DataView*>(&this_value.as_object());
-}
-
 // 25.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
 template<typename T>
 static Value get_view_value(GlobalObject& global_object, Value request_index, Value is_little_endian)
 {
     auto& vm = global_object.vm();
-    auto* view = typed_this(vm, global_object);
+    auto* view = DataViewPrototype::typed_this_value(global_object);
     if (!view)
         return {};
 
@@ -108,7 +98,7 @@ template<typename T>
 static Value set_view_value(GlobalObject& global_object, Value request_index, Value is_little_endian, Value value)
 {
     auto& vm = global_object.vm();
-    auto* view = typed_this(vm, global_object);
+    auto* view = DataViewPrototype::typed_this_value(global_object);
     if (!view)
         return {};
 
@@ -265,7 +255,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_uint_32)
 // 25.3.4.1 get DataView.prototype.buffer, https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer
 JS_DEFINE_NATIVE_GETTER(DataViewPrototype::buffer_getter)
 {
-    auto* data_view = typed_this(vm, global_object);
+    auto* data_view = typed_this_value(global_object);
     if (!data_view)
         return {};
     return data_view->viewed_array_buffer();
@@ -274,7 +264,7 @@ JS_DEFINE_NATIVE_GETTER(DataViewPrototype::buffer_getter)
 // 25.3.4.2 get DataView.prototype.byteLength, https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength
 JS_DEFINE_NATIVE_GETTER(DataViewPrototype::byte_length_getter)
 {
-    auto* data_view = typed_this(vm, global_object);
+    auto* data_view = typed_this_value(global_object);
     if (!data_view)
         return {};
     if (data_view->viewed_array_buffer()->is_detached()) {
@@ -287,7 +277,7 @@ JS_DEFINE_NATIVE_GETTER(DataViewPrototype::byte_length_getter)
 // 25.3.4.3 get DataView.prototype.byteOffset, https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset
 JS_DEFINE_NATIVE_GETTER(DataViewPrototype::byte_offset_getter)
 {
-    auto* data_view = typed_this(vm, global_object);
+    auto* data_view = typed_this_value(global_object);
     if (!data_view)
         return {};
     if (data_view->viewed_array_buffer()->is_detached()) {

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
@@ -7,11 +7,12 @@
 #pragma once
 
 #include <LibJS/Runtime/DataView.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class DataViewPrototype final : public Object {
-    JS_OBJECT(DataViewPrototype, Object);
+class DataViewPrototype final : public PrototypeObject<DataViewPrototype, DataView> {
+    JS_PROTOTYPE_OBJECT(DataViewPrototype, DataView, DataView);
 
 public:
     DataViewPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -12,7 +12,6 @@
 #include <LibCore/DateTime.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibJS/Runtime/BigInt.h>
-#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/DatePrototype.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -21,20 +20,8 @@
 
 namespace JS {
 
-static Date* typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-    if (!is<Date>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Date");
-        return nullptr;
-    }
-    return static_cast<Date*>(this_object);
-}
-
 DatePrototype::DatePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -108,7 +95,7 @@ DatePrototype::~DatePrototype()
 // 21.4.4.2 Date.prototype.getDate ( ), https://tc39.es/ecma262/#sec-date.prototype.getdate
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_date)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -121,7 +108,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_date)
 // 21.4.4.20 Date.prototype.setDate ( date ), https://tc39.es/ecma262/#sec-date.prototype.setdate
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_date)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -149,7 +136,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_date)
 // 21.4.4.3 Date.prototype.getDay ( ), https://tc39.es/ecma262/#sec-date.prototype.getday
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_day)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -162,7 +149,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_day)
 // 21.4.4.4 Date.prototype.getFullYear ( ), https://tc39.es/ecma262/#sec-date.prototype.getfullyear
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_full_year)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -175,7 +162,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_full_year)
 // 21.4.4.21 Date.prototype.setFullYear ( year [ , month [ , date ] ] ), https://tc39.es/ecma262/#sec-date.prototype.setfullyear
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_full_year)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -224,7 +211,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_full_year)
 // B.2.4.1 Date.prototype.getYear ( ), https://tc39.es/ecma262/#sec-date.prototype.getyear
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_year)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -237,7 +224,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_year)
 // B.2.4.2 Date.prototype.setYear ( year ), https://tc39.es/ecma262/#sec-date.prototype.setyear
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_year)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -268,7 +255,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_year)
 // 21.4.4.5 Date.prototype.getHours ( ), https://tc39.es/ecma262/#sec-date.prototype.gethours
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_hours)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -281,7 +268,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_hours)
 // 21.4.4.22 Date.prototype.setHours ( hour [ , min [ , sec [ , ms ] ] ] ), https://tc39.es/ecma262/#sec-date.prototype.sethours
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_hours)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -341,7 +328,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_hours)
 // 21.4.4.23 Date.prototype.setMilliseconds ( ms ), https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_milliseconds)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -354,7 +341,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_milliseconds)
 // 21.4.4.23 Date.prototype.setMilliseconds ( ms ), https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_milliseconds)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -390,7 +377,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_milliseconds)
 // 21.4.4.7 Date.prototype.getMinutes ( ), https://tc39.es/ecma262/#sec-date.prototype.getminutes
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_minutes)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -403,7 +390,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_minutes)
 // 21.4.4.24 Date.prototype.setMinutes ( min [ , sec [ , ms ] ] ), https://tc39.es/ecma262/#sec-date.prototype.setminutes
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_minutes)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -454,7 +441,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_minutes)
 // 21.4.4.8 Date.prototype.getMonth ( ), https://tc39.es/ecma262/#sec-date.prototype.getmonth
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_month)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -467,7 +454,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_month)
 // 21.4.4.25 Date.prototype.setMonth ( month [ , date ] ), https://tc39.es/ecma262/#sec-date.prototype.setmonth
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_month)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -506,7 +493,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_month)
 // 21.4.4.9 Date.prototype.getSeconds ( ), https://tc39.es/ecma262/#sec-date.prototype.getseconds
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_seconds)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -519,7 +506,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_seconds)
 // 21.4.4.26 Date.prototype.setSeconds ( sec [ , ms ] ), https://tc39.es/ecma262/#sec-date.prototype.setseconds
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_seconds)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -561,7 +548,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_seconds)
 // 21.4.4.10 Date.prototype.getTime ( ), https://tc39.es/ecma262/#sec-date.prototype.gettime
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_time)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -574,7 +561,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_time)
 // 21.4.4.27 Date.prototype.setTime ( time ), https://tc39.es/ecma262/#sec-date.prototype.settime
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_time)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -603,7 +590,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::set_time)
 // 21.4.4.11 Date.prototype.getTimezoneOffset ( ), https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_timezone_offset)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -617,7 +604,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_timezone_offset)
 // 21.4.4.12 Date.prototype.getUTCDate ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcdate
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_date)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -630,7 +617,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_date)
 // 21.4.4.13 Date.prototype.getUTCDay ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcday
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_day)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -643,7 +630,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_day)
 // 21.4.4.14 Date.prototype.getUTCFullYear ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_full_year)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -656,7 +643,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_full_year)
 // 21.4.4.15 Date.prototype.getUTCHours ( ), https://tc39.es/ecma262/#sec-date.prototype.getutchours
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_hours)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -669,7 +656,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_hours)
 // 21.4.4.16 Date.prototype.getUTCMilliseconds ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_milliseconds)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -682,7 +669,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_milliseconds)
 // 21.4.4.18 Date.prototype.getUTCMonth ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcmonth
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_month)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -695,7 +682,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_month)
 // 21.4.4.17 Date.prototype.getUTCMinutes ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcminutes
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_minutes)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -708,7 +695,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_minutes)
 // 21.4.4.19 Date.prototype.getUTCSeconds ( ), https://tc39.es/ecma262/#sec-date.prototype.getutcseconds
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_seconds)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -721,7 +708,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_seconds)
 // 21.4.4.35 Date.prototype.toDateString ( ), https://tc39.es/ecma262/#sec-date.prototype.todatestring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_date_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -742,7 +729,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_gmt_string)
 // 21.4.4.43 Date.prototype.toUTCString ( ), https://tc39.es/ecma262/#sec-date.prototype.toutcstring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_utc_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -757,7 +744,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_utc_string)
 // 21.4.4.36 Date.prototype.toISOString ( ), https://tc39.es/ecma262/#sec-date.prototype.toisostring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_iso_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -773,7 +760,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_iso_string)
 // 21.4.4.38 Date.prototype.toLocaleDateString ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_date_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -788,7 +775,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_date_string)
 // 21.4.4.39 Date.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -803,7 +790,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_string)
 // 21.4.4.40 Date.prototype.toLocaleTimeString ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_time_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -818,7 +805,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_time_string)
 // 21.4.4.42 Date.prototype.toTimeString ( ), https://tc39.es/ecma262/#sec-date.prototype.totimestring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_time_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -832,7 +819,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_time_string)
 // 21.4.4.41 Date.prototype.toString ( ), https://tc39.es/ecma262/#sec-date.prototype.tostring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_string)
 {
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (!this_object)
         return {};
 
@@ -862,7 +849,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_json)
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_temporal_instant)
 {
     // 1. Let t be ? thisTimeValue(this value).
-    auto* this_object = typed_this(vm, global_object);
+    auto* this_object = typed_this_object(global_object);
     if (vm.exception())
         return {};
     auto t = this_object->value_of();

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Date.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class DatePrototype final : public Object {
-    JS_OBJECT(DatePrototype, Object);
+class DatePrototype final : public PrototypeObject<DatePrototype, Date> {
+    JS_PROTOTYPE_OBJECT(DatePrototype, Date, Date);
 
 public:
     explicit DatePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -10,7 +10,7 @@
 namespace JS {
 
 FinalizationRegistryPrototype::FinalizationRegistryPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -32,22 +32,10 @@ FinalizationRegistryPrototype::~FinalizationRegistryPrototype()
 {
 }
 
-FinalizationRegistry* FinalizationRegistryPrototype::typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-    if (!is<FinalizationRegistry>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "FinalizationRegistry");
-        return nullptr;
-    }
-    return static_cast<FinalizationRegistry*>(this_object);
-}
-
 // @STAGE 2@ FinalizationRegistry.prototype.cleanupSome ( [ callback ] ), https://github.com/tc39/proposal-cleanup-some/blob/master/spec/finalization-registry.html
 JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::cleanup_some)
 {
-    auto* finalization_registry = typed_this(vm, global_object);
+    auto* finalization_registry = typed_this_object(global_object);
     if (!finalization_registry)
         return {};
 
@@ -65,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::cleanup_some)
 // 26.2.3.2 FinalizationRegistry.prototype.register ( target, heldValue [ , unregisterToken ] ), https://tc39.es/ecma262/#sec-finalization-registry.prototype.register
 JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::register_)
 {
-    auto* finalization_registry = typed_this(vm, global_object);
+    auto* finalization_registry = typed_this_object(global_object);
     if (!finalization_registry)
         return {};
 
@@ -95,7 +83,7 @@ JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::register_)
 // 26.2.3.3 FinalizationRegistry.prototype.unregister ( unregisterToken ), https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister
 JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::unregister)
 {
-    auto* finalization_registry = typed_this(vm, global_object);
+    auto* finalization_registry = typed_this_object(global_object);
     if (!finalization_registry)
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
@@ -7,11 +7,12 @@
 #pragma once
 
 #include <LibJS/Runtime/FinalizationRegistry.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class FinalizationRegistryPrototype final : public Object {
-    JS_OBJECT(FinalizationRegistryPrototype, Object);
+class FinalizationRegistryPrototype final : public PrototypeObject<FinalizationRegistryPrototype, FinalizationRegistry> {
+    JS_PROTOTYPE_OBJECT(FinalizationRegistryPrototype, FinalizationRegistry, FinalizationRegistry);
 
 public:
     FinalizationRegistryPrototype(GlobalObject&);
@@ -19,8 +20,6 @@ public:
     virtual ~FinalizationRegistryPrototype() override;
 
 private:
-    static FinalizationRegistry* typed_this(VM&, GlobalObject&);
-
     JS_DECLARE_NATIVE_FUNCTION(cleanup_some);
     JS_DECLARE_NATIVE_FUNCTION(register_);
     JS_DECLARE_NATIVE_FUNCTION(unregister);

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/OrdinaryFunctionObject.h>
 

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.cpp
@@ -5,25 +5,13 @@
  */
 
 #include <LibJS/Bytecode/Interpreter.h>
-#include <LibJS/Runtime/GeneratorObject.h>
 #include <LibJS/Runtime/GeneratorObjectPrototype.h>
+#include <LibJS/Runtime/GlobalObject.h>
 
 namespace JS {
 
-static GeneratorObject* typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<GeneratorObject>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Generator");
-        return nullptr;
-    }
-    return static_cast<GeneratorObject*>(this_object);
-}
-
 GeneratorObjectPrototype::GeneratorObjectPrototype(GlobalObject& global_object)
-    : Object(*global_object.iterator_prototype())
+    : PrototypeObject(*global_object.iterator_prototype())
 {
 }
 
@@ -47,7 +35,7 @@ GeneratorObjectPrototype::~GeneratorObjectPrototype()
 // 27.5.1.2 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.next
 JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::next)
 {
-    auto generator_object = typed_this(vm, global_object);
+    auto generator_object = typed_this_object(global_object);
     if (!generator_object)
         return {};
     return generator_object->next_impl(vm, global_object, {});
@@ -56,7 +44,7 @@ JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::next)
 // 27.5.1.3 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.return
 JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::return_)
 {
-    auto generator_object = typed_this(vm, global_object);
+    auto generator_object = typed_this_object(global_object);
     if (!generator_object)
         return {};
     generator_object->set_done();
@@ -66,7 +54,7 @@ JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::return_)
 // 27.5.1.4 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.throw
 JS_DEFINE_NATIVE_FUNCTION(GeneratorObjectPrototype::throw_)
 {
-    auto generator_object = typed_this(vm, global_object);
+    auto generator_object = typed_this_object(global_object);
     if (!generator_object)
         return {};
     return generator_object->next_impl(vm, global_object, vm.argument(0));

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObjectPrototype.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
-#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/GeneratorObject.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
 // 27.5.1 %GeneratorFunction.prototype.prototype%, https://tc39.es/ecma262/#sec-properties-of-generator-prototype
-class GeneratorObjectPrototype final : public Object {
-    JS_OBJECT(GeneratorObjectPrototype, Object);
+class GeneratorObjectPrototype final : public PrototypeObject<GeneratorObjectPrototype, GeneratorObject> {
+    JS_PROTOTYPE_OBJECT(GeneratorObjectPrototype, GeneratorObject, Generator);
 
 public:
     explicit GeneratorObjectPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -9,13 +9,12 @@
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/IteratorOperations.h>
-#include <LibJS/Runtime/MapIterator.h>
 #include <LibJS/Runtime/MapIteratorPrototype.h>
 
 namespace JS {
 
 MapIteratorPrototype::MapIteratorPrototype(GlobalObject& global_object)
-    : Object(*global_object.iterator_prototype())
+    : PrototypeObject(*global_object.iterator_prototype())
 {
 }
 
@@ -35,26 +34,23 @@ MapIteratorPrototype::~MapIteratorPrototype()
 // 24.1.5.2.1 %MapIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(MapIteratorPrototype::next)
 {
-    auto this_value = vm.this_value(global_object);
-    if (!this_value.is_object() || !is<MapIterator>(this_value.as_object())) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Map Iterator");
+    auto* map_iterator = typed_this_value(global_object);
+    if (vm.exception())
         return {};
-    }
 
-    auto& map_iterator = static_cast<MapIterator&>(this_value.as_object());
-    if (map_iterator.done())
+    if (map_iterator->done())
         return create_iterator_result_object(global_object, js_undefined(), true);
 
-    auto& map = map_iterator.map();
-    if (map_iterator.m_iterator == map.entries().end()) {
-        map_iterator.m_done = true;
+    auto& map = map_iterator->map();
+    if (map_iterator->m_iterator == map.entries().end()) {
+        map_iterator->m_done = true;
         return create_iterator_result_object(global_object, js_undefined(), true);
     }
 
-    auto iteration_kind = map_iterator.iteration_kind();
+    auto iteration_kind = map_iterator->iteration_kind();
 
-    auto entry = *map_iterator.m_iterator;
-    ++map_iterator.m_iterator;
+    auto entry = *map_iterator->m_iterator;
+    ++map_iterator->m_iterator;
     if (iteration_kind == Object::PropertyKind::Key)
         return create_iterator_result_object(global_object, entry.key, false);
     else if (iteration_kind == Object::PropertyKind::Value)

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/MapIterator.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class MapIteratorPrototype final : public Object {
-    JS_OBJECT(MapIteratorPrototype, Object)
+class MapIteratorPrototype final : public PrototypeObject<MapIteratorPrototype, MapIterator> {
+    JS_PROTOTYPE_OBJECT(MapIteratorPrototype, MapIterator, MapIterator);
 
 public:
     MapIteratorPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 MapPrototype::MapPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -42,22 +42,10 @@ MapPrototype::~MapPrototype()
 {
 }
 
-Map* MapPrototype::typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<Map>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Map");
-        return nullptr;
-    }
-    return static_cast<Map*>(this_object);
-}
-
 // 24.1.3.1 Map.prototype.clear ( ), https://tc39.es/ecma262/#sec-map.prototype.clear
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::clear)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     map->entries().clear();
@@ -67,7 +55,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::clear)
 // 24.1.3.3 Map.prototype.delete ( key ), https://tc39.es/ecma262/#sec-map.prototype.delete
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::delete_)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     return Value(map->entries().remove(vm.argument(0)));
@@ -76,7 +64,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::delete_)
 // 24.1.3.4 Map.prototype.entries ( ), https://tc39.es/ecma262/#sec-map.prototype.entries
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::entries)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
 
@@ -86,7 +74,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::entries)
 // 24.1.3.5 Map.prototype.forEach ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-map.prototype.foreach
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::for_each)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     if (!vm.argument(0).is_function()) {
@@ -105,7 +93,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::for_each)
 // 24.1.3.6 Map.prototype.get ( key ), https://tc39.es/ecma262/#sec-map.prototype.get
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::get)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     auto result = map->entries().get(vm.argument(0));
@@ -117,7 +105,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::get)
 // 24.1.3.7 Map.prototype.has ( key ), https://tc39.es/ecma262/#sec-map.prototype.has
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::has)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     auto& entries = map->entries();
@@ -127,7 +115,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::has)
 // 24.1.3.8 Map.prototype.keys ( ), https://tc39.es/ecma262/#sec-map.prototype.keys
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::keys)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
 
@@ -137,7 +125,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::keys)
 // 24.1.3.9 Map.prototype.set ( key, value ), https://tc39.es/ecma262/#sec-map.prototype.set
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::set)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     auto key = vm.argument(0);
@@ -150,7 +138,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::set)
 // 24.1.3.11 Map.prototype.values ( ), https://tc39.es/ecma262/#sec-map.prototype.values
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::values)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
 
@@ -160,7 +148,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::values)
 // 24.1.3.10 get Map.prototype.size, https://tc39.es/ecma262/#sec-get-map.prototype.size
 JS_DEFINE_NATIVE_GETTER(MapPrototype::size_getter)
 {
-    auto* map = typed_this(vm, global_object);
+    auto* map = typed_this_object(global_object);
     if (!map)
         return {};
     return Value(map->entries().size());

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.h
@@ -7,11 +7,12 @@
 #pragma once
 
 #include <LibJS/Runtime/Map.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class MapPrototype final : public Object {
-    JS_OBJECT(MapPrototype, Object);
+class MapPrototype final : public PrototypeObject<MapPrototype, Map> {
+    JS_PROTOTYPE_OBJECT(MapPrototype, Map, Map);
 
 public:
     MapPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -17,7 +17,7 @@
 namespace JS {
 
 PromisePrototype::PromisePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -35,22 +35,10 @@ void PromisePrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.Promise.as_string()), Attribute::Configurable);
 }
 
-static Promise* promise_from(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-    if (!is<Promise>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, vm.names.Promise);
-        return nullptr;
-    }
-    return static_cast<Promise*>(this_object);
-}
-
 // 27.2.5.4 Promise.prototype.then ( onFulfilled, onRejected ), https://tc39.es/ecma262/#sec-promise.prototype.then
 JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::then)
 {
-    auto* promise = promise_from(vm, global_object);
+    auto* promise = typed_this_object(global_object);
     if (!promise)
         return {};
     auto on_fulfilled = vm.argument(0);

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS {
 
-class PromisePrototype final : public Object {
-    JS_OBJECT(PromisePrototype, Object);
+class PromisePrototype final : public PrototypeObject<PromisePrototype, Promise> {
+    JS_PROTOTYPE_OBJECT(PromisePrototype, Promise, Promise);
 
 public:
     PromisePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/PrototypeObject.h
+++ b/Userland/Libraries/LibJS/Runtime/PrototypeObject.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/TypeCasts.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace JS {
+
+#define JS_PROTOTYPE_OBJECT(prototype_class, object_class, display_name_) \
+    using Prototype = PrototypeObject<prototype_class, object_class>;     \
+    JS_OBJECT(prototype_class, Prototype)                                 \
+    static constexpr StringView display_name() { return #display_name_##sv; }
+
+template<typename PrototypeType, typename ObjectType>
+class PrototypeObject : public Object {
+    JS_OBJECT(PrototypeObject, Object);
+
+public:
+    virtual ~PrototypeObject() override = default;
+
+    static Object* this_object(GlobalObject& global_object)
+    {
+        auto& vm = global_object.vm();
+
+        auto this_value = vm.this_value(global_object);
+
+        if (!this_value.is_object()) {
+            vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObject, this_value);
+            return nullptr;
+        }
+
+        return &this_value.as_object();
+    }
+
+    // Use typed_this_object() when the spec coerces |this| value to an object.
+    static ObjectType* typed_this_object(GlobalObject& global_object)
+    {
+        auto& vm = global_object.vm();
+
+        auto* this_object = vm.this_value(global_object).to_object(global_object);
+        if (!this_object)
+            return nullptr;
+
+        if (!is<ObjectType>(this_object)) {
+            vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, PrototypeType::display_name());
+            return nullptr;
+        }
+
+        return static_cast<ObjectType*>(this_object);
+    }
+
+    // Use typed_this_value() when the spec does not coerce |this| value to an object.
+    static ObjectType* typed_this_value(GlobalObject& global_object)
+    {
+        auto& vm = global_object.vm();
+
+        auto this_value = vm.this_value(global_object);
+
+        if (!this_value.is_object() || !is<ObjectType>(this_value.as_object())) {
+            vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, PrototypeType::display_name());
+            return nullptr;
+        }
+
+        return static_cast<ObjectType*>(&this_value.as_object());
+    }
+
+protected:
+    explicit PrototypeObject(Object& prototype)
+        : Object(prototype)
+    {
+    }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Runtime/PrototypeObject.h>
 #include <LibJS/Runtime/RegExpObject.h>
 #include <LibJS/Runtime/Utf16String.h>
 
@@ -14,8 +15,8 @@ namespace JS {
 Value regexp_exec(GlobalObject& global_object, Object& regexp_object, Utf16String string);
 size_t advance_string_index(Utf16View const& string, size_t index, bool unicode);
 
-class RegExpPrototype final : public Object {
-    JS_OBJECT(RegExpPrototype, Object);
+class RegExpPrototype final : public PrototypeObject<RegExpPrototype, RegExpObject> {
+    JS_PROTOTYPE_OBJECT(RegExpPrototype, RegExpObject, RegExp);
 
 public:
     explicit RegExpPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/RegExpStringIterator.h>
 
 namespace JS {
 
-class RegExpStringIteratorPrototype final : public Object {
-    JS_OBJECT(RegExpStringIteratorPrototype, Object)
+class RegExpStringIteratorPrototype final : public PrototypeObject<RegExpStringIteratorPrototype, RegExpStringIterator> {
+    JS_PROTOTYPE_OBJECT(RegExpStringIteratorPrototype, RegExpStringIterator, RegExpStringIterator);
 
 public:
     explicit RegExpStringIteratorPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -9,13 +9,12 @@
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/IteratorOperations.h>
-#include <LibJS/Runtime/SetIterator.h>
 #include <LibJS/Runtime/SetIteratorPrototype.h>
 
 namespace JS {
 
 SetIteratorPrototype::SetIteratorPrototype(GlobalObject& global_object)
-    : Object(*global_object.iterator_prototype())
+    : PrototypeObject(*global_object.iterator_prototype())
 {
 }
 
@@ -37,27 +36,24 @@ SetIteratorPrototype::~SetIteratorPrototype()
 // 24.2.5.2.1 %SetIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%setiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(SetIteratorPrototype::next)
 {
-    auto this_value = vm.this_value(global_object);
-    if (!this_value.is_object() || !is<SetIterator>(this_value.as_object())) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Set Iterator");
+    auto* set_iterator = typed_this_value(global_object);
+    if (vm.exception())
         return {};
-    }
 
-    auto& set_iterator = static_cast<SetIterator&>(this_value.as_object());
-    if (set_iterator.done())
+    if (set_iterator->done())
         return create_iterator_result_object(global_object, js_undefined(), true);
 
-    auto& set = set_iterator.set();
-    if (set_iterator.m_iterator == set.values().end()) {
-        set_iterator.m_done = true;
+    auto& set = set_iterator->set();
+    if (set_iterator->m_iterator == set.values().end()) {
+        set_iterator->m_done = true;
         return create_iterator_result_object(global_object, js_undefined(), true);
     }
 
-    auto iteration_kind = set_iterator.iteration_kind();
+    auto iteration_kind = set_iterator->iteration_kind();
     VERIFY(iteration_kind != Object::PropertyKind::Key);
 
-    auto value = *set_iterator.m_iterator;
-    ++set_iterator.m_iterator;
+    auto value = *set_iterator->m_iterator;
+    ++set_iterator->m_iterator;
     if (iteration_kind == Object::PropertyKind::Value)
         return create_iterator_result_object(global_object, value, false);
 

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/SetIterator.h>
 
 namespace JS {
 
-class SetIteratorPrototype final : public Object {
-    JS_OBJECT(SetIteratorPrototype, Object)
+class SetIteratorPrototype final : public PrototypeObject<SetIteratorPrototype, SetIterator> {
+    JS_PROTOTYPE_OBJECT(SetIteratorPrototype, SetIterator, SetIterator);
 
 public:
     SetIteratorPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -12,7 +12,7 @@
 namespace JS {
 
 SetPrototype::SetPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -44,22 +44,10 @@ SetPrototype::~SetPrototype()
 {
 }
 
-Set* SetPrototype::typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<Set>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Set");
-        return nullptr;
-    }
-    return static_cast<Set*>(this_object);
-}
-
 // 24.2.3.1 Set.prototype.add ( value ), https://tc39.es/ecma262/#sec-set.prototype.add
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::add)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
     auto value = vm.argument(0);
@@ -72,7 +60,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::add)
 // 24.2.3.2 Set.prototype.clear ( ), https://tc39.es/ecma262/#sec-set.prototype.clear
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::clear)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
     set->values().clear();
@@ -82,7 +70,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::clear)
 // 24.2.3.4 Set.prototype.delete ( value ), https://tc39.es/ecma262/#sec-set.prototype.delete
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::delete_)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
     return Value(set->values().remove(vm.argument(0)));
@@ -91,7 +79,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::delete_)
 // 24.2.3.5 Set.prototype.entries ( ), https://tc39.es/ecma262/#sec-set.prototype.entries
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::entries)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
 
@@ -101,7 +89,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::entries)
 // 24.2.3.6 Set.prototype.forEach ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-set.prototype.foreach
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::for_each)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
     if (!vm.argument(0).is_function()) {
@@ -120,7 +108,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::for_each)
 // 24.2.3.7 Set.prototype.has ( value ), https://tc39.es/ecma262/#sec-set.prototype.has
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::has)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
     auto& values = set->values();
@@ -130,7 +118,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::has)
 // 24.2.3.10 Set.prototype.values ( ), https://tc39.es/ecma262/#sec-set.prototype.values
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::values)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
 
@@ -140,7 +128,7 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::values)
 // 24.2.3.9 get Set.prototype.size, https://tc39.es/ecma262/#sec-get-set.prototype.size
 JS_DEFINE_NATIVE_GETTER(SetPrototype::size_getter)
 {
-    auto* set = typed_this(vm, global_object);
+    auto* set = typed_this_object(global_object);
     if (!set)
         return {};
     return Value(set->values().size());

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <LibJS/Runtime/PrototypeObject.h>
 #include <LibJS/Runtime/Set.h>
 
 namespace JS {
 
-class SetPrototype final : public Object {
-    JS_OBJECT(SetPrototype, Object);
+class SetPrototype final : public PrototypeObject<SetPrototype, Set> {
+    JS_PROTOTYPE_OBJECT(SetPrototype, Set, Set);
 
 public:
     SetPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -9,13 +9,12 @@
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/IteratorOperations.h>
-#include <LibJS/Runtime/StringIterator.h>
 #include <LibJS/Runtime/StringIteratorPrototype.h>
 
 namespace JS {
 
 StringIteratorPrototype::StringIteratorPrototype(GlobalObject& global_object)
-    : Object(*global_object.iterator_prototype())
+    : PrototypeObject(*global_object.iterator_prototype())
 {
 }
 
@@ -36,21 +35,17 @@ StringIteratorPrototype::~StringIteratorPrototype()
 // 22.1.5.1.1 %StringIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%stringiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(StringIteratorPrototype::next)
 {
-    auto this_value = vm.this_value(global_object);
-    if (!this_value.is_object() || !is<StringIterator>(this_value.as_object())) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "String Iterator");
+    auto* iterator = typed_this_value(global_object);
+    if (vm.exception())
         return {};
-    }
 
-    auto& this_object = this_value.as_object();
-    auto& iterator = static_cast<StringIterator&>(this_object);
-    if (iterator.done())
+    if (iterator->done())
         return create_iterator_result_object(global_object, js_undefined(), true);
 
-    auto& utf8_iterator = iterator.iterator();
+    auto& utf8_iterator = iterator->iterator();
 
     if (utf8_iterator.done()) {
-        iterator.m_done = true;
+        iterator->m_done = true;
         return create_iterator_result_object(global_object, js_undefined(), true);
     }
 

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
@@ -7,11 +7,13 @@
 #pragma once
 
 #include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/StringIterator.h>
 
 namespace JS {
 
-class StringIteratorPrototype final : public Object {
-    JS_OBJECT(StringIteratorPrototype, Object)
+class StringIteratorPrototype final : public PrototypeObject<StringIteratorPrototype, StringIterator> {
+    JS_PROTOTYPE_OBJECT(StringIteratorPrototype, StringIterator, StringIterator);
 
 public:
     StringIteratorPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 WeakMapPrototype::WeakMapPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -34,22 +34,10 @@ WeakMapPrototype::~WeakMapPrototype()
 {
 }
 
-WeakMap* WeakMapPrototype::typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<WeakMap>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "WeakMap");
-        return nullptr;
-    }
-    return static_cast<WeakMap*>(this_object);
-}
-
 // 24.3.3.2 WeakMap.prototype.delete ( key ), https://tc39.es/ecma262/#sec-weakmap.prototype.delete
 JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::delete_)
 {
-    auto* weak_map = typed_this(vm, global_object);
+    auto* weak_map = typed_this_object(global_object);
     if (!weak_map)
         return {};
     auto value = vm.argument(0);
@@ -61,7 +49,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::delete_)
 // 24.3.3.3 WeakMap.prototype.get ( key ), https://tc39.es/ecma262/#sec-weakmap.prototype.get
 JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::get)
 {
-    auto* weak_map = typed_this(vm, global_object);
+    auto* weak_map = typed_this_object(global_object);
     if (!weak_map)
         return {};
     auto value = vm.argument(0);
@@ -77,7 +65,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::get)
 // 24.3.3.4 WeakMap.prototype.has ( key ), https://tc39.es/ecma262/#sec-weakmap.prototype.has
 JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::has)
 {
-    auto* weak_map = typed_this(vm, global_object);
+    auto* weak_map = typed_this_object(global_object);
     if (!weak_map)
         return {};
     auto value = vm.argument(0);
@@ -90,7 +78,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::has)
 // 24.3.3.5 WeakMap.prototype.set ( key, value ), https://tc39.es/ecma262/#sec-weakmap.prototype.set
 JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::set)
 {
-    auto* weak_map = typed_this(vm, global_object);
+    auto* weak_map = typed_this_object(global_object);
     if (!weak_map)
         return {};
     auto value = vm.argument(0);

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <LibJS/Runtime/PrototypeObject.h>
 #include <LibJS/Runtime/WeakMap.h>
 
 namespace JS {
 
-class WeakMapPrototype final : public Object {
-    JS_OBJECT(WeakMapPrototype, Object);
+class WeakMapPrototype final : public PrototypeObject<WeakMapPrototype, WeakMap> {
+    JS_PROTOTYPE_OBJECT(WeakMapPrototype, WeakMap, WeakMap);
 
 public:
     WeakMapPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -10,7 +10,7 @@
 namespace JS {
 
 WeakRefPrototype::WeakRefPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -31,16 +31,12 @@ WeakRefPrototype::~WeakRefPrototype()
 // 26.1.3.2 WeakRef.prototype.deref ( ), https://tc39.es/ecma262/#sec-weak-ref.prototype.deref
 JS_DEFINE_NATIVE_FUNCTION(WeakRefPrototype::deref)
 {
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
+    auto* weak_ref = typed_this_object(global_object);
+    if (vm.exception())
         return {};
-    if (!is<WeakRef>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "WeakRef");
-        return {};
-    }
-    auto& weak_ref = static_cast<WeakRef&>(*this_object);
-    weak_ref.update_execution_generation();
-    return weak_ref.value() ?: js_undefined();
+
+    weak_ref->update_execution_generation();
+    return weak_ref->value() ?: js_undefined();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <LibJS/Runtime/PrototypeObject.h>
 #include <LibJS/Runtime/WeakRef.h>
 
 namespace JS {
 
-class WeakRefPrototype final : public Object {
-    JS_OBJECT(WeakRefPrototype, Object);
+class WeakRefPrototype final : public PrototypeObject<WeakRefPrototype, WeakRef> {
+    JS_PROTOTYPE_OBJECT(WeakRefPrototype, WeakRef, WeakRef);
 
 public:
     WeakRefPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 WeakSetPrototype::WeakSetPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -33,22 +33,10 @@ WeakSetPrototype::~WeakSetPrototype()
 {
 }
 
-WeakSet* WeakSetPrototype::typed_this(VM& vm, GlobalObject& global_object)
-{
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<WeakSet>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "WeakSet");
-        return nullptr;
-    }
-    return static_cast<WeakSet*>(this_object);
-}
-
 // 24.4.3.1 WeakSet.prototype.add ( value ), https://tc39.es/ecma262/#sec-weakset.prototype.add
 JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::add)
 {
-    auto* weak_set = typed_this(vm, global_object);
+    auto* weak_set = typed_this_object(global_object);
     if (!weak_set)
         return {};
     auto value = vm.argument(0);
@@ -63,7 +51,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::add)
 // 24.4.3.3 WeakSet.prototype.delete ( value ), https://tc39.es/ecma262/#sec-weakset.prototype.delete
 JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::delete_)
 {
-    auto* weak_set = typed_this(vm, global_object);
+    auto* weak_set = typed_this_object(global_object);
     if (!weak_set)
         return {};
     auto value = vm.argument(0);
@@ -75,7 +63,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::delete_)
 // 24.4.3.4 WeakSet.prototype.has ( value ), https://tc39.es/ecma262/#sec-weakset.prototype.has
 JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::has)
 {
-    auto* weak_set = typed_this(vm, global_object);
+    auto* weak_set = typed_this_object(global_object);
     if (!weak_set)
         return {};
     auto value = vm.argument(0);

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <LibJS/Runtime/PrototypeObject.h>
 #include <LibJS/Runtime/WeakSet.h>
 
 namespace JS {
 
-class WeakSetPrototype final : public Object {
-    JS_OBJECT(WeakSetPrototype, Object);
+class WeakSetPrototype final : public PrototypeObject<WeakSetPrototype, WeakSet> {
+    JS_PROTOTYPE_OBJECT(WeakSetPrototype, WeakSet, WeakSet);
 
 public:
     WeakSetPrototype(GlobalObject&);


### PR DESCRIPTION
Almost every JS prototype class defines a static `typed_this` helper to return the current `this` value as the analogous object type. This adds a `PrototypeObject` class to be inserted between the prototype object and the base `Object` class to define these methods on the prototype's behalf.

This converts most prototype objects directly under Userland/Libraries/LibJS/Runtime to this new hierarchy. Notably, it excludes subdirectories (Temporal, Intl), prototypes that have spec-specific variants of `typed_this`, and prototypes that have fast-path type checks (e.g. `is_function`).