### PR TITLE
Calculator : Fix trailing .9's when dividing

### DIFF
--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -105,7 +105,7 @@ KeypadValue::KeypadValue(double d)
     while (AK::pow(10.0, (double)current_pow) <= d)
         current_pow += 1;
     current_pow -= 1;
-    while (d != 0) {
+    while (current_pow >= 0) {
         m_value *= 10;
         m_value += (u64)(d / AK::pow(10.0, (double)current_pow)) % 10;
         if (current_pow < 0)


### PR DESCRIPTION
The constructor used by KeyPadValue to convert from double to the KeyPadValue values
got stuck in a loop while counting decimal places because it never changed the value in the conditional.