### PR TITLE
LibCrypto: Fix subtracting two negative `SignedBigInteger`s

### DIFF
--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -543,6 +543,15 @@ TEST_CASE(test_signed_subtraction_simple_subtraction_negative_result)
     EXPECT_EQ(num1.minus(num2), Crypto::SignedBigInteger { -20 });
 }
 
+TEST_CASE(test_signed_subtraction_both_negative)
+{
+    Crypto::SignedBigInteger num1(-50);
+    Crypto::SignedBigInteger num2(-70);
+
+    EXPECT_EQ(num1.minus(num2), Crypto::SignedBigInteger { 20 });
+    EXPECT_EQ(num2.minus(num1), Crypto::SignedBigInteger { -20 });
+}
+
 TEST_CASE(test_signed_subtraction_simple_subtraction_with_borrow)
 {
     Crypto::SignedBigInteger num1(Crypto::UnsignedBigInteger { UINT32_MAX });

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -109,11 +109,15 @@ FLATTEN SignedBigInteger SignedBigInteger::minus(const SignedBigInteger& other) 
     // -x - -y = y - x
     if (m_unsigned_data < other.m_unsigned_data) {
         // The result will be positive.
-        return SignedBigInteger { other.m_unsigned_data.minus(m_unsigned_data), true };
+        return SignedBigInteger { other.m_unsigned_data.minus(m_unsigned_data) };
     }
-    // The result will be either zero, or negative.
     // y - x = - (x - y)
-    return SignedBigInteger { m_unsigned_data.minus(other.m_unsigned_data) };
+    if (m_unsigned_data > other.m_unsigned_data) {
+        // The result will be negative.
+        return SignedBigInteger { m_unsigned_data.minus(other.m_unsigned_data), true };
+    }
+    // Both operands have the same magnitude, the result is positive zero.
+    return SignedBigInteger { 0 };
 }
 
 FLATTEN SignedBigInteger SignedBigInteger::plus(const UnsignedBigInteger& other) const

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-minus.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-minus.js
@@ -2,7 +2,7 @@ describe("minus behavior", () => {
     test("the basics", () => {
         expect(3n - 4n).toBe(-1n);
         expect(3n - -4n).toBe(7n);
-        expect(-3n - -4n).toBe(-1n);
+        expect(-3n - -4n).toBe(1n);
         expect(-3n - 4n).toBe(-7n);
     });
 });


### PR DESCRIPTION
Currently, we get the following results

    -1 - -2 = -1
    -2 - -1 =  1

Correct would be:

    -1 - -2 =  1
    -2 - -1 = -1

This was already attempted to be fixed in 7ed8970, but that change was
incorrect. This directly translates to LibJS BigInts having the same
incorrect behavior - it even was tested.