### PR TITLE
PixelPaint: Map color_distance_squared from 0 to 1

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -31,7 +31,7 @@ static float color_distance_squared(Gfx::Color const& lhs, Gfx::Color const& rhs
     int a = rhs.red() - lhs.red();
     int b = rhs.green() - lhs.green();
     int c = rhs.blue() - lhs.blue();
-    return (a * a + b * b + c * c) / (255.0f * 255.0f);
+    return (a * a + b * b + c * c) / (3.0f * 255.0f * 255.0f);
 }
 
 static void flood_fill(Gfx::Bitmap& bitmap, Gfx::IntPoint const& start_position, Color target_color, Color fill_color, int threshold)


### PR DESCRIPTION
color_distance_squared is returning results from 0 to 3, but threshold_normalized_squared is in 0-1 range. One consequence of this is, using Bucket Tool with threshold 100 doesn't fill every pixel. Mapping color_distance_squared from 0 to 1 produces more natural and expected results. 