### PR TITLE
Audio: Various access restrictions

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -1,6 +1,7 @@
 [ConfigServer]
 Socket=/tmp/portal/config
-SocketPermissions=600
+# FIXME: AudioServer needs to connect to this.
+SocketPermissions=666
 User=anon
 
 [RequestServer]
@@ -129,9 +130,10 @@ User=anon
 [AudioServer]
 # TODO: It would be nice to make this lazy, but Audio.Applet connects to it immediately on startup anyway.
 Socket=/tmp/portal/audio
+SocketPermissions=660
 Priority=high
 KeepAlive=1
-User=anon
+User=audio
 BootModes=text,graphical
 
 [Taskbar]

--- a/Base/etc/passwd
+++ b/Base/etc/passwd
@@ -1,4 +1,5 @@
 root::0:0:root:/root:/bin/Shell
+audio:!:4:4:AudioServer,,,:/:/bin/false
 lookup:!:10:10:LookupServer,,,:/:/bin/false
 window:!:13:13:WindowServer,,,:/:/bin/false
 sshd:!:19:19:OpenSSH privsep,,,:/:/bin/false

--- a/Userland/Services/AudioServer/CMakeLists.txt
+++ b/Userland/Services/AudioServer/CMakeLists.txt
@@ -16,4 +16,4 @@ set(SOURCES
 )
 
 serenity_bin(AudioServer)
-target_link_libraries(AudioServer LibCore LibThreading LibIPC)
+target_link_libraries(AudioServer LibCore LibThreading LibIPC LibConfig)

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -108,7 +108,7 @@ private:
 class Mixer : public Core::Object {
     C_OBJECT(Mixer)
 public:
-    Mixer(NonnullRefPtr<Core::ConfigFile> config);
+    Mixer();
     virtual ~Mixer() override;
 
     NonnullRefPtr<ClientAudioStream> create_queue(ClientConnection&);
@@ -124,8 +124,6 @@ public:
     u16 audiodevice_get_sample_rate() const;
 
 private:
-    void request_setting_sync();
-
     Vector<NonnullRefPtr<ClientAudioStream>> m_pending_mixing;
     Threading::Mutex m_pending_mutex;
     Threading::ConditionVariable m_mixing_necessary { m_pending_mutex };
@@ -136,9 +134,6 @@ private:
 
     bool m_muted { false };
     FadingProperty<double> m_main_volume { 1 };
-
-    NonnullRefPtr<Core::ConfigFile> m_config;
-    RefPtr<Core::Timer> m_config_write_timer;
 
     static u8 m_zero_filled_buffer[4096];
 

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "Mixer.h"
-#include <LibCore/ConfigFile.h>
+#include <LibConfig/Client.h>
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
 
@@ -17,20 +17,20 @@ int main(int, char**)
         return 1;
     }
 
-    auto config = Core::ConfigFile::open_for_app("Audio", Core::ConfigFile::AllowWriting::Yes);
-    if (unveil(config->filename().characters(), "rwc") < 0) {
+    if (unveil("/dev/audio", "wc") < 0) {
         perror("unveil");
         return 1;
     }
-    if (unveil("/dev/audio", "wc") < 0) {
+    if (unveil("/tmp/portal/config", "rw") < 0) {
         perror("unveil");
         return 1;
     }
     unveil(nullptr, nullptr);
 
     Core::EventLoop event_loop;
-    AudioServer::Mixer mixer { config };
+    AudioServer::Mixer mixer;
 
+    Config::pledge_domains("Audio");
     auto server = Core::LocalServer::construct();
     bool ok = server->take_over_from_system_server();
     VERIFY(ok);

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
+#include <LibCore/Account.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/Event.h>
@@ -180,7 +181,7 @@ static void populate_devfs_char_devices()
         case 42: {
             switch (minor_number) {
             case 42: {
-                create_devfs_char_device("/dev/audio", 0220, 42, 42);
+                create_devfs_char_device("/dev/audio", 0200, 42, 42);
                 break;
             }
             default:
@@ -395,9 +396,9 @@ static void prepare_synthetic_filesystems()
     // FIXME: Try to find a way to not hardcode the major number of tty nodes.
     chown_all_matching_device_nodes(tty_group, 4);
 
-    auto audio_group = getgrnam("audio");
-    VERIFY(audio_group);
-    chown_wrapper("/dev/audio", 0, audio_group->gr_gid);
+    auto audio_user = Core::Account::from_name("audio");
+    VERIFY(!audio_user.is_error());
+    chown_wrapper("/dev/audio", audio_user.value().uid(), audio_user.value().gid());
 
     // Note: We open the /dev/null device and set file descriptors 0, 1, 2 to it
     // because otherwise these file descriptors won't have a custody, making


### PR DESCRIPTION
These are a collection of security mitigations that limit how programs can interact with the audio subsystem. Playing audio to the audio device is now limited to the new audio user, which AudioServer runs as. Connecting to the AudioServer is restricted to the audio group, which anon is a part of.

This results in two additional changes: First, the audio server no longer writes its own config files and uses ConfigServer instead (good). Second, ConfigServer is now accessible by everyone, as audio is not part of the users group (bad?). There is no way of changing this unless either (1) ConfigServer writes to a directory that isn't only read/writable by anon, or (2) all of the above changes are reverted. I consider this an acceptable compromise.