### PR TITLE
LibVT: Show action of double click in tooltip

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -822,7 +822,18 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
     if (attribute.href_id != m_hovered_href_id) {
         if (m_active_href_id.is_null() || m_active_href_id == attribute.href_id) {
             m_hovered_href_id = attribute.href_id;
-            m_hovered_href = attribute.href;
+            auto handlers = Desktop::Launcher::get_handlers_for_url(attribute.href);
+            if (!handlers.is_empty()) {
+                auto path = URL(attribute.href).path();
+                auto name = LexicalPath::basename(path);
+                if (path == handlers[0]) {
+                    m_hovered_href = String::formatted("Execute {}", name);
+                } else {
+                    m_hovered_href = String::formatted("Open {} with {}", name, LexicalPath::basename(handlers[0]));
+                }
+            } else {
+                m_hovered_href = attribute.href;
+            }
         } else {
             m_hovered_href_id = {};
             m_hovered_href = {};


### PR DESCRIPTION
When hovering an item in Terminal we now show what application will
handle it, e.g "Open app-catdog.png in ImageViewer".

If the file is its own handler, i.e an executable, it will show
"Execute myscript.sh"

<img width="422" alt="Skärmavbild 2021-11-12 kl  22 48 34" src="https://user-images.githubusercontent.com/1099835/141540271-fa5f19bb-5c9f-453a-965a-6cd4997dbd98.png">

