### PR TITLE
LibWeb: Convert throw_dom_exception_if_needed() to ThrowCompletionOr

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
+++ b/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
@@ -20,19 +20,6 @@ constexpr bool IsExceptionOr = false;
 template<typename T>
 constexpr bool IsExceptionOr<DOM::ExceptionOr<T>> = true;
 
-template<typename T>
-ALWAYS_INLINE bool throw_dom_exception(JS::VM& vm, JS::GlobalObject& global_object, DOM::ExceptionOr<T>& result)
-{
-    if (result.is_exception()) {
-        result.materialized_exception(global_object)
-            .visit(
-                [&](NonnullRefPtr<DOM::DOMException> dom_exception) { vm.throw_exception(global_object, DOMExceptionWrapper::create(global_object, move(dom_exception))); },
-                [&](auto* js_exception) { vm.throw_exception(global_object, js_exception); });
-        return true;
-    }
-    return false;
-}
-
 namespace Detail {
 
 template<typename T>
@@ -60,22 +47,47 @@ struct ExtractExceptionOrValueType<DOM::ExceptionOr<void>> {
     using Type = JS::Value;
 };
 
+ALWAYS_INLINE JS::Completion dom_exception_to_throw_completion(auto&& global_object, auto&& exception)
+{
+    auto& vm = global_object.vm();
+
+    return exception.visit(
+        [&](DOM::SimpleException const& exception) {
+            switch (exception.type) {
+#define E(x)                          \
+    case DOM::SimpleExceptionType::x: \
+        return vm.template throw_completion<JS::x>(global_object, exception.message);
+
+                ENUMERATE_SIMPLE_WEBIDL_EXCEPTION_TYPES(E)
+
+#undef E
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        },
+        [&](NonnullRefPtr<DOM::DOMException> exception) {
+            return vm.template throw_completion<DOMExceptionWrapper>(global_object, move(exception));
+        });
+}
+
 }
 
 template<typename T>
 using ExtractExceptionOrValueType = typename Detail::ExtractExceptionOrValueType<T>::Type;
 
 // Return type depends on the return type of 'fn' (when invoked with no args):
-// void or ExceptionOr<void>: Optional<JS::Value>, always returns JS::js_undefined()
-// ExceptionOr<T>: Optional<T>
-// T: Optional<T>
+// void or ExceptionOr<void>: JS::ThrowCompletionOr<JS::Value>, always returns JS::js_undefined()
+// ExceptionOr<T>: JS::ThrowCompletionOr<T>
+// T: JS::ThrowCompletionOr<T>
 template<typename F, typename T = decltype(declval<F>()()), typename Ret = Conditional<!IsExceptionOr<T> && !IsVoid<T>, T, ExtractExceptionOrValueType<T>>>
-Optional<Ret> throw_dom_exception_if_needed(auto&& vm, auto&& global_object, F&& fn)
+JS::ThrowCompletionOr<Ret> throw_dom_exception_if_needed(auto&& global_object, F&& fn)
 {
     if constexpr (IsExceptionOr<T>) {
         auto&& result = fn();
-        if (throw_dom_exception(vm, global_object, result))
-            return {};
+
+        if (result.is_exception())
+            return Detail::dom_exception_to_throw_completion(global_object, result.exception());
+
         if constexpr (requires(T v) { v.value(); })
             return result.value();
         else
@@ -86,14 +98,6 @@ Optional<Ret> throw_dom_exception_if_needed(auto&& vm, auto&& global_object, F&&
     } else {
         return fn();
     }
-}
-
-template<typename T>
-bool should_return_empty(const Optional<T>& value)
-{
-    if constexpr (IsSame<JS::Value, T>)
-        return !value.has_value() || value.value().is_empty();
-    return !value.has_value();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -636,33 +636,31 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::screen_y_getter)
     return JS::Value(impl->screen_y());
 }
 
-#define __ENUMERATE(attribute, event_name)                                   \
-    JS_DEFINE_NATIVE_FUNCTION(WindowObject::attribute##_getter)              \
-    {                                                                        \
-        auto* impl = TRY(impl_from(vm, global_object));                      \
-        auto retval = impl->attribute();                                     \
-        if (retval.callback.is_null())                                       \
-            return JS::js_null();                                            \
-        return retval.callback.cell();                                       \
-    }                                                                        \
-    JS_DEFINE_NATIVE_FUNCTION(WindowObject::attribute##_setter)              \
-    {                                                                        \
-        auto* impl = TRY(impl_from(vm, global_object));                      \
-        auto value = vm.argument(0);                                         \
-        HTML::EventHandler cpp_value;                                        \
-        if (value.is_function()) {                                           \
-            cpp_value.callback = JS::make_handle(&value.as_function());      \
-        } else if (value.is_string()) {                                      \
-            cpp_value.string = value.as_string().string();                   \
-        } else {                                                             \
-            return JS::js_undefined();                                       \
-        }                                                                    \
-        auto result = throw_dom_exception_if_needed(vm, global_object, [&] { \
-            return impl->set_##attribute(cpp_value);                         \
-        });                                                                  \
-        if (should_return_empty(result))                                     \
-            return JS::throw_completion(vm.exception()->value());            \
-        return JS::js_undefined();                                           \
+#define __ENUMERATE(attribute, event_name)                              \
+    JS_DEFINE_NATIVE_FUNCTION(WindowObject::attribute##_getter)         \
+    {                                                                   \
+        auto* impl = TRY(impl_from(vm, global_object));                 \
+        auto retval = impl->attribute();                                \
+        if (retval.callback.is_null())                                  \
+            return JS::js_null();                                       \
+        return retval.callback.cell();                                  \
+    }                                                                   \
+    JS_DEFINE_NATIVE_FUNCTION(WindowObject::attribute##_setter)         \
+    {                                                                   \
+        auto* impl = TRY(impl_from(vm, global_object));                 \
+        auto value = vm.argument(0);                                    \
+        HTML::EventHandler cpp_value;                                   \
+        if (value.is_function()) {                                      \
+            cpp_value.callback = JS::make_handle(&value.as_function()); \
+        } else if (value.is_string()) {                                 \
+            cpp_value.string = value.as_string().string();              \
+        } else {                                                        \
+            return JS::js_undefined();                                  \
+        }                                                               \
+        TRY(throw_dom_exception_if_needed(global_object, [&] {          \
+            return impl->set_##attribute(cpp_value);                    \
+        }));                                                            \
+        return JS::js_undefined();                                      \
     }
 ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/DOM/ExceptionOr.h
+++ b/Userland/Libraries/LibWeb/DOM/ExceptionOr.h
@@ -80,30 +80,6 @@ public:
         return m_exception.template downcast<SimpleException, NonnullRefPtr<DOMException>>();
     }
 
-    auto materialized_exception(JS::GlobalObject& global_object) const
-    {
-#define E(x) JS::x*,
-        using ResultType = Variant<ENUMERATE_SIMPLE_WEBIDL_EXCEPTION_TYPES(E) NonnullRefPtr<DOMException>>;
-#undef E
-
-        return m_exception.visit(
-            [&](SimpleException& exception) -> ResultType {
-                switch (exception.type) {
-#define E(x)                     \
-    case SimpleExceptionType::x: \
-        return JS::x::create(global_object, exception.message);
-
-                    ENUMERATE_SIMPLE_WEBIDL_EXCEPTION_TYPES(E)
-
-#undef E
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            },
-            [&](NonnullRefPtr<DOMException> const& exception) -> ResultType { return exception; },
-            [](Empty) -> ResultType { VERIFY_NOT_REACHED(); });
-    }
-
     bool is_exception() const
     {
         return !m_exception.template has<Empty>();


### PR DESCRIPTION
This changes `Web::Bindings::throw_dom_exception_if_needed` to return a
`JS::ThrowCompletionOr` instead of an `Optional`. This allows callers to
wrap the invocation with a `TRY` macro instead of making a follow-up
call to `should_return_empty`. Further, this removes all invocations to
`vm.exception` in the generated bindings.