### PR TITLE
LibWeb: Parse missing `background-foo` properties

### DIFF
--- a/Base/res/html/misc/backgrounds.html
+++ b/Base/res/html/misc/backgrounds.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>CSS Background Tests</title>
+    <style>
+        .example {
+            width: 45%;
+            display: inline-block;
+        }
+
+        .box {
+            width: 180px;
+            height: 160px;
+            border: 1px solid black;
+            padding: 5px 10px 15px 20px;
+            overflow: auto;
+        }
+
+        .force-scroll {
+            width: 500px;
+            height: 500px;
+        }
+
+        code {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <h1>CSS Background Tests</h1>
+    <p>These are in no way exhaustive, but they cover a variety of different features.</p>
+    <p>The left and right columns should look identical - left uses a single background shorthand, and right uses separate properties.</p>
+
+    <h2>Attachment</h2>
+    <h3>Should remain motionless relative to the browser window</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') fixed</code>
+        <div class="box" style="background: url('background-repeat.png') fixed">
+            <div class="force-scroll"></div>
+        </div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-attachment: fixed;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-attachment: fixed;">
+            <div class="force-scroll"></div>
+        </div>
+    </div>
+
+    <h3>Should scroll with box content</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') local</code>
+        <div class="box" style="background: url('background-repeat.png') local">
+            <div class="force-scroll"></div>
+        </div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-attachment: local;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-attachment: local">
+            <div class="force-scroll"></div>
+        </div>
+    </div>
+
+    <h3>Should remain motionless relative to the box</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') scroll</code>
+        <div class="box" style="background: url('background-repeat.png') scroll">
+            <div class="force-scroll"></div>
+        </div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-attachment: scroll;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-attachment: scroll">
+            <div class="force-scroll"></div>
+        </div>
+    </div>
+
+    <h2>Position</h2>
+    <div class="example">
+        <code>background: url('background-repeat.png') bottom 5% right 10px no-repeat</code>
+        <div class="box" style="background: url('background-repeat.png') bottom 5% right 10px no-repeat"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-position: bottom 5% right 10px no;<br/>
+            background-repeat: no-repeat;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-position: bottom 5% right 10px; background-repeat: no-repeat"></div>
+    </div>
+
+    <h2>Clip and Origin</h2>
+
+    <h3>Images should fill the content-box, with padding on each side. (5px, 10px, 15px, 20px) and aligned so their top-left corner will be at the top-left of the box. This produces clipping.</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') padding-box content-box</code>
+        <div class="box" style="background: url('background-repeat.png') padding-box content-box"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-origin: padding-box;<br/>
+            background-clip: content-box;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-origin: padding-box; background-clip: content-box"></div>
+    </div>
+
+    <h2>Size</h2>
+    <h3>Image should be stretched as large as the box, without distorting or clipping</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') center / contain</code>
+        <div class="box" style="background: url('background-repeat.png') center / contain"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-position: center;<br/>
+            background-size: contain;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-position: center; background-size: contain"></div>
+    </div>
+
+    <h3>Image should be stretched so that the whole box is covered, without distorting</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') center / cover</code>
+        <div class="box" style="background: url('background-repeat.png') center / cover"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');
+            background-position: center;
+            background-size: cover;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-position: center; background-size: cover"></div>
+    </div>
+
+    <h3>Images should be squashed and repeated</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') top / 50% 25px</code>
+        <div class="box" style="background: url('background-repeat.png') top / 50% 25px"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');
+            background-position: top;
+            background-size: 50% 25px;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-position: top; background-size: 50% 25px"></div>
+    </div>
+
+    <h2>Repeat</h2>
+    <p>See <a href="background-repeat-test.html">here</a> for in-depth background-repeat tests.</p>
+    <h3>Images should all be whole, and be spaced apart to fill the box</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') space</code>
+        <div class="box" style="background: url('background-repeat.png') space"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');
+            background-repeat: space;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-repeat: space"></div>
+    </div>
+
+    <h3>Images should all be whole, and be distorted to fill the box</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') round</code>
+        <div class="box" style="background: url('background-repeat.png') round"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-repeat: round;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-repeat: round"></div>
+    </div>
+
+    <h2>Multiple backgrounds</h2>
+    <h3>Should have one smiley face in each corner and one in the center</h3>
+    <div class="example">
+        <code>
+            background: url('background-repeat.png') no-repeat top 5px left 5px,<br/>
+                url('background-repeat.png') no-repeat top 5px right 5px,<br/>
+                url('background-repeat.png') no-repeat bottom 5px left 5px,<br/>
+                url('background-repeat.png') no-repeat bottom 5px right 5px,<br/>
+                url('background-repeat.png') no-repeat center cyan;
+        </code>
+        <div class="box" style="background: url('background-repeat.png') no-repeat top 5px left 5px, url('background-repeat.png') no-repeat top 5px right 5px, url('background-repeat.png') no-repeat bottom 5px left 5px, url('background-repeat.png') no-repeat bottom 5px right 5px, url('background-repeat.png') no-repeat center cyan"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-color: cyan;<br/>
+            background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;<br/>
+            background-position: top 5px left 5px, top 5px right 5px, bottom 5px left 5px, bottom 5px right 5px, center;<br/>
+            background-image: url('background-repeat.png'), url('background-repeat.png'), url('background-repeat.png'), url('background-repeat.png'), url('background-repeat.png');
+        </code>
+        <div class="box" style="background-color: cyan;
+            background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;
+            background-position: top 5px left 5px, top 5px right 5px, bottom 5px left 5px, bottom 5px right 5px, center;
+            background-image: url('background-repeat.png'), url('background-repeat.png'), url('background-repeat.png'), url('background-repeat.png'), url('background-repeat.png');"></div>
+    </div>
+</body>
+
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -77,6 +77,8 @@
             <li><h3>CSSOM</h3></li>
             <li><a href="computed-style.html">Computed style</a></li>
             <li><a href="supports.html">CSS.supports() and @supports</a></li>
+            <li><a href="attributes.html">Attributes</a></li>
+            <li><a href="class-list.html">Class List</a></li>
             <li><h3>Selectors</h3></li>
             <li><a href="selectors.html">Selectors</a></li>
             <li><a href="attrselectors.html">Attribute selectors</a></li>
@@ -92,6 +94,8 @@
             <li><a href="not-selector.html">:not</a></li>
             <li><a href="hover.html">:hover</a></li>
             <li><h3>Properties</h3></li>
+            <li><a href="backgrounds.html">Backgrounds</a></li>
+            <li><a href="background-repeat-test.html">Background-repeat</a></li>
             <li><a href="box-shadow.html">Box-shadow</a></li>
             <li><a href="opacity.html">Opacity</a></li>
             <li><a href="text-decoration.html">Text-decoration</a></li>
@@ -110,8 +114,6 @@
             <li><a href="float-3.html">Floating boxes with overflow=hidden</a></li>
             <li><a href="clear-1.html">Float clearing</a></li>
             <li><a href="overflow.html">Overflow</a></li>
-            <li><a href="attributes.html">Attributes</a></li>
-            <li><a href="class-list.html">Class List</a></li>
             <li><h3>Features</h3></li>
             <li><a href="css.html">Basic functionality</a></li>
             <li><a href="colors.html">css colors</a></li>
@@ -122,7 +124,6 @@
             <li><a href="margin-collapse-1.html">margin collapsing 1</a></li>
             <li><a href="margin-collapse-2.html">margin collapsing 2</a></li>
             <li><a href="position-absolute-from-edges.html">position: absolute, offset from edges</a></li>
-            <li><a href="background-repeat-test.html">background image with repetition rules</a></li>
             <li><a href="link-over-zindex-block.html">link elements with background box placed with z-index</a></li>
             <li><a href="percent-css.html">Percentage values</a></li>
             <li><a href="position-absolute-top-left.html">position: absolute; for top and left</a></li>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
@@ -169,37 +169,6 @@ bool is_inherited_property(PropertyID property_id)
     }
 }
 
