### PR TITLE
LibC: Implement most langinfo values mentioned in POSIX

### DIFF
--- a/Userland/Libraries/LibC/langinfo.cpp
+++ b/Userland/Libraries/LibC/langinfo.cpp
@@ -6,11 +6,116 @@
 
 #include <langinfo.h>
 
+// Values taken from glibc's en_US locale files.
 static const char* __nl_langinfo(nl_item item)
 {
     switch (item) {
     case CODESET:
         return "UTF-8";
+    case D_T_FMT:
+        return "%a %d %b %Y %r %Z";
+    case D_FMT:
+        return "%m/%d/%Y";
+    case T_FMT:
+        return "%r";
+    case T_FMT_AMPM:
+        return "%I:%M:%S %p";
+    case AM_STR:
+        return "AM";
+    case PM_STR:
+        return "PM";
+    case DAY_1:
+        return "Sunday";
+    case DAY_2:
+        return "Monday";
+    case DAY_3:
+        return "Tuesday";
+    case DAY_4:
+        return "Wednesday";
+    case DAY_5:
+        return "Thursday";
+    case DAY_6:
+        return "Friday";
+    case DAY_7:
+        return "Saturday";
+    case ABDAY_1:
+        return "Sun";
+    case ABDAY_2:
+        return "Mon";
+    case ABDAY_3:
+        return "Tue";
+    case ABDAY_4:
+        return "Wed";
+    case ABDAY_5:
+        return "Thu";
+    case ABDAY_6:
+        return "Fri";
+    case ABDAY_7:
+        return "Sat";
+    case MON_1:
+        return "January";
+    case MON_2:
+        return "February";
+    case MON_3:
+        return "March";
+    case MON_4:
+        return "April";
+    case MON_5:
+        return "May";
+    case MON_6:
+        return "June";
+    case MON_7:
+        return "July";
+    case MON_8:
+        return "August";
+    case MON_9:
+        return "September";
+    case MON_10:
+        return "October";
+    case MON_11:
+        return "November";
+    case MON_12:
+        return "December";
+    case ABMON_1:
+        return "Jan";
+    case ABMON_2:
+        return "Feb";
+    case ABMON_3:
+        return "Mar";
+    case ABMON_4:
+        return "Apr";
+    case ABMON_5:
+        return "May";
+    case ABMON_6:
+        return "Jun";
+    case ABMON_7:
+        return "Jul";
+    case ABMON_8:
+        return "Aug";
+    case ABMON_9:
+        return "Sep";
+    case ABMON_10:
+        return "Oct";
+    case ABMON_11:
+        return "Nov";
+    case ABMON_12:
+        return "Dec";
+    case RADIXCHAR:
+        return ".";
+    case THOUSEP:
+        return ",";
+    case YESEXPR:
+        return "^[+1yY]";
+    case NOEXPR:
+        return "^[-0nN]";
+    // en_US does not have ERA.
+    case ERA:
+    case ERA_D_FMT:
+    case ERA_D_T_FMT:
+    case ERA_T_FMT:
+    // en_US also doesn't have special digit symbols.
+    case ALT_DIGITS:
+    // Invalid values also return an empty string.
     default:
         return "";
     }

--- a/Userland/Libraries/LibC/langinfo.h
+++ b/Userland/Libraries/LibC/langinfo.h
@@ -13,6 +13,67 @@ __BEGIN_DECLS
 
 enum {
     CODESET,
+
+    D_T_FMT,
+    D_FMT,
+    T_FMT,
+    T_FMT_AMPM,
+    AM_STR,
+    PM_STR,
+
+    DAY_1,
+    DAY_2,
+    DAY_3,
+    DAY_4,
+    DAY_5,
+    DAY_6,
+    DAY_7,
+
+    ABDAY_1,
+    ABDAY_2,
+    ABDAY_3,
+    ABDAY_4,
+    ABDAY_5,
+    ABDAY_6,
+    ABDAY_7,
+
+    MON_1,
+    MON_2,
+    MON_3,
+    MON_4,
+    MON_5,
+    MON_6,
+    MON_7,
+    MON_8,
+    MON_9,
+    MON_10,
+    MON_11,
+    MON_12,
+
+    ABMON_1,
+    ABMON_2,
+    ABMON_3,
+    ABMON_4,
+    ABMON_5,
+    ABMON_6,
+    ABMON_7,
+    ABMON_8,
+    ABMON_9,
+    ABMON_10,
+    ABMON_11,
+    ABMON_12,
+
+    ERA,
+    ERA_D_FMT,
+    ERA_D_T_FMT,
+    ERA_T_FMT,
+
+    ALT_DIGITS,
+    RADIXCHAR,
+    THOUSEP,
+    YESEXPR,
+    NOEXPR,
+    CRNCYSTR,
 };
 
 char* nl_langinfo(nl_item);


### PR DESCRIPTION
The values that have been implemented here are (almost) all the values that are mentioned in the POSIX manpage for `langinfo.h`. This helps with ports that rely on previously unimplemented properties, whose langinfo support recently got enabled because `nl_langinfo` exists now.

The values listed here have been taken from the en_US locale file of glibc. Values that do not apply to the `en_US` locale I explicitly left in as a switch case anyways, to document that fact. The only value that is missing is the currency symbol (`CRNCYSTR`), because I'm not sure whether I should use the Dollar sign, make up something new for Serenity, or if I should just leave it unimplemented.