### PR TITLE
Breakout: Add possibility to play with A and D

### DIFF
--- a/Userland/Games/Breakout/Game.cpp
+++ b/Userland/Games/Breakout/Game.cpp
@@ -153,10 +153,12 @@ void Game::keyup_event(GUI::KeyEvent& event)
         return;
     switch (event.key()) {
     case Key_A:
+        [[fallthrough]];
     case Key_Left:
         m_paddle.moving_left = false;
         break;
     case Key_D:
+        [[fallthrough]];
     case Key_Right:
         m_paddle.moving_right = false;
         break;
@@ -174,10 +176,12 @@ void Game::keydown_event(GUI::KeyEvent& event)
         GUI::Application::the()->quit();
         break;
     case Key_A:
+        [[fallthrough]];
     case Key_Left:
         m_paddle.moving_left = true;
         break;
     case Key_D:
+        [[fallthrough]];
     case Key_Right:
         m_paddle.moving_right = true;
         break;

--- a/Userland/Games/Breakout/Game.cpp
+++ b/Userland/Games/Breakout/Game.cpp
@@ -152,9 +152,11 @@ void Game::keyup_event(GUI::KeyEvent& event)
     if (m_paused)
         return;
     switch (event.key()) {
+    case Key_A:
     case Key_Left:
         m_paddle.moving_left = false;
         break;
+    case Key_D:
     case Key_Right:
         m_paddle.moving_right = false;
         break;
@@ -171,9 +173,11 @@ void Game::keydown_event(GUI::KeyEvent& event)
     case Key_Escape:
         GUI::Application::the()->quit();
         break;
+    case Key_A:
     case Key_Left:
         m_paddle.moving_left = true;
         break;
+    case Key_D:
     case Key_Right:
         m_paddle.moving_right = true;
         break;


### PR DESCRIPTION
This change will make the player able to control the game with
A and D keys, in addition to the current arrow keys and mouse.