### PR TITLE
ConfigServer+LibConfig: Add key removal and notification

### DIFF
--- a/Userland/Libraries/LibConfig/Client.cpp
+++ b/Userland/Libraries/LibConfig/Client.cpp
@@ -60,6 +60,11 @@ void Client::write_bool(StringView domain, StringView group, StringView key, boo
     async_write_bool_value(domain, group, key, value);
 }
 
+void Client::remove_key(StringView domain, StringView group, StringView key)
+{
+    async_remove_key(domain, group, key);
+}
+
 void Client::notify_changed_string_value(String const& domain, String const& group, String const& key, String const& value)
 {
     Listener::for_each([&](auto& listener) {
@@ -78,6 +83,13 @@ void Client::notify_changed_bool_value(String const& domain, String const& group
 {
     Listener::for_each([&](auto& listener) {
         listener.config_bool_did_change(domain, group, key, value);
+    });
+}
+
+void Client::notify_removed_key(const String& domain, const String& group, const String& key)
+{
+    Listener::for_each([&](auto& listener) {
+        listener.config_key_was_removed(domain, group, key);
     });
 }
 

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -31,6 +31,7 @@ public:
     void write_string(StringView domain, StringView group, StringView key, StringView value);
     void write_i32(StringView domain, StringView group, StringView key, i32 value);
     void write_bool(StringView domain, StringView group, StringView key, bool value);
+    void remove_key(StringView domain, StringView group, StringView key);
 
     static Client& the();
 
@@ -43,6 +44,7 @@ private:
     void notify_changed_string_value(String const& domain, String const& group, String const& key, String const& value) override;
     void notify_changed_i32_value(String const& domain, String const& group, String const& key, i32 value) override;
     void notify_changed_bool_value(String const& domain, String const& group, String const& key, bool value) override;
+    void notify_removed_key(String const& domain, String const& group, String const& key) override;
 };
 
 inline String read_string(StringView domain, StringView group, StringView key, StringView fallback = {})
@@ -73,6 +75,11 @@ inline void write_i32(StringView domain, StringView group, StringView key, i32 v
 inline void write_bool(StringView domain, StringView group, StringView key, bool value)
 {
     Client::the().write_bool(domain, group, key, value);
+}
+
+inline void remove_key(StringView domain, StringView group, StringView key)
+{
+    Client::the().remove_key(domain, group, key);
 }
 
 inline void pledge_domains(Vector<String> const& domains)

--- a/Userland/Libraries/LibConfig/Listener.cpp
+++ b/Userland/Libraries/LibConfig/Listener.cpp
@@ -41,4 +41,8 @@ void Listener::config_bool_did_change(String const&, String const&, String const
 {
 }
 
+void Listener::config_key_was_removed(String const&, String const&, String const&)
+{
+}
+
 }

--- a/Userland/Libraries/LibConfig/Listener.h
+++ b/Userland/Libraries/LibConfig/Listener.h
@@ -19,6 +19,7 @@ public:
     virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value);
     virtual void config_i32_did_change(String const& domain, String const& group, String const& key, i32 value);
     virtual void config_bool_did_change(String const& domain, String const& group, String const& key, bool value);
+    virtual void config_key_was_removed(String const& domain, String const& group, String const& key);
 
 protected:
     Listener();

--- a/Userland/Services/ConfigServer/ClientConnection.h
+++ b/Userland/Services/ConfigServer/ClientConnection.h
@@ -33,6 +33,7 @@ private:
     virtual void write_string_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key, [[maybe_unused]] String const& value) override;
     virtual void write_i32_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key, [[maybe_unused]] i32 value) override;
     virtual void write_bool_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key, [[maybe_unused]] bool value) override;
+    virtual void remove_key([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key) override;
 
     bool validate_access(String const& domain, String const& group, String const& key);
     void sync_dirty_domains_to_disk();

--- a/Userland/Services/ConfigServer/ConfigClient.ipc
+++ b/Userland/Services/ConfigServer/ConfigClient.ipc
@@ -3,4 +3,5 @@ endpoint ConfigClient
     notify_changed_string_value(String domain, String group, String key, String value) =|
     notify_changed_i32_value(String domain, String group, String key, i32 value) =|
     notify_changed_bool_value(String domain, String group, String key, bool value) =|
+    notify_removed_key(String domain, String group, String key) =|
 }

--- a/Userland/Services/ConfigServer/ConfigServer.ipc
+++ b/Userland/Services/ConfigServer/ConfigServer.ipc
@@ -11,4 +11,5 @@ endpoint ConfigServer
     write_string_value(String domain, String group, String key, String value) =|
     write_i32_value(String domain, String group, String key, i32 value) =|
     write_bool_value(String domain, String group, String key, bool value)  =|
+    remove_key(String domain, String group, String key) =|
 }


### PR DESCRIPTION
This addresses the ConfigServer FIXME of detecting key deletion and also adds the method to delete keys.

I plan to use this in a future commit to make quicklaunchbar in Taskbar editable. 