### PR TITLE
LibGUI+PixelPaint: Implement better automatic scrolling in LayerListWidget

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -45,6 +45,7 @@ private:
     virtual void image_did_modify_layer_properties(size_t) override;
     virtual void image_did_modify_layer_bitmap(size_t) override;
     virtual void image_did_modify_layer_stack() override;
+    virtual void on_automatic_scrolling_timer_fired() override;
 
     void rebuild_gadgets();
     void relayout_gadgets();
@@ -71,6 +72,8 @@ private:
 
     Optional<size_t> m_moving_gadget_index;
     Gfx::IntPoint m_moving_event_origin;
+
+    Gfx::IntPoint m_automatic_scroll_delta;
 
     size_t m_selected_gadget_index { 0 };
 };

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Timer.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGUI/Scrollbar.h>
 
@@ -28,6 +29,12 @@ AbstractScrollableWidget::AbstractScrollableWidget()
 
     m_corner_widget = add<Widget>();
     m_corner_widget->set_fill_with_background_color(true);
+
+    m_automatic_scrolling_timer = add<Core::Timer>();
+    m_automatic_scrolling_timer->set_interval(50);
+    m_automatic_scrolling_timer->on_timeout = [this] {
+        on_automatic_scrolling_timer_fired();
+    };
 }
 
 AbstractScrollableWidget::~AbstractScrollableWidget()
@@ -212,6 +219,38 @@ void AbstractScrollableWidget::scroll_to_top()
 void AbstractScrollableWidget::scroll_to_bottom()
 {
     scroll_into_view({ 0, content_height(), 0, 0 }, Orientation::Vertical);
+}
+
+void AbstractScrollableWidget::set_automatic_scrolling_timer(bool active)
+{
+    if (active == m_active_scrolling_enabled)
+        return;
+
+    m_active_scrolling_enabled = active;
+
+    if (active) {
+        on_automatic_scrolling_timer_fired();
+        m_automatic_scrolling_timer->start();
+    } else {
+        m_automatic_scrolling_timer->stop();
+    }
+}
+
+Gfx::IntPoint AbstractScrollableWidget::automatic_scroll_delta_from_position(const Gfx::IntPoint& pos) const
+{
+    Gfx::IntPoint delta { 0, 0 };
+
+    if (pos.y() < m_autoscroll_threshold)
+        delta.set_y(clamp(-(m_autoscroll_threshold - pos.y()), -m_autoscroll_threshold, 0));
+    else if (pos.y() > height() - m_autoscroll_threshold)
+        delta.set_y(clamp(m_autoscroll_threshold - (height() - pos.y()), 0, m_autoscroll_threshold));
+
+    if (pos.x() < m_autoscroll_threshold)
+        delta.set_x(clamp(-(m_autoscroll_threshold - pos.x()), -m_autoscroll_threshold, 0));
+    else if (pos.x() > width() - m_autoscroll_threshold)
+        delta.set_x(clamp(m_autoscroll_threshold - (width() - pos.x()), 0, m_autoscroll_threshold));
+
+    return delta;
 }
 
 Gfx::IntRect AbstractScrollableWidget::widget_inner_rect() const

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -51,6 +51,9 @@ public:
     void scroll_to_top();
     void scroll_to_bottom();
 
+    void set_automatic_scrolling_timer(bool active);
+    Gfx::IntPoint automatic_scroll_delta_from_position(const Gfx::IntPoint&) const;
+
     int width_occupied_by_vertical_scrollbar() const;
     int height_occupied_by_horizontal_scrollbar() const;
 
@@ -71,6 +74,7 @@ protected:
     virtual void did_scroll() { }
     void set_content_size(const Gfx::IntSize&);
     void set_size_occupied_by_fixed_elements(const Gfx::IntSize&);
+    virtual void on_automatic_scrolling_timer_fired() {};
 
 private:
     class AbstractScrollableWidgetScrollbar final : public Scrollbar {
@@ -103,6 +107,10 @@ private:
     Gfx::IntSize m_size_occupied_by_fixed_elements;
     bool m_scrollbars_enabled { true };
     bool m_should_hide_unnecessary_scrollbars { false };
+
+    RefPtr<Core::Timer> m_automatic_scrolling_timer;
+    bool m_active_scrolling_enabled { false };
+    int m_autoscroll_threshold { 20 };
 };
 
 }

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -26,6 +26,9 @@ public:
     int page_step() const { return m_page_step; }
     bool jump_to_cursor() const { return m_jump_to_cursor; }
 
+    bool is_min() const { return m_value == m_min; }
+    bool is_max() const { return m_value == m_max; }
+
     void set_range(int min, int max);
     virtual void set_value(int);
 


### PR DESCRIPTION
![output](https://user-images.githubusercontent.com/69970419/133665042-aaf4166b-30e3-4866-9e80-89bfaa8c1583.gif)

This PR implements a timer in AbstractScrollableWidget that is used when we want automatic scrolling. For example when dragging an object outside of the scroll area. The previous scrolling in LayerListWidget relied on mousemove events which didn't produce the desired effect.

By overriding `on_automatic_scrolling_timer_fired()` we can calculate the scrolling delta when dragging objects. A helper function, `automatic_scroll_delta_from_position()` gives us a delta that we can use to calculate speed and direction.
By default m_autoscroll_threshold is 20 pixels from the edge, and gives a linear change in scroll delta, incrementing when you get further away.