### PR TITLE
SoundPlayer: Fix stack-use-after-scope when playing file in loop mode

### DIFF
--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -38,7 +38,7 @@ Player::Player(Audio::ClientConnection& audio_client_connection)
     };
 }
 
-void Player::play_file_path(StringView path)
+void Player::play_file_path(String const& path)
 {
     if (path.is_null())
         return;

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -32,10 +32,10 @@ public:
     explicit Player(Audio::ClientConnection& audio_client_connection);
     virtual ~Player() { }
 
-    void play_file_path(StringView path);
+    void play_file_path(String const& path);
 
     Playlist& playlist() { return m_playlist; }
-    StringView loaded_filename() const { return m_loaded_filename; }
+    String const& loaded_filename() const { return m_loaded_filename; }
 
     PlayState play_state() const { return m_play_state; }
     void set_play_state(PlayState);
@@ -84,6 +84,6 @@ private:
     Audio::ClientConnection& m_audio_client_connection;
     PlaybackManager m_playback_manager;
 
-    StringView m_loaded_filename;
+    String m_loaded_filename;
     double m_volume { 0 };
 };


### PR DESCRIPTION
Fixes #10751

The path returned by GUI:FilePicker is stored on the stack when the
callback is executed. The player only stored a StringView to the path
however it should take ownership of the path instead since the path is
accessed even after the file menu open action has returned.