### PR TITLE
Kernel/AHCI: Simplify wait and timeout pattern significantly

### DIFF
--- a/Kernel/Storage/ATA/AHCIPort.cpp
+++ b/Kernel/Storage/ATA/AHCIPort.cpp
@@ -89,7 +89,6 @@ void AHCIPort::handle_interrupt()
     }
     if (m_interrupt_status.is_set(AHCI::PortInterruptFlag::PRC)) {
         clear_sata_error_register();
-        m_wait_connect_for_completion = true;
     }
     if (m_interrupt_status.is_set(AHCI::PortInterruptFlag::INF)) {
         // We need to defer the reset, because we can receive interrupts when

--- a/Kernel/Storage/ATA/AHCIPort.h
+++ b/Kernel/Storage/ATA/AHCIPort.h
@@ -107,7 +107,6 @@ private:
     Mutex m_lock { "AHCIPort" };
 
     mutable bool m_wait_for_completion { false };
-    bool m_wait_connect_for_completion { false };
 
     NonnullRefPtrVector<Memory::PhysicalPage> m_dma_buffers;
     NonnullRefPtrVector<Memory::PhysicalPage> m_command_table_pages;

--- a/Kernel/Storage/ATA/AHCIPort.h
+++ b/Kernel/Storage/ATA/AHCIPort.h
@@ -99,6 +99,8 @@ private:
 
     ALWAYS_INLINE bool is_interface_disabled() const { return (m_port_registers.ssts & 0xf) == 4; };
 
+    ALWAYS_INLINE void wait_until_condition_met_or_timeout(size_t delay_in_microseconds, size_t retries, Function<bool(void)> condition_being_met) const;
+
     // Data members
 
     EntropySource m_entropy_source;


### PR DESCRIPTION
Also just remove the AHCIPort `m_wait_connect_for_completion` class member because it's not being used anymore.