### PR TITLE
3DFileViewer: Implement vertex-normals parsing on .obj files

### DIFF
--- a/Userland/Applications/3DFileViewer/Common.h
+++ b/Userland/Applications/3DFileViewer/Common.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
+ * Copyright (c) 2021, Pedro Pereira <pmh.pereira@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,4 +31,8 @@ struct Triangle {
     GLuint tex_coord_index0;
     GLuint tex_coord_index1;
     GLuint tex_coord_index2;
+
+    GLuint normal_index0;
+    GLuint normal_index1;
+    GLuint normal_index2;
 };

--- a/Userland/Applications/3DFileViewer/Mesh.cpp
+++ b/Userland/Applications/3DFileViewer/Mesh.cpp
@@ -58,10 +58,30 @@ void Mesh::draw(float uv_scale)
             m_vertex_list.at(triangle.c).y,
             m_vertex_list.at(triangle.c).z);
 
-        // Compute the triangle normal
-        const FloatVector3 vec_ab = vertex_b - vertex_a;
-        const FloatVector3 vec_ac = vertex_c - vertex_a;
-        const FloatVector3 normal = vec_ab.cross(vec_ac).normalized();
+        FloatVector3 normal;
+        if (has_normals()) {
+            const FloatVector3 normal_a(
+                m_normal_list.at(triangle.normal_index0).x,
+                m_normal_list.at(triangle.normal_index0).y,
+                m_normal_list.at(triangle.normal_index0).z);
+
+            const FloatVector3 normal_b(
+                m_normal_list.at(triangle.normal_index1).x,
+                m_normal_list.at(triangle.normal_index1).y,
+                m_normal_list.at(triangle.normal_index1).z);
+
+            const FloatVector3 normal_c(
+                m_normal_list.at(triangle.normal_index2).x,
+                m_normal_list.at(triangle.normal_index2).y,
+                m_normal_list.at(triangle.normal_index2).z);
+
+            normal = (normal_a + normal_b + normal_c).normalized();
+        } else {
+            // Compute the triangle normal
+            const FloatVector3 vec_ab = vertex_b - vertex_a;
+            const FloatVector3 vec_ac = vertex_c - vertex_a;
+            normal = vec_ab.cross(vec_ac).normalized();
+        }
 
         // Compute lighting with a Lambertian color model
         const auto light_intensity = max(light_direction.dot(normal), 0.f);

--- a/Userland/Applications/3DFileViewer/Mesh.cpp
+++ b/Userland/Applications/3DFileViewer/Mesh.cpp
@@ -92,31 +92,31 @@ void Mesh::draw(float uv_scale)
         glColor4f(color.x(), color.y(), color.z(), color.w());
 
         if (is_textured())
-            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index0).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index0).v) * uv_scale);
+            glTexCoord2f(m_tex_coords.at(triangle.tex_coord_index0).u * uv_scale, (1.0f - m_tex_coords.at(triangle.tex_coord_index0).v) * uv_scale);
 
         // Vertex 1
         glVertex3f(
-            m_vertex_list.at(m_triangle_list[i].a).x,
-            m_vertex_list.at(m_triangle_list[i].a).y,
-            m_vertex_list.at(m_triangle_list[i].a).z);
+            m_vertex_list.at(triangle.a).x,
+            m_vertex_list.at(triangle.a).y,
+            m_vertex_list.at(triangle.a).z);
 
         if (is_textured())
-            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index1).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index1).v) * uv_scale);
+            glTexCoord2f(m_tex_coords.at(triangle.tex_coord_index1).u * uv_scale, (1.0f - m_tex_coords.at(triangle.tex_coord_index1).v) * uv_scale);
 
         // Vertex 2
         glVertex3f(
-            m_vertex_list.at(m_triangle_list[i].b).x,
-            m_vertex_list.at(m_triangle_list[i].b).y,
-            m_vertex_list.at(m_triangle_list[i].b).z);
+            m_vertex_list.at(triangle.b).x,
+            m_vertex_list.at(triangle.b).y,
+            m_vertex_list.at(triangle.b).z);
 
         if (is_textured())
