### PR TITLE
VimEditingEngine: Support paragraph as a motion

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -1295,6 +1295,7 @@ void VimEditingEngine::switch_to_visual_mode()
     m_selection_start_position = m_editor->cursor();
     m_editor->selection().set(m_editor->cursor(), { m_editor->cursor().line(), m_editor->cursor().column() + 1 });
     m_editor->did_update_selection();
+    m_editor->update();
     m_motion.reset();
 }
 
@@ -1313,6 +1314,7 @@ void VimEditingEngine::update_selection_on_cursor_move()
 
     m_editor->selection().set(start, end);
     m_editor->did_update_selection();
+    m_editor->update();
 }
 
 void VimEditingEngine::clamp_cursor_position()
@@ -1329,6 +1331,7 @@ void VimEditingEngine::clear_visual_mode_data()
     if (m_editor->has_selection()) {
         m_editor->selection().clear();
         m_editor->did_update_selection();
+        m_editor->update();
         clamp_cursor_position();
     }
     m_selection_start_position = {};

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -71,6 +71,8 @@ public:
         Unknown,
         // Document. Anything non-negative is counted as G while anything else is gg.
         Document,
+        // Paragraph. Block of code or prose separated by blank line.
+        Paragraph,
         // Lines.
         Line,
         // A sequence of letters, digits and underscores, or a sequence of other
@@ -120,6 +122,7 @@ public:
 
 private:
     void calculate_document_range(TextEditor&);
+    void calculate_paragraph_range(TextEditor&);
     void calculate_line_range(TextEditor&, bool normalize_for_position);
     void calculate_word_range(VimCursor&, int amount, bool normalize_for_position);
     void calculate_WORD_range(VimCursor&, int amount, bool normalize_for_position);


### PR DESCRIPTION
Per the request of a `FIXME` comment in `VimEditingEngine.cpp`, integrate paragraph as a Vim motion -- where a paragraph is any chunk of code or prose separated by a blank line.

With this change, it is possible to move by a multiple of paragraphs as well. It is also possible to visually select paragraphs -- the selection *functions* as expected, but it does not *look* as it functions. I'm not sure this is an issue specifically with the code here though.