### PR TITLE
AK+LibC+LibCore+LibCrypto: Fix MacOS build by replacing explicit_bzero with new AK::secure_zero

### DIFF
--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -40,3 +40,16 @@ ALWAYS_INLINE void fast_u32_fill(u32* dest, u32 value, size_t count)
     }
 #endif
 }
+
+namespace AK {
+inline void secure_zero(void* ptr, size_t size)
+{
+    __builtin_memset(ptr, 0, size);
+    // The memory barrier is here to avoid the compiler optimizing
+    // away the memset when we rely on it for wiping secrets.
+    asm volatile("" ::
+                     : "memory");
+}
+}
+
+using AK::secure_zero;

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Format.h>
 #include <AK/MemMem.h>
+#include <AK/Memory.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
@@ -481,8 +482,6 @@ size_t strxfrm(char* dest, const char* src, size_t n)
 
 void explicit_bzero(void* ptr, size_t size)
 {
-    memset(ptr, 0, size);
-    asm volatile("" ::
-                     : "memory");
+    secure_zero(ptr, size);
 }
 }

--- a/Userland/Libraries/LibCore/SecretString.cpp
+++ b/Userland/Libraries/LibCore/SecretString.cpp
@@ -5,12 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Platform.h>
+#include <AK/Memory.h>
 #include <LibCore/SecretString.h>
-#if defined(AK_OS_MACOS)
-#    define __STDC_WANT_LIB_EXT1__ 1
-#endif
-#include <string.h>
 
 namespace Core {
 
@@ -19,12 +15,9 @@ SecretString SecretString::take_ownership(char*& cstring, size_t length)
     auto buffer = ByteBuffer::copy(cstring, length);
     VERIFY(buffer.has_value());
 
-#if defined(AK_OS_MACOS)
-    memset_s(cstring, length, 0, length);
-#else
-    explicit_bzero(cstring, length);
-#endif
+    secure_zero(cstring, length);
     free(cstring);
+    cstring = nullptr;
 
     return SecretString(buffer.release_value());
 }
@@ -41,14 +34,10 @@ SecretString::SecretString(ByteBuffer&& buffer)
 
 SecretString::~SecretString()
 {
-    // Note: We use explicit_bzero to avoid the zeroing from being optimized out by the compiler,
+    // Note: We use secure_zero to avoid the zeroing from being optimized out by the compiler,
     // which is possible if memset was to be used here.
     if (!m_secure_buffer.is_empty()) {
-#if defined(AK_OS_MACOS)
-        memset_s(m_secure_buffer.data(), m_secure_buffer.size(), 0, m_secure_buffer.size());
-#else
-        explicit_bzero(m_secure_buffer.data(), m_secure_buffer.capacity());
-#endif
+        secure_zero(m_secure_buffer.data(), m_secure_buffer.capacity());
     }
 }
 

--- a/Userland/Libraries/LibCrypto/Hash/MD5.cpp
+++ b/Userland/Libraries/LibCrypto/Hash/MD5.cpp
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Memory.h>
 #include <AK/Types.h>
 #include <LibCrypto/Hash/MD5.h>
-#include <string.h>
 
 static constexpr u32 F(u32 x, u32 y, u32 z) { return (x & y) | ((~x) & z); };
 static constexpr u32 G(u32 x, u32 y, u32 z) { return (x & z) | ((~z) & y); };
@@ -200,7 +200,7 @@ void MD5::transform(const u8* block)
     m_C += c;
     m_D += d;
 
-    explicit_bzero(x, sizeof(x));
+    secure_zero(x, sizeof(x));
 }
 
 }

--- a/Userland/Libraries/LibCrypto/Hash/SHA1.cpp
+++ b/Userland/Libraries/LibCrypto/Hash/SHA1.cpp
@@ -5,9 +5,9 @@
  */
 
 #include <AK/Endian.h>
+#include <AK/Memory.h>
 #include <AK/Types.h>
 #include <LibCrypto/Hash/SHA1.h>
-#include <string.h>
 
 namespace Crypto {
 namespace Hash {
@@ -64,7 +64,7 @@ inline void SHA1::transform(const u8* data)
     c = 0;
     d = 0;
     e = 0;
-    explicit_bzero(blocks, 16 * sizeof(u32));
+    secure_zero(blocks, 16 * sizeof(u32));
 }
 
 void SHA1::update(const u8* message, size_t length)


### PR DESCRIPTION
It turned out relying on `explicit_bzero` was a bad idea, just implement it in AK so it can be used on all platforms we support building on. 