### PR TITLE
PixelPaint: Fix bugs, inconsistencies, crashes

### DIFF
--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -76,6 +76,7 @@ void EllipseTool::on_mouseup(Layer* layer, MouseEvent& event)
         GUI::Painter painter(layer->bitmap());
         draw_using(painter, m_ellipse_start_position, m_ellipse_end_position, m_thickness);
         m_drawing_button = GUI::MouseButton::None;
+        layer->did_modify_bitmap();
         m_editor->update();
         m_editor->did_complete_action();
     }

--- a/Userland/Applications/PixelPaint/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/EllipseTool.cpp
@@ -101,7 +101,7 @@ void EllipseTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
     auto preview_start = m_editor->layer_position_to_editor_position(*layer, m_ellipse_start_position).to_type<int>();
     auto preview_end = m_editor->layer_position_to_editor_position(*layer, m_ellipse_end_position).to_type<int>();
-    draw_using(painter, preview_start, preview_end, m_thickness * m_editor->scale());
+    draw_using(painter, preview_start, preview_end, AK::max(m_thickness * m_editor->scale(), 1));
 }
 
 void EllipseTool::on_keydown(GUI::KeyEvent& event)

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -277,9 +277,7 @@ size_t LayerListWidget::hole_index_during_move() const
     VERIFY(is_moving_gadget());
     auto& moving_gadget = m_gadgets[m_moving_gadget_index.value()];
     int center_y_of_moving_gadget = moving_gadget.rect.translated(0, moving_gadget.movement_delta.y()).center().y();
-
-    int top_of_gadgets = max(0, height() - m_total_gadget_height);
-    return (center_y_of_moving_gadget - top_of_gadgets) / vertical_step;
+    return center_y_of_moving_gadget / vertical_step;
 }
 
 void LayerListWidget::select_bottom_layer()
@@ -318,9 +316,7 @@ void LayerListWidget::cycle_through_selection(int delta)
 
 void LayerListWidget::relayout_gadgets()
 {
-    m_total_gadget_height = static_cast<int>(m_gadgets.size()) * vertical_step + 6;
-    int y = max(0, height() - m_total_gadget_height);
-
+    int y = 0;
     Optional<size_t> hole_index;
     if (is_moving_gadget())
         hole_index = hole_index_during_move();
@@ -336,8 +332,9 @@ void LayerListWidget::relayout_gadgets()
         ++index;
     }
 
-    set_content_size({ widget_inner_rect().width(), m_total_gadget_height });
-    vertical_scrollbar().set_range(0, max(m_total_gadget_height - height(), 0));
+    auto total_gadget_height = static_cast<int>(m_gadgets.size()) * vertical_step + 6;
+    set_content_size({ widget_inner_rect().width(), total_gadget_height });
+    vertical_scrollbar().set_range(0, max(total_gadget_height - height(), 0));
     update();
 }
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -73,7 +73,6 @@ private:
     Gfx::IntPoint m_moving_event_origin;
 
     size_t m_selected_gadget_index { 0 };
-    int m_total_gadget_height { 0 };
 };
 
 }

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -53,6 +53,7 @@ void LineTool::on_mousedown(Layer* layer, MouseEvent& event)
 
     m_drawing_button = layer_event.button();
 
+    m_drag_start_position = layer_event.position();
     m_line_start_position = layer_event.position();
     m_line_end_position = layer_event.position();
 
@@ -85,10 +86,17 @@ void LineTool::on_mousemove(Layer* layer, MouseEvent& event)
 
     if (layer_event.shift()) {
         constexpr auto ANGLE_STEP = M_PI / 8;
-        m_line_end_position = constrain_line_angle(m_line_start_position, layer_event.position(), ANGLE_STEP);
+        m_line_end_position = constrain_line_angle(m_drag_start_position, layer_event.position(), ANGLE_STEP);
     } else {
         m_line_end_position = layer_event.position();
     }
