### PR TITLE
Utilities/tar: Ignore directory entry if it already exists

### DIFF
--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
                 case Archive::TarFileType::Directory: {
                     Core::File::ensure_parent_directories(absolute_path);
 
-                    if (mkdir(absolute_path.characters(), header.mode())) {
+                    if (mkdir(absolute_path.characters(), header.mode()) && errno != EEXIST) {
                         perror("mkdir");
                         return 1;
                     }


### PR DESCRIPTION
There apparently are .tar archives (\*cough\* gcc \*cough\*) that list some subdirectory entries *after* a file inside those subdirectories has already been created.

I'm aware that this is more of a quick hack rather than a proper fix, so I'd appreciate input on what the best course of action would be (what to do with file permissions, do we just reorder the entries in the .tar, etc.).