### PR TITLE
Documentation: Added unzip to arch install list

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -43,7 +43,7 @@ for details.
 ### Arch Linux / Manjaro
 
 ```console
-sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu qemu-arch-extra ccache rsync
+sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu qemu-arch-extra ccache rsync unzip
 ```
 
 ### Other systems


### PR DESCRIPTION
After setting up the toochain on manjaro linux (new install) the build
of the toolchain failed as unzip was not found. The unzip package is
listed in the documentation for debian (apt) but is was missing for arch
linux.