### PR TITLE
LibJS: Fix Clang Toolchain CI build

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -93,7 +93,7 @@ ThrowCompletionOr<MarkedValueList> create_list_from_array_like(GlobalObject& glo
     }
 
     // 7. Return list.
-    return list;
+    return ThrowCompletionOr(move(list));
 }
 
 // 7.3.22 SpeciesConstructor ( O, defaultConstructor ), https://tc39.es/ecma262/#sec-speciesconstructor


### PR DESCRIPTION
Clang was failing because because it rightfully saw we were attempting
to call a deleted constructor of `MarkedValueList`. If you explicitly
called move(list) then GCC would complain that the move was unnecessary.

For what ever reason both tool chains accept when we construct the
ThrowCompletionOr explicitly that we move the list into and return that.