+
+    if (layer_event.alt()) {
+        m_line_start_position = m_drag_start_position + (m_drag_start_position - m_line_end_position);
+    } else {
+        m_line_start_position = m_drag_start_position;
+    }
+
     m_editor->update();
 }
 

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -71,6 +71,7 @@ void LineTool::on_mouseup(Layer* layer, MouseEvent& event)
         painter.draw_line(m_line_start_position, m_line_end_position, m_editor->color_for(m_drawing_button), m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();
+        m_editor->update();
         m_editor->did_complete_action();
     }
 }

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -108,8 +108,8 @@ void LineTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    auto preview_start = m_editor->layer_position_to_editor_position(*layer, m_line_start_position).to_type<int>();
-    auto preview_end = m_editor->layer_position_to_editor_position(*layer, m_line_end_position).to_type<int>();
+    auto preview_start = editor_stroke_position(m_line_start_position, m_thickness);
+    auto preview_end = editor_stroke_position(m_line_end_position, m_thickness);
     painter.draw_line(preview_start, preview_end, m_editor->color_for(m_drawing_button), AK::max(m_thickness * m_editor->scale(), 1));
 }
 

--- a/Userland/Applications/PixelPaint/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/LineTool.cpp
@@ -109,7 +109,7 @@ void LineTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
     auto preview_start = m_editor->layer_position_to_editor_position(*layer, m_line_start_position).to_type<int>();
     auto preview_end = m_editor->layer_position_to_editor_position(*layer, m_line_end_position).to_type<int>();
-    painter.draw_line(preview_start, preview_end, m_editor->color_for(m_drawing_button), m_thickness * m_editor->scale());
+    painter.draw_line(preview_start, preview_end, m_editor->color_for(m_drawing_button), AK::max(m_thickness * m_editor->scale(), 1));
 }
 
 void LineTool::on_keydown(GUI::KeyEvent& event)

--- a/Userland/Applications/PixelPaint/LineTool.h
+++ b/Userland/Applications/PixelPaint/LineTool.h
@@ -29,6 +29,7 @@ private:
     RefPtr<GUI::Widget> m_properties_widget;
 
     GUI::MouseButton m_drawing_button { GUI::MouseButton::None };
