### PR TITLE
grep: Implement '-n', the flag for outputting line numbers

### DIFF
--- a/Base/usr/share/man/man1/grep.md
+++ b/Base/usr/share/man/man1/grep.md
@@ -5,7 +5,7 @@ grep
 ## Synopsis
 
 ```sh
-$ grep [--recursive] [--extended-regexp] [--regexp Pattern] [-i] [--invert-match] [--quiet] [--no-messages] [--binary-mode ] [--text] [-I] [--color WHEN] [file...]
+$ grep [--recursive] [--extended-regexp] [--regexp Pattern] [-i] [--line-numbers] [--invert-match] [--quiet] [--no-messages] [--binary-mode ] [--text] [-I] [--color WHEN] [file...]
 ```
 
 ## Options:
@@ -16,6 +16,7 @@ $ grep [--recursive] [--extended-regexp] [--regexp Pattern] [-i] [--invert-match
 * `-E`, `--extended-regexp`: Extended regular expressions
 * `-e Pattern`, `--regexp Pattern`: Pattern
 * `-i`: Make matches case-insensitive
+* `-n`, `--line-numbers`: Output line-numbers
 * `-v`, `--invert-match`: Select non-matching lines
 * `-q`, `--quiet`: Do not write anything to standard output
 * `-s`, `--no-messages`: Suppress error messages for nonexistent or unreadable files

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        auto matches = [&](StringView str, StringView filename = "", bool print_filename = false, bool is_binary = false) {
+        auto matches = [&](StringView str, StringView filename, bool print_filename, bool is_binary) {
             size_t last_printed_char_pos { 0 };
             if (is_binary && binary_mode == BinaryFileMode::Skip)
                 return false;


### PR DESCRIPTION
I always write `grep -Ern` by default without thinking about it, so I tripped up a lot while doing #10793. Let's improve our grep!

![Bildschirmfoto_2021-11-06_12-58-13](https://user-images.githubusercontent.com/2690845/140608766-a6940f82-f82e-41e4-826b-9167b4b4a1f7.png)

The color choice is totally arbitrary, because we don't follow GNU grep anyway.

EDIT: You might need to try the regex `=true$`, because #10793 already got merged.
EDIT2: Fixed the screenshot