### PR TITLE
Ports: Don't add ports to the "built" list unless successful

### DIFF
--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -49,7 +49,6 @@ for file in *; do
                 popd > /dev/null
                 continue
             fi
-            built_ports="$built_ports $port $(./package.sh showproperty depends) "
 
             if [ "$clean" == true ]; then
                 if [ "$verbose" == true ]; then
@@ -64,6 +63,8 @@ for file in *; do
                 else
                     echo "ERROR: Build of ${port} was not successful!"
                     some_failed=true
+                    popd > /dev/null
+                    continue
                 fi
             else
                 if ./package.sh > /dev/null 2>&1; then
@@ -71,8 +72,12 @@ for file in *; do
                 else
                     echo "ERROR: Build of ${port} was not successful!"
                     some_failed=true
+                    popd > /dev/null
+                    continue
                 fi
             fi
+
+            built_ports="$built_ports $port $(./package.sh showproperty depends) "
         popd > /dev/null
     fi
 done


### PR DESCRIPTION
We were previously adding a port and all of its dependencies to the "We already built this, abort early" list, even if the port failed to build. This resulted in the script output erroneously showing that a port succeeded to build even if it didn't, as long as we already attempted to build it earlier, as part of another package.

Because that's what you do when you don't already have enough ports to fix, change the build script to show _more_ failures.