### PR TITLE
LibPthread: Add first test cases for RWlock

### DIFF
--- a/Tests/LibPthread/CMakeLists.txt
+++ b/Tests/LibPthread/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestLibPthreadSpinLocks.cpp
+    TestLibPthreadRWLocks.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibPthread/TestLibPthreadRWLocks.cpp
+++ b/Tests/LibPthread/TestLibPthreadRWLocks.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Rodrigo Tobar <rtobarc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPthread/pthread.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(rwlock_init)
+{
+    pthread_rwlock_t lock;
+    auto result = pthread_rwlock_init(&lock, nullptr);
+    EXPECT_EQ(0, result);
+}
+
+TEST_CASE(rwlock_rdlock)
+{
+    pthread_rwlock_t lock;
+    auto result = pthread_rwlock_init(&lock, nullptr);
+    EXPECT_EQ(0, result);
+
+    result = pthread_rwlock_rdlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+
+    result = pthread_rwlock_rdlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_rdlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+}
+
+TEST_CASE(rwlock_wrlock)
+{
+    pthread_rwlock_t lock;
+    auto result = pthread_rwlock_init(&lock, nullptr);
+    EXPECT_EQ(0, result);
+
+    result = pthread_rwlock_wrlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+}
+
+TEST_CASE(rwlock_rwr_sequence)
+{
+    pthread_rwlock_t lock;
+    auto result = pthread_rwlock_init(&lock, nullptr);
+    EXPECT_EQ(0, result);
+
+    result = pthread_rwlock_rdlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+
+    result = pthread_rwlock_wrlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+
+    result = pthread_rwlock_rdlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+}
+
+TEST_CASE(rwlock_wrlock_init_in_once)
+{
+    static pthread_rwlock_t lock;
+    static pthread_once_t once1 = PTHREAD_ONCE_INIT;
+    static pthread_once_t once2 = PTHREAD_ONCE_INIT;
+    static pthread_once_t once3 = PTHREAD_ONCE_INIT;
+    pthread_once(&once1, []() {
+        pthread_once(&once2, []() {
+            pthread_once(&once3, []() {
+                auto result = pthread_rwlock_init(&lock, nullptr);
+                EXPECT_EQ(0, result);
+            });
+        });
+    });
+    auto result = pthread_rwlock_wrlock(&lock);
+    EXPECT_EQ(0, result);
+    result = pthread_rwlock_unlock(&lock);
+    EXPECT_EQ(0, result);
+}


### PR DESCRIPTION
These tests are fairly simple, and were written while hunting the problem reported in #10241. I thought it would be useful to keep them around now that the problem has been fixed.

cc: @alimpfard 