### PR TITLE
LibWeb: Make flex-box play nicely with `position:absolute` children

### DIFF
--- a/Base/res/html/misc/flex-2.html
+++ b/Base/res/html/misc/flex-2.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Flex 2: Electric Boogaloo</title>
+    <style>
+        .my-container {
+            display: flex;
+            border: 1px solid salmon;
+        }
+
+        .width-constrained {
+            width: 250px;
+        }
+
+        .height-constrained {
+            height: 250px;
+        }
+
+        .column {
+            flex-direction: column;
+        }
+
+        .box {
+            width: 100px;
+            height: 100px;
+            border: 1px solid black;
+        }
+
+        .exception {
+            background: rgba(255, 0, 255, 0.5);
+            left: 50px;
+            top: 50px;
+        }
+
+        .width-constrained .exception {
+            background: rgba(0, 255, 0, 0.5);
+            left: 200px;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>FlexBox Tests</h1>
+    <p>This tests whether flex-box behaves well with unusual children.</p>
+    <p>The boxes are width and height 100px.</p>
+    <h2>Row</h2>
+    <h3>Width unconstrained</h3>
+    <p>With a <code>position: absolute;</code> child</p>
+    <div class="my-container">
+        <div class="box">1</div>
+        <div class="box exception" style="position: absolute;">Absolute</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: fixed;</code> child</p>
+    <div class="my-container">
+        <div class="box">1</div>
+        <div class="box exception" style="position: fixed;">Fixed</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: relative;</code> child</p>
+    <div class="my-container">
+        <div class="box">1</div>
+        <div class="box exception" style="position: relative;">Relative</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: static;</code> child</p>
+    <div class="my-container">
+        <div class="box">1</div>
+        <div class="box exception" style="position: static;">Static</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: sticky;</code> child</p>
+    <div class="my-container">
+        <div class="box">1</div>
+        <div class="box exception" style="position: sticky;">Sticky</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+
+    <h3>Width constrained</h3>
+    <p>With a <code>position: absolute;</code> child</p>
+    <div class="my-container width-constrained">
+        <div class="box">1</div>
+        <div class="box exception" style="position: absolute;">Absolute</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: fixed;</code> child</p>
+    <div class="my-container width-constrained">
+        <div class="box">1</div>
+        <div class="box exception" style="position: fixed;">Fixed</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: relative;</code> child</p>
+    <div class="my-container width-constrained">
+        <div class="box">1</div>
+        <div class="box exception" style="position: relative;">Relative</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: static;</code> child</p>
+    <div class="my-container width-constrained">
+        <div class="box">1</div>
+        <div class="box exception" style="position: static;">Static</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+    <p>With a <code>position: sticky;</code> child</p>
+    <div class="my-container width-constrained">
+        <div class="box">1</div>
+        <div class="box exception" style="position: sticky;">Sticky</div>
+        <div class="box">2</div>
+        <div class="box">3</div>
+    </div>
+
+    <div style="height: 2000px"></div>
+</body>
+
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -100,6 +100,7 @@
             <li><a href="lists.html">Lists</a></li>
             <li><a href="flex.html">Flexboxes</a></li>
             <li><a href="justify-content.html">Flexbox justify-content</a></li>
+            <li><a href="flex-2.html">Flexboxes with unusual children</a></li>
             <li><a href="inline-block.html">display: inline-block;</a></li>
             <li><a href="inline-block-link.html">link inside display: inline-block</a></li>
             <li><a href="padding-inline.html">inline elements with padding</a></li>

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -97,6 +97,8 @@ public:
     float absolute_y() const { return absolute_rect().y(); }
     Gfx::FloatPoint absolute_position() const { return absolute_rect().location(); }
 
+    bool is_out_of_flow(FormattingContext const&) const;
+
     virtual HitTestResult hit_test(const Gfx::IntPoint&, HitTestType) const override;
     virtual void set_needs_display() override;
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -238,6 +238,10 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
                 return IterationDecision::Continue;
         }
 
+        // Skip any "out-of-flow" children
+        if (child_box.is_out_of_flow(*this))
+            return IterationDecision::Continue;
+
         child_box.set_flex_item(true);
         flex_items.append({ child_box });
         return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -15,6 +15,8 @@ public:
     FlexFormattingContext(Box& containing_block, FormattingContext* parent);
     ~FlexFormattingContext();
 
+    virtual bool inhibits_floating() const override { return true; }
+
     virtual void run(Box&, LayoutMode) override;
 };
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -21,6 +21,7 @@ public:
     const FormattingContext* parent() const { return m_parent; }
 
     virtual bool is_block_formatting_context() const { return false; }
+    virtual bool inhibits_floating() const { return false; }
 
     static bool creates_block_formatting_context(const Box&);
 

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -219,8 +219,6 @@ private:
     float m_font_size { 0 };
     RefPtr<CSS::ImageStyleValue> m_background_image;
 
-    CSS::Position m_position;
-
     bool m_has_definite_height { false };
     bool m_has_definite_width { false };
 };


### PR DESCRIPTION
CSS has the concept of an element being "out of flow", which includes elements that are `float`, `position: absolute` or `position: fixed`. Previously, out-of-flow children still took up space inside a flex-box container, leaving an odd gap. Now they don't! :^)