### PR TITLE
LibWeb: Implement some resolved-style properties

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -32,6 +32,7 @@ public:
     static CSS::JustifyContent justify_content() { return CSS::JustifyContent::FlexStart; }
     static CSS::AlignItems align_items() { return CSS::AlignItems::FlexStart; }
     static CSS::Overflow overflow() { return CSS::Overflow::Visible; }
+    static CSS::BoxSizing box_sizing() { return CSS::BoxSizing::ContentBox; }
 };
 
 struct BorderData {
@@ -79,6 +80,7 @@ public:
     Optional<float> const& opacity() const { return m_noninherited.opacity; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
     Optional<BoxShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
+    CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
     const CSS::Length& width() const { return m_noninherited.width; }
     const CSS::Length& min_width() const { return m_noninherited.min_width; }
     const CSS::Length& max_width() const { return m_noninherited.max_width; }
@@ -176,6 +178,7 @@ protected:
         Optional<float> opacity;
         Optional<BoxShadowData> box_shadow {};
         Vector<CSS::Transformation> transformations {};
+        CSS::BoxSizing box_sizing { InitialValues::box_sizing() };
     } m_noninherited;
 };
 
@@ -228,6 +231,7 @@ public:
     void set_justify_content(CSS::JustifyContent value) { m_noninherited.justify_content = value; }
     void set_box_shadow(Optional<BoxShadowData> value) { m_noninherited.box_shadow = move(value); }
     void set_transformations(Vector<CSS::Transformation> value) { m_noninherited.transformations = move(value); }
+    void set_box_sizing(CSS::BoxSizing value) { m_noninherited.box_sizing = value; }
 
     void set_fill(Color value) { m_inherited.fill = value; }
     void set_stroke(Color value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -383,6 +383,33 @@ static CSS::ValueID to_css_value_id(CSS::ListStyleType value)
     VERIFY_NOT_REACHED();
 }
 
+static CSS::ValueID to_css_value_id(CSS::LineStyle value)
+{
+    switch (value) {
+    case CSS::LineStyle::None:
+        return CSS::ValueID::None;
+    case CSS::LineStyle::Hidden:
+        return CSS::ValueID::Hidden;
+    case CSS::LineStyle::Dotted:
+        return CSS::ValueID::Dotted;
+    case CSS::LineStyle::Dashed:
+        return CSS::ValueID::Dashed;
+    case CSS::LineStyle::Solid:
+        return CSS::ValueID::Solid;
+    case CSS::LineStyle::Double:
+        return CSS::ValueID::Double;
+    case CSS::LineStyle::Groove:
+        return CSS::ValueID::Groove;
+    case CSS::LineStyle::Ridge:
+        return CSS::ValueID::Ridge;
+    case CSS::LineStyle::Inset:
+        return CSS::ValueID::Inset;
+    case CSS::LineStyle::Outset:
+        return CSS::ValueID::Outset;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 static NonnullRefPtr<StyleValue> value_or_default(Optional<StyleProperty> property, NonnullRefPtr<StyleValue> default_style)
 {
     if (property.has_value())
@@ -548,6 +575,58 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return BorderRadiusStyleValue::create(layout_node.computed_values().border_top_left_radius(), layout_node.computed_values().border_top_left_radius());
     case CSS::PropertyID::BorderTopRightRadius:
         return BorderRadiusStyleValue::create(layout_node.computed_values().border_top_right_radius(), layout_node.computed_values().border_top_right_radius());
+    case CSS::PropertyID::BorderTopWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
+    case CSS::PropertyID::BorderRightWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
+    case CSS::PropertyID::BorderBottomWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
+    case CSS::PropertyID::BorderLeftWidth:
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
+    case CSS::PropertyID::BorderTopColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_top().color);
+    case CSS::PropertyID::BorderRightColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_right().color);
+    case CSS::PropertyID::BorderBottomColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
+    case CSS::PropertyID::BorderLeftColor:
+        return ColorStyleValue::create(layout_node.computed_values().border_left().color);
+    case CSS::PropertyID::BorderTopStyle:
+        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_top().line_style));
+    case CSS::PropertyID::BorderRightStyle:
+        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_right().line_style));
+    case CSS::PropertyID::BorderBottomStyle:
+        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_bottom().line_style));
+    case CSS::PropertyID::BorderLeftStyle:
+        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_left().line_style));
+    case CSS::PropertyID::BorderTop: {
+        auto border = layout_node.computed_values().border_top();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
+    }
+    case CSS::PropertyID::BorderRight: {
+        auto border = layout_node.computed_values().border_right();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
+    }
+    case CSS::PropertyID::BorderBottom: {
+        auto border = layout_node.computed_values().border_bottom();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
+    }
+    case CSS::PropertyID::BorderLeft: {
+        auto border = layout_node.computed_values().border_left();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return BorderStyleValue::create(width, style, color);
+    }
     case CSS::PropertyID::OverflowX:
         return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().overflow_x()));
     case CSS::PropertyID::OverflowY:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -480,6 +480,15 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         if (layout_node.computed_values().max_height().is_undefined())
             return IdentifierStyleValue::create(CSS::ValueID::None);
         return LengthStyleValue::create(layout_node.computed_values().max_height());
