### PR TITLE
Meta: Make Meta/ scripts run on macOS

### DIFF
--- a/Meta/check-ak-test-files.sh
+++ b/Meta/check-ak-test-files.sh
@@ -9,7 +9,7 @@ MISSING_FILES=n
 
 while IFS= read -r FILENAME; do
     # Simply search whether the CMakeLists.txt *ever* mention the test files.
-    if ! grep -qP "${FILENAME}" Tests/AK/CMakeLists.txt ; then
+    if ! grep -qF "${FILENAME}" Tests/AK/CMakeLists.txt ; then
         echo "Tests/AK/CMakeLists.txt is either missing the test file ${FILENAME} or is not in the commit's staged changes"
         MISSING_FILES=y
     fi

--- a/Meta/check-ak-test-files.sh
+++ b/Meta/check-ak-test-files.sh
@@ -14,7 +14,7 @@ while IFS= read -r FILENAME; do
         MISSING_FILES=y
     fi
 done < <(
-    git ls-files 'Tests/AK/Test*.cpp' | xargs -i basename {}
+    git ls-files 'Tests/AK/Test*.cpp' | xargs basename
 )
 
 if [ "n" != "${MISSING_FILES}" ] ; then

--- a/Meta/check-debug-flags.sh
+++ b/Meta/check-debug-flags.sh
@@ -16,7 +16,7 @@ while IFS= read -r FLAG; do
     # We simply search whether the CMakeLists.txt *ever* sets the flag.
     # There are (basically) no false positives, but there might be false negatives,
     # for example we intentionally don't check for commented-out lines here.
-    if ! grep -qP "set\(${FLAG}" Meta/CMake/all_the_debug_macros.cmake ; then
+    if ! grep -qF "set(${FLAG}" Meta/CMake/all_the_debug_macros.cmake ; then
         echo "'all_the_debug_macros.cmake' is missing ${FLAG}"
         MISSING_FLAGS=y
     fi
