### PR TITLE
Calculator: Fix copy button not copying the fractional part bug :^)

### DIFF
--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
         if (clipboard.mime_type == "text/plain") {
             if (!clipboard.data.is_empty()) {
                 auto data = atof(StringView(clipboard.data).to_string().characters());
-                widget.set_entry(data);
+                widget.set_entry(KeypadValue { data });
             }
         }
     }));


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/30195912/139475617-04172a24-a576-48da-8616-bf14eadaf628.mp4

After:

https://user-images.githubusercontent.com/30195912/139475627-cc5b3386-6bf9-4a7b-ac55-85a335e480a7.mp4

_(Not related) Note: Sorry if my pull requests seem spammy, I don't have much free time because of school so I thought I would give myself a day off and work on SerenityOS instead. :^)_
