### PR TITLE
LibWeb: Correct occasional blurriness when drawing a bitmap at its native size

### DIFF
--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -715,6 +715,11 @@ using FloatRect = Rect<float>;
     return Gfx::IntRect::from_two_points({ x1, y1 }, { x2, y2 });
 }
 
+[[nodiscard]] ALWAYS_INLINE IntRect rounded_int_rect(FloatRect const& float_rect)
+{
+    return IntRect { floorf(float_rect.x()), floorf(float_rect.y()), roundf(float_rect.width()), roundf(float_rect.height()) };
+}
+
 }
 
 namespace AK {

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -158,10 +158,10 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
             builder.appendff("@{:p} ", &layout_node);
 
         builder.appendff("at ({},{}) size {}x{}",
-            (int)box.absolute_x(),
-            (int)box.absolute_y(),
-            (int)box.width(),
-            (int)box.height());
+            box.absolute_x(),
+            box.absolute_y(),
+            box.width(),
+            box.height());
 
         if (box.is_positioned())
             builder.appendff(" {}positioned{}", positioned_color_on, color_off);
@@ -224,7 +224,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
                 builder.appendff("start: {}, length: {}, rect: {}\n",
                     fragment.start(),
                     fragment.length(),
-                    enclosing_int_rect(fragment.absolute_rect()).to_string());
+                    fragment.absolute_rect().to_string());
                 if (is<Layout::TextNode>(fragment.layout_node())) {
                     for (size_t i = 0; i < indent; ++i)
                         builder.append("  ");

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -100,7 +100,7 @@ void CanvasRenderingContext2D::draw_image(const HTMLImageElement& image_element,
     Gfx::FloatRect dst_rect = { x, y, (float)image_element.bitmap()->width(), (float)image_element.bitmap()->height() };
     auto rect = m_transform.map(dst_rect);
 
-    painter->draw_scaled_bitmap(enclosing_int_rect(rect), *image_element.bitmap(), src_rect, 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+    painter->draw_scaled_bitmap(rounded_int_rect(rect), *image_element.bitmap(), src_rect, 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
 }
 
 void CanvasRenderingContext2D::scale(float sx, float sy)

--- a/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
@@ -39,7 +39,7 @@ void CanvasBox::paint(PaintContext& context, PaintPhase phase)
             return;
 
         if (dom_node().bitmap())
-            context.painter().draw_scaled_bitmap(enclosing_int_rect(absolute_rect()), *dom_node().bitmap(), dom_node().bitmap()->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+            context.painter().draw_scaled_bitmap(rounded_int_rect(absolute_rect()), *dom_node().bitmap(), dom_node().bitmap()->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -96,7 +96,7 @@ void ImageBox::paint(PaintContext& context, PaintPhase phase)
                 alt = image_element.src();
             context.painter().draw_text(enclosing_int_rect(absolute_rect()), alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
         } else if (auto bitmap = m_image_loader.bitmap(m_image_loader.current_frame_index())) {
-            context.painter().draw_scaled_bitmap(enclosing_int_rect(absolute_rect()), *bitmap, bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+            context.painter().draw_scaled_bitmap(rounded_int_rect(absolute_rect()), *bitmap, bitmap->rect(), 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
         }
     }
 }


### PR DESCRIPTION
This fixes an issue with drawing images, where layout elements would be 1px larger than they should be, due to layout positions using float values, and then converting using `enclosing_int_rect()`. `rounded_int_rect()` replaces that use, by maintaining the original rect's size.

Other places in LibWeb could likely benefit from using this new function too, since there are 1px gaps around elements sometimes, but that's less visually bothersome.