### PR TITLE
SystemMonitor: Use size_t for graph values

### DIFF
--- a/Userland/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Userland/Applications/SystemMonitor/GraphWidget.cpp
@@ -20,7 +20,7 @@ GraphWidget::~GraphWidget()
 {
 }
 
-void GraphWidget::add_value(Vector<int, 1>&& value)
+void GraphWidget::add_value(Vector<size_t, 1>&& value)
 {
     m_values.enqueue(move(value));
     update();

--- a/Userland/Applications/SystemMonitor/GraphWidget.h
+++ b/Userland/Applications/SystemMonitor/GraphWidget.h
@@ -15,15 +15,15 @@ class GraphWidget final : public GUI::Frame {
 public:
     virtual ~GraphWidget() override;
 
-    void set_max(int max) { m_max = max; }
-    int max() const { return m_max; }
+    void set_max(size_t max) { m_max = max; }
+    size_t max() const { return m_max; }
 
-    void add_value(Vector<int, 1>&&);
+    void add_value(Vector<size_t, 1>&&);
 
     struct ValueFormat {
         Gfx::ColorRole graph_color_role { Gfx::ColorRole::Base };
         Color text_shadow_color { Color::Transparent };
-        Function<String(int)> text_formatter;
+        Function<String(size_t)> text_formatter;
     };
     void set_value_format(size_t index, ValueFormat&& format)
     {
@@ -38,9 +38,9 @@ private:
 
     virtual void paint_event(GUI::PaintEvent&) override;
 
-    int m_max { 100 };
+    size_t m_max { 100 };
     Vector<ValueFormat, 1> m_value_format;
-    CircularQueue<Vector<int, 1>, 4000> m_values;
+    CircularQueue<Vector<size_t, 1>, 4000> m_values;
     bool m_stack_values { false };
 
     Vector<Gfx::IntPoint, 1> m_calculated_points;

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -117,5 +117,5 @@ void MemoryStatsWidget::refresh()
     m_kmalloc_difference_label->set_text(String::formatted("{:+}", kmalloc_call_count - kfree_call_count));
 
     m_graph.set_max(page_count_to_bytes(total_userphysical_and_swappable_pages) + kmalloc_bytes_total);
-    m_graph.add_value({ (int)page_count_to_bytes(user_physical_committed), (int)page_count_to_bytes(user_physical_allocated), (int)kmalloc_bytes_total });
+    m_graph.add_value({ page_count_to_bytes(user_physical_committed), page_count_to_bytes(user_physical_allocated), kmalloc_bytes_total });
 }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -700,7 +700,7 @@ NonnullRefPtr<GUI::Widget> build_performance_tab()
     ProcessModel::the().on_cpu_info_change = [cpu_graphs](const NonnullOwnPtrVector<ProcessModel::CpuInfo>& cpus) {
         float sum_cpu = 0;
         for (size_t i = 0; i < cpus.size(); ++i) {
-            cpu_graphs[i].add_value({ (int)cpus[i].total_cpu_percent, (int)cpus[i].total_cpu_percent_kernel });
+            cpu_graphs[i].add_value({ static_cast<size_t>(cpus[i].total_cpu_percent), static_cast<size_t>(cpus[i].total_cpu_percent_kernel) });
             sum_cpu += cpus[i].total_cpu_percent;
         }
         float cpu_usage = sum_cpu / (float)cpus.size();


### PR DESCRIPTION
The memory and CPU graphs fail to display anything when the memory size
is larger than 2**31 bytes, because of the small range of int. This
commit makes replaces the type with size_t. Hopefully nobody will have
18 quintillion bytes of memory before this gets replaced. :^)