### PR TITLE
AK: Remove unimplemented method `fill_buffer` on `UUID`

### DIFF
--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -32,7 +32,6 @@ public:
 
 private:
     void convert_string_view_to_uuid(const StringView&);
-    void fill_buffer(ByteBuffer);
 
     Array<u8, 16> m_uuid_buffer {};
 };


### PR DESCRIPTION
This method was unused (and unimplemented!), so I've removed it.

In place of it, I've added a getter to return a const reference to the backing array. This getter is not used in Serenity code (which is discouraged as dead code), but I feel it is much more useful than what I removed. I will admit this getter has a personal use for one of my projects using Lagom.