### PR TITLE
FileManager: Extract a zip archive on double click

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -114,6 +114,17 @@ void DirectoryView::handle_activation(GUI::ModelIndex const& index)
         return;
     }
 
+    if (path.ends_with(".zip", AK::CaseSensitivity::CaseInsensitive)) {
+        auto result = GUI::MessageBox::show(window(),
+            String::formatted("Extract {} here?", LexicalPath::basename(path)),
+            "Confirm extraction",
+            GUI::MessageBox::Type::Question,
+            GUI::MessageBox::InputType::YesNo);
+        if (result == GUI::MessageBox::ExecYes)
+            do_unzip_archive({ path }, window());
+        return;
+    }
+
     auto url = URL::create_with_file_protocol(path);
     auto launcher_handlers = get_launch_handlers(url);
     auto default_launcher = get_default_launch_handler(launcher_handlers);

--- a/Userland/Applications/FileManager/FileUtils.h
+++ b/Userland/Applications/FileManager/FileUtils.h
@@ -22,4 +22,7 @@ enum class FileOperation {
 void delete_paths(Vector<String> const&, bool should_confirm, GUI::Window*);
 
 void run_file_operation(FileOperation, Vector<String> const& sources, String const& destination, GUI::Window*);
+
+void do_unzip_archive(Vector<String> const& selected_file_paths, GUI::Window* window);
+
 }


### PR DESCRIPTION
Currently, when the user double-clicks a .zip file, it opens TextEditor as the file format is not associated with any application. Instead, the user should be able to extract a zip archive from double-click. As the expected action is less obvious compared to the "Extract Here" right-click menu, this change also adds a confirmation dialog that's shown only when the user tries to extract a zip archive from double-click.