### PR TITLE
LibSQL: Implement table joins

### DIFF
--- a/Base/home/anon/Documents/sql/insert_values.sql
+++ b/Base/home/anon/Documents/sql/insert_values.sql
@@ -1,0 +1,14 @@
+CREATE SCHEMA TestSchema;
+CREATE TABLE TestSchema.TestTable
+(
+    TextColumn text,
+    IntColumn  integer
+);
+INSERT INTO TestSchema.TestTable (TextColumn, IntColumn)
+VALUES ('Test_1', 42),
+       ('Test_3', 44),
+       ('Test_2', 43),
+       ('Test_4', 45),
+       ('Test_5', 46);
+SELECT *
+FROM TestSchema.TestTable;

--- a/Base/home/anon/Documents/sql/select_cross_join.sql
+++ b/Base/home/anon/Documents/sql/select_cross_join.sql
@@ -1,0 +1,26 @@
+CREATE SCHEMA TestSchema;
+CREATE TABLE TestSchema.TestTable1
+(
+    TextColumn1 text,
+    IntColumn   integer
+);
+CREATE TABLE TestSchema.TestTable2
+(
+    TextColumn2 text,
+    IntColumn   integer
+);
+INSERT INTO TestSchema.TestTable1 (TextColumn1, IntColumn)
+VALUES ('Test_1', 42),
+       ('Test_3', 44),
+       ('Test_2', 43),
+       ('Test_4', 45),
+       ('Test_5', 46);
+INSERT INTO TestSchema.TestTable2 (TextColumn2, IntColumn)
+VALUES ('Test_10', 40),
+       ('Test_11', 41),
+       ('Test_12', 42),
+       ('Test_13', 47),
+       ('Test_14', 48);
+SELECT *
+FROM TestSchema.TestTable1,
+     TestSchema.TestTable2;

--- a/Base/home/anon/Documents/sql/select_from_table.sql
+++ b/Base/home/anon/Documents/sql/select_from_table.sql
@@ -1,0 +1,14 @@
+CREATE SCHEMA TestSchema;
+CREATE TABLE TestSchema.TestTable
+(
+    TextColumn text,
+    IntColumn  integer
+);
+INSERT INTO TestSchema.TestTable (TextColumn, IntColumn)
+VALUES ('Test_1', 42),
+       ('Test_3', 44),
+       ('Test_2', 43),
+       ('Test_4', 45),
+       ('Test_5', 46);
+SELECT *
+FROM TestSchema.TestTable;

--- a/Base/home/anon/Documents/sql/select_inner_join.sql
+++ b/Base/home/anon/Documents/sql/select_inner_join.sql
@@ -1,0 +1,27 @@
+CREATE SCHEMA TestSchema;
+CREATE TABLE TestSchema.TestTable1
+(
+    TextColumn1 text,
+    IntColumn   integer
+);
+CREATE TABLE TestSchema.TestTable2
+(
+    TextColumn2 text,
+    IntColumn   integer
+);
+INSERT INTO TestSchema.TestTable1 (TextColumn1, IntColumn)
+VALUES ('Test_1', 42),
+       ('Test_3', 44),
+       ('Test_2', 43),
+       ('Test_4', 45),
+       ('Test_5', 46);
+INSERT INTO TestSchema.TestTable2 (TextColumn2, IntColumn)
+VALUES ('Test_10', 40),
+       ('Test_11', 41),
+       ('Test_12', 42),
+       ('Test_13', 47),
+       ('Test_14', 48);
+SELECT TestTable1.IntColumn, TextColumn1, TextColumn2
+FROM TestSchema.TestTable1,
+     TestSchema.TestTable2
+WHERE TestTable1.IntColumn = TestTable2.IntColumn;

--- a/Base/home/anon/Documents/sql/select_with_column_names.sql
+++ b/Base/home/anon/Documents/sql/select_with_column_names.sql
@@ -1,0 +1,14 @@
+CREATE SCHEMA TestSchema;
+CREATE TABLE TestSchema.TestTable
+(
+    TextColumn text,
+    IntColumn  integer
+);
+INSERT INTO TestSchema.TestTable (TextColumn, IntColumn)
+VALUES ('Test_1', 42),
+       ('Test_3', 44),
+       ('Test_2', 43),
+       ('Test_4', 45),
+       ('Test_5', 46);
+SELECT TextColumn
+FROM TestSchema.TestTable;

