### PR TITLE
PixelPaint: Use main window’s icon in the ‘Create new image’ widget

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -17,6 +17,7 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     : Dialog(parent_window)
 {
     set_title("Create new image");
+    set_icon(parent_window->icon());
     resize(200, 200);
 
     auto& main_widget = set_main_widget<GUI::Widget>();


### PR DESCRIPTION
Before
![screenshot (5.3K)](https://user-images.githubusercontent.com/16520278/133887492-ba3cd12f-8a98-4f09-bcf1-28130766ffe1.png)

This PR:
![screenshot (5.4K)](https://user-images.githubusercontent.com/16520278/133887493-0a04ffb8-bd63-4e71-bd6c-69a979f1dd98.png)
