### PR TITLE
Kernel: Don't retrieve possibly nonexistent APIC table

### DIFF
--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -114,7 +114,10 @@ UNMAP_AFTER_INIT PhysicalAddress InterruptManagement::search_for_madt()
     auto rsdp = ACPI::StaticParsing::find_rsdp();
     if (!rsdp.has_value())
         return {};
-    return ACPI::StaticParsing::find_table(rsdp.value(), "APIC").value();
+    auto apic = ACPI::StaticParsing::find_table(rsdp.value(), "APIC");
+    if (!apic.has_value())
+        return {};
+    return apic.value();
 }
 
 UNMAP_AFTER_INIT InterruptManagement::InterruptManagement()


### PR DESCRIPTION
Some older hardware apparently doesn't have an APIC table, so just using `value()` would result in a crash. Instead, do the same thing that we are already doing if we don't find the RSDP at all and return an empty `PhysicalAddress`.