### PR TITLE
Ports: Compile against openssl to gain ssl module

### DIFF
--- a/Ports/python3/package.sh
+++ b/Ports/python3/package.sh
@@ -15,8 +15,7 @@ launcher_command="/usr/local/bin/python3"
 launcher_run_in_terminal="true"
 icon_file="../launcher.ico" # This is an older icon that's downloaded separately, so we need to go outside of $workdir
 
-# We could also add `openssl` here, but the _ssl modules doesn't build at the moment 
-depends=("bzip2" "libffi" "libuuid" "ncurses" "readline" "sqlite" "termcap" "zlib")
+depends=("bzip2" "libffi" "libuuid" "ncurses" "openssl" "readline" "sqlite" "termcap" "zlib")
 
 configopts=("--enable-optimizations" "--disable-ipv6" "--without-ensurepip" "ac_cv_file__dev_ptmx=no" "ac_cv_file__dev_ptc=no")
 


### PR DESCRIPTION
(Note that #10207 is required for this to work)

Compiling against an OpenSSL thread-enabled shared library (see #10207)
lets Python compile its _ssl module, which yields an importable ssl
module.

The ssl module suffers from the same problem described in #10014 though,
namely that python crashes when importing different modules results in
multiple libcrypto.so loads, and its functions are later invoked by one
of the modules. Once #10277 is merged though the module becomes quite
usable.