### PR TITLE
LibWeb: Flex correct main size

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -131,8 +131,8 @@ void Box::paint_border(PaintContext& context)
             circle_position.set_y(to.y());
             center.set_x(radius);
         } else {
-            // How did you get here?
-            VERIFY_NOT_REACHED();
+            // You are lying about your intentions of drawing a quarter circle, your coordinates are (partly) the same!
+            return;
         }
 
         Gfx::IntRect circle_rect = {

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -222,6 +222,9 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
     // This is particularly important since we take references to the items stored in flex_items
     // later, whose addresses won't be stable if we added or removed any items.
     Vector<FlexItem> flex_items;
+    if (!box.has_definite_width())
+        box.set_width(box.width_of_logical_containing_block());
+
     box.for_each_child_of_type<Box>([&](Box& child_box) {
         layout_inside(child_box, LayoutMode::Default);
         // Skip anonymous text runs that are only whitespace.


### PR DESCRIPTION
- Fix a bug in Painting of border radius

- Correctly layout nested `display:flex` containers. This bug took about 8 hours to find...