-bool is_pseudo_property(PropertyID property_id)
-{
-    switch (property_id) {
-)~~~");
-
-    properties.for_each_member([&](auto& name, auto& value) {
-        VERIFY(value.is_object());
-
-        bool pseudo = false;
-        if (value.as_object().has("pseudo")) {
-            auto& pseudo_value = value.as_object().get("pseudo");
-            VERIFY(pseudo_value.is_bool());
-            pseudo = pseudo_value.as_bool();
-        }
-
-        if (pseudo) {
-            auto member_generator = generator.fork();
-            member_generator.set("name:titlecase", title_casify(name));
-            member_generator.append(R"~~~(
-    case PropertyID::@name:titlecase@:
-        return true;
-)~~~");
-        }
-    });
-
-    generator.append(R"~~~(
-    default:
-        return false;
-    }
-}
-
 RefPtr<StyleValue> property_initial_value(PropertyID property_id)
 {
     static HashMap<PropertyID, NonnullRefPtr<StyleValue>> initial_values;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_h.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_h.cpp
@@ -104,7 +104,6 @@ PropertyID property_id_from_camel_case_string(StringView);
 PropertyID property_id_from_string(const StringView&);
 const char* string_from_property_id(PropertyID);
 bool is_inherited_property(PropertyID);
-bool is_pseudo_property(PropertyID);
 RefPtr<StyleValue> property_initial_value(PropertyID);
 
 bool property_accepts_value(PropertyID, StyleValue&);

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -65,6 +65,11 @@ struct BoxShadowData {
     Color color {};
 };
 
+struct BackgroundRepeatData {
+    CSS::Repeat repeat_x;
+    CSS::Repeat repeat_y;
+};
+
 class ComputedValues {
 public:
     CSS::Float float_() const { return m_noninherited.float_; }
@@ -114,8 +119,7 @@ public:
 
     Color color() const { return m_inherited.color; }
     Color background_color() const { return m_noninherited.background_color; }
-    CSS::Repeat background_repeat_x() const { return m_noninherited.background_repeat_x; }
-    CSS::Repeat background_repeat_y() const { return m_noninherited.background_repeat_y; }
+    BackgroundRepeatData background_repeat() const { return m_noninherited.background_repeat; }
 
     CSS::ListStyleType list_style_type() const { return m_inherited.list_style_type; }
 
@@ -172,8 +176,7 @@ protected:
         Length border_top_left_radius;
         Length border_top_right_radius;
         Color background_color { InitialValues::background_color() };
-        CSS::Repeat background_repeat_x { InitialValues::background_repeat() };
-        CSS::Repeat background_repeat_y { InitialValues::background_repeat() };
+        BackgroundRepeatData background_repeat { InitialValues::background_repeat(), InitialValues::background_repeat() };
         CSS::FlexDirection flex_direction { InitialValues::flex_direction() };
         CSS::FlexWrap flex_wrap { InitialValues::flex_wrap() };
         CSS::FlexBasisData flex_basis {};
@@ -199,8 +202,7 @@ public:
     void set_cursor(CSS::Cursor cursor) { m_inherited.cursor = cursor; }
     void set_pointer_events(CSS::PointerEvents value) { m_inherited.pointer_events = value; }
     void set_background_color(const Color& color) { m_noninherited.background_color = color; }
-    void set_background_repeat_x(CSS::Repeat repeat) { m_noninherited.background_repeat_x = repeat; }
-    void set_background_repeat_y(CSS::Repeat repeat) { m_noninherited.background_repeat_y = repeat; }
+    void set_background_repeat(BackgroundRepeatData repeat) { m_noninherited.background_repeat = repeat; }
     void set_float(CSS::Float value) { m_noninherited.float_ = value; }
     void set_clear(CSS::Clear value) { m_noninherited.clear = value; }
     void set_z_index(Optional<int> value) { m_noninherited.z_index = value; }

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -86,6 +86,7 @@
   "contents",
   "context-menu",
   "copy",
+  "cover",
   "crosshair",
   "currentcolor",
   "cursive",

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -163,6 +163,7 @@
   "outside",
   "overline",
   "p3",
+  "padding-box",
   "paged",
   "pointer",
   "portrait",

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2398,7 +2398,7 @@ RefPtr<StyleValue> Parser::parse_background_value(ParsingContext const& context,
     RefPtr<StyleValue> repeat_y;
     RefPtr<StyleValue> background_position;
     // FIXME: Implement background-size.
-    // FIXME: Implement background-attachment.
+    RefPtr<StyleValue> background_attachment;
     // FIXME: Implement background-clip.
     // FIXME: Implement background-origin.
 
@@ -2416,6 +2416,12 @@ RefPtr<StyleValue> Parser::parse_background_value(ParsingContext const& context,
         if (!value)
             return nullptr;
 
+        if (property_accepts_value(PropertyID::BackgroundAttachment, *value)) {
+            if (background_attachment)
+                return nullptr;
+            background_attachment = value.release_nonnull();
+            continue;
+        }
         if (property_accepts_value(PropertyID::BackgroundColor, *value)) {
             if (background_color)
                 return nullptr;
@@ -2479,8 +2485,10 @@ RefPtr<StyleValue> Parser::parse_background_value(ParsingContext const& context,
         repeat_x = property_initial_value(PropertyID::BackgroundRepeatX);
     if (!repeat_y)
         repeat_y = property_initial_value(PropertyID::BackgroundRepeatY);
+    if (!background_attachment)
+        background_attachment = property_initial_value(PropertyID::BackgroundAttachment);
 
-    return BackgroundStyleValue::create(background_color.release_nonnull(), background_image.release_nonnull(), background_position.release_nonnull(), repeat_x.release_nonnull(), repeat_y.release_nonnull());
+    return BackgroundStyleValue::create(background_color.release_nonnull(), background_image.release_nonnull(), background_position.release_nonnull(), repeat_x.release_nonnull(), repeat_y.release_nonnull(), background_attachment.release_nonnull());
 }
 
 RefPtr<StyleValue> Parser::parse_background_image_value(ParsingContext const& context, Vector<StyleComponentValueRule> const& component_values)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -216,6 +216,7 @@ private:
     static RefPtr<StyleValue> parse_background_image_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_single_background_position_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
     static RefPtr<StyleValue> parse_background_position_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    static RefPtr<StyleValue> parse_single_background_repeat_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
     static RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -218,6 +218,8 @@ private:
     static RefPtr<StyleValue> parse_background_position_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_single_background_repeat_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
     static RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    static RefPtr<StyleValue> parse_single_background_size_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    static RefPtr<StyleValue> parse_background_size_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_radius_shorthand_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -214,6 +214,8 @@ private:
     static RefPtr<StyleValue> parse_image_value(ParsingContext const&, StyleComponentValueRule const&);
     static RefPtr<StyleValue> parse_background_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_background_image_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    static RefPtr<StyleValue> parse_single_background_position_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    static RefPtr<StyleValue> parse_background_position_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
     static RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -90,6 +90,20 @@
       "space"
     ]
   },
+  "background-size": {
+    "inherited": false,
+    "initial": "auto",
+    "max-values": 2,
+    "valid-types": [
+      "length",
+      "percentage"
+    ],
+    "valid-identifiers": [
+      "auto",
+      "cover",
+      "contain"
+    ]
+  },
   "border": {
     "longhands": [
       "border-width",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -78,6 +78,7 @@
     ]
   },
   "background-repeat": {
+    "inherited": false,
     "initial": "repeat",
     "max-values": 2,
     "valid-identifiers": [
@@ -87,21 +88,7 @@
       "repeat-y",
       "round",
       "space"
-    ],
-    "longhands": [
-      "background-repeat-x",
-      "background-repeat-y"
     ]
-  },
-  "background-repeat-x": {
-    "inherited": false,
-    "initial": "repeat",
-    "pseudo": true
-  },
-  "background-repeat-y": {
-    "inherited": false,
-    "initial": "repeat",
-    "pseudo": true
   },
   "border": {
     "longhands": [

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -20,6 +20,15 @@
       "scroll"
     ]
   },
+  "background-clip": {
+    "inherited": false,
+    "initial": "border-box",
+    "valid-identifiers": [
+      "border-box",
+      "content-box",
+      "padding-box"
+    ]
+  },
   "background-color": {
     "inherited": false,
     "initial": "transparent",
@@ -38,6 +47,15 @@
     ],
     "valid-identifiers": [
       "none"
+    ]
+  },
+  "background-origin": {
+    "inherited": false,
+    "initial": "padding-box",
+    "valid-identifiers": [
+      "border-box",
+      "content-box",
+      "padding-box"
     ]
   },
   "background-position": {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -676,6 +676,8 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_background_repeat_x = property(CSS::PropertyID::BackgroundRepeatX);
         auto maybe_background_repeat_y = property(CSS::PropertyID::BackgroundRepeatY);
         auto maybe_background_attachment = property(CSS::PropertyID::BackgroundAttachment);
+        auto maybe_background_origin = property(CSS::PropertyID::BackgroundOrigin);
+        auto maybe_background_clip = property(CSS::PropertyID::BackgroundClip);
 
         return BackgroundStyleValue::create(
             value_or_default(maybe_background_color, InitialStyleValue::the()),
@@ -683,7 +685,9 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
             value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
             value_or_default(maybe_background_repeat_x, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
             value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
-            value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)));
+            value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),
+            value_or_default(maybe_background_origin, IdentifierStyleValue::create(CSS::ValueID::PaddingBox)),
+            value_or_default(maybe_background_clip, IdentifierStyleValue::create(CSS::ValueID::BorderBox)));
     }
     case CSS::PropertyID::ListStyleType:
         return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().list_style_type()));

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -653,6 +653,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
         auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);
         auto maybe_background_position = property(CSS::PropertyID::BackgroundPosition);
