### PR TITLE
ConfigServer: Sync config files to disk automatically

### DIFF
--- a/Userland/Services/ConfigServer/ClientConnection.h
+++ b/Userland/Services/ConfigServer/ClientConnection.h
@@ -35,11 +35,16 @@ private:
     virtual void write_bool_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key, [[maybe_unused]] bool value) override;
 
     bool validate_access(String const& domain, String const& group, String const& key);
+    void sync_dirty_domains_to_disk();
+    void start_or_restart_sync_timer();
 
     bool m_has_pledged { false };
     HashTable<String> m_pledged_domains;
 
     HashTable<String> m_monitored_domains;
+
+    NonnullRefPtr<Core::Timer> m_sync_timer;
+    HashTable<String> m_dirty_domains;
 };
 
 }


### PR DESCRIPTION
At the risk of introducing premature optimization, it only syncs to disk
5 seconds after the latest valid configuration update, to handle cases
where programs might send frequent updates that would go to disk every
time otherwise.
Also syncs to disk when the client connection closes.

Co-authored-by: Timothy Flynn <trflynn@pm.me>