### PR TITLE
Compile AK for Aarch64 - cleanup inside RegisterState

### DIFF
--- a/Kernel/Arch/x86/RegisterState.h
+++ b/Kernel/Arch/x86/RegisterState.h
@@ -118,10 +118,11 @@ struct [[gnu::packed]] RegisterState {
 
 #if ARCH(I386)
 #    define REGISTER_STATE_SIZE (19 * 4)
-#else
-#    define REGISTER_STATE_SIZE (22 * 8)
-#endif
 static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
+#elif ARCH(X86_64)
+#    define REGISTER_STATE_SIZE (22 * 8)
+static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
+#endif
 
 inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, const RegisterState& kernel_regs)
 {


### PR DESCRIPTION
This PR contains some changes related to getting AK to compile on Aarch64. 

The assert has been duplicated and moved into each part of the `#if` block. The `#if` block has been make more specific, so only `X86` platforms will define (and thus evaluate) the static_assert. (The assert will fail when trying to compile for Aarch64)