+    Gfx::IntPoint m_drag_start_position;
     Gfx::IntPoint m_line_start_position;
     Gfx::IntPoint m_line_end_position;
     int m_thickness { 1 };

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -255,7 +255,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     edit_menu.add_separator();
     edit_menu.add_action(GUI::Action::create(
-        "&Swap Colors", { Mod_None, Key_X }, [&](auto&) {
+        "S&wap Colors", { Mod_None, Key_X }, [&](auto&) {
             auto* editor = current_image_editor();
             if (!editor)
                 return;
@@ -316,7 +316,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         });
 
     m_add_guide_action = GUI::Action::create(
-        "Add Guide", [&](auto&) {
+        "&Add Guide", [&](auto&) {
             auto dialog = PixelPaint::EditGuideDialog::construct(&window);
             if (dialog->exec() != GUI::Dialog::ExecOK)
                 return;
@@ -330,7 +330,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     // Save this so other methods can use it
     m_show_guides_action = GUI::Action::create_checkable(
-        "Show Guides", [&](auto& action) {
+        "Show &Guides", [&](auto& action) {
             Config::write_bool("PixelPaint", "Guides", "Show", action.is_checked());
             if (auto* editor = current_image_editor()) {
                 editor->set_guide_visibility(action.is_checked());
@@ -351,14 +351,14 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     view_menu.add_action(*m_show_guides_action);
 
     view_menu.add_action(GUI::Action::create(
-        "Clear Guides", [&](auto&) {
+        "&Clear Guides", [&](auto&) {
             if (auto* editor = current_image_editor())
                 editor->clear_guides();
         }));
     view_menu.add_separator();
 
     auto show_pixel_grid_action = GUI::Action::create_checkable(
-        "Show Pixel Grid", [&](auto& action) {
+        "Show &Pixel Grid", [&](auto& action) {
             Config::write_bool("PixelPaint", "PixelGrid", "Show", action.is_checked());
             if (auto* editor = current_image_editor())
                 editor->set_pixel_grid_visibility(action.is_checked());
@@ -367,7 +367,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     view_menu.add_action(*show_pixel_grid_action);
 
     m_show_rulers_action = GUI::Action::create_checkable(
-        "Show Rulers", { Mod_Ctrl, Key_R }, [&](auto& action) {
+        "Show R&ulers", { Mod_Ctrl, Key_R }, [&](auto& action) {
             Config::write_bool("PixelPaint", "Rulers", "Show", action.is_checked());
             if (auto* editor = current_image_editor()) {
                 editor->set_ruler_visibility(action.is_checked());
@@ -458,7 +458,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             m_layer_list_widget->select_top_layer();
         }));
     layer_menu.add_action(GUI::Action::create(
-        "Select &Bottom Layer", { 0, Key_End }, [&](auto&) {
+        "Select B&ottom Layer", { 0, Key_End }, [&](auto&) {
             m_layer_list_widget->select_bottom_layer();
         }));
     layer_menu.add_separator();
@@ -531,7 +531,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     };
     layer_menu.add_separator();
     layer_menu.add_action(GUI::Action::create(
-        "&Flatten Image", { Mod_Ctrl, Key_F }, [&](auto&) {
+        "Fl&atten Image", { Mod_Ctrl, Key_F }, [&](auto&) {
             auto* editor = current_image_editor();
             if (!editor)
                 return;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -680,7 +680,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             editor->did_complete_action();
         }
     }));
-    color_filters_menu.add_action(GUI::Action::create("Invert", [&](auto&) {
+    color_filters_menu.add_action(GUI::Action::create("Invert", { Mod_Ctrl, Key_I }, [&](auto&) {
         auto* editor = current_image_editor();
         if (!editor)
             return;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -73,13 +73,8 @@ MainWidget::MainWidget()
         m_palette_widget->set_image_editor(image_editor);
         m_layer_list_widget->set_image(&image_editor.image());
         m_layer_properties_widget->set_layer(image_editor.active_layer());
-        // FIXME: This is badly factored. It transfers tools from the previously active editor to the new one.
-        m_toolbox->template for_each_tool([&](auto& tool) {
-            if (tool.editor()) {
-                tool.editor()->set_active_tool(nullptr);
-                image_editor.set_active_tool(&tool);
-            }
-        });
+        if (auto* active_tool = m_toolbox->active_tool())
+            image_editor.set_active_tool(active_tool);
         m_show_guides_action->set_checked(image_editor.guide_visibility());
         m_show_rulers_action->set_checked(image_editor.ruler_visibility());
     };

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -577,6 +577,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::LaplacianFilter filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false)) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -589,6 +590,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::LaplacianFilter filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true)) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -602,6 +604,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::SpatialGaussianBlurFilter<3> filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get()) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -614,6 +617,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::SpatialGaussianBlurFilter<5> filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<5>>::get()) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -626,6 +630,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::BoxBlurFilter<3> filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get()) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -638,6 +643,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::BoxBlurFilter<5> filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<5>>::get()) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -650,6 +656,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::SharpenFilter filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get()) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -664,6 +671,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             Gfx::GenericConvolutionFilter<5> filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::GenericConvolutionFilter<5>>::get(&window)) {
                 filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
         }
@@ -677,6 +685,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         if (auto* layer = editor->active_layer()) {
             Gfx::GrayscaleFilter filter;
             filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
+            layer->did_modify_bitmap(layer->rect());
             editor->did_complete_action();
         }
     }));
@@ -687,6 +696,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         if (auto* layer = editor->active_layer()) {
             Gfx::InvertFilter filter;
             filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
+            layer->did_modify_bitmap(layer->rect());
             editor->did_complete_action();
         }
     }));

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -107,7 +107,7 @@ void RectangleTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
     auto start_position = m_editor->layer_position_to_editor_position(*layer, m_rectangle_start_position).to_type<int>();
     auto end_position = m_editor->layer_position_to_editor_position(*layer, m_rectangle_end_position).to_type<int>();
-    draw_using(painter, start_position, end_position, m_thickness * m_editor->scale());
+    draw_using(painter, start_position, end_position, AK::max(m_thickness * m_editor->scale(), 1));
 }
 
 void RectangleTool::on_keydown(GUI::KeyEvent& event)

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -106,8 +106,8 @@ void RectangleTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    auto start_position = m_editor->layer_position_to_editor_position(*layer, m_rectangle_start_position).to_type<int>();
-    auto end_position = m_editor->layer_position_to_editor_position(*layer, m_rectangle_end_position).to_type<int>();
+    auto start_position = editor_stroke_position(m_rectangle_start_position, m_thickness);
+    auto end_position = editor_stroke_position(m_rectangle_end_position, m_thickness);
     draw_using(painter, start_position, end_position, AK::max(m_thickness * m_editor->scale(), 1));
 }
 

--- a/Userland/Applications/PixelPaint/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/RectangleTool.cpp
@@ -80,6 +80,7 @@ void RectangleTool::on_mouseup(Layer* layer, MouseEvent& event)
         draw_using(painter, m_rectangle_start_position, m_rectangle_end_position, m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();
+        m_editor->update();
         m_editor->did_complete_action();
     }
 }

