### PR TITLE
LibJS: Implement ToTemporalZonedDateTime and three functions that use it

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -223,6 +223,7 @@
     M(TemporalInvalidTime, "Invalid time")                                                                                              \
     M(TemporalInvalidTimeZoneName, "Invalid time zone name")                                                                            \
     M(TemporalInvalidUnitRange, "Invalid unit range, {} is larger than {}")                                                             \
+    M(TemporalInvalidZonedDateTimeOffset, "Invalid offset for the provided date and time in the current time zone")                     \
     M(TemporalMissingOptionsObject, "Required options object is missing or undefined")                                                  \
     M(TemporalObjectMustNotHave, "Object must not have a defined {} property")                                                          \
     M(TemporalPropertyMustBeFinite, "Property must not be Infinity")                                                                    \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.h
@@ -78,6 +78,11 @@ struct TemporalYearMonth {
     Optional<String> calendar = {};
 };
 
+struct TemporalZonedDateTime {
+    ISODateTime date_time;
+    TemporalTimeZone time_zone;
+};
+
 struct SecondsStringPrecision {
     Variant<StringView, u8> precision;
     String unit;
@@ -92,6 +97,7 @@ ThrowCompletionOr<Variant<String, NumberType>> get_string_or_number_option(Globa
 ThrowCompletionOr<String> to_temporal_overflow(GlobalObject&, Object const& normalized_options);
 ThrowCompletionOr<String> to_temporal_disambiguation(GlobalObject&, Object const& normalized_options);
 ThrowCompletionOr<String> to_temporal_rounding_mode(GlobalObject&, Object const& normalized_options, String const& fallback);
+ThrowCompletionOr<String> to_temporal_offset(GlobalObject&, Object const& normalized_options, String const& fallback);
 ThrowCompletionOr<String> to_show_calendar_option(GlobalObject&, Object const& normalized_options);
 ThrowCompletionOr<u64> to_temporal_rounding_increment(GlobalObject&, Object const& normalized_options, Optional<double> dividend, bool inclusive);
 ThrowCompletionOr<u64> to_temporal_date_time_rounding_increment(GlobalObject&, Object const& normalized_options, StringView smallest_unit);
@@ -109,6 +115,7 @@ i64 round_number_to_increment(double, u64 increment, StringView rounding_mode);
 BigInt* round_number_to_increment(GlobalObject&, BigInt const&, u64 increment, StringView rounding_mode);
 ThrowCompletionOr<ISODateTime> parse_iso_date_time(GlobalObject&, String const& iso_string);
 ThrowCompletionOr<TemporalInstant> parse_temporal_instant_string(GlobalObject&, String const& iso_string);
+ThrowCompletionOr<TemporalZonedDateTime> parse_temporal_zoned_date_time_string(GlobalObject&, String const& iso_string);
 ThrowCompletionOr<String> parse_temporal_calendar_string(GlobalObject&, String const& iso_string);
 ThrowCompletionOr<TemporalDate> parse_temporal_date_string(GlobalObject&, String const& iso_string);
 ThrowCompletionOr<ISODateTime> parse_temporal_date_time_string(GlobalObject&, String const& iso_string);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -646,4 +646,25 @@ ThrowCompletionOr<MarkedValueList> get_possible_instants_for(GlobalObject& globa
     return { move(list) };
 }
 
+// 11.6.18 TimeZoneEquals ( one, two ), https://tc39.es/proposal-temporal/#sec-temporal-timezoneequals
+ThrowCompletionOr<bool> time_zone_equals(GlobalObject& global_object, Object& one, Object& two)
+{
+    // 1. If one and two are the same Object value, return true.
+    if (&one == &two)
+        return true;
+
+    // 2. Let timeZoneOne be ? ToString(one).
+    auto time_zone_one = TRY(Value(&one).to_string(global_object));
+
+    // 3. Let timeZoneTwo be ? ToString(two).
+    auto time_zone_two = TRY(Value(&two).to_string(global_object));
+
+    // 4. If timeZoneOne is timeZoneTwo, return true.
+    if (time_zone_one == time_zone_two)
+        return true;
+
+    // 5. Return false.
+    return false;
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -53,6 +53,7 @@ ThrowCompletionOr<PlainDateTime*> builtin_time_zone_get_plain_date_time_for(Glob
 ThrowCompletionOr<Instant*> builtin_time_zone_get_instant_for(GlobalObject&, Value time_zone, PlainDateTime&, StringView disambiguation);
 ThrowCompletionOr<Instant*> disambiguate_possible_instants(GlobalObject&, Vector<Value> const& possible_instants, Value time_zone, PlainDateTime&, StringView disambiguation);
 ThrowCompletionOr<MarkedValueList> get_possible_instants_for(GlobalObject&, Value time_zone, PlainDateTime&);
+ThrowCompletionOr<bool> time_zone_equals(GlobalObject&, Object& one, Object& two);
 
 bool is_valid_time_zone_numeric_utc_offset_syntax(String const&);
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
@@ -40,6 +40,19 @@ struct NanosecondsToDaysResult {
     double day_length;
 };
 
+enum class OffsetBehavior {
+    Option,
+    Exact,
+    Wall,
+};
+
+enum class MatchBehavior {
+    MatchExactly,
+    MatchMinutes,
+};
+
+ThrowCompletionOr<BigInt const*> interpret_iso_date_time_offset(GlobalObject&, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond, OffsetBehavior offset_behavior, double offset_nanoseconds, Value time_zone, StringView disambiguation, StringView offset_option, MatchBehavior match_behavior);
+ThrowCompletionOr<ZonedDateTime*> to_temporal_zoned_date_time(GlobalObject&, Value item, Object* options = nullptr);
 ThrowCompletionOr<ZonedDateTime*> create_temporal_zoned_date_time(GlobalObject&, BigInt const& epoch_nanoseconds, Object& time_zone, Object& calendar, FunctionObject const* new_target = nullptr);
 ThrowCompletionOr<BigInt*> add_zoned_date_time(GlobalObject&, BigInt const& epoch_nanoseconds, Value time_zone, Object& calendar, double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds, Object* options = nullptr);
 ThrowCompletionOr<NanosecondsToDaysResult> nanoseconds_to_days(GlobalObject&, BigInt const& nanoseconds, Value relative_to);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -31,6 +32,7 @@ void ZonedDateTimeConstructor::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.from, from, 1, attr);
+    define_native_function(vm.names.compare, compare, 2, attr);
 
     define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
@@ -95,6 +97,19 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimeConstructor::from)
 
     // 3. Return ? ToTemporalZonedDateTime(item, options).
     return TRY(to_temporal_zoned_date_time(global_object, item, options));
+}
+
+// 6.2.3 Temporal.ZonedDateTime.compare ( one, two ), https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare
+JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimeConstructor::compare)
+{
+    // 1. Set one to ? ToTemporalZonedDateTime(one).
+    auto* one = TRY(to_temporal_zoned_date_time(global_object, vm.argument(0)));
+
+    // 2. Set two to ? ToTemporalZonedDateTime(two).
+    auto* two = TRY(to_temporal_zoned_date_time(global_object, vm.argument(1)));
+
+    // 3. Return 𝔽(! CompareEpochNanoseconds(one.[[Nanoseconds]], two.[[Nanoseconds]])).
+    return Value(compare_epoch_nanoseconds(one->nanoseconds(), two->nanoseconds()));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
@@ -25,6 +25,7 @@ private:
     virtual bool has_constructor() const override { return true; }
 
     JS_DECLARE_NATIVE_FUNCTION(from);
+    JS_DECLARE_NATIVE_FUNCTION(compare);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
@@ -23,6 +23,8 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
+
+    JS_DECLARE_NATIVE_FUNCTION(from);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
@@ -53,6 +53,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(with_plain_date);
     JS_DECLARE_NATIVE_FUNCTION(with_time_zone);
     JS_DECLARE_NATIVE_FUNCTION(with_calendar);
+    JS_DECLARE_NATIVE_FUNCTION(equals);
     JS_DECLARE_NATIVE_FUNCTION(value_of);
     JS_DECLARE_NATIVE_FUNCTION(start_of_day);
     JS_DECLARE_NATIVE_FUNCTION(to_instant);

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.compare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.compare.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("length is 2", () => {
+        expect(Temporal.ZonedDateTime.compare).toHaveLength(2);
+    });
+
+    test("basic functionality", () => {
+        const zonedDateTimeOne = new Temporal.ZonedDateTime(1n, new Temporal.TimeZone("UTC"));
+        const zonedDateTimeTwo = new Temporal.ZonedDateTime(2n, new Temporal.TimeZone("UTC"));
+
+        expect(Temporal.ZonedDateTime.compare(zonedDateTimeOne, zonedDateTimeOne)).toBe(0);
+        expect(Temporal.ZonedDateTime.compare(zonedDateTimeTwo, zonedDateTimeTwo)).toBe(0);
+        expect(Temporal.ZonedDateTime.compare(zonedDateTimeOne, zonedDateTimeTwo)).toBe(-1);
+        expect(Temporal.ZonedDateTime.compare(zonedDateTimeTwo, zonedDateTimeOne)).toBe(1);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.from.js
@@ -1,0 +1,151 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Temporal.ZonedDateTime.from).toHaveLength(1);
+    });
+
+    test("ZonedDateTime instance argument", () => {
+        const timeZone = new Temporal.TimeZone("UTC");
+        const calendar = new Temporal.Calendar("iso8601");
+        const zonedDateTime = new Temporal.ZonedDateTime(1627318123456789000n, timeZone, calendar);
+        const createdZoneDateTime = Temporal.ZonedDateTime.from(zonedDateTime);
+
+        expect(createdZoneDateTime).toBeInstanceOf(Temporal.ZonedDateTime);
+        expect(createdZoneDateTime).not.toBe(zonedDateTime);
+        expect(createdZoneDateTime.timeZone).toBe(timeZone);
+        expect(createdZoneDateTime.calendar).toBe(calendar);
+        expect(createdZoneDateTime.epochNanoseconds).toBe(1627318123456789000n);
+    });
+
+    test("PlainDate instance argument", () => {
+        const timeZone = new Temporal.TimeZone("UTC");
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainDate = new Temporal.PlainDate(2021, 11, 7, calendar);
+        plainDate.timeZone = timeZone;
+        const createdZoneDateTime = Temporal.ZonedDateTime.from(plainDate);
+
+        expect(createdZoneDateTime).toBeInstanceOf(Temporal.ZonedDateTime);
+        expect(createdZoneDateTime.timeZone).toBe(timeZone);
+        expect(createdZoneDateTime.calendar).toBe(calendar);
+        expect(createdZoneDateTime.year).toBe(2021);
+        expect(createdZoneDateTime.month).toBe(11);
+        expect(createdZoneDateTime.day).toBe(7);
+    });
+
+    test("PlainDateTime instance argument", () => {
+        const timeZone = new Temporal.TimeZone("UTC");
+        const calendar = new Temporal.Calendar("iso8601");
+        const plainDateTime = new Temporal.PlainDateTime(
+            2021,
+            11,
+            7,
+            0,
+            20,
+            5,
+            100,
+            200,
+            300,
+            calendar
+        );
+        plainDateTime.timeZone = timeZone;
+        const createdZoneDateTime = Temporal.ZonedDateTime.from(plainDateTime);
+
+        expect(createdZoneDateTime).toBeInstanceOf(Temporal.ZonedDateTime);
+        expect(createdZoneDateTime.timeZone).toBe(timeZone);
+        expect(createdZoneDateTime.calendar).toBe(calendar);
+        expect(createdZoneDateTime.year).toBe(2021);
+        expect(createdZoneDateTime.month).toBe(11);
+        expect(createdZoneDateTime.day).toBe(7);
+        expect(createdZoneDateTime.hour).toBe(0);
+        expect(createdZoneDateTime.minute).toBe(20);
+        expect(createdZoneDateTime.second).toBe(5);
+        expect(createdZoneDateTime.millisecond).toBe(100);
+        expect(createdZoneDateTime.microsecond).toBe(200);
+        expect(createdZoneDateTime.nanosecond).toBe(300);
+    });
+
+    test("ZonedDateTime-like argument", () => {
+        const timeZone = new Temporal.TimeZone("UTC");
+        const calendar = new Temporal.Calendar("iso8601");
+        const zdtLike = {
+            timeZone,
+            calendar,
+            year: 2021,
+            month: 11,
+            day: 7,
+            hour: 0,
+            minute: 20,
+            second: 5,
+            millisecond: 100,
+            microsecond: 200,
+            nanosecond: 300,
+        };
+        const createdZoneDateTime = Temporal.ZonedDateTime.from(zdtLike);
+
+        expect(createdZoneDateTime).toBeInstanceOf(Temporal.ZonedDateTime);
+        expect(createdZoneDateTime.timeZone).toBe(timeZone);
+        expect(createdZoneDateTime.calendar).toBe(calendar);
+        expect(createdZoneDateTime.year).toBe(2021);
+        expect(createdZoneDateTime.month).toBe(11);
+        expect(createdZoneDateTime.day).toBe(7);
+        expect(createdZoneDateTime.hour).toBe(0);
+        expect(createdZoneDateTime.minute).toBe(20);
+        expect(createdZoneDateTime.second).toBe(5);
+        expect(createdZoneDateTime.millisecond).toBe(100);
+        expect(createdZoneDateTime.microsecond).toBe(200);
+        expect(createdZoneDateTime.nanosecond).toBe(300);
+    });
+
+    // FIXME: Enable when parse_iso_date_time is implemented.
+    test.skip("from string", () => {
+        const zonedDateTime = Temporal.ZonedDateTime.from(
+            "2021-11-07T00:20:05.100200300+00:00[UTC][u-ca=iso8601]"
+        );
+
+        expect(zonedDateTime).toBeInstanceOf(Temporal.ZonedDateTime);
+        expect(zonedDateTime.timeZone).toBeInstanceOf(Temporal.TimeZone);
+        expect(zonedDateTime.timeZone.id).toBe("UTC");
+        expect(zonedDateTime.calendar).toBeInstanceOf(Temporal.Calendar);
+        expect(zonedDateTime.calendar.id).toBe("iso8601");
+        expect(createdZoneDateTime.year).toBe(2021);
+        expect(createdZoneDateTime.month).toBe(11);
+        expect(createdZoneDateTime.day).toBe(7);
+        expect(createdZoneDateTime.hour).toBe(0);
+        expect(createdZoneDateTime.minute).toBe(20);
+        expect(createdZoneDateTime.second).toBe(5);
+        expect(createdZoneDateTime.millisecond).toBe(100);
+        expect(createdZoneDateTime.microsecond).toBe(200);
+        expect(createdZoneDateTime.nanosecond).toBe(300);
+        expect(createdZoneDateTime.offset).toBe("+00:00");
+        expect(createdZoneDateTime.offsetNanoseconds).toBe(0);
+    });
+});
+
+describe("errors", () => {
+    test("requires timeZone property", () => {
+        expect(() => {
+            Temporal.ZonedDateTime.from({});
+        }).toThrowWithMessage(TypeError, "Required property timeZone is missing or undefined");
+    });
+
+    test("requires year property", () => {
+        expect(() => {
+            Temporal.ZonedDateTime.from({ timeZone: new Temporal.TimeZone("UTC") });
+        }).toThrowWithMessage(TypeError, "Required property year is missing or undefined");
+    });
+
+    test("requires month property", () => {
+        expect(() => {
+            Temporal.ZonedDateTime.from({ timeZone: new Temporal.TimeZone("UTC"), year: 2021 });
+        }).toThrowWithMessage(TypeError, "Required property month is missing or undefined");
+    });
+
+    test("requires day property", () => {
+        expect(() => {
+            Temporal.ZonedDateTime.from({
+                timeZone: new Temporal.TimeZone("UTC"),
+                year: 2021,
+                month: 11,
+            });
+        }).toThrowWithMessage(TypeError, "Required property day is missing or undefined");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.equals.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.equals.js
@@ -1,0 +1,23 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Temporal.ZonedDateTime.prototype.equals).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        const zonedDateTimeOne = new Temporal.ZonedDateTime(1n, new Temporal.TimeZone("UTC"));
+        const zonedDateTimeTwo = new Temporal.ZonedDateTime(2n, new Temporal.TimeZone("UTC"));
+
+        expect(zonedDateTimeOne.equals(zonedDateTimeOne)).toBeTrue();
+        expect(zonedDateTimeTwo.equals(zonedDateTimeTwo)).toBeTrue();
+        expect(zonedDateTimeOne.equals(zonedDateTimeTwo)).toBeFalse();
+        expect(zonedDateTimeTwo.equals(zonedDateTimeOne)).toBeFalse();
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.ZonedDateTime object", () => {
+        expect(() => {
+            Temporal.ZonedDateTime.prototype.equals.call("foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.ZonedDateTime");
+    });
+});


### PR DESCRIPTION
Ticks off three checkboxes in #8982.
The main thing I'm concerned about is the struct returned by parse_temporal_zoned_date_time_string and how it interacts with to_temporal_zoned_date_time (e.g. moving into result and such) as it's currently untested as parse_iso_date_time is not currently implemented.