### PR TITLE
LibSQL: Implement a table description statement

### DIFF
--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -675,6 +676,27 @@ TEST_CASE(select_with_offset_out_of_bounds)
     EXPECT(result->has_results());
     auto rows = result->results();
     EXPECT_EQ(rows.size(), 0u);
+}
+
+TEST_CASE(describe_table)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    EXPECT(!database->open().is_error());
+    create_table(database);
+    auto result = execute(database, "DESCRIBE TABLE TestSchema.TestTable;");
+    EXPECT(result->error().code == SQL::SQLErrorCode::NoError);
+    EXPECT(result->has_results());
+    EXPECT_EQ(result->results().size(), 2u);
+
+    auto rows = result->results();
+    auto& row1 = rows[0];
+    EXPECT_EQ(row1.row[0].to_string(), "TEXTCOLUMN");
+    EXPECT_EQ(row1.row[1].to_string(), "text");
+
+    auto& row2 = rows[1];
+    EXPECT_EQ(row2.row[0].to_string(), "INTCOLUMN");
+    EXPECT_EQ(row2.row[1].to_string(), "int");
 }
 
 }

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -1048,6 +1049,20 @@ private:
     RefPtr<GroupByClause> m_group_by_clause;
     NonnullRefPtrVector<OrderingTerm> m_ordering_term_list;
     RefPtr<LimitClause> m_limit_clause;
+};
+
+class DescribeTable : public Statement {
+public:
+    DescribeTable(NonnullRefPtr<QualifiedTableName> qualified_table_name)
+        : m_qualified_table_name(move(qualified_table_name))
+    {
+    }
+
+    NonnullRefPtr<QualifiedTableName> qualified_table_name() const { return m_qualified_table_name; }
+    RefPtr<SQLResult> execute(ExecutionContext&) const override;
+
+private:
+    NonnullRefPtr<QualifiedTableName> m_qualified_table_name;
 };
 
 }

--- a/Userland/Libraries/LibSQL/AST/Describe.cpp
+++ b/Userland/Libraries/LibSQL/AST/Describe.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSQL/AST/AST.h>
+#include <LibSQL/Database.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Row.h>
+
+namespace SQL::AST {
+
+RefPtr<SQLResult> DescribeTable::execute(ExecutionContext& context) const
+{
+    auto schema_name = m_qualified_table_name->schema_name();
+    auto table_name = m_qualified_table_name->table_name();
+
+    auto table_def_or_error = context.database->get_table(schema_name, table_name);
+    auto table_def = table_def_or_error.release_value();
+    if (!table_def) {
+        if (schema_name.is_null() || schema_name.is_empty())
+            schema_name = "default";
+        return SQLResult::construct(SQLCommand::Describe, SQLErrorCode::TableDoesNotExist, String::formatted("{}.{}", schema_name, table_name));
+    }
+
+    auto describe_table_def = context.database->get_table("master", "internal_describe_table").value();
+    NonnullRefPtr<TupleDescriptor> descriptor = describe_table_def->to_tuple_descriptor();
+
+    context.result = SQLResult::construct();
+
+    for (auto& column : table_def->columns()) {
+        Tuple tuple(descriptor);
+        tuple[0] = column.name();
+        tuple[1] = SQLType_name(column.type());
+        context.result->insert(tuple, Tuple {});
+    }
+
+    return context.result;
+}
+
+}

--- a/Userland/Libraries/LibSQL/AST/Parser.cpp
+++ b/Userland/Libraries/LibSQL/AST/Parser.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -46,6 +47,8 @@ NonnullRefPtr<Statement> Parser::parse_statement()
         return parse_alter_table_statement();
     case TokenType::Drop:
         return parse_drop_table_statement();
+    case TokenType::Describe:
+        return parse_describe_table_statement();
     case TokenType::Insert:
         return parse_insert_statement({});
     case TokenType::Update:
@@ -179,6 +182,16 @@ NonnullRefPtr<DropTable> Parser::parse_drop_table_statement()
     parse_schema_and_table_name(schema_name, table_name);
 
     return create_ast_node<DropTable>(move(schema_name), move(table_name), is_error_if_table_does_not_exist);
+}
+
+NonnullRefPtr<DescribeTable> Parser::parse_describe_table_statement()
+{
+    consume(TokenType::Describe);
+    consume(TokenType::Table);
+
+    auto table_name = parse_qualified_table_name();
+
+    return create_ast_node<DescribeTable>(move(table_name));
 }
 
 NonnullRefPtr<Insert> Parser::parse_insert_statement(RefPtr<CommonTableExpressionList> common_table_expression_list)

