### PR TITLE
LibC+Toolchain: Implement _aligned_malloc and _aligned_free

### DIFF
--- a/Toolchain/Patches/llvm.patch
+++ b/Toolchain/Patches/llvm.patch
@@ -555,19 +555,10 @@ index ad2820b32..deaa2c380 100644
  if (EXISTS "${LLVM_CMAKE_PATH}")
    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_PATH}")
 diff --git a/libcxx/include/__config b/libcxx/include/__config
-index 97e33f315..bfb221230 100644
+index 97e33f315..179bd2a67 100644
 --- a/libcxx/include/__config
 +++ b/libcxx/include/__config
-@@ -958,6 +958,8 @@ typedef unsigned int   char32_t;
- #  define _LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
- #elif defined(__MVS__)
- #  define _LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
-+#elif defined(__serenity__) && !defined(KERNEL)
-+#  define _LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
- #endif
- 
- #if defined(__APPLE__)
-@@ -1148,6 +1150,7 @@ extern "C" _LIBCPP_FUNC_VIS void __sanitizer_annotate_contiguous_container(
+@@ -1148,6 +1148,7 @@ extern "C" _LIBCPP_FUNC_VIS void __sanitizer_annotate_contiguous_container(
        defined(__sun__) || \
        defined(__MVS__) || \
        defined(_AIX) || \
@@ -645,6 +636,28 @@ index 8e584005d..f29f3453e 100644
  #    define _LIBCPP_HAS_CATOPEN 1
  #    include <nl_types.h>
  #  endif
+diff --git a/libcxx/include/new b/libcxx/include/new
+index aefc08c16..7ee71d16b 100644
+--- a/libcxx/include/new
++++ b/libcxx/include/new
+@@ -310,7 +310,7 @@ inline _LIBCPP_INLINE_VISIBILITY void __libcpp_deallocate_unsized(void* __ptr, s
+ // Returns the allocated memory, or `nullptr` on failure.
+ inline _LIBCPP_INLINE_VISIBILITY
+ void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
+-#if defined(_LIBCPP_MSVCRT_LIKE)
++#if defined(_LIBCPP_MSVCRT_LIKE) || (defined(__serenity__) && !defined(KERNEL))
+   return ::_aligned_malloc(__size, __alignment);
+ #else
+   void* __result = nullptr;
+@@ -322,7 +322,7 @@ void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
+ 
+ inline _LIBCPP_INLINE_VISIBILITY
+ void __libcpp_aligned_free(void* __ptr) {
+-#if defined(_LIBCPP_MSVCRT_LIKE)
++#if defined(_LIBCPP_MSVCRT_LIKE) || (defined(__serenity__) && !defined(KERNEL))
+   ::_aligned_free(__ptr);
+ #else
+   ::free(__ptr);
 diff --git a/libcxx/src/include/config_elast.h b/libcxx/src/include/config_elast.h
 index 7880c733f..87b25cf42 100644
 --- a/libcxx/src/include/config_elast.h

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -25,6 +25,8 @@ size_t malloc_good_size(size_t);
 void serenity_dump_malloc_stats(void);
 void free(void*);
 __attribute__((alloc_size(2))) void* realloc(void* ptr, size_t);
+__attribute__((malloc, alloc_size(1), alloc_align(2))) void* _aligned_malloc(size_t size, size_t alignment);
+void _aligned_free(void* memblock);
 char* getenv(const char* name);
 char* secure_getenv(const char* name);
 int putenv(char*);


### PR DESCRIPTION
### LibC: Implement _aligned_malloc and _aligned_free

C++17 introduced aligned versions of `new` and `delete`, which are
automatically called by the compiler when allocating over-aligned
objects. As with the regular allocator functions, these are generally
thin wrappers around LibC.

We did not have support for aligned allocations in LibC, so this was not
possible. While libstdc++ has a fallback implementation, libc++ does
not, so the aligned allocation function was disabled internally. This
made building the LLVM port with Clang impossible.

I chose not to implement the more Unix-y `memalign`, `posix_memalign`,
or the C11 `aligned_alloc`, because that would require us to
significantly alter the memory allocator's internals. See the comment in
malloc.cpp.

### Toolchain: Add aligned allocation support to libc++ 

Now that we have `_aligned_malloc` and `_aligned_free`, we can finally
enable C++17 aligned allocation support.

--- 
If Qt can be patched to use `_aligned_malloc` instead of `memalign`, this will tick one item in the to-do list of #9362.