### PR TITLE
LibSymbolication+SystemMonitor: Show ELF object in stack

### DIFF
--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -79,7 +79,7 @@ void ThreadStackWidget::custom_event(Core::CustomEvent& event)
     StringBuilder builder;
 
     for (auto& symbol : completion_event.symbols()) {
-        builder.appendff("{:p}", symbol.address);
+        builder.appendff("{:p} {:30s}", symbol.address, symbol.object);
         if (!symbol.name.is_empty())
             builder.appendff("  {}", symbol.name);
         builder.append('\n');

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -121,6 +121,7 @@ Optional<Symbol> symbolicate(String const& path, FlatPtr address)
     return Symbol {
         .address = address,
         .name = move(symbol),
+        .object = LexicalPath::basename(path),
         .offset = offset,
         .source_positions = move(positions),
     };

--- a/Userland/Libraries/LibSymbolication/Symbolication.h
+++ b/Userland/Libraries/LibSymbolication/Symbolication.h
@@ -14,6 +14,7 @@ namespace Symbolication {
 struct Symbol {
     FlatPtr address { 0 };
     String name {};
+    String object {};
     u32 offset { 0 };
     Vector<Debug::DebugInfo::SourcePosition> source_positions;
 };


### PR DESCRIPTION
This small patch allows SystemMonitor's Stack tab to show the name of
the ELF object to which the displayed address refers to. This gives a
bit more of contextual information to the viewer.

A better to show this is probably a table, but I'm not that familiar yet
with the GUI framework in general, so I'm keeping things simple.