### PR TITLE
Meta: Suppress rule v1047 in PVS-Studio Static Analysis

### DIFF
--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -100,10 +100,11 @@ jobs:
       # - We are the system headers: V677 Custom declaration of a standard '<example>' type. The declaration from system header files should be used instead.
       # - We have no choice: V1061 Extending the 'std' namespace may result in undefined behavior.
       # - TRY(..) macro breaks this rule: V530 The return value of function 'release_value' is required to be utilized.
+      # - False positives: V1047 Lifetime of the lambda is greater than lifetime of the local variable captured by reference.
       - name: Filter PVS Log
         working-directory: ${{ github.workspace }}/Build/${{ env.PVS_STUDIO_ANALYSIS_ARCH }}
         run: |
-          pvs-studio-analyzer suppress -v677 -v1061 -v530 project.plog
+          pvs-studio-analyzer suppress -v677 -v1061 -v530 -v1047 project.plog
           pvs-studio-analyzer filter-suppressed project.plog
 
       - name: Print PVS Log


### PR DESCRIPTION
This rule appears to produce a lot of noise, most of them look like false
positives (400+). Lets suppress for now to try to move the signal to noise
ratio higher for PVS-Studio.

Reference: tps://pvs-studio.com/en/docs/warnings/v1047/