### PR TITLE
aarch64: Baby steps towards bringing up a UART

### DIFF
--- a/Kernel/Prekernel/Arch/aarch64/MainIdRegister.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/MainIdRegister.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Prekernel/Arch/aarch64/MainIdRegister.h>
+
+namespace Prekernel {
+
+MainIdRegister::MainIdRegister()
+{
+    unsigned int mrs;
+    asm volatile("mrs %x0, MIDR_EL1"
+                 : "=r"(mrs));
+    m_value = mrs;
+}
+
+}

--- a/Kernel/Prekernel/Arch/aarch64/MainIdRegister.h
+++ b/Kernel/Prekernel/Arch/aarch64/MainIdRegister.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Prekernel {
+
+class MainIdRegister {
+public:
+    MainIdRegister();
+
+    enum Implementer {
+        ArmLimited = 0x41,
+    };
+    unsigned implementer() const { return (m_value >> 24) & 0xFF; }
+    unsigned variant() const { return (m_value >> 20) & 0xF; }
+    unsigned architecture() const { return (m_value >> 16) & 0xF; }
+
+    enum PartNum {
+        RaspberryPi1 = 0xB76,
+        RaspberryPi2 = 0xC07,
+        RaspberryPi3 = 0xD03,
+        RaspberryPi4 = 0xD08,
+    };
+    unsigned part_num() const { return (m_value >> 4) & 0xFFF; }
+
+    unsigned revision() const { return m_value & 0xF; }
+
+private:
+    unsigned int m_value;
+};
+
+}

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -5,10 +5,13 @@
  */
 
 #include <AK/Types.h>
+#include <Kernel/Prekernel/Arch/aarch64/MainIdRegister.h>
 
 extern "C" [[noreturn]] void init();
 extern "C" [[noreturn]] void init()
 {
+    Prekernel::MainIdRegister id;
+    [[maybe_unused]] unsigned part_num = id.part_num();
     for (;;) { }
 }
 

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Types.h>
+
 extern "C" [[noreturn]] void init();
 extern "C" [[noreturn]] void init()
 {
     for (;;) { }
 }
+
+// FIXME: Share this with the Intel Prekernel.
+extern size_t __stack_chk_guard;
+size_t __stack_chk_guard;

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
 
 add_executable(${PREKERNEL_TARGET} ${SOURCES})
-target_compile_options(${PREKERNEL_TARGET} PRIVATE -no-pie -fno-pic)
+target_compile_options(${PREKERNEL_TARGET} PRIVATE -no-pie -fno-pic -fno-threadsafe-statics)
 
 target_link_options(${PREKERNEL_TARGET} PRIVATE LINKER:-T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld -nostdlib LINKER:--no-pie)
 set_target_properties(${PREKERNEL_TARGET} PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -12,6 +12,7 @@ if ("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/boot.S
 
         ${SOURCES}
+        Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/init.cpp
     )
 else()

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -4,9 +4,15 @@ set(SOURCES
 )
 if ("${SERENITY_ARCH}" STREQUAL "aarch64")
     set(SOURCES
+        # This has to be first, so that the entry point is at the start of the image.
+        # Needed because:
+        # - execution starts at the start of the image
+        # - the stack pointer currently starts before the start symbol, so if the start symbol isn't the first symbol, the stack will clobber arbitrary code
+        # FIXME: Use an aarch64-specific linker script instead.
+        Arch/aarch64/boot.S
+
         ${SOURCES}
         Arch/aarch64/init.cpp
-        Arch/aarch64/boot.S
     )
 else()
     set(SOURCES


### PR DESCRIPTION
This (almost) gets us to the MMIO base address. After this we can add an mbox abstraction, use that to configure the UART, and then hopefully see UART output.

This probably doesn't belong into the prekernel but into the actual kernel, but let's get the UART up first.