### PR TITLE
LibAudio+Userland: Loader refactoring + FLAC optimization

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -108,6 +108,10 @@ public:
         return true;
     }
 
+    size_t buffered() const { return m_buffered; }
+    // Reading from the stream returned here will most definitely brick the buffering behavior of Buffered.
+    StreamType& underlying_stream() { return m_stream; }
+
 private:
     Bytes buffer() const { return { m_buffer, Size }; }
 

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -93,6 +93,10 @@ public:
     Result(const Result& other) = default;
     ~Result() = default;
 
+    // For compatibility with TRY().
+    void value() {};
+    void release_value() {};
+
     ErrorType& error()
     {
         return m_error.value();

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -491,7 +491,7 @@ public:
 
     ErrorOr<void> try_extend(Vector&& other)
     {
-        if (is_empty()) {
+        if (is_empty() && capacity() <= other.capacity()) {
             *this = move(other);
             return {};
         }

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -253,6 +253,15 @@ public:
         ++m_size;
     }
 
+    ALWAYS_INLINE void unchecked_append(StorageType const* values, size_t count)
+    {
+        if (count == 0)
+            return;
+        VERIFY((size() + count) <= capacity());
+        TypedTransfer<StorageType>::copy(slot(m_size), values, count);
+        m_size += count;
+    }
+
     template<class... Args>
     void empend(Args&&... args) requires(!contains_reference)
     {

--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -13,11 +13,16 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     auto flac_data = ByteBuffer::copy(data, size).release_value();
     auto flac = make<Audio::FlacLoaderPlugin>(flac_data);
 
-    if (!flac->sniff())
+    if (flac->initialize().is_error())
         return 1;
 
-    while (flac->get_more_samples())
-        ;
+    for (;;) {
+        auto samples = flac->get_more_samples();
+        if (samples.is_error())
+            return 2;
+        if (samples.value()->sample_count() > 0)
+            break;
+    }
 
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -13,11 +13,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     auto wav_data = ByteBuffer::copy(data, size).release_value();
     auto wav = make<Audio::WavLoaderPlugin>(wav_data);
 
-    if (!wav->sniff())
-        return 1;
-
-    while (wav->get_more_samples())
-        ;
+    for (;;) {
+        auto samples = wav->get_more_samples();
+        if (samples.is_error())
+            return 2;
+        if (samples.value()->sample_count() > 0)
+            break;
+    }
 
     return 0;
 }

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -18,7 +18,8 @@ static NonnullRefPtr<Audio::Buffer> music_samples_to_buffer(Array<Sample, sample
         Audio::Sample frame = { sample.left / (double)NumericLimits<i16>::max(), sample.right / (double)NumericLimits<i16>::max() };
         frames.unchecked_append(frame);
     }
-    return Audio::Buffer::create_with_samples(frames);
+    // FIXME: Handle OOM better.
+    return MUST(Audio::Buffer::create_with_samples(frames));
 }
 
 AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_write_wav, Audio::WavWriter& wav_writer)
@@ -42,7 +43,8 @@ void AudioPlayerLoop::enqueue_audio()
 {
     m_track_manager.fill_buffer(m_buffer);
     NonnullRefPtr<Audio::Buffer> audio_buffer = music_samples_to_buffer(m_buffer);
-    audio_buffer = Audio::resample_buffer(m_resampler.value(), *audio_buffer);
+    // FIXME: Handle OOM better.
+    audio_buffer = MUST(Audio::resample_buffer(m_resampler.value(), *audio_buffer));
     m_audio_client->async_enqueue(audio_buffer);
 
     // FIXME: This should be done somewhere else.

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "Track.h"
-#include "Music.h"
+#include <AK/Forward.h>
 #include <AK/Math.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/NumericLimits.h>

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -53,11 +53,12 @@ void Player::play_file_path(String const& path)
         return;
     }
 
