### PR TITLE
LibWeb: Expose the location object via Document.location

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
@@ -843,6 +843,11 @@ static void generate_return_statement(SourceGenerator& generator, IDL::Type cons
 
     return retval.callback.cell();
 )~~~");
+    } else if (return_type.name == "Location") {
+        // Location is special cased as it is already a JS::Object.
+        scoped_generator.append(R"~~~(
+    return JS::Value(retval);
+)~~~");
     } else {
         scoped_generator.append(R"~~~(
     return wrap(global_object, const_cast<@return_type@&>(*retval));
@@ -1440,6 +1445,7 @@ void generate_prototype_implementation(IDL::Interface const& interface)
 #include <LibWeb/Bindings/HTMLTableCaptionElementWrapper.h>
 #include <LibWeb/Bindings/HTMLTableSectionElementWrapper.h>
 #include <LibWeb/Bindings/ImageDataWrapper.h>
+#include <LibWeb/Bindings/LocationObject.h>
 #include <LibWeb/Bindings/NodeWrapperFactory.h>
 #include <LibWeb/Bindings/PerformanceTimingWrapper.h>
 #include <LibWeb/Bindings/RangeWrapper.h>

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -11,8 +11,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Window.h>
 
-namespace Web {
-namespace Bindings {
+namespace Web::Bindings {
 
 LocationObject::LocationObject(JS::GlobalObject& global_object)
     : Object(*global_object.object_prototype())
@@ -118,6 +117,25 @@ JS_DEFINE_NATIVE_FUNCTION(LocationObject::reload)
     return JS::js_undefined();
 }
 
+// https://html.spec.whatwg.org/multipage/history.html#location-setprototypeof
+bool LocationObject::internal_set_prototype_of(Object* prototype)
+{
+    // 1. Return ! SetImmutablePrototype(this, V).
+    return set_immutable_prototype(prototype);
+}
+
+// https://html.spec.whatwg.org/multipage/history.html#location-isextensible
+bool LocationObject::internal_is_extensible() const
+{
+    // 1. Return true.
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/history.html#location-preventextensions
+bool LocationObject::internal_prevent_extensions()
+{
+    // 1. Return false.
+    return false;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.h
@@ -20,6 +20,13 @@ public:
     virtual void initialize(JS::GlobalObject&) override;
     virtual ~LocationObject() override;
 
+    virtual bool internal_set_prototype_of(Object* prototype) override;
+    virtual bool internal_is_extensible() const override;
+    virtual bool internal_prevent_extensions() override;
+
+    // FIXME: There should also be a custom [[GetPrototypeOf]], [[GetOwnProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]] and [[OwnPropertyKeys]],
+    //        but we don't have the infrastructure in place to implement them yet.
+
 private:
     JS_DECLARE_NATIVE_FUNCTION(reload);
 

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -92,8 +92,12 @@ void WindowObject::initialize_global_object()
     // Legacy
     define_native_accessor("event", event_getter, event_setter, JS::Attribute::Enumerable);
 
+    m_location_object = heap().allocate<LocationObject>(*this, *this);
+
     define_direct_property("navigator", heap().allocate<NavigatorObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_direct_property("location", heap().allocate<LocationObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+
+    // NOTE: location is marked as [LegacyUnforgeable], meaning it isn't configurable.
+    define_direct_property("location", m_location_object, JS::Attribute::Enumerable);
 
     // WebAssembly "namespace"
     define_direct_property("WebAssembly", heap().allocate<WebAssemblyObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
@@ -108,6 +112,7 @@ WindowObject::~WindowObject()
 void WindowObject::visit_edges(Visitor& visitor)
 {
     GlobalObject::visit_edges(visitor);
+    visitor.visit(m_location_object);
     for (auto& it : m_prototypes)
         visitor.visit(it.value);
     for (auto& it : m_constructors)

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -30,6 +30,9 @@ public:
 
     Origin origin() const;
 
+    LocationObject* location_object() { return m_location_object; }
+    LocationObject const* location_object() const { return m_location_object; }
+
     JS::Object* web_prototype(const String& class_name) { return m_prototypes.get(class_name).value_or(nullptr); }
     JS::NativeFunction* web_constructor(const String& class_name) { return m_constructors.get(class_name).value_or(nullptr); }
 
@@ -95,6 +98,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(get_computed_style);
 
     NonnullRefPtr<DOM::Window> m_impl;
+
+    LocationObject* m_location_object;
 
     HashMap<String, JS::Object*> m_prototypes;
     HashMap<String, JS::NativeFunction*> m_constructors;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -979,4 +979,16 @@ bool Document::is_fully_active() const
     return browsing_context() && browsing_context()->active_document() == this && (browsing_context()->is_top_level() || browsing_context()->container_document()->is_fully_active());
 }
 
+// https://html.spec.whatwg.org/multipage/history.html#dom-document-location
+Bindings::LocationObject* Document::location()
+{
+    // The Document object's location attribute's getter must return this Document object's relevant global object's Location object,
+    // if this Document object is fully active, and null otherwise.
+
+    if (!is_fully_active())
+        return nullptr;
+
+    return window().wrapper()->location_object();
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -279,6 +279,8 @@ public:
 
     NonnullRefPtr<HTML::History> history() const { return m_history; }
 
+    Bindings::LocationObject* location();
+
 private:
     explicit Document(const URL&);
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -2,6 +2,9 @@ interface Document : Node {
 
     constructor();
 
+    // FIXME: These attributes currently don't do anything.
+    [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location;
+
     readonly attribute DOMImplementation implementation;
 
     readonly attribute DOMString characterSet;


### PR DESCRIPTION
Both Window.location and Document.location use the same instance of the
Location object. Some sites use it via Window, some via Document.