### PR TITLE
Docs(?): Update build instructions for Debian users.

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -18,7 +18,7 @@ On Ubuntu gcc-10 is available in the repositories of 20.04 (Focal) and later - a
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 ```
 
-On Debian your system must be on the _testing_ or _unstable_ branch as gcc 10 is not available on _stable_ or in the backports. If you want to switch from _stable_ to _testing_, see the instructions on the Debian website on [switching to testing](https://wiki.debian.org/DebianTesting). Alternatively, if you want to stay on _stable_, you can build SerenityOS in a Debian testing or Ubuntu [Docker](https://www.docker.com/) container.
+On Debian gcc-10 is available in the repositories of 11 (Bullseye) and later. If you are running an older version, [consider upgrading](https://www.debian.org/releases/stable/amd64/release-notes/ch-upgrading.en.html), or build SerenityOS in a Debian 11 or Ubuntu [Docker](https://www.docker.com/) container.
 
 Now on Ubuntu or Debian you can install gcc-10 with apt like this:
 


### PR DESCRIPTION
In Debian 11 the `gcc-10` package is available by default. I have removed the instructions for switching to testing and unstable for users of older versions as they're now intended for Debian 11, and it would be better to add the stable (bullseye) repository instead, but that may cause problems without changing its priority. I might make a full guide detailing how to do that and link it here. If anyone knows about an "oldunstable" repo you may comment about it.
PS. I know noticed I did not follow your commit naming conventions, sorry! You may rebase the commit to the correct name.