### PR TITLE
LibGUI: Enable/Disable the Open button on text change in FilePicker, and make it always active in the `OpenFolder` mode

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -187,7 +187,11 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
         done(ExecCancel);
     };
 
-    m_view->on_selection_change = [this, &ok_button] {
+    m_filename_textbox->on_change = [&] {
+        ok_button.set_enabled(!m_filename_textbox->text().is_empty());
+    };
+
+    m_view->on_selection_change = [this] {
         auto index = m_view->selection().first();
         auto& filter_model = (SortingProxyModel&)*m_view->model();
         auto local_index = filter_model.map_to_source(index);
@@ -199,7 +203,6 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
         } else if (m_mode != Mode::Save) {
             m_filename_textbox->clear();
         }
-        ok_button.set_enabled(!m_filename_textbox->text().is_empty());
     };
 
     m_view->on_activation = [this](auto& index) {

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -179,7 +179,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
     ok_button.on_click = [this](auto) {
         on_file_return();
     };
-    ok_button.set_enabled(!m_filename_textbox->text().is_empty());
+    ok_button.set_enabled(m_mode == Mode::OpenFolder || !m_filename_textbox->text().is_empty());
 
     auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.set_text("Cancel");
@@ -188,7 +188,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& filen
     };
 
     m_filename_textbox->on_change = [&] {
-        ok_button.set_enabled(!m_filename_textbox->text().is_empty());
+        ok_button.set_enabled(m_mode == Mode::OpenFolder || !m_filename_textbox->text().is_empty());
     };
 
     m_view->on_selection_change = [this] {


### PR DESCRIPTION
- **LibGUI: Enable/Disable the Open button on text change in FilePicker**

  Prior this change, the button was updated on user selection change in the file view.

  This isn’t quite right, as you could remove the text from the text box or (even worse) start typing a filename there and the button state wouldn’t change.

- **LibGUI: Make the Open button always active in the `OpenFolder` mode**

  We can just use the current opened directory as a path in that mode. :^)

