### PR TITLE
Kernel: Support execve with veiled Loader.so

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -48,6 +48,7 @@ public:
     KResult remount(Custody& mount_point, int new_flags);
     KResult unmount(Inode& guest_inode);
 
+    KResultOr<NonnullRefPtr<OpenFileDescription>> open(Custody& custody, int options);
     KResultOr<NonnullRefPtr<OpenFileDescription>> open(StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});
     KResultOr<NonnullRefPtr<OpenFileDescription>> create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> = {});
     KResult mkdir(StringView path, mode_t mode, Custody& base);
@@ -65,6 +66,7 @@ public:
     KResult rename(StringView oldpath, StringView newpath, Custody& base);
     KResult mknod(StringView path, mode_t, dev_t, Custody& base);
     KResultOr<NonnullRefPtr<Custody>> open_directory(StringView path, Custody& base);
+    KResultOr<NonnullRefPtr<OpenFileDescription>> open_executable_without_veil(StringView path, Custody& base);
 
     void for_each_mount(Function<void(const Mount&)>) const;
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -720,7 +720,7 @@ KResultOr<RefPtr<OpenFileDescription>> Process::find_elf_interpreter_for_executa
 
     if (!interpreter_path.is_empty()) {
         dbgln_if(EXEC_DEBUG, "exec({}): Using program interpreter {}", path, interpreter_path);
-        auto interpreter_description = TRY(VirtualFileSystem::the().open(interpreter_path, O_EXEC, 0, current_directory()));
+        auto interpreter_description = TRY(VirtualFileSystem::the().open_executable_without_veil(interpreter_path, current_directory()));
         auto interp_metadata = interpreter_description->metadata();
 
         VERIFY(interpreter_description->inode());


### PR DESCRIPTION
This removes the special unveil rule for /usr/lib/Loader.so and allows
the kernel to resolve the loader during the execve syscall by
ignoring the process veil in this case.

The execve syscall resets the process veil and gives control to the
newly loaded executable which is then responsible for its veils.
Therefore it doesn't make sense to apply the veil of the calling
process to the loader of the called executable.

In the future we can add command line options to Loader.so without the risk of introducing security flaws.