### PR TITLE
PixelPaint: Start persisting settings across runs

### DIFF
--- a/Base/home/anon/.config/PixelPaint.ini
+++ b/Base/home/anon/.config/PixelPaint.ini
@@ -1,0 +1,9 @@
+[PixelGrid]
+Threshold=15
+Show=1
+
+[Rulers]
+Show=1
+
+[Guides]
+Show=1

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -30,7 +30,12 @@ ImageEditor::ImageEditor(NonnullRefPtr<Image> image)
     m_undo_stack = make<GUI::UndoStack>();
     m_undo_stack->push(make<ImageUndoCommand>(*m_image));
     m_image->add_client(*this);
+
     m_pixel_grid_threshold = (float)Config::read_i32("PixelPaint", "PixelGrid", "Threshold", 15);
+    m_show_pixel_grid = Config::read_bool("PixelPaint", "PixelGrid", "Show", true);
+
+    m_show_rulers = Config::read_bool("PixelPaint", "Rulers", "Show", true);
+    m_show_guides = Config::read_bool("PixelPaint", "Guides", "Show", true);
 }
 
 ImageEditor::~ImageEditor()

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -12,6 +12,7 @@
 #include "EditGuideDialog.h"
 #include "FilterParams.h"
 #include <Applications/PixelPaint/PixelPaintWindowGML.h>
+#include <LibConfig/Client.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibFileSystemAccessClient/Client.h>
@@ -339,7 +340,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 editor->set_guide_visibility(action.is_checked());
             }
         });
-    m_show_guides_action->set_checked(true);
+    m_show_guides_action->set_checked(Config::read_bool("PixelPaint", "Guides", "Show", true));
 
     view_menu.add_action(*m_zoom_in_action);
     view_menu.add_action(*m_zoom_out_action);
@@ -365,7 +366,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             if (auto* editor = current_image_editor())
                 editor->set_pixel_grid_visibility(action.is_checked());
         });
-    show_pixel_grid_action->set_checked(true);
+    show_pixel_grid_action->set_checked(Config::read_bool("PixelPaint", "PixelGrid", "Show", true));
     view_menu.add_action(*show_pixel_grid_action);
 
     m_show_rulers_action = GUI::Action::create_checkable(
@@ -374,7 +375,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 editor->set_ruler_visibility(action.is_checked());
             }
         });
-    m_show_rulers_action->set_checked(true);
+    m_show_rulers_action->set_checked(Config::read_bool("PixelPaint", "Rulers", "Show", true));
     view_menu.add_action(*m_show_rulers_action);
 
     auto& tool_menu = window.add_menu("&Tool");

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -336,6 +336,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     // Save this so other methods can use it
     m_show_guides_action = GUI::Action::create_checkable(
         "Show Guides", [&](auto& action) {
+            Config::write_bool("PixelPaint", "Guides", "Show", action.is_checked());
             if (auto* editor = current_image_editor()) {
                 editor->set_guide_visibility(action.is_checked());
             }
@@ -363,6 +364,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     auto show_pixel_grid_action = GUI::Action::create_checkable(
         "Show Pixel Grid", [&](auto& action) {
+            Config::write_bool("PixelPaint", "PixelGrid", "Show", action.is_checked());
             if (auto* editor = current_image_editor())
                 editor->set_pixel_grid_visibility(action.is_checked());
         });
@@ -371,6 +373,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     m_show_rulers_action = GUI::Action::create_checkable(
         "Show Rulers", { Mod_Ctrl, Key_R }, [&](auto& action) {
+            Config::write_bool("PixelPaint", "Rulers", "Show", action.is_checked());
             if (auto* editor = current_image_editor()) {
                 editor->set_ruler_visibility(action.is_checked());
             }


### PR DESCRIPTION
I feel like an underrated but important part of the experience of using an application is having it remember the settings you made so that you don't have to enable / disable / re-select the features you want every time you start it. This PR starts persisting some basic settings that one might want not want by default (for now, Show Guides/Rulers/Pixel Grid).

It uses LibConfig to read the default values, and then on changes to these it writes them back, so they persistent across runs / on creating new images. I think that in the future it would also be nice to be storing last selected brush sizes / etc (but perhaps with some way to debounce them as they might change much more frequently).