-    NonnullRefPtr<Audio::Loader> loader = Audio::Loader::create(path);
-    if (loader->has_error()) {
-        audio_load_error(path, loader->error_string());
+    auto maybe_loader = Audio::Loader::create(path);
+    if (maybe_loader.is_error()) {
+        audio_load_error(path, maybe_loader.error().description);
         return;
     }
+    auto loader = maybe_loader.value();
 
     m_loaded_filename = path;
 

--- a/Userland/Applications/SoundPlayer/Playlist.cpp
+++ b/Userland/Applications/SoundPlayer/Playlist.cpp
@@ -52,8 +52,8 @@ void Playlist::try_fill_missing_info(Vector<M3UEntry>& entries, StringView path)
 
         if (!entry.extended_info->track_length_in_seconds.has_value()) {
             //TODO: Implement embedded metadata extractor for other audio formats
-            if (auto reader = Audio::Loader::create(entry.path); !reader->has_error())
-                entry.extended_info->track_length_in_seconds = reader->total_samples() / reader->sample_rate();
+            if (auto reader = Audio::Loader::create(entry.path); !reader.is_error())
+                entry.extended_info->track_length_in_seconds = reader.value()->total_samples() / reader.value()->sample_rate();
         }
 
         //TODO: Implement a metadata parser for the uncomfortably numerous popular embedded metadata formats

--- a/Userland/Libraries/LibAudio/Buffer.cpp
+++ b/Userland/Libraries/LibAudio/Buffer.cpp
@@ -122,13 +122,13 @@ static double read_norm_sample_8(InputMemoryStream& stream)
     return double(sample) / NumericLimits<u8>::max();
 }
 
-NonnullRefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, int num_channels, PcmSampleFormat sample_format)
+ErrorOr<NonnullRefPtr<Buffer>> Buffer::from_pcm_data(ReadonlyBytes data, int num_channels, PcmSampleFormat sample_format)
 {
     InputMemoryStream stream { data };
     return from_pcm_stream(stream, num_channels, sample_format, data.size() / (pcm_bits_per_sample(sample_format) / 8));
 }
 
-NonnullRefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, int num_channels, PcmSampleFormat sample_format, int num_samples)
+ErrorOr<NonnullRefPtr<Buffer>> Buffer::from_pcm_stream(InputMemoryStream& stream, int num_channels, PcmSampleFormat sample_format, int num_samples)
 {
     Vector<Sample> fdata;
     fdata.ensure_capacity(num_samples);
@@ -189,7 +189,7 @@ Vector<SampleType> ResampleHelper<SampleType>::resample(Vector<SampleType> to_re
 template Vector<i32> ResampleHelper<i32>::resample(Vector<i32>);
 template Vector<double> ResampleHelper<double>::resample(Vector<double>);
 
-NonnullRefPtr<Buffer> resample_buffer(ResampleHelper<double>& resampler, Buffer const& to_resample)
+ErrorOr<NonnullRefPtr<Buffer>> resample_buffer(ResampleHelper<double>& resampler, Buffer const& to_resample)
 {
     Vector<Sample> resampled;
     resampled.ensure_capacity(to_resample.sample_count() * ceil_div(resampler.source(), resampler.target()));

--- a/Userland/Libraries/LibAudio/Buffer.cpp
+++ b/Userland/Libraries/LibAudio/Buffer.cpp
@@ -122,13 +122,13 @@ static double read_norm_sample_8(InputMemoryStream& stream)
     return double(sample) / NumericLimits<u8>::max();
 }
 
-RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, int num_channels, PcmSampleFormat sample_format)
+NonnullRefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, int num_channels, PcmSampleFormat sample_format)
 {
     InputMemoryStream stream { data };
     return from_pcm_stream(stream, num_channels, sample_format, data.size() / (pcm_bits_per_sample(sample_format) / 8));
 }
 
-RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, int num_channels, PcmSampleFormat sample_format, int num_samples)
+NonnullRefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, int num_channels, PcmSampleFormat sample_format, int num_samples)
 {
     Vector<Sample> fdata;
     fdata.ensure_capacity(num_samples);

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+
+namespace Audio {
+
+struct LoaderError {
+
+    enum Category : u32 {
+        // The error category is unknown.
+        Unknown = 0,
+        IO,
+        // The read file doesn't follow the file format.
+        Format,
+        // Equivalent to an ASSERT(), except non-crashing.
+        Internal,
+        // The loader encountered something in the format that is not yet implemented.
+        Unimplemented,
+    };
+    Category category { Unknown };
+    // Binary index: where in the file the error occurred.
+    size_t index { 0 };
+    FlyString description { String::empty() };
+
+    constexpr LoaderError() = default;
+    LoaderError(Category category, size_t index, FlyString description)
+        : category(category)
+        , index(index)
+        , description(move(description))
+    {
+    }
+    LoaderError(FlyString description)
+        : description(move(description))
+    {
+    }
+    LoaderError(Category category, FlyString description)
+        : category(category)
+        , description(move(description))
+    {
+    }
+
+    LoaderError(LoaderError&) = default;
+    LoaderError(LoaderError&&) = default;
+};
+
+}

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -10,6 +10,7 @@
 #include <AK/Debug.h>
 #include <AK/NumericLimits.h>
 #include <AK/OwnPtr.h>
+#include <AK/Try.h>
 #include <LibCore/File.h>
 #include <LibCore/FileStream.h>
 
@@ -21,43 +22,43 @@ WavLoaderPlugin::WavLoaderPlugin(StringView path)
     : m_file(Core::File::construct(path))
 {
     if (!m_file->open(Core::OpenMode::ReadOnly)) {
-        m_error_string = String::formatted("Can't open file: {}", m_file->error_string());
+        m_error = LoaderError { String::formatted("Can't open file: {}", m_file->error_string()) };
         return;
     }
     m_stream = make<Core::InputFileStream>(*m_file);
+}
 
-    valid = parse_header();
-    if (!valid)
-        return;
+MaybeLoaderError WavLoaderPlugin::initialize()
+{
+    if (m_error.has_value())
+        return m_error.release_value();
+    TRY(parse_header());
+    return {};
 }
 
 WavLoaderPlugin::WavLoaderPlugin(const ByteBuffer& buffer)
 {
     m_stream = make<InputMemoryStream>(buffer);
     if (!m_stream) {
-        m_error_string = String::formatted("Can't open memory stream");
+        m_error = LoaderError { String::formatted("Can't open memory stream") };
         return;
     }
     m_memory_stream = static_cast<InputMemoryStream*>(m_stream.ptr());
-
-    valid = parse_header();
-    if (!valid)
-        return;
 }
 
-RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_input)
+LoaderSamples WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_input)
 {
     if (!m_stream)
-        return nullptr;
+        return LoaderError { LoaderError::Category::Internal, static_cast<size_t>(m_loaded_samples), "No stream" };
 
     int remaining_samples = m_total_samples - m_loaded_samples;
-    if (remaining_samples <= 0) {
-        return nullptr;
-    }
+    if (remaining_samples <= 0)
+        return Buffer::create_empty();
 
     // One "sample" contains data from all channels.
     // In the Wave spec, this is also called a block.
-    size_t bytes_per_sample = m_num_channels * pcm_bits_per_sample(m_sample_format) / 8;
+    size_t bytes_per_sample
+        = m_num_channels * pcm_bits_per_sample(m_sample_format) / 8;
 
     // Might truncate if not evenly divisible by the sample size
     int max_samples_to_read = static_cast<int>(max_bytes_to_read_from_input) / bytes_per_sample;
@@ -71,28 +72,30 @@ RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_i
 
     auto sample_data_result = ByteBuffer::create_zeroed(bytes_to_read);
     if (!sample_data_result.has_value())
-        return nullptr;
+        return LoaderError { LoaderError::Category::IO, static_cast<size_t>(m_loaded_samples), "Couldn't allocate sample buffer" };
     auto sample_data = sample_data_result.release_value();
     m_stream->read_or_error(sample_data.bytes());
-    if (m_stream->handle_any_error()) {
-        return nullptr;
-    }
+    if (m_stream->handle_any_error())
+        return LoaderError { LoaderError::Category::IO, static_cast<size_t>(m_loaded_samples), "Stream read error" };
 
-    RefPtr<Buffer> buffer = Buffer::from_pcm_data(
+    auto buffer = Buffer::from_pcm_data(
         sample_data.bytes(),
         m_num_channels,
         m_sample_format);
 
+    if (buffer.is_error())
+        return LoaderError { LoaderError::Category::Internal, static_cast<size_t>(m_loaded_samples), "Couldn't allocate sample buffer" };
+
     // m_loaded_samples should contain the amount of actually loaded samples
     m_loaded_samples += samples_to_read;
-    return buffer;
+    return buffer.release_value();
 }
 
-void WavLoaderPlugin::seek(const int sample_index)
+MaybeLoaderError WavLoaderPlugin::seek(const int sample_index)
 {
     dbgln_if(AWAVLOADER_DEBUG, "seek sample_index {}", sample_index);
     if (sample_index < 0 || sample_index >= m_total_samples)
-        return;
+        return LoaderError { LoaderError::Category::Internal, static_cast<size_t>(m_loaded_samples), "Seek outside the sample range" };
 
     size_t sample_offset = m_byte_offset_of_data_samples + (sample_index * m_num_channels * (pcm_bits_per_sample(m_sample_format) / 8));
 
@@ -104,13 +107,14 @@ void WavLoaderPlugin::seek(const int sample_index)
     }
 
     m_loaded_samples = sample_index;
+    return {};
 }
 
 // Specification reference: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
