### PR TITLE
Kernel: Correctly interpret ioctl's FIONBIO user value

### DIFF
--- a/Kernel/Syscalls/ioctl.cpp
+++ b/Kernel/Syscalls/ioctl.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Userspace.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
 #include <Kernel/Process.h>
 #include <LibC/sys/ioctl_numbers.h>
@@ -15,7 +16,9 @@ KResultOr<FlatPtr> Process::sys$ioctl(int fd, unsigned request, FlatPtr arg)
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     auto description = TRY(fds().open_file_description(fd));
     if (request == FIONBIO) {
-        description->set_blocking(arg == 0);
+        int non_blocking;
+        TRY(copy_from_user(&non_blocking, Userspace<const int*>(arg)));
+        description->set_blocking(non_blocking == 0);
         return KSuccess;
     }
     return description->file().ioctl(*description, request, arg);


### PR DESCRIPTION
Values in `ioctl` are given through a pointer, but ioctl's FIONBIO
implementation was interpreting this pointer as an integer directly.
This meant that programs using `ioctl` to set a file descriptor in
blocking mode met with incorrect behavior: they passed a non-null
pointer pointing to a value of 0, but the kernel interpreted the pointer
as a non-zero integer, thus making the file non-blocking.

This commit fixes this behavior by reading the value from the userspace
pointer and using that to set the non-blocking flag on the file
descriptor.

This bug was found while trying to run the openssl tool on serenity,
which used `ioctl` to ensure newly-created sockets are in blocking mode.