### PR TITLE
LibWeb: Add Element.webkitMatchesSelector

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -24,6 +24,9 @@ interface Element : Node {
 
     boolean matches(DOMString selectors);
 
+    // legacy alias of .matches
+    [ImplementedAs=matches] boolean webkitMatchesSelector(DOMString selectors);
+
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
 


### PR DESCRIPTION
This is an alias of Element.matches for web compatibility.
https://dom.spec.whatwg.org/#dom-element-webkitmatchesselector

Used by particularly old versions of Sizzle, such as 1.10.2:
https://github.com/jquery/jquery/blob/16b079b164d62bd807c612806842a13bf9b04d17/jquery.js#L1644

This particular version is used by DuckDuckGo.