### PR TITLE
AK+Everywhere: Make the Variant<Empty, …> pattern slightly easier

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -210,7 +210,11 @@ public:
     template<typename... NewTs>
     friend struct Variant;
 
-    Variant() = delete;
+    Variant() requires(!can_contain<Empty>()) = delete;
+    Variant() requires(can_contain<Empty>())
+        : Variant(Empty())
+    {
+    }
 
 #ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     Variant(const Variant&) requires(!(IsCopyConstructible<Ts> && ...)) = delete;

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -25,10 +25,9 @@ KResultOr<FlatPtr> Process::sys$waitid(Userspace<const Syscall::SC_waitid_params
     REQUIRE_PROMISE(proc);
     auto params = TRY(copy_typed_from_user(user_params));
 
-    Variant<Empty, NonnullRefPtr<Process>, NonnullRefPtr<ProcessGroup>> waitee = Empty {};
+    Variant<Empty, NonnullRefPtr<Process>, NonnullRefPtr<ProcessGroup>> waitee;
     switch (params.idtype) {
     case P_ALL:
-        waitee = Empty {};
         break;
     case P_PID: {
         auto waitee_process = Process::from_pid(params.id);

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -219,3 +219,10 @@ TEST_CASE(copy_assign)
         EXPECT_EQ(the_value.get<String>(), "Hello, world!");
     }
 }
+
+TEST_CASE(default_empty)
+{
+    Variant<Empty, int> my_variant;
+    EXPECT(my_variant.has<Empty>());
+    EXPECT(!my_variant.has<int>());
+}

--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -74,7 +74,7 @@ struct MultiHashDigestVariant {
     }
 
     using DigestVariant = Variant<Empty, MD5::DigestType, SHA1::DigestType, SHA256::DigestType, SHA384::DigestType, SHA512::DigestType>;
-    DigestVariant m_digest { Empty {} };
+    DigestVariant m_digest {};
 };
 
 class Manager final : public HashFunction<0, MultiHashDigestVariant> {
@@ -198,7 +198,7 @@ public:
 
 private:
     using AlgorithmVariant = Variant<Empty, MD5, SHA1, SHA256, SHA384, SHA512>;
-    AlgorithmVariant m_algorithm { Empty {} };
+    AlgorithmVariant m_algorithm {};
     HashKind m_kind { HashKind::None };
     ByteBuffer m_pre_init_buffer;
 };

