### PR TITLE
Spreadsheet+LibWeb: More ThrowCompletionOr conversions

### DIFF
--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -32,12 +32,12 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
     virtual void initialize_global_object() override;
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(get_real_cell_contents);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(set_real_cell_contents);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(parse_cell_name);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(current_cell_position);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(column_index);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(column_arithmetic);
+    JS_DECLARE_NATIVE_FUNCTION(get_real_cell_contents);
+    JS_DECLARE_NATIVE_FUNCTION(set_real_cell_contents);
+    JS_DECLARE_NATIVE_FUNCTION(parse_cell_name);
+    JS_DECLARE_NATIVE_FUNCTION(current_cell_position);
+    JS_DECLARE_NATIVE_FUNCTION(column_index);
+    JS_DECLARE_NATIVE_FUNCTION(column_arithmetic);
 
 private:
     virtual void visit_edges(Visitor&) override;
@@ -54,7 +54,7 @@ public:
 
     virtual void initialize(JS::GlobalObject&) override;
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(sheet);
+    JS_DECLARE_NATIVE_FUNCTION(sheet);
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Libraries/LibWeb/Bindings/CSSNamespace.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/CSSNamespace.cpp
@@ -26,40 +26,35 @@ void CSSNamespace::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
     u8 attr = JS::Attribute::Enumerable;
-    define_old_native_function("escape", escape, 1, attr);
-    define_old_native_function("supports", supports, 2, attr);
+    define_native_function("escape", escape, 1, attr);
+    define_native_function("supports", supports, 2, attr);
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-css-escape
-JS_DEFINE_OLD_NATIVE_FUNCTION(CSSNamespace::escape)
+JS_DEFINE_NATIVE_FUNCTION(CSSNamespace::escape)
 {
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "CSS.escape");
-        return {};
-    }
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "CSS.escape");
 
-    auto identifier = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
-
+    auto identifier = TRY(vm.argument(0).to_string(global_object));
     return JS::js_string(vm, Web::CSS::serialize_an_identifier(identifier));
 }
 
 // https://www.w3.org/TR/css-conditional-3/#dom-css-supports
-JS_DEFINE_OLD_NATIVE_FUNCTION(CSSNamespace::supports)
+JS_DEFINE_NATIVE_FUNCTION(CSSNamespace::supports)
 {
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "CSS.supports");
-        return {};
-    }
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "CSS.supports");
 
     if (vm.argument_count() >= 2) {
         // When the supports(property, value) method is invoked with two arguments property and value:
-        auto property_name = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        auto property_name = TRY(vm.argument(0).to_string(global_object));
 
         // If property is an ASCII case-insensitive match for any defined CSS property that the UA supports,
         // and value successfully parses according to that property’s grammar, return true.
         auto property = CSS::property_id_from_string(property_name);
         if (property != CSS::PropertyID::Invalid) {
-            auto value_string = TRY_OR_DISCARD(vm.argument(1).to_string(global_object));
+            auto value_string = TRY(vm.argument(1).to_string(global_object));
             if (parse_css_value({}, value_string, property))
                 return JS::Value(true);
         }
@@ -73,7 +68,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(CSSNamespace::supports)
         return JS::Value(false);
     } else {
         // When the supports(conditionText) method is invoked with a single conditionText argument:
-        auto supports_text = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        auto supports_text = TRY(vm.argument(0).to_string(global_object));
 
         // If conditionText, parsed and evaluated as a <supports-condition>, would return true, return true.
         if (auto supports = parse_css_supports({}, supports_text); supports && supports->matches())

--- a/Userland/Libraries/LibWeb/Bindings/CSSNamespace.h
+++ b/Userland/Libraries/LibWeb/Bindings/CSSNamespace.h
@@ -21,8 +21,8 @@ public:
     virtual ~CSSNamespace() override;
 
 private:
-    JS_DECLARE_OLD_NATIVE_FUNCTION(escape);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(supports);
+    JS_DECLARE_NATIVE_FUNCTION(escape);
+    JS_DECLARE_NATIVE_FUNCTION(supports);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -25,64 +25,62 @@ void LocationObject::initialize(JS::GlobalObject& global_object)
 
     Object::initialize(global_object);
     u8 attr = JS::Attribute::Writable | JS::Attribute::Enumerable;
-    define_old_native_accessor("href", href_getter, href_setter, attr);
-    define_old_native_accessor("host", host_getter, {}, attr);
-    define_old_native_accessor("hostname", hostname_getter, {}, attr);
-    define_old_native_accessor("pathname", pathname_getter, {}, attr);
-    define_old_native_accessor("hash", hash_getter, {}, attr);
-    define_old_native_accessor("search", search_getter, {}, attr);
-    define_old_native_accessor("protocol", protocol_getter, {}, attr);
-    define_old_native_accessor("port", port_getter, {}, attr);
+    define_native_accessor("href", href_getter, href_setter, attr);
+    define_native_accessor("host", host_getter, {}, attr);
+    define_native_accessor("hostname", hostname_getter, {}, attr);
+    define_native_accessor("pathname", pathname_getter, {}, attr);
+    define_native_accessor("hash", hash_getter, {}, attr);
+    define_native_accessor("search", search_getter, {}, attr);
+    define_native_accessor("protocol", protocol_getter, {}, attr);
+    define_native_accessor("port", port_getter, {}, attr);
 
-    define_old_native_function("reload", reload, 0, JS::Attribute::Enumerable);
-    define_old_native_function("replace", replace, 1, JS::Attribute::Enumerable);
+    define_native_function("reload", reload, 0, JS::Attribute::Enumerable);
+    define_native_function("replace", replace, 1, JS::Attribute::Enumerable);
 
-    define_old_native_function(vm.names.toString, href_getter, 0, JS::Attribute::Enumerable);
+    define_native_function(vm.names.toString, href_getter, 0, JS::Attribute::Enumerable);
 }
 
 LocationObject::~LocationObject()
 {
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::href_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::href_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::js_string(vm, window.impl().associated_document().url().to_string());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::href_setter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::href_setter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
-    auto new_href = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+    auto new_href = TRY(vm.argument(0).to_string(global_object));
     auto href_url = window.impl().associated_document().parse_url(new_href);
-    if (!href_url.is_valid()) {
-        vm.throw_exception<JS::URIError>(global_object, String::formatted("Invalid URL '{}'", new_href));
-        return {};
-    }
+    if (!href_url.is_valid())
+        return vm.throw_completion<JS::URIError>(global_object, String::formatted("Invalid URL '{}'", new_href));
     window.impl().did_set_location_href({}, href_url);
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::pathname_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::pathname_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::js_string(vm, window.impl().associated_document().url().path());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::hostname_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::hostname_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::js_string(vm, window.impl().associated_document().url().host());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::host_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::host_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     auto url = window.impl().associated_document().url();
     return JS::js_string(vm, String::formatted("{}:{}", url.host(), url.port_or_default()));
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::hash_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::hash_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     auto fragment = window.impl().associated_document().url().fragment();
@@ -94,7 +92,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::hash_getter)
     return JS::js_string(vm, builder.to_string());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::search_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::search_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     auto query = window.impl().associated_document().url().query();
