### PR TITLE
SoundPlayer: Allow volume output of up to 150% and add some keyboard shortcuts

### DIFF
--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -87,7 +87,7 @@ void Player::set_loop_mode(LoopMode mode)
 
 void Player::set_volume(double volume)
 {
-    m_volume = clamp(volume, 0, 1.0);
+    m_volume = clamp(volume, 0, 1.5);
     m_audio_client_connection.set_self_volume(m_volume);
     volume_changed(m_volume);
 }

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -142,6 +142,15 @@ void SoundPlayerWidgetAdvancedView::keydown_event(GUI::KeyEvent& event)
     if (event.key() == Key_Space)
         m_play_button->click();
 
+    if (event.key() == Key_S)
+        m_stop_button->click();
+
+    if (event.key() == Key_Up)
+        m_volume_slider->set_value(m_volume_slider->value() + m_volume_slider->page_step());
+
+    if (event.key() == Key_Down)
+        m_volume_slider->set_value(m_volume_slider->value() - m_volume_slider->page_step());
+
     GUI::Widget::keydown_event(event);
 }
 

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -102,13 +102,13 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
     m_volume_label = &menubar.add<GUI::Label>();
     m_volume_label->set_fixed_width(30);
 
-    auto& volume_slider = menubar.add<GUI::HorizontalSlider>();
-    volume_slider.set_fixed_width(95);
-    volume_slider.set_min(0);
-    volume_slider.set_max(150);
-    volume_slider.set_value(100);
+    m_volume_slider = &menubar.add<GUI::HorizontalSlider>();
+    m_volume_slider->set_fixed_width(95);
+    m_volume_slider->set_min(0);
+    m_volume_slider->set_max(150);
+    m_volume_slider->set_value(100);
 
-    volume_slider.on_change = [&](int value) {
+    m_volume_slider->on_change = [&](int value) {
         double volume = m_nonlinear_volume_slider ? (double)(value * value) / (100 * 100) : value / 100.;
         set_volume(volume);
     };

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -73,6 +73,7 @@ private:
     RefPtr<GUI::Button> m_next_button;
     RefPtr<AutoSlider> m_playback_progress_slider;
     RefPtr<GUI::Label> m_volume_label;
+    RefPtr<GUI::HorizontalSlider> m_volume_slider;
     RefPtr<GUI::Label> m_timestamp_label;
 
     bool m_nonlinear_volume_slider;


### PR DESCRIPTION
This PR does two things:

- Fixes a bug in the volume slider where we could move it above 100% but the volume output didn't change between 100-150%.
- Adds three keyboard shortcuts: stop (key S), volume up (key Up) and volume down (key Down).

This is my first PR so... if I can improve something, let me know!