### PR TITLE
Ports: Add compatibility symlinks to ncurses

### DIFF
--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -17,3 +17,9 @@ auth_type="sha256"
 pre_configure() {
     export CPPFLAGS="-P"
 }
+
+post_install() {
+    ln -sv libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libcurses.so"
+    ln -sv libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libtic.so"
+    ln -sv libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libtinfo.so"
+}


### PR DESCRIPTION
Some applications search for the external version of libtic and libtinfo, which are no longer present after 91ad7754fe156a6831eabdc49d1400e230b36b96.

Having a symlink fixes that, since libncurses exports the necessary functions if they aren't available as a seperate library.