### PR TITLE
Ports: Fix building zlib with Clang

### DIFF
--- a/Ports/zlib/package.sh
+++ b/Ports/zlib/package.sh
@@ -5,6 +5,12 @@ useconfigure=true
 files="https://www.zlib.net/zlib-${version}.tar.gz zlib-${version}.tar.gz c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 auth_type="sha256"
 
+pre_configure() {
+    # HACK: Even though Clang generates PIC objects by default, an R_386_PC32
+    # relocation still slips into libz.a if we don't set -fPIC explicitly.
+    export CFLAGS="-fPIC -O3"
+}
+
 configure() {
     # Set uname to linux to prevent it finding the host's `libtool` on e.g. Darwin
     run ./configure --uname=linux


### PR DESCRIPTION
Even though Clang generates PIC objects by default, an R_386_PC32
relocation still slips into libz.a if we don't set -fPIC explicitly.