### PR TITLE
Ports: Add a dependency on pcre to glib

### DIFF
--- a/Ports/glib/package.sh
+++ b/Ports/glib/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=glib
 version=2.70.0
-depends=("libiconv" "libffi" "zlib" "gettext")
+depends=("libiconv" "libffi" "zlib" "gettext" "pcre")
 useconfigure=true
 configopts=("--cross-file" "../cross_file-$SERENITY_ARCH.txt")
 files="https://gitlab.gnome.org/GNOME/glib/-/archive/${version}/glib-${version}.tar.gz glib-${version}.tar.gz aadf815ed908d4cc14ac3976f325b986b4ab2b65ad85bc214ddf2e200648bd1c"


### PR DESCRIPTION
This previously only worked because glib will automatically try and compile pcre, but due to ftp.pcre.org being down this no longer works.

Instead, just rely on the pcre port that we already have anyways.