### PR TITLE
DisplaySettings: Disable screen numbers when exiting the application

### DIFF
--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -67,12 +67,14 @@ int main(int argc, char** argv)
         monitor_settings_widget.apply_settings();
         desktop_settings_widget.apply_settings();
         font_settings_widget.apply_settings();
+        monitor_settings_widget.show_screen_numbers(false);
         app->quit();
     };
 
     auto& cancel_button = button_container.add<GUI::Button>("Cancel");
     cancel_button.set_fixed_width(75);
     cancel_button.on_click = [&](auto) {
+        monitor_settings_widget.show_screen_numbers(false);
         app->quit();
     };
 


### PR DESCRIPTION
This fixes #10422 though I'm not sure it's the correct way of doing it.

I thought the destructor of MonitorSettingsWidget would take care of it, but evidently not.
https://github.com/SerenityOS/serenity/blob/master/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h#L22