### PR TITLE
LibHTTP: Bump max HTTP header size up to 32KiB 

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -163,7 +163,8 @@ void Job::on_socket_connected()
         if (m_state == State::InHeaders || m_state == State::Trailers) {
             if (!can_read_line())
                 return;
-            auto line = read_line(PAGE_SIZE);
+            // There's no max limit defined on headers, but for our sanity, let's limit it to 32K.
+            auto line = read_line(32 * KiB);
             if (line.is_null()) {
                 if (m_state == State::Trailers) {
                     // Some servers like to send two ending chunks


### PR DESCRIPTION
Apparently discord likes to feed us headers as big as 6KiB, so clearly
there are large headers out there in the wild.
For reference, Apache's limit is 8KiB, and IIS's limit is 16KiB (this
limit is not defined by the spec, so nothing can stop a server from
sending massive headers - sadly)