### PR TITLE
Magnifier: Add 8x magnification and pausing

### DIFF
--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -22,13 +22,16 @@ MagnifierWidget::~MagnifierWidget()
 
 void MagnifierWidget::set_scale_factor(int scale_factor)
 {
-    VERIFY(scale_factor == 2 || scale_factor == 4);
+    VERIFY(scale_factor == 2 || scale_factor == 4 || scale_factor == 8);
     m_scale_factor = scale_factor;
     update();
 }
 
 void MagnifierWidget::sync()
 {
+    if (m_pause_capture)
+        return;
+
     auto size = frame_inner_rect().size();
     Gfx::IntSize grab_size { size.width() / m_scale_factor, size.height() / m_scale_factor };
     m_grabbed_bitmap = GUI::WindowServerConnection::the().get_screen_bitmap_around_cursor(grab_size).bitmap();

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -14,6 +14,7 @@ class MagnifierWidget final : public GUI::Frame {
 public:
     virtual ~MagnifierWidget();
     void set_scale_factor(int scale_factor);
+    void pause_capture(bool pause) { m_pause_capture = pause; }
 
 private:
     MagnifierWidget();
@@ -24,4 +25,5 @@ private:
 
     int m_scale_factor { 2 };
     RefPtr<Gfx::Bitmap> m_grabbed_bitmap;
+    bool m_pause_capture { false };
 };

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -56,23 +56,38 @@ int main(int argc, char** argv)
     auto size_action_group = make<GUI::ActionGroup>();
 
     auto two_x_action = GUI::Action::create_checkable(
-        "&2x", [&](auto&) {
+        "&2x", { Key_2 }, [&](auto&) {
             magnifier.set_scale_factor(2);
         });
 
     auto four_x_action = GUI::Action::create_checkable(
-        "&4x", [&](auto&) {
+        "&4x", { Key_4 }, [&](auto&) {
             magnifier.set_scale_factor(4);
+        });
+
+    auto eight_x_action = GUI::Action::create_checkable(
+        "&8x", { Key_8 }, [&](auto&) {
+            magnifier.set_scale_factor(8);
+        });
+
+    auto pause_action = GUI::Action::create_checkable(
+        "&Pause Capture", { Key_Space }, [&](auto& action) {
+            magnifier.pause_capture(action.is_checked());
         });
 
     size_action_group->add_action(two_x_action);
     size_action_group->add_action(four_x_action);
+    size_action_group->add_action(eight_x_action);
     size_action_group->set_exclusive(true);
 
     auto& view_menu = window->add_menu("&View");
     view_menu.add_action(two_x_action);
     view_menu.add_action(four_x_action);
+    view_menu.add_action(eight_x_action);
     two_x_action->set_checked(true);
+
+    view_menu.add_separator();
+    view_menu.add_action(pause_action);
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Magnifier", app_icon, window));


### PR DESCRIPTION
![Screenshot_20210917_230324](https://user-images.githubusercontent.com/69970419/133854047-4e8464c9-4cb0-4a2b-9ffa-27b804939f0f.png)

This application is a lifesaver when doing pixel tweaking, but often I find myself having to take a screenshot and zoom in more, so this PR adds 8x magnification. It also adds shortcuts to the different magnification levels and the ability to pause the capture with Space, which allows me to move the mouse outside of the QEMU-window and trigger a screenshot :^)