### PR TITLE
DisplaySettings+LibGfx: Fix crashes on changing desktop scaling and having garbage in /res/wallpapers/

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -93,7 +93,7 @@ public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_shareable(BitmapFormat, IntSize const&, int intrinsic_scale = 1);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_wrapper(BitmapFormat, IntSize const&, int intrinsic_scale, size_t pitch, void*);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_file(String const& path, int scale_factor = 1);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_fd_and_close(int fd, String const& path, int scale_factor = 1);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_load_from_fd_and_close(int fd, String const& path);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> try_create_with_anonymous_buffer(BitmapFormat, Core::AnonymousBuffer, IntSize const&, int intrinsic_scale, Vector<RGBA32> const& palette);
     static ErrorOr<NonnullRefPtr<Bitmap>> try_create_from_serialized_byte_buffer(ByteBuffer&&);
 


### PR DESCRIPTION
- **DisplaySettings: Handle errors when loading wallpaper bitmap**

  Prior this change, the app crashed if the first file in alphabetical order in /res/wallpapers couldn’t be decoded.

- **LibGfx: Remove scale factor option from `try_load_from_fd_and_close()`**

  … and bring it back to `try_load_from_file()`.

  Prior to this change, changing the scaling option to x2 in the Display Settings resulted in the following crash:

      WindowServer(15:15): ASSERTION FAILED: bitmap->width() % scale_factor == 0 ./Userland/Libraries/LibGfx/Bitmap.cpp:126

  That was caused by two minor overlooked yaks:

  - First, `Bitmap::try_load_from_fd_and_close()` tried to respect your scale factor.

    While requesting a bitmap from file can make a switcheroo to give you a higher resolution bitmap, doing the same when you already have an fd might violate the unveil agreement.
    ... but, it didn’t do that.

    It read bitmaps from requested fds, but also pretended all system bitmaps in /res/ are the HiDPI ones when you enabled that mode.

  - https://github.com/SerenityOS/serenity/commit/d85d741c5975dfa6e2883e93ac555c57ea9d4340 used this function to deduplicate `try_load_from_file()`.

    It actually made this bug a lot easier to replicate!

  Closes https://github.com/SerenityOS/serenity/issues/10920
