### PR TITLE
LibUnicode: Upgrade to CLDR version 40.0.0

### DIFF
--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -1,5 +1,5 @@
 set(UCD_VERSION 14.0.0)
-set(CLDR_VERSION 39.0.0)
+set(CLDR_VERSION 40.0.0)
 
 set(UCD_PATH "${CMAKE_BINARY_DIR}/UCD" CACHE PATH "Download location for UCD files")
 set(CLDR_PATH "${CMAKE_BINARY_DIR}/CLDR" CACHE PATH "Download location for CLDR files")

--- a/Tests/LibUnicode/TestUnicodeLocale.cpp
+++ b/Tests/LibUnicode/TestUnicodeLocale.cpp
@@ -456,4 +456,10 @@ TEST_CASE(canonicalize_unicode_locale_id)
     test("ZH-XIANG"sv, "hsn"sv);
     test("ja-latn-hepburn-heploc"sv, "ja-Latn-alalc97"sv);
     test("JA-LATN-HEPBURN-HEPLOC"sv, "ja-Latn-alalc97"sv);
+
+    // Default content.
+    test("en-us"sv, "en-US"sv);
+    test("EN-US"sv, "en-US"sv);
+    test("zh-Hans-CN"sv, "zh-Hans-CN"sv);
+    test("ZH-HANS-CN"sv, "zh-Hans-CN"sv);
 }


### PR DESCRIPTION
What I *actually* wanted to do with v40 is utilize the new `cldr-bcp47` package to remove a large set of hard-coded canonicalization rules:
https://github.com/SerenityOS/serenity/blob/3ae4ff109f39262515511a209b66d73fa834de09/Userland/Libraries/LibUnicode/Locale.cpp#L478-L487

However, the Unicode org forgot to actually package `cldr-bcp47` in their release package so that will have to wait :disappointed: 

I opened https://unicode-org.atlassian.net/browse/CLDR-15158 for that.