### PR TITLE
PixelPaint: Some small LayerListWidget/UI tweaks

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -420,8 +420,6 @@ void ImageEditor::set_active_layer(Layer* layer)
         if (on_active_layer_change)
             on_active_layer_change({});
     }
-
-    layers_did_change();
 }
 
 void ImageEditor::set_active_tool(Tool* tool)

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -342,6 +342,10 @@ void LayerListWidget::set_selected_layer(Layer* layer)
 {
     if (!m_image)
         return;
+
+    if (layer->is_selected())
+        return;
+
     for (size_t i = 0; i < m_image->layer_count(); ++i) {
         if (layer == &m_image->layer(i)) {
             m_image->layer(i).set_selected(true);

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -61,10 +61,12 @@
 
             @PixelPaint::LayerPropertiesWidget {
                 name: "layer_properties_widget"
+                max_height: 94
             }
 
             @PixelPaint::ToolPropertiesWidget {
                 name: "tool_properties_widget"
+                max_height: 144
             }
         }
     }


### PR DESCRIPTION
Here's three small tweaks/optimizations for PixelPaint that's been lurking on a forgotten branch.

Before and after the UI-tweak:

![Screenshot_20210916_134432](https://user-images.githubusercontent.com/69970419/133609223-d6397410-31be-498f-b7fc-41ae8084ef22.png)