-bool WavLoaderPlugin::parse_header()
+MaybeLoaderError WavLoaderPlugin::parse_header()
 {
     if (!m_stream)
-        return false;
+        return LoaderError { LoaderError::Category::Internal, 0, "No stream" };
 
     bool ok = true;
     size_t bytes_read = 0;
@@ -142,77 +146,74 @@ bool WavLoaderPlugin::parse_header()
         return value;
     };
 
-#define CHECK_OK(msg)                                                      \
-    do {                                                                   \
-        if (!ok) {                                                         \
-            m_error_string = String::formatted("Parsing failed: {}", msg); \
-            dbgln_if(AWAVLOADER_DEBUG, m_error_string);                    \
-            return {};                                                     \
-        }                                                                  \
+#define CHECK_OK(category, msg)                                                            \
+    do {                                                                                   \
+        if (!ok)                                                                           \
+            return LoaderError { category, String::formatted("Parsing failed: {}", msg) }; \
     } while (0)
 
     u32 riff = read_u32();
     ok = ok && riff == 0x46464952; // "RIFF"
-    CHECK_OK("RIFF header");
+    CHECK_OK(LoaderError::Category::Format, "RIFF header");
 
     u32 sz = read_u32();
     ok = ok && sz < maximum_wav_size;
-    CHECK_OK("File size");
+    CHECK_OK(LoaderError::Category::Format, "File size");
 
     u32 wave = read_u32();
     ok = ok && wave == 0x45564157; // "WAVE"
-    CHECK_OK("WAVE header");
+    CHECK_OK(LoaderError::Category::Format, "WAVE header");
 
     u32 fmt_id = read_u32();
     ok = ok && fmt_id == 0x20746D66; // "fmt "
-    CHECK_OK("FMT header");
+    CHECK_OK(LoaderError::Category::Format, "FMT header");
 
     u32 fmt_size = read_u32();
     ok = ok && (fmt_size == 16 || fmt_size == 18 || fmt_size == 40);
-    CHECK_OK("FMT size");
+    CHECK_OK(LoaderError::Category::Format, "FMT size");
 
     u16 audio_format = read_u16();
-    CHECK_OK("Audio format"); // incomplete read check
+    CHECK_OK(LoaderError::Category::Format, "Audio format"); // incomplete read check
     ok = ok && (audio_format == WAVE_FORMAT_PCM || audio_format == WAVE_FORMAT_IEEE_FLOAT || audio_format == WAVE_FORMAT_EXTENSIBLE);
-    CHECK_OK("Audio format PCM/Float"); // value check
+    CHECK_OK(LoaderError::Category::Unimplemented, "Audio format PCM/Float"); // value check
 
     m_num_channels = read_u16();
     ok = ok && (m_num_channels == 1 || m_num_channels == 2);
-    CHECK_OK("Channel count");
+    CHECK_OK(LoaderError::Category::Unimplemented, "Channel count");
 
     m_sample_rate = read_u32();
-    CHECK_OK("Sample rate");
+    CHECK_OK(LoaderError::Category::IO, "Sample rate");
 
     read_u32();
-    CHECK_OK("Data rate");
+    CHECK_OK(LoaderError::Category::IO, "Data rate");
 
     u16 block_size_bytes = read_u16();
-    CHECK_OK("Block size");
+    CHECK_OK(LoaderError::Category::IO, "Block size");
 
     u16 bits_per_sample = read_u16();
-    CHECK_OK("Bits per sample");
+    CHECK_OK(LoaderError::Category::IO, "Bits per sample");
 
     if (audio_format == WAVE_FORMAT_EXTENSIBLE) {
         ok = ok && (fmt_size == 40);
-        CHECK_OK("Extensible fmt size"); // value check
+        CHECK_OK(LoaderError::Category::Format, "Extensible fmt size"); // value check
 
         // Discard everything until the GUID.
         // We've already read 16 bytes from the stream. The GUID starts in another 8 bytes.
         read_u32();
         read_u32();
-        CHECK_OK("Discard until GUID");
+        CHECK_OK(LoaderError::Category::IO, "Discard until GUID");
 
         // Get the underlying audio format from the first two bytes of GUID
         u16 guid_subformat = read_u16();
         ok = ok && (guid_subformat == WAVE_FORMAT_PCM || guid_subformat == WAVE_FORMAT_IEEE_FLOAT);
-        CHECK_OK("GUID SubFormat");
+        CHECK_OK(LoaderError::Category::Unimplemented, "GUID SubFormat");
 
         audio_format = guid_subformat;
     }
 
     if (audio_format == WAVE_FORMAT_PCM) {
         ok = ok && (bits_per_sample == 8 || bits_per_sample == 16 || bits_per_sample == 24);
-        CHECK_OK("Bits per sample (PCM)"); // value check
+        CHECK_OK(LoaderError::Category::Unimplemented, "Bits per sample (PCM)"); // value check
 
         // We only support 8-24 bit audio right now because other formats are uncommon
         if (bits_per_sample == 8) {
@@ -224,7 +225,7 @@ bool WavLoaderPlugin::parse_header()
         }
     } else if (audio_format == WAVE_FORMAT_IEEE_FLOAT) {
         ok = ok && (bits_per_sample == 32 || bits_per_sample == 64);
-        CHECK_OK("Bits per sample (Float)"); // value check
+        CHECK_OK(LoaderError::Category::Unimplemented, "Bits per sample (Float)"); // value check
 
         // Again, only the common 32 and 64 bit
         if (bits_per_sample == 32) {
@@ -235,7 +236,7 @@ bool WavLoaderPlugin::parse_header()
     }
 
     ok = ok && (block_size_bytes == (m_num_channels * (bits_per_sample / 8)));
-    CHECK_OK("Block size sanity check");
+    CHECK_OK(LoaderError::Category::Format, "Block size sanity check");
 
     dbgln_if(AWAVLOADER_DEBUG, "WAV format {} at {} bit, {} channels, rate {}Hz ",
         sample_format_name(m_sample_format), pcm_bits_per_sample(m_sample_format), m_num_channels, m_sample_rate);
@@ -246,17 +247,17 @@ bool WavLoaderPlugin::parse_header()
     u8 search_byte = 0;
     while (true) {
         search_byte = read_u8();
-        CHECK_OK("Reading byte searching for data");
+        CHECK_OK(LoaderError::Category::IO, "Reading byte searching for data");
         if (search_byte != 0x64) // D
             continue;
 
         search_byte = read_u8();
-        CHECK_OK("Reading next byte searching for data");
+        CHECK_OK(LoaderError::Category::IO, "Reading next byte searching for data");
         if (search_byte != 0x61) // A
             continue;
 
         u16 search_remaining = read_u16();
-        CHECK_OK("Reading remaining bytes searching for data");
+        CHECK_OK(LoaderError::Category::IO, "Reading remaining bytes searching for data");
         if (search_remaining != 0x6174) // TA
             continue;
 
@@ -266,10 +267,10 @@ bool WavLoaderPlugin::parse_header()
     }
 
     ok = ok && found_data;
-    CHECK_OK("Found no data chunk");
+    CHECK_OK(LoaderError::Category::Format, "Found no data chunk");
 
     ok = ok && data_sz < maximum_wav_size;
-    CHECK_OK("Data was too large");
+    CHECK_OK(LoaderError::Category::Format, "Data was too large");
 
     m_total_samples = data_sz / block_size_bytes;
 
@@ -279,7 +280,6 @@ bool WavLoaderPlugin::parse_header()
         m_total_samples);
 
     m_byte_offset_of_data_samples = bytes_read;
-    return true;
+    return {};
 }
