### PR TITLE
LibC+AK: Various improvements to wchar_t, mbrtowc, and related functions

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -688,6 +688,19 @@ void Formatter<char>::format(FormatBuilder& builder, char value)
         return formatter.format(builder, { &value, 1 });
     }
 }
+void Formatter<wchar_t>::format(FormatBuilder& builder, wchar_t value)
+{
+    if (m_mode == Mode::Binary || m_mode == Mode::BinaryUppercase || m_mode == Mode::Decimal || m_mode == Mode::Octal || m_mode == Mode::Hexadecimal || m_mode == Mode::HexadecimalUppercase) {
+        Formatter<u32> formatter { *this };
+        return formatter.format(builder, static_cast<u32>(value));
+    } else {
+        StringBuilder codepoint;
+        codepoint.append_code_point(value);
+
+        Formatter<StringView> formatter { *this };
+        return formatter.format(builder, codepoint.to_string());
+    }
+}
 void Formatter<bool>::format(FormatBuilder& builder, bool value)
 {
     if (m_mode == Mode::Binary || m_mode == Mode::BinaryUppercase || m_mode == Mode::Decimal || m_mode == Mode::Octal || m_mode == Mode::Hexadecimal || m_mode == Mode::HexadecimalUppercase) {

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -423,6 +423,10 @@ struct Formatter<char> : StandardFormatter {
     void format(FormatBuilder&, char value);
 };
 template<>
+struct Formatter<wchar_t> : StandardFormatter {
+    void format(FormatBuilder& builder, wchar_t value);
+};
+template<>
 struct Formatter<bool> : StandardFormatter {
     void format(FormatBuilder&, bool value);
 };

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -323,3 +323,17 @@ TEST_CASE(vector_format)
         EXPECT_EQ(String::formatted("{}", v), "[ [ 1, 2 ], [ 3, 4 ] ]");
     }
 }
+
+TEST_CASE(format_wchar)
+{
+    EXPECT_EQ(String::formatted("{}", L'a'), "a");
+    EXPECT_EQ(String::formatted("{}", L'\U0001F41E'), "\xF0\x9F\x90\x9E");
+    EXPECT_EQ(String::formatted("{:x}", L'a'), "61");
+    EXPECT_EQ(String::formatted("{:x}", L'\U0001F41E'), "1f41e");
+    EXPECT_EQ(String::formatted("{:d}", L'a'), "97");
+    EXPECT_EQ(String::formatted("{:d}", L'\U0001F41E'), "128030");
+
+    EXPECT_EQ(String::formatted("{:6}", L'a'), "a     ");
+    EXPECT_EQ(String::formatted("{:6d}", L'a'), "    97");
+    EXPECT_EQ(String::formatted("{:#x}", L'\U0001F41E'), "0x1f41e");
+}

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -209,16 +209,11 @@ size_t mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* state)
         state = &_anonymous_state;
     }
 
-    // If s is nullptr, check if the state contains a complete multibyte character
+    // s being a null pointer is a shorthand for reading a single null byte.
     if (s == nullptr) {
-        if (mbstate_expected_bytes(state) == mbstate->stored_bytes) {
-            *state = {};
-            return 0;
-        } else {
-            *state = {};
-            errno = EILSEQ;
-            return -1;
-        }
+        pwc = nullptr;
+        s = "";
+        n = 1;
     }
 
     // Stop early if we can't read anything
@@ -284,6 +279,7 @@ size_t mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* state)
     state->stored_bytes = 0;
 
     if (codepoint == 0) {
+        *state = {};
         return 0;
     }
 

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -280,8 +280,8 @@ size_t mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* state)
         *pwc = codepoint;
     }
 
-    // We don't have a shift state that we need to keep, so just clear the entire state
-    *state = {};
+    // We want to read the next multibyte character, but keep all other properties.
+    state->stored_bytes = 0;
 
     if (codepoint == 0) {
         return 0;

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -21,6 +21,7 @@ typedef unsigned long int wctype_t;
 // A zero-initialized mbstate_t struct must be a valid initial state.
 typedef struct {
     unsigned char bytes[4];
+    unsigned int stored_bytes;
 } mbstate_t;
 
 size_t wcslen(const wchar_t*);

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -18,6 +18,7 @@ __BEGIN_DECLS
 typedef __WINT_TYPE__ wint_t;
 typedef unsigned long int wctype_t;
 
+// A zero-initialized mbstate_t struct must be a valid initial state.
 typedef struct {
     unsigned char bytes[4];
 } mbstate_t;


### PR DESCRIPTION
Some minor improvements to `mbrtowc`, added tests for `mbrtowc` and `mbsinit`, and the necessary `wchar_t` formatter in AK.