### PR TITLE
EchoServer: Defer removal of client from clients HashMap

### DIFF
--- a/Userland/Services/EchoServer/main.cpp
+++ b/Userland/Services/EchoServer/main.cpp
@@ -62,8 +62,10 @@ int main(int argc, char** argv)
 
         auto client = Client::create(id, move(client_socket));
         client->on_exit = [&clients, id] {
-            clients.remove(id);
-            outln("Client {} disconnected", id);
+            Core::deferred_invoke([&clients, id] {
+                clients.remove(id);
+                outln("Client {} disconnected", id);
+            });
         };
         clients.set(id, client);
     };


### PR DESCRIPTION
This is necessary to avoid trying to destruct the on_ready_to_read
function from inside the function.