### PR TITLE
LibMarkdown: Justify text rendered for terminal output

### DIFF
--- a/Userland/Libraries/LibMarkdown/CMakeLists.txt
+++ b/Userland/Libraries/LibMarkdown/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     Paragraph.cpp
     Table.cpp
     Text.cpp
+    TextAlignment.cpp
 )
 
 serenity_lib(LibMarkdown markdown)

--- a/Userland/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Userland/Libraries/LibMarkdown/Paragraph.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibMarkdown/Paragraph.h>
+#include <LibMarkdown/TextAlignment.h>
 #include <LibMarkdown/Visitor.h>
 
 namespace Markdown {
@@ -27,10 +28,10 @@ String Paragraph::render_to_html(bool tight) const
     return builder.build();
 }
 
-String Paragraph::render_for_terminal(size_t) const
+String Paragraph::render_for_terminal(size_t width) const
 {
     StringBuilder builder;
-    builder.append(m_text.render_for_terminal());
+    builder.append(TextAlignment::justify(m_text.render_for_terminal(), width - 1));
     builder.append("\n\n");
     return builder.build();
 }

--- a/Userland/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Userland/Libraries/LibMarkdown/Paragraph.cpp
@@ -31,7 +31,7 @@ String Paragraph::render_to_html(bool tight) const
 String Paragraph::render_for_terminal(size_t width) const
 {
     StringBuilder builder;
-    builder.append(TextAlignment::justify(m_text.render_for_terminal(), width - 1));
+    builder.append(TextAlignment::justify(m_text.render_for_terminal(), width));
     builder.append("\n\n");
     return builder.build();
 }

--- a/Userland/Libraries/LibMarkdown/TextAlignment.cpp
+++ b/Userland/Libraries/LibMarkdown/TextAlignment.cpp
@@ -13,7 +13,8 @@ String TextAlignment::justify(String text, int justification_width, bool ignore_
     StringBuilder justified_text;
 
     auto add_text_from_nodes = [&justified_text](RefPtr<WordNode> node) {
-        while (!node.is_null()) {
+        // We stop when next is null since we don't want to add the trailing space
+        while (!node->next.is_null()) {
             justified_text.append(node->value);
             node = node->next;
         }
@@ -31,7 +32,7 @@ String TextAlignment::justify(String text, int justification_width, bool ignore_
             if (ignore_terminal_sequences)
                 word_length = unadorned_text_length(word_text);
 
-            if (word_length + 1 > free_space_on_line) {
+            if (word_length > free_space_on_line && spaces.size()) {
                 spaces.remove(spaces.size() - 1);
 
                 while (free_space_on_line) {

--- a/Userland/Libraries/LibMarkdown/TextAlignment.cpp
+++ b/Userland/Libraries/LibMarkdown/TextAlignment.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, Dana Burkart <dana.burkart@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TextAlignment.h"
+
+namespace Markdown {
+
+String TextAlignment::justify(String text, int justification_width, bool ignore_terminal_sequences)
+{
+    StringBuilder justified_text;
+
+    auto add_text_from_nodes = [&justified_text](RefPtr<WordNode> node) {
+        while (!node.is_null()) {
+            justified_text.append(node->value);
+            node = node->next;
+        }
+        justified_text.append("\n");
+    };
+
+    for (auto sentence : text.split_view('\n')) {
+        RefPtr<WordNode> root, current;
+        bool at_beginning_of_line = true;
+        unsigned long free_space_on_line = justification_width;
+        Vector<RefPtr<WordNode>> spaces;
+
+        for (auto word_text : sentence.split_view(' ')) {
+            size_t word_length = word_text.length();
+            if (ignore_terminal_sequences)
+                word_length = unadorned_text_length(word_text);
+
+            if (word_length + 1 > free_space_on_line) {
+                spaces.remove(spaces.size() - 1);
+
+                while (free_space_on_line) {
+                    auto index = random() % spaces.size();
+                    auto space = spaces[index];
+
+                    if (spaces.size() >= free_space_on_line)
+                        spaces.remove(index);
+
+                    space->value = String::formatted("{}{}", space->value, " ");
+                    free_space_on_line -= 1;
+                }
+
+                add_text_from_nodes(root);
+                free_space_on_line = justification_width;
+                at_beginning_of_line = true;
+                spaces = Vector<RefPtr<WordNode>>();
+            }
+
+            auto word = try_make_ref_counted<WordNode>(word_text);
+            auto space = try_make_ref_counted<WordNode>(" ");
+
+            if (at_beginning_of_line) {
+                current = root = word;
+                at_beginning_of_line = false;
+            } else {
+                current->next = word;
+                current = current->next;
+            }
+
+            current->next = space;
+            current = current->next;
+            spaces.append(current);
+
+            free_space_on_line -= word_length + 1;
+        }
+
+        add_text_from_nodes(root);
+    }
+
+    return justified_text.build();
+}
+
+size_t TextAlignment::unadorned_text_length(String text)
+{
+    size_t length = 0;
+    bool in_terminal_sequence = false;
+    for (auto c : text) {
+        if (c == '\e')
+            in_terminal_sequence = true;
+
+        if (!in_terminal_sequence)
+            length += 1;
+
+        if (in_terminal_sequence && c == 'm')
+            in_terminal_sequence = false;
+    }
+
+    return length;
+}
+
+}

--- a/Userland/Libraries/LibMarkdown/TextAlignment.h
+++ b/Userland/Libraries/LibMarkdown/TextAlignment.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Dana Burkart <dana.burkart@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+
+namespace Markdown {
+
+class TextAlignment final {
+public:
+    static String justify(String text, int justification_width = 80, bool ignore_terminal_sequences = true);
+
+private:
+    struct WordNode : public RefCounted<WordNode> {
+        String value;
+        RefPtr<WordNode> next;
+
+        explicit WordNode(String word)
+            : value(word)
+        {
+        }
+    };
+
+    static size_t unadorned_text_length(String text);
+};
+
+}


### PR DESCRIPTION
As SerenityOS's documentation grows (both in number and length), I thought it'd be a nicer viewing experience if the text was justified. This PR does the following:

- Introduces a new TextAlignment class in LibMarkdown which knows how to justify text
- Teaches markdown Paragraphs to be justified

This is a work in progress, as there's a few corner-cases and missing features, but here's what it looks like so far:

![Justified Man Page](https://user-images.githubusercontent.com/55467/139506330-42eb760b-8724-4d51-a03f-f852a93fe605.png)