+    case CSS::PropertyID::Margin: {
+        auto margin = layout_node.computed_values().margin();
+        auto values = NonnullRefPtrVector<StyleValue> {};
+        values.append(LengthStyleValue::create(margin.top));
+        values.append(LengthStyleValue::create(margin.right));
+        values.append(LengthStyleValue::create(margin.bottom));
+        values.append(LengthStyleValue::create(margin.left));
+        return StyleValueList::create(move(values));
+    }
     case CSS::PropertyID::MarginTop:
         return LengthStyleValue::create(layout_node.computed_values().margin().top);
     case CSS::PropertyID::MarginRight:
@@ -488,6 +497,15 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return LengthStyleValue::create(layout_node.computed_values().margin().bottom);
     case CSS::PropertyID::MarginLeft:
         return LengthStyleValue::create(layout_node.computed_values().margin().left);
+    case CSS::PropertyID::Padding: {
+        auto padding = layout_node.computed_values().padding();
+        auto values = NonnullRefPtrVector<StyleValue> {};
+        values.append(LengthStyleValue::create(padding.top));
+        values.append(LengthStyleValue::create(padding.right));
+        values.append(LengthStyleValue::create(padding.bottom));
+        values.append(LengthStyleValue::create(padding.left));
+        return StyleValueList::create(move(values));
+    }
     case CSS::PropertyID::PaddingTop:
         return LengthStyleValue::create(layout_node.computed_values().padding().top);
     case CSS::PropertyID::PaddingRight:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -33,6 +33,17 @@ String ResolvedCSSStyleDeclaration::item(size_t index) const
     return {};
 }
 
+static CSS::ValueID to_css_value_id(CSS::BoxSizing value)
+{
+    switch (value) {
+    case CSS::BoxSizing::BorderBox:
+        return CSS::ValueID::BorderBox;
+    case CSS::BoxSizing::ContentBox:
+        return CSS::ValueID::ContentBox;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 static CSS::ValueID to_css_value_id(CSS::Display value)
 {
     switch (value) {
@@ -546,6 +557,8 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     }
     case CSS::PropertyID::ListStyleType:
         return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().list_style_type()));
+    case CSS::PropertyID::BoxSizing:
+        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().box_sizing()));
     case CSS::PropertyID::Invalid:
         return IdentifierStyleValue::create(CSS::ValueID::Invalid);
     case CSS::PropertyID::Custom:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -728,4 +728,20 @@ Optional<CSS::BoxShadowData> StyleProperties::box_shadow() const
     auto& box = value->as_box_shadow();
     return { { box.offset_x(), box.offset_y(), box.blur_radius(), box.color() } };
 }
+
+CSS::BoxSizing StyleProperties::box_sizing() const
+{
+    auto value = property(CSS::PropertyID::BoxSizing);
+    if (!value.has_value())
+        return {};
+
+    switch (value.value()->to_identifier()) {
+    case CSS::ValueID::BorderBox:
+        return CSS::BoxSizing::BorderBox;
+    case CSS::ValueID::ContentBox:
+        return CSS::BoxSizing::ContentBox;
+    default:
+        return {};
+    }
+}
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -66,6 +66,7 @@ public:
     Optional<CSS::Repeat> background_repeat_x() const;
     Optional<CSS::Repeat> background_repeat_y() const;
     Optional<CSS::BoxShadowData> box_shadow() const;
+    CSS::BoxSizing box_sizing() const;
 
     Vector<CSS::Transformation> transformations() const;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -39,6 +39,11 @@ enum class AlignItems {
     Stretch,
 };
 
+enum class BoxSizing {
+    BorderBox,
+    ContentBox,
+};
+
 enum class Clear {
     None,
     Left,

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -223,6 +223,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         m_background_image = bgimage.value()->as_image();
     }
 
+    computed_values.set_box_sizing(specified_style.box_sizing());
+
     // FIXME: BorderXRadius properties are now BorderRadiusStyleValues, so make use of that.
     auto border_bottom_left_radius = specified_style.property(CSS::PropertyID::BorderBottomLeftRadius);
     if (border_bottom_left_radius.has_value())


### PR DESCRIPTION
This adds the following CSS properties to `ResolvedCSSStyleDeclaration::style_value_for_property()` and thus to `getComputedStyle()` and related functions.

- border-bottom
- border-bottom-color
- border-bottom-style
- border-bottom-width
- border-left
- border-left-color
- border-left-style
- border-left-width
- border-right
- border-right-color
- border-right-style
- border-right-width
- border-top
- border-top-color
- border-top-style
- border-top-width
- box-sizing
- margin
- padding

Notably, this adds the box-sizing property to Nodes, but does not yet take it into account when measuring their size.