### PR TITLE
AudioServer+SoundPlayer: Allow each client on AudioServer to be muted

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -28,7 +28,7 @@ public:
         , m_show_percent(Config::read_bool("AudioApplet", "Applet", "ShowPercent", false))
     {
         m_audio_volume = static_cast<int>(m_audio_client->get_main_mix_volume() * 100);
-        m_audio_muted = m_audio_client->get_muted();
+        m_audio_muted = m_audio_client->is_main_mix_muted();
 
         m_audio_client->on_muted_state_change = [this](bool muted) {
             if (m_audio_muted == muted)
@@ -102,7 +102,7 @@ public:
         m_mute_box->set_tooltip(m_audio_muted ? "Unmute" : "Mute");
         m_mute_box->on_checked = [&](bool is_muted) {
             m_mute_box->set_tooltip(is_muted ? "Unmute" : "Mute");
-            m_audio_client->set_muted(is_muted);
+            m_audio_client->set_main_mix_muted(is_muted);
             GUI::Application::the()->hide_tooltip();
         };
     }
@@ -128,7 +128,7 @@ private:
             return;
         }
         if (event.button() == GUI::MouseButton::Secondary) {
-            m_audio_client->set_muted(!m_audio_muted);
+            m_audio_client->set_main_mix_muted(!m_audio_muted);
             update();
         }
     }

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -92,6 +92,15 @@ void Player::set_volume(double volume)
     volume_changed(m_volume);
 }
 
+void Player::set_mute(bool muted)
+{
+    if (m_muted != muted) {
+        m_muted = muted;
+        m_audio_client_connection.set_self_muted(muted);
+        mute_changed(muted);
+    }
+}
+
 void Player::set_shuffle_mode(ShuffleMode mode)
 {
     if (m_shuffle_mode != mode) {
@@ -123,6 +132,16 @@ void Player::stop()
 {
     m_playback_manager.stop();
     set_play_state(PlayState::Stopped);
+}
+
+void Player::mute()
+{
+    set_mute(true);
+}
+
+void Player::toggle_mute()
+{
+    set_mute(!m_muted);
 }
 
 void Player::seek(int sample)

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -49,10 +49,15 @@ public:
     double volume() const { return m_volume; }
     void set_volume(double value);
 
+    bool is_muted() const { return m_muted; }
+    void set_mute(bool);
+
     void play();
     void pause();
     void toggle_pause();
     void stop();
+    void mute();
+    void toggle_mute();
     void seek(int sample);
 
     virtual void play_state_changed(PlayState) = 0;
@@ -63,6 +68,7 @@ public:
     virtual void audio_load_error(StringView, StringView) = 0;
     virtual void shuffle_mode_changed(ShuffleMode) = 0;
     virtual void volume_changed(double) = 0;
+    virtual void mute_changed(bool) = 0;
     virtual void total_samples_changed(int) = 0;
     virtual void sound_buffer_played(RefPtr<Audio::Buffer>, [[maybe_unused]] int sample_rate, [[maybe_unused]] int samples_played) = 0;
 
@@ -73,6 +79,7 @@ protected:
         set_loop_mode(LoopMode::None);
         time_elapsed(0);
         set_volume(1.);
+        set_mute(false);
     }
 
 private:
@@ -86,4 +93,5 @@ private:
 
     StringView m_loaded_filename;
     double m_volume { 0 };
+    bool m_muted { false };
 };

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -167,6 +167,10 @@ void SoundPlayerWidgetAdvancedView::play_state_changed(Player::PlayState state)
     m_playback_progress_slider->set_enabled(state != PlayState::NoFileLoaded);
 }
 
