### PR TITLE
FontEditor: Random improvements

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -34,6 +34,7 @@
 #include <LibGUI/ToolbarContainer.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/BitmapFont.h>
+#include <LibGfx/Emoji.h>
 #include <LibGfx/FontStyleMapping.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/TextDirection.h>
@@ -741,6 +742,8 @@ void FontEditorWidget::update_statusbar()
 
     if (m_edited_font->contains_raw_glyph(glyph))
         builder.appendff(" [{}x{}]", m_edited_font->raw_glyph_width(glyph), m_edited_font->glyph_height());
+    else if (Gfx::Emoji::emoji_for_code_point(glyph))
+        builder.appendff(" [emoji]");
     m_statusbar->set_text(builder.to_string());
 }
 

--- a/Userland/Applications/FontEditor/FontEditor.h
+++ b/Userland/Applications/FontEditor/FontEditor.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "UndoGlyph.h"
+#include <LibConfig/Listener.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/UndoStack.h>
 #include <LibGUI/Widget.h>
@@ -15,7 +16,9 @@
 class GlyphEditorWidget;
 class GlyphMapWidget;
 
-class FontEditorWidget final : public GUI::Widget {
+class FontEditorWidget final
+    : public GUI::Widget
+    , public Config::Listener {
     C_OBJECT(FontEditorWidget)
 public:
     virtual ~FontEditorWidget() override;
@@ -40,12 +43,17 @@ private:
 
     virtual void drop_event(GUI::DropEvent&) override;
 
+    virtual void config_i32_did_change(String const& domain, String const& group, String const& key, i32 value) override;
+    virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override;
+
     void undo();
     void redo();
     void did_modify_font();
     void did_resize_glyph_editor();
     void update_statusbar();
     void update_preview();
+    void set_scale(i32);
+    void set_scale_and_save(i32);
 
     RefPtr<Gfx::BitmapFont> m_edited_font;
 

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.h
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.h
@@ -56,7 +56,7 @@ public:
     Function<void()> on_undo_event;
 
 private:
-    GlyphEditorWidget() {};
+    GlyphEditorWidget() = default;
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;

--- a/Userland/Applications/FontEditor/GlyphMapWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphMapWidget.cpp
@@ -8,6 +8,7 @@
 #include "GlyphMapWidget.h"
 #include <LibGUI/Painter.h>
 #include <LibGfx/BitmapFont.h>
+#include <LibGfx/Emoji.h>
 #include <LibGfx/Palette.h>
 
 GlyphMapWidget::GlyphMapWidget()
@@ -102,9 +103,14 @@ void GlyphMapWidget::paint_event(GUI::PaintEvent& event)
             painter.fill_rect(outer_rect, is_focused() ? palette().selection() : palette().inactive_selection());
             if (m_font->contains_raw_glyph(glyph))
                 painter.draw_glyph(inner_rect.location(), glyph, is_focused() ? palette().selection_text() : palette().inactive_selection_text());
+            else if (auto* emoji = Gfx::Emoji::emoji_for_code_point(glyph))
+                painter.draw_emoji(inner_rect.location(), *emoji, *m_font);
         } else if (m_font->contains_raw_glyph(glyph)) {
             painter.fill_rect(outer_rect, palette().base());
             painter.draw_glyph(inner_rect.location(), glyph, palette().base_text());
+        } else if (auto* emoji = Gfx::Emoji::emoji_for_code_point(glyph)) {
+            painter.fill_rect(outer_rect, Gfx::Color { 255, 150, 150 });
+            painter.draw_emoji(inner_rect.location(), *emoji, *m_font);
         }
     }
 }

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -6,6 +6,7 @@
 
 #include "FontEditor.h"
 #include <AK/URL.h>
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
@@ -27,6 +28,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/FontEditor.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
+    Config::pledge_domains("FontEditor");
+    Config::monitor_domain("FontEditor");
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
 
     char const* path = nullptr;


### PR DESCRIPTION
**FontEditor: Display something for emoji glyphs**

This commit makes FontEditor displaying emojis in GlyphMapWidget. They
are not editable, what is marked by red background of a glyph.

Additionally, a proper information is displayed in statusbar.

Fixes #10900.

**FontEditor: Save scale to config file**
![image](https://user-images.githubusercontent.com/42967349/141683288-94dbf9d2-89a3-4780-a862-db9f01baa5e5.png)
