### PR TITLE
PixelPaint: Ask to save for each tab on quitting PixelPaint

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -36,6 +36,7 @@ public:
     void open_image_fd(int fd, String const& path);
     void create_default_image();
     bool request_close();
+    bool request_close_all();
 
 private:
     MainWidget();

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
     main_widget.initialize_menubar(*window);
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
-        if (main_widget.request_close())
+        if (main_widget.request_close_all())
             return GUI::Window::CloseRequestDecision::Close;
         return GUI::Window::CloseRequestDecision::StayOpen;
     };


### PR DESCRIPTION
On closing PixelPaint, now we prompt a save as dialogue for each tab
that is open.