### PR TITLE
Kernel: Reject writable shared file mappings

### DIFF
--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -83,6 +83,11 @@ ErrorOr<void> InodeFile::ioctl(OpenFileDescription& description, unsigned reques
 
 ErrorOr<Memory::Region*> InodeFile::mmap(Process& process, OpenFileDescription& description, Memory::VirtualRange const& range, u64 offset, int prot, bool shared)
 {
+    // FIXME: Support writing changes made to shared file mappings back to disk.
+    // Some ports behave incorrectly if we silently discard writes to memory-mapped files, so let's not lie about what we can do.
+    if (shared && (prot & PROT_WRITE))
+        return ENOTSUP;
+
     // FIXME: If PROT_EXEC, check that the underlying file system isn't mounted noexec.
     RefPtr<Memory::InodeVMObject> vmobject;
     if (shared)


### PR DESCRIPTION
We have no way of writing changes to memory-mapped files back to disk,
and software relying on this functionality for output would fail
miserably. Let's just return ENOTSUP instead to allow callers to fall
back to standard file IO instead of silently discarding writes.

This makes the LLD port work, which uses memory-mapped files to write
its output by default.