+        auto maybe_background_size = property(CSS::PropertyID::BackgroundSize);
         auto maybe_background_repeat = property(CSS::PropertyID::BackgroundRepeat);
         auto maybe_background_attachment = property(CSS::PropertyID::BackgroundAttachment);
         auto maybe_background_origin = property(CSS::PropertyID::BackgroundOrigin);
@@ -662,6 +663,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
             value_or_default(maybe_background_color, InitialStyleValue::the()),
             value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
             value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
+            value_or_default(maybe_background_size, IdentifierStyleValue::create(CSS::ValueID::Auto)),
             value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(CSS::Repeat::Repeat, CSS::Repeat::Repeat)),
             value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),
             value_or_default(maybe_background_origin, IdentifierStyleValue::create(CSS::ValueID::PaddingBox)),

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -374,21 +374,6 @@ static CSS::ValueID to_css_value_id(CSS::Overflow value)
     VERIFY_NOT_REACHED();
 }
 
-static CSS::ValueID to_css_value_id(CSS::Repeat value)
-{
-    switch (value) {
-    case Repeat::NoRepeat:
-        return CSS::ValueID::NoRepeat;
-    case Repeat::Repeat:
-        return CSS::ValueID::Repeat;
-    case Repeat::Round:
-        return CSS::ValueID::Round;
-    case Repeat::Space:
-        return CSS::ValueID::Space;
-    }
-    VERIFY_NOT_REACHED();
-}
-
 static CSS::ValueID to_css_value_id(CSS::ListStyleType value)
 {
     switch (value) {
@@ -662,8 +647,8 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return ColorStyleValue::create(layout_node.computed_values().background_color());
     case CSS::PropertyID::BackgroundRepeat:
         return BackgroundRepeatStyleValue::create(
-            IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().background_repeat().repeat_x)),
-            IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().background_repeat().repeat_y)));
+            layout_node.computed_values().background_repeat().repeat_x,
+            layout_node.computed_values().background_repeat().repeat_y);
     case CSS::PropertyID::Background: {
         auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
         auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);
@@ -677,7 +662,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
             value_or_default(maybe_background_color, InitialStyleValue::the()),
             value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
             value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
-            value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(IdentifierStyleValue::create(CSS::ValueID::Repeat), IdentifierStyleValue::create(CSS::ValueID::Repeat))),
+            value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(CSS::Repeat::Repeat, CSS::Repeat::Repeat)),
             value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),
             value_or_default(maybe_background_origin, IdentifierStyleValue::create(CSS::ValueID::PaddingBox)),
             value_or_default(maybe_background_clip, IdentifierStyleValue::create(CSS::ValueID::BorderBox)));

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -673,8 +673,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
         auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);
         auto maybe_background_position = property(CSS::PropertyID::BackgroundPosition);
-        auto maybe_background_repeat_x = property(CSS::PropertyID::BackgroundRepeatX);
-        auto maybe_background_repeat_y = property(CSS::PropertyID::BackgroundRepeatY);
+        auto maybe_background_repeat = property(CSS::PropertyID::BackgroundRepeat);
         auto maybe_background_attachment = property(CSS::PropertyID::BackgroundAttachment);
         auto maybe_background_origin = property(CSS::PropertyID::BackgroundOrigin);
         auto maybe_background_clip = property(CSS::PropertyID::BackgroundClip);
@@ -683,8 +682,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
             value_or_default(maybe_background_color, InitialStyleValue::the()),
             value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
             value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
-            value_or_default(maybe_background_repeat_x, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
-            value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
+            value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(IdentifierStyleValue::create(CSS::ValueID::Repeat), IdentifierStyleValue::create(CSS::ValueID::Repeat))),
             value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)),
             value_or_default(maybe_background_origin, IdentifierStyleValue::create(CSS::ValueID::PaddingBox)),
             value_or_default(maybe_background_clip, IdentifierStyleValue::create(CSS::ValueID::BorderBox)));

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -660,15 +660,10 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return ColorStyleValue::create(layout_node.computed_values().color());
     case PropertyID::BackgroundColor:
         return ColorStyleValue::create(layout_node.computed_values().background_color());
-    case CSS::PropertyID::BackgroundRepeatX:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().background_repeat_x()));
-    case CSS::PropertyID::BackgroundRepeatY:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().background_repeat_y()));
-    case CSS::PropertyID::BackgroundRepeat: {
-        auto maybe_background_repeat_x = property(CSS::PropertyID::BackgroundRepeatX);
-        auto maybe_background_repeat_y = property(CSS::PropertyID::BackgroundRepeatY);
-        return BackgroundRepeatStyleValue::create(value_or_default(maybe_background_repeat_x, IdentifierStyleValue::create(CSS::ValueID::RepeatX)), value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatY)));
-    }
+    case CSS::PropertyID::BackgroundRepeat:
+        return BackgroundRepeatStyleValue::create(
+            IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().background_repeat().repeat_x)),
+            IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().background_repeat().repeat_y)));
     case CSS::PropertyID::Background: {
         auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
         auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -672,10 +672,16 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::Background: {
         auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
         auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);
+        auto maybe_background_position = property(CSS::PropertyID::BackgroundPosition);
         auto maybe_background_repeat_x = property(CSS::PropertyID::BackgroundRepeatX);
         auto maybe_background_repeat_y = property(CSS::PropertyID::BackgroundRepeatY);
 
-        return BackgroundStyleValue::create(value_or_default(maybe_background_color, InitialStyleValue::the()), value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)), value_or_default(maybe_background_repeat_x, IdentifierStyleValue::create(CSS::ValueID::RepeatX)), value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatX)));
+        return BackgroundStyleValue::create(
+            value_or_default(maybe_background_color, InitialStyleValue::the()),
+            value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
+            value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
+            value_or_default(maybe_background_repeat_x, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
+            value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatX)));
     }
     case CSS::PropertyID::ListStyleType:
         return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().list_style_type()));

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -675,13 +675,15 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         auto maybe_background_position = property(CSS::PropertyID::BackgroundPosition);
         auto maybe_background_repeat_x = property(CSS::PropertyID::BackgroundRepeatX);
         auto maybe_background_repeat_y = property(CSS::PropertyID::BackgroundRepeatY);
+        auto maybe_background_attachment = property(CSS::PropertyID::BackgroundAttachment);
 
         return BackgroundStyleValue::create(
             value_or_default(maybe_background_color, InitialStyleValue::the()),
             value_or_default(maybe_background_image, IdentifierStyleValue::create(CSS::ValueID::None)),
             value_or_default(maybe_background_position, PositionStyleValue::create(PositionEdge::Left, Length::make_px(0), PositionEdge::Top, Length::make_px(0))),
             value_or_default(maybe_background_repeat_x, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
-            value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatX)));
+            value_or_default(maybe_background_repeat_y, IdentifierStyleValue::create(CSS::ValueID::RepeatX)),
+            value_or_default(maybe_background_attachment, IdentifierStyleValue::create(CSS::ValueID::Scroll)));
     }
     case CSS::PropertyID::ListStyleType:
         return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().list_style_type()));

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -305,6 +305,8 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, background.repeat_x(), document, true);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, background.repeat_y(), document, true);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, background.attachment(), document);
+            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, background.origin(), document);
+            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, background.clip(), document);
         };
 
         if (value.is_background()) {
@@ -329,6 +331,8 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, value, document, true);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, value, document, true);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, value, document);
+        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, value, document);
+        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, value, document);
         return;
     }
 
