### PR TITLE
LibWeb: Handle unitless-length quirk more in line with the spec

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_h.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_h.cpp
@@ -76,6 +76,14 @@ bool is_inherited_property(PropertyID);
 bool is_pseudo_property(PropertyID);
 RefPtr<StyleValue> property_initial_value(PropertyID);
 
+enum class Quirk {
+    // https://quirks.spec.whatwg.org/#the-hashless-hex-color-quirk
+    HashlessHexColor,
+    // https://quirks.spec.whatwg.org/#the-unitless-length-quirk
+    UnitlessLength,
+};
+bool property_has_quirk(PropertyID, Quirk);
+
 } // namespace Web::CSS
 
 namespace AK {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2888,12 +2888,6 @@ RefPtr<StyleValue> Parser::parse_css_value(ParsingContext const& context, Proper
         }
     }
 
-    // FIXME: This is a hack for the `opacity` property which should really take an <alpha-value>
-    if (property_id == PropertyID::Opacity && component_value.is(Token::Type::Number)) {
-        String string = component_value.token().number_string_value();
-        return LengthStyleValue::create(Length::make_px(strtof(string.characters(), nullptr)));
-    }
-
     if (auto builtin = parse_builtin_value(context, component_value))
         return builtin;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1804,7 +1804,7 @@ RefPtr<StyleValue> Parser::parse_background_value(ParsingContext const& context,
             break;
         }
 
-        auto value = parse_css_value(context, PropertyID::Background, part);
+        auto value = parse_css_value(context, part);
         if (!value) {
             return nullptr;
         }
