### PR TITLE
HexEditor: streaming file access

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -11,6 +11,7 @@ compile_gml(FindDialog.gml FindDialogGML.h find_dialog_gml)
 set(SOURCES
     HexEditor.cpp
     HexEditorWidget.cpp
+    HexDocument.cpp
     FindDialog.cpp
     GoToOffsetDialog.cpp
     main.cpp

--- a/Userland/Applications/HexEditor/HexDocument.cpp
+++ b/Userland/Applications/HexEditor/HexDocument.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021, Arne Elster <arne@elster.li>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "HexDocument.h"
+
+void HexDocument::set(size_t position, u8 value)
+{
+    m_changes.set(position, value);
+}
+
+bool HexDocument::is_dirty() const
+{
+    return m_changes.size() > 0;
+}
+
+HexDocumentMemory::HexDocumentMemory(ByteBuffer&& buffer)
+    : m_buffer(move(buffer))
+{
+}
+
+HexDocument::Cell HexDocumentMemory::get(size_t position)
+{
+    auto tracked_change = m_changes.get(position);
+    if (tracked_change.has_value()) {
+        return Cell { tracked_change.value(), true };
+    } else {
+        return Cell { m_buffer[position], false };
+    }
+}
+
+size_t HexDocumentMemory::size() const
+{
+    return m_buffer.size();
+}
+
+HexDocument::Type HexDocumentMemory::type() const
+{
+    return Type::Memory;
+}
+
+void HexDocumentMemory::clear_changes()
+{
+    m_changes.clear();
+}
+
+bool HexDocumentMemory::write_to_file(NonnullRefPtr<Core::File> file)
+{
+    if (!file->seek(0))
+        return false;
+    if (!file->write(m_buffer.data(), m_buffer.size()))
+        return false;
+    for (auto& change : m_changes) {
+        file->seek(change.key, Core::SeekMode::SetPosition);
+        file->write(&change.value, 1);
+    }
+    return true;
+}
+
+HexDocumentFile::HexDocumentFile(NonnullRefPtr<Core::File> file)
+    : m_file(file)
+{
+    set_file(file);
+}
+
+void HexDocumentFile::write_to_file()
+{
+    for (auto& change : m_changes) {
+        m_file->seek(change.key, Core::SeekMode::SetPosition);
+        m_file->write(&change.value, 1);
+    }
+    clear_changes();
+    // make sure the next get operation triggers a read
+    m_buffer_file_pos = m_file_size + 1;
+}
+
+bool HexDocumentFile::write_to_file(NonnullRefPtr<Core::File> file)
+{
+    if (!file->truncate(size())) {
+        return false;
+    }
+
+    if (!file->seek(0) || !m_file->seek(0)) {
+        return false;
+    }
+
+    while (true) {
+        auto copy_buffer = m_file->read(64 * KiB);
+        if (copy_buffer.size() == 0)
+            break;
+        file->write(copy_buffer.data(), copy_buffer.size());
+    }
+
+    for (auto& change : m_changes) {
+        file->seek(change.key, Core::SeekMode::SetPosition);
+        file->write(&change.value, 1);
+    }
+
+    return true;
+}
+
+HexDocument::Cell HexDocumentFile::get(size_t position)
+{
+    auto tracked_change = m_changes.get(position);
+    if (tracked_change.has_value()) {
+        return Cell { tracked_change.value(), true };
+    }
+
+    if (position < m_buffer_file_pos || position >= m_buffer_file_pos + m_buffer.size()) {
+        m_file->seek(position, Core::SeekMode::SetPosition);
+        m_file->read(m_buffer.data(), m_buffer.size());
+        m_buffer_file_pos = position;
+    }
+    return { m_buffer[position - m_buffer_file_pos], false };
+}
+
+size_t HexDocumentFile::size() const
+{
+    return m_file_size;
+}
+
+HexDocument::Type HexDocumentFile::type() const
+{
+    return Type::File;
+}
+
+void HexDocumentFile::clear_changes()
+{
+    m_changes.clear();
+}
+
+void HexDocumentFile::set_file(NonnullRefPtr<Core::File> file)
+{
+    m_file = file;
+
+    off_t size = 0;
+    if (!file->seek(0, Core::SeekMode::FromEndPosition, &size)) {
+        m_file_size = 0;
+    } else {
+        m_file_size = size;
+    }
+    file->seek(0, Core::SeekMode::SetPosition);
+
+    clear_changes();
+    // make sure the next get operation triggers a read
+    m_buffer_file_pos = m_file_size + 1;
+}
+
+NonnullRefPtr<Core::File> HexDocumentFile::file() const
+{
+    return m_file;
+}

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -34,7 +34,7 @@ protected:
     HashMap<size_t, u8> m_changes;
 };
 
