### PR TITLE
LibMarkdown: Add support for different types of blocks in lists

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -116,7 +116,8 @@ Optional<T> convert_to_int(const StringView& str, TrimWhitespace trim_whitespace
 template Optional<i8> convert_to_int(const StringView& str, TrimWhitespace);
 template Optional<i16> convert_to_int(const StringView& str, TrimWhitespace);
 template Optional<i32> convert_to_int(const StringView& str, TrimWhitespace);
-template Optional<i64> convert_to_int(const StringView& str, TrimWhitespace);
+template Optional<long> convert_to_int(const StringView& str, TrimWhitespace);
+template Optional<long long> convert_to_int(const StringView& str, TrimWhitespace);
 
 template<typename T>
 Optional<T> convert_to_uint(const StringView& str, TrimWhitespace trim_whitespace)
@@ -146,7 +147,8 @@ Optional<T> convert_to_uint(const StringView& str, TrimWhitespace trim_whitespac
 template Optional<u8> convert_to_uint(const StringView& str, TrimWhitespace);
 template Optional<u16> convert_to_uint(const StringView& str, TrimWhitespace);
 template Optional<u32> convert_to_uint(const StringView& str, TrimWhitespace);
-template Optional<u64> convert_to_uint(const StringView& str, TrimWhitespace);
+template Optional<unsigned long> convert_to_uint(const StringView& str, TrimWhitespace);
+template Optional<unsigned long long> convert_to_uint(const StringView& str, TrimWhitespace);
 template Optional<long> convert_to_uint(const StringView& str, TrimWhitespace);
 template Optional<long long> convert_to_uint(const StringView& str, TrimWhitespace);
 

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -215,7 +215,8 @@ Optional<T> StringView::to_int() const
 template Optional<i8> StringView::to_int() const;
 template Optional<i16> StringView::to_int() const;
 template Optional<i32> StringView::to_int() const;
-template Optional<i64> StringView::to_int() const;
+template Optional<long> StringView::to_int() const;
+template Optional<long long> StringView::to_int() const;
 
 template<typename T>
 Optional<T> StringView::to_uint() const
@@ -226,7 +227,8 @@ Optional<T> StringView::to_uint() const
 template Optional<u8> StringView::to_uint() const;
 template Optional<u16> StringView::to_uint() const;
 template Optional<u32> StringView::to_uint() const;
-template Optional<u64> StringView::to_uint() const;
+template Optional<unsigned long> StringView::to_uint() const;
+template Optional<unsigned long long> StringView::to_uint() const;
 template Optional<long> StringView::to_uint() const;
 template Optional<long long> StringView::to_uint() const;
 

--- a/Userland/Libraries/LibMarkdown/Block.h
+++ b/Userland/Libraries/LibMarkdown/Block.h
@@ -15,7 +15,7 @@ class Block {
 public:
     virtual ~Block() { }
 
-    virtual String render_to_html() const = 0;
+    virtual String render_to_html(bool tight = false) const = 0;
     virtual String render_for_terminal(size_t view_width = 0) const = 0;
 };
 

--- a/Userland/Libraries/LibMarkdown/CMakeLists.txt
+++ b/Userland/Libraries/LibMarkdown/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     Document.cpp
     Heading.cpp
     HorizontalRule.cpp
+    LineIterator.cpp
     List.cpp
     Paragraph.cpp
     Table.cpp

--- a/Userland/Libraries/LibMarkdown/CMakeLists.txt
+++ b/Userland/Libraries/LibMarkdown/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     CodeBlock.cpp
+    ContainerBlock.cpp
     Document.cpp
     Heading.cpp
     HorizontalRule.cpp

--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -56,7 +56,7 @@ String CodeBlock::render_for_terminal(size_t) const
 
 static Regex<ECMA262> style_spec_re("\\s*([\\*_]*)\\s*([^\\*_\\s]*).*");
 
-OwnPtr<CodeBlock> CodeBlock::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<CodeBlock> CodeBlock::parse(LineIterator& lines)
 {
     if (lines.is_end())
         return {};

--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -11,7 +11,7 @@
 
 namespace Markdown {
 
-String CodeBlock::render_to_html() const
+String CodeBlock::render_to_html(bool) const
 {
     StringBuilder builder;
 

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -8,6 +8,7 @@
 
 #include <AK/OwnPtr.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/LineIterator.h>
 #include <LibMarkdown/Text.h>
 
 namespace Markdown {
@@ -24,7 +25,7 @@ public:
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
-    static OwnPtr<CodeBlock> parse(Vector<StringView>::ConstIterator& lines);
+    static OwnPtr<CodeBlock> parse(LineIterator& lines);
 
 private:
     String m_code;

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -23,7 +23,7 @@ public:
     }
     virtual ~CodeBlock() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<CodeBlock> parse(LineIterator& lines);
 

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
@@ -39,7 +39,7 @@ String ContainerBlock::render_for_terminal(size_t view_width) const
 }
 
 template<typename BlockType>
-static bool try_parse_block(Vector<StringView>::ConstIterator& lines, NonnullOwnPtrVector<Block>& blocks)
+static bool try_parse_block(LineIterator& lines, NonnullOwnPtrVector<Block>& blocks)
 {
     OwnPtr<BlockType> block = BlockType::parse(lines);
     if (!block)
@@ -48,7 +48,7 @@ static bool try_parse_block(Vector<StringView>::ConstIterator& lines, NonnullOwn
     return true;
 }
 
-OwnPtr<ContainerBlock> ContainerBlock::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<ContainerBlock> ContainerBlock::parse(LineIterator& lines)
 {
     NonnullOwnPtrVector<Block> blocks;
 

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibMarkdown/CodeBlock.h>
+#include <LibMarkdown/ContainerBlock.h>
+#include <LibMarkdown/Heading.h>
+#include <LibMarkdown/HorizontalRule.h>
+#include <LibMarkdown/List.h>
+#include <LibMarkdown/Paragraph.h>
+#include <LibMarkdown/Table.h>
+
+namespace Markdown {
+
+String ContainerBlock::render_to_html() const
+{
+    StringBuilder builder;
+
+    for (auto& block : m_blocks) {
+        auto s = block.render_to_html();
+        builder.append(s);
+    }
+
+    return builder.build();
+}
+
+String ContainerBlock::render_for_terminal(size_t view_width) const
+{
+    StringBuilder builder;
+
+    for (auto& block : m_blocks) {
+        auto s = block.render_for_terminal(view_width);
+        builder.append(s);
+    }
+
+    return builder.build();
+}
+
+template<typename BlockType>
+static bool try_parse_block(Vector<StringView>::ConstIterator& lines, NonnullOwnPtrVector<Block>& blocks)
+{
+    OwnPtr<BlockType> block = BlockType::parse(lines);
+    if (!block)
+        return false;
+    blocks.append(block.release_nonnull());
+    return true;
+}
+
+OwnPtr<ContainerBlock> ContainerBlock::parse(Vector<StringView>::ConstIterator& lines)
+{
+    NonnullOwnPtrVector<Block> blocks;
+
+    StringBuilder paragraph_text;
+
+    auto flush_paragraph = [&] {
+        if (paragraph_text.is_empty())
+            return;
+        auto paragraph = make<Paragraph>(Text::parse(paragraph_text.build()));
+        blocks.append(move(paragraph));
+        paragraph_text.clear();
+    };
+
+    while (true) {
+        if (lines.is_end())
+            break;
+
+        if ((*lines).is_empty()) {
+            ++lines;
+
+            flush_paragraph();
+            continue;
+        }
+
+        bool any = try_parse_block<Table>(lines, blocks) || try_parse_block<List>(lines, blocks) || try_parse_block<CodeBlock>(lines, blocks)
+            || try_parse_block<Heading>(lines, blocks) || try_parse_block<HorizontalRule>(lines, blocks);
+
+        if (any) {
+            if (!paragraph_text.is_empty()) {
+                auto last_block = blocks.take_last();
+                flush_paragraph();
+                blocks.append(move(last_block));
+            }
+            continue;
+        }
+
+        if (!paragraph_text.is_empty())
+            paragraph_text.append("\n");
+        paragraph_text.append(*lines++);
+    }
+
+    flush_paragraph();
+
+    return make<ContainerBlock>(move(blocks));
+}
+
+}

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.h
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.h
@@ -10,6 +10,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/LineIterator.h>
 
 namespace Markdown {
 
@@ -25,7 +26,7 @@ public:
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
 
-    static OwnPtr<ContainerBlock> parse(Vector<StringView>::ConstIterator& lines);
+    static OwnPtr<ContainerBlock> parse(LineIterator& lines);
 
 private:
     NonnullOwnPtrVector<Block> m_blocks;

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.h
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.h
@@ -16,20 +16,29 @@ namespace Markdown {
 
 class ContainerBlock final : public Block {
 public:
-    ContainerBlock(NonnullOwnPtrVector<Block> blocks)
+    ContainerBlock(NonnullOwnPtrVector<Block> blocks, bool has_blank_lines, bool has_trailing_blank_lines)
         : m_blocks(move(blocks))
+        , m_has_blank_lines(has_blank_lines)
+        , m_has_trailing_blank_lines(has_trailing_blank_lines)
     {
     }
 
     virtual ~ContainerBlock() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
 
     static OwnPtr<ContainerBlock> parse(LineIterator& lines);
 
+    bool has_blank_lines() const { return m_has_blank_lines; }
+    bool has_trailing_blank_lines() const { return m_has_trailing_blank_lines; }
+
+    NonnullOwnPtrVector<Block> const& blocks() const { return m_blocks; }
+
 private:
     NonnullOwnPtrVector<Block> m_blocks;
+    bool m_has_blank_lines;
+    bool m_has_trailing_blank_lines;
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.h
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtrVector.h>
+#include <AK/OwnPtr.h>
+#include <AK/String.h>
+#include <LibMarkdown/Block.h>
+
+namespace Markdown {
+
+class ContainerBlock final : public Block {
+public:
+    ContainerBlock(NonnullOwnPtrVector<Block> blocks)
+        : m_blocks(move(blocks))
+    {
+    }
+
+    virtual ~ContainerBlock() override { }
+
+    virtual String render_to_html() const override;
+    virtual String render_for_terminal(size_t view_width = 0) const override;
+
+    static OwnPtr<ContainerBlock> parse(Vector<StringView>::ConstIterator& lines);
+
+private:
+    NonnullOwnPtrVector<Block> m_blocks;
+};
+
+}

--- a/Userland/Libraries/LibMarkdown/Document.cpp
+++ b/Userland/Libraries/LibMarkdown/Document.cpp
@@ -6,13 +6,8 @@
  */
 
 #include <AK/StringBuilder.h>
-#include <LibMarkdown/CodeBlock.h>
 #include <LibMarkdown/Document.h>
-#include <LibMarkdown/Heading.h>
-#include <LibMarkdown/HorizontalRule.h>
-#include <LibMarkdown/List.h>
-#include <LibMarkdown/Paragraph.h>
-#include <LibMarkdown/Table.h>
+#include <LibMarkdown/LineIterator.h>
 
 namespace Markdown {
 
@@ -49,7 +44,7 @@ String Document::render_for_terminal(size_t view_width) const
 OwnPtr<Document> Document::parse(const StringView& str)
 {
     const Vector<StringView> lines_vec = str.lines();
-    auto lines = lines_vec.begin();
+    LineIterator lines(lines_vec.begin());
     return make<Document>(ContainerBlock::parse(lines));
 }
 

--- a/Userland/Libraries/LibMarkdown/Document.h
+++ b/Userland/Libraries/LibMarkdown/Document.h
@@ -6,14 +6,19 @@
 
 #pragma once
 
-#include <AK/NonnullOwnPtrVector.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/ContainerBlock.h>
 
 namespace Markdown {
 
 class Document final {
 public:
+    Document(OwnPtr<ContainerBlock> container)
+        : m_container(move(container))
+    {
+    }
     String render_to_html() const;
     String render_to_inline_html() const;
     String render_for_terminal(size_t view_width = 0) const;
@@ -21,7 +26,7 @@ public:
     static OwnPtr<Document> parse(const StringView&);
 
 private:
-    NonnullOwnPtrVector<Block> m_blocks;
+    OwnPtr<ContainerBlock> m_container;
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -35,7 +35,7 @@ String Heading::render_for_terminal(size_t) const
     return builder.build();
 }
 
-OwnPtr<Heading> Heading::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<Heading> Heading::parse(LineIterator& lines)
 {
     if (lines.is_end())
         return {};

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -9,7 +9,7 @@
 
 namespace Markdown {
 
-String Heading::render_to_html() const
+String Heading::render_to_html(bool) const
 {
     return String::formatted("<h{}>{}</h{}>\n", m_level, m_text.render_to_html(), m_level);
 }

--- a/Userland/Libraries/LibMarkdown/Heading.h
+++ b/Userland/Libraries/LibMarkdown/Heading.h
@@ -10,6 +10,7 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/LineIterator.h>
 #include <LibMarkdown/Text.h>
 
 namespace Markdown {
@@ -26,7 +27,7 @@ public:
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
-    static OwnPtr<Heading> parse(Vector<StringView>::ConstIterator& lines);
+    static OwnPtr<Heading> parse(LineIterator& lines);
 
 private:
     Text m_text;

--- a/Userland/Libraries/LibMarkdown/Heading.h
+++ b/Userland/Libraries/LibMarkdown/Heading.h
@@ -25,7 +25,7 @@ public:
     }
     virtual ~Heading() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<Heading> parse(LineIterator& lines);
 

--- a/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
+++ b/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
@@ -10,7 +10,7 @@
 
 namespace Markdown {
 
-String HorizontalRule::render_to_html() const
+String HorizontalRule::render_to_html(bool) const
 {
     return "<hr />\n";
 }

--- a/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
+++ b/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
@@ -24,7 +24,7 @@ String HorizontalRule::render_for_terminal(size_t view_width) const
     return builder.to_string();
 }
 
-OwnPtr<HorizontalRule> HorizontalRule::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<HorizontalRule> HorizontalRule::parse(LineIterator& lines)
 {
     if (lines.is_end())
         return {};

--- a/Userland/Libraries/LibMarkdown/HorizontalRule.h
+++ b/Userland/Libraries/LibMarkdown/HorizontalRule.h
@@ -10,6 +10,7 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/LineIterator.h>
 
 namespace Markdown {
 
@@ -22,7 +23,7 @@ public:
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
-    static OwnPtr<HorizontalRule> parse(Vector<StringView>::ConstIterator& lines);
+    static OwnPtr<HorizontalRule> parse(LineIterator& lines);
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/HorizontalRule.h
+++ b/Userland/Libraries/LibMarkdown/HorizontalRule.h
@@ -21,7 +21,7 @@ public:
     }
     virtual ~HorizontalRule() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<HorizontalRule> parse(LineIterator& lines);
 };

--- a/Userland/Libraries/LibMarkdown/LineIterator.cpp
+++ b/Userland/Libraries/LibMarkdown/LineIterator.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibMarkdown/LineIterator.h>
+
+namespace Markdown {
+
+bool LineIterator::is_indented(StringView const& line) const
+{
+    if (line.is_whitespace())
+        return true;
+
+    if (line.length() < m_indent)
+        return false;
+
+    for (size_t i = 0; i < m_indent; ++i) {
+        if (line[i] != ' ')
+            return false;
+    }
+
+    return true;
+}
+
+bool LineIterator::is_end() const
+{
+    return m_iterator.is_end() || (!m_ignore_prefix_mode && !is_indented(*m_iterator));
+}
+
+StringView LineIterator::operator*() const
+{
+    VERIFY(m_ignore_prefix_mode || is_indented(*m_iterator));
+    if (m_iterator->is_whitespace())
+        return *m_iterator;
+
+    return m_iterator->substring_view(m_indent);
+}
+
+}

--- a/Userland/Libraries/LibMarkdown/LineIterator.h
+++ b/Userland/Libraries/LibMarkdown/LineIterator.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Iterator.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+
+namespace Markdown {
+
+template<typename T>
+class FakePtr {
+public:
+    FakePtr(T item)
+        : m_item(move(item))
+    {
+    }
+
+    T const* operator->() const { return &m_item; }
+    T* operator->() { return &m_item; }
+
+private:
+    T m_item;
+};
+
+class LineIterator {
+public:
+    LineIterator(Vector<StringView>::ConstIterator const& lines, size_t indent = 0)
+        : m_iterator(lines)
+        , m_indent(indent)
+    {
+    }
+
+    bool is_end() const;
+    StringView operator*() const;
+
+    LineIterator operator++()
+    {
+        reset_ignore_prefix();
+        ++m_iterator;
+        return *this;
+    }
+
+    LineIterator operator++(int)
+    {
+        LineIterator tmp = *this;
+        reset_ignore_prefix();
+        ++m_iterator;
+        return tmp;
+    }
+
+    LineIterator operator+(ptrdiff_t delta) const { return LineIterator { m_iterator + delta, m_indent }; }
+    LineIterator operator-(ptrdiff_t delta) const { return LineIterator { m_iterator - delta, m_indent }; }
+    ptrdiff_t operator-(LineIterator other) const { return m_iterator - other.m_iterator; }
+
+    FakePtr<StringView> operator->() const { return FakePtr<StringView>(operator*()); }
+
+    size_t indent() const { return m_indent; }
+    void set_indent(size_t indent) { m_indent = indent; }
+    void ignore_next_prefix() { m_ignore_prefix_mode = true; }
+
+private:
+    void reset_ignore_prefix() { m_ignore_prefix_mode = false; }
+    bool is_indented(StringView const& line) const;
+
+    Vector<StringView>::ConstIterator m_iterator;
+    size_t m_indent;
+    bool m_ignore_prefix_mode { false };
+};
+
+}

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -46,7 +46,7 @@ String List::render_for_terminal(size_t) const
     return builder.build();
 }
 
-OwnPtr<List> List::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<List> List::parse(LineIterator& lines)
 {
     Vector<Text> items;
     bool is_ordered = false;

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -67,15 +67,19 @@ OwnPtr<List> List::parse(LineIterator& lines)
         const StringView& line = *lines;
 
         bool appears_unordered = false;
-        if (line.length() > 2) {
-            if (line[1] == ' ' && (line[0] == '*' || line[0] == '-')) {
+
+        while (offset < line.length() && line[offset] == ' ')
+            ++offset;
+
+        if (offset + 2 <= line.length()) {
+            if (line[offset + 1] == ' ' && (line[offset] == '*' || line[offset] == '-' || line[offset] == '+')) {
                 appears_unordered = true;
-                offset = 1;
+                offset++;
             }
         }
 
         bool appears_ordered = false;
-        for (size_t i = 0; i < 10 && i < line.length(); i++) {
+        for (size_t i = offset; i < 10 && i < line.length(); i++) {
             char ch = line[i];
             if ('0' <= ch && ch <= '9')
                 continue;

--- a/Userland/Libraries/LibMarkdown/List.h
+++ b/Userland/Libraries/LibMarkdown/List.h
@@ -15,14 +15,15 @@ namespace Markdown {
 
 class List final : public Block {
 public:
-    List(Vector<OwnPtr<ContainerBlock>> items, bool is_ordered)
+    List(Vector<OwnPtr<ContainerBlock>> items, bool is_ordered, bool is_tight)
         : m_items(move(items))
         , m_is_ordered(is_ordered)
+        , m_is_tight(is_tight)
     {
     }
     virtual ~List() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
 
     static OwnPtr<List> parse(LineIterator& lines);
@@ -30,6 +31,7 @@ public:
 private:
     Vector<OwnPtr<ContainerBlock>> m_items;
     bool m_is_ordered { false };
+    bool m_is_tight { false };
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/List.h
+++ b/Userland/Libraries/LibMarkdown/List.h
@@ -9,6 +9,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Vector.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/LineIterator.h>
 #include <LibMarkdown/Text.h>
 
 namespace Markdown {
@@ -25,7 +26,7 @@ public:
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
 
-    static OwnPtr<List> parse(Vector<StringView>::ConstIterator& lines);
+    static OwnPtr<List> parse(LineIterator& lines);
 
 private:
     // TODO: List items should be considered blocks of their own kind.

--- a/Userland/Libraries/LibMarkdown/List.h
+++ b/Userland/Libraries/LibMarkdown/List.h
@@ -15,10 +15,11 @@ namespace Markdown {
 
 class List final : public Block {
 public:
-    List(Vector<OwnPtr<ContainerBlock>> items, bool is_ordered, bool is_tight)
+    List(Vector<OwnPtr<ContainerBlock>> items, bool is_ordered, bool is_tight, size_t start_number)
         : m_items(move(items))
         , m_is_ordered(is_ordered)
         , m_is_tight(is_tight)
+        , m_start_number(start_number)
     {
     }
     virtual ~List() override { }
@@ -32,6 +33,7 @@ private:
     Vector<OwnPtr<ContainerBlock>> m_items;
     bool m_is_ordered { false };
     bool m_is_tight { false };
+    size_t m_start_number { 1 };
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/List.h
+++ b/Userland/Libraries/LibMarkdown/List.h
@@ -7,17 +7,16 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
-#include <AK/Vector.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/ContainerBlock.h>
 #include <LibMarkdown/LineIterator.h>
-#include <LibMarkdown/Text.h>
 
 namespace Markdown {
 
 class List final : public Block {
 public:
-    List(Vector<Text>&& text, bool is_ordered)
-        : m_items(move(text))
+    List(Vector<OwnPtr<ContainerBlock>> items, bool is_ordered)
+        : m_items(move(items))
         , m_is_ordered(is_ordered)
     {
     }
@@ -29,8 +28,7 @@ public:
     static OwnPtr<List> parse(LineIterator& lines);
 
 private:
-    // TODO: List items should be considered blocks of their own kind.
-    Vector<Text> m_items;
+    Vector<OwnPtr<ContainerBlock>> m_items;
     bool m_is_ordered { false };
 };
 

--- a/Userland/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Userland/Libraries/LibMarkdown/Paragraph.cpp
@@ -9,12 +9,20 @@
 
 namespace Markdown {
 
-String Paragraph::render_to_html() const
+String Paragraph::render_to_html(bool tight) const
 {
     StringBuilder builder;
-    builder.append("<p>");
+
+    if (!tight)
+        builder.append("<p>");
+
     builder.append(m_text.render_to_html());
-    builder.append("</p>\n");
+
+    if (!tight)
+        builder.append("</p>");
+
+    builder.append('\n');
+
     return builder.build();
 }
 

--- a/Userland/Libraries/LibMarkdown/Paragraph.h
+++ b/Userland/Libraries/LibMarkdown/Paragraph.h
@@ -22,7 +22,7 @@ public:
 
     virtual ~Paragraph() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
 
 private:

--- a/Userland/Libraries/LibMarkdown/Table.cpp
+++ b/Userland/Libraries/LibMarkdown/Table.cpp
@@ -96,7 +96,7 @@ String Table::render_to_html() const
     return builder.to_string();
 }
 
-OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<Table> Table::parse(LineIterator& lines)
 {
     auto peek_it = lines;
     auto first_line = *peek_it;
@@ -178,7 +178,7 @@ OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
     size_t row_count = 0;
     ++lines;
     while (!lines.is_end()) {
-        auto& line = *lines;
+        auto line = *lines;
         if (!line.starts_with('|'))
             break;
 

--- a/Userland/Libraries/LibMarkdown/Table.cpp
+++ b/Userland/Libraries/LibMarkdown/Table.cpp
@@ -65,7 +65,7 @@ String Table::render_for_terminal(size_t view_width) const
     return builder.to_string();
 }
 
-String Table::render_to_html() const
+String Table::render_to_html(bool) const
 {
     StringBuilder builder;
 

--- a/Userland/Libraries/LibMarkdown/Table.h
+++ b/Userland/Libraries/LibMarkdown/Table.h
@@ -9,6 +9,7 @@
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <LibMarkdown/Block.h>
+#include <LibMarkdown/LineIterator.h>
 #include <LibMarkdown/Text.h>
 
 namespace Markdown {
@@ -33,7 +34,7 @@ public:
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
-    static OwnPtr<Table> parse(Vector<StringView>::ConstIterator& lines);
+    static OwnPtr<Table> parse(LineIterator& lines);
 
 private:
     Vector<Column> m_columns;

--- a/Userland/Libraries/LibMarkdown/Table.h
+++ b/Userland/Libraries/LibMarkdown/Table.h
@@ -32,7 +32,7 @@ public:
     Table() { }
     virtual ~Table() override { }
 
-    virtual String render_to_html() const override;
+    virtual String render_to_html(bool tight = false) const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<Table> parse(LineIterator& lines);
 


### PR DESCRIPTION
- lists can contain different blocks (lists, code blocks, etc) instead of just text
- [loose/tight lists](https://spec.commonmark.org/0.30/#loose)
- spaces before list items
- non-1 start numbers for ordered lists

`TestCommonmark` pass rate:
227/652 -> 253/652