### PR TITLE
LibJS+LibWeb: Let WrapperGenerator deal with legacy_null_to_empty_string

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
@@ -906,7 +906,9 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         if (!optional) {
             if (!parameter.type.nullable) {
                 scoped_generator.append(R"~~~(
-    auto @cpp_name@ = @js_name@@js_suffix@.to_string(global_object, @legacy_null_to_empty_string@);
+    auto @cpp_name@ = @js_name@@js_suffix@.is_null() && @legacy_null_to_empty_string@
+        ? String::empty()
+        : @js_name@@js_suffix@.to_string(global_object);
     if (vm.exception())
         @return_statement@
 )~~~");
@@ -914,7 +916,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
                 scoped_generator.append(R"~~~(
     String @cpp_name@;
     if (!@js_name@@js_suffix@.is_nullish()) {
-        @cpp_name@ = @js_name@@js_suffix@.to_string(global_object, @legacy_null_to_empty_string@);
+        @cpp_name@ = @js_name@@js_suffix@.to_string(global_object);
         if (vm.exception())
             @return_statement@
     }
@@ -924,7 +926,9 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
             scoped_generator.append(R"~~~(
     String @cpp_name@;
     if (!@js_name@@js_suffix@.is_undefined()) {
-        @cpp_name@ = @js_name@@js_suffix@.to_string(global_object, @legacy_null_to_empty_string@);
+        @cpp_name@ = @js_name@@js_suffix@.is_null() && @legacy_null_to_empty_string@
+            ? String::empty()
+            : @js_name@@js_suffix@.to_string(global_object);
         if (vm.exception())
             @return_statement@
     })~~~");

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -333,13 +333,13 @@ PrimitiveString* Value::to_primitive_string(GlobalObject& global_object)
 }
 
 // 7.1.17 ToString ( argument ), https://tc39.es/ecma262/#sec-tostring
-String Value::to_string(GlobalObject& global_object, bool legacy_null_to_empty_string) const
+String Value::to_string(GlobalObject& global_object) const
 {
     switch (m_type) {
     case Type::Undefined:
         return "undefined";
     case Type::Null:
-        return !legacy_null_to_empty_string ? "null" : String::empty();
+        return "null";
     case Type::Boolean:
         return m_value.as_bool ? "true" : "false";
     case Type::Int32:

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -303,7 +303,7 @@ public:
 
     u64 encoded() const { return m_value.encoded; }
 
-    String to_string(GlobalObject&, bool legacy_null_to_empty_string = false) const;
+    String to_string(GlobalObject&) const;
     Utf16String to_utf16_string(GlobalObject&) const;
     PrimitiveString* to_primitive_string(GlobalObject&);
     Value to_primitive(GlobalObject&, PreferredType preferred_type = PreferredType::Default) const;


### PR DESCRIPTION
This concept is not present in ECMAScript, and it bothers me every time
I see it.
It's only used by WrapperGenerator, and even there only relevant in two
places, so let's fully remove it from LibJS and use a simple ternary
expression instead:

    cpp_name = js_name.is_null() && legacy_null_to_empty_string
        ? String::empty()
        : js_name.to_string(global_object);