### PR TITLE
ThemeEditor(+LibGfx): Save theme metrics and paths to file

### DIFF
--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -145,6 +145,16 @@ int main(int argc, char** argv)
             theme->write_entry("Colors", to_string(role), preview_widget.preview_palette().color(role).to_string());
         }
 
+#define __ENUMERATE_METRIC_ROLE(role) \
+    theme->write_num_entry("Metrics", #role, preview_widget.preview_palette().metric(Gfx::MetricRole::role));
+        ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
+#undef __ENUMERATE_METRIC_ROLE
+
+#define __ENUMERATE_PATH_ROLE(role) \
+    theme->write_entry("Paths", #role, preview_widget.preview_palette().path(Gfx::PathRole::role));
+        ENUMERATE_PATH_ROLES(__ENUMERATE_PATH_ROLE)
+#undef __ENUMERATE_PATH_ROLE
+
         theme->sync();
     };
 

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -77,12 +77,11 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
     ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
 #undef __ENUMERATE_COLOR_ROLE
 
-#define DO_METRIC(x) \
-    data->metric[(int)MetricRole::x] = get_metric(#x, (int)MetricRole::x)
-
-    DO_METRIC(TitleHeight);
-    DO_METRIC(TitleButtonWidth);
-    DO_METRIC(TitleButtonHeight);
+#undef __ENUMERATE_METRIC_ROLE
+#define __ENUMERATE_METRIC_ROLE(role) \
+    data->metric[(int)MetricRole::role] = get_metric(#role, (int)MetricRole::role);
+    ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
+#undef __ENUMERATE_METRIC_ROLE
 
 #define DO_PATH(x, allow_empty)                                                                                  \
     do {                                                                                                         \

--- a/Userland/Libraries/LibGfx/SystemTheme.h
+++ b/Userland/Libraries/LibGfx/SystemTheme.h
@@ -89,6 +89,19 @@ namespace Gfx {
     C(Window)                      \
     C(WindowText)
 
+#define ENUMERATE_METRIC_ROLES(C) \
+    C(TitleHeight)                \
+    C(TitleButtonWidth)           \
+    C(TitleButtonHeight)
+
+#define ENUMERATE_PATH_ROLES(C) \
+    C(TitleButtonIcons)         \
+    C(InactiveWindowShadow)     \
+    C(ActiveWindowShadow)       \
+    C(TaskbarShadow)            \
+    C(MenuShadow)               \
+    C(TooltipShadow)
+
 enum class ColorRole {
     NoRole,
 
@@ -121,21 +134,24 @@ inline const char* to_string(ColorRole role)
 
 enum class MetricRole {
     NoRole,
-    TitleHeight,
-    TitleButtonWidth,
-    TitleButtonHeight,
-    __Count,
+
+#undef __ENUMERATE_METRIC_ROLE
+#define __ENUMERATE_METRIC_ROLE(role) role,
+    ENUMERATE_METRIC_ROLES(__ENUMERATE_METRIC_ROLE)
+#undef __ENUMERATE_METRIC_ROLE
+
+        __Count,
 };
 
 enum class PathRole {
     NoRole,
-    TitleButtonIcons,
-    InactiveWindowShadow,
-    ActiveWindowShadow,
-    TaskbarShadow,
-    MenuShadow,
-    TooltipShadow,
-    __Count,
+
+#undef __ENUMERATE_PATH_ROLE
+#define __ENUMERATE_PATH_ROLE(role) role,
+    ENUMERATE_PATH_ROLES(__ENUMERATE_PATH_ROLE)
+#undef __ENUMERATE_PATH_ROLE
+
+        __Count,
 };
 
 struct SystemTheme {


### PR DESCRIPTION
- **LibGfx: Add support for enumerating by Metric and Path roles**

  For Theme Editor.

- **LibGfx: Enumerate metric theme roles**

  This change does practically nothing except that you no longer have to put new roles there, as they are now automatically read from the enum list.

- **ThemeEditor: Save theme metrics and paths to file**

  Prior this change, custom title metrics seen in the Basalt theme and custom icon paths in Redmond themes were dropped when saving a file.

  Now any entry, even empty, will be saved. This may end up with slightly larger files, but on other hand, users will be able to see every option in a text editor, without a need to look at the code/docs.

