### PR TITLE
LibGUI+HackStudio: Better autocomplete, especially in GML

### DIFF
--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -22,6 +22,7 @@ inline bool encode(IPC::Encoder& encoder, const GUI::AutocompleteProvider::Entry
     encoder << (u64)response.partial_input_length;
     encoder << (u32)response.language;
     encoder << response.display_text;
+    encoder << (u32)response.hide_autocomplete_after_applying;
     return true;
 }
 
@@ -30,14 +31,17 @@ inline bool decode(IPC::Decoder& decoder, GUI::AutocompleteProvider::Entry& resp
 {
     u32 language = 0;
     u64 partial_input_length = 0;
+    u32 hide_autocomplete_after_applying = 0;
     bool ok = decoder.decode(response.completion)
         && decoder.decode(partial_input_length)
         && decoder.decode(language)
-        && decoder.decode(response.display_text);
+        && decoder.decode(response.display_text)
+        && decoder.decode(hide_autocomplete_after_applying);
 
     if (ok) {
         response.language = static_cast<GUI::AutocompleteProvider::Language>(language);
         response.partial_input_length = partial_input_length;
+        response.hide_autocomplete_after_applying = static_cast<GUI::AutocompleteProvider::Entry::HideAutocompleteAfterApplying>(hide_autocomplete_after_applying);
     }
 
     return ok;

--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -22,6 +22,7 @@ inline bool encode(IPC::Encoder& encoder, const GUI::AutocompleteProvider::Entry
     encoder << (u64)response.partial_input_length;
     encoder << (u32)response.kind;
     encoder << (u32)response.language;
+    encoder << response.display_text;
     return true;
 }
 
@@ -34,7 +35,8 @@ inline bool decode(IPC::Decoder& decoder, GUI::AutocompleteProvider::Entry& resp
     bool ok = decoder.decode(response.completion)
         && decoder.decode(partial_input_length)
         && decoder.decode(kind)
-        && decoder.decode(language);
+        && decoder.decode(language)
+        && decoder.decode(response.display_text);
 
     if (ok) {
         response.kind = static_cast<GUI::AutocompleteProvider::CompletionKind>(kind);

--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -20,7 +20,6 @@ inline bool encode(IPC::Encoder& encoder, const GUI::AutocompleteProvider::Entry
 {
     encoder << response.completion;
     encoder << (u64)response.partial_input_length;
-    encoder << (u32)response.kind;
     encoder << (u32)response.language;
     encoder << response.display_text;
     return true;
@@ -29,17 +28,14 @@ inline bool encode(IPC::Encoder& encoder, const GUI::AutocompleteProvider::Entry
 template<>
 inline bool decode(IPC::Decoder& decoder, GUI::AutocompleteProvider::Entry& response)
 {
-    u32 kind = 0;
     u32 language = 0;
     u64 partial_input_length = 0;
     bool ok = decoder.decode(response.completion)
         && decoder.decode(partial_input_length)
-        && decoder.decode(kind)
         && decoder.decode(language)
         && decoder.decode(response.display_text);
 
     if (ok) {
-        response.kind = static_cast<GUI::AutocompleteProvider::CompletionKind>(kind);
         response.language = static_cast<GUI::AutocompleteProvider::Language>(language);
         response.partial_input_length = partial_input_length;
     }

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -693,7 +693,7 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_a
         if (Core::File::is_directory(LexicalPath::join(full_dir, path).string())) {
             // FIXME: Don't dismiss the autocomplete when filling these suggestions.
             auto completion = String::formatted("{}{}{}/", prefix, include_dir, path);
-            options.empend(completion, include_dir.length() + partial_basename.length() + 1, GUI::AutocompleteProvider::Language::Cpp, path);
+            options.empend(completion, include_dir.length() + partial_basename.length() + 1, GUI::AutocompleteProvider::Language::Cpp, path, GUI::AutocompleteProvider::Entry::HideAutocompleteAfterApplying::No);
         } else if (path.ends_with(".h")) {
             // FIXME: Place the cursor after the trailing > or ", even if it was
             //        already typed.

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -676,7 +676,7 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_a
         include_dir = partial_include.substring_view(1, last_slash.value());
     }
 
-    auto full_dir = String::formatted("{}{}", include_root, include_dir);
+    auto full_dir = LexicalPath::join(include_root, include_dir).string();
     dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "searching path: {}, partial_basename: {}", full_dir, partial_basename);
 
     Core::DirIterator it(full_dir, Core::DirIterator::Flags::SkipDots);
@@ -691,8 +691,8 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_a
             //        already typed.
             auto prefix = include_type == System ? "<" : "\"";
             auto suffix = include_type == System ? ">" : "\"";
-            auto completion = String::formatted("{}{}{}", prefix, path, already_has_suffix ? "" : suffix);
-            options.append({ completion, partial_basename.length() + 1, GUI::AutocompleteProvider::Language::Cpp, path });
+            auto completion = String::formatted("{}{}{}{}", prefix, include_dir, path, already_has_suffix ? "" : suffix);
+            options.append({ completion, include_dir.length() + partial_basename.length() + 1, GUI::AutocompleteProvider::Language::Cpp, path });
         }
     }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -670,7 +670,8 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_a
         if (!(path.ends_with(".h") || Core::File::is_directory(LexicalPath::join(full_dir, path).string())))
             continue;
         if (path.starts_with(partial_basename)) {
-            options.append({ path, partial_basename.length(), include_type, GUI::AutocompleteProvider::Language::Cpp });
+            auto completion = include_type == GUI::AutocompleteProvider::CompletionKind::ProjectInclude ? String::formatted("<{}>", path) : String::formatted("\"{}\"", path);
+            options.append({ completion, partial_basename.length() + 1, include_type, GUI::AutocompleteProvider::Language::Cpp, path });
         }
     }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.h
@@ -129,7 +129,7 @@ private:
     OwnPtr<DocumentData> create_document_data(String&& text, const String& filename);
     Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_property(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
     Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_name(const DocumentData&, const ASTNode&, Optional<Token> containing_token) const;
-    Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_include(const DocumentData&, Token include_path_token);
+    Optional<Vector<GUI::AutocompleteProvider::Entry>> try_autocomplete_include(const DocumentData&, Token include_path_token, Cpp::Position const& cursor_position) const;
     static bool is_symbol_available(const Symbol&, const Vector<StringView>& current_scope, const Vector<StringView>& reference_scope);
     Optional<FunctionParamsHint> get_function_params_hint(DocumentData const&, FunctionCall&, size_t argument_index);
 

--- a/Userland/DevTools/HackStudio/Locator.h
+++ b/Userland/DevTools/HackStudio/Locator.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <LibGUI/AutocompleteProvider.h>
 #include <LibGUI/Widget.h>
 
 namespace HackStudio {

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -258,7 +258,7 @@ static HashMap<StringView, ObjectClassRegistration*>& object_classes()
     return *map;
 }
 
-ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class)
+ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<RefPtr<Object>()> factory, ObjectClassRegistration* parent_class)
     : m_class_name(class_name)
     , m_factory(move(factory))
     , m_parent_class(parent_class)

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -20,6 +20,13 @@
 
 namespace Core {
 
+#define REGISTER_ABSTRACT_CORE_OBJECT(namespace_, class_name)                                                                 \
+    namespace Core {                                                                                                          \
+    namespace Registration {                                                                                                  \
+    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name, []() { return RefPtr<Object>(); }); \
+    }                                                                                                                         \
+    }
+
 #define REGISTER_CORE_OBJECT(namespace_, class_name)                                                                                             \
     namespace Core {                                                                                                                             \
     namespace Registration {                                                                                                                     \

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -32,12 +32,12 @@ class ObjectClassRegistration {
     AK_MAKE_NONMOVABLE(ObjectClassRegistration);
 
 public:
-    ObjectClassRegistration(StringView class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
+    ObjectClassRegistration(StringView class_name, Function<RefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
     ~ObjectClassRegistration();
 
     String class_name() const { return m_class_name; }
     const ObjectClassRegistration* parent_class() const { return m_parent_class; }
-    NonnullRefPtr<Object> construct() const { return m_factory(); }
+    RefPtr<Object> construct() const { return m_factory(); }
     bool is_derived_from(const ObjectClassRegistration& base_class) const;
 
     static void for_each(Function<void(const ObjectClassRegistration&)>);
@@ -45,7 +45,7 @@ public:
 
 private:
     StringView m_class_name;
-    Function<NonnullRefPtr<Object>()> m_factory;
+    Function<RefPtr<Object>()> m_factory;
     ObjectClassRegistration* m_parent_class { nullptr };
 };
 

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -181,10 +181,10 @@ void AutocompleteBox::apply_suggestion()
         return;
 
     auto suggestion_index = m_suggestion_view->model()->index(selected_index.row());
-    auto suggestion = suggestion_index.data((GUI::ModelRole)AutocompleteSuggestionModel::InternalRole::Completion).to_string();
+    auto completion = suggestion_index.data((GUI::ModelRole)AutocompleteSuggestionModel::InternalRole::Completion).to_string();
     size_t partial_length = suggestion_index.data((GUI::ModelRole)AutocompleteSuggestionModel::InternalRole::PartialInputLength).to_i64();
 
-    VERIFY(suggestion.length() >= partial_length);
+    VERIFY(completion.length() >= partial_length);
     if (!m_editor->has_selection()) {
         auto cursor = m_editor->cursor();
         VERIFY(m_editor->cursor().column() >= partial_length);
@@ -193,16 +193,6 @@ void AutocompleteBox::apply_suggestion()
         auto end = cursor;
         m_editor->delete_text_range(TextRange(start, end));
     }
-
-    auto completion_kind = (GUI::AutocompleteProvider::CompletionKind)suggestion_index.data((GUI::ModelRole)AutocompleteSuggestionModel::InternalRole::Kind).as_u32();
-
-    String completion;
-    if (suggestion.ends_with(".h") && completion_kind == GUI::AutocompleteProvider::CompletionKind::SystemInclude)
-        completion = String::formatted("{}{}", suggestion, ">");
-    else if (suggestion.ends_with(".h") && completion_kind == GUI::AutocompleteProvider::CompletionKind::ProjectInclude)
-        completion = String::formatted("{}{}", suggestion, "\"");
-    else
-        completion = suggestion;
 
     m_editor->insert_at_cursor_or_replace_selection(completion);
 }

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -32,7 +32,6 @@ public:
     enum InternalRole {
         __ModelRoleCustom = (int)GUI::ModelRole::Custom,
         PartialInputLength,
-        Kind,
         Completion,
     };
 
@@ -64,9 +63,6 @@ public:
                 return {};
             }
         }
-
-        if ((int)role == InternalRole::Kind)
-            return (u32)suggestion.kind;
 
         if ((int)role == InternalRole::PartialInputLength)
             return (i64)suggestion.partial_input_length;

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -112,11 +112,12 @@ void AutocompleteBox::update_suggestions(Vector<AutocompleteProvider::Entry>&& s
         model.set_suggestions(move(suggestions));
     } else {
         m_suggestion_view->set_model(adopt_ref(*new AutocompleteSuggestionModel(move(suggestions))));
-        if (has_suggestions)
-            m_suggestion_view->set_cursor(m_suggestion_view->model()->index(0), GUI::AbstractView::SelectionUpdate::Set);
     }
 
     m_suggestion_view->model()->invalidate();
+
+    if (has_suggestions)
+        m_suggestion_view->set_cursor(m_suggestion_view->model()->index(0), GUI::AbstractView::SelectionUpdate::Set);
 
     m_suggestion_view->set_visible(has_suggestions);
     m_no_suggestions_view->set_visible(!has_suggestions);
@@ -136,8 +137,6 @@ void AutocompleteBox::show(Gfx::IntPoint suggestion_box_location)
         return;
 
     m_popup_window->move_to(suggestion_box_location);
-    if (!is_visible())
-        m_suggestion_view->move_cursor(GUI::AbstractView::CursorMovement::Home, GUI::AbstractTableView::SelectionUpdate::Set);
     m_popup_window->show();
 }
 

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -8,6 +8,7 @@
 
 #include <LibGUI/Forward.h>
 #include <LibGUI/Label.h>
+#include <LibGUI/TableView.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Window.h>
 #include <LibIPC/Decoder.h>

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -20,13 +20,6 @@ class AutocompleteProvider {
 public:
     virtual ~AutocompleteProvider() { }
 
-    enum class CompletionKind {
-        Identifier,
-        PreprocessorDefinition,
-        SystemInclude,
-        ProjectInclude,
-    };
-
     enum class Language {
         Unspecified,
         Cpp,
@@ -35,7 +28,6 @@ public:
     struct Entry {
         String completion;
         size_t partial_input_length { 0 };
-        CompletionKind kind { CompletionKind::Identifier };
         Language language { Language::Unspecified };
         String display_text {};
     };

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -32,6 +32,12 @@ public:
         size_t partial_input_length { 0 };
         Language language { Language::Unspecified };
         String display_text {};
+
+        enum class HideAutocompleteAfterApplying {
+            No,
+            Yes,
+        };
+        HideAutocompleteAfterApplying hide_autocomplete_after_applying { HideAutocompleteAfterApplying::Yes };
     };
 
     struct ProjectLocation {
@@ -89,7 +95,7 @@ public:
     bool has_suggestions() { return m_suggestion_view->model()->row_count() > 0; }
     void next_suggestion();
     void previous_suggestion();
-    void apply_suggestion();
+    AutocompleteProvider::Entry::HideAutocompleteAfterApplying apply_suggestion();
 
 private:
     WeakPtr<TextEditor> m_editor;

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -37,6 +37,7 @@ public:
         size_t partial_input_length { 0 };
         CompletionKind kind { CompletionKind::Identifier };
         Language language { Language::Unspecified };
+        String display_text {};
     };
 
     struct ProjectLocation {

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -86,6 +86,7 @@ public:
     void show(Gfx::IntPoint suggestion_box_location);
     void close();
 
+    bool has_suggestions() { return m_suggestion_view->model()->row_count() > 0; }
     void next_suggestion();
     void previous_suggestion();
     void apply_suggestion();

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGUI/Forward.h>
+#include <LibGUI/Label.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Window.h>
 #include <LibIPC/Decoder.h>
@@ -92,6 +93,7 @@ private:
     WeakPtr<TextEditor> m_editor;
     RefPtr<GUI::Window> m_popup_window;
     RefPtr<GUI::TableView> m_suggestion_view;
+    RefPtr<GUI::Label> m_no_suggestions_view;
 };
 
 }

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -10,8 +10,8 @@
 #include <LibGfx/Orientation.h>
 #include <stdio.h>
 
-REGISTER_CORE_OBJECT(GUI, HorizontalBoxLayout)
-REGISTER_CORE_OBJECT(GUI, VerticalBoxLayout)
+REGISTER_LAYOUT(GUI, HorizontalBoxLayout)
+REGISTER_LAYOUT(GUI, VerticalBoxLayout)
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -168,9 +168,6 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         }
         if (can_have_declared_layout(class_names.last()) && "layout"sv.starts_with(identifier_string))
             identifier_entries.empend("layout: ", identifier_string.length(), Language::Unspecified, "layout");
-        // No need to suggest anything if it's already completely typed out!
-        if (identifier_entries.size() == 1 && identifier_entries.first().completion == identifier_string)
-            identifier_entries.clear();
         break;
     }
     case AfterClassName: {

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -189,6 +189,9 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
                 }
             }
         }