@@ -347,6 +351,21 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::BackgroundClip) {
+        if (value.is_value_list()) {
+            auto& background_clip_list = value.as_value_list().values();
+            // FIXME: Handle multiple backgrounds.
+            if (!background_clip_list.is_empty()) {
+                auto& background_clip = background_clip_list.first();
+                style.set_property(CSS::PropertyID::BackgroundClip, background_clip);
+            }
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::BackgroundClip, value);
+        return;
+    }
+
     if (property_id == CSS::PropertyID::BackgroundImage) {
         if (value.is_value_list()) {
             auto& background_image_list = value.as_value_list().values();
@@ -359,6 +378,21 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         }
 
         style.set_property(CSS::PropertyID::BackgroundImage, value);
+        return;
+    }
+
+    if (property_id == CSS::PropertyID::BackgroundOrigin) {
+        if (value.is_value_list()) {
+            auto& background_origin_list = value.as_value_list().values();
+            // FIXME: Handle multiple backgrounds.
+            if (!background_origin_list.is_empty()) {
+                auto& background_origin = background_origin_list.first();
+                style.set_property(CSS::PropertyID::BackgroundOrigin, background_origin);
+            }
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::BackgroundOrigin, value);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -418,6 +418,21 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::BackgroundSize) {
+        if (value.is_value_list()) {
+            auto& background_size_list = value.as_value_list().values();
+            // FIXME: Handle multiple backgrounds.
+            if (!background_size_list.is_empty()) {
+                auto& background_size = background_size_list.first();
+                style.set_property(CSS::PropertyID::BackgroundSize, background_size);
+            }
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::BackgroundSize, value);
+        return;
+    }
+
     if (property_id == CSS::PropertyID::Margin) {
         if (value.is_value_list()) {
             auto& values_list = value.as_value_list();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -343,6 +343,21 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         return;
     }
 
+    if (property_id == CSS::PropertyID::BackgroundPosition) {
+        if (value.is_value_list()) {
+            auto& background_position_list = value.as_value_list().values();
+            // FIXME: Handle multiple backgrounds.
+            if (!background_position_list.is_empty()) {
+                auto& background_position = background_position_list.first();
+                style.set_property(CSS::PropertyID::BackgroundPosition, background_position);
+            }
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::BackgroundPosition, value);
+        return;
+    }
+
     if (property_id == CSS::PropertyID::BackgroundRepeat) {
         if (value.is_value_list()) {
             auto& background_repeat_list = value.as_value_list().values();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -304,6 +304,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, background.position(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, background.repeat_x(), document, true);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, background.repeat_y(), document, true);
+            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, background.attachment(), document);
         };
 
         if (value.is_background()) {
@@ -327,6 +328,22 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, value, document, true);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, value, document, true);
+        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, value, document);
+        return;
+    }
+
+    if (property_id == CSS::PropertyID::BackgroundAttachment) {
+        if (value.is_value_list()) {
+            auto& background_attachment_list = value.as_value_list().values();
+            // FIXME: Handle multiple backgrounds.
+            if (!background_attachment_list.is_empty()) {
+                auto& background_attachment = background_attachment_list.first();
+                style.set_property(CSS::PropertyID::BackgroundAttachment, background_attachment);
+            }
+            return;
+        }
+
+        style.set_property(CSS::PropertyID::BackgroundAttachment, value);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -123,13 +123,8 @@ static bool contains(Edge a, Edge b)
     return a == b || b == Edge::All;
 }
 
-static void set_property_expanding_shorthands(StyleProperties& style, CSS::PropertyID property_id, StyleValue const& value, DOM::Document& document, bool is_internally_generated_pseudo_property = false)
+static void set_property_expanding_shorthands(StyleProperties& style, CSS::PropertyID property_id, StyleValue const& value, DOM::Document& document)
 {
-    if (is_pseudo_property(property_id) && !is_internally_generated_pseudo_property) {
-        dbgln("Ignoring non-internally-generated pseudo property: {}", string_from_property_id(property_id));
-        return;
-    }
-
     auto assign_edge_values = [&style](PropertyID top_property, PropertyID right_property, PropertyID bottom_property, PropertyID left_property, auto const& values) {
         if (values.size() == 4) {
             style.set_property(top_property, values[0]);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -414,33 +414,12 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             auto& background_repeat_list = value.as_value_list().values();
             // FIXME: Handle multiple backgrounds.
             if (!background_repeat_list.is_empty()) {
-                auto& maybe_background_repeat = background_repeat_list.first();
-                if (maybe_background_repeat.is_background_repeat()) {
-                    auto& background_repeat = maybe_background_repeat.as_background_repeat();
-                    set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatX, background_repeat.repeat_x(), document, true);
-                    set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatY, background_repeat.repeat_y(), document, true);
-                }
+                auto& background_repeat = background_repeat_list.first();
+                style.set_property(CSS::PropertyID::BackgroundRepeat, background_repeat);
             }
             return;
         }
-        if (value.is_background_repeat()) {
-            auto& background_repeat = value.as_background_repeat();
-            set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatX, background_repeat.repeat_x(), document, true);
-            set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatY, background_repeat.repeat_y(), document, true);
-            return;
-        }
-
-        set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatX, value, document, true);
-        set_property_expanding_shorthands(style, PropertyID::BackgroundRepeatY, value, document, true);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundRepeatX || property_id == CSS::PropertyID::BackgroundRepeatY) {
-        auto value_id = value.to_identifier();
-        if (value_id == CSS::ValueID::RepeatX || value_id == CSS::ValueID::RepeatY)
-            return;
-
-        style.set_property(property_id, value);
+        style.set_property(CSS::PropertyID::BackgroundRepeat, value);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -302,8 +302,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, background.color(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, background.image(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, background.position(), document);
-            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, background.repeat_x(), document, true);
-            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, background.repeat_y(), document, true);
+            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeat, background.repeat(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, background.attachment(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, background.origin(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, background.clip(), document);
@@ -328,8 +327,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, value, document);
-        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, value, document, true);
-        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, value, document, true);
+        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeat, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, value, document);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -297,6 +297,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, background.color(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, background.image(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, background.position(), document);
+            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundSize, background.size(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeat, background.repeat(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, background.attachment(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, background.origin(), document);
@@ -322,6 +323,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, value, document);
+        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundSize, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeat, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, value, document);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -301,6 +301,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         auto set_single_background = [&](CSS::BackgroundStyleValue const& background) {
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, background.color(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, background.image(), document);
+            set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, background.position(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, background.repeat_x(), document, true);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, background.repeat_y(), document, true);
         };
@@ -323,6 +324,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
 
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, value, document);
+        set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatX, value, document, true);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundRepeatY, value, document, true);
         return;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -688,42 +688,33 @@ Optional<CSS::Overflow> StyleProperties::overflow(CSS::PropertyID property_id) c
     }
 }
 
-Optional<CSS::Repeat> StyleProperties::background_repeat_x() const
+Optional<BackgroundRepeatData> StyleProperties::background_repeat() const
 {
-    auto value = property(CSS::PropertyID::BackgroundRepeatX);
-    if (!value.has_value())
+    auto value = property(CSS::PropertyID::BackgroundRepeat);
+    if (!value.has_value() || !value.value()->is_background_repeat())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::NoRepeat:
-        return CSS::Repeat::NoRepeat;
-    case CSS::ValueID::Repeat:
-        return CSS::Repeat::Repeat;
-    case CSS::ValueID::Round:
-        return CSS::Repeat::Round;
-    case CSS::ValueID::Space:
-        return CSS::Repeat::Space;
-    default:
-        return {};
-    }
-}
+    auto& background_repeat = value.value()->as_background_repeat();
 
