### PR TITLE
Everywhere: Fix more Copyright header inconsistencies

### DIFF
--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibC/TestWctype.cpp
+++ b/Tests/LibC/TestWctype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Applications/MailSettings/MailSettingsWindow.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Applications/MailSettings/MailSettingsWindow.h
+++ b/Userland/Applications/MailSettings/MailSettingsWindow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, The SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
- * 2018-2021, the SerenityOS developers
+ * Copyright (c) 2018-2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
- * 2018-2021, the SerenityOS developers
+ * Copyright (c) 2018-2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/fnmatch.cpp
+++ b/Userland/Libraries/LibC/fnmatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/fnmatch.h
+++ b/Userland/Libraries/LibC/fnmatch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/langinfo.cpp
+++ b/Userland/Libraries/LibC/langinfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/langinfo.h
+++ b/Userland/Libraries/LibC/langinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/nl_types.h
+++ b/Userland/Libraries/LibC/nl_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/resolv.cpp
+++ b/Userland/Libraries/LibC/resolv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/resolv.h
+++ b/Userland/Libraries/LibC/resolv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/stdio_ext.h
+++ b/Userland/Libraries/LibC/stdio_ext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/sys/xattr.cpp
+++ b/Userland/Libraries/LibC/sys/xattr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/sys/xattr.h
+++ b/Userland/Libraries/LibC/sys/xattr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/wctype.cpp
+++ b/Userland/Libraries/LibC/wctype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibC/wctype.h
+++ b/Userland/Libraries/LibC/wctype.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers
+ * Copyright (c) 2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibGfx/Streamer.h
+++ b/Userland/Libraries/LibGfx/Streamer.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>, the SerenityOS developers
+ * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2020, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
Most of this is just fixing occurrences where the copyright header wasn't exactly written as `the SerenityOS developers.`. Where I have noticed, I also split up lines with multiple attributees and added `Copyright (c)` if it was missing in front of a copyright line.