### PR TITLE
LibRegex: Avoid creating a new temporary RegexStringView in Char compare

### DIFF
--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -555,15 +555,12 @@ ALWAYS_INLINE void OpCode_Compare::compare_char(MatchInput const& input, MatchSt
     if (state.string_position == input.view.length())
         return;
 
-    auto input_view = input.view.substring_view(state.string_position, 1);
-    Optional<String> str;
-    Vector<u16, 1> utf16;
-    auto compare_view = input_view.construct_as_same({ &ch1, 1 }, str, utf16);
+    auto input_view = input.view.substring_view(state.string_position, 1)[0];
     bool equal;
     if (input.regex_options & AllFlags::Insensitive)
-        equal = input_view.equals_ignoring_case(compare_view);
+        equal = to_ascii_lowercase(input_view) == to_ascii_lowercase(ch1); // FIXME: Implement case-insensitive matching for non-ascii characters
     else
-        equal = input_view.equals(compare_view);
+        equal = input_view == ch1;
 
     if (equal) {
         if (inverse)


### PR DESCRIPTION
Instead of making a new string to compare against, simply grab the first
code unit of the input and compare against that.