### PR TITLE
LibWeb: Clean-up StyleValue API

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
@@ -284,7 +284,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                         auto type_args = type_parts.size() > 1 ? type_parts[1] : ""sv;
                         if (type_name == "color") {
                             property_generator.append(R"~~~(
-        if (style_value.is_color())
+        if (style_value.has_color())
             return true;
 )~~~");
                         } else if (type_name == "image") {
@@ -295,7 +295,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                         } else if (type_name == "length" || type_name == "percentage") {
                             // FIXME: Handle lengths and percentages separately
                             property_generator.append(R"~~~(
-        if (style_value.is_length() || style_value.is_calculated())
+        if (style_value.has_length() || style_value.is_calculated())
             return true;
 )~~~");
                         } else if (type_name == "number" || type_name == "integer") {
@@ -309,14 +309,14 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                                 max_value = type_args.substring_view(comma_index + 1, type_args.length() - comma_index - 2);
                             }
                             property_generator.append(R"~~~(
-        if (style_value.is_numeric())~~~");
+        if (style_value.has_number())~~~");
                             if (!min_value.is_empty()) {
                                 property_generator.set("minvalue", min_value);
-                                property_generator.append(" && (style_value.as_number() >= (float)@minvalue@)");
+                                property_generator.append(" && (style_value.to_number() >= (float)@minvalue@)");
                             }
                             if (!max_value.is_empty()) {
                                 property_generator.set("maxvalue", max_value);
-                                property_generator.append(" && (style_value.as_number() <= (float)@maxvalue@)");
+                                property_generator.append(" && (style_value.to_number() <= (float)@maxvalue@)");
                             }
                             property_generator.append(R"~~~()
             return true;

--- a/Userland/Libraries/LibWeb/CSS/ComputedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ComputedCSSStyleDeclaration.cpp
@@ -484,20 +484,20 @@ RefPtr<StyleValue> ComputedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_bottom_right_radius = property(CSS::PropertyID::BorderBottomRightRadius);
         RefPtr<BorderRadiusStyleValue> top_left_radius, top_right_radius, bottom_left_radius, bottom_right_radius;
         if (maybe_top_left_radius.has_value()) {
-            VERIFY(maybe_top_left_radius.value().value->type() == StyleValue::Type::BorderRadius);
-            top_left_radius = *static_cast<BorderRadiusStyleValue*>(maybe_top_left_radius.value().value.ptr());
+            VERIFY(maybe_top_left_radius.value().value->is_border_radius());
+            top_left_radius = maybe_top_left_radius.value().value->as_border_radius();
         }
         if (maybe_top_right_radius.has_value()) {
-            VERIFY(maybe_top_right_radius.value().value->type() == StyleValue::Type::BorderRadius);
-            top_right_radius = *static_cast<BorderRadiusStyleValue*>(maybe_top_right_radius.value().value.ptr());
+            VERIFY(maybe_top_right_radius.value().value->is_border_radius());
+            top_right_radius = maybe_top_right_radius.value().value->as_border_radius();
         }
         if (maybe_bottom_left_radius.has_value()) {
-            VERIFY(maybe_bottom_left_radius.value().value->type() == StyleValue::Type::BorderRadius);
-            bottom_left_radius = *static_cast<BorderRadiusStyleValue*>(maybe_bottom_left_radius.value().value.ptr());
+            VERIFY(maybe_bottom_left_radius.value().value->is_border_radius());
+            bottom_left_radius = maybe_bottom_left_radius.value().value->as_border_radius();
         }
         if (maybe_bottom_right_radius.has_value()) {
-            VERIFY(maybe_bottom_right_radius.value().value->type() == StyleValue::Type::BorderRadius);
-            bottom_right_radius = *static_cast<BorderRadiusStyleValue*>(maybe_bottom_right_radius.value().value.ptr());
+            VERIFY(maybe_bottom_right_radius.value().value->is_border_radius());
+            bottom_right_radius = maybe_bottom_right_radius.value().value->as_border_radius();
         }
 
         return CombinedBorderRadiusStyleValue::create(top_left_radius.release_nonnull(), top_right_radius.release_nonnull(), bottom_right_radius.release_nonnull(), bottom_left_radius.release_nonnull());

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2095,7 +2095,7 @@ RefPtr<StyleValue> Parser::parse_flex_value(ParsingContext const& context, Vecto
             return nullptr;
 
         // Zero is a valid value for basis, but only if grow and shrink are already specified.
-        if (value->is_numeric() && static_cast<NumericStyleValue&>(*value).value() == 0) {
+        if (value->has_number() && value->to_number() == 0) {
             if (flex_grow && flex_shrink && !flex_basis) {
                 flex_basis = LengthStyleValue::create(Length(0, Length::Type::Px));
                 continue;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -268,7 +268,7 @@ Optional<int> StyleProperties::z_index() const
         return {};
     auto& value = maybe_value.value();
 
-    if (value->is_auto())
+    if (value->has_auto())
         return 0;
     if (value->is_numeric())
         return static_cast<int>(static_cast<NumericStyleValue&>(*value).value());
@@ -339,7 +339,7 @@ Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
     if (value.value()->is_identifier() && value.value()->to_identifier() == CSS::ValueID::Content)
         return { { CSS::FlexBasis::Content, {} } };
 
-    if (value.value()->is_auto())
+    if (value.value()->has_auto())
         return { { CSS::FlexBasis::Auto, {} } };
 
     if (value.value()->is_length())

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -152,7 +152,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::TextDecoration) {
         if (value.is_text_decoration()) {
-            auto& text_decoration = static_cast<TextDecorationStyleValue const&>(value);
+            auto& text_decoration = value.as_text_decoration();
             style.set_property(CSS::PropertyID::TextDecorationLine, text_decoration.line());
             style.set_property(CSS::PropertyID::TextDecorationStyle, text_decoration.style());
             style.set_property(CSS::PropertyID::TextDecorationColor, text_decoration.color());
@@ -167,7 +167,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::Overflow) {
         if (value.is_overflow()) {
-            auto& overflow = static_cast<OverflowStyleValue const&>(value);
+            auto& overflow = value.as_overflow();
             style.set_property(CSS::PropertyID::OverflowX, overflow.overflow_x());
             style.set_property(CSS::PropertyID::OverflowY, overflow.overflow_y());
             return;
@@ -189,7 +189,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BorderRadius) {
         if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value);
+            auto& values_list = value.as_value_list();
             assign_edge_values(PropertyID::BorderTopLeftRadius, PropertyID::BorderTopRightRadius, PropertyID::BorderBottomRightRadius, PropertyID::BorderBottomLeftRadius, values_list.values());
             return;
         }
@@ -225,7 +225,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         }
 
         if (value.is_border()) {
-            auto& border = static_cast<BorderStyleValue const&>(value);
+            auto& border = value.as_border();
             if (contains(Edge::Top, edge)) {
                 style.set_property(PropertyID::BorderTopWidth, border.border_width());
                 style.set_property(PropertyID::BorderTopStyle, border.border_style());
@@ -253,7 +253,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BorderStyle) {
         if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value);
+            auto& values_list = value.as_value_list();
             assign_edge_values(PropertyID::BorderTopStyle, PropertyID::BorderRightStyle, PropertyID::BorderBottomStyle, PropertyID::BorderLeftStyle, values_list.values());
             return;
         }
@@ -267,7 +267,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BorderWidth) {
         if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value);
+            auto& values_list = value.as_value_list();
             assign_edge_values(PropertyID::BorderTopWidth, PropertyID::BorderRightWidth, PropertyID::BorderBottomWidth, PropertyID::BorderLeftWidth, values_list.values());
             return;
         }
@@ -281,7 +281,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BorderColor) {
         if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value);
+            auto& values_list = value.as_value_list();
             assign_edge_values(PropertyID::BorderTopColor, PropertyID::BorderRightColor, PropertyID::BorderBottomColor, PropertyID::BorderLeftColor, values_list.values());
             return;
         }
@@ -302,17 +302,17 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         };
 
         if (value.is_background()) {
-            auto& background = static_cast<CSS::BackgroundStyleValue const&>(value);
+            auto& background = value.as_background();
             set_single_background(background);
             return;
         }
         if (value.is_value_list()) {
-            auto& background_list = static_cast<CSS::StyleValueList const&>(value).values();
+            auto& background_list = value.as_value_list().values();
             // FIXME: Handle multiple backgrounds.
             if (!background_list.is_empty()) {
                 auto& background = background_list.first();
                 if (background.is_background())
-                    set_single_background(static_cast<CSS::BackgroundStyleValue const&>(background));
+                    set_single_background(background.as_background());
             }
             return;
         }
