### PR TITLE
Piano: Always show Processor parameter values

### DIFF
--- a/Userland/Applications/Piano/ProcessorParameterSlider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterSlider.cpp
@@ -21,8 +21,16 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, LibD
         LibDSP::ParameterFixedPoint real_value;
         real_value.raw() = value;
         m_parameter.set_value_sneaky(real_value, LibDSP::Detail::ProcessorParameterSetValueTag {});
-        if (m_value_label)
-            m_value_label->set_text(String::formatted("{:.2f}", static_cast<double>(m_parameter)));
+        if (m_value_label) {
+            double value = static_cast<double>(m_parameter);
+            String label_text = String::formatted("{:.2f}", value);
+            // FIXME: This is a magic value; we know that with normal font sizes, the label will disappear starting from approximately this length.
+            //        Can we do this dynamically?
+            if (label_text.length() > 7)
+                m_value_label->set_text(String::formatted("{:.0f}", value));
+            else
+                m_value_label->set_text(label_text);
+        }
     };
     m_parameter.did_change_value = [this](auto value) {
         set_value(value.raw());


### PR DESCRIPTION
The processor parameter values are displayed with two decimal places by
default. However, when these values become very large and exceed about 7
text symbols, the text is too long to fit the label and it'll simply not
show up. This commit fixes that by disabling the decimal place for such
large values, which allows us to show values up to 9,999,999, be it
only at integer precision.
