### PR TITLE
LibGUI+Applications: Add intrinsic margins to Widgets + ScrollableContainerWidget Improvements

### DIFF
--- a/Userland/Applications/DisplaySettings/DesktopSettings.gml
+++ b/Userland/Applications/DisplaySettings/DesktopSettings.gml
@@ -7,7 +7,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [24, 16, 6]
+            margins: [14, 14, 4]
         }
 
         title: "Workspaces"

--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -34,7 +34,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [24, 16, 6]
+            margins: [14, 14, 4]
         }
 
         title: "Screen settings"

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -135,7 +135,7 @@ DirectoryView::DirectoryView(Mode mode)
     , m_sorting_model(GUI::SortingProxyModel::create(m_model))
 {
     set_active_widget(nullptr);
-    set_content_margins(2);
+    set_grabbable_margins(2);
 
     setup_actions();
 

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -75,7 +75,7 @@
                 title: "Metadata"
                 fixed_height: 220
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [16, 8, 8, 8]
+                    margins: [6, 6, 6, 6]
                 }
 
                 @GUI::Widget {

--- a/Userland/Applications/FontEditor/NewFontDialogPage2.gml
+++ b/Userland/Applications/FontEditor/NewFontDialogPage2.gml
@@ -11,7 +11,7 @@
             title: "Metadata"
             fixed_width: 200
             layout: @GUI::VerticalBoxLayout {
-                margins: [16, 8, 8]
+                margins: [4]
             }
 
             @GUI::Widget {

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -149,7 +149,6 @@ int main(int argc, char** argv)
     bottom_widget.set_layout<GUI::HorizontalBoxLayout>();
     bottom_widget.layout()->add_spacer();
     bottom_widget.set_fixed_height(30);
-    bottom_widget.set_content_margins({ 4, 0 });
 
     auto& ok_button = bottom_widget.add<GUI::Button>();
     ok_button.set_text("OK");

--- a/Userland/Applications/MailSettings/MailSettingsWindow.gml
+++ b/Userland/Applications/MailSettings/MailSettingsWindow.gml
@@ -11,7 +11,7 @@
         fixed_height: 170
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [6]
             spacing: 2
         }
 
@@ -101,7 +101,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [6]
             spacing: 2
         }
 

--- a/Userland/Applications/MouseSettings/Mouse.gml
+++ b/Userland/Applications/MouseSettings/Mouse.gml
@@ -11,7 +11,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [6]
             spacing: 2
         }
 
@@ -60,7 +60,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [6]
             spacing: 2
         }
 
@@ -114,7 +114,7 @@
         fixed_height: 110
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [6]
             spacing: 2
         }
 

--- a/Userland/Applications/MouseSettings/Theme.gml
+++ b/Userland/Applications/MouseSettings/Theme.gml
@@ -9,7 +9,7 @@
         title: "Available Cursor Themes"
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 8, 8]
+            margins: [6]
             spacing: 4
         }
 

