### PR TITLE
LibJS: Don't crash with VERIFY on generator functions

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -3371,11 +3371,11 @@ void ScopeNode::add_hoisted_function(NonnullRefPtr<FunctionDeclaration> declarat
     m_functions_hoistable_with_annexB_extension.append(move(declaration));
 }
 
-Value ImportStatement::execute(Interpreter& interpreter, GlobalObject&) const
+Value ImportStatement::execute(Interpreter& interpreter, GlobalObject& global_object) const
 {
     InterpreterNodeScope node_scope { interpreter, *this };
     dbgln("Modules are not fully supported yet!");
-    TODO();
+    interpreter.vm().throw_exception<InternalError>(global_object, ErrorType::NotImplemented, "'import' in modules");
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -697,7 +697,8 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
 
         return normal_completion(GeneratorObject::create(global_object(), result, this, vm.running_execution_context().lexical_environment, bytecode_interpreter->snapshot_frame()));
     } else {
-        VERIFY(m_kind != FunctionKind::Generator);
+        if (m_kind != FunctionKind::Regular)
+            return vm.throw_completion<InternalError>(global_object(), ErrorType::NotImplemented, "Non regular function execution in AST interpreter");
         OwnPtr<Interpreter> local_interpreter;
         Interpreter* ast_interpreter = vm.interpreter_if_exists();
 

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -72,6 +72,7 @@
     M(NotAnObjectOrString, "{} is neither an object nor a string")                                                                      \
     M(NotAString, "{} is not a string")                                                                                                 \
     M(NotASymbol, "{} is not a symbol")                                                                                                 \
+    M(NotImplemented, "TODO({} is not implemented in LibJS)")                                                                           \
     M(NotIterable, "{} is not iterable")                                                                                                \
     M(NotObjectCoercible, "{} cannot be converted to an object")                                                                        \
     M(NotUndefined, "{} is not undefined")                                                                                              \


### PR DESCRIPTION
See the other relevant PRs:
https://github.com/SerenityOS/discord-bot/pull/281
https://github.com/linusg/libjs-website/pull/11
https://github.com/linusg/libjs-test262/pull/43

I believe most of the order does not matter but the libjs-test262 should be after the website and bot else those will hit unknown error types.

This should all work correctly but testing this is a huge hassle :disappointed: 