### PR TITLE
Ports: byacc+gmp+m4: Split auth_opts strings into array elements

### DIFF
--- a/Ports/byacc/package.sh
+++ b/Ports/byacc/package.sh
@@ -6,4 +6,4 @@ https://invisible-mirror.net/archives/byacc/byacc-${version}.tgz.asc byacc-${ver
 useconfigure=true
 auth_type="sig"
 auth_import_key="C52048C0C0748FEE227D47A2702353E0F7E48EDB"
-auth_opts=("byacc-${version}.tgz.asc byacc-${version}.tgz")
+auth_opts=("byacc-${version}.tgz.asc" "byacc-${version}.tgz")

--- a/Ports/gmp/package.sh
+++ b/Ports/gmp/package.sh
@@ -6,4 +6,4 @@ files="https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2 gmp-${version}.t
 https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2.sig gmp-${version}.tar.bz2.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg gmp-${version}.tar.bz2.sig")
+auth_opts=("--keyring" "./gnu-keyring.gpg" "gmp-${version}.tar.bz2.sig")

--- a/Ports/m4/package.sh
+++ b/Ports/m4/package.sh
@@ -6,4 +6,4 @@ files="https://ftpmirror.gnu.org/gnu/m4/m4-${version}.tar.gz m4-${version}.tar.g
 https://ftpmirror.gnu.org/gnu/m4/m4-${version}.tar.gz.sig m4-${version}.tar.gz.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
-auth_opts=("--keyring" "./gnu-keyring.gpg m4-${version}.tar.gz.sig")
+auth_opts=("--keyring" "./gnu-keyring.gpg" "m4-${version}.tar.gz.sig")


### PR DESCRIPTION
A few of these `auth_opts` strings were missed/malformed when `auth_opts` was converted from a string to an array in #10222.
