### PR TITLE
LibCore: trim trailing whitespaces in ConfigFile::reparse()

### DIFF
--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -106,7 +106,8 @@ void ConfigFile::reparse()
                 // We're not in a group yet, create one with the name ""...
                 current_group = &m_groups.ensure("");
             }
-            current_group->set(key_builder.to_string(), value_builder.to_string());
+	    auto value_string = value_builder.to_string();
+            current_group->set(key_builder.to_string(), value_string.trim_whitespace(TrimMode::Right));
         }
         }
     }


### PR DESCRIPTION
Previously, trailing whitespaces were not removed from values in
.ini-files. This could cause errors with poorly formatted .ini files.
This commit fixes this by trimming whitespaces from values in ConfigFile::reparse()