### PR TITLE
LibWeb: Implement basic SVG styling using CSS

### DIFF
--- a/Base/res/html/misc/svg.html
+++ b/Base/res/html/misc/svg.html
@@ -1,10 +1,21 @@
 <!DOCTYPE html>
 <html>
-<head><title>SVG test</title></head>
+<head>
+    <title>SVG test</title>
+    <style>
+        .css {
+            fill: magenta;
+            stroke: yellow;
+            stroke-width: 3;
+        }
+    </style>
+</head>
 <body>
 <svg width="800" height="400">
     <path d="M 10 10 h 100 l -50 80 z" fill="green" stroke="black" stroke-width="3"></path>
     <path d="M 60 10 h 100 l -50 80 z" fill="red" stroke="blue" stroke-width="3"></path>
+    <path d="M 110 10 h 100 l -50 80 z" class="css"></path>
+
     <path d="M 135 275 v -100 a 100,100 0 0,0 -100,100 z" fill="yellow" stroke="blue" stroke-width="3"></path>
     <path d="M 150 290 v -100 a 100,100 0 1,1 -100,100 z" fill="red" stroke="blue" stroke-width="3"></path>
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -486,6 +486,9 @@ void Painter::draw_ellipse_intersecting(const IntRect& rect, Color color, int th
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
 
+    if (thickness <= 0)
+        return;
+
     constexpr int number_samples = 100; // FIXME: dynamically work out the number of samples based upon the rect size
     double increment = M_PI / number_samples;
 
@@ -589,6 +592,9 @@ void Painter::draw_rect(const IntRect& a_rect, Color color, bool rough)
 void Painter::draw_rect_with_thickness(const IntRect& rect, Color color, int thickness)
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
+
+    if (thickness <= 0)
+        return;
 
     IntPoint p1 = rect.location();
     IntPoint p2 = { rect.location().x() + rect.width(), rect.location().y() };
@@ -1634,6 +1640,9 @@ void Painter::draw_physical_pixel(const IntPoint& physical_position, Color color
     // (including scaling thickness).
     VERIFY(draw_op() == DrawOp::Copy);
 
+    if (thickness <= 0)
+        return;
+
     if (thickness == 1) { // Implies scale() == 1.
         auto& pixel = m_target->scanline(physical_position.y())[physical_position.x()];
         return set_physical_pixel_with_draw_op(pixel, Color::from_rgba(pixel).blend(color));
@@ -1646,6 +1655,9 @@ void Painter::draw_physical_pixel(const IntPoint& physical_position, Color color
 
 void Painter::draw_line(IntPoint const& a_p1, IntPoint const& a_p2, Color color, int thickness, LineStyle style, Color alternate_color)
 {
+    if (thickness <= 0)
+        return;
+
     if (color.alpha() == 0)
         return;
 
@@ -1837,6 +1849,9 @@ void Painter::draw_quadratic_bezier_curve(const IntPoint& control_point, const I
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
 
+    if (thickness <= 0)
+        return;
+
     for_each_line_segment_on_bezier_curve(FloatPoint(control_point), FloatPoint(p1), FloatPoint(p2), [&](const FloatPoint& fp1, const FloatPoint& fp2) {
         draw_line(IntPoint(fp1.x(), fp1.y()), IntPoint(fp2.x(), fp2.y()), color, thickness, style);
     });
@@ -1902,6 +1917,9 @@ void Painter::draw_elliptical_arc(const IntPoint& p1, const IntPoint& p2, const 
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
 
+    if (thickness <= 0)
+        return;
+
     for_each_line_segment_on_elliptical_arc(FloatPoint(p1), FloatPoint(p2), FloatPoint(center), radii, x_axis_rotation, theta_1, theta_delta, [&](const FloatPoint& fp1, const FloatPoint& fp2) {
         draw_line(IntPoint(fp1.x(), fp1.y()), IntPoint(fp2.x(), fp2.y()), color, thickness, style);
     });
@@ -1932,6 +1950,9 @@ PainterStateSaver::~PainterStateSaver()
 void Painter::stroke_path(const Path& path, Color color, int thickness)
 {
     VERIFY(scale() == 1); // FIXME: Add scaling support.
+
+    if (thickness <= 0)
+        return;
 
     FloatPoint cursor;
 

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -104,6 +104,10 @@ public:
 
     CSS::ListStyleType list_style_type() const { return m_inherited.list_style_type; }
 
+    Optional<Color> fill() const { return m_inherited.fill; }
+    Optional<Color> stroke() const { return m_inherited.stroke; }
+    Optional<Length> stroke_width() const { return m_inherited.stroke_width; }
+
     ComputedValues clone_inherited_values() const
     {
         ComputedValues clone;
@@ -119,6 +123,10 @@ protected:
         CSS::TextTransform text_transform { InitialValues::text_transform() };
         CSS::WhiteSpace white_space { InitialValues::white_space() };
         CSS::ListStyleType list_style_type { InitialValues::list_style_type() };
+
+        Optional<Color> fill;
+        Optional<Color> stroke;
+        Optional<Length> stroke_width;
     } m_inherited;
 
     struct {
@@ -210,6 +218,10 @@ public:
     void set_opacity(Optional<float> value) { m_noninherited.opacity = value; }
     void set_justify_content(CSS::JustifyContent value) { m_noninherited.justify_content = value; }
     void set_box_shadow(Optional<BoxShadowData> value) { m_noninherited.box_shadow = move(value); }
+
+    void set_fill(Color value) { m_inherited.fill = value; }
+    void set_stroke(Color value) { m_inherited.stroke = value; }
+    void set_stroke_width(Length value) { m_inherited.stroke_width = value; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -545,6 +545,14 @@
       "unitless-length"
     ]
   },
+  "stroke": {
+    "inherited": true,
+    "initial": "transparent"
+  },
+  "stroke-width": {
+    "inherited": true,
+    "initial": "1px"
+  },
   "text-align": {
     "inherited": true,
     "initial": "left"

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -360,6 +360,19 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     do_border_style(computed_values.border_top(), CSS::PropertyID::BorderTopWidth, CSS::PropertyID::BorderTopColor, CSS::PropertyID::BorderTopStyle);
     do_border_style(computed_values.border_right(), CSS::PropertyID::BorderRightWidth, CSS::PropertyID::BorderRightColor, CSS::PropertyID::BorderRightStyle);
     do_border_style(computed_values.border_bottom(), CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor, CSS::PropertyID::BorderBottomStyle);
+
+    if (auto fill = specified_style.property(CSS::PropertyID::Fill); fill.has_value())
+        computed_values.set_fill(fill.value()->to_color(document()));
+    if (auto stroke = specified_style.property(CSS::PropertyID::Stroke); stroke.has_value())
+        computed_values.set_stroke(stroke.value()->to_color(document()));
+    if (auto stroke_width = specified_style.property(CSS::PropertyID::StrokeWidth); stroke_width.has_value()) {
+        // FIXME: Converting to pixels isn't really correct - values should be in "user units"
+        //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
+        if (stroke_width.value()->is_numeric())
+            computed_values.set_stroke_width(CSS::Length::make_px(static_cast<CSS::NumericStyleValue const&>(*stroke_width.value()).value()));
+        else
+            computed_values.set_stroke_width(stroke_width.value()->to_length());
+    }
 }
 
 void Node::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned, unsigned)

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +14,7 @@ SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, QualifiedName qu
 {
 }
 
-void SVGGraphicsElement::parse_attribute(const FlyString& name, const String& value)
+void SVGGraphicsElement::parse_attribute(FlyString const& name, String const& value)
 {
     SVGElement::parse_attribute(name, value);
 
@@ -26,6 +27,41 @@ void SVGGraphicsElement::parse_attribute(const FlyString& name, const String& va
         if (result.has_value())
             m_stroke_width = result.value();
     }
+}
+
+Optional<Gfx::Color> SVGGraphicsElement::fill_color() const
+{
+    if (m_fill_color.has_value())
+        return m_fill_color;
+    if (!layout_node())
+        return {};
+    // FIXME: In the working-draft spec, `fill` is intended to be a shorthand, with `fill-color`
+    //        being what we actually want to use. But that's not final or widely supported yet.
+    return layout_node()->computed_values().fill();
+}
+
+Optional<Gfx::Color> SVGGraphicsElement::stroke_color() const
+{
+    if (m_stroke_color.has_value())
+        return m_stroke_color;
+    if (!layout_node())
+        return {};
+    // FIXME: In the working-draft spec, `stroke` is intended to be a shorthand, with `stroke-color`
+    //        being what we actually want to use. But that's not final or widely supported yet.
+    return layout_node()->computed_values().stroke();
+}
+
+Optional<float> SVGGraphicsElement::stroke_width() const
+{
+    if (m_stroke_width.has_value())
+        return m_stroke_width;
+    if (!layout_node())
+        return {};
+    // FIXME: Converting to pixels isn't really correct - values should be in "user units"
+    //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
+    if (auto width = layout_node()->computed_values().stroke_width(); width.has_value())
+        return width->to_px(*layout_node());
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,11 +20,11 @@ public:
 
     SVGGraphicsElement(DOM::Document&, QualifiedName);
 
-    virtual void parse_attribute(const FlyString& name, const String& value) override;
+    virtual void parse_attribute(FlyString const& name, String const& value) override;
 
-    const Optional<Gfx::Color>& fill_color() const { return m_fill_color; }
-    const Optional<Gfx::Color>& stroke_color() const { return m_stroke_color; }
-    const Optional<float>& stroke_width() const { return m_stroke_width; }
+    Optional<Gfx::Color> fill_color() const;
+    Optional<Gfx::Color> stroke_color() const;
+    Optional<float> stroke_width() const;
 
 protected:
     Optional<Gfx::Color> m_fill_color;


### PR DESCRIPTION
A lot of sites use the CSS `fill` property to color their SVG icons. And since our `SVGGraphicsElement` only has `fill`, `stroke` and `stroke-width` attributes, I've implemented the CSS properties for all 3! :^)

The spec is in a weird situation, it's a work-in-progress that nobody seems to support yet. They define `fill` and `stroke` as shorthands for several other properties, but neither Firefox nor Chrome implement those individual properties, so for now we're just implementing `fill` and `stroke` as taking a Color value, which matches how they are supported elsewhere.

Also here as a bonus: Fixed an infinite loop when asking Painter to paint lines that are 0px wide.