### PR TITLE
Kernel: Untangle {File,Description}::absolute_path interface

### DIFF
--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -140,18 +140,9 @@ Device::~Device()
     VERIFY(m_state == State::BeingRemoved);
 }
 
-String Device::absolute_path() const
+KResultOr<NonnullOwnPtr<KString>> Device::pseudo_path(const OpenFileDescription&) const
 {
-    // FIXME: I assume we can't really provide a well known path in the kernel
-    // because this is a violation of abstraction layers between userland and the
-    // kernel, but maybe the whole name of "absolute_path" is just wrong as this
-    // is really not an "absolute_path".
-    return String::formatted("device:{},{}", major(), minor());
-}
-
-String Device::absolute_path(const OpenFileDescription&) const
-{
-    return absolute_path();
+    return KString::try_create(String::formatted("device:{},{}", major(), minor()));
 }
 
 void Device::process_next_queued_request(Badge<AsyncDeviceRequest>, const AsyncDeviceRequest& completed_request)

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -40,8 +40,7 @@ public:
     unsigned major() const { return m_major; }
     unsigned minor() const { return m_minor; }
 
-    virtual String absolute_path(const OpenFileDescription&) const override;
-    virtual String absolute_path() const;
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override;
 
     UserID uid() const { return m_uid; }
     GroupID gid() const { return m_gid; }

--- a/Kernel/FileSystem/AnonymousFile.cpp
+++ b/Kernel/FileSystem/AnonymousFile.cpp
@@ -30,4 +30,9 @@ KResultOr<Memory::Region*> AnonymousFile::mmap(Process& process, OpenFileDescrip
     return process.address_space().allocate_region_with_vmobject(range, m_vmobject, offset, {}, prot, shared);
 }
 
+KResultOr<NonnullOwnPtr<KString>> AnonymousFile::pseudo_path(const OpenFileDescription&) const
+{
+    return KString::try_create(":anonymous-file:"sv);
+}
+
 }

--- a/Kernel/FileSystem/AnonymousFile.h
+++ b/Kernel/FileSystem/AnonymousFile.h
@@ -24,7 +24,7 @@ public:
 
 private:
     virtual StringView class_name() const override { return "AnonymousFile"sv; }
-    virtual String absolute_path(const OpenFileDescription&) const override { return ":anonymous-file:"; }
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const;
     virtual bool can_read(const OpenFileDescription&, size_t) const override { return false; }
     virtual bool can_write(const OpenFileDescription&, size_t) const override { return false; }
     virtual KResultOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override { return ENOTSUP; }

--- a/Kernel/FileSystem/DevTmpFS.cpp
+++ b/Kernel/FileSystem/DevTmpFS.cpp
@@ -126,11 +126,6 @@ InodeMetadata DevTmpFSInode::metadata() const
         break;
     case Type::Link:
         metadata.inode = { fsid(), index() };
-        // FIXME: For now, it might not be possible to change the m_mode due to
-        // it pointing to another device node which its absolute_path() is not
-        // recognizable by the VirtualFileSystem.
-        // When we resolve the issues with the clunky absolute_path() interface,
-        // this should work out of the box...
         metadata.mode = S_IFLNK | m_mode;
         break;
     default:

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -132,9 +132,9 @@ KResultOr<size_t> FIFO::write(OpenFileDescription& fd, u64, const UserOrKernelBu
     return m_buffer->write(buffer, size);
 }
 
-String FIFO::absolute_path(const OpenFileDescription&) const
+KResultOr<NonnullOwnPtr<KString>> FIFO::pseudo_path(const OpenFileDescription&) const
 {
-    return String::formatted("fifo:{}", m_fifo_id);
+    return KString::try_create(String::formatted("fifo:{}", m_fifo_id));
 }
 
 KResult FIFO::stat(::stat& st) const

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -45,7 +45,7 @@ private:
     virtual KResult stat(::stat&) const override;
     virtual bool can_read(const OpenFileDescription&, size_t) const override;
     virtual bool can_write(const OpenFileDescription&, size_t) const override;
