### PR TITLE
WindowServer: Revert removing of call to Menu::set_visible

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -638,6 +638,7 @@ void Menu::do_popup(const Gfx::IntPoint& position, bool make_input, bool as_subm
     }
 
     window.move_to(adjusted_pos);
+    set_visible(true);
     MenuManager::the().open_menu(*this, make_input);
     WindowManager::the().did_popup_a_menu({});
 }


### PR DESCRIPTION
Fixes #10828
This reverts commit 239520ae549b21f1700e966d45eb0daaac939ae1.

The call to set_visible() is not redundant. Removing the call leads
to the "start" button in the taskbar not being painted as "pressed" even
when it is.