### PR TITLE
LibCore: Allow reads smaller than the buffered data size in IODevice

### DIFF
--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -47,15 +47,6 @@ ByteBuffer IODevice::read(size_t max_size)
     if (m_buffered_data.size() < max_size)
         populate_read_buffer(max(max_size - m_buffered_data.size(), 1024));
 
-    if (m_buffered_data.size() > max_size) {
-        if (m_error)
-            return {};
-        if (m_eof) {
-            dbgln("IODevice::read: At EOF but there's more than max_size({}) buffered", max_size);
-            return {};
-        }
-    }
-
     auto size = min(max_size, m_buffered_data.size());
     auto buffer_result = ByteBuffer::create_uninitialized(size);
     if (!buffer_result.has_value()) {


### PR DESCRIPTION
This restriction doesn't make much sense, a user should be free to
consume the buffered data with as small a max_size as they desire.
This fixes a possible RequestServer spin when talking to HTTP servers.