### PR TITLE
CI: Batch master builds in Azure DevOps to help with CI latency

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,8 @@
 trigger:
-  - master
+  batch: true
+  branches:
+    include:
+    - master
 
 jobs:
   - template: Meta/Azure/Lagom.yml


### PR DESCRIPTION
The CI system often develops a significant backlog when we have a lot
of PRs in the queue, and folks are pushing to master directly, or
other PRs are getting merged. The individual pushes to master or PR
merges to master each end up creating a dedicated master CI build.
These builds complete for machines with the normal PR validation builds.

To aid with this, Azure DevOps has a feature where they allow the CI
builds to "batch" multiple changes together, instead of running
multiple builds for each change.

Azure DevOps defines batching as:

    When a pipeline is running, the system waits until the run is
    completed, then starts another run with all changes that have
    not yet been built.

Documentation Reference:
https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#batching-ci-runs