### PR TITLE
ImageViewer: Use scaled image size when resizing window to fit it

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -299,7 +299,7 @@ void ViewWidget::resize_window()
     if (!m_bitmap)
         return;
 
-    auto new_size = m_bitmap->size();
+    auto new_size = m_bitmap_rect.size();
 
     if (new_size.width() < 300)
         new_size.set_width(300);


### PR DESCRIPTION
When the image is flipped or rotated, the window is resized to ensure
that the image still fits in the frame. However, currently the original
bitmap rect is used, which doesn't take into account the scaling
factor. Fix this by using the scaled rect instead.