### PR TITLE
PixelPaint: Use a bucket cursor for the bucket tool

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -11,6 +11,7 @@
 #include "Guide.h"
 #include "Image.h"
 #include "Selection.h"
+#include <AK/Variant.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/UndoStack.h>
 #include <LibGfx/Point.h>
@@ -163,7 +164,7 @@ private:
 
     float m_pixel_grid_threshold { 15.0f };
 
-    Gfx::StandardCursor m_active_cursor { Gfx::StandardCursor::None };
+    Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_active_cursor { Gfx::StandardCursor::None };
 
     Selection m_selection;
 };

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -20,7 +20,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
     void set_size(int size) { m_size = size; }
     int size() const { return m_size; }

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -20,6 +20,9 @@ namespace PixelPaint {
 
 BucketTool::BucketTool()
 {
+    auto bucket_icon = Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/bucket.png");
+    if (!bucket_icon.is_null())
+        m_cursor = bucket_icon.release_nonnull();
 }
 
 BucketTool::~BucketTool()

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.h
@@ -17,10 +17,12 @@ public:
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return m_cursor; }
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;
     int m_threshold { 0 };
+    Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_cursor { Gfx::StandardCursor::Crosshair };
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -52,7 +52,7 @@ void CloneTool::draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::Int
     BrushTool::draw_line(bitmap, color, start, end);
 }
 
-Gfx::StandardCursor CloneTool::cursor()
+Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> CloneTool::cursor()
 {
     if (m_is_selecting_location)
         return Gfx::StandardCursor::Eyedropper;

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.h
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.h
@@ -16,7 +16,7 @@ public:
     virtual ~CloneTool() override = default;
 
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override;
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override;
 
 protected:
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point) override;

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.h
@@ -24,7 +24,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     enum class FillMode {

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.h
@@ -26,7 +26,7 @@ public:
     virtual void on_tool_activation() override;
 
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     RefPtr<Guide> closest_guide(Gfx::IntPoint const&);

--- a/Userland/Applications/PixelPaint/Tools/LineTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.h
@@ -23,7 +23,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -19,7 +19,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Move; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Move; }
 
 private:
     RefPtr<Layer> m_layer_being_moved;

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.h
@@ -19,7 +19,7 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent&) override;
 
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Eyedropper; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Eyedropper; }
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
@@ -26,7 +26,7 @@ public:
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     enum class MovingMode {

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.h
@@ -24,7 +24,7 @@ public:
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual void on_keydown(GUI::KeyEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     enum class FillMode {

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.h
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.h
@@ -22,7 +22,7 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Crosshair; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:
     void paint_it();

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Variant.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/ValueSlider.h>
@@ -60,7 +61,7 @@ public:
     virtual void on_keyup(GUI::KeyEvent&) { }
     virtual void on_tool_activation() { }
     virtual GUI::Widget* get_properties_widget() { return nullptr; }
-    virtual Gfx::StandardCursor cursor() { return Gfx::StandardCursor::None; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() { return Gfx::StandardCursor::None; }
 
     void clear() { m_editor = nullptr; }
     void setup(ImageEditor&);

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.h
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.h
@@ -19,7 +19,7 @@ public:
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual GUI::Widget* get_properties_widget() override;
-    virtual Gfx::StandardCursor cursor() override { return Gfx::StandardCursor::Zoom; }
+    virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor() override { return Gfx::StandardCursor::Zoom; }
 
 private:
     RefPtr<GUI::Widget> m_properties_widget;

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1020,14 +1020,23 @@ Gfx::IntRect Widget::children_clip_rect() const
     return rect();
 }
 
-void Widget::set_override_cursor(Gfx::StandardCursor cursor)
+void Widget::set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> cursor)
 {
-    if (m_override_cursor == cursor)
+    auto const& are_cursors_the_same = [](AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const& a, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const& b) {
+        if (a.has<Gfx::StandardCursor>() != b.has<Gfx::StandardCursor>())
+            return false;
+        if (a.has<Gfx::StandardCursor>())
+            return a.get<Gfx::StandardCursor>() == b.get<Gfx::StandardCursor>();
+        return a.get<NonnullRefPtr<Gfx::Bitmap>>().ptr() == b.get<NonnullRefPtr<Gfx::Bitmap>>().ptr();
+    };
+
+    if (are_cursors_the_same(m_override_cursor, cursor))
         return;
 
-    m_override_cursor = cursor;
-    if (auto* window = this->window())
+    m_override_cursor = move(cursor);
+    if (auto* window = this->window()) {
         window->update_cursor({});
+    }
 }
 
 bool Widget::load_from_gml(const StringView& gml_string)

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -9,6 +9,7 @@
 #include <AK/EnumBits.h>
 #include <AK/JsonObject.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <LibCore/Object.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/FocusPolicy.h>
@@ -267,8 +268,8 @@ public:
 
     virtual Gfx::IntRect children_clip_rect() const;
 
-    Gfx::StandardCursor override_cursor() const { return m_override_cursor; }
-    void set_override_cursor(Gfx::StandardCursor);
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> override_cursor() const { return m_override_cursor; }
+    void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>>);
 
     bool load_from_gml(const StringView&);
     bool load_from_gml(const StringView&, RefPtr<Core::Object> (*unregistered_child_handler)(const String&));
@@ -368,7 +369,7 @@ private:
     WeakPtr<Widget> m_focus_proxy;
     FocusPolicy m_focus_policy { FocusPolicy::NoFocus };
 
-    Gfx::StandardCursor m_override_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_override_cursor { Gfx::StandardCursor::None };
 };
 
 inline Widget* Widget::parent_widget()

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -317,21 +317,28 @@ void Window::make_window_manager(unsigned event_mask)
     GUI::WindowManagerServerConnection::the().async_set_manager_window(m_window_id);
 }
 
