### PR TITLE
AK: Header cleanup of old defines

### DIFF
--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -8,25 +8,18 @@
 
 #include <AK/String.h>
 #include <AK/StringView.h>
-
-#ifndef BUILDING_SERENITY_TOOLCHAIN
-#    include <cxxabi.h>
-#endif
+#include <cxxabi.h>
 
 namespace AK {
 
 inline String demangle(const StringView& name)
 {
-#ifdef BUILDING_SERENITY_TOOLCHAIN
-    return name;
-#else
     int status = 0;
     auto* demangled_name = abi::__cxa_demangle(name.to_string().characters(), nullptr, nullptr, &status);
     auto string = String(status == 0 ? demangled_name : name);
     if (status == 0)
         kfree(demangled_name);
     return string;
-#endif
 }
 
 }

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -9,13 +9,7 @@
 #include <AK/HashTable.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
-
-// NOTE: We can't include <initializer_list> during the toolchain bootstrap,
-//       since it's part of libstdc++, and libstdc++ depends on LibC.
-//       For this reason, we don't support HashMap(initializer_list) in LibC.
-#ifndef SERENITY_LIBC_BUILD
-#    include <initializer_list>
-#endif
+#include <initializer_list>
 
 namespace AK {
 
@@ -38,14 +32,12 @@ public:
 
     HashMap() = default;
 
-#ifndef SERENITY_LIBC_BUILD
     HashMap(std::initializer_list<Entry> list)
     {
         ensure_capacity(list.size());
         for (auto& item : list)
             set(item.key, item.value);
     }
-#endif
 
     [[nodiscard]] bool is_empty() const
     {

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -19,10 +19,6 @@
 #include <AK/kmalloc.h>
 #include <initializer_list>
 
-#ifndef __serenity__
-#    include <new>
-#endif
-
 namespace AK {
 
 namespace Detail {

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -17,13 +17,7 @@
 #include <AK/Traits.h>
 #include <AK/TypedTransfer.h>
 #include <AK/kmalloc.h>
-
-// NOTE: We can't include <initializer_list> during the toolchain bootstrap,
-//       since it's part of libstdc++, and libstdc++ depends on LibC.
-//       For this reason, we don't support Vector(initializer_list) in LibC.
-#ifndef SERENITY_LIBC_BUILD
-#    include <initializer_list>
-#endif
+#include <initializer_list>
 
 #ifndef __serenity__
 #    include <new>
@@ -65,14 +59,12 @@ public:
     {
     }
 
-#ifndef SERENITY_LIBC_BUILD
     Vector(std::initializer_list<T> list) requires(!IsLvalueReference<T>)
     {
         ensure_capacity(list.size());
         for (auto& item : list)
             unchecked_append(item);
     }
-#endif
 
     Vector(Vector&& other)
         : m_size(other.m_size)

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -85,7 +85,7 @@ elseif ("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(CRTN_SOURCE "arch/x86_64/crtn.S")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -DSERENITY_LIBC_BUILD")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
 
 add_library(crt0 STATIC crt0.cpp)
 add_custom_command(


### PR DESCRIPTION
Remove the only uses of BUILDING_SERENITY_TOOLCHAIN and SERENITY_LIBC_BUILD, which haven't been required in a long time.

Also remove a redundant include of `<new>` from Vector.h.