### PR TITLE
CI: Rewrite the lintcommits workflow using an inline script

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -10,58 +10,65 @@ jobs:
     if: always() && github.repository == 'SerenityOS/serenity'
 
     steps:
-      - name: Get PR Commits
-        id: 'get-pr-commits'
-        uses: IdanHo/get-pr-commits@d94b66d146a31ef91e54a2597dee4fb523157232
+      - name: Lint PR commits
+        uses: actions/github-script@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const rules = [
+              {
+                pattern: /^[^\r]*$/,
+                error: "Commit message contains CRLF line breaks (only unix-style LF linebreaks are allowed)",
+              },
+              {
+                pattern: /^.{0,72}(?:\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$/,
+                error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs)",
+              },
+              {
+                pattern: /^\S.*?\S: .+/,
+                error: "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)",
+              },
+              {
+                pattern: /^\S.*?: [A-Z0-9]/,
+                error: "First word of commit after the subsystem is not capitalized",
+              },
+              {
+                pattern: /^.+[^.\n](\n.*)*$/,
+                error: "Commit title ends in a period",
+              },
+              {
+                pattern: /^((?!Signed-off-by: )[\s\S])*$/,
+                error: "Commit body contains a Signed-off-by tag",
+              },
+            ];
 
-      - name: Check linebreaks
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^[^\r]*$'
-          error: 'Commit message contains CRLF line breaks (only unix-style LF linebreaks are allowed)'
+            const { repository, pull_request } = context.payload;
 
-      - name: Check Line Length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,72}(?:\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$'
-          error: 'Commit message lines are too long (maximum allowed is 72 characters, except for URLs)'
+            // NOTE: This maxes out at 250 commits. If this becomes a problem, see:
+            // https://octokit.github.io/rest.js/v18#pulls-list-commits
+            const opts = github.rest.pulls.listCommits.endpoint.merge({
+              owner: repository.owner.login,
+              repo: repository.name,
+              pull_number: pull_request.number,
+            });
+            const commits = await github.paginate(opts);
 
-      - name: Check subsystem
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^\S.*?\S: .+'
-          error: 'Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)'
+            const errors = [];
+            for (const { sha, commit: { message } } of commits) {
+              const commitErrors = [];
+              for (const { pattern, error } of rules) {
+                if (!pattern.test(message)) {
+                  commitErrors.push(error);
+                }
+              }
+              if (commitErrors.length > 0) {
+                const title = message.split("\n")[0];
+                errors.push([`${title} (${sha}):`, ...commitErrors].join("\n  "));
+              }
+            }
 
-      - name: Check first word of title for capitalization
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^\S.*?: [A-Z0-9]'
-          error: 'First word of commit after the subsystem is not capitalized'
-
-      - name: Check title
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.+[^.\n](\n.*)*$'
-          error: 'Commit title ends in a period'
-
-      - name: Check body for sign off
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^((?!Signed-off-by: )[\s\S])*$'
-          error: 'Commit body contains a Signed-off-by tag'
+            if (errors.length > 0) {
+              core.setFailed(`One or more of the commits in this PR do not match the code submission policy:\n\n${errors.join("\n")}`);
+            }
 
       - name: Comment on PR
         if: ${{ failure() && !github.event.pull_request.draft }}


### PR DESCRIPTION
tim-actions/commit-message-checker-with-regex@v0.3.1 only uses the
keys 'sha' and 'commit.message'. Passing more information than that
is unnecessary and can lead to CI failures like this one:
https://github.com/SerenityOS/serenity/runs/4029269017?check_suite_focus=true#step:4:7

Instead of trying to pass data between workflow steps, we can instead
just do it all at once (plus this gives us more control over
formatting, which has also been improved).

This supersedes #10665.