### PR TITLE
ConfigServer+LibConfig: Add methods to list groups and keys

### DIFF
--- a/Userland/Libraries/LibConfig/Client.cpp
+++ b/Userland/Libraries/LibConfig/Client.cpp
@@ -30,6 +30,16 @@ void Client::monitor_domain(String const& domain)
     async_monitor_domain(domain);
 }
 
+Vector<String> Client::list_keys(StringView domain, StringView group)
+{
+    return list_config_keys(domain, group);
+}
+
+Vector<String> Client::list_groups(StringView domain)
+{
+    return list_config_groups(domain);
+}
+
 String Client::read_string(StringView domain, StringView group, StringView key, StringView fallback)
 {
     return read_string_value(domain, group, key).value_or(fallback);

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -24,6 +24,9 @@ public:
     void pledge_domains(Vector<String> const&);
     void monitor_domain(String const&);
 
+    Vector<String> list_groups(StringView domain);
+    Vector<String> list_keys(StringView domain, StringView group);
+
     String read_string(StringView domain, StringView group, StringView key, StringView fallback);
     i32 read_i32(StringView domain, StringView group, StringView key, i32 fallback);
     bool read_bool(StringView domain, StringView group, StringView key, bool fallback);
@@ -46,6 +49,16 @@ private:
     void notify_changed_bool_value(String const& domain, String const& group, String const& key, bool value) override;
     void notify_removed_key(String const& domain, String const& group, String const& key) override;
 };
+
+inline Vector<String> list_groups(StringView domain)
+{
+    return Client::the().list_groups(domain);
+}
+
+inline Vector<String> list_keys(StringView domain, StringView group)
+{
+    return Client::the().list_keys(domain, group);
+}
 
 inline String read_string(StringView domain, StringView group, StringView key, StringView fallback = {})
 {

--- a/Userland/Services/ConfigServer/ClientConnection.cpp
+++ b/Userland/Services/ConfigServer/ClientConnection.cpp
@@ -135,6 +135,22 @@ void ClientConnection::sync_dirty_domains_to_disk()
     }
 }
 
+Messages::ConfigServer::ListConfigKeysResponse ClientConnection::list_config_keys(String const& domain, String const& group)
+{
+    if (!validate_access(domain, group, ""))
+        return Vector<String> {};
+    auto& config = ensure_domain_config(domain);
+    return { config.keys(group) };
+}
+
+Messages::ConfigServer::ListConfigGroupsResponse ClientConnection::list_config_groups(String const& domain)
+{
+    if (!validate_access(domain, "", ""))
+        return Vector<String> {};
+    auto& config = ensure_domain_config(domain);
+    return { config.groups() };
+}
+
 Messages::ConfigServer::ReadStringValueResponse ClientConnection::read_string_value(String const& domain, String const& group, String const& key)
 {
     if (!validate_access(domain, group, key))

--- a/Userland/Services/ConfigServer/ClientConnection.h
+++ b/Userland/Services/ConfigServer/ClientConnection.h
@@ -27,6 +27,8 @@ private:
 
     virtual void pledge_domains(Vector<String> const&) override;
     virtual void monitor_domain(String const&) override;
+    virtual Messages::ConfigServer::ListConfigGroupsResponse list_config_groups([[maybe_unused]] String const& domain) override;
+    virtual Messages::ConfigServer::ListConfigKeysResponse list_config_keys([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group) override;
     virtual Messages::ConfigServer::ReadStringValueResponse read_string_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key) override;
     virtual Messages::ConfigServer::ReadI32ValueResponse read_i32_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key) override;
     virtual Messages::ConfigServer::ReadBoolValueResponse read_bool_value([[maybe_unused]] String const& domain, [[maybe_unused]] String const& group, [[maybe_unused]] String const& key) override;

--- a/Userland/Services/ConfigServer/ConfigServer.ipc
+++ b/Userland/Services/ConfigServer/ConfigServer.ipc
@@ -4,6 +4,9 @@ endpoint ConfigServer
 
     monitor_domain(String domain) =|
 
+    list_config_groups(String domain) => (Vector<String> groups)
+    list_config_keys(String domain, String group) => (Vector<String> keys)
+
     read_string_value(String domain, String group, String key) => (Optional<String> value)
     read_i32_value(String domain, String group, String key) => (Optional<i32> value)
     read_bool_value(String domain, String group, String key) => (Optional<bool> value)


### PR DESCRIPTION
Starting to implement a TaskbarSettings application which allows to add/remove quicklaunch items, I need a way to list keys in a config group. 

At the moment this can only be done by using `Core::ConfigFile` directly, which is unwieldy since I need to maintain a ConfigServer connection anyways for applying the updates. 

This change adds the needed functionality and allows to tighten pledges for the application.