-Optional<CSS::Repeat> StyleProperties::background_repeat_y() const
-{
-    auto value = property(CSS::PropertyID::BackgroundRepeatY);
-    if (!value.has_value())
-        return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::NoRepeat:
-        return CSS::Repeat::NoRepeat;
-    case CSS::ValueID::Repeat:
-        return CSS::Repeat::Repeat;
-    case CSS::ValueID::Round:
-        return CSS::Repeat::Round;
-    case CSS::ValueID::Space:
-        return CSS::Repeat::Space;
-    default:
-        return {};
-    }
+    auto to_repeat = [](auto value) -> Optional<CSS::Repeat> {
+        switch (value->to_identifier()) {
+        case CSS::ValueID::NoRepeat:
+            return CSS::Repeat::NoRepeat;
+        case CSS::ValueID::Repeat:
+            return CSS::Repeat::Repeat;
+        case CSS::ValueID::Round:
+            return CSS::Repeat::Round;
+        case CSS::ValueID::Space:
+            return CSS::Repeat::Space;
+        default:
+            return {};
+        }
+    };
+    auto repeat_x = to_repeat(background_repeat.repeat_x());
+    auto repeat_y = to_repeat(background_repeat.repeat_y());
+    if (repeat_x.has_value() && repeat_y.has_value())
+        return BackgroundRepeatData { repeat_x.value(), repeat_y.value() };
+
+    return {};
 }
 
 Optional<CSS::BoxShadowData> StyleProperties::box_shadow() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -693,28 +693,9 @@ Optional<BackgroundRepeatData> StyleProperties::background_repeat() const
     auto value = property(CSS::PropertyID::BackgroundRepeat);
     if (!value.has_value() || !value.value()->is_background_repeat())
         return {};
+
     auto& background_repeat = value.value()->as_background_repeat();
-
-    auto to_repeat = [](auto value) -> Optional<CSS::Repeat> {
-        switch (value->to_identifier()) {
-        case CSS::ValueID::NoRepeat:
-            return CSS::Repeat::NoRepeat;
-        case CSS::ValueID::Repeat:
-            return CSS::Repeat::Repeat;
-        case CSS::ValueID::Round:
-            return CSS::Repeat::Round;
-        case CSS::ValueID::Space:
-            return CSS::Repeat::Space;
-        default:
-            return {};
-        }
-    };
-    auto repeat_x = to_repeat(background_repeat.repeat_x());
-    auto repeat_y = to_repeat(background_repeat.repeat_y());
-    if (repeat_x.has_value() && repeat_y.has_value())
-        return BackgroundRepeatData { repeat_x.value(), repeat_y.value() };
-
-    return {};
+    return BackgroundRepeatData { background_repeat.repeat_x(), background_repeat.repeat_y() };
 }
 
 Optional<CSS::BoxShadowData> StyleProperties::box_shadow() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -62,8 +62,7 @@ public:
     Optional<CSS::JustifyContent> justify_content() const;
     Optional<CSS::Overflow> overflow_x() const;
     Optional<CSS::Overflow> overflow_y() const;
-    Optional<CSS::Repeat> background_repeat_x() const;
-    Optional<CSS::Repeat> background_repeat_y() const;
+    Optional<BackgroundRepeatData> background_repeat() const;
     Optional<CSS::BoxShadowData> box_shadow() const;
     CSS::BoxSizing box_sizing() const;
     Optional<CSS::PointerEvents> pointer_events() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -139,6 +139,12 @@ OverflowStyleValue const& StyleValue::as_overflow() const
     return static_cast<OverflowStyleValue const&>(*this);
 }
 
+PositionStyleValue const& StyleValue::as_position() const
+{
+    VERIFY(is_position());
+    return static_cast<PositionStyleValue const&>(*this);
+}
+
 StringStyleValue const& StyleValue::as_string() const
 {
     VERIFY(is_string());
@@ -399,6 +405,25 @@ String ColorStyleValue::to_string() const
     if (m_color.alpha() == 1)
         return String::formatted("rgb({}, {}, {})", m_color.red(), m_color.green(), m_color.blue());
     return String::formatted("rgba({}, {}, {}, {})", m_color.red(), m_color.green(), m_color.blue(), (float)(m_color.alpha()) / 255.0f);
+}
+
+String PositionStyleValue::to_string() const
+{
+    auto to_string = [](PositionEdge edge) {
+        switch (edge) {
+        case PositionEdge::Left:
+            return "left";
+        case PositionEdge::Right:
+            return "right";
+        case PositionEdge::Top:
+            return "top";
+        case PositionEdge::Bottom:
+            return "bottom";
+        }
+        VERIFY_NOT_REACHED();
+    };
+
+    return String::formatted("{} {} {} {}", to_string(m_edge_x), m_offset_x.to_string(), to_string(m_edge_y), m_offset_y.to_string());
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -37,6 +37,12 @@ BackgroundRepeatStyleValue const& StyleValue::as_background_repeat() const
     return static_cast<BackgroundRepeatStyleValue const&>(*this);
 }
 
+BackgroundSizeStyleValue const& StyleValue::as_background_size() const
+{
+    VERIFY(is_background_size());
+    return static_cast<BackgroundSizeStyleValue const&>(*this);
+}
+
 BorderStyleValue const& StyleValue::as_border() const
 {
     VERIFY(is_border());

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -398,12 +398,13 @@ public:
         NonnullRefPtr<StyleValue> color,
         NonnullRefPtr<StyleValue> image,
         NonnullRefPtr<StyleValue> position,
+        NonnullRefPtr<StyleValue> size,
         NonnullRefPtr<StyleValue> repeat,
         NonnullRefPtr<StyleValue> attachment,
         NonnullRefPtr<StyleValue> origin,
         NonnullRefPtr<StyleValue> clip)
     {
-        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat, attachment, origin, clip));
+        return adopt_ref(*new BackgroundStyleValue(color, image, position, size, repeat, attachment, origin, clip));
     }
     virtual ~BackgroundStyleValue() override { }
 
@@ -414,10 +415,11 @@ public:
     NonnullRefPtr<StyleValue> origin() const { return m_origin; }
     NonnullRefPtr<StyleValue> position() const { return m_position; }
     NonnullRefPtr<StyleValue> repeat() const { return m_repeat; }
+    NonnullRefPtr<StyleValue> size() const { return m_size; }
 
     virtual String to_string() const override
     {
-        return String::formatted("{} {} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat->to_string(), m_attachment->to_string(), m_origin->to_string(), m_clip->to_string());
+        return String::formatted("{} {} {} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_size->to_string(), m_repeat->to_string(), m_attachment->to_string(), m_origin->to_string(), m_clip->to_string());
     }
 
 private:
@@ -425,6 +427,7 @@ private:
         NonnullRefPtr<StyleValue> color,
         NonnullRefPtr<StyleValue> image,
         NonnullRefPtr<StyleValue> position,
+        NonnullRefPtr<StyleValue> size,
         NonnullRefPtr<StyleValue> repeat,
         NonnullRefPtr<StyleValue> attachment,
         NonnullRefPtr<StyleValue> origin,
@@ -433,6 +436,7 @@ private:
         , m_color(color)
         , m_image(image)
         , m_position(position)
+        , m_size(size)
         , m_repeat(repeat)
         , m_attachment(attachment)
         , m_origin(origin)
@@ -442,7 +446,7 @@ private:
     NonnullRefPtr<StyleValue> m_color;
     NonnullRefPtr<StyleValue> m_image;
     NonnullRefPtr<StyleValue> m_position;
-    // FIXME: background-size
+    NonnullRefPtr<StyleValue> m_size;
     NonnullRefPtr<StyleValue> m_repeat;
     NonnullRefPtr<StyleValue> m_attachment;
     NonnullRefPtr<StyleValue> m_origin;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -377,39 +377,43 @@ public:
     static NonnullRefPtr<BackgroundStyleValue> create(
         NonnullRefPtr<StyleValue> color,
         NonnullRefPtr<StyleValue> image,
+        NonnullRefPtr<StyleValue> position,
         NonnullRefPtr<StyleValue> repeat_x,
         NonnullRefPtr<StyleValue> repeat_y)
     {
-        return adopt_ref(*new BackgroundStyleValue(color, image, repeat_x, repeat_y));
+        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat_x, repeat_y));
     }
     virtual ~BackgroundStyleValue() override { }
 
     NonnullRefPtr<StyleValue> color() const { return m_color; }
     NonnullRefPtr<StyleValue> image() const { return m_image; }
