### PR TITLE
ThemeEditor(+LibGfx): Open files from an argument, the Menu action, and by dropping a file

### DIFF
--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -97,6 +97,16 @@ void PreviewWidget::set_preview_palette(const Gfx::Palette& palette)
     update();
 }
 
+void PreviewWidget::set_theme_from_file(String const& path, int fd)
+{
+    auto file = Core::ConfigFile::open(path, fd);
+    auto theme = Gfx::load_system_theme(file);
+    VERIFY(theme.is_valid());
+
+    m_preview_palette = Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(theme));
+    set_preview_palette(m_preview_palette);
+}
+
 void PreviewWidget::paint_event(GUI::PaintEvent& event)
 {
     GUI::Frame::paint_event(event);

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -105,6 +105,8 @@ void PreviewWidget::set_theme_from_file(String const& path, int fd)
 
     m_preview_palette = Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(theme));
     set_preview_palette(m_preview_palette);
+    if (on_theme_load_from_file)
+        on_theme_load_from_file(path);
 }
 
 void PreviewWidget::paint_event(GUI::PaintEvent& event)

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -23,6 +23,8 @@ public:
     void set_preview_palette(const Gfx::Palette&);
     void set_theme_from_file(String const& path, int fd);
 
+    Function<void(String const&)> on_theme_load_from_file;
+
 private:
     explicit PreviewWidget(const Gfx::Palette&);
 

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -30,6 +30,7 @@ private:
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void drop_event(GUI::DropEvent&) override;
 
     Gfx::Palette m_preview_palette;
 

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -21,6 +21,7 @@ public:
 
     const Gfx::Palette& preview_palette() const { return m_preview_palette; }
     void set_preview_palette(const Gfx::Palette&);
+    void set_theme_from_file(String const& path, int fd);
 
 private:
     explicit PreviewWidget(const Gfx::Palette&);

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
 
     auto app_icon = GUI::Icon::default_icon("app-theme-editor");
 
-    Gfx::Palette preview_palette = file_to_edit ? Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(Gfx::load_system_theme(*path))) : app->palette();
+    Gfx::Palette startup_preview_palette = file_to_edit ? Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(Gfx::load_system_theme(*path))) : app->palette();
 
     auto window = GUI::Window::construct();
 
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::VerticalBoxLayout>();
 
-    auto& preview_widget = main_widget.add<ThemeEditor::PreviewWidget>(preview_palette);
+    auto& preview_widget = main_widget.add<ThemeEditor::PreviewWidget>(startup_preview_palette);
     preview_widget.set_fixed_size(480, 360);
 
     auto& horizontal_container = main_widget.add<GUI::Widget>();
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
         preview_palette.set_color(role, color_input.color());
         preview_widget.set_preview_palette(preview_palette);
     };
-    color_input.set_color(preview_palette.color(Gfx::ColorRole::Window));
+    color_input.set_color(startup_preview_palette.color(Gfx::ColorRole::Window));
 
     auto& file_menu = window->add_menu("&File");
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
 
     Optional<String> path = {};
 
