### PR TITLE
LoginServer: Mark this component as `REQUIRED`

### DIFF
--- a/Userland/Services/LoginServer/CMakeLists.txt
+++ b/Userland/Services/LoginServer/CMakeLists.txt
@@ -1,5 +1,6 @@
 serenity_component(
     LoginServer
+    REQUIRED
     TARGETS LoginServer
 )
 


### PR DESCRIPTION
Prior to this change, there was no requirement to build this server.

If you build serenity without `-DBUILD_EVERYTHING` flag, or just play around with your [build configuration][1], it left you with a blank screen and this debug line:

    SystemServer(6:6): LoginServer: binary "/bin/LoginServer" does not exist, skipping service.

[1]: https://github.com/SerenityOS/serenity/blob/master/Documentation/AdvancedBuildInstructions.md#component-configuration