-
 }

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -36,20 +36,17 @@ public:
     explicit WavLoaderPlugin(StringView path);
     explicit WavLoaderPlugin(const ByteBuffer& buffer);
 
-    virtual bool sniff() override { return valid; }
-
-    virtual bool has_error() override { return !m_error_string.is_null(); }
-    virtual const String& error_string() override { return m_error_string; }
+    virtual MaybeLoaderError initialize() override;
 
     // The Buffer returned contains input data resampled at the
     // destination audio device sample rate.
-    virtual RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
+    virtual LoaderSamples get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
 
-    virtual void reset() override { return seek(0); }
+    virtual MaybeLoaderError reset() override { return seek(0); }
 
     // sample_index 0 is the start of the raw audio sample data
     // within the file/stream.
-    virtual void seek(const int sample_index) override;
+    virtual MaybeLoaderError seek(const int sample_index) override;
 
     virtual int loaded_samples() override { return m_loaded_samples; }
     virtual int total_samples() override { return m_total_samples; }
@@ -59,13 +56,12 @@ public:
     virtual RefPtr<Core::File> file() override { return m_file; }
 
 private:
-    bool parse_header();
+    MaybeLoaderError parse_header();
 
-    bool valid { false };
     RefPtr<Core::File> m_file;
     OwnPtr<AK::InputStream> m_stream;
     AK::InputMemoryStream* m_memory_stream;
