### PR TITLE
Base: Make /usr/Tests read-only since it's now suid capable

### DIFF
--- a/Base/etc/fstab
+++ b/Base/etc/fstab
@@ -8,6 +8,6 @@
 /root	/root	bind	bind,nodev,nosuid
 /var	/var	bind	bind,nodev,nosuid
 /www	/www	bind	bind,nodev,nosuid
-/usr/Tests	/usr/Tests	bind	bind,nodev
+/usr/Tests	/usr/Tests	bind	bind,nodev,ro
 
 none	/tmp	tmp	nodev,nosuid


### PR DESCRIPTION
Commit cf0dbc906 recently added the ability for setuid binaries to be
located in /usr/Tests. This should really now be read only to mitigate
the potential misuse of any of the setuid binaries.