### PR TITLE
WindowServer: Add missing window_was_constructed call

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -111,6 +111,7 @@ Window::Window(ClientConnection& client, WindowType window_type, int window_id, 
     if (parent_window)
         set_parent_window(*parent_window);
     WindowManager::the().add_window(*this);
+    frame().window_was_constructed({});
 }
 
 Window::~Window()


### PR DESCRIPTION
In 2e6bb987a31179eddcd3f85f405ad9e8c1e2bc24 the "did_construct" API in
Core::Object was removed, since it had only one user. For a replacement,
the Window would manually call the frame's "frame_was_constructed"
method. However, WindowServer::Window has two constructors, and only one
of them called this method. This caused windows to spawn without
buttons and various other breakage that spawned from this.