### PR TITLE
strace: Nicer code and output around bitflags, interpret pointer-like return codes better

### DIFF
--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -386,7 +386,12 @@ public:
 
     void format_result(void* res)
     {
-        m_builder.appendff(") = {}\n", res);
+        if (res == MAP_FAILED)
+            m_builder.append(") = MAP_FAILED\n");
+        else if (FlatPtr(res) > FlatPtr(-EMAXERRNO))
+            m_builder.appendff(") = {} {}\n", res, errno_name(-static_cast<int>(FlatPtr(res))));
+        else
+            m_builder.appendff(") = {}\n", res);
     }
 
     void format_result()


### PR DESCRIPTION
In this PR:
- Print unrecognized flags instead of hiding them (after all, this might be what the user of strace is looking for!)
- Extend support for many more flag values
- Introduce a more ergonomic way to format bitflag arguments
- Interpret pointer-like return codes as errno or `MAP_FAILED`

Some highlights:
![Bildschirmfoto_2021-11-07_13-00-11](https://user-images.githubusercontent.com/2690845/140648543-400a81c3-d37a-4f9f-9db5-c666cb2ff767.png)
![Bildschirmfoto_2021-11-07_13-04-06](https://user-images.githubusercontent.com/2690845/140648545-e43717ce-39d9-4b94-868a-64fd5b76886e.png)
![Bildschirmfoto_2021-11-07_14-38-24](https://user-images.githubusercontent.com/2690845/140648548-190a5f1e-fd1c-4c3a-ae7b-b5c777cc3927.png)
![Bildschirmfoto_2021-11-07_15-00-20](https://user-images.githubusercontent.com/2690845/140648551-36245482-56e1-47fb-9e30-dfae4e79f0d7.png)
