### PR TITLE
HexEditor: Show blinking caret at current position

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -574,8 +574,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             Gfx::Color text_color = edited_flag ? Color::Red : palette().color(foreground_role());
 
             if (highlight_flag) {
-                background_color = palette().selection();
-                text_color = edited_flag ? Color::from_rgb(0xFFC0CB) : palette().selection_text();
+                background_color = edited_flag ? palette().selection().inverted() : palette().selection();
+                text_color = edited_flag ? palette().selection_text().inverted() : palette().selection_text();
             } else if (byte_position == m_position && m_edit_mode == EditMode::Text) {
                 background_color = palette().inactive_selection();
                 text_color = palette().inactive_selection_text();
@@ -605,8 +605,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             text_color = edited_flag ? Color::Red : palette().color(foreground_role());
 
             if (highlight_flag) {
-                background_color = palette().selection();
-                text_color = edited_flag ? Color::from_rgb(0xFFC0CB) : palette().selection_text();
+                background_color = edited_flag ? palette().selection().inverted() : palette().selection();
+                text_color = edited_flag ? palette().selection_text().inverted() : palette().selection_text();
             } else if (byte_position == m_position && m_edit_mode == EditMode::Hex) {
                 background_color = palette().inactive_selection();
                 text_color = palette().inactive_selection_text();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -190,8 +190,8 @@ bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
 void HexEditor::set_bytes_per_row(size_t bytes_per_row)
 {
     m_bytes_per_row = bytes_per_row;
-    auto newWidth = offset_margin_width() + (m_bytes_per_row * (character_width() * 3)) + 10 + (m_bytes_per_row * character_width()) + 20;
-    auto newHeight = total_rows() * line_height() + 10;
+    auto newWidth = offset_margin_width() + (m_bytes_per_row * cell_width()) + 2 * m_padding + (m_bytes_per_row * character_width()) + 4 * m_padding;
+    auto newHeight = total_rows() * line_height() + 2 * m_padding;
     set_content_size({ static_cast<int>(newWidth), static_cast<int>(newHeight) });
     update();
 }
@@ -201,8 +201,8 @@ void HexEditor::set_content_length(size_t length)
     if (length == m_content_length)
         return;
     m_content_length = length;
-    auto newWidth = offset_margin_width() + (m_bytes_per_row * (character_width() * 3)) + 10 + (m_bytes_per_row * character_width()) + 20;
-    auto newHeight = total_rows() * line_height() + 10;
+    auto newWidth = offset_margin_width() + (m_bytes_per_row * cell_width()) + 2 * m_padding + (m_bytes_per_row * character_width()) + 4 * m_padding;
+    auto newHeight = total_rows() * line_height() + 2 * m_padding;
     set_content_size({ static_cast<int>(newWidth), static_cast<int>(newHeight) });
 }
 
@@ -215,21 +215,21 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
     auto absolute_x = horizontal_scrollbar().value() + event.x();
     auto absolute_y = vertical_scrollbar().value() + event.y();
 
-    auto hex_start_x = frame_thickness() + 90;
-    auto hex_start_y = frame_thickness() + 5;
-    auto hex_end_x = static_cast<int>(hex_start_x + (bytes_per_row() * (character_width() * 3)));
-    auto hex_end_y = static_cast<int>(hex_start_y + 5 + (total_rows() * line_height()));
+    auto hex_start_x = frame_thickness() + m_address_bar_width;
+    auto hex_start_y = frame_thickness() + m_padding;
+    auto hex_end_x = static_cast<int>(hex_start_x + bytes_per_row() * cell_width());
+    auto hex_end_y = static_cast<int>(hex_start_y + m_padding + total_rows() * line_height());
 
-    auto text_start_x = static_cast<int>(frame_thickness() + 100 + (bytes_per_row() * (character_width() * 3)));
-    auto text_start_y = frame_thickness() + 5;
-    auto text_end_x = static_cast<int>(text_start_x + (bytes_per_row() * character_width()));
-    auto text_end_y = static_cast<int>(text_start_y + 5 + (total_rows() * line_height()));
+    auto text_start_x = static_cast<int>(frame_thickness() + m_address_bar_width + 2 * m_padding + bytes_per_row() * cell_width());
+    auto text_start_y = frame_thickness() + m_padding;
+    auto text_end_x = static_cast<int>(text_start_x + bytes_per_row() * character_width());
+    auto text_end_y = static_cast<int>(text_start_y + m_padding + total_rows() * line_height());
 
     if (absolute_x >= hex_start_x && absolute_x <= hex_end_x && absolute_y >= hex_start_y && absolute_y <= hex_end_y) {
         if (absolute_x < hex_start_x || absolute_y < hex_start_y)
             return;
 
-        auto byte_x = (absolute_x - hex_start_x) / (character_width() * 3);
+        auto byte_x = (absolute_x - hex_start_x) / cell_width();
         auto byte_y = (absolute_y - hex_start_y) / line_height();
         auto offset = (byte_y * m_bytes_per_row) + byte_x;
 
@@ -277,15 +277,15 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
     auto absolute_x = horizontal_scrollbar().value() + event.x();
     auto absolute_y = vertical_scrollbar().value() + event.y();
 
-    auto hex_start_x = frame_thickness() + 90;
-    auto hex_start_y = frame_thickness() + 5;
-    auto hex_end_x = static_cast<int>(hex_start_x + (bytes_per_row() * (character_width() * 3)));
-    auto hex_end_y = static_cast<int>(hex_start_y + 5 + (total_rows() * line_height()));
+    auto hex_start_x = frame_thickness() + m_address_bar_width;
+    auto hex_start_y = frame_thickness() + m_padding;
+    auto hex_end_x = static_cast<int>(hex_start_x + bytes_per_row() * cell_width());
+    auto hex_end_y = static_cast<int>(hex_start_y + m_padding + total_rows() * line_height());
 
-    auto text_start_x = static_cast<int>(frame_thickness() + 100 + (bytes_per_row() * (character_width() * 3)));
-    auto text_start_y = frame_thickness() + 5;
-    auto text_end_x = static_cast<int>(text_start_x + (bytes_per_row() * character_width()));
-    auto text_end_y = static_cast<int>(text_start_y + 5 + (total_rows() * line_height()));
+    auto text_start_x = static_cast<int>(frame_thickness() + m_address_bar_width + 2 * m_padding + bytes_per_row() * cell_width());
+    auto text_start_y = frame_thickness() + m_padding;
+    auto text_end_x = static_cast<int>(text_start_x + bytes_per_row() * character_width());
+    auto text_end_y = static_cast<int>(text_start_y + m_padding + total_rows() * line_height());
 
     if ((absolute_x >= hex_start_x && absolute_x <= hex_end_x
             && absolute_y >= hex_start_y && absolute_y <= hex_end_y)
@@ -301,7 +301,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
             if (absolute_x < hex_start_x || absolute_y < hex_start_y)
                 return;
 
-            auto byte_x = (absolute_x - hex_start_x) / (character_width() * 3);
+            auto byte_x = (absolute_x - hex_start_x) / cell_width();
             auto byte_y = (absolute_y - hex_start_y) / line_height();
             auto offset = (byte_y * m_bytes_per_row) + byte_x;
 
@@ -356,9 +356,9 @@ void HexEditor::scroll_position_into_view(size_t position)
     size_t y = position / bytes_per_row();
     size_t x = position % bytes_per_row();
     Gfx::IntRect rect {
-        static_cast<int>(frame_thickness() + offset_margin_width() + (x * (character_width() * 3)) + 10),
-        static_cast<int>(frame_thickness() + 5 + (y * line_height())),
-        static_cast<int>((character_width() * 3)),
+        static_cast<int>(frame_thickness() + offset_margin_width() + x * cell_width() + 2 * m_padding),
+        static_cast<int>(frame_thickness() + m_padding + y * line_height()),
+        static_cast<int>(cell_width()),
         static_cast<int>(line_height() - m_line_spacing)
     };
     scroll_into_view(rect, true, true);
@@ -526,13 +526,13 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     Gfx::IntRect offset_clip_rect {
         0,
         vertical_scrollbar().value(),
-        85,
+        m_address_bar_width - m_padding,
         height() - height_occupied_by_horizontal_scrollbar() //(total_rows() * line_height()) + 5
     };
     painter.fill_rect(offset_clip_rect, palette().ruler());
     painter.draw_line(offset_clip_rect.top_right(), offset_clip_rect.bottom_right(), palette().ruler_border());
 
-    auto margin_and_hex_width = static_cast<int>(offset_margin_width() + (m_bytes_per_row * (character_width() * 3)) + 15);
+    auto margin_and_hex_width = static_cast<int>(offset_margin_width() + m_bytes_per_row * cell_width() + 3 * m_padding);
     painter.draw_line({ margin_and_hex_width, 0 },
         { margin_and_hex_width, vertical_scrollbar().value() + (height() - height_occupied_by_horizontal_scrollbar()) },
         palette().ruler_border());
@@ -544,8 +544,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
     // paint offsets
     for (size_t i = min_row; i < max_row; i++) {
         Gfx::IntRect side_offset_rect {
-            frame_thickness() + 5,
-            static_cast<int>(frame_thickness() + 5 + (i * line_height())),
+            frame_thickness() + m_padding,
+            static_cast<int>(frame_thickness() + m_padding + i * line_height()),
             width() - width_occupied_by_vertical_scrollbar(),
             height() - height_occupied_by_horizontal_scrollbar()
         };
@@ -573,9 +573,9 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             const bool highlight_flag = selection_inbetween_start_end || selection_inbetween_end_start;
 
             Gfx::IntRect hex_display_rect {
-                frame_thickness() + offset_margin_width() + (static_cast<int>(j) * (character_width() * 3)) + 10,
-                frame_thickness() + 5 + (static_cast<int>(i) * line_height()),
-                (character_width() * 3),
+                frame_thickness() + offset_margin_width() + static_cast<int>(j) * cell_width() + 2 * m_padding,
+                frame_thickness() + m_padding + static_cast<int>(i) * line_height(),
+                cell_width(),
                 line_height() - m_line_spacing
             };
 
@@ -607,8 +607,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             }
 
             Gfx::IntRect text_display_rect {
-                static_cast<int>(frame_thickness() + offset_margin_width() + (bytes_per_row() * (character_width() * 3)) + (j * character_width()) + 20),
-                static_cast<int>(frame_thickness() + 5 + (i * line_height())),
+                static_cast<int>(frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + j * character_width() + 4 * m_padding),
+                static_cast<int>(frame_thickness() + m_padding + i * line_height()),
                 static_cast<int>(character_width()),
                 static_cast<int>(line_height() - m_line_spacing)
             };

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -32,30 +32,30 @@ public:
     bool is_readonly() const { return m_readonly; }
     void set_readonly(bool);
 
-    int buffer_size() const { return m_buffer.size(); }
+    size_t buffer_size() const { return m_buffer.size(); }
     void set_buffer(const ByteBuffer&);
     void fill_selection(u8 fill_byte);
     bool write_to_file(const String& path);
     bool write_to_file(int fd);
 
     void select_all();
-    bool has_selection() const { return !(m_selection_start == -1 || m_selection_end == -1 || (m_selection_end - m_selection_start) <= 0 || m_buffer.is_empty()); }
+    bool has_selection() const { return !((m_selection_end < m_selection_start) || m_buffer.is_empty()); }
     size_t selection_size();
-    int selection_start_offset() const { return m_selection_start; }
+    size_t selection_start_offset() const { return m_selection_start; }
     bool copy_selected_text_to_clipboard();
     bool copy_selected_hex_to_clipboard();
     bool copy_selected_hex_to_clipboard_as_c_code();
 
-    int bytes_per_row() const { return m_bytes_per_row; }
-    void set_bytes_per_row(int);
+    size_t bytes_per_row() const { return m_bytes_per_row; }
+    void set_bytes_per_row(size_t);
 
-    void set_position(int position);
-    void highlight(int start, int end);
-    int find(ByteBuffer& needle, int start = 0);
-    int find_and_highlight(ByteBuffer& needle, int start = 0);
-    Vector<Match> find_all(ByteBuffer& needle, int start = 0);
+    void set_position(size_t position);
+    void highlight(size_t start, size_t end);
+    Optional<size_t> find(ByteBuffer& needle, size_t start = 0);
+    Optional<size_t> find_and_highlight(ByteBuffer& needle, size_t start = 0);
+    Vector<Match> find_all(ByteBuffer& needle, size_t start = 0);
     Vector<Match> find_all_strings(size_t min_length = 4);
-    Function<void(int, EditMode, int, int)> on_status_change; // position, edit mode, selection start, selection end
+    Function<void(size_t, EditMode, size_t, size_t)> on_status_change; // position, edit mode, selection start, selection end
     Function<void()> on_change;
 
 protected:
@@ -69,31 +69,31 @@ protected:
 
 private:
     bool m_readonly { false };
-    int m_line_spacing { 4 };
-    int m_content_length { 0 };
-    int m_bytes_per_row { 16 };
+    size_t m_line_spacing { 4 };
+    size_t m_content_length { 0 };
+    size_t m_bytes_per_row { 16 };
     ByteBuffer m_buffer;
     bool m_in_drag_select { false };
-    int m_selection_start { 0 };
-    int m_selection_end { 0 };
-    HashMap<int, u8> m_tracked_changes;
-    int m_position { 0 };
-    int m_byte_position { 0 }; // 0 or 1
+    size_t m_selection_start { 0 };
+    size_t m_selection_end { 0 };
+    HashMap<size_t, u8> m_tracked_changes;
+    size_t m_position { 0 };
+    bool m_cursor_at_low_nibble { false };
     EditMode m_edit_mode { Hex };
     NonnullRefPtr<Core::Timer> m_blink_timer;
     bool m_cursor_blink_active { false };
 
-    void scroll_position_into_view(int position);
+    void scroll_position_into_view(size_t position);
 
-    int total_rows() const { return ceil_div(m_content_length, m_bytes_per_row); }
-    int line_height() const { return font().glyph_height() + m_line_spacing; }
-    int character_width() const { return font().glyph_width('W'); }
-    int offset_margin_width() const { return 80; }
+    size_t total_rows() const { return ceil_div(m_content_length, m_bytes_per_row); }
+    size_t line_height() const { return font().glyph_height() + m_line_spacing; }
+    size_t character_width() const { return font().glyph_width('W'); }
+    size_t offset_margin_width() const { return 80; }
 
     void hex_mode_keydown_event(GUI::KeyEvent&);
     void text_mode_keydown_event(GUI::KeyEvent&);
 
-    void set_content_length(int); // I might make this public if I add fetching data on demand.
+    void set_content_length(size_t); // I might make this public if I add fetching data on demand.
     void update_status();
     void did_change();
 

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -14,6 +14,7 @@
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/StdLibExtras.h>
+#include <LibCore/Timer.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGfx/Font.h>
 #include <LibGfx/TextAlignment.h>
@@ -38,7 +39,7 @@ public:
     bool write_to_file(int fd);
 
     void select_all();
-    bool has_selection() const { return !(m_selection_start == -1 || m_selection_end == -1 || (m_selection_end - m_selection_start) < 0 || m_buffer.is_empty()); }
+    bool has_selection() const { return !(m_selection_start == -1 || m_selection_end == -1 || (m_selection_end - m_selection_start) <= 0 || m_buffer.is_empty()); }
     size_t selection_size();
     int selection_start_offset() const { return m_selection_start; }
     bool copy_selected_text_to_clipboard();
@@ -79,6 +80,8 @@ private:
     int m_position { 0 };
     int m_byte_position { 0 }; // 0 or 1
     EditMode m_edit_mode { Hex };
+    NonnullRefPtr<Core::Timer> m_blink_timer;
+    bool m_cursor_blink_active { false };
 
     void scroll_position_into_view(int position);
 
@@ -93,4 +96,6 @@ private:
     void set_content_length(int); // I might make this public if I add fetching data on demand.
     void update_status();
     void did_change();
+
+    void reset_cursor_blink_state();
 };

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -83,11 +83,15 @@ private:
     NonnullRefPtr<Core::Timer> m_blink_timer;
     bool m_cursor_blink_active { false };
 
+    static constexpr int m_address_bar_width = 90;
+    static constexpr int m_padding = 5;
+
     void scroll_position_into_view(size_t position);
 
     size_t total_rows() const { return ceil_div(m_content_length, m_bytes_per_row); }
     size_t line_height() const { return font().glyph_height() + m_line_spacing; }
     size_t character_width() const { return font().glyph_width('W'); }
+    size_t cell_width() const { return character_width() * 3; }
     size_t offset_margin_width() const { return 80; }
 
     void hex_mode_keydown_event(GUI::KeyEvent&);

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -174,12 +174,12 @@ HexEditorWidget::HexEditorWidget()
 
                 auto result = m_editor->find_and_highlight(m_search_buffer, same_buffers ? last_found_index() : 0);
 
-                if (result == -1) {
+                if (!result.has_value()) {
                     GUI::MessageBox::show(window(), String::formatted("Pattern \"{}\" not found in this file", m_search_text), "Not found", GUI::MessageBox::Type::Warning);
                     return;
                 }
 
-                m_last_found_index = result;
+                m_last_found_index = result.value();
             }
 
             m_editor->update();
@@ -268,12 +268,12 @@ void HexEditorWidget::initialize_menubar(GUI::Window& window)
         }
 
         auto result = m_editor->find_and_highlight(m_search_buffer, last_found_index());
-        if (!result) {
+        if (!result.has_value()) {
             GUI::MessageBox::show(&window, String::formatted("No more matches for \"{}\" found in this file", m_search_text), "Not found", GUI::MessageBox::Type::Warning);
             return;
         }
         m_editor->update();
-        m_last_found_index = result;
+        m_last_found_index = result.value();
     }));
 
     edit_menu.add_action(GUI::Action::create("Find All &Strings", { Mod_Ctrl | Mod_Shift, Key_S }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/find.png"), [&](const GUI::Action&) {


### PR DESCRIPTION
For better visibility of wether the editing focus is on the hex or the
ascii view, render a blinking caret instead of a solid cell background.
For that to work, it's also necessary to change the way selection works.
The selection shouldn't extend to the current position but up to the
byte before it.