-    String m_error_string;
+    Optional<LoaderError> m_error {};
 
     u32 m_sample_rate { 0 };
     u16 m_num_channels { 0 };

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -97,7 +97,8 @@ Messages::AudioServer::EnqueueBufferResponse ClientConnection::enqueue_buffer(Co
     if (m_queue->is_full())
         return false;
 
-    m_queue->enqueue(Audio::Buffer::create_with_anonymous_buffer(buffer, buffer_id, sample_count));
+    // There's not a big allocation to worry about here.
+    m_queue->enqueue(MUST(Audio::Buffer::create_with_anonymous_buffer(buffer, buffer_id, sample_count)));
     return true;
 }
 

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND REQUIRED_TARGETS
     touch tr true umount uname uniq uptime w wc which whoami xargs yes less
 )
 list(APPEND RECOMMENDED_TARGETS
-    adjtime aplay asctl bt checksum chres cksum copy fortune gunzip gzip init keymap lsirq lsof lspci man mknod mktemp
+    adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init keymap lsirq lsof lspci man mknod mktemp
     modload modunload nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
 )
 
@@ -54,6 +54,7 @@ endforeach()
 target_link_libraries(allocate LibMain)
 target_link_libraries(aplay LibAudio LibMain)
 target_link_libraries(arp LibMain)
