### PR TITLE
Kernel: Drop the receive buffer when socket enters the TimeWait state

### DIFF
--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -91,6 +91,7 @@ protected:
     void set_peer_address(IPv4Address address) { m_peer_address = address; }
 
     static KResultOr<NonnullOwnPtr<DoubleBuffer>> try_create_receive_buffer();
+    void drop_receive_buffer();
 
 private:
     virtual bool is_ipv4() const override { return true; }
@@ -115,7 +116,7 @@ private:
 
     SinglyLinkedListWithCount<ReceivedPacket> m_receive_queue;
 
-    NonnullOwnPtr<DoubleBuffer> m_receive_buffer;
+    OwnPtr<DoubleBuffer> m_receive_buffer;
 
     u16 m_local_port { 0 };
     u16 m_peer_port { 0 };

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -43,6 +43,13 @@ void TCPSocket::set_state(State new_state)
         [[maybe_unused]] auto rc = set_so_error(KSuccess);
     }
 
+    if (new_state == State::TimeWait) {
+        // Once we hit TimeWait, we are only holding the socket in case there
+        // are packets on the way which we wouldn't want a new socket to get hit
+        // with, so there's no point in keeping the receive buffer around.
+        drop_receive_buffer();
+    }
+
     if (new_state == State::Closed) {
         closing_sockets().with_exclusive([&](auto& table) {
             table.remove(tuple());


### PR DESCRIPTION
The TimeWait state is intended to prevent another socket from taking the
address tuple in case any packets are still in transit after the final
close. Since this state never delivers packets to userspace, it doesn't
make sense to keep the receive buffer around.