### PR TITLE
Kernel+Utilities: Better usability

### DIFF
--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -198,6 +198,13 @@ KResult Process::procfs_get_fds_stats(KBufferBuilder& builder) const
         description_object.add("blocking", description->is_blocking());
         description_object.add("can_read", description->can_read());
         description_object.add("can_write", description->can_write());
+        Inode* inode = description->inode();
+        if (inode != nullptr) {
+            auto inode_object = description_object.add_object("inode");
+            inode_object.add("fsid", inode->fsid());
+            inode_object.add("index", inode->index().value());
+            inode_object.finish();
+        }
         count++;
     });
 

--- a/Userland/Utilities/syscall.cpp
+++ b/Userland/Utilities/syscall.cpp
@@ -9,6 +9,7 @@
 #include <AK/Iterator.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
+#include <errno_numbers.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -93,12 +94,14 @@ int main(int argc, char** argv)
 
     dbgln_if(SYSCALL_1_DEBUG, "Calling {} {:p} {:p} {:p}\n", arg[0], arg[1], arg[2], arg[3]);
     int rc = syscall(arg[0], arg[1], arg[2], arg[3]);
-    if (rc == -1)
-        perror("syscall");
     if (output_buffer)
         fwrite(outbuf, 1, sizeof(outbuf), stdout);
 
-    warnln("Syscall return: {}", rc);
+    if (-rc >= 0 && -rc < EMAXERRNO) {
+        warnln("Syscall return: {} ({})", rc, strerror(-rc));
+    } else {
+        warnln("Syscall return: {} (?)", rc);
+    }
     return 0;
 }
 


### PR DESCRIPTION
This fixes the ability to call `syscall -o …somesyscall… | hexdump`, and provides more interesting results from that call, as well as in the file `/proc/self/fds`.

![Bildschirmfoto_2021-11-06_22-37-45](https://user-images.githubusercontent.com/2690845/140627100-607f529f-d1e7-4019-b8ae-07df8b8998bd.png)

Background: I was fiddling around and wondering "Hmm, how often in practice does a file description have an inode available?"