### PR TITLE
LibJS: Make Intl and Temporal prototypes a PrototypeObject

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -12,25 +12,9 @@
 
 namespace JS::Intl {
 
-static DisplayNames* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-
-    if (!is<DisplayNames>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Intl.DisplayNames");
-        return nullptr;
-    }
-
-    return static_cast<DisplayNames*>(this_object);
-}
-
 // 12.4 Properties of the Intl.DisplayNames Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-prototype-object
 DisplayNamesPrototype::DisplayNamesPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -55,7 +39,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
 
     // 1. Let displayNames be this value.
     // 2. Perform ? RequireInternalSlot(displayNames, [[InitializedDisplayNames]]).
-    auto* display_names = typed_this(global_object);
+    auto* display_names = typed_this_object(global_object);
     if (!display_names)
         return {};
 
@@ -107,7 +91,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::resolved_options)
 {
     // 1. Let displayNames be this value.
     // 2. Perform ? RequireInternalSlot(displayNames, [[InitializedDisplayNames]]).
-    auto* display_names = typed_this(global_object);
+    auto* display_names = typed_this_object(global_object);
     if (!display_names)
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/DisplayNames.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS::Intl {
 
-class DisplayNamesPrototype final : public Object {
-    JS_OBJECT(DisplayNamesPrototype, Object);
+class DisplayNamesPrototype final : public PrototypeObject<DisplayNamesPrototype, DisplayNames> {
+    JS_PROTOTYPE_OBJECT(DisplayNamesPrototype, DisplayNames, Intl.DisplayNames);
 
 public:
     explicit DisplayNamesPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -12,25 +12,9 @@
 
 namespace JS::Intl {
 
-static ListFormat* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-
-    if (!is<ListFormat>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Intl.ListFormat");
-        return nullptr;
-    }
-
-    return static_cast<ListFormat*>(this_object);
-}
-
 // 13.4 Properties of the Intl.ListFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
 ListFormatPrototype::ListFormatPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -56,7 +40,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format)
 
     // 1. Let lf be the this value.
     // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-    auto* list_format = typed_this(global_object);
+    auto* list_format = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -77,7 +61,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format_to_parts)
 
     // 1. Let lf be the this value.
     // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-    auto* list_format = typed_this(global_object);
+    auto* list_format = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -95,7 +79,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
 {
     // 1. Let lf be the this value.
     // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
-    auto* list_format = typed_this(global_object);
+    auto* list_format = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/ListFormat.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS::Intl {
 
-class ListFormatPrototype final : public Object {
-    JS_OBJECT(ListFormatPrototype, Object);
+class ListFormatPrototype final : public PrototypeObject<ListFormatPrototype, ListFormat> {
+    JS_PROTOTYPE_OBJECT(ListFormatPrototype, ListFormat, Intl.ListFormat);
 
 public:
     explicit ListFormatPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -12,25 +12,9 @@
 
 namespace JS::Intl {
 
-static Locale* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-
-    if (!is<Locale>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Intl.Locale");
-        return nullptr;
-    }
-
-    return static_cast<Locale*>(this_object);
-}
-
 // 14.3 Properties of the Intl.Locale Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-locale-prototype-object
 LocalePrototype::LocalePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -65,7 +49,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::maximize)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -85,7 +69,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::minimize)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -105,7 +89,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::to_string)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -118,7 +102,7 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::base_name)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -142,15 +126,15 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::base_name)
 // 14.3.9 get Intl.Locale.prototype.collation, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation
 // 14.3.10 get Intl.Locale.prototype.hourCycle, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle
 // 14.3.12 get Intl.Locale.prototype.numberingSystem, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem
-#define __JS_ENUMERATE(keyword)                          \
-    JS_DEFINE_NATIVE_GETTER(LocalePrototype::keyword)    \
-    {                                                    \
-        auto* locale_object = typed_this(global_object); \
-        if (!locale_object)                              \
-            return {};                                   \
-        if (!locale_object->has_##keyword())             \
-            return js_undefined();                       \
-        return js_string(vm, locale_object->keyword());  \
+#define __JS_ENUMERATE(keyword)                                 \
+    JS_DEFINE_NATIVE_GETTER(LocalePrototype::keyword)           \
+    {                                                           \
+        auto* locale_object = typed_this_object(global_object); \
+        if (!locale_object)                                     \
+            return {};                                          \
+        if (!locale_object->has_##keyword())                    \
+            return js_undefined();                              \
+        return js_string(vm, locale_object->keyword());         \
     }
 JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES
 #undef __JS_ENUMERATE
@@ -160,7 +144,7 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::numeric)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -173,7 +157,7 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::language)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -192,7 +176,7 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::script)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 
@@ -215,7 +199,7 @@ JS_DEFINE_NATIVE_GETTER(LocalePrototype::region)
 {
     // 1. Let loc be the this value.
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto* locale_object = typed_this(global_object);
+    auto* locale_object = typed_this_object(global_object);
     if (!locale_object)
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/Locale.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS::Intl {
 
-class LocalePrototype final : public Object {
-    JS_OBJECT(LocalePrototype, Object);
+class LocalePrototype final : public PrototypeObject<LocalePrototype, Locale> {
+    JS_PROTOTYPE_OBJECT(LocalePrototype, Locale, Intl.Locale);
 
 public:
     explicit LocalePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -11,25 +11,9 @@
 
 namespace JS::Intl {
 
-static NumberFormat* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return nullptr;
-
-    if (!is<NumberFormat>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Intl.NumberFormat");
-        return nullptr;
-    }
-
-    return static_cast<NumberFormat*>(this_object);
-}
-
 // 15.4 Properties of the Intl.NumberFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-numberformat-prototype-object
 NumberFormatPrototype::NumberFormatPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -53,7 +37,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
     // 2. If the implementation supports the normative optional constructor mode of 4.3 Note 1, then
     //     a. Set nf to ? UnwrapNumberFormat(nf).
     // 3. Perform ? RequireInternalSlot(nf, [[InitializedNumberFormat]]).
-    auto* number_format = typed_this(global_object);
+    auto* number_format = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/NumberFormat.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 
 namespace JS::Intl {
 
-class NumberFormatPrototype final : public Object {
-    JS_OBJECT(NumberFormatPrototype, Object);
+class NumberFormatPrototype final : public PrototypeObject<NumberFormatPrototype, NumberFormat> {
+    JS_PROTOTYPE_OBJECT(NumberFormatPrototype, NumberFormat, Intl.NumberFormat);
 
 public:
     explicit NumberFormatPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.h
@@ -20,8 +20,6 @@ public:
     virtual ~MapPrototype() override;
 
 private:
-    static Map* typed_this(VM&, GlobalObject&);
-
     JS_DECLARE_NATIVE_FUNCTION(clear);
     JS_DECLARE_NATIVE_FUNCTION(delete_);
     JS_DECLARE_NATIVE_FUNCTION(entries);

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.h
@@ -20,8 +20,6 @@ public:
     virtual ~SetPrototype() override;
 
 private:
-    static Set* typed_this(VM&, GlobalObject&);
-
     JS_DECLARE_NATIVE_FUNCTION(add);
     JS_DECLARE_NATIVE_FUNCTION(clear);
     JS_DECLARE_NATIVE_FUNCTION(delete_);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -21,7 +21,7 @@ namespace JS::Temporal {
 
 // 12.4 Properties of the Temporal.Calendar Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-calendar-prototype-object
 CalendarPrototype::CalendarPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -61,19 +61,6 @@ void CalendarPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.eraYear, era_year, 1, attr);
 }
 
-static Calendar* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<Calendar>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.Calendar");
-        return {};
-    }
-    return static_cast<Calendar*>(this_object);
-}
-
 // 12.4.3 get Temporal.Calendar.prototype.id, https://tc39.es/proposal-temporal/#sec-get-temporal.calendar.prototype.id
 JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::id_getter)
 {
@@ -90,7 +77,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::date_from_fields)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -124,7 +111,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::year_month_from_fields)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -158,7 +145,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::month_day_from_fields)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -192,7 +179,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::date_add)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -240,7 +227,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::year)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -266,7 +253,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::month)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -300,7 +287,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::month_code)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -326,7 +313,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::day)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -352,7 +339,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::day_of_week)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -374,7 +361,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::day_of_year)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -396,7 +383,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::week_of_year)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -418,7 +405,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::days_in_week)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -440,7 +427,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::days_in_month)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -466,7 +453,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::days_in_year)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -492,7 +479,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::months_in_year)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -518,7 +505,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::in_leap_year)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -546,7 +533,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::fields)
 
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -622,7 +609,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::merge_fields)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -648,7 +635,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::to_string)
 {
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -673,7 +660,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::era)
 
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -705,7 +692,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::era_year)
 
     // 1. Let calendar be the this value.
     // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
