### PR TITLE
AK+Kernel: Remove implicit conversion from Userspace<T> to FlatPtr

### DIFF
--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -10,6 +10,10 @@
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
+#ifdef KERNEL
+#    include <Kernel/VirtualAddress.h>
+#endif
+
 namespace AK {
 
 template<typename T>
@@ -19,8 +23,6 @@ template<PointerTypeName T>
 class Userspace {
 public:
     Userspace() = default;
-
-    operator FlatPtr() const { return (FlatPtr)m_ptr; }
 
     // Disable default implementations that would use surprising integer promotion.
     bool operator==(const Userspace&) const = delete;
@@ -38,7 +40,8 @@ public:
     explicit operator bool() const { return m_ptr != 0; }
 
     FlatPtr ptr() const { return m_ptr; }
-    T unsafe_userspace_ptr() const { return (T)m_ptr; }
+    VirtualAddress vaddr() const { return VirtualAddress(m_ptr); }
+    T unsafe_userspace_ptr() const { return reinterpret_cast<T>(m_ptr); }
 #else
     Userspace(T ptr)
         : m_ptr(ptr)

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -74,7 +74,7 @@ ErrorOr<void> InodeFile::ioctl(OpenFileDescription& description, unsigned reques
     }
     case FIONREAD: {
         int remaining_bytes = inode().size() - description.offset();
-        return copy_to_user(Userspace<int*>(arg), &remaining_bytes);
+        return copy_to_user(static_ptr_cast<int*>(arg), &remaining_bytes);
     }
     default:
         return EINVAL;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -763,7 +763,7 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
 
     case FIONREAD: {
         int readable = m_receive_buffer->immediately_readable();
-        return copy_to_user(Userspace<int*>(arg), &readable);
+        return copy_to_user(static_ptr_cast<int*>(arg), &readable);
     }
     }
 

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -425,7 +425,7 @@ ErrorOr<void> LocalSocket::ioctl(OpenFileDescription& description, unsigned requ
     switch (request) {
     case FIONREAD: {
         int readable = receive_buffer_for(description)->immediately_readable();
-        return copy_to_user(Userspace<int*>(arg), &readable);
+        return copy_to_user(static_ptr_cast<int*>(arg), &readable);
     }
     }
 

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -15,7 +15,7 @@
 
 ErrorOr<NonnullOwnPtr<Kernel::KString>> try_copy_kstring_from_user(Userspace<const char*> user_str, size_t user_str_size)
 {
-    bool is_user = Kernel::Memory::is_user_range(VirtualAddress(user_str), user_str_size);
+    bool is_user = Kernel::Memory::is_user_range(user_str.vaddr(), user_str_size);
     if (!is_user)
         return EFAULT;
     Kernel::SmapDisabler disabler;

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -193,12 +193,12 @@ ErrorOr<void> StorageDevice::ioctl(OpenFileDescription&, unsigned request, Users
     switch (request) {
     case STORAGE_DEVICE_GET_SIZE: {
         size_t disk_size = m_max_addressable_block * block_size();
-        return copy_to_user(Userspace<size_t*>(arg), &disk_size);
+        return copy_to_user(static_ptr_cast<size_t*>(arg), &disk_size);
         break;
     }
     case STORAGE_DEVICE_GET_BLOCK_SIZE: {
         size_t size = block_size();
-        return copy_to_user(Userspace<size_t*>(arg), &size);
+        return copy_to_user(static_ptr_cast<size_t*>(arg), &size);
         break;
     }
     default:

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -276,7 +276,7 @@ ErrorOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int p
         REQUIRE_PROMISE(prot_exec);
     }
 
-    auto range_to_mprotect = TRY(expand_range_to_page_boundaries(addr, size));
+    auto range_to_mprotect = TRY(expand_range_to_page_boundaries(addr.ptr(), size));
     if (!range_to_mprotect.size())
         return EINVAL;
 
@@ -411,7 +411,7 @@ ErrorOr<FlatPtr> Process::sys$madvise(Userspace<void*> address, size_t size, int
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
 
-    auto range_to_madvise = TRY(expand_range_to_page_boundaries(address, size));
+    auto range_to_madvise = TRY(expand_range_to_page_boundaries(address.ptr(), size));
 
     if (!range_to_madvise.size())
         return EINVAL;
@@ -469,7 +469,7 @@ ErrorOr<FlatPtr> Process::sys$munmap(Userspace<void*> addr, size_t size)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     REQUIRE_PROMISE(stdio);
-    TRY(address_space().unmap_mmap_range(VirtualAddress { addr }, size));
+    TRY(address_space().unmap_mmap_range(addr.vaddr(), size));
     return 0;
 }
 
@@ -576,10 +576,10 @@ ErrorOr<FlatPtr> Process::sys$msyscall(Userspace<void*> address)
         return 0;
     }
 
-    if (!Memory::is_user_address(VirtualAddress { address }))
+    if (!Memory::is_user_address(address.vaddr()))
         return EFAULT;
 
-    auto* region = address_space().find_region_containing(Memory::VirtualRange { VirtualAddress { address }, 1 });
+    auto* region = address_space().find_region_containing(Memory::VirtualRange { address.vaddr(), 1 });
     if (!region)
         return EINVAL;
 

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -178,7 +178,7 @@ ErrorOr<u32> Process::peek_user_data(Userspace<const u32*> address)
 
 ErrorOr<void> Process::poke_user_data(Userspace<u32*> address, u32 data)
 {
-    Memory::VirtualRange range = { VirtualAddress(address), sizeof(u32) };
+    Memory::VirtualRange range = { address.vaddr(), sizeof(u32) };
     auto* region = address_space().find_region_containing(range);
     if (!region)
         return EFAULT;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -87,7 +87,7 @@ void Process::sys$exit_thread(Userspace<void*> exit_value, Userspace<void*> stac
     PerformanceManager::add_thread_exit_event(*current_thread);
 
     if (stack_location) {
-        auto unmap_result = address_space().unmap_mmap_range(VirtualAddress { stack_location }, stack_size);
+        auto unmap_result = address_space().unmap_mmap_range(stack_location.vaddr(), stack_size);
         if (unmap_result.is_error())
             dbgln("Failed to unmap thread stack, terminating thread anyway. Error code: {}", unmap_result.error());
     }

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -5,8 +5,6 @@
  */
 
 #include <AK/Checked.h>
-#include <AK/String.h>
-#include <AK/StringBuilder.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/PerformanceManager.h>
 #include <Kernel/Process.h>
@@ -43,13 +41,10 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<con
 
     auto thread = TRY(Thread::try_create(*this));
 
-    // FIXME: Don't make a temporary String here
-    auto new_thread_name = TRY(KString::try_create(String::formatted("{} [{}]", m_name, thread->tid().value())));
-
     // We know this thread is not the main_thread,
     // So give it a unique name until the user calls $set_thread_name on it
-    // length + 4 to give space for our extra junk at the end
-    StringBuilder builder(m_name->length() + 4);
+    // FIXME: Don't make a temporary String here
+    auto new_thread_name = TRY(KString::try_create(String::formatted("{} [{}]", m_name, thread->tid().value())));
     thread->set_name(move(new_thread_name));
 
     if (!is_thread_joinable)


### PR DESCRIPTION
Some light refactoring to make the Userspace type a bit more explicit in its uses.

- Replace some `Userspace<T>` --> `Userspace<U>` conversions with a static_ptr_cast
- Remove the FlatPtr conversion operator and add a named VirtualAddress conversion function
- Use the ptr() and vaddr() conversion functions in places that used to do an implicit conversion to FlatPtr.
- Drive-by remove unused StringBuilder from sys$create_thread().