### PR TITLE
PixelPaint: Correctly offset stroke position for even thicknesses

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/Tool.cpp
@@ -56,7 +56,7 @@ void Tool::on_keydown(GUI::KeyEvent& event)
 Gfx::IntPoint Tool::editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const
 {
     auto position = m_editor->image_position_to_editor_position(pixel_coords);
-    auto offset = (stroke_thickness % 2 == 0) ? m_editor->scale() : m_editor->scale() / 2;
+    auto offset = (stroke_thickness % 2 == 0) ? 0 : m_editor->scale() / 2;
     position = position.translated(offset, offset);
     return position.to_type<int>();
 }


### PR DESCRIPTION
Currently, when drawing lines (or rectangles) with an even thickness, the displayed position when dragging, and the final position when the mouse button is released are different because the stroke position is calculated differently. This fixes this inconsistency.