### PR TITLE
AK: Improve distinction between BitmapView (read-only) and Bitmap (read-write)

### DIFF
--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -37,7 +37,6 @@ public:
     {
     }
 
-    [[nodiscard]] BitmapView view() { return { m_data, m_size }; }
     [[nodiscard]] BitmapView const view() const { return { m_data, m_size }; }
 
     Bitmap(Bitmap&& other)

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -32,14 +32,6 @@ public:
         VERIFY(index < m_size);
         return 0 != (m_data[index / 8] & (1u << (index % 8)));
     }
-    void set(size_t index, bool value) const
-    {
-        VERIFY(index < m_size);
-        if (value)
-            m_data[index / 8] |= static_cast<u8>((1u << (index % 8)));
-        else
-            m_data[index / 8] &= static_cast<u8>(~(1u << (index % 8)));
-    }
 
     size_t count_slow(bool value) const
     {

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -19,26 +19,28 @@ static constexpr Array bitmask_last_byte = { 0x00, 0x1, 0x3, 0x7, 0xF, 0x1F, 0x3
 
 class BitmapView {
 public:
+    BitmapView() = default;
+
     BitmapView(u8* data, size_t size)
         : m_data(data)
         , m_size(size)
     {
     }
 
-    size_t size() const { return m_size; }
-    size_t size_in_bytes() const { return ceil_div(m_size, static_cast<size_t>(8)); }
-    bool get(size_t index) const
+    [[nodiscard]] size_t size() const { return m_size; }
+    [[nodiscard]] size_t size_in_bytes() const { return ceil_div(m_size, static_cast<size_t>(8)); }
+    [[nodiscard]] bool get(size_t index) const
     {
         VERIFY(index < m_size);
         return 0 != (m_data[index / 8] & (1u << (index % 8)));
     }
 
-    size_t count_slow(bool value) const
+    [[nodiscard]] size_t count_slow(bool value) const
     {
         return count_in_range(0, m_size, value);
     }
 
-    size_t count_in_range(size_t start, size_t len, bool value) const
+    [[nodiscard]] size_t count_in_range(size_t start, size_t len, bool value) const
     {
         VERIFY(start < m_size);
         VERIFY(start + len <= m_size);
@@ -84,9 +86,9 @@ public:
         return count;
     }
 
-    bool is_null() const { return !m_data; }
+    [[nodiscard]] bool is_null() const { return !m_data; }
 
-    const u8* data() const { return m_data; }
+    [[nodiscard]] const u8* data() const { return m_data; }
 
     template<bool VALUE>
     Optional<size_t> find_one_anywhere(size_t hint = 0) const
@@ -358,7 +360,7 @@ public:
 
     static constexpr size_t max_size = 0xffffffff;
 
-private:
+protected:
     u8* m_data { nullptr };
     size_t m_size { 0 };
 };

--- a/Kernel/Bus/PCI/SysFSPCI.h
+++ b/Kernel/Bus/PCI/SysFSPCI.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Bitmap.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/PCI/Definitions.h>

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/BitmapView.h>
+#include <AK/Bitmap.h>
 #include <AK/HashMap.h>
 #include <Kernel/FileSystem/BlockBasedFileSystem.h>
 #include <Kernel/FileSystem/Inode.h>
@@ -176,7 +176,7 @@ private:
         BlockIndex bitmap_block_index { 0 };
         bool dirty { false };
         NonnullOwnPtr<KBuffer> buffer;
-        BitmapView bitmap(u32 blocks_per_group) { return BitmapView { buffer->data(), blocks_per_group }; }
+        Bitmap bitmap(u32 blocks_per_group) { return Bitmap { buffer->data(), blocks_per_group }; }
     };
 
     KResultOr<CachedBitmap*> get_bitmap_block(BlockIndex);

--- a/Kernel/Memory/PrivateInodeVMObject.h
+++ b/Kernel/Memory/PrivateInodeVMObject.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Bitmap.h>
 #include <Kernel/Memory/InodeVMObject.h>
 #include <Kernel/UnixTypes.h>
 

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Bitmap.h>
 #include <Kernel/Memory/InodeVMObject.h>
 #include <Kernel/UnixTypes.h>
 

--- a/Userland/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Bitmap.h>
 #include <AK/Utf8View.h>
 #include <LibCrypto/ASN1/DER.h>
 


### PR DESCRIPTION
Previously, BitmapView had a `set(size_t, bool) const` method that meant that BitmapView was read-write. However, Bitmap already supported the use-case of that method, namely manipulating a non-owned region, so there was no need to have BitmapView be read-write.

This PR makes BitmapView read-only again, following what seems to become a new convention: class Foo is read-write and (possibly) owning, class FooView is read-only and non-owning.