### PR TITLE
Ports: Fix dependencies for SDL2

### DIFF
--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -4,7 +4,8 @@ version=git
 workdir=SDL-main-serenity
 useconfigure=true
 files="https://github.com/SerenityPorts/SDL/archive/main-serenity.tar.gz SDL2-git.tar.gz"
-configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-DPULSEAUDIO=OFF" "-DJACK=OFF")
+configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-DPULSEAUDIO=OFF" "-DJACK=OFF" "-DEXTRA_LDFLAGS=-liconv;-ldl")
+depends=("libiconv")
 
 configure() {
     run cmake "${configopts[@]}"


### PR DESCRIPTION
We are doing nonstandard stuff with our headers, so SDL assumed that both iconv and dlopen are available inside LibC, which they aren't, resulting in it failing to link.

Fix that by adding a dependency on libiconv and adding additional linker flags.