### PR TITLE
ThemeEditor: Add "flag" support

### DIFF
--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -210,7 +210,7 @@ void PreviewWidget::paint_event(GUI::PaintEvent& event)
         }
     };
 
-    auto active_rect = Gfx::IntRect(0, 0, 320, 240).centered_within(frame_inner_rect());
+    auto active_rect = Gfx::IntRect(0, 0, 320, 240).centered_within(frame_inner_rect()).translated(0, 20);
     auto inactive_rect = active_rect.translated(-20, -20);
 
     paint_window("Inactive window", inactive_rect, Gfx::WindowTheme::WindowState::Inactive, *m_active_window_icon);
@@ -219,7 +219,7 @@ void PreviewWidget::paint_event(GUI::PaintEvent& event)
 
 void PreviewWidget::resize_event(GUI::ResizeEvent&)
 {
-    m_gallery->set_relative_rect(Gfx::IntRect(0, 0, 320, 240).centered_within(rect()));
+    m_gallery->set_relative_rect(Gfx::IntRect(0, 0, 320, 240).centered_within(rect()).translated(0, 20));
 }
 
 void PreviewWidget::drop_event(GUI::DropEvent& event)

--- a/Userland/Applications/ThemeEditor/ThemeEditor.gml
+++ b/Userland/Applications/ThemeEditor/ThemeEditor.gml
@@ -30,6 +30,28 @@
             margins: [16, 8, 8, 8]
         }
         shrink_to_fit: true
+        title: "Flags"
+
+        @GUI::ComboBox {
+            name: "flag_combo_box"
+            model_only: true
+            fixed_width: 230
+        }
+
+        @GUI::Widget {
+        }
+
+        @GUI::CheckBox {
+            name: "flag_input"
+            fixed_width: 13
+        }
+    }
+
+    @GUI::GroupBox {
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [16, 8, 8, 8]
+        }
+        shrink_to_fit: true
         title: "Metrics"
 
         @GUI::ComboBox {

--- a/Userland/Libraries/LibGUI/Variant.cpp
+++ b/Userland/Libraries/LibGUI/Variant.cpp
@@ -48,6 +48,8 @@ const char* to_string(Variant::Type type)
         return "TextAlignment";
     case Variant::Type::ColorRole:
         return "ColorRole";
+    case Variant::Type::FlagRole:
+        return "FlagRole";
     case Variant::Type::MetricRole:
         return "MetricRole";
     case Variant::Type::PathRole:
@@ -95,6 +97,12 @@ Variant::Variant(Gfx::ColorRole value)
     : m_type(Type::ColorRole)
 {
     m_value.as_color_role = value;
+}
+
+Variant::Variant(Gfx::FlagRole value)
+    : m_type(Type::FlagRole)
+{
+    m_value.as_flag_role = value;
 }
 
 Variant::Variant(Gfx::MetricRole value)
@@ -347,6 +355,9 @@ void Variant::copy_from(const Variant& other)
     case Type::ColorRole:
         m_value.as_color_role = other.m_value.as_color_role;
         break;
+    case Type::FlagRole:
+        m_value.as_flag_role = other.m_value.as_flag_role;
+        break;
     case Type::MetricRole:
         m_value.as_metric_role = other.m_value.as_metric_role;
         break;
@@ -395,6 +406,8 @@ bool Variant::operator==(const Variant& other) const
         return m_value.as_text_alignment == other.m_value.as_text_alignment;
     case Type::ColorRole:
         return m_value.as_color_role == other.m_value.as_color_role;
+    case Type::FlagRole:
+        return m_value.as_flag_role == other.m_value.as_flag_role;
     case Type::MetricRole:
         return m_value.as_metric_role == other.m_value.as_metric_role;
     case Type::PathRole:
@@ -438,6 +451,7 @@ bool Variant::operator<(const Variant& other) const
     case Type::Font:
     case Type::TextAlignment:
     case Type::ColorRole:
+    case Type::FlagRole:
     case Type::MetricRole:
     case Type::PathRole:
         // FIXME: Figure out how to compare these.
@@ -498,6 +512,8 @@ String Variant::to_string() const
     }
     case Type::ColorRole:
         return String::formatted("Gfx::ColorRole::{}", Gfx::to_string(m_value.as_color_role));
