### PR TITLE
LibRegex+Tests: Correctly translate BRE pattern end anchors

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -929,3 +929,36 @@ TEST_CASE(optimizer_char_class_lut)
     for (size_t i = 0; i < 1'000'000; ++i)
         EXPECT_EQ(re.match("1635488940000"sv).success, false);
 }
+
+TEST_CASE(posix_basic_dollar_is_end_anchor)
+{
+    // Ensure that a dollar sign at the end only matches the end of the line.
+    {
+        Regex<PosixBasic> re("abc$");
+        EXPECT_EQ(re.match("123abcdef", PosixFlags::Global).success, false);
+        EXPECT_EQ(re.match("123abc", PosixFlags::Global).success, true);
+        EXPECT_EQ(re.match("123abc$def", PosixFlags::Global).success, false);
+        EXPECT_EQ(re.match("123abc$", PosixFlags::Global).success, false);
+    }
+}
+
+TEST_CASE(posix_basic_dollar_is_literal)
+{
+    // Ensure that a dollar sign in the middle is treated as a literal.
+    {
+        Regex<PosixBasic> re("abc$d");
+        EXPECT_EQ(re.match("123abcdef", PosixFlags::Global).success, false);
+        EXPECT_EQ(re.match("123abc", PosixFlags::Global).success, false);
+        EXPECT_EQ(re.match("123abc$def", PosixFlags::Global).success, true);
+        EXPECT_EQ(re.match("123abc$", PosixFlags::Global).success, false);
+    }
+
+    // Ensure that a dollar sign is always treated as a literal if escaped, even if at the end of the pattern.
+    {
+        Regex<PosixBasic> re("abc\\$");
+        EXPECT_EQ(re.match("123abcdef", PosixFlags::Global).success, false);
+        EXPECT_EQ(re.match("123abc", PosixFlags::Global).success, false);
+        EXPECT_EQ(re.match("123abc$def", PosixFlags::Global).success, true);
+        EXPECT_EQ(re.match("123abc$", PosixFlags::Global).success, true);
+    }
+}

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -516,6 +516,20 @@ bool PosixBasicParser::parse_one_char_or_collation_element(ByteCode& bytecode, s
         return true;
     }
 
+    // Dollars are special if at the end of a pattern.
+    if (match(TokenType::Dollar)) {
+        consume();
+
+        // If we are at the end of a pattern, emit an end check instruction.
+        if (match(TokenType::Eof)) {
+            bytecode.empend((ByteCodeValueType)OpCodeId::CheckEnd);
+            return true;
+        }
+
+        // We are not at the end of the string, so we should roll back and continue as normal.
+        back(2);
+    }
+
     // None of these are special in BRE.
     if (match(TokenType::Char) || match(TokenType::Questionmark) || match(TokenType::RightParen) || match(TokenType::HyphenMinus)
         || match(TokenType::Circumflex) || match(TokenType::RightCurly) || match(TokenType::Comma) || match(TokenType::Colon)


### PR DESCRIPTION
Previously we were always choosing the "nothing special" code path, even if the dollar symbol was at the end of the pattern (and therefore should have been considered special).

Fix that by actually checking if the pattern end follows, and emitting the correct instruction if necessary.