### PR TITLE
LibC: Implement wctype, wctrans and related functions

### DIFF
--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     TestStackSmash.cpp
     TestStrlcpy.cpp
     TestStrtodAccuracy.cpp
+    TestWctype.cpp
 )
 
 set_source_files_properties(TestStrtodAccuracy.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin-strtod")

--- a/Tests/LibC/TestWctype.cpp
+++ b/Tests/LibC/TestWctype.cpp
@@ -39,3 +39,30 @@ TEST_CASE(wctrans)
     EXPECT(wctrans("") == 0);
     EXPECT(wctrans("abc") == 0);
 }
+
+TEST_CASE(iswctype)
+{
+    const wint_t test_chars[] = { L'A', L'a', L'F', L'f', L'Z', L'z', L'0', L'\n', L'.', L'\x00' };
+
+    // Test that valid properties are wired to the correct implementation.
+    for (unsigned int i = 0; i < sizeof(test_chars) / sizeof(test_chars[0]); i++) {
+        EXPECT(iswctype(test_chars[i], wctype("alnum")) == iswalnum(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("alpha")) == iswalpha(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("blank")) == iswblank(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("cntrl")) == iswcntrl(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("digit")) == iswdigit(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("graph")) == iswgraph(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("lower")) == iswlower(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("print")) == iswprint(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("punct")) == iswpunct(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("space")) == iswspace(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("upper")) == iswupper(test_chars[i]));
+        EXPECT(iswctype(test_chars[i], wctype("xdigit")) == iswxdigit(test_chars[i]));
+    }
+
+    // Test that invalid properties always return zero.
+    for (unsigned int i = 0; i < sizeof(test_chars) / sizeof(test_chars[0]); i++) {
+        EXPECT(iswctype(test_chars[i], 0) == 0);
+        EXPECT(iswctype(test_chars[i], -1) == 0);
+    }
+}

--- a/Tests/LibC/TestWctype.cpp
+++ b/Tests/LibC/TestWctype.cpp
@@ -28,3 +28,14 @@ TEST_CASE(wctype)
     EXPECT(wctype("") == 0);
     EXPECT(wctype("abc") == 0);
 }
+
+TEST_CASE(wctrans)
+{
+    // Test that existing character mappings return non-zero wctrans values.
+    EXPECT(wctrans("tolower") != 0);
+    EXPECT(wctrans("toupper") != 0);
+
+    // Test that invalid character mappings return the "invalid" wctrans value (0).
+    EXPECT(wctrans("") == 0);
+    EXPECT(wctrans("abc") == 0);
+}

--- a/Tests/LibC/TestWctype.cpp
+++ b/Tests/LibC/TestWctype.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <wctype.h>
+
+TEST_CASE(wctype)
+{
+    // Test that existing properties return non-zero wctypes.
+    EXPECT(wctype("alnum") != 0);
+    EXPECT(wctype("alpha") != 0);
+    EXPECT(wctype("blank") != 0);
+    EXPECT(wctype("cntrl") != 0);
+    EXPECT(wctype("digit") != 0);
+    EXPECT(wctype("graph") != 0);
+    EXPECT(wctype("lower") != 0);
+    EXPECT(wctype("print") != 0);
+    EXPECT(wctype("punct") != 0);
+    EXPECT(wctype("space") != 0);
+    EXPECT(wctype("upper") != 0);
+    EXPECT(wctype("xdigit") != 0);
+
+    // Test that invalid properties return the "invalid" wctype (0).
+    EXPECT(wctype("") == 0);
+    EXPECT(wctype("abc") == 0);
+}

--- a/Tests/LibC/TestWctype.cpp
+++ b/Tests/LibC/TestWctype.cpp
@@ -66,3 +66,20 @@ TEST_CASE(iswctype)
         EXPECT(iswctype(test_chars[i], -1) == 0);
     }
 }
+
+TEST_CASE(towctrans)
+{
+    const wint_t test_chars[] = { L'A', L'a', L'F', L'f', L'Z', L'z', L'0', L'\n', L'.', L'\x00' };
+
+    // Test that valid mappings are wired to the correct implementation.
+    for (unsigned int i = 0; i < sizeof(test_chars) / sizeof(test_chars[0]); i++) {
+        EXPECT(towctrans(test_chars[i], wctrans("tolower")) == towlower(test_chars[i]));
+        EXPECT(towctrans(test_chars[i], wctrans("toupper")) == towupper(test_chars[i]));
+    }
+
+    // Test that invalid mappings always return the character unchanged.
+    for (unsigned int i = 0; i < sizeof(test_chars) / sizeof(test_chars[0]); i++) {
+        EXPECT(towctrans(test_chars[i], 0) == test_chars[i]);
+        EXPECT(towctrans(test_chars[i], -1) == test_chars[i]);
+    }
+}

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -187,10 +187,18 @@ wint_t towupper(wint_t wc)
     return __inline_toupper(wc);
 }
 
