### PR TITLE
LibPDF: Check if there is data left before consuming

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -1144,11 +1144,13 @@ bool Parser::matches_regular_character() const
 
 bool Parser::consume_eol()
 {
+    if (m_reader.done()) {
+        return false;
+    }
     if (m_reader.matches("\r\n")) {
         consume(2);
         return true;
     }
-
     auto consumed = consume();
     return consumed == 0xd || consumed == 0xa;
 }


### PR DESCRIPTION
Add a check to `Parser::consume_eol` to ensure that there is more data
to read before actually consuming any data. Not checking if there is
data left leads to failing an assertion in case of e.g., a truncated
pdf file.

Fixes #10717.