### PR TITLE
LibSQL and sql utility: Improve error handling

### DIFF
--- a/Tests/LibSQL/TestSqlBtreeIndex.cpp
+++ b/Tests/LibSQL/TestSqlBtreeIndex.cpp
@@ -146,6 +146,7 @@ void insert_and_get_to_and_from_btree(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 
@@ -162,6 +163,7 @@ void insert_and_get_to_and_from_btree(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 
@@ -180,6 +182,7 @@ void insert_into_and_scan_btree(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 
@@ -197,6 +200,7 @@ void insert_into_and_scan_btree(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto btree = setup_btree(serializer);
 

--- a/Tests/LibSQL/TestSqlHashIndex.cpp
+++ b/Tests/LibSQL/TestSqlHashIndex.cpp
@@ -141,6 +141,7 @@ void insert_and_get_to_and_from_hash_index(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
 
@@ -158,6 +159,7 @@ void insert_and_get_to_and_from_hash_index(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
 
@@ -237,6 +239,7 @@ void insert_into_and_scan_hash_index(int num_keys)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
 
@@ -254,6 +257,7 @@ void insert_into_and_scan_hash_index(int num_keys)
 
     {
         auto heap = SQL::Heap::construct("/tmp/test.db");
+        EXPECT(!heap->open().is_error());
         SQL::Serializer serializer(heap);
         auto hash_index = setup_hash_index(serializer);
         Vector<bool> found;

--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -137,6 +137,28 @@ TEST_CASE(insert_wrong_number_of_values)
     EXPECT(result->inserted() == 0);
 }
 
+TEST_CASE(insert_identifier_as_value)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    EXPECT(!database->open().is_error());
+    create_table(database);
+    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ( identifier, 42 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::SyntaxError);
+    EXPECT(result->inserted() == 0);
+}
+
+TEST_CASE(insert_quoted_identifier_as_value)
+{
+    ScopeGuard guard([]() { unlink(db_name); });
+    auto database = SQL::Database::construct(db_name);
+    EXPECT(!database->open().is_error());
+    create_table(database);
+    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ( \"QuotedIdentifier\", 42 );");
+    EXPECT(result->error().code == SQL::SQLErrorCode::SyntaxError);
+    EXPECT(result->inserted() == 0);
+}
+
 TEST_CASE(insert_without_column_names)
 {
     ScopeGuard guard([]() { unlink(db_name); });

--- a/Userland/Libraries/LibSQL/AST/CreateSchema.cpp
+++ b/Userland/Libraries/LibSQL/AST/CreateSchema.cpp
@@ -12,7 +12,10 @@ namespace SQL::AST {
 
 RefPtr<SQLResult> CreateSchema::execute(ExecutionContext& context) const
 {
-    auto schema_def = context.database->get_schema(m_schema_name);
+    auto schema_def_or_error = context.database->get_schema(m_schema_name);
+    if (schema_def_or_error.is_error())
+        return SQLResult::construct(SQLCommand::Create, SQLErrorCode::InternalError, schema_def_or_error.error());
+    auto schema_def = schema_def_or_error.release_value();
     if (schema_def) {
         if (m_is_error_if_schema_exists) {
             return SQLResult::construct(SQLCommand::Create, SQLErrorCode::SchemaExists, m_schema_name);
@@ -21,7 +24,8 @@ RefPtr<SQLResult> CreateSchema::execute(ExecutionContext& context) const
     }
 
     schema_def = SchemaDef::construct(m_schema_name);
-    context.database->add_schema(*schema_def);
+    if (auto maybe_error = context.database->add_schema(*schema_def); maybe_error.is_error())
+        return SQLResult::construct(SQLCommand::Create, SQLErrorCode::InternalError, maybe_error.error());
     return SQLResult::construct(SQLCommand::Create, 0, 1);
 }
 

--- a/Userland/Libraries/LibSQL/AST/CreateTable.cpp
+++ b/Userland/Libraries/LibSQL/AST/CreateTable.cpp
@@ -12,10 +12,16 @@ namespace SQL::AST {
 RefPtr<SQLResult> CreateTable::execute(ExecutionContext& context) const
 {
     auto schema_name = (!m_schema_name.is_null() && !m_schema_name.is_empty()) ? m_schema_name : "default";
-    auto schema_def = context.database->get_schema(schema_name);
+    auto schema_def_or_error = context.database->get_schema(schema_name);
+    if (schema_def_or_error.is_error())
+        return SQLResult::construct(SQLCommand::Create, SQLErrorCode::InternalError, schema_def_or_error.error());
+    auto schema_def = schema_def_or_error.release_value();
     if (!schema_def)
         return SQLResult::construct(SQLCommand::Create, SQLErrorCode::SchemaDoesNotExist, m_schema_name);
-    auto table_def = context.database->get_table(schema_name, m_table_name);
+    auto table_def_or_error = context.database->get_table(schema_name, m_table_name);
+    if (table_def_or_error.is_error())
+        return SQLResult::construct(SQLCommand::Create, SQLErrorCode::InternalError, table_def_or_error.error());
+    auto table_def = table_def_or_error.release_value();
     if (table_def) {
         if (m_is_error_if_table_exists) {
             return SQLResult::construct(SQLCommand::Create, SQLErrorCode::TableExists, m_table_name);
@@ -37,7 +43,8 @@ RefPtr<SQLResult> CreateTable::execute(ExecutionContext& context) const
         }
         table_def->append_column(column.name(), type);
     }
-    context.database->add_table(*table_def);
+    if (auto maybe_error = context.database->add_table(*table_def); maybe_error.is_error())
+        return SQLResult::construct(SQLCommand::Create, SQLErrorCode::InternalError, maybe_error.release_error());
     return SQLResult::construct(SQLCommand::Create, 0, 1);
 }
 

--- a/Userland/Libraries/LibSQL/AST/Expression.cpp
+++ b/Userland/Libraries/LibSQL/AST/Expression.cpp
@@ -169,6 +169,10 @@ Value UnaryOperatorExpression::evaluate(ExecutionContext& context) const
 
 Value ColumnNameExpression::evaluate(ExecutionContext& context) const
 {
+    if (!context.current_row) {
+        context.result->set_error(SQLErrorCode::SyntaxError, column_name());
+        return Value::null();
+    }
     auto& descriptor = *context.current_row->descriptor();
     VERIFY(context.current_row->size() == descriptor.size());
     Optional<size_t> index_in_row;

--- a/Userland/Libraries/LibSQL/AST/Expression.cpp
+++ b/Userland/Libraries/LibSQL/AST/Expression.cpp
@@ -66,7 +66,8 @@ Value BinaryOperatorExpression::evaluate(ExecutionContext& context) const
     switch (type()) {
     case BinaryOperator::Concatenate: {
         if (lhs_value.type() != SQLType::Text) {
-            VERIFY_NOT_REACHED();
+            context.result->set_error(SQLErrorCode::BooleanOperatorTypeMismatch, BinaryOperator_name(type()));
+            return Value::null();
         }
         AK::StringBuilder builder;
         builder.append(lhs_value.to_string());
@@ -110,7 +111,7 @@ Value BinaryOperatorExpression::evaluate(ExecutionContext& context) const
             context.result->set_error(SQLErrorCode::BooleanOperatorTypeMismatch, BinaryOperator_name(type()));
             return Value::null();
         }
-        return Value(lhs_bool_maybe.value() && rhs_bool_maybe.value());
+        return Value(lhs_bool_maybe.release_value() && rhs_bool_maybe.release_value());
     }
     case BinaryOperator::Or: {
         auto lhs_bool_maybe = lhs_value.to_bool();
@@ -119,7 +120,7 @@ Value BinaryOperatorExpression::evaluate(ExecutionContext& context) const
             context.result->set_error(SQLErrorCode::BooleanOperatorTypeMismatch, BinaryOperator_name(type()));
             return Value::null();
         }
-        return Value(lhs_bool_maybe.value() || rhs_bool_maybe.value());
+        return Value(lhs_bool_maybe.release_value() || rhs_bool_maybe.release_value());
     }
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -18,31 +18,65 @@
 namespace SQL {
 
 Database::Database(String name)
-    : m_heap(Heap::construct(name))
+    : m_heap(Heap::construct(move(name)))
     , m_serializer(m_heap)
-    , m_schemas(BTree::construct(m_serializer, SchemaDef::index_def()->to_tuple_descriptor(), m_heap->schemas_root()))
-    , m_tables(BTree::construct(m_serializer, TableDef::index_def()->to_tuple_descriptor(), m_heap->tables_root()))
-    , m_table_columns(BTree::construct(m_serializer, ColumnDef::index_def()->to_tuple_descriptor(), m_heap->table_columns_root()))
 {
+}
+
+ErrorOr<void> Database::open()
+{
+    TRY(m_heap->open());
+    m_schemas = BTree::construct(m_serializer, SchemaDef::index_def()->to_tuple_descriptor(), m_heap->schemas_root());
     m_schemas->on_new_root = [&]() {
         m_heap->set_schemas_root(m_schemas->root());
     };
+
+    m_tables = BTree::construct(m_serializer, TableDef::index_def()->to_tuple_descriptor(), m_heap->tables_root());
     m_tables->on_new_root = [&]() {
         m_heap->set_tables_root(m_tables->root());
     };
+
+    m_table_columns = BTree::construct(m_serializer, ColumnDef::index_def()->to_tuple_descriptor(), m_heap->table_columns_root());
     m_table_columns->on_new_root = [&]() {
         m_heap->set_table_columns_root(m_table_columns->root());
     };
-    auto default_schema = get_schema("default");
+
+    m_open = true;
+    auto default_schema = TRY(get_schema("default"));
     if (!default_schema) {
         default_schema = SchemaDef::construct("default");
-        add_schema(*default_schema);
+        TRY(add_schema(*default_schema));
     }
+    return {};
 }
 
-void Database::add_schema(SchemaDef const& schema)
+Database::~Database()
 {
-    m_schemas->insert(schema.key());
+    // This crashes if the database can't commit. It's recommended to commit
+    // before the Database goes out of scope so the application can handle
+    // errors.
+    // Maybe we should enforce that by having a VERIFY here that there are no
+    // pending writes. But that's a new API on Heap so let's not do that right
+    // now.
+    if (is_open())
+        MUST(commit());
+}
+
+ErrorOr<void> Database::commit()
+{
+    VERIFY(is_open());
+    TRY(m_heap->flush());
+    return {};
+}
+
+ErrorOr<void> Database::add_schema(SchemaDef const& schema)
+{
+    VERIFY(is_open());
+    if (!m_schemas->insert(schema.key())) {
+        warnln("Duplicate schema name {}"sv, schema.name());
+        return Error::from_string_literal("Duplicate schema name"sv);
+    }
+    return {};
 }
 
 Key Database::get_schema_key(String const& schema_name)
@@ -52,30 +86,37 @@ Key Database::get_schema_key(String const& schema_name)
     return key;
 }
 
-RefPtr<SchemaDef> Database::get_schema(String const& schema)
+ErrorOr<RefPtr<SchemaDef>> Database::get_schema(String const& schema)
 {
+    VERIFY(is_open());
     auto schema_name = schema;
     if (schema.is_null() || schema.is_empty())
         schema_name = "default";
     Key key = get_schema_key(schema_name);
     auto schema_def_opt = m_schema_cache.get(key.hash());
-    if (schema_def_opt.has_value())
-        return schema_def_opt.value();
+    if (schema_def_opt.has_value()) {
+        return RefPtr<SchemaDef>(schema_def_opt.value());
+    }
     auto schema_iterator = m_schemas->find(key);
     if (schema_iterator.is_end() || (*schema_iterator != key)) {
-        return nullptr;
+        return RefPtr<SchemaDef>(nullptr);
     }
     auto ret = SchemaDef::construct(*schema_iterator);
     m_schema_cache.set(key.hash(), ret);
-    return ret;
+    return RefPtr<SchemaDef>(ret);
 }
 
-void Database::add_table(TableDef& table)
+ErrorOr<void> Database::add_table(TableDef& table)
 {
-    m_tables->insert(table.key());
-    for (auto& column : table.columns()) {
-        m_table_columns->insert(column.key());
+    VERIFY(is_open());
+    if (!m_tables->insert(table.key())) {
+        warnln("Duplicate table name '{}'.'{}'"sv, table.parent()->name(), table.name());
+        return Error::from_string_literal("Duplicate table name"sv);
     }
+    for (auto& column : table.columns()) {
+        VERIFY(m_table_columns->insert(column.key()));
+    }
+    return {};
 }
 
 Key Database::get_table_key(String const& schema_name, String const& table_name)
@@ -85,36 +126,39 @@ Key Database::get_table_key(String const& schema_name, String const& table_name)
     return key;
 }
 
-RefPtr<TableDef> Database::get_table(String const& schema, String const& name)
+ErrorOr<RefPtr<TableDef>> Database::get_table(String const& schema, String const& name)
 {
+    VERIFY(is_open());
     auto schema_name = schema;
     if (schema.is_null() || schema.is_empty())
         schema_name = "default";
     Key key = get_table_key(schema_name, name);
     auto table_def_opt = m_table_cache.get(key.hash());
     if (table_def_opt.has_value())
-        return table_def_opt.value();
+        return RefPtr<TableDef>(table_def_opt.value());
     auto table_iterator = m_tables->find(key);
     if (table_iterator.is_end() || (*table_iterator != key)) {
-        return nullptr;
+        return RefPtr<TableDef>(nullptr);
     }
-    auto schema_def = get_schema(schema);
-    VERIFY(schema_def);
+    auto schema_def = TRY(get_schema(schema));
+    if (!schema_def) {
+        warnln("Schema '{}' does not exist"sv, schema);
+        return Error::from_string_literal("Schema does not exist"sv);
+    }
     auto ret = TableDef::construct(schema_def, name);
     ret->set_pointer((*table_iterator).pointer());
     m_table_cache.set(key.hash(), ret);
     auto hash = ret->hash();
     auto column_key = ColumnDef::make_key(ret);
-
     for (auto column_iterator = m_table_columns->find(column_key);
          !column_iterator.is_end() && ((*column_iterator)["table_hash"].to_u32().value() == hash);
          column_iterator++) {
         ret->append_column(*column_iterator);
     }
-    return ret;
+    return RefPtr<TableDef>(ret);
 }
 
-Vector<Row> Database::select_all(TableDef const& table)
+ErrorOr<Vector<Row>> Database::select_all(TableDef const& table)
 {
     VERIFY(m_table_cache.get(table.key().hash()).has_value());
     Vector<Row> ret;
@@ -124,7 +168,7 @@ Vector<Row> Database::select_all(TableDef const& table)
     return ret;
 }
 
-Vector<Row> Database::match(TableDef const& table, Key const& key)
+ErrorOr<Vector<Row>> Database::match(TableDef const& table, Key const& key)
 {
     VERIFY(m_table_cache.get(table.key().hash()).has_value());
     Vector<Row> ret;
@@ -140,12 +184,14 @@ Vector<Row> Database::match(TableDef const& table, Key const& key)
     return ret;
 }
 
-bool Database::insert(Row& row)
+ErrorOr<void> Database::insert(Row& row)
 {
     VERIFY(m_table_cache.get(row.table()->key().hash()).has_value());
+    // TODO Check constraints
+
     row.set_pointer(m_heap->new_record_pointer());
     row.next_pointer(row.table()->pointer());
-    update(row);
+    TRY(update(row));
 
     // TODO update indexes defined on table.
 
@@ -153,16 +199,18 @@ bool Database::insert(Row& row)
     table_key.set_pointer(row.pointer());
     VERIFY(m_tables->update_key_pointer(table_key));
     row.table()->set_pointer(row.pointer());
-    return true;
+    return {};
 }
 
-bool Database::update(Row& tuple)
+ErrorOr<void> Database::update(Row& tuple)
 {
     VERIFY(m_table_cache.get(tuple.table()->key().hash()).has_value());
+    // TODO Check constraints
     m_serializer.reset();
-    return m_serializer.serialize_and_write<Tuple>(tuple, tuple.pointer());
+    m_serializer.serialize_and_write<Tuple>(tuple, tuple.pointer());
 
     // TODO update indexes defined on table.
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibSQL/Database.h
+++ b/Userland/Libraries/LibSQL/Database.h
@@ -24,26 +24,29 @@ class Database : public Core::Object {
     C_OBJECT(Database);
 
 public:
-    ~Database() override = default;
+    ~Database() override;
 
-    void commit() { m_heap->flush(); }
+    ErrorOr<void> open();
+    bool is_open() const { return m_open; }
+    ErrorOr<void> commit();
 
-    void add_schema(SchemaDef const&);
+    ErrorOr<void> add_schema(SchemaDef const&);
     static Key get_schema_key(String const&);
-    RefPtr<SchemaDef> get_schema(String const&);
+    ErrorOr<RefPtr<SchemaDef>> get_schema(String const&);
 
-    void add_table(TableDef& table);
+    ErrorOr<void> add_table(TableDef& table);
     static Key get_table_key(String const&, String const&);
-    RefPtr<TableDef> get_table(String const&, String const&);
+    ErrorOr<RefPtr<TableDef>> get_table(String const&, String const&);
 
-    Vector<Row> select_all(TableDef const&);
-    Vector<Row> match(TableDef const&, Key const&);
-    bool insert(Row&);
-    bool update(Row&);
+    ErrorOr<Vector<Row>> select_all(TableDef const&);
+    ErrorOr<Vector<Row>> match(TableDef const&, Key const&);
+    ErrorOr<void> insert(Row&);
+    ErrorOr<void> update(Row&);
 
 private:
     explicit Database(String);
 
+    bool m_open { false };
     NonnullRefPtr<Heap> m_heap;
     Serializer m_serializer;
     RefPtr<BTree> m_schemas;

--- a/Userland/Libraries/LibSQL/SQLResult.h
+++ b/Userland/Libraries/LibSQL/SQLResult.h
@@ -43,6 +43,8 @@ constexpr char const* command_tag(SQLCommand command)
 
 #define ENUMERATE_SQL_ERRORS(S)                                                          \
     S(NoError, "No error")                                                               \
+    S(InternalError, "{}")                                                               \
+    S(NotYetImplemented, "{}")                                                           \
     S(DatabaseUnavailable, "Database Unavailable")                                       \
     S(StatementUnavailable, "Statement with id '{}' Unavailable")                        \
     S(SyntaxError, "Syntax Error")                                                       \
@@ -144,6 +146,12 @@ private:
     SQLResult(SQLCommand command, SQLErrorCode error_code, String error_argument)
         : m_command(command)
         , m_error({ error_code, move(error_argument) })
+    {
+    }
+
+    SQLResult(SQLCommand command, SQLErrorCode error_code, AK::Error error)
+        : m_command(command)
+        , m_error({ error_code, error.string_literal() })
     {
     }
 


### PR DESCRIPTION
Fixes for two issues. The fix for 10667 seems large (and it is) because it involves in a whole bunch of busywork to bubble errors up from the storage layer to the user. It also coincided with the deprecation of `AK::Result<Foo, Bar>` in favour of `AK::ErrorOr<Foo>`, adding to the fun.

Fixes https://github.com/SerenityOS/serenity/issues/10667 
Fixes https://github.com/SerenityOS/serenity/issues/10730