### PR TITLE
LibWeb: Fix opacity ComputedCSSStyleDeclaration

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ComputedCSSStyleDeclaration.cpp
@@ -495,7 +495,7 @@ Optional<StyleProperty> ComputedCSSStyleDeclaration::property(PropertyID propert
         };
     }
     case CSS::PropertyID::Opacity: {
-        auto maybe_opacity = layout_node.computed_values().flex_grow_factor();
+        auto maybe_opacity = layout_node.computed_values().opacity();
         if (!maybe_opacity.has_value())
             return {};
 


### PR DESCRIPTION
There was a classic copy&paste error, opacity wasn't getting the right
computed value to convert.
Thx @danners for pointing that out!