### PR TITLE
LibWeb: Also avoid setting definite size for height

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -61,10 +61,12 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
         return length.resolved(CSS::Length::make_px(0), box, box.containing_block()->width()).to_px(box);
     };
     auto layout_for_maximum_main_size = [&](Box& box) {
-        if (is_row)
+        if (is_row) {
             layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
-        else
-            layout_inside(box, LayoutMode::AllPossibleLineBreaks);
+            return box.width();
+        } else {
+            return BlockFormattingContext::compute_theoretical_height(box);
+        }
     };
     auto containing_block_effective_main_size = [&is_row, &main_size_is_infinite](Box& box) {
         if (is_row) {
@@ -330,11 +332,9 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
             if (has_definite_main_size(child_box)) {
                 flex_item.flex_base_size = specified_main_size_of_child_box(box, child_box);
             } else {
-                layout_for_maximum_main_size(child_box);
-                flex_item.flex_base_size = calculated_main_size(child_box);
+                flex_item.flex_base_size = layout_for_maximum_main_size(child_box);
             }
         }
-
         auto clamp_min = has_main_min_size(child_box)
             ? specified_main_min_size(child_box)
             : 0;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -335,7 +335,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     computed_values.set_min_width(specified_style.length_or_fallback(CSS::PropertyID::MinWidth, {}));
     computed_values.set_max_width(specified_style.length_or_fallback(CSS::PropertyID::MaxWidth, {}));
 
-    if (auto height = specified_style.property(CSS::PropertyID::Height); height.has_value())
+    if (auto height = specified_style.property(CSS::PropertyID::Height); height.has_value() && !height.value()->is_auto())
         m_has_definite_height = true;
     computed_values.set_height(specified_style.length_or_fallback(CSS::PropertyID::Height, {}));
     computed_values.set_min_height(specified_style.length_or_fallback(CSS::PropertyID::MinHeight, {}));


### PR DESCRIPTION
This patch patches ef22a1b to also check for is_auto() on the height
property when setting definite_height.

flex-direction: column was borked before