### PR TITLE
Toolchain: Build pretty. Use xz, not gz. Use sha256, not md5 

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -7,7 +7,7 @@ Make sure you have all the dependencies installed:
 ### Debian / Ubuntu
 
 ```console
-sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync genext2fs unzip texinfo
+sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-i386 qemu-utils ccache rsync genext2fs unzip xz-utils texinfo
 ```
 
 #### GCC 10
@@ -43,7 +43,7 @@ for details.
 ### Arch Linux / Manjaro
 
 ```console
-sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu qemu-arch-extra ccache rsync unzip
+sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu qemu-arch-extra ccache rsync unzip xz
 ```
 
 ### Other systems

--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -3,25 +3,25 @@
 ### Fedora
 
 ```console
-sudo dnf install binutils-devel curl cmake mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja-build patch ccache rsync @"C Development Tools and Libraries" @Virtualization
+sudo dnf install binutils-devel curl cmake mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja-build patch ccache rsync xz @"C Development Tools and Libraries" @Virtualization
 ```
 
 ## openSUSE
 
 ```console
-sudo zypper install curl cmake mpfr-devel mpc-devel ninja gmp-devel e2fsprogs patch qemu-x86 qemu-audio-pa gcc gcc-c++ ccache rsync patterns-devel-C-C++-devel_C_C++
+sudo zypper install curl cmake mpfr-devel mpc-devel ninja gmp-devel e2fsprogs patch qemu-x86 qemu-audio-pa gcc gcc-c++ ccache rsync xz patterns-devel-C-C++-devel_C_C++
 ```
 
 ## Void Linux
 
 ```console
-sudo xbps-install -S base-devel cmake curl mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja qemu ccache rsync
+sudo xbps-install -S base-devel cmake curl mpfr-devel libmpc-devel gmp-devel e2fsprogs ninja qemu ccache rsync xz
 ```
 
 ## ALT Linux
 
 ```console
-apt-get install curl cmake libmpc-devel gmp-devel e2fsprogs libmpfr-devel ninja-build patch gcc ccache rsync
+apt-get install curl cmake libmpc-devel gmp-devel e2fsprogs libmpfr-devel ninja-build patch gcc ccache rsync xz
 ```
 
 ## NixOS
