### PR TITLE
WebContent: Check for a closed client connection

### DIFF
--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -207,6 +207,10 @@ void PageHost::page_did_request_image_context_menu(const Gfx::IntPoint& content_
 
 String PageHost::page_did_request_cookie(const URL& url, Web::Cookie::Source source)
 {
+    if (!m_client.is_open()) {
+        return {};
+    }
+
     return m_client.did_request_cookie(url, static_cast<u8>(source));
 }
 


### PR DESCRIPTION
When requesting cookies from the PageHost's client connection, check if
the connection is closed, if so return nothing for any request to
retrieve cookies.