### PR TITLE
Meta: Warn on `rebuild-toolchain i686 clang`

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -93,6 +93,10 @@ case "$1" in
         TOOLCHAIN_TYPE="$1"; shift
         ;;
     *)
+        if [ -n "$1" ]; then
+            echo "WARNING: unknown toolchain '$1'. Defaulting to GNU."
+            echo "         Valid values are 'Clang', 'GNU' (default)"
+        fi
         TOOLCHAIN_TYPE="GNU"
         ;;
 esac


### PR DESCRIPTION
It's "Clang" (capitalized). Silently building gcc if the toolchain
isn't know seems a bit unfriendly. So print a warning for this
(and for other unknown toolchains).