### PR TITLE
LibELF+LibC+Kernel: Implement the `DT_RELR` relocation format (Clang-only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,9 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     # Clang doesn't add compiler_rt to the search path when compiling with -nostdlib.
     link_directories(${TOOLCHAIN_ROOT}/lib/clang/${CMAKE_CXX_COMPILER_VERSION}/lib/${SERENITY_ARCH}-pc-serenity/)
     add_link_options(LINKER:--allow-shlib-undefined)
+
+    # FIXME: Make me default in the next toolchain update
+    add_link_options(LINKER:--pack-dyn-relocs=relr)
 endif()
 
 add_link_options(LINKER:-z,text)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -512,7 +512,7 @@ endif()
 add_custom_command(
     TARGET Kernel POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E env CXXFILT=${SERENITY_CXXFILT} NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-    COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${SERENITY_GNU_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
     COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -7,10 +7,13 @@ endif()
 
 if ("${SERENITY_ARCH}" STREQUAL "aarch64")
     set(KERNEL_ARCH aarch64)
+    set(BFDNAME elf64-littleaarch64)
 elseif ("${SERENITY_ARCH}" STREQUAL "i686")
     set(KERNEL_ARCH i386)
+    set(BFDNAME elf32-i386)
 elseif("${SERENITY_ARCH}" STREQUAL "x86_64")
     set(KERNEL_ARCH x86_64)
+    set(BFDNAME elf64-x86-64)
 endif()
 
 set(KERNEL_HEAP_SOURCES
@@ -367,7 +370,7 @@ else()
     set(SOURCES
         ${SOURCES}
         ${AK_SOURCES}
-        
+
         Arch/aarch64/dummy.cpp
         Arch/aarch64/SmapDisabler.cpp
         Arch/aarch64/ScopedCritical.cpp
@@ -408,7 +411,7 @@ else() # Assume Clang
 
     # We need this in order to pick up the #define __serenity__, otherwise we end up including unistd.h into the linker script
     set(TARGET_STRING "--target=${CMAKE_CXX_COMPILER_TARGET}")
-    
+
     add_link_options(LINKER:--build-id=none)
 endif()
 
@@ -512,7 +515,8 @@ endif()
 add_custom_command(
     TARGET Kernel POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E env CXXFILT=${SERENITY_CXXFILT} NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
-    COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${SERENITY_GNU_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${SERENITY_GNU_OBJCOPY} BFDNAME=${BFDNAME} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
+    COMMAND ${CMAKE_OBJCOPY} --target=${BFDNAME} Kernel # HACK: GNU objcopy strips the machine type on x86_64 Clang, we add it back.
     COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -511,7 +511,7 @@ endif()
 
 add_custom_command(
     TARGET Kernel POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E env CXXFILT=${SERENITY_CXXFILT} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env CXXFILT=${SERENITY_CXXFILT} NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
     COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
     COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel

--- a/Kernel/embedmap.sh
+++ b/Kernel/embedmap.sh
@@ -2,5 +2,5 @@
 tmp=$(mktemp)
 (cat kernel.map; printf '%b' '\0') > "$tmp"
 OBJCOPY="${OBJCOPY:-objcopy}"
-"$OBJCOPY" --update-section .ksyms="$tmp" Kernel
+"$OBJCOPY" ${BFDNAME:+"--target=$BFDNAME"} --update-section .ksyms="$tmp" Kernel
 rm -f "$tmp"

--- a/Kernel/mkmap.sh
+++ b/Kernel/mkmap.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 tmp=$(mktemp)
-nm -n Kernel | grep -vE \\.Lubsan_data | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
+NM="${NM:-nm}"
+"$NM" -n Kernel | grep -vE \\.Lubsan_data | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
 printf "%08x\n" "$(wc -l "$tmp" | awk '{print $1}')" > kernel.map
 CXXFILT="${CXXFILT:-c++filt}"
 "$CXXFILT" < "$tmp" >> kernel.map

--- a/Toolchain/CMake/ClangToolchain.txt.in
+++ b/Toolchain/CMake/ClangToolchain.txt.in
@@ -24,9 +24,10 @@ set(CMAKE_LINKER ${TOOLCHAIN_PATH}/ld.lld)
 set(CMAKE_RANLIB ${TOOLCHAIN_PATH}/llvm-ranlib)
 set(CMAKE_STRIP ${TOOLCHAIN_PATH}/llvm-strip)
 set(CMAKE_AR ${TOOLCHAIN_PATH}/llvm-ar)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PATH}/llvm-objcopy)
 set(SERENITY_CXXFILT ${TOOLCHAIN_PATH}/llvm-cxxfilt)
 # FIXME: Persuade LLVM maintainers to add `--update-section` to llvm-objcopy, as it's required for the kernel symbol map.
-set(CMAKE_OBJCOPY ${TOOLCHAIN_PATH}/gnu-objcopy)
+set(SERENITY_GNU_OBJCOPY ${TOOLCHAIN_PATH}/gnu-objcopy)
 
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,max-page-size=0x1000,-z,separate-code")
 

--- a/Toolchain/CMake/GNUToolchain.txt.in
+++ b/Toolchain/CMake/GNUToolchain.txt.in
@@ -23,6 +23,7 @@ set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}strip)
 set(CMAKE_AR ${TOOLCHAIN_PREFIX}gcc-ar)
 set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
 set(SERENITY_CXXFILT ${TOOLCHAIN_PREFIX}c++filt)
+set(SERENITY_GNU_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
 
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,max-page-size=0x1000,-z,separate-code")
 

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -138,7 +138,7 @@ add_custom_target(LibCStatic
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:ssp>
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibSystemStatic>
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibUBSanitizerStatic>
-        COMMAND ${CMAKE_AR} -qcs ${CMAKE_CURRENT_BINARY_DIR}/libc.a *.o
+        COMMAND ${CMAKE_AR} -rcs ${CMAKE_CURRENT_BINARY_DIR}/libc.a *.o
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS LibCStaticWithoutDeps ssp LibSystemStatic LibUBSanitizerStatic
         )

--- a/Userland/Libraries/LibC/elf.h
+++ b/Userland/Libraries/LibC/elf.h
@@ -406,6 +406,9 @@ typedef struct {
     Elf32_Sword r_addend;
 } Elf32_Rela;
 
+/* Packed relative relocation */
+typedef Elf32_Word Elf32_Relr;
+
 /* Extract relocation info - r_info */
 #define ELF32_R_SYM(i) ((i) >> 8)
 #define ELF32_R_TYPE(i) ((unsigned char)(i))
@@ -421,6 +424,9 @@ typedef struct {
     Elf64_Xword r_info;    /* index & type of relocation */
     Elf64_Sxword r_addend; /* adjustment value */
 } Elf64_Rela;
+
+/* Packed relative relocation */
+typedef Elf64_Xword Elf64_Relr;
 
 #define ELF64_R_SYM(info) ((info) >> 32)
 #define ELF64_R_TYPE(info) ((info)&0xFFFFFFFF)
@@ -545,10 +551,19 @@ typedef struct {
 #define DT_ENCODING 31        /* further DT_* follow encoding rules */
 #define DT_PREINIT_ARRAY 32   /* address of array of preinit func */
 #define DT_PREINIT_ARRAYSZ 33 /* size of array of preinit func */
-#define DT_LOOS 0x6000000d    /* reserved range for OS */
-#define DT_HIOS 0x6ffff000    /*  specific dynamic array tags */
-#define DT_LOPROC 0x70000000  /* reserved range for processor */
-#define DT_HIPROC 0x7fffffff  /*  specific dynamic array tags */
+/*
+ * NOTE: These values are not yet standardized, but are already used by major implementations
+ * There's an ongoing effort to add them to the gABI.
+ * See: https://sourceware.org/pipermail/libc-alpha/2021-October/131781.html
+ */
+#define DT_RELRSZ 35  /* size of DT_RELR relocation table */
+#define DT_RELR 36    /* address of packed relocation table */
+#define DT_RELRENT 37 /* size of DT_RELR relocation entry */
+
+#define DT_LOOS 0x6000000d   /* reserved range for OS */
+#define DT_HIOS 0x6ffff000   /*  specific dynamic array tags */
+#define DT_LOPROC 0x70000000 /* reserved range for processor */
+#define DT_HIPROC 0x7fffffff /*  specific dynamic array tags */
 
 /* some other useful tags */
 #define DT_GNU_HASH 0x6ffffef5  /* address of GNU hash table */

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -130,6 +130,7 @@ private:
         ResolveLater = 2,
     };
     RelocationResult do_relocation(const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
+    void do_packed_relocations(const DynamicObject::Section&);
     size_t calculate_tls_size() const;
     ssize_t negative_offset_from_tls_block_end(ssize_t tls_offset, size_t value_of_symbol) const;
 

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -135,6 +135,15 @@ void DynamicObject::parse()
         case DT_RELCOUNT:
             m_number_of_relocations = entry.val();
             break;
+        case DT_RELR:
+            m_packed_relocation_table_offset = entry.ptr() - m_elf_base_address.get();
+            break;
+        case DT_RELRSZ:
+            m_size_of_packed_relocation_table = entry.val();
+            break;
+        case DT_RELRENT:
+            m_size_of_packed_relocations_entry = entry.val();
+            break;
         case DT_FLAGS:
             m_dt_flags = entry.val();
             break;
@@ -235,6 +244,11 @@ DynamicObject::RelocationSection DynamicObject::relocation_section() const
 DynamicObject::RelocationSection DynamicObject::plt_relocation_section() const
 {
     return RelocationSection(Section(*this, m_plt_relocation_offset_location, m_size_of_plt_relocation_entry_list, m_size_of_relocation_entry, "DT_JMPREL"sv), false);
+}
+
+DynamicObject::Section DynamicObject::packed_relocation_section() const
+{
+    return Section(*this, m_packed_relocation_table_offset, m_size_of_packed_relocation_table, m_size_of_packed_relocations_entry, "DT_RELR"sv);
 }
 
 ElfW(Half) DynamicObject::program_header_count() const
@@ -432,6 +446,12 @@ const char* DynamicObject::name_for_dtag(ElfW(Sword) d_tag)
         return "VERNEEDED";
     case DT_VERNEEDEDNUM:
         return "VERNEEDEDNUM";
+    case DT_RELR:
+        return "DT_RELR";
+    case DT_RELRSZ:
+        return "DT_RELRSZ";
+    case DT_RELRENT:
+        return "DT_RELRENT";
     default:
         return "??";
     }

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -272,6 +272,7 @@ public:
 
     RelocationSection relocation_section() const;
     RelocationSection plt_relocation_section() const;
+    Section packed_relocation_section() const;
 
     bool should_process_origin() const { return m_dt_flags & DF_ORIGIN; }
     bool requires_symbolic_symbol_resolution() const { return m_dt_flags & DF_SYMBOLIC; }
@@ -374,6 +375,10 @@ private:
     size_t m_size_of_relocation_table { 0 };
     bool m_addend_used { false };
     FlatPtr m_relocation_table_offset { 0 };
+    // ld.lld may also generate fancy RELR entries
+    size_t m_size_of_packed_relocations_entry { 0 };
+    size_t m_size_of_packed_relocation_table { 0 };
+    FlatPtr m_packed_relocation_table_offset { 0 };
     bool m_is_elf_dynamic { false };
 
     // DT_FLAGS


### PR DESCRIPTION
**note:** Before we get too excited, I must clarify that `DT_RELR` is currently **not supported** by the GNU toolchain, neither in the stable version, nor on `master`.

The DT_RELR relocation is a relatively new relocation encoding designed
to achieve space-efficient relative relocations in PIE programs.

The original proposal (which suggested a slightly different format) is
available at this URL:
https://groups.google.com/g/generic-abi/c/bX460iggiKg/m/GxjM0L-PBAAJ

It was later changed to an even more space-efficient encoding, which is
the one that current implementations support:
https://groups.google.com/g/generic-abi/c/bX460iggiKg/m/Pi9aSwwABgAJ

It works by using a bitmap to store the offsets which need to be
relocated. Even entries are *address* entries: they contain an address
(relative to the base of the executable) which needs to be relocated.
Subsequent even entries are *bitmap* entries: "1" bits encode offsets
(in `sizeof(FlatPtr)` increments) relative to the last address entry
which need to be relocated.

The LLD linker and the runtime linker implementations in Android and
Chromium OS both use this changed format. [Bionic libc] and MaskRay's
[glibc patches] served as a reference for my implementation. There is an
ongoing effort to upstream patches into musl too, and the current
maintainer of the gABI has expressed interest in standardizing the
format.

The messages describing the format suggest an overall 5-20% reduction in
the file size of various programs. Due to us not stripping debug info,
our measurements will tend to skew to the lower side of this spectrum.
Compiling the current master branch (ae405ed) on x86-64, I get the
following results:

Kernel:
24457056 (.rela.dyn: 6239520)
18280288 (.relr.dyn: 64224)
=> 25.2% decrease

libc.so:
1623192 (.rela.dyn: 9072)
1619200 (.relr.dyn+rela.dyn: 2144)
=> 0.2% decrease

libunicode.so:
4554272 (.rela.dyn: 1171800)
3395216 (.relr.dyn+rela.dyn: 12696)
=> 25.4% decrease

/bin/Browser:
1032176 (.rela.dyn: 41400)
999512  (.relr.dyn+.rela.dyn: 11240)
=> 3.2% decrease

/bin/PixelPaint:
1408256 (.rela.dyn: 54984)
1367400 (.relr.dyn+.rela.dyn: 14640)
=> 2.9% decrease

[Bionic libc]:
https://android.googlesource.com/platform/bionic/+/f16b65932bb7adb1568a3a1e11ffa750d18e30ae/linker/linker.cpp#2606
[glibc patches]: https://sourceware.org/pipermail/libc-alpha/2021-October/131768.html

---
I didn't want to include this remark in the commit message, but the tread on `libc-alpha` where MaskRay submitted the glibc patch is quite interesting and drama-heavy. So if you have a bit of free time and a bucket of popcorn, I suggest reading it.