### PR TITLE
Kernel: Fix using waitid() on traced, non-child processes

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -661,8 +661,14 @@ void Process::disowned_by_waiter(Process& process)
 
 void Process::unblock_waiters(Thread::WaitBlocker::UnblockFlags flags, u8 signal)
 {
-    if (auto parent = Process::from_pid(ppid()))
-        parent->m_wait_blocker_set.unblock(*this, flags, signal);
+    RefPtr<Process> waiter_process;
+    if (auto* my_tracer = tracer())
+        waiter_process = Process::from_pid(my_tracer->tracer_pid());
+    else
+        waiter_process = Process::from_pid(ppid());
+
+    if (waiter_process)
+        waiter_process->m_wait_blocker_set.unblock(*this, flags, signal);
 }
 
 void Process::die()

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -32,9 +32,12 @@ KResultOr<FlatPtr> Process::sys$waitid(Userspace<const Syscall::SC_waitid_params
         break;
     case P_PID: {
         auto waitee_process = Process::from_pid(params.id);
-        if (!waitee_process || waitee_process->ppid() != Process::current().pid()) {
+        if (!waitee_process)
             return ECHILD;
-        }
+        bool waitee_is_child = waitee_process->ppid() == Process::current().pid();
+        bool waitee_is_our_tracee = waitee_process->has_tracee_thread(Process::current().pid());
+        if (!waitee_is_child && !waitee_is_our_tracee)
+            return ECHILD;
         waitee = waitee_process.release_nonnull();
         break;
     }


### PR DESCRIPTION
After this fix, `strace -p <pid>` works again.