### PR TITLE
Websites: Simplify a link table of serenityos.org

### DIFF
--- a/Meta/Websites/serenityos.org/github-sponsors/index.html
+++ b/Meta/Websites/serenityos.org/github-sponsors/index.html
@@ -27,10 +27,10 @@
 <p>Thank you for checking it out :^)</p>
 <p class="pinkbar"><b>Andreas</b>
     (
-    <a href="https://github.com/awesomekling">GitHub</a> | 
-    <a href="https://youtube.com/c/AndreasKling">YouTube</a> | 
-    <a href="https://twitter.com/awesomekling">Twitter</a> | 
-    <a href="https://patreon.com/serenityos">Patreon</a> | 
+    <a href="https://github.com/awesomekling">GitHub</a> |
+    <a href="https://youtube.com/c/AndreasKling">YouTube</a> |
+    <a href="https://twitter.com/awesomekling">Twitter</a> |
+    <a href="https://patreon.com/serenityos">Patreon</a> |
     <a href="https://paypal.me/awesomekling">PayPal</a> )
 </p>
 </div>


### PR DESCRIPTION
Simplify the link table at `serenityos.org/github-sponsors/index.html`
by removing useless whitespace.