### PR TITLE
LibELF: Fix dynamic linking of dlopen()-ed libs

### DIFF
--- a/Tests/LibELF/CMakeLists.txt
+++ b/Tests/LibELF/CMakeLists.txt
@@ -1,7 +1,21 @@
+macro(add_dlopen_lib NAME FUNCTION)
+    add_library(${NAME} SHARED Dynlib.cpp)
+    target_compile_definitions(${NAME} PRIVATE -DFUNCTION=${FUNCTION})
+    # LibLine is not special, just an "external" dependency
+    target_link_libraries(${NAME} LibLine)
+	 # Avoid execution by the test runner
+    install(TARGETS ${NAME}
+            DESTINATION usr/Tests/LibELF
+            PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
+endmacro()
+add_dlopen_lib(DynlibA dynliba_function)
+add_dlopen_lib(DynlibB dynlibb_function)
+
 set(TEST_SOURCES
     test-elf.cpp
+    TestDlOpen.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)
-    serenity_test("${source}"  LibELF)
+    serenity_test("${source}" LibELF LIBS LibDl)
 endforeach()

--- a/Tests/LibELF/Dynlib.cpp
+++ b/Tests/LibELF/Dynlib.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021, Rodrigo Tobar <rtobarc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibLine/Span.h>
+
+extern "C" {
+int FUNCTION();
+int FUNCTION()
+{
+    return (int)Line::Span(0, 0).beginning();
+}
+}

--- a/Tests/LibELF/TestDlOpen.cpp
+++ b/Tests/LibELF/TestDlOpen.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, Rodrigo Tobar <rtobarc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibDl/dlfcn.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(test_dlopen)
+{
+    auto liba = dlopen("/usr/Tests/LibELF/libDynlibA.so", 0);
+    EXPECT_NE(liba, nullptr);
+    auto libb = dlopen("/usr/Tests/LibELF/libDynlibB.so", 0);
+    EXPECT_NE(libb, nullptr);
+
+    typedef int (*dynlib_func_t)();
+    dynlib_func_t func_a = (dynlib_func_t)dlsym(liba, "dynliba_function");
+    EXPECT_NE(func_a, nullptr);
+    EXPECT_EQ(0, func_a());
+
+    dynlib_func_t func_b = (dynlib_func_t)dlsym(libb, "dynlibb_function");
+    EXPECT_NE(func_b, nullptr);
+    EXPECT_EQ(0, func_b());
+}


### PR DESCRIPTION
Consider the situation where two shared libraries libA and libB, both
depending (as in having a NEEDED dtag) on libC. libA is first
dlopen()-ed, which produces libC to be mapped and linked. When libB is
dlopen()-ed the DynamicLinker would re-map and re-link libC though,
causing any previous references to its old location to be invalid. And
if libA's PLT has been patched to point to libC's symbols, then any
further invocations to libA will cause the code to jump to a virtual
address that isn't mapped anymore, therefore causing a crash. This
situation was reported in #10014, although the setup was more convolved
in the ticket.

This commit fixes the issue by distinguishing between a main program
loading being performed by Loader.so, and a dlopen() call. The main
difference between these two cases is that in the former the
s_globals_objects maps is always empty, while in the latter it might
already contain dependencies for the library being dlopen()-ed. Hence,
when collecting dependencies to map and link, dlopen() should skip those
that are present in the global map to avoid the issue described above.

With this patch the original issue seen in #10014 is gone, with all
python3 modules (so far) loading correctly.

A unit test reproducing a simplified issue is also included in this
commit. The unit test includes the building of two dynamic libraries A
and B with both depending on libline.so (and B also depending on A); the
test then dlopen()s libA, invokes one its function, then does the same
with libB.