### PR TITLE
AK: Add missing AK/Types.h include to VirtIO/Protocol.h

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/Protocol.h
+++ b/Kernel/Graphics/VirtIOGPU/Protocol.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 #define VIRTIO_GPU_MAX_SCANOUTS 16
 
 namespace Kernel::Graphics::VirtIOGPU::Protocol {


### PR DESCRIPTION
How did this even work?