### PR TITLE
LibWeb: Have CSSStyleRule inherit from CSSRule in IDL

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.idl
@@ -1,7 +1,6 @@
-interface CSSStyleRule {
+interface CSSStyleRule : CSSRule {
 
     attribute CSSOMString selectorText;
-    attribute CSSOMString cssText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 
 };


### PR DESCRIPTION
This also allows removing the cssText attribute being on CSSStyleRule.