-    auto save_to_result = [&](FileSystemAccessClient::Result result) {
+    auto save_to_result = [&](FileSystemAccessClient::Result const& result) {
         if (result.error != 0)
             return;
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -130,6 +130,10 @@ int main(int argc, char** argv)
 
     auto& file_menu = window->add_menu("&File");
 
+    preview_widget.on_theme_load_from_file = [&](String const& new_path) {
+        path = new_path;
+    };
+
     auto save_to_result = [&](FileSystemAccessClient::Result const& result) {
         if (result.error != 0)
             return;

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -143,6 +143,14 @@ int main(int argc, char** argv)
         theme->sync();
     };
 
+    file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
+        auto result = FileSystemAccessClient::Client::the().open_file(window->window_id(), "Select theme file", "/res/themes");
+        if (result.error != 0)
+            return;
+
+        preview_widget.set_theme_from_file(*result.chosen_file, *result.fd);
+    }));
+
     file_menu.add_action(GUI::CommonActions::make_save_action([&](auto&) {
         if (path.has_value()) {
             save_to_result(FileSystemAccessClient::Client::the().request_file(window->window_id(), *path, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate));

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -115,13 +115,14 @@ int main(int argc, char** argv)
     combo_box.set_model(adopt_ref(*new ColorRoleModel(color_roles)));
     combo_box.on_change = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_color_role();
-        color_input.set_color(preview_palette.color(role));
+        color_input.set_color(preview_widget.preview_palette().color(role));
     };
 
     combo_box.set_selected_index((size_t)Gfx::ColorRole::Window - 1);
 
     color_input.on_change = [&] {
         auto role = combo_box.model()->index(combo_box.selected_index()).data(GUI::ModelRole::Custom).to_color_role();
+        auto preview_palette = preview_widget.preview_palette();
         preview_palette.set_color(role, color_input.color());
         preview_widget.set_preview_palette(preview_palette);
     };
@@ -137,7 +138,7 @@ int main(int argc, char** argv)
 
         auto theme = Core::ConfigFile::open(*result.chosen_file, *result.fd);
         for (auto role : color_roles) {
-            theme->write_entry("Colors", to_string(role), preview_palette.color(role).to_string());
+            theme->write_entry("Colors", to_string(role), preview_widget.preview_palette().color(role).to_string());
         }
 
         theme->sync();

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -26,15 +26,14 @@ void set_system_theme(Core::AnonymousBuffer buffer)
     theme_page = theme_buffer.data<SystemTheme>();
 }
 
-Core::AnonymousBuffer load_system_theme(const String& path)
+Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
 {
-    auto file = Core::ConfigFile::open(path);
     auto buffer = Core::AnonymousBuffer::create_with_size(sizeof(SystemTheme));
 
     auto* data = buffer.data<SystemTheme>();
 
     auto get_color = [&](auto& name) {
-        auto color_string = file->read_entry("Colors", name);
+        auto color_string = file.read_entry("Colors", name);
         auto color = Color::from_string(color_string);
         if (!color.has_value())
             return Color(Color::Black);
@@ -42,7 +41,7 @@ Core::AnonymousBuffer load_system_theme(const String& path)
     };
 
     auto get_metric = [&](auto& name, auto role) {
-        int metric = file->read_num_entry("Metrics", name, -1);
+        int metric = file.read_num_entry("Metrics", name, -1);
         if (metric == -1) {
             switch (role) {
             case (int)MetricRole::TitleHeight:
@@ -60,7 +59,7 @@ Core::AnonymousBuffer load_system_theme(const String& path)
     };
 
     auto get_path = [&](auto& name, auto role, bool allow_empty) {
-        auto path = file->read_entry("Paths", name);
+        auto path = file.read_entry("Paths", name);
         if (path.is_empty()) {
             switch (role) {
             case (int)PathRole::TitleButtonIcons:
@@ -100,6 +99,11 @@ Core::AnonymousBuffer load_system_theme(const String& path)
     DO_PATH(TooltipShadow, true);
 
     return buffer;
+}
+
+Core::AnonymousBuffer load_system_theme(String const& path)
+{
+    return load_system_theme(Core::ConfigFile::open(path));
 }
 
 }

--- a/Userland/Libraries/LibGfx/SystemTheme.h
+++ b/Userland/Libraries/LibGfx/SystemTheme.h
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/ConfigFile.h>
 #include <LibGfx/Color.h>
 
 namespace Gfx {
@@ -145,7 +146,8 @@ struct SystemTheme {
 
 Core::AnonymousBuffer& current_system_theme_buffer();
 void set_system_theme(Core::AnonymousBuffer);
-Core::AnonymousBuffer load_system_theme(const String& path);
+Core::AnonymousBuffer load_system_theme(Core::ConfigFile const&);
+Core::AnonymousBuffer load_system_theme(String const& path);
 
 }
 


### PR DESCRIPTION
This PR is a bit big, so I split them here into small sections.

---

Preparation:
- **ThemeEditor: Create menu contents after creating widgets**
  My next commits will be more readable that way. :^)
- **ThemeEditor: Reference `FileSystemAccessClient::Result` in `save_to_result`**
  Found by clazy. It says the size is 32 bytes.

Open from an argument:
- **ThemeEditor: Open files from an argument**
  This commit allows you to open a theme file from an argument, i.e. `ThemeEditor Theme.ini`.

Menu action:
- **LibGfx: Add `SystemTheme::load_system_theme(Core::ConfigFile const&)`**
  This makes loading system themes possible via `FileSystemAccessClient` (needed for the Theme Editor). :^)
- **ThemeEditor: Add 'Open file' menu action**

Menu action fixes:
- **ThemeEditor: Use `preview_palette` from the `PreviewWidget`**
  Prior this change, when you opened a file using the brand new Open action and tried to change the Color Role or save it, then it would just go back to the startup palette.
- **ThemeEditor: Rename main()'s `preview_palette` to `startup_preview_palette`**
  This is to avoid ambiguity from the preview_widget.preview_palette().
- **ThemeEditor: Update theme path on theme load**
  Prior to this change, the 'Save' action was saving a file to the startup path (or just showed a File Picker dialog) if a file has been opened by the Open action or by drag-n-dropping a file to the program.

File drops:
  - **ThemeEditor: Accept drop events**

