### PR TITLE
Ports: Fix nano authentication options splitting

### DIFF
--- a/Ports/nano/package.sh
+++ b/Ports/nano/package.sh
@@ -8,7 +8,7 @@ configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--disable-browser" "--disab
 depends=("ncurses")
 auth_type="sig"
 auth_import_key="BFD009061E535052AD0DF2150D28D4D2A0ACE884"
-auth_opts=("nano-${version}.tar.xz.asc nano-${version}.tar.xz")
+auth_opts=("nano-${version}.tar.xz.asc" "nano-${version}.tar.xz")
 
 export CPPFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/ncurses"
 export PKG_CONFIG_PATH="${SERENITY_INSTALL_ROOT}/usr/local/lib/pkgconfig"


### PR DESCRIPTION
This was a typo from when everything was migrated to arrays.