### PR TITLE
LibC: Reduce mprotect spam during startup and finalization

### DIFF
--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -39,6 +39,7 @@ int _entry(int argc, char** argv, char** env)
 
     environ = env;
     __environ_is_malloced = false;
+    __begin_atexit_locking();
 
     _init();
 

--- a/Userland/Libraries/LibC/sys/internals.h
+++ b/Userland/Libraries/LibC/sys/internals.h
@@ -15,6 +15,7 @@ typedef void (*AtExitFunction)(void*);
 extern void __libc_init();
 extern void __malloc_init();
 extern void __stdio_init();
+extern void __begin_atexit_locking();
 extern void _init();
 extern bool __environ_is_malloced;
 extern bool __stdio_is_initialized;


### PR DESCRIPTION
I noticed that strace spits out lots and lots of silly `mprotect`s that seem to do nothing useful:

```
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
mprotect(0x01a44000, 4096, PROT_READ | PROT_WRITE) = 0
mprotect(0x01a44000, 4096, PROT_READ) = 0
// And so on, for hundreds of lines
```

This can be traced back to the `atexit` mechanism:
- During startup, lots and lots of initializers run, which call `__cxa_atexit`. [This mitigation](https://github.com/SerenityOS/serenity/commit/553361d83f7bc6499dc4821eff9b23a6549bd99c) makes sure that the atexit region is "locked", so that an attacker cannot easily use an arbitrary write primitive to achieve code execution. However, during program startup, no input has been read yet anyway, so this safety mechanism causes some cost for zero benefit. This PR introduces a new internal flag `atexit_region_should_lock`, which disables locking of the region. Note that an attacker cannot just set that flag to `false` during normal execution, because at that point the memory region already is `mprotect`ed. (And if the attacker can set it to `false` *during* a legitimate `atexit` call, then the attacker probably has simpler ways to achieve code execution.)
- During program finalization, `__cxa_finalize` must jump through some hoops to make sure that each atexit-entry is called exactly once. Previously, this was done by tracking in each entry whether it has already been called, which necessitates unlocking and relocking the region all the time. This PR moves the flag to a separate piece of memory, which means we no longer need to unlock the region, and it reduces memory pressure (by one page) during program execution. This does not grant additional attack surface (the attacker was always able to overwrite the unprotected `atexit_entry_count` with zero).

Overall, this PR means that *every* program uses one fewer page of memory, and does about 138 fewer syscalls, or even fewer than that.

The impact on whole-system startup time is negligible. I measure an improvement of about 30ms, which could just as well be noise.