### PR TITLE
LibGUI: add ctrl delete support

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -327,7 +327,6 @@ MainWidget::MainWidget()
     m_toolbar->add_action(m_editor->cut_action());
     m_toolbar->add_action(m_editor->copy_action());
     m_toolbar->add_action(m_editor->paste_action());
-    m_toolbar->add_action(m_editor->delete_action());
 
     m_toolbar->add_separator();
 
@@ -384,7 +383,6 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     edit_menu.add_action(m_editor->cut_action());
     edit_menu.add_action(m_editor->copy_action());
     edit_menu.add_action(m_editor->paste_action());
-    edit_menu.add_action(m_editor->delete_action());
     edit_menu.add_separator();
     edit_menu.add_action(*m_vim_emulation_setting_action);
     edit_menu.add_separator();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -845,13 +845,22 @@ void TextEditor::keydown_event(KeyEvent& event)
 
         if (m_cursor.column() < current_line().length()) {
             // Delete within line
-            TextRange erased_range(m_cursor, { m_cursor.line(), m_cursor.column() + 1 });
+            int erase_count = 1;
+            if (event.modifiers() == Mod_Ctrl) {
+                auto word_break_pos = document().first_word_break_after(m_cursor);
+                erase_count = word_break_pos.column() - m_cursor.column();
+            }
+            TextRange erased_range(m_cursor, { m_cursor.line(), m_cursor.column() + erase_count });
             execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
             return;
         }
         if (m_cursor.column() == current_line().length() && m_cursor.line() != line_count() - 1) {
             // Delete at end of line; merge with next line
-            TextRange erased_range(m_cursor, { m_cursor.line() + 1, 0 });
+            size_t erase_count = 0;
+            if (event.modifiers() == Mod_Ctrl) {
+                erase_count = document().first_word_break_after({ m_cursor.line() + 1, 0 }).column();
+            }
+            TextRange erased_range(m_cursor, { m_cursor.line() + 1, erase_count });
             execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
             return;
         }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -84,7 +84,6 @@ void TextEditor::create_actions()
     m_copy_action->set_enabled(false);
     m_paste_action = CommonActions::make_paste_action([&](auto&) { paste(); }, this);
     m_paste_action->set_enabled(is_editable() && Clipboard::the().mime_type().starts_with("text/") && !Clipboard::the().data().is_empty());
-    m_delete_action = CommonActions::make_delete_action([&](auto&) { do_delete(); }, this);
     if (is_multi_line()) {
         m_go_to_line_action = Action::create(
             "Go to line...", { Mod_Ctrl, Key_L }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
@@ -834,8 +833,28 @@ void TextEditor::keydown_event(KeyEvent& event)
     }
 
     if (event.key() == KeyCode::Key_Delete) {
+        if (!is_editable())
+            return;
         if (m_autocomplete_box)
             hide_autocomplete();
+        if (has_selection()) {
+            delete_selection();
+            did_update_selection();
+            return;
+        }
+
+        if (m_cursor.column() < current_line().length()) {
+            // Delete within line
+            TextRange erased_range(m_cursor, { m_cursor.line(), m_cursor.column() + 1 });
+            execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
+            return;
+        }
+        if (m_cursor.column() == current_line().length() && m_cursor.line() != line_count() - 1) {
+            // Delete at end of line; merge with next line
+            TextRange erased_range(m_cursor, { m_cursor.line() + 1, 0 });
+            execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
+            return;
+        }
         return;
     }
 
@@ -1531,14 +1550,12 @@ void TextEditor::set_mode(const Mode mode)
     switch (mode) {
     case Editable:
         m_cut_action->set_enabled(has_selection() && !text_is_secret());
-        m_delete_action->set_enabled(true);
         m_paste_action->set_enabled(true);
         set_accepts_emoji_input(true);
         break;
     case DisplayOnly:
     case ReadOnly:
         m_cut_action->set_enabled(false);
-        m_delete_action->set_enabled(false);
         m_paste_action->set_enabled(false);
         set_accepts_emoji_input(false);
         break;
@@ -1577,7 +1594,6 @@ void TextEditor::context_menu_event(ContextMenuEvent& event)
         m_context_menu->add_action(cut_action());
         m_context_menu->add_action(copy_action());
         m_context_menu->add_action(paste_action());
-        m_context_menu->add_action(delete_action());
         m_context_menu->add_separator();
         m_context_menu->add_action(select_all_action());
         if (is_multi_line()) {

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -166,7 +166,6 @@ public:
     Action& cut_action() { return *m_cut_action; }
     Action& copy_action() { return *m_copy_action; }
     Action& paste_action() { return *m_paste_action; }
-    Action& delete_action() { return *m_delete_action; }
     Action& go_to_line_action() { return *m_go_to_line_action; }
     Action& select_all_action() { return *m_select_all_action; }
 
@@ -365,7 +364,6 @@ private:
     RefPtr<Action> m_cut_action;
     RefPtr<Action> m_copy_action;
     RefPtr<Action> m_paste_action;
-    RefPtr<Action> m_delete_action;
     RefPtr<Action> m_go_to_line_action;
     RefPtr<Action> m_select_all_action;
     Core::ElapsedTimer m_triple_click_timer;


### PR DESCRIPTION
Allow deleting the word after the cursor using Ctrl+Delete in a similar to how Ctrl+Backspace deletes the word before the cursor.

In order to support this, I had to migrate the handling of the delete key from an action to keydown_event so I could look at key modifiers. This did mean removing the delete button and menu entry from TextEditor, but that was kinda a weird design choice anyway.

(Note: this is technically a re-opening of https://github.com/SerenityOS/serenity/pull/9535 because I couldn't figure out how to re-open that one after it got closed from inactivity. But the changes are still good to go in.)