### PR TITLE
LibWeb: Don't assert if reconsuming on an empty TokenStream

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -105,8 +105,8 @@ T const& TokenStream<T>::current_token()
 template<typename T>
 void TokenStream<T>::reconsume_current_input_token()
 {
-    VERIFY(m_iterator_offset >= 0);
-    --m_iterator_offset;
+    if (m_iterator_offset >= 0)
+        --m_iterator_offset;
 }
 
 template<typename T>


### PR DESCRIPTION
This fixes #9978.

When a TokenStream is empty, reading its `current_token()` still returns
a token (for EOF) so it makes sense to allow users to
`reconsume_current_input_token()` that token, so they do not have to
handle that themselves. Instead of VERIFY()ing, we can just no-op when
reconsuming token 0.