### PR TITLE
LibWeb: Log the lifetime of each call to the ResourceLoader  

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -165,6 +165,16 @@ public:
         return list;
     }
 
+    [[nodiscard]] u32 hash() const
+    {
+        u32 hash = 0;
+        for (auto& it : *this) {
+            auto entry_hash = pair_int_hash(it.key.hash(), it.value.hash());
+            hash = pair_int_hash(hash, entry_hash);
+        }
+        return hash;
+    }
+
 private:
     HashTableType m_table;
 };

--- a/Userland/Libraries/LibCore/ElapsedTimer.cpp
+++ b/Userland/Libraries/LibCore/ElapsedTimer.cpp
@@ -34,4 +34,9 @@ int ElapsedTimer::elapsed() const
     return diff.tv_sec * 1000 + diff.tv_usec / 1000;
 }
 
+Time ElapsedTimer::elapsed_time() const
+{
+    return Time::from_milliseconds(elapsed());
+}
+
 }

--- a/Userland/Libraries/LibCore/ElapsedTimer.h
+++ b/Userland/Libraries/LibCore/ElapsedTimer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Time.h>
 #include <sys/time.h>
 
 namespace Core {
@@ -20,6 +21,7 @@ public:
     bool is_valid() const { return m_valid; }
     void start();
     int elapsed() const;
+    Time elapsed_time() const;
 
     const struct timeval& origin_time() const { return m_origin_time; }
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -137,7 +137,7 @@ bool FrameLoader::parse_document(DOM::Document& document, const ByteBuffer& data
     return false;
 }
 
-bool FrameLoader::load(const LoadRequest& request, Type type)
+bool FrameLoader::load(LoadRequest& request, Type type)
 {
     if (!request.is_valid()) {
         load_error_page(request.url(), "Invalid request");

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -27,7 +27,7 @@ public:
     ~FrameLoader();
 
     bool load(const URL&, Type);
-    bool load(const LoadRequest&, Type);
+    bool load(LoadRequest&, Type);
 
     void load_html(const StringView&, const URL&);
 

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.h
@@ -8,7 +8,9 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/HashMap.h>
+#include <AK/Time.h>
 #include <AK/URL.h>
+#include <LibCore/ElapsedTimer.h>
 #include <LibWeb/Forward.h>
 
 namespace Web {
@@ -31,6 +33,9 @@ public:
 
     const ByteBuffer& body() const { return m_body; }
     void set_body(const ByteBuffer& body) { m_body = body; }
+
+    void start_timer() { m_load_timer.start(); };
+    Time load_time() const { return m_load_timer.elapsed_time(); }
 
     unsigned hash() const
     {
@@ -64,6 +69,7 @@ private:
     String m_method { "GET" };
     HashMap<String, String> m_headers;
     ByteBuffer m_body;
+    Core::ElapsedTimer m_load_timer;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.h
@@ -34,8 +34,10 @@ public:
 
     unsigned hash() const
     {
-        // FIXME: Include headers in the hash as well
-        return pair_int_hash(pair_int_hash(m_url.to_string().hash(), m_method.hash()), string_hash((const char*)m_body.data(), m_body.size()));
+        auto body_hash = string_hash((const char*)m_body.data(), m_body.size());
+        auto body_and_headers_hash = pair_int_hash(body_hash, m_headers.hash());
+        auto url_and_method_hash = pair_int_hash(m_url.to_string().hash(), m_method.hash());
+        return pair_int_hash(body_and_headers_hash, url_and_method_hash);
     }
 
     bool operator==(const LoadRequest& other) const

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -7,6 +7,7 @@
 #include <AK/Base64.h>
 #include <AK/Debug.h>
 #include <AK/JsonObject.h>
+#include <LibCore/ElapsedTimer.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibProtocol/Request.h>
@@ -32,7 +33,7 @@ ResourceLoader::ResourceLoader()
 {
 }
 
-void ResourceLoader::load_sync(const LoadRequest& request, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback)
+void ResourceLoader::load_sync(LoadRequest& request, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback)
 {
     Core::EventLoop loop;
 
@@ -53,7 +54,7 @@ void ResourceLoader::load_sync(const LoadRequest& request, Function<void(Readonl
 
 static HashMap<LoadRequest, NonnullRefPtr<Resource>> s_resource_cache;
 
-RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, const LoadRequest& request)
+RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, LoadRequest& request)
 {
     if (!request.is_valid())
         return nullptr;
@@ -92,6 +93,7 @@ RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, const LoadRe
 void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback)
 {
     auto& url = request.url();
+    request.start_timer();
 
     if (is_port_blocked(url.port())) {
         dbgln("ResourceLoader::load: Error: blocked port {} from URL {}", url.port(), url);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -30,11 +30,11 @@ class ResourceLoader : public Core::Object {
 public:
     static ResourceLoader& the();
 
-    RefPtr<Resource> load_resource(Resource::Type, const LoadRequest&);
+    RefPtr<Resource> load_resource(Resource::Type, LoadRequest&);
 
-    void load(const LoadRequest&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback = nullptr);
+    void load(LoadRequest&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback = nullptr);
     void load(const URL&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback = nullptr);
-    void load_sync(const LoadRequest&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback = nullptr);
+    void load_sync(LoadRequest&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> success_callback, Function<void(const String&, Optional<u32> status_code)> error_callback = nullptr);
 
     Function<void()> on_load_counter_change;
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -36,7 +36,7 @@ void Page::load(const URL& url)
     top_level_browsing_context().loader().load(url, FrameLoader::Type::Navigation);
 }
 
-void Page::load(const LoadRequest& request)
+void Page::load(LoadRequest& request)
 {
     top_level_browsing_context().loader().load(request, FrameLoader::Type::Navigation);
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -42,7 +42,7 @@ public:
     void set_focused_browsing_context(Badge<EventHandler>, BrowsingContext&);
 
     void load(const URL&);
-    void load(const LoadRequest&);
+    void load(LoadRequest&);
 
     void load_html(const StringView&, const URL&);
 


### PR DESCRIPTION
  When debugging why your website isn't loading in LibWeb the
  resource loader is a blind spot as we don't have much logging
  except on certain error paths. This can lead to confusing situations
  where the browser just appears to hang.

  This changes attempts to fix that by adding common success and
  failure logging handlers so all resource loading outcomes can
  are logged.