### PR TITLE
AK: Allow hash-compatible key types for Hash[Table|Map] lookup

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <AK/IterationDecision.h>
 #include <AK/StdLibExtras.h>
 
@@ -31,6 +32,9 @@ concept Enum = IsEnum<T>;
 
 template<typename T, typename U>
 concept SameAs = IsSame<T, U>;
+
+template<typename T>
+concept AnyString = Detail::IsConstructible<StringView, T>;
 
 // FIXME: remove once Clang formats these properly.
 // clang-format off

--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -36,6 +36,9 @@ concept SameAs = IsSame<T, U>;
 template<typename T>
 concept AnyString = Detail::IsConstructible<StringView, T>;
 
+template<typename T, typename U>
+concept HashCompatible = IsHashCompatible<Detail::Decay<T>, Detail::Decay<U>>;
+
 // FIXME: remove once Clang formats these properly.
 // clang-format off
 template<typename Func, typename... Args>

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -47,7 +47,7 @@ public:
     [[nodiscard]] size_t size() const { return m_members.size(); }
     [[nodiscard]] bool is_empty() const { return m_members.is_empty(); }
 
-    [[nodiscard]] JsonValue const& get(String const& key) const
+    [[nodiscard]] JsonValue const& get(StringView key) const
     {
         auto* value = get_ptr(key);
         static JsonValue* s_null_value { nullptr };
@@ -59,7 +59,7 @@ public:
         return *value;
     }
 
-    [[nodiscard]] JsonValue const* get_ptr(String const& key) const
+    [[nodiscard]] JsonValue const* get_ptr(StringView key) const
     {
         auto it = m_members.find(key);
         if (it == m_members.end())
@@ -67,63 +67,63 @@ public:
         return &(*it).value;
     }
 
-    [[nodiscard]] [[nodiscard]] bool has(String const& key) const
+    [[nodiscard]] [[nodiscard]] bool has(StringView key) const
     {
         return m_members.contains(key);
     }
 
-    [[nodiscard]] bool has_null(String const& key) const
+    [[nodiscard]] bool has_null(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_null();
     }
-    [[nodiscard]] bool has_bool(String const& key) const
+    [[nodiscard]] bool has_bool(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_bool();
     }
-    [[nodiscard]] bool has_string(String const& key) const
+    [[nodiscard]] bool has_string(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_string();
     }
-    [[nodiscard]] bool has_i32(String const& key) const
+    [[nodiscard]] bool has_i32(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_i32();
     }
-    [[nodiscard]] bool has_u32(String const& key) const
+    [[nodiscard]] bool has_u32(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_u32();
     }
-    [[nodiscard]] bool has_i64(String const& key) const
+    [[nodiscard]] bool has_i64(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_i64();
     }
-    [[nodiscard]] bool has_u64(String const& key) const
+    [[nodiscard]] bool has_u64(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_u64();
     }
-    [[nodiscard]] bool has_number(String const& key) const
+    [[nodiscard]] bool has_number(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_number();
     }
-    [[nodiscard]] bool has_array(String const& key) const
+    [[nodiscard]] bool has_array(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_array();
     }
-    [[nodiscard]] bool has_object(String const& key) const
+    [[nodiscard]] bool has_object(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_object();
     }
 #ifndef KERNEL
-    [[nodiscard]] [[nodiscard]] bool has_double(String const& key) const
+    [[nodiscard]] [[nodiscard]] bool has_double(StringView key) const
     {
         auto* value = get_ptr(key);
         return value && value->is_double();

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -575,6 +575,12 @@ using Decay = typename __decay<T>::type;
 
 template<typename T, typename U>
 inline constexpr bool IsPointerOfType = IsPointer<Decay<U>>&& IsSame<T, RemoveCV<RemovePointer<Decay<U>>>>;
+
+template<typename T, typename U>
+inline constexpr bool IsHashCompatible = false;
+template<typename T>
+inline constexpr bool IsHashCompatible<T, T> = true;
+
 }
 using AK::Detail::AddConst;
 using AK::Detail::AddLvalueReference;
@@ -605,6 +611,7 @@ using AK::Detail::IsEnum;
 using AK::Detail::IsFloatingPoint;
 using AK::Detail::IsFunction;
 using AK::Detail::IsFundamental;
+using AK::Detail::IsHashCompatible;
 using AK::Detail::IsIntegral;
 using AK::Detail::IsLvalueReference;
 using AK::Detail::IsMoveAssignable;

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -573,6 +573,8 @@ struct __decay<T[N]> {
 template<typename T>
 using Decay = typename __decay<T>::type;
 
+template<typename T, typename U>
+inline constexpr bool IsPointerOfType = IsPointer<Decay<U>>&& IsSame<T, RemoveCV<RemovePointer<Decay<U>>>>;
 }
 using AK::Detail::AddConst;
 using AK::Detail::AddLvalueReference;

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -557,6 +557,22 @@ inline constexpr bool IsSpecializationOf = false;
 template<template<typename...> typename U, typename... Us>
 inline constexpr bool IsSpecializationOf<U<Us...>, U> = true;
 
+template<typename T>
+struct __decay {
+    typedef Detail::RemoveCVReference<T> type;
+};
+template<typename T>
+struct __decay<T[]> {
+    typedef T* type;
+};
+template<typename T, decltype(sizeof(T)) N>
+struct __decay<T[N]> {
+    typedef T* type;
+};
+// FIXME: Function decay
+template<typename T>
+using Decay = typename __decay<T>::type;
+
 }
 using AK::Detail::AddConst;
 using AK::Detail::AddLvalueReference;

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -7,9 +7,15 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Forward.h>
 
 namespace AK {
+
+namespace Detail {
+template<Concepts::AnyString T, Concepts::AnyString U>
+inline constexpr bool IsHashCompatible<T, U> = true;
+}
 
 enum class CaseSensitivity {
     CaseInsensitive,

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -222,14 +222,14 @@ void abort()
     _abort();
 }
 
-static HashTable<const char*> s_malloced_environment_variables;
+static HashTable<FlatPtr> s_malloced_environment_variables;
 
 static void free_environment_variable_if_needed(const char* var)
 {
-    if (!s_malloced_environment_variables.contains(var))
+    if (!s_malloced_environment_variables.contains((FlatPtr)var))
         return;
     free(const_cast<char*>(var));
-    s_malloced_environment_variables.remove(var);
+    s_malloced_environment_variables.remove((FlatPtr)var);
 }
 
 char* getenv(const char* name)
@@ -304,7 +304,7 @@ int setenv(const char* name, const char* value, int overwrite)
     auto length = strlen(name) + strlen(value) + 2;
     auto* var = (char*)malloc(length);
     snprintf(var, length, "%s=%s", name, value);
-    s_malloced_environment_variables.set(var);
+    s_malloced_environment_variables.set((FlatPtr)var);
     return putenv(var);
 }
 


### PR DESCRIPTION
These should changes should save us a good amount of needless allocation when handling HashContainers and JSON.
This should cause minor performance improvements in areas using these.
This might improve OOM-safety of the EXT2 filesystem, which uses a String keyed HashMap as a lookup cache.

Adding KStrings to these specializations might be an idea for the future, but currently nobody uses them and looks things up.

Commit name yak-shedding welcome.