### PR TITLE
WindowServer: Ensure menu visibility after pushing menu to the open s…

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -638,7 +638,6 @@ void Menu::do_popup(const Gfx::IntPoint& position, bool make_input, bool as_subm
     }
 
     window.move_to(adjusted_pos);
-    set_visible(true);
     MenuManager::the().open_menu(*this, make_input);
     WindowManager::the().did_popup_a_menu({});
 }

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -298,6 +298,8 @@ void MenuManager::open_menu(Menu& menu, bool as_current_menu)
 
     m_open_menu_stack.append(menu);
 
+    menu.set_visible(true);
+
     if (!menu.is_empty()) {
         menu.redraw_if_theme_changed();
         auto* window = menu.menu_window();


### PR DESCRIPTION
…tack

We need to make sure the menu was pushed to the open menu stack before
calling set_visible, as this may trigger cursor re-evaluation, which
in turn expects the menu to be considered open.

Fixes #10836