### PR TITLE
CI: Notify discord when a PR draft is finished

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -13,4 +13,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           CUSTOM_GITHUB_EVENT_NAME: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }} # fake the event type as discord doesn't know how to parse the special pull_request_target context
         uses: IdanHo/action-discord@754598254f288e6d8e9fca637832e3c163515ba8
-        if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !github.event.pull_request.draft) || github.event['commits'] }}
+        if: ${{ (github.event['pull_request'] && ((github.event['action'] == 'opened' && !github.event.pull_request.draft) || github.event['action'] == 'ready_for_review')) || github.event['commits'] }}


### PR DESCRIPTION
If a PR is created as a draft, this workflow will ignore it, which
makes perfect sense. The problem is that when the draft is finished
it does not fire the 'open' event again. Instead it fires the event
'ready_for_review', which is being ignored.

This patch makes it so that marking a draft PR as ready also notifies
the Discord, same as opening a normal PR would.