### PR TITLE
LibThreading: Remove redundant method

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -132,7 +132,7 @@ void FileProvider::query(const String& query, Function<void(NonnullRefPtrVector<
     if (m_fuzzy_match_work)
         m_fuzzy_match_work->cancel();
 
-    m_fuzzy_match_work = Threading::BackgroundAction<NonnullRefPtrVector<Result>>::create(
+    m_fuzzy_match_work = Threading::BackgroundAction<NonnullRefPtrVector<Result>>::construct(
         [this, query](auto& task) {
             NonnullRefPtrVector<Result> results;
 
@@ -163,7 +163,7 @@ void FileProvider::build_filesystem_cache()
     m_building_cache = true;
     m_work_queue.enqueue("/");
 
-    Threading::BackgroundAction<int>::create(
+    Threading::BackgroundAction<int>::construct(
         [this](auto&) {
             String slash = "/";
             auto timer = Core::ElapsedTimer::start_new();

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -30,7 +30,7 @@ bool MonitorWidget::set_wallpaper(String path)
     if (!is_different_to_current_wallpaper_path(path))
         return false;
 
-    Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::create(
+    Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::construct(
         [path](auto&) {
             RefPtr<Gfx::Bitmap> bmp;
             if (!path.is_empty())

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -113,7 +113,7 @@ private:
 
 void ThreadStackWidget::refresh()
 {
-    Threading::BackgroundAction<Vector<Symbolication::Symbol>>::create(
+    Threading::BackgroundAction<Vector<Symbolication::Symbol>>::construct(
         [pid = m_pid, tid = m_tid](auto&) {
             return Symbolication::symbolicate_thread(pid, tid, Symbolication::IncludeSourcePosition::No);
         },

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -652,7 +652,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
 
     auto weak_this = make_weak_ptr();
 
-    Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::create(
+    Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::construct(
         [path](auto&) {
             return render_thumbnail(path);
         },

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -38,13 +38,6 @@ class BackgroundAction final : public Core::Object
     C_OBJECT(BackgroundAction);
 
 public:
-    static NonnullRefPtr<BackgroundAction<Result>> create(
-        Function<Result(BackgroundAction&)> action,
-        Function<void(Result)> on_complete = nullptr)
-    {
-        return adopt_ref(*new BackgroundAction(move(action), move(on_complete)));
-    }
-
     void cancel()
     {
         m_cancelled = true;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -807,7 +807,7 @@ bool Compositor::set_wallpaper_mode(const String& mode)
 
 bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callback)
 {
-    Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::create(
+    Threading::BackgroundAction<RefPtr<Gfx::Bitmap>>::construct(
         [path](auto&) {
             return Gfx::Bitmap::try_load_from_file(path);
         },


### PR DESCRIPTION
Apparently the author of `create()` overlooked the fact that `C_OBJECT(…)` already provides `construct()`.

Found while doing #10745.