### PR TITLE
Meta: Upgrade sonar scanner to latest 4.6.2.2475 release

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     env:
       # Latest scanner version is tracked on: https://sonarcloud.io/documentation/analysis/scan/sonarscanner/
-      SONAR_SCANNER_VERSION: 4.6.1.2450
+      SONAR_SCANNER_VERSION: 4.6.2.2475
       SONAR_SERVER_URL: "https://sonarcloud.io"
       SONAR_ANALYSIS_ARCH: i686
     steps:


### PR DESCRIPTION
I didn't realize there was a new release, as it wasn't posted in the
Sonar Cloud Documentatoin, but was tagged on the github project page.

See: https://github.com/SonarSource/sonar-scanner-cli/releases