### PR TITLE
CI: Add missing `$` to Sonar Cloud build steps

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -119,8 +119,8 @@ jobs:
         #       binary directory for that project.
         run: |
           ninja -C Build/superbuild serenity-configure
-          cmake -B Build/{{ env.SONAR_ANALYSIS_ARCH }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          ninja -C Build/{{ env.SONAR_ANALYSIS_ARCH }} all_generated
+          cmake -B Build/${{ env.SONAR_ANALYSIS_ARCH }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          ninja -C Build/${{ env.SONAR_ANALYSIS_ARCH }} all_generated
 
       - name: Run sonar-scanner, upload results
         env:


### PR DESCRIPTION
Without the `$` GitHub Actions doesn't do the environment variable
replacement and CMake thinks we want a source directory of `./}}`