### PR TITLE
LibDSP+Piano: Move Piano's DSP fully to LibDSP

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -46,6 +46,7 @@ public:
     [[nodiscard]] size_t size() const { return m_table.size(); }
     [[nodiscard]] size_t capacity() const { return m_table.capacity(); }
     void clear() { m_table.clear(); }
+    void clear_with_capacity() { m_table.clear_with_capacity(); }
 
     HashSetResult set(const K& key, const V& value) { return m_table.set({ key, value }); }
     HashSetResult set(const K& key, V&& value) { return m_table.set({ key, move(value) }); }

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -258,6 +258,17 @@ public:
     {
         *this = HashTable();
     }
+    void clear_with_capacity()
+    {
+        __builtin_memset(m_buckets, 0, capacity());
+        m_size = 0;
+        m_deleted_count = 0;
+
+        if constexpr (IsOrdered)
+            m_collection_data = { nullptr, nullptr };
+        else
+            m_buckets[m_capacity].end = true;
+    }
 
     template<typename U = T>
     HashSetResult try_set(U&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace)

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -12,10 +12,10 @@
 // Converts Piano-internal data to an Audio::Buffer that AudioServer receives
 static NonnullRefPtr<Audio::Buffer> music_samples_to_buffer(Array<Sample, sample_count> samples)
 {
-    Vector<Audio::Frame, sample_count> frames;
+    Vector<Audio::Sample, sample_count> frames;
     frames.ensure_capacity(sample_count);
     for (auto sample : samples) {
-        Audio::Frame frame = { sample.left / (double)NumericLimits<i16>::max(), sample.right / (double)NumericLimits<i16>::max() };
+        Audio::Sample frame = { sample.left / (double)NumericLimits<i16>::max(), sample.right / (double)NumericLimits<i16>::max() };
         frames.unchecked_append(frame);
     }
     return Audio::Buffer::create_with_samples(frames);

--- a/Userland/Applications/Piano/CMakeLists.txt
+++ b/Userland/Applications/Piano/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SOURCES
     RollWidget.cpp
     SamplerWidget.cpp
     WaveWidget.cpp
-    ProcessorParameterSlider.cpp
+    ProcessorParameterWidget/Slider.cpp
 )
 
 serenity_app(Piano ICON app-piano)

--- a/Userland/Applications/Piano/KeysWidget.cpp
+++ b/Userland/Applications/Piano/KeysWidget.cpp
@@ -42,7 +42,7 @@ void KeysWidget::set_key(int key, Switch switch_key)
     }
     VERIFY(m_key_on[key] <= 2);
 
-    m_track_manager.set_note_current_octave(key, switch_key);
+    m_track_manager.set_keyboard_note(key + m_track_manager.octave_base(), switch_key);
 }
 
 bool KeysWidget::note_is_set(int note) const

--- a/Userland/Applications/Piano/KnobsWidget.cpp
+++ b/Userland/Applications/Piano/KnobsWidget.cpp
@@ -7,7 +7,9 @@
 
 #include "KnobsWidget.h"
 #include "MainWidget.h"
+#include "ProcessorParameterWidget/Slider.h"
 #include "TrackManager.h"
+#include <LibDSP/ProcessorParameter.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Slider.h>
@@ -26,11 +28,6 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
 
     m_volume_label = m_labels_container->add<GUI::Label>("Volume");
     m_octave_label = m_labels_container->add<GUI::Label>("Octave");
-    m_wave_label = m_labels_container->add<GUI::Label>("Wave");
-    m_attack_label = m_labels_container->add<GUI::Label>("Attack");
-    m_decay_label = m_labels_container->add<GUI::Label>("Decay");
-    m_sustain_label = m_labels_container->add<GUI::Label>("Sustain");
-    m_release_label = m_labels_container->add<GUI::Label>("Release");
 
     m_values_container = add<GUI::Widget>();
     m_values_container->set_layout<GUI::HorizontalBoxLayout>();
@@ -38,11 +35,6 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
 
     m_volume_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track().volume()));
     m_octave_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.octave()));
-    m_wave_value = m_values_container->add<GUI::Label>(wave_strings[m_track_manager.current_track().wave()]);
-    m_attack_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track().attack()));
-    m_decay_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track().decay()));
-    m_sustain_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track().sustain()));
-    m_release_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track().release()));
 
     m_knobs_container = add<GUI::Widget>();
     m_knobs_container->set_layout<GUI::HorizontalBoxLayout>();
@@ -74,70 +66,32 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
         m_octave_value->set_text(String::number(new_octave));
     };
 