-wint_t towctrans(wint_t, wctrans_t)
+wint_t towctrans(wint_t wc, wctrans_t desc)
 {
-    dbgln("FIXME: Implement towctrans()");
-    TODO();
+    switch (desc) {
+    case WCTRANS_TOLOWER:
+        return towlower(wc);
+
+    case WCTRANS_TOUPPER:
+        return towupper(wc);
+
+    default:
+        return wc;
+    }
 }
 
 wctrans_t wctrans(const char* charclass)

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -24,6 +24,12 @@ enum {
     WCTYPE_XDIGIT,
 };
 
+enum {
+    WCTRANS_INVALID = 0,
+    WCTRANS_TOLOWER,
+    WCTRANS_TOUPPER,
+};
+
 extern "C" {
 
 int iswalnum(wint_t wc)
@@ -149,9 +155,14 @@ wint_t towctrans(wint_t, wctrans_t)
     TODO();
 }
 
-wctrans_t wctrans(const char*)
+wctrans_t wctrans(const char* charclass)
 {
-    dbgln("FIXME: Implement wctrans()");
-    TODO();
+    if (strcmp(charclass, "tolower") == 0)
+        return WCTRANS_TOLOWER;
+
+    if (strcmp(charclass, "toupper") == 0)
+        return WCTRANS_TOUPPER;
+
+    return WCTRANS_INVALID;
 }
 }

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -92,10 +92,48 @@ int iswblank(wint_t wc)
     return __inline_isblank(wc);
 }
 
-int iswctype(wint_t, wctype_t)
+int iswctype(wint_t wc, wctype_t charclass)
 {
-    dbgln("FIXME: Implement iswctype()");
-    TODO();
+    switch (charclass) {
+    case WCTYPE_ALNUM:
+        return iswalnum(wc);
+
+    case WCTYPE_ALPHA:
+        return iswalpha(wc);
+
+    case WCTYPE_BLANK:
+        return iswblank(wc);
+
+    case WCTYPE_CNTRL:
+        return iswcntrl(wc);
+
+    case WCTYPE_DIGIT:
+        return iswdigit(wc);
+
+    case WCTYPE_GRAPH:
+        return iswgraph(wc);
+
+    case WCTYPE_LOWER:
+        return iswlower(wc);
+
+    case WCTYPE_PRINT:
+        return iswprint(wc);
+
+    case WCTYPE_PUNCT:
+        return iswpunct(wc);
+
+    case WCTYPE_SPACE:
+        return iswspace(wc);
+
+    case WCTYPE_UPPER:
+        return iswupper(wc);
+
+    case WCTYPE_XDIGIT:
+        return iswxdigit(wc);
+
+    default:
+        return 0;
+    }
 }
 
 wctype_t wctype(const char* property)

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -5,7 +5,24 @@
  */
 
 #include <AK/Format.h>
+#include <string.h>
 #include <wctype.h>
+
+enum {
+    WCTYPE_INVALID = 0,
+    WCTYPE_ALNUM,
+    WCTYPE_ALPHA,
+    WCTYPE_BLANK,
+    WCTYPE_CNTRL,
+    WCTYPE_DIGIT,
+    WCTYPE_GRAPH,
+    WCTYPE_LOWER,
+    WCTYPE_PRINT,
+    WCTYPE_PUNCT,
+    WCTYPE_SPACE,
+    WCTYPE_UPPER,
+    WCTYPE_XDIGIT,
+};
 
 extern "C" {
 
@@ -75,10 +92,45 @@ int iswctype(wint_t, wctype_t)
     TODO();
 }
 
-wctype_t wctype(const char*)
+wctype_t wctype(const char* property)
 {
-    dbgln("FIXME: Implement wctype()");
-    TODO();
+    if (strcmp(property, "alnum") == 0)
+        return WCTYPE_ALNUM;
+
+    if (strcmp(property, "alpha") == 0)
+        return WCTYPE_ALPHA;
+
+    if (strcmp(property, "blank") == 0)
+        return WCTYPE_BLANK;
+
+    if (strcmp(property, "cntrl") == 0)
+        return WCTYPE_CNTRL;
+
+    if (strcmp(property, "digit") == 0)
+        return WCTYPE_DIGIT;
+
+    if (strcmp(property, "graph") == 0)
+        return WCTYPE_GRAPH;
+
+    if (strcmp(property, "lower") == 0)
+        return WCTYPE_LOWER;
+
+    if (strcmp(property, "print") == 0)
+        return WCTYPE_PRINT;
+
+    if (strcmp(property, "punct") == 0)
+        return WCTYPE_PUNCT;
+
+    if (strcmp(property, "space") == 0)
+        return WCTYPE_SPACE;
+
+    if (strcmp(property, "upper") == 0)
+        return WCTYPE_UPPER;
+
+    if (strcmp(property, "xdigit") == 0)
+        return WCTYPE_XDIGIT;
+
+    return WCTYPE_INVALID;
 }
 
 wint_t towlower(wint_t wc)

--- a/Userland/Libraries/LibC/wctype.h
+++ b/Userland/Libraries/LibC/wctype.h
@@ -12,7 +12,7 @@
 
 __BEGIN_DECLS
 
-typedef const int* wctrans_t;
+typedef long wctrans_t;
 
 int iswalnum(wint_t wc);
 int iswalpha(wint_t wc);


### PR DESCRIPTION
`sed` occasionally runs into cases where `wctype` is required, and at that point we might as well just implement all of them.