### PR TITLE
LibWeb: Change Document.{hidden,visibilityState} spec links to HTML

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1089,13 +1089,13 @@ Bindings::LocationObject* Document::location()
     return window().wrapper()->location_object();
 }
 
-// https://w3c.github.io/page-visibility/#hidden-attribute
+// https://html.spec.whatwg.org/multipage/interaction.html#dom-document-hidden
 bool Document::hidden() const
 {
     return false;
 }
 
-// https://w3c.github.io/page-visibility/#visibilitystate-attribute
+// https://html.spec.whatwg.org/multipage/interaction.html#dom-document-visibilitystate
 String Document::visibility_state() const
 {
     return hidden() ? "hidden" : "visible";


### PR DESCRIPTION
The page visibility API was moved to HTML here: https://github.com/whatwg/html/commit/9bed042ab3f4db4449363c7b893c2838f5d8a539