+        if (can_have_declared_layout(class_names.last()))
+            identifier_entries.empend("layout: ", 0u, Language::Unspecified, "layout");
+
         Core::ObjectClassRegistration::for_each([&](const Core::ObjectClassRegistration& registration) {
             if (!registration.is_derived_from(widget_class))
                 return;

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -198,7 +198,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
 
         break;
     }
-    case InIdentifier: {
+    case InIdentifier:
         if (after_token_on_same_line) {
             // After an identifier, but with extra space
             // TODO: Maybe suggest a colon?
@@ -207,8 +207,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
 
         register_properties_and_widgets_matching_pattern(make_fuzzy(identifier_string), identifier_string.length());
         break;
-    }
-    case AfterClassName: {
+    case AfterClassName:
         if (last_seen_token && last_seen_token->m_end.line == cursor.line()) {
             if (last_seen_token->m_type != GUI::GMLToken::Type::Identifier || last_seen_token->m_end.column != cursor.column()) {
                 // Inside braces, but on the same line as some other stuff (and not the continuation of one!)
@@ -219,7 +218,6 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
 
         register_properties_and_widgets_matching_pattern("*", 0u);
         break;
-    }
     case AfterIdentifier:
         if (last_seen_token && last_seen_token->m_end.line != cursor.line())
             break;

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, thislooksfun <tlf@thislooks.fun>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -155,9 +155,10 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
             identifier_entries.empend("layout: ", partial_input_length, Language::Unspecified, "layout");
     };
 
+    bool after_token_on_same_line = last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line();
     switch (state) {
     case Free:
-        if (last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
+        if (after_token_on_same_line) {
             // After some token, but with extra space, not on a new line.
             // Nothing to put here.
             break;
@@ -168,7 +169,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     case InClassName: {
         if (class_names.is_empty())
             break;
-        if (last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
+        if (after_token_on_same_line) {
             // After a class name, but haven't seen braces.
             // TODO: Suggest braces?
             break;
@@ -184,7 +185,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         break;
     }
     case InIdentifier: {
-        if (last_seen_token && last_seen_token->m_end.column != cursor.column() && last_seen_token->m_end.line == cursor.line()) {
+        if (after_token_on_same_line) {
             // After an identifier, but with extra space
             // TODO: Maybe suggest a colon?
             break;

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -202,8 +202,15 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
                 break;
             }
         }
-        if (!class_names.is_empty())
+        if (!class_names.is_empty()) {
             register_class_properties_matching_pattern("*", 0u);
+
+            auto parent_registration = Core::ObjectClassRegistration::find(class_names.last());
+            if (parent_registration && parent_registration->is_derived_from(layout_class)) {
+                // Layouts can't have child classes, so why suggest them?
+                break;
+            }
+        }
 
         Core::ObjectClassRegistration::for_each([&](const Core::ObjectClassRegistration& registration) {
             if (!registration.is_derived_from(widget_class))

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -145,10 +145,11 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         }
         auto registration = Core::ObjectClassRegistration::find(class_names.last());
         if (registration && registration->is_derived_from(widget_class)) {
-            auto instance = registration->construct();
-            for (auto& it : instance->properties()) {
-                if (it.key.starts_with(identifier_string))
-                    identifier_entries.empend(it.key, identifier_string.length());
+            if (auto instance = registration->construct()) {
+                for (auto& it : instance->properties()) {
+                    if (it.key.starts_with(identifier_string))
+                        identifier_entries.empend(it.key, identifier_string.length());
+                }
             }
         }
         if (can_have_declared_layout(class_names.last()) && "layout"sv.starts_with(identifier_string))
@@ -169,10 +170,11 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         if (!class_names.is_empty()) {
             auto registration = Core::ObjectClassRegistration::find(class_names.last());
             if (registration && registration->is_derived_from(widget_class)) {
-                auto instance = registration->construct();
-                for (auto& it : instance->properties()) {
-                    if (!it.value->is_readonly())
-                        identifier_entries.empend(it.key, 0u);
+                if (auto instance = registration->construct()) {
+                    for (auto& it : instance->properties()) {
+                        if (!it.value->is_readonly())
+                            identifier_entries.empend(it.key, 0u);
+                    }
                 }
             }
         }

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -152,7 +152,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         }
 
         if (can_have_declared_layout(class_names.last()) && "layout"sv.matches(pattern))
-            identifier_entries.empend("layout: ", partial_input_length, Language::Unspecified, "layout");
+            identifier_entries.empend("layout: ", partial_input_length, Language::Unspecified, "layout", AutocompleteProvider::Entry::HideAutocompleteAfterApplying::No);
     };
 
     auto register_properties_and_widgets_matching_pattern = [&](String pattern, size_t partial_input_length) {

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -105,6 +105,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
     }
 
     auto& widget_class = *Core::ObjectClassRegistration::find("GUI::Widget");
+    auto& layout_class = *Core::ObjectClassRegistration::find("GUI::Layout");
 
     Vector<GUI::AutocompleteProvider::Entry> class_entries, identifier_entries;
     switch (state) {
@@ -190,10 +191,9 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
             break;
         if (identifier_string == "layout") {
             Core::ObjectClassRegistration::for_each([&](const Core::ObjectClassRegistration& registration) {
-                if (!registration.is_derived_from(widget_class))
+                if (&registration == &layout_class || !registration.is_derived_from(layout_class))
                     return;
-                if (registration.class_name().contains("Layout"))
-                    class_entries.empend(String::formatted("@{}", registration.class_name()), 0u);
+                class_entries.empend(String::formatted("@{}", registration.class_name()), 0u);
             });
         }
         break;

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -158,7 +158,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
             break;
         }
         auto registration = Core::ObjectClassRegistration::find(class_names.last());
-        if (registration && registration->is_derived_from(widget_class)) {
+        if (registration && (registration->is_derived_from(widget_class) || registration->is_derived_from(layout_class))) {
             if (auto instance = registration->construct()) {
                 for (auto& it : instance->properties()) {
                     if (it.key.starts_with(identifier_string))
@@ -183,7 +183,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         }
         if (!class_names.is_empty()) {
             auto registration = Core::ObjectClassRegistration::find(class_names.last());
-            if (registration && registration->is_derived_from(widget_class)) {
+            if (registration && (registration->is_derived_from(widget_class) || registration->is_derived_from(layout_class))) {
                 if (auto instance = registration->construct()) {
                     for (auto& it : instance->properties()) {
                         if (!it.value->is_readonly())

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -186,9 +186,8 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
         break;
     }
     case AfterIdentifier:
-        if (last_seen_token && last_seen_token->m_end.line != cursor.line()) {
+        if (last_seen_token && last_seen_token->m_end.line != cursor.line())
             break;
-        }
         if (identifier_string == "layout") {
             Core::ObjectClassRegistration::for_each([&](const Core::ObjectClassRegistration& registration) {
                 if (!registration.is_derived_from(widget_class))

--- a/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GMLAutocompleteProvider.cpp
@@ -162,12 +162,12 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
             if (auto instance = registration->construct()) {
                 for (auto& it : instance->properties()) {
                     if (it.key.starts_with(identifier_string))
-                        identifier_entries.empend(it.key, identifier_string.length());
+                        identifier_entries.empend(String::formatted("{}: ", it.key), identifier_string.length(), Language::Unspecified, it.key);
                 }
             }
         }
         if (can_have_declared_layout(class_names.last()) && "layout"sv.starts_with(identifier_string))
-            identifier_entries.empend("layout", identifier_string.length());
+            identifier_entries.empend("layout: ", identifier_string.length(), Language::Unspecified, "layout");
         // No need to suggest anything if it's already completely typed out!
         if (identifier_entries.size() == 1 && identifier_entries.first().completion == identifier_string)
             identifier_entries.clear();
@@ -187,7 +187,7 @@ void GMLAutocompleteProvider::provide_completions(Function<void(Vector<Entry>)> 
                 if (auto instance = registration->construct()) {
                     for (auto& it : instance->properties()) {
                         if (!it.value->is_readonly())
-                            identifier_entries.empend(it.key, 0u);
+                            identifier_entries.empend(String::formatted("{}: ", it.key), 0u, Language::Unspecified, it.key);
                     }
                 }
             }

--- a/Userland/Libraries/LibGUI/Layout.cpp
+++ b/Userland/Libraries/LibGUI/Layout.cpp
@@ -9,6 +9,8 @@
 #include <LibGUI/Layout.h>
 #include <LibGUI/Widget.h>
 
+REGISTER_ABSTRACT_CORE_OBJECT(GUI, Layout)
+
 namespace GUI {
 
 Layout::Layout()

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -14,6 +14,20 @@
 #include <LibGUI/Margins.h>
 #include <LibGfx/Forward.h>
 
+namespace Core {
+namespace Registration {
+extern Core::ObjectClassRegistration registration_Layout;
+}
+}
+
+#define REGISTER_LAYOUT(namespace_, class_name)                                                                                                   \
+    namespace Core {                                                                                                                              \
+    namespace Registration {                                                                                                                      \
+    Core::ObjectClassRegistration registration_##class_name(                                                                                      \
+        #namespace_ "::" #class_name, []() { return static_ptr_cast<Core::Object>(namespace_::class_name::construct()); }, &registration_Layout); \
+    }                                                                                                                                             \
+    }
+
 namespace GUI {
 
 class Layout : public Core::Object {

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1987,7 +1987,10 @@ void TextEditor::set_should_autocomplete_automatically(bool value)
 
     if (value) {
         VERIFY(m_autocomplete_provider);
-        m_autocomplete_timer = Core::Timer::create_single_shot(m_automatic_autocomplete_delay_ms, [this] { try_show_autocomplete(UserRequestedAutocomplete::No); });
+        m_autocomplete_timer = Core::Timer::create_single_shot(m_automatic_autocomplete_delay_ms, [this] {
+            if (m_autocomplete_box && !m_autocomplete_box->is_visible())
+                try_show_autocomplete(UserRequestedAutocomplete::No);
+        });
         return;
     }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -740,12 +740,12 @@ void TextEditor::keydown_event(KeyEvent& event)
 {
     if (m_autocomplete_box && m_autocomplete_box->is_visible() && (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Tab)) {
         m_autocomplete_box->apply_suggestion();
-        m_autocomplete_box->close();
+        hide_autocomplete();
         return;
     }
 
     if (m_autocomplete_box && m_autocomplete_box->is_visible() && event.key() == KeyCode::Key_Escape) {
-        m_autocomplete_box->close();
+        hide_autocomplete();
         return;
     }
 
@@ -826,13 +826,13 @@ void TextEditor::keydown_event(KeyEvent& event)
 
     if (event.modifiers() == Mod_Shift && event.key() == KeyCode::Key_Delete) {
         if (m_autocomplete_box)
-            m_autocomplete_box->close();
+            hide_autocomplete();
         return;
     }
 
     if (event.key() == KeyCode::Key_Delete) {
         if (m_autocomplete_box)
-            m_autocomplete_box->close();
+            hide_autocomplete();
         return;
     }
 
@@ -840,7 +840,7 @@ void TextEditor::keydown_event(KeyEvent& event)
         if (!is_editable())
             return;
         if (m_autocomplete_box)
-            m_autocomplete_box->close();
+            hide_autocomplete();
         if (has_selection()) {
             delete_selection();
             did_update_selection();
@@ -1481,7 +1481,13 @@ void TextEditor::force_update_autocomplete(Function<void()> callback)
 
 void TextEditor::hide_autocomplete_if_needed()
 {
-    if (m_autocomplete_box && !m_should_keep_autocomplete_box) {
+    if (!m_should_keep_autocomplete_box)
+        hide_autocomplete();
+}
+
+void TextEditor::hide_autocomplete()
+{
+    if (m_autocomplete_box) {
         m_autocomplete_box->close();
         if (m_autocomplete_timer)
             m_autocomplete_timer->stop();
@@ -1913,7 +1919,7 @@ void TextEditor::set_autocomplete_provider(OwnPtr<AutocompleteProvider>&& provid
             m_autocomplete_box = make<AutocompleteBox>(*this);
     }
     if (m_autocomplete_box)
-        m_autocomplete_box->close();
+        hide_autocomplete();
 }
 
 EditingEngine const* TextEditor::editing_engine() const

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -814,7 +814,7 @@ void TextEditor::keydown_event(KeyEvent& event)
 
     if (is_multi_line() && !event.shift() && !event.alt() && event.ctrl() && event.key() == KeyCode::Key_Space) {
         if (m_autocomplete_provider) {
-            try_show_autocomplete();
+            try_show_autocomplete(UserRequestedAutocomplete::Yes);
             update_autocomplete.disarm();
             return;
         }
@@ -1456,14 +1456,14 @@ void TextEditor::undefer_reflow()
     }
 }
 
-void TextEditor::try_show_autocomplete()
+void TextEditor::try_show_autocomplete(UserRequestedAutocomplete user_requested_autocomplete)
 {
     if (m_autocomplete_provider) {
         m_autocomplete_provider->provide_completions([&](auto completions) {
             auto has_completions = !completions.is_empty();
             m_autocomplete_box->update_suggestions(move(completions));
             auto position = content_rect_for_position(cursor()).translated(0, -visible_content_rect().y()).bottom_right().translated(screen_relative_rect().top_left().translated(ruler_width(), 0).translated(10, 5));
-            if (has_completions)
+            if (has_completions || user_requested_autocomplete == Yes)
                 m_autocomplete_box->show(position);
         });
     }
@@ -1958,7 +1958,7 @@ void TextEditor::set_should_autocomplete_automatically(bool value)
 
     if (value) {
         VERIFY(m_autocomplete_provider);
-        m_autocomplete_timer = Core::Timer::create_single_shot(m_automatic_autocomplete_delay_ms, [this] { try_show_autocomplete(); });
+        m_autocomplete_timer = Core::Timer::create_single_shot(m_automatic_autocomplete_delay_ms, [this] { try_show_autocomplete(UserRequestedAutocomplete::No); });
         return;
     }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -739,8 +739,11 @@ void TextEditor::select_all()
 void TextEditor::keydown_event(KeyEvent& event)
 {
     if (m_autocomplete_box && m_autocomplete_box->is_visible() && (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Tab)) {
-        m_autocomplete_box->apply_suggestion();
-        hide_autocomplete();
+        TemporaryChange change { m_should_keep_autocomplete_box, true };
+        if (m_autocomplete_box->apply_suggestion() == AutocompleteProvider::Entry::HideAutocompleteAfterApplying::Yes)
+            hide_autocomplete();
+        else
+            try_update_autocomplete();
         return;
     }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -229,7 +229,7 @@ protected:
     virtual void context_menu_event(ContextMenuEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
     virtual void theme_change_event(ThemeChangeEvent&) override;
-    virtual void cursor_did_change() { }
+    virtual void cursor_did_change();
     Gfx::IntRect ruler_content_rect(size_t line) const;
     Gfx::IntRect gutter_content_rect(size_t line) const;
 
@@ -279,6 +279,7 @@ private:
         Yes
     };
     void try_show_autocomplete(UserRequestedAutocomplete);
+    void hide_autocomplete_if_needed();
 
     int icon_size() const { return 16; }
     int icon_padding() const { return 2; }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -274,7 +274,11 @@ private:
     void defer_reflow();
     void undefer_reflow();
 
-    void try_show_autocomplete();
+    enum UserRequestedAutocomplete {
+        No,
+        Yes
+    };
+    void try_show_autocomplete(UserRequestedAutocomplete);
 
     int icon_size() const { return 16; }
     int icon_padding() const { return 2; }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -282,6 +282,7 @@ private:
     void try_update_autocomplete(Function<void()> callback = {});
     void force_update_autocomplete(Function<void()> callback = {});
     void hide_autocomplete_if_needed();
+    void hide_autocomplete();
 
     int icon_size() const { return 16; }
     int icon_padding() const { return 2; }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -279,6 +279,8 @@ private:
         Yes
     };
     void try_show_autocomplete(UserRequestedAutocomplete);
+    void try_update_autocomplete(Function<void()> callback = {});
+    void force_update_autocomplete(Function<void()> callback = {});
     void hide_autocomplete_if_needed();
 
     int icon_size() const { return 16; }

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1099,6 +1099,7 @@ bool Widget::load_from_json(const JsonObject& json, RefPtr<Core::Object> (*unreg
         });
     }
 
+    auto& widget_class = *Core::ObjectClassRegistration::find("GUI::Widget");
     auto children = json.get("children");
     if (children.is_array()) {
         for (auto& child_json_value : children.as_array().values()) {
@@ -1114,6 +1115,10 @@ bool Widget::load_from_json(const JsonObject& json, RefPtr<Core::Object> (*unreg
             RefPtr<Core::Object> child;
             if (auto* registration = Core::ObjectClassRegistration::find(class_name.as_string())) {
                 child = registration->construct();
+                if (!child || !registration->is_derived_from(widget_class)) {
+                    dbgln("Invalid widget class: '{}'", class_name.to_string());
+                    return false;
+                }
             } else {
                 child = unregistered_child_handler(class_name.as_string());
             }

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1081,10 +1081,14 @@ bool Widget::load_from_json(const JsonObject& json, RefPtr<Core::Object> (*unreg
             return false;
         }
 
-        if (class_name.to_string() == "GUI::VerticalBoxLayout") {
-            set_layout<GUI::VerticalBoxLayout>();
-        } else if (class_name.to_string() == "GUI::HorizontalBoxLayout") {
-            set_layout<GUI::HorizontalBoxLayout>();
+        auto& layout_class = *Core::ObjectClassRegistration::find("GUI::Layout");
+        if (auto* registration = Core::ObjectClassRegistration::find(class_name.as_string())) {
+            auto layout = registration->construct();
+            if (!layout || !registration->is_derived_from(layout_class)) {
+                dbgln("Invalid layout class: '{}'", class_name.to_string());
+                return false;
+            }
+            set_layout(static_ptr_cast<Layout>(layout).release_nonnull());
         } else {
             dbgln("Unknown layout class: '{}'", class_name.to_string());
             return false;


### PR DESCRIPTION
Recently I was watching @awesomekling's video on [rewriting the mouse settings dialog](https://youtu.be/gZehZnWMpbA), and I noticed the autocomplete [not behaving](https://youtu.be/gZehZnWMpbA?t=581) the way it should... so I decided to fix it! And in the course of doing so I found quite a few other bugs / quirks that I've smoothed out, plus I added some new quality-of-life improvements.

## Noteworthy changes:
- `GUI::AutocompleteProvider`:
  - Add a way for suggestions to display different text than they fill
  - Always pre-select the first item
  - Add a method for suggestions to tell the autocomplete system that the box should stay open after they are applied
- `GUI::GMLAutocompleteProvider`:
  - Actually suggest layout classes
  - Suggest layout properties
  - Append ': ' after suggested properties
  - Make suggestions use fuzzy matching
  - Don't suggest widgets as children of layouts
  - Keep the autocomplete box open after applying the `layout: ` suggestion
- `GUI::TextEditor`:
  - Always show something when the user requests autocomplete
  - Hide autocomplete when the cursor moves
  - Fixed a bug wherein the autocomplete box would appear to "jump" to the side
- `GUI::Widget`:
  - Make GML layout class parsing dynamic (not technically part of autocomplete, but it does reduce the barrier to adding more layouts and it requires some changes made in this PR)
  - Make GML parsing now enforces that widgets are, in fact, widgets (also not directly autocomplete, but it just makes sense)
- HackStudio:
  - Fixed a bug where autocompleting `#include` paths that contained a `/` would fail
  - Allow autocompleting `#include`s while between the `<>` or `""`
  - Keep the autocomplete box open after applying an '#include' directory suggestion

If you want to see these changes in action, I made a [before and after](https://youtu.be/ZEL5Y5nz0NU) video!

There are also several smaller commits not included in the above list. They are either cleaning up nearby areas of the code or prepping areas for upcoming changes.

This is a big PR, so if it needs to be broken up I understand and will do my best.