### PR TITLE
LibRegex: Don't ignore empty alternatives in append_alternation()

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -898,6 +898,7 @@ TEST_CASE(optimizer_atomic_groups)
         // Alternative fuse
         Tuple { "(abcfoo|abcbar|abcbaz).*x"sv, "abcbarx"sv, true },
         Tuple { "(a|a)"sv, "a"sv, true },
+        Tuple { "(a|)"sv, ""sv, true }, // Ensure that empty alternatives are not outright removed
         // ForkReplace shouldn't be applied where it would change the semantics
         Tuple { "(1+)\\1"sv, "11"sv, true },
         Tuple { "(1+)1"sv, "11"sv, true },


### PR DESCRIPTION
Doing so would cause patterns like `(a|)` to not match the empty string.

Note: this change wasn't made with my usual setup (i.e. no testing, maybe crlf mess-up), please let the CI pass before merging, kthx.