### PR TITLE
SpaceAnalyzer: Make files removable depending on directory permissions

### DIFF
--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -231,7 +231,7 @@ static void analyze(RefPtr<Tree> tree, SpaceAnalyzer::TreeMapWidget& treemapwidg
 static bool is_removable(const String& absolute_path)
 {
     VERIFY(!absolute_path.is_empty());
-    int access_result = access(absolute_path.characters(), W_OK);
+    int access_result = access(LexicalPath::dirname(absolute_path).characters(), W_OK);
     if (access_result != 0 && errno != EACCES)
         perror("access");
     return access_result == 0;


### PR DESCRIPTION
Prior this patch, you couldn’t remove any files from the context menu if you didn’t have write access to them.

It was incorrect, as the write permission for files means that you can modify the contents of the file, where for directories it means that you can create, rename, and remove the files there.