+bool Window::are_cursors_the_same(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const& left, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const& right) const
+{
+    if (left.has<Gfx::StandardCursor>() != right.has<Gfx::StandardCursor>())
+        return false;
+    if (left.has<Gfx::StandardCursor>())
+        return left.get<Gfx::StandardCursor>() == right.get<Gfx::StandardCursor>();
+    return left.get<NonnullRefPtr<Gfx::Bitmap>>().ptr() == right.get<NonnullRefPtr<Gfx::Bitmap>>().ptr();
+}
+
 void Window::set_cursor(Gfx::StandardCursor cursor)
 {
-    if (m_cursor == cursor)
+    if (are_cursors_the_same(m_cursor, cursor))
         return;
     m_cursor = cursor;
-    m_custom_cursor = nullptr;
     update_cursor();
 }
 
-void Window::set_cursor(const Gfx::Bitmap& cursor)
+void Window::set_cursor(NonnullRefPtr<Gfx::Bitmap> cursor)
 {
-    if (m_custom_cursor == &cursor)
+    if (are_cursors_the_same(m_cursor, cursor))
         return;
-    m_cursor = Gfx::StandardCursor::None;
-    m_custom_cursor = &cursor;
+    m_cursor = cursor;
     update_cursor();
 }
 
@@ -1140,21 +1147,22 @@ void Window::set_progress(Optional<int> progress)
 
 void Window::update_cursor()
 {
-    Gfx::StandardCursor new_cursor;
+    auto new_cursor = m_cursor;
 
-    if (m_hovered_widget && m_hovered_widget->override_cursor() != Gfx::StandardCursor::None)
-        new_cursor = m_hovered_widget->override_cursor();
-    else
-        new_cursor = m_cursor;
+    if (m_hovered_widget) {
+        auto override_cursor = m_hovered_widget->override_cursor();
+        if (override_cursor.has<NonnullRefPtr<Gfx::Bitmap>>() || override_cursor.get<Gfx::StandardCursor>() != Gfx::StandardCursor::None)
+            new_cursor = move(override_cursor);
+    }
 
-    if (!m_custom_cursor && m_effective_cursor == new_cursor)
+    if (are_cursors_the_same(m_effective_cursor, new_cursor))
         return;
     m_effective_cursor = new_cursor;
 
-    if (m_custom_cursor)
-        WindowServerConnection::the().async_set_window_custom_cursor(m_window_id, m_custom_cursor->to_shareable_bitmap());
+    if (new_cursor.has<NonnullRefPtr<Gfx::Bitmap>>())
+        WindowServerConnection::the().async_set_window_custom_cursor(m_window_id, new_cursor.get<NonnullRefPtr<Gfx::Bitmap>>()->to_shareable_bitmap());
     else
-        WindowServerConnection::the().async_set_window_cursor(m_window_id, (u32)m_effective_cursor);
+        WindowServerConnection::the().async_set_window_cursor(m_window_id, (u32)new_cursor.get<Gfx::StandardCursor>());
 }
 
 void Window::focus_a_widget_if_possible(FocusSource source)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -9,6 +9,7 @@
 #include <AK/Function.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Object.h>
 #include <LibGUI/FocusSource.h>
