### PR TITLE
LibJS+LibUnicode: Implement number grouping for Intl.NumberFormat

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -204,6 +204,52 @@ describe("style=decimal", () => {
         expect(ar.format(-0)).toBe("\u0660");
         expect(ar.format(-1)).toBe("\u061c-\u0661");
     });
+
+    test("useGrouping=true", () => {
+        const en = new Intl.NumberFormat("en", { useGrouping: true });
+        expect(en.format(123)).toBe("123");
+        expect(en.format(1234)).toBe("1,234");
+        expect(en.format(12345)).toBe("12,345");
+        expect(en.format(123456)).toBe("123,456");
+        expect(en.format(1234567)).toBe("1,234,567");
+
+        const enIn = new Intl.NumberFormat("en-IN", { useGrouping: true });
+        expect(enIn.format(123)).toBe("123");
+        expect(enIn.format(1234)).toBe("1,234");
+        expect(enIn.format(12345)).toBe("12,345");
+        expect(enIn.format(123456)).toBe("1,23,456");
+        expect(enIn.format(1234567)).toBe("12,34,567");
+
+        const ar = new Intl.NumberFormat("ar", { useGrouping: true });
+        expect(ar.format(123)).toBe("\u0661\u0662\u0663");
+        expect(ar.format(1234)).toBe("\u0661\u066c\u0662\u0663\u0664");
+        expect(ar.format(12345)).toBe("\u0661\u0662\u066c\u0663\u0664\u0665");
+        expect(ar.format(123456)).toBe("\u0661\u0662\u0663\u066c\u0664\u0665\u0666");
+        expect(ar.format(1234567)).toBe("\u0661\u066c\u0662\u0663\u0664\u066c\u0665\u0666\u0667");
+    });
+
+    test("useGrouping=false", () => {
+        const en = new Intl.NumberFormat("en", { useGrouping: false });
+        expect(en.format(123)).toBe("123");
+        expect(en.format(1234)).toBe("1234");
+        expect(en.format(12345)).toBe("12345");
+        expect(en.format(123456)).toBe("123456");
+        expect(en.format(1234567)).toBe("1234567");
+
+        const enIn = new Intl.NumberFormat("en-IN", { useGrouping: false });
+        expect(enIn.format(123)).toBe("123");
+        expect(enIn.format(1234)).toBe("1234");
+        expect(enIn.format(12345)).toBe("12345");
+        expect(enIn.format(123456)).toBe("123456");
+        expect(enIn.format(1234567)).toBe("1234567");
+
+        const ar = new Intl.NumberFormat("ar", { useGrouping: false });
+        expect(ar.format(123)).toBe("\u0661\u0662\u0663");
+        expect(ar.format(1234)).toBe("\u0661\u0662\u0663\u0664");
+        expect(ar.format(12345)).toBe("\u0661\u0662\u0663\u0664\u0665");
+        expect(ar.format(123456)).toBe("\u0661\u0662\u0663\u0664\u0665\u0666");
+        expect(ar.format(1234567)).toBe("\u0661\u0662\u0663\u0664\u0665\u0666\u0667");
+    });
 });
 
 describe("style=percent", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
@@ -180,6 +180,70 @@ describe("style=decimal", () => {
             { type: "integer", value: "\u0661" },
         ]);
     });