--- a/Base/home/anon/Documents/sql/select_with_where.sql
+++ b/Base/home/anon/Documents/sql/select_with_where.sql
@@ -1,0 +1,15 @@
+CREATE SCHEMA TestSchema;
+CREATE TABLE TestSchema.TestTable
+(
+    TextColumn text,
+    IntColumn  integer
+);
+INSERT INTO TestSchema.TestTable (TextColumn, IntColumn)
+VALUES ('Test_1', 42),
+       ('Test_3', 44),
+       ('Test_2', 43),
+       ('Test_4', 45),
+       ('Test_5', 46);
+SELECT TextColumn, IntColumn
+FROM TestSchema.TestTable
+WHERE IntColumn > 44;

--- a/Tests/LibSQL/TestSqlBtreeIndex.cpp
+++ b/Tests/LibSQL/TestSqlBtreeIndex.cpp
@@ -127,7 +127,7 @@ void insert_into_and_scan_btree(int);
 NonnullRefPtr<SQL::BTree> setup_btree(SQL::Serializer& serializer)
 {
     NonnullRefPtr<SQL::TupleDescriptor> tuple_descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    tuple_descriptor->append({ "key_value", SQL::SQLType::Integer, SQL::Order::Ascending });
+    tuple_descriptor->append({ "schema", "table", "key_value", SQL::SQLType::Integer, SQL::Order::Ascending });
 
     auto root_pointer = serializer.heap().user_value(0);
     if (!root_pointer) {

--- a/Tests/LibSQL/TestSqlHashIndex.cpp
+++ b/Tests/LibSQL/TestSqlHashIndex.cpp
@@ -124,8 +124,8 @@ void insert_into_and_scan_hash_index(int);
 NonnullRefPtr<SQL::HashIndex> setup_hash_index(SQL::Serializer& serializer)
 {
     NonnullRefPtr<SQL::TupleDescriptor> tuple_descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    tuple_descriptor->append({ "key_value", SQL::SQLType::Integer, SQL::Order::Ascending });
-    tuple_descriptor->append({ "text_value", SQL::SQLType::Text, SQL::Order::Ascending });
+    tuple_descriptor->append({ "schema", "table", "key_value", SQL::SQLType::Integer, SQL::Order::Ascending });
+    tuple_descriptor->append({ "schema", "table", "text_value", SQL::SQLType::Text, SQL::Order::Ascending });
 
     auto directory_pointer = serializer.heap().user_value(0);
     if (!directory_pointer) {

--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -25,8 +25,7 @@ RefPtr<SQL::SQLResult> execute(NonnullRefPtr<SQL::Database> database, String con
     EXPECT(!parser.has_errors());
     if (parser.has_errors())
         outln("{}", parser.errors()[0].to_string());
-    SQL::AST::ExecutionContext context { database };
-    auto result = statement->execute(context);
+    auto result = statement->execute(move(database));
     if (result->error().code != SQL::SQLErrorCode::NoError)
         outln("{}", result->error().to_string());
     return result;

--- a/Tests/LibSQL/TestSqlValueAndTuple.cpp
+++ b/Tests/LibSQL/TestSqlValueAndTuple.cpp
@@ -286,8 +286,8 @@ TEST_CASE(serialize_boolean_value)
 TEST_CASE(tuple_value)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
 
     auto v = SQL::Value::create_tuple(descriptor);
     Vector<SQL::Value> values;
@@ -303,8 +303,8 @@ TEST_CASE(tuple_value)
 TEST_CASE(copy_tuple_value)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
 
     auto v = SQL::Value::create_tuple(descriptor);
     Vector<SQL::Value> values;
@@ -321,7 +321,7 @@ TEST_CASE(copy_tuple_value)
 TEST_CASE(tuple_value_wrong_type)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
 
     auto v = SQL::Value::create_tuple(descriptor);
     Vector<SQL::Value> values;
@@ -333,7 +333,7 @@ TEST_CASE(tuple_value_wrong_type)
 TEST_CASE(tuple_value_too_many_values)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
 
     auto v = SQL::Value::create_tuple(descriptor);
     Vector<SQL::Value> values;
@@ -346,8 +346,8 @@ TEST_CASE(tuple_value_too_many_values)
 TEST_CASE(tuple_value_not_enough_values)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Ascending });
 
     auto v = SQL::Value::create_tuple(descriptor);
     Vector<SQL::Value> values;
@@ -365,8 +365,8 @@ TEST_CASE(tuple_value_not_enough_values)
 TEST_CASE(serialize_tuple_value)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
 
     auto v = SQL::Value::create_tuple(descriptor);
     Vector<SQL::Value> values;
@@ -477,8 +477,8 @@ TEST_CASE(order_int_values)
 TEST_CASE(tuple)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
     SQL::Tuple tuple(descriptor);
 
     tuple["col1"] = "Test";
@@ -490,8 +490,8 @@ TEST_CASE(tuple)
 TEST_CASE(serialize_tuple)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
     SQL::Tuple tuple(descriptor);
 
     tuple["col1"] = "Test";
@@ -512,8 +512,8 @@ TEST_CASE(serialize_tuple)
 TEST_CASE(copy_tuple)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
     SQL::Tuple tuple(descriptor);
 
     tuple["col1"] = "Test";
@@ -530,8 +530,8 @@ TEST_CASE(copy_tuple)
 TEST_CASE(compare_tuples)
 {
     NonnullRefPtr<SQL::TupleDescriptor> descriptor = adopt_ref(*new SQL::TupleDescriptor);
-    descriptor->append({ "col1", SQL::SQLType::Text, SQL::Order::Ascending });
-    descriptor->append({ "col2", SQL::SQLType::Integer, SQL::Order::Descending });
+    descriptor->append({ "schema", "table", "col1", SQL::SQLType::Text, SQL::Order::Ascending });
+    descriptor->append({ "schema", "table", "col2", SQL::SQLType::Integer, SQL::Order::Descending });
 
     SQL::Tuple tuple1(descriptor);
     tuple1["col1"] = "Test";

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -298,6 +298,7 @@ private:
 struct ExecutionContext {
     NonnullRefPtr<Database> database;
     RefPtr<SQLResult> result { nullptr };
+    class Statement const* statement;
     Tuple* current_row { nullptr };
 };
 
@@ -722,6 +723,7 @@ private:
 
 class Statement : public ASTNode {
 public:
+    RefPtr<SQLResult> execute(AK::NonnullRefPtr<Database> database) const;
     virtual RefPtr<SQLResult> execute(ExecutionContext&) const { return nullptr; }
 };
 

--- a/Userland/Libraries/LibSQL/AST/Statement.cpp
+++ b/Userland/Libraries/LibSQL/AST/Statement.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSQL/AST/AST.h>
+#include <LibSQL/Database.h>
+#include <LibSQL/Meta.h>
+#include <LibSQL/Row.h>
+
+namespace SQL::AST {
+
+RefPtr<SQLResult> Statement::execute(AK::NonnullRefPtr<Database> database) const
+{
+    ExecutionContext context { move(database), nullptr, this, nullptr };
+    return execute(context);
+}
+
+}

--- a/Userland/Libraries/LibSQL/CMakeLists.txt
+++ b/Userland/Libraries/LibSQL/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     AST/Lexer.cpp
     AST/Parser.cpp
     AST/Select.cpp
+    AST/Statement.cpp
     AST/SyntaxHighlighter.cpp
     AST/Token.cpp
     BTree.cpp

--- a/Userland/Libraries/LibSQL/Meta.cpp
+++ b/Userland/Libraries/LibSQL/Meta.cpp
@@ -118,7 +118,7 @@ NonnullRefPtr<TupleDescriptor> IndexDef::to_tuple_descriptor() const
 {
     NonnullRefPtr<TupleDescriptor> ret = adopt_ref(*new TupleDescriptor);
     for (auto& part : m_key_definition) {
-        ret->append({ part.name(), part.type(), part.sort_order() });
+        ret->append({ "", "", part.name(), part.type(), part.sort_order() });
     }
     return ret;
 }
@@ -161,7 +161,7 @@ NonnullRefPtr<TupleDescriptor> TableDef::to_tuple_descriptor() const
 {
     NonnullRefPtr<TupleDescriptor> ret = adopt_ref(*new TupleDescriptor);
     for (auto& part : m_columns) {
-        ret->append({ part.name(), part.type(), Order::Ascending });
+        ret->append({ parent()->name(), name(), part.name(), part.type(), Order::Ascending });
     }
     return ret;
 }

--- a/Userland/Libraries/LibSQL/SQLResult.h
+++ b/Userland/Libraries/LibSQL/SQLResult.h
@@ -51,6 +51,7 @@ constexpr char const* command_tag(SQLCommand command)
     S(SchemaExists, "Schema '{}' already exist")                                         \
     S(TableDoesNotExist, "Table '{}' does not exist")                                    \
     S(ColumnDoesNotExist, "Column '{}' does not exist")                                  \
+    S(AmbiguousColumnName, "Column name '{}' is ambiguous")                              \
     S(TableExists, "Table '{}' already exist")                                           \
     S(InvalidType, "Invalid type '{}'")                                                  \
     S(InvalidDatabaseName, "Invalid database name '{}'")                                 \

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -132,6 +132,15 @@ Tuple& Tuple::operator+=(Value const& value)
     return *this;
 }
 
+void Tuple::extend(Tuple const& other)
+{
+    VERIFY((descriptor()->size() == size()) || (descriptor()->size() >= size() + other.size()));
+    if (descriptor()->size() == size()) {
+        descriptor()->extend(other.descriptor());
+    }
+    m_data.extend(other.m_data);
+}
+
 bool Tuple::is_compatible(Tuple const& other) const
 {
     if ((m_descriptor->size() == 0) && (other.m_descriptor->size() == 0)) {

--- a/Userland/Libraries/LibSQL/Tuple.h
+++ b/Userland/Libraries/LibSQL/Tuple.h
@@ -55,6 +55,7 @@ public:
     Value& operator[](String const& name);
     void append(Value const&);
     Tuple& operator+=(Value const&);
+    void extend(Tuple const&);
     [[nodiscard]] bool is_compatible(Tuple const&) const;
 
     [[nodiscard]] u32 pointer() const { return m_pointer; }

--- a/Userland/Libraries/LibSQL/TupleDescriptor.h
+++ b/Userland/Libraries/LibSQL/TupleDescriptor.h
@@ -13,6 +13,8 @@
 namespace SQL {
 
 struct TupleElementDescriptor {
+    String schema { "" };
+    String table { "" };
     String name { "" };
     SQLType type { SQLType::Text };
     Order order { Order::Ascending };

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -261,6 +261,8 @@ Value& Value::operator=(Value const& other)
     if (this != &other) {
         if (other.is_null()) {
             assign(null());
+        } else if (is_null()) {
+            assign(other);
         } else {
             VERIFY(can_cast(other));
             assign(other);

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -1014,7 +1014,7 @@ void TupleImpl::infer_descriptor()
 void TupleImpl::extend_descriptor(Value const& value)
 {
     VERIFY(m_descriptor_inferred);
-    m_descriptor->empend("", value.type(), Order::Ascending);
+    m_descriptor->empend("", "", "", value.type(), Order::Ascending);
 }
 
 bool TupleImpl::validate_before_assignment(Vector<Value> const& values)

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -130,7 +130,7 @@ public:
 
     [[nodiscard]] TupleElementDescriptor descriptor() const
     {
-        return { "", type(), Order::Ascending };
+        return { "", "", "", type(), Order::Ascending };
     }
 
     static Value const& null();

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -67,8 +67,7 @@ void SQLStatement::execute()
             return;
         }
         VERIFY(!connection()->database().is_null());
-        SQL::AST::ExecutionContext context { connection()->database().release_nonnull() };
-        m_result = m_statement->execute(context);
+        m_result = m_statement->execute(connection()->database().release_nonnull());
         if (m_result->error().code != SQL::SQLErrorCode::NoError) {
             report_error(m_result->error());
             return;


### PR DESCRIPTION
The Serenity SQL database can almost do useful things now:

```
SELECT foo.bar, quux.baz FROM foo, quux WHERE foo.frob = quux.frob;
```

now works. The implementation is still pretty dumb, but it works.