@@ -169,7 +170,7 @@ public:
     void set_resize_aspect_ratio(const Optional<Gfx::IntSize>& ratio);
 
     void set_cursor(Gfx::StandardCursor);
-    void set_cursor(const Gfx::Bitmap&);
+    void set_cursor(NonnullRefPtr<Gfx::Bitmap>);
 
     void set_icon(const Gfx::Bitmap*);
     void apply_icon();
@@ -238,6 +239,8 @@ private:
     void flip(const Vector<Gfx::IntRect, 32>& dirty_rects);
     void force_update();
 
+    bool are_cursors_the_same(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const&, AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> const&) const;
+
     WeakPtr<Widget> m_previously_focused_widget;
 
     OwnPtr<WindowBackingStore> m_front_store;
@@ -246,7 +249,6 @@ private:
     NonnullRefPtr<Menubar> m_menubar;
 
     RefPtr<Gfx::Bitmap> m_icon;
-    RefPtr<Gfx::Bitmap> m_custom_cursor;
     int m_window_id { 0 };
     float m_opacity_when_windowless { 1.0f };
     float m_alpha_hit_threshold { 0.0f };
@@ -263,8 +265,8 @@ private:
     Gfx::IntSize m_base_size;
     Color m_background_color { Color::WarmGray };
     WindowType m_window_type { WindowType::Normal };
-    Gfx::StandardCursor m_cursor { Gfx::StandardCursor::None };
-    Gfx::StandardCursor m_effective_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_cursor { Gfx::StandardCursor::None };
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_effective_cursor { Gfx::StandardCursor::None };
     bool m_is_active_input { false };
     bool m_has_alpha_channel { false };
     bool m_double_buffering_enabled { true };

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -395,10 +395,8 @@ void WindowManager::greet_window_manager(WMClientConnection& conn)
 
     for_each_window_stack([&](auto& window_stack) {
         window_stack.for_each_window([&](Window& other_window) {
-            //if (conn.window_id() != other_window.window_id()) {
             tell_wm_about_window(conn, other_window);
             tell_wm_about_window_icon(conn, other_window);
-            //}
             return IterationDecision::Continue;
         });
         return IterationDecision::Continue;


### PR DESCRIPTION
Previously when selecting the Bucket tool we kept the default arrow cursor.  

These 2 commits add a new 'Bucket' cursor type and use it for PixelPaint.

The cursor icon is the same as the icon for the bucket tool in PixelPaint. The dark mode one has the black border recolored to white.

Nitpick: is the type 'LibGfx' correct for the first commit? It also touches WindowManager and adds the 2 icons