### PR TITLE
LibTLS: Close the underlying socket on EOF

### DIFF
--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -142,31 +142,42 @@ bool TLSv12::common_connect(const struct sockaddr* saddr, socklen_t length)
     return true;
 }
 
+void TLSv12::notify_client_for_app_data()
+{
+    if (m_context.application_buffer.size() > 0) {
+        if (!m_has_scheduled_app_data_flush) {
+            deferred_invoke([this] { notify_client_for_app_data(); });
+            m_has_scheduled_app_data_flush = true;
+        }
+        if (on_tls_ready_to_read)
+            on_tls_ready_to_read(*this);
+    } else {
+        if (m_context.connection_finished && !m_context.has_invoked_finish_or_error_callback) {
+            m_context.has_invoked_finish_or_error_callback = true;
+            if (on_tls_finished)
+                on_tls_finished();
+        }
+    }
+    m_has_scheduled_app_data_flush = false;
+}
+
 void TLSv12::read_from_socket()
 {
-    auto did_schedule_read = false;
-    auto notify_client_for_app_data = [&] {
-        if (m_context.application_buffer.size() > 0) {
-            if (!did_schedule_read) {
-                deferred_invoke([&] { read_from_socket(); });
-                did_schedule_read = true;
-            }
-            if (on_tls_ready_to_read)
-                on_tls_ready_to_read(*this);
-        }
-    };
-
     // If there's anything before we consume stuff, let the client know
     // since we won't be consuming things if the connection is terminated.
     notify_client_for_app_data();
+
+    ScopeGuard notify_guard {
+        [this] {
+            // If anything new shows up, tell the client about the event.
+            notify_client_for_app_data();
+        }
+    };
 
     if (!check_connection_state(true))
         return;
 
     consume(Core::Socket::read(4 * MiB));
-
-    // If anything new shows up, tell the client about the event.
-    notify_client_for_app_data();
 }
 
 void TLSv12::write_into_socket()
@@ -188,20 +199,27 @@ void TLSv12::write_into_socket()
 
 bool TLSv12::check_connection_state(bool read)
 {
+    if (m_context.connection_finished)
+        return false;
+
     if (!Core::Socket::is_open() || !Core::Socket::is_connected() || Core::Socket::eof()) {
         // an abrupt closure (the server is a jerk)
         dbgln_if(TLS_DEBUG, "Socket not open, assuming abrupt closure");
         m_context.connection_finished = true;
+        Core::Socket::close();
+        return false;
     }
     if (m_context.critical_error) {
         dbgln_if(TLS_DEBUG, "CRITICAL ERROR {} :(", m_context.critical_error);
 
+        m_context.has_invoked_finish_or_error_callback = true;
         if (on_tls_error)
             on_tls_error((AlertDescription)m_context.critical_error);
         return false;
     }
     if (((read && m_context.application_buffer.size() == 0) || !read) && m_context.connection_finished) {
         if (m_context.application_buffer.size() == 0 && m_context.connection_status != ConnectionStatus::Disconnected) {
+            m_context.has_invoked_finish_or_error_callback = true;
             if (on_tls_finished)
                 on_tls_finished();
         }
@@ -210,7 +228,7 @@ bool TLSv12::check_connection_state(bool read)
                 m_context.tls_buffer.size(),
                 m_context.application_buffer.size());
         } else {
-            m_context.connection_finished = false;
+            m_context.connection_finished = true;
             dbgln_if(TLS_DEBUG, "FINISHED");
         }
         if (!m_context.application_buffer.size()) {

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -290,6 +290,7 @@ struct Context {
     ClientVerificationStaus client_verified { Verified };
 
     bool connection_finished { false };
+    bool has_invoked_finish_or_error_callback { false };
 
     // message flags
     u8 handshake_messages[11] { 0 };
@@ -412,6 +413,7 @@ private:
     void read_from_socket();
 
     bool check_connection_state(bool read);
+    void notify_client_for_app_data();
 
     ssize_t handle_server_hello(ReadonlyBytes, WritePacketStage&);
     ssize_t handle_handshake_finished(ReadonlyBytes, WritePacketStage&);
@@ -515,6 +517,7 @@ private:
     CipherVariant m_cipher_remote { Empty {} };
 
     bool m_has_scheduled_write_flush { false };
+    bool m_has_scheduled_app_data_flush { false };
     i32 m_max_wait_time_for_handshake_in_seconds { 10 };
 
     RefPtr<Core::Timer> m_handshake_timeout_timer;


### PR DESCRIPTION
Take two of #10044.

This is 23febbed41d8296cf9e532a17145822cd099b591 but without the bug that makes the CI hang :^)