### PR TITLE
LibWeb: Weakly store NamedNodeMap's & Attribute's associated Element

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Attribute.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attribute.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/DOM/Attribute.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 
 namespace Web::DOM {
 
@@ -20,6 +21,16 @@ Attribute::Attribute(Document& document, FlyString local_name, String value, Ele
     , m_value(move(value))
     , m_owner_element(owner_element)
 {
+}
+
+Element const* Attribute::owner_element() const
+{
+    return m_owner_element;
+}
+
+void Attribute::set_owner_element(Element const* owner_element)
+{
+    m_owner_element = owner_element;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Attribute.h
+++ b/Userland/Libraries/LibWeb/DOM/Attribute.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/WeakPtr.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/QualifiedName.h>
 
@@ -31,8 +32,8 @@ public:
     String const& value() const { return m_value; }
     void set_value(String value) { m_value = move(value); }
 
-    Element const* owner_element() const { return m_owner_element; }
-    void set_owner_element(Element const* owner_element) { m_owner_element = owner_element; }
+    Element const* owner_element() const;
+    void set_owner_element(Element const* owner_element);
 
     // Always returns true: https://dom.spec.whatwg.org/#dom-attr-specified
     constexpr bool specified() const { return true; }
@@ -42,7 +43,7 @@ private:
 
     QualifiedName m_qualified_name;
     String m_value;
-    Element const* m_owner_element { nullptr };
+    WeakPtr<Element> m_owner_element;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -10,6 +10,7 @@
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/WeakPtr.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/ExceptionOr.h>
 #include <LibWeb/Forward.h>
@@ -50,7 +51,7 @@ public:
 private:
     explicit NamedNodeMap(Element const& associated_element);
 
-    Element const& m_associated_element;
+    WeakPtr<Element> m_associated_element;
     NonnullRefPtrVector<Attribute> m_attributes;
 };
 


### PR DESCRIPTION
This is similar to how Gecko avoids a reference cycle, where both the
NamedNodeMap and Attribute would otherwise store a strong reference to
their associated Element. Gecko manually clears stored raw references
when an Element is destroyed, whereas we use weak references to do so
automatically.

Attribute's ownerElement getter and setter are moved out of line to
avoid an #include cycle between Element and Attribute.