@@ -326,7 +326,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BackgroundImage) {
         if (value.is_value_list()) {
-            auto& background_image_list = static_cast<CSS::StyleValueList const&>(value).values();
+            auto& background_image_list = value.as_value_list().values();
             // FIXME: Handle multiple backgrounds.
             if (!background_image_list.is_empty()) {
                 auto& background_image = background_image_list.first();
@@ -341,12 +341,12 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::BackgroundRepeat) {
         if (value.is_value_list()) {
-            auto& background_repeat_list = static_cast<CSS::StyleValueList const&>(value).values();
+            auto& background_repeat_list = value.as_value_list().values();
             // FIXME: Handle multiple backgrounds.
             if (!background_repeat_list.is_empty()) {
                 auto& maybe_background_repeat = background_repeat_list.first();
                 if (maybe_background_repeat.is_background_repeat()) {
-                    auto& background_repeat = static_cast<BackgroundRepeatStyleValue const&>(maybe_background_repeat);
+                    auto& background_repeat = maybe_background_repeat.as_background_repeat();
                     set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatX, background_repeat.repeat_x(), document, true);
                     set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatY, background_repeat.repeat_y(), document, true);
                 }
@@ -354,7 +354,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             return;
         }
         if (value.is_background_repeat()) {
-            auto& background_repeat = static_cast<BackgroundRepeatStyleValue const&>(value);
+            auto& background_repeat = value.as_background_repeat();
             set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatX, background_repeat.repeat_x(), document, true);
             set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatY, background_repeat.repeat_y(), document, true);
             return;
@@ -376,7 +376,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::Margin) {
         if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value);
+            auto& values_list = value.as_value_list();
             assign_edge_values(PropertyID::MarginTop, PropertyID::MarginRight, PropertyID::MarginBottom, PropertyID::MarginLeft, values_list.values());
             return;
         }
