### PR TITLE
LibDSP: Optimize the processor chain

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -46,6 +46,7 @@ public:
     [[nodiscard]] size_t size() const { return m_table.size(); }
     [[nodiscard]] size_t capacity() const { return m_table.capacity(); }
     void clear() { m_table.clear(); }
+    void clear_with_capacity() { m_table.clear_with_capacity(); }
 
     HashSetResult set(const K& key, const V& value) { return m_table.set({ key, value }); }
     HashSetResult set(const K& key, V&& value) { return m_table.set({ key, move(value) }); }

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -258,6 +258,21 @@ public:
     {
         *this = HashTable();
     }
+    void clear_with_capacity()
+    {
+        if constexpr (!Detail::IsTriviallyDestructible<T>) {
+            for (auto* bucket : *this)
+                bucket->~T();
+        }
+        __builtin_memset(m_buckets, 0, size_in_bytes(capacity()));
+        m_size = 0;
+        m_deleted_count = 0;
+
+        if constexpr (IsOrdered)
+            m_collection_data = { nullptr, nullptr };
+        else
+            m_buckets[m_capacity].end = true;
+    }
 
     template<typename U = T>
     HashSetResult try_set(U&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace)

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/Types.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
@@ -33,12 +34,14 @@ enum class SignalType : u8 {
     Note
 };
 
-struct Signal : public Variant<Sample, Vector<RollNote>> {
+using RollNotes = OrderedHashMap<u8, RollNote>;
+
+struct Signal : public Variant<Sample, RollNotes> {
     using Variant::Variant;
     ALWAYS_INLINE SignalType type() const
     {
-        return has<Sample>() ? SignalType::Sample : has<Vector<RollNote>>() ? SignalType::Note
-                                                                            : SignalType::Invalid;
+        return has<Sample>() ? SignalType::Sample : has<RollNotes>() ? SignalType::Note
+                                                                     : SignalType::Invalid;
     }
 };
 

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -19,7 +19,7 @@ using Sample = Audio::Frame;
 Sample const SAMPLE_OFF = { 0.0, 0.0 };
 
 struct RollNote {
-    u32 length() const { return (off_sample - on_sample) + 1; }
+    constexpr u32 length() const { return (off_sample - on_sample) + 1; }
 
     u32 on_sample;
     u32 off_sample;

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -6,13 +6,12 @@
 
 #pragma once
 
-#include "AK/Forward.h"
-#include "LibGUI/Label.h"
-#include "Music.h"
 #include <AK/FixedPoint.h>
 #include <AK/Format.h>
+#include <AK/Forward.h>
 #include <AK/Types.h>
 #include <LibCore/Object.h>
+#include <LibDSP/Music.h>
 
 namespace LibDSP {
 

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -19,6 +19,7 @@ class Track : public Core::Object {
 public:
     Track(NonnullRefPtr<Transport> transport)
         : m_transport(move(transport))
+        , m_current_signal(Sample {})
     {
     }
     virtual ~Track() override = default;
@@ -36,10 +37,12 @@ protected:
     bool check_processor_chain_valid_with_initial_type(SignalType initial_type) const;
 
     // Subclasses override to provide the base signal to the processing chain
-    virtual Signal current_clips_signal() = 0;
+    virtual void compute_current_clips_signal() = 0;
 
     NonnullRefPtrVector<Processor> m_processor_chain;
-    NonnullRefPtr<Transport> const m_transport;
+    NonnullRefPtr<Transport> m_transport;
+    // The current signal is stored here, to prevent unnecessary reallocation.
+    Signal m_current_signal;
 };
 
 class NoteTrack final : public Track {
@@ -50,7 +53,7 @@ public:
     NonnullRefPtrVector<NoteClip> const& clips() const { return m_clips; }
 
 protected:
-    virtual Signal current_clips_signal() override;
+    virtual void compute_current_clips_signal() override;
 
 private:
     NonnullRefPtrVector<NoteClip> m_clips;
@@ -64,7 +67,7 @@ public:
     NonnullRefPtrVector<AudioClip> const& clips() const { return m_clips; }
 
 protected:
-    virtual Signal current_clips_signal() override;
+    virtual void compute_current_clips_signal() override;
 
 private:
     NonnullRefPtrVector<AudioClip> m_clips;

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -16,12 +16,13 @@ namespace LibDSP {
 class Transport final : public Core::Object {
     C_OBJECT(Transport)
 public:
-    u32 const& time() const { return m_time; }
-    u16 beats_per_minute() const { return m_beats_per_minute; }
-    double current_second() const { return m_time / m_sample_rate; }
-    double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }
-    double sample_rate() const { return m_sample_rate; }
-    double current_measure() const { return m_time / samples_per_measure(); }
+    constexpr u32& time() { return m_time; }
+    constexpr u16 beats_per_minute() const { return m_beats_per_minute; }
+    constexpr double current_second() const { return static_cast<double>(m_time) / m_sample_rate; }
+    constexpr double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }
+    constexpr double sample_rate() const { return m_sample_rate; }
+    constexpr double ms_sample_rate() const { return m_sample_rate / 1000.; }
+    constexpr double current_measure() const { return m_time / samples_per_measure(); }
 
 private:
     Transport(u16 beats_per_minute, u8 beats_per_measure, u32 sample_rate)
@@ -35,6 +36,8 @@ private:
     {
     }
 
+    // FIXME: You can't make more than 24h of (48kHz) music with this.
+    // But do you want to, really? :^)
     u32 m_time { 0 };
     u16 const m_beats_per_minute { 0 };
     u8 const m_beats_per_measure { 0 };


### PR DESCRIPTION
A collection of changes that mainly makes the processor chain faster. With these changes extracted from #10167, the processor chain mainly avoids reallocations wherever possible by re-using a hash map for storing note values. Additionally, a constexpr refactoring should improve performance further