### PR TITLE
LibWeb: Make property_initial_value() always return a valid value

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
@@ -169,7 +169,7 @@ bool is_inherited_property(PropertyID property_id)
     }
 }
 
-RefPtr<StyleValue> property_initial_value(PropertyID property_id)
+NonnullRefPtr<StyleValue> property_initial_value(PropertyID property_id)
 {
     static HashMap<PropertyID, NonnullRefPtr<StyleValue>> initial_values;
     if (initial_values.is_empty()) {
@@ -219,10 +219,7 @@ RefPtr<StyleValue> property_initial_value(PropertyID property_id)
     generator.append(R"~~~(
     }
 
-    auto it = initial_values.find(property_id);
-    if (it == initial_values.end())
-        return nullptr;
-    return it->value;
+    return *initial_values.find(property_id)->value;
 }
 
 bool property_has_quirk(PropertyID property_id, Quirk quirk)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_h.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_h.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv)
     generator.append(R"~~~(
 #pragma once
 
+#include <AK/NonnullRefPtr.h>
 #include <AK/StringView.h>
 #include <AK/Traits.h>
 #include <LibWeb/Forward.h>
@@ -104,7 +105,7 @@ PropertyID property_id_from_camel_case_string(StringView);
 PropertyID property_id_from_string(const StringView&);
 const char* string_from_property_id(PropertyID);
 bool is_inherited_property(PropertyID);
-RefPtr<StyleValue> property_initial_value(PropertyID);
+NonnullRefPtr<StyleValue> property_initial_value(PropertyID);
 
 bool property_accepts_value(PropertyID, StyleValue&);
 size_t property_maximum_value_count(PropertyID);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3438,6 +3438,12 @@ RefPtr<StyleValue> Parser::parse_transform_value(ParsingContext const& context, 
     NonnullRefPtrVector<StyleValue> transformations;
 
     for (auto& part : component_values) {
+        if (part.is(Token::Type::Ident) && part.token().ident().equals_ignoring_case("none")) {
+            if (!transformations.is_empty())
+                return nullptr;
+            return IdentifierStyleValue::create(ValueID::None);
+        }
+
         if (!part.is_function())
             return nullptr;
         auto maybe_function = parse_transform_function_name(part.function().name());

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1,7 +1,7 @@
 {
   "align-items": {
     "inherited": false,
-    "initial": "normal",
+    "initial": "stretch",
     "valid-identifiers": [
       "center",
       "baseline",
@@ -314,7 +314,7 @@
   },
   "border-spacing": {
     "inherited": true,
-    "initial": "0px 0px",
+    "initial": "0",
     "quirks": [
       "unitless-length"
     ]
@@ -1195,7 +1195,7 @@
   },
   "text-decoration-thickness": {
     "inherited": false,
-    "initial": "none",
+    "initial": "auto",
     "valid-types": [
       "length",
       "percentage"

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -10,7 +10,20 @@
       "stretch"
     ]
   },
-  "background": {},
+  "background": {
+    "inherited": false,
+    "initial": "transparent",
+    "longhands": [
+      "background-attachment",
+      "background-clip",
+      "background-color",
+      "background-image",
+      "background-origin",
+      "background-position",
+      "background-repeat",
+      "background-size"
+    ]
+  },
   "background-attachment": {
     "inherited": false,
     "initial": "scroll",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -118,6 +118,8 @@
     ]
   },
   "border": {
+    "inherited": false,
+    "initial": "medium currentcolor none",
     "longhands": [
       "border-width",
       "border-style",
@@ -125,6 +127,8 @@
     ]
   },
   "border-top": {
+    "inherited": false,
+    "initial": "medium currentcolor none",
     "longhands": [
       "border-top-width",
       "border-top-style",
@@ -132,6 +136,8 @@
     ]
   },
   "border-right": {
+    "inherited": false,
+    "initial": "medium currentcolor none",
     "longhands": [
       "border-right-width",
       "border-right-style",
@@ -139,6 +145,8 @@
     ]
   },
   "border-bottom": {
+    "inherited": false,
+    "initial": "medium currentcolor none",
     "longhands": [
       "border-bottom-width",
       "border-bottom-style",
@@ -146,6 +154,8 @@
     ]
   },
   "border-left": {
+    "inherited": false,
+    "initial": "medium currentcolor none",
     "longhands": [
       "border-left-width",
       "border-left-style",
@@ -277,6 +287,8 @@
     ]
   },
   "border-radius": {
+    "inherited": false,
+    "initial": "0",
     "longhands": [
       "border-top-left-radius",
       "border-top-right-radius",
@@ -581,6 +593,8 @@
     ]
   },
   "flex": {
+    "inherited": false,
+    "initial": "0 1 auto",
     "longhands": [
       "flex-grow",
       "flex-shrink",
@@ -610,6 +624,8 @@
     ]
   },
   "flex-flow": {
+    "inherited": false,
+    "initial": "row nowrap",
     "longhands": [
       "flex-direction",
       "flex-wrap"
@@ -648,6 +664,8 @@
     ]
   },
   "font": {
+    "inherited": true,
+    "initial": "normal medium sans-serif",
     "longhands": [
       "font-family",
       "font-size",
@@ -778,6 +796,7 @@
   },
   "list-style": {
     "inherited": true,
+    "initial": "outside disc",
     "longhands": [
       "list-style-type",
       "list-style-position",
@@ -824,6 +843,8 @@
     ]
   },
   "margin": {
+    "inherited": false,
+    "initial": "0",
     "longhands": [
       "margin-top",
       "margin-right",
@@ -964,6 +985,8 @@
   },
   "outline": {
     "inherited": false,
+    "__comment": "FIXME: Initial value is really `medium invert none` but we don't yet parse the outline shorthand.",
+    "initial": "none",
     "longhands": [
       "outline-color",
       "outline-style",
@@ -1047,6 +1070,8 @@
     ]
   },
   "padding": {
+    "inherited": false,
+    "initial": "0",
     "longhands": [
       "padding-top",
       "padding-right",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -635,18 +635,10 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
     // FIXME: Transition declarations [css-transitions-1]
 }
 
-static NonnullRefPtr<StyleValue> get_initial_value(CSS::PropertyID property_id)
-{
-    auto value = property_initial_value(property_id);
-    if (!value)
-        return InitialStyleValue::the();
-    return value.release_nonnull();
-};
-
 static NonnullRefPtr<StyleValue> get_inherit_value(CSS::PropertyID property_id, DOM::Element const* element)
 {
     if (!element || !element->parent_element() || !element->parent_element()->specified_css_values())
-        return get_initial_value(property_id);
+        return property_initial_value(property_id);
     auto& map = element->parent_element()->specified_css_values()->properties();
     auto it = map.find(property_id);
     VERIFY(it != map.end());
@@ -662,12 +654,12 @@ void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM
         if (is_inherited_property(property_id))
             style.m_property_values.set(property_id, get_inherit_value(property_id, element));
         else
-            style.m_property_values.set(property_id, get_initial_value(property_id));
+            style.m_property_values.set(property_id, property_initial_value(property_id));
         return;
     }
 
     if (it->value->is_initial()) {
-        it->value = get_initial_value(property_id);
+        it->value = property_initial_value(property_id);
         return;
     }
 


### PR DESCRIPTION
After spending ages tracking down weird bugs that turned out to be silent failures when parsing initial values for CSS properties, I decided to make that more reliable. This PR makes sure that all the properties in Properties.json have initial values provided, and that those parse correctly. The generator verifies at compile time that initial values are provided, and any time an initial value fails to parse, it verifies in a way where it's obvious which property failed.

The end result of this, is that `property_initial_value()` can be relied on to always return a valid StyleValue for the given property, without user code needing to provide its own backup default values.