### PR TITLE
LibJS: Implement Intl.NumberFormat.prototype.formatToParts

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -605,7 +605,7 @@ Vector<PatternPartition> partition_number_pattern(NumberFormat& number_format, d
         // b. If p is "literal", then
         if (part == "literal"sv) {
             // i. Append a new Record { [[Type]]: "literal", [[Value]]: patternPart.[[Value]] } as the last element of result.
-            result.append({ part, move(pattern_part.value) });
+            result.append({ "literal"sv, move(pattern_part.value) });
         }
 
         // c. Else if p is equal to "number", then
@@ -621,7 +621,7 @@ Vector<PatternPartition> partition_number_pattern(NumberFormat& number_format, d
             // i. Let plusSignSymbol be the ILND String representing the plus sign.
             auto plus_sign_symbol = Unicode::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), "plusSign"sv).value_or("+"sv);
             // ii. Append a new Record { [[Type]]: "plusSign", [[Value]]: plusSignSymbol } as the last element of result.
-            result.append({ part, plus_sign_symbol });
+            result.append({ "plusSign"sv, plus_sign_symbol });
         }
 
         // e. Else if p is equal to "minusSign", then
@@ -629,7 +629,7 @@ Vector<PatternPartition> partition_number_pattern(NumberFormat& number_format, d
             // i. Let minusSignSymbol be the ILND String representing the minus sign.
             auto minus_sign_symbol = Unicode::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), "minusSign"sv).value_or("-"sv);
             // ii. Append a new Record { [[Type]]: "minusSign", [[Value]]: minusSignSymbol } as the last element of result.
-            result.append({ part, minus_sign_symbol });
+            result.append({ "minusSign"sv, minus_sign_symbol });
         }
 
         // f. Else if p is equal to "percentSign" and numberFormat.[[Style]] is "percent", then
@@ -637,7 +637,7 @@ Vector<PatternPartition> partition_number_pattern(NumberFormat& number_format, d
             // i. Let percentSignSymbol be the ILND String representing the percent sign.
             auto percent_sign_symbol = Unicode::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), "percentSign"sv).value_or("%"sv);
             // ii. Append a new Record { [[Type]]: "percentSign", [[Value]]: percentSignSymbol } as the last element of result.
-            result.append({ part, percent_sign_symbol });
+            result.append({ "percentSign"sv, percent_sign_symbol });
         }
 
         // g. Else if p is equal to "unitPrefix" and numberFormat.[[Style]] is "unit", then
@@ -804,7 +804,7 @@ Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_for
             // ii. If p is "literal", then
             if (part == "literal"sv) {
                 // 1. Append a new Record { [[Type]]: "literal", [[Value]]: patternPart.[[Value]] } as the last element of result.
-                result.append({ part, move(pattern_part.value) });
+                result.append({ "literal"sv, move(pattern_part.value) });
             }
             // iii. Else if p is equal to "number", then
             else if (part == "number"sv) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -97,6 +97,7 @@ public:
     CurrencyDisplay currency_display() const { return *m_currency_display; }
     StringView currency_display_string() const;
     void set_currency_display(StringView currency_display);
+    StringView resolve_currency_display();
 
     bool has_currency_sign() const { return m_currency_sign.has_value(); }
     CurrencySign currency_sign() const { return *m_currency_sign; }
@@ -177,6 +178,9 @@ private:
     Optional<CompactDisplay> m_compact_display {};          // [[CompactDisplay]]
     SignDisplay m_sign_display { SignDisplay::Invalid };    // [[SignDisplay]]
     NativeFunction* m_bound_format { nullptr };             // [[BoundFormat]]
+
+    // Non-standard. Stores the resolved currency display string based on [[Locale]], [[Currency]], and [[CurrencyDisplay]].
+    Optional<StringView> m_resolved_currency_display;
 };
 
 struct FormatResult {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -199,6 +199,7 @@ FormatResult format_numeric_to_string(NumberFormat& number_format, double number
 Vector<PatternPartition> partition_number_pattern(NumberFormat& number_format, double number);
 Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_format, double number, String formatted_string, int exponent);
 String format_numeric(NumberFormat& number_format, double number);
+Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number_format, double number);
 RawFormatResult to_raw_precision(double number, int min_precision, int max_precision);
 RawFormatResult to_raw_fixed(double number, int min_fraction, int max_fraction);
 ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_object, NumberFormat& intl_object, Object const& options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -41,6 +41,10 @@ ThrowCompletionOr<Value> NumberFormatFunction::call()
     // 4. Let x be ? ToNumeric(value).
     value = TRY(value.to_numeric(global_object));
 