@@ -106,7 +104,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::search_getter)
     return JS::js_string(vm, builder.to_string());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::protocol_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::protocol_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     StringBuilder builder;
@@ -115,23 +113,23 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::protocol_getter)
     return JS::js_string(vm, builder.to_string());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::port_getter)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::port_getter)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     return JS::Value(window.impl().associated_document().url().port_or_default());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::reload)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::reload)
 {
     auto& window = static_cast<WindowObject&>(global_object);
     window.impl().did_call_location_reload({});
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(LocationObject::replace)
+JS_DEFINE_NATIVE_FUNCTION(LocationObject::replace)
 {
     auto& window = static_cast<WindowObject&>(global_object);
-    auto url = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+    auto url = TRY(vm.argument(0).to_string(global_object));
     // FIXME: This needs spec compliance work.
     window.impl().did_call_location_replace({}, move(url));
     return JS::js_undefined();

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.h
@@ -29,19 +29,19 @@ public:
     //        but we don't have the infrastructure in place to implement them yet.
 
 private:
-    JS_DECLARE_OLD_NATIVE_FUNCTION(reload);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(replace);
+    JS_DECLARE_NATIVE_FUNCTION(reload);
+    JS_DECLARE_NATIVE_FUNCTION(replace);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(href_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(href_setter);
+    JS_DECLARE_NATIVE_FUNCTION(href_getter);
+    JS_DECLARE_NATIVE_FUNCTION(href_setter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(host_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(hostname_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(pathname_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(hash_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(search_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(protocol_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(port_getter);
+    JS_DECLARE_NATIVE_FUNCTION(host_getter);
+    JS_DECLARE_NATIVE_FUNCTION(hostname_getter);
+    JS_DECLARE_NATIVE_FUNCTION(pathname_getter);
+    JS_DECLARE_NATIVE_FUNCTION(hash_getter);
+    JS_DECLARE_NATIVE_FUNCTION(search_getter);
+    JS_DECLARE_NATIVE_FUNCTION(protocol_getter);
+    JS_DECLARE_NATIVE_FUNCTION(port_getter);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -33,8 +33,8 @@ void NavigatorObject::initialize(JS::GlobalObject& global_object)
     define_direct_property("platform", js_string(heap, "SerenityOS"), attr);
     define_direct_property("product", js_string(heap, "Gecko"), attr);
 
-    define_old_native_accessor("userAgent", user_agent_getter, {}, JS::Attribute::Configurable | JS::Attribute::Enumerable);
-    define_old_native_accessor("cookieEnabled", cookie_enabled_getter, {}, JS::Attribute::Configurable | JS::Attribute::Enumerable);
+    define_native_accessor("userAgent", user_agent_getter, {}, JS::Attribute::Configurable | JS::Attribute::Enumerable);
+    define_native_accessor("cookieEnabled", cookie_enabled_getter, {}, JS::Attribute::Configurable | JS::Attribute::Enumerable);
 
     // FIXME: Reflect actual connectivity status.
     define_direct_property("onLine", JS::Value(true), attr);
@@ -44,12 +44,12 @@ NavigatorObject::~NavigatorObject()
 {
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(NavigatorObject::user_agent_getter)
+JS_DEFINE_NATIVE_FUNCTION(NavigatorObject::user_agent_getter)
 {
     return JS::js_string(vm, ResourceLoader::the().user_agent());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(NavigatorObject::cookie_enabled_getter)
+JS_DEFINE_NATIVE_FUNCTION(NavigatorObject::cookie_enabled_getter)
 {
     // No way of disabling cookies right now :^)
     return JS::Value(true);

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.h
@@ -21,8 +21,8 @@ public:
     virtual ~NavigatorObject() override;
 
 private:
-    JS_DECLARE_OLD_NATIVE_FUNCTION(user_agent_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(cookie_enabled_getter);
+    JS_DECLARE_NATIVE_FUNCTION(user_agent_getter);
+    JS_DECLARE_NATIVE_FUNCTION(cookie_enabled_getter);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/Replaceable.h
+++ b/Userland/Libraries/LibWeb/Bindings/Replaceable.h
@@ -6,12 +6,10 @@
 
 #pragma once
 
-#define REPLACEABLE_PROPERTY_SETTER(ObjectType, property)                                                \
-    auto this_value = vm.this_value(global_object);                                                      \
-    if (!this_value.is_object() || !is<ObjectType>(this_value.as_object())) {                            \
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, #ObjectType); \
-        return {};                                                                                       \
-    }                                                                                                    \
-    TRY_OR_DISCARD(this_value.as_object().internal_define_own_property(                                  \
-        #property, JS::PropertyDescriptor { .value = vm.argument(0), .writable = true }));               \
+#define REPLACEABLE_PROPERTY_SETTER(ObjectType, property)                                                        \
+    auto this_value = vm.this_value(global_object);                                                              \
+    if (!this_value.is_object() || !is<ObjectType>(this_value.as_object()))                                      \
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, #ObjectType); \
+    TRY(this_value.as_object().internal_define_own_property(                                                     \
+        #property, JS::PropertyDescriptor { .value = vm.argument(0), .writable = true }));                       \
     return JS::js_undefined();

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -63,54 +63,54 @@ void WindowObject::initialize_global_object()
     define_direct_property("window", this, JS::Attribute::Enumerable);
     define_direct_property("frames", this, JS::Attribute::Enumerable);
     define_direct_property("self", this, JS::Attribute::Enumerable);
-    define_old_native_accessor("top", top_getter, nullptr, JS::Attribute::Enumerable);
-    define_old_native_accessor("parent", parent_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("document", document_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("history", history_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("performance", performance_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("crypto", crypto_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("screen", screen_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("innerWidth", inner_width_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("innerHeight", inner_height_getter, {}, JS::Attribute::Enumerable);
-    define_old_native_accessor("devicePixelRatio", device_pixel_ratio_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor("top", top_getter, nullptr, JS::Attribute::Enumerable);
+    define_native_accessor("parent", parent_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("document", document_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("history", history_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("performance", performance_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("crypto", crypto_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("screen", screen_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("innerWidth", inner_width_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("innerHeight", inner_height_getter, {}, JS::Attribute::Enumerable);
+    define_native_accessor("devicePixelRatio", device_pixel_ratio_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
     u8 attr = JS::Attribute::Writable | JS::Attribute::Enumerable | JS::Attribute::Configurable;
-    define_old_native_function("alert", alert, 0, attr);
-    define_old_native_function("confirm", confirm, 0, attr);
-    define_old_native_function("prompt", prompt, 0, attr);
-    define_old_native_function("setInterval", set_interval, 1, attr);
-    define_old_native_function("setTimeout", set_timeout, 1, attr);
-    define_old_native_function("clearInterval", clear_interval, 1, attr);
-    define_old_native_function("clearTimeout", clear_timeout, 1, attr);
-    define_old_native_function("requestAnimationFrame", request_animation_frame, 1, attr);
-    define_old_native_function("cancelAnimationFrame", cancel_animation_frame, 1, attr);
-    define_old_native_function("atob", atob, 1, attr);
-    define_old_native_function("btoa", btoa, 1, attr);
+    define_native_function("alert", alert, 0, attr);
+    define_native_function("confirm", confirm, 0, attr);
+    define_native_function("prompt", prompt, 0, attr);
+    define_native_function("setInterval", set_interval, 1, attr);
+    define_native_function("setTimeout", set_timeout, 1, attr);
+    define_native_function("clearInterval", clear_interval, 1, attr);
+    define_native_function("clearTimeout", clear_timeout, 1, attr);
+    define_native_function("requestAnimationFrame", request_animation_frame, 1, attr);
+    define_native_function("cancelAnimationFrame", cancel_animation_frame, 1, attr);
+    define_native_function("atob", atob, 1, attr);
+    define_native_function("btoa", btoa, 1, attr);
 
-    define_old_native_function("queueMicrotask", queue_microtask, 1, attr);
+    define_native_function("queueMicrotask", queue_microtask, 1, attr);
 
-    define_old_native_function("getComputedStyle", get_computed_style, 1, attr);
-    define_old_native_function("matchMedia", match_media, 1, attr);
-    define_old_native_function("getSelection", get_selection, 0, attr);
+    define_native_function("getComputedStyle", get_computed_style, 1, attr);
+    define_native_function("matchMedia", match_media, 1, attr);
+    define_native_function("getSelection", get_selection, 0, attr);
 
     // FIXME: These properties should be [Replaceable] according to the spec, but [Writable+Configurable] is the closest we have.
-    define_old_native_accessor("scrollX", scroll_x_getter, {}, attr);
-    define_old_native_accessor("pageXOffset", scroll_x_getter, {}, attr);
-    define_old_native_accessor("scrollY", scroll_y_getter, {}, attr);
-    define_old_native_accessor("pageYOffset", scroll_y_getter, {}, attr);
+    define_native_accessor("scrollX", scroll_x_getter, {}, attr);
+    define_native_accessor("pageXOffset", scroll_x_getter, {}, attr);
+    define_native_accessor("scrollY", scroll_y_getter, {}, attr);
+    define_native_accessor("pageYOffset", scroll_y_getter, {}, attr);
 
-    define_old_native_function("scroll", scroll, 2, attr);
-    define_old_native_function("scrollTo", scroll, 2, attr);
-    define_old_native_function("scrollBy", scroll_by, 2, attr);
+    define_native_function("scroll", scroll, 2, attr);
+    define_native_function("scrollTo", scroll, 2, attr);
+    define_native_function("scrollBy", scroll_by, 2, attr);
 
-    define_old_native_accessor("screenX", screen_x_getter, {}, attr);
-    define_old_native_accessor("screenY", screen_y_getter, {}, attr);
-    define_old_native_accessor("screenLeft", screen_left_getter, {}, attr);
-    define_old_native_accessor("screenTop", screen_top_getter, {}, attr);
+    define_native_accessor("screenX", screen_x_getter, {}, attr);
+    define_native_accessor("screenY", screen_y_getter, {}, attr);
+    define_native_accessor("screenLeft", screen_left_getter, {}, attr);
+    define_native_accessor("screenTop", screen_top_getter, {}, attr);
 
     define_direct_property("CSS", heap().allocate<CSSNamespace>(*this, *this), 0);
 
     // Legacy
-    define_old_native_accessor("event", event_getter, event_setter, JS::Attribute::Enumerable);
+    define_native_accessor("event", event_getter, event_setter, JS::Attribute::Enumerable);
 
     m_location_object = heap().allocate<LocationObject>(*this, *this);
 
@@ -124,7 +124,7 @@ void WindowObject::initialize_global_object()
 
     // HTML::GlobalEventHandlers
 #define __ENUMERATE(attribute, event_name) \
-    define_old_native_accessor(#attribute, attribute##_getter, attribute##_setter, attr);
+    define_native_accessor(#attribute, attribute##_getter, attribute##_setter, attr);
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE);
 #undef __ENUMERATE
 
@@ -157,7 +157,7 @@ JS::ThrowCompletionOr<bool> WindowObject::internal_set_prototype_of(JS::Object* 
     return set_immutable_prototype(prototype);
 }
 
-static DOM::Window* impl_from(JS::VM& vm, JS::GlobalObject& global_object)
+static JS::ThrowCompletionOr<DOM::Window*> impl_from(JS::VM& vm, JS::GlobalObject& global_object)
 {
     // Since this is a non built-in function we must treat it as non-strict mode
     // this means that a nullish this_value should be converted to the
@@ -172,51 +172,43 @@ static DOM::Window* impl_from(JS::VM& vm, JS::GlobalObject& global_object)
 
     auto* this_object = MUST(this_value.to_object(global_object));
 
-    if (StringView("WindowObject") != this_object->class_name()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "WindowObject");
-        return nullptr;
-    }
+    if (StringView("WindowObject") != this_object->class_name())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "WindowObject");
     return &static_cast<WindowObject*>(this_object)->impl();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::alert)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::alert)
 {
     // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#simple-dialogs
     // Note: This method is defined using two overloads, instead of using an optional argument,
     //       for historical reasons. The practical impact of this is that alert(undefined) is
     //       treated as alert("undefined"), but alert() is treated as alert("").
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     String message = "";
     if (vm.argument_count())
-        message = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        message = TRY(vm.argument(0).to_string(global_object));
     impl->alert(message);
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::confirm)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::confirm)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     String message = "";
     if (!vm.argument(0).is_undefined())
-        message = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        message = TRY(vm.argument(0).to_string(global_object));
     return JS::Value(impl->confirm(message));
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::prompt)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::prompt)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     String message = "";
     String default_ = "";
     if (!vm.argument(0).is_undefined())
-        message = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        message = TRY(vm.argument(0).to_string(global_object));
     if (!vm.argument(1).is_undefined())
-        default_ = TRY_OR_DISCARD(vm.argument(1).to_string(global_object));
+        default_ = TRY(vm.argument(1).to_string(global_object));
     auto response = impl->prompt(message, default_);
     if (response.is_null())
         return JS::js_null();
@@ -224,22 +216,18 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::prompt)
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::set_interval)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::set_interval)
 {
     // FIXME: Ideally this would share more code with setTimeout() using the "timer initialization steps"
     // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "setInterval");
-        return {};
-    }
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "setInterval");
     JS::FunctionObject* callback;
     if (vm.argument(0).is_function()) {
         callback = &vm.argument(0).as_function();
     } else {
-        auto script_source = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        auto script_source = TRY(vm.argument(0).to_string(global_object));
         // FIXME: This needs more work once we have a environment settings object.
         // The spec wants us to use a task for the "run function or script string" part,
         // using a NativeFunction for the latter is a workaround so that we can reuse the
@@ -251,7 +239,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::set_interval)
     }
     i32 interval = 0;
     if (vm.argument_count() >= 2) {
-        interval = TRY_OR_DISCARD(vm.argument(1).to_i32(global_object));
+        interval = TRY(vm.argument(1).to_i32(global_object));
         if (interval < 0)
             interval = 0;
     }
@@ -261,22 +249,18 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::set_interval)
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::set_timeout)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::set_timeout)
 {
     // FIXME: Ideally this would share more code with setInterval() using the "timer initialization steps"
     // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "setTimeout");
-        return {};
-    }
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "setTimeout");
     JS::FunctionObject* callback;
     if (vm.argument(0).is_function()) {
         callback = &vm.argument(0).as_function();
     } else {
-        auto script_source = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+        auto script_source = TRY(vm.argument(0).to_string(global_object));
         // FIXME: This needs more work once we have a environment settings object.
         // The spec wants us to use a task for the "run function or script string" part,
         // using a NativeFunction for the latter is a workaround so that we can reuse the
@@ -288,7 +272,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::set_timeout)
     }
     i32 interval = 0;
     if (vm.argument_count() >= 2) {
-        interval = TRY_OR_DISCARD(vm.argument(1).to_i32(global_object));
+        interval = TRY(vm.argument(1).to_i32(global_object));
         if (interval < 0)
             interval = 0;
     }
@@ -297,99 +281,68 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::set_timeout)
     return JS::Value(timer_id);
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::clear_timeout)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::clear_timeout)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "clearTimeout");
-        return {};
-    }
-    i32 timer_id = TRY_OR_DISCARD(vm.argument(0).to_i32(global_object));
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "clearTimeout");
+    i32 timer_id = TRY(vm.argument(0).to_i32(global_object));
     impl->clear_timeout(timer_id);
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::clear_interval)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::clear_interval)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "clearInterval");
-        return {};
-    }
-    i32 timer_id = TRY_OR_DISCARD(vm.argument(0).to_i32(global_object));
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "clearInterval");
+    i32 timer_id = TRY(vm.argument(0).to_i32(global_object));
     impl->clear_interval(timer_id);
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::request_animation_frame)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::request_animation_frame)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "requestAnimationFrame");
-        return {};
-    }
-    auto* callback_object = TRY_OR_DISCARD(vm.argument(0).to_object(global_object));
-    if (!callback_object->is_function()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAFunctionNoParam);
-        return {};
-    }
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "requestAnimationFrame");
+    auto* callback_object = TRY(vm.argument(0).to_object(global_object));
+    if (!callback_object->is_function())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAFunctionNoParam);
     return JS::Value(impl->request_animation_frame(*static_cast<JS::FunctionObject*>(callback_object)));
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::cancel_animation_frame)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::cancel_animation_frame)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "cancelAnimationFrame");
-        return {};
-    }
-    auto id = TRY_OR_DISCARD(vm.argument(0).to_i32(global_object));
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "cancelAnimationFrame");
+    auto id = TRY(vm.argument(0).to_i32(global_object));
     impl->cancel_animation_frame(id);
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::queue_microtask)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::queue_microtask)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "queueMicrotask");
-        return {};
-    }
-    auto* callback_object = TRY_OR_DISCARD(vm.argument(0).to_object(global_object));
-    if (!callback_object->is_function()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAFunctionNoParam);
-        return {};
-    }
+    auto* impl = TRY(impl_from(vm, global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountAtLeastOne, "queueMicrotask");
+    auto* callback_object = TRY(vm.argument(0).to_object(global_object));
+    if (!callback_object->is_function())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAFunctionNoParam);
 
     impl->queue_microtask(static_cast<JS::FunctionObject&>(*callback_object));
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::atob)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::atob)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "atob");
-        return {};
-    }
-    auto string = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "atob");
+    auto string = TRY(vm.argument(0).to_string(global_object));
     auto decoded = decode_base64(StringView(string));
