### PR TITLE
Ports: Improve OpenSSL compilation

### DIFF
--- a/Ports/openssl/package.sh
+++ b/Ports/openssl/package.sh
@@ -8,7 +8,7 @@ files="https://ftp.nluug.nl/security/openssl/openssl-${version}.tar.gz openssl-$
 auth_type=sha256
 
 depends=("zlib")
-configopts=("--prefix=/usr/local" "-DOPENSSL_SYS_SERENITY=1" "-DOPENSSL_USE_IPV6=0" "gcc" "zlib" "no-tests" "no-threads" "no-asm")
+configopts=("--prefix=/usr/local" "-DOPENSSL_SYS_SERENITY=1" "-DOPENSSL_USE_IPV6=0" "zlib" "threads" "no-tests" "no-asm" "serenity-generic")
 
 configure() {
     run ./"$configscript" "${configopts[@]}"

--- a/Ports/openssl/patches/serenity-configuration.patch
+++ b/Ports/openssl/patches/serenity-configuration.patch
@@ -1,0 +1,33 @@
+--- openssl-1.1.1k/Configurations/10-main.conf	2021-03-25 21:28:38.000000000 +0800
++++ openssl-1.1.1k/Configurations/10-main.conf	2021-09-26 00:05:04.340004623 +0800
+@@ -627,6 +627,30 @@
+         shared_extension => ".so",
+     },
+ 
++### Serenity
++    "serenity-generic" => {
++        inherit_from     => [ "BASE_unix" ],
++        CC               => "gcc",
++        CXX              => "g++",
++        CFLAGS           => picker(default => "-Wall",
++                                   debug   => "-O0 -g",
++                                   release => "-O3"),
++        CXXFLAGS         => picker(default => "-Wall",
++                                   debug   => "-O0 -g",
++                                   release => "-O3"),
++        cflags           => threads("-pthread"),
++        cxxflags         => combine("-std=c++11", threads("-pthread")),
++        lib_cppflags     => "-DOPENSSL_USE_NODELETE",
++        ex_libs          => add("-ldl", threads("-pthread")),
++        bn_ops           => "BN_LLONG RC4_CHAR",
++        thread_scheme    => "pthreads",
++        dso_scheme       => "dlfcn",
++        shared_target    => "serenity-shared",
++        shared_cflag     => "-fPIC",
++        shared_ldflag    => sub { $disabled{pinshared} ? () : "-Wl,-znodelete" },
++        shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",
++    },
++
+ ####
+ #### Variety of LINUX:-)
+ ####

--- a/Ports/openssl/patches/shared-info.patch
+++ b/Ports/openssl/patches/shared-info.patch
@@ -1,0 +1,16 @@
+--- openssl-1.1.1k/Configurations/shared-info.pl	2021-03-25 21:28:38.000000000 +0800
++++ openssl-1.1.1k/Configurations/shared-info.pl	2021-09-26 00:05:04.340004623 +0800
+@@ -34,6 +34,13 @@
+             shared_defflag    => '-Wl,--version-script=',
+         };
+     },
++    'serenity-shared' => {
++        shared_ldflag         => '-shared',
++        shared_sonameflag     => '-Wl,-soname=',
++        # -Map is not really what should be used here, but we need a flag that
++        # accepts a filename and that it's '-version-map'
++        shared_defflag        => "-Wl,-Map=",
++    },
+     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },
+     'bsd-shared' => sub {
+         return $shared_info{'gnu-shared'} if detect_gnu_ld();


### PR DESCRIPTION
By defining our own target platform in the OpenSSL compilation configuration we can now compile an OpenSSL shared library. We need to avoid symbol versioning though, as serenity's LibELF doesn't support this yet.

We are now also compiling with threading support to allow using the ssl module (to some extent) in Python. I have the Python changes ready, but since it depends on this PR I'd rather submit this one first and then Python's.