+    // FIXME: Support BigInt number formatting.
+    if (value.is_bigint())
+        return vm.throw_completion<InternalError>(global_object, ErrorType::NotImplemented, "BigInt number formatting");
+
     // 5. Return ? FormatNumeric(nf, x).
     // Note: Our implementation of FormatNumeric does not throw.
     auto formatted = format_numeric(m_number_format, value.as_double());

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
@@ -21,6 +21,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(format);
+    JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -14,6 +14,16 @@ describe("errors", () => {
             Intl.NumberFormat().format(Symbol.hasInstance);
         }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
     });
+
+    // FIXME: Remove this and add BigInt tests when BigInt number formatting is supported.
+    test("bigint", () => {
+        expect(() => {
+            Intl.NumberFormat().format(1n);
+        }).toThrowWithMessage(
+            InternalError,
+            "BigInt number formatting is not implemented in LibJS"
+        );
+    });
 });
 
 describe("special values", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
@@ -1,0 +1,912 @@
+describe("errors", () => {
+    test("called on non-NumberFormat object", () => {
+        expect(() => {
+            Intl.NumberFormat.prototype.formatToParts(1);
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.NumberFormat");
+    });
+
+    test("called with value that cannot be converted to a number", () => {
+        expect(() => {
+            Intl.NumberFormat().formatToParts(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+    });
+
+    // FIXME: Remove this and add BigInt tests when BigInt number formatting is supported.
+    test("bigint", () => {
+        expect(() => {
+            Intl.NumberFormat().formatToParts(1n);
+        }).toThrowWithMessage(
+            InternalError,
+            "BigInt number formatting is not implemented in LibJS"
+        );
+    });
+});
+
+describe("special values", () => {
+    test("NaN", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.formatToParts()).toEqual([{ type: "nan", value: "NaN" }]);
+        expect(en.formatToParts(NaN)).toEqual([{ type: "nan", value: "NaN" }]);
+        expect(en.formatToParts(undefined)).toEqual([{ type: "nan", value: "NaN" }]);
+
+        const ar = new Intl.NumberFormat("ar");
+        expect(ar.formatToParts()).toEqual([{ type: "nan", value: "ليس رقم" }]);
+        expect(ar.formatToParts(NaN)).toEqual([{ type: "nan", value: "ليس رقم" }]);
+        expect(ar.formatToParts(undefined)).toEqual([{ type: "nan", value: "ليس رقم" }]);
+    });
+
+    test("Infinity", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.formatToParts(Infinity)).toEqual([{ type: "infinity", value: "∞" }]);
+        expect(en.formatToParts(-Infinity)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "infinity", value: "∞" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar");
+        expect(ar.formatToParts(Infinity)).toEqual([{ type: "infinity", value: "∞" }]);
+        expect(ar.formatToParts(-Infinity)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "infinity", value: "∞" },
+        ]);
+    });
+});
+
+describe("style=decimal", () => {
+    test("default", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.formatToParts(123)).toEqual([{ type: "integer", value: "123" }]);
+        expect(en.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "23" },
+        ]);
+        expect(en.formatToParts(12.3)).toEqual([
+            { type: "integer", value: "12" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "3" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar");
+        expect(ar.formatToParts(123)).toEqual([{ type: "integer", value: "\u0661\u0662\u0663" }]);
+        expect(ar.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662\u0663" },
+        ]);
+        expect(ar.formatToParts(12.3)).toEqual([
+            { type: "integer", value: "\u0661\u0662" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0663" },
+        ]);
+    });
+
+    test("signDisplay=never", () => {
+        const en = new Intl.NumberFormat("en", { signDisplay: "never" });
+        expect(en.formatToParts(1)).toEqual([{ type: "integer", value: "1" }]);
+        expect(en.formatToParts(-1)).toEqual([{ type: "integer", value: "1" }]);
+
+        const ar = new Intl.NumberFormat("ar", { signDisplay: "never" });
+        expect(ar.formatToParts(1)).toEqual([{ type: "integer", value: "\u0661" }]);
+        expect(ar.formatToParts(-1)).toEqual([{ type: "integer", value: "\u0661" }]);
+    });
+
+    test("signDisplay=auto", () => {
+        const en = new Intl.NumberFormat("en", { signDisplay: "auto" });
+        expect(en.formatToParts(0)).toEqual([{ type: "integer", value: "0" }]);
+        expect(en.formatToParts(1)).toEqual([{ type: "integer", value: "1" }]);
+        expect(en.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "0" },
+        ]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "1" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { signDisplay: "auto" });
+        expect(ar.formatToParts(0)).toEqual([{ type: "integer", value: "\u0660" }]);
+        expect(ar.formatToParts(1)).toEqual([{ type: "integer", value: "\u0661" }]);
+        expect(ar.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0660" },
+        ]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+        ]);
+    });
+
+    test("signDisplay=always", () => {
+        const en = new Intl.NumberFormat("en", { signDisplay: "always" });
+        expect(en.formatToParts(0)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "integer", value: "0" },
+        ]);
+        expect(en.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "integer", value: "1" },
+        ]);
+        expect(en.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "0" },
+        ]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "1" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { signDisplay: "always" });
+        expect(ar.formatToParts(0)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0660" },
+        ]);
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0661" },
+        ]);
+        expect(ar.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0660" },
+        ]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+        ]);
+    });
+
+    test("signDisplay=exceptZero", () => {
+        const en = new Intl.NumberFormat("en", { signDisplay: "exceptZero" });
+        expect(en.formatToParts(0)).toEqual([{ type: "integer", value: "0" }]);
+        expect(en.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "integer", value: "1" },
+        ]);
+        expect(en.formatToParts(-0)).toEqual([{ type: "integer", value: "0" }]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "1" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { signDisplay: "exceptZero" });
+        expect(ar.formatToParts(0)).toEqual([{ type: "integer", value: "\u0660" }]);
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0661" },
+        ]);
+        expect(ar.formatToParts(-0)).toEqual([{ type: "integer", value: "\u0660" }]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+        ]);
+    });
+});
+
+describe("style=percent", () => {
+    test("default", () => {
+        const en = new Intl.NumberFormat("en", { style: "percent", minimumFractionDigits: 2 });
+        expect(en.formatToParts(1)).toEqual([
+            { type: "integer", value: "100" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(1.2345)).toEqual([
+            { type: "integer", value: "123" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "45" },
+            { type: "percentSign", value: "%" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { style: "percent", minimumFractionDigits: 2 });
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661\u0660\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(1.2345)).toEqual([
+            { type: "integer", value: "\u0661\u0662\u0663" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0664\u0665" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+    });
+
+    test("signDisplay=never", () => {
+        const en = new Intl.NumberFormat("en", { style: "percent", signDisplay: "never" });
+        expect(en.formatToParts(0.01)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.01)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { style: "percent", signDisplay: "never" });
+        expect(ar.formatToParts(0.01)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.01)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+    });
+
+    test("signDisplay=auto", () => {
+        const en = new Intl.NumberFormat("en", { style: "percent", signDisplay: "auto" });
+        expect(en.formatToParts(0.0)).toEqual([
+            { type: "integer", value: "0" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(0.01)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.0)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "0" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.01)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { style: "percent", signDisplay: "auto" });
+        expect(ar.formatToParts(0.0)).toEqual([
+            { type: "integer", value: "\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(0.01)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.0)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.01)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+    });
+
+    test("signDisplay=always", () => {
+        const en = new Intl.NumberFormat("en", { style: "percent", signDisplay: "always" });
+        expect(en.formatToParts(0.0)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "integer", value: "0" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(0.01)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.0)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "0" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.01)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { style: "percent", signDisplay: "always" });
+        expect(ar.formatToParts(0.0)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(0.01)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.0)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.01)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+    });
+
+    test("signDisplay=exceptZero", () => {
+        const en = new Intl.NumberFormat("en", { style: "percent", signDisplay: "exceptZero" });
+        expect(en.formatToParts(0.0)).toEqual([
+            { type: "integer", value: "0" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(0.01)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.0)).toEqual([
+            { type: "integer", value: "0" },
+            { type: "percentSign", value: "%" },
+        ]);
+        expect(en.formatToParts(-0.01)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "integer", value: "1" },
+            { type: "percentSign", value: "%" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { style: "percent", signDisplay: "exceptZero" });
+        expect(ar.formatToParts(0.0)).toEqual([
+            { type: "integer", value: "\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(0.01)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.0)).toEqual([
+            { type: "integer", value: "\u0660" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+        expect(ar.formatToParts(-0.01)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+            { type: "percentSign", value: "\u066a\u061c" },
+        ]);
+    });
+});
+
+describe("style=currency", () => {
+    test("currencyDisplay=code", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "code",
+        });
+        expect(en.formatToParts(1)).toEqual([
+            { type: "currency", value: "USD" },
+            { type: "literal", value: "\u00a0" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(1.23)).toEqual([
+            { type: "currency", value: "USD" },
+            { type: "literal", value: "\u00a0" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "23" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "code",
+        });
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "USD" },
+        ]);
+        expect(ar.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662\u0663" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "USD" },
+        ]);
+    });
+
+    test("currencyDisplay=symbol", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "symbol",
+        });
+        expect(en.formatToParts(1)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(1.23)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "23" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "symbol",
+        });
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662\u0663" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+    });
+
+    test("currencyDisplay=narrowSymbol", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "narrowSymbol",
+        });
+        expect(en.formatToParts(1)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(1.23)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "23" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "narrowSymbol",
+        });
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662\u0663" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+    });
+
+    test("currencyDisplay=name", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "name",
+        });
+        expect(en.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+            { type: "literal", value: " " },
+            { type: "currency", value: "US dollars" },
+        ]);
+        expect(en.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "23" },
+            { type: "literal", value: " " },
+            { type: "currency", value: "US dollars" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "name",
+        });
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: " " },
+            { type: "currency", value: "دولار أمريكي" },
+        ]);
+        expect(ar.formatToParts(1.23)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662\u0663" },
+            { type: "literal", value: " " },
+            { type: "currency", value: "دولار أمريكي" },
+        ]);
+    });
+
+    test("signDisplay=never", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "never",
+        });
+        expect(en.formatToParts(1)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "never",
+        });
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+
+        const zh = new Intl.NumberFormat("zh-Hant-u-nu-hanidec", {
+            style: "currency",
+            currency: "USD",
+            currencySign: "accounting",
+            signDisplay: "never",
+        });
+        expect(zh.formatToParts(1)).toEqual([
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(-1)).toEqual([
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+    });
+
+    test("signDisplay=auto", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "auto",
+        });
+        expect(en.formatToParts(0)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "0" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(1)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "0" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "auto",
+        });
+        expect(ar.formatToParts(0)).toEqual([
+            { type: "integer", value: "\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+
+        const zh = new Intl.NumberFormat("zh-Hant-u-nu-hanidec", {
+            style: "currency",
+            currency: "USD",
+            currencySign: "accounting",
+            signDisplay: "auto",
+        });
+        expect(zh.formatToParts(0)).toEqual([
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "〇" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(1)).toEqual([
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(-0)).toEqual([
+            { type: "literal", value: "(" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "〇" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+            { type: "literal", value: ")" },
+        ]);
+        expect(zh.formatToParts(-1)).toEqual([
+            { type: "literal", value: "(" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+            { type: "literal", value: ")" },
+        ]);
+    });
+
+    test("signDisplay=always", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "always",
+        });
+        expect(en.formatToParts(0)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "0" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "0" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "always",
+        });
+        expect(ar.formatToParts(0)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-0)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+
+        const zh = new Intl.NumberFormat("zh-Hant-u-nu-hanidec", {
+            style: "currency",
+            currency: "USD",
+            currencySign: "accounting",
+            signDisplay: "always",
+        });
+        expect(zh.formatToParts(0)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "〇" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(-0)).toEqual([
+            { type: "literal", value: "(" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "〇" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+            { type: "literal", value: ")" },
+        ]);
+        expect(zh.formatToParts(-1)).toEqual([
+            { type: "literal", value: "(" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+            { type: "literal", value: ")" },
+        ]);
+    });
+
+    test("signDisplay=exceptZero", () => {
+        const en = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "exceptZero",
+        });
+        expect(en.formatToParts(0)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "0" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-0)).toEqual([
+            { type: "currency", value: "$" },
+            { type: "integer", value: "0" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+        expect(en.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "-" },
+            { type: "currency", value: "$" },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "00" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "currency",
+            currency: "USD",
+            signDisplay: "exceptZero",
+        });
+        expect(ar.formatToParts(0)).toEqual([
+            { type: "integer", value: "\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "\u061c+" },
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-0)).toEqual([
+            { type: "integer", value: "\u0660" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+        expect(ar.formatToParts(-1)).toEqual([
+            { type: "minusSign", value: "\u061c-" },
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0660\u0660" },
+            { type: "literal", value: "\u00a0" },
+            { type: "currency", value: "US$" },
+        ]);
+
+        const zh = new Intl.NumberFormat("zh-Hant-u-nu-hanidec", {
+            style: "currency",
+            currency: "USD",
+            currencySign: "accounting",
+            signDisplay: "exceptZero",
+        });
+        expect(zh.formatToParts(0)).toEqual([
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "〇" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(1)).toEqual([
+            { type: "plusSign", value: "+" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(-0)).toEqual([
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "〇" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+        ]);
+        expect(zh.formatToParts(-1)).toEqual([
+            { type: "literal", value: "(" },
+            { type: "currency", value: "US$" },
+            { type: "integer", value: "一" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "〇〇" },
+            { type: "literal", value: ")" },
+        ]);
+    });
+});

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -1013,18 +1013,30 @@ String create_currency_format_pattern(StringView currency_display, StringView ba
     Utf8View utf8_currency_display { currency_display };
     Optional<String> currency_display_with_spacing;
 
+    auto last_code_point = [](StringView string) {
+        Utf8View utf8_string { string };
+        u32 code_point = 0;
+
+        for (auto it = utf8_string.begin(); it != utf8_string.end(); ++it)
+            code_point = *it;
+
+        return code_point;
+    };
+
     if (*number_index < *currency_index) {
-        if (!base_pattern.substring_view(0, *currency_index).ends_with(spacing)) {
+        u32 last_pattern_code_point = last_code_point(base_pattern.substring_view(0, *currency_index));
+
+        if (!code_point_has_general_category(last_pattern_code_point, GeneralCategory::Separator)) {
             u32 first_currency_code_point = *utf8_currency_display.begin();
 
             if (!code_point_has_general_category(first_currency_code_point, GeneralCategory::Symbol))
                 currency_display_with_spacing = String::formatted("{}{}", spacing, currency_display);
         }
     } else {
-        if (!base_pattern.substring_view(0, *number_index).ends_with(spacing)) {
-            u32 last_currency_code_point = 0;
-            for (auto it = utf8_currency_display.begin(); it != utf8_currency_display.end(); ++it)
-                last_currency_code_point = *it;
+        u32 last_pattern_code_point = last_code_point(base_pattern.substring_view(0, *number_index));
+
+        if (!code_point_has_general_category(last_pattern_code_point, GeneralCategory::Separator)) {
+            u32 last_currency_code_point = last_code_point(currency_display);
 
             if (!code_point_has_general_category(last_currency_code_point, GeneralCategory::Symbol))
                 currency_display_with_spacing = String::formatted("{}{}", currency_display, spacing);

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -997,7 +997,7 @@ Optional<NumberFormat> select_currency_unit_pattern(StringView locale, StringVie
 }
 
 // https://www.unicode.org/reports/tr35/tr35-numbers.html#Currencies
-String create_currency_format_pattern(StringView currency_display, StringView base_pattern)
+Optional<String> augment_currency_format_pattern([[maybe_unused]] StringView currency_display, [[maybe_unused]] StringView base_pattern)
 {
 #if ENABLE_UNICODE_DATA
     constexpr auto number_key = "{number}"sv;
@@ -1011,7 +1011,7 @@ String create_currency_format_pattern(StringView currency_display, StringView ba
     VERIFY(currency_index.has_value());
 
     Utf8View utf8_currency_display { currency_display };
-    Optional<String> currency_display_with_spacing;
+    Optional<String> currency_key_with_spacing;
 
     auto last_code_point = [](StringView string) {
         Utf8View utf8_string { string };
@@ -1030,7 +1030,7 @@ String create_currency_format_pattern(StringView currency_display, StringView ba
             u32 first_currency_code_point = *utf8_currency_display.begin();
 
             if (!code_point_has_general_category(first_currency_code_point, GeneralCategory::Symbol))
-                currency_display_with_spacing = String::formatted("{}{}", spacing, currency_display);
+                currency_key_with_spacing = String::formatted("{}{}", spacing, currency_key);
         }
     } else {
         u32 last_pattern_code_point = last_code_point(base_pattern.substring_view(0, *number_index));
@@ -1039,15 +1039,15 @@ String create_currency_format_pattern(StringView currency_display, StringView ba
             u32 last_currency_code_point = last_code_point(currency_display);
 
             if (!code_point_has_general_category(last_currency_code_point, GeneralCategory::Symbol))
-                currency_display_with_spacing = String::formatted("{}{}", currency_display, spacing);
+                currency_key_with_spacing = String::formatted("{}{}", currency_key, spacing);
         }
     }
 
-    if (currency_display_with_spacing.has_value())
-        return base_pattern.replace(currency_key, *currency_display_with_spacing);
+    if (currency_key_with_spacing.has_value())
+        return base_pattern.replace(currency_key, *currency_key_with_spacing);
 #endif
 
-    return base_pattern.replace(currency_key, currency_display);
+    return {};
 }
 
 String LanguageID::to_string() const

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -196,6 +196,6 @@ Optional<LanguageID> remove_likely_subtags(LanguageID const& language_id);
 String resolve_most_likely_territory(LanguageID const& language_id, StringView territory_alias);
 
 Optional<NumberFormat> select_currency_unit_pattern(StringView locale, StringView system, double number);
-String create_currency_format_pattern(StringView currency_display, StringView base_pattern);
+Optional<String> augment_currency_format_pattern(StringView currency_display, StringView base_pattern);
 
 }


### PR DESCRIPTION
Fun fact! SpiderMonkey and V8 (so, probably, ICU) have a bug handling some non-printable characters in the `ar` locale.

Using V8:
```js
> p = Intl.NumberFormat('ar', {style: 'currency', currency: 'USD'}).formatToParts(-1)
[
  { type: 'literal', value: '؜' },
  { type: 'minusSign', value: '-' },
  { type: 'integer', value: '١' },
  { type: 'decimal', value: '٫' },
  { type: 'fraction', value: '٠٠' },
  { type: 'literal', value: ' ' },
  { type: 'currency', value: 'US$' }
]

> p[0].value.codePointAt(0).toString(16)
'61c'

```

Using LibJS:
```js
> p = Intl.NumberFormat('ar', {style: 'currency', currency: 'USD'}).formatToParts(-1)
[ { "type": "minusSign", "value": "؜-" }, { "type": "integer", "value": "١" }, { "type": "decimal", "value": "٫" }, { "type": "fraction", "value": "٠٠" }, { "type": "literal", "value": " " }, { "type": "currency", "value": "US$" } ]

> p[0].value.codePointAt(0).toString(16)
"61c"
> p[0].value.codePointAt(1).toString(16)
"2d"

```

The bug is that they split the Arabic minus sign into a "literal" (U+061C, ARABIC LETTER MARK) and the minus sign itself. The Arabic minus sign is [listed here](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-numbers-modern/main/ar/numbers.json#L23). It's hard to tell with the naked eye, because U+061C is non-printable, but that is U+061C followed by "-". These code points should not be split.