### PR TITLE
Meta: Fix typo in release sonar-scanner version

### DIFF
--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     env:
       # Latest scanner version is tracked on: https://sonarcloud.io/documentation/analysis/scan/sonarscanner/
-      SONAR_SCANNER_VERSION: 4.6.2.2475
+      SONAR_SCANNER_VERSION: 4.6.2.2472
       SONAR_SERVER_URL: "https://sonarcloud.io"
       SONAR_ANALYSIS_ARCH: i686
     steps:


### PR DESCRIPTION
The version is 4.6.2.2472, I had a typo when I committed the previous
change to update the version.

https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/