### PR TITLE
Kernel: Use find_largest_not_above in VirtualRangeAllocator

### DIFF
--- a/Kernel/Memory/VirtualRangeAllocator.h
+++ b/Kernel/Memory/VirtualRangeAllocator.h
@@ -31,7 +31,7 @@ public:
     bool contains(VirtualRange const& range) const { return m_total_range.contains(range); }
 
 private:
-    void carve_at_iterator(auto&, VirtualRange const&);
+    void carve_from_region(VirtualRange const& from, VirtualRange const&);
 
     RedBlackTree<FlatPtr, VirtualRange> m_available_ranges;
     VirtualRange m_total_range;


### PR DESCRIPTION
Instead of iterating over the regions in the tree which is O(n), we can just use RedBlackTree's find_largest_not_above method, which is O(logn)