### PR TITLE
LibWeb: Flexbox: Take parents' specified main size into account

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -410,7 +410,7 @@ void FlexFormattingContext::run(Box& box, LayoutMode)
     }
 
     // 4. Determine the main size of the flex container
-    if (!main_is_constrained || main_available_size == 0) {
+    if ((!main_is_constrained && main_size_is_infinite) || main_available_size == 0) {
         // Uses https://www.w3.org/TR/css-flexbox-1/#intrinsic-main-sizes
         // 9.9.1
         // 1.


### PR DESCRIPTION
Previously, if the parent of the container had a definite main size, it
would've been disregarded when calculating the main size of the
container if it had no definite size and neither min- nor max-main-size
constraints.
This patch fixes that behavior by additionally checking whether the main
size is not only not constrained but also infinite.