### PR TITLE
LibWeb: Parse "none" value for box-shadow property

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2571,6 +2571,13 @@ RefPtr<StyleValue> Parser::parse_border_radius_shorthand_value(ParsingContext co
 
 RefPtr<StyleValue> Parser::parse_box_shadow_value(ParsingContext const& context, Vector<StyleComponentValueRule> const& component_values)
 {
+    // "none"
+    if (component_values.size() == 1 && component_values.first().is(Token::Type::Ident)) {
+        auto ident = parse_identifier_value(context, component_values.first());
+        if (ident && ident->to_identifier() == ValueID::None)
+            return ident;
+    }
+
     // FIXME: Also support inset, spread-radius and multiple comma-separated box-shadows
     Length offset_x {};
     Length offset_y {};

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -415,7 +415,10 @@
   },
   "box-shadow": {
     "inherited": false,
-    "initial": "none"
+    "initial": "none",
+    "valid-identifiers": [
+      "none"
+    ]
   },
   "box-sizing": {
     "inherited": false,


### PR DESCRIPTION
Previously, `box-shadow: none` would fail to parse, meaning that in this
example:

```css
p {
  box-shadow: 20px 10px 5px magenta;
}

p.foo {
  box-shadow: none;
}
```

... a `<p class="foo">` would still have a box-shadow, when it should
not have one. Now, we handle the `none` value. :^)