### PR TITLE
Revert "LibTLS: Close the underlying socket on EOF"

### DIFF
--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -142,21 +142,20 @@ bool TLSv12::common_connect(const struct sockaddr* saddr, socklen_t length)
     return true;
 }
 
-void TLSv12::notify_client_for_app_data()
-{
-    if (m_context.application_buffer.size() > 0) {
-        if (!m_has_scheduled_app_data_flush) {
-            deferred_invoke([this] { notify_client_for_app_data(); });
-            m_has_scheduled_app_data_flush = true;
-        }
-        if (on_tls_ready_to_read)
-            on_tls_ready_to_read(*this);
-    }
-    m_has_scheduled_app_data_flush = false;
-}
-
 void TLSv12::read_from_socket()
 {
+    auto did_schedule_read = false;
+    auto notify_client_for_app_data = [&] {
+        if (m_context.application_buffer.size() > 0) {
+            if (!did_schedule_read) {
+                deferred_invoke([&] { read_from_socket(); });
+                did_schedule_read = true;
+            }
+            if (on_tls_ready_to_read)
+                on_tls_ready_to_read(*this);
+        }
+    };
+
     // If there's anything before we consume stuff, let the client know
     // since we won't be consuming things if the connection is terminated.
     notify_client_for_app_data();
@@ -189,15 +188,10 @@ void TLSv12::write_into_socket()
 
 bool TLSv12::check_connection_state(bool read)
 {
-    if (m_context.connection_finished)
-        return false;
-
     if (!Core::Socket::is_open() || !Core::Socket::is_connected() || Core::Socket::eof()) {
         // an abrupt closure (the server is a jerk)
         dbgln_if(TLS_DEBUG, "Socket not open, assuming abrupt closure");
         m_context.connection_finished = true;
-        Core::Socket::close();
-        return false;
     }
     if (m_context.critical_error) {
         dbgln_if(TLS_DEBUG, "CRITICAL ERROR {} :(", m_context.critical_error);
@@ -216,7 +210,7 @@ bool TLSv12::check_connection_state(bool read)
                 m_context.tls_buffer.size(),
                 m_context.application_buffer.size());
         } else {
-            m_context.connection_finished = true;
+            m_context.connection_finished = false;
             dbgln_if(TLS_DEBUG, "FINISHED");
         }
         if (!m_context.application_buffer.size()) {

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -412,7 +412,6 @@ private:
     void read_from_socket();
 
     bool check_connection_state(bool read);
-    void notify_client_for_app_data();
 
     ssize_t handle_server_hello(ReadonlyBytes, WritePacketStage&);
     ssize_t handle_handshake_finished(ReadonlyBytes, WritePacketStage&);
@@ -516,7 +515,6 @@ private:
     CipherVariant m_cipher_remote { Empty {} };
 
     bool m_has_scheduled_write_flush { false };
-    bool m_has_scheduled_app_data_flush { false };
     i32 m_max_wait_time_for_handshake_in_seconds { 10 };
 
     RefPtr<Core::Timer> m_handshake_timeout_timer;


### PR DESCRIPTION
This reverts commit 23febbed41d8296cf9e532a17145822cd099b591.

It breaks the TestTLSHandshake test used in CI, it causes it
to hang, and all CI jobs have been hanging.