### PR TITLE
Meta: Only apply -fsantize=fuzzer to actual fuzzers and not libraries

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -111,11 +111,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
     add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216)
 
-    if (ENABLE_FUZZER_SANITIZER)
-        add_compile_options(-fsanitize=fuzzer -fno-omit-frame-pointer)
-        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")
-    endif()
-
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-expansion-to-defined)
 endif()

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -1,5 +1,6 @@
 function(add_simple_fuzzer name)
   add_executable(${name} "${name}.cpp")
+  target_compile_options(${name} PRIVATE -fsanitize=fuzzer -fno-omit-frame-pointer)
 
   if (ENABLE_OSS_FUZZ)
       target_link_libraries(${name}


### PR DESCRIPTION
When -fsanitize=fuzzer was applied globally in lagom it failed to build
LagomCore due to linking issues when -fno-semantic-interposition was
specified.