### PR TITLE
Kernel: Process vmmouse events immediately

### DIFF
--- a/Kernel/Devices/HID/VMWareMouseDevice.cpp
+++ b/Kernel/Devices/HID/VMWareMouseDevice.cpp
@@ -44,7 +44,6 @@ void VMWareMouseDevice::irq_handle_byte_read(u8)
         }
         evaluate_block_conditions();
     }
-    return;
 }
 
 VMWareMouseDevice::VMWareMouseDevice(const I8042Controller& ps2_controller)

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -183,22 +183,26 @@ void VMWareBackdoor::send(VMWareCommand& command)
         command.dx);
 }
 
-Optional<MousePacket> VMWareBackdoor::receive_mouse_packet()
+u16 VMWareBackdoor::read_mouse_status_queue_size()
 {
     VMWareCommand command;
     command.bx = 0;
     command.command = VMMOUSE_STATUS;
     send(command);
+
     if (command.ax == 0xFFFF0000) {
         dbgln_if(PS2MOUSE_DEBUG, "PS2MouseDevice: Resetting VMWare mouse");
         disable_absolute_vmmouse();
         enable_absolute_vmmouse();
-        return {};
+        return 0;
     }
-    int words = command.ax & 0xFFFF;
 
-    if (!words || words % 4)
-        return {};
+    return command.ax & 0xFFFF;
+}
+
+MousePacket VMWareBackdoor::receive_mouse_packet()
+{
+    VMWareCommand command;
     command.size = 4;
     command.command = VMMOUSE_DATA;
     send(command);

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -204,9 +204,9 @@ Optional<MousePacket> VMWareBackdoor::receive_mouse_packet()
     send(command);
 
     int buttons = (command.ax & 0xFFFF);
-    int x = (command.bx);
-    int y = (command.cx);
-    int z = (i8)(command.dx); // signed 8 bit value only!
+    int x = command.bx;
+    int y = command.cx;
+    int z = static_cast<i8>(command.dx); // signed 8 bit value only!
 
     if constexpr (PS2MOUSE_DEBUG) {
         dbgln("Absolute Mouse: Buttons {:x}", buttons);

--- a/Kernel/Devices/VMWareBackdoor.h
+++ b/Kernel/Devices/VMWareBackdoor.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Optional.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 #include <Kernel/API/MousePacket.h>
@@ -51,7 +50,8 @@ public:
     void disable_absolute_vmmouse();
     void send(VMWareCommand& command);
 
-    Optional<MousePacket> receive_mouse_packet();
+    u16 read_mouse_status_queue_size();
+    MousePacket receive_mouse_packet();
 
 private:
     void send_high_bandwidth(VMWareCommand& command);


### PR DESCRIPTION
The Qemu I8042 controller does not send one IRQ per event, it sends over four since it will not stop trying to emulate the PS/2 mouse.

If the VMWare backdoor is active, a fake I8042 mouse event will be sent that we can then use to check if there are VMWare mouse events present. However, we were only processing one mouse event at a time, even though multiple events could have been queued up. Luckily this does not often lead to issues, since after the first IRQ we would still get three additional interrupts that would then empty the queue.

This change makes sure we always empty the event queue immediately, instead of waiting on the next interrupt to happen. Functionally this changes nothing - it could merely improve latency by not waiting for new interrupts to come in.

Coincidently, this brings our implementation closer to how Linux deals with the VMMouse.