### PR TITLE
AK: Fixes a compilation error for Aarch64 where char is unsigned

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -146,7 +146,7 @@ void StringBuilder::append_as_lowercase(char ch)
 
 void StringBuilder::append_escaped_for_json(StringView const& string)
 {
-    for (auto ch : string) {
+    for (signed char ch : string) {
         switch (ch) {
         case '\b':
             append("\\b");


### PR DESCRIPTION
Related PR: https://github.com/SerenityOS/serenity/commit/d476144565c29a041b48fa21c734fd71d4508fe8

This fixes a compiler error discovered when working on Aarch64. On Aarch64 a `char` by default is `unsigned`. This causes the compiler to generate an error on line 167 due to the non-nonsensical `>= 0` test.