### PR TITLE
SystemMonitor: Kill/stop UI improvements

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv)
     };
 
     auto kill_action = GUI::Action::create(
-        "&Kill Process", { Mod_Ctrl, Key_K }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/kill.png").release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
+        "&Kill Process", { Mod_Ctrl, Key_K }, { Key_Delete }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/kill.png").release_value_but_fixme_should_propagate_errors(), [&](const GUI::Action&) {
             pid_t pid = selected_id(ProcessModel::Column::PID);
             if (pid != -1)
                 kill(pid, SIGKILL);


### PR DESCRIPTION
**SystemMonitor: Add Delete as alternate shortcut for killing a process**
    
This matches behaviour of other "system monitors", like Windows's Task
Manager

**SystemMonitor: Ask user before trying to kill/stop process**
    
These actions can be dangerous, especially for important system
processes. Let's make accidental breaking of the system a bit
harder. :^)