### PR TITLE
Ports: p7zip: Link iconv and pthread libraries

### DIFF
--- a/Ports/p7zip/package.sh
+++ b/Ports/p7zip/package.sh
@@ -9,7 +9,9 @@ configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 workdir=$port-$version/CPP
 
 post_fetch() {
+    run_replace_in_file "s/\r//" 7zip/CMAKE/7z_/CMakeLists.txt
     run_replace_in_file "s/\r//" 7zip/CMAKE/7za/CMakeLists.txt
+    run_replace_in_file "s/\r//" 7zip/CMAKE/7zr/CMakeLists.txt
 }
 
 configure() {

--- a/Ports/p7zip/patches/fixes.patch
+++ b/Ports/p7zip/patches/fixes.patch
@@ -19,7 +19,7 @@ index 469e325..32388ac 100644
  )
  
 +IF(SERENITYOS)
-+  TARGET_LINK_LIBRARIES(7za ${CMAKE_THREAD_LIBS_INIT} dl iconv)
++  TARGET_LINK_LIBRARIES(7za ${CMAKE_THREAD_LIBS_INIT} dl iconv pthread)
 +ENDIF(SERENITYOS)
  
  IF(APPLE)
@@ -37,3 +37,41 @@ index 497d197..fa402c6 100644
    
    #if !defined(ENV_BEOS) && !defined(ANDROID_NDK)
  
+--- a/7zip/CMAKE/7z_/CMakeLists.txt	2021-11-06 03:56:46.251920013 -0700
++++ b/7zip/CMAKE/7z_/CMakeLists.txt	2021-11-06 03:57:06.883896751 -0700
+@@ -101,6 +101,10 @@
+
+ link_directories(${DL_LIB_PATH})
+
++IF(SERENITYOS)
++  TARGET_LINK_LIBRARIES(7z_ ${CMAKE_THREAD_LIBS_INIT} dl iconv pthread)
++ENDIF(SERENITYOS)
++
+ IF(APPLE)
+    TARGET_LINK_LIBRARIES(7z_ ${COREFOUNDATION_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+ ELSE(APPLE)
+
+--- a/7zip/CMAKE/7zr/CMakeLists.txt	2021-11-06 04:02:15.647809299 -0700
++++ b/7zip/CMAKE/7zr/CMakeLists.txt	2021-11-06 04:02:28.807814262 -0700
+@@ -183,6 +183,10 @@
+ )
+
+
++IF(SERENITYOS)
++  TARGET_LINK_LIBRARIES(7zr ${CMAKE_THREAD_LIBS_INIT} dl iconv pthread)
++ENDIF(SERENITYOS)
++
+ IF(APPLE)
+    TARGET_LINK_LIBRARIES(7zr ${COREFOUNDATION_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+ ELSE(APPLE)
+
+--- a/7zip/CMAKE/CMakeLists.txt	2021-11-06 04:16:04.848820892 -0700
++++ b/7zip/CMAKE/CMakeLists.txt	2021-11-06 04:16:18.604844736 -0700
+@@ -21,7 +21,7 @@
+
+ add_definitions(-DENV_HAVE_GCCVISIBILITYPATCH)
+
+-SET(CMAKE_CXX_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -std=gnu++11")
++SET(CMAKE_CXX_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -std=gnu++11 -ldl -liconv -lpthread")
+
+ add_subdirectory(7za)


### PR DESCRIPTION
The `p7zip` port is currently broken due to missing `pthread`. This PR fixes it by linking `pthread`. Linking `iconv` is also required.

`7za` and `7zr` executables now work as expected.

![7z list](https://user-images.githubusercontent.com/434827/140610968-8060b895-d747-4dc1-bcbf-79163de2f4a2.png)

![7z extract](https://user-images.githubusercontent.com/434827/140611245-45115da5-18db-4735-b9d7-f3b0f7cbe60e.png)

`7z_` executable is still broken as it attempts to load `7z.so` from the working directory which is doomed to failure.

If someone wants to fix this, a [Sourceforge post](https://sourceforge.net/p/p7zip/discussion/383044/thread/3cf20fb8/) suggests that `7z_` (aka `7z`) should be placed in `/usr/local/lib/` along with `7z.so`, and only called via a wrapper which lives in `/usr/local/bin` (or any path within `PATH`). Ubuntu does exactly this:

```
user@ubuntu:~/Desktop/serenity$ which 7z
/usr/bin/7z
user@ubuntu:~/Desktop/serenity$ file /usr/bin/7z
/usr/bin/7z: POSIX shell script, ASCII text executable
user@ubuntu:~/Desktop/serenity$ cat /usr/bin/7z
#! /bin/sh
exec /usr/lib/p7zip/7z "$@"
user@ubuntu:~/Desktop/serenity$ cp /usr/lib/p7zip/7z ./
user@ubuntu:~/Desktop/serenity$ ./7z l Base/home/anon/7z2104-src.7z 

7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
p7zip Version 16.02 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,2 CPUs Intel(R) Core(TM) i5-4690 CPU @ 3.50GHz (306C3),ASM,AES-NI)

Can't load './7z.dll' (./7z.so: cannot open shared object file: No such file or directory)


ERROR:
7-Zip cannot find the code that works with archives.
```

