### PR TITLE
Kernel: Pass all flags from pipe flags

### DIFF
--- a/Kernel/Syscalls/pipe.cpp
+++ b/Kernel/Syscalls/pipe.cpp
@@ -19,7 +19,7 @@ KResultOr<FlatPtr> Process::sys$pipe(int pipefd[2], int flags)
     if ((flags & (O_CLOEXEC | O_NONBLOCK)) != flags)
         return EINVAL;
 
-    u32 fd_flags = (flags & O_CLOEXEC) ? FD_CLOEXEC : 0;
+    u32 fd_flags = flags & (O_CLOEXEC | O_NONBLOCK);
     auto fifo = TRY(FIFO::try_create(uid()));
 
     auto reader_fd_allocation = TRY(m_fds.allocate());


### PR DESCRIPTION
I saw that fd_flags was getting set only with O_CLOEXEC flag, added
O_NONBLOCK as well.

Should have caught this in my last PR, but I didn't not see any change in behavior with how fd_flags was set, so I didn't notice in my testing. I assume fd_flags should have all flags?