### PR TITLE
Kernel: Clean up PCI::Device namespace formatting

### DIFF
--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -10,7 +10,9 @@
 #include <Kernel/Bus/PCI/Definitions.h>
 
 namespace Kernel {
-class PCI::Device {
+namespace PCI {
+
+class Device {
 public:
     Address pci_address() const { return m_pci_address; };
 
@@ -33,4 +35,6 @@ protected:
 private:
     Address m_pci_address;
 };
+
+}
 }


### PR DESCRIPTION
This commit was somewhere buried in #10001 and got lost when #10001 was closed.

@supercomputer7 reminded me to create a new PR for this tiny change.