### PR TITLE
Ports/libtheora: Change download link to http instead of https

### DIFF
--- a/Ports/libtheora/package.sh
+++ b/Ports/libtheora/package.sh
@@ -2,7 +2,7 @@
 port=libtheora
 version=1.1.1
 useconfigure=true
-files="https://downloads.xiph.org/releases/theora/libtheora-${version}.tar.bz2 libtheora-${version}.tar.bz2 b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
+files="https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-${version}.tar.bz2 libtheora-${version}.tar.bz2 b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
 auth_type="sha256"
 depends=("libvorbis")
 configopts=("--disable-examples")


### PR DESCRIPTION
Fixes download on Mac where an old version of LibreSSL won't redirect to the download mirror.