### PR TITLE
Meta: Set SERENITY_ARCH if it is not set in debug-kernel.sh

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -2,6 +2,10 @@
 
 SCRIPT_DIR="$(dirname "${0}")"
 
+if [ -z "$SERENITY_ARCH" ]; then
+    SERENITY_ARCH="i686"
+fi
+
 # Set this environment variable to override the default debugger.
 #
 if [ -z "$SERENITY_KERNEL_DEBUGGER" ]; then


### PR DESCRIPTION
This appears to have regressed recently in commit 783a58dbc.

CC: @IdanHo 