### PR TITLE
LibC: Implement/Stub wchar functions that are needed for Clang with less patches

### DIFF
--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -114,6 +114,29 @@ TEST_CASE(wmemcpy)
     EXPECT_EQ(memcmp(buf, input, 8 * sizeof(wchar_t)), 0);
 }
 
+TEST_CASE(wmemset)
+{
+    auto buf_length = 8;
+    auto buf = static_cast<wchar_t*>(calloc(buf_length, sizeof(wchar_t)));
+
+    if (!buf) {
+        FAIL("Could not allocate memory for target buffer");
+        return;
+    }
+
+    wchar_t* ret = wmemset(buf, L'\U0001f41e', buf_length - 1);
+
+    EXPECT_EQ(ret, buf);
+
+    for (int i = 0; i < buf_length - 1; i++) {
+        EXPECT_EQ(buf[i], L'\U0001f41e');
+    }
+
+    EXPECT_EQ(buf[buf_length - 1], L'\0');
+
+    free(buf);
+}
+
 TEST_CASE(wcscoll)
 {
     // Check if wcscoll is sorting correctly. At the moment we are doing raw char comparisons,

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -35,6 +35,36 @@ TEST_CASE(wcspbrk)
     EXPECT_EQ(ret, input + 2);
 }
 
+TEST_CASE(wcsstr)
+{
+    const wchar_t* input = L"abcde";
+    wchar_t* ret;
+
+    // Empty needle should return haystack.
+    ret = wcsstr(input, L"");
+    EXPECT_EQ(ret, input);
+
+    // Test exact match.
+    ret = wcsstr(input, input);
+    EXPECT_EQ(ret, input);
+
+    // Test match at string start.
+    ret = wcsstr(input, L"ab");
+    EXPECT_EQ(ret, input);
+
+    // Test match at string end.
+    ret = wcsstr(input, L"de");
+    EXPECT_EQ(ret, input + 3);
+
+    // Test no match.
+    ret = wcsstr(input, L"z");
+    EXPECT_EQ(ret, nullptr);
+
+    // Test needle that is longer than the haystack.
+    ret = wcsstr(input, L"abcdef");
+    EXPECT_EQ(ret, nullptr);
+}
+
 TEST_CASE(wcscoll)
 {
     // Check if wcscoll is sorting correctly. At the moment we are doing raw char comparisons,

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -65,6 +65,38 @@ TEST_CASE(wcsstr)
     EXPECT_EQ(ret, nullptr);
 }
 
