### PR TITLE
AK+LibCore: Standardize on AK_OS_MACOS instead of __APPLE__

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -17,7 +17,7 @@
 #    include <unistd.h>
 #endif
 
-#if defined(__APPLE__)
+#if defined(AK_OS_MACOS)
 #    include <sys/random.h>
 #endif
 
@@ -28,7 +28,7 @@ inline void fill_with_random([[maybe_unused]] void* buffer, [[maybe_unused]] siz
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
 #elif defined(OSS_FUZZ)
-#elif defined(__unix__) or defined(__APPLE__)
+#elif defined(__unix__) or defined(AK_OS_MACOS)
     [[maybe_unused]] int rc = getentropy(buffer, length);
 #endif
 }

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -5,13 +5,14 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/Platform.h>
 #include <AK/StackInfo.h>
 #include <stdio.h>
 #include <string.h>
 
 #ifdef __serenity__
 #    include <serenity.h>
-#elif defined(__linux__) or defined(__APPLE__)
+#elif defined(__linux__) or defined(AK_OS_MACOS)
 #    include <pthread.h>
 #endif
 
@@ -36,7 +37,7 @@ StackInfo::StackInfo()
         VERIFY_NOT_REACHED();
     }
     pthread_attr_destroy(&attr);
-#elif __APPLE__
+#elif defined(AK_OS_MACOS)
     // NOTE: !! On MacOS, pthread_get_stackaddr_np gives the TOP of the stack, not the bottom!
     FlatPtr top_of_stack = (FlatPtr)pthread_get_stackaddr_np(pthread_self());
     m_size = (size_t)pthread_get_stacksize_np(pthread_self());

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -104,7 +104,7 @@ bool LocalServer::listen(const String& address)
     fcntl(m_fd, F_SETFD, FD_CLOEXEC);
 #endif
     VERIFY(m_fd >= 0);
-#ifndef __APPLE__
+#ifndef AK_OS_MACOS
     rc = fchmod(m_fd, 0600);
     if (rc < 0) {
         perror("fchmod");


### PR DESCRIPTION
We use our custom platform definitions in most places, remove
the few remaining places we weren't using `AK_OS_MACOS`.