### PR TITLE
Utilities: Make "hexdump | less" work

### DIFF
--- a/Userland/Utilities/hexdump.cpp
+++ b/Userland/Utilities/hexdump.cpp
@@ -45,15 +45,16 @@ int main(int argc, char** argv)
                 out("  ");
         }
 
-        out("  ");
+        out("  |");
 
-        for (size_t i = 0; i < 16; ++i) {
-            if (i < line.size() && isprint(line[i]))
+        for (size_t i = 0; i < line.size(); ++i) {
+            if (isprint(line[i]))
                 putchar(line[i]);
             else
-                putchar(' ');
+                putchar('.');
         }
 
+        putchar('|');
         putchar('\n');
     };
 

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -139,7 +139,7 @@ public:
     {
         clear_status();
 
-        while (n - (m_lines.size() - m_line) + m_height - 1 > 0) {
+        while (m_lines.size() < m_line + n + m_height - 1) {
             if (!read_line())
                 break;
         }


### PR DESCRIPTION
`hexdump | less` is a nice way to quickly inspect binary data, or just poke around various devices and see what's going on. Of course there's the obvious limitations, but the headers and the first few megabytes can be interesting, too. (Did you know that for some reason `SERENITY_SOURCE_DIR` ends up in the image at offset 0x488? Now you do!)

This PR:
* Prettifies hexdump's output format (see screenshots "before" and "after")
* Makes hexdump process data incrementally, avoiding `read_all` (instead it uses `IODevice::read(u8*, int)`, which will not interfere with #9977)
* Fixes an unsigned underflow bug in less(1), which caused it to hang whenever there was strictly more than enough data already bufffered.

before
![Bildschirmfoto_2021-10-31_02-02-11](https://user-images.githubusercontent.com/2690845/139599680-1f849a2a-20b1-4921-adf9-1b8bae7930d9.png)

after
![Bildschirmfoto_2021-10-31_02-01-21](https://user-images.githubusercontent.com/2690845/139599683-c1728cd1-a316-43f1-894c-392bbf92c492.png)
![Bildschirmfoto_2021-10-31_21-01-12](https://user-images.githubusercontent.com/2690845/139599687-9f75d90e-db16-4fff-bdab-982a2e8e68d7.png)

---

(I dislike the message about the broken pipe, but it's technically correct.)