### PR TITLE
PixelPaint: Fix Undo/Redo buttons

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -259,13 +259,20 @@ void Image::restore_snapshot(Image const& snapshot)
 {
     m_layers.clear();
     select_layer(nullptr);
+
+    bool layer_selected = false;
     for (const auto& snapshot_layer : snapshot.m_layers) {
         auto layer = Layer::try_create_snapshot(*this, snapshot_layer);
         VERIFY(layer);
-        if (layer->is_selected())
+        if (layer->is_selected()) {
             select_layer(layer.ptr());
+            layer_selected = true;
+        }
         add_layer(*layer);
     }
+
+    if (!layer_selected)
+        select_layer(&layer(0));
 
     did_modify_layer_stack();
 }


### PR DESCRIPTION
~~The "Undo" action would crash the program due to a nullptr dereference. The first commit fixes that.~~  
This was fixed in another commit meanwhile.

The now first commit is due to the fact that undoing to the start of the drawing would deselect all layers so we just select the first one if there were no layers selected in the snapshot.

The second commit fixes the fact that you sometimes needed to press undo twice to actually start undo-ing stuff, and also that you couldn't undo the very first action you did in the editor.

Fixes #5814.