### PR TITLE
Symbolication improvements

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -141,6 +141,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    if (unveil("/usr/local/lib", "r") < 0 && errno != ENOENT) {
+        perror("unveil");
+        return 1;
+    }
+
     if (unveil("/bin/Profiler", "rx") < 0) {
         perror("unveil");
         return 1;

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -72,7 +72,7 @@ Optional<Symbol> symbolicate(String const& path, FlatPtr address)
         if (!elf->is_valid()) {
             dbgln("ELF not valid: {}", path);
             s_cache.set(path, {});
-            {};
+            return {};
         }
         auto cached_elf = make<CachedELF>(mapped_file.release_value(), make<Debug::DebugInfo>(*elf), move(elf));
         s_cache.set(path, move(cached_elf));


### PR DESCRIPTION
These changes ultimately allow SystemMonitor's to show the symbols from libraries installed under `/usr/local/lib` under the Stack tab. I wanted this to further debug the python3 port and its ssl module in particular, but is useful in general. More details in the commit comments.