+target_link_libraries(abench LibAudio LibMain LibCore)
 target_link_libraries(asctl LibAudio LibMain)
 target_link_libraries(base64 LibMain)
 target_link_libraries(basename LibMain)

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NumericLimits.h>
+#include <AK/Types.h>
+#include <LibAudio/Loader.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/ElapsedTimer.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+#include <stdio.h>
+
+// The Kernel has problems with large anonymous buffers, so let's limit sample reads ourselves.
+static constexpr size_t MAX_CHUNK_SIZE = 1 * MiB / 2;
+
+ErrorOr<int> serenity_main(Main::Arguments args)
+{
+    char const* path = nullptr;
+    int sample_count = -1;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("Benchmark audio loading");
+    args_parser.add_positional_argument(path, "Path to audio file", "path");
+    args_parser.add_option(sample_count, "How many samples to load at maximum", "sample-count", 's', "samples");
+    args_parser.parse(args);
+
+    TRY(Core::System::unveil(Core::File::absolute_path(path), "r"));
+    TRY(Core::System::unveil(nullptr, nullptr));
+    TRY(Core::System::pledge("stdio recvfd rpath", nullptr));
+
+    auto maybe_loader = Audio::Loader::create(path);
+    if (maybe_loader.is_error()) {
+        warnln("Failed to load audio file: {}", maybe_loader.error().description);
+        return 1;
+    }
+    auto loader = maybe_loader.release_value();
+
+    Core::ElapsedTimer sample_timer { true };
+    u64 total_loader_time = 0;
+    int remaining_samples = sample_count > 0 ? sample_count : NumericLimits<int>::max();
+    unsigned total_loaded_samples = 0;
+
+    for (;;) {
+        if (remaining_samples > 0) {
+            sample_timer = sample_timer.start_new();
+            auto samples = loader->get_more_samples(min(MAX_CHUNK_SIZE, remaining_samples));
+            auto elapsed = static_cast<u64>(sample_timer.elapsed());
+            total_loader_time += static_cast<u64>(elapsed);
+            if (!samples.is_error()) {
+                remaining_samples -= samples.value()->sample_count();
+                total_loaded_samples += samples.value()->sample_count();
+                if (samples.value()->sample_count() == 0)
+                    break;
+            } else {
+                warnln("Error while loading audio: {}", samples.error().description);
+                return 1;
+            }
+        } else
+            break;
+    }
+
+    auto time_per_sample = static_cast<double>(total_loader_time) / static_cast<double>(total_loaded_samples) * 1000.;
+    auto playback_time_per_sample = (1. / static_cast<double>(loader->sample_rate())) * 1000'000.;
+
+    outln("Loaded {:10d} samples in {:06.3f} s, {:9.3f} µs/sample, {:6.1f}% speed (realtime {:9.3f} µs/sample)", total_loaded_samples, static_cast<double>(total_loader_time) / 1000., time_per_sample, playback_time_per_sample / time_per_sample * 100., playback_time_per_sample);
+
+    return 0;
+}

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -4,12 +4,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Types.h>
 #include <LibAudio/ClientConnection.h>
 #include <LibAudio/Loader.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibMain/Main.h>
 #include <stdio.h>
+
+// The Kernel has issues with very large anonymous buffers.
+// FIXME: This appears to be fine for now, but it's really a hack.
+constexpr size_t LOAD_CHUNK_SIZE = 128 * KiB;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -24,11 +29,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Core::EventLoop loop;
 
     auto audio_client = Audio::ClientConnection::construct();
