### PR TITLE
Elf improvements

### DIFF
--- a/Userland/Libraries/LibC/elf.h
+++ b/Userland/Libraries/LibC/elf.h
@@ -552,9 +552,14 @@ typedef struct {
 
 /* some other useful tags */
 #define DT_GNU_HASH 0x6ffffef5  /* address of GNU hash table */
+#define DT_VERSYM 0x6ffffff0    /* address of table provided by .gnu.version */
 #define DT_RELACOUNT 0x6ffffff9 /* if present, number of RELATIVE */
 #define DT_RELCOUNT 0x6ffffffa  /* relocs, which must come first */
 #define DT_FLAGS_1 0x6ffffffb
+#define DT_VERDEF 0x6ffffffc       /* address of version definition table */
+#define DT_VERDEFNUM 0x6ffffffd    /* number of version definitions */
+#define DT_VERNEEDED 0x6ffffffe    /* address of the dependency table */
+#define DT_VERNEEDEDNUM 0x6fffffff /* number of entries in VERNEEDED */
 
 /* Dynamic Flags - DT_FLAGS .dynamic entry */
 #define DF_ORIGIN 0x00000001

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -422,6 +422,16 @@ const char* DynamicObject::name_for_dtag(ElfW(Sword) d_tag)
         return "RELCOUNT"; /* relocs, which must come first */
     case DT_FLAGS_1:
         return "FLAGS_1";
+    case DT_VERDEF:
+        return "VERDEF";
+    case DT_VERDEFNUM:
+        return "VERDEFNUM";
+    case DT_VERSYM:
+        return "VERSYM";
+    case DT_VERNEEDED:
+        return "VERNEEDED";
+    case DT_VERNEEDEDNUM:
+        return "VERNEEDEDNUM";
     default:
         return "??";
     }

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -166,7 +166,7 @@ void DynamicObject::parse()
         case DT_SYMBOLIC:
             break;
         default:
-            dbgln("DynamicObject: DYNAMIC tag handling not implemented for DT_{}", name_for_dtag(entry.tag()));
+            dbgln("DynamicObject: DYNAMIC tag handling not implemented for DT_{} ({})", name_for_dtag(entry.tag()), entry.tag());
             VERIFY_NOT_REACHED(); // FIXME: Maybe just break out here and return false?
             break;
         }

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -16,8 +16,6 @@
 
 namespace ELF {
 
-static const char* name_for_dtag(ElfW(Sword) d_tag);
-
 DynamicObject::DynamicObject(const String& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address)
     : m_filename(filename)
     , m_base_address(base_address)
@@ -337,7 +335,7 @@ DynamicObject::InitializationFunction DynamicObject::init_section_function() con
     return (InitializationFunction)init_section().address().as_ptr();
 }
 
