### PR TITLE
LibJS: Goodbye variables

### DIFF
--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -77,19 +77,19 @@ TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)
         return {};
     }
 
-    auto variable = outer_environment.value()->lexical_environment->get_from_environment(variable_name.string());
-    if (!variable.has_value()) {
-        vm.throw_exception<JS::ReferenceError>(global_object, JS::ErrorType::UnknownIdentifier, variable_name.string());
-        return {};
-    }
+    auto reference = vm.resolve_binding(variable_name.string(), outer_environment.value()->lexical_environment);
 
-    if (!variable->value.is_object()) {
+    auto value = reference.get_value(global_object);
+    if (vm.exception())
+        return {};
+
+    if (!value.is_object()) {
         vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAnObject, String::formatted("Variable with name {}", variable_name.string()));
         return {};
     }
 
-    vm.heap().uproot_cell(&variable->value.as_object());
-    outer_environment.value()->lexical_environment->delete_from_environment(variable_name.string());
+    vm.heap().uproot_cell(&value.as_object());
+    reference.delete_(global_object);
 
     return JS::js_undefined();
 }

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -8,7 +8,6 @@
 #include "Spreadsheet.h"
 #include "Workbook.h"
 #include <LibJS/Lexer.h>
-#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
@@ -100,6 +99,17 @@ SheetGlobalObject::SheetGlobalObject(Sheet& sheet)
 
 SheetGlobalObject::~SheetGlobalObject()
 {
+}
+
+JS::ThrowCompletionOr<bool> SheetGlobalObject::internal_has_property(JS::PropertyName const& name) const
+{
+    if (name.is_string()) {
+        if (name.as_string() == "value")
+            return true;
+        if (m_sheet.parse_cell_name(name.as_string()).has_value())
+            return true;
+    }
+    return Object::internal_has_property(name);
 }
 
 JS::ThrowCompletionOr<JS::Value> SheetGlobalObject::internal_get(const JS::PropertyName& property_name, JS::Value receiver) const

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -27,6 +27,7 @@ public:
 
     virtual ~SheetGlobalObject() override;
 
