### PR TITLE
Kernel: Add a zero check condition for .bss clear on Aarch64

### DIFF
--- a/Kernel/Prekernel/Arch/aarch64/boot.S
+++ b/Kernel/Prekernel/Arch/aarch64/boot.S
@@ -24,9 +24,12 @@ start:
   // Clear BSS.
   ldr x14, =start_of_bss
   ldr x15, =size_of_bss_divided_by_8
+  tst x15, x15
+  beq Linit
 Lbss_clear_loop:
   str xzr, [x14], #8
   subs x15, x15, #1
   bne Lbss_clear_loop
 
+Linit:
   b init


### PR DESCRIPTION
Currently, if the .bss section of Prekernel is empty, the code will
enter infinite loop. This is unlikely to happen but possible.

This small patch adds an additional check for 0 size of .bss section.