### PR TITLE
Revert "AK+WindowServer: Remove did_construct() framework used only o…

### DIFF
--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -70,6 +70,8 @@ public:                                                                \
     static inline NonnullRefPtr<klass> construct(Args&&... args)       \
     {                                                                  \
         auto obj = adopt_ref(*new Klass(forward<Args>(args)...));      \
+        if constexpr (requires { declval<Klass>().did_construct(); })  \
+            obj->did_construct();                                      \
         return obj;                                                    \
     }
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -85,7 +85,6 @@ Window::Window(Core::Object& parent, WindowType type)
         m_minimum_size = s_default_normal_minimum_size;
 
     WindowManager::the().add_window(*this);
-    frame().window_was_constructed({});
 }
 
 Window::Window(ClientConnection& client, WindowType window_type, int window_id, bool modal, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window)

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -362,6 +362,11 @@ public:
     const Vector<Screen*, default_screen_count>& screens() const { return m_screens; }
     Vector<Screen*, default_screen_count>& screens() { return m_screens; }
 
+    void did_construct()
+    {
+        frame().window_was_constructed({});
+    }
+
     void set_moving_to_another_stack(bool value) { m_moving_to_another_stack = value; }
     bool is_moving_to_another_stack() const { return m_moving_to_another_stack; }
 


### PR DESCRIPTION
…nce"

This reverts commit 2e6bb987a31179eddcd3f85f405ad9e8c1e2bc24.

The removal of did_construct caused the window buttons to disappear,
which in turn caused WindowServer crashes when one tried to maximize
windows.