### PR TITLE
LibWeb: Don't try to ad-block data: urls

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
@@ -25,6 +25,9 @@ ContentFilter::~ContentFilter()
 
 bool ContentFilter::is_filtered(const AK::URL& url) const
 {
+    if (url.protocol() == "data")
+        return false;
+
     auto url_string = url.to_string();
 
     for (auto& pattern : m_patterns) {


### PR DESCRIPTION
In some cases these can be several KiB or more in size, making checking
very slow, and it doesn't make sense to filter them out anyway. This
change speeds up loading pages with large data: urls, which previously
took up to 1ms per byte to process.