### PR TITLE
LibGUI: Refine AbstractButton pressing behaviour

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -50,6 +50,7 @@ protected:
     virtual void keyup_event(KeyEvent&) override;
     virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;
+    virtual void focusout_event(GUI::FocusEvent&) override;
     virtual void change_event(Event&) override;
 
     void paint_text(Painter&, const Gfx::IntRect&, const Gfx::Font&, Gfx::TextAlignment, Gfx::TextWrapping = Gfx::TextWrapping::DontWrap);
@@ -60,6 +61,7 @@ private:
     bool m_checkable { false };
     bool m_hovered { false };
     bool m_being_pressed { false };
+    bool m_being_keyboard_pressed { false };
     bool m_exclusive { false };
 
     int m_auto_repeat_interval { 0 };


### PR DESCRIPTION
Previously the code couldn't handle leaving the AbstractButton through
tab, while having it pressed through space or enter.
The problem: (what this fixes - how it won't be after this is merged)
![cursed-buttons](https://user-images.githubusercontent.com/28605587/134784643-59467d74-bc63-4b0f-a57b-c1c7c43cfe53.gif)