-    virtual String absolute_path(const OpenFileDescription&) const override;
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override;
     virtual StringView class_name() const override { return "FIFO"sv; }
     virtual bool is_fifo() const override { return true; }
 

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -93,7 +93,8 @@ public:
     virtual KResultOr<Memory::Region*> mmap(Process&, OpenFileDescription&, Memory::VirtualRange const&, u64 offset, int prot, bool shared);
     virtual KResult stat(::stat&) const { return EBADF; }
 
-    virtual String absolute_path(const OpenFileDescription&) const = 0;
+    // Although this might be better described "name" or "description", these terms already have other meanings.
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const = 0;
 
     virtual KResult truncate(u64) { return EINVAL; }
     virtual KResult sync() { return EINVAL; }

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -89,15 +89,14 @@ KResultOr<Memory::Region*> InodeFile::mmap(Process& process, OpenFileDescription
         vmobject = TRY(Memory::SharedInodeVMObject::try_create_with_inode(inode()));
     else
         vmobject = TRY(Memory::PrivateInodeVMObject::try_create_with_inode(inode()));
-    auto path = TRY(description.try_serialize_absolute_path());
+    auto path = TRY(description.pseudo_path());
     return process.address_space().allocate_region_with_vmobject(range, vmobject.release_nonnull(), offset, path->view(), prot, shared);
 }
 
-String InodeFile::absolute_path(const OpenFileDescription& description) const
+KResultOr<NonnullOwnPtr<KString>> InodeFile::pseudo_path(const OpenFileDescription&) const
 {
+    // If it has an inode, then it has a path, and therefore the caller should have been able to get a custody at some point.
     VERIFY_NOT_REACHED();
-    VERIFY(description.custody());
-    return description.absolute_path();
 }
 
 KResult InodeFile::truncate(u64 size)

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -36,7 +36,7 @@ public:
     virtual KResultOr<Memory::Region*> mmap(Process&, OpenFileDescription&, Memory::VirtualRange const&, u64 offset, int prot, bool shared) override;
     virtual KResult stat(::stat& buffer) const override { return inode().metadata().stat(buffer); }
 
-    virtual String absolute_path(const OpenFileDescription&) const override;
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override;
 
     virtual KResult truncate(u64) override;
     virtual KResult sync() override;

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -81,9 +81,9 @@ KResult InodeWatcher::close()
     return KSuccess;
 }
 
-String InodeWatcher::absolute_path(const OpenFileDescription&) const
+KResultOr<NonnullOwnPtr<KString>> InodeWatcher::pseudo_path(const OpenFileDescription&) const
 {
-    return String::formatted("InodeWatcher:({})", m_wd_to_watches.size());
+    return KString::try_create(String::formatted("InodeWatcher:({})", m_wd_to_watches.size()));
 }
 
 void InodeWatcher::notify_inode_event(Badge<Inode>, InodeIdentifier inode_id, InodeWatcherEvent::Type event_type, String const& name)

--- a/Kernel/FileSystem/InodeWatcher.h
+++ b/Kernel/FileSystem/InodeWatcher.h
@@ -50,7 +50,7 @@ public:
     virtual KResultOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return EIO; }
     virtual KResult close() override;
 
-    virtual String absolute_path(const OpenFileDescription&) const override;
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override;
     virtual StringView class_name() const override { return "InodeWatcher"sv; };
     virtual bool is_inode_watcher() const override { return true; }
 

--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -349,19 +349,18 @@ KResult OpenFileDescription::close()
     return m_file->close();
 }
 
