### PR TITLE
shot: Fix hanging issue

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -968,7 +968,7 @@ Messages::WindowServer::GetScreenBitmapResponse ClientConnection::get_screen_bit
         auto* screen = Screen::find_by_index(screen_index.value());
         if (!screen) {
             dbgln("get_screen_bitmap: Screen {} does not exist!", screen_index.value());
-            return { {} };
+            return { Gfx::ShareableBitmap() };
         }
         if (rect.has_value()) {
             auto bitmap = Compositor::the().front_bitmap_for_screenshot({}, *screen).cropped(rect.value());
@@ -994,7 +994,7 @@ Messages::WindowServer::GetScreenBitmapResponse ClientConnection::get_screen_bit
         });
         return bitmap->to_shareable_bitmap();
     }
-    return { {} };
+    return { Gfx::ShareableBitmap() };
 }
 
 Messages::WindowServer::GetScreenBitmapAroundCursorResponse ClientConnection::get_screen_bitmap_around_cursor(Gfx::IntSize const& size)

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
-    Gfx::IntRect crop_region;
+    Optional<Gfx::IntRect> crop_region;
     if (select_region) {
         auto window = GUI::Window::construct();
         auto& container = window->set_main_widget<SelectableLayover>(window);
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
         app->exec();
 
         crop_region = container.region();
-        if (crop_region.is_empty()) {
+        if (crop_region.value().is_empty()) {
             dbgln("cancelled...");
             return 0;
         }


### PR DESCRIPTION
- `shot` was refactored to retrive crop_region, but it is empty when `-r` flag is not used. This causes shot to hang and no screenshot is taken.
- Handling of screen index argument was too verbose.
- `shot` would hang when non-existing screen index is passed, this is fixed by explicity returning `ShareableBitmap`.