### PR TITLE
Ports: Force-create ncurses compatibility symlinks

### DIFF
--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -19,7 +19,7 @@ pre_configure() {
 }
 
 post_install() {
-    ln -sv libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libcurses.so"
-    ln -sv libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libtic.so"
-    ln -sv libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libtinfo.so"
+    ln -svf libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libcurses.so"
+    ln -svf libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libtic.so"
+    ln -svf libncurses.so "${SERENITY_INSTALL_ROOT}/usr/local/lib/libtinfo.so"
 }


### PR DESCRIPTION
I haven't considered that someone might try to build ncurses twice.