### PR TITLE
Kernel: Zero out .bss contents on aarch64

### DIFF
--- a/Kernel/Prekernel/Arch/aarch64/UART.h
+++ b/Kernel/Prekernel/Arch/aarch64/UART.h
@@ -30,10 +30,10 @@ public:
     {
         char buf[11];
         int i = 0;
-        while (n) {
+        do {
             buf[i++] = (n % 10) + '0';
             n /= 10;
-        }
+        } while (n);
         for (i--; i >= 0; i--)
             send(buf[i]);
     }

--- a/Kernel/Prekernel/Arch/aarch64/boot.S
+++ b/Kernel/Prekernel/Arch/aarch64/boot.S
@@ -21,6 +21,14 @@ start:
   ldr x14, =start
   mov sp, x14
 
+  // Clear BSS.
+  ldr x14, =start_of_bss
+  ldr x15, =size_of_bss_divided_by_8
+Lbss_clear_loop:
+  str xzr, [x14], #8
+  subs x15, x15, #1
+  bne Lbss_clear_loop
+
   b init
 
 .globl wait_cycles

--- a/Kernel/Prekernel/Arch/aarch64/linker.ld
+++ b/Kernel/Prekernel/Arch/aarch64/linker.ld
@@ -29,6 +29,10 @@ SECTIONS
 
     .bss ALIGN(4K) (NOLOAD) : AT (ADDR(.bss))
     {
+	start_of_bss = .;
         *(.bss)
+	end_of_bss = .;
     } :bss
 }
+
+size_of_bss_divided_by_8 = (end_of_bss - start_of_bss) / 8;


### PR DESCRIPTION
After building and running

     objcopy -O binary Build/aarch64/Kernel/Prekernel/Prekernel \
                       /media/sdcard/kernel8.img

things start booting on an actual RPi4 :^)

(Assuming the sdcard contains RPi firmware, an empty config.txt,
and no other kernel*.img files).