-    if (!decoded.has_value()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::InvalidFormat, "Base64");
-        return {};
-    }
+    if (!decoded.has_value())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::InvalidFormat, "Base64");
 
     // decode_base64() returns a byte string. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.
     auto decoder = TextCodec::decoder_for("windows-1252");
@@ -397,24 +350,17 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::atob)
     return JS::js_string(vm, decoder->to_utf8(decoded.value()));
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::btoa)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::btoa)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    if (!vm.argument_count()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "btoa");
-        return {};
-    }
-    auto string = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+    if (!vm.argument_count())
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "btoa");
+    auto string = TRY(vm.argument(0).to_string(global_object));
 
     Vector<u8> byte_string;
     byte_string.ensure_capacity(string.length());
     for (u32 code_point : Utf8View(string)) {
-        if (code_point > 0xff) {
-            vm.throw_exception<JS::InvalidCharacterError>(global_object, JS::ErrorType::NotAByteString, "btoa");
-            return {};
-        }
+        if (code_point > 0xff)
+            return vm.throw_completion<JS::InvalidCharacterError>(global_object, JS::ErrorType::NotAByteString, "btoa");
         byte_string.append(code_point);
     }
 
@@ -423,11 +369,9 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::btoa)
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#dom-top
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::top_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::top_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
 
     auto* this_browsing_context = impl->associated_document().browsing_context();
     if (!this_browsing_context)
