### PR TITLE
Kernel: Add UBSanitizer.cpp to the Aarch64 kernel build

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -360,6 +360,7 @@ else()
     set(SOURCES
         Arch/aarch64/dummy.cpp
         ${AK_SOURCES}
+        UBSanitizer.cpp
     )
 
     # Otherwise linker errors e.g undefined reference to `__aarch64_cas8_acq_rel'


### PR DESCRIPTION
Should have been part of https://github.com/SerenityOS/serenity/pull/10453 - but I managed to clobber this line in the cmake file without realising.
