### PR TITLE
LibMarkdown: Have one newline between lists in terminal renders

### DIFF
--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -48,7 +48,6 @@ String List::render_for_terminal(size_t) const
         else
             builder.append("* ");
         builder.append(item->render_for_terminal());
-        builder.append("\n");
     }
     builder.append("\n");
 


### PR DESCRIPTION
Before this patch the markdown lists would have two space inbetween each
item. This patch removes one of these newlines for a nicer render.

Before: 
![image](https://user-images.githubusercontent.com/13297896/136653208-ac347f71-c7e0-4564-9ad3-d220696dd07f.png)


After:
![image](https://user-images.githubusercontent.com/13297896/136653137-74106e63-6661-41cf-b180-b562c344759a.png)
