### PR TITLE
TelnetServer: Defer removal of client from clients HashMap

### DIFF
--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -135,7 +135,9 @@ int main(int argc, char** argv)
         run_command(ptm_fd, command);
 
         auto client = Client::create(id, move(client_socket), ptm_fd);
-        client->on_exit = [&clients, id] { clients.remove(id); };
+        client->on_exit = [&clients, id] {
+            Core::deferred_invoke([&clients, id] { clients.remove(id); });
+        };
         clients.set(id, client);
     };
 


### PR DESCRIPTION
This is necessary to avoid trying to destruct the on_ready_to_read
function from inside the function.