### PR TITLE
AK+Tests: Fix formatting of infinity and NaN values

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -365,14 +365,14 @@ void FormatBuilder::put_f64(
             string_builder.append('-');
         else if (sign_mode == SignMode::Always)
             string_builder.append('+');
-        else
+        else if (sign_mode == SignMode::Reserved)
             string_builder.append(' ');
 
         if (isnan(value))
             string_builder.append(upper_case ? "NAN"sv : "nan"sv);
         else
             string_builder.append(upper_case ? "INF"sv : "inf"sv);
-        format_builder.put_string(string_builder.string_view(), align, min_width, NumericLimits<size_t>::max(), fill);
+        put_string(string_builder.string_view(), align, min_width, NumericLimits<size_t>::max(), fill);
         return;
     }
 
@@ -431,14 +431,14 @@ void FormatBuilder::put_f80(
             string_builder.append('-');
         else if (sign_mode == SignMode::Always)
             string_builder.append('+');
-        else
+        else if (sign_mode == SignMode::Reserved)
             string_builder.append(' ');
 
         if (isnan(value))
             string_builder.append(upper_case ? "NAN"sv : "nan"sv);
         else
             string_builder.append(upper_case ? "INF"sv : "inf"sv);
-        format_builder.put_string(string_builder.string_view(), align, min_width, NumericLimits<size_t>::max(), fill);
+        put_string(string_builder.string_view(), align, min_width, NumericLimits<size_t>::max(), fill);
         return;
     }
 

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
+#include <math.h>
 
 TEST_CASE(is_integral_works_properly)
 {
@@ -240,6 +241,10 @@ TEST_CASE(floating_point_numbers)
     EXPECT_EQ(String::formatted("{:.3}", 1.12), "1.12");
     EXPECT_EQ(String::formatted("{:.1}", 1.12), "1.1");
     EXPECT_EQ(String::formatted("{}", -1.12), "-1.12");
+
+    EXPECT_EQ(String::formatted("{}", NAN), "nan");
+    EXPECT_EQ(String::formatted("{}", INFINITY), "inf");
+    EXPECT_EQ(String::formatted("{}", -INFINITY), "-inf");
 
     // FIXME: There is always the question what we mean with the width field. Do we mean significant digits?
     //        Do we mean the whole width? This is what was the simplest to implement:


### PR DESCRIPTION
When I added this code in 1472f6d, I forgot to add tests for it. That's
why I didn't realize that the values were appended to the wrong
FormatBuilder object, so an empty string was returned instead of the
expected "nan"/"inf". This made debugging some FPU issues with the
ScummVM port significantly more difficult.