### PR TITLE
LibWeb: Use AK::Variant default initialization in one more place

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/ExceptionOr.h
+++ b/Userland/Libraries/LibWeb/DOM/ExceptionOr.h
@@ -112,7 +112,7 @@ public:
 private:
     Optional<ValueType> m_result;
     // https://heycam.github.io/webidl/#idl-exceptions
-    Variant<Empty, SimpleException, NonnullRefPtr<DOMException>> m_exception { Empty {} };
+    Variant<Empty, SimpleException, NonnullRefPtr<DOMException>> m_exception {};
 };
 
 template<>


### PR DESCRIPTION
I forgot this one when doing #10154.