### PR TITLE
WidgetGallery: Make custom cursors visible only in the cursors tab

### DIFF
--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -306,7 +306,7 @@ GalleryWidget::GalleryWidget()
 
     m_cursors_tableview->on_activation = [&](const GUI::ModelIndex& index) {
         auto icon_index = index.model()->index(index.row(), MouseCursorModel::Column::Bitmap);
-        window()->set_cursor(icon_index.data().as_bitmap());
+        m_cursors_tableview->set_override_cursor(NonnullRefPtr<Gfx::Bitmap>(icon_index.data().as_bitmap()));
     };
 
     auto& icons_tab = tab_widget.add_tab<GUI::Widget>("Icons");


### PR DESCRIPTION
Prior to this change, the selected cursor stayed changed throughout the app, even after switching tabs, which didn’t look quite right.

https://user-images.githubusercontent.com/16520278/140647053-e4d72569-2bce-4688-94dd-eebf5dbfef60.mp4

https://user-images.githubusercontent.com/16520278/140647055-a277c8f1-cf7c-4878-b75a-1da7043b8275.mp4