+
+    test("useGrouping=true", () => {
+        const en = new Intl.NumberFormat("en", { useGrouping: true });
+        expect(en.formatToParts(123456)).toEqual([
+            { type: "integer", value: "123" },
+            { type: "group", value: "," },
+            { type: "integer", value: "456" },
+        ]);
+        expect(en.formatToParts(1234567)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "group", value: "," },
+            { type: "integer", value: "234" },
+            { type: "group", value: "," },
+            { type: "integer", value: "567" },
+        ]);
+
+        const enIn = new Intl.NumberFormat("en-IN", { useGrouping: true });
+        expect(enIn.formatToParts(123456)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "group", value: "," },
+            { type: "integer", value: "23" },
+            { type: "group", value: "," },
+            { type: "integer", value: "456" },
+        ]);
+        expect(enIn.formatToParts(1234567)).toEqual([
+            { type: "integer", value: "12" },
+            { type: "group", value: "," },
+            { type: "integer", value: "34" },
+            { type: "group", value: "," },
+            { type: "integer", value: "567" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", { useGrouping: true });
+        expect(ar.formatToParts(123456)).toEqual([
+            { type: "integer", value: "\u0661\u0662\u0663" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0664\u0665\u0666" },
+        ]);
+        expect(ar.formatToParts(1234567)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0662\u0663\u0664" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0665\u0666\u0667" },
+        ]);
+    });
+
+    test("useGrouping=false", () => {
+        const en = new Intl.NumberFormat("en", { useGrouping: false });
+        expect(en.formatToParts(123456)).toEqual([{ type: "integer", value: "123456" }]);
+        expect(en.formatToParts(1234567)).toEqual([{ type: "integer", value: "1234567" }]);
+
+        const enIn = new Intl.NumberFormat("en-IN", { useGrouping: false });
+        expect(enIn.formatToParts(123456)).toEqual([{ type: "integer", value: "123456" }]);
+        expect(enIn.formatToParts(1234567)).toEqual([{ type: "integer", value: "1234567" }]);
+
+        const ar = new Intl.NumberFormat("ar", { useGrouping: false });
+        expect(ar.formatToParts(123456)).toEqual([
+            { type: "integer", value: "\u0661\u0662\u0663\u0664\u0665\u0666" },
+        ]);
+        expect(ar.formatToParts(1234567)).toEqual([
+            { type: "integer", value: "\u0661\u0662\u0663\u0664\u0665\u0666\u0667" },
+        ]);
+    });
 });
 
 describe("style=percent", () => {

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -30,6 +30,7 @@ struct ListPatterns;
 struct LocaleExtension;
 struct LocaleID;
 struct NumberFormat;
+struct NumberGroupings;
 struct OtherExtension;
 struct SpecialCasing;
 struct TransformedExtension;

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -824,6 +824,15 @@ Optional<StringView> get_number_system_symbol([[maybe_unused]] StringView locale
 #endif
 }
 
+Optional<NumberGroupings> get_number_system_groupings([[maybe_unused]] StringView locale, [[maybe_unused]] StringView system)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_number_system_groupings(locale, system);
+#else
+    return {};
+#endif
+}
+
 Vector<NumberFormat> get_compact_number_system_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView system, [[maybe_unused]] CompactNumberFormatType type)
 {
 #if ENABLE_UNICODE_DATA

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -85,6 +85,11 @@ enum class Style : u8 {
     Numeric,
 };
 
+struct NumberGroupings {
+    u8 primary_grouping_size { 0 };
+    u8 secondary_grouping_size { 0 };
+};
+
 enum class StandardNumberFormatType : u8 {
     Decimal,
     Currency,
@@ -181,6 +186,7 @@ Optional<StringView> get_locale_script_mapping(StringView locale, StringView scr
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style);
 Vector<StringView> get_locale_key_mapping(StringView locale, StringView keyword);
 Optional<StringView> get_number_system_symbol(StringView locale, StringView system, StringView symbol);
+Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system);
 Optional<NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);
 Vector<NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type);
 Optional<ListPatterns> get_locale_list_patterns(StringView locale, StringView type, StringView style);


### PR DESCRIPTION
```js
> Intl.NumberFormat('en').format(123456789)
"123,456,789"
> Intl.NumberFormat('en-IN').format(123456789)
"12,34,56,789"
> Intl.NumberFormat('ar').format(123456789)
"١٢٣٬٤٥٦٬٧٨٩"
```

No test262 changes, they don't test this :(