@@ -48,6 +48,7 @@ stdenv.mkDerivation {
     ccache
     rsync
     unzip
+    xz
 
     # Example Build-time Additional Dependencies
     pkgconfig
@@ -73,7 +74,7 @@ First, make sure you have enabled the `community` repository in `/etc/apk/reposi
 
 ```console
 # the basics, if you have not already done so
-apk add bash curl git util-linux sudo
+apk add bash curl git util-linux sudo xz
 
 # rough equivalent of build-essential
 apk add build-base
@@ -88,7 +89,7 @@ apk add cmake e2fsprogs grub-bios samurai mpc1-dev mpfr-dev gmp-dev ccache rsync
 ## OpenBSD prerequisites
 
 ```console
-doas pkg_add bash cmake g++ gcc git gmake gmp ninja ccache rsync coreutils qemu sudo
+doas pkg_add bash cmake g++ gcc git gmake gmp ninja ccache rsync coreutils qemu sudo xz
 ```
 
 ## FreeBSD prerequisites

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -16,7 +16,7 @@ BUILD="$DIR/../Build/$ARCH"
 SYSROOT="$BUILD/Root"
 
 MAKE="make"
-MD5SUM="md5sum"
+SHA256SUM="sha256sum"
 NPROC="nproc"
 REALPATH="realpath"
 
@@ -36,7 +36,7 @@ export CXXFLAGS="-g0 -O2 -mtune=native"
 
 if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     MAKE=gmake
-    MD5SUM="md5 -q"
+    SHA256SUM="sha256 -q"
     NPROC="sysctl -n hw.ncpuonline"
     REALPATH="readlink -f"
     export CC=egcc
@@ -45,7 +45,7 @@ if [ "$SYSTEM_NAME" = "OpenBSD" ]; then
     export LDFLAGS=-Wl,-z,notext
 elif [ "$SYSTEM_NAME" = "FreeBSD" ]; then
     MAKE=gmake
-    MD5SUM="md5 -q"
+    SHA256SUM="sha256 -q"
     NPROC="sysctl -n hw.ncpu"
     export with_gmp=/usr/local
     export with_mpfr=/usr/local
@@ -73,13 +73,13 @@ mkdir -p "$DIR/Tarballs"
 
 # Note: The version number and hash in BuildClang.sh needs to be kept in sync with this.
 BINUTILS_VERSION="2.37"
-BINUTILS_MD5SUM="1e55743d73c100b7a0d67ffb32398cdb"
+BINUTILS_SHA256SUM="820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
 BINUTILS_NAME="binutils-$BINUTILS_VERSION"
 BINUTILS_PKG="${BINUTILS_NAME}.tar.gz"
 BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils"
 
 GDB_VERSION="10.2"
-GDB_MD5SUM="7aeb896762924ae9a2ec59525088bada"
+GDB_SHA256SUM="aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
 GDB_NAME="gdb-$GDB_VERSION"
 GDB_PKG="${GDB_NAME}.tar.gz"
 GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb"
@@ -87,7 +87,7 @@ GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb"
 # Note: If you bump the gcc version, you also have to update the matching
 #       GCC_VERSION variable in the project's root CMakeLists.txt
 GCC_VERSION="11.2.0"
-GCC_MD5SUM="dc6886bd44bb49e2d3d662aed9729278"
+GCC_SHA256SUM="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
 GCC_NAME="gcc-$GCC_VERSION"
 GCC_PKG="${GCC_NAME}.tar.gz"
 GCC_BASE_URL="https://ftp.gnu.org/gnu/gcc"
@@ -182,12 +182,12 @@ popd
 pushd "$DIR/Tarballs"
     # Build aarch64-gdb for cross-debugging support on x86 systems
     if [ "$ARCH" = "aarch64" ]; then
-        md5=""
+        SHA256=""
         if [ -e "$GDB_PKG" ]; then
-            md5="$($MD5SUM $GDB_PKG | cut -f1 -d' ')"
-            echo "bu md5='$md5'"
+            SHA256="$($SHA256SUM $GDB_PKG | cut -f1 -d' ')"
+            buildstep toolchain_dl printf "bu SHA256='$SHA256'\n"
         fi
-        if [ "$md5" != ${GDB_MD5SUM} ] ; then
+        if [ "$SHA256" != ${GDB_SHA256SUM} ] ; then
             rm -f $GDB_PKG
             curl -LO "$GDB_BASE_URL/$GDB_PKG"
         else
@@ -195,24 +195,24 @@ pushd "$DIR/Tarballs"
         fi
     fi
 
-    md5=""
+    SHA256=""
     if [ -e "$BINUTILS_PKG" ]; then
-        md5="$($MD5SUM $BINUTILS_PKG | cut -f1 -d' ')"
-        echo "bu md5='$md5'"
+        SHA256="$($SHA256SUM $BINUTILS_PKG | cut -f1 -d' ')"
+        buildstep toolchain_dl printf "bu SHA256='$SHA256'\n"
     fi
-    if [ "$md5" != ${BINUTILS_MD5SUM} ] ; then
+    if [ "$SHA256" != ${BINUTILS_SHA256SUM} ] ; then
         rm -f $BINUTILS_PKG
         curl -LO "$BINUTILS_BASE_URL/$BINUTILS_PKG"
     else
         echo "Skipped downloading binutils"
     fi
 
-    md5=""
+    SHA256=""
     if [ -e "$GCC_PKG" ]; then
-        md5="$($MD5SUM ${GCC_PKG} | cut -f1 -d' ')"
-        echo "gc md5='$md5'"
+        SHA256="$($SHA256SUM ${GCC_PKG} | cut -f1 -d' ')"
+        buildstep toolchain_dl printf "gc SHA256='$SHA256'\n"
     fi
-    if [ "$md5" != ${GCC_MD5SUM} ] ; then
+    if [ "$SHA256" != ${GCC_SHA256SUM} ] ; then
         rm -f $GCC_PKG
         curl -LO "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
     else
@@ -236,7 +236,7 @@ pushd "$DIR/Tarballs"
             else
                 patch -p1 < "$DIR"/Patches/gdb.patch > /dev/null
             fi
-            $MD5SUM "$DIR"/Patches/gdb.patch > .patch.applied
+            $SHA256SUM "$DIR"/Patches/gdb.patch > .patch.applied
         popd
     fi
 
@@ -256,7 +256,7 @@ pushd "$DIR/Tarballs"
         else
             patch -p1 < "$DIR"/Patches/binutils.patch > /dev/null
         fi
-        $MD5SUM "$DIR"/Patches/binutils.patch > .patch.applied
+        $SHA256SUM "$DIR"/Patches/binutils.patch > .patch.applied
     popd
 
     if [ -d ${GCC_NAME} ]; then
@@ -276,7 +276,7 @@ pushd "$DIR/Tarballs"
         else
             patch -p1 < "$DIR/Patches/gcc.patch" > /dev/null
         fi
-        $MD5SUM "$DIR/Patches/gcc.patch" > .patch.applied
+        $SHA256SUM "$DIR/Patches/gcc.patch" > .patch.applied
     popd
 
     if [ "$SYSTEM_NAME" = "Darwin" ]; then

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -75,22 +75,22 @@ mkdir -p "$DIR/Tarballs"
 BINUTILS_VERSION="2.37"
 BINUTILS_SHA256SUM="820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
 BINUTILS_NAME="binutils-$BINUTILS_VERSION"
-BINUTILS_PKG="${BINUTILS_NAME}.tar.gz"
-BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils"
+BINUTILS_PKG="${BINUTILS_NAME}.tar.xz"
+BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils" # option if that is slow: https://fossies.org/linux/misc/
 
 GDB_VERSION="10.2"
 GDB_SHA256SUM="aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
 GDB_NAME="gdb-$GDB_VERSION"
-GDB_PKG="${GDB_NAME}.tar.gz"
-GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb"
+GDB_PKG="${GDB_NAME}.tar.xz"
+GDB_BASE_URL="https://ftp.gnu.org/gnu/gdb" # option if that is slow: https://fossies.org/linux/misc/legacy/
 
 # Note: If you bump the gcc version, you also have to update the matching
 #       GCC_VERSION variable in the project's root CMakeLists.txt
 GCC_VERSION="11.2.0"
 GCC_SHA256SUM="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
 GCC_NAME="gcc-$GCC_VERSION"
-GCC_PKG="${GCC_NAME}.tar.gz"
-GCC_BASE_URL="https://ftp.gnu.org/gnu/gcc"
+GCC_PKG="${GCC_NAME}.tar.xz"
+GCC_BASE_URL="https://ftp.gnu.org/gnu/gcc" # option if that is slow: https://fossies.org/linux/misc/
 
 buildstep() {
     NAME=$1
@@ -179,6 +179,11 @@ popd
 
 # === DOWNLOAD AND PATCH ===
 
+buildstep toolchain_dl printf "\tChecking if we must download toolchain tarballs (gdb, binutils, gcc) ...\n"
+buildstep toolchain_dl printf "\tSometimes the GNU servers we pull these from are particularly slow.\n"
+buildstep toolchain_dl printf "\tIf this is taking a very long time, you may want to manually download\n"
+buildstep toolchain_dl printf "\tthe right tarballs here from another source.\n"
+buildstep toolchain_dl printf "\t(this script is: $DIR/${BASH_SOURCE[0]} )\n"
 pushd "$DIR/Tarballs"
     # Build aarch64-gdb for cross-debugging support on x86 systems
     if [ "$ARCH" = "aarch64" ]; then
@@ -225,7 +230,7 @@ pushd "$DIR/Tarballs"
             rm -rf "$DIR/Build/$ARCH/$GDB_NAME"
         fi
         echo "Extracting GDB..."
-        tar -xzf ${GDB_PKG}
+        tar -xJf ${GDB_PKG}
 
         pushd ${GDB_NAME}
             if [ "$git_patch" = "1" ]; then
@@ -245,7 +250,7 @@ pushd "$DIR/Tarballs"
         rm -rf "$DIR/Build/$ARCH/$BINUTILS_NAME"
     fi
     echo "Extracting binutils..."
-    tar -xzf ${BINUTILS_PKG}
+    tar -xJf ${BINUTILS_PKG}
 
     pushd ${BINUTILS_NAME}
         if [ "$git_patch" = "1" ]; then
@@ -266,7 +271,7 @@ pushd "$DIR/Tarballs"
         rm -rf "$DIR/Build/$ARCH/$GCC_NAME"
     fi
     echo "Extracting gcc..."
-    tar -xzf $GCC_PKG
+    tar -xJf $GCC_PKG
     pushd $GCC_NAME
         if [ "$git_patch" = "1" ]; then
             git init > /dev/null


### PR DESCRIPTION
We were already using lzma in the clang build, but not specifying it as a dependency. I fixed the dependency specs and switched the downloads in BuildIt.sh to xz instead of gz. The files are almost half the size. Also added a note about potential slowness of the GNU servers and an alternative (I started this edit because my initial download took nearly an hour off the GNU server).

It is safer to use sha256 than md5. Even sha1 is broken now: https://github.com/NixOS/nixpkgs/issues/77238

I fully integrated the buildstep helper into the BuildIt.sh output. Also, printf = better echo (easier to use formatting and doesn't fork another process). Output formatting made so it is easier to follow the build process in general.