### PR TITLE
LibC: Use unsigned char instead of boolean in ioctl

### DIFF
--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -19,10 +19,10 @@ struct winsize {
 };
 
 struct FBProperties {
-    bool multihead_support;
-    bool doublebuffer_support;
-    bool flushing_support;
-    bool partial_flushing_support;
+    unsigned char multihead_support;
+    unsigned char doublebuffer_support;
+    unsigned char flushing_support;
+    unsigned char partial_flushing_support;
 };
 
 struct FBHeadProperties {


### PR DESCRIPTION
`bool` doesn't exist on all C standards, and we don't want to force in our own, so `unsigned char` it is.

This makes `bash` compile again.