### PR TITLE
HexEditor: Added option to show selection offset and size in hex

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -53,6 +53,7 @@ private:
     RefPtr<GUI::Action> m_goto_offset_action;
     RefPtr<GUI::Action> m_layout_toolbar_action;
     RefPtr<GUI::Action> m_layout_search_results_action;
+    RefPtr<GUI::Action> m_selection_information_format_mode_action;
 
     GUI::ActionGroup m_bytes_per_row_actions;
 
@@ -63,4 +64,5 @@ private:
     RefPtr<GUI::Widget> m_search_results_container;
 
     bool m_document_dirty { false };
+    bool m_show_selection_information_as_hex { false };
 };


### PR DESCRIPTION
This patch adds menu item "Selection info in hex" to "View" menu. When toggled, selection information such as selection start, end and size is shown in hexadecimal format, if not then in decimal.