### PR TITLE
Aarch64: Print current CPU exception level after booting

### DIFF
--- a/Kernel/Prekernel/Arch/aarch64/aarch64_asm_utils.S
+++ b/Kernel/Prekernel/Arch/aarch64/aarch64_asm_utils.S
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+.global get_current_exception_level
+get_current_exception_level:
+  mrs x0, CurrentEL
+  lsr x0, x0, #2
+  and x0, x0, #0x3
+  ret

--- a/Kernel/Prekernel/Arch/aarch64/aarch64_asm_utils.h
+++ b/Kernel/Prekernel/Arch/aarch64/aarch64_asm_utils.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+extern "C" uint8_t get_current_exception_level();

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
+ * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 #include <Kernel/Prekernel/Arch/aarch64/Mailbox.h>
 #include <Kernel/Prekernel/Arch/aarch64/Timer.h>
 #include <Kernel/Prekernel/Arch/aarch64/UART.h>
+#include <Kernel/Prekernel/Arch/aarch64/aarch64_asm_utils.h>
 
 extern "C" [[noreturn]] void halt();
 
@@ -23,6 +25,11 @@ extern "C" [[noreturn]] void init()
     u32 firmware_version = Prekernel::Mailbox::query_firmware_version();
     uart.print_str("Firmware version: ");
     uart.print_num(firmware_version);
+    uart.print_str("\r\n");
+
+    auto exception_level = get_current_exception_level();
+    uart.print_str("Current CPU exception level: ");
+    uart.print_num(exception_level);
     uart.print_str("\r\n");
 
     auto& timer = Prekernel::Timer::the();

--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -11,6 +11,7 @@ if ("${SERENITY_ARCH}" STREQUAL "aarch64")
         Arch/aarch64/MMIO.cpp
         Arch/aarch64/Timer.cpp
         Arch/aarch64/UART.cpp
+        Arch/aarch64/aarch64_asm_utils.S
         Arch/aarch64/boot.S
         Arch/aarch64/init.cpp
     )


### PR DESCRIPTION
Hey folks!

This is my first pull request for SerenityOS. As stated in guidelines - starting with something small :) 
I'd love to hear your feedback and suggestions regarding coding style or anything else.

This PR is 1 commit only - to estabilish grounds and introduce myself :)
I'd like to help with porting Serenity to ARM64, Rasperry Pi specifically.

This PR is a first step to switch to CPU exception level 1 - the one OS should run in.
After that's done, I'll set up interrupts.

Cheers!