-class HexDocumentMemory : public HexDocument {
+class HexDocumentMemory final : public HexDocument {
 public:
     explicit HexDocumentMemory(ByteBuffer&& buffer);
     virtual ~HexDocumentMemory() = default;
@@ -49,7 +49,7 @@ private:
     ByteBuffer m_buffer;
 };
 
-class HexDocumentFile : public HexDocument {
+class HexDocumentFile final : public HexDocument {
 public:
     explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
     virtual ~HexDocumentFile() = default;

--- a/Userland/Applications/HexEditor/HexDocument.h
+++ b/Userland/Applications/HexEditor/HexDocument.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, Arne Elster <arne@elster.li>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/Types.h>
+#include <LibCore/File.h>
+
+class HexDocument {
+public:
+    enum class Type {
+        Memory,
+        File
+    };
+
+    struct Cell {
+        u8 value;
+        bool modified;
+    };
+
+    virtual ~HexDocument() = default;
+    virtual Cell get(size_t position) = 0;
+    virtual void set(size_t position, u8 value);
+    virtual size_t size() const = 0;
+    virtual Type type() const = 0;
+    virtual bool is_dirty() const;
+    virtual void clear_changes() = 0;
+
+protected:
+    HashMap<size_t, u8> m_changes;
+};
+
+class HexDocumentMemory : public HexDocument {
+public:
+    explicit HexDocumentMemory(ByteBuffer&& buffer);
+    virtual ~HexDocumentMemory() = default;
+
+    Cell get(size_t position) override;
+    size_t size() const override;
+    Type type() const override;
+    void clear_changes() override;
+    bool write_to_file(NonnullRefPtr<Core::File> file);
+
+private:
+    ByteBuffer m_buffer;
+};
+
+class HexDocumentFile : public HexDocument {
+public:
+    explicit HexDocumentFile(NonnullRefPtr<Core::File> file);
+    virtual ~HexDocumentFile() = default;
+
+    HexDocumentFile(const HexDocumentFile&) = delete;
+
+    void set_file(NonnullRefPtr<Core::File> file);
+    NonnullRefPtr<Core::File> file() const;
+    void write_to_file();
+    bool write_to_file(NonnullRefPtr<Core::File> file);
+    Cell get(size_t position) override;
+    size_t size() const override;
+    Type type() const override;
+    void clear_changes() override;
+
+private:
+    NonnullRefPtr<Core::File> m_file;
+    size_t m_file_size;
+
+    Array<u8, 2048> m_buffer;
+    size_t m_buffer_file_pos;
+};

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -68,6 +68,9 @@ bool HexEditor::open_new_file(size_t size)
     set_content_length(m_document->size());
     m_position = 0;
     m_cursor_at_low_nibble = false;
+    m_selection_start = 0;
+    m_selection_end = 0;
+    scroll_position_into_view(m_position);
     update();
     update_status();
 
@@ -80,6 +83,9 @@ void HexEditor::open_file(NonnullRefPtr<Core::File> file)
     set_content_length(m_document->size());
     m_position = 0;
     m_cursor_at_low_nibble = false;
+    m_selection_start = 0;
+    m_selection_end = 0;
+    scroll_position_into_view(m_position);
     update();
     update_status();
 }

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -123,13 +123,13 @@ bool HexEditor::save_as(int fd)
     }
 
     if (m_document->type() == HexDocument::Type::File) {
-        HexDocumentFile* fileDoc = static_cast<HexDocumentFile*>(m_document.ptr());
-        if (!fileDoc->write_to_file(new_file))
+        HexDocumentFile* fileDocument = static_cast<HexDocumentFile*>(m_document.ptr());
+        if (!fileDocument->write_to_file(new_file))
             return false;
-        fileDoc->set_file(new_file);
+        fileDocument->set_file(new_file);
     } else {
-        HexDocumentMemory* memDoc = static_cast<HexDocumentMemory*>(m_document.ptr());
-        if (!memDoc->write_to_file(new_file))
+        HexDocumentMemory* memoryDocument = static_cast<HexDocumentMemory*>(m_document.ptr());
+        if (!memoryDocument->write_to_file(new_file))
             return false;
         m_document = make<HexDocumentFile>(new_file);
     }

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "HexDocument.h"
 #include "SearchResultsModel.h"
 #include <AK/ByteBuffer.h>
 #include <AK/Function.h>
@@ -32,14 +33,15 @@ public:
     bool is_readonly() const { return m_readonly; }
     void set_readonly(bool);
 
-    size_t buffer_size() const { return m_buffer.size(); }
-    void set_buffer(const ByteBuffer&);
+    size_t buffer_size() const { return m_document->size(); }
+    bool open_new_file(size_t size);
+    void open_file(NonnullRefPtr<Core::File> file);
     void fill_selection(u8 fill_byte);
-    bool write_to_file(const String& path);
-    bool write_to_file(int fd);
+    bool save_as(int fd);
+    bool save();
 
     void select_all();
-    bool has_selection() const { return !((m_selection_end < m_selection_start) || m_buffer.is_empty()); }
+    bool has_selection() const { return !((m_selection_end < m_selection_start) || m_document->size()); }
     size_t selection_size();
     size_t selection_start_offset() const { return m_selection_start; }
     bool copy_selected_text_to_clipboard();
@@ -72,16 +74,15 @@ private:
     size_t m_line_spacing { 4 };
     size_t m_content_length { 0 };
     size_t m_bytes_per_row { 16 };
-    ByteBuffer m_buffer;
     bool m_in_drag_select { false };
     size_t m_selection_start { 0 };
     size_t m_selection_end { 0 };
-    HashMap<size_t, u8> m_tracked_changes;
     size_t m_position { 0 };
     bool m_cursor_at_low_nibble { false };
     EditMode m_edit_mode { Hex };
     NonnullRefPtr<Core::Timer> m_blink_timer;
     bool m_cursor_blink_active { false };
+    NonnullOwnPtr<HexDocument> m_document;
 
     static constexpr int m_address_bar_width = 90;
     static constexpr int m_padding = 5;

--- a/Userland/Applications/HexEditor/SearchResultsModel.h
+++ b/Userland/Applications/HexEditor/SearchResultsModel.h
@@ -14,7 +14,7 @@
 #include <LibGUI/Model.h>
 
 struct Match {
-    int offset;
+    u64 offset;
     String value;
 };
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -68,7 +68,7 @@ Result Client::request_file(i32 parent_window_id, String const& path, Core::Open
     return m_promise->await();
 }
 
-Result Client::open_file(i32 parent_window_id, String const& window_title, StringView path)
+Result Client::open_file(i32 parent_window_id, String const& window_title, StringView path, Core::OpenMode requested_access)
 {
     m_promise = Core::Promise<Result>::construct();
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -80,12 +80,12 @@ Result Client::open_file(i32 parent_window_id, String const& window_title, Strin
         GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, Core::OpenMode::ReadOnly);
+    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
 
     return m_promise->await();
 }
 
-Result Client::save_file(i32 parent_window_id, String const& name, String const ext)
+Result Client::save_file(i32 parent_window_id, String const& name, String const ext, Core::OpenMode requested_access)
 {
     m_promise = Core::Promise<Result>::construct();
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -97,7 +97,7 @@ Result Client::save_file(i32 parent_window_id, String const& name, String const 
         GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
+    async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
     return m_promise->await();
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -29,8 +29,8 @@ class Client final
 public:
     Result request_file_read_only_approved(i32 parent_window_id, String const& path);
     Result request_file(i32 parent_window_id, String const& path, Core::OpenMode mode);
-    Result open_file(i32 parent_window_id, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory());
-    Result save_file(i32 parent_window_id, String const& name, String const ext);
+    Result open_file(i32 parent_window_id, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
+    Result save_file(i32 parent_window_id, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
 
     static Client& the();
 


### PR DESCRIPTION
HexEditor would read an input file completely into memory. That was bad because of load times and memory usage.
As the editor usually only shows a couple of bytes at the same time, the data to render can be read on the fly.
This PR does this by abstracting data access in the HexEditor widget into socalled HexDocuments.
There are two HexDocuments: one for memory based streaming (for new files that haven't been saved yet) and one for file based streaming. The HexDocuments track changes instead of the HexEditor. The idea was that changes are bound to a document, therefore they're not HexEditor's concern.

I also extended the FileSystemAccessClient: Because HexEditor doesn't store the entire file in memory, reopening the same file when saving using FSAC will clear its contents. It seemed nicer to be able to tell FSAC exactly the mode to open the file in, no matter if through an open or a save dialog.