### PR TITLE
LibWeb: FlexBox: Use correct source when querying for the main size

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -85,15 +85,15 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
     auto has_definite_cross_size = [&is_row](Box& box) {
         return is_row ? box.has_definite_height() : box.has_definite_width();
     };
-    auto specified_main_size = [&is_row, &get_pixel_size](Box& box) {
+    auto specified_main_size = [&is_row](Box& box) {
         return is_row
-            ? get_pixel_size(box, box.computed_values().width())
-            : get_pixel_size(box, box.computed_values().height());
+            ? box.width()
+            : box.height();
     };
-    auto specified_cross_size = [&is_row, &get_pixel_size](Box& box) {
+    auto specified_cross_size = [&is_row](Box& box) {
         return is_row
-            ? get_pixel_size(box, box.computed_values().height())
-            : get_pixel_size(box, box.computed_values().width());
+            ? box.height()
+            : box.width();
     };
     auto has_main_min_size = [&is_row](Box& box) {
         return is_row


### PR DESCRIPTION
This was an error in understanding what calculated_values are and that
those are not what is wanted when getting the main available size of the
box in the FlexFormattingContext.
The calculation around the size calculation is still a bit wonky, but
this is definietly better.