### PR TITLE
LibWeb: Accept a Block token as the body of a CSS At-Rule

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1204,7 +1204,13 @@ NonnullRefPtr<StyleRule> Parser::consume_an_at_rule(TokenStream<T>& tokens)
             return rule;
         }
 
-        // how is "simple block with an associated token of <{-token>" a valid token?
+        if constexpr (IsSame<T, StyleComponentValueRule>) {
+            StyleComponentValueRule const& component_value = token;
+            if (component_value.is_block() && component_value.block().is_curly()) {
+                rule->m_block = component_value.block();
+                return rule;
+            }
+        }
 
         tokens.reconsume_current_input_token();
         auto value = consume_a_component_value(tokens);


### PR DESCRIPTION
I previously fixed this for `consume_a_qualified_rule()` and didn't
notice the same comment in `consume_an_at_rule()` until now.