### PR TITLE
Kernel/Storage: Don't use interrupts when resetting SATA AHCI devices

### DIFF
--- a/Kernel/Storage/ATA/AHCIPort.h
+++ b/Kernel/Storage/ATA/AHCIPort.h
@@ -64,7 +64,7 @@ private:
     const char* try_disambiguate_sata_status();
     void try_disambiguate_sata_error();
 
-    bool initiate_sata_reset(SpinlockLocker<Spinlock>&);
+    bool initiate_sata_reset();
     void rebase();
     void recover_from_fatal_error();
     bool shutdown();


### PR DESCRIPTION
Don't use interrupts when trying to reset a device that is connected to
a port on the AHCI controller, and instead poll for changes in status to
break out from the loop. At the worst case scenario we can wait 0.01
seconds for each SATA reset.