### PR TITLE
LibDebug: Annotate fallthrough statement

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
@@ -57,6 +57,7 @@ void AddressRanges::for_each_range(Function<void(Range)> callback)
         }
         case RangeListEntryType::EndOfList:
             return;
+            [[fallthrough]];
         default:
             dbgln("unsupported range list entry type: 0x{:x}", (int)entry_type);
             return;


### PR DESCRIPTION
#10242 was missing a `[[fallthrough]]` annotation.