### PR TITLE
Taskbar: make quicklaunch bar editable

### DIFF
--- a/Base/usr/share/man/man1/config.md
+++ b/Base/usr/share/man/man1/config.md
@@ -5,7 +5,7 @@ config
 ## Synopsis
 
 ```sh
-$ config <domain> <group> <key> [value]
+$ config [--remove] <domain> <group> <key> [value]
 ```
 
 ## Description
@@ -16,6 +16,7 @@ Show or modify values in the configuration files through ConfigServer.
 
 * `--help`: Display help message and exit
 * `--version`: Print version
+* `-r`, `--remove`: Remove key
 
 ## Arguments:
 

--- a/Userland/Services/Taskbar/CMakeLists.txt
+++ b/Userland/Services/Taskbar/CMakeLists.txt
@@ -14,5 +14,5 @@ set(SOURCES
 )
 
 serenity_bin(Taskbar)
-target_link_libraries(Taskbar LibGUI LibDesktop)
+target_link_libraries(Taskbar LibGUI LibDesktop LibConfig)
 serenity_install_headers(Services/Taskbar)

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -26,6 +26,9 @@
 #include <serenity.h>
 #include <stdio.h>
 
+constexpr const char* quick_launch = "QuickLaunch";
+constexpr int quick_launch_button_size = 24;
+
 class TaskbarWidget final : public GUI::Widget {
     C_OBJECT(TaskbarWidget);
 
@@ -108,16 +111,42 @@ void TaskbarWindow::show_desktop_button_clicked(unsigned)
     GUI::WindowManagerServerConnection::the().async_toggle_show_desktop();
 }
 
+void TaskbarWindow::config_key_was_removed(String const& domain, String const& group, String const& key)
+{
+    if (domain == "Taskbar" && group == quick_launch) {
+        auto button = m_quick_launch_bar->find_child_of_type_named<GUI::Button>(key);
+        if (button)
+            m_quick_launch_bar->remove_child(*button);
+    }
+}
+
+void TaskbarWindow::config_string_did_change(String const& domain, String const& group, String const& key, String const& value)
+{
+    if (domain == "Taskbar" && group == quick_launch) {
+        auto af_path = String::formatted("{}/{}", Desktop::AppFile::APP_FILES_DIRECTORY, value);
+        auto af = Desktop::AppFile::open(af_path);
+        if (!af->is_valid())
+            return;
+
+        auto button = m_quick_launch_bar->find_child_of_type_named<GUI::Button>(key);
+        if (button) {
+            set_quick_launch_button_data(*button, key, af);
+        } else {
+            auto& new_button = m_quick_launch_bar->add<GUI::Button>();
+            set_quick_launch_button_data(new_button, key, af);
+        }
+    }
+}
+
 void TaskbarWindow::create_quick_launch_bar()
 {
-    auto& quick_launch_bar = main_widget()->add<GUI::Frame>();
-    quick_launch_bar.set_shrink_to_fit(true);
-    quick_launch_bar.set_layout<GUI::HorizontalBoxLayout>();
-    quick_launch_bar.layout()->set_spacing(0);
-    quick_launch_bar.set_frame_thickness(0);
+    m_quick_launch_bar = main_widget()->add<GUI::Frame>();
+    m_quick_launch_bar->set_shrink_to_fit(true);
+    m_quick_launch_bar->set_layout<GUI::HorizontalBoxLayout>();
+    m_quick_launch_bar->layout()->set_spacing(0);
+    m_quick_launch_bar->set_frame_thickness(0);
 
     auto config = Core::ConfigFile::open_for_app("Taskbar");
-    constexpr const char* quick_launch = "QuickLaunch";
 
     // FIXME: Core::ConfigFile does not keep the order of the entries.
     for (auto& name : config->keys(quick_launch)) {
@@ -126,36 +155,41 @@ void TaskbarWindow::create_quick_launch_bar()
         auto af = Desktop::AppFile::open(af_path);
         if (!af->is_valid())
             continue;
-        auto app_executable = af->executable();
-        auto app_run_in_terminal = af->run_in_terminal();
-        const int button_size = 24;
-        auto& button = quick_launch_bar.add<GUI::Button>();
-        button.set_fixed_size(button_size, button_size);
-        button.set_button_style(Gfx::ButtonStyle::Coolbar);
-        button.set_icon(af->icon().bitmap_for_size(16));
-        button.set_tooltip(af->name());
-        button.on_click = [app_executable, app_run_in_terminal](auto) {
-            pid_t pid = fork();
-            if (pid < 0) {
-                perror("fork");
-            } else if (pid == 0) {
-                if (chdir(Core::StandardPaths::home_directory().characters()) < 0) {
-                    perror("chdir");
-                    exit(1);
-                }
-                if (app_run_in_terminal)
-                    execl("/bin/Terminal", "Terminal", "-e", app_executable.characters(), nullptr);
-                else
-                    execl(app_executable.characters(), app_executable.characters(), nullptr);
-                perror("execl");
-                VERIFY_NOT_REACHED();
-            } else {
-                if (disown(pid) < 0)
-                    perror("disown");
-            }
-        };
+        auto& button = m_quick_launch_bar->add<GUI::Button>();
+        set_quick_launch_button_data(button, name, af);
     }
-    quick_launch_bar.set_fixed_height(24);
+    m_quick_launch_bar->set_fixed_height(24);
+}
+
+void TaskbarWindow::set_quick_launch_button_data(GUI::Button& button, String const& button_name, NonnullRefPtr<Desktop::AppFile> app_file)
+{
+    auto app_executable = app_file->executable();
+    auto app_run_in_terminal = app_file->run_in_terminal();
+    button.set_fixed_size(quick_launch_button_size, quick_launch_button_size);
+    button.set_button_style(Gfx::ButtonStyle::Coolbar);
+    button.set_icon(app_file->icon().bitmap_for_size(16));
+    button.set_tooltip(app_file->name());
+    button.set_name(button_name);
+    button.on_click = [app_executable, app_run_in_terminal](auto) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+        } else if (pid == 0) {
+            if (chdir(Core::StandardPaths::home_directory().characters()) < 0) {
+                perror("chdir");
+                exit(1);
+            }
+            if (app_run_in_terminal)
+                execl("/bin/Terminal", "Terminal", "-e", app_executable.characters(), nullptr);
+            else
+                execl(app_executable.characters(), app_executable.characters(), nullptr);
+            perror("execl");
+            VERIFY_NOT_REACHED();
+        } else {
+            if (disown(pid) < 0)
+                perror("disown");
+        }
+    };
 }
 
 void TaskbarWindow::on_screen_rects_change(const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index)

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -7,11 +7,15 @@
 #pragma once
 
 #include "WindowList.h"
