### PR TITLE
Kernel: Handle backspace for tab character in TTY cooked mode

### DIFF
--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -93,7 +93,7 @@ public:
     };
 
     ConstIterator begin() const { return ConstIterator(*this, m_head); }
-    ConstIterator end() const { return ConstIterator(*this, size()); }
+    ConstIterator end() const { return ConstIterator(*this, (m_head + size()) % Capacity); }
 
     size_t head_index() const { return m_head; }
 


### PR DESCRIPTION
Before, serenity would only backspace one character for a tab. This is the only feature that my OS has and serenity doesn't.