### PR TITLE
Shell: Add min and max iteration times to time -n in builtin_time

### DIFF
--- a/AK/Statistics.h
+++ b/AK/Statistics.h
@@ -29,6 +29,28 @@ public:
     T const sum() const { return m_sum; }
     float average() const { return (float)sum() / size(); }
 
+    T const min() const
+    {
+        T minimum = m_values[0];
+        for (T number : values()) {
+            if (number < minimum) {
+                minimum = number;
+            }
+        }
+        return minimum;
+    }
+
+    T const max() const
+    {
+        T maximum = m_values[0];
+        for (T number : values()) {
+            if (number > maximum) {
+                maximum = number;
+            }
+        }
+        return maximum;
+    }
+
     // FIXME: Implement a better algorithm
     T const median()
     {

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -920,8 +920,14 @@ int Shell::builtin_time(int argc, const char** argv)
         warnln("Timing report:");
         warnln("==============");
         warnln("Command:         {}", String::join(' ', args));
-        warnln("Average time:    {:.2} ms (median: {}, stddev: {:.2})", iteration_times.average(), iteration_times.median(), iteration_times.standard_deviation());
-        warnln("Excluding first: {:.2} ms (median: {}, stddev: {:.2})", iteration_times_excluding_first.average(), iteration_times_excluding_first.median(), iteration_times_excluding_first.standard_deviation());
+        warnln("Average time:    {:.2} ms (median: {}, stddev: {:.2}, min: {}, max:{})",
+            iteration_times.average(), iteration_times.median(),
+            iteration_times.standard_deviation(),
+            iteration_times.min(), iteration_times.max());
+        warnln("Excluding first: {:.2} ms (median: {}, stddev: {:.2}, min: {}, max:{})",
+            iteration_times_excluding_first.average(), iteration_times_excluding_first.median(),
+            iteration_times_excluding_first.standard_deviation(),
+            iteration_times_excluding_first.min(), iteration_times_excluding_first.max());
     }
 
     return exit_code;


### PR DESCRIPTION
Re-submitting #9750

Related:
https://github.com/SerenityOS/serenity/pull/9750#discussion_r701793152
https://github.com/SerenityOS/serenity/pull/9750#discussion_r701768992