### PR TITLE
LibJS: Create the RegExpExec result's "input" field last

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -241,8 +241,8 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(GlobalObject& global_object,
     }
 
     MUST(array->create_data_property_or_throw(vm.names.index, Value(match_index)));
-    MUST(array->create_data_property_or_throw(vm.names.input, js_string(vm, move(string))));
     MUST(array->create_data_property_or_throw(0, js_string(vm, match.view.u16_view())));
+    MUST(array->create_data_property_or_throw(vm.names.input, js_string(vm, move(string))));
 
     return array;
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
@@ -205,3 +205,10 @@ test("multiline stateful match", () => {
     );
     expect(res.index).toBe(231);
 });
+
+test("string coercion", () => {
+    let result = /1/.exec(1);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe("1");
+    expect(result.index).toBe(0);
+});


### PR DESCRIPTION
We move the input string into this field to avoid a string copy, so we
must do this step last to avoid using any views into it (note that
match.view here is a view into this string).