-    NonnullRefPtr<Audio::Loader> loader = Audio::Loader::create(path);
-    if (loader->has_error()) {
-        warnln("Failed to load audio file: {}", loader->error_string());
+    auto maybe_loader = Audio::Loader::create(path);
+    if (maybe_loader.is_error()) {
+        warnln("Failed to load audio file: {}", maybe_loader.error().description);
         return 1;
     }
+    auto loader = maybe_loader.release_value();
 
     outln("\033[34;1m Playing\033[0m: {}", path);
     outln("\033[34;1m  Format\033[0m: {} Hz, {}-bit, {}",
@@ -39,25 +45,43 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto resampler = Audio::ResampleHelper<double>(loader->sample_rate(), audio_client->get_sample_rate());
 
+    // If we're downsampling, we need to appropriately load more samples at once.
+    size_t const load_size = static_cast<size_t>(LOAD_CHUNK_SIZE * static_cast<double>(loader->sample_rate()) / static_cast<double>(audio_client->get_sample_rate()));
+    // We assume that the loader can load samples at at least 2x speed (testing confirms 9x-12x for FLAC, 14x for WAV).
+    // Therefore, when the server-side buffer can only play as long as the time it takes us to load a chunk,
+    // we give it new data.
+    int const min_buffer_size = load_size / 2;
+
     for (;;) {
-        auto samples = loader->get_more_samples();
-        if (samples) {
-            out("\033[u");
-            out("{}/{}", loader->loaded_samples(), loader->total_samples());
-            fflush(stdout);
-            resampler.reset();
-            samples = Audio::resample_buffer(resampler, *samples);
-            audio_client->enqueue(*samples);
-        } else if (loader->has_error()) {
-            outln();
-            outln("Error: {}", loader->error_string());
-            break;
-        } else if (should_loop) {
-            loader->reset();
-        } else if (audio_client->get_remaining_samples()) {
-            sleep(1);
+        auto samples = loader->get_more_samples(load_size);
+        if (!samples.is_error()) {
+            if (samples.value()->sample_count() > 0) {
+                // We can read and enqueue more samples
+                out("\033[u");
+                out("{}/{}", loader->loaded_samples(), loader->total_samples());
+                fflush(stdout);
+                resampler.reset();
+                auto resampled_samples = TRY(Audio::resample_buffer(resampler, *samples.value()));
+                audio_client->async_enqueue(*resampled_samples);
+            } else if (should_loop) {
+                // We're done: now loop
+                auto result = loader->reset();
+                if (result.is_error()) {
+                    outln();
+                    outln("Error while resetting: {} (at {:x})", result.error().description, result.error().index);
+                }
+            } else if (samples.value()->sample_count() == 0 && audio_client->get_remaining_samples() == 0) {
+                // We're done and the server is done
+                break;
+            }
+            while (audio_client->get_remaining_samples() > min_buffer_size) {
+                // The server has enough data for now
+                sleep(1);
+            }
         } else {
-            break;
+            outln();
+            outln("Error: {} (at {:x})", samples.error().description, samples.error().index);
+            return 1;
         }
     }
     outln();

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <math.h>
 #include <stdio.h>
@@ -40,6 +41,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(command, "Command, either (g)et or (s)et\n\n\tThe get command accepts a list of variables to print.\n\tThey are printed in the given order.\n\tIf no value is specified, all are printed.\n\n\tThe set command accepts a any number of variables\n\tfollowed by the value they should be set to.\n\n\tPossible variables are (v)olume, (m)ute, sample(r)ate.\n", "command");
     args_parser.add_positional_argument(command_arguments, "Arguments for the command", "args", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    TRY(Core::System::unveil(nullptr, nullptr));
+    TRY(Core::System::pledge("stdio rpath wpath recvfd", nullptr));
 
     if (command.equals_ignoring_case("get") || command == "g") {
         // Get variables


### PR DESCRIPTION
1. A collection of optimizations and improvements to the FLAC decoder, with auxiliary changes. Please read the commit messages for the individual changes to get a detailed idea of why it's better this way.

2. Fundamental refactoring of the Loader infrastructure. Now, loaders do modern `Result`- and `TRY`-based error propagation that revolves around the new `LoaderError` struct. The adaption of users is minimal, as much audio user code is to be rewritten in the near future (exceptions: abench and aplay)

Auxiliary changes:
* `abench` utility to benchmark audio reading. The utility reads any audio file you give it and prints out benchmarking stats. This was how I tested these optimizations, and it will be convenient for future audio work as well. For example, abench can tell you whether your audio reader is fast enough to decode audio while it's playing.
* `AK::Buffered` exposes two of its internal properties.
* `Audio::Buffer` allows an empty buffer to be created.