### PR TITLE
LibC: Primitively implement wcscoll()

### DIFF
--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     TestStackSmash.cpp
     TestStrlcpy.cpp
     TestStrtodAccuracy.cpp
+    TestWchar.cpp
     TestWctype.cpp
 )
 

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <wchar.h>
+
+TEST_CASE(wcscoll)
+{
+    // Check if wcscoll is sorting correctly. At the moment we are doing raw char comparisons,
+    // so it's digits, then uppercase letters, then lowercase letters.
+
+    // Equalness between equal strings.
+    EXPECT(wcscoll(L"", L"") == 0);
+    EXPECT(wcscoll(L"0", L"0") == 0);
+
+    // Shorter strings before longer strings.
+    EXPECT(wcscoll(L"", L"0") < 0);
+    EXPECT(wcscoll(L"0", L"") > 0);
+    EXPECT(wcscoll(L"123", L"1234") < 0);
+    EXPECT(wcscoll(L"1234", L"123") > 0);
+
+    // Order within digits.
+    EXPECT(wcscoll(L"0", L"9") < 0);
+    EXPECT(wcscoll(L"9", L"0") > 0);
+
+    // Digits before uppercase letters.
+    EXPECT(wcscoll(L"9", L"A") < 0);
+    EXPECT(wcscoll(L"A", L"9") > 0);
+
+    // Order within uppercase letters.
+    EXPECT(wcscoll(L"A", L"Z") < 0);
+    EXPECT(wcscoll(L"Z", L"A") > 0);
+
+    // Uppercase letters before lowercase letters.
+    EXPECT(wcscoll(L"Z", L"a") < 0);
+    EXPECT(wcscoll(L"a", L"Z") > 0);
+
+    // Uppercase letters before lowercase letters.
+    EXPECT(wcscoll(L"a", L"z") < 0);
+    EXPECT(wcscoll(L"z", L"a") > 0);
+}

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -317,10 +317,11 @@ size_t wcrtomb(char*, wchar_t, mbstate_t*)
     TODO();
 }
 
-int wcscoll(const wchar_t*, const wchar_t*)
+int wcscoll(const wchar_t* ws1, const wchar_t* ws2)
 {
-    dbgln("FIXME: Implement wcscoll()");
-    TODO();
+    // TODO: Actually implement a sensible sort order for this,
+    // because right now we are doing what LC_COLLATE=C would do.
+    return wcscmp(ws1, ws2);
 }
 
 int wctob(wint_t)


### PR DESCRIPTION
At the moment, sorting like `LC_COLLATE=C` would do is better than nothing.

This also makes `sed` more happy after the recent wchar changes.