### PR TITLE
LibJS: Take a pointer in get_or_prune_cached_prototype_transition()

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -36,9 +36,9 @@ Shape* Shape::get_or_prune_cached_forward_transition(TransitionKey const& key)
     return it->value;
 }
 
-Shape* Shape::get_or_prune_cached_prototype_transition(Object& prototype)
+Shape* Shape::get_or_prune_cached_prototype_transition(Object* prototype)
 {
-    auto it = m_prototype_transitions.find(&prototype);
+    auto it = m_prototype_transitions.find(prototype);
     if (it == m_prototype_transitions.end())
         return nullptr;
     if (!it->value) {
@@ -71,7 +71,7 @@ Shape* Shape::create_configure_transition(const StringOrSymbol& property_name, P
 
 Shape* Shape::create_prototype_transition(Object* new_prototype)
 {
-    if (auto* existing_shape = get_or_prune_cached_prototype_transition(*new_prototype))
+    if (auto* existing_shape = get_or_prune_cached_prototype_transition(new_prototype))
         return existing_shape;
     auto* new_shape = heap().allocate_without_global_object<Shape>(*this, new_prototype);
     m_prototype_transitions.set(new_prototype, new_shape);

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -91,7 +91,7 @@ private:
     virtual void did_become_zombie() override;
 
     Shape* get_or_prune_cached_forward_transition(TransitionKey const&);
-    Shape* get_or_prune_cached_prototype_transition(Object& prototype);
+    Shape* get_or_prune_cached_prototype_transition(Object* prototype);
 
     void ensure_property_table() const;
 


### PR DESCRIPTION
Prototypes can be set to null, and while the previous version also kinda
allowed null (by not reading through the null reference), it was making
UBSAN very sad.