### PR TITLE
LibGUI: Make links only clickable where the text is

### DIFF
--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -21,7 +21,6 @@ namespace GUI {
 LinkLabel::LinkLabel(String text)
     : Label(move(text))
 {
-    set_override_cursor(Gfx::StandardCursor::Hand);
     set_foreground_role(Gfx::ColorRole::Link);
     set_focus_policy(FocusPolicy::TabFocus);
     setup_actions();
@@ -37,13 +36,29 @@ void LinkLabel::setup_actions()
     m_copy_action = CommonActions::make_copy_action([this](auto&) { Clipboard::the().set_plain_text(text()); }, this);
 }
 
+void LinkLabel::set_hovered(bool hover)
+{
+    if (hover == m_hovered)
+        return;
+
+    m_hovered = hover;
+    set_override_cursor(hover ? Gfx::StandardCursor::Hand : Gfx::StandardCursor::None);
+    update();
+}
+
+void LinkLabel::mousemove_event(MouseEvent& event)
+{
+    static const int extra_target_width = 3;
+    set_hovered(event.position().x() <= font().width(text()) + extra_target_width);
+}
+
 void LinkLabel::mousedown_event(MouseEvent& event)
 {
     if (event.button() != MouseButton::Left)
         return;
 
     Label::mousedown_event(event);
-    if (on_click) {
+    if (m_hovered && on_click) {
         on_click();
     }
 }
@@ -69,18 +84,10 @@ void LinkLabel::paint_event(PaintEvent& event)
         painter.draw_focus_rect(text_rect(), palette().focus_outline());
 }
 
-void LinkLabel::enter_event(Core::Event& event)
-{
-    Label::enter_event(event);
-    m_hovered = true;
-    update();
-}
-
 void LinkLabel::leave_event(Core::Event& event)
 {
     Label::leave_event(event);
-    m_hovered = false;
-    update();
+    set_hovered(false);
 }
 
 void LinkLabel::did_change_text()

--- a/Userland/Libraries/LibGUI/LinkLabel.h
+++ b/Userland/Libraries/LibGUI/LinkLabel.h
@@ -19,10 +19,10 @@ public:
 private:
     explicit LinkLabel(String text = {});
 
+    virtual void mousemove_event(MouseEvent&) override;
     virtual void mousedown_event(MouseEvent&) override;
     virtual void paint_event(PaintEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
-    virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;
     virtual void keydown_event(KeyEvent&) override;
     virtual void context_menu_event(ContextMenuEvent&) override;
@@ -31,6 +31,7 @@ private:
 
     void update_tooltip_if_needed();
     void setup_actions();
+    void set_hovered(bool);
 
     RefPtr<Menu> m_context_menu;
     RefPtr<Action> m_open_action;


### PR DESCRIPTION
Before: "It's clickable!" – "What?" – "IT'S CLICKABLE!" – "Yeah, but *what* is clickable?" – "That thing over there!"

---

![Bildschirmfoto_2021-10-21_19-56-51](https://user-images.githubusercontent.com/2690845/138331889-bd62dc43-8d29-47da-9972-c563fa89d4d0.png)

---

After: "This is empty space. It's not clickable."

---

![Bildschirmfoto_2021-10-21_19-55-50](https://user-images.githubusercontent.com/2690845/138331815-a9e9a7da-fe41-4141-bd43-30de732645ce.png)

---