### PR TITLE
LibGUI: Implement autoscrolling when dragging in AbstractView

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -242,13 +242,13 @@ Gfx::IntPoint AbstractScrollableWidget::automatic_scroll_delta_from_position(con
 
     if (pos.y() < m_autoscroll_threshold)
         delta.set_y(clamp(-(m_autoscroll_threshold - pos.y()), -m_autoscroll_threshold, 0));
-    else if (pos.y() > height() - m_autoscroll_threshold)
-        delta.set_y(clamp(m_autoscroll_threshold - (height() - pos.y()), 0, m_autoscroll_threshold));
+    else if (pos.y() > widget_inner_rect().height() - m_autoscroll_threshold)
+        delta.set_y(clamp(m_autoscroll_threshold - (widget_inner_rect().height() - pos.y()), 0, m_autoscroll_threshold));
 
     if (pos.x() < m_autoscroll_threshold)
         delta.set_x(clamp(-(m_autoscroll_threshold - pos.x()), -m_autoscroll_threshold, 0));
-    else if (pos.x() > width() - m_autoscroll_threshold)
-        delta.set_x(clamp(m_autoscroll_threshold - (width() - pos.x()), 0, m_autoscroll_threshold));
+    else if (pos.x() > widget_inner_rect().width() - m_autoscroll_threshold)
+        delta.set_x(clamp(m_autoscroll_threshold - (widget_inner_rect().width() - pos.x()), 0, m_autoscroll_threshold));
 
     return delta;
 }

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -52,7 +52,7 @@ public:
     void scroll_to_bottom();
 
     void set_automatic_scrolling_timer(bool active);
-    Gfx::IntPoint automatic_scroll_delta_from_position(const Gfx::IntPoint&) const;
+    virtual Gfx::IntPoint automatic_scroll_delta_from_position(const Gfx::IntPoint&) const;
 
     int width_occupied_by_vertical_scrollbar() const;
     int height_occupied_by_horizontal_scrollbar() const;
@@ -75,6 +75,7 @@ protected:
     void set_content_size(const Gfx::IntSize&);
     void set_size_occupied_by_fixed_elements(const Gfx::IntSize&);
     virtual void on_automatic_scrolling_timer_fired() {};
+    int autoscroll_threshold() const { return m_autoscroll_threshold; }
 
 private:
     class AbstractScrollableWidgetScrollbar final : public Scrollbar {

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -460,4 +460,14 @@ bool AbstractTableView::is_navigation(GUI::KeyEvent& event)
         return false;
     }
 }
+
+Gfx::IntPoint AbstractTableView::automatic_scroll_delta_from_position(const Gfx::IntPoint& pos) const
+{
+    if (pos.y() > column_header().height() + autoscroll_threshold())
+        return AbstractScrollableWidget::automatic_scroll_delta_from_position(pos);
+
+    Gfx::IntPoint position_excluding_header = { pos.x(), pos.y() - column_header().height() };
+    return AbstractScrollableWidget::automatic_scroll_delta_from_position(position_excluding_header);
+}
+
 }

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -100,6 +100,8 @@ protected:
 
     void move_cursor_relative(int vertical_steps, int horizontal_steps, SelectionUpdate);
 
+    virtual Gfx::IntPoint automatic_scroll_delta_from_position(const Gfx::IntPoint& pos) const override;
+
 private:
     void layout_headers();
     bool is_navigation(GUI::KeyEvent&);

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -142,6 +142,8 @@ protected:
     virtual void hide_event(HideEvent&) override;
     virtual void focusin_event(FocusEvent&) override;
 
+    virtual void on_automatic_scrolling_timer_fired() override;
+
     virtual void clear_selection();
     virtual void set_selection(ModelIndex const&);
     virtual void set_selection_start_index(ModelIndex const&);
@@ -202,6 +204,8 @@ private:
     bool m_is_dragging { false };
     bool m_draw_item_text_with_shadow { false };
     bool m_suppress_update_on_selection_change { false };
+
+    Gfx::IntPoint m_automatic_scroll_delta {};
 };
 
 }

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -711,10 +711,12 @@ String FileSystemModel::column_name(int column) const
 
 bool FileSystemModel::accepts_drag(ModelIndex const& index, Vector<String> const& mime_types) const
 {
-    if (!index.is_valid())
-        return false;
     if (!mime_types.contains_slow("text/uri-list"))
         return false;
+
+    if (!index.is_valid())
+        return true;
+
     auto& node = this->node(index);
     return node.is_directory();
 }


### PR DESCRIPTION
![out](https://user-images.githubusercontent.com/69970419/133971412-d8858578-caf2-4847-a24c-8b24bfc0ca65.gif)

This PR implements automatic scrolling when receiving Drag Events in AbstractViews. Further improvements could be made regarding the selection logic since it only updates the selection on mouse move and not on automatic scroll, but the behavior is still quite satisfying :)