### PR TITLE
Kernel: Fix TOCTOU and missing filesystem ID in (f)statvfs

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -535,7 +535,7 @@ private:
     ErrorOr<void> do_exec(NonnullRefPtr<OpenFileDescription> main_program_description, NonnullOwnPtrVector<KString> arguments, NonnullOwnPtrVector<KString> environment, RefPtr<OpenFileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags, const ElfW(Ehdr) & main_program_header);
     ErrorOr<FlatPtr> do_write(OpenFileDescription&, const UserOrKernelBuffer&, size_t);
 
-    ErrorOr<FlatPtr> do_statvfs(StringView path, statvfs* buf);
+    ErrorOr<FlatPtr> do_statvfs(FileSystem const& path, Custody const*, statvfs* buf);
 
     ErrorOr<RefPtr<OpenFileDescription>> find_elf_interpreter_for_executable(StringView path, ElfW(Ehdr) const& main_executable_header, size_t main_executable_header_size, size_t file_size);
 

--- a/Kernel/Syscalls/statvfs.cpp
+++ b/Kernel/Syscalls/statvfs.cpp
@@ -26,7 +26,7 @@ ErrorOr<FlatPtr> Process::do_statvfs(FileSystem const& fs, Custody const* custod
     kernelbuf.f_ffree = fs.free_inode_count();
     kernelbuf.f_favail = fs.free_inode_count(); // FIXME: same as f_bavail
 
-    kernelbuf.f_fsid = 0; // FIXME: Implement "Filesystem ID" into Filesystem
+    kernelbuf.f_fsid = fs.fsid();
 
     kernelbuf.f_namemax = 255;
 


### PR DESCRIPTION
Previously, fstatvfs reported stats on whatever happened to be at the path where the file descriptor was originally opened. That's a time-of-creation time-of-use error, as by the time fstatvfs is called, the open file (or any parent directory) could have been moved, and new directories / mounts / filesystems could have taken up the path.

Furthermore, (f)statvfs refused to set the filesystem ID for no reason.

This PR fixes both of these issues, with the small wart that under *weird* conditions, fstatvfs might erroneously return mount flags of 0, in particular if the file description does not have an associated Custody. I don't think that can reasonably happen.

Finally, I'm not entirely sure about what fstatvfs should return if a file descriptor **does** refer to an existing file description (and is therefore a valid open file descriptor), but that file description does **not** refer to an inode. I picked ENOENT, because I think "[not a valid open file descriptor](https://www.man7.org/linux/man-pages/man3/statvfs.3.html)" (EBADF) does not apply.

Currently, no Serenity program uses (f)statvfs, and it probably improves some Ports. Therefore, you'll have to use syscall(1) to call it:

![Bildschirmfoto_2021-11-07_00-06-32](https://user-images.githubusercontent.com/2690845/140627055-9447d010-1399-4f31-9c09-033193539840.png)
![Bildschirmfoto_2021-11-07_00-05-32](https://user-images.githubusercontent.com/2690845/140627056-8b70519a-04d6-4779-b1bd-a1f5c462d448.png)
![Bildschirmfoto_2021-11-07_00-04-54](https://user-images.githubusercontent.com/2690845/140627057-56e6f5a6-0a7f-439c-80c0-c33ac319b713.png)

In order to run these examples, you'll need #10830, as hexdump is currently broken (which ironically is my fault).