+    NonnullRefPtr<StyleValue> position() const { return m_position; }
     NonnullRefPtr<StyleValue> repeat_x() const { return m_repeat_x; }
     NonnullRefPtr<StyleValue> repeat_y() const { return m_repeat_y; }
 
     virtual String to_string() const override
     {
-        return String::formatted("{} {} {} {}", m_color->to_string(), m_image->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string());
+        return String::formatted("{} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string());
     }
 
 private:
     BackgroundStyleValue(
         NonnullRefPtr<StyleValue> color,
         NonnullRefPtr<StyleValue> image,
+        NonnullRefPtr<StyleValue> position,
         NonnullRefPtr<StyleValue> repeat_x,
         NonnullRefPtr<StyleValue> repeat_y)
         : StyleValue(Type::Background)
         , m_color(color)
         , m_image(image)
+        , m_position(position)
         , m_repeat_x(repeat_x)
         , m_repeat_y(repeat_y)
     {
     }
     NonnullRefPtr<StyleValue> m_color;
     NonnullRefPtr<StyleValue> m_image;
-    // FIXME: background-position
+    NonnullRefPtr<StyleValue> m_position;
     // FIXME: background-size
     NonnullRefPtr<StyleValue> m_repeat_x;
     NonnullRefPtr<StyleValue> m_repeat_y;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -181,6 +181,22 @@ enum class Repeat : u8 {
     Space,
 };
 
+constexpr StringView to_string(Repeat value)
+{
+    switch (value) {
+    case Repeat::NoRepeat:
+        return "no-repeat"sv;
+    case Repeat::Repeat:
+        return "repeat"sv;
+    case Repeat::Round:
+        return "round"sv;
+    case Repeat::Space:
+        return "space"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 enum class TextAlign {
     Left,
     Center,
@@ -462,30 +478,30 @@ private:
 
 class BackgroundRepeatStyleValue final : public StyleValue {
 public:
-    static NonnullRefPtr<BackgroundRepeatStyleValue> create(NonnullRefPtr<StyleValue> repeat_x, NonnullRefPtr<StyleValue> repeat_y)
+    static NonnullRefPtr<BackgroundRepeatStyleValue> create(Repeat repeat_x, Repeat repeat_y)
     {
         return adopt_ref(*new BackgroundRepeatStyleValue(repeat_x, repeat_y));
     }
     virtual ~BackgroundRepeatStyleValue() override { }
 
-    NonnullRefPtr<StyleValue> repeat_x() const { return m_repeat_x; }
-    NonnullRefPtr<StyleValue> repeat_y() const { return m_repeat_y; }
+    Repeat repeat_x() const { return m_repeat_x; }
+    Repeat repeat_y() const { return m_repeat_y; }
 
     virtual String to_string() const override
     {
-        return String::formatted("{} {}", m_repeat_x->to_string(), m_repeat_y->to_string());
+        return String::formatted("{} {}", CSS::to_string(m_repeat_x), CSS::to_string(m_repeat_y));
     }
 
 private:
-    BackgroundRepeatStyleValue(NonnullRefPtr<StyleValue> repeat_x, NonnullRefPtr<StyleValue> repeat_y)
+    BackgroundRepeatStyleValue(Repeat repeat_x, Repeat repeat_y)
         : StyleValue(Type::BackgroundRepeat)
         , m_repeat_x(repeat_x)
         , m_repeat_y(repeat_y)
     {
     }
 
-    NonnullRefPtr<StyleValue> m_repeat_x;
-    NonnullRefPtr<StyleValue> m_repeat_y;
+    Repeat m_repeat_x;
+    Repeat m_repeat_y;
 };
 
 class BorderStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -378,13 +378,12 @@ public:
         NonnullRefPtr<StyleValue> color,
         NonnullRefPtr<StyleValue> image,
         NonnullRefPtr<StyleValue> position,
-        NonnullRefPtr<StyleValue> repeat_x,
-        NonnullRefPtr<StyleValue> repeat_y,
+        NonnullRefPtr<StyleValue> repeat,
         NonnullRefPtr<StyleValue> attachment,
         NonnullRefPtr<StyleValue> origin,
         NonnullRefPtr<StyleValue> clip)
     {
-        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat_x, repeat_y, attachment, origin, clip));
+        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat, attachment, origin, clip));
     }
     virtual ~BackgroundStyleValue() override { }
 
@@ -394,12 +393,11 @@ public:
     NonnullRefPtr<StyleValue> image() const { return m_image; }
     NonnullRefPtr<StyleValue> origin() const { return m_origin; }
     NonnullRefPtr<StyleValue> position() const { return m_position; }
-    NonnullRefPtr<StyleValue> repeat_x() const { return m_repeat_x; }
-    NonnullRefPtr<StyleValue> repeat_y() const { return m_repeat_y; }
+    NonnullRefPtr<StyleValue> repeat() const { return m_repeat; }
 
     virtual String to_string() const override
     {
-        return String::formatted("{} {} {} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string(), m_attachment->to_string(), m_origin->to_string(), m_clip->to_string());
+        return String::formatted("{} {} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat->to_string(), m_attachment->to_string(), m_origin->to_string(), m_clip->to_string());
     }
 
 private:
@@ -407,8 +405,7 @@ private:
         NonnullRefPtr<StyleValue> color,
         NonnullRefPtr<StyleValue> image,
         NonnullRefPtr<StyleValue> position,
-        NonnullRefPtr<StyleValue> repeat_x,
-        NonnullRefPtr<StyleValue> repeat_y,
+        NonnullRefPtr<StyleValue> repeat,
         NonnullRefPtr<StyleValue> attachment,
         NonnullRefPtr<StyleValue> origin,
         NonnullRefPtr<StyleValue> clip)
@@ -416,8 +413,7 @@ private:
         , m_color(color)
         , m_image(image)
         , m_position(position)
-        , m_repeat_x(repeat_x)
-        , m_repeat_y(repeat_y)
+        , m_repeat(repeat)
         , m_attachment(attachment)
         , m_origin(origin)
         , m_clip(clip)
@@ -427,8 +423,7 @@ private:
     NonnullRefPtr<StyleValue> m_image;
     NonnullRefPtr<StyleValue> m_position;
     // FIXME: background-size
-    NonnullRefPtr<StyleValue> m_repeat_x;
-    NonnullRefPtr<StyleValue> m_repeat_y;
+    NonnullRefPtr<StyleValue> m_repeat;
     NonnullRefPtr<StyleValue> m_attachment;
     NonnullRefPtr<StyleValue> m_origin;
     NonnullRefPtr<StyleValue> m_clip;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -380,22 +380,26 @@ public:
         NonnullRefPtr<StyleValue> position,
         NonnullRefPtr<StyleValue> repeat_x,
         NonnullRefPtr<StyleValue> repeat_y,
-        NonnullRefPtr<StyleValue> attachment)
+        NonnullRefPtr<StyleValue> attachment,
+        NonnullRefPtr<StyleValue> origin,
+        NonnullRefPtr<StyleValue> clip)
     {
-        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat_x, repeat_y, attachment));
+        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat_x, repeat_y, attachment, origin, clip));
     }
     virtual ~BackgroundStyleValue() override { }
 
     NonnullRefPtr<StyleValue> attachment() const { return m_attachment; }
+    NonnullRefPtr<StyleValue> clip() const { return m_clip; }
     NonnullRefPtr<StyleValue> color() const { return m_color; }
     NonnullRefPtr<StyleValue> image() const { return m_image; }
+    NonnullRefPtr<StyleValue> origin() const { return m_origin; }
     NonnullRefPtr<StyleValue> position() const { return m_position; }
     NonnullRefPtr<StyleValue> repeat_x() const { return m_repeat_x; }
     NonnullRefPtr<StyleValue> repeat_y() const { return m_repeat_y; }
 
     virtual String to_string() const override
     {
-        return String::formatted("{} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string(), m_attachment->to_string());
+        return String::formatted("{} {} {} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string(), m_attachment->to_string(), m_origin->to_string(), m_clip->to_string());
     }
 
 private:
@@ -405,7 +409,9 @@ private:
         NonnullRefPtr<StyleValue> position,
         NonnullRefPtr<StyleValue> repeat_x,
         NonnullRefPtr<StyleValue> repeat_y,
-        NonnullRefPtr<StyleValue> attachment)
+        NonnullRefPtr<StyleValue> attachment,
+        NonnullRefPtr<StyleValue> origin,
+        NonnullRefPtr<StyleValue> clip)
         : StyleValue(Type::Background)
         , m_color(color)
         , m_image(image)
