### PR TITLE
LibCore+Everywhere: Remove a few landmines

### DIFF
--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -20,7 +20,7 @@
 class NetworkWidget final : public GUI::ImageWidget {
     C_OBJECT(NetworkWidget);
 
-public:
+private:
     NetworkWidget(bool notifications)
     {
         m_notifications = notifications;
@@ -28,7 +28,6 @@ public:
         start_timer(5000);
     }
 
-private:
     virtual void timer_event(Core::TimerEvent&) override
     {
         update_widget();

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -30,6 +30,7 @@ class GraphWidget final : public GUI::Frame {
 public:
     static constexpr size_t history_size = 24;
 
+private:
     GraphWidget(GraphType graph_type, Optional<Gfx::Color> graph_color, Optional<Gfx::Color> graph_error_color)
         : m_graph_type(graph_type)
     {
@@ -39,7 +40,6 @@ public:
         start_timer(1000);
     }
 
-private:
     virtual void timer_event(Core::TimerEvent&) override
     {
         switch (m_graph_type) {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -35,26 +35,6 @@ struct AppState {
 class ResultRow final : public GUI::Widget {
     C_OBJECT(ResultRow)
 public:
-    ResultRow()
-    {
-        auto& layout = set_layout<GUI::HorizontalBoxLayout>();
-        layout.set_spacing(12);
-        layout.set_margins(4);
-
-        m_image = add<GUI::ImageWidget>();
-
-        m_label_container = add<GUI::Widget>();
-        m_label_container->set_layout<GUI::VerticalBoxLayout>();
-        m_label_container->set_fixed_height(30);
-
-        m_title = m_label_container->add<GUI::Label>();
-        m_title->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-
-        set_shrink_to_fit(true);
-        set_fill_with_background_color(true);
-        set_greedy_for_hits(true);
-    }
-
     void set_image(RefPtr<Gfx::Bitmap> bitmap)
     {
         m_image->set_bitmap(bitmap);
@@ -89,6 +69,26 @@ public:
     Function<void()> on_selected;
 
 private:
+    ResultRow()
+    {
+        auto& layout = set_layout<GUI::HorizontalBoxLayout>();
+        layout.set_spacing(12);
+        layout.set_margins(4);
+
+        m_image = add<GUI::ImageWidget>();
+
+        m_label_container = add<GUI::Widget>();
+        m_label_container->set_layout<GUI::VerticalBoxLayout>();
+        m_label_container->set_fixed_height(30);
+
+        m_title = m_label_container->add<GUI::Label>();
+        m_title->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+
+        set_shrink_to_fit(true);
+        set_fill_with_background_color(true);
+        set_greedy_for_hits(true);
+    }
+
     void mousedown_event(GUI::MouseEvent&) override
     {
         set_background_role(ColorRole::MenuBase);

--- a/Userland/Applications/KeyboardMapper/KeyButton.h
+++ b/Userland/Applications/KeyboardMapper/KeyButton.h
@@ -8,7 +8,7 @@
 
 #include <LibGUI/AbstractButton.h>
 
-class KeyButton : public GUI::AbstractButton {
+class KeyButton final : public GUI::AbstractButton {
     C_OBJECT(KeyButton)
 
 public:
@@ -25,5 +25,7 @@ protected:
     virtual void paint_event(GUI::PaintEvent&) override;
 
 private:
+    KeyButton() = default;
+
     bool m_pressed { false };
 };

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
@@ -10,11 +10,10 @@
 #include <LibGUI/Button.h>
 #include <LibKeyboard/CharacterMapData.h>
 
-class KeyboardMapperWidget : public GUI::Widget {
+class KeyboardMapperWidget final : public GUI::Widget {
     C_OBJECT(KeyboardMapperWidget)
 
 public:
-    KeyboardMapperWidget();
     virtual ~KeyboardMapperWidget() override;
 
     void create_frame();
@@ -31,6 +30,8 @@ protected:
     void update_window_title();
 
 private:
+    KeyboardMapperWidget();
+
     Vector<KeyButton*> m_keys;
     RefPtr<GUI::Widget> m_map_group;
 

--- a/Userland/Applications/PDFViewer/NumericInput.h
+++ b/Userland/Applications/PDFViewer/NumericInput.h
@@ -12,7 +12,6 @@
 class NumericInput final : public GUI::TextBox {
     C_OBJECT(NumericInput)
 public:
-    NumericInput();
     virtual ~NumericInput() override = default;
 
     Function<void(i32)> on_number_changed;
@@ -22,6 +21,7 @@ public:
     void set_current_number(i32 number, bool call_change_handler = true);
 
 private:
+    NumericInput();
     void on_focus_lost();
 
     bool m_needs_text_reset { false };

--- a/Userland/Applications/Piano/AudioPlayerLoop.h
+++ b/Userland/Applications/Piano/AudioPlayerLoop.h
@@ -17,17 +17,17 @@ class TrackManager;
 
 // Wrapper class accepting custom events to advance the track playing and forward audio data to the system.
 // This does not run on a separate thread, preventing IPC multithreading madness.
-class AudioPlayerLoop : public Core::Object {
+class AudioPlayerLoop final : public Core::Object {
     C_OBJECT(AudioPlayerLoop)
 public:
-    AudioPlayerLoop(TrackManager& track_manager, bool& need_to_write_wav, Audio::WavWriter& wav_writer);
-
     void enqueue_audio();
 
     void toggle_paused();
     bool is_playing() { return m_should_play_audio; }
 
 private:
+    AudioPlayerLoop(TrackManager& track_manager, bool& need_to_write_wav, Audio::WavWriter& wav_writer);
+
     TrackManager& m_track_manager;
     Array<Sample, sample_count> m_buffer;
     Optional<Audio::ResampleHelper<double>> m_resampler;

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -15,7 +15,7 @@
 
 Track::Track(const u32& time)
     : m_time(time)
-    , m_temporary_transport(make_ref_counted<LibDSP::Transport>(120, 4))
+    , m_temporary_transport(LibDSP::Transport::construct(120, 4))
     , m_delay(make_ref_counted<LibDSP::Effects::Delay>(m_temporary_transport))
 {
     set_volume(volume_max);

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -24,13 +24,6 @@ class ColorWidget : public GUI::Frame {
     C_OBJECT(ColorWidget);
 
 public:
-    explicit ColorWidget(Color color, PaletteWidget& palette_widget)
-        : m_palette_widget(palette_widget)
-        , m_color(color)
-    {
-        set_fixed_width(16);
-    }
-
     virtual ~ColorWidget() override
     {
     }
@@ -57,6 +50,13 @@ public:
     }
 
 private:
+    explicit ColorWidget(Color color, PaletteWidget& palette_widget)
+        : m_palette_widget(palette_widget)
+        , m_color(color)
+    {
+        set_fixed_width(16);
+    }
+
     PaletteWidget& m_palette_widget;
     Color m_color;
 };
@@ -87,6 +87,9 @@ public:
 
     Function<void(Color const&)> on_color_change;
     Color m_color = Color::White;
+
+private:
+    SelectedColorWidget() = default;
 };
 
 PaletteWidget::PaletteWidget()

--- a/Userland/Applications/SoundPlayer/Common.h
+++ b/Userland/Applications/SoundPlayer/Common.h
@@ -21,7 +21,7 @@ public:
 
     bool mouse_is_down() const { return m_mouse_is_down; }
 
-protected:
+private:
     AutoSlider(Orientation orientation)
         : GUI::Slider(orientation)
     {
@@ -42,6 +42,5 @@ protected:
         GUI::Slider::mouseup_event(event);
     }
 
-private:
     bool m_mouse_is_down { false };
 };

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.cpp
@@ -92,6 +92,8 @@ String PlaylistModel::column_name(int column) const
     VERIFY_NOT_REACHED();
 }
 
+PlaylistTableView::PlaylistTableView() = default;
+
 void PlaylistTableView::doubleclick_event(GUI::MouseEvent& event)
 {
     AbstractView::doubleclick_event(event);

--- a/Userland/Applications/SoundPlayer/PlaylistWidget.h
+++ b/Userland/Applications/SoundPlayer/PlaylistWidget.h
@@ -40,19 +40,22 @@ public:
     void doubleclick_event(GUI::MouseEvent& event) override;
 
     Function<void(const Gfx::Point<int>&)> on_doubleclick;
+
+private:
+    PlaylistTableView();
 };
 
 class PlaylistWidget : public GUI::Widget {
     C_OBJECT(PlaylistWidget)
 public:
-    PlaylistWidget();
     void set_data_model(RefPtr<PlaylistModel> model)
     {
         m_table_view->set_model(model);
         m_table_view->update();
     }
 
-protected:
 private:
+    PlaylistWidget();
+
     RefPtr<PlaylistTableView> m_table_view;
 };

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -21,8 +21,6 @@ class SoundPlayerWidgetAdvancedView final : public GUI::Widget
     C_OBJECT(SoundPlayerWidgetAdvancedView)
 
 public:
-    explicit SoundPlayerWidgetAdvancedView(GUI::Window&, Audio::ClientConnection&);
-
     void set_nonlinear_volume_slider(bool nonlinear);
     void set_playlist_visible(bool visible);
 
@@ -51,6 +49,8 @@ protected:
     void keydown_event(GUI::KeyEvent&) override;
 
 private:
+    SoundPlayerWidgetAdvancedView(GUI::Window&, Audio::ClientConnection&);
+
     void sync_previous_next_buttons();
 
     void drop_event(GUI::DropEvent& event) override;

--- a/Userland/Applications/SoundPlayer/VisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/VisualizationWidget.h
@@ -17,5 +17,6 @@ public:
     virtual void set_samplerate(int) { }
 
 protected:
+    VisualizationWidget() = default;
     virtual ~VisualizationWidget() = default;
 };

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -218,6 +218,8 @@ class Mandelbrot : public GUI::Frame {
     void reset();
 
 private:
+    Mandelbrot() = default;
+
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent& event) override;
     virtual void mousemove_event(GUI::MouseEvent& event) override;

--- a/Userland/DevTools/HackStudio/ClassViewWidget.h
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.h
@@ -18,11 +18,12 @@ class ClassViewWidget final : public GUI::Widget {
     C_OBJECT(ClassViewWidget)
 public:
     virtual ~ClassViewWidget() override { }
-    ClassViewWidget();
 
     void refresh();
 
 private:
+    ClassViewWidget();
+
     RefPtr<GUI::TreeView> m_class_tree;
 };
 

--- a/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.h
+++ b/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.h
@@ -14,10 +14,9 @@ namespace HackStudio {
 class EvaluateExpressionDialog : public GUI::Dialog {
     C_OBJECT(EvaluateExpressionDialog);
 
-public:
+private:
     explicit EvaluateExpressionDialog(Window* parent_window);
 
-private:
     void build(Window* parent_window);
     void handle_evaluation(const String& expression);
     void set_output(const StringView& html);

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
@@ -14,7 +14,7 @@ namespace LanguageServers::Cpp {
 class ClientConnection final : public LanguageServers::ClientConnection {
     C_OBJECT(ClientConnection);
 
-public:
+private:
     ClientConnection(NonnullRefPtr<Core::LocalSocket> socket, int client_id)
         : LanguageServers::ClientConnection(move(socket), client_id)
     {

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
@@ -15,6 +15,7 @@ namespace LanguageServers::Shell {
 class ClientConnection final : public LanguageServers::ClientConnection {
     C_OBJECT(ClientConnection);
 
+private:
     ClientConnection(NonnullRefPtr<Core::LocalSocket> socket, int client_id)
         : LanguageServers::ClientConnection(move(socket), client_id)
     {

--- a/Userland/Games/Chess/Engine.h
+++ b/Userland/Games/Chess/Engine.h
@@ -20,7 +20,7 @@ public:
     Engine(const Engine&) = delete;
     Engine& operator=(const Engine&) = delete;
 
-    virtual void handle_bestmove(const Chess::UCI::BestMoveCommand&);
+    virtual void handle_bestmove(const Chess::UCI::BestMoveCommand&) override;
 
     template<typename Callback>
     void get_best_move(const Chess::Board& board, int time_limit, Callback&& callback)

--- a/Userland/Games/Minesweeper/Field.h
+++ b/Userland/Games/Minesweeper/Field.h
@@ -43,7 +43,6 @@ class Field final : public GUI::Frame {
     friend class SquareLabel;
 
 public:
-    Field(GUI::Label& flag_label, GUI::Label& time_label, GUI::Button& face_button, Function<void(Gfx::IntSize)> on_size_changed);
     virtual ~Field() override;
 
     size_t rows() const { return m_rows; }
@@ -58,6 +57,8 @@ public:
     void reset();
 
 private:
+    Field(GUI::Label& flag_label, GUI::Label& time_label, GUI::Button& face_button, Function<void(Gfx::IntSize)> on_size_changed);
+
     virtual void paint_event(GUI::PaintEvent&) override;
 
     void on_square_clicked(Square&);

--- a/Userland/Libraries/LibAudio/ClientConnection.h
+++ b/Userland/Libraries/LibAudio/ClientConnection.h
@@ -19,8 +19,6 @@ class ClientConnection final
     , public AudioClientEndpoint {
     C_OBJECT(ClientConnection)
 public:
-    ClientConnection();
-
     void enqueue(Buffer const&);
     bool try_enqueue(Buffer const&);
     void async_enqueue(Buffer const&);
@@ -31,6 +29,8 @@ public:
     Function<void(double volume)> on_client_volume_change;
 
 private:
+    ClientConnection();
+
     virtual void finished_playing_buffer(i32) override;
     virtual void muted_state_changed(bool) override;
     virtual void main_mix_volume_changed(double) override;

--- a/Userland/Libraries/LibChess/UCIEndpoint.h
+++ b/Userland/Libraries/LibChess/UCIEndpoint.h
@@ -18,9 +18,6 @@ class Endpoint : public Core::Object {
 public:
     virtual ~Endpoint() override { }
 
-    Endpoint() { }
-    Endpoint(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevice> out);
-
     virtual void handle_uci() { }
     virtual void handle_debug(const DebugCommand&) { }
     virtual void handle_isready() { }
@@ -47,6 +44,10 @@ public:
         set_in_notifier();
     }
     void set_out(RefPtr<Core::IODevice> out) { m_out = out; }
+
+protected:
+    Endpoint() { }
+    Endpoint(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevice> out);
 
 private:
     void set_in_notifier();

--- a/Userland/Libraries/LibChess/UCIEndpoint.h
+++ b/Userland/Libraries/LibChess/UCIEndpoint.h
@@ -36,7 +36,7 @@ public:
 
     void send_command(const Command&);
 
-    virtual void event(Core::Event&);
+    virtual void event(Core::Event&) override;
 
     Core::IODevice& in() { return *m_in; }
     Core::IODevice& out() { return *m_out; }

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -125,7 +125,7 @@ pid_t EventLoop::s_pid;
 
 class InspectorServerConnection : public Object {
     C_OBJECT(InspectorServerConnection)
-public:
+private:
     explicit InspectorServerConnection(RefPtr<LocalSocket> socket)
         : m_socket(move(socket))
         , m_client_id(s_id_allocator->allocate())
@@ -162,6 +162,7 @@ public:
             inspected_object->decrement_inspector_count({});
     }
 
+public:
     void send_response(const JsonObject& response)
     {
         auto serialized = response.to_string();

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -63,8 +63,6 @@ public:                                                                \
     static inline NonnullRefPtr<klass> construct(Args&&... args)       \
     {                                                                  \
         auto obj = adopt_ref(*new Klass(forward<Args>(args)...));      \
-        if constexpr (requires { declval<Klass>().did_construct(); })  \
-            obj->did_construct();                                      \
         return obj;                                                    \
     }
 

--- a/Userland/Libraries/LibCore/Promise.h
+++ b/Userland/Libraries/LibCore/Promise.h
@@ -14,9 +14,6 @@ template<typename Result>
 class Promise : public Object {
     C_OBJECT(Promise);
 
-private:
-    Optional<Result> m_pending;
-
 public:
     Function<void(Result&)> on_resolved;
 
@@ -51,5 +48,10 @@ public:
         };
         return new_promise;
     }
+
+private:
+    Promise() = default;
+
+    Optional<Result> m_pending;
 };
 }

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -16,6 +16,14 @@ namespace LibDSP {
 class Transport final : public Core::Object {
     C_OBJECT(Transport)
 public:
+    u32 const& time() const { return m_time; }
+    u16 beats_per_minute() const { return m_beats_per_minute; }
+    double current_second() const { return m_time / m_sample_rate; }
+    double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }
+    double sample_rate() const { return m_sample_rate; }
+    double current_measure() const { return m_time / samples_per_measure(); }
+
+private:
     Transport(u16 beats_per_minute, u8 beats_per_measure, u32 sample_rate)
         : m_beats_per_minute(beats_per_minute)
         , m_beats_per_measure(beats_per_measure)
@@ -27,14 +35,6 @@ public:
     {
     }
 
-    u32 const& time() const { return m_time; }
-    u16 beats_per_minute() const { return m_beats_per_minute; }
-    double current_second() const { return m_time / m_sample_rate; }
-    double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }
-    double sample_rate() const { return m_sample_rate; }
-    double current_measure() const { return m_time / samples_per_measure(); }
-
-private:
     u32 m_time { 0 };
     u16 const m_beats_per_minute { 0 };
     u8 const m_beats_per_measure { 0 };

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -81,7 +81,7 @@ private:
     class AbstractScrollableWidgetScrollbar final : public Scrollbar {
         C_OBJECT(AbstractScrollableWidgetScrollbar);
 
-    protected:
+    private:
         explicit AbstractScrollableWidgetScrollbar(AbstractScrollableWidget& owner, Gfx::Orientation orientation)
             : Scrollbar(orientation)
             , m_owner(owner)
@@ -93,7 +93,6 @@ private:
             m_owner.handle_wheel_event(event, *this);
         }
 
-    private:
         AbstractScrollableWidget& m_owner;
     };
     friend class ScrollableWidgetScrollbar;

--- a/Userland/Libraries/LibGUI/BoxLayout.h
+++ b/Userland/Libraries/LibGUI/BoxLayout.h
@@ -36,7 +36,7 @@ private:
 class VerticalBoxLayout final : public BoxLayout {
     C_OBJECT(VerticalBoxLayout);
 
-public:
+private:
     explicit VerticalBoxLayout()
         : BoxLayout(Gfx::Orientation::Vertical)
     {
@@ -47,7 +47,7 @@ public:
 class HorizontalBoxLayout final : public BoxLayout {
     C_OBJECT(HorizontalBoxLayout);
 
-public:
+private:
     explicit HorizontalBoxLayout()
         : BoxLayout(Gfx::Orientation::Horizontal)
     {

--- a/Userland/Libraries/LibGUI/Calendar.h
+++ b/Userland/Libraries/LibGUI/Calendar.h
@@ -30,9 +30,6 @@ public:
         YearOnly
     };
 
-    Calendar(Core::DateTime date_time = Core::DateTime::now(), Mode mode = Month);
-    virtual ~Calendar() override;
-
     void set_selected_date(Core::DateTime date_time) { m_selected_date = date_time; }
     Core::DateTime selected_date() const { return m_selected_date; }
 
@@ -75,6 +72,9 @@ public:
     Function<void()> on_month_click;
 
 private:
+    Calendar(Core::DateTime date_time = Core::DateTime::now(), Mode mode = Month);
+    virtual ~Calendar() override;
+
     virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;

--- a/Userland/Libraries/LibGUI/Calendar.h
+++ b/Userland/Libraries/LibGUI/Calendar.h
@@ -80,7 +80,7 @@ private:
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(MouseEvent&) override;
     virtual void mouseup_event(MouseEvent&) override;
-    virtual void doubleclick_event(MouseEvent&);
+    virtual void doubleclick_event(MouseEvent&) override;
     virtual void leave_event(Core::Event&) override;
 
     struct Day {

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -156,8 +156,8 @@ public:
     Function<void(Color)> on_color_changed;
 
 private:
-    virtual void mousedown_event(GUI::MouseEvent&) { m_event_loop->quit(1); }
-    virtual void mousemove_event(GUI::MouseEvent&)
+    virtual void mousedown_event(GUI::MouseEvent&) override { m_event_loop->quit(1); }
+    virtual void mousemove_event(GUI::MouseEvent&) override
     {
         auto new_col = WindowServerConnection::the().get_color_under_cursor();
         if (new_col == m_col)
@@ -167,7 +167,7 @@ private:
             on_color_changed(m_col);
     }
 
-    virtual void keydown_event(GUI::KeyEvent& event)
+    virtual void keydown_event(GUI::KeyEvent& event) override
     {
         if (event.key() == KeyCode::Key_Escape) {
             event.accept();

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -129,11 +129,6 @@ private:
 class ColorSelectOverlay final : public Widget {
     C_OBJECT(ColorSelectOverlay)
 public:
-    ColorSelectOverlay()
-    {
-        set_override_cursor(Gfx::StandardCursor::Eyedropper);
-    }
-
     Optional<Color> exec()
     {
         m_event_loop = make<Core::EventLoop>();
@@ -156,6 +151,11 @@ public:
     Function<void(Color)> on_color_changed;
 
 private:
+    ColorSelectOverlay()
+    {
+        set_override_cursor(Gfx::StandardCursor::Eyedropper);
+    }
+
     virtual void mousedown_event(GUI::MouseEvent&) override { m_event_loop->quit(1); }
     virtual void mousemove_event(GUI::MouseEvent&) override
     {

--- a/Userland/Libraries/LibGUI/TextBox.h
+++ b/Userland/Libraries/LibGUI/TextBox.h
@@ -14,7 +14,6 @@ namespace GUI {
 class TextBox : public TextEditor {
     C_OBJECT(TextBox)
 public:
-    TextBox();
     virtual ~TextBox() override;
 
     Function<void()> on_up_pressed;
@@ -22,6 +21,9 @@ public:
 
     void set_history_enabled(bool enabled) { m_history_enabled = enabled; }
     void add_current_text_to_history();
+
+protected:
+    TextBox();
 
 private:
     virtual void keydown_event(GUI::KeyEvent&) override;
@@ -39,20 +41,21 @@ private:
 
 class PasswordBox : public TextBox {
     C_OBJECT(PasswordBox)
-public:
+private:
     PasswordBox();
 };
 
 class UrlBox : public TextBox {
     C_OBJECT(UrlBox)
 public:
-    UrlBox();
     virtual ~UrlBox() override;
 
     void set_focus_transition(bool focus_transition) { m_focus_transition = focus_transition; }
     bool is_focus_transition() const { return m_focus_transition; }
 
 private:
+    UrlBox();
+
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void focusout_event(GUI::FocusEvent&) override;
 

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
@@ -18,14 +18,14 @@ class WindowManagerServerConnection final
     , public WindowManagerClientEndpoint {
     C_OBJECT(WindowManagerServerConnection)
 public:
+    static WindowManagerServerConnection& the();
+
+private:
     WindowManagerServerConnection()
         : IPC::ServerConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>(*this, "/tmp/portal/wm")
     {
     }
 
-    static WindowManagerServerConnection& the();
-
-private:
     virtual void window_removed(i32, i32, i32) override;
     virtual void window_state_changed(i32, i32, i32, i32, i32, u32, u32, bool, bool, bool, bool, i32, String const&, Gfx::IntRect const&, Optional<i32> const&) override;
     virtual void window_icon_bitmap_changed(i32, i32, i32, Gfx::ShareableBitmap const&) override;

--- a/Userland/Libraries/LibGemini/GeminiJob.h
+++ b/Userland/Libraries/LibGemini/GeminiJob.h
@@ -17,12 +17,6 @@ namespace Gemini {
 class GeminiJob final : public Job {
     C_OBJECT(GeminiJob)
 public:
-    explicit GeminiJob(const GeminiRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certificates = nullptr)
-        : Job(request, output_stream)
-        , m_override_ca_certificates(override_certificates)
-    {
-    }
-
     virtual ~GeminiJob() override
     {
     }
@@ -50,6 +44,12 @@ protected:
     virtual void read_while_data_available(Function<IterationDecision()>) override;
 
 private:
+    explicit GeminiJob(const GeminiRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certificates = nullptr)
+        : Job(request, output_stream)
+        , m_override_ca_certificates(override_certificates)
+    {
+    }
+
     RefPtr<TLS::TLSv12> m_socket;
     const Vector<Certificate>* m_override_ca_certificates { nullptr };
 };

--- a/Userland/Libraries/LibHTTP/HttpJob.h
+++ b/Userland/Libraries/LibHTTP/HttpJob.h
@@ -18,11 +18,6 @@ namespace HTTP {
 class HttpJob final : public Job {
     C_OBJECT(HttpJob)
 public:
-    explicit HttpJob(const HttpRequest& request, OutputStream& output_stream)
-        : Job(request, output_stream)
-    {
-    }
-
     virtual ~HttpJob() override
     {
     }
@@ -46,6 +41,11 @@ protected:
     virtual bool is_established() const override { return true; }
 
 private:
+    explicit HttpJob(const HttpRequest& request, OutputStream& output_stream)
+        : Job(request, output_stream)
+    {
+    }
+
     RefPtr<Core::Socket> m_socket;
 };
 

--- a/Userland/Libraries/LibHTTP/HttpsJob.h
+++ b/Userland/Libraries/LibHTTP/HttpsJob.h
@@ -18,12 +18,6 @@ namespace HTTP {
 class HttpsJob final : public Job {
     C_OBJECT(HttpsJob)
 public:
-    explicit HttpsJob(const HttpRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certs = nullptr)
-        : Job(request, output_stream)
-        , m_override_ca_certificates(override_certs)
-    {
-    }
-
     virtual ~HttpsJob() override
     {
     }
@@ -51,6 +45,12 @@ protected:
     virtual void read_while_data_available(Function<IterationDecision()>) override;
 
 private:
+    explicit HttpsJob(const HttpRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certs = nullptr)
+        : Job(request, output_stream)
+        , m_override_ca_certificates(override_certs)
+    {
+    }
+
     RefPtr<TLS::TLSv12> m_socket;
     const Vector<Certificate>* m_override_ca_certificates { nullptr };
 };

--- a/Userland/Libraries/LibSQL/Database.h
+++ b/Userland/Libraries/LibSQL/Database.h
@@ -24,7 +24,6 @@ class Database : public Core::Object {
     C_OBJECT(Database);
 
 public:
-    explicit Database(String);
     ~Database() override = default;
 
     void commit() { m_heap->flush(); }
@@ -43,6 +42,8 @@ public:
     bool update(Row&);
 
 private:
+    explicit Database(String);
+
     NonnullRefPtr<Heap> m_heap;
     Serializer m_serializer;
     RefPtr<BTree> m_schemas;

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -32,7 +32,6 @@ class Heap : public Core::Object {
     C_OBJECT(Heap);
 
 public:
-    explicit Heap(String);
     virtual ~Heap() override { flush(); }
 
     u32 size() const { return m_end_of_file; }
@@ -93,6 +92,8 @@ public:
     void flush();
 
 private:
+    explicit Heap(String);
+
     bool seek_block(u32);
     void read_zero_block();
     void initialize_zero_block();

--- a/Userland/Libraries/LibSQL/Meta.h
+++ b/Userland/Libraries/LibSQL/Meta.h
@@ -96,10 +96,11 @@ class KeyPartDef : public ColumnDef {
     C_OBJECT(KeyPartDef);
 
 public:
-    KeyPartDef(IndexDef*, String, SQLType, Order = Order::Ascending);
     Order sort_order() const { return m_sort_order; }
 
 private:
+    KeyPartDef(IndexDef*, String, SQLType, Order = Order::Ascending);
+
     Order m_sort_order { Order::Ascending };
 };
 

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -27,7 +27,6 @@ class TerminalWidget final
     C_OBJECT(TerminalWidget);
 
 public:
-    TerminalWidget(int ptm_fd, bool automatic_size_policy);
     virtual ~TerminalWidget() override;
 
     void set_pty_master_fd(int fd);
@@ -95,6 +94,8 @@ public:
     void set_color_scheme(const StringView&);
 
 private:
+    TerminalWidget(int ptm_fd, bool automatic_size_policy);
+
     // ^GUI::Widget
     virtual void event(Core::Event&) override;
     virtual void paint_event(GUI::PaintEvent&) override;

--- a/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.h
+++ b/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.h
@@ -22,7 +22,6 @@ class TCPWebSocketConnectionImpl final : public AbstractWebSocketImpl {
 
 public:
     virtual ~TCPWebSocketConnectionImpl() override;
-    explicit TCPWebSocketConnectionImpl(Core::Object* parent = nullptr);
 
     virtual void connect(ConnectionInfo const& connection) override;
 
@@ -39,6 +38,8 @@ public:
     virtual void discard_connection() override;
 
 private:
+    explicit TCPWebSocketConnectionImpl(Core::Object* parent = nullptr);
+
     RefPtr<Core::Notifier> m_notifier;
     RefPtr<Core::TCPSocket> m_socket;
 };

--- a/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.h
+++ b/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.h
@@ -21,7 +21,6 @@ class TLSv12WebSocketConnectionImpl final : public AbstractWebSocketImpl {
 
 public:
     virtual ~TLSv12WebSocketConnectionImpl() override;
-    explicit TLSv12WebSocketConnectionImpl(Core::Object* parent = nullptr);
 
     void connect(ConnectionInfo const& connection) override;
 
@@ -38,6 +37,8 @@ public:
     virtual void discard_connection() override;
 
 private:
+    explicit TLSv12WebSocketConnectionImpl(Core::Object* parent = nullptr);
+
     RefPtr<TLS::TLSv12> m_socket;
 };
 

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -23,7 +23,6 @@ class Mixer;
 class ClientConnection final : public IPC::ClientConnection<AudioClientEndpoint, AudioServerEndpoint> {
     C_OBJECT(ClientConnection)
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id, Mixer& mixer);
     ~ClientConnection() override;
 
     void did_finish_playing_buffer(Badge<ClientAudioStream>, int buffer_id);
@@ -36,6 +35,8 @@ public:
     static void for_each(Function<void(ClientConnection&)>);
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id, Mixer& mixer);
+
     virtual Messages::AudioServer::GetMainMixVolumeResponse get_main_mix_volume() override;
     virtual void set_main_mix_volume(double) override;
     virtual Messages::AudioServer::GetSelfVolumeResponse get_self_volume() override;

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -108,7 +108,6 @@ private:
 class Mixer : public Core::Object {
     C_OBJECT(Mixer)
 public:
-    Mixer(NonnullRefPtr<Core::ConfigFile> config);
     virtual ~Mixer() override;
 
     NonnullRefPtr<ClientAudioStream> create_queue(ClientConnection&);
@@ -124,6 +123,8 @@ public:
     u16 audiodevice_get_sample_rate() const;
 
 private:
+    Mixer(NonnullRefPtr<Core::ConfigFile> config);
+
     void request_setting_sync();
 
     Vector<NonnullRefPtr<ClientAudioStream>> m_pending_mixing;

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -29,7 +29,7 @@ int main(int, char**)
     unveil(nullptr, nullptr);
 
     Core::EventLoop event_loop;
-    AudioServer::Mixer mixer { config };
+    auto mixer = AudioServer::Mixer::construct(config);
 
     auto server = Core::LocalServer::construct();
     bool ok = server->take_over_from_system_server();
@@ -42,7 +42,7 @@ int main(int, char**)
         }
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<AudioServer::ClientConnection>(client_socket.release_nonnull(), client_id, mixer);
+        IPC::new_client_connection<AudioServer::ClientConnection>(client_socket.release_nonnull(), client_id, *mixer);
     };
 
     if (pledge("stdio recvfd thread accept cpath rpath wpath", nullptr) < 0) {

--- a/Userland/Services/ChessEngine/ChessEngine.h
+++ b/Userland/Services/ChessEngine/ChessEngine.h
@@ -20,9 +20,9 @@ public:
     {
     }
 
-    virtual void handle_uci();
-    virtual void handle_position(const Chess::UCI::PositionCommand&);
-    virtual void handle_go(const Chess::UCI::GoCommand&);
+    virtual void handle_uci() override;
+    virtual void handle_position(const Chess::UCI::PositionCommand&) override;
+    virtual void handle_go(const Chess::UCI::GoCommand&) override;
 
 private:
     Chess::Board m_board;

--- a/Userland/Services/ChessEngine/ChessEngine.h
+++ b/Userland/Services/ChessEngine/ChessEngine.h
@@ -14,16 +14,16 @@ class ChessEngine : public Chess::UCI::Endpoint {
 public:
     virtual ~ChessEngine() override { }
 
+    virtual void handle_uci() override;
+    virtual void handle_position(const Chess::UCI::PositionCommand&) override;
+    virtual void handle_go(const Chess::UCI::GoCommand&) override;
+
+private:
     ChessEngine() { }
     ChessEngine(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevice> out)
         : Endpoint(in, out)
     {
     }
 
-    virtual void handle_uci() override;
-    virtual void handle_position(const Chess::UCI::PositionCommand&) override;
-    virtual void handle_go(const Chess::UCI::GoCommand&) override;
-
-private:
     Chess::Board m_board;
 };

--- a/Userland/Services/Clipboard/ClientConnection.h
+++ b/Userland/Services/Clipboard/ClientConnection.h
@@ -18,7 +18,6 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     virtual ~ClientConnection() override;
 
     virtual void die() override;
@@ -28,6 +27,8 @@ public:
     void notify_about_clipboard_change();
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::ClipboardServer::GetClipboardDataResponse get_clipboard_data() override;
     virtual void set_clipboard_data(Core::AnonymousBuffer const&, String const&, IPC::Dictionary const&) override;
 };

--- a/Userland/Services/DHCPClient/DHCPv4Client.h
+++ b/Userland/Services/DHCPClient/DHCPv4Client.h
@@ -40,7 +40,6 @@ class DHCPv4Client final : public Core::Object {
     C_OBJECT(DHCPv4Client)
 
 public:
-    explicit DHCPv4Client();
     virtual ~DHCPv4Client() override;
 
     void dhcp_discover(const InterfaceDescriptor& ifname);
@@ -57,6 +56,8 @@ public:
     static Result<Interfaces, String> get_discoverable_interfaces();
 
 private:
+    explicit DHCPv4Client();
+
     void try_discover_ifs();
 
     HashMap<u32, OwnPtr<DHCPv4Transaction>> m_ongoing_transactions;

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.h
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.h
@@ -20,12 +20,13 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     ~ClientConnection() override;
 
     virtual void die() override;
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual void request_file_read_only_approved(i32, i32, String const&) override;
     virtual void request_file(i32, i32, String const&, Core::OpenMode const&) override;
     virtual void prompt_open_file(i32, i32, String const&, String const&, Core::OpenMode const&) override;

--- a/Userland/Services/ImageDecoder/ClientConnection.h
+++ b/Userland/Services/ImageDecoder/ClientConnection.h
@@ -20,12 +20,13 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     ~ClientConnection() override;
 
     virtual void die() override;
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&) override;
 };
 

--- a/Userland/Services/InspectorServer/ClientConnection.h
+++ b/Userland/Services/InspectorServer/ClientConnection.h
@@ -18,12 +18,13 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     ~ClientConnection() override;
 
     virtual void die() override;
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::InspectorServer::GetAllObjectsResponse get_all_objects(pid_t) override;
     virtual Messages::InspectorServer::SetInspectedObjectResponse set_inspected_object(pid_t, u64 object_id) override;
     virtual Messages::InspectorServer::SetObjectPropertyResponse set_object_property(pid_t, u64 object_id, String const& name, String const& value) override;

--- a/Userland/Services/LookupServer/ClientConnection.h
+++ b/Userland/Services/LookupServer/ClientConnection.h
@@ -18,12 +18,13 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     virtual ~ClientConnection() override;
 
     virtual void die() override;
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::LookupServer::LookupNameResponse lookup_name(String const&) override;
     virtual Messages::LookupServer::LookupAddressResponse lookup_address(String const&) override;
 };

--- a/Userland/Services/RequestServer/ClientConnection.h
+++ b/Userland/Services/RequestServer/ClientConnection.h
@@ -19,7 +19,6 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     ~ClientConnection() override;
 
     virtual void die() override;
@@ -30,6 +29,8 @@ public:
     void did_request_certificates(Badge<Request>, Request&);
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(String const&) override;
     virtual Messages::RequestServer::StartRequestResponse start_request(String const&, URL const&, IPC::Dictionary const&, ByteBuffer const&) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(i32) override;

--- a/Userland/Services/SQLServer/ClientConnection.h
+++ b/Userland/Services/SQLServer/ClientConnection.h
@@ -18,7 +18,6 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     virtual ~ClientConnection() override;
 
     virtual void die() override;
@@ -26,6 +25,8 @@ public:
     static RefPtr<ClientConnection> client_connection_for(int client_id);
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::SQLServer::ConnectResponse connect(String const&) override;
     virtual Messages::SQLServer::SqlStatementResponse sql_statement(int, String const&) override;
     virtual void statement_execute(int) override;

--- a/Userland/Services/SQLServer/DatabaseConnection.h
+++ b/Userland/Services/SQLServer/DatabaseConnection.h
@@ -14,6 +14,8 @@ namespace SQLServer {
 
 class DatabaseConnection final : public Core::Object {
     C_OBJECT(DatabaseConnection)
+
+public:
     ~DatabaseConnection() override = default;
 
     static RefPtr<DatabaseConnection> connection_for(int connection_id);

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -18,6 +18,8 @@ namespace SQLServer {
 
 class SQLStatement final : public Core::Object {
     C_OBJECT(SQLStatement)
+
+public:
     ~SQLStatement() override = default;
 
     static RefPtr<SQLStatement> statement_for(int statement_id);

--- a/Userland/Services/SpiceAgent/ClipboardServerConnection.h
+++ b/Userland/Services/SpiceAgent/ClipboardServerConnection.h
@@ -17,6 +17,7 @@ class ClipboardServerConnection final
     , public ClipboardClientEndpoint {
     C_OBJECT(ClipboardServerConnection);
 
+public:
     Function<void()> on_data_changed;
     RefPtr<Gfx::Bitmap> get_bitmap();
     void set_bitmap(Gfx::Bitmap const& bitmap);

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -25,7 +25,6 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     ~ClientConnection() override;
 
     virtual void die() override;
@@ -33,6 +32,8 @@ public:
     void initialize_js_console(Badge<PageHost>);
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     Web::Page& page();
     const Web::Page& page() const;
 

--- a/Userland/Services/WebSocket/ClientConnection.h
+++ b/Userland/Services/WebSocket/ClientConnection.h
@@ -19,12 +19,13 @@ class ClientConnection final
     C_OBJECT(ClientConnection);
 
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
     ~ClientConnection() override;
 
     virtual void die() override;
 
 private:
+    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+
     virtual Messages::WebSocketServer::ConnectResponse connect(URL const&, String const&, Vector<String> const&, Vector<String> const&, IPC::Dictionary const&) override;
     virtual Messages::WebSocketServer::ReadyStateResponse ready_state(i32) override;
     virtual void send(i32, bool, ByteBuffer const&) override;

--- a/Userland/Services/WindowServer/AppletManager.h
+++ b/Userland/Services/WindowServer/AppletManager.h
@@ -14,7 +14,6 @@ namespace WindowServer {
 class AppletManager : public Core::Object {
     C_OBJECT(AppletManager)
 public:
-    AppletManager();
     ~AppletManager();
 
     static AppletManager& the();
@@ -35,6 +34,8 @@ public:
     void did_change_theme();
 
 private:
+    AppletManager();
+
     void repaint();
     void draw_applet(const Window& applet);
     void set_hovered_applet(Window*);

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -1084,10 +1084,10 @@ void Compositor::recompute_overlay_rects()
 void Compositor::recompute_occlusions()
 {
     auto& wm = WindowManager::the();
-    bool is_switcher_visible = wm.m_switcher.is_visible();
+    bool is_switcher_visible = wm.m_switcher->is_visible();
     auto never_occlude = [&](WindowStack& window_stack) {
         if (is_switcher_visible) {
-            switch (wm.m_switcher.mode()) {
+            switch (wm.m_switcher->mode()) {
             case WindowSwitcher::Mode::ShowCurrentDesktop:
                 // Any window on the currently rendered desktop should not be occluded, even if it's behind
                 // another window entirely.
@@ -1540,7 +1540,7 @@ void Compositor::finish_window_stack_switch()
     m_window_stack_transition_animation = nullptr;
 
     auto& wm = WindowManager::the();
-    if (!wm.m_switcher.is_visible())
+    if (!wm.m_switcher->is_visible())
         previous_window_stack->set_all_occluded(true);
     wm.did_switch_window_stack({}, *previous_window_stack, *m_current_window_stack);
 

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -28,7 +28,6 @@ class Menu final : public Core::Object {
     C_OBJECT(Menu);
 
 public:
-    Menu(ClientConnection*, int menu_id, String name);
     virtual ~Menu() override;
 
     ClientConnection* client() { return m_client; }
@@ -129,6 +128,8 @@ public:
     const Vector<size_t>* items_with_alt_shortcut(u32 alt_shortcut) const;
 
 private:
+    Menu(ClientConnection*, int menu_id, String name);
+
     virtual void event(Core::Event&) override;
 
     void handle_mouse_move_event(const MouseEvent&);

--- a/Userland/Services/WindowServer/MenuManager.h
+++ b/Userland/Services/WindowServer/MenuManager.h
@@ -20,7 +20,6 @@ class MenuManager final : public Core::Object {
 public:
     static MenuManager& the();
 
-    MenuManager();
     virtual ~MenuManager() override;
 
     bool is_open(const Menu&) const;
@@ -48,6 +47,8 @@ public:
     Menu* hovered_menu() { return m_hovered_menu; }
 
 private:
+    MenuManager();
+
     void close_menus(const Vector<Menu&>&);
 
     virtual void event(Core::Event&) override;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -85,6 +85,7 @@ Window::Window(Core::Object& parent, WindowType type)
         m_minimum_size = s_default_normal_minimum_size;
 
     WindowManager::the().add_window(*this);
+    frame().window_was_constructed({});
 }
 
 Window::Window(ClientConnection& client, WindowType window_type, int window_id, bool modal, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window)

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -362,11 +362,6 @@ public:
     const Vector<Screen*, default_screen_count>& screens() const { return m_screens; }
     Vector<Screen*, default_screen_count>& screens() { return m_screens; }
 
-    void did_construct()
-    {
-        frame().window_was_constructed({});
-    }
-
     void set_moving_to_another_stack(bool value) { m_moving_to_another_stack = value; }
     bool is_moving_to_another_stack() const { return m_moving_to_another_stack; }
 

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -68,7 +68,6 @@ public:
 
     static WindowManager& the();
 
-    explicit WindowManager(Gfx::PaletteImpl const&);
     virtual ~WindowManager() override;
 
     Palette palette() const { return Palette(*m_palette); }
@@ -322,6 +321,8 @@ public:
     void apply_cursor_theme(String const& name);
 
 private:
+    explicit WindowManager(Gfx::PaletteImpl const&);
+
     void notify_new_active_window(Window&);
     void notify_new_active_input_window(Window&);
     void notify_previous_active_window(Window&);

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -432,7 +432,7 @@ private:
 
     u8 m_keyboard_modifiers { 0 };
 
-    WindowSwitcher m_switcher;
+    NonnullRefPtr<WindowSwitcher> m_switcher;
 
     WeakPtr<Button> m_cursor_tracking_button;
     WeakPtr<Button> m_hovered_button;

--- a/Userland/Services/WindowServer/WindowSwitcher.h
+++ b/Userland/Services/WindowServer/WindowSwitcher.h
@@ -26,7 +26,6 @@ public:
     };
     static WindowSwitcher& the();
 
-    WindowSwitcher();
     virtual ~WindowSwitcher() override;
 
     bool is_visible() const { return m_visible; }
@@ -49,6 +48,8 @@ public:
     Mode mode() const { return m_mode; }
 
 private:
+    WindowSwitcher();
+
     int thumbnail_width() const { return 40; }
     int thumbnail_height() const { return 40; }
     int item_height() const { return 10 + thumbnail_height(); }

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -24,13 +24,6 @@
 class SelectableLayover final : public GUI::Widget {
     C_OBJECT(SelectableLayover)
 public:
-    SelectableLayover(GUI::Window* window)
-        : m_window(window)
-        , m_background_color(palette().threed_highlight().with_alpha(128))
-    {
-        set_override_cursor(Gfx::StandardCursor::Crosshair);
-    }
-
     virtual ~SelectableLayover() override {};
 
     Gfx::IntRect region() const
@@ -39,6 +32,13 @@ public:
     }
 
 private:
+    SelectableLayover(GUI::Window* window)
+        : m_window(window)
+        , m_background_color(palette().threed_highlight().with_alpha(128))
+    {
+        set_override_cursor(Gfx::StandardCursor::Crosshair);
+    }
+
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
         if (event.button() == GUI::MouseButton::Primary)


### PR DESCRIPTION
This PR addresses some landmines; I found them by blowing my leg off (i.e. writing code that accidentally misuses something):
- All derivatives of `Core::Object` should have `protected` or `private` constructors, and only be created through `SomeClass::construct(…)`, as these are ref-counted objects, and handling the Object directly without ever creating a `RefPtr` has weird effects (e.g. if some other code decides to create a new RefPtr and later drop it, suddenly the destructor of the object gets called and the memory freed. Whoops!)
- The `Object::did_construct()` automagic mechanism was used only in one place (`WindowServer::Window`), where it was not necessary. Also, post-constructor initialization is a bit of a wart, let's not encourage it.
- Some drive-by fixes to mark overriding methods as `override`.