### PR TITLE
LibWeb: Consider empty fragments the same as whitespace in LineBox

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -61,6 +61,8 @@ bool LineBox::is_empty_or_ends_in_whitespace() const
 {
     if (m_fragments.is_empty())
         return true;
+    if (m_fragments.last().length() == 0)
+        return true;
     return m_fragments.last().ends_in_whitespace();
 }
 


### PR DESCRIPTION
When computing whether whitespace should be collapsed or not, we have to consider empty fragments, since `<br>` will produce an empty fragment to force a line break.

LineBox::is_empty_or_ends_in_whitespace() is amended to look at the length of the last fragment, and return true if it is 0.

Fixes Issue #10334 