### PR TITLE
LibWeb: Implement ChildNode.remove

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
 
@@ -14,6 +15,7 @@ namespace Web::DOM {
 
 class CharacterData
     : public Node
+    , public ChildNode<CharacterData>
     , public NonDocumentTypeChildNode<CharacterData> {
 public:
     using WrapperType = Bindings::CharacterDataWrapper;

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -6,4 +6,7 @@ interface CharacterData : Node {
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
 
+    // FIXME: This should come from a ChildNode mixin
+    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
+
 };

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#childnode
+template<typename NodeType>
+class ChildNode {
+public:
+    // https://dom.spec.whatwg.org/#dom-childnode-remove
+    void remove_binding()
+    {
+        auto* node = static_cast<NodeType*>(this);
+
+        // 1. If this’s parent is null, then return.
+        if (!node->parent())
+            return;
+
+        // 2. Remove this.
+        node->remove();
+    }
+
+protected:
+    ChildNode() = default;
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.h
@@ -7,11 +7,14 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/Node.h>
 
 namespace Web::DOM {
 
-class DocumentType final : public Node {
+class DocumentType final
+    : public Node
+    , public ChildNode<DocumentType> {
 public:
     using WrapperType = Bindings::DocumentTypeWrapper;
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.idl
@@ -4,4 +4,7 @@ interface DocumentType : Node {
     readonly attribute DOMString publicId;
     readonly attribute DOMString systemId;
 
+    // FIXME: This should come from a ChildNode mixin
+    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
+
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -11,6 +11,7 @@
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Attribute.h>
+#include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/ExceptionOr.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
 #include <LibWeb/DOM/ParentNode.h>
@@ -24,6 +25,7 @@ namespace Web::DOM {
 
 class Element
     : public ParentNode
+    , public ChildNode<Element>
     , public NonDocumentTypeChildNode<Element> {
 
 public:

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -37,4 +37,7 @@ interface Element : Node {
 
     DOMRect getBoundingClientRect();
 
+    // FIXME: This should come from a ChildNode mixin
+    [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
+
 };


### PR DESCRIPTION
LibWeb: Add initial support for the IDL [Unscopable] extended attribute

This adds support for the [Unscopable] extended attribute to attributes
and functions.

I believe it should be applicable to all interface members, but I
haven't done that here.

-----

LibWeb: Implement ChildNode.remove 