### PR TITLE
Profiler: Fix crash when viewing kernel addresses in disassembly mode + drive-by perf fix

### DIFF
--- a/Userland/DevTools/Profiler/DisassemblyModel.h
+++ b/Userland/DevTools/Profiler/DisassemblyModel.h
@@ -54,7 +54,6 @@ private:
 
     Profile& m_profile;
     ProfileNode& m_node;
-    RefPtr<MappedFile> m_kernel_file;
 
     Vector<InstructionData> m_instructions;
 };

--- a/Userland/DevTools/Profiler/Process.cpp
+++ b/Userland/DevTools/Profiler/Process.cpp
@@ -102,8 +102,15 @@ void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, const String& name)
             if (!mapped_object)
                 return;
         }
-        m_libraries.set(path_string, adopt_own(*new Library { base, size, path_string, mapped_object }));
+        m_libraries.set(path_string, adopt_own(*new Library { base, size, path_string, mapped_object, {} }));
     }
+}
+
+const Debug::DebugInfo& LibraryMetadata::Library::load_debug_info(FlatPtr base_address) const
+{
+    if (debug_info == nullptr)
+        debug_info = make<Debug::DebugInfo>(object->elf, String::empty(), base_address);
+    return *debug_info.ptr();
 }
 
 String LibraryMetadata::Library::symbolicate(FlatPtr ptr, u32* offset) const

--- a/Userland/DevTools/Profiler/Process.h
+++ b/Userland/DevTools/Profiler/Process.h
@@ -11,6 +11,7 @@
 #include <AK/MappedFile.h>
 #include <AK/OwnPtr.h>
 #include <AK/Vector.h>
+#include <LibDebug/DebugInfo.h>
 #include <LibELF/Image.h>
 
 namespace Profiler {
@@ -29,8 +30,11 @@ public:
         size_t size;
         String name;
         MappedObject* object { nullptr };
+        // This is loaded lazily because we only need it in disassembly view
+        mutable OwnPtr<Debug::DebugInfo> debug_info;
 
         String symbolicate(FlatPtr, u32* offset) const;
+        const Debug::DebugInfo& load_debug_info(FlatPtr base_address) const;
     };
 
     void handle_mmap(FlatPtr base, size_t size, const String& name);

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -212,6 +212,7 @@ void Profile::rebuild_tree()
 }
 
 Optional<MappedObject> g_kernel_debuginfo_object;
+OwnPtr<Debug::DebugInfo> g_kernel_debug_info;
 
 Result<NonnullOwnPtr<Profile>, String> Profile::load_from_perfcore_file(const StringView& path)
 {

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -29,6 +29,7 @@
 namespace Profiler {
 
 extern Optional<MappedObject> g_kernel_debuginfo_object;
+extern OwnPtr<Debug::DebugInfo> g_kernel_debug_info;
 
 class ProfileNode : public RefCounted<ProfileNode> {
 public:

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -28,6 +28,8 @@
 
 namespace Profiler {
 
+extern Optional<MappedObject> g_kernel_debuginfo_object;
+
 class ProfileNode : public RefCounted<ProfileNode> {
 public:
     static NonnullRefPtr<ProfileNode> create(Process const& process, FlyString object_name, String symbol, FlatPtr address, u32 offset, u64 timestamp, pid_t pid)


### PR DESCRIPTION
### Profiler: Share the mapped kernel between Profile and DisassemblyModel 

There is no point in keeping around a separate MappedFile object for
/boot/Kernel.debug for each DisassemblyModel we create and re-parsing
the kernel image multiple times. This will significantly speed up
browsing through profile entries from the kernel in disassembly view.

### Profiler: Load the actual kernel binary for disassembly

/boot/Kernel.debug only contains the symbol table and DWARF debug
information, and has its `.text` and other PT_LOAD segments stripped
out. When we try to parse its data as instructions, we get a crash from
within LibX86.

We now load the actual /boot/Kernel binary when we want to disassemble
kernel functions.

### Profiler: Cache parsed DWARF debug information in disassembly view

This changes browsing through disassembled functions in Profiler from a
painfully sluggish experience into quite a swift one. It's especially
true for profiling the kernel, as it has more than 10 megabytes of DWARF
data to churn through.