### PR TITLE
PixelPaint: LayerListWidget::set_selected_layer now handles nullptr

### DIFF
--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -381,7 +381,7 @@ void LayerListWidget::set_selected_layer(Layer* layer)
     if (!m_image)
         return;
 
-    if (layer->is_selected())
+    if (layer && layer->is_selected())
         return;
 
     for (size_t i = 0; i < m_image->layer_count(); ++i) {


### PR DESCRIPTION
If undo is performed in PixelPaint before any action is taken, the only action in the undo stack is an `ImageUndoCommand` with an initial snapshot where no layer is selected, so `set_selected_layer` is called with a layer `nullptr`. The pointer is now checked before being dereferenced.