### PR TITLE
LibWeb: Make innerHTML more spec compliant and add ParentNode.children

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -64,6 +64,8 @@ interface Document : Node {
     Element? querySelector(DOMString selectors);
     ArrayFromVector querySelectorAll(DOMString selectors);
 
+    [SameObject] readonly attribute HTMLCollection children;
+
     // FIXME: These should all come from a GlobalEventHandlers mixin
     attribute EventHandler onabort;
     attribute EventHandler onauxclick;

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -12,4 +12,6 @@ interface DocumentFragment : Node {
     Element? querySelector(DOMString selectors);
     ArrayFromVector querySelectorAll(DOMString selectors);
 
+    [SameObject] readonly attribute HTMLCollection children;
+
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/DOMParsing/InnerHTML.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
 #include <LibWeb/Layout/BlockBox.h>
@@ -244,16 +245,15 @@ NonnullRefPtr<CSS::StyleProperties> Element::computed_style()
     return properties;
 }
 
-void Element::set_inner_html(StringView markup)
+ExceptionOr<void> Element::set_inner_html(String const& markup)
 {
-    auto new_children = HTML::HTMLDocumentParser::parse_html_fragment(*this, markup);
-    remove_all_children();
-    while (!new_children.is_empty()) {
-        append_child(new_children.take_first());
-    }
+    auto result = DOMParsing::InnerHTML::inner_html_setter(*this, markup);
+    if (result.is_exception())
+        return result.exception();
 
     set_needs_style_update(true);
     document().invalidate_layout();
+    return {};
 }
 
 // https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -108,6 +108,9 @@ public:
 
     void queue_an_element_task(HTML::Task::Source, Function<void()>);
 
+    bool is_void_element() const;
+    bool serializes_as_void() const;
+
 protected:
     RefPtr<Layout::Node> create_layout_node() override;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -81,9 +81,8 @@ public:
 
     NonnullRefPtr<CSS::CSSStyleDeclaration> style_for_bindings();
 
-    // FIXME: innerHTML also appears on shadow roots. https://w3c.github.io/DOM-Parsing/#dom-innerhtml
     String inner_html() const;
-    void set_inner_html(StringView);
+    ExceptionOr<void> set_inner_html(String const&);
 
     bool is_focused() const;
     virtual bool is_focusable() const { return false; }

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -31,4 +31,6 @@ interface Element : Node {
 
     Element? querySelector(DOMString selectors);
     ArrayFromVector querySelectorAll(DOMString selectors);
+
+    [SameObject] readonly attribute HTMLCollection children;
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -13,7 +13,9 @@ interface Element : Node {
     HTMLCollection getElementsByTagName(DOMString tagName);
     HTMLCollection getElementsByClassName(DOMString className);
 
-    [LegacyNullToEmptyString] attribute DOMString innerHTML;
+    // FIXME: This should come from a InnerHTML mixin.
+    [LegacyNullToEmptyString, CEReactions] attribute DOMString innerHTML;
+
     [Reflect] attribute DOMString id;
     [Reflect=class] attribute DOMString className;
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
+#include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -766,6 +767,18 @@ void Node::string_replace_all(String const& string)
         node = make_ref_counted<Text>(document(), string);
 
     replace_all(node);
+}
+
+// https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm
+String Node::serialize_fragment(/* FIXME: Requires well-formed flag */) const
+{
+    // FIXME: Let context document be the value of node's node document.
+
+    // FIXME: If context document is an HTML document, return an HTML serialization of node.
+    //        (We currently always do this)
+    return HTML::HTMLDocumentParser::serialize_html_fragment(*this);
+
+    // FIXME: Otherwise, context document is an XML document; return an XML serialization of node passing the flag require well-formed.
 }
 
 // https://dom.spec.whatwg.org/#dom-node-issamenode

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -183,6 +183,8 @@ public:
     i32 id() const { return m_id; }
     static Node* from_id(i32 node_id);
 
+    String serialize_fragment() const;
+
     void replace_all(RefPtr<Node>);
     void string_replace_all(String const&);
 

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/SelectorEngine.h>
+#include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/Dump.h>
 
@@ -73,6 +74,17 @@ u32 ParentNode::child_element_count() const
             ++count;
     }
     return count;
+}
+
+// https://dom.spec.whatwg.org/#dom-parentnode-children
+NonnullRefPtr<HTMLCollection> ParentNode::children()
+{
+    // The children getter steps are to return an HTMLCollection collection rooted at this matching only element children.
+    // FIXME: This should return the same HTMLCollection object every time,
+    //        but that would cause a reference cycle since HTMLCollection refs the root.
+    return HTMLCollection::create(*this, [this](Element const& element) {
+        return is_parent_of(element);
+    });
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -25,6 +25,8 @@ public:
     ExceptionOr<RefPtr<Element>> query_selector(StringView);
     ExceptionOr<NonnullRefPtrVector<Element>> query_selector_all(StringView);
 
+    NonnullRefPtr<HTMLCollection> children();
+
 protected:
     ParentNode(Document& document, NodeType type)
         : Node(document, type)

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOMParsing/InnerHTML.h>
 #include <LibWeb/Layout/BlockBox.h>
 
 namespace Web::DOM {
@@ -31,6 +33,24 @@ EventTarget* ShadowRoot::get_parent(const Event& event)
 RefPtr<Layout::Node> ShadowRoot::create_layout_node()
 {
     return adopt_ref(*new Layout::BlockBox(document(), this, CSS::ComputedValues {}));
+}
+
+// https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
+String ShadowRoot::inner_html() const
+{
+    return serialize_fragment(/* FIXME: Providing true for the require well-formed flag (which may throw) */);
+}
+
+// https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
+ExceptionOr<void> ShadowRoot::set_inner_html(String const& markup)
+{
+    auto result = DOMParsing::InnerHTML::inner_html_setter(*this, markup);
+    if (result.is_exception())
+        return result.exception();
+
+    set_needs_style_update(true);
+    document().invalidate_layout();
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -28,6 +28,9 @@ public:
     // NOTE: This is intended for the JS bindings.
     String mode() const { return m_closed ? "closed" : "open"; }
 
+    String inner_html() const;
+    ExceptionOr<void> set_inner_html(String const&);
+
 private:
     // ^Node
     virtual FlyString node_name() const override { return "#shadow-root"; }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -3,4 +3,7 @@ interface ShadowRoot : DocumentFragment {
     readonly attribute DOMString mode;
     readonly attribute Element host;
 
+    // FIXME: This should come from a InnerHTML mixin.
+    [LegacyNullToEmptyString] attribute DOMString innerHTML;
+
 };

--- a/Userland/Libraries/LibWeb/DOMParsing/Algorithms.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/Algorithms.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/DocumentFragment.h>
+#include <LibWeb/DOM/ExceptionOr.h>
+#include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
+
+namespace Web::DOMParsing {
+
+// https://w3c.github.io/DOM-Parsing/#dfn-fragment-parsing-algorithm
+static DOM::ExceptionOr<NonnullRefPtr<DOM::DocumentFragment>> parse_fragment(String const& markup, DOM::Element& context_element)
+{
+    // FIXME: Handle XML documents.
+
+    auto new_children = HTML::HTMLDocumentParser::parse_html_fragment(context_element, markup);
+    auto fragment = make_ref_counted<DOM::DocumentFragment>(context_element.document());
+
+    for (auto& child : new_children) {
+        // I don't know if this can throw here, but let's be safe.
+        auto result = fragment->append_child(child);
+        if (result.is_exception())
+            return result.exception();
+    }
+
+    return fragment;
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/ExceptionOr.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOMParsing/Algorithms.h>
+#include <LibWeb/HTML/HTMLTemplateElement.h>
+
+namespace Web::DOMParsing::InnerHTML {
+
+// https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
+static DOM::ExceptionOr<void> inner_html_setter(NonnullRefPtr<DOM::Node> context_object, String const& value)
+{
+    // 1. Let context element be the context object's host if the context object is a ShadowRoot object, or the context object otherwise.
+    //    (This is handled in Element and ShadowRoot)
+    NonnullRefPtr<DOM::Element> context_element = is<DOM::ShadowRoot>(*context_object) ? *verify_cast<DOM::ShadowRoot>(*context_object).host() : verify_cast<DOM::Element>(*context_object);
+
+    // 2. Let fragment be the result of invoking the fragment parsing algorithm with the new value as markup, and with context element.
+    auto fragment_or_exception = parse_fragment(value, context_element);
+    if (fragment_or_exception.is_exception())
+        return fragment_or_exception.exception();
+    auto fragment = fragment_or_exception.release_value();
+
+    // 3. If the context object is a template element, then let context object be the template's template contents (a DocumentFragment).
+    if (is<HTML::HTMLTemplateElement>(*context_object))
+        context_object = verify_cast<HTML::HTMLTemplateElement>(*context_object).content();
+
+    // 4. Replace all with fragment within the context object.
+    context_object->replace_all(fragment);
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
@@ -53,6 +53,7 @@ public:
     DOM::Document& document();
 
     static NonnullRefPtrVector<DOM::Node> parse_html_fragment(DOM::Element& context_element, const StringView&);
+    static String serialize_html_fragment(DOM::Node const& node);
 
     enum class InsertionMode {
 #define __ENUMERATE_INSERTION_MODE(mode) mode,

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -398,6 +398,15 @@ public:
         return nullptr;
     }
 
+    bool is_parent_of(T const& other) const
+    {
+        for (auto* child = first_child(); child; child = child->next_sibling()) {
+            if (&other == child)
+                return true;
+        }
+        return false;
+    }
+
     ~TreeNode()
     {
         VERIFY(!m_parent);


### PR DESCRIPTION
This makes innerHTML near spec compliant. It's missing attribute namespaces, the `is` value for custom elements and non-breaking spaces (as they have an extra byte before them for reasons unknown).
This is a sample of the results of `html/syntax/serializing-html-fragments/serializing.html` WPT:
![Screenshot from 2021-09-13 23-31-33](https://user-images.githubusercontent.com/25595356/133165009-51798128-0710-4e97-b0ec-85f9ccfd514c.png)
(The vast majority of the failed tests are outerHTML tests, which we don't have)
