### PR TITLE
LibC+DynamicLoader: Store the auxiliary vector address at startup

### DIFF
--- a/Userland/Libraries/LibC/libcinit.cpp
+++ b/Userland/Libraries/LibC/libcinit.cpp
@@ -19,10 +19,23 @@ __thread int errno;
 char** environ;
 bool __environ_is_malloced;
 bool __stdio_is_initialized;
+void* __auxiliary_vector;
+
+static void __auxiliary_vector_init();
 
 void __libc_init()
 {
+    __auxiliary_vector_init();
     __malloc_init();
     __stdio_init();
+}
+
+static void __auxiliary_vector_init()
+{
+    char** env;
+    for (env = environ; *env; ++env) {
+    }
+
+    __auxiliary_vector = (void*)++env;
 }
 }

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -182,11 +182,8 @@ extern "C" {
 long getauxval(long type)
 {
     errno = 0;
-    char** env;
-    for (env = environ; *env; ++env) {
-    }
 
-    auxv_t* auxvp = (auxv_t*)++env;
+    auxv_t* auxvp = (auxv_t*)__auxiliary_vector;
     for (; auxvp->a_type != AT_NULL; ++auxvp) {
         if (auxvp->a_type == type)
             return auxvp->a_un.a_val;

--- a/Userland/Libraries/LibC/sys/internals.h
+++ b/Userland/Libraries/LibC/sys/internals.h
@@ -19,6 +19,7 @@ extern void _init();
 extern bool __environ_is_malloced;
 extern bool __stdio_is_initialized;
 extern bool __heap_is_stable;
+extern void* __auxiliary_vector;
 
 int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle);
 void __cxa_finalize(void* dso_handle);


### PR DESCRIPTION
`getauxval()` always re-calculated the address of the auxiliary vector by traversing to the end of the `environ` pointer, but the `environ` array may get re-allocated at runtime which caused `getauxval()` to work with an incorrect auxiliary vector address.

Fixes #10087.