@@ -439,11 +383,9 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::top_getter)
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#dom-parent
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::parent_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::parent_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
 
     auto* this_browsing_context = impl->associated_document().browsing_context();
     if (!this_browsing_context)
@@ -458,126 +400,98 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::parent_getter)
     return impl->wrapper();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::document_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::document_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return wrap(global_object, impl->associated_document());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::performance_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::performance_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return wrap(global_object, impl->performance());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::screen_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return wrap(global_object, impl->screen());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::event_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::event_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     if (!impl->current_event())
         return JS::js_undefined();
     return wrap(global_object, const_cast<DOM::Event&>(*impl->current_event()));
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::event_setter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::event_setter)
 {
     REPLACEABLE_PROPERTY_SETTER(WindowObject, event);
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::crypto_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::crypto_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return wrap(global_object, impl->crypto());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::inner_width_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::inner_width_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->inner_width());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::inner_height_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::inner_height_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->inner_height());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::device_pixel_ratio_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::device_pixel_ratio_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->device_pixel_ratio());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::get_computed_style)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::get_computed_style)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    auto* object = TRY_OR_DISCARD(vm.argument(0).to_object(global_object));
-    if (!is<ElementWrapper>(object)) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "DOM element");
-        return {};
-    }
+    auto* impl = TRY(impl_from(vm, global_object));
+    auto* object = TRY(vm.argument(0).to_object(global_object));
+    if (!is<ElementWrapper>(object))
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "DOM element");
 
     return wrap(global_object, impl->get_computed_style(static_cast<ElementWrapper*>(object)->impl()));
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::get_selection)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::get_selection)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     auto* selection = impl->get_selection();
     if (!selection)
         return JS::js_null();
     return wrap(global_object, *selection);
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::match_media)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::match_media)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
-    auto media = TRY_OR_DISCARD(vm.argument(0).to_string(global_object));
+    auto* impl = TRY(impl_from(vm, global_object));
+    auto media = TRY(vm.argument(0).to_string(global_object));
     return wrap(global_object, impl->match_media(move(media)));
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-window-scrollx
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_x_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::scroll_x_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->scroll_x());
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-window-scrolly
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_y_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::scroll_y_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->scroll_y());
 }
 
