### PR TITLE
SoundPlayer: Allow playback progress slider jump to cursor

### DIFF
--- a/Userland/Applications/SoundPlayer/Common.h
+++ b/Userland/Applications/SoundPlayer/Common.h
@@ -15,7 +15,7 @@ public:
     Function<void(int)> on_knob_released;
     void set_value(int value)
     {
-        if (!knob_dragging())
+        if (!knob_dragging() && !mouse_is_down())
             GUI::Slider::set_value(value);
     }
 


### PR DESCRIPTION
Previously we could only move the progress slider dragging the knob, which wasn't really convenient.

The slider had enabled the 'jump_to_cursor()' mechanism but it wasn't working properly because the selected value was being overwritten by the player. With this fix, we make sure we're neither dragging the knob nor clicking down before updating the value.

This is how it was before (we could only move it by dragging the knob):
https://user-images.githubusercontent.com/26639800/140420229-bfdbe69b-8bdc-4f22-9302-31319ddaddba.mp4

This is fixed (both, jump to cursor and dragging the knob work):
https://user-images.githubusercontent.com/26639800/140420336-b3d6d1fb-4f3b-4113-baf5-9203b176bffe.mp4