-    m_wave_knob = m_knobs_container->add<GUI::VerticalSlider>();
-    m_wave_knob->set_tooltip("C: cycle through waveforms");
-    m_wave_knob->set_range(0, last_wave);
-    m_wave_knob->set_value(last_wave - m_track_manager.current_track().wave());
-    m_wave_knob->set_step(1);
-    m_wave_knob->on_change = [this](int value) {
-        int new_wave = last_wave - value;
-        if (m_change_underlying)
-            m_track_manager.current_track().set_wave(new_wave);
-        VERIFY(new_wave == m_track_manager.current_track().wave());
-        m_wave_value->set_text(wave_strings[new_wave]);
-    };
-
-    m_attack_knob = m_knobs_container->add<GUI::VerticalSlider>();
-    m_attack_knob->set_tooltip("Envelope attack in milliseconds");
-    m_attack_knob->set_range(0, attack_max);
-    m_attack_knob->set_value(attack_max - m_track_manager.current_track().attack());
-    m_attack_knob->set_step(25);
-    m_attack_knob->on_change = [this](int value) {
-        int new_attack = attack_max - value;
-        if (m_change_underlying)
-            m_track_manager.current_track().set_attack(new_attack);
-        VERIFY(new_attack == m_track_manager.current_track().attack());
-        m_attack_value->set_text(String::number(new_attack));
-    };
-
-    m_decay_knob = m_knobs_container->add<GUI::VerticalSlider>();
-    m_decay_knob->set_tooltip("Envelope decay in milliseconds");
-    m_decay_knob->set_range(0, decay_max);
-    m_decay_knob->set_value(decay_max - m_track_manager.current_track().decay());
-    m_decay_knob->set_step(25);
-    m_decay_knob->on_change = [this](int value) {
-        int new_decay = decay_max - value;
-        if (m_change_underlying)
-            m_track_manager.current_track().set_decay(new_decay);
-        VERIFY(new_decay == m_track_manager.current_track().decay());
-        m_decay_value->set_text(String::number(new_decay));
-    };
-
-    m_sustain_knob = m_knobs_container->add<GUI::VerticalSlider>();
-    m_sustain_knob->set_tooltip("Envelope sustain level percent");
-    m_sustain_knob->set_range(0, sustain_max);
-    m_sustain_knob->set_value(sustain_max - m_track_manager.current_track().sustain());
-    m_sustain_knob->set_step(25);
-    m_sustain_knob->on_change = [this](int value) {
-        int new_sustain = sustain_max - value;
-        if (m_change_underlying)
-            m_track_manager.current_track().set_sustain(new_sustain);
-        VERIFY(new_sustain == m_track_manager.current_track().sustain());
-        m_sustain_value->set_text(String::number(new_sustain));
-    };
-
-    m_release_knob = m_knobs_container->add<GUI::VerticalSlider>();
-    m_release_knob->set_tooltip("Envelope release in milliseconds");
-    m_release_knob->set_range(0, release_max);
-    m_release_knob->set_value(release_max - m_track_manager.current_track().release());
-    m_release_knob->set_step(25);
-    m_release_knob->on_change = [this](int value) {
-        int new_release = release_max - value;
-        if (m_change_underlying)
-            m_track_manager.current_track().set_release(new_release);
-        VERIFY(new_release == m_track_manager.current_track().release());
-        m_release_value->set_text(String::number(new_release));
-    };
+    for (auto& raw_parameter : m_track_manager.current_track().synth()->parameters()) {
+        // The synth has range and enum parameters
+        switch (raw_parameter.type()) {
+        case LibDSP::ParameterType::Range: {
+            auto& parameter = static_cast<LibDSP::ProcessorRangeParameter&>(raw_parameter);
+            m_synth_values.append(m_values_container->add<GUI::Label>(String::number(static_cast<double>(parameter.value()))));
+            auto& parameter_knob_value = m_synth_values.last();
+            m_synth_labels.append(m_labels_container->add<GUI::Label>(String::formatted("Synth: {}", parameter.name())));
+            m_synth_knobs.append(m_knobs_container->add<ProcessorParameterSlider>(Orientation::Vertical, parameter, parameter_knob_value));
+            break;
+        }
+        case LibDSP::ParameterType::Enum: {
+            // FIXME: We shouldn't do that, but we know the synth and it is nice
+            auto& parameter = static_cast<LibDSP::ProcessorEnumParameter<LibDSP::Synthesizers::Waveform>&>(raw_parameter);
+            // The value is empty for enum parameters
+            m_synth_values.append(m_values_container->add<GUI::Label>(String::empty()));
+            m_synth_labels.append(m_labels_container->add<GUI::Label>(String::formatted("Synth: {}", parameter.name())));
+            auto enum_strings = Vector<String> { "Sine", "Triangle", "Square", "Saw", "Noise" };
+            m_synth_knobs.append(m_knobs_container->add<ProcessorParameterDropdown<LibDSP::Synthesizers::Waveform>>(parameter, move(enum_strings)));
+            m_synth_waveform = static_cast<ProcessorParameterDropdown<LibDSP::Synthesizers::Waveform>&>(m_synth_knobs.last());
+            break;
+        }
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
 
     for (auto& raw_parameter : m_track_manager.current_track().delay()->parameters()) {
         // FIXME: We shouldn't do that, but we know the effect and it's nice.
@@ -153,10 +107,13 @@ KnobsWidget::~KnobsWidget()
 {
 }
 
+void KnobsWidget::cycle_waveform()
+{
+    m_synth_waveform->set_selected_index((m_synth_waveform->selected_index() + 1) % m_synth_waveform->model()->row_count());
+}
+
 void KnobsWidget::update_knobs()
 {
-    m_wave_knob->set_value(last_wave - m_track_manager.current_track().wave());
-
     // FIXME: This is needed because when the slider is changed normally, we
     // need to change the underlying value, but if the keyboard was used, we
     // need to change the slider without changing the underlying value.
@@ -164,11 +121,6 @@ void KnobsWidget::update_knobs()
 
     m_volume_knob->set_value(volume_max - m_track_manager.current_track().volume());
     m_octave_knob->set_value(octave_max - m_track_manager.octave());
-    m_wave_knob->set_value(last_wave - m_track_manager.current_track().wave());
-    m_attack_knob->set_value(attack_max - m_track_manager.current_track().attack());
-    m_decay_knob->set_value(decay_max - m_track_manager.current_track().decay());
-    m_sustain_knob->set_value(sustain_max - m_track_manager.current_track().sustain());
-    m_release_knob->set_value(release_max - m_track_manager.current_track().release());
 
     m_change_underlying = true;
 }

--- a/Userland/Applications/Piano/KnobsWidget.h
+++ b/Userland/Applications/Piano/KnobsWidget.h
@@ -7,9 +7,14 @@
 
 #pragma once
 
-#include "ProcessorParameterSlider.h"
+#include "LibGUI/Widget.h"
+#include "ProcessorParameterWidget/Dropdown.h"
+#include "ProcessorParameterWidget/Slider.h"
 #include <AK/NonnullRefPtrVector.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibDSP/Synthesizers.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/Label.h>
 
 class TrackManager;
 class MainWidget;
@@ -20,6 +25,7 @@ public:
     virtual ~KnobsWidget() override;
 
     void update_knobs();
+    void cycle_waveform();
 
 private:
     KnobsWidget(TrackManager&, MainWidget&);
@@ -30,31 +36,20 @@ private:
     RefPtr<GUI::Widget> m_labels_container;
     RefPtr<GUI::Label> m_volume_label;
     RefPtr<GUI::Label> m_octave_label;
-    RefPtr<GUI::Label> m_wave_label;
-    RefPtr<GUI::Label> m_attack_label;
-    RefPtr<GUI::Label> m_decay_label;
-    RefPtr<GUI::Label> m_sustain_label;
-    RefPtr<GUI::Label> m_release_label;
+    NonnullRefPtrVector<GUI::Label> m_synth_labels;
     NonnullRefPtrVector<GUI::Label> m_delay_labels;
 
     RefPtr<GUI::Widget> m_values_container;
     RefPtr<GUI::Label> m_volume_value;
     RefPtr<GUI::Label> m_octave_value;
-    RefPtr<GUI::Label> m_wave_value;
-    RefPtr<GUI::Label> m_attack_value;
-    RefPtr<GUI::Label> m_decay_value;
-    RefPtr<GUI::Label> m_sustain_value;
-    RefPtr<GUI::Label> m_release_value;
+    NonnullRefPtrVector<GUI::Label> m_synth_values;
     NonnullRefPtrVector<GUI::Label> m_delay_values;
 
     RefPtr<GUI::Widget> m_knobs_container;
     RefPtr<GUI::Slider> m_volume_knob;
     RefPtr<GUI::Slider> m_octave_knob;
-    RefPtr<GUI::Slider> m_wave_knob;
-    RefPtr<GUI::Slider> m_attack_knob;
-    RefPtr<GUI::Slider> m_decay_knob;
-    RefPtr<GUI::Slider> m_sustain_knob;
-    RefPtr<GUI::Slider> m_release_knob;
+    RefPtr<ProcessorParameterDropdown<LibDSP::Synthesizers::Waveform>> m_synth_waveform;
+    NonnullRefPtrVector<GUI::Widget> m_synth_knobs;
     NonnullRefPtrVector<ProcessorParameterSlider> m_delay_knobs;
 
     bool m_change_underlying { true };

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -117,8 +117,7 @@ void MainWidget::special_key_action(int key_code)
         set_octave_and_ensure_note_change(Up);
         break;
     case Key_C:
-        m_track_manager.current_track().set_wave(Up);
-        m_knobs_widget->update_knobs();
+        m_knobs_widget->cycle_waveform();
         break;
     }
 }

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -38,46 +38,9 @@ enum Switch {
     On,
 };
 
-struct RollNote {
-    u32 length() const { return (off_sample - on_sample) + 1; }
-
-    u32 on_sample;
-    u32 off_sample;
-    u8 pitch;
-    i8 velocity;
-};
-
 enum Direction {
     Down,
     Up,
-};
-
-enum Wave {
-    Sine,
-    Triangle,
-    Square,
-    Saw,
-    Noise,
-    RecordedSample,
-};
-
-constexpr const char* wave_strings[] = {
-    "Sine",
-    "Triangle",
-    "Square",
-    "Saw",
-    "Noise",
-    "Frame",
-};
-
-constexpr int first_wave = Sine;
-constexpr int last_wave = RecordedSample;
-
-enum Envelope {
-    Done,
-    Attack,
-    Decay,
-    Release,
 };
 
 enum KeyColor {
@@ -142,6 +105,9 @@ const Color left_wave_colors[] = {
     },
 };
 
+// HACK: make the display code shut up for now
+constexpr int RecordedSample = 5;
+
 const Color right_wave_colors[] = {
     // Sine
     {
@@ -187,13 +153,7 @@ constexpr int black_keys_per_octave = 5;
 constexpr int octave_min = 1;
 constexpr int octave_max = 7;
 
-// These values represent the user-side bounds, the application may use a different scale.
-constexpr int attack_max = 1000;
-constexpr int decay_max = 1000;
-constexpr int sustain_max = 1000;
-constexpr int release_max = 1000;
 constexpr int volume_max = 1000;
-constexpr int delay_max = 8;
 
 constexpr double beats_per_minute = 60;
 constexpr int beats_per_bar = 4;

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -30,9 +30,6 @@ constexpr int buffer_size = sample_count * sizeof(Sample);
 
 constexpr double sample_rate = 44100;
 
-// Headroom for the synth
-constexpr double volume_factor = 0.1;
-
 enum Switch {
     Off,
     On,

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "WidgetWithLabel.h"
+#include <AK/Vector.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/ItemListModel.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/ModelIndex.h>
+
+template<typename EnumT>
+requires(IsEnum<EnumT>) class ProcessorParameterDropdown : public GUI::ComboBox {
+    C_OBJECT(ProcessorParameterDropdown);
+
+public:
+    ProcessorParameterDropdown(LibDSP::ProcessorEnumParameter<EnumT>& parameter, Vector<String> modes)
+        : ComboBox()
+        , m_parameter(parameter)
+        , m_modes(move(modes))
+    {
+        auto model = GUI::ItemListModel<EnumT, Vector<String>>::create(m_modes);
+        set_model(model);
+        set_only_allow_values_from_model(true);
+        set_model_column(0);
+        set_selected_index(0);
+        m_parameter.set_value(static_cast<EnumT>(0));
+
+        on_change = [this]([[maybe_unused]] auto name, GUI::ModelIndex model_index) {
+            auto value = static_cast<EnumT>(model_index.row());
+            m_parameter.set_value_sneaky(value, LibDSP::Detail::ProcessorParameterSetValueTag {});
+        };
+        m_parameter.did_change_value = [this](auto new_value) {
+            set_selected_index(static_cast<int>(new_value));
+        };
+    }
+
+    // Release focus when escape is pressed
+    virtual void keydown_event(GUI::KeyEvent& event) override
+    {
+        if (event.key() == Key_Escape) {
+            if (is_focused())
+                set_focus(false);
+            event.accept();
+        } else
+            GUI::ComboBox::keydown_event(event);
+    }
+
+private:
+    LibDSP::ProcessorEnumParameter<EnumT>& m_parameter;
+    Vector<String> m_modes;
+};

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "ProcessorParameterSlider.h"
+#include "Slider.h"
+#include "WidgetWithLabel.h"
 
 ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, LibDSP::ProcessorRangeParameter& parameter, RefPtr<GUI::Label> value_label)
     : Slider(orientation)
+    , WidgetWithLabel(move(value_label))
     , m_parameter(parameter)
-    , m_value_label(move(value_label))
 {
     set_range(m_parameter.min_value().raw(), m_parameter.max_value().raw());
     set_value(m_parameter.value().raw());

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -22,8 +22,16 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, LibD
         LibDSP::ParameterFixedPoint real_value;
         real_value.raw() = value;
         m_parameter.set_value_sneaky(real_value, LibDSP::Detail::ProcessorParameterSetValueTag {});
-        if (m_value_label)
-            m_value_label->set_text(String::formatted("{:.2f}", static_cast<double>(m_parameter)));
+        if (m_value_label) {
+            double value = static_cast<double>(m_parameter);
+            String label_text = String::formatted("{:.2f}", value);
+            // FIXME: This is a magic value; we know that with normal font sizes, the label will disappear starting from approximately this length.
+            //        Can we do this dynamically?
+            if (label_text.length() > 7)
+                m_value_label->set_text(String::formatted("{:.0f}", value));
+            else
+                m_value_label->set_text(label_text);
+        }
     };
     m_parameter.did_change_value = [this](auto value) {
         set_value(value.raw());

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
@@ -6,19 +6,19 @@
 
 #pragma once
 
+#include "WidgetWithLabel.h"
 #include <LibDSP/ProcessorParameter.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Slider.h>
 #include <LibGfx/Orientation.h>
 
-class ProcessorParameterSlider : public GUI::Slider {
+class ProcessorParameterSlider : public GUI::Slider
+    , public WidgetWithLabel {
     C_OBJECT(ProcessorParameterSlider);
 
 public:
     ProcessorParameterSlider(Orientation, LibDSP::ProcessorRangeParameter&, RefPtr<GUI::Label>);
-    RefPtr<GUI::Label> value_label() { return m_value_label; }
 
-private:
+protected:
     LibDSP::ProcessorRangeParameter& m_parameter;
-    RefPtr<GUI::Label> m_value_label;
 };

--- a/Userland/Applications/Piano/ProcessorParameterWidget/WidgetWithLabel.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/WidgetWithLabel.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <LibGUI/Label.h>
+
+class WidgetWithLabel {
+public:
+    WidgetWithLabel(RefPtr<GUI::Label> value_label)
+        : m_value_label(move(value_label))
+    {
+    }
+    RefPtr<GUI::Label> value_label() { return m_value_label; }
+
+protected:
+    RefPtr<GUI::Label> m_value_label;
+};

--- a/Userland/Applications/Piano/RollWidget.h
+++ b/Userland/Applications/Piano/RollWidget.h
@@ -10,9 +10,11 @@
 
 #include "KeysWidget.h"
 #include "Music.h"
+#include <LibDSP/Music.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 
 class TrackManager;
+using LibDSP::RollNote;
 
 class RollWidget final : public GUI::AbstractScrollableWidget {
     C_OBJECT(RollWidget)

--- a/Userland/Applications/Piano/SamplerWidget.cpp
+++ b/Userland/Applications/Piano/SamplerWidget.cpp
@@ -89,11 +89,7 @@ SamplerWidget::SamplerWidget(TrackManager& track_manager)
         Optional<String> open_path = GUI::FilePicker::get_open_filepath(window());
         if (!open_path.has_value())
             return;
-        String error_string = m_track_manager.current_track().set_recorded_sample(open_path.value());
-        if (!error_string.is_empty()) {
-            GUI::MessageBox::show(window(), String::formatted("Failed to load WAV file: {}", error_string.characters()), "Error", GUI::MessageBox::Type::Error);
-            return;
-        }
+        // TODO: We don't actually load the sample.
         m_recorded_sample_name->set_text(open_path.value());
         m_wave_editor->update();
     };

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -63,8 +63,8 @@ void Track::fill_sample(Sample& sample)
     sample.right += new_sample.right;
 
     // TODO: Use the master processor
-    sample.left *= m_volume / static_cast<double>(volume_max) * volume_factor;
-    sample.right *= m_volume / static_cast<double>(volume_max) * volume_factor;
+    sample.left *= m_volume / static_cast<double>(volume_max);
+    sample.right *= m_volume / static_cast<double>(volume_max);
 }
 
 void Track::reset()

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -31,7 +31,9 @@ Track::~Track()
 
 void Track::fill_sample(Sample& sample)
 {
-    Audio::Frame new_sample;
+    m_temporary_transport->time() = m_time;
+
+    Audio::Sample new_sample;
 
     for (size_t note = 0; note < note_count; ++note) {
         if (!m_roll_iterators[note].is_end()) {
@@ -161,7 +163,7 @@ String Track::set_recorded_sample(const StringView& path)
 
 // All of the information for these waves is on Wikipedia.
 
-Audio::Frame Track::sine(size_t note)
+Audio::Sample Track::sine(size_t note)
 {
     double pos = note_frequencies[note] / sample_rate;
     double sin_step = pos * 2 * M_PI;
@@ -170,7 +172,7 @@ Audio::Frame Track::sine(size_t note)
     return w;
 }
 
-Audio::Frame Track::saw(size_t note)
+Audio::Sample Track::saw(size_t note)
 {
     double saw_step = note_frequencies[note] / sample_rate;
     double t = m_pos[note];
@@ -179,7 +181,7 @@ Audio::Frame Track::saw(size_t note)
     return w;
 }
 
-Audio::Frame Track::square(size_t note)
+Audio::Sample Track::square(size_t note)
 {
     double pos = note_frequencies[note] / sample_rate;
     double square_step = pos * 2 * M_PI;
@@ -188,7 +190,7 @@ Audio::Frame Track::square(size_t note)
     return w;
 }
 
-Audio::Frame Track::triangle(size_t note)
+Audio::Sample Track::triangle(size_t note)
 {
     double triangle_step = note_frequencies[note] / sample_rate;
     double t = m_pos[note];
@@ -197,7 +199,7 @@ Audio::Frame Track::triangle(size_t note)
     return w;
 }
 
-Audio::Frame Track::noise(size_t note)
+Audio::Sample Track::noise(size_t note)
 {
     double step = note_frequencies[note] / sample_rate;
     // m_pos keeps track of the time since the last random sample
@@ -210,7 +212,7 @@ Audio::Frame Track::noise(size_t note)
     return m_last_w[note];
 }
 
-Audio::Frame Track::recorded_sample(size_t note)
+Audio::Sample Track::recorded_sample(size_t note)
 {
     int t = m_pos[note];
     if (t >= static_cast<int>(m_recorded_sample.size()))

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "Track.h"
+#include "Music.h"
 #include <AK/Math.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/NumericLimits.h>
 #include <LibAudio/Loader.h>
 #include <LibDSP/Music.h>
@@ -17,12 +19,9 @@ Track::Track(const u32& time)
     : m_time(time)
     , m_temporary_transport(make_ref_counted<LibDSP::Transport>(120, 4))
     , m_delay(make_ref_counted<LibDSP::Effects::Delay>(m_temporary_transport))
+    , m_synth(make_ref_counted<LibDSP::Synthesizers::Classic>(m_temporary_transport))
 {
     set_volume(volume_max);
-    set_sustain_impl(1000);
-    set_attack(5);
-    set_decay(1000);
-    set_release(5);
 }
 
 Track::~Track()
@@ -34,76 +33,26 @@ void Track::fill_sample(Sample& sample)
     m_temporary_transport->time() = m_time;
 
     Audio::Sample new_sample;
+    auto playing_notes = LibDSP::RollNotes {};
 
-    for (size_t note = 0; note < note_count; ++note) {
-        if (!m_roll_iterators[note].is_end()) {
-            if (m_roll_iterators[note]->on_sample == m_time) {
-                set_note(note, On);
-            } else if (m_roll_iterators[note]->off_sample == m_time) {
-                set_note(note, Off);
-                ++m_roll_iterators[note];
-                if (m_roll_iterators[note].is_end())
-                    m_roll_iterators[note] = m_roll_notes[note].begin();
-            }
+    for (size_t i = 0; i < note_count; ++i) {
+        auto& notes_at_pitch = m_roll_notes[i];
+        for (auto& note : notes_at_pitch) {
+            if (note.is_playing(m_time))
+                playing_notes.set(i, note);
         }
-
-        switch (m_envelope[note]) {
-        case Done:
-            continue;
-        case Attack:
-            m_power[note] += m_attack_step;
-            if (m_power[note] >= 1) {
-                m_power[note] = 1;
-                m_envelope[note] = Decay;
-            }
-            break;
-        case Decay:
-            m_power[note] -= m_decay_step;
-            if (m_power[note] < m_sustain_level)
-                m_power[note] = m_sustain_level;
-            break;
-        case Release:
-            m_power[note] -= m_release_step[note];
-            if (m_power[note] <= 0) {
-                m_power[note] = 0;
-                m_envelope[note] = Done;
-                continue;
-            }
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-
-        Audio::Frame note_sample;
-        switch (m_wave) {
-        case Wave::Sine:
-            note_sample = sine(note);
-            break;
-        case Wave::Saw:
-            note_sample = saw(note);
-            break;
-        case Wave::Square:
-            note_sample = square(note);
-            break;
-        case Wave::Triangle:
-            note_sample = triangle(note);
-            break;
-        case Wave::Noise:
-            note_sample = noise(note);
-            break;
-        case Wave::RecordedSample:
-            note_sample = recorded_sample(note);
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-        new_sample.left += note_sample.left * m_power[note] * NumericLimits<i16>::max() * volume_factor * (static_cast<double>(volume()) / volume_max);
-        new_sample.right += note_sample.right * m_power[note] * NumericLimits<i16>::max() * volume_factor * (static_cast<double>(volume()) / volume_max);
+        auto& key_at_pitch = m_keyboard_notes[i];
+        if (key_at_pitch.has_value() && key_at_pitch.value().is_playing(m_time))
+            playing_notes.set(i, key_at_pitch.value());
+        // No need to keep non-playing keyboard notes around.
+        else
+            m_keyboard_notes[i] = {};
     }
 
-    auto new_sample_dsp = LibDSP::Signal(LibDSP::Sample { new_sample.left / NumericLimits<i16>::max(), new_sample.right / NumericLimits<i16>::max() });
-    auto delayed_sample = m_delay->process(new_sample_dsp).get<LibDSP::Sample>();
+    auto synthesized_sample = m_synth->process(playing_notes).get<LibDSP::Sample>();
+    auto delayed_sample = m_delay->process(synthesized_sample).get<LibDSP::Sample>();
 
+    // HACK: Convert to old Piano datastructures
     new_sample.left = delayed_sample.left * NumericLimits<i16>::max();
     new_sample.right = delayed_sample.right * NumericLimits<i16>::max();
 
@@ -112,156 +61,16 @@ void Track::fill_sample(Sample& sample)
 
     sample.left += new_sample.left;
     sample.right += new_sample.right;
+
+    // TODO: Use the master processor
+    sample.left *= m_volume / static_cast<double>(volume_max) * volume_factor;
+    sample.right *= m_volume / static_cast<double>(volume_max) * volume_factor;
 }
 
 void Track::reset()
 {
-
-    memset(m_note_on, 0, sizeof(m_note_on));
-    memset(m_power, 0, sizeof(m_power));
-    memset(m_envelope, 0, sizeof(m_envelope));
-
     for (size_t note = 0; note < note_count; ++note)
         m_roll_iterators[note] = m_roll_notes[note].begin();
-}
-
-String Track::set_recorded_sample(const StringView& path)
-{
-    NonnullRefPtr<Audio::Loader> loader = Audio::Loader::create(path);
-    if (loader->has_error())
-        return String(loader->error_string());
-    auto buffer = loader->get_more_samples(60 * loader->sample_rate()); // 1 minute maximum
-    if (loader->has_error())
-        return String(loader->error_string());
-    // Resample to Piano's internal sample rate
-    auto resampler = Audio::ResampleHelper<double>(loader->sample_rate(), sample_rate);
-    buffer = Audio::resample_buffer(resampler, *buffer);
-
-    if (!m_recorded_sample.is_empty())
-        m_recorded_sample.clear();
-    m_recorded_sample.resize(buffer->sample_count());
-
-    double peak = 0;
-    for (int i = 0; i < buffer->sample_count(); ++i) {
-        double left_abs = fabs(buffer->samples()[i].left);
-        double right_abs = fabs(buffer->samples()[i].right);
-        if (left_abs > peak)
-            peak = left_abs;
-        if (right_abs > peak)
-            peak = right_abs;
-    }
-
-    if (peak) {
-        for (int i = 0; i < buffer->sample_count(); ++i) {
-            m_recorded_sample[i].left = buffer->samples()[i].left / peak;
-            m_recorded_sample[i].right = buffer->samples()[i].right / peak;
-        }
-    }
-
-    return String::empty();
-}
-
-// All of the information for these waves is on Wikipedia.
-
-Audio::Sample Track::sine(size_t note)
-{
-    double pos = note_frequencies[note] / sample_rate;
-    double sin_step = pos * 2 * M_PI;
-    double w = sin(m_pos[note]);
-    m_pos[note] += sin_step;
-    return w;
-}
-
-Audio::Sample Track::saw(size_t note)
-{
-    double saw_step = note_frequencies[note] / sample_rate;
-    double t = m_pos[note];
-    double w = (0.5 - (t - floor(t))) * 2;
-    m_pos[note] += saw_step;
-    return w;
-}
-
-Audio::Sample Track::square(size_t note)
-{
-    double pos = note_frequencies[note] / sample_rate;
-    double square_step = pos * 2 * M_PI;
-    double w = AK::sin(m_pos[note]) >= 0 ? 1 : -1;
-    m_pos[note] += square_step;
-    return w;
-}
-
-Audio::Sample Track::triangle(size_t note)
-{
-    double triangle_step = note_frequencies[note] / sample_rate;
-    double t = m_pos[note];
-    double w = AK::fabs(AK::fmod((4 * t) + 1, 4.) - 2) - 1.;
-    m_pos[note] += triangle_step;
-    return w;
-}
-
-Audio::Sample Track::noise(size_t note)
-{
-    double step = note_frequencies[note] / sample_rate;
-    // m_pos keeps track of the time since the last random sample
-    m_pos[note] += step;
-    if (m_pos[note] > 0.05) {
-        double random_percentage = static_cast<double>(rand()) / RAND_MAX;
-        m_last_w[note] = (random_percentage * 2) - 1;
-        m_pos[note] = 0;
-    }
-    return m_last_w[note];
-}
-
-Audio::Sample Track::recorded_sample(size_t note)
-{
-    int t = m_pos[note];
-    if (t >= static_cast<int>(m_recorded_sample.size()))
-        return 0;
-    double w_left = m_recorded_sample[t].left;
-    double w_right = m_recorded_sample[t].right;
-    if (t + 1 < static_cast<int>(m_recorded_sample.size())) {
-        double t_fraction = m_pos[note] - t;
-        w_left += (m_recorded_sample[t + 1].left - m_recorded_sample[t].left) * t_fraction;
-        w_right += (m_recorded_sample[t + 1].right - m_recorded_sample[t].right) * t_fraction;
-    }
-    double recorded_sample_step = note_frequencies[note] / middle_c;
-    m_pos[note] += recorded_sample_step;
-    return { w_left, w_right };
-}
-
-static inline double calculate_step(double distance, int milliseconds)
-{
-    if (milliseconds == 0)
-        return distance;
-
-    constexpr double samples_per_millisecond = sample_rate / 1000.0;
-    double samples = milliseconds * samples_per_millisecond;
-    double step = distance / samples;
-    return step;
-}
-
-void Track::set_note(int note, Switch switch_note)
-{
-    VERIFY(note >= 0 && note < note_count);
-
-    if (switch_note == On) {
-        if (m_note_on[note] == 0) {
-            m_pos[note] = 0;
-            m_envelope[note] = Attack;
-        }
-        ++m_note_on[note];
-    } else {
-        if (m_note_on[note] >= 1) {
-            if (m_note_on[note] == 1) {
-                m_release_step[note] = calculate_step(m_power[note], m_release);
-                m_envelope[note] = Release;
-            }
-            --m_note_on[note];
-        }
-    }
-
-    VERIFY(m_note_on[note] != NumericLimits<u8>::max());
-    VERIFY(m_power[note] >= 0);
 }
 
 void Track::sync_roll(int note)
@@ -288,15 +97,11 @@ void Track::set_roll_note(int note, u32 on_sample, u32 off_sample)
             return;
         }
         if (it->on_sample <= new_roll_note.on_sample && it->off_sample >= new_roll_note.on_sample) {
-            if (m_time >= it->on_sample && m_time <= it->off_sample)
-                set_note(note, Off);
             it.remove(m_roll_notes[note]);
             sync_roll(note);
             return;
         }
         if ((new_roll_note.on_sample == 0 || it->on_sample >= new_roll_note.on_sample - 1) && it->on_sample <= new_roll_note.off_sample) {
-            if (m_time >= new_roll_note.off_sample && m_time <= it->off_sample)
-                set_note(note, Off);
             it.remove(m_roll_notes[note]);
             it = m_roll_notes[note].begin();
             continue;
@@ -308,58 +113,26 @@ void Track::set_roll_note(int note, u32 on_sample, u32 off_sample)
     sync_roll(note);
 }
 
-void Track::set_wave(int wave)
+void Track::set_keyboard_note(int note, Switch state)
 {
-    VERIFY(wave >= first_wave && wave <= last_wave);
-    m_wave = wave;
-}
-
-void Track::set_wave(Direction direction)
-{
-    if (direction == Up) {
-        if (++m_wave > last_wave)
-            m_wave = first_wave;
-    } else {
-        if (--m_wave < first_wave)
-            m_wave = last_wave;
-    }
+    VERIFY(note >= 0 && note < note_count);
+    if (state == Switch::Off) {
+        // If the note is playing, we need to start releasing it, otherwise just delete
+        if (auto& maybe_roll_note = m_keyboard_notes[note]; maybe_roll_note.has_value()) {
+            auto& roll_note = maybe_roll_note.value();
+            if (roll_note.is_playing(m_time))
+                roll_note.off_sample = m_time;
+            else
+                m_keyboard_notes[note] = {};
+        }
+    } else
+        // FIXME: The end time needs to be far in the future.
+        m_keyboard_notes[note]
+            = RollNote { m_time, m_time + static_cast<u32>(sample_rate) * 10'000, static_cast<u8>(note), 0 };
 }
 
 void Track::set_volume(int volume)
 {
     VERIFY(volume >= 0);
     m_volume = volume;
-}
-
-void Track::set_attack(int attack)
-{
-    VERIFY(attack >= 0);
-    m_attack = attack;
-    m_attack_step = calculate_step(1, m_attack);
-}
-
-void Track::set_decay(int decay)
-{
-    VERIFY(decay >= 0);
-    m_decay = decay;
-    m_decay_step = calculate_step(1 - m_sustain_level, m_decay);
-}
-
-void Track::set_sustain_impl(int sustain)
-{
-    VERIFY(sustain >= 0);
-    m_sustain = sustain;
-    m_sustain_level = sustain / 1000.0;
-}
-
-void Track::set_sustain(int sustain)
-{
-    set_sustain_impl(sustain);
-    set_decay(m_decay);
-}
-
-void Track::set_release(int release)
-{
-    VERIFY(release >= 0);
-    m_release = release;
 }

--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -24,7 +24,7 @@ public:
     explicit Track(const u32& time);
     ~Track();
 
-    const Vector<Audio::Frame>& recorded_sample() const { return m_recorded_sample; }
+    const Vector<Audio::Sample>& recorded_sample() const { return m_recorded_sample; }
     const SinglyLinkedList<RollNote>& roll_notes(int note) const { return m_roll_notes[note]; }
     int wave() const { return m_wave; }
     int volume() const { return m_volume; }
@@ -48,17 +48,17 @@ public:
     void set_release(int release);
 
 private:
-    Audio::Frame sine(size_t note);
-    Audio::Frame saw(size_t note);
-    Audio::Frame square(size_t note);
-    Audio::Frame triangle(size_t note);
-    Audio::Frame noise(size_t note);
-    Audio::Frame recorded_sample(size_t note);
+    Audio::Sample sine(size_t note);
+    Audio::Sample saw(size_t note);
+    Audio::Sample square(size_t note);
+    Audio::Sample triangle(size_t note);
+    Audio::Sample noise(size_t note);
+    Audio::Sample recorded_sample(size_t note);
 
     void sync_roll(int note);
     void set_sustain_impl(int sustain);
 
-    Vector<Audio::Frame> m_recorded_sample;
+    Vector<Audio::Sample> m_recorded_sample;
 
     u8 m_note_on[note_count] { 0 };
     double m_power[note_count] { 0 };

--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -10,10 +10,14 @@
 
 #include "Music.h"
 #include <AK/Noncopyable.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/SinglyLinkedList.h>
 #include <LibAudio/Buffer.h>
 #include <LibDSP/Effects.h>
+#include <LibDSP/Music.h>
+#include <LibDSP/Synthesizers.h>
 
+using LibDSP::RollNote;
 using RollIter = AK::SinglyLinkedListIterator<SinglyLinkedList<RollNote>, RollNote>;
 
 class Track {
@@ -26,63 +30,33 @@ public:
 
     const Vector<Audio::Sample>& recorded_sample() const { return m_recorded_sample; }
     const SinglyLinkedList<RollNote>& roll_notes(int note) const { return m_roll_notes[note]; }
-    int wave() const { return m_wave; }
     int volume() const { return m_volume; }
-    int attack() const { return m_attack; }
-    int decay() const { return m_decay; }
-    int sustain() const { return m_sustain; }
-    int release() const { return m_release; }
+    NonnullRefPtr<LibDSP::Synthesizers::Classic> synth() { return m_synth; }
     NonnullRefPtr<LibDSP::Effects::Delay> delay() { return m_delay; }
 
     void fill_sample(Sample& sample);
     void reset();
     String set_recorded_sample(const StringView& path);
-    void set_note(int note, Switch);
     void set_roll_note(int note, u32 on_sample, u32 off_sample);
-    void set_wave(int wave);
-    void set_wave(Direction);
+    void set_keyboard_note(int note, Switch state);
     void set_volume(int volume);
-    void set_attack(int attack);
-    void set_decay(int decay);
-    void set_sustain(int sustain);
-    void set_release(int release);
 
 private:
-    Audio::Sample sine(size_t note);
-    Audio::Sample saw(size_t note);
-    Audio::Sample square(size_t note);
-    Audio::Sample triangle(size_t note);
-    Audio::Sample noise(size_t note);
     Audio::Sample recorded_sample(size_t note);
 
     void sync_roll(int note);
-    void set_sustain_impl(int sustain);
 
     Vector<Audio::Sample> m_recorded_sample;
 
-    u8 m_note_on[note_count] { 0 };
-    double m_power[note_count] { 0 };
-    double m_pos[note_count]; // Initialized lazily.
-    // Synths may use this to keep track of the last wave position
-    double m_last_w[note_count] { 0 };
-    Envelope m_envelope[note_count] { Done };
-
-    int m_wave { first_wave };
     int m_volume;
-    int m_attack;
-    double m_attack_step;
-    int m_decay;
-    double m_decay_step;
-    int m_sustain;
-    double m_sustain_level;
-    int m_release;
-    double m_release_step[note_count];
 
     const u32& m_time;
 
     NonnullRefPtr<LibDSP::Transport> m_temporary_transport;
     NonnullRefPtr<LibDSP::Effects::Delay> m_delay;
+    NonnullRefPtr<LibDSP::Synthesizers::Classic> m_synth;
 
     SinglyLinkedList<RollNote> m_roll_notes[note_count];
     RollIter m_roll_iterators[note_count];
+    Array<Optional<RollNote>, note_count> m_keyboard_notes;
 };

--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TrackManager.h"
+#include "Applications/Piano/Music.h"
 
 TrackManager::TrackManager()
 {
@@ -61,9 +62,9 @@ void TrackManager::reset()
         track->reset();
 }
 
-void TrackManager::set_note_current_octave(int note, Switch switch_note)
+void TrackManager::set_keyboard_note(int note, Switch note_switch)
 {
-    current_track().set_note(note + octave_base(), switch_note);
+    m_tracks[m_current_track]->set_keyboard_note(note, note_switch);
 }
 
 void TrackManager::set_octave(Direction direction)

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -33,8 +33,8 @@ public:
 
     void fill_buffer(Span<Sample>);
     void reset();
+    void set_keyboard_note(int note, Switch note_switch);
     void set_should_loop(bool b) { m_should_loop = b; }
-    void set_note_current_octave(int note, Switch);
     void set_octave(Direction);
     void set_octave(int octave);
     void add_track();

--- a/Userland/Applications/Piano/WaveWidget.cpp
+++ b/Userland/Applications/Piano/WaveWidget.cpp
@@ -36,8 +36,8 @@ void WaveWidget::paint_event(GUI::PaintEvent& event)
     painter.fill_rect(frame_inner_rect(), Color::Black);
     painter.translate(frame_thickness(), frame_thickness());
 
-    Color left_wave_color = left_wave_colors[m_track_manager.current_track().wave()];
-    Color right_wave_color = right_wave_colors[m_track_manager.current_track().wave()];
+    Color left_wave_color = left_wave_colors[m_track_manager.current_track().synth()->wave()];
+    Color right_wave_color = right_wave_colors[m_track_manager.current_track().synth()->wave()];
     auto buffer = m_track_manager.buffer();
     double width_scale = static_cast<double>(frame_inner_rect().width()) / buffer.size();
 

--- a/Userland/Libraries/LibAudio/Buffer.cpp
+++ b/Userland/Libraries/LibAudio/Buffer.cpp
@@ -45,7 +45,7 @@ i32 Buffer::allocate_id()
 }
 
 template<typename SampleReader>
-static void read_samples_from_stream(InputMemoryStream& stream, SampleReader read_sample, Vector<Frame>& samples, int num_channels)
+static void read_samples_from_stream(InputMemoryStream& stream, SampleReader read_sample, Vector<Sample>& samples, int num_channels)
 {
     double norm_l = 0;
     double norm_r = 0;
@@ -54,7 +54,7 @@ static void read_samples_from_stream(InputMemoryStream& stream, SampleReader rea
     case 1:
         for (;;) {
             norm_l = read_sample(stream);
-            samples.append(Frame(norm_l));
+            samples.append(Sample(norm_l));
 
             if (stream.handle_any_error()) {
                 break;
@@ -65,7 +65,7 @@ static void read_samples_from_stream(InputMemoryStream& stream, SampleReader rea
         for (;;) {
             norm_l = read_sample(stream);
             norm_r = read_sample(stream);
-            samples.append(Frame(norm_l, norm_r));
+            samples.append(Sample(norm_l, norm_r));
 
             if (stream.handle_any_error()) {
                 break;
@@ -130,7 +130,7 @@ RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, int num_channels, PcmSa
 
 RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, int num_channels, PcmSampleFormat sample_format, int num_samples)
 {
-    Vector<Frame> fdata;
+    Vector<Sample> fdata;
     fdata.ensure_capacity(num_samples);
 
     switch (sample_format) {
@@ -189,7 +189,7 @@ template Vector<double> ResampleHelper<double>::resample(Vector<double>);
 
 NonnullRefPtr<Buffer> resample_buffer(ResampleHelper<double>& resampler, Buffer const& to_resample)
 {
-    Vector<Frame> resampled;
+    Vector<Sample> resampled;
     resampled.ensure_capacity(to_resample.sample_count() * ceil_div(resampler.source(), resampler.target()));
     for (size_t i = 0; i < static_cast<size_t>(to_resample.sample_count()); ++i) {
         auto sample = to_resample.samples()[i];

--- a/Userland/Libraries/LibAudio/Buffer.cpp
+++ b/Userland/Libraries/LibAudio/Buffer.cpp
@@ -47,14 +47,14 @@ i32 Buffer::allocate_id()
 template<typename SampleReader>
 static void read_samples_from_stream(InputMemoryStream& stream, SampleReader read_sample, Vector<Sample>& samples, int num_channels)
 {
-    double norm_l = 0;
-    double norm_r = 0;
+    double left_sample = 0;
+    double right_sample = 0;
 
     switch (num_channels) {
     case 1:
         for (;;) {
-            norm_l = read_sample(stream);
-            samples.append(Sample(norm_l));
+            left_sample = read_sample(stream);
+            samples.append(Sample(left_sample));
 
             if (stream.handle_any_error()) {
                 break;
@@ -63,9 +63,9 @@ static void read_samples_from_stream(InputMemoryStream& stream, SampleReader rea
         break;
     case 2:
         for (;;) {
-            norm_l = read_sample(stream);
-            norm_r = read_sample(stream);
-            samples.append(Sample(norm_l, norm_r));
+            left_sample = read_sample(stream);
+            right_sample = read_sample(stream);
+            samples.append(Sample(left_sample, right_sample));
 
             if (stream.handle_any_error()) {
                 break;

--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -90,6 +90,20 @@ struct Frame {
         return new_frame;
     }
 
+    ALWAYS_INLINE Frame& log_pan(double const pan)
+    {
+        left *= log_factor(min(pan * -1 + 1.0, 1.0));
+        right *= log_factor(min(pan + 1.0, 1.0));
+        return *this;
+    }
+
+    ALWAYS_INLINE Frame log_pan(double const pan) const
+    {
+        Frame new_frame { left, right };
+        new_frame.log_pan(pan);
+        return new_frame;
+    }
+
     constexpr Frame& operator*=(double const mult)
     {
         left *= mult;

--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -70,9 +70,14 @@ struct Frame {
     // This is a good dynamic range because it can represent all loudness values from
     // 30 dB(A) (barely hearable with background noise)
     // to 90 dB(A) (almost too loud to hear and about the reasonable limit of actual sound equipment).
+    ALWAYS_INLINE double log_factor(double const change)
+    {
+        return VOLUME_A * exp(VOLUME_B * change);
+    }
+
     ALWAYS_INLINE Frame& log_multiply(double const change)
     {
-        double factor = VOLUME_A * exp(VOLUME_B * change);
+        double factor = log_factor(change);
         left *= factor;
         right *= factor;
         return *this;

--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -8,129 +8,15 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
-#include <AK/Math.h>
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
-#include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibAudio/Frame.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <string.h>
 
 namespace Audio {
 using namespace AK::Exponentials;
-
-// Constants for logarithmic volume. See Frame::operator*
-// Corresponds to 60dB
-constexpr double DYNAMIC_RANGE = 1000;
-constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
-double const VOLUME_B = log(DYNAMIC_RANGE);
-
-// A single sample in an audio buffer.
-// Values are floating point, and should range from -1.0 to +1.0
-struct Frame {
-    constexpr Frame()
-        : left(0)
-        , right(0)
-    {
-    }
-
-    // For mono
-    constexpr Frame(double left)
-        : left(left)
-        , right(left)
-    {
-    }
-
-    // For stereo
-    constexpr Frame(double left, double right)
-        : left(left)
-        , right(right)
-    {
-    }
-
-    void clip()
-    {
-        if (left > 1)
-            left = 1;
-        else if (left < -1)
-            left = -1;
-
-        if (right > 1)
-            right = 1;
-        else if (right < -1)
-            right = -1;
-    }
-
-    // Logarithmic scaling, as audio should ALWAYS do.
-    // Reference: https://www.dr-lex.be/info-stuff/volumecontrols.html
-    // We use the curve `factor = a * exp(b * change)`,
-    // where change is the input fraction we want to change by,
-    // a = 1/1000, b = ln(1000) = 6.908 and factor is the multiplier used.
-    // The value 1000 represents the dynamic range in sound pressure, which corresponds to 60 dB(A).
-    // This is a good dynamic range because it can represent all loudness values from
-    // 30 dB(A) (barely hearable with background noise)
-    // to 90 dB(A) (almost too loud to hear and about the reasonable limit of actual sound equipment).
-    ALWAYS_INLINE double log_factor(double const change)
-    {
-        return VOLUME_A * exp(VOLUME_B * change);
-    }
-
-    ALWAYS_INLINE Frame& log_multiply(double const change)
-    {
-        double factor = log_factor(change);
-        left *= factor;
-        right *= factor;
-        return *this;
-    }
-
-    ALWAYS_INLINE Frame log_multiplied(double const volume_change) const
-    {
-        Frame new_frame { left, right };
-        new_frame.log_multiply(volume_change);
-        return new_frame;
-    }
-
-    ALWAYS_INLINE Frame& log_pan(double const pan)
-    {
-        left *= log_factor(min(pan * -1 + 1.0, 1.0));
-        right *= log_factor(min(pan + 1.0, 1.0));
-        return *this;
-    }
-
-    ALWAYS_INLINE Frame log_pan(double const pan) const
-    {
-        Frame new_frame { left, right };
-        new_frame.log_pan(pan);
-        return new_frame;
-    }
-
-    constexpr Frame& operator*=(double const mult)
-    {
-        left *= mult;
-        right *= mult;
-        return *this;
-    }
-
-    constexpr Frame operator*(double const mult)
-    {
-        return { left * mult, right * mult };
-    }
-
-    constexpr Frame& operator+=(Frame const& other)
-    {
-        left += other.left;
-        right += other.right;
-        return *this;
-    }
-
-    constexpr Frame operator+(Frame const& other)
-    {
-        return { left + other.left, right + other.right };
-    }
-
-    double left;
-    double right;
-};
 
 // Supported PCM sample formats.
 enum PcmSampleFormat : u8 {

--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -11,7 +11,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibAudio/Frame.h>
+#include <LibAudio/Sample.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <string.h>
 
@@ -68,7 +68,7 @@ class Buffer : public RefCounted<Buffer> {
 public:
     static RefPtr<Buffer> from_pcm_data(ReadonlyBytes data, int num_channels, PcmSampleFormat sample_format);
     static RefPtr<Buffer> from_pcm_stream(InputMemoryStream& stream, int num_channels, PcmSampleFormat sample_format, int num_samples);
-    static NonnullRefPtr<Buffer> create_with_samples(Vector<Frame>&& samples)
+    static NonnullRefPtr<Buffer> create_with_samples(Vector<Sample>&& samples)
     {
         return adopt_ref(*new Buffer(move(samples)));
     }
@@ -77,20 +77,20 @@ public:
         return adopt_ref(*new Buffer(move(buffer), buffer_id, sample_count));
     }
 
-    const Frame* samples() const { return (const Frame*)data(); }
+    const Sample* samples() const { return (const Sample*)data(); }
     int sample_count() const { return m_sample_count; }
     const void* data() const { return m_buffer.data<void>(); }
-    int size_in_bytes() const { return m_sample_count * (int)sizeof(Frame); }
+    int size_in_bytes() const { return m_sample_count * (int)sizeof(Sample); }
     int id() const { return m_id; }
     const Core::AnonymousBuffer& anonymous_buffer() const { return m_buffer; }
 
 private:
-    explicit Buffer(const Vector<Frame> samples)
-        : m_buffer(Core::AnonymousBuffer::create_with_size(samples.size() * sizeof(Frame)))
+    explicit Buffer(const Vector<Sample> samples)
+        : m_buffer(Core::AnonymousBuffer::create_with_size(samples.size() * sizeof(Sample)))
         , m_id(allocate_id())
         , m_sample_count(samples.size())
     {
-        memcpy(m_buffer.data<void>(), samples.data(), samples.size() * sizeof(Frame));
+        memcpy(m_buffer.data<void>(), samples.data(), samples.size() * sizeof(Sample));
     }
 
     explicit Buffer(Core::AnonymousBuffer buffer, i32 buffer_id, int sample_count)

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -231,7 +231,7 @@ void FlacLoaderPlugin::seek(const int position)
 
 RefPtr<Buffer> FlacLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_input)
 {
-    Vector<Frame> samples;
+    Vector<Sample> samples;
     ssize_t remaining_samples = m_total_samples - m_loaded_samples;
     if (remaining_samples <= 0) {
         return nullptr;
@@ -417,7 +417,7 @@ void FlacLoaderPlugin::next_frame()
     m_current_frame_data.ensure_capacity(left.size());
     // zip together channels
     for (size_t i = 0; i < left.size(); ++i) {
-        Frame frame = { left[i] / sample_rescale, right[i] / sample_rescale };
+        Sample frame = { left[i] / sample_rescale, right[i] / sample_rescale };
         m_current_frame_data.unchecked_append(frame);
     }
 

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -143,7 +143,7 @@ private:
     u64 m_data_start_location { 0 };
     OwnPtr<FlacInputStream> m_stream;
     Optional<FlacFrameHeader> m_current_frame;
-    Vector<Frame> m_current_frame_data;
+    Vector<Sample> m_current_frame_data;
     u64 m_current_sample_or_frame { 0 };
 };
 

--- a/Userland/Libraries/LibAudio/Frame.h
+++ b/Userland/Libraries/LibAudio/Frame.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+
+namespace Audio {
+using namespace AK::Exponentials;
+
+// Constants for logarithmic volume. See Frame::operator*
+// Corresponds to 60dB
+constexpr double DYNAMIC_RANGE = 1000;
+constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
+double const VOLUME_B = log(DYNAMIC_RANGE);
+
+// A single sample in an audio buffer.
+// Values are floating point, and should range from -1.0 to +1.0
+struct Frame {
+    constexpr Frame()
+        : left(0)
+        , right(0)
+    {
+    }
+
+    // For mono
+    constexpr Frame(double left)
+        : left(left)
+        , right(left)
+    {
+    }
+
+    // For stereo
+    constexpr Frame(double left, double right)
+        : left(left)
+        , right(right)
+    {
+    }
+
+    void clip()
+    {
+        if (left > 1)
+            left = 1;
+        else if (left < -1)
+            left = -1;
+
+        if (right > 1)
+            right = 1;
+        else if (right < -1)
+            right = -1;
+    }
+
+    // Logarithmic scaling, as audio should ALWAYS do.
+    // Reference: https://www.dr-lex.be/info-stuff/volumecontrols.html
+    // We use the curve `factor = a * exp(b * change)`,
+    // where change is the input fraction we want to change by,
+    // a = 1/1000, b = ln(1000) = 6.908 and factor is the multiplier used.
+    // The value 1000 represents the dynamic range in sound pressure, which corresponds to 60 dB(A).
+    // This is a good dynamic range because it can represent all loudness values from
+    // 30 dB(A) (barely hearable with background noise)
+    // to 90 dB(A) (almost too loud to hear and about the reasonable limit of actual sound equipment).
+    ALWAYS_INLINE double log_factor(double const change)
+    {
+        return VOLUME_A * exp(VOLUME_B * change);
+    }
+
+    ALWAYS_INLINE Frame& log_multiply(double const change)
+    {
+        double factor = log_factor(change);
+        left *= factor;
+        right *= factor;
+        return *this;
+    }
+
+    ALWAYS_INLINE Frame log_multiplied(double const volume_change) const
+    {
+        Frame new_frame { left, right };
+        new_frame.log_multiply(volume_change);
+        return new_frame;
+    }
+
+    ALWAYS_INLINE Frame& log_pan(double const pan)
+    {
+        left *= log_factor(min(pan * -1 + 1.0, 1.0));
+        right *= log_factor(min(pan + 1.0, 1.0));
+        return *this;
+    }
+
+    ALWAYS_INLINE Frame log_pan(double const pan) const
+    {
+        Frame new_frame { left, right };
+        new_frame.log_pan(pan);
+        return new_frame;
+    }
+
+    constexpr Frame& operator*=(double const mult)
+    {
+        left *= mult;
+        right *= mult;
+        return *this;
+    }
+
+    constexpr Frame operator*(double const mult)
+    {
+        return { left * mult, right * mult };
+    }
+
+    constexpr Frame& operator+=(Frame const& other)
+    {
+        left += other.left;
+        right += other.right;
+        return *this;
+    }
+    constexpr Frame& operator+=(double other)
+    {
+        left += other;
+        right += other;
+        return *this;
+    }
+
+    constexpr Frame operator+(Frame const& other)
+    {
+        return { left + other.left, right + other.right };
+    }
+
+    double left;
+    double right;
+};
+
+}

--- a/Userland/Libraries/LibAudio/Frame.h
+++ b/Userland/Libraries/LibAudio/Frame.h
@@ -21,11 +21,7 @@ double const VOLUME_B = log(DYNAMIC_RANGE);
 // A single sample in an audio buffer.
 // Values are floating point, and should range from -1.0 to +1.0
 struct Frame {
-    constexpr Frame()
-        : left(0)
-        , right(0)
-    {
-    }
+    constexpr Frame() = default;
 
     // For mono
     constexpr Frame(double left)
@@ -127,8 +123,8 @@ struct Frame {
         return { left + other.left, right + other.right };
     }
 
-    double left;
-    double right;
+    double left { 0 };
+    double right { 0 };
 };
 
 }

--- a/Userland/Libraries/LibAudio/Frame.h
+++ b/Userland/Libraries/LibAudio/Frame.h
@@ -15,6 +15,7 @@ using namespace AK::Exponentials;
 // Constants for logarithmic volume. See Frame::linear_to_log
 // Corresponds to 60dB
 constexpr double DYNAMIC_RANGE = 1000;
+constexpr double DYNAMIC_RANGE_DB = 60;
 constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
 double const VOLUME_B = log(DYNAMIC_RANGE);
 
@@ -63,6 +64,7 @@ struct Frame {
     // Format ranges:
     // - Linear:        0.0 to 1.0
     // - Logarithmic:   0.0 to 1.0
+    // - dB:          -60.0 to 0.0
 
     ALWAYS_INLINE double linear_to_log(double const change)
     {
@@ -74,6 +76,16 @@ struct Frame {
     {
         // TODO: Add linear slope around 0
         return log(val / VOLUME_A) / VOLUME_B;
+    }
+
+    ALWAYS_INLINE double db_to_linear(double const dB)
+    {
+        return (dB + DYNAMIC_RANGE_DB) / DYNAMIC_RANGE_DB;
+    }
+
+    ALWAYS_INLINE double linear_to_db(double const val)
+    {
+        return val * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
     }
 
     ALWAYS_INLINE Frame& log_multiply(double const change)

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -12,7 +12,7 @@
 
 namespace Audio {
 using namespace AK::Exponentials;
-// Constants for logarithmic volume. See Frame::linear_to_log
+// Constants for logarithmic volume. See Sample::linear_to_log
 // Corresponds to 60dB
 constexpr double DYNAMIC_RANGE = 1000;
 constexpr double DYNAMIC_RANGE_DB = 60;
@@ -21,18 +21,18 @@ double const VOLUME_B = log(DYNAMIC_RANGE);
 
 // A single sample in an audio buffer.
 // Values are floating point, and should range from -1.0 to +1.0
-struct Frame {
-    constexpr Frame() = default;
+struct Sample {
+    constexpr Sample() = default;
 
     // For mono
-    constexpr Frame(double left)
+    constexpr Sample(double left)
         : left(left)
         , right(left)
     {
     }
 
     // For stereo
-    constexpr Frame(double left, double right)
+    constexpr Sample(double left, double right)
         : left(left)
         , right(right)
     {
@@ -88,7 +88,7 @@ struct Frame {
         return val * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
     }
 
-    ALWAYS_INLINE Frame& log_multiply(double const change)
+    ALWAYS_INLINE Sample& log_multiply(double const change)
     {
         double factor = linear_to_log(change);
         left *= factor;
@@ -96,53 +96,53 @@ struct Frame {
         return *this;
     }
 
-    ALWAYS_INLINE Frame log_multiplied(double const volume_change) const
+    ALWAYS_INLINE Sample log_multiplied(double const volume_change) const
     {
-        Frame new_frame { left, right };
+        Sample new_frame { left, right };
         new_frame.log_multiply(volume_change);
         return new_frame;
     }
 
-    ALWAYS_INLINE Frame& log_pan(double const pan)
+    ALWAYS_INLINE Sample& log_pan(double const pan)
     {
         left *= linear_to_log(min(pan * -1 + 1.0, 1.0));
         right *= linear_to_log(min(pan + 1.0, 1.0));
         return *this;
     }
 
-    ALWAYS_INLINE Frame log_pan(double const pan) const
+    ALWAYS_INLINE Sample log_pan(double const pan) const
     {
-        Frame new_frame { left, right };
+        Sample new_frame { left, right };
         new_frame.log_pan(pan);
         return new_frame;
     }
 
-    constexpr Frame& operator*=(double const mult)
+    constexpr Sample& operator*=(double const mult)
     {
         left *= mult;
         right *= mult;
         return *this;
     }
 
-    constexpr Frame operator*(double const mult)
+    constexpr Sample operator*(double const mult)
     {
         return { left * mult, right * mult };
     }
 
-    constexpr Frame& operator+=(Frame const& other)
+    constexpr Sample& operator+=(Sample const& other)
     {
         left += other.left;
         right += other.right;
         return *this;
     }
-    constexpr Frame& operator+=(double other)
+    constexpr Sample& operator+=(double other)
     {
         left += other;
         right += other;
         return *this;
     }
 
-    constexpr Frame operator+(Frame const& other)
+    constexpr Sample operator+(Sample const& other)
     {
         return { left + other.left, right + other.right };
     }

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -103,18 +103,22 @@ struct Sample {
         return new_frame;
     }
 
-    ALWAYS_INLINE Sample& log_pan(double const pan)
+    // Constant power panning
+    ALWAYS_INLINE Sample& pan(double const position)
     {
-        left *= linear_to_log(min(pan * -1 + 1.0, 1.0));
-        right *= linear_to_log(min(pan + 1.0, 1.0));
+        double const pi_over_2 = AK::Pi<double> * 0.5;
+        double const root_over_2 = AK::sqrt(2.0) * 0.5;
+        double const angle = position * pi_over_2 * 0.5;
+        left *= root_over_2 * (AK::cos(angle) - AK::sin(angle));
+        right *= root_over_2 * (AK::cos(angle) + AK::sin(angle));
         return *this;
     }
 
-    ALWAYS_INLINE Sample log_pan(double const pan) const
+    ALWAYS_INLINE Sample panned(double const position) const
     {
-        Sample new_frame { left, right };
-        new_frame.log_pan(pan);
-        return new_frame;
+        Sample new_sample { left, right };
+        new_sample.pan(position);
+        return new_sample;
     }
 
     constexpr Sample& operator*=(double const mult)

--- a/Userland/Libraries/LibDSP/CMakeLists.txt
+++ b/Userland/Libraries/LibDSP/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     Clip.cpp
     Track.cpp
     Effects.cpp
+    Synthesizers.cpp
 )
 
 serenity_lib(LibDSP dsp)

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -53,12 +53,27 @@ Signal Delay::process_impl(Signal const& input_signal)
 
 Mastering::Mastering(NonnullRefPtr<Transport> transport)
     : EffectProcessor(move(transport))
+    , m_master_volume("Master"sv, 0, 1, 1)
+    , m_pan("Pan"sv, -1, 1, 0)
+    , m_mute("Mute"sv, false)
 {
+    m_parameters.append(m_master_volume);
+    m_parameters.append(m_pan);
+    m_parameters.append(m_mute);
 }
 
-Signal Mastering::process_impl([[maybe_unused]] Signal const& input_signal)
+Signal Mastering::process_impl(Signal const& input_signal)
 {
-    TODO();
+    Sample const& in = input_signal.get<Sample>();
+    Sample out;
+
+    if (m_mute.value()) {
+        return Signal(out);
+    }
+
+    out += in.log_pan(static_cast<double>(m_pan));
+    out += in.log_multiplied(static_cast<double>(m_master_volume));
+    return Signal(out);
 }
 
 }

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -71,7 +71,7 @@ Signal Mastering::process_impl(Signal const& input_signal)
         return Signal(out);
     }
 
-    out += in.log_pan(static_cast<double>(m_pan));
+    out += in.panned(static_cast<double>(m_pan));
     out += in.log_multiplied(static_cast<double>(m_master_volume));
     return Signal(out);
 }

--- a/Userland/Libraries/LibDSP/Effects.h
+++ b/Userland/Libraries/LibDSP/Effects.h
@@ -39,6 +39,10 @@ public:
 
 private:
     virtual Signal process_impl(Signal const&) override;
+
+    ProcessorRangeParameter m_master_volume;
+    ProcessorRangeParameter m_pan;
+    ProcessorBooleanParameter m_mute;
 };
 
 }

--- a/Userland/Libraries/LibDSP/Envelope.h
+++ b/Userland/Libraries/LibDSP/Envelope.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+
+namespace LibDSP {
+
+enum class EnvelopeState : u8 {
+    Off,
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+};
+
+struct Envelope {
+    constexpr Envelope() = default;
+    constexpr Envelope(double envelope)
+        : envelope(envelope)
+    {
+    }
+
+    constexpr bool is_attack() const { return 0 <= envelope && envelope < 1; }
+    constexpr double attack() const { return clamp(envelope, 0, 1); }
+    constexpr void set_attack(double offset) { envelope = offset; }
+    static constexpr Envelope from_attack(double attack) { return Envelope(attack); }
+
+    constexpr bool is_decay() const { return 1 <= envelope && envelope < 2; }
+    constexpr double decay() const { return clamp(envelope, 1, 2) - 1; }
+    constexpr void set_decay(double offset) { envelope = 1 + offset; }
+    static constexpr Envelope from_decay(double decay) { return Envelope(decay + 1); }
+
+    constexpr bool is_sustain() const { return 2 <= envelope && envelope < 3; }
+    constexpr double sustain() const { return clamp(envelope, 2, 3) - 2; }
+    constexpr void set_sustain(double offset) { envelope = 2 + offset; }
+    static constexpr Envelope from_sustain(double decay) { return Envelope(decay + 2); }
+
+    constexpr bool is_release() const { return 3 <= envelope && envelope < 4; }
+    constexpr double release() const { return clamp(envelope, 3, 4) - 3; }
+    constexpr void set_release(double offset) { envelope = 3 + offset; }
+    static constexpr Envelope from_release(double decay) { return Envelope(decay + 3); }
+
+    constexpr bool is_active() const { return 0 <= envelope && envelope < 4; }
+
+    constexpr void reset() { envelope = -1; }
+
+    constexpr operator EnvelopeState()
+    {
+        if (!is_active())
+            return EnvelopeState::Off;
+        if (is_attack())
+            return EnvelopeState::Attack;
+        if (is_decay())
+            return EnvelopeState::Decay;
+        if (is_sustain())
+            return EnvelopeState::Sustain;
+        if (is_release())
+            return EnvelopeState::Release;
+        VERIFY_NOT_REACHED();
+    }
+
+    double envelope { -1 };
+};
+
+}

--- a/Userland/Libraries/LibDSP/Envelope.h
+++ b/Userland/Libraries/LibDSP/Envelope.h
@@ -10,7 +10,8 @@
 
 namespace LibDSP {
 
-enum class EnvelopeState : u8 {
+// For now, this cannot be optimal as clang doesn't know underlying type specifications.
+enum EnvelopeState {
     Off,
     Attack,
     Decay,

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -19,7 +19,7 @@ using Sample = Audio::Sample;
 Sample const SAMPLE_OFF = { 0.0, 0.0 };
 
 struct RollNote {
-    u32 length() const { return (off_sample - on_sample) + 1; }
+    constexpr u32 length() const { return (off_sample - on_sample) + 1; }
 
     u32 on_sample;
     u32 off_sample;

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -14,7 +14,7 @@
 namespace LibDSP {
 
 // FIXME: Audio::Frame is 64-bit float, which is quite large for long clips.
-using Sample = Audio::Frame;
+using Sample = Audio::Sample;
 
 Sample const SAMPLE_OFF = { 0.0, 0.0 };
 

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/Types.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
@@ -33,12 +34,14 @@ enum class SignalType : u8 {
     Note
 };
 
-struct Signal : public Variant<Sample, Vector<RollNote>> {
+using RollNotes = OrderedHashMap<u8, RollNote>;
+
+struct Signal : public Variant<Sample, RollNotes> {
     using Variant::Variant;
     ALWAYS_INLINE SignalType type() const
     {
-        return has<Sample>() ? SignalType::Sample : has<Vector<RollNote>>() ? SignalType::Note
-                                                                            : SignalType::Invalid;
+        return has<Sample>() ? SignalType::Sample : has<RollNotes>() ? SignalType::Note
+                                                                     : SignalType::Invalid;
     }
 };
 

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -6,13 +6,12 @@
 
 #pragma once
 
-#include "AK/Forward.h"
-#include "LibGUI/Label.h"
-#include "Music.h"
 #include <AK/FixedPoint.h>
 #include <AK/Format.h>
+#include <AK/Forward.h>
 #include <AK/Types.h>
 #include <LibCore/Object.h>
+#include <LibDSP/Music.h>
 
 namespace LibDSP {
 

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -63,6 +63,7 @@ Signal Classic::process_impl(Signal const& input_signal)
     return out;
 }
 
+// Linear ADSR envelope with no peak adjustment.
 double Classic::volume_from_envelope(Envelope envelope)
 {
     switch (static_cast<EnvelopeState>(envelope)) {
@@ -71,10 +72,12 @@ double Classic::volume_from_envelope(Envelope envelope)
     case EnvelopeState::Attack:
         return envelope.attack();
     case EnvelopeState::Decay:
-        return (1. - envelope.decay()) * m_sustain + m_sustain;
+        // As we fade from high (1) to low (headroom above the sustain level) here, use 1-decay as the interpolation.
+        return (1. - envelope.decay()) * (1. - m_sustain) + m_sustain;
     case EnvelopeState::Sustain:
         return m_sustain;
     case EnvelopeState::Release:
+        // Same goes for the release fade from high to low.
         return (1. - envelope.release()) * m_sustain;
     }
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/HashMap.h>
+#include <AK/Math.h>
+#include <AK/Random.h>
+#include <LibDSP/Envelope.h>
+#include <LibDSP/Processor.h>
+#include <LibDSP/Synthesizers.h>
+#include <math.h>
+
+namespace LibDSP::Synthesizers {
+
+Classic::Classic(NonnullRefPtr<Transport> transport)
+    : LibDSP::SynthesizerProcessor(transport)
+    , m_waveform("Waveform"sv, Waveform::Saw)
+    , m_attack("Attack"sv, 0, 2000, 5)
+    , m_decay("Decay"sv, 0, 20'000, 80)
+    , m_sustain("Sustain"sv, 0, 1, 0.725)
+    , m_release("Release", 0, 6'000, 120)
+{
+    m_parameters.append(m_waveform);
+    m_parameters.append(m_attack);
+    m_parameters.append(m_decay);
+    m_parameters.append(m_sustain);
+    m_parameters.append(m_release);
+}
+
+Signal Classic::process_impl(Signal const& input_signal)
+{
+    auto& in = input_signal.get<RollNotes>();
+
+    Sample out;
+
+    SinglyLinkedList<PitchedEnvelope> playing_envelopes;
+
+    // "Press" the necessary notes in the internal representation,
+    // and "release" all of the others
+    for (u8 i = 0; i < note_count; ++i) {
+        if (auto maybe_note = in.get(i); maybe_note.has_value())
+            m_playing_notes.set(i, maybe_note.value());
+
+        if (m_playing_notes.contains(i)) {
+            Envelope note_envelope = m_playing_notes.get(i)->to_envelope(m_transport->time(), m_attack * m_transport->ms_sample_rate(), m_decay * m_transport->ms_sample_rate(), m_release * m_transport->ms_sample_rate());
+            if (!note_envelope.is_active()) {
+                m_playing_notes.remove(i);
+                continue;
+            }
+
+            playing_envelopes.append(PitchedEnvelope { note_envelope, i });
+        }
+    }
+
+    for (auto envelope : playing_envelopes) {
+        double volume = volume_from_envelope(envelope);
+        double wave = wave_position(envelope.note);
+        out += volume * wave;
+    }
+
+    return out;
+}
+
+double Classic::volume_from_envelope(Envelope envelope)
+{
+    switch (static_cast<EnvelopeState>(envelope)) {
+    case EnvelopeState::Off:
+        return 0;
+    case EnvelopeState::Attack:
+        return envelope.attack();
+    case EnvelopeState::Decay:
+        return (1. - envelope.decay()) * m_sustain + m_sustain;
+    case EnvelopeState::Sustain:
+        return m_sustain;
+    case EnvelopeState::Release:
+        return (1. - envelope.release()) * m_sustain;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+double Classic::wave_position(u8 note)
+{
+    switch (m_waveform) {
+    case Sine:
+        return sin_position(note);
+    case Triangle:
+        return triangle_position(note);
+    case Square:
+        return square_position(note);
+    case Saw:
+        return saw_position(note);
+    case Noise:
+        return noise_position(note);
+    }
+    VERIFY_NOT_REACHED();
+}
+
+double Classic::samples_per_cycle(u8 note)
+{
+    return m_transport->sample_rate() / note_frequencies[note];
+}
+
+double Classic::sin_position(u8 note)
+{
+    double spc = samples_per_cycle(note);
+    double cycle_pos = m_transport->time() / spc;
+    return AK::sin(cycle_pos * 2 * AK::Pi<double>);
+}
+
+// Absolute value of the saw wave "flips" the negative portion into the positive, creating a ramp up and down.
+double Classic::triangle_position(u8 note)
+{
+    double saw = saw_position(note);
+    return AK::fabs(saw) * 2 - 1;
+}
+
+// The first half of the cycle period is 1, the other half -1.
+double Classic::square_position(u8 note)
+{
+    double spc = samples_per_cycle(note);
+    double progress = AK::fmod(static_cast<double>(m_transport->time()), spc) / spc;
+    return progress >= 0.5 ? -1 : 1;
+}
+
+// Modulus creates inverse saw, which we need to flip and scale.
+double Classic::saw_position(u8 note)
+{
+    double spc = samples_per_cycle(note);
+    double unscaled = spc - AK::fmod(static_cast<double>(m_transport->time()), spc);
+    return unscaled / (samples_per_cycle(note) / 2.) - 1;
+}
+
+// We resample the noise twenty times per cycle.
+double Classic::noise_position(u8 note)
+{
+    double spc = samples_per_cycle(note);
+    u32 getrandom_interval = max(static_cast<u32>(spc / 2), 1);
+    // Note that this code only works well if the processor is called for every increment of time.
+    if (m_transport->time() % getrandom_interval == 0)
+        last_random[note] = (get_random<u16>() / static_cast<double>(NumericLimits<u16>::max()) - .5) * 2;
+    return last_random[note];
+}
+
+}

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "LibDSP/Music.h"
+#include <AK/SinglyLinkedList.h>
+#include <LibDSP/Processor.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibDSP/Transport.h>
+
+namespace LibDSP::Synthesizers {
+
+enum Waveform : u8 {
+    Sine,
+    Triangle,
+    Square,
+    Saw,
+    Noise,
+};
+
+struct PitchedEnvelope : Envelope {
+    constexpr PitchedEnvelope() = default;
+    constexpr PitchedEnvelope(double envelope, u8 note)
+        : Envelope(envelope)
+        , note(note)
+    {
+    }
+    constexpr PitchedEnvelope(Envelope envelope, u8 note)
+        : Envelope(envelope)
+        , note(note)
+    {
+    }
+
+    u8 note;
+};
+
+class Classic : public SynthesizerProcessor {
+public:
+    Classic(NonnullRefPtr<Transport>);
+
+    static Envelope compute_envelope(RollNote&);
+
+    Waveform wave() const { return m_waveform.value(); }
+
+private:
+    virtual Signal process_impl(Signal const&) override;
+
+    double volume_from_envelope(Envelope);
+    double wave_position(u8 note);
+    double samples_per_cycle(u8 note);
+    double sin_position(u8 note);
+    double triangle_position(u8 note);
+    double square_position(u8 note);
+    double saw_position(u8 note);
+    double noise_position(u8 note);
+    double get_random_from_seed(u64 note);
+
+    ProcessorEnumParameter<Waveform> m_waveform;
+    ProcessorRangeParameter m_attack;
+    ProcessorRangeParameter m_decay;
+    ProcessorRangeParameter m_sustain;
+    ProcessorRangeParameter m_release;
+
+    RollNotes m_playing_notes;
+    Array<double, note_count> last_random;
+};
+
+}

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -19,6 +19,7 @@ class Track : public Core::Object {
 public:
     Track(NonnullRefPtr<Transport> transport)
         : m_transport(move(transport))
+        , m_current_signal(Sample {})
     {
     }
     virtual ~Track() override = default;
@@ -36,10 +37,12 @@ protected:
     bool check_processor_chain_valid_with_initial_type(SignalType initial_type) const;
 
     // Subclasses override to provide the base signal to the processing chain
-    virtual Signal current_clips_signal() = 0;
+    virtual void compute_current_clips_signal() = 0;
 
     NonnullRefPtrVector<Processor> m_processor_chain;
-    NonnullRefPtr<Transport> const m_transport;
+    NonnullRefPtr<Transport> m_transport;
+    // The current signal is stored here, to prevent unnecessary reallocation.
+    Signal m_current_signal;
 };
 
 class NoteTrack final : public Track {
@@ -50,7 +53,7 @@ public:
     NonnullRefPtrVector<NoteClip> const& clips() const { return m_clips; }
 
 protected:
-    virtual Signal current_clips_signal() override;
+    virtual void compute_current_clips_signal() override;
 
 private:
     NonnullRefPtrVector<NoteClip> m_clips;
@@ -64,7 +67,7 @@ public:
     NonnullRefPtrVector<AudioClip> const& clips() const { return m_clips; }
 
 protected:
-    virtual Signal current_clips_signal() override;
+    virtual void compute_current_clips_signal() override;
 
 private:
     NonnullRefPtrVector<AudioClip> m_clips;

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -27,14 +27,17 @@ public:
     {
     }
 
-    u32 const& time() const { return m_time; }
-    u16 beats_per_minute() const { return m_beats_per_minute; }
-    double current_second() const { return m_time / m_sample_rate; }
-    double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }
-    double sample_rate() const { return m_sample_rate; }
-    double current_measure() const { return m_time / samples_per_measure(); }
+    constexpr u32& time() { return m_time; }
+    constexpr u16 beats_per_minute() const { return m_beats_per_minute; }
+    constexpr double current_second() const { return static_cast<double>(m_time) / m_sample_rate; }
+    constexpr double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }
+    constexpr double sample_rate() const { return m_sample_rate; }
+    constexpr double ms_sample_rate() const { return m_sample_rate / 1000.; }
+    constexpr double current_measure() const { return m_time / samples_per_measure(); }
 
 private:
+    // FIXME: You can't make more than 24h of (48kHz) music with this.
+    // But do you want to, really? :^)
     u32 m_time { 0 };
     u16 const m_beats_per_minute { 0 };
     u8 const m_beats_per_measure { 0 };

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -77,8 +77,8 @@ void Mixer::mix()
 
         active_mix_queues.remove_all_matching([&](auto& entry) { return !entry->client(); });
 
-        Audio::Frame mixed_buffer[1024];
-        auto mixed_buffer_length = (int)(sizeof(mixed_buffer) / sizeof(Audio::Frame));
+        Audio::Sample mixed_buffer[1024];
+        auto mixed_buffer_length = (int)(sizeof(mixed_buffer) / sizeof(Audio::Sample));
 
         m_main_volume.advance_time();
 
@@ -94,7 +94,7 @@ void Mixer::mix()
 
             for (int i = 0; i < mixed_buffer_length; ++i) {
                 auto& mixed_sample = mixed_buffer[i];
-                Audio::Frame sample;
+                Audio::Sample sample;
                 if (!queue->get_next_sample(sample))
                     break;
                 sample.log_multiply(SAMPLE_HEADROOM);

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -40,7 +40,7 @@ public:
     bool is_full() const { return m_queue.size() >= 3; }
     void enqueue(NonnullRefPtr<Audio::Buffer>&&);
 
-    bool get_next_sample(Audio::Frame& sample)
+    bool get_next_sample(Audio::Sample& sample)
     {
         if (m_paused)
             return false;


### PR DESCRIPTION
Road to #6528 step 3. Piano is now free of DSP code except for sequencing, which will be refactored in the next step.

- [x] Master processor (@Granddave )
- [x] "Classic" synth processor that replicates Piano's old synth engine
- [x] Make both processors work with Piano (master postponed)
- [x] UI integration

Auxiliary changes:
* Several volume type conversion functions in LibAudio along with a move of Frame into its own file (@Granddave )
* clear_with_capacity in Hash{Table, Map} (@Hendiadyoin1 )
* ProcessorEnumParameter (LibDSP) for discrete enum-based parameters. Used for the Classic synth waveform.
* ProcessorEnumWidget (Piano) for controlling ProcessorEnumParameter

Known issues:
* Note data doesn't carry over when the loop repeats
* Multiple synths (one for each track) are broken for now

Note that the sampler is removed for the time being, it will be re-added as its own processor once we have the opportunity to (at least programmatically) swap out processors.

Thanks to @Granddave and @Hendiadyoin1 for their work.