### PR TITLE
Utilities: Add delay to yes between messages

### DIFF
--- a/Userland/Utilities/yes.cpp
+++ b/Userland/Utilities/yes.cpp
@@ -17,10 +17,15 @@ int main(int argc, char** argv)
 
     const char* string = "yes";
 
+    static int delay = 0;
+
     Core::ArgsParser args_parser;
+    args_parser.add_option(delay, "The amount of time to wait between each message", "delay", 'n', "milliseconds");
     args_parser.add_positional_argument(string, "String to output (defaults to 'yes')", "string", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
-    for (;;)
+    for (;;) {
         puts(string);
+        usleep(delay * 1000);
+    }
 }


### PR DESCRIPTION
This PR adds a delay option to the `yes` utility which allows you to print at a certain rate. This makes the program more practical.