@@ -595,13 +509,11 @@ static void perform_a_scroll(Page& page, double x, double y, ScrollBehavior)
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-window-scroll
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::scroll)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     if (!impl->page())
-        return {};
+        return JS::js_undefined();
     auto& page = *impl->page();
 
     auto viewport_rect = page.top_level_browsing_context().viewport_rect();
@@ -610,22 +522,20 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll)
     String behavior_string = "auto";
 
     if (vm.argument_count() == 1) {
-        auto* options = TRY_OR_DISCARD(vm.argument(0).to_object(global_object));
-        auto left = TRY_OR_DISCARD(options->get("left"));
+        auto* options = TRY(vm.argument(0).to_object(global_object));
+        auto left = TRY(options->get("left"));
         if (!left.is_undefined())
             x_value = left;
 
-        auto top = TRY_OR_DISCARD(options->get("top"));
+        auto top = TRY(options->get("top"));
         if (!top.is_undefined())
             y_value = top;
 
-        auto behavior_string_value = TRY_OR_DISCARD(options->get("behavior"));
+        auto behavior_string_value = TRY(options->get("behavior"));
         if (!behavior_string_value.is_undefined())
-            behavior_string = TRY_OR_DISCARD(behavior_string_value.to_string(global_object));
-        if (behavior_string != "smooth" && behavior_string != "auto") {
-            vm.throw_exception<JS::TypeError>(global_object, "Behavior is not one of 'smooth' or 'auto'");
-            return {};
-        }
+            behavior_string = TRY(behavior_string_value.to_string(global_object));
+        if (behavior_string != "smooth" && behavior_string != "auto")
+            return vm.throw_completion<JS::TypeError>(global_object, "Behavior is not one of 'smooth' or 'auto'");
 
     } else if (vm.argument_count() >= 2) {
         // We ignore arguments 2+ in line with behavior of Chrome and Firefox
@@ -635,10 +545,10 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll)
 
     ScrollBehavior behavior = (behavior_string == "smooth") ? ScrollBehavior::Smooth : ScrollBehavior::Auto;
 
