### PR TITLE
Kernel: Note if the page fault address is a destroyed smart pointer

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -13,6 +13,8 @@
 #include <AK/Traits.h>
 #include <AK/Types.h>
 
+#define NONNULLOWNPTR_SCRUB_BYTE 0xf1
+
 namespace AK {
 
 template<typename T, typename PtrTraits>
@@ -51,7 +53,7 @@ public:
     {
         clear();
 #ifdef SANITIZE_PTRS
-        m_ptr = (T*)(explode_byte(0xe3));
+        m_ptr = (T*)(explode_byte(NONNULLOWNPTR_SCRUB_BYTE));
 #endif
     }
 

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#define NONNULLREFPTR_SCRUB_BYTE 0xe1
+
 #ifdef KERNEL
 #    include <Kernel/Library/ThreadSafeNonnullRefPtr.h>
 #else
@@ -97,7 +99,7 @@ public:
         unref_if_not_null(m_ptr);
         m_ptr = nullptr;
 #    ifdef SANITIZE_PTRS
-        m_ptr = reinterpret_cast<T*>(explode_byte(0xb0));
+        m_ptr = reinterpret_cast<T*>(explode_byte(NONNULLREFPTR_SCRUB_BYTE));
 #    endif
     }
 

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -12,6 +12,8 @@
 #    include <Kernel/API/KResult.h>
 #endif
 
+#define OWNPTR_SCRUB_BYTE 0xf0
+
 namespace AK {
 
 template<typename T>
@@ -43,7 +45,7 @@ public:
     {
         clear();
 #ifdef SANITIZE_PTRS
-        m_ptr = (T*)(explode_byte(0xe1));
+        m_ptr = (T*)(explode_byte(OWNPTR_SCRUB_BYTE));
 #endif
     }
 

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#define REFPTR_SCRUB_BYTE 0xe0
+
 #ifdef KERNEL
 #    include <Kernel/Library/ThreadSafeRefPtr.h>
 #else
@@ -100,7 +102,7 @@ public:
     {
         clear();
 #    ifdef SANITIZE_PTRS
-        m_ptr = reinterpret_cast<T*>(explode_byte(0xe0));
+        m_ptr = reinterpret_cast<T*>(explode_byte(REFPTR_SCRUB_BYTE));
 #    endif
     }
 

--- a/Kernel/Library/ThreadSafeNonnullRefPtr.h
+++ b/Kernel/Library/ThreadSafeNonnullRefPtr.h
@@ -16,6 +16,8 @@
 #    include <Kernel/Arch/x86/ScopedCritical.h>
 #endif
 
+#define THREADSAFENONNULLREFPTR_SCRUB_BYTE 0xa1
+
 namespace AK {
 
 template<typename T>
@@ -95,7 +97,7 @@ public:
     {
         assign(nullptr);
 #ifdef SANITIZE_PTRS
-        m_bits.store(explode_byte(0xb0), AK::MemoryOrder::memory_order_relaxed);
+        m_bits.store(explode_byte(THREADSAFENONNULLREFPTR_SCRUB_BYTE), AK::MemoryOrder::memory_order_relaxed);
 #endif
     }
 

--- a/Kernel/Library/ThreadSafeRefPtr.h
+++ b/Kernel/Library/ThreadSafeRefPtr.h
@@ -19,6 +19,8 @@
 #    include <Kernel/Arch/x86/ScopedCritical.h>
 #endif
 
+#define THREADSAFEREFPTR_SCRUB_BYTE 0xa0
+
 namespace AK {
 
 template<typename T>
@@ -182,7 +184,7 @@ public:
     {
         clear();
 #ifdef SANITIZE_PTRS
-        m_bits.store(explode_byte(0xe0), AK::MemoryOrder::memory_order_relaxed);
+        m_bits.store(explode_byte(THREADSAFEREFPTR_SCRUB_BYTE), AK::MemoryOrder::memory_order_relaxed);
 #endif
     }
 


### PR DESCRIPTION
While I was working on LibWeb, I got a page fault at 0xe0e0e0e4.
This indicates a destroyed RefPtr if compiled with SANITIZE_PTRS
defined. However, the page fault handler didn't print out this
indication.

This makes the page fault handler print out a note if the faulting
address looks like a recently destroyed RefPtr, OwnPtr, NonnullRefPtr,
NonnullOwnPtr, ThreadSafeRefPtr or ThreadSafeNonnullRefPtr. It will
only do this if SANITIZE_PTRS is defined, as smart pointers don't get
scrubbed without it being defined.