### PR TITLE
LibC: Spec compliant IN6_IS_ADDR_V4MAPPED

### DIFF
--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -45,6 +45,6 @@ static inline uint32_t ntohl(uint32_t value)
     (addr->s6_addr[0] == 0 && addr->s6_addr[1] == 0 && addr->s6_addr[2] == 0 && addr->s6_addr[3] == 0 && addr->s6_addr[4] == 0 && addr->s6_addr[5] == 0 && addr->s6_addr[6] == 0 && addr->s6_addr[7] == 0 && addr->s6_addr[8] == 0 && addr->s6_addr[9] == 0 && addr->s6_addr[10] == 0 && addr->s6_addr[11] == 0 && addr->s6_addr[12] == 0 && addr->s6_addr[13] == 0 && addr->s6_addr[14] == 0 && addr->s6_addr[15] == 1)
 
 #define IN6_IS_ADDR_V4MAPPED(addr) \
-    ((((addr)->s6_addr[0]) == 0) && (((addr)->s6_addr[1]) == 0) && (((addr)->s6_addr[2]) == 0) && (((addr)->s6_addr[3]) == 0) && (((addr)->s6_addr[4]) == 0) && (((addr)->s6_addr[5]) == 0xFFFF))
+    ((((addr)->s6_addr[0]) == 0) && (((addr)->s6_addr[1]) == 0) && (((addr)->s6_addr[2]) == 0) && (((addr)->s6_addr[3]) == 0) && (((addr)->s6_addr[4]) == 0) && (((addr)->s6_addr[5]) == 0) && (((addr)->s6_addr[6]) == 0) && (((addr)->s6_addr[7]) == 0) && (((addr)->s6_addr[8]) == 0) && (((addr)->s6_addr[9]) == 0) && (((addr)->s6_addr[10]) == 0xFF) && (((addr)->s6_addr[11]) == 0xFF))
 
 __END_DECLS


### PR DESCRIPTION
An IPv4 mapped IPv6 address consist of 80 "0" bits, followed by 16 "1"
bits, followed by the 32-bit IPv4 address.

Example of IPv4 mapped IPv6 address:
IPv4 address: 169.219.13.133
IPv6 address: 0000:0000:0000:0000:FFFF:A9DB:0D85
Simplified  : ::FFFF:A9DB:0D85