### PR TITLE
Minesweeper: Set time label to a fixed width

### DIFF
--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
     time_image.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/minesweeper/timer.png"));
 
     auto& time_label = container.add<GUI::Label>();
-    time_label.set_autosize(true);
+    time_label.set_fixed_width(50);
     time_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
     container.layout()->add_spacer();


### PR DESCRIPTION
Before, labels wiggle around a lot:

https://user-images.githubusercontent.com/30195912/139450858-dac093df-56cb-4fa1-9ab6-54e3594ac9f0.mp4


After:

https://user-images.githubusercontent.com/30195912/139450883-3d0a1fcd-f9a6-42ad-ac99-a19dff87bc10.mp4



