### PR TITLE
AK: Calculate CircularQueue::end() correctly (for real this time)

### DIFF
--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -73,13 +73,11 @@ public:
         bool operator!=(const ConstIterator& other) { return m_index != other.m_index; }
         ConstIterator& operator++()
         {
-            m_index = (m_index + 1) % Capacity;
-            if (m_index == m_queue.m_head)
-                m_index = m_queue.m_size;
+            ++m_index;
             return *this;
         }
 
-        const T& operator*() const { return m_queue.elements()[m_index]; }
+        const T& operator*() const { return m_queue.at(m_index); }
 
     private:
         friend class CircularQueue;
@@ -92,8 +90,8 @@ public:
         size_t m_index { 0 };
     };
 
-    ConstIterator begin() const { return ConstIterator(*this, m_head); }
-    ConstIterator end() const { return ConstIterator(*this, (m_head + size()) % Capacity); }
+    ConstIterator begin() const { return ConstIterator(*this, 0); }
+    ConstIterator end() const { return ConstIterator(*this, size()); }
 
     size_t head_index() const { return m_head; }
 


### PR DESCRIPTION
Both my approach and the previous approach were wrong for different cases. I've changed the Iterators index from storage-relative to queue-relative, and it's much simpler and more obviously correct.

fixes #10383