+void SoundPlayerWidgetAdvancedView::mute_changed(bool)
+{
+}
+
 void SoundPlayerWidgetAdvancedView::loop_mode_changed(Player::LoopMode)
 {
 }

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -111,6 +111,7 @@ SoundPlayerWidgetAdvancedView::SoundPlayerWidgetAdvancedView(GUI::Window& window
     volume_slider.on_change = [&](int value) {
         double volume = m_nonlinear_volume_slider ? (double)(value * value) / (100 * 100) : value / 100.;
         set_volume(volume);
+        //FIXME: Update volume slider when its muted
     };
 
     set_nonlinear_volume_slider(false);
@@ -141,6 +142,9 @@ void SoundPlayerWidgetAdvancedView::keydown_event(GUI::KeyEvent& event)
 {
     if (event.key() == Key_Space)
         m_play_button->click();
+
+    if (event.key() == Key_M)
+        toggle_mute();
 
     GUI::Widget::keydown_event(event);
 }

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -43,6 +43,7 @@ public:
     virtual void file_name_changed(StringView) override;
     virtual void playlist_loaded(StringView, bool) override;
     virtual void audio_load_error(StringView path, StringView error_reason) override;
+    virtual void mute_changed(bool) override;
     virtual void volume_changed(double) override;
     virtual void total_samples_changed(int) override;
     virtual void sound_buffer_played(RefPtr<Audio::Buffer>, int sample_rate, int samples_played) override;

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -5,6 +5,8 @@ endpoint AudioServer
     // Mixer functions
     set_main_mix_muted(bool muted) => ()
     is_main_mix_muted() => (bool muted)
+    set_self_muted(bool muted) => ()
+    is_self_muted() => (bool muted)
     get_main_mix_volume() => (double volume)
     set_main_mix_volume(double volume) => ()
     get_self_volume() => (double volume)

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -3,8 +3,8 @@
 endpoint AudioServer
 {
     // Mixer functions
-    set_muted(bool muted) => ()
-    get_muted() => (bool muted)
+    set_main_mix_muted(bool muted) => ()
+    is_main_mix_muted() => (bool muted)
     get_main_mix_volume() => (double volume)
     set_main_mix_volume(double volume) => ()
     get_self_volume() => (double volume)

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -148,4 +148,18 @@ void ClientConnection::set_main_mix_muted(bool muted)
 {
     m_mixer.set_muted(muted);
 }
+
+Messages::AudioServer::IsSelfMutedResponse ClientConnection::is_self_muted()
+{
+    if (m_queue)
+        return m_queue->is_muted();
+
+    return false;
+}
+
+void ClientConnection::set_self_muted(bool muted)
+{
+    if (m_queue)
+        m_queue->set_muted(muted);
+}
 }

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -139,12 +139,12 @@ Messages::AudioServer::GetPlayingBufferResponse ClientConnection::get_playing_bu
     return id;
 }
 
-Messages::AudioServer::GetMutedResponse ClientConnection::get_muted()
+Messages::AudioServer::IsMainMixMutedResponse ClientConnection::is_main_mix_muted()
 {
     return m_mixer.is_muted();
 }
 
-void ClientConnection::set_muted(bool muted)
+void ClientConnection::set_main_mix_muted(bool muted)
 {
     m_mixer.set_muted(muted);
 }

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -46,8 +46,8 @@ private:
     virtual void set_paused(bool) override;
     virtual void clear_buffer(bool) override;
     virtual Messages::AudioServer::GetPlayingBufferResponse get_playing_buffer() override;
-    virtual Messages::AudioServer::GetMutedResponse get_muted() override;
-    virtual void set_muted(bool) override;
+    virtual Messages::AudioServer::IsMainMixMutedResponse is_main_mix_muted() override;
+    virtual void set_main_mix_muted(bool) override;
     virtual void set_sample_rate(u16 sample_rate) override;
     virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
 

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -48,6 +48,8 @@ private:
     virtual Messages::AudioServer::GetPlayingBufferResponse get_playing_buffer() override;
     virtual Messages::AudioServer::IsMainMixMutedResponse is_main_mix_muted() override;
     virtual void set_main_mix_muted(bool) override;
+    virtual Messages::AudioServer::IsSelfMutedResponse is_self_muted() override;
+    virtual void set_self_muted(bool) override;
     virtual void set_sample_rate(u16 sample_rate) override;
     virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
 

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -97,6 +97,8 @@ void Mixer::mix()
                 Audio::Frame sample;
                 if (!queue->get_next_sample(sample))
                     break;
+                if (queue->is_muted())
+                    continue;
                 sample.log_multiply(SAMPLE_HEADROOM);
                 sample.log_multiply(queue->volume());
                 mixed_sample += sample;

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -92,6 +92,8 @@ public:
     FadingProperty<double>& volume() { return m_volume; }
     double volume() const { return m_volume; }
     void set_volume(double const volume) { m_volume = volume; }
+    bool is_muted() const { return m_muted; }
+    void set_muted(bool muted) { m_muted = muted; }
 
 private:
     RefPtr<Audio::Buffer> m_current;
@@ -100,6 +102,7 @@ private:
     int m_remaining_samples { 0 };
     int m_played_samples { 0 };
     bool m_paused { false };
+    bool m_muted { false };
 
     WeakPtr<ClientConnection> m_client;
     FadingProperty<double> m_volume { 1 };

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
                 break;
             }
             case AudioVariable::Mute: {
-                bool muted = audio_client->get_muted();
+                bool muted = audio_client->is_main_mix_muted();
                 if (human_mode)
                     outln("Muted: {}", muted ? "Yes" : "No");
                 else
@@ -146,7 +146,7 @@ int main(int argc, char** argv)
             }
             case AudioVariable::Mute: {
                 bool& mute = to_set.value.get<bool>();
-                audio_client->set_muted(mute);
+                audio_client->set_main_mix_muted(mute);
                 break;
             }
             case AudioVariable::SampleRate: {


### PR DESCRIPTION
This PR does three things:

- Refactors the IPC methods of AudioPlayer to differentiate between 'main mix mute' and 'self mute' settings.
- Using the former methods, adds a way to the output mix to ignore muted clients.
- Adds a mute shortcut to SoundPlayer but it still doesn't update the volume slidebar.
