### PR TITLE
echo: Obey -n when text is empty

### DIFF
--- a/Userland/Utilities/echo.cpp
+++ b/Userland/Utilities/echo.cpp
@@ -114,7 +114,8 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     if (text.is_empty()) {
-        outln();
+        if (!no_trailing_newline)
+            outln();
         return 0;
     }
 


### PR DESCRIPTION
What it says in the tin. Otherwise `echo -n` actually produces a newline, confusing other tools down the pipeilne.