### PR TITLE
Utilities: Add 'quiet' and 'suppress errors' options to grep

### DIFF
--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -47,6 +47,7 @@ int main(int argc, char** argv)
     BinaryFileMode binary_mode { BinaryFileMode::Binary };
     bool case_insensitive = false;
     bool invert_match = false;
+    bool quiet_mode = false;
     bool colored_output = isatty(STDOUT_FILENO);
 
     Core::ArgsParser args_parser;
@@ -55,6 +56,7 @@ int main(int argc, char** argv)
     args_parser.add_option(pattern, "Pattern", "regexp", 'e', "Pattern");
     args_parser.add_option(case_insensitive, "Make matches case-insensitive", nullptr, 'i');
     args_parser.add_option(invert_match, "Select non-matching lines", "invert-match", 'v');
+    args_parser.add_option(quiet_mode, "Do not write anything to standard output", "quiet", 'q');
     args_parser.add_option(Core::ArgsParser::Option {
         .requires_argument = true,
         .help_string = "Action to take for binary files ([binary], text, skip)",
@@ -132,6 +134,9 @@ int main(int argc, char** argv)
 
             auto result = re.match(str, PosixFlags::Global);
             if (result.success ^ invert_match) {
+                if (quiet_mode)
+                    return true;
+
                 if (is_binary && binary_mode == BinaryFileMode::Binary) {
                     outln(colored_output ? "binary file \x1B[34m{}\x1B[0m matches" : "binary file {} matches", filename);
                 } else {

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -48,6 +48,7 @@ int main(int argc, char** argv)
     bool case_insensitive = false;
     bool invert_match = false;
     bool quiet_mode = false;
+    bool suppress_errors = false;
     bool colored_output = isatty(STDOUT_FILENO);
 
     Core::ArgsParser args_parser;
@@ -57,6 +58,7 @@ int main(int argc, char** argv)
     args_parser.add_option(case_insensitive, "Make matches case-insensitive", nullptr, 'i');
     args_parser.add_option(invert_match, "Select non-matching lines", "invert-match", 'v');
     args_parser.add_option(quiet_mode, "Do not write anything to standard output", "quiet", 'q');
+    args_parser.add_option(suppress_errors, "Suppress error messages for nonexistent or unreadable files", "no-messages", 's');
     args_parser.add_option(Core::ArgsParser::Option {
         .requires_argument = true,
         .help_string = "Action to take for binary files ([binary], text, skip)",
@@ -158,10 +160,11 @@ int main(int argc, char** argv)
             return false;
         };
 
-        auto handle_file = [&matches, binary_mode](StringView filename, bool print_filename) -> bool {
+        auto handle_file = [&matches, binary_mode, suppress_errors](StringView filename, bool print_filename) -> bool {
             auto file = Core::File::construct(filename);
             if (!file->open(Core::OpenMode::ReadOnly)) {
-                warnln("Failed to open {}: {}", filename, file->error_string());
+                if (!suppress_errors)
+                    warnln("Failed to open {}: {}", filename, file->error_string());
                 return false;
             }
 


### PR DESCRIPTION
These are respectively '-q' and '-s'. This is the POSIX description of what these 2 options should do (from here: https://pubs.opengroup.org/onlinepubs/9699919799/ )

> -q
>     Quiet. Nothing shall be written to the standard output, regardless of matching lines. Exit with zero status if an input line is selected.
> -s
>     Suppress the error messages ordinarily written for nonexistent or unreadable files. Other error messages shall not be suppressed.