--- a/Userland/Applications/PixelPaint/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tool.cpp
@@ -53,4 +53,12 @@ void Tool::on_keydown(GUI::KeyEvent& event)
     }
 }
 
+Gfx::IntPoint Tool::editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const
+{
+    auto position = m_editor->image_position_to_editor_position(pixel_coords);
+    auto offset = (stroke_thickness % 2 == 0) ? m_editor->scale() : m_editor->scale() / 2;
+    position = position.translated(offset, offset);
+    return position.to_type<int>();
+}
+
 }

--- a/Userland/Applications/PixelPaint/Tool.h
+++ b/Userland/Applications/PixelPaint/Tool.h
@@ -76,6 +76,8 @@ protected:
     WeakPtr<ImageEditor> m_editor;
     RefPtr<GUI::Action> m_action;
 
+    virtual Gfx::IntPoint editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const;
+
     void set_primary_slider(GUI::ValueSlider* primary) { m_primary_slider = primary; }
     void set_secondary_slider(GUI::ValueSlider* secondary) { m_secondary_slider = secondary; }
 

--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -53,10 +53,12 @@ void ToolboxWidget::setup_tools()
     auto add_tool = [&](String name, StringView const& icon_name, GUI::Shortcut const& shortcut, NonnullOwnPtr<Tool> tool) {
         auto action = GUI::Action::create_checkable(move(name), shortcut, Gfx::Bitmap::try_load_from_file(String::formatted("/res/icons/pixelpaint/{}.png", icon_name)),
             [this, tool = tool.ptr()](auto& action) {
-                if (action.is_checked())
+                if (action.is_checked()) {
                     on_tool_selection(tool);
-                else
+                    m_active_tool = tool;
+                } else {
                     on_tool_selection(nullptr);
+                }
             });
         m_action_group.add_action(action);
         auto& button = m_toolbar->add_action(action);

--- a/Userland/Applications/PixelPaint/ToolboxWidget.h
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.h
@@ -29,6 +29,8 @@ public:
             callback(tool);
     }
 
+    Tool* active_tool() const { return m_active_tool; }
+
 private:
     friend class ToolButton;
 
@@ -38,6 +40,7 @@ private:
     RefPtr<GUI::Toolbar> m_toolbar;
     GUI::ActionGroup m_action_group;
     NonnullOwnPtrVector<Tool> m_tools;
+    Tool* m_active_tool { nullptr };
 };
 
 }


### PR DESCRIPTION
... I've shaved a lot of Yaks with this one. Here's a summary of the changes:

## Inconsistencies

- Layers being drawn from the bottom of the layer list. I thought this would have been a good idea earlier, but it's been looking a bit odd. Andreas pointed out on Friday that no other list in the system has items justified from the bottom, so I'm making the layers draw from the top again

- Menu ampersand shortcuts have been fixed. Earlier, few menu items didn't have any ampersand shortcuts, and others had conflicts. All of these have been fixed.

- Unlike `RectangleTool` and `EllipseTool`, the `LineTool` didn't let you draw from the center using the `alt` key, this has also been added.

## Bugs Fixed

- Filters didn't notify `ImageClient`s that the layer bitmap had been modified. Same for `RectangleTool` and `LineTool`. All of them now call `Layer::did_modify_bitmap` properly.

- Closing a tab would not transfer the active tool to the next active editor. The prior mechanism for doing so assumed the old editor still existed, which was not the case since it was destroyed by the `TabWidget` when the tab was closed.

- While drawing certain shapes if part of them went outside the bounds of the image, it would not be cleared when the mouse was released until the next editor update, this looked weird. 

- Fixed #9986, which made the application crash on drawing shapes when the effective thickness while doing a second paint got truncated to 0.

- (Mostly) Fixed #9970 , but ellipses are a bit more annoying than anticipated. Will need to look into this in the future.

## Miscellaneous

- Add a shortcut to the invert filter, which is commonly used for most image editing applications. (Drive by fix while i was shaving the other yaks)
