### PR TITLE
LibJS: Implement parsing and execution of optional chains

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -251,7 +251,7 @@ Value CallExpression::execute(Interpreter& interpreter, GlobalObject& global_obj
 
     auto& function = callee.as_function();
 
-    if (is<Identifier>(*m_callee) && static_cast<Identifier const&>(*m_callee).string() == vm.names.eval.as_string() && &function == global_object.eval_function()) {
+    if (&function == global_object.eval_function() && is<Identifier>(*m_callee) && static_cast<Identifier const&>(*m_callee).string() == vm.names.eval.as_string()) {
         auto script_value = arg_list.size() == 0 ? js_undefined() : arg_list[0];
         return perform_eval(script_value, global_object, vm.in_strict_mode() ? CallerMode::Strict : CallerMode::NonStrict, EvalMode::Direct);
     }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1507,6 +1507,15 @@ NonnullRefPtr<Expression> Parser::parse_secondary_expression(NonnullRefPtr<Expre
         return parse_assignment_expression(AssignmentOp::NullishAssignment, move(lhs), min_precedence, associativity);
     case TokenType::QuestionMark:
         return parse_conditional_expression(move(lhs));
+    case TokenType::QuestionMarkPeriod:
+        // FIXME: This should allow `(new Foo)?.bar', but as our parser strips parenthesis,
+        //        we can't really tell if `lhs' was parenthesized at this point.
+        if (is<NewExpression>(lhs.ptr())) {
+            syntax_error("'new' cannot be used with optional chaining", position());
+            consume();
+            return lhs;
+        }
+        return parse_optional_chain(move(lhs));
     default:
         expected("secondary expression");
         consume();
@@ -1606,16 +1615,11 @@ NonnullRefPtr<Identifier> Parser::parse_identifier()
         token.value());
 }
 
-NonnullRefPtr<Expression> Parser::parse_call_expression(NonnullRefPtr<Expression> lhs)
+Vector<CallExpression::Argument> Parser::parse_arguments()
 {
-    auto rule_start = push_start();
-    if (!m_state.allow_super_constructor_call && is<SuperExpression>(*lhs))
-        syntax_error("'super' keyword unexpected here");
-
-    consume(TokenType::ParenOpen);
-
     Vector<CallExpression::Argument> arguments;
 
+    consume(TokenType::ParenOpen);
     while (match_expression() || match(TokenType::TripleDot)) {
         if (match(TokenType::TripleDot)) {
             consume();
@@ -1629,6 +1633,16 @@ NonnullRefPtr<Expression> Parser::parse_call_expression(NonnullRefPtr<Expression
     }
 
     consume(TokenType::ParenClose);
+    return arguments;
+}
+
+NonnullRefPtr<Expression> Parser::parse_call_expression(NonnullRefPtr<Expression> lhs)
+{
+    auto rule_start = push_start();
+    if (!m_state.allow_super_constructor_call && is<SuperExpression>(*lhs))
+        syntax_error("'super' keyword unexpected here");
+
+    auto arguments = parse_arguments();
 
     if (is<SuperExpression>(*lhs))
         return create_ast_node<SuperCall>({ m_state.current_token.filename(), rule_start.position(), position() }, move(arguments));
@@ -1641,7 +1655,7 @@ NonnullRefPtr<NewExpression> Parser::parse_new_expression()
     auto rule_start = push_start();
     consume(TokenType::New);
 
-    auto callee = parse_expression(g_operator_precedence.get(TokenType::New), Associativity::Right, { TokenType::ParenOpen });
+    auto callee = parse_expression(g_operator_precedence.get(TokenType::New), Associativity::Right, { TokenType::ParenOpen, TokenType::QuestionMarkPeriod });
 
     Vector<CallExpression::Argument> arguments;
 
@@ -2358,6 +2372,80 @@ NonnullRefPtr<ConditionalExpression> Parser::parse_conditional_expression(Nonnul
     return create_ast_node<ConditionalExpression>({ m_state.current_token.filename(), rule_start.position(), position() }, move(test), move(consequent), move(alternate));
 }
 
+NonnullRefPtr<OptionalChain> Parser::parse_optional_chain(NonnullRefPtr<Expression> base)
+{
+    auto rule_start = push_start();
+    Vector<OptionalChain::Reference> chain;
+    do {
+        if (match(TokenType::QuestionMarkPeriod)) {
+            consume(TokenType::QuestionMarkPeriod);
+            switch (m_state.current_token.type()) {
+            case TokenType::ParenOpen:
+                chain.append(OptionalChain::Call { parse_arguments(), OptionalChain::Mode::Optional });
+                break;
+            case TokenType::BracketOpen:
+                consume();
+                chain.append(OptionalChain::ComputedReference { parse_expression(0), OptionalChain::Mode::Optional });
+                consume(TokenType::BracketClose);
+                break;
+            case TokenType::TemplateLiteralStart:
+                // 13.3.1.1 - Static Semantics: Early Errors
+                // OptionalChain :
+                //        ?. TemplateLiteral
+                //        OptionalChain TemplateLiteral
+                // This is a hard error.
+                syntax_error("Invalid tagged template literal after ?.", position());
+                break;
+            default:
+                if (match_identifier_name()) {
+                    auto start = position();
+                    auto identifier = consume();
+                    chain.append(OptionalChain::MemberReference {
+                        create_ast_node<Identifier>({ m_state.current_token.filename(), start, position() }, identifier.value()),
+                        OptionalChain::Mode::Optional,
+                    });
+                } else {
+                    syntax_error("Invalid optional chain reference after ?.", position());
+                }
+                break;
+            }
+        } else if (match(TokenType::ParenOpen)) {
+            chain.append(OptionalChain::Call { parse_arguments(), OptionalChain::Mode::NotOptional });
+        } else if (match(TokenType::Period)) {
+            consume();
+            if (match_identifier_name()) {
+                auto start = position();
+                auto identifier = consume();
+                chain.append(OptionalChain::MemberReference {
+                    create_ast_node<Identifier>({ m_state.current_token.filename(), start, position() }, identifier.value()),
+                    OptionalChain::Mode::NotOptional,
+                });
+            } else {
+                expected("an identifier");
+                break;
+            }
+        } else if (match(TokenType::TemplateLiteralStart)) {
+            // 13.3.1.1 - Static Semantics: Early Errors
+            // OptionalChain :
+            //        ?. TemplateLiteral
+            //        OptionalChain TemplateLiteral
+            syntax_error("Invalid tagged template literal after optional chain", position());
+            break;
+        } else if (match(TokenType::BracketOpen)) {
+            consume();
+            chain.append(OptionalChain::ComputedReference { parse_expression(2), OptionalChain::Mode::NotOptional });
+            consume(TokenType::BracketClose);
+        } else {
+            break;
+        }
+    } while (!done());
+
+    return create_ast_node<OptionalChain>(
+        { m_state.current_token.filename(), rule_start.position(), position() },
+        move(base),
+        move(chain));
+}
+
 NonnullRefPtr<TryStatement> Parser::parse_try_statement()
 {
     auto rule_start = push_start();
@@ -2774,7 +2862,8 @@ bool Parser::match_secondary_expression(const Vector<TokenType>& forbidden) cons
         || type == TokenType::DoublePipe
         || type == TokenType::DoublePipeEquals
         || type == TokenType::DoubleQuestionMark
-        || type == TokenType::DoubleQuestionMarkEquals;
+        || type == TokenType::DoubleQuestionMarkEquals
+        || type == TokenType::QuestionMarkPeriod;
 }
 
 bool Parser::match_statement() const

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -76,6 +76,7 @@ public:
     NonnullRefPtr<WithStatement> parse_with_statement();
     NonnullRefPtr<DebuggerStatement> parse_debugger_statement();
     NonnullRefPtr<ConditionalExpression> parse_conditional_expression(NonnullRefPtr<Expression> test);
+    NonnullRefPtr<OptionalChain> parse_optional_chain(NonnullRefPtr<Expression> base);
     NonnullRefPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right, const Vector<TokenType>& forbidden = {});
     PrimaryExpressionParseResult parse_primary_expression();
     NonnullRefPtr<Expression> parse_unary_prefixed_expression();
@@ -99,6 +100,8 @@ public:
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
     RefPtr<Statement> try_parse_labelled_statement(AllowLabelledFunction allow_function);
     RefPtr<MetaProperty> try_parse_new_target_expression();
+
+    Vector<CallExpression::Argument> parse_arguments();
 
     struct Error {
         String message;

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -73,7 +73,7 @@ void Reference::put_value(GlobalObject& global_object, Value value)
     }
 }
 
-void Reference::throw_reference_error(GlobalObject& global_object)
+void Reference::throw_reference_error(GlobalObject& global_object) const
 {
     auto& vm = global_object.vm();
     if (!m_name.is_valid())
@@ -83,7 +83,7 @@ void Reference::throw_reference_error(GlobalObject& global_object)
 }
 
 // 6.2.4.5 GetValue ( V ), https://tc39.es/ecma262/#sec-getvalue
-Value Reference::get_value(GlobalObject& global_object, bool throw_if_undefined)
+Value Reference::get_value(GlobalObject& global_object, bool throw_if_undefined) const
 {
     if (is_unresolvable()) {
         throw_reference_error(global_object);

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -97,6 +97,12 @@ public:
         return !m_this_value.is_empty();
     }
 
+    // Note: Non-standard helper.
+    bool is_environment_reference() const
+    {
+        return m_base_type == BaseType::Environment;
+    }
+
     void put_value(GlobalObject&, Value);
     Value get_value(GlobalObject&, bool throw_if_undefined = true) const;
     bool delete_(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -98,13 +98,13 @@ public:
     }
 
     void put_value(GlobalObject&, Value);
-    Value get_value(GlobalObject&, bool throw_if_undefined = true);
+    Value get_value(GlobalObject&, bool throw_if_undefined = true) const;
     bool delete_(GlobalObject&);
 
     String to_string() const;
 
 private:
-    void throw_reference_error(GlobalObject&);
+    void throw_reference_error(GlobalObject&) const;
 
     BaseType m_base_type { BaseType::Unresolvable };
     union {

--- a/Userland/Libraries/LibJS/Tests/syntax/optional-chaining.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/optional-chaining.js
@@ -1,0 +1,40 @@
+test("parse optional-chaining", () => {
+    expect(`a?.b`).toEval();
+    expect(`a?.4:.5`).toEval();
+    expect(`a?.[b]`).toEval();
+    expect(`a?.b[b]`).toEval();
+    expect(`a?.b(c)`).toEval();
+    expect(`a?.b?.(c, d)`).toEval();
+    expect(`a?.b?.()`).toEval();
+    expect("a?.b``").not.toEval();
+    expect("a?.b?.``").not.toEval();
+    expect("new Foo?.bar").not.toEval();
+    expect("new (Foo?.bar)").toEval();
+    // FIXME: This should pass.
+    // expect("(new Foo)?.bar").toEval();
+});
+
+test("evaluate optional-chaining", () => {
+    for (let nullishObject of [null, undefined]) {
+        expect((() => nullishObject?.b)()).toBeUndefined();
+    }
+
+    expect(
+        (() => {
+            let a = {};
+            return a?.foo?.bar?.baz;
+        })()
+    ).toBeUndefined();
+
+    expect(
+        (() => {
+            let a = { foo: { bar: () => 42 } };
+            return `${a?.foo?.bar?.()}-${a?.foo?.baz?.()}`;
+        })()
+    ).toBe("42-undefined");
+
+    expect(() => {
+        let a = { foo: { bar: () => 42 } };
+        return a.foo?.baz.nonExistentProperty;
+    }).toThrow();
+});


### PR DESCRIPTION
```js
this?.yakbait?.(this);
```

Things left unimplemented:
- Private identifiers
- `(new Foo)?.bar` is incorrectly flagged as a syntax error.