+TEST_CASE(wmemchr)
+{
+    const wchar_t* input = L"abcde";
+    wchar_t* ret;
+
+    // Empty haystack returns nothing.
+    ret = wmemchr(L"", L'c', 0);
+    EXPECT_EQ(ret, nullptr);
+
+    // Not included character returns nothing.
+    ret = wmemchr(input, L'z', 5);
+    EXPECT_EQ(ret, nullptr);
+
+    // Match at string start.
+    ret = wmemchr(input, L'a', 5);
+    EXPECT_EQ(ret, input);
+
+    // Match at string end.
+    ret = wmemchr(input, L'e', 5);
+    EXPECT_EQ(ret, input + 4);
+
+    input = L"abcde\0fg";
+
+    // Handle finding null characters.
+    ret = wmemchr(input, L'\0', 8);
+    EXPECT_EQ(ret, input + 5);
+
+    // Don't stop at null characters.
+    ret = wmemchr(input, L'f', 8);
+    EXPECT_EQ(ret, input + 6);
+}
+
 TEST_CASE(wcscoll)
 {
     // Check if wcscoll is sorting correctly. At the moment we are doing raw char comparisons,

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -8,6 +8,33 @@
 
 #include <wchar.h>
 
+TEST_CASE(wcspbrk)
+{
+    const wchar_t* input;
+    wchar_t* ret;
+
+    // Test empty haystack.
+    ret = wcspbrk(L"", L"ab");
+    EXPECT_EQ(ret, nullptr);
+
+    // Test empty needle.
+    ret = wcspbrk(L"ab", L"");
+    EXPECT_EQ(ret, nullptr);
+
+    // Test search for a single character.
+    input = L"abcd";
+    ret = wcspbrk(input, L"a");
+    EXPECT_EQ(ret, input);
+
+    // Test search for multiple characters, none matches.
+    ret = wcspbrk(input, L"zxy");
+    EXPECT_EQ(ret, nullptr);
+
+    // Test search for multiple characters, last matches.
+    ret = wcspbrk(input, L"zxyc");
+    EXPECT_EQ(ret, input + 2);
+}
+
 TEST_CASE(wcscoll)
 {
     // Check if wcscoll is sorting correctly. At the moment we are doing raw char comparisons,

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -137,6 +137,32 @@ TEST_CASE(wmemset)
     free(buf);
 }
 
+TEST_CASE(wmemmove)
+{
+    wchar_t* ret;
+    const wchar_t* string = L"abc\0def";
+    auto buf = static_cast<wchar_t*>(calloc(32, sizeof(wchar_t)));
+
+    if (!buf) {
+        FAIL("Could not allocate memory for target buffer");
+        return;
+    }
+
+    // Test moving to smaller addresses.
+    wmemcpy(buf + 3, string, 8);
+    ret = wmemmove(buf + 1, buf + 3, 8);
+    EXPECT_EQ(ret, buf + 1);
+    EXPECT_EQ(memcmp(string, buf + 1, 8 * sizeof(wchar_t)), 0);
+
+    // Test moving to larger addresses.
+    wmemcpy(buf + 16, string, 8);
+    ret = wmemmove(buf + 18, buf + 16, 8);
+    EXPECT_EQ(ret, buf + 18);
+    EXPECT_EQ(memcmp(string, buf + 18, 8 * sizeof(wchar_t)), 0);
+
+    free(buf);
+}
+
 TEST_CASE(wcscoll)
 {
     // Check if wcscoll is sorting correctly. At the moment we are doing raw char comparisons,

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <string.h>
 #include <wchar.h>
 
 TEST_CASE(wcspbrk)
@@ -95,6 +96,22 @@ TEST_CASE(wmemchr)
     // Don't stop at null characters.
     ret = wmemchr(input, L'f', 8);
     EXPECT_EQ(ret, input + 6);
+}
+
+TEST_CASE(wmemcpy)
+{
+    const wchar_t* input = L"abc\0def";
+    auto buf = static_cast<wchar_t*>(malloc(8 * sizeof(wchar_t)));
+
+    if (!buf) {
+        FAIL("Could not allocate space for copy target");
+        return;
+    }
+
+    wchar_t* ret = wmemcpy(buf, input, 8);
+
+    EXPECT_EQ(ret, buf);
+    EXPECT_EQ(memcmp(buf, input, 8 * sizeof(wchar_t)), 0);
 }
 
 TEST_CASE(wcscoll)

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -393,4 +393,13 @@ wchar_t* wmemcpy(wchar_t* dest, const wchar_t* src, size_t n)
 
     return dest;
 }
+
+wchar_t* wmemset(wchar_t* wcs, wchar_t wc, size_t n)
+{
+    for (size_t i = 0; i < n; i++) {
+        wcs[i] = wc;
+    }
+
+    return wcs;
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -435,4 +435,10 @@ float wcstof(const wchar_t*, wchar_t**)
     dbgln("TODO: Implement wcstof()");
     TODO();
 }
