### PR TITLE
Assistant: pump the EventLoop once on unfocus

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -277,8 +277,11 @@ int main(int argc, char** argv)
         GUI::Application::the()->quit();
     };
     window->on_active_window_change = [](bool is_active_window) {
-        if (!is_active_window)
-            GUI::Application::the()->quit();
+        if (!is_active_window) {
+            auto app = GUI::Application::the();
+            app->quit();
+            app->event_loop().pump();
+        }
     };
 
     auto update_ui_timer = Core::Timer::create_single_shot(10, [&] {


### PR DESCRIPTION
When running the Assistant and defocusing the window, the app is supposed to be closed, however the process remains running. This can be solved my manually pumping the EventLoop once.