### PR TITLE
LibJS: Return undefined from generated EventHandler setters

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
@@ -744,7 +744,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     } else if (@js_name@@js_suffix@.is_string()) {
         @cpp_name@.string = @js_name@@js_suffix@.as_string().string();
     } else {
-        @return_statement@
+        return JS::js_undefined();
     }
 )~~~");
     } else if (parameter.type.name == "any") {


### PR DESCRIPTION
Returning an empty value without throwing an exception is no longer valid.