### PR TITLE
PixelPaint: Allow panning when right-clicking with MoveTool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -568,6 +568,15 @@ void ImageEditor::scale_by(float scale_delta)
     }
 }
 
+void ImageEditor::set_pan_origin(Gfx::FloatPoint const& pan_origin)
+{
+    if (m_pan_origin == pan_origin)
+        return;
+
+    m_pan_origin = pan_origin;
+    relayout();
+}
+
 void ImageEditor::fit_image_to_view()
 {
     auto viewport_rect = rect();

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -58,6 +58,9 @@ public:
     void reset_scale_and_position();
     void scale_by(float);
 
+    void set_pan_origin(Gfx::FloatPoint const&);
+    Gfx::FloatPoint pan_origin() const { return m_pan_origin; }
+
     Color primary_color() const { return m_primary_color; }
     void set_primary_color(Color);
 

--- a/Userland/Applications/PixelPaint/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/MoveTool.cpp
@@ -25,6 +25,14 @@ MoveTool::~MoveTool()
 
 void MoveTool::on_mousedown(Layer* layer, MouseEvent& event)
 {
+    if (event.image_event().button() == GUI::MouseButton::Right && !m_is_panning) {
+        m_is_panning = true;
+        m_event_origin = event.raw_event().position();
+        m_saved_pan_origin = m_editor->pan_origin();
+        m_editor->set_override_cursor(Gfx::StandardCursor::Drag);
+        return;
+    }
+
     if (!layer)
         return;
 
@@ -41,6 +49,15 @@ void MoveTool::on_mousedown(Layer* layer, MouseEvent& event)
 
 void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
 {
+    if (m_is_panning) {
+        auto& raw_event = event.raw_event();
+        auto delta = raw_event.position() - m_event_origin;
+        m_editor->set_pan_origin(m_saved_pan_origin.translated(
+            -delta.x(),
+            -delta.y()));
+        return;
+    }
+
     if (!layer)
         return;
 
@@ -54,6 +71,12 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
 
 void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
 {
+    if (event.image_event().button() == GUI::MouseButton::Right && m_is_panning) {
+        m_is_panning = false;
+        m_editor->set_override_cursor(cursor());
+        return;
+    }
+
     if (!layer)
         return;
 

--- a/Userland/Applications/PixelPaint/MoveTool.h
+++ b/Userland/Applications/PixelPaint/MoveTool.h
@@ -25,6 +25,9 @@ private:
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
+
+    bool m_is_panning { false };
+    Gfx::FloatPoint m_saved_pan_origin;
 };
 
 }


### PR DESCRIPTION
I don't know if this is the best solution - but currently if you're on a laptop and don't have an external mouse, it's not really possible to pan around in PixelPaint. This combined with issue 9900 means that it's incredibly difficult to zoom into a particular region that you want to, so this is a compromise to fix that.

Ideally we should implement something along the lines of #9693 , but I'm not sure if the author of that intends to complete it themself anytime soon, and in any case the current implementation proposed there conflicts with some of the shortcuts used in moving around selections.