### PR TITLE
Kernel: Weakly hold on to the file in LocalSocket

### DIFF
--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -23,7 +23,8 @@
 
 namespace Kernel {
 
-class Inode : public ListedRefCounted<Inode> {
+class Inode : public ListedRefCounted<Inode>
+    , public Weakable<Inode> {
     friend class VirtualFileSystem;
     friend class FileSystem;
 

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -71,8 +71,8 @@ private:
 
     KResult try_set_path(StringView);
 
-    // An open socket file on the filesystem.
-    RefPtr<OpenFileDescription> m_file;
+    // The inode this socket is bound to.
+    WeakPtr<Inode> m_inode;
 
     UserID m_prebind_uid { 0 };
     GroupID m_prebind_gid { 0 };


### PR DESCRIPTION
Because we were holding a strong ref to the OpenFileDescription in
LocalSocket and a strong ref to the LocalSocket in Inode, we were
creating a reference cycle in the event of the socket being cleaned up
after the file description did (i.e. unlinking the file before closing
the socket), because the file description never got destructed.