### PR TITLE
LibWeb: Fix inline blocks swallowing trailing whitespace

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BreakNode.h
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.h
@@ -19,9 +19,13 @@ public:
     const HTML::HTMLBRElement& dom_node() const { return verify_cast<HTML::HTMLBRElement>(*Node::dom_node()); }
 
 private:
+    virtual bool is_break_node() const final { return true; }
     virtual void paint(PaintContext&, PaintPhase) override;
 
     virtual void split_into_lines(InlineFormattingContext&, LayoutMode) override;
 };
+
+template<>
+inline bool Node::fast_is<BreakNode>() const { return is_break_node(); }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -5,8 +5,10 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/TypeCasts.h>
 #include <AK/Utf8View.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/BreakNode.h>
 #include <LibWeb/Layout/LineBox.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -61,9 +63,13 @@ bool LineBox::is_empty_or_ends_in_whitespace() const
 {
     if (m_fragments.is_empty())
         return true;
-    if (m_fragments.last().length() == 0)
-        return true;
+
     return m_fragments.last().ends_in_whitespace();
+}
+
+bool LineBox::ends_with_forced_line_break() const
+{
+    return is<BreakNode>(m_fragments.last().layout_node());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/LineBox.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.h
@@ -26,6 +26,7 @@ public:
     void trim_trailing_whitespace();
 
     bool is_empty_or_ends_in_whitespace() const;
+    bool ends_with_forced_line_break() const;
 
 private:
     friend class BlockContainer;

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -99,6 +99,7 @@ public:
     // These are used to optimize hot is<T> variants for some classes where dynamic_cast is too slow.
     virtual bool is_box() const { return false; }
     virtual bool is_block_container() const { return false; }
+    virtual bool is_break_node() const { return false; }
     virtual bool is_text_node() const { return false; }
     virtual bool is_initial_containing_block_box() const { return false; }
     virtual bool is_svg_box() const { return false; }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -217,7 +217,7 @@ void TextNode::split_into_lines_by_rules(InlineFormattingContext& context, Layou
 
         float chunk_width;
         if (do_wrap_lines) {
-            if (do_collapse && is_ascii_space(*chunk.view.begin()) && line_boxes.last().is_empty_or_ends_in_whitespace()) {
+            if (do_collapse && is_ascii_space(*chunk.view.begin()) && (line_boxes.last().is_empty_or_ends_in_whitespace() || line_boxes.last().ends_with_forced_line_break())) {
                 // This is a non-empty chunk that starts with collapsible whitespace.
                 // We are at either at the start of a new line, or after something that ended in whitespace,
                 // so we don't need to contribute our own whitespace to the line. Skip over it instead!


### PR DESCRIPTION
In #10434 an issue with leading whitespace in new lines after
a `<br>` element was fixed by checking whether the last fragment
of LineBox is empty.

However, this introduced a regression by which whitespace following
inline elements was swallowed, so `<b>Test</b> 123` would appear
like `Test123`.

By asking specifically if we are handling a forced linebreak
instead of implicity asking for a property that may be shared by
other Node types, we can maintain the correct behavior in regards
to leading whitespace on new lines, as well as trailing whitespace
of inline elements.

![00_example_help](https://user-images.githubusercontent.com/7746494/138900283-3839856d-52c2-4e3a-81e7-ac5d1ed2c41c.png)
*Example in Help application*

Given the following (deliberately sketchily formatted) HTML document:

```html
<!DOCTYPE html>
<body>
<p>
    This is a paragraph containing a <br> forced
    line break with appended whitespace<br>and
    one without appended whitespace.

</p>
<p>
    This paragraph contains <strong>strong</strong> opinions.</p>
</body>
```

We get the following results:

![01_before_the_original_fix](https://user-images.githubusercontent.com/7746494/138901866-a5e69563-5fae-4735-a201-21a3c66afb99.png)
*Before the original fix in #10434*

![02_after_the_original_fix](https://user-images.githubusercontent.com/7746494/138901993-cbc3fcb4-34c0-4fcc-9fcf-c0b316a8f64d.png)
*Current behavior*

![03_after_this_commit](https://user-images.githubusercontent.com/7746494/138902055-39158bfc-5863-4f6b-a333-37ab6c9b9213.png)
*New behavior*

