### PR TITLE
LibDiff+Utilites: Add an initial mechanism to diff text + the `diff` utility

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -746,6 +746,12 @@ public:
         return {};
     }
 
+    void reverse()
+    {
+        for (size_t i = 0; i < size() / 2; ++i)
+            AK::swap(at(i), at(size() - i - 1));
+    }
+
 private:
     void reset_capacity()
     {

--- a/Userland/Libraries/LibDiff/CMakeLists.txt
+++ b/Userland/Libraries/LibDiff/CMakeLists.txt
@@ -1,7 +1,8 @@
 
 set(SOURCES
-    Hunks.cpp
     Format.cpp
+    Generator.cpp
+    Hunks.cpp
 )
 
 serenity_lib(LibDiff diff)

--- a/Userland/Libraries/LibDiff/Generator.cpp
+++ b/Userland/Libraries/LibDiff/Generator.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Generator.h"
+
+namespace Diff {
+
+Vector<Hunk> from_text(StringView const& old_text, StringView const& new_text)
+{
+    auto old_lines = old_text.lines();
+    auto new_lines = new_text.lines();
+
+    /**
+     * This is a simple implementation of the Longest Common Subsequence algorithm (over
+     * the lines of the text as opposed to the characters). A Dynamic programming approach
+     * is used here.
+     */
+
+    enum class Direction {
+        Up,       // Added a new line
+        Left,     // Removed a line
+        Diagonal, // Line remained the same
+    };
+
+    // A single cell in the DP-matrix. Cell (i, j) represents the longest common
+    // sub-sequence of lines between old_lines[0 : i] and new_lines[0 : j].
+    struct Cell {
+        size_t length;
+        Direction direction;
+    };
+
+    auto dp_matrix = Vector<Cell>();
+    dp_matrix.resize((old_lines.size() + 1) * (new_lines.size() + 1));
+
+    auto dp = [&dp_matrix, width = old_lines.size() + 1](size_t i, size_t j) -> Cell& {
+        return dp_matrix[i + width * j];
+    };
+
+    // Initialize the first row and column
+    for (size_t i = 0; i <= old_lines.size(); ++i)
+        dp(i, 0) = { 0, Direction::Left };
+
+    for (size_t j = 0; j <= new_lines.size(); ++j)
+        dp(0, j) = { 0, Direction::Up };
+
+    // Fill in the rest of the DP table
+    for (size_t i = 1; i <= old_lines.size(); ++i) {
+        for (size_t j = 1; j <= new_lines.size(); ++j) {
+            if (old_lines[i - 1] == new_lines[j - 1]) {
+                dp(i, j) = { dp(i - 1, j - 1).length + 1, Direction::Diagonal };
+            } else {
+                auto up = dp(i, j - 1).length;
+                auto left = dp(i - 1, j).length;
+                if (up > left)
+                    dp(i, j) = { up, Direction::Up };
+                else
+                    dp(i, j) = { left, Direction::Left };
+            }
+        }
+    }
+
+    Vector<Hunk> hunks;
+    size_t i = old_lines.size();
+    size_t j = new_lines.size();
+
+    // FIXME: This creates a hunk per line, very inefficient.
+    while (i > 0 && j > 0) {
+        auto& cell = dp(i, j);
+        if (cell.direction == Direction::Up) {
+            --j;
+            hunks.append({ i, j, {}, { new_lines[j] } });
+        } else if (cell.direction == Direction::Left) {
+            --i;
+            hunks.append({ i, j, { old_lines[i] }, {} });
+        } else if (cell.direction == Direction::Diagonal) {
+            --i;
+            --j;
+        }
+    }
+
+    hunks.reverse();
+    return hunks;
+}
+
+}

--- a/Userland/Libraries/LibDiff/Generator.h
+++ b/Userland/Libraries/LibDiff/Generator.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Hunks.h"
+
+namespace Diff {
+
+Vector<Hunk> from_text(StringView const& old_text, StringView const& new_text);
+
+}

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB CMD_SOURCES  CONFIGURE_DEPENDS "*.cpp")
 list(APPEND SPECIAL_TARGETS test install)
 list(APPEND REQUIRED_TARGETS
-    arp base64 basename cat chmod chown clear comm cp cut date dd df dirname dmesg du echo env expr false fgrep
+    arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false fgrep
     file find grep groups head host hostname id ifconfig kill killall ln ls mkdir mount mv nproc
     pgrep pidof ping pmap ps readlink realpath reboot rm rmdir seq shutdown sleep sort stat stty su tail test
     touch tr true umount uname uniq uptime w wc which whoami xargs yes less
@@ -59,6 +59,7 @@ target_link_libraries(chres LibGUI)
 target_link_libraries(cksum LibCrypto)
 target_link_libraries(config LibConfig)
 target_link_libraries(copy LibGUI)
+target_link_libraries(diff LibDiff)
 target_link_libraries(disasm LibX86)
 target_link_libraries(expr LibRegex)
 target_link_libraries(file LibGfx LibIPC LibCompress)

--- a/Userland/Utilities/diff.cpp
+++ b/Userland/Utilities/diff.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibDiff/Generator.h>
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    if (pledge("stdio rpath", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    Core::ArgsParser parser;
+    char const* filename1;
+    char const* filename2;
+
+    parser.add_positional_argument(filename1, "First file to compare", "file1", Core::ArgsParser::Required::Yes);
+    parser.add_positional_argument(filename2, "Second file to compare", "file2", Core::ArgsParser::Required::Yes);
+    parser.parse(argc, argv, Core::ArgsParser::FailureBehavior::PrintUsageAndExit);
+
+    auto file1 = Core::File::construct(filename1);
+    if (!file1->open(Core::OpenMode::ReadOnly)) {
+        warnln("Error: Cannot open {}: {}", filename1, file1->error_string());
+        return 1;
+    }
+    auto file2 = Core::File::construct(filename2);
+    if (!file2->open(Core::OpenMode::ReadOnly)) {
+        warnln("Error: Cannot open {}: {}", filename2, file2->error_string());
+        return 1;
+    }
+
+    auto hunks = Diff::from_text(file1->read_all(), file2->read_all());
+    for (const auto& hunk : hunks) {
+        outln("Hunk: {}, {}", hunk.original_start_line, hunk.target_start_line);
+        for (const auto& line : hunk.removed_lines) {
+            outln("\033[31;1m< {}\033[0m", line);
+        }
+        if (hunk.added_lines.size() > 0 && hunk.removed_lines.size() > 0)
+            outln("---");
+        for (const auto& line : hunk.added_lines)
+            outln("\033[32;1m> {}\033[0m", line);
+    }
+
+    return hunks.is_empty() ? 0 : 1;
+}


### PR DESCRIPTION
My first attempt at implementing something like this: it's a very naive dynamic-programming implementation of the [Longest Common Subsequence](https://www.geeksforgeeks.org/longest-common-subsequence-dp-4/) algorithm, and then going backwards to re-construct the solution.

The algorithm itself is likely far from ideal, but just something for now to help set up the general interfaces we are using. Work still needs to be done on coalescing the Hunks together, but I only have limited time to work on this nowadays so adding it t the Yak stack for a later date.

Any comments on how to better improve the API / better way structure the actual code doing the DP / low hanging fruit is appreciated. 

Kind of a drive by commit adding a `Vector::reverse()` method since I needed to use it anyway