-    auto* calendar = typed_this(global_object);
+    auto* calendar = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/Calendar.h>
 
 namespace JS::Temporal {
 
-class CalendarPrototype final : public Object {
-    JS_OBJECT(CalendarPrototype, Object);
+class CalendarPrototype final : public PrototypeObject<CalendarPrototype, Calendar> {
+    JS_PROTOTYPE_OBJECT(CalendarPrototype, Calendar, Temporal.Calendar);
 
 public:
     explicit CalendarPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -14,7 +14,7 @@ namespace JS::Temporal {
 
 // 7.3 Properties of the Temporal.Duration Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-duration-prototype-object
 DurationPrototype::DurationPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -47,25 +47,12 @@ void DurationPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
-static Duration* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<Duration>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.Duration");
-        return {};
-    }
-    return static_cast<Duration*>(this_object);
-}
-
 // 7.3.3 get Temporal.Duration.prototype.years, https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.years
 JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::years_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -78,7 +65,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::months_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -91,7 +78,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::weeks_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -104,7 +91,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::days_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -117,7 +104,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::hours_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -130,7 +117,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::minutes_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -143,7 +130,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::seconds_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -156,7 +143,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::milliseconds_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -169,7 +156,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::microseconds_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -182,7 +169,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::nanoseconds_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -195,7 +182,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::sign_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -208,7 +195,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::blank_getter)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -228,7 +215,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::with)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -306,7 +293,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::negated)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -319,7 +306,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::abs)
 {
     // 1. Let duration be the this value.
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-    auto* duration = typed_this(global_object);
+    auto* duration = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/Duration.h>
 
 namespace JS::Temporal {
 
-class DurationPrototype final : public Object {
-    JS_OBJECT(DurationPrototype, Object);
+class DurationPrototype final : public PrototypeObject<DurationPrototype, Duration> {
+    JS_PROTOTYPE_OBJECT(DurationPrototype, Duration, Temporal.Duration);
 
 public:
     explicit DurationPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -19,7 +19,7 @@ namespace JS::Temporal {
 
 // 8.3 Properties of the Temporal.Instant Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-instant-prototype-object
 InstantPrototype::InstantPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -52,25 +52,12 @@ void InstantPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.toZonedDateTimeISO, to_zoned_date_time_iso, 1, attr);
 }
 
-static Instant* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<Instant>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.Instant");
-        return {};
-    }
-    return static_cast<Instant*>(this_object);
-}
-
 // 8.3.3 get Temporal.Instant.prototype.epochSeconds, https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochseconds
 JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_seconds_getter)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -89,7 +76,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_milliseconds_getter)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -108,7 +95,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_microseconds_getter)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -127,7 +114,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_nanoseconds_getter)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -145,7 +132,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::add)
 
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -170,7 +157,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::subtract)
 
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -193,7 +180,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::until)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -253,7 +240,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::since)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -313,7 +300,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::round)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -400,7 +387,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::equals)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -422,7 +409,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::to_string)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -476,7 +463,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::to_locale_string)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -493,7 +480,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::to_json)
 {
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -520,7 +507,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::to_zoned_date_time)
 
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -576,7 +563,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::to_zoned_date_time_iso)
 
     // 1. Let instant be the this value.
     // 2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