@@ -413,6 +419,8 @@ private:
         , m_repeat_x(repeat_x)
         , m_repeat_y(repeat_y)
         , m_attachment(attachment)
+        , m_origin(origin)
+        , m_clip(clip)
     {
     }
     NonnullRefPtr<StyleValue> m_color;
@@ -422,8 +430,8 @@ private:
     NonnullRefPtr<StyleValue> m_repeat_x;
     NonnullRefPtr<StyleValue> m_repeat_y;
     NonnullRefPtr<StyleValue> m_attachment;
-    // FIXME: background-clip
-    // FIXME: background-origin
+    NonnullRefPtr<StyleValue> m_origin;
+    NonnullRefPtr<StyleValue> m_clip;
 };
 
 class PositionStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -246,6 +246,7 @@ public:
     enum class Type {
         Background,
         BackgroundRepeat,
+        BackgroundSize,
         Border,
         BorderRadius,
         BoxShadow,
@@ -277,6 +278,7 @@ public:
 
     bool is_background() const { return type() == Type::Background; }
     bool is_background_repeat() const { return type() == Type::BackgroundRepeat; }
+    bool is_background_size() const { return type() == Type::BackgroundSize; }
     bool is_border() const { return type() == Type::Border; }
     bool is_border_radius() const { return type() == Type::BorderRadius; }
     bool is_box_shadow() const { return type() == Type::BoxShadow; }
@@ -305,6 +307,7 @@ public:
 
     BackgroundStyleValue const& as_background() const;
     BackgroundRepeatStyleValue const& as_background_repeat() const;
+    BackgroundSizeStyleValue const& as_background_size() const;
     BorderRadiusStyleValue const& as_border_radius() const;
     BorderStyleValue const& as_border() const;
     BoxShadowStyleValue const& as_box_shadow() const;
@@ -331,6 +334,7 @@ public:
 
     BackgroundStyleValue& as_background() { return const_cast<BackgroundStyleValue&>(const_cast<StyleValue const&>(*this).as_background()); }
     BackgroundRepeatStyleValue& as_background_repeat() { return const_cast<BackgroundRepeatStyleValue&>(const_cast<StyleValue const&>(*this).as_background_repeat()); }
+    BackgroundSizeStyleValue& as_background_size() { return const_cast<BackgroundSizeStyleValue&>(const_cast<StyleValue const&>(*this).as_background_size()); }
     BorderRadiusStyleValue& as_border_radius() { return const_cast<BorderRadiusStyleValue&>(const_cast<StyleValue const&>(*this).as_border_radius()); }
     BorderStyleValue& as_border() { return const_cast<BorderStyleValue&>(const_cast<StyleValue const&>(*this).as_border()); }
     BoxShadowStyleValue& as_box_shadow() { return const_cast<BoxShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_box_shadow()); }
@@ -502,6 +506,35 @@ private:
 
     Repeat m_repeat_x;
     Repeat m_repeat_y;
+};
+
+// NOTE: This is not used for identifier sizes, like `cover` and `contain`.
+class BackgroundSizeStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<BackgroundSizeStyleValue> create(Length size_x, Length size_y)
+    {
+        return adopt_ref(*new BackgroundSizeStyleValue(size_x, size_y));
+    }
+    virtual ~BackgroundSizeStyleValue() override { }
+
+    Length size_x() const { return m_size_x; }
+    Length size_y() const { return m_size_y; }
+
+    virtual String to_string() const override
+    {
+        return String::formatted("{} {}", m_size_x.to_string(), m_size_y.to_string());
+    }
+
+private:
+    BackgroundSizeStyleValue(Length size_x, Length size_y)
+        : StyleValue(Type::BackgroundSize)
+        , m_size_x(size_x)
+        , m_size_y(size_y)
+    {
+    }
+
+    Length m_size_x;
+    Length m_size_y;
 };
 
 class BorderStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -167,6 +167,13 @@ enum class Position {
     Sticky,
 };
 
+enum class PositionEdge {
+    Left,
+    Right,
+    Top,
+    Bottom,
+};
+
 enum class Repeat : u8 {
     NoRepeat,
     Repeat,
@@ -242,6 +249,7 @@ public:
         ListStyle,
         Numeric,
         Overflow,
+        Position,
         String,
         TextDecoration,
         Transformation,
@@ -270,6 +278,7 @@ public:
     bool is_list_style() const { return type() == Type::ListStyle; }
     bool is_numeric() const { return type() == Type::Numeric; }
     bool is_overflow() const { return type() == Type::Overflow; }
+    bool is_position() const { return type() == Type::Position; }
     bool is_string() const { return type() == Type::String; }
     bool is_text_decoration() const { return type() == Type::TextDecoration; }
     bool is_transformation() const { return type() == Type::Transformation; }
@@ -278,8 +287,8 @@ public:
 
     bool is_builtin() const { return is_inherit() || is_initial() || is_unset(); }
 
-    BackgroundRepeatStyleValue const& as_background_repeat() const;
     BackgroundStyleValue const& as_background() const;
+    BackgroundRepeatStyleValue const& as_background_repeat() const;
     BorderRadiusStyleValue const& as_border_radius() const;
     BorderStyleValue const& as_border() const;
     BoxShadowStyleValue const& as_box_shadow() const;
@@ -297,14 +306,15 @@ public:
     ListStyleStyleValue const& as_list_style() const;
     NumericStyleValue const& as_numeric() const;
     OverflowStyleValue const& as_overflow() const;
+    PositionStyleValue const& as_position() const;
     StringStyleValue const& as_string() const;
     TextDecorationStyleValue const& as_text_decoration() const;
     TransformationStyleValue const& as_transformation() const;
     UnsetStyleValue const& as_unset() const;
     StyleValueList const& as_value_list() const;
 
-    BackgroundRepeatStyleValue& as_background_repeat() { return const_cast<BackgroundRepeatStyleValue&>(const_cast<StyleValue const&>(*this).as_background_repeat()); }
     BackgroundStyleValue& as_background() { return const_cast<BackgroundStyleValue&>(const_cast<StyleValue const&>(*this).as_background()); }
+    BackgroundRepeatStyleValue& as_background_repeat() { return const_cast<BackgroundRepeatStyleValue&>(const_cast<StyleValue const&>(*this).as_background_repeat()); }
     BorderRadiusStyleValue& as_border_radius() { return const_cast<BorderRadiusStyleValue&>(const_cast<StyleValue const&>(*this).as_border_radius()); }
     BorderStyleValue& as_border() { return const_cast<BorderStyleValue&>(const_cast<StyleValue const&>(*this).as_border()); }
     BoxShadowStyleValue& as_box_shadow() { return const_cast<BoxShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_box_shadow()); }
@@ -322,6 +332,7 @@ public:
     ListStyleStyleValue& as_list_style() { return const_cast<ListStyleStyleValue&>(const_cast<StyleValue const&>(*this).as_list_style()); }
     NumericStyleValue& as_numeric() { return const_cast<NumericStyleValue&>(const_cast<StyleValue const&>(*this).as_numeric()); }
     OverflowStyleValue& as_overflow() { return const_cast<OverflowStyleValue&>(const_cast<StyleValue const&>(*this).as_overflow()); }
+    PositionStyleValue& as_position() { return const_cast<PositionStyleValue&>(const_cast<StyleValue const&>(*this).as_position()); }
     StringStyleValue& as_string() { return const_cast<StringStyleValue&>(const_cast<StyleValue const&>(*this).as_string()); }
     TextDecorationStyleValue& as_text_decoration() { return const_cast<TextDecorationStyleValue&>(const_cast<StyleValue const&>(*this).as_text_decoration()); }
     TransformationStyleValue& as_transformation() { return const_cast<TransformationStyleValue&>(const_cast<StyleValue const&>(*this).as_transformation()); }
@@ -405,6 +416,37 @@ private:
     // FIXME: background-attachment
     // FIXME: background-clip
     // FIXME: background-origin
