### PR TITLE
LibGUI: ComboBox interaction improvements

### DIFF
--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -193,8 +193,11 @@ void ComboBox::set_selected_index(size_t index)
 {
     if (!m_list_view->model())
         return;
+    size_t previous_index = selected_index();
     TemporaryChange change(m_updating_model, true);
     m_list_view->set_cursor(m_list_view->model()->index(index, 0), AbstractView::SelectionUpdate::Set);
+    if (previous_index != selected_index() && on_change)
+        on_change(m_editor->text(), m_list_view->cursor_index());
 }
 
 size_t ComboBox::selected_index() const

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -7,10 +7,12 @@
 #include <LibGUI/Button.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/Desktop.h>
+#include <LibGUI/Event.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGUI/TextBox.h>
+#include <LibGUI/TextEditor.h>
 #include <LibGUI/Window.h>
 
 REGISTER_WIDGET(GUI, ComboBox)
@@ -35,6 +37,16 @@ private:
             set_focus(true);
         if (on_mousewheel)
             on_mousewheel(event.wheel_delta());
+    }
+
+    virtual void keydown_event(KeyEvent& event) override
+    {
+        if (event.key() == Key_Escape) {
+            if (is_focused())
+                set_focus(false);
+            event.accept();
+        } else
+            TextEditor::keydown_event(event);
     }
 };
 


### PR DESCRIPTION
This came up while trying to use a ComboBox in the new synthesizer processor for Piano.

The first commit lets ComboBox report on_change if the selected index is set programmatically. All other widgets with similar functionality also do this so it seems very appropriate to have it.

The second commit makes it so that the ComboBox text editor releases focus when Escape is pressed, stopping it from swallowing key presses and helping in situations where you can't tab to another widget. Before that, once you clicked on the synthesizer processor's waveform selector, the keyboard piano input wouldn't work anymore (, again, ever).