@@ -390,7 +390,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::Padding) {
         if (value.is_value_list()) {
-            auto& values_list = static_cast<StyleValueList const&>(value);
+            auto& values_list = value.as_value_list();
             assign_edge_values(PropertyID::PaddingTop, PropertyID::PaddingRight, PropertyID::PaddingBottom, PropertyID::PaddingLeft, values_list.values());
             return;
         }
@@ -404,7 +404,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::ListStyle) {
         if (value.is_list_style()) {
-            auto& list_style = static_cast<CSS::ListStyleStyleValue const&>(value);
+            auto& list_style = value.as_list_style();
             style.set_property(CSS::PropertyID::ListStylePosition, list_style.position());
             style.set_property(CSS::PropertyID::ListStyleImage, list_style.image());
             style.set_property(CSS::PropertyID::ListStyleType, list_style.style_type());
@@ -419,7 +419,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::Font) {
         if (value.is_font()) {
-            auto& font_shorthand = static_cast<CSS::FontStyleValue const&>(value);
+            auto& font_shorthand = value.as_font();
             style.set_property(CSS::PropertyID::FontSize, font_shorthand.font_size());
             style.set_property(CSS::PropertyID::FontFamily, font_shorthand.font_families());
             style.set_property(CSS::PropertyID::FontStyle, font_shorthand.font_style());
@@ -440,7 +440,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::Flex) {
         if (value.is_flex()) {
-            auto& flex = static_cast<CSS::FlexStyleValue const&>(value);
+            auto& flex = value.as_flex();
             style.set_property(CSS::PropertyID::FlexGrow, flex.grow());
             style.set_property(CSS::PropertyID::FlexShrink, flex.shrink());
             style.set_property(CSS::PropertyID::FlexBasis, flex.basis());
@@ -455,7 +455,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
     if (property_id == CSS::PropertyID::FlexFlow) {
         if (value.is_flex_flow()) {
-            auto& flex_flow = static_cast<FlexFlowStyleValue const&>(value);
+            auto& flex_flow = value.as_flex_flow();
             style.set_property(CSS::PropertyID::FlexDirection, flex_flow.flex_direction());
             style.set_property(CSS::PropertyID::FlexWrap, flex_flow.flex_wrap());
             return;
@@ -517,7 +517,7 @@ void StyleResolver::cascade_declarations(StyleProperties& style, DOM::Element& e
                 continue;
             auto property_value = property.value;
             if (property.value->is_custom_property()) {
-                auto custom_property_name = static_cast<CSS::CustomStyleValue const&>(*property.value).custom_property_name();
+                auto custom_property_name = property.value->as_custom_property().custom_property_name();
                 auto resolved = resolve_custom_property(element, custom_property_name);
                 if (resolved.has_value()) {
                     property_value = resolved.value().value;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -26,14 +26,158 @@ StyleValue::~StyleValue()
 {
 }
 
-bool StyleValue::is_color() const
+BackgroundStyleValue const& StyleValue::as_background() const
 {
-    if (type() == Type::Color)
-        return true;
-    if (type() != Type::Identifier)
-        return false;
+    VERIFY(is_background());
+    return static_cast<BackgroundStyleValue const&>(*this);
+}
 
-    switch (to_identifier()) {
+BackgroundRepeatStyleValue const& StyleValue::as_background_repeat() const
+{
+    VERIFY(is_background_repeat());
+    return static_cast<BackgroundRepeatStyleValue const&>(*this);
+}
+
+BorderStyleValue const& StyleValue::as_border() const
+{
+    VERIFY(is_border());
+    return static_cast<BorderStyleValue const&>(*this);
+}
+
+BorderRadiusStyleValue const& StyleValue::as_border_radius() const
+{
+    VERIFY(is_border_radius());
+    return static_cast<BorderRadiusStyleValue const&>(*this);
+}
+
+BoxShadowStyleValue const& StyleValue::as_box_shadow() const
+{
+    VERIFY(is_box_shadow());
+    return static_cast<BoxShadowStyleValue const&>(*this);
+}
+
+CalculatedStyleValue const& StyleValue::as_calculated() const
+{
+    VERIFY(is_calculated());
+    return static_cast<CalculatedStyleValue const&>(*this);
+}
+
+ColorStyleValue const& StyleValue::as_color() const
+{
+    VERIFY(is_color());
+    return static_cast<ColorStyleValue const&>(*this);
+}
+
+CustomStyleValue const& StyleValue::as_custom_property() const
+{
+    VERIFY(is_custom_property());
+    return static_cast<CustomStyleValue const&>(*this);
+}
+
+FlexStyleValue const& StyleValue::as_flex() const
+{
+    VERIFY(is_flex());
+    return static_cast<FlexStyleValue const&>(*this);
+}
+
+FlexFlowStyleValue const& StyleValue::as_flex_flow() const
+{
+    VERIFY(is_flex_flow());
+    return static_cast<FlexFlowStyleValue const&>(*this);
+}
+
+FontStyleValue const& StyleValue::as_font() const
+{
+    VERIFY(is_font());
+    return static_cast<FontStyleValue const&>(*this);
+}
+
+IdentifierStyleValue const& StyleValue::as_identifier() const
+{
+    VERIFY(is_identifier());
+    return static_cast<IdentifierStyleValue const&>(*this);
+}
+
+ImageStyleValue const& StyleValue::as_image() const
+{
+    VERIFY(is_image());
+    return static_cast<ImageStyleValue const&>(*this);
+}
+
+InheritStyleValue const& StyleValue::as_inherit() const
+{
+    VERIFY(is_inherit());
+    return static_cast<InheritStyleValue const&>(*this);
+}
+
+InitialStyleValue const& StyleValue::as_initial() const
+{
+    VERIFY(is_initial());
+    return static_cast<InitialStyleValue const&>(*this);
+}
+
+LengthStyleValue const& StyleValue::as_length() const
+{
+    VERIFY(is_length());
+    return static_cast<LengthStyleValue const&>(*this);
+}
+
+ListStyleStyleValue const& StyleValue::as_list_style() const
+{
+    VERIFY(is_list_style());
+    return static_cast<ListStyleStyleValue const&>(*this);
+}
+
+NumericStyleValue const& StyleValue::as_numeric() const
+{
+    VERIFY(is_numeric());
+    return static_cast<NumericStyleValue const&>(*this);
+}
+
+OverflowStyleValue const& StyleValue::as_overflow() const
+{
+    VERIFY(is_overflow());
+    return static_cast<OverflowStyleValue const&>(*this);
+}
+
+StringStyleValue const& StyleValue::as_string() const
+{
+    VERIFY(is_string());
+    return static_cast<StringStyleValue const&>(*this);
+}
+
+TextDecorationStyleValue const& StyleValue::as_text_decoration() const
+{
+    VERIFY(is_text_decoration());
+    return static_cast<TextDecorationStyleValue const&>(*this);
+}
+
+TransformationStyleValue const& StyleValue::as_transformation() const
+{
+    VERIFY(is_transformation());
+    return static_cast<TransformationStyleValue const&>(*this);
+}
+
+UnsetStyleValue const& StyleValue::as_unset() const
+{
+    VERIFY(is_unset());
+    return static_cast<UnsetStyleValue const&>(*this);
+}
+
+StyleValueList const& StyleValue::as_value_list() const
+{
+    VERIFY(is_value_list());
+    return static_cast<StyleValueList const&>(*this);
+}
+
+String IdentifierStyleValue::to_string() const
+{
+    return CSS::string_from_value_id(m_id);
+}
+
+bool IdentifierStyleValue::has_color() const
+{
+    switch (m_id) {
     case ValueID::Currentcolor:
     case ValueID::LibwebLink:
     case ValueID::LibwebPaletteActiveLink:
@@ -92,21 +236,8 @@ bool StyleValue::is_color() const
     case ValueID::LibwebPaletteWindowText:
         return true;
     default:
-        break;
+        return false;
     }
-
-    return false;
-}
-
-float StyleValue::as_number() const
-{
-    VERIFY(is_numeric());
-    return static_cast<NumericStyleValue const&>(*this).value();
-}
-
-String IdentifierStyleValue::to_string() const
-{
-    return CSS::string_from_value_id(m_id);
 }
 
 Color IdentifierStyleValue::to_color(Layout::NodeWithStyle const& node) const
@@ -255,5 +386,4 @@ void ImageStyleValue::resource_did_load()
     if (m_document->browsing_context())
         m_document->browsing_context()->set_needs_display({});
 }
-
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -228,60 +228,60 @@ public:
     virtual ~StyleValue();
 
     enum class Type {
-        Invalid,
-        Inherit,
-        Initial,
-        Unset,
-        String,
-        Length,
-        Color,
-        Identifier,
-        Image,
-        CustomProperty,
-        Numeric,
-        ValueList,
-        Calculated,
         Background,
         BackgroundRepeat,
         Border,
         BorderRadius,
-        CombinedBorderRadius,
         BoxShadow,
+        Calculated,
+        Color,
+        CombinedBorderRadius,
+        CustomProperty,
         Flex,
         FlexFlow,
         Font,
+        Identifier,
+        Image,
+        Inherit,
+        Initial,
+        Invalid,
+        Length,
         ListStyle,
+        Numeric,
         Overflow,
+        String,
         TextDecoration,
         Transformation,
+        Unset,
+        ValueList,
     };
 
     Type type() const { return m_type; }
 
-    bool is_inherit() const { return type() == Type::Inherit; }
-    bool is_initial() const { return type() == Type::Initial; }
-    bool is_unset() const { return type() == Type::Unset; }
-    bool is_color() const;
-    bool is_identifier() const { return type() == Type::Identifier || is_auto(); }
-    bool is_image() const { return type() == Type::Image; }
-    bool is_string() const { return type() == Type::String; }
-    virtual bool is_length() const { return type() == Type::Length; }
-    bool is_custom_property() const { return type() == Type::CustomProperty; }
-    bool is_numeric() const { return type() == Type::Numeric; }
-    bool is_value_list() const { return type() == Type::ValueList; }
-    bool is_calculated() const { return type() == Type::Calculated; }
     bool is_background() const { return type() == Type::Background; }
     bool is_background_repeat() const { return type() == Type::BackgroundRepeat; }
     bool is_border() const { return type() == Type::Border; }
     bool is_border_radius() const { return type() == Type::BorderRadius; }
     bool is_box_shadow() const { return type() == Type::BoxShadow; }
+    bool is_calculated() const { return type() == Type::Calculated; }
+    bool is_color() const { return type() == Type::Color; }
+    bool is_custom_property() const { return type() == Type::CustomProperty; }
     bool is_flex() const { return type() == Type::Flex; }
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
+    bool is_identifier() const { return type() == Type::Identifier || is_auto(); }
+    bool is_image() const { return type() == Type::Image; }
+    bool is_inherit() const { return type() == Type::Inherit; }
+    bool is_initial() const { return type() == Type::Initial; }
+    virtual bool is_length() const { return type() == Type::Length; }
     bool is_list_style() const { return type() == Type::ListStyle; }
+    bool is_numeric() const { return type() == Type::Numeric; }
     bool is_overflow() const { return type() == Type::Overflow; }
+    bool is_string() const { return type() == Type::String; }
     bool is_text_decoration() const { return type() == Type::TextDecoration; }
     bool is_transformation() const { return type() == Type::Transformation; }
+    bool is_unset() const { return type() == Type::Unset; }
+    bool is_value_list() const { return type() == Type::ValueList; }
 
     bool is_builtin() const { return is_inherit() || is_initial() || is_unset(); }
 
@@ -316,382 +316,6 @@ protected:
 
 private:
     Type m_type { Type::Invalid };
-};
-
-// FIXME: Allow for fallback
-class CustomStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<CustomStyleValue> create(const String& custom_property_name)
-    {
-        return adopt_ref(*new CustomStyleValue(custom_property_name));
-    }
-    String custom_property_name() const { return m_custom_property_name; }
-    String to_string() const override { return m_custom_property_name; }
-
-private:
-    explicit CustomStyleValue(const String& custom_property_name)
-        : StyleValue(Type::CustomProperty)
-        , m_custom_property_name(custom_property_name)
-    {
-    }
-
-    String m_custom_property_name {};
-};
-
-class NumericStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<NumericStyleValue> create(float value)
-    {
-        return adopt_ref(*new NumericStyleValue(value));
-    }
-
-    virtual bool is_length() const override { return m_value == 0; }
-    virtual Length to_length() const override { return Length(0, Length::Type::Px); }
-
-    float value() const { return m_value; }
-    String to_string() const override { return String::formatted("{}", m_value); }
-
-    virtual bool equals(StyleValue const& other) const override
-    {
-        if (type() != other.type())
-            return false;
-        return m_value == static_cast<NumericStyleValue const&>(other).m_value;
-    }
-
-private:
-    explicit NumericStyleValue(float value)
-        : StyleValue(Type::Numeric)
-        , m_value(value)
-    {
-    }
-
-    float m_value { 0 };
-};
-
-class StringStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<StringStyleValue> create(const String& string)
-    {
-        return adopt_ref(*new StringStyleValue(string));
-    }
-    virtual ~StringStyleValue() override { }
-
-    String to_string() const override { return m_string; }
-
-private:
-    explicit StringStyleValue(const String& string)
-        : StyleValue(Type::String)
-        , m_string(string)
-    {
-    }
-
-    String m_string;
-};
-
-class BoxShadowStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<BoxShadowStyleValue> create(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
-    {
-        return adopt_ref(*new BoxShadowStyleValue(offset_x, offset_y, blur_radius, color));
-    }
-    virtual ~BoxShadowStyleValue() override { }
-
-    Length const& offset_x() const { return m_offset_x; }
-    Length const& offset_y() const { return m_offset_y; }
-    Length const& blur_radius() const { return m_blur_radius; }
-    Color const& color() const { return m_color; }
-
-    String to_string() const override { return String::formatted("BoxShadow offset_x: {}, offset_y: {}, blur_radius: {}, color: {}",
-        m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string()); }
-
-private:
-    explicit BoxShadowStyleValue(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
-        : StyleValue(Type::BoxShadow)
-        , m_offset_x(offset_x)
-        , m_offset_y(offset_y)
-        , m_blur_radius(blur_radius)
-        , m_color(color)
-    {
-    }
-
-    Length m_offset_x;
-    Length m_offset_y;
-    Length m_blur_radius;
-    Color m_color;
-};
-
-class LengthStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<LengthStyleValue> create(const Length& length)
-    {
-        return adopt_ref(*new LengthStyleValue(length));
-    }
-    virtual ~LengthStyleValue() override { }
-
-    virtual String to_string() const override { return m_length.to_string(); }
-    virtual Length to_length() const override { return m_length; }
-
-    const Length& length() const { return m_length; }
-
-    virtual bool is_auto() const override { return m_length.is_auto(); }
-
-    virtual bool equals(const StyleValue& other) const override
-    {
-        if (type() != other.type())
-            return false;
-        return m_length == static_cast<const LengthStyleValue&>(other).m_length;
-    }
-
-private:
-    explicit LengthStyleValue(const Length& length)
-        : StyleValue(Type::Length)
-        , m_length(length)
-    {
-    }
-
-    Length m_length;
-};
-
-class CalculatedStyleValue : public StyleValue {
-public:
-    struct CalcSum;
-    struct CalcSumPartWithOperator;
-    struct CalcProduct;
-    struct CalcProductPartWithOperator;
-    struct CalcNumberSum;
-    struct CalcNumberSumPartWithOperator;
-    struct CalcNumberProduct;
-    struct CalcNumberProductPartWithOperator;
-
-    using CalcNumberValue = Variant<float, NonnullOwnPtr<CalcNumberSum>>;
-    using CalcValue = Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>>;
-
-    // This represents that: https://drafts.csswg.org/css-values-3/#calc-syntax
-    struct CalcSum {
-        CalcSum(NonnullOwnPtr<CalcProduct> first_calc_product, NonnullOwnPtrVector<CalcSumPartWithOperator> additional)
-            : first_calc_product(move(first_calc_product))
-            , zero_or_more_additional_calc_products(move(additional)) {};
-
-        NonnullOwnPtr<CalcProduct> first_calc_product;
-        NonnullOwnPtrVector<CalcSumPartWithOperator> zero_or_more_additional_calc_products;
-    };
-
-    struct CalcNumberSum {
-        CalcNumberSum(NonnullOwnPtr<CalcNumberProduct> first_calc_number_product, NonnullOwnPtrVector<CalcNumberSumPartWithOperator> additional)
-            : first_calc_number_product(move(first_calc_number_product))
-            , zero_or_more_additional_calc_number_products(move(additional)) {};
-
-        NonnullOwnPtr<CalcNumberProduct> first_calc_number_product;
-        NonnullOwnPtrVector<CalcNumberSumPartWithOperator> zero_or_more_additional_calc_number_products;
-    };
-
-    struct CalcProduct {
-        CalcValue first_calc_value;
-        NonnullOwnPtrVector<CalcProductPartWithOperator> zero_or_more_additional_calc_values;
-    };
-
-    struct CalcSumPartWithOperator {
-        enum Operation {
-            Add,
-            Subtract,
-        };
-
-        CalcSumPartWithOperator(Operation op, NonnullOwnPtr<CalcProduct> calc_product)
-            : op(op)
-            , calc_product(move(calc_product)) {};
-
-        Operation op;
-        NonnullOwnPtr<CalcProduct> calc_product;
-    };
-
-    struct CalcProductPartWithOperator {
-        enum {
-            Multiply,
-            Divide,
-        } op;
-        Variant<CalcValue, CalcNumberValue> value;
-    };
-
-    struct CalcNumberProduct {
-        CalcNumberValue first_calc_number_value;
-        NonnullOwnPtrVector<CalcNumberProductPartWithOperator> zero_or_more_additional_calc_number_values;
-    };
-
-    struct CalcNumberProductPartWithOperator {
-        enum {
-            Multiply,
-            Divide,
-        } op;
-        CalcNumberValue value;
-    };
-
-    struct CalcNumberSumPartWithOperator {
-        enum Operation {
-            Add,
-            Subtract,
-        };
-
-        CalcNumberSumPartWithOperator(Operation op, NonnullOwnPtr<CalcNumberProduct> calc_number_product)
-            : op(op)
-            , calc_number_product(move(calc_number_product)) {};
-
-        Operation op;
-        NonnullOwnPtr<CalcNumberProduct> calc_number_product;
-    };
-
-    static NonnullRefPtr<CalculatedStyleValue> create(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)
-    {
-        return adopt_ref(*new CalculatedStyleValue(expression_string, move(calc_sum)));
-    }
-
-    String to_string() const override { return m_expression_string; }
-    NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
-
-private:
-    explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)
-        : StyleValue(Type::Calculated)
-        , m_expression_string(expression_string)
-        , m_expression(move(calc_sum))
-    {
-    }
-
-    String m_expression_string;
-    NonnullOwnPtr<CalcSum> m_expression;
-};
-
-class InitialStyleValue final : public StyleValue {
-public:
-    static NonnullRefPtr<InitialStyleValue> the()
-    {
-        static NonnullRefPtr<InitialStyleValue> instance = adopt_ref(*new InitialStyleValue);
-        return instance;
-    }
-    virtual ~InitialStyleValue() override { }
-
-    String to_string() const override { return "initial"; }
-
-private:
-    InitialStyleValue()
-        : StyleValue(Type::Initial)
-    {
-    }
-};
-
-class InheritStyleValue final : public StyleValue {
-public:
-    static NonnullRefPtr<InheritStyleValue> the()
-    {
-        static NonnullRefPtr<InheritStyleValue> instance = adopt_ref(*new InheritStyleValue);
-        return instance;
-    }
-    virtual ~InheritStyleValue() override { }
-
-    String to_string() const override { return "inherit"; }
-
-private:
-    InheritStyleValue()
-        : StyleValue(Type::Inherit)
-    {
-    }
-};
-
-class UnsetStyleValue final : public StyleValue {
-public:
-    static NonnullRefPtr<UnsetStyleValue> the()
-    {
-        static NonnullRefPtr<UnsetStyleValue> instance = adopt_ref(*new UnsetStyleValue);
-        return instance;
-    }
-    virtual ~UnsetStyleValue() override { }
-
-    String to_string() const override { return "unset"; }
-
-private:
-    UnsetStyleValue()
-        : StyleValue(Type::Unset)
-    {
-    }
-};
-
-class ColorStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<ColorStyleValue> create(Color color)
-    {
-        return adopt_ref(*new ColorStyleValue(color));
-    }
-    virtual ~ColorStyleValue() override { }
-
-    Color color() const { return m_color; }
-    String to_string() const override { return m_color.to_string(); }
-    Color to_color(Layout::NodeWithStyle const&) const override { return m_color; }
-
-    virtual bool equals(const StyleValue& other) const override
-    {
-        if (type() != other.type())
-            return false;
-        return m_color == static_cast<const ColorStyleValue&>(other).m_color;
-    }
-
-private:
-    explicit ColorStyleValue(Color color)
-        : StyleValue(Type::Color)
-        , m_color(color)
-    {
-    }
-
-    Color m_color;
-};
-
-class IdentifierStyleValue final : public StyleValue {
-public:
-    static NonnullRefPtr<IdentifierStyleValue> create(CSS::ValueID id)
-    {
-        return adopt_ref(*new IdentifierStyleValue(id));
-    }
-    virtual ~IdentifierStyleValue() override { }
-
-    CSS::ValueID id() const { return m_id; }
-
-    virtual String to_string() const override;
-    virtual Color to_color(Layout::NodeWithStyle const& node) const override;
-
-    virtual bool equals(const StyleValue& other) const override
-    {
-        if (type() != other.type())
-            return false;
-        return m_id == static_cast<const IdentifierStyleValue&>(other).m_id;
-    }
-
-private:
-    explicit IdentifierStyleValue(CSS::ValueID id)
-        : StyleValue(Type::Identifier)
-        , m_id(id)
-    {
-    }
-
-    CSS::ValueID m_id { CSS::ValueID::Invalid };
-};
-
-class ImageStyleValue final
-    : public StyleValue
-    , public ImageResourceClient {
-public:
-    static NonnullRefPtr<ImageStyleValue> create(const AK::URL& url, DOM::Document& document) { return adopt_ref(*new ImageStyleValue(url, document)); }
-    virtual ~ImageStyleValue() override { }
-
-    String to_string() const override { return String::formatted("Image({})", m_url.to_string()); }
-
-    const Gfx::Bitmap* bitmap() const { return m_bitmap; }
-
-private:
-    ImageStyleValue(const AK::URL&, DOM::Document&);
-
-    // ^ResourceClient
-    virtual void resource_did_load() override;
-
-    AK::URL m_url;
-    WeakPtr<DOM::Document> m_document;
-    RefPtr<Gfx::Bitmap> m_bitmap;
 };
 
 class BackgroundStyleValue final : public StyleValue {
@@ -849,6 +473,174 @@ private:
     Length m_vertical_radius;
 };
 
+class BoxShadowStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<BoxShadowStyleValue> create(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
+    {
+        return adopt_ref(*new BoxShadowStyleValue(offset_x, offset_y, blur_radius, color));
+    }
+    virtual ~BoxShadowStyleValue() override { }
+
+    Length const& offset_x() const { return m_offset_x; }
+    Length const& offset_y() const { return m_offset_y; }
+    Length const& blur_radius() const { return m_blur_radius; }
+    Color const& color() const { return m_color; }
+
+    String to_string() const override { return String::formatted("BoxShadow offset_x: {}, offset_y: {}, blur_radius: {}, color: {}",
+        m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string()); }
+
+private:
+    explicit BoxShadowStyleValue(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
+        : StyleValue(Type::BoxShadow)
+        , m_offset_x(offset_x)
+        , m_offset_y(offset_y)
+        , m_blur_radius(blur_radius)
+        , m_color(color)
+    {
+    }
+
+    Length m_offset_x;
+    Length m_offset_y;
+    Length m_blur_radius;
+    Color m_color;
+};
+
+class CalculatedStyleValue : public StyleValue {
+public:
+    struct CalcSum;
+    struct CalcSumPartWithOperator;
+    struct CalcProduct;
+    struct CalcProductPartWithOperator;
+    struct CalcNumberSum;
+    struct CalcNumberSumPartWithOperator;
+    struct CalcNumberProduct;
+    struct CalcNumberProductPartWithOperator;
+
+    using CalcNumberValue = Variant<float, NonnullOwnPtr<CalcNumberSum>>;
+    using CalcValue = Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>>;
+
+    // This represents that: https://drafts.csswg.org/css-values-3/#calc-syntax
+    struct CalcSum {
+        CalcSum(NonnullOwnPtr<CalcProduct> first_calc_product, NonnullOwnPtrVector<CalcSumPartWithOperator> additional)
+            : first_calc_product(move(first_calc_product))
+            , zero_or_more_additional_calc_products(move(additional)) {};
+
+        NonnullOwnPtr<CalcProduct> first_calc_product;
+        NonnullOwnPtrVector<CalcSumPartWithOperator> zero_or_more_additional_calc_products;
+    };
+
+    struct CalcNumberSum {
+        CalcNumberSum(NonnullOwnPtr<CalcNumberProduct> first_calc_number_product, NonnullOwnPtrVector<CalcNumberSumPartWithOperator> additional)
+            : first_calc_number_product(move(first_calc_number_product))
+            , zero_or_more_additional_calc_number_products(move(additional)) {};
+
+        NonnullOwnPtr<CalcNumberProduct> first_calc_number_product;
+        NonnullOwnPtrVector<CalcNumberSumPartWithOperator> zero_or_more_additional_calc_number_products;
+    };
+
+    struct CalcProduct {
+        CalcValue first_calc_value;
+        NonnullOwnPtrVector<CalcProductPartWithOperator> zero_or_more_additional_calc_values;
+    };
+
+    struct CalcSumPartWithOperator {
+        enum Operation {
+            Add,
+            Subtract,
+        };
+
+        CalcSumPartWithOperator(Operation op, NonnullOwnPtr<CalcProduct> calc_product)
+            : op(op)
+            , calc_product(move(calc_product)) {};
+
+        Operation op;
+        NonnullOwnPtr<CalcProduct> calc_product;
+    };
+
+    struct CalcProductPartWithOperator {
+        enum {
+            Multiply,
+            Divide,
+        } op;
+        Variant<CalcValue, CalcNumberValue> value;
+    };
+
+    struct CalcNumberProduct {
+        CalcNumberValue first_calc_number_value;
+        NonnullOwnPtrVector<CalcNumberProductPartWithOperator> zero_or_more_additional_calc_number_values;
+    };
+
+    struct CalcNumberProductPartWithOperator {
+        enum {
+            Multiply,
+            Divide,
+        } op;
+        CalcNumberValue value;
+    };
+
+    struct CalcNumberSumPartWithOperator {
+        enum Operation {
+            Add,
+            Subtract,
+        };
+
+        CalcNumberSumPartWithOperator(Operation op, NonnullOwnPtr<CalcNumberProduct> calc_number_product)
+            : op(op)
+            , calc_number_product(move(calc_number_product)) {};
+
+        Operation op;
+        NonnullOwnPtr<CalcNumberProduct> calc_number_product;
+    };
+
+    static NonnullRefPtr<CalculatedStyleValue> create(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)
+    {
+        return adopt_ref(*new CalculatedStyleValue(expression_string, move(calc_sum)));
+    }
+
+    String to_string() const override { return m_expression_string; }
+    NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
+
+private:
+    explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)
+        : StyleValue(Type::Calculated)
+        , m_expression_string(expression_string)
+        , m_expression(move(calc_sum))
+    {
+    }
+
+    String m_expression_string;
+    NonnullOwnPtr<CalcSum> m_expression;
+};
+
+class ColorStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<ColorStyleValue> create(Color color)
+    {
+        return adopt_ref(*new ColorStyleValue(color));
+    }
+    virtual ~ColorStyleValue() override { }
+
+    Color color() const { return m_color; }
+    String to_string() const override { return m_color.to_string(); }
+    Color to_color(Layout::NodeWithStyle const&) const override { return m_color; }
+
+    virtual bool equals(const StyleValue& other) const override
+    {
+        if (type() != other.type())
+            return false;
+        return m_color == static_cast<const ColorStyleValue&>(other).m_color;
+    }
+
+private:
+    explicit ColorStyleValue(Color color)
+        : StyleValue(Type::Color)
+        , m_color(color)
+    {
+    }
+
+    Color m_color;
+};
+
 class CombinedBorderRadiusStyleValue final : public StyleValue {
 public:
     static NonnullRefPtr<CombinedBorderRadiusStyleValue> create(NonnullRefPtr<BorderRadiusStyleValue> top_left, NonnullRefPtr<BorderRadiusStyleValue> top_right, NonnullRefPtr<BorderRadiusStyleValue> bottom_right, NonnullRefPtr<BorderRadiusStyleValue> bottom_left)
@@ -881,6 +673,26 @@ private:
     NonnullRefPtr<BorderRadiusStyleValue> m_top_right;
     NonnullRefPtr<BorderRadiusStyleValue> m_bottom_right;
     NonnullRefPtr<BorderRadiusStyleValue> m_bottom_left;
+};
+
+// FIXME: Allow for fallback
+class CustomStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<CustomStyleValue> create(const String& custom_property_name)
+    {
+        return adopt_ref(*new CustomStyleValue(custom_property_name));
+    }
+    String custom_property_name() const { return m_custom_property_name; }
+    String to_string() const override { return m_custom_property_name; }
+
+private:
+    explicit CustomStyleValue(const String& custom_property_name)
+        : StyleValue(Type::CustomProperty)
+        , m_custom_property_name(custom_property_name)
+    {
+    }
+
+    String m_custom_property_name {};
 };
 
 class FlexStyleValue final : public StyleValue {
@@ -984,6 +796,126 @@ private:
     // FIXME: Implement font-stretch and font-variant.
 };
 
+class IdentifierStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<IdentifierStyleValue> create(CSS::ValueID id)
+    {
+        return adopt_ref(*new IdentifierStyleValue(id));
+    }
+    virtual ~IdentifierStyleValue() override { }
+
+    CSS::ValueID id() const { return m_id; }
+
+    virtual String to_string() const override;
+    virtual Color to_color(Layout::NodeWithStyle const& node) const override;
+
+    virtual bool equals(const StyleValue& other) const override
+    {
+        if (type() != other.type())
+            return false;
+        return m_id == static_cast<const IdentifierStyleValue&>(other).m_id;
+    }
+
+private:
+    explicit IdentifierStyleValue(CSS::ValueID id)
+        : StyleValue(Type::Identifier)
+        , m_id(id)
+    {
+    }
+
+    CSS::ValueID m_id { CSS::ValueID::Invalid };
+};
+
+class ImageStyleValue final
+    : public StyleValue
+    , public ImageResourceClient {
+public:
+    static NonnullRefPtr<ImageStyleValue> create(const AK::URL& url, DOM::Document& document) { return adopt_ref(*new ImageStyleValue(url, document)); }
+    virtual ~ImageStyleValue() override { }
+
+    String to_string() const override { return String::formatted("Image({})", m_url.to_string()); }
+
+    const Gfx::Bitmap* bitmap() const { return m_bitmap; }
+
+private:
+    ImageStyleValue(const AK::URL&, DOM::Document&);
+
+    // ^ResourceClient
+    virtual void resource_did_load() override;
+
+    AK::URL m_url;
+    WeakPtr<DOM::Document> m_document;
+    RefPtr<Gfx::Bitmap> m_bitmap;
+};
+
+class InheritStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<InheritStyleValue> the()
+    {
+        static NonnullRefPtr<InheritStyleValue> instance = adopt_ref(*new InheritStyleValue);
+        return instance;
+    }
+    virtual ~InheritStyleValue() override { }
+
+    String to_string() const override { return "inherit"; }
+
+private:
+    InheritStyleValue()
+        : StyleValue(Type::Inherit)
+    {
+    }
+};
+
+class InitialStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<InitialStyleValue> the()
+    {
+        static NonnullRefPtr<InitialStyleValue> instance = adopt_ref(*new InitialStyleValue);
+        return instance;
+    }
+    virtual ~InitialStyleValue() override { }
+
+    String to_string() const override { return "initial"; }
+
+private:
+    InitialStyleValue()
+        : StyleValue(Type::Initial)
+    {
+    }
+};
+
+class LengthStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<LengthStyleValue> create(const Length& length)
+    {
+        return adopt_ref(*new LengthStyleValue(length));
+    }
+    virtual ~LengthStyleValue() override { }
+
+    virtual String to_string() const override { return m_length.to_string(); }
+    virtual Length to_length() const override { return m_length; }
+
+    const Length& length() const { return m_length; }
+
+    virtual bool is_auto() const override { return m_length.is_auto(); }
+
+    virtual bool equals(const StyleValue& other) const override
+    {
+        if (type() != other.type())
+            return false;
+        return m_length == static_cast<const LengthStyleValue&>(other).m_length;
+    }
+
+private:
+    explicit LengthStyleValue(const Length& length)
+        : StyleValue(Type::Length)
+        , m_length(length)
+    {
+    }
+
+    Length m_length;
+};
+
 class ListStyleStyleValue final : public StyleValue {
 public:
     static NonnullRefPtr<ListStyleStyleValue> create(
@@ -1021,6 +953,36 @@ private:
     NonnullRefPtr<StyleValue> m_style_type;
 };
 
+class NumericStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<NumericStyleValue> create(float value)
+    {
+        return adopt_ref(*new NumericStyleValue(value));
+    }
+
+    virtual bool is_length() const override { return m_value == 0; }
+    virtual Length to_length() const override { return Length(0, Length::Type::Px); }
+
+    float value() const { return m_value; }
+    String to_string() const override { return String::formatted("{}", m_value); }
+
+    virtual bool equals(StyleValue const& other) const override
+    {
+        if (type() != other.type())
+            return false;
+        return m_value == static_cast<NumericStyleValue const&>(other).m_value;
+    }
+
+private:
+    explicit NumericStyleValue(float value)
+        : StyleValue(Type::Numeric)
+        , m_value(value)
+    {
+    }
+
+    float m_value { 0 };
+};
+
 class OverflowStyleValue final : public StyleValue {
 public:
     static NonnullRefPtr<OverflowStyleValue> create(NonnullRefPtr<StyleValue> overflow_x, NonnullRefPtr<StyleValue> overflow_y)
@@ -1047,6 +1009,26 @@ private:
 
     NonnullRefPtr<StyleValue> m_overflow_x;
     NonnullRefPtr<StyleValue> m_overflow_y;
+};
+
+class StringStyleValue : public StyleValue {
+public:
+    static NonnullRefPtr<StringStyleValue> create(const String& string)
+    {
+        return adopt_ref(*new StringStyleValue(string));
+    }
+    virtual ~StringStyleValue() override { }
+
+    String to_string() const override { return m_string; }
+
+private:
+    explicit StringStyleValue(const String& string)
+        : StyleValue(Type::String)
+        , m_string(string)
+    {
+    }
+
+    String m_string;
 };
 
 class TextDecorationStyleValue final : public StyleValue {
@@ -1112,6 +1094,24 @@ private:
 
     CSS::TransformFunction m_transform_function;
     NonnullRefPtrVector<StyleValue> m_values;
+};
+
+class UnsetStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<UnsetStyleValue> the()
+    {
+        static NonnullRefPtr<UnsetStyleValue> instance = adopt_ref(*new UnsetStyleValue);
+        return instance;
+    }
+    virtual ~UnsetStyleValue() override { }
+
+    String to_string() const override { return "unset"; }
+
+private:
+    UnsetStyleValue()
+        : StyleValue(Type::Unset)
+    {
+    }
 };
 
 class StyleValueList final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -269,11 +269,11 @@ public:
     bool is_flex() const { return type() == Type::Flex; }
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
-    bool is_identifier() const { return type() == Type::Identifier || is_auto(); }
+    bool is_identifier() const { return type() == Type::Identifier; }
     bool is_image() const { return type() == Type::Image; }
     bool is_inherit() const { return type() == Type::Inherit; }
     bool is_initial() const { return type() == Type::Initial; }
