### PR TITLE
PixelPaint: Close New Image dialog after pressing return key, and Close image tabs on middle click

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -65,6 +65,10 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
         m_image_size.set_height(value);
     };
 
+    m_name_textbox->on_return_pressed = [this] {
+        done(ExecOK);
+    };
+
     width_spinbox.set_range(1, 16384);
     height_spinbox.set_range(1, 16384);
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -55,6 +55,10 @@ MainWidget::MainWidget()
         m_tool_properties_widget->set_active_tool(tool);
     };
 
+    m_tab_widget->on_middle_click = [&](auto& widget) {
+        m_tab_widget->on_tab_close_click(widget);
+    };
+
     m_tab_widget->on_tab_close_click = [&](auto& widget) {
         auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
 


### PR DESCRIPTION
- **PixelPaint: Close New Image dialog after pressing return key**

  13e526de43847ac86d74e3cb0be2d6b930f1d46f added the feature to new Layer dialog. This patch adds it to Image dialog to stay  consistent across the app. :^)

- **PixelPaint: Close image tabs on middle click**