-KResultOr<NonnullOwnPtr<KString>> OpenFileDescription::try_serialize_absolute_path()
+KResultOr<NonnullOwnPtr<KString>> OpenFileDescription::original_absolute_path() const
+{
+    if (!m_custody)
+        return ENOENT;
+    return m_custody->try_serialize_absolute_path();
+}
+
+KResultOr<NonnullOwnPtr<KString>> OpenFileDescription::pseudo_path() const
 {
     if (m_custody)
         return m_custody->try_serialize_absolute_path();
-    // FIXME: Don't go through a String here!
-    return KString::try_create(m_file->absolute_path(*this));
-}
-
-String OpenFileDescription::absolute_path() const
-{
-    if (m_custody)
-        return m_custody->absolute_path();
-    return m_file->absolute_path(*this);
+    return m_file->pseudo_path(*this);
 }
 
 InodeMetadata OpenFileDescription::metadata() const

--- a/Kernel/FileSystem/OpenFileDescription.h
+++ b/Kernel/FileSystem/OpenFileDescription.h
@@ -64,8 +64,8 @@ public:
 
     KResultOr<NonnullOwnPtr<KBuffer>> read_entire_file();
 
-    KResultOr<NonnullOwnPtr<KString>> try_serialize_absolute_path();
-    String absolute_path() const;
+    KResultOr<NonnullOwnPtr<KString>> original_absolute_path() const;
+    KResultOr<NonnullOwnPtr<KString>> pseudo_path() const;
 
     bool is_direct() const { return m_direct; }
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -724,11 +724,12 @@ KResult VirtualFileSystem::rmdir(StringView path, Custody& base)
     return parent_inode.remove_child(KLexicalPath::basename(path));
 }
 
-void VirtualFileSystem::for_each_mount(Function<void(Mount const&)> callback) const
+void VirtualFileSystem::for_each_mount(Function<IterationDecision(Mount const&)> callback) const
 {
     m_mounts.with_shared([&](auto& mounts) {
         for (auto& mount : mounts) {
-            callback(mount);
+            if (callback(mount) == IterationDecision::Break)
+                break;
         }
     });
 }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -124,7 +124,8 @@ KResult VirtualFileSystem::mount_root(FileSystem& fs)
     }
 
     m_root_inode = root_inode;
-    dmesgln("VirtualFileSystem: mounted root from {} ({})", fs.class_name(), static_cast<FileBackedFileSystem&>(fs).file_description().absolute_path());
+    auto pseudo_path = TRY(static_cast<FileBackedFileSystem&>(fs).file_description().pseudo_path());
+    dmesgln("VirtualFileSystem: mounted root from {} ({})", fs.class_name(), pseudo_path);
 
     m_mounts.with_exclusive([&](auto& mounts) {
         mounts.append(move(mount));

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -66,7 +66,7 @@ public:
     KResult mknod(StringView path, mode_t, dev_t, Custody& base);
     KResultOr<NonnullRefPtr<Custody>> open_directory(StringView path, Custody& base);
 
-    void for_each_mount(Function<void(const Mount&)>) const;
+    void for_each_mount(Function<IterationDecision(const Mount&)>) const;
 
     InodeIdentifier root_inode_id() const;
 

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -351,7 +351,8 @@ private:
     virtual KResult try_generate(KBufferBuilder& builder) override
     {
         JsonArraySerializer array { builder };
-        VirtualFileSystem::the().for_each_mount([&array](auto& mount) {
+        KResult result = KSuccess;
+        VirtualFileSystem::the().for_each_mount([&array, &result](auto& mount) {
             auto& fs = mount.guest_fs();
             auto fs_object = array.add_object();
             fs_object.add("class_name", fs.class_name());
@@ -368,6 +369,8 @@ private:
                 fs_object.add("source", static_cast<const FileBackedFileSystem&>(fs).file_description().absolute_path());
             else
                 fs_object.add("source", "none");
+
+            return IterationDecision::Continue;
         });
         array.finish();
         return KSuccess;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -456,10 +456,10 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
     return true;
 }
 
-String IPv4Socket::absolute_path(const OpenFileDescription&) const
+KResultOr<NonnullOwnPtr<KString>> IPv4Socket::pseudo_path(const OpenFileDescription&) const
 {
     if (m_role == Role::None)
-        return "socket";
+        return KString::try_create("socket"sv);
 
     StringBuilder builder;
     builder.append("socket:");
@@ -485,7 +485,7 @@ String IPv4Socket::absolute_path(const OpenFileDescription&) const
         VERIFY_NOT_REACHED();
     }
 
-    return builder.to_string();
+    return KString::try_create(builder.to_string());
 }
 
 KResult IPv4Socket::setsockopt(int level, int option, Userspace<const void*> user_value, socklen_t user_value_size)

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -61,7 +61,7 @@ public:
 
     IPv4SocketTuple tuple() const { return IPv4SocketTuple(m_local_address, m_local_port, m_peer_address, m_peer_port); }
 
-    String absolute_path(const OpenFileDescription& description) const override;
+    KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription& description) const override;
 
     u8 type_of_service() const { return m_type_of_service; }
     u8 ttl() const { return m_ttl; }

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -355,7 +355,7 @@ StringView LocalSocket::socket_path() const
     return m_path->view();
 }
 
-String LocalSocket::absolute_path(const OpenFileDescription& description) const
+KResultOr<NonnullOwnPtr<KString>> LocalSocket::pseudo_path(const OpenFileDescription& description) const
 {
     StringBuilder builder;
     builder.append("socket:");
@@ -378,7 +378,7 @@ String LocalSocket::absolute_path(const OpenFileDescription& description) const
         break;
     }
 
-    return builder.to_string();
+    return KString::try_create(builder.to_string());
 }
 
 KResult LocalSocket::getsockopt(OpenFileDescription& description, int level, int option, Userspace<void*> value, Userspace<socklen_t*> value_size)

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -32,7 +32,7 @@ public:
     static void for_each(Function<void(const LocalSocket&)>);
 
     StringView socket_path() const;
