### PR TITLE
LibC: Correctly evaluate addr in IN6_IS_ADDR_LOOPBACK

### DIFF
--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -42,7 +42,7 @@ static inline uint32_t ntohl(uint32_t value)
 }
 
 #define IN6_IS_ADDR_LOOPBACK(addr) \
-    (addr->s6_addr[0] == 0 && addr->s6_addr[1] == 0 && addr->s6_addr[2] == 0 && addr->s6_addr[3] == 0 && addr->s6_addr[4] == 0 && addr->s6_addr[5] == 0 && addr->s6_addr[6] == 0 && addr->s6_addr[7] == 0 && addr->s6_addr[8] == 0 && addr->s6_addr[9] == 0 && addr->s6_addr[10] == 0 && addr->s6_addr[11] == 0 && addr->s6_addr[12] == 0 && addr->s6_addr[13] == 0 && addr->s6_addr[14] == 0 && addr->s6_addr[15] == 1)
+    ((addr)->s6_addr[0] == 0 && (addr)->s6_addr[1] == 0 && (addr)->s6_addr[2] == 0 && (addr)->s6_addr[3] == 0 && (addr)->s6_addr[4] == 0 && (addr)->s6_addr[5] == 0 && (addr)->s6_addr[6] == 0 && (addr)->s6_addr[7] == 0 && (addr)->s6_addr[8] == 0 && (addr)->s6_addr[9] == 0 && (addr)->s6_addr[10] == 0 && (addr)->s6_addr[11] == 0 && (addr)->s6_addr[12] == 0 && (addr)->s6_addr[13] == 0 && (addr)->s6_addr[14] == 0 && (addr)->s6_addr[15] == 1)
 
 #define IN6_IS_ADDR_V4MAPPED(addr) \
     ((((addr)->s6_addr[0]) == 0) && (((addr)->s6_addr[1]) == 0) && (((addr)->s6_addr[2]) == 0) && (((addr)->s6_addr[3]) == 0) && (((addr)->s6_addr[4]) == 0) && (((addr)->s6_addr[5]) == 0) && (((addr)->s6_addr[6]) == 0) && (((addr)->s6_addr[7]) == 0) && (((addr)->s6_addr[8]) == 0) && (((addr)->s6_addr[9]) == 0) && (((addr)->s6_addr[10]) == 0xFF) && (((addr)->s6_addr[11]) == 0xFF))


### PR DESCRIPTION
Without putting the argument in parentheses we might not evaluate it correctly.

This fixes the openssh port.