### PR TITLE
Ports: gnucobol: Build with ncurses and without NLS

### DIFF
--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -2,10 +2,21 @@
 port=gnucobol
 version=3.1.2
 useconfigure="true"
-depends=("gmp" "gcc" "bash")
+depends=("gmp" "gcc" "bash" "ncurses")
 files="https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2
 https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2.sig gnucobol-${version}.tar.bz2.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts=("--keyring" "./gnu-keyring.gpg" "gnucobol-${version}.tar.bz2.sig")
-configopts=("--prefix=/usr/local" "--enable-hardening" "--disable-rpath" "--with-gnu-ld" "--with-dl" "--with-math=gmp" "--with-db=no" "--with-json=no" "--with-curses=curses")
+configopts=(
+    "--prefix=/usr/local"
+    "--enable-hardening"
+    "--disable-rpath"
+    "--disable-nls"
+    "--with-gnu-ld"
+    "--with-dl"
+    "--with-math=gmp"
+    "--with-curses=ncurses"
+    "--with-db=no"
+    "--with-json=no"
+)


### PR DESCRIPTION
The GNUCOBOL port broke some time in the last year. It was on Tim's list of broken ports. This fixes it.

![image](https://user-images.githubusercontent.com/434827/139642560-f2283a8b-20bf-4319-9c84-574b35d5645f.png)