-    double x = TRY_OR_DISCARD(x_value.to_double(global_object));
+    double x = TRY(x_value.to_double(global_object));
     x = JS::Value(x).is_finite_number() ? x : 0.0;
 
-    double y = TRY_OR_DISCARD(y_value.to_double(global_object));
+    double y = TRY(y_value.to_double(global_object));
     y = JS::Value(y).is_finite_number() ? y : 0.0;
 
     // FIXME: Are we calculating the viewport in the way this function expects?
@@ -649,13 +559,11 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll)
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-window-scrollby
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_by)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::scroll_by)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     if (!impl->page())
-        return {};
+        return JS::js_undefined();
     auto& page = *impl->page();
 
     JS::Object* options = nullptr;
@@ -663,7 +571,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_by)
     if (vm.argument_count() == 0) {
         options = JS::Object::create(global_object, nullptr);
     } else if (vm.argument_count() == 1) {
-        options = TRY_OR_DISCARD(vm.argument(0).to_object(global_object));
+        options = TRY(vm.argument(0).to_object(global_object));
     } else if (vm.argument_count() >= 2) {
         // We ignore arguments 2+ in line with behavior of Chrome and Firefox
         options = JS::Object::create(global_object, nullptr);
@@ -672,11 +580,11 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_by)
         MUST(options->set("behavior", JS::js_string(vm, "auto"), ShouldThrowExceptions::No));
     }
 
