### PR TITLE
LibWeb: Speed up computed style calculation

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ComputedCSSStyleDeclaration.cpp
@@ -381,7 +381,7 @@ static NonnullRefPtr<StyleValue> value_or_default(Optional<StyleProperty> proper
 
 Optional<StyleProperty> ComputedCSSStyleDeclaration::property(PropertyID property_id) const
 {
-    const_cast<DOM::Document&>(m_element->document()).force_layout();
+    const_cast<DOM::Document&>(m_element->document()).ensure_layout();
 
     if (!m_element->layout_node()) {
         auto style = m_element->document().style_resolver().resolve_style(const_cast<DOM::Element&>(*m_element));

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -400,6 +400,12 @@ void Document::force_layout()
     update_layout();
 }
 
+void Document::ensure_layout()
+{
+    if (!m_layout_root)
+        update_layout();
+}
+
 void Document::update_layout()
 {
     if (!browsing_context())

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -144,6 +144,7 @@ public:
 
     void force_layout();
     void invalidate_layout();
+    void ensure_layout();
 
     void update_style();
     void update_layout();


### PR DESCRIPTION
Rather than destroying and rebuilding the entire document layout tree in
every call to `ComputedCSSStyleDeclaration::property()`, we now just
make sure that the layout tree exists.

This speeds up the DOM Inspector significantly, from taking several
seconds to select an element, to almost instant. :^)