### PR TITLE
CMake: Assume working compiler instead of using static linking

### DIFF
--- a/Toolchain/CMake/ClangToolchain.txt.in
+++ b/Toolchain/CMake/ClangToolchain.txt.in
@@ -33,7 +33,13 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecs
 # FIXME: We could eliminate this setting by building LibC and support asm files (crti.o, crtn.o)
 #        in a separate build stage before the main build to ensure that LibC is available
 #        for the try_compile check for the main build.
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+#        Note that `set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)` is not a suitable replacement,
+#        since applications might try and use `try_compile()` to detect which library a symbol is in,
+#        which doesn't work when using static linking.
+#        Instead, just tell CMake directly that the compiler works fine, so that it doesn't have to run
+#        a compile check before the build.
+set(CMAKE_C_COMPILER_WORKS TRUE)
+set(CMAKE_CXX_COMPILER_WORKS TRUE)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/Toolchain/CMake/GNUToolchain.txt.in
+++ b/Toolchain/CMake/GNUToolchain.txt.in
@@ -29,7 +29,13 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecs
 # FIXME: We could eliminate this setting by building LibC and support asm files (crti.o, crtn.o)
 #        in a separate build stage before the main build to ensure that LibC is available
 #        for the try_compile check for the main build.
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+#        Note that `set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)` is not a suitable replacement,
+#        since applications might try and use `try_compile()` to detect which library a symbol is in,
+#        which doesn't work when using static linking.
+#        Instead, just tell CMake directly that the compiler works fine, so that it doesn't have to run
+#        a compile check before the build.
+set(CMAKE_C_COMPILER_WORKS TRUE)
+set(CMAKE_CXX_COMPILER_WORKS TRUE)
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
We were previously using TRY_COMPILE_TARGET_TYPE to bypass the compiler check at the beginning of the CMake build, since we don't have LibC available and therefore can't link at that point.

However, this breaks a lot of assumptions in try_compile when it comes to library checks. While this was the main idea behind our usage of the flag, it also has some really nasty side effects when software wants to find out what library a symbol is in.

Instead, just manually tell CMake that our compiler works as intended and keep the target type setting at its default.

This fixes a bunch of ports that were broken since the superbuild migration, such as `cmake`, `libzip`, `llvm`, and `p7zip`.