-    auto* instant = typed_this(global_object);
+    auto* instant = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/Instant.h>
 
 namespace JS::Temporal {
 
-class InstantPrototype final : public Object {
-    JS_OBJECT(InstantPrototype, Object);
+class InstantPrototype final : public PrototypeObject<InstantPrototype, Instant> {
+    JS_PROTOTYPE_OBJECT(InstantPrototype, Instant, Temporal.Instant);
 
 public:
     explicit InstantPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -20,7 +20,7 @@ namespace JS::Temporal {
 
 // 3.3 Properties of the Temporal.PlainDate Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindate-prototype-object
 PlainDatePrototype::PlainDatePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -62,25 +62,12 @@ void PlainDatePrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
-static PlainDate* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<PlainDate>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.PlainDate");
-        return {};
-    }
-    return static_cast<PlainDate*>(this_object);
-}
-
 // 3.3.3 get Temporal.PlainDate.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendar
 JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::calendar_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -93,7 +80,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::year_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -109,7 +96,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::month_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -125,7 +112,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::month_code_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -141,7 +128,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::day_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -157,7 +144,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::day_of_week_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -173,7 +160,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::day_of_year_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -189,7 +176,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::week_of_year_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -205,7 +192,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::days_in_week_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -221,7 +208,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::days_in_month_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -237,7 +224,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::days_in_year_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -253,7 +240,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::months_in_year_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -269,7 +256,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::in_leap_year_getter)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -285,7 +272,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::era_getter)
 {
     // 1. Let plainDate be the this value.
     // 2. Perform ? RequireInternalSlot(plainDate, [[InitializedTemporalDate]]).
-    auto* plain_date = typed_this(global_object);
+    auto* plain_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -301,7 +288,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::era_year_getter)
 {
     // 1. Let plainDate be the this value.
     // 2. Perform ? RequireInternalSlot(plainDate, [[InitializedTemporalDate]]).
-    auto* plain_date = typed_this(global_object);
+    auto* plain_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -317,7 +304,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_plain_year_month)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -343,7 +330,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_plain_month_day)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -369,7 +356,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::get_iso_fields)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -397,7 +384,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::with_calendar)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -415,7 +402,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::equals)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -442,7 +429,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_plain_date_time)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -466,7 +453,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_string)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -494,7 +481,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_locale_string)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -511,7 +498,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::to_json)
 {
     // 1. Let temporalDate be the this value.
     // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-    auto* temporal_date = typed_this(global_object);
+    auto* temporal_date = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/PlainDate.h>
 
 namespace JS::Temporal {
 
-class PlainDatePrototype final : public Object {
-    JS_OBJECT(PlainDatePrototype, Object);
+class PlainDatePrototype final : public PrototypeObject<PlainDatePrototype, PlainDate> {
+    JS_PROTOTYPE_OBJECT(PlainDatePrototype, PlainDate, Temporal.PlainDate);
 
 public:
     explicit PlainDatePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -17,7 +17,7 @@ namespace JS::Temporal {
 
 // 5.3 Properties of the Temporal.PlainDateTime Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object
 PlainDateTimePrototype::PlainDateTimePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -65,25 +65,12 @@ void PlainDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.getISOFields, get_iso_fields, 0, attr);
 }
 
-static PlainDateTime* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<PlainDateTime>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.PlainDateTime");
-        return {};
-    }
-    return static_cast<PlainDateTime*>(this_object);
-}
-
 // 5.3.3 get Temporal.PlainDateTime.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendar
 JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::calendar_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -96,7 +83,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::year_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -112,7 +99,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -128,7 +115,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_code_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -144,7 +131,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -160,7 +147,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::hour_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -173,7 +160,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::minute_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -186,7 +173,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::second_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -199,7 +186,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::millisecond_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -212,7 +199,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::microsecond_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -225,7 +212,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::nanosecond_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -238,7 +225,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_of_week_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -254,7 +241,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::day_of_year_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -270,7 +257,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::week_of_year_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -286,7 +273,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_week_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -302,7 +289,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_month_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -318,7 +305,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::days_in_year_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -334,7 +321,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::months_in_year_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -350,7 +337,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::in_leap_year_getter)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -366,7 +353,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::era_getter)
 {
     // 1. Let plainDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(plainDateTime, [[InitializedTemporalDateTime]]).
-    auto* plain_date_time = typed_this(global_object);
+    auto* plain_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -382,7 +369,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::era_year_getter)
 {
     // 1. Let plainDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(plainDateTime, [[InitializedTemporalDateTime]]).
-    auto* plain_date_time = typed_this(global_object);
+    auto* plain_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -398,7 +385,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::with_plain_time)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -422,7 +409,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::with_plain_date)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -445,7 +432,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::with_calendar)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -463,7 +450,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::equals)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -496,7 +483,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::to_plain_date)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -509,7 +496,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::to_plain_year_month)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -535,7 +522,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::to_plain_month_day)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -561,7 +548,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::to_plain_time)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -574,7 +561,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::get_iso_fields)
 {
     // 1. Let dateTime be the this value.
     // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
-    auto* date_time = typed_this(global_object);
+    auto* date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/PlainDateTime.h>
 
 namespace JS::Temporal {
 
-class PlainDateTimePrototype final : public Object {
-    JS_OBJECT(PlainDateTimePrototype, Object);
+class PlainDateTimePrototype final : public PrototypeObject<PlainDateTimePrototype, PlainDateTime> {
+    JS_PROTOTYPE_OBJECT(PlainDateTimePrototype, PlainDateTime, Temporal.PlainDateTime);
 
 public:
     explicit PlainDateTimePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
@@ -15,7 +15,7 @@ namespace JS::Temporal {
 
 // 10.3 Properties of the Temporal.PlainMonthDay Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainmonthday-prototype-object
 PlainMonthDayPrototype::PlainMonthDayPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -41,25 +41,12 @@ void PlainMonthDayPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.getISOFields, get_iso_fields, 0, attr);
 }
 
-static PlainMonthDay* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<PlainMonthDay>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.PlainMonthDay");
-        return {};
-    }
-    return static_cast<PlainMonthDay*>(this_object);
-}
-
 // 10.3.3 get Temporal.PlainMonthDay.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendar
 JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::calendar_getter)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -72,7 +59,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::month_code_getter)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -88,7 +75,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::day_getter)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -104,7 +91,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::equals)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -134,7 +121,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::to_string)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -162,7 +149,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::to_locale_string)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -179,7 +166,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::to_json)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -204,7 +191,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::get_iso_fields)
 {
     // 1. Let monthDay be the this value.
     // 2. Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
-    auto* month_day = typed_this(global_object);
+    auto* month_day = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/PlainMonthDay.h>
 
 namespace JS::Temporal {
 
-class PlainMonthDayPrototype final : public Object {
-    JS_OBJECT(PlainMonthDayPrototype, Object);
+class PlainMonthDayPrototype final : public PrototypeObject<PlainMonthDayPrototype, PlainMonthDay> {
+    JS_PROTOTYPE_OBJECT(PlainMonthDayPrototype, PlainMonthDay, Temporal.PlainMonthDay);
 
 public:
     explicit PlainMonthDayPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -16,7 +16,7 @@ namespace JS::Temporal {
 
 // 4.3 Properties of the Temporal.PlainTime Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-prototype-object
 PlainTimePrototype::PlainTimePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -48,25 +48,12 @@ void PlainTimePrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
-static PlainTime* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<PlainTime>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.PlainTime");
-        return {};
-    }
-    return static_cast<PlainTime*>(this_object);
-}
-
 // 4.3.3 get Temporal.PlainTime.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.calendar
 JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::calendar_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -79,7 +66,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::hour_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -92,7 +79,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::minute_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -105,7 +92,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::second_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -118,7 +105,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::millisecond_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -131,7 +118,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::microsecond_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -144,7 +131,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::nanosecond_getter)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -157,7 +144,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::with)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -266,7 +253,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::equals)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -308,7 +295,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::to_plain_date_time)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -326,7 +313,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::get_iso_fields)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -363,7 +350,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::to_string)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -395,7 +382,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::to_locale_string)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -409,7 +396,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainTimePrototype::to_json)
 {
     // 1. Let temporalTime be the this value.
     // 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]).
-    auto* temporal_time = typed_this(global_object);
+    auto* temporal_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/PlainTime.h>
 
 namespace JS::Temporal {
 
-class PlainTimePrototype final : public Object {
-    JS_OBJECT(PlainTimePrototype, Object);
+class PlainTimePrototype final : public PrototypeObject<PlainTimePrototype, PlainTime> {
+    JS_PROTOTYPE_OBJECT(PlainTimePrototype, PlainTime, Temporal.PlainTime);
 
 public:
     explicit PlainTimePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -15,7 +15,7 @@ namespace JS::Temporal {
 
 // 9.3 Properties of the Temporal.PlainYearMonth Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainyearmonth-prototype-object
 PlainYearMonthPrototype::PlainYearMonthPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -48,25 +48,12 @@ void PlainYearMonthPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.getISOFields, get_iso_fields, 0, attr);
 }
 
-static PlainYearMonth* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<PlainYearMonth>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.PlainYearMonth");
-        return {};
-    }
-    return static_cast<PlainYearMonth*>(this_object);
-}
-
 // 9.3.3 get Temporal.PlainYearMonth.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendar
 JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::calendar_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -79,7 +66,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::year_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -95,7 +82,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::month_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -111,7 +98,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::month_code_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -127,7 +114,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::days_in_year_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -143,7 +130,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::days_in_month_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -159,7 +146,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::months_in_year_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -175,7 +162,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::in_leap_year_getter)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -191,7 +178,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::era_getter)
 {
     // 1. Let plainYearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(plainYearMonth, [[InitializedTemporalYearMonth]]).
-    auto* plain_year_month = typed_this(global_object);
+    auto* plain_year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -207,7 +194,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::era_year_getter)
 {
     // 1. Let plainYearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(plainYearMonth, [[InitializedTemporalYearMonth]]).
-    auto* plain_year_month = typed_this(global_object);
+    auto* plain_year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -223,7 +210,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::equals)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -253,7 +240,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::to_string)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -281,7 +268,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::to_locale_string)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -298,7 +285,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::to_json)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -323,7 +310,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::get_iso_fields)
 {
     // 1. Let yearMonth be the this value.
     // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
-    auto* year_month = typed_this(global_object);
+    auto* year_month = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/PlainYearMonth.h>
 
 namespace JS::Temporal {
 
-class PlainYearMonthPrototype final : public Object {
-    JS_OBJECT(PlainYearMonthPrototype, Object);
+class PlainYearMonthPrototype final : public PrototypeObject<PlainYearMonthPrototype, PlainYearMonth> {
+    JS_PROTOTYPE_OBJECT(PlainYearMonthPrototype, PlainYearMonth, Temporal.PlainYearMonth);
 
 public:
     explicit PlainYearMonthPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -16,7 +16,7 @@ namespace JS::Temporal {
 
 // 11.4 Properties of the Temporal.TimeZone Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-timezone-prototype-object
 TimeZonePrototype::TimeZonePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -38,19 +38,6 @@ void TimeZonePrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Temporal.TimeZone"), Attribute::Configurable);
 }
 
-static TimeZone* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<TimeZone>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.TimeZone");
-        return {};
-    }
-    return static_cast<TimeZone*>(this_object);
-}
-
 // 11.4.3 get Temporal.TimeZone.prototype.id, https://tc39.es/proposal-temporal/#sec-get-temporal.timezone.prototype.id
 JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::id_getter)
 {
@@ -66,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_offset_nanoseconds_for)
 {
     // 1. Let timeZone be the this value.
     // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
-    auto* time_zone = typed_this(global_object);
+    auto* time_zone = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -88,7 +75,7 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_offset_string_for)
 {
     // 1. Let timeZone be the this value.
     // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
-    auto* time_zone = typed_this(global_object);
+    auto* time_zone = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -129,7 +116,7 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::to_string)
 {
     // 1. Let timeZone be the this value.
     // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
-    auto* time_zone = typed_this(global_object);
+    auto* time_zone = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/TimeZone.h>
 
 namespace JS::Temporal {
 
-class TimeZonePrototype final : public Object {
-    JS_OBJECT(TimeZonePrototype, Object);
+class TimeZonePrototype final : public PrototypeObject<TimeZonePrototype, TimeZone> {
+    JS_PROTOTYPE_OBJECT(TimeZonePrototype, TimeZone, Temporal.TimeZone);
 
 public:
     explicit TimeZonePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -20,7 +20,7 @@ namespace JS::Temporal {
 
 // 6.3 Properties of the Temporal.ZonedDateTime Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object
 ZonedDateTimePrototype::ZonedDateTimePrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : PrototypeObject(*global_object.object_prototype())
 {
 }
 
@@ -73,25 +73,12 @@ void ZonedDateTimePrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.getISOFields, get_iso_fields, 0, attr);
 }
 
-static ZonedDateTime* typed_this(GlobalObject& global_object)
-{
-    auto& vm = global_object.vm();
-    auto* this_object = vm.this_value(global_object).to_object(global_object);
-    if (!this_object)
-        return {};
-    if (!is<ZonedDateTime>(this_object)) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOfType, "Temporal.ZonedDateTime");
-        return {};
-    }
-    return static_cast<ZonedDateTime*>(this_object);
-}
-
 // 6.3.3 get Temporal.ZonedDateTime.prototype.calendar, https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendar
 JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::calendar_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -104,7 +91,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::time_zone_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -117,7 +104,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -144,7 +131,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::month_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -171,7 +158,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::month_code_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -198,7 +185,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::day_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -225,7 +212,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::hour_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -252,7 +239,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::minute_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -279,7 +266,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::second_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -306,7 +293,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::millisecond_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -333,7 +320,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::microsecond_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -360,7 +347,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::nanosecond_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -387,7 +374,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_seconds_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -406,7 +393,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_milliseconds_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -425,7 +412,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_microseconds_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -444,7 +431,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_nanoseconds_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -457,7 +444,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::day_of_week_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -484,7 +471,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::day_of_year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -511,7 +498,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::week_of_year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -538,7 +525,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::days_in_week_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -565,7 +552,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::days_in_month_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -592,7 +579,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::days_in_year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -619,7 +606,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::months_in_year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -646,7 +633,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::in_leap_year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -673,7 +660,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::offset_nanoseconds_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -692,7 +679,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::offset_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -711,7 +698,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::era_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -738,7 +725,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::era_year_getter)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -773,7 +760,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_instant)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -786,7 +773,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_plain_date)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -813,7 +800,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_plain_time)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -840,7 +827,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_plain_date_time)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -859,7 +846,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_plain_year_month)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -896,7 +883,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_plain_month_day)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 
