### PR TITLE
Kernel: Add post build step to generate kernel8.img

### DIFF
--- a/Kernel/Prekernel/CMakeLists.txt
+++ b/Kernel/Prekernel/CMakeLists.txt
@@ -61,6 +61,14 @@ if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
     )
 endif()
 
+if ("${SERENITY_ARCH}" STREQUAL "aarch64")
+    add_custom_command(
+        TARGET Prekernel POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -O binary Prekernel kernel8.img
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel8.img
+    )
+endif()
+
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Prekernel" DESTINATION boot)
 
 # Remove options which the Prekernel environment doesn't support.


### PR DESCRIPTION
The raspberry pi hardware requires raw binary files (not elf files) to boot from. This PR adds a post build step to generate this raw binary file from the Prekernel elf file. The file is named `kernel8.img` which is the convention for raspberry pi 64 bit binary images.

To test:

1) SERENITY_ARCH=aarch64 Meta/serenity.sh build
2) Copy Build/aarch64/Kernel/Prekernel/kernel8.img to the boot folder (usually on an SD card)
3) Boot the raspi and see output from the uart

Notes:
Ensure `enable_uart=1` is set in the raspi's `config.txt` file