### PR TITLE
PixelPaint: Create an empty layer when the last layer is removed

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -522,7 +522,11 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 auto& next_active_layer = editor->image().layer(active_layer_index > 0 ? active_layer_index - 1 : 0);
                 editor->set_active_layer(&next_active_layer);
             } else {
-                editor->set_active_layer(nullptr);
+                auto layer = PixelPaint::Layer::try_create_with_size(editor->image(), editor->image().size(), "Background");
+                VERIFY(layer);
+                editor->image().add_layer(layer.release_nonnull());
+                editor->layers_did_change();
+                m_layer_list_widget->select_top_layer();
             }
         }));
 


### PR DESCRIPTION
Previously, when the last layer got deleted, the active layer was
set to nullptr, causing a crash.

Now, we create a new transparent background layer with the image
dimensions instead.