--- a/Userland/Applications/PixelPaint/EditGuideDialog.gml
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.gml
@@ -14,7 +14,7 @@
             shrink_to_fit: true
             
             layout: @GUI::HorizontalBoxLayout {
-                margins: [20, 10, 10]
+                margins: [10, 8, 8]
             }
 
             @GUI::RadioButton {

--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
@@ -25,7 +25,7 @@ LayerPropertiesWidget::LayerPropertiesWidget()
     auto& group_box = add<GUI::GroupBox>("Layer properties");
     auto& layout = group_box.set_layout<GUI::VerticalBoxLayout>();
 
-    layout.set_margins({ 20, 10, 10 });
+    layout.set_margins({ 8 });
 
     auto& name_container = group_box.add<GUI::Widget>();
     name_container.set_fixed_height(20);

--- a/Userland/Applications/PixelPaint/PixelPaintWindow.gml
+++ b/Userland/Applications/PixelPaint/PixelPaintWindow.gml
@@ -51,7 +51,7 @@
             @GUI::GroupBox {
                 title: "Layers"
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [16, 6, 6]
+                    margins: [6]
                 }
 
                 @PixelPaint::LayerListWidget {

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
@@ -19,7 +19,7 @@ ToolPropertiesWidget::ToolPropertiesWidget()
 
     m_group_box = add<GUI::GroupBox>("Tool properties");
     auto& layout = m_group_box->set_layout<GUI::VerticalBoxLayout>();
-    layout.set_margins({ 20, 10, 10 });
+    layout.set_margins({ 8 });
     m_tool_widget_stack = m_group_box->add<GUI::StackWidget>();
     m_blank_widget = m_tool_widget_stack->add<GUI::Widget>();
 }

--- a/Userland/Applications/Spreadsheet/csv_export.gml
+++ b/Userland/Applications/Spreadsheet/csv_export.gml
@@ -18,8 +18,7 @@
                     title: "Delimiter"
 
                     layout: @GUI::VerticalBoxLayout {
-                        // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10]
+                        margins: [10, 8, 8]
                     }
 
                     @GUI::RadioButton {
@@ -69,8 +68,7 @@
                     title: "Quote"
 
                     layout: @GUI::VerticalBoxLayout {
-                        // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10]
+                        margins: [10, 8, 8]
                     }
 
                     @GUI::RadioButton {
@@ -151,8 +149,7 @@
             fixed_width: 150
 
             layout: @GUI::VerticalBoxLayout {
-                // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                margins: [20, 10, 10]
+                margins: [10, 8, 8]
             }
 
             @GUI::TextEditor {

--- a/Userland/Applications/Spreadsheet/csv_import.gml
+++ b/Userland/Applications/Spreadsheet/csv_import.gml
@@ -18,8 +18,7 @@
                     title: "Delimiter"
 
                     layout: @GUI::VerticalBoxLayout {
-                        // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10]
+                        margins: [10, 8, 8]
                     }
 
                     @GUI::RadioButton {
@@ -69,8 +68,7 @@
                     title: "Quote"
 
                     layout: @GUI::VerticalBoxLayout {
-                        // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                        margins: [20, 10, 10]
+                        margins: [10, 8, 8]
                     }
 
                     @GUI::RadioButton {
@@ -133,7 +131,7 @@
                 fixed_height: 40
 
                 layout: @GUI::VerticalBoxLayout {
-                    margins: [6, 6, 0]
+                    margins: [4, 4, 0]
                 }
 
                 @GUI::Widget {
@@ -164,8 +162,7 @@
             fixed_width: 150
 
             layout: @GUI::VerticalBoxLayout {
-                // FIXME: This is working around the fact that group boxes don't allocate space for their title and border!
-                margins: [20, 10, 10]
+                margins: [10, 8, 8]
             }
 
             @GUI::StackWidget {

--- a/Userland/Applications/Terminal/TerminalSettingsWindow.gml
+++ b/Userland/Applications/Terminal/TerminalSettingsWindow.gml
@@ -10,7 +10,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6]
+            margins: [4]
         }
 
         @GUI::RadioButton {
@@ -34,7 +34,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6]
+            margins: [4]
         }
 
         @GUI::OpacitySlider {
@@ -50,7 +50,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6]
+            margins: [4]
         }
 
         @GUI::SpinBox {
@@ -66,7 +66,7 @@
         shrink_to_fit: true
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [16, 6, 6]
+            margins: [4]
         }
 
         @GUI::ComboBox {

--- a/Userland/Applications/TextEditor/TextEditorWindow.gml
+++ b/Userland/Applications/TextEditor/TextEditorWindow.gml
@@ -36,7 +36,7 @@
 
         layout: @GUI::VerticalBoxLayout {
             spacing: 2
-            margins: [5]
+            margins: [3]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
@@ -237,7 +237,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/CursorsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/CursorsTab.gml
@@ -6,7 +6,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::TableView {

--- a/Userland/Demos/WidgetGallery/GalleryGML/IconsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/IconsTab.gml
@@ -6,7 +6,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::TableView {

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -7,7 +7,7 @@
     @GUI::GroupBox {
         fixed_height: 129
         layout: @GUI::VerticalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::GroupBox {
@@ -92,7 +92,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::HorizontalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::VerticalProgressbar {
@@ -140,7 +140,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::Widget {

--- a/Userland/Demos/WidgetGallery/GalleryGML/WizardsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/WizardsTab.gml
@@ -6,7 +6,7 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {
-            margins: [8]
+            margins: [6]
         }
 
         @GUI::Button {

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -62,7 +62,6 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
         auto& label = right_container.add<Label>(text);
         label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         label.set_fixed_height(14);
-        label.set_content_margins({ 0, 8, 0 });
         if (bold)
             label.set_font(Gfx::FontDatabase::default_font().bold_variant());
     };

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -93,8 +93,9 @@ void AbstractScrollableWidget::resize_event(ResizeEvent& event)
 
 Gfx::IntSize AbstractScrollableWidget::available_size() const
 {
-    unsigned available_width = max(frame_inner_rect().width() - m_size_occupied_by_fixed_elements.width() - width_occupied_by_vertical_scrollbar(), 0);
-    unsigned available_height = max(frame_inner_rect().height() - m_size_occupied_by_fixed_elements.height() - height_occupied_by_horizontal_scrollbar(), 0);
+    auto inner_size = Widget::content_size();
+    unsigned available_width = max(inner_size.width() - m_size_occupied_by_fixed_elements.width(), 0);
+    unsigned available_height = max(inner_size.height() - m_size_occupied_by_fixed_elements.height(), 0);
     return { available_width, available_height };
 }
 
@@ -159,13 +160,19 @@ int AbstractScrollableWidget::width_occupied_by_vertical_scrollbar() const
     return m_vertical_scrollbar->is_visible() ? m_vertical_scrollbar->width() : 0;
 }
 
+Margins AbstractScrollableWidget::content_margins() const
+{
+    return Frame::content_margins() + Margins { 0, width_occupied_by_vertical_scrollbar(), height_occupied_by_horizontal_scrollbar(), 0 };
+}
+
 Gfx::IntRect AbstractScrollableWidget::visible_content_rect() const
 {
+    auto inner_size = Widget::content_size();
     Gfx::IntRect rect {
         m_horizontal_scrollbar->value(),
         m_vertical_scrollbar->value(),
-        min(m_content_size.width(), frame_inner_rect().width() - width_occupied_by_vertical_scrollbar() - m_size_occupied_by_fixed_elements.width()),
-        min(m_content_size.height(), frame_inner_rect().height() - height_occupied_by_horizontal_scrollbar() - m_size_occupied_by_fixed_elements.height())
+        min(m_content_size.width(), inner_size.width() - m_size_occupied_by_fixed_elements.width()),
+        min(m_content_size.height(), inner_size.height() - m_size_occupied_by_fixed_elements.height())
     };
     if (rect.is_empty())
         return {};

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -57,6 +57,8 @@ public:
     int width_occupied_by_vertical_scrollbar() const;
     int height_occupied_by_horizontal_scrollbar() const;
 
+    virtual Margins content_margins() const override;
+
     void set_should_hide_unnecessary_scrollbars(bool b) { m_should_hide_unnecessary_scrollbars = b; }
     bool should_hide_unnecessary_scrollbars() const { return m_should_hide_unnecessary_scrollbars; }
 

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -33,6 +33,7 @@ Gfx::IntSize BoxLayout::preferred_size() const
 
 int BoxLayout::preferred_primary_size() const
 {
+    auto widget = verify_cast<GUI::Widget>(parent());
     int size = 0;
 
     for (auto& entry : m_entries) {
@@ -52,10 +53,11 @@ int BoxLayout::preferred_primary_size() const
     if (size > 0)
         size -= spacing();
 
+    auto content_margins = widget->content_margins();
     if (orientation() == Gfx::Orientation::Horizontal)
-        size += margins().left() + margins().right();
+        size += margins().left() + margins().right() + content_margins.left() + content_margins.right();
     else
-        size += margins().top() + margins().bottom();
+        size += margins().top() + margins().bottom() + content_margins.top() + content_margins.bottom();
 
     if (!size)
         return -1;
@@ -64,6 +66,7 @@ int BoxLayout::preferred_primary_size() const
 
 int BoxLayout::preferred_secondary_size() const
 {
+    auto widget = verify_cast<GUI::Widget>(parent());
     int size = 0;
     for (auto& entry : m_entries) {
         if (!entry.widget || !entry.widget->is_visible())
@@ -77,10 +80,11 @@ int BoxLayout::preferred_secondary_size() const
         size = max(min_size, size);
     }
 
+    auto content_margins = widget->content_margins();
     if (orientation() == Gfx::Orientation::Horizontal)
-        size += margins().top() + margins().bottom();
+        size += margins().top() + margins().bottom() + content_margins.top() + content_margins.bottom();
     else
-        size += margins().left() + margins().right();
+        size += margins().left() + margins().right() + content_margins.left() + content_margins.right();
 
     if (!size)
         return -1;

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/JsonObject.h>
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/Margins.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Orientation.h>
 #include <stdio.h>
@@ -125,7 +126,8 @@ void BoxLayout::run(Widget& widget)
     if (items.is_empty())
         return;
 
-    int available_size = widget.size().primary_size_for_orientation(orientation()) - spacing() * (items.size() - 1);
+    Gfx::IntRect content_rect = widget.content_rect();
+    int available_size = content_rect.size().primary_size_for_orientation(orientation()) - spacing() * (items.size() - 1);
     int unfinished_items = items.size();
 
     if (orientation() == Gfx::Orientation::Horizontal)
@@ -180,10 +182,10 @@ void BoxLayout::run(Widget& widget)
     }
 
     // Pass 3: Place the widgets.
-    int current_x = margins().left();
-    int current_y = margins().top();
+    int current_x = margins().left() + content_rect.x();
+    int current_y = margins().top() + content_rect.y();
 
-    auto widget_rect_with_margins_subtracted = widget.rect();
+    auto widget_rect_with_margins_subtracted = content_rect;
     widget_rect_with_margins_subtracted.take_from_left(margins().left());
     widget_rect_with_margins_subtracted.take_from_top(margins().top());
     widget_rect_with_margins_subtracted.take_from_right(margins().right());
@@ -195,7 +197,7 @@ void BoxLayout::run(Widget& widget)
         rect.set_primary_size_for_orientation(orientation(), item.size);
 
         if (item.widget) {
-            int secondary = widget.size().secondary_size_for_orientation(orientation());
+            int secondary = widget.content_size().secondary_size_for_orientation(orientation());
             if (orientation() == Gfx::Orientation::Horizontal)
                 secondary -= margins().top() + margins().bottom();
             else

--- a/Userland/Libraries/LibGUI/Frame.cpp
+++ b/Userland/Libraries/LibGUI/Frame.cpp
@@ -42,7 +42,7 @@ void Frame::set_frame_thickness(int thickness)
     if (m_thickness == thickness)
         return;
     m_thickness = thickness;
-    set_content_margins(thickness);
+    set_grabbable_margins(thickness);
 }
 
 void Frame::paint_event(PaintEvent& event)

--- a/Userland/Libraries/LibGUI/Frame.h
+++ b/Userland/Libraries/LibGUI/Frame.h
@@ -19,6 +19,8 @@ public:
     int frame_thickness() const { return m_thickness; }
     void set_frame_thickness(int thickness);
 
+    virtual Margins content_margins() const override { return { frame_thickness() }; }
+
     Gfx::FrameShadow frame_shadow() const { return m_shadow; }
     void set_frame_shadow(Gfx::FrameShadow shadow) { m_shadow = shadow; }
 

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -153,6 +153,8 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
 
         if (can_have_declared_layout(class_names.last()) && "layout"sv.matches(pattern))
             identifier_entries.empend("layout: ", partial_input_length, Language::Unspecified, "layout", AutocompleteProvider::Entry::HideAutocompleteAfterApplying::No);
+        if (class_names.last() == "GUI::ScrollableContainerWidget" && "content_widget"sv.matches(pattern))
+            identifier_entries.empend("content_widget: ", partial_input_length, Language::Unspecified, "content_widget", AutocompleteProvider::Entry::HideAutocompleteAfterApplying::No);
     };
 
     auto register_properties_and_widgets_matching_pattern = [&](String pattern, size_t partial_input_length) {
@@ -223,6 +225,8 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
             break;
         if (identifier_string == "layout")
             register_layouts_matching_pattern("*", 0u);
+        if (identifier_string == "content_widget")
+            register_widgets_matching_pattern("*", 0u);
         break;
     default:
         break;

--- a/Userland/Libraries/LibGUI/GroupBox.cpp
+++ b/Userland/Libraries/LibGUI/GroupBox.cpp
@@ -24,6 +24,16 @@ GroupBox::~GroupBox()
 {
 }
 
+Margins GroupBox::content_margins() const
+{
+    return {
+        (!m_title.is_empty() ? font().glyph_height() + 1 /*room for the focus rect*/ : 2),
+        2,
+        2,
+        2
+    };
+}
+
 void GroupBox::paint_event(PaintEvent& event)
 {
     Painter painter(*this);

--- a/Userland/Libraries/LibGUI/GroupBox.cpp
+++ b/Userland/Libraries/LibGUI/GroupBox.cpp
@@ -52,6 +52,12 @@ void GroupBox::paint_event(PaintEvent& event)
     }
 }
 
+void GroupBox::fonts_change_event(FontsChangeEvent& event)
+{
+    Widget::fonts_change_event(event);
+    invalidate_layout();
+}
+
 void GroupBox::set_title(const StringView& title)
 {
     if (m_title == title)

--- a/Userland/Libraries/LibGUI/GroupBox.h
+++ b/Userland/Libraries/LibGUI/GroupBox.h
@@ -23,6 +23,7 @@ protected:
     explicit GroupBox(const StringView& title = {});
 
     virtual void paint_event(PaintEvent&) override;
+    virtual void fonts_change_event(FontsChangeEvent&) override;
 
 private:
     String m_title;

--- a/Userland/Libraries/LibGUI/GroupBox.h
+++ b/Userland/Libraries/LibGUI/GroupBox.h
@@ -17,6 +17,7 @@ public:
 
     String title() const { return m_title; }
     void set_title(const StringView&);
+    virtual Margins content_margins() const override;
 
 protected:
     explicit GroupBox(const StringView& title = {});

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <LibGfx/Rect.h>
+
 namespace GUI {
 
 class Margins {
@@ -41,6 +43,16 @@ public:
     }
     ~Margins() = default;
 
+    [[nodiscard]] Gfx::IntRect applied_to(Gfx::IntRect const& input) const
+    {
+        Gfx::IntRect output = input;
+        output.take_from_left(left());
+        output.take_from_top(top());
+        output.take_from_right(right());
+        output.take_from_bottom(bottom());
+        return output;
+    }
+
     bool is_null() const { return !m_left && !m_top && !m_right && !m_bottom; }
 
     int top() const { return m_top; }
@@ -59,6 +71,11 @@ public:
             && m_top == other.m_top
             && m_right == other.m_right
             && m_bottom == other.m_bottom;
+    }
+
+    Margins operator+(Margins const& other) const
+    {
+        return Margins { top() + other.top(), right() + other.right(), bottom() + other.bottom(), left() + other.left() };
     }
 
 private:

--- a/Userland/Libraries/LibGUI/MultiView.cpp
+++ b/Userland/Libraries/LibGUI/MultiView.cpp
@@ -20,7 +20,7 @@ namespace GUI {
 MultiView::MultiView()
 {
     set_active_widget(nullptr);
-    set_content_margins(2);
+    set_grabbable_margins(2);
     m_icon_view = add<IconView>();
     m_table_view = add<TableView>();
     m_columns_view = add<ColumnsView>();

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -48,7 +48,6 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     auto& button_container = widget.add<GUI::Widget>();
     button_container.set_fixed_height(30);
     button_container.set_layout<GUI::HorizontalBoxLayout>();
-    button_container.set_content_margins({ 4, 0 });
     button_container.layout()->set_margins({ 0, 4, 0 });
     button_container.layout()->add_spacer();
 

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -44,6 +44,15 @@ void ScrollableContainerWidget::update_widget_size()
             new_size.set_height(preferred_size.height());
         m_widget->resize(new_size);
         set_content_size(new_size);
+    } else {
+        auto inner_size = Widget::content_size();
+        auto min_size = m_widget->min_size();
+        auto new_size = Gfx::Size {
+            max(inner_size.width(), min_size.width()),
+            max(inner_size.height(), min_size.height())
+        };
+        m_widget->resize(new_size);
+        set_content_size(new_size);
     }
 }
 

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -27,7 +27,7 @@ void ScrollableContainerWidget::update_widget_position()
 {
     if (!m_widget)
         return;
-    m_widget->move_to(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
+    m_widget->move_to(-horizontal_scrollbar().value() + content_margins().left(), -vertical_scrollbar().value() + content_margins().top());
 }
 
 void ScrollableContainerWidget::update_widget_size()
@@ -36,7 +36,7 @@ void ScrollableContainerWidget::update_widget_size()
         return;
     m_widget->do_layout();
     if (m_widget->is_shrink_to_fit() && m_widget->layout()) {
-        auto new_size = frame_inner_rect().size();
+        auto new_size = Widget::content_size();
         auto preferred_size = m_widget->layout()->preferred_size();
         if (preferred_size.width() != -1)
             new_size.set_width(preferred_size.width());

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -27,6 +27,7 @@ protected:
 private:
     void update_widget_size();
     void update_widget_position();
+    virtual bool load_from_json(const JsonObject&, RefPtr<Core::Object> (*unregistered_child_handler)(const String&)) override;
 
     ScrollableContainerWidget();
 

--- a/Userland/Libraries/LibGUI/Splitter.cpp
+++ b/Userland/Libraries/LibGUI/Splitter.cpp
@@ -137,10 +137,10 @@ void Splitter::mousedown_event(MouseEvent& event)
     m_resize_origin = event.position();
 }
 
-Gfx::IntRect Splitter::rect_between_widgets(GUI::Widget const& first_widget, GUI::Widget const& second_widget, bool honor_content_margins) const
+Gfx::IntRect Splitter::rect_between_widgets(GUI::Widget const& first_widget, GUI::Widget const& second_widget, bool honor_grabbable_margins) const
 {
-    auto first_widget_rect = honor_content_margins ? first_widget.content_rect() : first_widget.relative_rect();
-    auto second_widget_rect = honor_content_margins ? second_widget.content_rect() : second_widget.relative_rect();
+    auto first_widget_rect = honor_grabbable_margins ? first_widget.relative_non_grabbable_rect() : first_widget.relative_rect();
+    auto second_widget_rect = honor_grabbable_margins ? second_widget.relative_non_grabbable_rect() : second_widget.relative_rect();
 
     auto first_edge = first_widget_rect.last_edge_for_orientation(m_orientation);
     auto second_edge = second_widget_rect.first_edge_for_orientation(m_orientation);

--- a/Userland/Libraries/LibGUI/Splitter.h
+++ b/Userland/Libraries/LibGUI/Splitter.h
@@ -35,7 +35,7 @@ protected:
 
 private:
     void override_cursor(bool do_override);
-    Gfx::IntRect rect_between_widgets(GUI::Widget const& first_widget, GUI::Widget const& second_widget, bool honor_content_margins) const;
+    Gfx::IntRect rect_between_widgets(GUI::Widget const& first_widget, GUI::Widget const& second_widget, bool honor_grabbable_margins) const;
 
     Gfx::Orientation m_orientation;
     bool m_resizing { false };

--- a/Userland/Libraries/LibGUI/ToolbarContainer.cpp
+++ b/Userland/Libraries/LibGUI/ToolbarContainer.cpp
@@ -25,8 +25,6 @@ ToolbarContainer::ToolbarContainer(Gfx::Orientation orientation)
 
     auto& layout = set_layout<VerticalBoxLayout>();
     layout.set_spacing(2);
-    layout.set_margins(2);
-
     set_shrink_to_fit(true);
 }
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -657,7 +657,7 @@ Widget* Widget::child_at(const Gfx::IntPoint& point) const
         auto& child = verify_cast<Widget>(children()[i]);
         if (!child.is_visible())
             continue;
-        if (child.content_rect().contains(point))
+        if (child.relative_non_grabbable_rect().contains(point))
             return const_cast<Widget*>(&child);
     }
     return nullptr;
@@ -999,20 +999,20 @@ void Widget::did_end_inspection()
     update();
 }
 
-void Widget::set_content_margins(const Margins& margins)
+void Widget::set_grabbable_margins(const Margins& margins)
 {
-    if (m_content_margins == margins)
+    if (m_grabbable_margins == margins)
         return;
-    m_content_margins = margins;
+    m_grabbable_margins = margins;
     invalidate_layout();
 }
 
-Gfx::IntRect Widget::content_rect() const
+Gfx::IntRect Widget::relative_non_grabbable_rect() const
 {
     auto rect = relative_rect();
-    rect.translate_by(m_content_margins.left(), m_content_margins.top());
-    rect.set_width(rect.width() - (m_content_margins.left() + m_content_margins.right()));
-    rect.set_height(rect.height() - (m_content_margins.top() + m_content_margins.bottom()));
+    rect.translate_by(m_grabbable_margins.left(), m_grabbable_margins.top());
+    rect.set_width(rect.width() - (m_grabbable_margins.left() + m_grabbable_margins.right()));
+    rect.set_height(rect.height() - (m_grabbable_margins.top() + m_grabbable_margins.bottom()));
     return rect;
 }
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -263,10 +263,10 @@ public:
     Gfx::Palette palette() const;
     void set_palette(const Gfx::Palette&);
 
-    const Margins& content_margins() const { return m_content_margins; }
-    void set_content_margins(const Margins&);
+    const Margins& grabbable_margins() const { return m_grabbable_margins; }
+    void set_grabbable_margins(const Margins&);
 
-    Gfx::IntRect content_rect() const;
+    Gfx::IntRect relative_non_grabbable_rect() const;
 
     void set_accepts_emoji_input(bool b) { m_accepts_emoji_input = b; }
     bool accepts_emoji_input() const { return m_accepts_emoji_input; }
@@ -357,7 +357,7 @@ private:
 
     Gfx::IntSize m_min_size { -1, -1 };
     Gfx::IntSize m_max_size { -1, -1 };
-    Margins m_content_margins;
+    Margins m_grabbable_margins;
 
     bool m_fill_with_background_color { false };
     bool m_visible { true };

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -134,8 +134,12 @@ public:
     int height() const { return m_relative_rect.height(); }
     int length(Orientation orientation) const { return orientation == Orientation::Vertical ? height() : width(); }
 
+    virtual Margins content_margins() const { return { 0 }; }
+
     Gfx::IntRect rect() const { return { 0, 0, width(), height() }; }
     Gfx::IntSize size() const { return m_relative_rect.size(); }
+    Gfx::IntRect content_rect() const { return this->content_margins().applied_to(rect()); };
+    Gfx::IntSize content_size() const { return this->content_rect().size(); };
 
     // Invalidate the widget (or an area thereof), causing a repaint to happen soon.
     void update();


### PR DESCRIPTION
Before, content margins (as specified as a property of the layout) were measured relative to the outer most edge of the container widget, which lead to the awkward workaround of always including the border width of Frame or GroupBox in the margins. The worst problem with this approach becomes apparent when you consider that the title of GroupBoxes was also included in these margins.
![Bildschirmfoto von 2021-09-28 17-19-19](https://user-images.githubusercontent.com/28605587/135117486-a85ca901-70c9-4e39-b8f9-0b5a5501a35f.png)

This also improves the AbstractScrollableWidget using the content margin interface, in order to not consider the area obscured by the scrollbars as visible. This mainly is to the benefit of ScrollableContainerWidget usability, as a general purpose container. Because of that I also added ScrollableContainerWidget to be usable from GML. It still has it's problems (specifically when `should_hide_unnecessary_scrollbars: true` is set), but should now be solid enough to iterate upon.
With a widget that tries to fill the entire visible area of the ScrollableContainerWidget, which is something that has only become easily achievable now, there are some problems when downsizing while `should_hide_unnecessary_scrollbars: true`. But that is a problem to solve separately, as it also seems to appear before, in the Browser for example.

All this functionality will come in really handy, when implementing more dynamic layouts, that don't rely so heavily on manually set sizes. That is already something I'm working on, and it already somewhat works, but I wanted to get this merged first, so it doesn't turn into an unmanageable monster PR. This is also the reason why the `preferred_size` method of Layout is a bit awkward now, because it will most likely shortly be moved into Widget. (if I have it my way)

fixes https://github.com/SerenityOS/serenity/issues/5887