-    String absolute_path(const OpenFileDescription& description) const override;
+    KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription& description) const override;
 
     // ^Socket
     virtual KResult bind(Userspace<const sockaddr*>, socklen_t) override;

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -105,7 +105,7 @@ public:
     virtual KResultOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override final;
     virtual KResultOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override final;
     virtual KResult stat(::stat&) const override;
-    virtual String absolute_path(const OpenFileDescription&) const override = 0;
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override = 0;
 
     bool has_receive_timeout() const { return m_receive_timeout != Time::zero(); }
     const Time& receive_timeout() const { return m_receive_timeout; }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -565,9 +565,11 @@ bool Process::dump_perfcore()
 
     // Try to generate a filename which isn't already used.
     auto base_filename = String::formatted("{}_{}", name(), pid().value());
-    auto description_or_error = VirtualFileSystem::the().open(String::formatted("{}.profile", base_filename), O_CREAT | O_EXCL, 0400, current_directory(), UidAndGid { uid(), gid() });
+    auto perfcore_filename = String::formatted("{}.profile", base_filename);
+    auto description_or_error = VirtualFileSystem::the().open(perfcore_filename, O_CREAT | O_EXCL, 0400, current_directory(), UidAndGid { uid(), gid() });
     for (size_t attempt = 1; attempt < 10 && description_or_error.is_error(); ++attempt)
-        description_or_error = VirtualFileSystem::the().open(String::formatted("{}.{}.profile", base_filename, attempt), O_CREAT | O_EXCL, 0400, current_directory(), UidAndGid { uid(), gid() });
+        perfcore_filename = String::formatted("{}.{}.profile", base_filename, attempt);
+    description_or_error = VirtualFileSystem::the().open(perfcore_filename, O_CREAT | O_EXCL, 0400, current_directory(), UidAndGid { uid(), gid() });
     if (description_or_error.is_error()) {
         dbgln("Failed to generate perfcore for pid {}: Could not generate filename for the perfcore file.", pid().value());
         return false;
@@ -596,7 +598,7 @@ bool Process::dump_perfcore()
         return false;
     }
 
