### PR TITLE
LibAudio(+SoundPlayer): Implement seeking in FLAC using seektables :^)

### DIFF
--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -64,13 +64,13 @@ void PlaybackManager::seek(const int position)
     if (!m_loader)
         return;
 
-    m_last_seek = position;
     bool paused_state = m_paused;
     set_paused(true);
 
     m_connection->clear_buffer(true);
     m_current_buffer = nullptr;
     m_loader->seek(position);
+    m_last_seek = m_loader->loaded_samples();
 
     if (!paused_state)
         set_paused(false);

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -141,6 +141,7 @@ private:
 
     // keep track of the start of the data in the FLAC stream to seek back more easily
     u64 m_data_start_location { 0 };
+    Vector<FlacSeekPoint> m_seektable;
     OwnPtr<FlacInputStream> m_stream;
     Optional<FlacFrameHeader> m_current_frame;
     Vector<Frame> m_current_frame_data;

--- a/Userland/Libraries/LibAudio/FlacTypes.h
+++ b/Userland/Libraries/LibAudio/FlacTypes.h
@@ -25,7 +25,7 @@ enum FlacMetadataBlockType : u8 {
     STREAMINFO = 0,     // Important data about the audio format
     PADDING = 1,        // Non-data block to be ignored
     APPLICATION = 2,    // Ignored
-    SEEKTABLE = 3,      // Seeking info, maybe to be used later
+    SEEKTABLE = 3,      // Seeking info
     VORBIS_COMMENT = 4, // Ignored
     CUESHEET = 5,       // Ignored
     PICTURE = 6,        // Ignored
@@ -69,6 +69,12 @@ struct FlacRawMetadataBlock {
     FlacMetadataBlockType type;
     u32 length; // 24 bits
     ByteBuffer data;
+};
+
+struct FlacSeekPoint {
+    u64 sample_index;
+    u64 offset;
+    u16 sample_count;
 };
 
 // An abstract, parsed and validated FLAC frame


### PR DESCRIPTION
- **LibAudio: Implement seeking in FLAC using seektables :^)**

- **SoundPlayer: Set m_last_seek after seeking**

  Prior this change, the manager didn't pay attention whether a loader sought exactly to the given position. So if a loader couldn't do that (just like flacs right now), then the slider progress stopped showing the correct position anymore.