@@ -1834,7 +1834,7 @@ RefPtr<StyleValue> Parser::parse_background_value(ParsingContext const& context,
 
             // Check following value, if it's also a repeat, set both.
             if (i + 1 < component_values.size()) {
-                auto next_value = parse_css_value(context, PropertyID::Background, component_values[i + 1]);
+                auto next_value = parse_css_value(context, component_values[i + 1]);
                 if (next_value && is_background_repeat(*next_value)) {
                     ++i;
                     repeat_x = value.release_nonnull();
@@ -1866,7 +1866,7 @@ RefPtr<StyleValue> Parser::parse_background_value(ParsingContext const& context,
 RefPtr<StyleValue> Parser::parse_background_image_value(ParsingContext const& context, Vector<StyleComponentValueRule> const& component_values)
 {
     if (component_values.size() == 1) {
-        auto maybe_value = parse_css_value(context, PropertyID::BackgroundImage, component_values.first());
+        auto maybe_value = parse_css_value(context, component_values.first());
         if (!maybe_value)
             return nullptr;
         auto value = maybe_value.release_nonnull();
@@ -1888,7 +1888,7 @@ RefPtr<StyleValue> Parser::parse_background_repeat_value(ParsingContext const& c
     };
 
     if (component_values.size() == 1) {
-        auto maybe_value = parse_css_value(context, PropertyID::BackgroundRepeat, component_values.first());
+        auto maybe_value = parse_css_value(context, component_values.first());
         if (!maybe_value)
             return nullptr;
         auto value = maybe_value.release_nonnull();
@@ -1905,8 +1905,8 @@ RefPtr<StyleValue> Parser::parse_background_repeat_value(ParsingContext const& c
     }
 
     if (component_values.size() == 2) {
-        auto maybe_x_value = parse_css_value(context, PropertyID::BackgroundRepeatX, component_values[0]);
-        auto maybe_y_value = parse_css_value(context, PropertyID::BackgroundRepeatY, component_values[1]);
+        auto maybe_x_value = parse_css_value(context, component_values[0]);
+        auto maybe_y_value = parse_css_value(context, component_values[1]);
         if (!maybe_x_value || !maybe_y_value)
             return nullptr;
 
@@ -1924,7 +1924,7 @@ RefPtr<StyleValue> Parser::parse_background_repeat_value(ParsingContext const& c
     return nullptr;
 }
 
-RefPtr<StyleValue> Parser::parse_border_value(ParsingContext const& context, PropertyID property_id, Vector<StyleComponentValueRule> const& component_values)
+RefPtr<StyleValue> Parser::parse_border_value(ParsingContext const& context, Vector<StyleComponentValueRule> const& component_values)
 {
     auto is_line_style = [](StyleValue const& value) -> bool {
         switch (value.to_identifier()) {
@@ -1965,7 +1965,7 @@ RefPtr<StyleValue> Parser::parse_border_value(ParsingContext const& context, Pro
     RefPtr<StyleValue> border_style;
 
     for (auto& part : component_values) {
-        auto value = parse_css_value(context, property_id, part);
+        auto value = parse_css_value(context, part);
         if (!value)
             return nullptr;
 
@@ -2167,7 +2167,7 @@ RefPtr<StyleValue> Parser::parse_flex_value(ParsingContext const& context, Vecto
     };
 
     if (component_values.size() == 1) {
-        auto value = parse_css_value(context, PropertyID::Flex, component_values[0]);
+        auto value = parse_css_value(context, component_values[0]);
         if (!value)
             return nullptr;
 
@@ -2190,7 +2190,7 @@ RefPtr<StyleValue> Parser::parse_flex_value(ParsingContext const& context, Vecto
     RefPtr<StyleValue> flex_basis;
 
     for (size_t i = 0; i < component_values.size(); ++i) {
-        auto value = parse_css_value(context, PropertyID::Flex, component_values[i]);
+        auto value = parse_css_value(context, component_values[i]);
         if (!value)
             return nullptr;
 
@@ -2209,7 +2209,7 @@ RefPtr<StyleValue> Parser::parse_flex_value(ParsingContext const& context, Vecto
 
             // Flex-shrink may optionally follow directly after.
             if (i + 1 < component_values.size()) {
-                auto second_value = parse_css_value(context, PropertyID::Flex, component_values[i + 1]);
+                auto second_value = parse_css_value(context, component_values[i + 1]);
                 if (second_value && is_flex_grow_or_shrink(*second_value)) {
                     flex_shrink = second_value.release_nonnull();
                     i++;
@@ -2270,7 +2270,7 @@ RefPtr<StyleValue> Parser::parse_flex_flow_value(ParsingContext const& context, 
     RefPtr<StyleValue> flex_wrap;
 
     for (auto& part : component_values) {
-        auto value = parse_css_value(context, PropertyID::FlexFlow, part);
+        auto value = parse_css_value(context, part);
         if (!value)
             return nullptr;
         if (is_flex_direction(*value)) {
@@ -2369,7 +2369,7 @@ RefPtr<StyleValue> Parser::parse_font_value(ParsingContext const& context, Vecto
     int normal_count = 0;
 
     for (size_t i = 0; i < component_values.size(); ++i) {
-        auto value = parse_css_value(context, PropertyID::Font, component_values[i]);
+        auto value = parse_css_value(context, component_values[i]);
         if (!value)
             return nullptr;
 
@@ -2398,7 +2398,7 @@ RefPtr<StyleValue> Parser::parse_font_value(ParsingContext const& context, Vecto
             if (i + 2 < component_values.size()) {
                 auto maybe_solidus = component_values[i + 1];
                 if (maybe_solidus.is(Token::Type::Delim) && maybe_solidus.token().delim() == "/"sv) {
-                    auto maybe_line_height = parse_css_value(context, PropertyID::Font, component_values[i + 2]);
+                    auto maybe_line_height = parse_css_value(context, component_values[i + 2]);
                     if (!(maybe_line_height && is_line_height(*maybe_line_height)))
                         return nullptr;
                     line_height = maybe_line_height.release_nonnull();
@@ -2485,7 +2485,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(ParsingContext const& context
         }
         if (part.is(Token::Type::Ident)) {
             // If this is a valid identifier, it's NOT a custom-ident and can't be part of a larger name.
-            auto maybe_ident = parse_css_value(context, PropertyID::FontFamily, part);
+            auto maybe_ident = parse_css_value(context, part);
             if (maybe_ident) {
                 // CSS-wide keywords are not allowed
                 if (maybe_ident->is_builtin())
@@ -2577,7 +2577,7 @@ RefPtr<StyleValue> Parser::parse_list_style_value(ParsingContext const& context,
     int found_nones = 0;
 
     for (auto& part : component_values) {
-        auto value = parse_css_value(context, PropertyID::ListStyle, part);
+        auto value = parse_css_value(context, part);
         if (!value)
             return nullptr;
 
@@ -2652,7 +2652,7 @@ RefPtr<StyleValue> Parser::parse_overflow_value(ParsingContext const& context, V
     };
 
     if (component_values.size() == 1) {
-        auto maybe_value = parse_css_value(context, PropertyID::Overflow, component_values.first());
+        auto maybe_value = parse_css_value(context, component_values.first());
         if (!maybe_value)
             return nullptr;
         auto value = maybe_value.release_nonnull();
@@ -2662,8 +2662,8 @@ RefPtr<StyleValue> Parser::parse_overflow_value(ParsingContext const& context, V
     }
 
     if (component_values.size() == 2) {
-        auto maybe_x_value = parse_css_value(context, PropertyID::OverflowX, component_values[0]);
-        auto maybe_y_value = parse_css_value(context, PropertyID::OverflowY, component_values[1]);
+        auto maybe_x_value = parse_css_value(context, component_values[0]);
+        auto maybe_y_value = parse_css_value(context, component_values[1]);
 
         if (!maybe_x_value || !maybe_y_value)
             return nullptr;
@@ -2714,7 +2714,7 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(ParsingContext const& con
     // FIXME: Implement 'text-decoration-thickness' parameter. https://www.w3.org/TR/css-text-decor-4/#text-decoration-width-property
 
     for (auto& part : component_values) {
-        auto value = parse_css_value(context, PropertyID::TextDecoration, part);
+        auto value = parse_css_value(context, part);
         if (!value)
             return nullptr;
 
@@ -2804,7 +2804,7 @@ RefPtr<StyleValue> Parser::parse_css_value(PropertyID property_id, TokenStream<S
     case PropertyID::BorderLeft:
     case PropertyID::BorderRight:
     case PropertyID::BorderTop:
-        if (auto parsed_value = parse_border_value(m_context, property_id, component_values))
+        if (auto parsed_value = parse_border_value(m_context, component_values))
             return parsed_value;
         break;
     case PropertyID::BorderTopLeftRadius:
@@ -2855,13 +2855,13 @@ RefPtr<StyleValue> Parser::parse_css_value(PropertyID property_id, TokenStream<S
     }
 
     if (component_values.size() == 1)
-        return parse_css_value(m_context, property_id, component_values.first());
+        return parse_css_value(m_context, component_values.first());
 
     // We have multiple values, so treat them as a StyleValueList.
     // FIXME: Specify in Properties.json whether to permit this for each property.
     NonnullRefPtrVector<StyleValue> parsed_values;
     for (auto& component_value : component_values) {
-        auto parsed = parse_css_value(m_context, property_id, component_value);
+        auto parsed = parse_css_value(m_context, component_value);
         if (!parsed)
             return {};
         parsed_values.append(parsed.release_nonnull());
@@ -2872,7 +2872,7 @@ RefPtr<StyleValue> Parser::parse_css_value(PropertyID property_id, TokenStream<S
     return {};
 }
 
-RefPtr<StyleValue> Parser::parse_css_value(ParsingContext const& context, PropertyID, StyleComponentValueRule const& component_value)
+RefPtr<StyleValue> Parser::parse_css_value(ParsingContext const& context, StyleComponentValueRule const& component_value)
 {
     if (auto builtin = parse_builtin_value(context, component_value))
         return builtin;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2756,6 +2756,7 @@ RefPtr<StyleValue> Parser::parse_as_css_value(PropertyID property_id)
 
 RefPtr<StyleValue> Parser::parse_css_value(PropertyID property_id, TokenStream<StyleComponentValueRule>& tokens)
 {
+    m_context.set_current_property_id(property_id);
     Vector<StyleComponentValueRule> component_values;
 
     while (tokens.has_next_token()) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2872,22 +2872,8 @@ RefPtr<StyleValue> Parser::parse_css_value(PropertyID property_id, TokenStream<S
     return {};
 }
 
-RefPtr<StyleValue> Parser::parse_css_value(ParsingContext const& context, PropertyID property_id, StyleComponentValueRule const& component_value)
+RefPtr<StyleValue> Parser::parse_css_value(ParsingContext const& context, PropertyID, StyleComponentValueRule const& component_value)
 {
-    // FIXME: Figure out if we still need takes_integer_value, and if so, move this information
-    // into Properties.json.
-    auto takes_integer_value = [](PropertyID property_id) -> bool {
-        return property_id == PropertyID::ZIndex
-            || property_id == PropertyID::FontWeight
-            || property_id == PropertyID::Custom;
-    };
-    if (takes_integer_value(property_id) && component_value.is(Token::Type::Number)) {
-        auto number = component_value.token();
-        if (number.m_number_type == Token::NumberType::Integer) {
-            return LengthStyleValue::create(Length::make_px(number.to_integer()));
-        }
-    }
-
     if (auto builtin = parse_builtin_value(context, component_value))
         return builtin;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -40,8 +40,12 @@ public:
     DOM::Document* document() const { return m_document; }
     URL complete_url(String const&) const;
 
+    PropertyID current_property_id() const { return m_current_property_id; }
+    void set_current_property_id(PropertyID property_id) { m_current_property_id = property_id; }
+
 private:
     DOM::Document* m_document { nullptr };
+    PropertyID m_current_property_id { PropertyID::Invalid };
 };
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -99,10 +99,6 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
-    // FIXME: These want to be private, but StyleResolver still uses them for now.
-    RefPtr<StyleValue> parse_css_value(PropertyID, TokenStream<StyleComponentValueRule>&);
-    static RefPtr<StyleValue> parse_css_value(ParsingContext const&, PropertyID, StyleComponentValueRule const&);
-
 private:
     template<typename T>
     NonnullRefPtr<CSSStyleSheet> parse_a_stylesheet(TokenStream<T>&);
@@ -172,6 +168,8 @@ private:
     static Optional<Length> parse_length(ParsingContext const&, StyleComponentValueRule const&);
     static Optional<URL> parse_url_function(ParsingContext const&, StyleComponentValueRule const&);
 
+    RefPtr<StyleValue> parse_css_value(PropertyID, TokenStream<StyleComponentValueRule>&);
+    static RefPtr<StyleValue> parse_css_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_builtin_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_dynamic_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_length_value(ParsingContext const&, StyleComponentValueRule const&);
@@ -183,7 +181,7 @@ private:
     static RefPtr<StyleValue> parse_background_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_background_image_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_border_value(ParsingContext const&, PropertyID, Vector<StyleComponentValueRule> const&);
+    static RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_radius_shorthand_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_box_shadow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -6,7 +6,10 @@
   },
   "background-color": {
     "inherited": false,
-    "initial": "transparent"
+    "initial": "transparent",
+    "quirks": [
+      "hashless-hex-color"
+    ]
   },
   "background-image": {
     "inherited": false,
@@ -14,7 +17,10 @@
   },
   "background-position": {
     "inherited": false,
-    "initial": "0% 0%"
+    "initial": "0% 0%",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "background-repeat": {
     "longhands": [
@@ -69,7 +75,10 @@
   },
   "border-bottom-color": {
     "initial": "currentColor",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "hashless-hex-color"
+    ]
   },
   "border-bottom-left-radius": {
     "initial": "0",
@@ -85,7 +94,10 @@
   },
   "border-bottom-width": {
     "initial": "medium",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "border-color": {
     "longhands": [
@@ -93,6 +105,9 @@
       "border-right-color",
       "border-bottom-color",
       "border-left-color"
+    ],
+    "quirks": [
+      "hashless-hex-color"
     ]
   },
   "border-collapse": {
@@ -101,7 +116,10 @@
   },
   "border-left-color": {
     "initial": "currentColor",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "hashless-hex-color"
+    ]
   },
   "border-left-style": {
     "initial": "none",
@@ -109,7 +127,10 @@
   },
   "border-left-width": {
     "initial": "medium",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "border-radius": {
     "longhands": [
@@ -121,7 +142,10 @@
   },
   "border-right-color": {
     "initial": "currentColor",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "hashless-hex-color"
+    ]
   },
   "border-right-style": {
     "initial": "none",
@@ -129,11 +153,17 @@
   },
   "border-right-width": {
     "initial": "medium",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "border-spacing": {
     "inherited": true,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "border-style": {
     "longhands": [
@@ -145,7 +175,10 @@
   },
   "border-top-color": {
     "initial": "currentColor",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "hashless-hex-color"
+    ]
   },
   "border-top-left-radius": {
     "initial": "0",
@@ -161,7 +194,10 @@
   },
   "border-top-width": {
     "initial": "medium",
-    "inherited": false
+    "inherited": false,
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "border-width": {
     "longhands": [
@@ -169,11 +205,17 @@
       "border-right-width",
       "border-bottom-width",
       "border-left-width"
+    ],
+    "quirks": [
+      "unitless-length"
     ]
   },
   "bottom": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "box-shadow":{
     "inherited": false,
@@ -189,11 +231,17 @@
   },
   "clip": {
     "inherited": true,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "color": {
     "inherited": true,
-    "initial": ""
+    "initial": "",
+    "quirks": [
+      "hashless-hex-color"
+    ]
   },
   "cursor": {
     "inherited": true,
@@ -258,7 +306,10 @@
   },
   "font-size": {
     "inherited": true,
-    "initial": "medium"
+    "initial": "medium",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "font-style": {
     "inherited": true,
@@ -274,7 +325,10 @@
   },
   "height": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "justify-content": {
     "inherited": false,
@@ -282,11 +336,17 @@
   },
   "left": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "letter-spacing": {
     "inherited": true,
-    "initial": "normal"
+    "initial": "normal",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "line-height": {
     "inherited": true,
@@ -318,39 +378,66 @@
       "margin-right",
       "margin-bottom",
       "margin-left"
+    ],
+    "quirks": [
+      "unitless-length"
     ]
   },
   "margin-bottom": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "margin-left": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "margin-right": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "margin-top": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "max-height": {
     "inherited": false,
-    "initial": "none"
+    "initial": "none",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "max-width": {
     "inherited": false,
-    "initial": "none"
+    "initial": "none",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "min-height": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "min-width": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "opacity": {
     "inherited": false,
@@ -378,23 +465,38 @@
       "padding-right",
       "padding-bottom",
       "padding-left"
+    ],
+    "quirks": [
+      "unitless-length"
     ]
   },
   "padding-bottom": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "padding-left": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "padding-right": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "padding-top": {
     "inherited": false,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "position": {
     "inherited": false,
@@ -402,7 +504,10 @@
   },
   "right": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "text-align": {
     "inherited": true,
@@ -437,7 +542,10 @@
   },
   "text-indent": {
     "inherited": true,
-    "initial": "0"
+    "initial": "0",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "text-transform": {
     "inherited": true,
@@ -445,11 +553,17 @@
   },
   "top": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "vertical-align": {
     "inherited": false,
-    "initial": "baseline"
+    "initial": "baseline",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "visibility": {
     "inherited": true,
@@ -457,7 +571,10 @@
   },
   "width": {
     "inherited": false,
-    "initial": "auto"
+    "initial": "auto",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "white-space": {
     "inherited": true,
@@ -465,7 +582,10 @@
   },
   "word-spacing": {
     "inherited": true,
-    "initial": "normal"
+    "initial": "normal",
+    "quirks": [
+      "unitless-length"
+    ]
   },
   "z-index": {
     "inherited": false,

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -291,10 +291,16 @@ float StyleProperties::line_height(const Layout::Node& layout_node) const
 
 Optional<int> StyleProperties::z_index() const
 {
-    auto value = property(CSS::PropertyID::ZIndex);
-    if (!value.has_value())
+    auto maybe_value = property(CSS::PropertyID::ZIndex);
+    if (!maybe_value.has_value())
         return {};
-    return static_cast<int>(value.value()->to_length().raw_value());
+    auto& value = maybe_value.value();
+
+    if (value->is_auto())
+        return 0;
+    if (value->is_numeric())
+        return static_cast<int>(static_cast<NumericStyleValue&>(*value).value());
+    return {};
 }
 
 Optional<float> StyleProperties::opacity() const


### PR DESCRIPTION
Previously if we ran in quirks mode, every number was interpreted as a pixel length, which is 1) wrong and 2) makes processing the values more complicated as everywhere that expects a number had to also check for a length. Now, we only apply the unitless-length quirk to the properties listed in the quirks spec.

This properly fixes the opacity bug which previously had a hack fixing it. :^)

Checking the quirks for a property is done with the new `CSS::property_has_quirk(PropertyID, Quirk)` static function, generated from `Properties.json`. This supports both the unitless-length and hashless-hex-color quirks, which are the only ones that are restricted to a certain set of properties. We do not yet deal with hashless-hex-color but when we do, the infrastructure is already there. :^)