### PR TITLE
LibDebug: Optimize symbolification by reducing allocations while building Dwarf DIE cache

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -66,9 +66,13 @@ void AbbreviationsMap::populate_map()
     }
 }
 
-Optional<AbbreviationsMap::AbbreviationEntry> AbbreviationsMap::get(u32 code) const
+AbbreviationsMap::AbbreviationEntry const* AbbreviationsMap::get(u32 code) const
 {
-    return m_entries.get(code);
+    auto it = m_entries.find(code);
+    if (it == m_entries.end()) {
+        return nullptr;
+    }
+    return &it->value;
 }
 
 }

--- a/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.h
+++ b/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.h
@@ -20,14 +20,12 @@ public:
     AbbreviationsMap(DwarfInfo const& dwarf_info, u32 offset);
 
     struct AbbreviationEntry {
-
         EntryTag tag;
         bool has_children;
 
         Vector<AttributeSpecification> attribute_specifications;
     };
-
-    Optional<AbbreviationEntry> get(u32 code) const;
+    AbbreviationEntry const* get(u32 code) const;
 
 private:
     void populate_map();

--- a/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -32,13 +32,13 @@ void DIE::rehydrate_from(u32 offset, Optional<u32> parent_offset)
         m_tag = EntryTag::None;
     } else {
         auto abbreviation_info = m_compilation_unit.abbreviations_map().get(m_abbreviation_code);
-        VERIFY(abbreviation_info.has_value());
+        VERIFY(abbreviation_info);
 
-        m_tag = abbreviation_info.value().tag;
-        m_has_children = abbreviation_info.value().has_children;
+        m_tag = abbreviation_info->tag;
+        m_has_children = abbreviation_info->has_children;
 
         // We iterate the attributes data only to calculate this DIE's size
-        for (auto& attribute_spec : abbreviation_info.value().attribute_specifications) {
+        for (auto& attribute_spec : abbreviation_info->attribute_specifications) {
             m_compilation_unit.dwarf_info().get_attribute_value(attribute_spec.form, attribute_spec.value, stream, &m_compilation_unit);
         }
     }
@@ -52,9 +52,9 @@ Optional<AttributeValue> DIE::get_attribute(Attribute const& attribute) const
     stream.discard_or_error(m_data_offset);
 
     auto abbreviation_info = m_compilation_unit.abbreviations_map().get(m_abbreviation_code);
-    VERIFY(abbreviation_info.has_value());
+    VERIFY(abbreviation_info);
 
-    for (const auto& attribute_spec : abbreviation_info.value().attribute_specifications) {
+    for (const auto& attribute_spec : abbreviation_info->attribute_specifications) {
         auto value = m_compilation_unit.dwarf_info().get_attribute_value(attribute_spec.form, attribute_spec.value, stream, &m_compilation_unit);
         if (attribute_spec.attribute == attribute) {
             return value;

--- a/Userland/Libraries/LibDebug/Dwarf/DIE.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.h
@@ -36,6 +36,7 @@ public:
     Optional<u32> parent_offset() const { return m_parent_offset; }
 
 private:
+    void rehydrate_from(u32 offset, Optional<u32> parent_offset);
     CompilationUnit const& m_compilation_unit;
     u32 m_offset { 0 };
     u32 m_data_offset { 0 };


### PR DESCRIPTION
Running `bt` as root or inspecting stacks in `SystemMonitor` is noticeably slow for a process that is blocked in the kernel. 
When looking at a profile, all the time appears to be spent in `DwarfInfo::build_cached_dies()` for all the binaries in a given stack.

Looking at the code we are mostly stuck in this heavily recursive algorithm, and we could avoid a substantial amount of allocations and speed up execution with some small code tweaks. 

Before: 
![image](https://user-images.githubusercontent.com/1212/133763128-180515fd-48b8-4e62-9e78-c6768958e3b7.png)

After:
![image](https://user-images.githubusercontent.com/1212/133763042-8ff99c42-f713-42b7-9aa1-1643655c0b60.png)

Not ground breaking progress, but some movement in the right direction. 