### PR TITLE
LibCore: Fix EventLoop::post_event use-after-free during destruction

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -108,6 +108,7 @@ private:
     Vector<QueuedEvent, 64> m_queued_events;
     static pid_t s_pid;
 
+    bool m_destroying { false };
     bool m_exit_requested { false };
     int m_exit_code { 0 };
 


### PR DESCRIPTION
It's possible that Event destructors trigger other deferred invocations 
that end up calling EventLoop::post_event. This is usually not a        
problem unless this is triggered when the EventLoop itself is           
destructed (while destructing m_queued_events). At this point the       
EventLoop object is still semi-alive, but some members were already     
destructed while others are still valid.                                
                                                                        
So, when we start destructing the EventLoop we'll set a flag that       
we can check in EventLoop::post_event, and if it is true we simply      
return without doing anything.

Fixes #10601, #10084