### PR TITLE
Kernel: Fix common misuse of KString in debug messages

### DIFF
--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -64,6 +64,14 @@ struct Formatter<OwnPtr<Kernel::KString>> : Formatter<StringView> {
 };
 
 template<>
+struct Formatter<NonnullOwnPtr<Kernel::KString>> : Formatter<StringView> {
+    void format(FormatBuilder& builder, NonnullOwnPtr<Kernel::KString> const& value)
+    {
+        Formatter<StringView>::format(builder, value->view());
+    }
+};
+
+template<>
 struct Traits<NonnullOwnPtr<Kernel::KString>> : public GenericTraits<NonnullOwnPtr<Kernel::KString>> {
     using PeekType = Kernel::KString*;
     using ConstPeekType = Kernel::KString const*;


### PR DESCRIPTION
In several places, we have code like this:
```
NonnullOwnPtr<KString> foo = /* ... */;
dbgln("{}", foo);
```

Currently, this outputs a pointer like `0xc14faee4` which is usually not helpful. This PR makes the above code behave as (probably) intended.

Example diff during boot:

```diff
 mount(8:8): Mounting all filesystems...
 mount(8:8): Skipping mounting root
 mount(8:8): Mounting /bin (bind) on /bin
-[#0 mount(8:8)]: mount bind: source fd 4 @ 0xc14faee4
+[#0 mount(8:8)]: mount bind: source fd 4 @ /bin
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:32513 at inode 1:32513
 mount(8:8): Mounting /etc (bind) on /etc
-[#0 mount(8:8)]: mount bind: source fd 5 @ 0xc14faee4
+[#0 mount(8:8)]: mount bind: source fd 5 @ /etc
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:8129 at inode 1:8129
 mount(8:8): Mounting /home (bind) on /home
-[#0 mount(8:8)]: mount bind: source fd 6 @ 0xc14faee4
+[#0 mount(8:8)]: mount bind: source fd 6 @ /home
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:16257 at inode 1:16257
 mount(8:8): Mounting /root (bind) on /root
-[#0 mount(8:8)]: mount bind: source fd 7 @ 0xc14faee4
+[#0 mount(8:8)]: mount bind: source fd 7 @ /root
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:32514 at inode 1:32514
 mount(8:8): Mounting /var (bind) on /var
-[#0 mount(8:8)]: mount bind: source fd 8 @ 0xc14faee4
+[#0 mount(8:8)]: mount bind: source fd 8 @ /var
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:20 at inode 1:20
 mount(8:8): Mounting /www (bind) on /www
-[#0 mount(8:8)]: mount bind: source fd 9 @ 0xc14f6004
+[#0 mount(8:8)]: mount bind: source fd 9 @ /www
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:16258 at inode 1:16258
 mount(8:8): Mounting /usr/Tests (bind) on /usr/Tests
-[#0 mount(8:8)]: mount bind: source fd 10 @ 0xc14f6004
+[#0 mount(8:8)]: mount bind: source fd 10 @ /usr/Tests
 [#0 mount(8:8)]: VirtualFileSystem: Bind-mounting inode 1:8358 at inode 1:8358
 mount(8:8): Mounting none (tmp) on /tmp
-[#0 mount(8:8)]: mount tmp @ 0xc14f6004
+[#0 mount(8:8)]: mount tmp @ /tmp
 [#0 mount(8:8)]: VirtualFileSystem: Mounting TmpFS at inode 1:18 with flags 5
-[#0 SystemServer(6:6)]: mount proc @ 0xc14b9e04
+[#0 SystemServer(6:6)]: mount proc @ /proc
 [#0 SystemServer(6:6)]: VirtualFileSystem: Mounting ProcFS at inode 1:16 with flags 4
-[#0 SystemServer(6:6)]: mount sys @ 0xc14b9e04
+[#0 SystemServer(6:6)]: mount sys @ /sys
 [#0 SystemServer(6:6)]: VirtualFileSystem: Mounting SysFS at inode 1:24 with flags 0
-[#0 SystemServer(6:6)]: mount dev @ 0xc14b9e04
+[#0 SystemServer(6:6)]: mount dev @ /dev
 [#0 SystemServer(6:6)]: VirtualFileSystem: Mounting DevTmpFS at inode 1:23 with flags 0
-[#0 SystemServer(6:6)]: mount devpts @ 0xc14b9c04
+[#0 SystemServer(6:6)]: mount devpts @ /dev/pts
 [#0 SystemServer(6:6)]: VirtualFileSystem: Mounting DevPtsFS at inode 5:25 with flags 0
```