### PR TITLE
CrashReporter: Don't crash when "Generating..." Window gets closed

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -41,19 +41,29 @@ struct TitleAndText {
 static NonnullRefPtr<GUI::Window> create_progress_window()
 {
     auto window = GUI::Window::construct();
+
     window->set_title("CrashReporter");
     window->set_resizable(false);
     window->resize(240, 64);
     window->center_on_screen();
+
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::VerticalBoxLayout>();
+
     auto& label = main_widget.add<GUI::Label>("Generating crash report...");
     label.set_fixed_height(30);
+
     auto& progressbar = main_widget.add<GUI::Progressbar>();
     progressbar.set_name("progressbar");
     progressbar.set_fixed_width(150);
     progressbar.set_fixed_height(22);
+
+    window->on_close = [&]() {
+        if (progressbar.value() != progressbar.max())
+            exit(0);
+    };
+
     return window;
 }
 


### PR DESCRIPTION
Previously, if you closed the "Generating..." Window before it finished, CrashReporter would still try to push progress updates to the closed window, encountering a VERIFY().
This PR checks if the window still exists before pushing updates, and closes the whole application when the "Generating..." Window gets closed by the user.

Closes #10264