### PR TITLE
LibJS: Fixes to labels, switches and for loops

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -395,9 +395,9 @@ Value WhileStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
         if (interpreter.exception())
             return {};
         if (interpreter.vm().should_unwind()) {
-            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                 interpreter.vm().stop_unwind();
-            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                 interpreter.vm().stop_unwind();
                 break;
             } else {
@@ -421,9 +421,9 @@ Value DoWhileStatement::execute(Interpreter& interpreter, GlobalObject& global_o
         if (interpreter.exception())
             return {};
         if (interpreter.vm().should_unwind()) {
-            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                 interpreter.vm().stop_unwind();
-            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                 interpreter.vm().stop_unwind();
                 break;
             } else {
@@ -477,9 +477,9 @@ Value ForStatement::execute(Interpreter& interpreter, GlobalObject& global_objec
             if (interpreter.exception())
                 return {};
             if (interpreter.vm().should_unwind()) {
-                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                     interpreter.vm().stop_unwind();
-                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                     interpreter.vm().stop_unwind();
                     break;
                 } else {
@@ -498,9 +498,9 @@ Value ForStatement::execute(Interpreter& interpreter, GlobalObject& global_objec
             if (interpreter.exception())
                 return {};
             if (interpreter.vm().should_unwind()) {
-                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                     interpreter.vm().stop_unwind();
-                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                     interpreter.vm().stop_unwind();
                     break;
                 } else {
@@ -570,9 +570,9 @@ Value ForInStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
             if (interpreter.exception())
                 return {};
             if (interpreter.vm().should_unwind()) {
-                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                     interpreter.vm().stop_unwind();
-                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                     interpreter.vm().stop_unwind();
                     break;
                 } else {
@@ -613,9 +613,9 @@ Value ForOfStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
         if (interpreter.exception())
             return IterationDecision::Break;
         if (interpreter.vm().should_unwind()) {
-            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                 interpreter.vm().stop_unwind();
-            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                 interpreter.vm().stop_unwind();
                 return IterationDecision::Break;
             } else {
@@ -2329,6 +2329,11 @@ void ThrowStatement::dump(int indent) const
     argument().dump(indent + 1);
 }
 
+void TryStatement::add_label(FlyString string)
+{
+    m_block->add_label(move(string));
+}
+
 Value TryStatement::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
@@ -2410,6 +2415,7 @@ Value ThrowStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
     return {};
 }
 
+// 14.12.2 Runtime Semantics: CaseBlockEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-caseblockevaluation
 Value SwitchStatement::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
@@ -2460,10 +2466,10 @@ Value SwitchStatement::execute(Interpreter& interpreter, GlobalObject& global_ob
             if (interpreter.exception())
                 return {};
             if (interpreter.vm().should_unwind()) {
-                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+                if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_labels)) {
                     // No stop_unwind(), the outer loop will handle that - we just need to break out of the switch/case.
                     return last_value;
-                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+                } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_labels)) {
                     interpreter.vm().stop_unwind();
                     return last_value;
                 } else {

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -185,6 +185,14 @@ Value Interpreter::execute_statement(GlobalObject& global_object, const Statemen
         return statement.execute(*this, global_object);
 
     auto& block = static_cast<const ScopeNode&>(statement);
+    Vector<FlyString> const& labels = [&] {
+        if (is<BlockStatement>(block)) {
+            return static_cast<BlockStatement const&>(block).labels();
+        } else {
+            return Vector<FlyString>();
+        }
+    }();
+
     enter_scope(block, scope_type, global_object);
 
     Value last_value;
@@ -193,7 +201,7 @@ Value Interpreter::execute_statement(GlobalObject& global_object, const Statemen
         if (!value.is_empty())
             last_value = value;
         if (vm().should_unwind()) {
-            if (!block.label().is_null() && vm().should_unwind_until(ScopeType::Breakable, block.label()))
+            if (!labels.is_empty() && vm().should_unwind_until(ScopeType::Breakable, labels))
                 vm().stop_unwind();
             break;
         }

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -246,7 +246,7 @@ private:
 
         Vector<Vector<FunctionNode::Parameter>&> function_parameters;
 
-        HashMap<StringView, bool> labels_in_scope;
+        HashMap<StringView, Optional<Position>> labels_in_scope;
         bool strict_mode { false };
         bool allow_super_property_lookup { false };
         bool allow_super_constructor_call { false };

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -186,6 +186,8 @@ private:
     bool try_parse_arrow_function_expression_failed_at_position(const Position&) const;
     void set_try_parse_arrow_function_expression_failed_at_position(const Position&, bool);
 
+    bool match_invalid_escaped_keyword() const;
+
     struct RulePosition {
         AK_MAKE_NONCOPYABLE(RulePosition);
         AK_MAKE_NONMOVABLE(RulePosition);

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -224,7 +224,7 @@ void VM::assign(const NonnullRefPtr<BindingPattern>& target, Value value, Global
                 VERIFY(i == binding.entries.size() - 1);
 
                 auto* array = Array::create(global_object, 0);
-                for (;;) {
+                for (; iterator;) {
                     auto next_object = iterator_next(*iterator);
                     if (!next_object)
                         return;

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -193,11 +193,13 @@ public:
         m_unwind_until = ScopeType::None;
         m_unwind_until_label = {};
     }
-    bool should_unwind_until(ScopeType type, FlyString const& label) const
+    bool should_unwind_until(ScopeType type, Vector<FlyString> const& labels) const
     {
         if (m_unwind_until_label.is_null())
             return m_unwind_until == type;
-        return m_unwind_until == type && m_unwind_until_label == label;
+        return m_unwind_until == type && any_of(labels.begin(), labels.end(), [&](FlyString const& label) {
+            return m_unwind_until_label == label;
+        });
     }
     bool should_unwind() const { return m_unwind_until != ScopeType::None; }
 

--- a/Userland/Libraries/LibJS/Tests/labels.js
+++ b/Userland/Libraries/LibJS/Tests/labels.js
@@ -65,6 +65,73 @@ test("can break on every label", () => {
     expect(i).toBe(3);
 });
 
+test("can use certain 'keywords' as labels", () => {
+    let i = 0;
+
+    yield: {
+        i++;
+        break yield;
+        expect().fail();
+    }
+
+    await: {
+        i++;
+        break await;
+        expect().fail();
+    }
+
+    async: {
+        i++;
+        break async;
+        expect().fail();
+    }
+
+    let: {
+        i++;
+        break let;
+        expect().fail();
+    }
+
+    // prettier-ignore
+    l\u0065t: {
+        i++;
+        break let;
+        expect().fail();
+    }
+
+    private: {
+        i++;
+        break private;
+        expect().fail();
+    }
+
+    expect(i).toBe(6);
+
+    expect(`const: { break const; }`).not.toEval();
+});
+
+test("can use certain 'keywords' even in strict mode", () => {
+    "use strict";
+
+    let i = 0;
+    await: {
+        i++;
+        break await;
+        expect().fail();
+    }
+
+    async: {
+        i++;
+        break async;
+        expect().fail();
+    }
+    expect(i).toBe(2);
+
+    expect(`'use strict'; let: { break let; }`).not.toEval();
+
+    expect(`'use strict'; l\u0065t: { break l\u0065t; }`).not.toEval();
+});
+
 test("invalid label usage", () => {
     expect(() =>
         eval(`
@@ -75,6 +142,7 @@ test("invalid label usage", () => {
             }
         `)
     ).toThrowWithMessage(SyntaxError, "Label 'label' not found");
+
     expect(() =>
         eval(`
             label: {
@@ -82,7 +150,7 @@ test("invalid label usage", () => {
                     continue label;
                 }
             }
-        `),
+        `)
     ).toThrowWithMessage(
         SyntaxError,
         "labelled continue statement cannot use non iterating statement"
@@ -93,6 +161,6 @@ test("invalid label usage", () => {
             label: label: {
                 break label;
             }
-        `),
+        `)
     ).toThrowWithMessage(SyntaxError, "Label 'label' has already been declared");
 });

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -51,7 +51,20 @@ test("use already-declared variable", () => {
 });
 
 test("allow binding patterns", () => {
-    expect(`for (let [a, b] in foo) {}`).toEval();
+    const expected = [
+        ["1", "3", []],
+        ["s", undefined, []],
+        ["l", "n", ["g", "N", "a", "m", "e"]],
+    ];
+    let counter = 0;
+
+    for (let [a, , b, ...c] in { 123: 1, sm: 2, longName: 3 }) {
+        expect(a).toBe(expected[counter][0]);
+        expect(b).toBe(expected[counter][1]);
+        expect(c).toEqual(expected[counter][2]);
+        counter++;
+    }
+    expect(counter).toBe(3);
 });
 
 test("allow member expression as variable", () => {

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -53,3 +53,9 @@ test("use already-declared variable", () => {
 test("allow binding patterns", () => {
     expect(`for (let [a, b] in foo) {}`).toEval();
 });
+
+test("allow member expression as variable", () => {
+    const f = {};
+    for (f.a in "abc");
+    expect(f.a).toBe("2");
+});

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -100,7 +100,16 @@ describe("errors", () => {
 });
 
 test("allow binding patterns", () => {
-    expect(`for (let [a, b] of foo) {}`).toEval();
+    let counter = 0;
+    for (let [a, b] of [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+    ]) {
+        expect(a + 1).toBe(b);
+        counter++;
+    }
+    expect(counter).toBe(3);
 });
 
 test("allow member expression as variable", () => {

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -102,3 +102,9 @@ describe("errors", () => {
 test("allow binding patterns", () => {
     expect(`for (let [a, b] of foo) {}`).toEval();
 });
+
+test("allow member expression as variable", () => {
+    const f = {};
+    for (f.a of "abc");
+    expect(f.a).toBe("c");
+});

--- a/Userland/Libraries/LibJS/Tests/switch-basic.js
+++ b/Userland/Libraries/LibJS/Tests/switch-basic.js
@@ -100,6 +100,10 @@ describe("basic switch tests", () => {
 describe("errors", () => {
     test("syntax errors", () => {
         expect("switch () {}").not.toEval();
+        expect("switch () { case 1: continue; }").not.toEval();
+        expect("switch () { case 1: break doesnotexist; }").not.toEval();
+        expect("label: switch () { case 1: break not_the_right_label; }").not.toEval();
+        expect("label: switch () { case 1: continue label; }").not.toEval();
         expect("switch (foo) { bar }").not.toEval();
         expect("switch (foo) { default: default: }").not.toEval();
     });

--- a/Userland/Libraries/LibJS/Tests/switch-basic.js
+++ b/Userland/Libraries/LibJS/Tests/switch-basic.js
@@ -67,6 +67,34 @@ describe("basic switch tests", () => {
         }
         expect(i).toBe(5);
     });
+
+    test("default branch is not taken if more exact branch exists", () => {
+        function switchTest(i) {
+            let result = 0;
+            switch (i) {
+                case 1:
+                    result += 1;
+                    break;
+                case 1:
+                    expect().fail();
+                case 2:
+                    result += 2;
+                default:
+                    result += 4;
+                case 3:
+                    result += 8;
+                    break;
+                case 2:
+                    expect().fail();
+            }
+            return result;
+        }
+
+        expect(switchTest(1)).toBe(1);
+        expect(switchTest(2)).toBe(14);
+        expect(switchTest(3)).toBe(8);
+        expect(switchTest(4)).toBe(12);
+    });
 });
 
 describe("errors", () => {

--- a/Userland/Libraries/LibJS/Tests/syntax/destructuring-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/destructuring-assignment.js
@@ -196,6 +196,11 @@ describe("evaluating", () => {
             expect(a).toBe(o[0]);
             expect(length).toBe(o[1].length);
         }
+        {
+            expect(() => {
+                let [a, b, [...{ length }]] = o;
+            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+        }
     });
 
     test("patterns with default", () => {


### PR DESCRIPTION
- We now support multiple labels (although this seems like it will never be used but whatever and is barely tested in test262)
- Switch statements now only take default if no branch matches
- We allow memberexpressions in for loops
- A small fix in destructuring bindings
- Small escaped keyword fixes