### PR TITLE
LibJS: Make accessing the current function's arguments cheaper

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1011,10 +1011,30 @@ Reference Identifier::to_reference(Interpreter& interpreter, GlobalObject&) cons
             environment = environment->outer_environment();
         VERIFY(environment);
         VERIFY(environment->is_declarative_environment());
-        if (!environment->is_permanently_screwed_by_eval())
+        if (!environment->is_permanently_screwed_by_eval()) {
+            if (m_lexically_bound_function_argument.has_value()) {
+                return Reference {
+                    *environment,
+                    string(),
+                    *m_lexically_bound_function_argument,
+                    interpreter.vm().in_strict_mode(),
+                    m_cached_environment_coordinate,
+                    &interpreter.vm().running_execution_context(),
+                };
+            }
             return Reference { *environment, string(), interpreter.vm().in_strict_mode(), m_cached_environment_coordinate };
+        }
         m_cached_environment_coordinate = {};
     }
+    if (m_lexically_bound_function_argument.has_value()) {
+        return Reference {
+            string(),
+            *m_lexically_bound_function_argument,
+            interpreter.vm().in_strict_mode(),
+            &interpreter.vm().running_execution_context(),
+        };
+    }
+
     auto reference = interpreter.vm().resolve_binding(string());
     if (reference.environment_coordinate().has_value())
         m_cached_environment_coordinate = reference.environment_coordinate();

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -982,6 +982,7 @@ public:
     }
 
     FlyString const& string() const { return m_string; }
+    void set_lexically_bound_function_argument_index(size_t index) { m_lexically_bound_function_argument = index; }
 
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
@@ -992,6 +993,7 @@ private:
     virtual bool is_identifier() const override { return true; }
 
     FlyString m_string;
+    Optional<size_t> m_lexically_bound_function_argument;
     mutable Optional<EnvironmentCoordinate> m_cached_environment_coordinate;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/EnvironmentCoordinate.h>
+#include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/PropertyName.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -51,6 +52,28 @@ public:
         , m_name(move(referenced_name))
         , m_strict(strict)
         , m_environment_coordinate(move(environment_coordinate))
+    {
+    }
+
+    Reference(FlyString referenced_name, size_t function_argument_index, bool strict = false, ExecutionContext* function_context = nullptr)
+        : m_base_type(BaseType::Environment)
+        , m_base_environment(nullptr)
+        , m_name(move(referenced_name))
+        , m_strict(strict)
+        , m_environment_coordinate({})
+        , m_function_argument_index(function_argument_index)
+        , m_referenced_function_context(function_context)
+    {
+    }
+
+    Reference(Environment& base, FlyString referenced_name, size_t function_argument_index, bool strict = false, Optional<EnvironmentCoordinate> environment_coordinate = {}, ExecutionContext* function_context = nullptr)
+        : m_base_type(BaseType::Environment)
+        , m_base_environment(&base)
+        , m_name(move(referenced_name))
+        , m_strict(strict)
+        , m_environment_coordinate(move(environment_coordinate))
+        , m_function_argument_index(function_argument_index)
+        , m_referenced_function_context(function_context)
     {
     }
 
@@ -128,12 +151,14 @@ private:
     BaseType m_base_type { BaseType::Unresolvable };
     union {
         Value m_base_value {};
-        Environment* m_base_environment;
+        mutable Environment* m_base_environment;
     };
     PropertyName m_name;
     Value m_this_value;
     bool m_strict { false };
     Optional<EnvironmentCoordinate> m_environment_coordinate;
+    Optional<size_t> m_function_argument_index;
+    ExecutionContext* m_referenced_function_context { nullptr };
 };
 
 }


### PR DESCRIPTION
Instead of going through an environment record, make arguments of the
currently executing function generate references via the argument index,
which can later be resolved directly through the ExecutionContext.

NOTE: This is not confirmed to be 100% correct, test-js passes but
      test262 changes have not been measured yet.