### PR TITLE
Kernel+LibC: Pass off_t to pread() via a pointer

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -294,7 +294,7 @@ public:
     ErrorOr<FlatPtr> sys$open(Userspace<const Syscall::SC_open_params*>);
     ErrorOr<FlatPtr> sys$close(int fd);
     ErrorOr<FlatPtr> sys$read(int fd, Userspace<u8*>, size_t);
-    ErrorOr<FlatPtr> sys$pread(int fd, Userspace<u8*>, size_t, off_t);
+    ErrorOr<FlatPtr> sys$pread(int fd, Userspace<u8*>, size_t, Userspace<off_t*>);
     ErrorOr<FlatPtr> sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count);
     ErrorOr<FlatPtr> sys$write(int fd, Userspace<const u8*>, size_t);
     ErrorOr<FlatPtr> sys$writev(int fd, Userspace<const struct iovec*> iov, int iov_count);

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -90,7 +90,7 @@ ErrorOr<FlatPtr> Process::sys$read(int fd, Userspace<u8*> buffer, size_t size)
     return TRY(description->read(user_buffer.value(), size));
 }
 
-ErrorOr<FlatPtr> Process::sys$pread(int fd, Userspace<u8*> buffer, size_t size, off_t offset)
+ErrorOr<FlatPtr> Process::sys$pread(int fd, Userspace<u8*> buffer, size_t size, Userspace<off_t*> userspace_offset)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
@@ -98,6 +98,8 @@ ErrorOr<FlatPtr> Process::sys$pread(int fd, Userspace<u8*> buffer, size_t size, 
         return 0;
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
+    off_t offset;
+    TRY(copy_from_user(&offset, userspace_offset));
     if (offset < 0)
         return EINVAL;
     dbgln_if(IO_DEBUG, "sys$pread({}, {}, {}, {})", fd, buffer.ptr(), size, offset);

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -296,7 +296,7 @@ ssize_t read(int fd, void* buf, size_t count)
 
 ssize_t pread(int fd, void* buf, size_t count, off_t offset)
 {
-    int rc = syscall(SC_pread, fd, buf, count, offset);
+    int rc = syscall(SC_pread, fd, buf, count, &offset);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 


### PR DESCRIPTION
`off_t` is a 64-bit signed integer, so passing it in a register on i686
is not the best idea.

This fix gets us one step closer to making the LLVM port work.