### PR TITLE
Browser: Check m_console_client is non-null before dereferencing it

### DIFF
--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -317,7 +317,8 @@ void ClientConnection::run_javascript(String const& js_source)
 
 void ClientConnection::js_console_request_messages(i32 start_index)
 {
-    m_console_client->send_messages(start_index);
+    if (m_console_client)
+        m_console_client->send_messages(start_index);
 }
 
 Messages::WebContentServer::GetSelectedTextResponse ClientConnection::get_selected_text()


### PR DESCRIPTION
This added check matches CientConnection::js_console_input and makes sure the webcontent process doesn't crash if the console is opened while no page is available (like in a file not found situation)