+#include <LibConfig/Listener.h>
 #include <LibDesktop/AppFile.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <WindowServer/ScreenLayout.h>
 
-class TaskbarWindow final : public GUI::Window {
+class TaskbarWindow final : public GUI::Window
+    , public Config::Listener {
     C_OBJECT(TaskbarWindow);
 
 public:
@@ -20,10 +24,14 @@ public:
     static int taskbar_height() { return 27; }
     static int taskbar_icon_size() { return 16; }
 
+    virtual void config_key_was_removed(String const&, String const&, String const&) override;
+    virtual void config_string_did_change(String const&, String const&, String const&, String const&) override;
+
 private:
     explicit TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu);
     static void show_desktop_button_clicked(unsigned);
     void create_quick_launch_bar();
+    void set_quick_launch_button_data(GUI::Button&, String const&, NonnullRefPtr<Desktop::AppFile>);
     void on_screen_rects_change(const Vector<Gfx::IntRect, 4>&, size_t);
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
     void add_window_button(::Window&, const WindowIdentifier&);
@@ -45,6 +53,7 @@ private:
     NonnullRefPtr<GUI::Menu> m_start_menu;
     RefPtr<GUI::Widget> m_task_button_container;
     RefPtr<Gfx::Bitmap> m_default_icon;
+    RefPtr<GUI::Frame> m_quick_launch_bar;
 
     Gfx::IntSize m_applet_area_size;
     RefPtr<GUI::Frame> m_applet_area_container;

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -9,6 +9,7 @@
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
+#include <LibConfig/Client.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/EventLoop.h>
@@ -37,8 +38,9 @@ int main(int argc, char** argv)
         perror("pledge");
         return 1;
     }
-
     auto app = GUI::Application::construct(argc, argv);
+    Config::pledge_domains("Taskbar");
+    Config::monitor_domain("Taskbar");
     app->event_loop().register_signal(SIGCHLD, [](int) {
         // Wait all available children
         while (waitpid(-1, nullptr, WNOHANG) > 0)

--- a/Userland/Utilities/config.cpp
+++ b/Userland/Utilities/config.cpp
@@ -15,14 +15,21 @@ int main(int argc, char** argv)
     String group;
     String key;
     String value_to_write;
+    bool remove_key = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Show or modify values in the configuration files through ConfigServer.");
+    args_parser.add_option(remove_key, "Remove key", "remove", 'r');
     args_parser.add_positional_argument(domain, "Config domain", "domain");
     args_parser.add_positional_argument(group, "Group name", "group");
     args_parser.add_positional_argument(key, "Key name", "key");
     args_parser.add_positional_argument(value_to_write, "Value to write", "value", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
+
+    if (remove_key) {
+        Config::remove_key(domain, group, key);
+        return 0;
+    }
 
     if (!value_to_write.is_empty()) {
         Config::write_string(domain, group, key, value_to_write);


### PR DESCRIPTION
This change makes use of the added functionality of config key removal notifications. Taskbar items may now be removed/added by changing the Taskbar config. 

Example:
```
config -r Taskbar QuickLaunch Terminal
config Taskbar QuickLaunch Hearts Hearts.af
```