### PR TITLE
Ports/vim: Add symlink 'vi' pointing to target 'vim'

### DIFF
--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -15,3 +15,7 @@ export vim_cv_tgetent=zero
 export vim_cv_terminfo=yes
 export vim_cv_toupper_broken=no
 export vim_cv_tty_group=world
+
+post_install() {
+    run ln -sf vim "${SERENITY_INSTALL_ROOT}/usr/local/bin/vi"
+}


### PR DESCRIPTION
This adds a symlink named 'vi' which points to the target 'vim'. It's
useful in scenarios where a third-party application might rely on 'vi'.