### PR TITLE
LibC: Fix `scanf()`'s `%n` specifier

### DIFF
--- a/Tests/LibC/TestScanf.cpp
+++ b/Tests/LibC/TestScanf.cpp
@@ -173,6 +173,8 @@ const TestSuite test_suites[] {
     // Note: '9223372036854775806' is the max value for 'long long'.
     { "%lld", "9223372036854775805", 1, 1, { longlongarg0 }, { to_value_t(9223372036854775805LL) } },
     { "%llu", "9223372036854775810", 1, 1, { unsignedlonglongarg0 }, { to_value_t(9223372036854775810ULL) } },
+    { "%n", "", 0, 1, { intarg0 }, { to_value_t(0) } },
+    { "%d %n", "1 a", 1, 2, { intarg0, intarg1 }, { to_value_t(1), to_value_t(2) } },
 };
 
 bool g_any_failed = false;

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -611,8 +611,9 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
                 ++elements_matched;
             break;
         case ConversionSpecifier::OutputNumberOfBytes: {
+            input_lexer.ignore_while(isspace);
             if (!suppress_assignment) {
-                auto* ptr = va_arg(ap, int*);
+                auto* ptr = va_arg(copy, int*);
                 *ptr = input_lexer.tell();
             }
             break;


### PR DESCRIPTION
Fixes two LibC bugs in `scanf()` with the `%n` specifier, adds a regression test and fixes the accompanying test suite in one go.

As a result, Grim Fandango no longer crashes and goes in-game! (Hint: take a look at #10515 as well)

![Screenshot_20211025_001449](https://user-images.githubusercontent.com/3210731/138615519-fbd04ba7-ff84-4cc0-9e9d-b718a8fab20e.png)