### PR TITLE
Kernel/Net: Generate interface name near construction point

### DIFF
--- a/Kernel/Net/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/E1000ENetworkAdapter.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Net/E1000ENetworkAdapter.h>
+#include <Kernel/Net/NetworkingManagement.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
@@ -180,14 +181,18 @@ static bool is_valid_device_id(u16 device_id)
     }
 }
 
-UNMAP_AFTER_INIT RefPtr<E1000ENetworkAdapter> E1000ENetworkAdapter::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier, NonnullOwnPtr<KString> interface_name)
+UNMAP_AFTER_INIT RefPtr<E1000ENetworkAdapter> E1000ENetworkAdapter::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     if (pci_device_identifier.hardware_id().vendor_id != PCI::VendorID::Intel)
         return {};
     if (!is_valid_device_id(pci_device_identifier.hardware_id().device_id))
         return {};
     u8 irq = pci_device_identifier.interrupt_line().value();
-    auto adapter = adopt_ref_if_nonnull(new (nothrow) E1000ENetworkAdapter(pci_device_identifier.address(), irq, move(interface_name)));
+    // FIXME: Better propagate errors here
+    auto interface_name_or_error = NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier);
+    if (interface_name_or_error.is_error())
+        return {};
+    auto adapter = adopt_ref_if_nonnull(new (nothrow) E1000ENetworkAdapter(pci_device_identifier.address(), irq, interface_name_or_error.release_value()));
     if (!adapter)
         return {};
     if (adapter->initialize())

--- a/Kernel/Net/E1000ENetworkAdapter.h
+++ b/Kernel/Net/E1000ENetworkAdapter.h
@@ -21,7 +21,7 @@ namespace Kernel {
 class E1000ENetworkAdapter final
     : public E1000NetworkAdapter {
 public:
-    static RefPtr<E1000ENetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&, NonnullOwnPtr<KString>);
+    static RefPtr<E1000ENetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&);
 
     virtual bool initialize() override;
 

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Net/E1000NetworkAdapter.h>
+#include <Kernel/Net/NetworkingManagement.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
@@ -158,14 +159,18 @@ UNMAP_AFTER_INIT static bool is_valid_device_id(u16 device_id)
     }
 }
 
-UNMAP_AFTER_INIT RefPtr<E1000NetworkAdapter> E1000NetworkAdapter::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier, NonnullOwnPtr<KString> interface_name)
+UNMAP_AFTER_INIT RefPtr<E1000NetworkAdapter> E1000NetworkAdapter::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     if (pci_device_identifier.hardware_id().vendor_id != PCI::VendorID::Intel)
         return {};
     if (!is_valid_device_id(pci_device_identifier.hardware_id().device_id))
         return {};
     u8 irq = pci_device_identifier.interrupt_line().value();
-    auto adapter = adopt_ref_if_nonnull(new (nothrow) E1000NetworkAdapter(pci_device_identifier.address(), irq, move(interface_name)));
+    // FIXME: Better propagate errors here
+    auto interface_name_or_error = NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier);
+    if (interface_name_or_error.is_error())
+        return {};
+    auto adapter = adopt_ref_if_nonnull(new (nothrow) E1000NetworkAdapter(pci_device_identifier.address(), irq, interface_name_or_error.release_value()));
     if (!adapter)
         return {};
     if (adapter->initialize())

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -20,7 +20,7 @@ class E1000NetworkAdapter : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static RefPtr<E1000NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&, NonnullOwnPtr<KString>);
+    static RefPtr<E1000NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&);
 
     virtual bool initialize();
 

--- a/Kernel/Net/NE2000NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000NetworkAdapter.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Net/NE2000NetworkAdapter.h>
+#include <Kernel/Net/NetworkingManagement.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
@@ -137,7 +138,7 @@ struct [[gnu::packed]] received_packet_header {
     u16 length;
 };
 
-UNMAP_AFTER_INIT RefPtr<NE2000NetworkAdapter> NE2000NetworkAdapter::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier, NonnullOwnPtr<KString> interface_name)
+UNMAP_AFTER_INIT RefPtr<NE2000NetworkAdapter> NE2000NetworkAdapter::try_to_initialize(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     constexpr auto ne2k_ids = Array {
         PCI::HardwareID { 0x10EC, 0x8029 }, // RealTek RTL-8029(AS)
@@ -157,7 +158,11 @@ UNMAP_AFTER_INIT RefPtr<NE2000NetworkAdapter> NE2000NetworkAdapter::try_to_initi
     if (!ne2k_ids.span().contains_slow(pci_device_identifier.hardware_id()))
         return {};
     u8 irq = pci_device_identifier.interrupt_line().value();
-    return adopt_ref_if_nonnull(new (nothrow) NE2000NetworkAdapter(pci_device_identifier.address(), irq, move(interface_name)));
+    // FIXME: Better propagate errors here
+    auto interface_name_or_error = NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier);
+    if (interface_name_or_error.is_error())
+        return {};
+    return adopt_ref_if_nonnull(new (nothrow) NE2000NetworkAdapter(pci_device_identifier.address(), irq, interface_name_or_error.release_value()));
 }
 
 UNMAP_AFTER_INIT NE2000NetworkAdapter::NE2000NetworkAdapter(PCI::Address address, u8 irq, NonnullOwnPtr<KString> interface_name)

--- a/Kernel/Net/NE2000NetworkAdapter.h
+++ b/Kernel/Net/NE2000NetworkAdapter.h
@@ -20,7 +20,7 @@ class NE2000NetworkAdapter final : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static RefPtr<NE2000NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&, NonnullOwnPtr<KString>);
+    static RefPtr<NE2000NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&);
 
     virtual ~NE2000NetworkAdapter() override;
 

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -12,6 +12,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/Locking/Mutex.h>
 #include <Kernel/Memory/Region.h>
 
 namespace Kernel {
@@ -25,6 +26,8 @@ public:
     static NetworkingManagement& the();
     static bool is_initialized();
     bool initialize();
+
+    static KResultOr<NonnullOwnPtr<KString>> generate_interface_name_from_pci_address(PCI::DeviceIdentifier const&);
 
     NetworkingManagement();
 

--- a/Kernel/Net/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/RTL8139NetworkAdapter.h
@@ -22,7 +22,7 @@ class RTL8139NetworkAdapter final : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static RefPtr<RTL8139NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&, NonnullOwnPtr<KString>);
+    static RefPtr<RTL8139NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&);
 
     virtual ~RTL8139NetworkAdapter() override;
 

--- a/Kernel/Net/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/RTL8168NetworkAdapter.h
@@ -22,7 +22,7 @@ class RTL8168NetworkAdapter final : public NetworkAdapter
     , public PCI::Device
     , public IRQHandler {
 public:
-    static RefPtr<RTL8168NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&, NonnullOwnPtr<KString>);
+    static RefPtr<RTL8168NetworkAdapter> try_to_initialize(PCI::DeviceIdentifier const&);
 
     virtual ~RTL8168NetworkAdapter() override;
 


### PR DESCRIPTION
This change allows the Kernel to actually construct other interfaces
besides the E1000 type.
This solves a breakage that was introduced recently because of move
semantics.

Fixes a problem mentioned in #10198, that was probably introduced in 2770433d300e0892498014173f57794291e3f4ba.