+    case Type::FlagRole:
+        return String::formatted("Gfx::FlagRole::{}", Gfx::to_string(m_value.as_flag_role));
     case Type::MetricRole:
         return String::formatted("Gfx::MetricRole::{}", Gfx::to_string(m_value.as_metric_role));
     case Type::PathRole:

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -35,6 +35,7 @@ public:
     Variant(const Gfx::Font&);
     Variant(const Gfx::TextAlignment);
     Variant(const Gfx::ColorRole);
+    Variant(const Gfx::FlagRole);
     Variant(const Gfx::MetricRole);
     Variant(const Gfx::PathRole);
     Variant(const JsonValue&);
@@ -67,6 +68,7 @@ public:
         Font,
         TextAlignment,
         ColorRole,
+        FlagRole,
         MetricRole,
         PathRole,
     };
@@ -88,6 +90,7 @@ public:
     bool is_font() const { return m_type == Type::Font; }
     bool is_text_alignment() const { return m_type == Type::TextAlignment; }
     bool is_color_role() const { return m_type == Type::ColorRole; }
+    bool is_flag_role() const { return m_type == Type::FlagRole; }
     bool is_metric_role() const { return m_type == Type::MetricRole; }
     bool is_path_role() const { return m_type == Type::PathRole; }
     Type type() const { return m_type; }
@@ -251,6 +254,13 @@ public:
         return m_value.as_color_role;
     }
 
+    Gfx::FlagRole to_flag_role() const
+    {
+        if (type() != Type::FlagRole)
+            return Gfx::FlagRole::NoRole;
+        return m_value.as_flag_role;
+    }
+
     Gfx::MetricRole to_metric_role() const
     {
         if (type() != Type::MetricRole)
@@ -315,6 +325,7 @@ private:
         Gfx::RGBA32 as_color;
         Gfx::TextAlignment as_text_alignment;
         Gfx::ColorRole as_color_role;
+        Gfx::FlagRole as_flag_role;
         Gfx::MetricRole as_metric_role;
         Gfx::PathRole as_path_role;
         RawPoint as_point;

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -42,8 +42,7 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
     };
 
     auto get_flag = [&](auto& name) {
-        auto flag_string = file.read_entry("Flags", name);
-        return flag_string.equals_ignoring_case("true");
+        return file.read_bool_entry("Flags", name, false);
     };
 
     auto get_metric = [&](auto& name, auto role) {

--- a/Userland/Libraries/LibGfx/SystemTheme.h
+++ b/Userland/Libraries/LibGfx/SystemTheme.h
@@ -147,6 +147,22 @@ enum class FlagRole {
         __Count,
 };
 
+inline const char* to_string(FlagRole role)
+{
+    switch (role) {
+    case FlagRole::NoRole:
+        return "NoRole";
+#undef __ENUMERATE_FLAG_ROLE
+#define __ENUMERATE_FLAG_ROLE(role) \
+    case FlagRole::role:            \
+        return #role;
+        ENUMERATE_FLAG_ROLES(__ENUMERATE_FLAG_ROLE)
+#undef __ENUMERATE_FLAG_ROLE
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 enum class MetricRole {
     NoRole,
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/139711364-6f4b8624-a03b-44d7-967b-002316937d7c.png)

Also rolled in a couple of little fixes that I missed in my previous PR.

The UI for editing the flags is a bit awkward, so if anyone has a better idea I'm happy to change it. Just having a list of checkboxes would be nicer, but that would expand the window vertically, unless someone manually modifies the ThemeEditor GML every time a flag is added (which seems unlikely). For now, at least it's consistent with the other editor sections.