-    virtual bool is_length() const { return type() == Type::Length; }
+    bool is_length() const { return type() == Type::Length; }
     bool is_list_style() const { return type() == Type::ListStyle; }
     bool is_numeric() const { return type() == Type::Numeric; }
     bool is_overflow() const { return type() == Type::Overflow; }
@@ -285,21 +285,67 @@ public:
 
     bool is_builtin() const { return is_inherit() || is_initial() || is_unset(); }
 
-    bool is_builtin_or_dynamic() const
-    {
-        return is_builtin() || is_custom_property() || is_calculated();
-    }
+    BackgroundRepeatStyleValue const& as_background_repeat() const;
+    BackgroundStyleValue const& as_background() const;
+    BorderRadiusStyleValue const& as_border_radius() const;
+    BorderStyleValue const& as_border() const;
+    BoxShadowStyleValue const& as_box_shadow() const;
+    CalculatedStyleValue const& as_calculated() const;
+    ColorStyleValue const& as_color() const;
+    CustomStyleValue const& as_custom_property() const;
+    FlexFlowStyleValue const& as_flex_flow() const;
+    FlexStyleValue const& as_flex() const;
+    FontStyleValue const& as_font() const;
+    IdentifierStyleValue const& as_identifier() const;
+    ImageStyleValue const& as_image() const;
+    InheritStyleValue const& as_inherit() const;
+    InitialStyleValue const& as_initial() const;
+    LengthStyleValue const& as_length() const;
+    ListStyleStyleValue const& as_list_style() const;
+    NumericStyleValue const& as_numeric() const;
+    OverflowStyleValue const& as_overflow() const;
+    StringStyleValue const& as_string() const;
+    TextDecorationStyleValue const& as_text_decoration() const;
+    TransformationStyleValue const& as_transformation() const;
+    UnsetStyleValue const& as_unset() const;
+    StyleValueList const& as_value_list() const;
 
