### PR TITLE
LibWeb: Add support for custom #import IDL statements

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
@@ -8,15 +8,6 @@
 
 namespace Web::DOM {
 
-CustomEvent::CustomEvent(FlyString const& event_name)
-    : Event(event_name)
-{
-}
-
-CustomEvent::~CustomEvent()
-{
-}
-
 void CustomEvent::visit_edges(JS::Cell::Visitor& visitor)
 {
     visitor.visit(m_detail);

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.h
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.h
@@ -10,17 +10,25 @@
 
 namespace Web::DOM {
 
+struct CustomEventInit : public EventInit {
+    JS::Value detail { JS::js_null() };
+};
+
 // https://dom.spec.whatwg.org/#customevent
 class CustomEvent : public Event {
 public:
     using WrapperType = Bindings::CustomEventWrapper;
 
-    static NonnullRefPtr<CustomEvent> create(FlyString const& event_name)
+    static NonnullRefPtr<CustomEvent> create(FlyString const& event_name, CustomEventInit const& event_init = {})
     {
-        return adopt_ref(*new CustomEvent(event_name));
+        return adopt_ref(*new CustomEvent(event_name, event_init));
+    }
+    static NonnullRefPtr<CustomEvent> create_with_global_object(Bindings::WindowObject&, const FlyString& event_name, CustomEventInit const& event_init)
+    {
+        return CustomEvent::create(event_name, event_init);
     }
 
-    virtual ~CustomEvent() override;
+    virtual ~CustomEvent() override = default;
 
     // https://dom.spec.whatwg.org/#dom-customevent-detail
     JS::Value detail() const { return m_detail; }
@@ -30,7 +38,16 @@ public:
     void init_custom_event(String const& type, bool bubbles, bool cancelable, JS::Value detail);
 
 private:
-    CustomEvent(FlyString const&);
+    explicit CustomEvent(FlyString const& event_name)
+        : Event(event_name)
+    {
+    }
+
+    CustomEvent(FlyString const& event_name, CustomEventInit const& event_init)
+        : Event(event_name, event_init)
+        , m_detail(event_init.detail)
+    {
+    }
 
     // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent-type-bubbles-cancelable-detail-detail
     JS::Value m_detail { JS::js_null() };

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.idl
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.idl
@@ -1,8 +1,14 @@
+#import <Event.idl>
+
 [Exposed=(Window,Worker), CustomVisit]
 interface CustomEvent : Event {
-    // FIXME: constructor(DOMString type, optional CustomEventInit eventInitDict = {});
+    constructor(DOMString type, optional CustomEventInit eventInitDict = {});
 
     readonly attribute any detail;
 
     undefined initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);
+};
+
+dictionary CustomEventInit : EventInit {
+    any detail = null;
 };


### PR DESCRIPTION
This will currently be used to support dictionary inheritance between dictionaries defined across different IDL definition files.