--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -59,6 +60,7 @@ private:
     NonnullRefPtr<CreateTable> parse_create_table_statement();
     NonnullRefPtr<AlterTable> parse_alter_table_statement();
     NonnullRefPtr<DropTable> parse_drop_table_statement();
+    NonnullRefPtr<DescribeTable> parse_describe_table_statement();
     NonnullRefPtr<Insert> parse_insert_statement(RefPtr<CommonTableExpressionList>);
     NonnullRefPtr<Update> parse_update_statement(RefPtr<CommonTableExpressionList>);
     NonnullRefPtr<Delete> parse_delete_statement(RefPtr<CommonTableExpressionList>);

--- a/Userland/Libraries/LibSQL/AST/Token.h
+++ b/Userland/Libraries/LibSQL/AST/Token.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,6 +54,7 @@ namespace SQL::AST {
     __ENUMERATE_SQL_TOKEN("DEFERRED", Deferred, Keyword)                  \
     __ENUMERATE_SQL_TOKEN("DELETE", Delete, Keyword)                      \
     __ENUMERATE_SQL_TOKEN("DESC", Desc, Keyword)                          \
+    __ENUMERATE_SQL_TOKEN("DESCRIBE", Describe, Keyword)                  \
     __ENUMERATE_SQL_TOKEN("DETACH", Detach, Keyword)                      \
     __ENUMERATE_SQL_TOKEN("DISTINCT", Distinct, Keyword)                  \
     __ENUMERATE_SQL_TOKEN("DO", Do, Keyword)                              \

--- a/Userland/Libraries/LibSQL/CMakeLists.txt
+++ b/Userland/Libraries/LibSQL/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     AST/CreateSchema.cpp
     AST/CreateTable.cpp
+    AST/Describe.cpp
     AST/Expression.cpp
     AST/Insert.cpp
     AST/Lexer.cpp

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -47,6 +48,21 @@ ErrorOr<void> Database::open()
         default_schema = SchemaDef::construct("default");
         TRY(add_schema(*default_schema));
     }
+
+    auto master_schema = TRY(get_schema("master"));
+    if (!master_schema) {
+        master_schema = SchemaDef::construct("master");
+        TRY(add_schema(*master_schema));
+    }
+
+    auto table_def = TRY(get_table("master", "internal_describe_table"));
+    if (!table_def) {
+        auto describe_internal_table = TableDef::construct(master_schema, "internal_describe_table");
+        describe_internal_table->append_column("Name", SQLType::Text);
+        describe_internal_table->append_column("Type", SQLType::Text);
+        TRY(add_table(*describe_internal_table));
+    }
+
     return {};
 }
 

--- a/Userland/Libraries/LibSQL/Database.h
+++ b/Userland/Libraries/LibSQL/Database.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2021, Mahmoud Mandour <ma.mandourr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibSQL/SQLResult.h
+++ b/Userland/Libraries/LibSQL/SQLResult.h
@@ -19,6 +19,7 @@ namespace SQL {
 #define ENUMERATE_SQL_COMMANDS(S) \
     S(Create)                     \
     S(Delete)                     \
+    S(Describe)                   \
     S(Insert)                     \
     S(Select)                     \
     S(Update)

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -704,10 +704,13 @@ bool IntegerImpl::can_cast(Value const& other_value)
 int IntegerImpl::compare(Value const& other) const
 {
     auto casted = other.to_int();
-    if (!casted.has_value()) {
+    if (!casted.has_value())
         return 1;
-    }
-    return value() - casted.value();
+
+    if (value() == casted.value())
+        return 0;
+
+    return value() < casted.value() ? -1 : 1;
 }
 
 u32 IntegerImpl::hash() const


### PR DESCRIPTION
This adds the support for a non-standard `DESCRIBE TABLE TableName;` statement in our DBMS implementation. Even though it's non-standard, practically every DBMS out there has a sort of table-description user-facing mechanism. This is done by simply having an internal schema that defines the relation having information about a table. For now, it only contains column names and their data types.

![Screenshot from 2021-10-05 21-41-17](https://user-images.githubusercontent.com/19896973/136091762-c922fc3b-65e3-4acf-aab7-2d3f4a477687.png)

