### PR TITLE
LibRegex: Use a match table for character classes

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -910,3 +910,21 @@ TEST_CASE(optimizer_atomic_groups)
         EXPECT_EQ(result.success, test.get<2>());
     }
 }
+
+TEST_CASE(optimizer_char_class_lut)
+{
+    Regex<ECMA262> re(R"([\f\n\r\t\v\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+$)");
+
+    if constexpr (REGEX_DEBUG) {
+        dbgln("\n");
+        RegexDebug regex_dbg(stderr);
+        regex_dbg.print_raw_bytecode(re);
+        regex_dbg.print_header();
+        regex_dbg.print_bytecode(re);
+        dbgln("\n");
+    }
+
+    // This will go through _all_ alternatives in the character class, and then fail.
+    for (size_t i = 0; i < 1'000'000; ++i)
+        EXPECT_EQ(re.match("1635488940000"sv).success, false);
+}

--- a/Userland/Libraries/LibRegex/Forward.h
+++ b/Userland/Libraries/LibRegex/Forward.h
@@ -9,6 +9,8 @@
 #include <AK/Types.h>
 
 namespace regex {
+struct CompareTypeAndValuePair;
+
 enum class Error : u8;
 class Lexer;
 class PosixExtendedParser;

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -61,21 +61,22 @@ enum class OpCodeId : ByteCodeValueType {
 };
 // clang-format on
 
-#define ENUMERATE_CHARACTER_COMPARE_TYPES                \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(Undefined)        \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(Inverse)          \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(TemporaryInverse) \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(AnyChar)          \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(Char)             \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(String)           \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(CharClass)        \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(CharRange)        \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(Reference)        \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(Property)         \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(GeneralCategory)  \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(Script)           \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(ScriptExtension)  \
-    __ENUMERATE_CHARACTER_COMPARE_TYPE(RangeExpressionDummy)
+#define ENUMERATE_CHARACTER_COMPARE_TYPES                    \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Undefined)            \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Inverse)              \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(TemporaryInverse)     \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(AnyChar)              \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Char)                 \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(String)               \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(CharClass)            \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(CharRange)            \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Reference)            \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Property)             \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(GeneralCategory)      \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(Script)               \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(ScriptExtension)      \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(RangeExpressionDummy) \
+    __ENUMERATE_CHARACTER_COMPARE_TYPE(LookupTable)
 
 enum class CharacterCompareType : ByteCodeValueType {
 #define __ENUMERATE_CHARACTER_COMPARE_TYPE(x) x,
@@ -186,26 +187,7 @@ public:
 
     void insert_bytecode_compare_values(Vector<CompareTypeAndValuePair>&& pairs)
     {
-        ByteCode bytecode;
-
-        bytecode.empend(static_cast<ByteCodeValueType>(OpCodeId::Compare));
-        bytecode.empend(pairs.size()); // number of arguments
-
-        ByteCode arguments;
-        for (auto& value : pairs) {
-            VERIFY(value.type != CharacterCompareType::RangeExpressionDummy);
-            VERIFY(value.type != CharacterCompareType::Undefined);
-            VERIFY(value.type != CharacterCompareType::String);
-
-            arguments.append((ByteCodeValueType)value.type);
-            if (value.type != CharacterCompareType::Inverse && value.type != CharacterCompareType::AnyChar && value.type != CharacterCompareType::TemporaryInverse)
-                arguments.append(move(value.value));
-        }
-
-        bytecode.empend(arguments.size()); // size of arguments
-        bytecode.extend(move(arguments));
-
-        extend(move(bytecode));
+        Optimizer::append_character_class(*this, move(pairs));
     }
 
     void insert_bytecode_check_boundary(BoundaryCheckType type)

--- a/Userland/Libraries/LibRegex/RegexBytecodeStreamOptimizer.h
+++ b/Userland/Libraries/LibRegex/RegexBytecodeStreamOptimizer.h
@@ -7,12 +7,14 @@
 #pragma once
 
 #include "Forward.h"
+#include <AK/Vector.h>
 
 namespace regex {
 
 class Optimizer {
 public:
     static void append_alternation(ByteCode& target, ByteCode&& left, ByteCode&& right);
+    static void append_character_class(ByteCode& target, Vector<CompareTypeAndValuePair>&& pairs);
 };
 
 }


### PR DESCRIPTION
Generate a sorted, compressed series of ranges in a match table for
character classes, and use a binary search to find the matches.
This is about a 3-4x speedup for character class match performance. :^)