### PR TITLE
PixelPaint: Several fixes, some code cleanup

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -44,4 +44,4 @@ set(SOURCES
 )
 
 serenity_app(PixelPaint ICON app-pixel-paint)
-target_link_libraries(PixelPaint LibImageDecoderClient LibGUI LibGfx LibFileSystemAccessClient)
+target_link_libraries(PixelPaint LibImageDecoderClient LibGUI LibGfx LibFileSystemAccessClient LibConfig)

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -12,6 +12,7 @@
 #include "Layer.h"
 #include "MoveTool.h"
 #include "Tool.h"
+#include <LibConfig/Client.h>
 #include <LibGUI/Command.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/DisjointRectSet.h>
@@ -29,6 +30,7 @@ ImageEditor::ImageEditor(NonnullRefPtr<Image> image)
     m_undo_stack = make<GUI::UndoStack>();
     m_undo_stack->push(make<ImageUndoCommand>(*m_image));
     m_image->add_client(*this);
+    m_pixel_grid_threshold = (float)Config::read_i32("PixelPaint", "PixelGrid", "Threshold", 15);
 }
 
 ImageEditor::~ImageEditor()
@@ -86,8 +88,7 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
         painter.draw_rect(enclosing_int_rect(image_rect_to_editor_rect(m_active_layer->relative_rect())).inflated(2, 2), Color::Black);
     }
 
-    const float pixel_grid_threshold = 15.0f;
-    if (m_show_pixel_grid && m_scale > pixel_grid_threshold) {
+    if (m_show_pixel_grid && m_scale > m_pixel_grid_threshold) {
         auto event_image_rect = enclosing_int_rect(editor_rect_to_image_rect(event.rect())).inflated(1, 1);
         auto image_rect = m_image->rect().inflated(1, 1).intersected(event_image_rect);
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -562,13 +562,27 @@ void ImageEditor::scale_by(float scale_delta)
 
 void ImageEditor::fit_image_to_view()
 {
+    auto viewport_rect = rect();
+    m_pan_origin = Gfx::FloatPoint(0, 0);
+
+    if (m_show_rulers) {
+        viewport_rect = {
+            viewport_rect.x() + m_ruler_thickness,
+            viewport_rect.y() + m_ruler_thickness,
+            viewport_rect.width() - m_ruler_thickness,
+            viewport_rect.height() - m_ruler_thickness
+        };
+    }
+
     const float border_ratio = 0.95f;
     auto image_size = image().size();
-    auto height_ratio = rect().height() / (float)image_size.height();
-    auto width_ratio = rect().width() / (float)image_size.width();
+    auto height_ratio = viewport_rect.height() / (float)image_size.height();
+    auto width_ratio = viewport_rect.width() / (float)image_size.width();
     m_scale = border_ratio * min(height_ratio, width_ratio);
 
-    m_pan_origin = Gfx::FloatPoint(0, 0);
+    float offset = m_show_rulers ? -m_ruler_thickness / (m_scale * 2.0f) : 0.0f;
+    m_pan_origin = Gfx::FloatPoint(offset, offset);
+
     relayout();
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -88,8 +88,8 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
 
     const float pixel_grid_threshold = 15.0f;
     if (m_show_pixel_grid && m_scale > pixel_grid_threshold) {
-        auto grid_rect = m_editor_image_rect.intersected(event.rect());
-        auto image_rect = enclosing_int_rect(editor_rect_to_image_rect(grid_rect)).inflated(1, 1);
+        auto event_image_rect = enclosing_int_rect(editor_rect_to_image_rect(event.rect())).inflated(1, 1);
+        auto image_rect = m_image->rect().inflated(1, 1).intersected(event_image_rect);
 
         for (auto i = image_rect.left(); i < image_rect.right(); i++) {
             auto start_point = image_position_to_editor_position({ i, image_rect.top() }).to_type<int>();

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -157,6 +157,8 @@ private:
     int m_ruler_thickness { 20 };
     int m_mouse_indicator_triangle_size { 5 };
 
+    float m_pixel_grid_threshold { 15.0f };
+
     Gfx::StandardCursor m_active_cursor { Gfx::StandardCursor::None };
 
     Selection m_selection;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -812,6 +812,7 @@ ImageEditor& MainWidget::create_new_editor(NonnullRefPtr<Image> image)
 
     m_tab_widget->set_active_widget(&image_editor);
     image_editor.set_focus(true);
+    image_editor.fit_image_to_view();
     return image_editor;
 }
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -719,18 +719,6 @@ void MainWidget::open_image_fd(int fd, String const& path)
     m_layer_list_widget->set_image(&image);
 }
 
-void MainWidget::open_image_file(String const& path)
-{
-    auto try_load = m_loader.try_load_from_path(path);
-    if (try_load.is_error()) {
-        GUI::MessageBox::show_error(window(), String::formatted("Unable to open file: {}", path));
-        return;
-    }
-    auto& image = *m_loader.release_image();
-    create_new_editor(image);
-    m_layer_list_widget->set_image(&image);
-}
-
 void MainWidget::create_default_image()
 {
     auto image = Image::try_create_with_size({ 480, 360 });

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -34,7 +34,6 @@ public:
     void initialize_menubar(GUI::Window&);
 
     void open_image_fd(int fd, String const& path);
-    void open_image_file(String const& path);
     void create_default_image();
 
 private:

--- a/Userland/Applications/PixelPaint/ProjectLoader.cpp
+++ b/Userland/Applications/PixelPaint/ProjectLoader.cpp
@@ -63,13 +63,5 @@ Result<void, String> ProjectLoader::try_load_from_fd_and_close(int fd, StringVie
     m_image = image;
     return {};
 }
-Result<void, String> ProjectLoader::try_load_from_path(StringView path)
-{
-    auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
-    if (file_or_error.is_error())
-        return String::formatted("Unable to open file because: {}", file_or_error.release_error());
-
-    return try_load_from_fd_and_close(file_or_error.release_value()->leak_fd(), path);
-}
 
 }

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -19,7 +19,6 @@ public:
     ~ProjectLoader() = default;
 
     Result<void, String> try_load_from_fd_and_close(int fd, StringView path);
-    Result<void, String> try_load_from_path(StringView path);
 
     bool is_raw_image() const { return m_is_raw_image; }
     bool has_image() const { return !m_image.is_null(); }

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "MainWidget.h"
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
@@ -26,6 +27,7 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
+    Config::pledge_domains("PixelPaint");
 
     const char* image_file = nullptr;
     Core::ArgsParser args_parser;


### PR DESCRIPTION
These 2 bugs are fixed:
- Drawing pixel grid outside image bounds (#9971)
- `Fit Image To View` action not working properly with rulers

Cleanup:
- Use FileSystemAccessServer exclusively now, remove unused methods 
- Use LibConfig to read in the pixel grid threshold as opposed to hardcoding it

Misc:
- Resize image to fit view on opening (I think this is a good default)

Fixes #9971