### PR TITLE
WidgetGallery(+LibGUI+MouseSettings): Set the correct cursor on double-click

### DIFF
--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -60,8 +60,7 @@ void MouseCursorModel::invalidate()
 
         Cursor cursor;
         cursor.path = move(path);
-        auto filename_split = cursor.path.split('/');
-        cursor.name = filename_split[3];
+        cursor.name = LexicalPath::basename(cursor.path);
 
         // FIXME: Animated cursor bitmaps
         auto cursor_bitmap = Gfx::Bitmap::try_load_from_file(cursor.path);

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -12,6 +12,7 @@
 #include <LibCore/DirIterator.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/WindowServerConnection.h>
+#include <LibGfx/CursorParams.h>
 
 class MouseCursorModel final : public GUI::Model {
 public:
@@ -69,8 +70,15 @@ public:
                 continue;
             Cursor cursor;
             cursor.path = move(path);
-            cursor.bitmap = Gfx::Bitmap::try_load_from_file(cursor.path);
             cursor.name = LexicalPath::basename(cursor.path);
+
+            // FIXME: Animated cursor bitmaps
+            auto cursor_bitmap = Gfx::Bitmap::try_load_from_file(cursor.path);
+            auto cursor_bitmap_rect = cursor_bitmap->rect();
+
+            cursor.params = Gfx::CursorParams::parse_from_filename(cursor.name, cursor_bitmap_rect.center()).constrained(*cursor_bitmap);
+            cursor.bitmap = cursor_bitmap->cropped(Gfx::IntRect(Gfx::FloatRect(cursor_bitmap_rect).scaled(1.0 / cursor.params.frames(), 1.0)));
+
             m_cursors.append(move(cursor));
         }
 
@@ -84,6 +92,7 @@ private:
         RefPtr<Gfx::Bitmap> bitmap;
         String path;
         String name;
+        Gfx::CursorParams params;
     };
 
     Vector<Cursor> m_cursors;

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <LibCore/DirIterator.h>
@@ -69,8 +70,7 @@ public:
             Cursor cursor;
             cursor.path = move(path);
             cursor.bitmap = Gfx::Bitmap::try_load_from_file(cursor.path);
-            auto filename_split = cursor.path.split('/');
-            cursor.name = filename_split[3];
+            cursor.name = LexicalPath::basename(cursor.path);
             m_cursors.append(move(cursor));
         }
 
@@ -150,8 +150,7 @@ public:
                 continue;
             IconSet icon_set;
             icon_set.big_icon = Gfx::Bitmap::try_load_from_file(path);
-            auto filename_split = path.split('/');
-            icon_set.name = filename_split[3];
+            icon_set.name = LexicalPath::basename(path);
             m_icon_sets.append(move(icon_set));
         }
 
@@ -165,8 +164,7 @@ public:
                 continue;
             IconSet icon_set;
             icon_set.little_icon = Gfx::Bitmap::try_load_from_file(path);
-            auto filename_split = path.split('/');
-            icon_set.name = filename_split[3];
+            icon_set.name = LexicalPath::basename(path);
             for (size_t i = 0; i < big_icons_found; i++) {
                 if (icon_set.name == m_icon_sets[i].name) {
                     m_icon_sets[i].little_icon = icon_set.little_icon;

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -304,58 +304,8 @@ GalleryWidget::GalleryWidget()
     m_cursors_tableview->set_column_width(0, 25);
 
     m_cursors_tableview->on_activation = [&](const GUI::ModelIndex& index) {
-        switch (index.row()) {
-        case 0:
-            window()->set_cursor(Gfx::StandardCursor::Arrow);
-            break;
-        case 1:
-            window()->set_cursor(Gfx::StandardCursor::Crosshair);
-            break;
-        case 2:
-            window()->set_cursor(Gfx::StandardCursor::Disallowed);
-            break;
-        case 3:
-            window()->set_cursor(Gfx::StandardCursor::Drag);
-            break;
-        case 4:
-            window()->set_cursor(Gfx::StandardCursor::Hand);
-            break;
-        case 5:
-            window()->set_cursor(Gfx::StandardCursor::Help);
-            break;
-        case 6:
-            window()->set_cursor(Gfx::StandardCursor::Hidden);
-            break;
-        case 7:
-            window()->set_cursor(Gfx::StandardCursor::IBeam);
-            break;
-        case 8:
-            window()->set_cursor(Gfx::StandardCursor::Move);
-            break;
-        case 9:
-            window()->set_cursor(Gfx::StandardCursor::ResizeColumn);
-            break;
-        case 10:
-            window()->set_cursor(Gfx::StandardCursor::ResizeDiagonalBLTR);
-            break;
-        case 11:
-            window()->set_cursor(Gfx::StandardCursor::ResizeDiagonalTLBR);
-            break;
-        case 12:
-            window()->set_cursor(Gfx::StandardCursor::ResizeHorizontal);
-            break;
-        case 13:
-            window()->set_cursor(Gfx::StandardCursor::ResizeRow);
-            break;
-        case 14:
-            window()->set_cursor(Gfx::StandardCursor::ResizeVertical);
-            break;
-        case 15:
-            window()->set_cursor(Gfx::StandardCursor::Wait);
-            break;
-        default:
-            window()->set_cursor(Gfx::StandardCursor::Arrow);
-        }
+        auto icon_index = index.model()->index(index.row(), MouseCursorModel::Column::Bitmap);
+        window()->set_cursor(icon_index.data().as_bitmap());
     };
 
     auto& icons_tab = tab_widget.add_tab<GUI::Widget>("Icons");

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -1142,7 +1142,7 @@ void Window::update_cursor()
     else
         new_cursor = m_cursor;
 
-    if (m_effective_cursor == new_cursor)
+    if (!m_custom_cursor && m_effective_cursor == new_cursor)
         return;
     m_effective_cursor = new_cursor;
 


### PR DESCRIPTION
- **LibGUI: Update the window cursor if it was provided as a bitmap**

  This condition rejected almost every bitmap cursor change.

- **WidgetGallery: Simplify cursor change code**

  The code here wasn’t updated when a new file icons appeared, so double-clicking a cursor didn’t always set it to the correct one.

  Also, the cursor list is sorted alphabetically, by the file name. So if a theme used a different file naming in Config.ini, then the previous code would also be incorrect.

  Here we will just take the bitmap icon from the model.

  Closes: #10142

- **WidgetGallery+MouseSettings: Use `LexicalPath::basename()`**

- **WidgetGallery: Crop animated cursors**

  Selecting the wait cursor displayed the full sprite image.

  This has been borrowed from the MouseSettings.

