### PR TITLE
LibJS: Defer execution of switch default clause until after case clauses

### DIFF
--- a/Userland/Libraries/LibJS/Tests/switch-default-before-case.js
+++ b/Userland/Libraries/LibJS/Tests/switch-default-before-case.js
@@ -1,0 +1,9 @@
+test("default clause before matching case clause", () => {
+    switch (1 + 2) {
+        default:
+            expect().fail();
+            break;
+        case 3:
+            return;
+    }
+});


### PR DESCRIPTION
When we encounter a default clause in a switch statement, we should not
execute it immediately, instead we need to wait until all case clauses
have been executed as a matching case clause can break from the
switch/case.

The code is nowhere close to the spec, so instead of fixing it properly
I just made it slightly worse, but correct. Needs a complete refactor at
some point.