@@ -26,7 +26,7 @@ done < <(
         '*.h' \
         '*.in' \
         ':!:Kernel/FileSystem/ext2_fs.h' \
-    | xargs grep -P '(_DEBUG|DEBUG_)' \
+    | xargs grep -E '(_DEBUG|DEBUG_)' \
     | sed -re 's,^.*[^a-zA-Z0-9_]([a-zA-Z0-9_]*DEBUG[a-zA-Z0-9_]*).*$,\1,' \
     | sort \
     | uniq

--- a/Meta/check-syscall-lists.sh
+++ b/Meta/check-syscall-lists.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.."
 
-SYSCALLS_KERNEL="$(echo 'Kernel syscalls'; echo; grep -Pio '(?<=^    S\().*(?=\)( +\\)?$)' Kernel/API/Syscall.h | sort)"
-SYSCALLS_UE="$(echo 'Implemented in UserspaceEmulator'; echo; grep -Pio '(?<=^    case SC_).*(?=:$)' Userland/DevTools/UserspaceEmulator/Emulator.cpp | sort)"
+SYSCALLS_KERNEL="$(echo 'Kernel syscalls'; echo; grep -Eio '(?<=^    S\().*(?=\)( +\\)?$)' Kernel/API/Syscall.h | sort)"
+SYSCALLS_UE="$(echo 'Implemented in UserspaceEmulator'; echo; grep -Eio '(?<=^    case SC_).*(?=:$)' Userland/DevTools/UserspaceEmulator/Emulator.cpp | sort)"
 SYSCALLS_MAN2="$(echo 'Documented syscalls'; echo; find Base/usr/share/man/man2/ ! -type d -printf '%f\n' | sed -Ee 's,\.md,,' | sort)"
 
 set +e

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -41,7 +41,7 @@ if (( ${#files[@]} )); then
         exit 1
     fi
 
-    if [ "$#" -gt "0" ] && [ "x--overwrite-inplace" = "x$1" ] ; then
+    if [ "$#" -gt "0" ] && [ "--overwrite-inplace" = "$1" ] ; then
         true # The only way to run this script.
     else
         # Note that this branch also covers --help, -h, -help, -?, etc.

--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -29,12 +29,12 @@ while read -r line; do
   line_length=${#line}
 
   category_pattern="^\S.*?\S: .+"
-  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -P -v -q "$category_pattern"); then
+  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -E -v -q "$category_pattern"); then
     error "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)"
   fi
 
   title_case_pattern="^\S.*?: [A-Z0-9]"
-  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -P -v -q "$title_case_pattern"); then
+  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -E -v -q "$title_case_pattern"); then
     error "First word of commit after the subsystem is not capitalized"
   fi
 
@@ -43,7 +43,7 @@ while read -r line; do
   fi
 
   url_pattern="([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&\/=]|-)+"
-  if [[ $line_length -gt 72 ]] && (echo "$line" | grep -P -v -q "$url_pattern"); then
+  if [[ $line_length -gt 72 ]] && (echo "$line" | grep -E -v -q "$url_pattern"); then
     error "Commit message lines are too long (maximum allowed is 72 characters)"
   fi
 

--- a/Meta/lint-executable-resources.sh
+++ b/Meta/lint-executable-resources.sh
@@ -5,7 +5,12 @@ set -eo pipefail
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."
 
-BAD_FILES=$(find Base/etc/ Base/res/ Base/www/ -type f -executable)
+if [ "$(uname -s)" = "Darwin" ]; then
+    # MacOS's find does not support '-executable' OR '-perm /mode'.
+    BAD_FILES=$(find Base/etc/ Base/res/ Base/www/ -type f -perm +111)
+else
+    BAD_FILES=$(find Base/etc/ Base/res/ Base/www/ -type f -executable)
+fi
 
 if [ -n "${BAD_FILES}" ]
 then

--- a/Meta/lint-ipc-ids.sh
+++ b/Meta/lint-ipc-ids.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."
 
-ALL_ENDPOINTS=$(find \( -name Toolchain -o -name Build -o -name .git -o -name Ports \) -prune -o -name '*.ipc' -print0 | xargs -0 grep -E '^endpoint ' | sort -k4 -n)
+ALL_ENDPOINTS=$(find . \( -name Toolchain -o -name Build -o -name .git -o -name Ports \) -prune -o -name '*.ipc' -print0 | xargs -0 grep -E '^endpoint ' | sort -k4 -n)
 
 BAD_ENDPOINTS=$(echo "${ALL_ENDPOINTS}" | cut -d' ' -f4 | uniq -d)
 

--- a/Meta/lint-ipc-ids.sh
+++ b/Meta/lint-ipc-ids.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."
 
-ALL_ENDPOINTS=$(find \( -name Toolchain -o -name Build -o -name .git -o -name Ports \) -prune -o -name '*.ipc' -print0 | xargs -0 grep -P '^endpoint ' | sort -k4 -n)
+ALL_ENDPOINTS=$(find \( -name Toolchain -o -name Build -o -name .git -o -name Ports \) -prune -o -name '*.ipc' -print0 | xargs -0 grep -E '^endpoint ' | sort -k4 -n)
 
 BAD_ENDPOINTS=$(echo "${ALL_ENDPOINTS}" | cut -d' ' -f4 | uniq -d)
 

--- a/Meta/lint-missing-resources.sh
+++ b/Meta/lint-missing-resources.sh
@@ -7,7 +7,7 @@ cd "$script_path/.."
 
 # The dollar symbol in sed's argument is for "end of line", not any shell variable.
 # shellcheck disable=SC2016
-grep -Pirh '(?<!file://)(?<!\.)(?<!})(?<!\()/(etc|res|usr|www)/' AK/ Base DevTools/ Documentation/ Kernel/ Services/ Userland/ | \
+grep -Eirh '(?<!file://)(?<!\.)(?<!})(?<!\()/(etc|res|usr|www)/' AK/ Base DevTools/ Documentation/ Kernel/ Services/ Userland/ | \
 sed -re 's,^.*["= `]/([^"%`: ]+[^"%`: /.])/?(["%`: .].*)?$,\1,' | \
 sort -u | \
 while read -r referenced_resource

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -29,6 +29,15 @@ if (( ${#files[@]} )); then
     fi
 
     shellcheck "${files[@]}"
+
+    for file in "${files[@]}"; do
+        if (< "$file" grep -qE "grep [^|);]*-[^- ]*P"); then
+            # '\x2D' is the unicode escape sequence for '-'. This is used so
+            # that this script does not flag itself for containing grep dash P.
+            echo -e "The script '$file' contains 'grep \x2DP', which is not supported on macOS. Please use grep -E instead."
+            exit 1
+        fi
+    done
 else
     echo "No .sh files to check."
 fi


### PR DESCRIPTION
macOS uses BSD versions of many tools, which only guarantee adherence to POSIX. Thankfully, none of the non-POSIX features were actually required.

It's still not plug-and-play, since there are some tools that are required (like prettier and clang-format-11) that aren't installed by default, but the existing error messages when running will point users in the right direction, and once the tools are installed `Meta/lint-ci.sh` will now run successfully on macOS!