-            glTexCoord2f(m_tex_coords.at(m_triangle_list[i].tex_coord_index2).u * uv_scale, (1.0f - m_tex_coords.at(m_triangle_list[i].tex_coord_index2).v) * uv_scale);
+            glTexCoord2f(m_tex_coords.at(triangle.tex_coord_index2).u * uv_scale, (1.0f - m_tex_coords.at(triangle.tex_coord_index2).v) * uv_scale);
 
         // Vertex 3
         glVertex3f(
-            m_vertex_list.at(m_triangle_list[i].c).x,
-            m_vertex_list.at(m_triangle_list[i].c).y,
-            m_vertex_list.at(m_triangle_list[i].c).z);
+            m_vertex_list.at(triangle.c).x,
+            m_vertex_list.at(triangle.c).y,
+            m_vertex_list.at(triangle.c).z);
 
         glEnd();
     }

--- a/Userland/Applications/3DFileViewer/Mesh.cpp
+++ b/Userland/Applications/3DFileViewer/Mesh.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
+ * Copyright (c) 2021, Pedro Pereira <pmh.pereira@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,9 +23,10 @@ const Color colors[] {
     Color::White
 };
 
-Mesh::Mesh(Vector<Vertex> vertices, Vector<TexCoord> tex_coords, Vector<Triangle> triangles)
+Mesh::Mesh(Vector<Vertex> vertices, Vector<TexCoord> tex_coords, Vector<Vertex> normals, Vector<Triangle> triangles)
     : m_vertex_list(move(vertices))
     , m_tex_coords(move(tex_coords))
+    , m_normal_list(move(normals))
     , m_triangle_list(move(triangles))
 {
 }

--- a/Userland/Applications/3DFileViewer/Mesh.h
+++ b/Userland/Applications/3DFileViewer/Mesh.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Mathieu Gaillard <gaillard.mathieu.39@gmail.com>
+ * Copyright (c) 2021, Pedro Pereira <pmh.pereira@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,7 +17,7 @@ class Mesh : public RefCounted<Mesh> {
 public:
     Mesh() = delete;
 
-    Mesh(Vector<Vertex> vertices, Vector<TexCoord> tex_coords, Vector<Triangle> triangles);
+    Mesh(Vector<Vertex> vertices, Vector<TexCoord> tex_coords, Vector<Vertex> normals, Vector<Triangle> triangles);
 
     size_t vertex_count() const { return m_vertex_list.size(); }
 
@@ -29,5 +30,6 @@ public:
 private:
     Vector<Vertex> m_vertex_list;
     Vector<TexCoord> m_tex_coords;
+    Vector<Vertex> m_normal_list;
     Vector<Triangle> m_triangle_list;
 };

--- a/Userland/Applications/3DFileViewer/Mesh.h
+++ b/Userland/Applications/3DFileViewer/Mesh.h
@@ -27,6 +27,8 @@ public:
 
     bool is_textured() const { return m_tex_coords.size() > 0; }
 
+    bool has_normals() const { return m_normal_list.size() > 0; }
+
 private:
     Vector<Vertex> m_vertex_list;
     Vector<TexCoord> m_tex_coords;

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -127,5 +127,5 @@ RefPtr<Mesh> WavefrontOBJLoader::load(Core::File& file)
     }
 
     dbgln("Wavefront: Done.");
-    return adopt_ref(*new Mesh(vertices, tex_coords, triangles));
+    return adopt_ref(*new Mesh(vertices, tex_coords, normals, triangles));
 }


### PR DESCRIPTION
These changes allow us to view .obj files with included normals `vn x y z` and faces `f v1/vt/vn1`.
The face normals are calculated from averaging the 3 vertice normals.

The .gif below shows three different .obj models:

1. The current teapot model, to prove backwards compatibility.
2. The teapot model but with normals exported from Blender, to prove same visual result.
3. The teapot model but with **inverted** normals, to prove that we are indeed loading the normals from the .obj file.
The expected visual result is an inside-out 3D model.

![3DFileViewer-Normals](https://user-images.githubusercontent.com/886261/140513626-ca7b589f-efa4-40d7-a11f-f053cea580ed.gif)