+};
+
+class PositionStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<PositionStyleValue> create(PositionEdge edge_x, Length const& offset_x, PositionEdge edge_y, Length const& offset_y)
+    {
+        return adopt_ref(*new PositionStyleValue(edge_x, offset_x, edge_y, offset_y));
+    }
+    virtual ~PositionStyleValue() override { }
+
+    PositionEdge edge_x() const { return m_edge_x; }
+    Length const& offset_x() const { return m_offset_x; }
+    PositionEdge edge_y() const { return m_edge_y; }
+    Length const& offset_y() const { return m_offset_y; }
+
+    virtual String to_string() const override;
+
+private:
+    PositionStyleValue(PositionEdge edge_x, Length const& offset_x, PositionEdge edge_y, Length const& offset_y)
+        : StyleValue(Type::Position)
+        , m_edge_x(edge_x)
+        , m_offset_x(offset_x)
+        , m_edge_y(edge_y)
+        , m_offset_y(offset_y)
+    {
+    }
+
+    PositionEdge m_edge_x;
+    Length m_offset_x;
+    PositionEdge m_edge_y;
+    Length m_offset_y;
 };
 
 class BackgroundRepeatStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -379,12 +379,14 @@ public:
         NonnullRefPtr<StyleValue> image,
         NonnullRefPtr<StyleValue> position,
         NonnullRefPtr<StyleValue> repeat_x,
-        NonnullRefPtr<StyleValue> repeat_y)
+        NonnullRefPtr<StyleValue> repeat_y,
+        NonnullRefPtr<StyleValue> attachment)
     {
-        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat_x, repeat_y));
+        return adopt_ref(*new BackgroundStyleValue(color, image, position, repeat_x, repeat_y, attachment));
     }
     virtual ~BackgroundStyleValue() override { }
 
+    NonnullRefPtr<StyleValue> attachment() const { return m_attachment; }
     NonnullRefPtr<StyleValue> color() const { return m_color; }
     NonnullRefPtr<StyleValue> image() const { return m_image; }
     NonnullRefPtr<StyleValue> position() const { return m_position; }
@@ -393,7 +395,7 @@ public:
 
     virtual String to_string() const override
     {
-        return String::formatted("{} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string());
+        return String::formatted("{} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_repeat_x->to_string(), m_repeat_y->to_string(), m_attachment->to_string());
     }
 
 private:
@@ -402,13 +404,15 @@ private:
         NonnullRefPtr<StyleValue> image,
         NonnullRefPtr<StyleValue> position,
         NonnullRefPtr<StyleValue> repeat_x,
-        NonnullRefPtr<StyleValue> repeat_y)
+        NonnullRefPtr<StyleValue> repeat_y,
+        NonnullRefPtr<StyleValue> attachment)
         : StyleValue(Type::Background)
         , m_color(color)
         , m_image(image)
         , m_position(position)
         , m_repeat_x(repeat_x)
         , m_repeat_y(repeat_y)
+        , m_attachment(attachment)
     {
     }
     NonnullRefPtr<StyleValue> m_color;
@@ -417,7 +421,7 @@ private:
     // FIXME: background-size
     NonnullRefPtr<StyleValue> m_repeat_x;
     NonnullRefPtr<StyleValue> m_repeat_y;
-    // FIXME: background-attachment
+    NonnullRefPtr<StyleValue> m_attachment;
     // FIXME: background-clip
     // FIXME: background-origin
 };

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -379,7 +379,7 @@ CSS::Repeat Document::background_repeat_x() const
     if (!body_layout_node)
         return CSS::Repeat::Repeat;
 
-    return body_layout_node->computed_values().background_repeat_x();
+    return body_layout_node->computed_values().background_repeat().repeat_x;
 }
 
 CSS::Repeat Document::background_repeat_y() const
@@ -392,7 +392,7 @@ CSS::Repeat Document::background_repeat_y() const
     if (!body_layout_node)
         return CSS::Repeat::Repeat;
 
-    return body_layout_node->computed_values().background_repeat_y();
+    return body_layout_node->computed_values().background_repeat().repeat_y;
 }
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -53,6 +53,7 @@ class MediaQueryList;
 class MediaQueryListEvent;
 class NumericStyleValue;
 class OverflowStyleValue;
+class PositionStyleValue;
 class PropertyOwningCSSStyleDeclaration;
 class Screen;
 class Selector;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -19,6 +19,7 @@ class Crypto;
 
 namespace Web::CSS {
 class BackgroundRepeatStyleValue;
+class BackgroundSizeStyleValue;
 class BackgroundStyleValue;
 class BorderRadiusStyleValue;
 class BorderStyleValue;

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -73,8 +73,7 @@ void Box::paint_background(PaintContext& context)
     Gfx::IntRect background_rect;
     Color background_color = computed_values().background_color();
     const Gfx::Bitmap* background_image = this->background_image() ? this->background_image()->bitmap() : nullptr;
-    CSS::Repeat background_repeat_x = computed_values().background_repeat_x();
-    CSS::Repeat background_repeat_y = computed_values().background_repeat_y();
+    CSS::BackgroundRepeatData background_repeat = computed_values().background_repeat();
 
     if (is_root_element()) {
         // CSS 2.1 Appendix E.2: If the element is a root element, paint the background over the entire canvas.
@@ -85,8 +84,7 @@ void Box::paint_background(PaintContext& context)
         if (document().html_element()->should_use_body_background_properties()) {
             background_color = document().background_color(context.palette());
             background_image = document().background_image();
-            background_repeat_x = document().background_repeat_x();
-            background_repeat_y = document().background_repeat_y();
+            background_repeat = { document().background_repeat_x(), document().background_repeat_y() };
         }
     } else {
         background_rect = enclosing_int_rect(padded_rect());
@@ -100,8 +98,8 @@ void Box::paint_background(PaintContext& context)
     auto background_data = Painting::BackgroundData {
         .color = background_color,
         .image = background_image,
-        .repeat_x = background_repeat_x,
-        .repeat_y = background_repeat_y
+        .repeat_x = background_repeat.repeat_x,
+        .repeat_y = background_repeat.repeat_y
     };
     Painting::paint_background(context, background_rect, background_data, normalized_border_radius_data());
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -52,8 +52,8 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
         auto background_data = Painting::BackgroundData {
             .color = computed_values().background_color(),
             .image = background_image() ? background_image()->bitmap() : nullptr,
-            .repeat_x = computed_values().background_repeat_x(),
-            .repeat_y = computed_values().background_repeat_y()
+            .repeat_x = computed_values().background_repeat().repeat_x,
+            .repeat_y = computed_values().background_repeat().repeat_y
         };
 
         auto top_left_border_radius = computed_values().border_top_left_radius();

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -240,13 +240,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     if (border_top_right_radius.has_value())
         computed_values.set_border_top_right_radius(border_top_right_radius.value()->to_length());
 
-    auto background_repeat_x = specified_style.background_repeat_x();
-    if (background_repeat_x.has_value())
-        computed_values.set_background_repeat_x(background_repeat_x.value());
-
-    auto background_repeat_y = specified_style.background_repeat_y();
-    if (background_repeat_y.has_value())
-        computed_values.set_background_repeat_y(background_repeat_y.value());
+    auto background_repeat = specified_style.background_repeat();
+    if (background_repeat.has_value())
+        computed_values.set_background_repeat(background_repeat.value());
 
     computed_values.set_display(specified_style.display());
 


### PR DESCRIPTION
This adds parsing (but not rendering) for the following properties, on their own and as part of `background`:
- `background-attachment`
- `background-clip`
- `background-origin`
- `background-position`
- `background-size`

Also, this cleans up `background-repeat`:
- Using the same code for parsing it on its own and as part of `background`.
- Removing the two `background-repeat-x/y` pseudo-properties, and the concept of pseudo-properties altogether.
- Making `BackgroundRepeatStyleValue` hold `CSS::Repeat` values directly instead of `StyleValue` pointers.

And we now have a `backgrounds.html` test page with some tests that we don't pass yet. :^)

Not included here is multiple-backgrounds support, which I'm splitting into a follow-up PR because this is already bigger than I'd planned; and some refactoring of the CSS Parser that I did in a frustration-rage at my previous decisions, but that might not be an improvement. :sweat_smile: 