### PR TITLE
Utilities/tr: Rework squeezing to be supported during more operations

### DIFF
--- a/Base/usr/share/man/man1/tr.md
+++ b/Base/usr/share/man/man1/tr.md
@@ -14,7 +14,7 @@ $ tr [--complement] [--delete] [--squeeze-repeats] <from> [to]
 * `--version`: Print version
 * `-c`, `--complement`: Take the complement of the first set
 * `-d`, `--delete`: Delete characters instead of replacing
-* `-s`, `--squeeze-repeats`: Omit repeated characters listed in the 'to' set from the output
+* `-s`, `--squeeze-repeats`: Omit repeated characters listed in the last given set from the output
 
 ## Arguments:
 


### PR DESCRIPTION
With various settings you can also squeeze during deletion (or while not doing any other operation at all), so this PR streamlines the internals of `tr` to allow for arbitrary combinations of operands (apart from a few specific cases that are checked for in the beginning).

PS: Should be the last `tr` change for a while :^)