### PR TITLE
Aarch64: More steps towards a UART

### DIFF
--- a/Kernel/Prekernel/Arch/aarch64/MMIO.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/MMIO.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Prekernel/Arch/aarch64/MMIO.h>
+#include <Kernel/Prekernel/Arch/aarch64/MainIdRegister.h>
+
+namespace Prekernel {
+
+MMIO::MMIO()
+    : m_base_address(0xFE00'0000)
+{
+    MainIdRegister id;
+    if (id.part_num() <= MainIdRegister::RaspberryPi3)
+        m_base_address = 0x3F00'0000;
+}
+
+MMIO& MMIO::the()
+{
+    static MMIO instance;
+    return instance;
+}
+
+}

--- a/Kernel/Prekernel/Arch/aarch64/MMIO.h
+++ b/Kernel/Prekernel/Arch/aarch64/MMIO.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Prekernel {
+
+// Knows about memory-mapped IO addresses on the Broadcom family of SOCs used in Raspberry Pis.
+// RPi3 is the first Raspberry Pi that supports aarch64.
+// https://datasheets.raspberrypi.org/bcm2836/bcm2836-peripherals.pdf (RPi3)
+// https://datasheets.raspberrypi.org/bcm2711/bcm2711-peripherals.pdf (RPi4 Model B)
+class MMIO {
+public:
+    static MMIO& the();
+
+private:
+    MMIO();
+
+    unsigned int m_base_address;
+};
+
+}

--- a/Kernel/Prekernel/Arch/aarch64/MMIO.h
+++ b/Kernel/Prekernel/Arch/aarch64/MMIO.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 namespace Prekernel {
 
 // Knows about memory-mapped IO addresses on the Broadcom family of SOCs used in Raspberry Pis.
@@ -15,6 +17,9 @@ namespace Prekernel {
 class MMIO {
 public:
     static MMIO& the();
+
+    u32 read(FlatPtr offset) { return *(u32 volatile*)(m_base_address + offset); }
+    void write(FlatPtr offset, u32 value) { *(u32 volatile*)(m_base_address + offset) = value; }
 
 private:
     MMIO();

--- a/Kernel/Prekernel/Arch/aarch64/Mailbox.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/Mailbox.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Prekernel/Arch/aarch64/MMIO.h>
+#include <Kernel/Prekernel/Arch/aarch64/Mailbox.h>
+
+namespace Prekernel {
+
+// There's one mailbox at MBOX_BASE_OFFSET for reading responses from VideoCore, and one at MBOX_BASE_OFFSET + 0x20 for sending requests.
+// Each has its own status word.
+
+constexpr u32 MBOX_BASE_OFFSET = 0xB880;
+constexpr u32 MBOX_0 = MBOX_BASE_OFFSET;
+constexpr u32 MBOX_1 = MBOX_BASE_OFFSET + 0x20;
+
+constexpr u32 MBOX_READ_DATA = MBOX_0;
+constexpr u32 MBOX_READ_POLL = MBOX_0 + 0x10;
+constexpr u32 MBOX_READ_SENDER = MBOX_0 + 0x14;
+constexpr u32 MBOX_READ_STATUS = MBOX_0 + 0x18;
+constexpr u32 MBOX_READ_CONFIG = MBOX_0 + 0x1C;
+
+constexpr u32 MBOX_WRITE_DATA = MBOX_1;
+constexpr u32 MBOX_WRITE_STATUS = MBOX_1 + 0x18;
+
+constexpr u32 MBOX_RESPONSE_SUCCESS = 0x8000'0000;
+constexpr u32 MBOX_RESPONSE_PARTIAL = 0x8000'0001;
+constexpr u32 MBOX_REQUEST = 0;
+constexpr u32 MBOX_FULL = 0x8000'0000;
+constexpr u32 MBOX_EMPTY = 0x4000'0000;
+
+constexpr int ARM_TO_VIDEOCORE_CHANNEL = 8;
+
+static void wait_until_we_can_write(MMIO& mmio)
+{
+    // Since nothing else writes to the mailbox, this wait is mostly cargo-culted.
+    // Most baremetal tutorials on the internet query MBOX_READ_STATUS here, which I think is incorrect and only works because this wait really isn't needed.
+    while (mmio.read(MBOX_WRITE_STATUS) & MBOX_FULL)
+        ;
+}
+
+static void wait_for_reply(MMIO& mmio)
+{
+    while (mmio.read(MBOX_READ_STATUS) & MBOX_EMPTY)
+        ;
+}
+
+bool Mailbox::call(u8 channel, u32 volatile* __attribute__((aligned(16))) message)
+{
+    auto& mmio = MMIO::the();
+
+    // The mailbox interface has a FIFO for message deliverly in both directions.
+    // Responses can be delivered out of order to requests, but we currently ever only send on request at once.
+    // It'd be nice to have an async interface here where we send a message, then return immediately, and read the response when an interrupt arrives.
+    // But for now, this is synchronous.
+
+    wait_until_we_can_write(mmio);
+
+    // The mailbox message is 32-bit based, so this assumes that message is in the first 4 GiB.
+    u32 request = static_cast<u32>(reinterpret_cast<FlatPtr>(message) & ~0xF) | (channel & 0xF);
+    mmio.write(MBOX_WRITE_DATA, request);
+
+    for (;;) {
+        wait_for_reply(mmio);
+
+        u32 response = mmio.read(MBOX_READ_DATA);
+        // We keep at most one message in flight and do synchronous communication, so response will always be == request for us.
+        if (response == request)
+            return message[1] == MBOX_RESPONSE_SUCCESS;
+    }
+
+    return true;
+}
+
+constexpr u32 MBOX_TAG_GET_FIRMWARE_VERSION = 0x0000'0001;
+
+u32 Mailbox::query_firmware_version()
+{
+    // See https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface for data format.
+    u32 __attribute__((aligned(16))) message[7];
+    message[0] = sizeof(message);
+    message[1] = MBOX_REQUEST;
+
+    message[2] = MBOX_TAG_GET_FIRMWARE_VERSION;
+    message[3] = 0; // Tag data size. MBOX_TAG_GET_FIRMWARE_VERSION needs no arguments.
+    message[4] = MBOX_REQUEST;
+    message[5] = 0; // Trailing zero for request, room for data in response.
+
+    message[6] = 0; // Room for trailing zero in response.
+
+    if (call(ARM_TO_VIDEOCORE_CHANNEL, message) && message[2] == MBOX_TAG_GET_FIRMWARE_VERSION)
+        return message[5];
+
+    return 0xffff'ffff;
+}
+
+}

--- a/Kernel/Prekernel/Arch/aarch64/Mailbox.h
+++ b/Kernel/Prekernel/Arch/aarch64/Mailbox.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Prekernel {
+
+// Can exchange mailbox messages with the Raspberry Pi's VideoCore chip.
+// https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
+class Mailbox {
+public:
+    static bool call(u8 channel, u32 volatile* __attribute__((aligned(16))) data);
+
+    static u32 query_firmware_version();
+};
+
+}

--- a/Kernel/Prekernel/Arch/aarch64/boot.S
+++ b/Kernel/Prekernel/Arch/aarch64/boot.S
@@ -12,7 +12,7 @@ start:
   // Let only core 0 continue, put other cores to sleep.
   mrs x13, MPIDR_EL1
   and x13, x13, 0xff
-  cbnz x13, Lhalt
+  cbnz x13, halt
 
   // Let stack start before .text for now.
   // 512 kiB (0x8000) of stack are probably not sufficient, especially once we give the other cores some stack too,
@@ -21,7 +21,3 @@ start:
   mov sp, x14
 
   b init
-
-Lhalt:
-  wfi
-  b Lhalt

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -18,3 +18,16 @@ extern "C" [[noreturn]] void init()
 // FIXME: Share this with the Intel Prekernel.
 extern size_t __stack_chk_guard;
 size_t __stack_chk_guard;
+extern "C" [[noreturn]] void __stack_chk_fail();
+
+[[noreturn]] static void halt()
+{
+    for (;;) {
+        asm volatile("wfi");
+    }
+}
+
+void __stack_chk_fail()
+{
+    halt();
+}

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -5,15 +5,14 @@
  */
 
 #include <AK/Types.h>
-#include <Kernel/Prekernel/Arch/aarch64/MainIdRegister.h>
+#include <Kernel/Prekernel/Arch/aarch64/MMIO.h>
 
 extern "C" [[noreturn]] void halt();
 
 extern "C" [[noreturn]] void init();
 extern "C" [[noreturn]] void init()
 {
-    Prekernel::MainIdRegister id;
-    [[maybe_unused]] unsigned part_num = id.part_num();
+    [[maybe_unused]] auto& MMIO = Prekernel::MMIO::the();
     halt();
 }
 

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -7,12 +7,14 @@
 #include <AK/Types.h>
 #include <Kernel/Prekernel/Arch/aarch64/MainIdRegister.h>
 
+extern "C" [[noreturn]] void halt();
+
 extern "C" [[noreturn]] void init();
 extern "C" [[noreturn]] void init()
 {
     Prekernel::MainIdRegister id;
     [[maybe_unused]] unsigned part_num = id.part_num();
-    for (;;) { }
+    halt();
 }
 
 // FIXME: Share this with the Intel Prekernel.
@@ -20,7 +22,7 @@ extern size_t __stack_chk_guard;
 size_t __stack_chk_guard;
 extern "C" [[noreturn]] void __stack_chk_fail();
 
-[[noreturn]] static void halt()
+[[noreturn]] void halt()
 {
     for (;;) {
         asm volatile("wfi");

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -5,14 +5,14 @@
  */
 
 #include <AK/Types.h>
-#include <Kernel/Prekernel/Arch/aarch64/MMIO.h>
+#include <Kernel/Prekernel/Arch/aarch64/Mailbox.h>
 
 extern "C" [[noreturn]] void halt();
 
 extern "C" [[noreturn]] void init();
 extern "C" [[noreturn]] void init()
 {
-    [[maybe_unused]] auto& MMIO = Prekernel::MMIO::the();
+    [[maybe_unused]] u32 firmware_version = Prekernel::Mailbox::query_firmware_version();
     halt();
 }
 

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -12,6 +12,7 @@ if ("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/boot.S
 
         ${SOURCES}
+        Arch/aarch64/Mailbox.cpp
         Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/MMIO.cpp
         Arch/aarch64/init.cpp

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -13,6 +13,7 @@ if ("${SERENITY_ARCH}" STREQUAL "aarch64")
 
         ${SOURCES}
         Arch/aarch64/MainIdRegister.cpp
+        Arch/aarch64/MMIO.cpp
         Arch/aarch64/init.cpp
     )
 else()


### PR DESCRIPTION
Only the UART itself missing, and then we'll be able to print things.

Again, this probably all belongs in the actual Kernel, eventually, but let's get an UART up first.

This is all very rpi-specific.