-    float as_number() const;
+    BackgroundRepeatStyleValue& as_background_repeat() { return const_cast<BackgroundRepeatStyleValue&>(const_cast<StyleValue const&>(*this).as_background_repeat()); }
+    BackgroundStyleValue& as_background() { return const_cast<BackgroundStyleValue&>(const_cast<StyleValue const&>(*this).as_background()); }
+    BorderRadiusStyleValue& as_border_radius() { return const_cast<BorderRadiusStyleValue&>(const_cast<StyleValue const&>(*this).as_border_radius()); }
+    BorderStyleValue& as_border() { return const_cast<BorderStyleValue&>(const_cast<StyleValue const&>(*this).as_border()); }
+    BoxShadowStyleValue& as_box_shadow() { return const_cast<BoxShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_box_shadow()); }
+    CalculatedStyleValue& as_calculated() { return const_cast<CalculatedStyleValue&>(const_cast<StyleValue const&>(*this).as_calculated()); }
+    ColorStyleValue& as_color() { return const_cast<ColorStyleValue&>(const_cast<StyleValue const&>(*this).as_color()); }
+    CustomStyleValue& as_custom_property() { return const_cast<CustomStyleValue&>(const_cast<StyleValue const&>(*this).as_custom_property()); }
+    FlexFlowStyleValue& as_flex_flow() { return const_cast<FlexFlowStyleValue&>(const_cast<StyleValue const&>(*this).as_flex_flow()); }
+    FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
+    FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
+    IdentifierStyleValue& as_identifier() { return const_cast<IdentifierStyleValue&>(const_cast<StyleValue const&>(*this).as_identifier()); }
+    ImageStyleValue& as_image() { return const_cast<ImageStyleValue&>(const_cast<StyleValue const&>(*this).as_image()); }
+    InheritStyleValue& as_inherit() { return const_cast<InheritStyleValue&>(const_cast<StyleValue const&>(*this).as_inherit()); }
+    InitialStyleValue& as_initial() { return const_cast<InitialStyleValue&>(const_cast<StyleValue const&>(*this).as_initial()); }
+    LengthStyleValue& as_length() { return const_cast<LengthStyleValue&>(const_cast<StyleValue const&>(*this).as_length()); }
+    ListStyleStyleValue& as_list_style() { return const_cast<ListStyleStyleValue&>(const_cast<StyleValue const&>(*this).as_list_style()); }
+    NumericStyleValue& as_numeric() { return const_cast<NumericStyleValue&>(const_cast<StyleValue const&>(*this).as_numeric()); }
+    OverflowStyleValue& as_overflow() { return const_cast<OverflowStyleValue&>(const_cast<StyleValue const&>(*this).as_overflow()); }
+    StringStyleValue& as_string() { return const_cast<StringStyleValue&>(const_cast<StyleValue const&>(*this).as_string()); }
+    TextDecorationStyleValue& as_text_decoration() { return const_cast<TextDecorationStyleValue&>(const_cast<StyleValue const&>(*this).as_text_decoration()); }
+    TransformationStyleValue& as_transformation() { return const_cast<TransformationStyleValue&>(const_cast<StyleValue const&>(*this).as_transformation()); }
+    UnsetStyleValue& as_unset() { return const_cast<UnsetStyleValue&>(const_cast<StyleValue const&>(*this).as_unset()); }
+    StyleValueList& as_value_list() { return const_cast<StyleValueList&>(const_cast<StyleValue const&>(*this).as_value_list()); }
 
