### PR TITLE
LibWeb: Flexbox: Use maximum size of container as available size

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -269,6 +269,7 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
     } else {
         if (has_main_max_size(box)) {
             main_max_size = specified_main_max_size(box);
+            main_available_size = main_max_size;
             main_is_constrained = true;
         }
         if (has_main_min_size(box)) {


### PR DESCRIPTION
This previously wouldn't work well with flex-grow.