### PR TITLE
Meta: Work around crash in Sonar Cloud Static Analysis

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -40,8 +40,6 @@ jobs:
           echo "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> $GITHUB_PATH
           echo "sonar.projectKey=SerenityOS_serenity" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.organization=serenityos" >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.cfamily.cache.enabled=true" >> ${{ github.workspace }}/sonar-project.properties
-          echo "sonar.cfamily.cache.path=.sonar" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.compile-commands=${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}/compile_commands.json" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.threads=2" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.host.url=${{ env.SONAR_SERVER_URL }}" >> ${{ github.workspace }}/sonar-project.properties

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -42,6 +42,7 @@ jobs:
           echo "sonar.organization=serenityos" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.compile-commands=${{ github.workspace }}/Build/${{ env.SONAR_ANALYSIS_ARCH }}/compile_commands.json" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.cfamily.threads=2" >> ${{ github.workspace }}/sonar-project.properties
+          echo "sonar.exclusions=Userland/Libraries/LibWasm/Parser/Parser.cpp" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.host.url=${{ env.SONAR_SERVER_URL }}" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.sources=AK,Build,Userland,Kernel,Meta" >> ${{ github.workspace }}/sonar-project.properties
           echo "sonar.tests=Tests" >> ${{ github.workspace }}/sonar-project.properties


### PR DESCRIPTION

- **Meta: Exclude LibWasm Parser.cpp from Sonar Cloud Static Analysis**

    We need to exclude this file from analysis for now, as there is a bug in
    the sonar-runner tool where it crashes when trying to understand the use
    of AK::Variant in LibWasm/Parser/Parser.cpp

    See #10122 for details + link to the bug report to Sonar Cloud.

-  **Meta: Remove unused caching from Sonar Cloud configuration**
    I was experimenting with using caching while doing the initial prototype
    of the Sonar Cloud workflow. However the cache size for the static
    analysis data ended up being large enough that it would put us over the
    git hub actions limit. Given that we currently only run this pipeline
    once a day, it seems reasonable to just remove caching.

    If in the future we decide to run the pipeline on every PR, caching
    would become crucial as the current un-cached analysis time is around
    1 hour and 50 minutes. If we did this we would need to move the pipeline
    to Azure DevOps where we have effectively infinite cache available.