-    virtual String to_string() const = 0;
-    virtual Length to_length() const { return {}; }
+    virtual bool has_auto() const { return false; }
+    virtual bool has_color() const { return false; }
+    virtual bool has_identifier() const { return false; }
+    virtual bool has_length() const { return false; }
+    virtual bool has_number() const { return false; }
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
-
-    CSS::ValueID to_identifier() const;
-
-    virtual bool is_auto() const { return false; }
+    virtual CSS::ValueID to_identifier() const { return ValueID::Invalid; }
+    virtual Length to_length() const { return {}; }
+    virtual float to_number() const { return {}; }
+    virtual String to_string() const = 0;
 
     bool operator==(const StyleValue& other) const { return equals(other); }
     bool operator!=(const StyleValue& other) const { return !(*this == other); }
@@ -621,8 +667,9 @@ public:
     virtual ~ColorStyleValue() override { }
 
     Color color() const { return m_color; }
-    String to_string() const override { return m_color.to_string(); }
-    Color to_color(Layout::NodeWithStyle const&) const override { return m_color; }
+    virtual String to_string() const override { return m_color.to_string(); }
+    virtual bool has_color() const override { return true; }
+    virtual Color to_color(Layout::NodeWithStyle const&) const override { return m_color; }
 
     virtual bool equals(const StyleValue& other) const override
     {
@@ -806,8 +853,12 @@ public:
 
     CSS::ValueID id() const { return m_id; }
 
-    virtual String to_string() const override;
+    virtual bool has_auto() const override { return m_id == ValueID::Auto; }
+    virtual bool has_identifier() const override { return true; }
+    virtual CSS::ValueID to_identifier() const override { return m_id; }
+    virtual bool has_color() const override;
     virtual Color to_color(Layout::NodeWithStyle const& node) const override;
+    virtual String to_string() const override;
 
     virtual bool equals(const StyleValue& other) const override
     {
@@ -892,12 +943,12 @@ public:
     }
     virtual ~LengthStyleValue() override { }
 
+    Length const& length() const { return m_length; }
+
+    virtual bool has_auto() const override { return m_length.is_auto(); }
+    virtual bool has_length() const override { return true; }
     virtual String to_string() const override { return m_length.to_string(); }
     virtual Length to_length() const override { return m_length; }
-
-    const Length& length() const { return m_length; }
-
-    virtual bool is_auto() const override { return m_length.is_auto(); }
 
     virtual bool equals(const StyleValue& other) const override
     {
@@ -960,10 +1011,15 @@ public:
         return adopt_ref(*new NumericStyleValue(value));
     }
 
-    virtual bool is_length() const override { return m_value == 0; }
+    virtual bool has_length() const override { return m_value == 0; }
     virtual Length to_length() const override { return Length(0, Length::Type::Px); }
 
+    virtual bool has_number() const override { return true; }
+    virtual float to_number() const override { return m_value; }
+
     float value() const { return m_value; }
+    // FIXME: Store integer values separately
+    i64 int_value() const { return roundf(m_value); }
     String to_string() const override { return String::formatted("{}", m_value); }
 
     virtual bool equals(StyleValue const& other) const override
@@ -1143,12 +1199,4 @@ private:
     NonnullRefPtrVector<StyleValue> m_values;
 };
 
