### PR TITLE
LibC: Fix huge libc.a file size due to the use of `llvm-ar -q`

### DIFF
--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -139,7 +139,7 @@ add_custom_target(LibCStatic
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:ssp>
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibSystemStatic>
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibUBSanitizerStatic>
-        COMMAND ${CMAKE_AR} -qcs ${CMAKE_CURRENT_BINARY_DIR}/libc.a *.o
+        COMMAND ${CMAKE_AR} -rcs ${CMAKE_CURRENT_BINARY_DIR}/libc.a *.o
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS LibCStaticWithoutDeps ssp LibSystemStatic LibUBSanitizerStatic
         )


### PR DESCRIPTION
Before this change, we would generate the static C library by running
the command `ar -qcs` to collect the various `*.o` files into a single
archive.

The `q` option stands for "quick append", which simply appends new files
to the archive, without replacing any pre-existing entries for the same
file. The problem with this is obvious: each LibC rebuild would add
approximately 1 MB (the size of a cleanly built libc.a) to the size of
the file. It got so bad on my machine that the total file size ended up
being 3 gigabytes.

Note that this did not affect the GNU toolchain, because, as the `ar(1)`
manpage says:
> Note - GNU ar treats the command qs as a synonym for r - replacing
> already existing files in the archive and appending new ones at the
> end.