@@ -933,7 +920,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::get_iso_fields)
 {
     // 1. Let zonedDateTime be the this value.
     // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
-    auto* zoned_date_time = typed_this(global_object);
+    auto* zoned_date_time = typed_this_object(global_object);
     if (vm.exception())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+#include <LibJS/Runtime/Temporal/ZonedDateTime.h>
 
 namespace JS::Temporal {
 
-class ZonedDateTimePrototype final : public Object {
-    JS_OBJECT(ZonedDateTimePrototype, Object);
+class ZonedDateTimePrototype final : public PrototypeObject<ZonedDateTimePrototype, ZonedDateTime> {
+    JS_PROTOTYPE_OBJECT(ZonedDateTimePrototype, ZonedDateTime, Temporal.ZonedDateTime);
 
 public:
     explicit ZonedDateTimePrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
@@ -20,8 +20,6 @@ public:
     virtual ~WeakMapPrototype() override;
 
 private:
-    static WeakMap* typed_this(VM&, GlobalObject&);
-
     JS_DECLARE_NATIVE_FUNCTION(delete_);
     JS_DECLARE_NATIVE_FUNCTION(get);
     JS_DECLARE_NATIVE_FUNCTION(has);

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -20,8 +20,6 @@ public:
     virtual ~WeakSetPrototype() override;
 
 private:
-    static WeakSet* typed_this(VM&, GlobalObject&);
-
     JS_DECLARE_NATIVE_FUNCTION(add);
     JS_DECLARE_NATIVE_FUNCTION(delete_);
     JS_DECLARE_NATIVE_FUNCTION(has);


### PR DESCRIPTION
No more `typed_this()` in LibJS :^)