### PR TITLE
LibRegex: Transform 0,1 min/unbounded max repetitions to * or +

### DIFF
--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -341,6 +341,13 @@ public:
     template<typename T>
     static void transform_bytecode_repetition_min_max(ByteCode& bytecode_to_repeat, T minimum, Optional<T> maximum, size_t min_repetition_mark_id, size_t max_repetition_mark_id, bool greedy = true) requires(IsIntegral<T>)
     {
+        if (!maximum.has_value()) {
+            if (minimum == 0)
+                return transform_bytecode_repetition_any(bytecode_to_repeat, greedy);
+            if (minimum == 1)
+                return transform_bytecode_repetition_min_one(bytecode_to_repeat, greedy);
+        }
+
         ByteCode new_bytecode;
         new_bytecode.insert_bytecode_repetition_n(bytecode_to_repeat, minimum, min_repetition_mark_id);
 


### PR DESCRIPTION
The implementation of transform_bytecode_repetition_min_max expects at
least min=1, so let's also optimise on our way out of a bug where
'x{0,}' would cause a crash.