### PR TITLE
FontEditor: Accept file drops + some code refactor

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -714,3 +714,20 @@ void FontEditorWidget::update_preview()
     if (m_font_preview_window)
         m_font_preview_window->update();
 }
+
+void FontEditorWidget::drop_event(GUI::DropEvent& event)
+{
+    event.accept();
+
+    if (event.mime_data().has_urls()) {
+        auto urls = event.mime_data().urls();
+        if (urls.is_empty())
+            return;
+
+        window()->move_to_front();
+        if (!request_close())
+            return;
+
+        open_file(urls.first().path());
+    }
+}

--- a/Userland/Applications/FontEditor/FontEditor.h
+++ b/Userland/Applications/FontEditor/FontEditor.h
@@ -37,6 +37,8 @@ public:
 private:
     FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&);
 
+    virtual void drop_event(GUI::DropEvent&) override;
+
     void open_file(String const&);
     void undo();
     void redo();


### PR DESCRIPTION
- **FontEditor: Reuse the `request_close()` function in Open action**
- **FontEditor: Add `FontEditorWidget::open_file()` function**
  This part is also quite needed when opening files from drag-and-drop events.

+ **FontEditor: Accept file drops**