+
+double wcstod(const wchar_t*, wchar_t**)
+{
+    dbgln("TODO: Implement wcstod()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -441,4 +441,10 @@ double wcstod(const wchar_t*, wchar_t**)
     dbgln("TODO: Implement wcstod()");
     TODO();
 }
+
+long double wcstold(const wchar_t*, wchar_t**)
+{
+    dbgln("TODO: Implement wcstold()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -447,4 +447,10 @@ long double wcstold(const wchar_t*, wchar_t**)
     dbgln("TODO: Implement wcstold()");
     TODO();
 }
+
+int swprintf(wchar_t*, size_t, const wchar_t*, ...)
+{
+    dbgln("TODO: Implement swprintf()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -402,4 +402,19 @@ wchar_t* wmemset(wchar_t* wcs, wchar_t wc, size_t n)
 
     return wcs;
 }
+
+wchar_t* wmemmove(wchar_t* dest, const wchar_t* src, size_t n)
+{
+    if (dest > src) {
+        for (size_t i = 1; i <= n; i++) {
+            dest[n - i] = src[n - i];
+        }
+    } else if (dest < src) {
+        for (size_t i = 0; i < n; i++) {
+            dest[i] = src[i];
+        }
+    }
+
+    return dest;
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -355,4 +355,24 @@ wchar_t* wcspbrk(const wchar_t* wcs, const wchar_t* accept)
 
     return nullptr;
 }
+
+wchar_t* wcsstr(const wchar_t* haystack, const wchar_t* needle)
+{
+    size_t nlen = wcslen(needle);
+
+    if (nlen == 0)
+        return const_cast<wchar_t*>(haystack);
+
+    size_t hlen = wcslen(haystack);
+
+    while (hlen >= nlen) {
+        if (wcsncmp(haystack, needle, nlen) == 0)
+            return const_cast<wchar_t*>(haystack);
+
+        haystack++;
+        hlen--;
+    }
+
+    return nullptr;
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -344,4 +344,15 @@ int mbsinit(const mbstate_t* state)
 
     return 1;
 }
+
+wchar_t* wcspbrk(const wchar_t* wcs, const wchar_t* accept)
+{
+    for (const wchar_t* cur = accept; *cur; cur++) {
+        wchar_t* res = wcschr(wcs, *cur);
+        if (res)
+            return res;
+    }
+
+    return nullptr;
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -385,4 +385,12 @@ wchar_t* wmemchr(const wchar_t* s, wchar_t c, size_t n)
 
     return nullptr;
 }
+
+wchar_t* wmemcpy(wchar_t* dest, const wchar_t* src, size_t n)
+{
+    for (size_t i = 0; i < n; i++)
+        dest[i] = src[i];
+
+    return dest;
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -375,4 +375,14 @@ wchar_t* wcsstr(const wchar_t* haystack, const wchar_t* needle)
 
     return nullptr;
 }
+
+wchar_t* wmemchr(const wchar_t* s, wchar_t c, size_t n)
+{
+    for (size_t i = 0; i < n; i++) {
+        if (s[i] == c)
+            return const_cast<wchar_t*>(&s[i]);
+    }
+
+    return nullptr;
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -429,4 +429,10 @@ unsigned long long wcstoull(const wchar_t*, wchar_t**, int)
     dbgln("TODO: Implement wcstoull()");
     TODO();
 }
+
+float wcstof(const wchar_t*, wchar_t**)
+{
+    dbgln("TODO: Implement wcstof()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -417,4 +417,10 @@ wchar_t* wmemmove(wchar_t* dest, const wchar_t* src, size_t n)
 
     return dest;
 }
+
+unsigned long wcstoul(const wchar_t*, wchar_t**, int)
+{
+    dbgln("TODO: Implement wcstoul()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -423,4 +423,10 @@ unsigned long wcstoul(const wchar_t*, wchar_t**, int)
     dbgln("TODO: Implement wcstoul()");
     TODO();
 }
+
+unsigned long long wcstoull(const wchar_t*, wchar_t**, int)
+{
+    dbgln("TODO: Implement wcstoull()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -44,5 +44,6 @@ int mbsinit(const mbstate_t*);
 wchar_t* wcspbrk(const wchar_t*, const wchar_t*);
 wchar_t* wcsstr(const wchar_t*, const wchar_t*);
 wchar_t* wmemchr(const wchar_t*, wchar_t, size_t);
+wchar_t* wmemcpy(wchar_t*, const wchar_t*, size_t);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -47,5 +47,6 @@ wchar_t* wmemchr(const wchar_t*, wchar_t, size_t);
 wchar_t* wmemcpy(wchar_t*, const wchar_t*, size_t);
 wchar_t* wmemset(wchar_t*, wchar_t, size_t);
 wchar_t* wmemmove(wchar_t*, const wchar_t*, size_t);
+unsigned long wcstoul(const wchar_t*, wchar_t**, int);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -48,5 +48,6 @@ wchar_t* wmemcpy(wchar_t*, const wchar_t*, size_t);
 wchar_t* wmemset(wchar_t*, wchar_t, size_t);
 wchar_t* wmemmove(wchar_t*, const wchar_t*, size_t);
 unsigned long wcstoul(const wchar_t*, wchar_t**, int);
+unsigned long long wcstoull(const wchar_t*, wchar_t**, int);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -50,5 +50,6 @@ wchar_t* wmemmove(wchar_t*, const wchar_t*, size_t);
 unsigned long wcstoul(const wchar_t*, wchar_t**, int);
 unsigned long long wcstoull(const wchar_t*, wchar_t**, int);
 float wcstof(const wchar_t*, wchar_t**);
+double wcstod(const wchar_t*, wchar_t**);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -46,5 +46,6 @@ wchar_t* wcsstr(const wchar_t*, const wchar_t*);
 wchar_t* wmemchr(const wchar_t*, wchar_t, size_t);
 wchar_t* wmemcpy(wchar_t*, const wchar_t*, size_t);
 wchar_t* wmemset(wchar_t*, wchar_t, size_t);
+wchar_t* wmemmove(wchar_t*, const wchar_t*, size_t);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -45,5 +45,6 @@ wchar_t* wcspbrk(const wchar_t*, const wchar_t*);
 wchar_t* wcsstr(const wchar_t*, const wchar_t*);
 wchar_t* wmemchr(const wchar_t*, wchar_t, size_t);
 wchar_t* wmemcpy(wchar_t*, const wchar_t*, size_t);
+wchar_t* wmemset(wchar_t*, wchar_t, size_t);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -41,5 +41,6 @@ size_t wcrtomb(char*, wchar_t, mbstate_t*);
 int wcscoll(const wchar_t*, const wchar_t*);
 int wctob(wint_t);
 int mbsinit(const mbstate_t*);
+wchar_t* wcspbrk(const wchar_t*, const wchar_t*);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -42,5 +42,6 @@ int wcscoll(const wchar_t*, const wchar_t*);
 int wctob(wint_t);
 int mbsinit(const mbstate_t*);
 wchar_t* wcspbrk(const wchar_t*, const wchar_t*);
+wchar_t* wcsstr(const wchar_t*, const wchar_t*);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -52,5 +52,6 @@ unsigned long long wcstoull(const wchar_t*, wchar_t**, int);
 float wcstof(const wchar_t*, wchar_t**);
 double wcstod(const wchar_t*, wchar_t**);
 long double wcstold(const wchar_t*, wchar_t**);
+int swprintf(wchar_t*, size_t, const wchar_t*, ...);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -43,5 +43,6 @@ int wctob(wint_t);
 int mbsinit(const mbstate_t*);
 wchar_t* wcspbrk(const wchar_t*, const wchar_t*);
 wchar_t* wcsstr(const wchar_t*, const wchar_t*);
+wchar_t* wmemchr(const wchar_t*, wchar_t, size_t);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -49,5 +49,6 @@ wchar_t* wmemset(wchar_t*, wchar_t, size_t);
 wchar_t* wmemmove(wchar_t*, const wchar_t*, size_t);
 unsigned long wcstoul(const wchar_t*, wchar_t**, int);
 unsigned long long wcstoull(const wchar_t*, wchar_t**, int);
+float wcstof(const wchar_t*, wchar_t**);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -51,5 +51,6 @@ unsigned long wcstoul(const wchar_t*, wchar_t**, int);
 unsigned long long wcstoull(const wchar_t*, wchar_t**, int);
 float wcstof(const wchar_t*, wchar_t**);
 double wcstod(const wchar_t*, wchar_t**);
+long double wcstold(const wchar_t*, wchar_t**);
 
 __END_DECLS


### PR DESCRIPTION
This allows us to remove 370 lines of patchfile from the Clang toolchain.