### PR TITLE
LibWeb: Flex use ifc if needed

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -75,13 +75,14 @@ void FormattingContext::layout_inside(Box& box, LayoutMode layout_mode)
         return;
     }
 
-    if (creates_block_formatting_context(box)) {
-        BlockFormattingContext context(box, this);
+    if (box.computed_values().display() == CSS::Display::Flex) {
+        FlexFormattingContext context(box, this);
         context.run(box, layout_mode);
         return;
     }
-    if (box.computed_values().display() == CSS::Display::Flex) {
-        FlexFormattingContext context(box, this);
+
+    if (creates_block_formatting_context(box)) {
+        BlockFormattingContext context(box, this);
         context.run(box, layout_mode);
         return;
     }

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -31,6 +31,9 @@ struct AvailableSpaceForLineInfo {
 
 static AvailableSpaceForLineInfo available_space_for_line(const InlineFormattingContext& context, size_t line_index)
 {
+    if (!context.parent()->is_block_formatting_context())
+        return { 0, context.context_box().width() };
+
     AvailableSpaceForLineInfo info;
 
     // FIXME: This is a total hack guess since we don't actually know the final y position of lines here!


### PR DESCRIPTION
This is hackish, but works. A proper handling of inline children of flex containers is needed, for now though this hack along with a few fixes brings us closer to nice flexboxes.