### PR TITLE
LibWeb: Support align items and stuff

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -69,6 +69,7 @@ public:
     FlexBasisData flex_basis() const { return m_noninherited.flex_basis; }
     Optional<float> flex_grow_factor() const { return m_noninherited.flex_grow_factor; }
     Optional<float> flex_shrink_factor() const { return m_noninherited.flex_shrink_factor; }
+    CSS::AlignItems align_items() const { return m_noninherited.align_items; }
     Optional<float> opacity() const { return m_noninherited.opacity; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
     Optional<BoxShadowData> box_shadow() const { return m_noninherited.box_shadow; }
@@ -152,6 +153,7 @@ protected:
         CSS::FlexBasisData flex_basis {};
         Optional<float> flex_grow_factor;
         Optional<float> flex_shrink_factor;
+        CSS::AlignItems align_items;
         CSS::JustifyContent justify_content { InitialValues::justify_content() };
         CSS::Overflow overflow_x { InitialValues::overflow() };
         CSS::Overflow overflow_y { InitialValues::overflow() };
@@ -204,6 +206,7 @@ public:
     void set_flex_basis(FlexBasisData value) { m_noninherited.flex_basis = value; }
     void set_flex_grow_factor(Optional<float> value) { m_noninherited.flex_grow_factor = value; }
     void set_flex_shrink_factor(Optional<float> value) { m_noninherited.flex_shrink_factor = value; }
+    void set_align_items(CSS::AlignItems value) { m_noninherited.align_items = value; }
     void set_opacity(Optional<float> value) { m_noninherited.opacity = value; }
     void set_justify_content(CSS::JustifyContent value) { m_noninherited.justify_content = value; }
     void set_box_shadow(Optional<BoxShadowData> value) { m_noninherited.box_shadow = move(value); }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -424,6 +424,27 @@ Optional<CSS::JustifyContent> StyleProperties::justify_content() const
     }
 }
 
+Optional<CSS::AlignItems> StyleProperties::align_items() const
+{
+    auto value = property(CSS::PropertyID::AlignItems);
+    if (!value.has_value())
+        return {};
+    switch (value.value()->to_identifier()) {
+    case CSS::ValueID::FlexStart:
+        return CSS::AlignItems::FlexStart;
+    case CSS::ValueID::FlexEnd:
+        return CSS::AlignItems::FlexEnd;
+    case CSS::ValueID::Center:
+        return CSS::AlignItems::Center;
+    case CSS::ValueID::Baseline:
+        return CSS::AlignItems::Baseline;
+    case CSS::ValueID::Stretch:
+        return CSS::AlignItems::Stretch;
+    default:
+        return {};
+    }
+}
+
 Optional<CSS::Position> StyleProperties::position() const
 {
     auto value = property(CSS::PropertyID::Position);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -55,6 +55,7 @@ public:
     Optional<CSS::FlexBasisData> flex_basis() const;
     Optional<float> flex_grow_factor() const;
     Optional<float> flex_shrink_factor() const;
+    Optional<CSS::AlignItems> align_items() const;
     Optional<float> opacity() const;
     Optional<CSS::JustifyContent> justify_content() const;
     Optional<CSS::Overflow> overflow_x() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -211,6 +211,14 @@ enum class JustifyContent {
     SpaceAround,
 };
 
+enum class AlignItems {
+    FlexStart,
+    FlexEnd,
+    Center,
+    Baseline,
+    Stretch,
+};
+
 class StyleValue : public RefCounted<StyleValue> {
 public:
     virtual ~StyleValue();

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -610,10 +610,10 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
     // FIXME: This
 
     // 11. Determine the used cross size of each flex item.
-    // FIXME: align-stretch
+    // FIXME: Get the alignment via "align-self" of the item (which accesses "align-items" of the parent if unset)
     for (auto& flex_line : flex_lines) {
         for (auto& flex_item : flex_line.items) {
-            if (is_cross_auto(flex_item->box)) {
+            if (is_cross_auto(flex_item->box) && box.computed_values().align_items() == CSS::AlignItems::Stretch) {
                 // FIXME: Take margins into account
                 flex_item->cross_size = flex_line.cross_size;
             } else {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -269,6 +269,10 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     if (justify_content.has_value())
         computed_values.set_justify_content(justify_content.value());
 
+    auto align_items = specified_style.align_items();
+    if (align_items.has_value())
+        computed_values.set_align_items(align_items.value());
+
     auto position = specified_style.position();
     if (position.has_value()) {
         computed_values.set_position(position.value());

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -329,7 +329,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     if (computed_values.opacity() == 0)
         m_visible = false;
 
-    if (auto width = specified_style.property(CSS::PropertyID::Width); width.has_value())
+    if (auto width = specified_style.property(CSS::PropertyID::Width); width.has_value() && !width.value()->is_auto())
         m_has_definite_width = true;
     computed_values.set_width(specified_style.length_or_fallback(CSS::PropertyID::Width, {}));
     computed_values.set_min_width(specified_style.length_or_fallback(CSS::PropertyID::MinWidth, {}));


### PR DESCRIPTION
This adds partial support for the align-items property
Also a minor bug was fixed where a dimension of "auto" was seen as "definite" which is wrong.