### PR TITLE
LibCore: Buffer small byte reads (for flac)

### DIFF
--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -103,7 +103,7 @@ protected:
     virtual void did_update_fd(int) { }
 
 private:
-    bool populate_read_buffer() const;
+    bool populate_read_buffer(size_t size = 1024) const;
     bool can_read_from_fd() const;
 
     int m_fd { -1 };


### PR DESCRIPTION
- **LibCore: Add optional custom read size argument in populate_read_buffer**

  This is a small preparation so `IODevice::read()` can use it in the next commit.

- **LibCore: Buffer small byte reads**

  Prior this change, if you had a program which frequently reads small amount of bytes, then it would constantly fire up syscalls.

  This patch sets that the minimum size that is passed to the read syscall is 1024 and then it saves these additional bytes in a buffer for next reads, which greatly improves the cpu usage on such cases.

  In other words: reading flacs is now very efficient.

---
Before:
![screenshot (31KiB)](https://user-images.githubusercontent.com/16520278/134773768-4bd2a593-723c-4ae5-b79c-b86e138d3ab0.png)

Now:
![screenshot (26KiB)](https://user-images.githubusercontent.com/16520278/134773635-f2b4fc08-8f83-4222-a741-9bbf34497c1e.png)