--- a/Userland/Libraries/LibIMAP/Objects.cpp
+++ b/Userland/Libraries/LibIMAP/Objects.cpp
@@ -138,7 +138,6 @@ String serialize_astring(StringView string)
 String SearchKey::serialize() const
 {
     return data.visit(
-        [&](Empty const&) { VERIFY_NOT_REACHED(); return String("The compiler complains if you remove this."); },
         [&](All const&) { return String("ALL"); },
         [&](Answered const&) { return String("ANSWERED"); },
         [&](Bcc const& x) { return String::formatted("BCC {}", serialize_astring(x.bcc)); },

--- a/Userland/Libraries/LibIMAP/Objects.h
+++ b/Userland/Libraries/LibIMAP/Objects.h
@@ -460,7 +460,7 @@ public:
     struct Unseen { };
     // clang-format on
 
-    Variant<Empty, All, Answered, Bcc, Cc, Deleted, Draft, From, Header, Keyword,
+    Variant<All, Answered, Bcc, Cc, Deleted, Draft, From, Header, Keyword,
         Larger, New, Not, Old, On, Or, Recent, SearchKeys, Seen, SentBefore, SentOn,
         SentSince, SequenceSet, Since, Smaller, Subject, Text, To, UID, Unanswered,
         Undeleted, Undraft, Unkeyword, Unseen>

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -317,8 +317,8 @@ struct BindingPattern : RefCounted<BindingPattern> {
     // This covers both BindingProperty and BindingElement, hence the more generic name
     struct BindingEntry {
         // If this entry represents a BindingElement, then name will be Empty
-        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<Expression>, Empty> name { Empty {} };
-        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, Empty> alias { Empty {} };
+        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<Expression>, Empty> name {};
+        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, Empty> alias {};
         RefPtr<Expression> initializer {};
         bool is_rest { false };
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -2180,7 +2180,7 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(bool for_l
 
     NonnullRefPtrVector<VariableDeclarator> declarations;
     for (;;) {
-        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, Empty> target { Empty() };
+        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, Empty> target {};
         if (match_identifier()) {
             auto identifier_start = push_start();
             auto name = consume_identifier().value();

--- a/Userland/Libraries/LibJS/Token.h
+++ b/Userland/Libraries/LibJS/Token.h
@@ -239,7 +239,7 @@ private:
     String m_message;
     StringView m_trivia;
     StringView m_original_value;
-    Variant<Empty, StringView, FlyString> m_value { Empty {} };
+    Variant<Empty, StringView, FlyString> m_value {};
     StringView m_filename;
     size_t m_line_number { 0 };
     size_t m_line_column { 0 };

--- a/Userland/Libraries/LibPDF/Value.h
+++ b/Userland/Libraries/LibPDF/Value.h
@@ -20,11 +20,6 @@ class Value : public Variant<Empty, std::nullptr_t, bool, int, float, Reference,
 public:
     using Variant::Variant;
 
-    Value()
-        : Variant(Empty())
-    {
-    }
-
     template<IsObject T>
     Value(RefPtr<T> const& refptr)
         : Variant(nullptr)

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1567,7 +1567,7 @@ bool ECMA262Parser::parse_atom_escape(ByteCode& stack, size_t& match_length_mini
     }
 
     if (unicode) {
-        PropertyEscape property { Empty {} };
+        PropertyEscape property {};
         bool negated = false;
 
         if (parse_unicode_property_escape(property, negated)) {
@@ -1847,7 +1847,7 @@ bool ECMA262Parser::parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&
                 if (try_skip("-"))
                     return { CharClassRangeElement { .code_point = '-', .is_character_class = false } };
 
-                PropertyEscape property { Empty {} };
+                PropertyEscape property {};
                 bool negated = false;
                 if (parse_unicode_property_escape(property, negated)) {
                     return property.visit(

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -521,8 +521,8 @@ private:
         Empty,
         Crypto::Cipher::AESCipher::CBCMode,
         Crypto::Cipher::AESCipher::GCMMode>;
-    CipherVariant m_cipher_local { Empty {} };
-    CipherVariant m_cipher_remote { Empty {} };
+    CipherVariant m_cipher_local {};
+    CipherVariant m_cipher_remote {};
 
     bool m_has_scheduled_write_flush { false };
     bool m_has_scheduled_app_data_flush { false };

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -381,7 +381,7 @@ Optional<InstantiationError> AbstractMachine::allocate_all_initial_phase(Module 
     });
     module.for_each_section_of_type<ExportSection>([&](ExportSection const& section) {
         for (auto& entry : section.entries()) {
-            Variant<FunctionAddress, TableAddress, MemoryAddress, GlobalAddress, Empty> address { Empty {} };
+            Variant<FunctionAddress, TableAddress, MemoryAddress, GlobalAddress, Empty> address {};
             entry.description().visit(
                 [&](FunctionIndex const& index) {
                     if (module_instance.functions().size() > index.value())

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -352,7 +352,7 @@ private:
     // Type::Comment (comment data), Type::StartTag and Type::EndTag (tag name)
     String m_string_data;
 
-    Variant<Empty, u32, OwnPtr<DoctypeData>, OwnPtr<Vector<Attribute>>> m_data { Empty {} };
+    Variant<Empty, u32, OwnPtr<DoctypeData>, OwnPtr<Vector<Attribute>>> m_data {};
 
     Position m_start_position;
     Position m_end_position;


### PR DESCRIPTION
I've noticed that we use `AK::Variant<Empty, …>` in several places, but didn't have any default constructor for it in that case, so we used to have to write `VariantWithEmpty m_foo { Empty {} };` every time, which is slightly silly.

Furthermore, it turns out that there was a use of `Variant<Empty, …>` that didn't even use the `Empty` option, to the point where that value would have been a bug.