### PR TITLE
RequestServer: Cache and reuse connections to the same host

### DIFF
--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -82,6 +82,7 @@ public:
     bool can_read_line() const;
 
     bool can_read() const;
+    bool can_read_only_from_buffer() const { return !m_buffered_data.is_empty() && !can_read_from_fd(); }
 
     bool seek(i64, SeekMode = SeekMode::SetPosition, off_t* = nullptr);
 

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -29,6 +29,9 @@ void NetworkJob::shutdown()
 
 void NetworkJob::did_finish(NonnullRefPtr<NetworkResponse>&& response)
 {
+    if (is_cancelled())
+        return;
+
     // NOTE: We protect ourselves here, since the on_finish callback may otherwise
     //       trigger destruction of this job somehow.
     NonnullRefPtr<NetworkJob> protector(*this);
@@ -42,6 +45,9 @@ void NetworkJob::did_finish(NonnullRefPtr<NetworkResponse>&& response)
 
 void NetworkJob::did_fail(Error error)
 {
+    if (is_cancelled())
+        return;
+
     // NOTE: We protect ourselves here, since the on_finish callback may otherwise
     //       trigger destruction of this job somehow.
     NonnullRefPtr<NetworkJob> protector(*this);
@@ -55,6 +61,9 @@ void NetworkJob::did_fail(Error error)
 
 void NetworkJob::did_progress(Optional<u32> total_size, u32 downloaded)
 {
+    if (is_cancelled())
+        return;
+
     // NOTE: We protect ourselves here, since the callback may otherwise
     //       trigger destruction of this job somehow.
     NonnullRefPtr<NetworkJob> protector(*this);

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -19,7 +19,7 @@ NetworkJob::~NetworkJob()
 {
 }
 
-void NetworkJob::start()
+void NetworkJob::start(NonnullRefPtr<Core::Socket>)
 {
 }
 

--- a/Userland/Libraries/LibCore/NetworkJob.h
+++ b/Userland/Libraries/LibCore/NetworkJob.h
@@ -35,7 +35,7 @@ public:
     NetworkResponse* response() { return m_response.ptr(); }
     const NetworkResponse* response() const { return m_response.ptr(); }
 
-    virtual void start() = 0;
+    virtual void start(NonnullRefPtr<Core::Socket>) = 0;
     virtual void shutdown() = 0;
 
     void cancel()

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -213,8 +213,6 @@ void Socket::ensure_read_notifier()
     VERIFY(m_connected);
     m_read_notifier = Notifier::construct(fd(), Notifier::Event::Read, this);
     m_read_notifier->on_ready_to_read = [this] {
-        if (!can_read())
-            return;
         if (on_ready_to_read)
             on_ready_to_read();
     };

--- a/Userland/Libraries/LibGemini/GeminiJob.cpp
+++ b/Userland/Libraries/LibGemini/GeminiJob.cpp
@@ -93,9 +93,10 @@ void GeminiJob::register_on_ready_to_read(Function<void()> callback)
 
 void GeminiJob::register_on_ready_to_write(Function<void()> callback)
 {
-    m_socket->on_tls_ready_to_write = [callback = move(callback)](auto&) {
+    m_socket->set_on_tls_ready_to_write([callback = move(callback)](auto& tls) {
+        Core::deferred_invoke([&tls] { tls.set_on_tls_ready_to_write(nullptr); });
         callback();
-    };
+    });
 }
 
 bool GeminiJob::can_read_line() const

--- a/Userland/Libraries/LibGemini/GeminiJob.h
+++ b/Userland/Libraries/LibGemini/GeminiJob.h
@@ -27,9 +27,12 @@ public:
     {
     }
 
-    virtual void start() override;
+    virtual void start(NonnullRefPtr<Core::Socket>) override;
     virtual void shutdown() override;
     void set_certificate(String certificate, String key);
+
+    Core::Socket const* socket() const { return m_socket; }
+    URL url() const { return m_request.url(); }
 
     Function<void(GeminiJob&)> on_certificate_requested;
 

--- a/Userland/Libraries/LibGemini/Job.h
+++ b/Userland/Libraries/LibGemini/Job.h
@@ -19,7 +19,7 @@ public:
     explicit Job(const GeminiRequest&, OutputStream&);
     virtual ~Job() override;
 
-    virtual void start() override = 0;
+    virtual void start(NonnullRefPtr<Core::Socket>) override = 0;
     virtual void shutdown() override = 0;
 
     GeminiResponse* response() { return static_cast<GeminiResponse*>(Core::NetworkJob::response()); }

--- a/Userland/Libraries/LibHTTP/HttpJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpJob.cpp
@@ -12,26 +12,35 @@
 #include <unistd.h>
 
 namespace HTTP {
-void HttpJob::start()
+void HttpJob::start(NonnullRefPtr<Core::Socket> socket)
 {
     VERIFY(!m_socket);
-    m_socket = Core::TCPSocket::construct(this);
-    m_socket->on_connected = [this] {
-        dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_connected callback");
-        on_socket_connected();
-    };
+    m_socket = move(socket);
     m_socket->on_error = [this] {
         dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_error callback");
         deferred_invoke([this] {
             did_fail(Core::NetworkJob::Error::ConnectionFailed);
         });
     };
-    bool success = m_socket->connect(m_request.url().host(), m_request.url().port_or_default());
-    if (!success) {
+    if (m_socket->is_connected()) {
+        dbgln("Reusing previous connection for {}", url());
         deferred_invoke([this] {
-            return did_fail(Core::NetworkJob::Error::ConnectionFailed);
+            dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_connected callback");
+            on_socket_connected();
         });
-    }
+    } else {
+        dbgln("Creating new connection for {}", url());
+        m_socket->on_connected = [this] {
+            dbgln_if(CHTTPJOB_DEBUG, "HttpJob: on_connected callback");
+            on_socket_connected();
+        };
+        bool success = m_socket->connect(m_request.url().host(), m_request.url().port_or_default());
+        if (!success) {
+            deferred_invoke([this] {
+                return did_fail(Core::NetworkJob::Error::ConnectionFailed);
+            });
+        }
+    };
 }
 
 void HttpJob::shutdown()
@@ -40,13 +49,24 @@ void HttpJob::shutdown()
         return;
     m_socket->on_ready_to_read = nullptr;
     m_socket->on_connected = nullptr;
-    remove_child(*m_socket);
     m_socket = nullptr;
 }
 
 void HttpJob::register_on_ready_to_read(Function<void()> callback)
 {
-    m_socket->on_ready_to_read = move(callback);
+    m_socket->on_ready_to_read = [callback = move(callback), this] {
+        callback();
+        // As IODevice so graciously buffers everything, there's a possible
+        // scenario where it buffers the entire response, and we get stuck waiting
+        // for select() in the notifier (which will never return).
+        // So handle this case by exhausting the buffer here.
+        if (m_socket->can_read_only_from_buffer() && m_state != State::Finished && !has_error()) {
+            deferred_invoke([this] {
+                if (m_socket && m_socket->on_ready_to_read)
+                    m_socket->on_ready_to_read();
+            });
+        }
+    };
 }
 
 void HttpJob::register_on_ready_to_write(Function<void()> callback)

--- a/Userland/Libraries/LibHTTP/HttpJob.h
+++ b/Userland/Libraries/LibHTTP/HttpJob.h
@@ -27,8 +27,11 @@ public:
     {
     }
 
-    virtual void start() override;
+    virtual void start(NonnullRefPtr<Core::Socket>) override;
     virtual void shutdown() override;
+
+    Core::Socket const* socket() const { return m_socket; }
+    URL url() const { return m_request.url(); }
 
 protected:
     virtual bool should_fail_on_empty_payload() const override { return false; }

--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -55,7 +55,6 @@ ByteBuffer HttpRequest::to_raw_request() const
         builder.append(header.value);
         builder.append("\r\n");
     }
-    builder.append("Connection: close\r\n");
     if (!m_body.is_empty()) {
         builder.appendff("Content-Length: {}\r\n\r\n", m_body.size());
         builder.append((char const*)m_body.data(), m_body.size());

--- a/Userland/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpsJob.cpp
@@ -68,6 +68,7 @@ void HttpsJob::shutdown()
         return;
     m_socket->on_tls_ready_to_read = nullptr;
     m_socket->on_tls_connected = nullptr;
+    m_socket->set_on_tls_ready_to_write(nullptr);
     m_socket = nullptr;
 }
 
@@ -97,9 +98,10 @@ void HttpsJob::register_on_ready_to_read(Function<void()> callback)
 
 void HttpsJob::register_on_ready_to_write(Function<void()> callback)
 {
-    m_socket->on_tls_ready_to_write = [callback = move(callback)](auto&) {
+    m_socket->set_on_tls_ready_to_write([callback = move(callback)](auto& tls) {
+        Core::deferred_invoke([&tls] { tls.set_on_tls_ready_to_write(nullptr); });
         callback();
-    };
+    });
 }
 
 bool HttpsJob::can_read_line() const

--- a/Userland/Libraries/LibHTTP/HttpsJob.h
+++ b/Userland/Libraries/LibHTTP/HttpsJob.h
@@ -28,9 +28,12 @@ public:
     {
     }
 
-    virtual void start() override;
+    virtual void start(NonnullRefPtr<Core::Socket>) override;
     virtual void shutdown() override;
     void set_certificate(String certificate, String key);
+
+    Core::Socket const* socket() const { return m_socket; }
+    URL url() const { return m_request.url(); }
 
     Function<void(HttpsJob&)> on_certificate_requested;
 

--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -21,7 +21,7 @@ public:
     explicit Job(const HttpRequest&, OutputStream&);
     virtual ~Job() override;
 
-    virtual void start() override = 0;
+    virtual void start(NonnullRefPtr<Core::Socket>) override = 0;
     virtual void shutdown() override = 0;
 
     HttpResponse* response() { return static_cast<HttpResponse*>(Core::NetworkJob::response()); }

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -373,8 +373,16 @@ public:
     bool can_read() const { return m_context.application_buffer.size() > 0; }
     String read_line(size_t max_size);
 
+    void set_on_tls_ready_to_write(Function<void(TLSv12&)> function)
+    {
+        on_tls_ready_to_write = move(function);
+        if (on_tls_ready_to_write) {
+            if (is_established())
+                on_tls_ready_to_write(*this);
+        }
+    }
+
     Function<void(TLSv12&)> on_tls_ready_to_read;
-    Function<void(TLSv12&)> on_tls_ready_to_write;
     Function<void(AlertDescription)> on_tls_error;
     Function<void()> on_tls_connected;
     Function<void()> on_tls_finished;
@@ -521,6 +529,7 @@ private:
     i32 m_max_wait_time_for_handshake_in_seconds { 10 };
 
     RefPtr<Core::Timer> m_handshake_timeout_timer;
+    Function<void(TLSv12&)> on_tls_ready_to_write;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -13,6 +13,7 @@
 
 namespace Protocol {
 class RequestClient;
+class Request;
 }
 
 namespace Web {
@@ -53,6 +54,7 @@ private:
 
     int m_pending_loads { 0 };
 
+    HashTable<NonnullRefPtr<Protocol::Request>> m_active_requests;
     RefPtr<Protocol::RequestClient> m_protocol_client;
     String m_user_agent;
 };

--- a/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.cpp
@@ -33,9 +33,10 @@ void TLSv12WebSocketConnectionImpl::connect(ConnectionInfo const& connection)
     m_socket->on_tls_ready_to_read = [this](auto&) {
         on_ready_to_read();
     };
-    m_socket->on_tls_ready_to_write = [this](auto&) {
+    m_socket->set_on_tls_ready_to_write([this](auto& tls) {
+        tls.set_on_tls_ready_to_write(nullptr);
         on_connected();
-    };
+    });
     m_socket->on_tls_finished = [this] {
         on_connection_error();
     };

--- a/Userland/Services/RequestServer/CMakeLists.txt
+++ b/Userland/Services/RequestServer/CMakeLists.txt
@@ -8,6 +8,7 @@ compile_ipc(RequestClient.ipc RequestClientEndpoint.h)
 
 set(SOURCES
     ClientConnection.cpp
+    ConnectionCache.cpp
     Request.cpp
     RequestClientEndpoint.h
     RequestServerEndpoint.h

--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ConnectionCache.h"
+#include <LibCore/EventLoop.h>
+
+namespace RequestServer::ConnectionCache {
+
+HashMap<ConnectionKey, Vector<Connection<Core::TCPSocket>>> g_tcp_connection_cache {};
+HashMap<ConnectionKey, Vector<Connection<TLS::TLSv12>>> g_tls_connection_cache {};
+
+void request_did_finish(URL const& url, Core::Socket const* socket)
+{
+    if (!socket) {
+        dbgln("Request with a null socket finished for URL {}", url);
+        return;
+    }
+
+    dbgln("Request for {} finished", url);
+
+    ConnectionKey key { url.host(), url.port_or_default() };
+    auto fire_off_next_job = [&](auto& cache) {
+        auto it = cache.find(key);
+        if (it == cache.end()) {
+            dbgln("Request for URL {} finished, but we don't own that!", url);
+            return;
+        }
+        auto connection_it = it->value.find_if([&](auto& connection) { return connection.socket == socket; });
+        if (connection_it.is_end()) {
+            dbgln("Request for URL {} finished, but we don't have a socket for that!", url);
+            return;
+        }
+
+        auto& connection = *connection_it;
+        if (connection.request_queue.is_empty()) {
+            connection.has_started = false;
+            connection.removal_timer->on_timeout = [&connection, &cache_entry = it->value] {
+                Core::deferred_invoke([&] {
+                    dbgln("Removing no-longer-used connection {}", &connection);
+                    cache_entry.remove_first_matching([&](auto& entry) { return &entry == &connection; });
+                });
+            };
+            connection.removal_timer->start();
+        } else {
+            using SocketType = RemoveCVReference<decltype(*connection.socket)>;
+            bool is_connected;
+            if constexpr (IsSame<SocketType, TLS::TLSv12>)
+                is_connected = connection.socket->is_established();
+            else
+                is_connected = connection.socket->is_connected();
+            if (!is_connected) {
+                // Create another socket for the connection.
+                dbgln("Creating a new socket for {}", url);
+                connection.socket = SocketType::construct(nullptr);
+            }
+            dbgln("Running next job in queue for connection {}", &connection);
+            auto request = connection.request_queue.take_first();
+            request(connection.socket);
+        }
+    };
+
+    if (is<TLS::TLSv12>(socket))
+        fire_off_next_job(g_tls_connection_cache);
+    else if (is<Core::TCPSocket>(socket))
+        fire_off_next_job(g_tcp_connection_cache);
+    else
+        dbgln("Unknown socket {} finished for URL {}", *socket, url);
+}
+
+}

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/URL.h>
+#include <AK/Vector.h>
+#include <LibCore/TCPSocket.h>
+#include <LibCore/Timer.h>
+#include <LibTLS/TLSv12.h>
+
+namespace RequestServer::ConnectionCache {
+
+template<typename Socket>
+struct Connection {
+    using QueueType = Vector<Function<void(Core::Socket&)>>;
+    using SocketType = Socket;
+
+    NonnullRefPtr<Socket> socket;
+    QueueType request_queue;
+    NonnullRefPtr<Core::Timer> removal_timer;
+    bool has_started { false };
+};
+
+struct ConnectionKey {
+    String hostname;
+    u16 port { 0 };
+
+    bool operator==(ConnectionKey const&) const = default;
+};
+
+};
+
+template<>
+struct AK::Traits<RequestServer::ConnectionCache::ConnectionKey> : public AK::GenericTraits<RequestServer::ConnectionCache::ConnectionKey> {
+    static u32 hash(RequestServer::ConnectionCache::ConnectionKey const& key)
+    {
+        return pair_int_hash(key.hostname.hash(), key.port);
+    }
+};
+
+namespace RequestServer::ConnectionCache {
+
+extern HashMap<ConnectionKey, Vector<Connection<Core::TCPSocket>>> g_tcp_connection_cache;
+extern HashMap<ConnectionKey, Vector<Connection<TLS::TLSv12>>> g_tls_connection_cache;
+
+void request_did_finish(URL const&, Core::Socket const*);
+
+constexpr static inline size_t MaxConcurrentConnectionsPerURL = 2;
+constexpr static inline size_t ConnectionKeepAliveTimeMilliseconds = 10'000;
+
+decltype(auto) get_or_create_connection(auto& cache, URL const& url, auto& job)
+{
+    auto start_job = [&job](auto& socket) {
+        job.start(socket);
+    };
+    auto& sockets_for_url = cache.ensure({ url.host(), url.port_or_default() });
+    auto it = sockets_for_url.find_if([](auto& connection) { return connection.request_queue.is_empty(); });
+    auto did_add_new_connection = false;
+    if (it.is_end() && sockets_for_url.size() < ConnectionCache::MaxConcurrentConnectionsPerURL) {
+        sockets_for_url.append({
+            RemoveCVReference<decltype(cache.begin()->value.at(0))>::SocketType::construct(nullptr),
+            {},
+            Core::Timer::create_single_shot(ConnectionKeepAliveTimeMilliseconds, nullptr),
+        });
+        did_add_new_connection = true;
+    }
+    size_t index;
+    if (it.is_end()) {
+        if (did_add_new_connection) {
+            index = sockets_for_url.size() - 1;
+        } else {
+            // Find the least backed-up connection (based on how many entries are in their request queue.
+            index = 0;
+            auto min_queue_size = (size_t)-1;
+            for (auto it = sockets_for_url.begin(); it != sockets_for_url.end(); ++it) {
+                if (auto queue_size = it->request_queue.size(); min_queue_size > queue_size) {
+                    index = it.index();
+                    min_queue_size = queue_size;
+                }
+            }
+        }
+    } else {
+        index = it.index();
+    }
+    auto& connection = sockets_for_url[index];
+    if (!connection.has_started) {
+        dbgln("Immediately start request for url {} in {}", url, &connection);
+        connection.has_started = true;
+        connection.removal_timer->stop();
+        start_job(*connection.socket);
+    } else {
+        dbgln("Enqueue request for URL {} in {}", url, &connection);
+        connection.request_queue.append(move(start_job));
+    }
+    return connection;
+}
+
+}

--- a/Userland/Services/RequestServer/GeminiProtocol.cpp
+++ b/Userland/Services/RequestServer/GeminiProtocol.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "ConnectionCache.h"
 #include <LibGemini/GeminiJob.h>
 #include <LibGemini/GeminiRequest.h>
 #include <RequestServer/GeminiProtocol.h>
@@ -34,7 +35,9 @@ OwnPtr<Request> GeminiProtocol::start_request(ClientConnection& client, const St
     auto job = Gemini::GeminiJob::construct(request, *output_stream);
     auto protocol_request = GeminiRequest::create_with_job({}, client, (Gemini::GeminiJob&)*job, move(output_stream));
     protocol_request->set_request_fd(pipe_result.value().read_fd);
-    job->start();
+
+    ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, *job);
+
     return protocol_request;
 }
 

--- a/Userland/Services/RequestServer/GeminiRequest.cpp
+++ b/Userland/Services/RequestServer/GeminiRequest.cpp
@@ -58,7 +58,7 @@ GeminiRequest::~GeminiRequest()
 {
     m_job->on_finish = nullptr;
     m_job->on_progress = nullptr;
-    m_job->shutdown();
+    m_job->cancel();
 }
 
 NonnullOwnPtr<GeminiRequest> GeminiRequest::create_with_job(Badge<GeminiProtocol>, ClientConnection& client, NonnullRefPtr<Gemini::GeminiJob> job, NonnullOwnPtr<OutputFileStream>&& output_stream)

--- a/Userland/Services/RequestServer/GeminiRequest.cpp
+++ b/Userland/Services/RequestServer/GeminiRequest.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "ConnectionCache.h"
+#include <LibCore/EventLoop.h>
 #include <LibGemini/GeminiJob.h>
 #include <LibGemini/GeminiResponse.h>
 #include <RequestServer/GeminiRequest.h>
@@ -15,6 +17,9 @@ GeminiRequest::GeminiRequest(ClientConnection& client, NonnullRefPtr<Gemini::Gem
     , m_job(job)
 {
     m_job->on_finish = [this](bool success) {
+        Core::deferred_invoke([url = m_job->url(), socket = m_job->socket()] {
+            ConnectionCache::request_did_finish(url, socket);
+        });
         if (auto* response = m_job->response()) {
             set_downloaded_size(this->output_stream().size());
             if (!response->meta().is_empty()) {

--- a/Userland/Services/RequestServer/GeminiRequest.h
+++ b/Userland/Services/RequestServer/GeminiRequest.h
@@ -18,6 +18,8 @@ public:
     virtual ~GeminiRequest() override;
     static NonnullOwnPtr<GeminiRequest> create_with_job(Badge<GeminiProtocol>, ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>, NonnullOwnPtr<OutputFileStream>&&);
 
+    Gemini::GeminiJob const& job() const { return *m_job; }
+
 private:
     explicit GeminiRequest(ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>, NonnullOwnPtr<OutputFileStream>&&);
 

--- a/Userland/Services/RequestServer/HttpRequest.cpp
+++ b/Userland/Services/RequestServer/HttpRequest.cpp
@@ -22,7 +22,7 @@ HttpRequest::~HttpRequest()
 {
     m_job->on_finish = nullptr;
     m_job->on_progress = nullptr;
-    m_job->shutdown();
+    m_job->cancel();
 }
 
 NonnullOwnPtr<HttpRequest> HttpRequest::create_with_job(Badge<HttpProtocol>&&, ClientConnection& client, NonnullRefPtr<HTTP::HttpJob> job, NonnullOwnPtr<OutputFileStream>&& output_stream)

--- a/Userland/Services/RequestServer/HttpRequest.h
+++ b/Userland/Services/RequestServer/HttpRequest.h
@@ -20,6 +20,7 @@ public:
     static NonnullOwnPtr<HttpRequest> create_with_job(Badge<HttpProtocol>&&, ClientConnection&, NonnullRefPtr<HTTP::HttpJob>, NonnullOwnPtr<OutputFileStream>&&);
 
     HTTP::HttpJob& job() { return m_job; }
+    HTTP::HttpJob const& job() const { return m_job; }
 
 private:
     explicit HttpRequest(ClientConnection&, NonnullRefPtr<HTTP::HttpJob>, NonnullOwnPtr<OutputFileStream>&&);

--- a/Userland/Services/RequestServer/HttpsRequest.cpp
+++ b/Userland/Services/RequestServer/HttpsRequest.cpp
@@ -27,7 +27,7 @@ HttpsRequest::~HttpsRequest()
 {
     m_job->on_finish = nullptr;
     m_job->on_progress = nullptr;
-    m_job->shutdown();
+    m_job->cancel();
 }
 
 NonnullOwnPtr<HttpsRequest> HttpsRequest::create_with_job(Badge<HttpsProtocol>&&, ClientConnection& client, NonnullRefPtr<HTTP::HttpsJob> job, NonnullOwnPtr<OutputFileStream>&& output_stream)

--- a/Userland/Services/RequestServer/HttpsRequest.h
+++ b/Userland/Services/RequestServer/HttpsRequest.h
@@ -19,6 +19,7 @@ public:
     static NonnullOwnPtr<HttpsRequest> create_with_job(Badge<HttpsProtocol>&&, ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<OutputFileStream>&&);
 
     HTTP::HttpsJob& job() { return m_job; }
+    HTTP::HttpsJob const& job() const { return m_job; }
 
 private:
     explicit HttpsRequest(ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<OutputFileStream>&&);


### PR DESCRIPTION
This makes connections (particularly TLS-based ones) do the handshaking
stuff only once.
...and fixes a whole bunch of random things that came up while working on that