-    dbgln("Wrote perfcore for pid {} to {}", pid().value(), description.absolute_path());
+    dbgln("Wrote perfcore for pid {} to {}", pid().value(), perfcore_filename);
     return true;
 }
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -275,7 +275,7 @@ static KResultOr<LoadResult> load_elf_object(NonnullOwnPtr<Memory::AddressSpace>
     size_t master_tls_alignment = 0;
     FlatPtr load_base_address = 0;
 
-    auto elf_name = TRY(object_description.try_serialize_absolute_path());
+    auto elf_name = TRY(object_description.pseudo_path());
     VERIFY(!Processor::in_critical());
 
     Memory::MemoryManager::enter_address_space(*new_space);
@@ -438,7 +438,9 @@ KResult Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_descrip
 {
     VERIFY(is_user_process());
     VERIFY(!Processor::in_critical());
-    auto path = TRY(main_program_description->try_serialize_absolute_path());
+    // Although we *could* handle a pseudo_path here, trying to execute something that doesn't have
+    // a custody (e.g. BlockDevice or RandomDevice) is pretty suspicious anyway.
+    auto path = TRY(main_program_description->original_absolute_path());
 
     dbgln_if(EXEC_DEBUG, "do_exec: {}", path);
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -739,19 +739,19 @@ KResultOr<RefPtr<OpenFileDescription>> Process::find_elf_interpreter_for_executa
 
         auto elf_header = (ElfW(Ehdr)*)first_page;
         if (!ELF::validate_elf_header(*elf_header, interp_metadata.size)) {
-            dbgln("exec({}): Interpreter ({}) has invalid ELF header", path, interpreter_description->absolute_path());
+            dbgln("exec({}): Interpreter ({}) has invalid ELF header", path, interpreter_path);
             return ENOEXEC;
         }
 
         // Not using KResultOr here because we'll want to do the same thing in userspace in the RTLD
         String interpreter_interpreter_path;
         if (!ELF::validate_program_headers(*elf_header, interp_metadata.size, (u8*)first_page, nread, &interpreter_interpreter_path)) {
-            dbgln("exec({}): Interpreter ({}) has invalid ELF Program headers", path, interpreter_description->absolute_path());
+            dbgln("exec({}): Interpreter ({}) has invalid ELF Program headers", path, interpreter_path);
             return ENOEXEC;
         }
 
         if (!interpreter_interpreter_path.is_empty()) {
-            dbgln("exec({}): Interpreter ({}) has its own interpreter ({})! No thank you!", path, interpreter_description->absolute_path(), interpreter_interpreter_path);
+            dbgln("exec({}): Interpreter ({}) has its own interpreter ({})! No thank you!", path, interpreter_path, interpreter_interpreter_path);
             return ELOOP;
         }
 

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -70,7 +70,8 @@ KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*>
             return ENODEV;
         }
 
-        dbgln("mount: attempting to mount {} on {}", description->absolute_path(), target);
+        auto source_pseudo_path = TRY(description->pseudo_path());
+        dbgln("mount: attempting to mount {} on {}", source_pseudo_path, target);
 
         fs = TRY(Ext2FS::try_create(*description));
     } else if (fs_type == "9p"sv || fs_type == "Plan9FS"sv) {
@@ -96,7 +97,8 @@ KResultOr<FlatPtr> Process::sys$mount(Userspace<const Syscall::SC_mount_params*>
             dbgln("mount: this is not a seekable file");
             return ENODEV;
         }
-        dbgln("mount: attempting to mount {} on {}", description->absolute_path(), target);
+        auto source_pseudo_path = TRY(description->pseudo_path());
+        dbgln("mount: attempting to mount {} on {}", source_pseudo_path, target);
         fs = TRY(ISO9660FS::try_create(*description));
     } else {
         return ENODEV;

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -38,19 +38,19 @@ KResultOr<FlatPtr> Process::do_statvfs(StringView path, statvfs* buf)
 
     while (current_custody) {
         VirtualFileSystem::the().for_each_mount([&kernelbuf, &current_custody](auto& mount) {
-            if (current_custody) {
-                if (&current_custody->inode() == &mount.guest()) {
-                    int mountflags = mount.flags();
-                    int flags = 0;
-                    if (mountflags & MS_RDONLY)
-                        flags = flags | ST_RDONLY;
-                    if (mountflags & MS_NOSUID)
-                        flags = flags | ST_NOSUID;
+            if (&current_custody->inode() == &mount.guest()) {
+                int mountflags = mount.flags();
+                int flags = 0;
+                if (mountflags & MS_RDONLY)
+                    flags = flags | ST_RDONLY;
+                if (mountflags & MS_NOSUID)
+                    flags = flags | ST_NOSUID;
 
-                    kernelbuf.f_flag = flags;
-                    current_custody = nullptr;
-                }
+                kernelbuf.f_flag = flags;
+                current_custody = nullptr;
+                return IterationDecision::Break;
             }
+            return IterationDecision::Continue;
         });
 
         if (current_custody) {

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -77,7 +77,9 @@ KResultOr<FlatPtr> Process::sys$fstatvfs(int fd, statvfs* buf)
     REQUIRE_PROMISE(stdio);
 
     auto description = TRY(fds().open_file_description(fd));
-    return do_statvfs(description->absolute_path(), buf);
+    auto absolute_path = TRY(description->original_absolute_path());
+    // FIXME: TOCTOU bug! The file connected to the fd may or may not have been moved, and the name possibly taken by a different file.
+    return do_statvfs(absolute_path->view(), buf);
 }
 
 }

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -127,9 +127,10 @@ KResult MasterPTY::ioctl(OpenFileDescription& description, unsigned request, Use
     return EINVAL;
 }
 
-String MasterPTY::absolute_path(const OpenFileDescription&) const
+KResultOr<NonnullOwnPtr<KString>> MasterPTY::pseudo_path(const OpenFileDescription&) const
 {
-    return String::formatted("ptm:{}", m_pts_name);
+    // FIXME: Replace this and others of this pattern by KString::formatted()
+    return KString::try_create(String::formatted("ptm:{}", m_pts_name));
 }
 
 }

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -26,7 +26,7 @@ public:
     void notify_slave_closed(Badge<SlavePTY>);
     bool is_closed() const { return m_closed; }
 
-    virtual String absolute_path(const OpenFileDescription&) const override;
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override;
 
 private:
     explicit MasterPTY(unsigned index, NonnullOwnPtr<DoubleBuffer> buffer);

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -576,6 +576,11 @@ KResult TTY::ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg)
     return EINVAL;
 }
 
