### PR TITLE
Unbork the CI by including Vector.h in a few places

### DIFF
--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/Format.h>
 #include <AK/Random.h>
+#include <AK/Vector.h>
 #include <LibCrypto/PK/Code/Code.h>
 
 namespace Crypto {

--- a/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -10,6 +10,7 @@
 #include <AK/Format.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 
 namespace JS {
 

--- a/Userland/Libraries/LibPDF/Command.h
+++ b/Userland/Libraries/LibPDF/Command.h
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/Vector.h>
 #include <LibPDF/Value.h>
 
 #define ENUMERATE_COMMANDS(V)                                                            \

--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -11,6 +11,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/Span.h>
 #include <AK/String.h>
+#include <AK/Vector.h>
 
 namespace PDF {
 

--- a/Userland/Libraries/LibPDF/XRefTable.h
+++ b/Userland/Libraries/LibPDF/XRefTable.h
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <AK/Vector.h>
 
 namespace PDF {
 


### PR DESCRIPTION
This was being transitively pulled in, but that no longer happens after
5f7d008791f9e358638283dc2f0d709a601344ff.