### PR TITLE
Piano: Create controller widgets for processor parameters

### DIFF
--- a/Userland/Applications/Piano/CMakeLists.txt
+++ b/Userland/Applications/Piano/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SOURCES
     RollWidget.cpp
     SamplerWidget.cpp
     WaveWidget.cpp
-    ProcessorParameterSlider.cpp
+    ProcessorParameterWidget/Slider.cpp
 )
 
 serenity_app(Piano ICON app-piano)

--- a/Userland/Applications/Piano/KnobsWidget.h
+++ b/Userland/Applications/Piano/KnobsWidget.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "ProcessorParameterSlider.h"
+#include "ProcessorParameterWidget/Slider.h"
 #include <AK/NonnullRefPtrVector.h>
 #include <LibGUI/Frame.h>
 

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "WidgetWithLabel.h"
+#include <AK/Vector.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/ItemListModel.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/ModelIndex.h>
+
+template<typename EnumT>
+requires(IsEnum<EnumT>) class ProcessorParameterDropdown : public GUI::ComboBox {
+    C_OBJECT(ProcessorParameterDropdown);
+
+public:
+    ProcessorParameterDropdown(LibDSP::ProcessorEnumParameter<EnumT>& parameter, Vector<String> modes)
+        : ComboBox()
+        , m_parameter(parameter)
+        , m_modes(move(modes))
+    {
+        auto model = GUI::ItemListModel<EnumT, Vector<String>>::create(m_modes);
+        set_model(model);
+        set_only_allow_values_from_model(true);
+        set_model_column(0);
+        set_selected_index(0);
+        m_parameter.set_value(static_cast<EnumT>(0));
+
+        on_change = [this]([[maybe_unused]] auto name, GUI::ModelIndex model_index) {
+            auto value = static_cast<EnumT>(model_index.row());
+            m_parameter.set_value_sneaky(value, LibDSP::Detail::ProcessorParameterSetValueTag {});
+        };
+        m_parameter.did_change_value = [this](auto new_value) {
+            set_selected_index(static_cast<int>(new_value));
+        };
+    }
+
+    // Release focus when escape is pressed
+    virtual void keydown_event(GUI::KeyEvent& event) override
+    {
+        if (event.key() == Key_Escape) {
+            if (is_focused())
+                set_focus(false);
+            event.accept();
+        } else {
+            GUI::ComboBox::keydown_event(event);
+        }
+    }
+
+private:
+    LibDSP::ProcessorEnumParameter<EnumT>& m_parameter;
+    Vector<String> m_modes;
+};

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "ProcessorParameterSlider.h"
+#include "Slider.h"
+#include "WidgetWithLabel.h"
 
 ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, LibDSP::ProcessorRangeParameter& parameter, RefPtr<GUI::Label> value_label)
     : Slider(orientation)
+    , WidgetWithLabel(move(value_label))
     , m_parameter(parameter)
-    , m_value_label(move(value_label))
 {
     set_range(m_parameter.min_value().raw(), m_parameter.max_value().raw());
     set_value(m_parameter.value().raw());

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
@@ -6,19 +6,20 @@
 
 #pragma once
 
+#include "WidgetWithLabel.h"
 #include <LibDSP/ProcessorParameter.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Slider.h>
 #include <LibGfx/Orientation.h>
 
-class ProcessorParameterSlider : public GUI::Slider {
+class ProcessorParameterSlider
+    : public GUI::Slider
+    , public WidgetWithLabel {
     C_OBJECT(ProcessorParameterSlider);
 
 public:
     ProcessorParameterSlider(Orientation, LibDSP::ProcessorRangeParameter&, RefPtr<GUI::Label>);
-    RefPtr<GUI::Label> value_label() { return m_value_label; }
 
-private:
+protected:
     LibDSP::ProcessorRangeParameter& m_parameter;
-    RefPtr<GUI::Label> m_value_label;
 };

--- a/Userland/Applications/Piano/ProcessorParameterWidget/WidgetWithLabel.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/WidgetWithLabel.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <LibGUI/Label.h>
+
+class WidgetWithLabel {
+public:
+    WidgetWithLabel(RefPtr<GUI::Label> value_label)
+        : m_value_label(move(value_label))
+    {
+    }
+    RefPtr<GUI::Label> value_label() { return m_value_label; }
+
+protected:
+    RefPtr<GUI::Label> m_value_label;
+};


### PR DESCRIPTION
These widgets attach to a processor parameter and keep the two sides in sync. They will become very useful for smart processor interfaces.

Note that the dropdown widget is currently unused, which will change with #10726 where we need it for the waveform selection of the synthesizer. The other option is to consolidate these PRs which Andreas has expressed is not something good.