### PR TITLE
WindowServer: Support displaying window titles when there are no buttons

### DIFF
--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -245,8 +245,7 @@ void WindowFrame::paint_notification_frame(Gfx::Painter& painter)
 void WindowFrame::paint_tool_window_frame(Gfx::Painter& painter)
 {
     auto palette = WindowManager::the().palette();
-    auto leftmost_button_rect = m_buttons.is_empty() ? Gfx::IntRect() : m_buttons.last().relative_rect();
-    Gfx::WindowTheme::current().paint_tool_window_frame(painter, window_state_for_theme(), m_window.rect(), m_window.computed_title(), palette, leftmost_button_rect);
+    Gfx::WindowTheme::current().paint_tool_window_frame(painter, window_state_for_theme(), m_window.rect(), m_window.computed_title(), palette, leftmost_titlebar_button_rect());
 }
 
 void WindowFrame::paint_menubar(Gfx::Painter& painter)
@@ -281,8 +280,7 @@ void WindowFrame::paint_menubar(Gfx::Painter& painter)
 void WindowFrame::paint_normal_frame(Gfx::Painter& painter)
 {
     auto palette = WindowManager::the().palette();
-    auto leftmost_button_rect = m_buttons.is_empty() ? Gfx::IntRect() : m_buttons.last().relative_rect();
-    Gfx::WindowTheme::current().paint_normal_frame(painter, window_state_for_theme(), m_window.rect(), m_window.computed_title(), m_window.icon(), palette, leftmost_button_rect, menu_row_count(), m_window.is_modified());
+    Gfx::WindowTheme::current().paint_normal_frame(painter, window_state_for_theme(), m_window.rect(), m_window.computed_title(), m_window.icon(), palette, leftmost_titlebar_button_rect(), menu_row_count(), m_window.is_modified());
 
     if (m_window.menubar().has_menus() && m_window.should_show_menubar())
         paint_menubar(painter);
@@ -527,6 +525,16 @@ Gfx::IntRect WindowFrame::constrained_render_rect_to_screen(const Gfx::IntRect& 
     if (m_window.is_maximized() || m_window.tiled() != WindowTileType::None)
         return render_rect.intersected(Screen::closest_to_rect(rect()).rect());
     return render_rect;
+}
+
+Gfx::IntRect WindowFrame::leftmost_titlebar_button_rect() const
+{
+    if (!m_buttons.is_empty())
+        return m_buttons.last().relative_rect();
+
+    auto rect = titlebar_rect();
+    rect.translate_by(rect.width(), 0);
+    return rect;
 }
 
 Gfx::IntRect WindowFrame::render_rect() const

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -136,6 +136,7 @@ private:
     String computed_title() const;
 
     Gfx::IntRect constrained_render_rect_to_screen(const Gfx::IntRect&) const;
+    Gfx::IntRect leftmost_titlebar_button_rect() const;
 
     Window& m_window;
     NonnullOwnPtrVector<Button> m_buttons;


### PR DESCRIPTION
This allows the window title of the login window to display:
![title](https://user-images.githubusercontent.com/5600524/138459157-d7af7c43-c3cf-4cd0-99bf-3ad4a8301f45.png)

And the title is properly cut off with elipses when it is too long:
![titletitletitle](https://user-images.githubusercontent.com/5600524/138459206-52cf01bb-f0b2-4505-9ed2-a414fbcc3b91.png)
