### PR TITLE
LibHTTP: Fix logic error leading to buffer over-read

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -325,7 +325,7 @@ void Job::on_socket_connected()
             if (m_content_length.has_value()) {
                 auto length = m_content_length.value();
                 if (m_received_size + payload.size() >= length) {
-                    payload.resize(length - m_buffered_size);
+                    payload.resize(length - m_received_size);
                     read_everything = true;
                 }
             }
@@ -338,6 +338,7 @@ void Job::on_socket_connected()
             deferred_invoke([this] { did_progress(m_content_length, m_received_size); });
 
             if (read_everything) {
+                VERIFY(m_received_size <= m_content_length.value());
                 finish_up();
                 return IterationDecision::Break;
             }


### PR DESCRIPTION
When we receive HTTP payloads, we have to ensure that the number of
bytes read is *at most* the value specified in the Content-Length
header.

However, we did not use the correct value when calculating the truncated
size of the last payload. `m_buffered_size` does not store the total
number of bytes received, but rather the number of bytes that haven't
been read from us.

This means that if some data has already been read from us,
`m_buffered_size` is smaller than `m_received_size`. Because of this, we
ended up resizing the `payload` ByteBuffer to a larger size than its
contents. This garbage data was then read by consumers, producing this
warning when executing scripts:

> Extension byte 0xdc in 1 position after first byte 0xdc doesn't make
> sense.