### PR TITLE
LibGUI: Remember the maximized value if a window hasn’t been created yet

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -167,6 +167,7 @@ void Window::show()
         return IterationDecision::Continue;
     });
 
+    set_maximized(m_maximized_when_windowless);
     reified_windows->set(m_window_id, this);
     Application::the()->did_create_window({});
     update();
@@ -998,14 +999,17 @@ void Window::set_forced_shadow(bool shadow)
 bool Window::is_maximized() const
 {
     if (!is_visible())
-        return false;
+        return m_maximized_when_windowless;
 
     return WindowServerConnection::the().is_maximized(m_window_id);
 }
 
 void Window::set_maximized(bool maximized)
 {
-    VERIFY(m_window_id != 0);
+    m_maximized_when_windowless = maximized;
+    if (!is_visible())
+        return;
+
     WindowServerConnection::the().async_set_maximized(m_window_id, maximized);
 }
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -269,6 +269,7 @@ private:
     bool m_resizable { true };
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};
     bool m_minimizable { true };
+    bool m_maximized_when_windowless { false };
     bool m_fullscreen { false };
     bool m_frameless { false };
     bool m_forced_shadow { false };


### PR DESCRIPTION
d0fb511d75762e9d97fa80a01585381843b90a0a set the maximized window value in the File Manager before a window was created, which resulted in crash everytime you tried to open the program that was closed while it was maximized. *ugh*

Here we do more-or-less what `GUI::Window::set_rect()` does, except we don’t add new variable to the `WindowServer::create_window()` IPC call. That’s because the Window Server knows nothing about menus at this point and just assumes they don’t need to be visible. So if we try to maximize the window then, it could be slightly taller and a titlebar could be hidden.

So even though it looks how it looks like, it does work and it doesn’t show in the startup size, as described in the mentioned commit (the call is put a few lines before the initial `update()`). :^)