### PR TITLE
Ports: quake: Do no set PATH environment variable in package.sh

### DIFF
--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -9,6 +9,3 @@ depends=("SDL2")
 launcher_name=Quake
 launcher_category=Games
 launcher_command=quake
-
-# FIXME: Uhh, the things in this directory are not supposed to run on the host, why add this to $PATH?!
-export PATH="${SERENITY_INSTALL_ROOT}/usr/bin:${PATH}"


### PR DESCRIPTION
`export PATH=${SERENITY_ROOT}/Root/usr/bin:$PATH` was added to `package.sh` in the following commit with no explanation:

https://github.com/SerenityOS/serenity/commit/f46d80ac4fc2d9c4d3da9baf5515d2af9c577596#diff-88373a5255f2207b0ad8fa685c54913f8d3677243cef8a99dd162565de44f34e

```
Ports: Added checksums / signature files and other fixes

* Use ${version} instead of explicit version numbers in urls/filenames
* Move -L option to port script, as this is always good
* Fix some various other stuff
```

This commit also introduced a rogue and unnecessary space character, indicating that the changes might have been committed in error (?)

A comment expressing confusion about this change was later added in the following commit:

https://github.com/SerenityOS/serenity/commit/f318ab6bed4603a18198b36da682b6fd36a68f91#diff-88373a5255f2207b0ad8fa685c54913f8d3677243cef8a99dd162565de44f34e

```
# FIXME: Uhh, the things in this directory are not supposed to run on the host, why add this to $PATH?!
```

I have no idea what exporting the `PATH` was meant to do. It is unlikely that we can even execute files located in `${SERENITY_INSTALL_ROOT}/usr/bin` during build...

The quake port builds fine without setting `PATH`. `quake` also appears to run fine (except for mouse look, which was broken).

![quake](https://user-images.githubusercontent.com/434827/139910995-75d1c84a-441d-433d-91c8-b04330d0db1f.png)
