### PR TITLE
Documentation: Fix spelling error

### DIFF
--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -28,7 +28,7 @@ Run cmake at least once for this to work. clangd has difficulty finding specific
 These extensions can be used as-is, but you need to point them to the custom Serenity compilers. Use the following cpp-preferences to circumvent some errors:
 
 <details>
-<summary>.vscode/c_cpp_propperties.json</summary>
+<summary>.vscode/c_cpp_properties.json</summary>
 
 ```json
 {


### PR DESCRIPTION
A spelling error caused an invalid file to be referenced, change the summary value so it mentions the right file.