### PR TITLE
Kernel: Initialize regs.fs in Processor::init_context

### DIFF
--- a/Kernel/Arch/x86/i386/Processor.cpp
+++ b/Kernel/Arch/x86/i386/Processor.cpp
@@ -172,7 +172,7 @@ FlatPtr Processor::init_context(Thread& thread, bool leave_crit)
     regs.cs = GDT_SELECTOR_CODE0;
     regs.ds = GDT_SELECTOR_DATA0;
     regs.es = GDT_SELECTOR_DATA0;
-    regs.gs = GDT_SELECTOR_DATA0;
+    regs.fs = GDT_SELECTOR_DATA0;
     regs.ss = GDT_SELECTOR_DATA0;
     regs.gs = GDT_SELECTOR_PROC;
     return stack_top;


### PR DESCRIPTION
[This commit](https://github.com/SerenityOS/serenity/commit/f285241cb83735665a28b20b0f0cabfce1b30e5a) replaced the line that sets `regs.fs` with a line that sets `regs.gs`, but not vice versa.