-inline CSS::ValueID StyleValue::to_identifier() const
-{
-    if (type() == Type::Identifier)
-        return static_cast<const IdentifierStyleValue&>(*this).id();
-    if (is_auto())
-        return CSS::ValueID::Auto;
-    return CSS::ValueID::Invalid;
-}
 }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -28,8 +28,33 @@ class Selector;
 class StyleProperties;
 class StyleResolver;
 class StyleSheet;
-class StyleValue;
 enum class Display;
+
+class StyleValue;
+class BackgroundRepeatStyleValue;
+class BackgroundStyleValue;
+class BorderRadiusStyleValue;
+class BorderStyleValue;
+class BoxShadowStyleValue;
+class CalculatedStyleValue;
+class ColorStyleValue;
+class CustomStyleValue;
+class FlexFlowStyleValue;
+class FlexStyleValue;
+class FontStyleValue;
+class IdentifierStyleValue;
+class ImageStyleValue;
+class InheritStyleValue;
+class InitialStyleValue;
+class LengthStyleValue;
+class ListStyleStyleValue;
+class NumericStyleValue;
+class OverflowStyleValue;
+class StringStyleValue;
+class TextDecorationStyleValue;
+class TransformationStyleValue;
+class UnsetStyleValue;
+class StyleValueList;
 }
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -329,13 +329,13 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     if (computed_values.opacity() == 0)
         m_visible = false;
 
