### PR TITLE
Kernel/Graphics: Modernize Bochs graphics driver

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -19,6 +19,8 @@
 #define VBE_DISPI_IOPORT_INDEX 0x01CE
 #define VBE_DISPI_IOPORT_DATA 0x01CF
 
+#define VBE_DISPI_ID5 0xB0C5
+
 #define VBE_DISPI_INDEX_ID 0x0
 #define VBE_DISPI_INDEX_XRES 0x1
 #define VBE_DISPI_INDEX_YRES 0x2
@@ -156,6 +158,14 @@ static u16 get_register_with_io(u16 index)
     return IO::in16(VBE_DISPI_IOPORT_DATA);
 }
 
+BochsGraphicsAdapter::IndexID BochsGraphicsAdapter::index_id() const
+{
+    if (m_io_required) {
+        return get_register_with_io(0);
+    }
+    return m_registers->bochs_regs.index_id;
+}
+
 void BochsGraphicsAdapter::set_resolution_registers_via_io(size_t width, size_t height)
 {
     dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
@@ -184,7 +194,9 @@ void BochsGraphicsAdapter::set_resolution_registers(size_t width, size_t height)
     m_registers->bochs_regs.enable = VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED;
     full_memory_barrier();
     m_registers->bochs_regs.bank = 0;
-    set_framebuffer_to_little_endian_format();
+    if (index_id().value() == VBE_DISPI_ID5) {
+        set_framebuffer_to_little_endian_format();
+    }
 }
 
 bool BochsGraphicsAdapter::try_to_set_resolution(size_t output_port_index, size_t width, size_t height)

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -25,6 +25,9 @@ class BochsGraphicsAdapter final : public GraphicsDevice
     AK_MAKE_ETERNAL
     friend class GraphicsManagement;
 
+private:
+    TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
+
 public:
     static NonnullRefPtr<BochsGraphicsAdapter> initialize(PCI::Address);
     virtual ~BochsGraphicsAdapter() = default;
@@ -45,6 +48,8 @@ private:
     virtual void disable_consoles() override;
 
     explicit BochsGraphicsAdapter(PCI::Address);
+
+    IndexID index_id() const;
 
     void set_safe_resolution();
     void unblank();

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -56,6 +56,9 @@ private:
     bool validate_setup_resolution_with_io(size_t width, size_t height);
     void set_y_offset(size_t);
 
+    void set_framebuffer_to_big_endian_format();
+    void set_framebuffer_to_little_endian_format();
+
     PhysicalAddress m_mmio_registers;
     Memory::TypedMapping<BochsDisplayMMIORegisters volatile> m_registers;
     RefPtr<FramebufferDevice> m_framebuffer_device;


### PR DESCRIPTION
Three things are done in this PR:
1. Ensure we set BGR format on `bochs-display` if possible. Although this is the default, it doesn't hurt anyone to do that, so as a future-proof measure, it's good to do that.
2. Add initial support to actually check if we can set the framebuffer format. I expect it to expand further to check if we deal with the VirtualBox graphical adapter and if so, to use more advanced features :)
3. (@alimpfard you will like it) Reducing the amount of define macros in favor to enum classes. In my opinion, it looks much nicer to the eye this way (macros are fine, but we don't really need them here).