### PR TITLE
Meta: Superbuild fallout fixes

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -42,7 +42,7 @@ jobs:
           echo "sonar.organization=serenityos" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.cache.enabled=true" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.cache.path=.sonar" >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.cfamily.compile-commands=${{ github.workspace }}/Build/compile_commands.json" >> ${{ github.workspace }}/sonar-project.properties
+          echo "sonar.cfamily.compile-commands=${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}/compile_commands.json" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.threads=2" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.host.url=${{ env.SONAR_SERVER_URL }}" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.sources=AK,Build,Userland,Kernel,Meta" >> ${{ github.workspace }}/sonar-project.properties
@@ -98,19 +98,29 @@ jobs:
 
       - name: Create build directory
         run: |
-          mkdir -p ${{ github.workspace }}/Build
-          mkdir -p ${{ github.workspace }}/Build/UCD
-          mkdir -p ${{ github.workspace }}/Build/CLDR
+          mkdir -p ${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}/UCD
+          mkdir -p ${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}/CLDR
 
       - name: Create build environment
-        working-directory: ${{ github.workspace }}/Build
-        run: cmake .. -GNinja -DSERENITY_ARCH=i686 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_PCI_IDS_DOWNLOAD=OFF -DENABLE_USB_IDS_DOWNLOAD=OFF -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
-
+        working-directory: ${{ github.workspace }}
+        run: |
+          cmake -S Meta/CMake/Superbuild -B Build/superbuild -GNinja \
+            -DSERENITY_ARCH=${{ env.SONAR_ANALYSIS_ARCH }} \
+            -DSERENITY_TOOLCHAIN=GNU \
+            -DCMAKE_C_COMPILER=gcc-10 \
+            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DENABLE_PCI_IDS_DOWNLOAD=OFF \
+            -DENABLE_USB_IDS_DOWNLOAD=OFF
 
       - name: Build generated sources so they are available for analysis.
-        working-directory: ${{ github.workspace }}/Build
+        working-directory: ${{ github.workspace }}
+        # Note: The superbuild will create the Build/arch directory when doing the
+        #       configure step for the serenity ExternalProject, as that's the configured
+        #       binary directory for that project.
         run: |
-          ninja all_generated
+          ninja -C Build/superbuild serenity-configure
+          cmake -B Build/{{ env.SONAR_ANALYSIS_ARCH }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          ninja -C Build/{{ env.SONAR_ANALYSIS_ARCH }} all_generated
 
       - name: Run sonar-scanner, upload results
         env:

--- a/Documentation/CLionConfiguration.md
+++ b/Documentation/CLionConfiguration.md
@@ -14,7 +14,7 @@ After opening the `serenity` repository in CLion as a new project, the "`Open Pr
 ```
 -GNinja
 -DCMAKE_TOOLCHAIN_FILE=$CMakeProjectDir$/Build/i686/CMakeToolchain.txt
--DCMAKE_INSTALL_PREFIX=$CMakeProjectDir$/Build/lagom-install
+-DCMAKE_PREFIX_PATH=$CMakeProjectDir$/Build/lagom-install
 -DSERENITY_ARCH=i686
 ```
 

--- a/Meta/CMake/Superbuild/CMakeLists.txt
+++ b/Meta/CMake/Superbuild/CMakeLists.txt
@@ -130,7 +130,7 @@ ExternalProject_Add(
     BUILD_ALWAYS YES
     # Host tools must be built and installed before the OS can be built
     DEPENDS lagom-install
-    STEP_TARGETS install
+    STEP_TARGETS configure install
     ${console_access}
 )
 

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -71,12 +71,19 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(GNUInstallDirs) # make sure to include before we mess w/RPATH
+
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 # See slide 100 of the following ppt :^)
 # https://crascit.com/wp-content/uploads/2019/09/Deep-CMake-For-Library-Authors-Craig-Scott-CppCon-2019.pdf
-if (NOT APPLE)
-    set(CMAKE_INSTALL_RPATH $ORIGIN:$ORIGIN/../lib)
+if (APPLE)
+    # FIXME: This doesn't work for the full BUILD_LAGOM=ON build, see #10055
+    set(CMAKE_MACOSX_RPATH TRUE)
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
+    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+else()
+    set(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
 endif()
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -129,7 +136,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # install rules, think about moving to its own helper cmake file
 include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
 
 # find_package(<package>) call for consumers to find this project
 set(package Lagom)

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -199,6 +199,11 @@ run_tests() {
 }
 
 build_target() {
+    if [ "$TARGET" = "lagom" ]; then
+        # Ensure that all lagom binaries get built, in case user first
+        # invoked superbuild for serenity target that doesn't set -DBUILD_LAGOM=ON
+        cmake -S "$SERENITY_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR" -DBUILD_LAGOM=ON
+    fi
     # With zero args, we are doing a standard "build"
     # With multiple args, we are doing an install/image/run
     if [ $# -eq 0 ]; then


### PR DESCRIPTION
- Multi-lib distros like Gentoo and Fedora install lagom-core.so into
lagom-install/lib64 rather than lib. Set the install RPATH based on
CMAKE_INSTALL_LIBDIR to avoid the wrong path being set in the binaries.

- Also apply macOS specific RPATH rules to fix the build on that platform.

- Use correct var in clion docs

- Fix(?) Sonar Cloud job.

- Fix running `./Meta/serenity.sh test lagom` with an existing lagom build dir.

cc @alimpfard 