### PR TITLE
Userland+LibGUI: Various audio fixes

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>
+ * Copyright (c) 2021, David Isaksson <davidisaksson93@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -40,6 +41,7 @@ public:
 
         m_audio_client->on_main_mix_volume_change = [this](double volume) {
             m_audio_volume = static_cast<int>(volume * 100);
+            m_slider->set_value(m_slider->max() - m_audio_volume, GUI::CallOnChange::No);
             if (!m_audio_muted)
                 update();
         };

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -76,13 +76,8 @@ public:
         m_percent_box->set_checked(m_show_percent);
         m_percent_box->on_checked = [&](bool show_percent) {
             m_show_percent = show_percent;
-            if (!m_show_percent) {
-                window()->resize(16, 16);
-                m_percent_box->set_tooltip("Show percent");
-            } else {
-                window()->resize(44, 16);
-                m_percent_box->set_tooltip("Hide percent");
-            }
+            set_audio_widget_size(m_show_percent);
+            m_percent_box->set_tooltip(m_show_percent ? "Hide percent" : "Show percent");
             GUI::Application::the()->hide_tooltip();
 
             Config::write_bool("AudioApplet", "Applet", "ShowPercent", m_show_percent);
@@ -113,6 +108,14 @@ public:
     }
 
     virtual ~AudioWidget() override { }
+
+    void set_audio_widget_size(bool show_percent)
+    {
+        if (show_percent)
+            window()->resize(44, 16);
+        else
+            window()->resize(16, 16);
+    }
 
 private:
     virtual void mousedown_event(GUI::MouseEvent& event) override
@@ -238,11 +241,7 @@ int main(int argc, char** argv)
     window->show();
 
     // This positioning code depends on the window actually existing.
-    if (!Config::read_bool("AudioApplet", "Applet", "ShowPercent", false)) {
-        window->resize(16, 16);
-    } else {
-        window->resize(44, 16);
-    }
+    static_cast<AudioWidget*>(window->main_widget())->set_audio_widget_size(Config::read_bool("AudioApplet", "Applet", "ShowPercent", false));
 
     if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
         perror("pledge");

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -40,7 +40,7 @@ public:
         };
 
         m_audio_client->on_main_mix_volume_change = [this](double volume) {
-            m_audio_volume = static_cast<int>(volume * 100);
+            m_audio_volume = static_cast<int>(round(volume * 100));
             m_slider->set_value(m_slider->max() - m_audio_volume, GUI::CallOnChange::No);
             if (!m_audio_muted)
                 update();

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -95,7 +95,8 @@ public:
         m_slider->set_value(m_slider->max() - m_audio_volume);
         m_slider->set_knob_size_mode(GUI::Slider::KnobSizeMode::Proportional);
         m_slider->on_change = [&](int value) {
-            double volume = clamp(static_cast<double>(m_slider->max() - value) / m_slider->max(), 0.0, 1.0);
+            m_audio_volume = m_slider->max() - value;
+            double volume = clamp(static_cast<double>(m_audio_volume) / m_slider->max(), 0.0, 1.0);
             m_audio_client->set_main_mix_volume(volume);
             update();
         };

--- a/Userland/Libraries/LibGUI/AbstractSlider.cpp
+++ b/Userland/Libraries/LibGUI/AbstractSlider.cpp
@@ -53,7 +53,7 @@ void AbstractSlider::set_range(int min, int max)
     update();
 }
 
-void AbstractSlider::set_value(int value)
+void AbstractSlider::set_value(int value, CallOnChange call_on_change)
 {
     value = clamp(value, m_min, m_max);
     if (m_value == value)
@@ -61,7 +61,7 @@ void AbstractSlider::set_value(int value)
     m_value = value;
     update();
 
-    if (on_change)
+    if (on_change && call_on_change == CallOnChange::Yes)
         on_change(m_value);
 }
 

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -30,7 +30,7 @@ public:
     bool is_max() const { return m_value == m_max; }
 
     void set_range(int min, int max);
-    virtual void set_value(int);
+    virtual void set_value(int, CallOnChange call_on_change = CallOnChange::Yes);
 
     void set_min(int min) { set_range(min, max()); }
     void set_max(int max) { set_range(min(), max); }

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -141,9 +141,9 @@ int ValueSlider::value_at(const Gfx::IntPoint& position) const
     return (int)(relative_offset * (float)max());
 }
 
-void ValueSlider::set_value(int value)
+void ValueSlider::set_value(int value, CallOnChange call_on_change)
 {
-    AbstractSlider::set_value(value);
+    AbstractSlider::set_value(value, call_on_change);
     m_textbox->set_text(formatted_value());
 }
 

--- a/Userland/Libraries/LibGUI/ValueSlider.h
+++ b/Userland/Libraries/LibGUI/ValueSlider.h
@@ -24,7 +24,7 @@ public:
     void set_suffix(String suffix) { m_suffix = move(suffix); }
     void set_knob_style(KnobStyle knobstyle) { m_knob_style = knobstyle; }
 
-    virtual void set_value(int value) override;
+    virtual void set_value(int value, CallOnChange call_on_change = CallOnChange::Yes) override;
 
 protected:
     virtual void paint_event(PaintEvent&) override;

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -39,6 +39,7 @@ enum class HorizontalDirection {
     Left,
     Right
 };
+
 enum class VerticalDirection {
     Up,
     Down
@@ -52,6 +53,11 @@ enum class FocusPolicy {
 };
 
 AK_ENUM_BITWISE_OPERATORS(FocusPolicy)
+
+enum class CallOnChange {
+    No,
+    Yes
+};
 
 class Widget : public Core::Object {
     C_OBJECT(Widget)


### PR DESCRIPTION
Fixes

- `asctl`: Fixes for the internal volume representation.
- LibGUI: Add option to disable call to `on_change` function when setting value to sliders.
- AudioApplet: Fixes volume synchronization between the applet and AudioServer.