### PR TITLE
Kernel: Let MouseDevice and KeyboardDevice write method return EINVAL (fixes kernel panic)

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -306,11 +306,6 @@ KResultOr<size_t> KeyboardDevice::read(OpenFileDescription&, u64, UserOrKernelBu
     return nread;
 }
 
-KResultOr<size_t> KeyboardDevice::write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t)
-{
-    return 0;
-}
-
 KResult KeyboardDevice::ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg)
 {
     switch (request) {

--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -27,7 +27,7 @@ public:
     // ^CharacterDevice
     virtual KResultOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const OpenFileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return EINVAL; }
     virtual bool can_write(const OpenFileDescription&, size_t) const override { return true; }
 
     // ^HIDDevice

--- a/Kernel/Devices/HID/MouseDevice.cpp
+++ b/Kernel/Devices/HID/MouseDevice.cpp
@@ -48,9 +48,4 @@ KResultOr<size_t> MouseDevice::read(OpenFileDescription&, u64, UserOrKernelBuffe
     return nread;
 }
 
-KResultOr<size_t> MouseDevice::write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t)
-{
-    return 0;
-}
-
 }

--- a/Kernel/Devices/HID/MouseDevice.h
+++ b/Kernel/Devices/HID/MouseDevice.h
@@ -25,7 +25,7 @@ public:
     // ^CharacterDevice
     virtual KResultOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const OpenFileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return EINVAL; }
     virtual bool can_write(const OpenFileDescription&, size_t) const override { return true; }
 
     // ^HIDDevice


### PR DESCRIPTION
Currently, writing anything to `/dev/mouse0` or `/dev/keyboard0` causes the Kernel to panic. The reason for this is that
`[Mouse,Keyboard]Device::write` returns 0, which is explicitly prohibited by `VERIFY` macro in `Process::sys$write`. 

Although I'm a SerenityOS newbie, I've decided to open this PR, because the fix seems trivial; `write` should return EINVAL instead (as is the case with, for example, `KCOVDevice`). (Alternatively, `can_write` could always return false so that the thread gets blocked before any attempt to write, although this seems less suitable.)
