### PR TITLE
LibTLS: Close the underlying socket on EOF

### DIFF
--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -164,7 +164,7 @@ void TLSv12::read_from_socket()
     if (!check_connection_state(true))
         return;
 
-    consume(Core::Socket::read(4096));
+    consume(Core::Socket::read(4 * MiB));
 
     // If anything new shows up, tell the client about the event.
     notify_client_for_app_data();

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -412,6 +412,7 @@ private:
     void read_from_socket();
 
     bool check_connection_state(bool read);
+    void notify_client_for_app_data();
 
     ssize_t handle_server_hello(ReadonlyBytes, WritePacketStage&);
     ssize_t handle_handshake_finished(ReadonlyBytes, WritePacketStage&);
@@ -515,6 +516,7 @@ private:
     CipherVariant m_cipher_remote { Empty {} };
 
     bool m_has_scheduled_write_flush { false };
+    bool m_has_scheduled_app_data_flush { false };
     i32 m_max_wait_time_for_handshake_in_seconds { 10 };
 
     RefPtr<Core::Timer> m_handshake_timeout_timer;


### PR DESCRIPTION
There's no reason to keep waiting when there's nothing else to come.
This makes RequestServer not spin on Core::Socket::read() (in some
scenarios).