-    if (auto width = specified_style.property(CSS::PropertyID::Width); width.has_value() && !width.value()->is_auto())
+    if (auto width = specified_style.property(CSS::PropertyID::Width); width.has_value() && !width.value()->has_auto())
         m_has_definite_width = true;
     computed_values.set_width(specified_style.length_or_fallback(CSS::PropertyID::Width, {}));
     computed_values.set_min_width(specified_style.length_or_fallback(CSS::PropertyID::MinWidth, {}));
     computed_values.set_max_width(specified_style.length_or_fallback(CSS::PropertyID::MaxWidth, {}));
 
-    if (auto height = specified_style.property(CSS::PropertyID::Height); height.has_value() && !height.value()->is_auto())
+    if (auto height = specified_style.property(CSS::PropertyID::Height); height.has_value() && !height.value()->has_auto())
         m_has_definite_height = true;
     computed_values.set_height(specified_style.length_or_fallback(CSS::PropertyID::Height, {}));
     computed_values.set_min_height(specified_style.length_or_fallback(CSS::PropertyID::MinHeight, {}));

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -220,7 +220,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
 
     auto bgimage = specified_style.property(CSS::PropertyID::BackgroundImage);
     if (bgimage.has_value() && bgimage.value()->is_image()) {
-        m_background_image = static_ptr_cast<CSS::ImageStyleValue>(bgimage.value());
+        m_background_image = bgimage.value()->as_image();
     }
 
     // FIXME: BorderXRadius properties are now BorderRadiusStyleValues, so make use of that.
@@ -374,7 +374,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         // FIXME: Converting to pixels isn't really correct - values should be in "user units"
         //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
         if (stroke_width.value()->is_numeric())
-            computed_values.set_stroke_width(CSS::Length::make_px(static_cast<CSS::NumericStyleValue const&>(*stroke_width.value()).value()));
+            computed_values.set_stroke_width(CSS::Length::make_px(stroke_width.value()->to_number()));
         else
             computed_values.set_stroke_width(stroke_width.value()->to_length());
     }


### PR DESCRIPTION
Several times I've run into bugs caused by user code assuming `StyleValue::is_foo()` methods meaning it's a `FooStyleValue`, when in reality it sometimes would be some other `StyleValue` that was able to return a `Foo`. This PR clarifies the naming by splitting `is_foo()` (referring to the type) and `has_foo()` (can return the value); and adding `as_foo()` methods to safely do the cast for you.

Also, sorted some things alphabetically to make navigating them easier.

Obviously this doesn't solve all the confusion, since we still have values that can be more than one thing (`0` can be a Length or a Number; `auto` can be a Length or an Identifier) but this should make things clearer.