### PR TITLE
LibWeb: Make window.event [Replaceable] and a minimal React example work (again)

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/Replaceable.h
+++ b/Userland/Libraries/LibWeb/Bindings/Replaceable.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define REPLACEABLE_PROPERTY_SETTER(ObjectType, property)                                                                                 \
+    auto this_value = vm.this_value(global_object);                                                                                       \
+    if (!this_value.is_object() || !is<ObjectType>(this_value.as_object())) {                                                             \
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, #ObjectType);                                  \
+        return {};                                                                                                                        \
+    }                                                                                                                                     \
+    this_value.as_object().internal_define_own_property(#property, JS::PropertyDescriptor { .value = vm.argument(0), .writable = true }); \
+    return JS::js_undefined();

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Bindings/NavigatorObject.h>
 #include <LibWeb/Bindings/NodeWrapperFactory.h>
 #include <LibWeb/Bindings/PerformanceWrapper.h>
+#include <LibWeb/Bindings/Replaceable.h>
 #include <LibWeb/Bindings/ScreenWrapper.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/DOM/Document.h>
@@ -89,7 +90,7 @@ void WindowObject::initialize_global_object()
     define_native_function("scrollBy", scroll_by, 2, attr);
 
     // Legacy
-    define_native_accessor("event", event_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("event", event_getter, event_setter, JS::Attribute::Enumerable);
 
     define_direct_property("navigator", heap().allocate<NavigatorObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
     define_direct_property("location", heap().allocate<LocationObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
@@ -437,6 +438,11 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::event_getter)
     if (!impl->current_event())
         return JS::js_undefined();
     return wrap(global_object, const_cast<DOM::Event&>(*impl->current_event()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::event_setter)
+{
+    REPLACEABLE_PROPERTY_SETTER(WindowObject, event);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(WindowObject::inner_width_getter)

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -68,6 +68,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(screen_getter);
 
     JS_DECLARE_NATIVE_FUNCTION(event_getter);
+    JS_DECLARE_NATIVE_FUNCTION(event_setter);
 
     JS_DECLARE_NATIVE_FUNCTION(inner_width_getter);
     JS_DECLARE_NATIVE_FUNCTION(inner_height_getter);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19366641/132987035-85a0f4f7-6f9b-42a0-b75d-8f2952476084.png)

---

The aftermath:

```
$ grep console.log react-dom.development.js | wc -l
96
```