### PR TITLE
LibGfx: Include Vector.h in PNGLoader.cpp

### DIFF
--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/Endian.h>
+#include <AK/Vector.h>
 #include <LibCompress/Zlib.h>
 #include <LibGfx/PNGLoader.h>
 #include <fcntl.h>


### PR DESCRIPTION
This was being transitively included from Deflate.h on SerenityOS builds
but not on Lagom builds.