+KResultOr<NonnullOwnPtr<KString>> TTY::pseudo_path(const OpenFileDescription&) const
+{
+    return KString::try_create(tty_name());
+}
+
 void TTY::set_size(unsigned short columns, unsigned short rows)
 {
     m_rows = rows;

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -26,7 +26,7 @@ public:
     virtual bool can_read(const OpenFileDescription&, size_t) const override;
     virtual bool can_write(const OpenFileDescription&, size_t) const override;
     virtual KResult ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override final;
-    virtual String absolute_path(const OpenFileDescription&) const override { return tty_name(); }
+    virtual KResultOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription&) const override;
 
     virtual String const& tty_name() const = 0;
 


### PR DESCRIPTION
Found due to smelly code in InodeFile::absolute_path.

In particular, this replaces the following misleading methods:

`File::absolute_path`
This method *never* returns an actual path, and if called on an InodeFile (which is impossible), it would VERIFY_NOT_REACHED().

`OpenFileDescription::try_serialize_absolute_path` and `OpenFileDescription::absolute_path`
These methods do not guarantee to return an actual path (just like the other method), and even if they do, they do not guarantee that the path is still up-to-date (just like Custody::absolute_path). In particular, just renaming the method made a TOCTOU bug in `Process::sys$fstatvfs` obvious.

The new method signatures use KResultOr, just like try_serialize_absolute_path() already did.

For this PR I'll consider the following things out of scope:
- Fixing the already-existing TOCTOU bug
- Fixing the already-existing uses of StringBuilder where KBufferBuilder may be a better idea (primarily because KBufferBuilder does not return a KString)