-    auto left_value = TRY_OR_DISCARD(options->get("left"));
-    auto left = TRY_OR_DISCARD(left_value.to_double(global_object));
+    auto left_value = TRY(options->get("left"));
+    auto left = TRY(left_value.to_double(global_object));
 
-    auto top_value = TRY_OR_DISCARD(options->get("top"));
-    auto top = TRY_OR_DISCARD(top_value.to_double(global_object));
+    auto top_value = TRY(options->get("top"));
+    auto top = TRY(top_value.to_double(global_object));
 
     left = JS::Value(left).is_finite_number() ? left : 0.0;
     top = JS::Value(top).is_finite_number() ? top : 0.0;
@@ -685,12 +593,10 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_by)
     left = left + current_scroll_position.x();
     top = top + current_scroll_position.y();
 
-    auto behavior_string_value = TRY_OR_DISCARD(options->get("behavior"));
-    auto behavior_string = behavior_string_value.is_undefined() ? "auto" : TRY_OR_DISCARD(behavior_string_value.to_string(global_object));
-    if (behavior_string != "smooth" && behavior_string != "auto") {
-        vm.throw_exception<JS::TypeError>(global_object, "Behavior is not one of 'smooth' or 'auto'");
-        return {};
-    }
+    auto behavior_string_value = TRY(options->get("behavior"));
+    auto behavior_string = behavior_string_value.is_undefined() ? "auto" : TRY(behavior_string_value.to_string(global_object));
+    if (behavior_string != "smooth" && behavior_string != "auto")
+        return vm.throw_completion<JS::TypeError>(global_object, "Behavior is not one of 'smooth' or 'auto'");
     ScrollBehavior behavior = (behavior_string == "smooth") ? ScrollBehavior::Smooth : ScrollBehavior::Auto;
 
     // FIXME: Spec wants us to call scroll(options) here.
@@ -700,62 +606,48 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::scroll_by)
     return JS::js_undefined();
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::history_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::history_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return wrap(global_object, impl->associated_document().history());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::screen_left_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_left_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->screen_x());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::screen_top_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_top_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->screen_y());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::screen_x_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_x_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->screen_x());
 }
 
-JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::screen_y_getter)
+JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_y_getter)
 {
-    auto* impl = impl_from(vm, global_object);
-    if (!impl)
-        return {};
+    auto* impl = TRY(impl_from(vm, global_object));
     return JS::Value(impl->screen_y());
 }
 
 #define __ENUMERATE(attribute, event_name)                                   \
