### PR TITLE
CI: Create a secondary ccache for the Clang toolchain build

### DIFF
--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -5,6 +5,8 @@ parameters:
   build_directory: ''
   ccache_version: 1 # Increment this number if CI has trouble with ccache.
   serenity_ccache_path: $(CCACHE_DIR)
+  toolchain_ccache_path: $(CCACHE_DIR)
+  toolchain_ccache_size: $(CCACHE_MAXSIZE)
   with_unicode_caches: true
 
 steps:
@@ -18,13 +20,26 @@ steps:
         inputs:
           key: '"toolchain" | "${{ parameters.arch }}" | Toolchain/BuildClang.sh | Toolchain/Patches/*[!gcc].patch | Userland/Libraries/LibC/**/*.h | Userland/Libraries/LibPthread/**/*.h'
           path: $(Build.SourcesDirectory)/Toolchain/Cache
-        displayName: 'Toolchain Cache'
+        displayName: 'Toolchain Prebuilt Cache'
     - ${{ if eq(parameters.toolchain, 'gcc') }}:
       - task: Cache@2
         inputs:
           key: '"toolchain" | "${{ parameters.arch }}" | Toolchain/BuildIt.sh | Toolchain/Patches/*[!llvm].patch | Userland/Libraries/LibC/**/*.h | Userland/Libraries/LibPthread/**/*.h'
           path: $(Build.SourcesDirectory)/Toolchain/Cache
-        displayName: 'Toolchain Cache'
+        displayName: 'Toolchain Prebuilt Cache'
+
+    - task: Cache@2
+      inputs:
+        key: '"toolchain ccache" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}" | "$(timestamp)"'
+        restoreKeys: |
+          "toolchain ccache" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}"
+        path: ${{ parameters.toolchain_ccache_path }}
+      displayName: 'Toolchain Compiler Cache'
+
+    - script: |
+        CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -M ${{ parameters.toolchain_ccache_size }}
+        CCACHE_DIR=${{ parameters.toolchain_ccache_path }} ccache -s
+      displayName: 'Configure Toolchain ccache'
 
   - task: Cache@2
     inputs:

--- a/Meta/Azure/Caches.yml
+++ b/Meta/Azure/Caches.yml
@@ -4,6 +4,7 @@ parameters:
   toolchain: 'gcc'
   build_directory: ''
   ccache_version: 1 # Increment this number if CI has trouble with ccache.
+  serenity_ccache_path: $(CCACHE_DIR)
   with_unicode_caches: true
 
 steps:
@@ -30,8 +31,8 @@ steps:
       key: '"ccache" | "${{ parameters.os }}" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}" | "$(timestamp)"'
       restoreKeys: |
         "ccache" | "${{ parameters.os }}" | "${{ parameters.arch }}" | "${{ parameters.toolchain }}" | "${{ parameters.ccache_version }}"
-      path: $(CCACHE_DIR)
-    displayName: 'Compiler Cache'
+      path: ${{ parameters.serenity_ccache_path }}
+    displayName: 'Serenity Compiler Cache'
 
   - ${{ if eq(parameters.with_unicode_caches, true) }}:
     - task: Cache@2
@@ -47,6 +48,6 @@ steps:
       displayName: 'UnicodeLocale Cache'
 
   - script: |
-      ccache -M 5G
-      ccache -s
-    displayName: 'Configure ccache'
+      CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -M 5G
+      CCACHE_DIR=${{ parameters.serenity_ccache_path }} ccache -s
+    displayName: 'Configure Serenity ccache'

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -7,7 +7,7 @@ jobs:
   - job: 'Lagom_${{ parameters.os }}_${{ parameters.fuzzer }}'
 
     variables:
-    - name: CCACHE_DIR
+    - name: SERENITY_CCACHE_DIR
       value: $(Build.SourcesDirectory)/.ccache
 
     - name: job_pool
@@ -36,6 +36,7 @@ jobs:
         arch: 'Lagom'
         toolchain: '$(toolchain)'
         build_directory: 'Meta/Lagom/Build'
