### PR TITLE
AK: Improve BumpAllocator, fix some bugs

### DIFF
--- a/AK/BumpAllocator.h
+++ b/AK/BumpAllocator.h
@@ -51,12 +51,6 @@ public:
         return (void*)aligned_ptr;
     }
 
-    template<typename T>
-    T* allocate()
-    {
-        return (T*)allocate(sizeof(T), alignof(T));
-    }
-
     void deallocate_all()
     {
         if (!m_head_chunk)
@@ -160,9 +154,13 @@ public:
         destroy_all();
     }
 
-    T* allocate()
+    template<typename... Args>
+    T* allocate(Args&&... args)
     {
-        return Allocator::template allocate<T>();
+        auto ptr = (T*)Allocator::allocate(sizeof(T), alignof(T));
+        if (!ptr)
+            return nullptr;
+        return new (ptr) T { forward<Args>(args)... };
     }
 
     void deallocate_all()

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -333,13 +333,12 @@ public:
 
     ALWAYS_INLINE void append(T value)
     {
-        auto new_node = m_allocator.allocate();
-        VERIFY(new_node);
-        auto node_ptr = new (new_node) Node { move(value), nullptr, nullptr };
+        auto node_ptr = m_allocator.allocate(move(value));
+        VERIFY(node_ptr);
 
         if (!m_first) {
-            m_first = new_node;
-            m_last = new_node;
+            m_first = node_ptr;
+            m_last = node_ptr;
             return;
         }
 


### PR DESCRIPTION
Most prominently, this fixes a bug found by OSS Fuzz, which may have caused several issues at least [this issue in FuzzMarkdown](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38733&q=label%3AProj-serenity) (going through LibRegex, so it's likely that some of the Regex issues files by OSS Fuzz are the same bug).

~~Also, this PR does *not* fix the "awkward" design that the caller has to initialize the allocated memory themselves. A better solution would be something to do with a perfect-forwarding template, like `emplace` and `empend` often do. However, there's too many ways to mess that up, and I don't want to do that today.~~

EDIT: Apparently I do.