### PR TITLE
LibWeb: Remove duplicated auto height computation

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -55,6 +55,11 @@ protected:
 
     static float tentative_width_for_replaced_element(const ReplacedBox&, const CSS::Length& width);
     static float tentative_height_for_replaced_element(const ReplacedBox&, const CSS::Length& height);
+    enum ConsiderFloats {
+        Yes,
+        No,
+    };
+    static float compute_auto_height_for_block_level_element(Box const&, ConsiderFloats consider_floats = ConsiderFloats::Yes);
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box&);
 


### PR DESCRIPTION
Note that these two implementation differ, but the one in FormattingContext.cpp seems to be more complete. It is also more recent.