### PR TITLE
LibSQL: Parse INSERT statement without column names and check data types of input tuples (and a small `sql` fix)

### DIFF
--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -28,13 +28,13 @@ RefPtr<SQL::SQLResult> execute(NonnullRefPtr<SQL::Database> database, String con
     }
     SQL::AST::ExecutionContext context { database };
     auto result = statement->execute(context);
-    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     return result;
 }
 
 void create_schema(NonnullRefPtr<SQL::Database> database)
 {
     auto result = execute(database, "CREATE SCHEMA TestSchema;");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->inserted() == 1);
 }
 
@@ -42,6 +42,7 @@ void create_table(NonnullRefPtr<SQL::Database> database)
 {
     create_schema(database);
     auto result = execute(database, "CREATE TABLE TestSchema.TestTable ( TextColumn text, IntColumn integer );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->inserted() == 1);
 }
 
@@ -69,6 +70,7 @@ TEST_CASE(insert_into_table)
     auto database = SQL::Database::construct(db_name);
     create_table(database);
     auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test', 42 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->inserted() == 1);
 
     auto table = database->get_table("TESTSCHEMA", "TESTTABLE");
@@ -88,12 +90,16 @@ TEST_CASE(select_from_table)
     auto database = SQL::Database::construct(db_name);
     create_table(database);
     auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_1', 42 ), ( 'Test_2', 43 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->inserted() == 2);
     result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_3', 44 ), ( 'Test_4', 45 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->inserted() == 2);
     result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_5', 46 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->inserted() == 1);
     result = execute(database, "SELECT * FROM TestSchema.TestTable;");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
     EXPECT(result->has_results());
     EXPECT_EQ(result->results().size(), 5u);
 }

--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -84,6 +84,26 @@ TEST_CASE(insert_into_table)
     EXPECT_EQ(count, 1);
 }
 
+TEST_CASE(insert_into_table_wrong_data_types)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    create_table(database);
+    auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES (43, 'Test_2');");
+    EXPECT(result->inserted() == 0);
+    EXPECT(result->error().code == SQL::SQLErrorCode::InvalidValueType);
+}
+
+TEST_CASE(insert_into_table_multiple_tuples_wrong_data_types)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    create_table(database);
+    auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ('Test_1', 42), (43, 'Test_2');");
+    EXPECT(result->inserted() == 0);
+    EXPECT(result->error().code == SQL::SQLErrorCode::InvalidValueType);
+}
+
 TEST_CASE(select_from_table)
 {
     ScopeGuard guard([]() { unlink(db_name); });

--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -104,6 +104,16 @@ TEST_CASE(insert_into_table_multiple_tuples_wrong_data_types)
     EXPECT(result->error().code == SQL::SQLErrorCode::InvalidValueType);
 }
 
+TEST_CASE(insert_wrong_number_of_values)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    create_table(database);
+    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ( 42 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::InvalidNumberOfValues);
+    EXPECT(result->inserted() == 0);
+}
+
 TEST_CASE(select_from_table)
 {
     ScopeGuard guard([]() { unlink(db_name); });

--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -114,6 +114,19 @@ TEST_CASE(insert_wrong_number_of_values)
     EXPECT(result->inserted() == 0);
 }
 
+TEST_CASE(insert_without_column_names)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    create_table(database);
+    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ('Test_1', 42), ('Test_2', 43);");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
+    EXPECT(result->inserted() == 2);
+
+    auto table = database->get_table("TESTSCHEMA", "TESTTABLE");
+    EXPECT_EQ(database->select_all(*table).size(), 2u);
+}
+
 TEST_CASE(select_from_table)
 {
     ScopeGuard guard([]() { unlink(db_name); });

--- a/Userland/Libraries/LibSQL/AST/Insert.cpp
+++ b/Userland/Libraries/LibSQL/AST/Insert.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,9 +38,20 @@ RefPtr<SQLResult> Insert::execute(ExecutionContext& context) const
         auto row_value = row_expr.evaluate(context);
         VERIFY(row_value.type() == SQLType::Tuple);
         auto values = row_value.to_vector().value();
-        for (auto ix = 0u; ix < values.size(); ix++) {
-            auto& column_name = m_column_names[ix];
-            row[column_name] = values[ix];
+
+        // FIXME: Check that the values[ix] match the data type of the column.
+        if (m_column_names.size() > 0) {
+            for (auto ix = 0u; ix < values.size(); ix++) {
+                auto& column_name = m_column_names[ix];
+                row[column_name] = values[ix];
+            }
+        } else {
+            if (values.size() != row.size()) {
+                return SQLResult::construct(SQLCommand::Insert, SQLErrorCode::InvalidNumberOfValues, "");
+            }
+            for (auto ix = 0u; ix < values.size(); ix++) {
+                row[ix] = values[ix];
+            }
         }
         context.database->insert(row);
     }

--- a/Userland/Libraries/LibSQL/SQLResult.h
+++ b/Userland/Libraries/LibSQL/SQLResult.h
@@ -54,6 +54,7 @@ constexpr char const* command_tag(SQLCommand command)
     S(TableExists, "Table '{}' already exist")                    \
     S(InvalidType, "Invalid type '{}'")                           \
     S(InvalidDatabaseName, "Invalid database name '{}'")          \
+    S(InvalidValueType, "Invalid type for attribute '{}'")        \
     S(InvalidNumberOfValues, "Number of values does not match number of columns")
 
 enum class SQLErrorCode {

--- a/Userland/Libraries/LibSQL/SQLResult.h
+++ b/Userland/Libraries/LibSQL/SQLResult.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -52,7 +53,8 @@ constexpr char const* command_tag(SQLCommand command)
     S(ColumnDoesNotExist, "Column '{}' does not exist")           \
     S(TableExists, "Table '{}' already exist")                    \
     S(InvalidType, "Invalid type '{}'")                           \
-    S(InvalidDatabaseName, "Invalid database name '{}'")
+    S(InvalidDatabaseName, "Invalid database name '{}'")          \
+    S(InvalidNumberOfValues, "Number of values does not match number of columns")
 
 enum class SQLErrorCode {
 #undef __ENUMERATE_SQL_ERROR

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -112,9 +112,8 @@ int main()
 
         bool indenters_starting_line = true;
         for (SQL::AST::Token token = lexer.next(); token.type() != SQL::AST::TokenType::Eof; token = lexer.next()) {
-            auto length = token.value().length();
             auto start = token.start_position().column - 1;
-            auto end = start + length;
+            auto end = token.end_position().column - 1;
 
             if (indenters_starting_line) {
                 if (token.type() != SQL::AST::TokenType::ParenClose)


### PR DESCRIPTION
This adds the ability to parse SQL INSERT statements in the following
form:

    INSERT INTO schema.tablename VALUES (column1, column2, ...),
                                        (column1, column2, ...), ...

Implements tests for the implemented statement.

Fixes a small syntax-highlighting issue in the `sql` utility.

Resolves #10028 