### PR TITLE
wc: Count last line even if it doesn't end in newline

### DIFF
--- a/Userland/Utilities/wc.cpp
+++ b/Userland/Utilities/wc.cpp
@@ -55,7 +55,9 @@ static Count get_count(const String& file_specifier)
     }
 
     bool start_a_new_word = true;
+    int last_ch = EOF;
     for (int ch = fgetc(file_pointer); ch != EOF; ch = fgetc(file_pointer)) {
+        last_ch = ch;
         count.bytes++;
         if (isspace(ch)) {
             start_a_new_word = true;
@@ -66,6 +68,8 @@ static Count get_count(const String& file_specifier)
             count.words++;
         }
     }
+    if (last_ch != '\n')
+        count.lines++;
 
     if (file_pointer != stdin)
         fclose(file_pointer);


### PR DESCRIPTION
Files not ending in newline didn't have their line counted correctly by `wc`, which would report one line less than there actually is.