-    JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::attribute##_getter)          \
+    JS_DEFINE_NATIVE_FUNCTION(WindowObject::attribute##_getter)              \
     {                                                                        \
-        auto* impl = impl_from(vm, global_object);                           \
-        if (!impl)                                                           \
-            return {};                                                       \
+        auto* impl = TRY(impl_from(vm, global_object));                      \
         auto retval = impl->attribute();                                     \
         if (retval.callback.is_null())                                       \
             return JS::js_null();                                            \
         return retval.callback.cell();                                       \
     }                                                                        \
-    JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::attribute##_setter)          \
+    JS_DEFINE_NATIVE_FUNCTION(WindowObject::attribute##_setter)              \
     {                                                                        \
-        auto* impl = impl_from(vm, global_object);                           \
-        if (!impl)                                                           \
-            return {};                                                       \
+        auto* impl = TRY(impl_from(vm, global_object));                      \
         auto value = vm.argument(0);                                         \
         HTML::EventHandler cpp_value;                                        \
         if (value.is_function()) {                                           \
@@ -769,7 +661,7 @@ JS_DEFINE_OLD_NATIVE_FUNCTION(WindowObject::screen_y_getter)
             return impl->set_##attribute(cpp_value);                         \
         });                                                                  \
         if (should_return_empty(result))                                     \
-            return {};                                                       \
+            return JS::throw_completion(vm.exception()->value());            \
         return JS::js_undefined();                                           \
     }
 ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -66,57 +66,57 @@ public:
 private:
     virtual void visit_edges(Visitor&) override;
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(top_getter);
+    JS_DECLARE_NATIVE_FUNCTION(top_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(document_getter);
+    JS_DECLARE_NATIVE_FUNCTION(document_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(performance_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(history_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(screen_getter);
+    JS_DECLARE_NATIVE_FUNCTION(performance_getter);
+    JS_DECLARE_NATIVE_FUNCTION(history_getter);
+    JS_DECLARE_NATIVE_FUNCTION(screen_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(event_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(event_setter);
+    JS_DECLARE_NATIVE_FUNCTION(event_getter);
+    JS_DECLARE_NATIVE_FUNCTION(event_setter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(inner_width_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(inner_height_getter);
+    JS_DECLARE_NATIVE_FUNCTION(inner_width_getter);
+    JS_DECLARE_NATIVE_FUNCTION(inner_height_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(parent_getter);
+    JS_DECLARE_NATIVE_FUNCTION(parent_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(device_pixel_ratio_getter);
+    JS_DECLARE_NATIVE_FUNCTION(device_pixel_ratio_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(scroll_x_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(scroll_y_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(scroll);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(scroll_by);
+    JS_DECLARE_NATIVE_FUNCTION(scroll_x_getter);
+    JS_DECLARE_NATIVE_FUNCTION(scroll_y_getter);
+    JS_DECLARE_NATIVE_FUNCTION(scroll);
+    JS_DECLARE_NATIVE_FUNCTION(scroll_by);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(screen_x_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(screen_y_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(screen_left_getter);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(screen_top_getter);
+    JS_DECLARE_NATIVE_FUNCTION(screen_x_getter);
+    JS_DECLARE_NATIVE_FUNCTION(screen_y_getter);
+    JS_DECLARE_NATIVE_FUNCTION(screen_left_getter);
+    JS_DECLARE_NATIVE_FUNCTION(screen_top_getter);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(alert);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(confirm);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(prompt);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(set_interval);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(set_timeout);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(clear_interval);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(clear_timeout);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(request_animation_frame);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(cancel_animation_frame);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(atob);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(btoa);
+    JS_DECLARE_NATIVE_FUNCTION(alert);
+    JS_DECLARE_NATIVE_FUNCTION(confirm);
+    JS_DECLARE_NATIVE_FUNCTION(prompt);
+    JS_DECLARE_NATIVE_FUNCTION(set_interval);
+    JS_DECLARE_NATIVE_FUNCTION(set_timeout);
+    JS_DECLARE_NATIVE_FUNCTION(clear_interval);
+    JS_DECLARE_NATIVE_FUNCTION(clear_timeout);
+    JS_DECLARE_NATIVE_FUNCTION(request_animation_frame);
+    JS_DECLARE_NATIVE_FUNCTION(cancel_animation_frame);
+    JS_DECLARE_NATIVE_FUNCTION(atob);
+    JS_DECLARE_NATIVE_FUNCTION(btoa);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(get_computed_style);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(match_media);
-    JS_DECLARE_OLD_NATIVE_FUNCTION(get_selection);
+    JS_DECLARE_NATIVE_FUNCTION(get_computed_style);
+    JS_DECLARE_NATIVE_FUNCTION(match_media);
+    JS_DECLARE_NATIVE_FUNCTION(get_selection);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(queue_microtask);
+    JS_DECLARE_NATIVE_FUNCTION(queue_microtask);
 
-    JS_DECLARE_OLD_NATIVE_FUNCTION(crypto_getter);
+    JS_DECLARE_NATIVE_FUNCTION(crypto_getter);
 
-#define __ENUMERATE(attribute, event_name)              \
-    JS_DECLARE_OLD_NATIVE_FUNCTION(attribute##_getter); \
-    JS_DECLARE_OLD_NATIVE_FUNCTION(attribute##_setter);
+#define __ENUMERATE(attribute, event_name)          \
+    JS_DECLARE_NATIVE_FUNCTION(attribute##_getter); \
+    JS_DECLARE_NATIVE_FUNCTION(attribute##_setter);
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE);
 #undef __ENUMERATE
 

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -207,13 +207,14 @@ String URLSearchParams::to_string()
     return url_encode(m_list, AK::URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded);
 }
 
-void URLSearchParams::for_each(Function<IterationDecision(String const&, String const&)> callback)
+JS::ThrowCompletionOr<void> URLSearchParams::for_each(ForEachCallback callback)
 {
     for (auto i = 0u; i < m_list.size(); ++i) {
         auto& query_param = m_list[i]; // We are explicitly iterating over the indices here as the callback might delete items from the list
-        if (callback(query_param.name, query_param.value) == IterationDecision::Break)
-            break;
+        TRY(callback(query_param.name, query_param.value));
     }
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -43,7 +43,8 @@ public:
 
     String to_string();
 
-    void for_each(Function<IterationDecision(String const&, String const&)>);
+    using ForEachCallback = Function<JS::ThrowCompletionOr<void>(String const&, String const&)>;
+    JS::ThrowCompletionOr<void> for_each(ForEachCallback);
 
 private:
     friend class URL;


### PR DESCRIPTION
Intended to bang out converting the rest of Serenity to use `ThrowCompletionOr`, but decided to pause after the LibWeb bindings generator :)

TBH I'm not quite sure how we should be handling combining `TRY` with `throw_dom_exception_if_needed`. For now I kept up the existing pattern of:
```c++
    auto result = throw_dom_exception_if_needed(vm, global_object, [](){});
    if (should_return_empty(result))
        return JS::throw_completion(vm.exception()->value());
```