### PR TITLE
LibDebug: Improve inline information in backtraces

### DIFF
--- a/Userland/Libraries/LibDebug/CMakeLists.txt
+++ b/Userland/Libraries/LibDebug/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     DebugInfo.cpp
     DebugSession.cpp
     Dwarf/AbbreviationsMap.cpp
+    Dwarf/AddressRanges.cpp
     Dwarf/CompilationUnit.cpp
     Dwarf/DIE.cpp
     Dwarf/DwarfInfo.cpp

--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020-2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "AddressRanges.h"
+#include "DwarfTypes.h"
+
+namespace Debug::Dwarf {
+
+AddressRanges::AddressRanges(ReadonlyBytes range_lists_data, size_t offset, CompilationUnit const& compilation_unit)
+    : m_range_lists_stream(range_lists_data)
+    , m_compilation_unit(compilation_unit)
+{
+    m_range_lists_stream.seek(offset);
+}
+
+void AddressRanges::for_each_range(Function<void(Range)> callback)
+{
+    // Dwarf version 5, section 2.17.3 "Non-Contiguous Address Ranges"
+
+    Optional<FlatPtr> current_base_address;
+    while (!m_range_lists_stream.eof() && !m_range_lists_stream.has_any_error()) {
+        u8 entry_type;
+        m_range_lists_stream >> entry_type;
+        switch (static_cast<RangeListEntryType>(entry_type)) {
+        case RangeListEntryType::BaseAddress: {
+            FlatPtr base;
+            m_range_lists_stream >> base;
+            current_base_address = base;
+            break;
+        }
+        case RangeListEntryType::OffsetPair: {
+            Optional<FlatPtr> base_address = current_base_address;
+            if (!base_address.has_value()) {
+                base_address = m_compilation_unit.base_address();
+            }
+
+            if (!base_address.has_value()) {
+                dbgln("expected base_address for rangelist");
+                return;
+            }
+
+            size_t start_offset, end_offset;
+            m_range_lists_stream.read_LEB128_unsigned(start_offset);
+            m_range_lists_stream.read_LEB128_unsigned(end_offset);
+            callback(Range { start_offset + *base_address, end_offset + *base_address });
+            break;
+        }
+        case RangeListEntryType::StartLength: {
+            FlatPtr start;
+            m_range_lists_stream >> start;
+            size_t length;
+            m_range_lists_stream.read_LEB128_unsigned(length);
+            callback(Range { start, start + length });
+        }
+        case RangeListEntryType::EndOfList:
+            return;
+        default:
+            dbgln("unsupported range list entry type: 0x{:x}", (int)entry_type);
+            return;
+        }
+    }
+}
+
+}

--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.h
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020-2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "CompilationUnit.h"
+#include <AK/Forward.h>
+#include <AK/Function.h>
+#include <AK/MemoryStream.h>
+#include <AK/Noncopyable.h>
+
+namespace Debug::Dwarf {
+
+class AddressRanges {
+    AK_MAKE_NONCOPYABLE(AddressRanges);
+    AK_MAKE_NONMOVABLE(AddressRanges);
+
+public:
+    AddressRanges(ReadonlyBytes range_lists_data, size_t offset, CompilationUnit const& compilation_unit);
+
+    struct Range {
+        FlatPtr start { 0 };
+        FlatPtr end { 0 };
+    };
+    void for_each_range(Function<void(Range)>);
+
+private:
+    InputMemoryStream m_range_lists_stream;
+    CompilationUnit const& m_compilation_unit;
+};
+
+}

--- a/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.cpp
@@ -30,4 +30,18 @@ DIE CompilationUnit::get_die_at_offset(u32 die_offset) const
     return DIE(*this, die_offset);
 }
 
+Optional<FlatPtr> CompilationUnit::base_address() const
+{
+    if (m_has_cached_base_address)
+        return m_cached_base_address;
+
+    auto die = root_die();
+    auto res = die.get_attribute(Attribute::LowPc);
+    if (res.has_value()) {
+        m_cached_base_address = res->data.as_addr;
+    }
+    m_has_cached_base_address = true;
+    return m_cached_base_address;
+}
+
 }

--- a/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
+++ b/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
@@ -34,6 +34,7 @@ public:
     DwarfInfo const& dwarf_info() const { return m_dwarf_info; }
     AbbreviationsMap const& abbreviations_map() const { return m_abbreviations; }
     LineProgram const& line_program() const { return *m_line_program; }
+    Optional<FlatPtr> base_address() const;
 
 private:
     DwarfInfo const& m_dwarf_info;
@@ -41,6 +42,8 @@ private:
     CompilationUnitHeader m_header;
     AbbreviationsMap m_abbreviations;
     NonnullOwnPtr<LineProgram> m_line_program;
+    mutable bool m_has_cached_base_address { false };
+    mutable Optional<FlatPtr> m_cached_base_address;
 };
 
 }

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
@@ -30,6 +30,7 @@ public:
     ReadonlyBytes abbreviation_data() const { return m_abbreviation_data; }
     ReadonlyBytes debug_strings_data() const { return m_debug_strings_data; }
     ReadonlyBytes debug_line_strings_data() const { return m_debug_line_strings_data; }
+    ReadonlyBytes debug_range_lists_data() const { return m_debug_range_lists_data; }
 
     template<typename Callback>
     void for_each_compilation_unit(Callback) const;
@@ -58,6 +59,7 @@ private:
     ReadonlyBytes m_debug_strings_data;
     ReadonlyBytes m_debug_line_data;
     ReadonlyBytes m_debug_line_strings_data;
+    ReadonlyBytes m_debug_range_lists_data;
 
     NonnullOwnPtrVector<Dwarf::CompilationUnit> m_compilation_units;
 

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfTypes.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfTypes.h
@@ -317,4 +317,16 @@ struct [[gnu::packed]] AttributeSpecification {
     ssize_t value;
 };
 
+// Dwarf version 5, section 7.25
+enum class RangeListEntryType : u8 {
+    EndOfList = 0,
+    BaseAddressX = 0x1,
+    StartXEndX = 0x2,
+    StartXLength = 0x3,
+    OffsetPair = 0x4,
+    BaseAddress = 0x5,
+    StartEnd = 0x6,
+    StartLength = 0x7
+};
+
 }


### PR DESCRIPTION
This implements parsing DWARF "range lists" of DIEs with non-contiguous address ranges.

We previously only supported DIEs with a contiguous address range, which caused us to often miss inlined function calls when retrieving source locations.

For example, in the backtrace of the acid3 crash, the following entry missed some inlined function calls:
`[libjs.so] JS::VM::prepare_for_ordinary_call(JS::FunctionObject&, JS::ExecutionContext&, JS::Object*) +0x415 (Vector.h:138 => Vector.h:152 => VM.h:123)`
It now has the full chain of inlined calls:
`[libjs.so] JS::VM::prepare_for_ordinary_call(JS::FunctionObject&, JS::ExecutionContext&, JS::Object*) +0x415 (Vector.h:138 => Vector.h:152 => VM.h:123 => VM.h:137 => VM.cpp:614)`