### PR TITLE
Kernel: Don't crash on writes to ProcFS

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -244,7 +244,7 @@ ProcFSProcessAssociatedInode::ProcFSProcessAssociatedInode(const ProcFS& fs, Pro
 
 KResultOr<size_t> ProcFSProcessAssociatedInode::write_bytes(off_t, size_t, const UserOrKernelBuffer&, OpenFileDescription*)
 {
-    VERIFY_NOT_REACHED();
+    return ENOTSUP;
 }
 
 KResultOr<NonnullRefPtr<ProcFSProcessDirectoryInode>> ProcFSProcessDirectoryInode::try_create(const ProcFS& procfs, ProcessID pid)

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -106,6 +106,10 @@ if [ -f mnt/usr/Tests/Kernel/TestMemoryDeviceMmap ]; then
     chown 0:0 mnt/usr/Tests/Kernel/TestMemoryDeviceMmap
     chmod 4755 mnt/usr/Tests/Kernel/TestMemoryDeviceMmap
 fi
+if [ -f mnt/usr/Tests/Kernel/TestProcFSWrite ]; then
+    chown 0:0 mnt/usr/Tests/Kernel/TestProcFSWrite
+    chmod 4755 mnt/usr/Tests/Kernel/TestProcFSWrite
+fi
 
 chmod 0400 mnt/res/kernel.map
 chmod 0400 mnt/boot/Kernel

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LIBTEST_BASED_SOURCES
     TestMemoryDeviceMmap.cpp
     TestMunMap.cpp
     TestProcFS.cpp
+    TestProcFSWrite.cpp
 )
 
 foreach(libtest_source IN LISTS LIBTEST_BASED_SOURCES)

--- a/Tests/Kernel/TestProcFSWrite.cpp
+++ b/Tests/Kernel/TestProcFSWrite.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <fcntl.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+
+TEST_CASE(check_root)
+{
+    auto uid = geteuid();
+    // This test only makes sense as root.
+    EXPECT_EQ(uid, 0u);
+
+    // Before we make the process dumpable, become "fully" root, so that the user cannot tamper with our memory:
+    EXPECT_EQ(setuid(0), 0);
+
+    // If running as setuid, the process is automatically marked as non-dumpable, which bars access to /proc/self/.
+    // However, that is the easiest guess for a /proc/$PID/ directory, so we'd like to use that.
+    // In order to do so, mark this process as dumpable:
+    EXPECT_EQ(prctl(PR_SET_DUMPABLE, 1, 0), 0);
+}
+
+TEST_CASE(root_writes_to_procfs)
+{
+    int fd = open("/proc/self/unveil", O_RDWR | O_APPEND | O_CREAT, 0666); // = 6
+    if (fd < 0) {
+        perror("open");
+        dbgln("fd was {}", fd);
+        FAIL("open failed?! See debugout");
+        return;
+    }
+
+    int rc = write(fd, "hello", 5);
+    perror("write");
+    dbgln("write rc = {}", rc);
+    if (rc >= 0) {
+        FAIL("Wrote successfully?!");
+    }
+}


### PR DESCRIPTION
Found by searching for `VERIFY_NOT_REACHED` and looking at weird results.