### PR TITLE
LibJS: Make References see into Environment's bindings as well

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -417,6 +417,8 @@ Reference VM::get_identifier_reference(Environment* environment, FlyString name,
         auto possible_match = environment->get_from_environment(name);
         if (possible_match.has_value())
             return Reference { *environment, move(name), strict };
+        if (environment->has_binding(name))
+            return Reference { *environment, move(name), strict };
     }
 
     auto& global_environment = interpreter().realm().global_environment();


### PR DESCRIPTION
'bindings' is the spec-compliant version of 'variables', but we were
simply not even looking at them, which made things using bindings (such
as named function expressions) break in unexpected ways after the move
to using references in call expressions.