### PR TITLE
LibWeb: Skip decoding favicon.ico if downloaded data is empty

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -172,6 +172,8 @@ bool FrameLoader::load(LoadRequest& request, Type type)
             favicon_url,
             [this, favicon_url](auto data, auto&, auto) {
                 dbgln_if(SPAM_DEBUG, "Favicon downloaded, {} bytes from {}", data.size(), favicon_url);
+                if (data.is_empty())
+                    return;
                 RefPtr<Gfx::Bitmap> favicon_bitmap;
                 auto decoder = Gfx::ImageDecoder::try_create(data);
                 if (!decoder) {


### PR DESCRIPTION
Some sites don't have favicon.ico, so we may get 404 response.
In such cases, ResourceLoader still calls success_callback.
For favicon loading, we are not checking response headers or payload size.
This will ultimately fail in Gfx::ImageDecoder::try_create().

So avoid unnecessary work by returning early if data is empty.