### PR TITLE
Assistant: Release lockfile when it closed for focus change

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -276,9 +276,11 @@ int main(int argc, char** argv)
     text_box.on_escape_pressed = []() {
         GUI::Application::the()->quit();
     };
-    window->on_active_window_change = [](bool is_active_window) {
-        if (!is_active_window)
+    window->on_active_window_change = [&](bool is_active_window) {
+        if (!is_active_window) {
+            lockfile.release();
             GUI::Application::the()->quit();
+        }
     };
 
     auto update_ui_timer = Core::Timer::create_single_shot(10, [&] {


### PR DESCRIPTION
Before of this after the first open of Assistant it was never show up
to screen because lockfile was busy.

https://user-images.githubusercontent.com/41150432/133925334-e6c80eab-b18c-4091-b7ab-1bf35b8ba7b8.mp4