+        serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
         ${{ if eq(parameters.fuzzer, 'Fuzz') }}:
           with_unicode_caches: false
         ${{ if eq(parameters.fuzzer, 'NoFuzz') }}:
@@ -59,6 +60,8 @@ jobs:
             ..
         displayName: 'Create Build Environment'
         workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build
+        env:
+          CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
     - ${{ if eq(parameters.fuzzer, 'NoFuzz') }}:
       - script: |
           cmake -GNinja \
@@ -77,11 +80,14 @@ jobs:
         workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build
         env:
           PATH: '$(PATH):$(Build.SourcesDirectory)/wabt-1.0.23/bin'
+          CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
 
     - script: |
         cmake --build .
       displayName: 'Build'
       workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build
+      env:
+        CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
 
     - ${{ if eq(parameters.fuzzer, 'NoFuzz') }}:
       - script: |
@@ -96,5 +102,5 @@ jobs:
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
 
     - script: |
-        ccache -s
+        CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache -s
       displayName: 'Cache Stats'

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -6,7 +6,7 @@ jobs:
     timeoutInMinutes: 0 # Setting to 0 means the maximum allowed timeout is used.
 
     variables:
-    - name: CCACHE_DIR
+    - name: SERENITY_CCACHE_DIR
       value: $(Build.SourcesDirectory)/.ccache
 
     pool:
@@ -22,6 +22,7 @@ jobs:
         arch: '${{ parameters.arch }}'
         toolchain: 'clang'
         build_directory: 'Build/${{ parameters.arch }}clang'
+        serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
 
     - script: ./Toolchain/BuildClang.sh
       displayName: Build Toolchain
@@ -44,11 +45,15 @@ jobs:
           -DCMAKE_CXX_COMPILER=g++-10
       displayName: 'Create Build Environment'
       workingDirectory: $(Build.SourcesDirectory)
+      env:
+        CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
 
     - script: |
         cmake --build ./Build/superbuild
       displayName: 'Build'
       workingDirectory: $(Build.SourcesDirectory)
+      env:
+        CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
 
     - script: |
         ninja install && ninja image
@@ -86,5 +91,5 @@ jobs:
       condition: failed()
 
     - script: |
-        ccache -s
+        CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache -s
       displayName: 'Cache Stats'

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -8,6 +8,10 @@ jobs:
     variables:
     - name: SERENITY_CCACHE_DIR
       value: $(Build.SourcesDirectory)/.ccache
+    - name: LLVM_CCACHE_DIR
+      value: $(Build.SourcesDirectory)/Toolchain/.ccache
+    - name: LLVM_CCACHE_MAXSIZE
+      value: 20GB
 
     pool:
       vmImage: ubuntu-20.04
@@ -23,8 +27,10 @@ jobs:
         toolchain: 'clang'
         build_directory: 'Build/${{ parameters.arch }}clang'
         serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
+        toolchain_ccache_path: '$(LLVM_CCACHE_DIR)'
+        toolchain_ccache_size: '$(LLVM_CCACHE_MAXSIZE)'
 
-    - script: ./Toolchain/BuildClang.sh
+    - script: ./Toolchain/BuildClang.sh --ci
       displayName: Build Toolchain
       env:
         TRY_USE_LOCAL_TOOLCHAIN: 'y'
@@ -91,5 +97,9 @@ jobs:
       condition: failed()
 
     - script: |
+        echo "##[section]Toolchain Cache"
+        CCACHE_DIR='$(LLVM_CCACHE_DIR)' ccache -s
+
+        echo "##[section]Serenity Cache"
         CCACHE_DIR='$(SERENITY_CCACHE_DIR)' ccache -s
       displayName: 'Cache Stats'


### PR DESCRIPTION
We bust the prebuilt cache when any header in e.g. LibC changes. Doing a
full toolchain rebuild probably isn't necessary, so this adds a separate
ccache to speed up toolchain builds.