-static const char* name_for_dtag(ElfW(Sword) d_tag)
+const char* DynamicObject::name_for_dtag(ElfW(Sword) d_tag)
 {
     switch (d_tag) {
     case DT_NULL:

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -20,6 +20,7 @@ namespace ELF {
 class DynamicObject : public RefCounted<DynamicObject> {
 public:
     static NonnullRefPtr<DynamicObject> create(const String& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address);
+    static const char* name_for_dtag(ElfW(Sword) d_tag);
 
     ~DynamicObject();
     void dump() const;

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -268,98 +268,6 @@ static const char* object_relocation_type_to_string(ElfW(Word) type)
     }
 }
 
-static const char* object_tag_to_string(ElfW(Sword) dt_tag)
-{
-    switch (dt_tag) {
-    case DT_NULL:
-        return "NULL"; /* marks end of _DYNAMIC array */
-    case DT_NEEDED:
-        return "NEEDED"; /* string table offset of needed lib */
-    case DT_PLTRELSZ:
-        return "PLTRELSZ"; /* size of relocation entries in PLT */
-    case DT_PLTGOT:
-        return "PLTGOT"; /* address PLT/GOT */
-    case DT_HASH:
-        return "HASH"; /* address of symbol hash table */
-    case DT_STRTAB:
-        return "STRTAB"; /* address of string table */
-    case DT_SYMTAB:
-        return "SYMTAB"; /* address of symbol table */
-    case DT_RELA:
-        return "RELA"; /* address of relocation table */
-    case DT_RELASZ:
-        return "RELASZ"; /* size of relocation table */
-    case DT_RELAENT:
-        return "RELAENT"; /* size of relocation entry */
-    case DT_STRSZ:
-        return "STRSZ"; /* size of string table */
-    case DT_SYMENT:
-        return "SYMENT"; /* size of symbol table entry */
-    case DT_INIT:
-        return "INIT"; /* address of initialization func. */
-    case DT_FINI:
-        return "FINI"; /* address of termination function */
-    case DT_SONAME:
-        return "SONAME"; /* string table offset of shared obj */
-    case DT_RPATH:
-        return "RPATH"; /* string table offset of library search path */
-    case DT_SYMBOLIC:
-        return "SYMBOLIC"; /* start sym search in shared obj. */
-    case DT_REL:
-        return "REL"; /* address of rel. tbl. w addends */
-    case DT_RELSZ:
-        return "RELSZ"; /* size of DT_REL relocation table */
-    case DT_RELENT:
-        return "RELENT"; /* size of DT_REL relocation entry */
-    case DT_PLTREL:
-        return "PLTREL"; /* PLT referenced relocation entry */
-    case DT_DEBUG:
-        return "DEBUG"; /* bugger */
-    case DT_TEXTREL:
-        return "TEXTREL"; /* Allow rel. mod. to unwritable seg */
-    case DT_JMPREL:
-        return "JMPREL"; /* add. of PLT's relocation entries */
-    case DT_BIND_NOW:
-        return "BIND_NOW"; /* Bind now regardless of env setting */
-    case DT_INIT_ARRAY:
-        return "INIT_ARRAY"; /* address of array of init func */
-    case DT_FINI_ARRAY:
-        return "FINI_ARRAY"; /* address of array of term func */
-    case DT_INIT_ARRAYSZ:
-        return "INIT_ARRAYSZ"; /* size of array of init func */
-    case DT_FINI_ARRAYSZ:
-        return "FINI_ARRAYSZ"; /* size of array of term func */
-    case DT_RUNPATH:
-        return "RUNPATH"; /* strtab offset of lib search path */
-    case DT_FLAGS:
-        return "FLAGS"; /* Set of DF_* flags */
-    case DT_ENCODING:
-        return "ENCODING"; /* further DT_* follow encoding rules */
-    case DT_PREINIT_ARRAY:
-        return "PREINIT_ARRAY"; /* address of array of preinit func */
-    case DT_PREINIT_ARRAYSZ:
-        return "PREINIT_ARRAYSZ"; /* size of array of preinit func */
-    case DT_LOOS:
-        return "LOOS"; /* reserved range for OS */
-    case DT_HIOS:
-        return "HIOS"; /*  specific dynamic array tags */
-    case DT_LOPROC:
-        return "LOPROC"; /* reserved range for processor */
-    case DT_HIPROC:
-        return "HIPROC"; /*  specific dynamic array tags */
-    case DT_GNU_HASH:
-        return "GNU_HASH"; /* address of GNU hash table */
-    case DT_RELACOUNT:
-        return "RELACOUNT"; /* if present, number of RELATIVE */
-    case DT_RELCOUNT:
-        return "RELCOUNT"; /* relocs, which must come first */
-    case DT_FLAGS_1:
-        return "FLAGS_1";
-    default:
-        return "??";
-    }
-}
-
 int main(int argc, char** argv)
 {
     if (pledge("stdio rpath", nullptr) < 0) {
@@ -616,7 +524,7 @@ int main(int argc, char** argv)
             outln("  Tag        Type              Name / Value");
             object->for_each_dynamic_entry([&library_index, &libraries, &object](const ELF::DynamicObject::DynamicEntry& entry) {
                 out("  {:#08x} ", entry.tag());
-                out("{:17} ", object_tag_to_string(entry.tag()));
+                out("{:17} ", ELF::DynamicObject::name_for_dtag(entry.tag()));
 
                 if (entry.tag() == DT_NEEDED) {
                     outln("Shared library: {}", libraries[library_index]);


### PR DESCRIPTION
This PR contains three small changes around LibELF: firstly, it removes a duplicated dtag->string function in `readelf` whose logic was already present in `LibELF` as a static function.Secondly, it adds definitions for some DT tags that might be present in gnu-ld-generated binaries and are used for symbol versioning support (but doesn't add the actual support). Finally, it improves on an assertion message to add additional information required for better context.

I'm not totally sure if the addition of a static function in `DynamicObject` is the best decision, please advise if a different preferred option exists.