+    virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyName const& name) const override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyName const&, JS::Value receiver) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyName const&, JS::Value value, JS::Value receiver) override;
     virtual void initialize_global_object() override;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -163,6 +163,9 @@ Sheet::ValueAndException Sheet::evaluate(const StringView& source, Cell* on_beha
     if (parser.has_errors() || interpreter().exception())
         return { JS::js_undefined(), interpreter().exception() };
 
+    // FIXME: This creates a GlobalEnvironment for every evaluate call which we might be able to circumvent with multiple realms.
+    interpreter().realm().set_global_object(global_object(), &global_object());
+
     interpreter().run(global_object(), program);
     if (interpreter().exception()) {
         auto exc = interpreter().exception();

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1331,6 +1331,8 @@ void BindingPattern::dump(int indent) const
             entry.alias.get<NonnullRefPtr<Identifier>>()->dump(indent + 3);
         } else if (entry.alias.has<NonnullRefPtr<BindingPattern>>()) {
             entry.alias.get<NonnullRefPtr<BindingPattern>>()->dump(indent + 3);
+        } else if (entry.alias.has<NonnullRefPtr<MemberExpression>>()) {
+            entry.alias.get<NonnullRefPtr<MemberExpression>>()->dump(indent + 3);
         } else {
             print_indent(indent + 3);
             outln("<empty>");

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2326,6 +2326,11 @@ void ThrowStatement::dump(int indent) const
     argument().dump(indent + 1);
 }
 
+void TryStatement::add_label(FlyString string)
+{
+    m_block->add_label(move(string));
+}
+
 Value TryStatement::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -27,6 +27,7 @@ namespace JS {
 class VariableDeclaration;
 class FunctionDeclaration;
 class Identifier;
+class MemberExpression;
 
 enum class FunctionKind {
     Generator,
@@ -319,7 +320,7 @@ struct BindingPattern : RefCounted<BindingPattern> {
     struct BindingEntry {
         // If this entry represents a BindingElement, then name will be Empty
         Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<Expression>, Empty> name {};
-        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, Empty> alias {};
+        Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>, NonnullRefPtr<MemberExpression>, Empty> alias {};
         RefPtr<Expression> initializer {};
         bool is_rest { false };
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -778,6 +778,9 @@ static void generate_array_binding_pattern_bytecode(Bytecode::Generator& generat
                 auto target_reg = generator.allocate_register();
                 generator.emit<Bytecode::Op::Store>(target_reg);
                 generate_binding_pattern_bytecode(generator, pattern, target_reg);
+            },
+            [&](NonnullRefPtr<MemberExpression> const&) {
+                TODO();
             });
     };
 

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -8,6 +8,7 @@
 #include <AK/ScopeGuard.h>
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/FunctionEnvironment.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
@@ -91,141 +92,6 @@ Realm& Interpreter::realm()
 const Realm& Interpreter::realm() const
 {
     return static_cast<const Realm&>(*m_realm.cell());
-}
-
-void Interpreter::enter_scope(const ScopeNode& scope_node, ScopeType scope_type, GlobalObject& global_object)
-{
-    ScopeGuard guard([&] {
-        for (auto& declaration : scope_node.hoisted_functions()) {
-            lexical_environment()->put_into_environment(declaration.name(), { js_undefined(), DeclarationKind::Var });
-        }
-        for (auto& declaration : scope_node.functions()) {
-            auto* function = ECMAScriptFunctionObject::create(global_object, declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), lexical_environment(), declaration.kind(), declaration.is_strict_mode());
-            vm().set_variable(declaration.name(), function, global_object);
-        }
-    });
-
-    if (scope_type == ScopeType::Function) {
-        push_scope({ scope_type, scope_node, false });
-        for (auto& declaration : scope_node.functions())
-            lexical_environment()->put_into_environment(declaration.name(), { js_undefined(), DeclarationKind::Var });
-        return;
-    }
-
-    HashMap<FlyString, Variable> scope_variables_with_declaration_kind;
-
-    if (!scope_node.variables().is_empty())
-        scope_variables_with_declaration_kind.ensure_capacity(16);
-
-    bool is_program_node = is<Program>(scope_node);
-
-    for (auto& declaration : scope_node.variables()) {
-        for (auto& declarator : declaration.declarations()) {
-            if (is_program_node && declaration.declaration_kind() == DeclarationKind::Var) {
-                declarator.target().visit(
-                    [&](const NonnullRefPtr<Identifier>& id) {
-                        global_object.define_direct_property(id->string(), js_undefined(), JS::Attribute::Writable | JS::Attribute::Enumerable);
-                    },
-                    [&](const NonnullRefPtr<BindingPattern>& binding) {
-                        binding->for_each_bound_name([&](const auto& name) {
-                            global_object.define_direct_property(name, js_undefined(), JS::Attribute::Writable | JS::Attribute::Enumerable);
-                        });
-                    });
-                if (exception())
-                    return;
-            } else {
-                declarator.target().visit(
-                    [&](const NonnullRefPtr<Identifier>& id) {
-                        scope_variables_with_declaration_kind.set(id->string(), { js_undefined(), declaration.declaration_kind() });
-                    },
-                    [&](const NonnullRefPtr<BindingPattern>& binding) {
-                        binding->for_each_bound_name([&](const auto& name) {
-                            scope_variables_with_declaration_kind.set(name, { js_undefined(), declaration.declaration_kind() });
-                        });
-                    });
-            }
-        }
-    }
-
-    bool pushed_environment = false;
-
-    if (!scope_variables_with_declaration_kind.is_empty()) {
-        auto* environment = heap().allocate<DeclarativeEnvironment>(global_object, move(scope_variables_with_declaration_kind), lexical_environment());
-        vm().running_execution_context().lexical_environment = environment;
-        vm().running_execution_context().variable_environment = environment;
-        pushed_environment = true;
-    }
-
-    push_scope({ scope_type, scope_node, pushed_environment });
-}
-
-void Interpreter::exit_scope(const ScopeNode& scope_node)
-{
-    while (!m_scope_stack.is_empty()) {
-        auto popped_scope = m_scope_stack.take_last();
-        if (popped_scope.pushed_environment) {
-            vm().running_execution_context().lexical_environment = vm().running_execution_context().lexical_environment->outer_environment();
-            vm().running_execution_context().variable_environment = vm().running_execution_context().variable_environment->outer_environment();
-        }
-        if (popped_scope.scope_node.ptr() == &scope_node)
-            break;
-    }
-
-    // If we unwind all the way, just reset m_unwind_until so that future "return" doesn't break.
-    if (m_scope_stack.is_empty())
-        vm().stop_unwind();
-}
-
-void Interpreter::push_scope(ScopeFrame frame)
-{
-    m_scope_stack.append(move(frame));
-}
-
-Value Interpreter::execute_statement(GlobalObject& global_object, const Statement& statement, ScopeType scope_type)
-{
-    if (!is<ScopeNode>(statement))
-        return statement.execute(*this, global_object);
-
-    auto& block = static_cast<const ScopeNode&>(statement);
-    Vector<FlyString> const& labels = [&] {
-        if (is<BlockStatement>(block)) {
-            return static_cast<BlockStatement const&>(block).labels();
-        } else {
-            return Vector<FlyString>();
-        }
-    }();
-
-    enter_scope(block, scope_type, global_object);
-
-    Value last_value;
-    for (auto& node : block.children()) {
-        auto value = node.execute(*this, global_object);
-        if (!value.is_empty())
-            last_value = value;
-        if (vm().should_unwind()) {
-            if (!labels.is_empty() && vm().should_unwind_until(ScopeType::Breakable, labels))
-                vm().stop_unwind();
-            break;
-        }
-    }
-
-    if (scope_type == ScopeType::Function) {
-        bool did_return = vm().unwind_until() == ScopeType::Function;
-        if (!did_return)
-            last_value = js_undefined();
-    }
-
-    if (vm().unwind_until() == scope_type)
-        vm().stop_unwind();
-
-    exit_scope(block);
-
-    return last_value;
-}
-
-FunctionEnvironment* Interpreter::current_function_environment()
-{
-    return verify_cast<FunctionEnvironment>(vm().running_execution_context().lexical_environment);
 }
 
 }

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -187,6 +187,14 @@ Value Interpreter::execute_statement(GlobalObject& global_object, const Statemen
         return statement.execute(*this, global_object);
 
     auto& block = static_cast<const ScopeNode&>(statement);
+    Vector<FlyString> const& labels = [&] {
+        if (is<BlockStatement>(block)) {
+            return static_cast<BlockStatement const&>(block).labels();
+        } else {
+            return Vector<FlyString>();
+        }
+    }();
+
     enter_scope(block, scope_type, global_object);
 
     Value last_value;
@@ -195,7 +203,7 @@ Value Interpreter::execute_statement(GlobalObject& global_object, const Statemen
         if (!value.is_empty())
             last_value = value;
         if (vm().should_unwind()) {
-            if (!block.labels().is_empty() && vm().should_unwind_until(ScopeType::Breakable, block.labels()))
+            if (!labels.is_empty() && vm().should_unwind_until(ScopeType::Breakable, labels))
                 vm().stop_unwind();
             break;
         }

--- a/Userland/Libraries/LibJS/Interpreter.h
+++ b/Userland/Libraries/LibJS/Interpreter.h
@@ -67,11 +67,6 @@ public:
 
     Environment* lexical_environment() { return vm().lexical_environment(); }
 
-    FunctionEnvironment* current_function_environment();
-
-    void enter_scope(const ScopeNode&, ScopeType, GlobalObject&);
-    void exit_scope(const ScopeNode&);
-
     void push_ast_node(ExecutingASTNodeChain& chain_node)
     {
         chain_node.previous = m_ast_node_chain;
@@ -85,17 +80,10 @@ public:
     }
 
     const ASTNode* current_node() const { return m_ast_node_chain ? &m_ast_node_chain->node : nullptr; }
-    ExecutingASTNodeChain* executing_ast_node_chain() { return m_ast_node_chain; }
-    const ExecutingASTNodeChain* executing_ast_node_chain() const { return m_ast_node_chain; }
-
-    Value execute_statement(GlobalObject&, const Statement&, ScopeType = ScopeType::Block);
 
 private:
     explicit Interpreter(VM&);
 
-    void push_scope(ScopeFrame frame);
-
-    Vector<ScopeFrame> m_scope_stack;
     ExecutingASTNodeChain* m_ast_node_chain { nullptr };
 
     NonnullRefPtr<VM> m_vm;

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -586,13 +586,26 @@ RefPtr<Statement> Parser::try_parse_labelled_statement(AllowLabelledFunction all
         return {};
     }
 
-    auto identifier = consume_identifier_reference().value();
+    auto identifier = [&] {
+        if (m_state.current_token.value() == "await"sv) {
+            return consume().value();
+        }
+        return consume_identifier_reference().value();
+    }();
     if (!match(TokenType::Colon))
         return {};
     consume(TokenType::Colon);
 
     if (!match_statement())
         return {};
+
+    state_rollback_guard.disarm();
+    discard_saved_state();
+
+    if (m_state.strict_mode && identifier == "let"sv) {
+        syntax_error("Strict mode reserved word 'let' is not allowed in label", rule_start.position());
+        return {};
+    }
 
     if (match(TokenType::Function) && (allow_function == AllowLabelledFunction::No || m_state.strict_mode)) {
         syntax_error("Not allowed to declare a function here");
@@ -604,8 +617,10 @@ RefPtr<Statement> Parser::try_parse_labelled_statement(AllowLabelledFunction all
 
     RefPtr<Statement> labelled_statement;
 
+    auto is_iteration_statement = false;
+
     if (match(TokenType::Function)) {
-        m_state.labels_in_scope.set(identifier, false);
+        m_state.labels_in_scope.set(identifier, {});
         auto function_declaration = parse_function_node<FunctionDeclaration>();
         m_state.current_scope->function_declarations.append(function_declaration);
         auto hoisting_target = m_state.current_scope->get_current_function_scope();
@@ -615,16 +630,23 @@ RefPtr<Statement> Parser::try_parse_labelled_statement(AllowLabelledFunction all
 
         labelled_statement = move(function_declaration);
     } else {
-        auto is_iteration_statement = match(TokenType::For) || match(TokenType::Do) || match(TokenType::While);
-        m_state.labels_in_scope.set(identifier, is_iteration_statement);
-        labelled_statement = parse_statement();
+        m_state.labels_in_scope.set(identifier, {});
+        labelled_statement = parse_statement(allow_function);
+        if (is<IterationStatement>(*labelled_statement)) {
+            is_iteration_statement = true;
+            static_cast<IterationStatement&>(*labelled_statement).add_label(identifier);
+        } else if (is<LabelableStatement>(*labelled_statement)) {
+            static_cast<LabelableStatement&>(*labelled_statement).add_label(identifier);
+        }
+    }
+
+    if (!is_iteration_statement) {
+        if (auto entry = m_state.labels_in_scope.find(identifier); entry != m_state.labels_in_scope.end() && entry->value.has_value())
+            syntax_error("labelled continue statement cannot use non iterating statement", m_state.labels_in_scope.get(identifier).value());
     }
 
     m_state.labels_in_scope.remove(identifier);
 
-    labelled_statement->add_label(identifier);
-    state_rollback_guard.disarm();
-    discard_saved_state();
     return labelled_statement.release_nonnull();
 }
 
@@ -2376,7 +2398,7 @@ NonnullRefPtr<BreakStatement> Parser::parse_break_statement()
     if (match(TokenType::Semicolon)) {
         consume();
     } else {
-        if (match(TokenType::Identifier) && !m_state.current_token.trivia_contains_line_terminator()) {
+        if (!m_state.current_token.trivia_contains_line_terminator() && match_identifier()) {
             target_label = consume().value();
 
             auto label = m_state.labels_in_scope.find(target_label);
@@ -2404,12 +2426,15 @@ NonnullRefPtr<ContinueStatement> Parser::parse_continue_statement()
         consume();
         return create_ast_node<ContinueStatement>({ m_state.current_token.filename(), rule_start.position(), position() }, target_label);
     }
-    if (match(TokenType::Identifier) && !m_state.current_token.trivia_contains_line_terminator()) {
+    if (!m_state.current_token.trivia_contains_line_terminator() && match_identifier()) {
+        auto label_position = position();
         target_label = consume().value();
 
         auto label = m_state.labels_in_scope.find(target_label);
-        if (label == m_state.labels_in_scope.end() || !label->value)
+        if (label == m_state.labels_in_scope.end())
             syntax_error(String::formatted("Label '{}' not found or invalid", target_label));
+        else
+            label->value = label_position;
     }
     consume_or_insert_semicolon();
     return create_ast_node<ContinueStatement>({ m_state.current_token.filename(), rule_start.position(), position() }, target_label);

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1990,11 +1990,9 @@ Vector<FunctionNode::Parameter> Parser::parse_formal_parameters(int& function_le
                 syntax_error("Generator function parameter initializer cannot contain a reference to an identifier named \"yield\"");
         }
         parameters.append({ move(parameter), default_value, is_rest });
-        if (match(TokenType::ParenClose))
+        if (match(TokenType::ParenClose) || is_rest)
             break;
         consume(TokenType::Comma);
-        if (is_rest)
-            break;
     }
     if (parse_options & FunctionNodeParseOptions::IsSetterFunction && parameters.is_empty())
         syntax_error("Setter function must have one argument");

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -199,6 +199,8 @@ private:
     bool try_parse_arrow_function_expression_failed_at_position(const Position&) const;
     void set_try_parse_arrow_function_expression_failed_at_position(const Position&, bool);
 
+    bool match_invalid_escaped_keyword() const;
+
     struct RulePosition {
         AK_MAKE_NONCOPYABLE(RulePosition);
         AK_MAKE_NONMOVABLE(RulePosition);

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -42,7 +42,18 @@ public:
     template<typename FunctionNodeType>
     NonnullRefPtr<FunctionNodeType> parse_function_node(u8 parse_options = FunctionNodeParseOptions::CheckForFunctionAndName);
     Vector<FunctionNode::Parameter> parse_formal_parameters(int& function_length, u8 parse_options = 0);
-    RefPtr<BindingPattern> parse_binding_pattern(bool strict_checks = false);
+
+    enum class AllowDuplicates {
+        Yes,
+        No
+    };
+
+    enum class AllowMemberExpressions {
+        Yes,
+        No
+    };
+
+    RefPtr<BindingPattern> parse_binding_pattern(AllowDuplicates is_var_declaration = AllowDuplicates::No, AllowMemberExpressions allow_member_expressions = AllowMemberExpressions::No);
 
     struct PrimaryExpressionParseResult {
         NonnullRefPtr<Expression> result;
@@ -178,6 +189,8 @@ private:
     void load_state();
     void discard_saved_state();
     Position position() const;
+
+    RefPtr<BindingPattern> synthesize_binding_pattern(Expression const& expression);
 
     Token next_token();
 

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -259,7 +259,7 @@ private:
 
         Vector<Vector<FunctionNode::Parameter>&> function_parameters;
 
-        HashMap<StringView, bool> labels_in_scope;
+        HashMap<StringView, Optional<Position>> labels_in_scope;
         bool strict_mode { false };
         bool allow_super_property_lookup { false };
         bool allow_super_constructor_call { false };

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -42,6 +42,8 @@ enum class EvalMode {
 };
 ThrowCompletionOr<Value> perform_eval(Value, GlobalObject&, CallerMode, EvalMode);
 
+ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, GlobalObject& global_object, Program const& program, Environment* variable_environment, Environment* lexical_environment, bool strict);
+
 // 10.1.13 OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] ), https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor
 template<typename T, typename... Args>
 ThrowCompletionOr<T*> ordinary_create_from_constructor(GlobalObject& global_object, FunctionObject const& constructor, Object* (GlobalObject::*intrinsic_default_prototype)(), Args&&... args)

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -43,9 +43,9 @@ Value BoundFunction::construct(FunctionObject& new_target)
     return m_bound_target_function->construct(new_target);
 }
 
-FunctionEnvironment* BoundFunction::create_environment(FunctionObject& function_being_invoked)
+FunctionEnvironment* BoundFunction::new_function_environment(Object* new_target)
 {
-    return m_bound_target_function->create_environment(function_being_invoked);
+    return m_bound_target_function->new_function_environment(new_target);
 }
 
 void BoundFunction::visit_edges(Visitor& visitor)

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.h
@@ -20,7 +20,7 @@ public:
 
     virtual Value call() override;
     virtual Value construct(FunctionObject& new_target) override;
-    virtual FunctionEnvironment* create_environment(FunctionObject&) override;
+    virtual FunctionEnvironment* new_function_environment(Object* new_target) override;
     virtual const FlyString& name() const override { return m_name; }
     virtual bool is_strict_mode() const override { return m_bound_target_function->is_strict_mode(); }
     virtual bool has_constructor() const override { return true; }

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -19,15 +19,7 @@ class DeclarativeEnvironment : public Environment {
 public:
     DeclarativeEnvironment();
     explicit DeclarativeEnvironment(Environment* parent_scope);
-    DeclarativeEnvironment(HashMap<FlyString, Variable> variables, Environment* parent_scope);
     virtual ~DeclarativeEnvironment() override;
-
-    // ^Environment
-    virtual Optional<Variable> get_from_environment(FlyString const&) const override;
-    virtual bool put_into_environment(FlyString const&, Variable) override;
-    virtual bool delete_from_environment(FlyString const&) override;
-
-    HashMap<FlyString, Variable> const& variables() const { return m_variables; }
 
     virtual bool has_binding(FlyString const& name) const override;
     virtual void create_mutable_binding(GlobalObject&, FlyString const& name, bool can_be_deleted) override;
@@ -37,13 +29,13 @@ public:
     virtual Value get_binding_value(GlobalObject&, FlyString const& name, bool strict) override;
     virtual bool delete_binding(GlobalObject&, FlyString const& name) override;
 
+    void initialize_or_set_mutable_binding(Badge<ScopeNode>, GlobalObject& global_object, FlyString const& name, Value value);
+
 protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
     virtual bool is_declarative_environment() const override { return true; }
-
-    HashMap<FlyString, Variable> m_variables;
 
     struct Binding {
         Value value;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -78,9 +78,10 @@ protected:
 
 private:
     virtual bool is_ecmascript_function_object() const override { return true; }
-    virtual FunctionEnvironment* create_environment(FunctionObject&) override;
+    virtual FunctionEnvironment* new_function_environment(Object* new_target) override;
     virtual void visit_edges(Visitor&) override;
 
+    ThrowCompletionOr<void> function_declaration_instantiation(Interpreter*);
     Value execute_function_body();
 
     // Internal Slots of ECMAScript Function Objects, https://tc39.es/ecma262/#table-internal-slots-of-ecmascript-function-objects

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -27,10 +27,6 @@ public:
 
     virtual void initialize(GlobalObject&) override;
 
-    virtual Optional<Variable> get_from_environment(FlyString const&) const = 0;
-    virtual bool put_into_environment(FlyString const&, Variable) = 0;
-    virtual bool delete_from_environment(FlyString const&) = 0;
-
     virtual bool has_this_binding() const { return false; }
     virtual Value get_this_binding(GlobalObject&) const { return {}; }
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -23,6 +23,7 @@
     M(ConstructorWithoutNew, "{} constructor must be called with 'new'")                                                                \
     M(Convert, "Cannot convert {} to {}")                                                                                               \
     M(DataViewOutOfRangeByteOffset, "Data view byte offset {} is out of range for buffer with length {}")                               \
+    M(DerivedConstructorReturningInvalidValue, "Derived constructor return invalid value")                                              \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
     M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                                   \
     M(DivisionByZero, "Division by zero")                                                                                               \
@@ -223,6 +224,7 @@
     M(BadArgCountAtLeastOne, "{}() needs at least one argument")                                                                        \
     M(BadArgCountMany, "{}() needs {} arguments")                                                                                       \
     M(FixmeAddAnErrorString, "FIXME: Add a string for this error.")                                                                     \
+    M(FixmeAddAnErrorStringWithMessage, "FIXME: Add a real string for this error '{}'")                                                 \
     M(NotEnoughMemoryToAllocate, "Not enough memory to allocate {} bytes")
 
 namespace JS {

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
@@ -11,8 +11,8 @@
 
 namespace JS {
 
-FunctionEnvironment::FunctionEnvironment(Environment* parent_scope, HashMap<FlyString, Variable> variables)
-    : DeclarativeEnvironment(move(variables), parent_scope)
+FunctionEnvironment::FunctionEnvironment(Environment* parent_scope)
+    : DeclarativeEnvironment(parent_scope)
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
@@ -21,7 +21,7 @@ public:
         Uninitialized,
     };
 
-    FunctionEnvironment(Environment* parent_scope, HashMap<FlyString, Variable> variables);
+    explicit FunctionEnvironment(Environment* parent_scope);
     virtual ~FunctionEnvironment() override;
 
     // [[ThisValue]]

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -21,7 +21,7 @@ public:
     virtual Value call() = 0;
     virtual Value construct(FunctionObject& new_target) = 0;
     virtual const FlyString& name() const = 0;
-    virtual FunctionEnvironment* create_environment(FunctionObject&) = 0;
+    virtual FunctionEnvironment* new_function_environment(Object* new_target) = 0;
 
     BoundFunction* bind(Value bound_this_value, Vector<Value> arguments);
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
@@ -30,27 +30,9 @@ void GlobalEnvironment::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_declarative_record);
 }
 
-Optional<Variable> GlobalEnvironment::get_from_environment(FlyString const& name) const
-{
-    // FIXME: This should be a "composite" of the object record and the declarative record.
-    return m_object_record->get_from_environment(name);
-}
-
-bool GlobalEnvironment::put_into_environment(FlyString const& name, Variable variable)
-{
-    // FIXME: This should be a "composite" of the object record and the declarative record.
-    return m_object_record->put_into_environment(name, variable);
-}
-
-bool GlobalEnvironment::delete_from_environment(FlyString const& name)
-{
-    // FIXME: This should be a "composite" of the object record and the declarative record.
-    return object_record().delete_from_environment(name);
-}
-
 Value GlobalEnvironment::get_this_binding(GlobalObject&) const
 {
-    return &global_object();
+    return m_global_this_value;
 }
 
 // 9.1.1.4.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-global-environment-records-hasbinding-n

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -16,9 +16,6 @@ class GlobalEnvironment final : public Environment {
 public:
     GlobalEnvironment(GlobalObject&, Object& this_value);
 
-    virtual Optional<Variable> get_from_environment(FlyString const&) const override;
-    virtual bool put_into_environment(FlyString const&, Variable) override;
-    virtual bool delete_from_environment(FlyString const&) override;
     virtual bool has_this_binding() const final { return true; }
     virtual Value get_this_binding(GlobalObject&) const final;
 

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/FunctionEnvironment.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Value.h>
@@ -55,14 +56,22 @@ Value NativeFunction::construct(FunctionObject&)
     return {};
 }
 
-FunctionEnvironment* NativeFunction::create_environment(FunctionObject&)
+FunctionEnvironment* NativeFunction::new_function_environment(Object* new_target)
 {
-    return nullptr;
+    // Simplified version of 9.1.2.4 NewFunctionEnvironment ( F, newTarget )
+    Environment* parent_scope = nullptr;
+    if (!vm().execution_context_stack().is_empty())
+        parent_scope = vm().lexical_environment();
+
+    auto* environment = heap().allocate<FunctionEnvironment>(global_object(), parent_scope);
+    environment->set_new_target(new_target ? new_target : js_undefined());
+
+    return environment;
 }
 
 bool NativeFunction::is_strict_mode() const
 {
-    return vm().in_strict_mode();
+    return true;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -33,7 +33,7 @@ protected:
     explicit NativeFunction(Object& prototype);
 
 private:
-    virtual FunctionEnvironment* create_environment(FunctionObject&) override final;
+    virtual FunctionEnvironment* new_function_environment(Object* new_target) override final;
     virtual bool is_native_function() const final { return true; }
 
     FlyString m_name;

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -88,6 +88,7 @@ public:
     bool set_integrity_level(IntegrityLevel);
     bool test_integrity_level(IntegrityLevel) const;
     MarkedValueList enumerable_own_property_names(PropertyKind kind) const;
+    ThrowCompletionOr<Object*> copy_data_properties(Value source, HashTable<PropertyName, PropertyNameTraits> const& seen_names, GlobalObject& global_object);
 
     // 10.1 Ordinary Object Internal Methods and Internal Slots, https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
 

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -24,24 +24,6 @@ void ObjectEnvironment::visit_edges(Cell::Visitor& visitor)
     visitor.visit(&m_binding_object);
 }
 
-Optional<Variable> ObjectEnvironment::get_from_environment(FlyString const& name) const
-{
-    if (!m_binding_object.storage_has(name))
-        return {};
-    auto value = m_binding_object.get(name);
-    return Variable { value, DeclarationKind::Var };
-}
-
-bool ObjectEnvironment::put_into_environment(FlyString const& name, Variable variable)
-{
-    return m_binding_object.set(name, variable.value, Object::ShouldThrowExceptions::No);
-}
-
-bool ObjectEnvironment::delete_from_environment(FlyString const& name)
-{
-    return TRY_OR_DISCARD(m_binding_object.internal_delete(name));
-}
-
 // 9.1.1.2.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-object-environment-records-hasbinding-n
 bool ObjectEnvironment::has_binding(FlyString const& name) const
 {

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -20,10 +20,6 @@ public:
     };
     ObjectEnvironment(Object& binding_object, IsWithEnvironment, Environment* outer_environment);
 
-    virtual Optional<Variable> get_from_environment(FlyString const&) const override;
-    virtual bool put_into_environment(FlyString const&, Variable) override;
-    virtual bool delete_from_environment(FlyString const&) override;
-
     virtual bool has_binding(FlyString const& name) const override;
     virtual void create_mutable_binding(GlobalObject&, FlyString const& name, bool can_be_deleted) override;
     virtual void create_immutable_binding(GlobalObject&, FlyString const& name, bool strict) override;

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -891,10 +891,10 @@ const FlyString& ProxyObject::name() const
     return static_cast<FunctionObject&>(m_target).name();
 }
 
-FunctionEnvironment* ProxyObject::create_environment(FunctionObject& function_being_invoked)
+FunctionEnvironment* ProxyObject::new_function_environment(Object* new_target)
 {
     VERIFY(is_function());
-    return static_cast<FunctionObject&>(m_target).create_environment(function_being_invoked);
+    return static_cast<FunctionObject&>(m_target).new_function_environment(new_target);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -24,7 +24,7 @@ public:
     virtual Value call() override;
     virtual Value construct(FunctionObject& new_target) override;
     virtual const FlyString& name() const override;
-    virtual FunctionEnvironment* create_environment(FunctionObject&) override;
+    virtual FunctionEnvironment* new_function_environment(Object* new_target) override;
     virtual bool has_constructor() const override { return true; }
 
     const Object& target() const { return m_target; }

--- a/Userland/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Reference.cpp
@@ -16,6 +16,11 @@ void Reference::put_value(GlobalObject& global_object, Value value)
 {
     auto& vm = global_object.vm();
 
+    if (!is_valid_reference()) {
+        vm.throw_exception<ReferenceError>(global_object, ErrorType::InvalidLeftHandAssignment);
+        return;
+    }
+
     if (is_unresolvable()) {
         if (m_strict) {
             throw_reference_error(global_object);
@@ -88,7 +93,7 @@ void Reference::throw_reference_error(GlobalObject& global_object) const
 // 6.2.4.5 GetValue ( V ), https://tc39.es/ecma262/#sec-getvalue
 Value Reference::get_value(GlobalObject& global_object, bool throw_if_undefined) const
 {
-    if (is_unresolvable()) {
+    if (!is_valid_reference() || is_unresolvable()) {
         throw_reference_error(global_object);
         return {};
     }

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -103,8 +103,15 @@ public:
         return m_base_type == BaseType::Environment;
     }
 
+    void initialize_referenced_binding(GlobalObject& global_object, Value value) const
+    {
+        VERIFY(!is_unresolvable());
+        VERIFY(m_base_type == BaseType::Environment);
+        m_base_environment->initialize_binding(global_object, m_name.as_string(), value);
+    }
+
     void put_value(GlobalObject&, Value);
-    Value get_value(GlobalObject&, bool throw_if_undefined = true) const;
+    Value get_value(GlobalObject&) const;
     bool delete_(GlobalObject&);
 
     String to_string() const;

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -109,6 +109,8 @@ public:
 
     String to_string() const;
 
+    bool is_valid_reference() const { return m_name.is_valid(); }
+
 private:
     void throw_reference_error(GlobalObject&) const;
 

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -168,29 +168,6 @@ void VM::set_variable(const FlyString& name, Value value, GlobalObject& global_o
     global_object.set(name, value, Object::ShouldThrowExceptions::Yes);
 }
 
-bool VM::delete_variable(FlyString const& name)
-{
-    Environment* specific_scope = nullptr;
-    Optional<Variable> possible_match;
-    if (!m_execution_context_stack.is_empty()) {
-        for (auto* environment = lexical_environment(); environment; environment = environment->outer_environment()) {
-            possible_match = environment->get_from_environment(name);
-            if (possible_match.has_value()) {
-                specific_scope = environment;
-                break;
-            }
-        }
-    }
-
-    if (!possible_match.has_value())
-        return false;
-    if (possible_match.value().declaration_kind == DeclarationKind::Const)
-        return false;
-
-    VERIFY(specific_scope);
-    return specific_scope->delete_from_environment(name);
-}
-
 void VM::assign(const FlyString& target, Value value, GlobalObject& global_object, bool first_assignment, Environment* specific_scope)
 {
     set_variable(target, move(value), global_object, first_assignment, specific_scope);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -206,7 +206,6 @@ public:
 
     Value get_variable(const FlyString& name, GlobalObject&);
     void set_variable(const FlyString& name, Value, GlobalObject&, bool first_assignment = false, Environment* specific_scope = nullptr);
-    bool delete_variable(FlyString const& name);
     void assign(const Variant<NonnullRefPtr<Identifier>, NonnullRefPtr<BindingPattern>>& target, Value, GlobalObject&, bool first_assignment = false, Environment* specific_scope = nullptr);
     void assign(const FlyString& target, Value, GlobalObject&, bool first_assignment = false, Environment* specific_scope = nullptr);
     void assign(const NonnullRefPtr<BindingPattern>& target, Value, GlobalObject&, bool first_assignment = false, Environment* specific_scope = nullptr);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -193,11 +193,13 @@ public:
         m_unwind_until = ScopeType::None;
         m_unwind_until_label = {};
     }
-    bool should_unwind_until(ScopeType type, HashTable<FlyString> const& labels) const
+    bool should_unwind_until(ScopeType type, Vector<FlyString> const& labels) const
     {
         if (m_unwind_until_label.is_null())
             return m_unwind_until == type;
-        return m_unwind_until == type && labels.contains(m_unwind_until_label);
+        return m_unwind_until == type && any_of(labels.begin(), labels.end(), [&](FlyString const& label) {
+            return m_unwind_until_label == label;
+        });
     }
     bool should_unwind() const { return m_unwind_until != ScopeType::None; }
 

--- a/Userland/Libraries/LibJS/Tests/functions/function-name.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-name.js
@@ -39,8 +39,9 @@ test("functions in objects", () => {
     expect(o.a.name).toBe("a");
     expect(o.b.name).toBe("a");
 
+    // Member expressions do not get named.
     o.c = function () {};
-    expect(o.c.name).toBe("c");
+    expect(o.c.name).toBe("");
 });
 
 test("names of native functions", () => {
@@ -49,16 +50,25 @@ test("names of native functions", () => {
     expect(console.debug.name).toBe("debug");
 });
 
-test("no invalid autonaming of anonymous functions", () => {
-    // prettier-ignore
-    let f1 = (function () {});
-    expect(f1.name).toBe("");
-    let f2 = f1;
-    expect(f2.name).toBe("");
-    let f3;
-    f3 = false || f2;
-    expect(f3.name).toBe("");
-    let f4 = false;
-    f4 ||= function () {};
-    expect(f4.name).toBe("");
+describe("some anonymous functions get renamed", () => {
+    test("direct assignment does name new function expression", () => {
+        // prettier-ignore
+        let f1 = (function () {});
+        expect(f1.name).toBe("f1");
+
+        let f2 = false;
+        f2 ||= function () {};
+        expect(f2.name).toBe("f2");
+    });
+
+    test("assignment from variable does not name", () => {
+        const f1 = function () {};
+        let f3 = f1;
+        expect(f3.name).toBe("f1");
+    });
+
+    test("assignment via expression does not name", () => {
+        let f4 = false || function () {};
+        expect(f4.name).toBe("");
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/labels.js
+++ b/Userland/Libraries/LibJS/Tests/labels.js
@@ -110,6 +110,28 @@ test("can use certain 'keywords' as labels", () => {
     expect(`const: { break const; }`).not.toEval();
 });
 
+test("can use certain 'keywords' even in strict mode", () => {
+    "use strict";
+
+    let i = 0;
+    await: {
+        i++;
+        break await;
+        expect().fail();
+    }
+
+    async: {
+        i++;
+        break async;
+        expect().fail();
+    }
+    expect(i).toBe(2);
+
+    expect(`'use strict'; let: { break let; }`).not.toEval();
+
+    expect(`'use strict'; l\u0065t: { break l\u0065t; }`).not.toEval();
+});
+
 test("invalid label usage", () => {
     expect(() =>
         eval(`

--- a/Userland/Libraries/LibJS/Tests/labels.js
+++ b/Userland/Libraries/LibJS/Tests/labels.js
@@ -1,16 +1,16 @@
 test("labeled plain scope", () => {
-    test: {
+    notused: test: alsonotused: {
         let o = 1;
         expect(o).toBe(1);
-        break test;
+        unused: break test;
         expect().fail();
     }
 });
 
 test("break on plain scope from inner scope", () => {
-    outer: {
+    notused: outer: alsonotused: {
         {
-            break outer;
+            unused: break outer;
         }
         expect().fail();
     }
@@ -18,7 +18,7 @@ test("break on plain scope from inner scope", () => {
 
 test("labeled for loop with break", () => {
     let counter = 0;
-    outer: for (a of [1, 2, 3]) {
+    notused: outer: alsonotused: for (a of [1, 2, 3]) {
         for (b of [4, 5, 6]) {
             if (a === 2 && b === 5) break outer;
             counter++;
@@ -29,7 +29,7 @@ test("labeled for loop with break", () => {
 
 test("labeled for loop with continue", () => {
     let counter = 0;
-    outer: for (a of [1, 2, 3]) {
+    notused: outer: alsonotused: for (a of [1, 2, 3]) {
         for (b of [4, 5, 6]) {
             if (b === 6) continue outer;
             counter++;
@@ -38,10 +38,107 @@ test("labeled for loop with continue", () => {
     expect(counter).toBe(6);
 });
 
-test("invalid label across scope", () => {
-    expect(`
-        label: {
-            (() => { break label; });
+test("break on try catch statement", () => {
+    let entered = false;
+    label1: label2: label3: try {
+        entered = true;
+        break label2;
+        expect().fail();
+    } catch (e) {
+        expect().fail();
+    }
+    expect(entered).toBeTrue();
+});
+
+test("can break on every label", () => {
+    let i = 0;
+    label0: label1: label2: for (; i < 3; i++) {
+        block: {
+            break block;
+            expect().fail();
         }
-    `).not.toEval();
+        if (i === 0) continue label0;
+        if (i === 1) continue label1;
+        if (i === 2) continue label2;
+        expect().fail();
+    }
+    expect(i).toBe(3);
+});
+
+test("can use certain 'keywords' as labels", () => {
+    let i = 0;
+
+    yield: {
+        i++;
+        break yield;
+        expect().fail();
+    }
+
+    await: {
+        i++;
+        break await;
+        expect().fail();
+    }
+
+    async: {
+        i++;
+        break async;
+        expect().fail();
+    }
+
+    let: {
+        i++;
+        break let;
+        expect().fail();
+    }
+
+    // prettier-ignore
+    l\u0065t: {
+        i++;
+        break let;
+        expect().fail();
+    }
+
+    private: {
+        i++;
+        break private;
+        expect().fail();
+    }
+
+    expect(i).toBe(6);
+
+    expect(`const: { break const; }`).not.toEval();
+});
+
+test("invalid label usage", () => {
+    expect(() =>
+        eval(`
+            label: {
+                (() => {
+                    break label;
+                });
+            }
+        `)
+    ).toThrowWithMessage(SyntaxError, "Label 'label' not found");
+
+    expect(() =>
+        eval(`
+            label: {
+                while (false) {
+                    continue label;
+                }
+            }
+        `)
+    ).toThrowWithMessage(
+        SyntaxError,
+        "labelled continue statement cannot use non iterating statement"
+    );
+
+    expect(() =>
+        eval(`
+            label: label: {
+                break label;
+            }
+        `)
+    ).toThrowWithMessage(SyntaxError, "Label 'label' has already been declared");
 });

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -51,5 +51,24 @@ test("use already-declared variable", () => {
 });
 
 test("allow binding patterns", () => {
-    expect(`for (let [a, b] in foo) {}`).toEval();
+    const expected = [
+        ["1", "3", []],
+        ["s", undefined, []],
+        ["l", "n", ["g", "N", "a", "m", "e"]],
+    ];
+    let counter = 0;
+
+    for (let [a, , b, ...c] in { 123: 1, sm: 2, longName: 3 }) {
+        expect(a).toBe(expected[counter][0]);
+        expect(b).toBe(expected[counter][1]);
+        expect(c).toEqual(expected[counter][2]);
+        counter++;
+    }
+    expect(counter).toBe(3);
+});
+
+test("allow member expression as variable", () => {
+    const f = {};
+    for (f.a in "abc");
+    expect(f.a).toBe("2");
 });

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -100,5 +100,20 @@ describe("errors", () => {
 });
 
 test("allow binding patterns", () => {
-    expect(`for (let [a, b] of foo) {}`).toEval();
+    let counter = 0;
+    for (let [a, b] of [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+    ]) {
+        expect(a + 1).toBe(b);
+        counter++;
+    }
+    expect(counter).toBe(3);
+});
+
+test("allow member expression as variable", () => {
+    const f = {};
+    for (f.a of "abc");
+    expect(f.a).toBe("c");
 });

--- a/Userland/Libraries/LibJS/Tests/operators/delete-local-variable.js
+++ b/Userland/Libraries/LibJS/Tests/operators/delete-local-variable.js
@@ -1,8 +1,16 @@
 test("basic functionality", () => {
     let a = 5;
-    expect(delete a).toBeTrue();
+    var b = 6;
+    c = 7;
+    expect(delete a).toBeFalse();
+    expect(a).toBe(5);
+
+    expect(delete b).toBeFalse();
+    expect(b).toBe(6);
+
+    expect(delete c).toBeTrue();
 
     expect(() => {
-        a;
-    }).toThrowWithMessage(ReferenceError, "'a' is not defined");
+        c;
+    }).toThrowWithMessage(ReferenceError, "'c' is not defined");
 });

--- a/Userland/Libraries/LibJS/Tests/strict-mode-errors.js
+++ b/Userland/Libraries/LibJS/Tests/strict-mode-errors.js
@@ -4,15 +4,12 @@ test("basic functionality", () => {
     [true, false, "foo", 123].forEach(primitive => {
         expect(() => {
             primitive.foo = "bar";
-        }).toThrowWithMessage(
-            TypeError,
-            `Cannot set property 'foo' of ${typeof primitive} '${primitive}'`
-        );
+        }).toThrowWithMessage(TypeError, `Cannot set property 'foo' of ${primitive}`);
         expect(() => {
             primitive[Symbol.hasInstance] = 123;
         }).toThrowWithMessage(
             TypeError,
-            `Cannot set property 'Symbol(Symbol.hasInstance)' of ${typeof primitive} '${primitive}'`
+            `Cannot set property 'Symbol(Symbol.hasInstance)' of ${primitive}`
         );
     });
     [null, undefined].forEach(primitive => {

--- a/Userland/Libraries/LibJS/Tests/string-escapes.js
+++ b/Userland/Libraries/LibJS/Tests/string-escapes.js
@@ -58,6 +58,8 @@ describe("octal escapes", () => {
         expect("'use strict'; '\\123'").not.toEval();
         expect('"use strict"; "\\123"').not.toEval();
         // Special case, string literal precedes use strict directive
-        expect("'\\123'; somethingElse; 'use strict'").not.toEval();
+        expect("'\\123'; 'use strict'").not.toEval();
+        // Because of the non string statement in the middle strict mode is not enabled.
+        expect("'\\123'; somethingElse; 'use strict'").toEval();
     });
 });

--- a/Userland/Libraries/LibJS/Tests/switch-basic.js
+++ b/Userland/Libraries/LibJS/Tests/switch-basic.js
@@ -67,11 +67,43 @@ describe("basic switch tests", () => {
         }
         expect(i).toBe(5);
     });
+
+    test("default branch is not taken if more exact branch exists", () => {
+        function switchTest(i) {
+            let result = 0;
+            switch (i) {
+                case 1:
+                    result += 1;
+                    break;
+                case 1:
+                    expect().fail();
+                case 2:
+                    result += 2;
+                default:
+                    result += 4;
+                case 3:
+                    result += 8;
+                    break;
+                case 2:
+                    expect().fail();
+            }
+            return result;
+        }
+
+        expect(switchTest(1)).toBe(1);
+        expect(switchTest(2)).toBe(14);
+        expect(switchTest(3)).toBe(8);
+        expect(switchTest(4)).toBe(12);
+    });
 });
 
 describe("errors", () => {
     test("syntax errors", () => {
         expect("switch () {}").not.toEval();
+        expect("switch () { case 1: continue; }").not.toEval();
+        expect("switch () { case 1: break doesnotexist; }").not.toEval();
+        expect("label: switch () { case 1: break not_the_right_label; }").not.toEval();
+        expect("label: switch () { case 1: continue label; }").not.toEval();
         expect("switch (foo) { bar }").not.toEval();
         expect("switch (foo) { default: default: }").not.toEval();
     });

--- a/Userland/Libraries/LibJS/Tests/syntax/destructuring-assignment.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/destructuring-assignment.js
@@ -196,6 +196,11 @@ describe("evaluating", () => {
             expect(a).toBe(o[0]);
             expect(length).toBe(o[1].length);
         }
+        {
+            expect(() => {
+                let [a, b, [...{ length }]] = o;
+            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+        }
     });
 
     test("patterns with default", () => {

--- a/Userland/Libraries/LibJS/Tests/syntax/switch-as-statement.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/switch-as-statement.js
@@ -1,0 +1,69 @@
+describe("switch statement is a valid statement and gets executed", () => {
+    test("switch statement in a block", () => {
+        let hit = false;
+        {
+            switch (true) {
+                case true:
+                    hit = true;
+            }
+            expect(hit).toBeTrue();
+        }
+    });
+
+    test("switch statement in an if statement when true", () => {
+        let hit = false;
+        var a = true;
+        if (a)
+            switch (true) {
+                case true:
+                    hit = true;
+            }
+        else
+            switch (true) {
+                case true:
+                    expect().fail();
+            }
+
+        expect(hit).toBeTrue();
+    });
+
+    test("switch statement in an if statement when false", () => {
+        let hit = false;
+        var a = false;
+        if (a)
+            switch (a) {
+                default:
+                    expect().fail();
+            }
+        else
+            switch (a) {
+                default:
+                    hit = true;
+            }
+
+        expect(hit).toBeTrue();
+    });
+
+    test("switch statement in an while statement", () => {
+        var a = 0;
+        var loops = 0;
+        while (a < 1 && loops++ < 5)
+            switch (a) {
+                case 0:
+                    a = 1;
+            }
+
+        expect(a).toBe(1);
+    });
+
+    test("switch statement in an for statement", () => {
+        var loops = 0;
+        for (let a = 0; a < 1 && loops++ < 5; )
+            switch (a) {
+                case 0:
+                    a = 1;
+            }
+
+        expect(loops).toBe(1);
+    });
+});

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -237,8 +237,9 @@ inline AK::Result<NonnullRefPtr<JS::SourceTextModule>, ParserError> parse_module
 
 inline Optional<JsonValue> get_test_results(JS::Interpreter& interpreter)
 {
-    auto result = g_vm->get_variable("__TestResults__", interpreter.global_object());
-    auto json_string = JS::JSONObject::stringify_impl(interpreter.global_object(), result, JS::js_undefined(), JS::js_undefined());
+    auto results = interpreter.global_object().get("__TestResults__");
+    VERIFY(!results.is_empty());
+    auto json_string = JS::JSONObject::stringify_impl(interpreter.global_object(), results, JS::js_undefined(), JS::js_undefined());
 
     auto json = JsonValue::from_string(json_string);
     if (!json.has_value())
@@ -382,7 +383,10 @@ inline JSFileResult TestRunner::run_file_test(const String& test_path)
     JSFileResult file_result { test_path.substring(m_test_root.length() + 1, test_path.length() - m_test_root.length() - 1) };
 
     // Collect logged messages
-    auto& arr = interpreter->vm().get_variable("__UserOutput__", interpreter->global_object()).as_array();
+    auto user_output = interpreter->global_object().get("__UserOutput__");
+    VERIFY(!user_output.is_empty());
+
+    auto& arr = user_output.as_array();
     for (auto& entry : arr.indexed_properties()) {
         auto message = arr.get(entry.index());
         file_result.logged_messages.append(message.to_string_without_side_effects());

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1332,14 +1332,21 @@ int main(int argc, char** argv)
 
             switch (mode) {
             case CompleteProperty: {
-                auto maybe_variable = vm->get_variable(variable_name, interpreter->global_object());
-                if (maybe_variable.is_empty()) {
-                    maybe_variable = interpreter->global_object().get(FlyString(variable_name));
-                    if (maybe_variable.is_empty())
+                Optional<JS::Value> maybe_value;
+                auto maybe_variable = vm->resolve_binding(variable_name);
+                if (vm->exception())
+                    break;
+                if (!maybe_variable.is_unresolvable()) {
+                    maybe_value = maybe_variable.get_value(interpreter->global_object());
+                    if (vm->exception())
+                        break;
+                } else {
+                    maybe_value = interpreter->global_object().get(FlyString(variable_name));
+                    if (maybe_value->is_empty())
                         break;
                 }
 
-                auto variable = maybe_variable;
+                auto variable = *maybe_value;
                 if (!variable.is_object())
                     break;
 


### PR DESCRIPTION
Implements a lot of scoping variables and more since a lot broken.
Things left to do / look at / could be done in another PR?
- [x] Fix the parser to not produce duplicated names where not allowed ~(other PR?)~ 
              Nope this is necessary for proper behavior
- [x] Classes
- [x] Switches
- [x] While loops
- [x] Refactoring
- [ ] ~Add tests to `test-js`~ Already existed
- [x] Check the other parts of the system which use LibJS
- [x] Split the commits up further? I already tried my hardest here.

Also this supersedes #10029 since that was kind of where I started and it did not really get any comments.

~I'm currently at only `-369 ✅    +205 ❌   +164 💥️`. Which is much better than the `-10000` or something I started with.~

Things which are currently broken.
- [x] Some AnnexB things (250+ regressions)
- [x] Native function calls wipe environment (100+ regression)
- [x] Switch statement scoping escapes switch in parser (??)
- [x] Fix `test-js`


Final comments:
Bytecode is probably broken.
Just 2 test262 regression to do with realms.