### PR TITLE
LibJS: Implement unit number formatting

### DIFF
--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -58,6 +58,9 @@ set(CLDR_MISC_PATH "${CLDR_PATH}/${CLDR_MISC_SOURCE}")
 set(CLDR_NUMBERS_SOURCE cldr-numbers-modern)
 set(CLDR_NUMBERS_PATH "${CLDR_PATH}/${CLDR_NUMBERS_SOURCE}")
 
+set(CLDR_UNITS_SOURCE cldr-units-modern)
+set(CLDR_UNITS_PATH "${CLDR_PATH}/${CLDR_UNITS_SOURCE}")
+
 function(remove_unicode_data_if_version_changed version version_file cache_path)
     set(version_differs YES)
 
@@ -119,6 +122,7 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
     extract_cldr_file("${CLDR_LOCALES_SOURCE}" "${CLDR_LOCALES_PATH}")
     extract_cldr_file("${CLDR_MISC_SOURCE}" "${CLDR_MISC_PATH}")
     extract_cldr_file("${CLDR_NUMBERS_SOURCE}" "${CLDR_NUMBERS_PATH}")
+    extract_cldr_file("${CLDR_UNITS_SOURCE}" "${CLDR_UNITS_PATH}")
 
     set(UNICODE_DATA_HEADER LibUnicode/UnicodeData.h)
     set(UNICODE_DATA_IMPLEMENTATION LibUnicode/UnicodeData.cpp)
@@ -170,12 +174,12 @@ if (ENABLE_UNICODE_DATABASE_DOWNLOAD)
 
     add_custom_command(
         OUTPUT ${UNICODE_NUMBER_FORMAT_HEADER} ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION}
-        COMMAND $<TARGET_FILE:Lagom::GenerateUnicodeNumberFormat> -h ${UNICODE_NUMBER_FORMAT_HEADER}.tmp -c ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION}.tmp -r ${CLDR_CORE_PATH} -n ${CLDR_NUMBERS_PATH}
+        COMMAND $<TARGET_FILE:Lagom::GenerateUnicodeNumberFormat> -h ${UNICODE_NUMBER_FORMAT_HEADER}.tmp -c ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION}.tmp -r ${CLDR_CORE_PATH} -n ${CLDR_NUMBERS_PATH} -u ${CLDR_UNITS_PATH}
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${UNICODE_NUMBER_FORMAT_HEADER}.tmp ${UNICODE_NUMBER_FORMAT_HEADER}
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION}.tmp ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION}
         COMMAND "${CMAKE_COMMAND}" -E remove ${UNICODE_NUMBER_FORMAT_HEADER}.tmp ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION}.tmp
         VERBATIM
-        DEPENDS Lagom::GenerateUnicodeNumberFormat ${CLDR_CORE_PATH} ${CLDR_LOCALES_PATH} ${CLDR_MISC_PATH} ${CLDR_NUMBERS_PATH}
+        DEPENDS Lagom::GenerateUnicodeNumberFormat ${CLDR_CORE_PATH} ${CLDR_LOCALES_PATH} ${CLDR_MISC_PATH} ${CLDR_NUMBERS_PATH} ${CLDR_UNITS_PATH}
     )
     add_custom_target(generate_${UNICODE_META_TARGET_PREFIX}UnicodeNumberFormat DEPENDS ${UNICODE_NUMBER_FORMAT_HEADER} ${UNICODE_NUMBER_FORMAT_IMPLEMENTATION})
     add_dependencies(all_generated generate_${UNICODE_META_TARGET_PREFIX}UnicodeNumberFormat)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -93,7 +93,7 @@ struct UnicodeLocaleData {
 
 static String parse_identifiers(String pattern, StringView replacement, UnicodeLocaleData& locale_data, NumberFormat& format)
 {
-    static Utf8View whitespace { "\u0020\u00a0"sv };
+    static Utf8View whitespace { "\u0020\u00a0\u200f"sv };
 
     while (true) {
         Utf8View utf8_pattern { pattern };

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1370,7 +1370,9 @@ Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& nu
 
         // Handling of other [[CurrencyDisplay]] options will occur after [[SignDisplay]].
         if (number_format.currency_display() == NumberFormat::CurrencyDisplay::Name) {
-            auto maybe_patterns = Unicode::select_currency_unit_pattern(number_format.data_locale(), number_format.numbering_system(), number);
+            auto formats = Unicode::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), Unicode::CompactNumberFormatType::CurrencyUnit);
+
+            auto maybe_patterns = Unicode::select_pattern_with_plurality(formats, number);
             if (maybe_patterns.has_value()) {
                 patterns = maybe_patterns.release_value();
                 break;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -962,11 +962,14 @@ Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_for
             }
             // iv. Else if p is equal to "compactSymbol", then
             // v. Else if p is equal to "compactName", then
-            else if (part == "compactIdentifier"sv) {
+            else if (part.starts_with("compactIdentifier:"sv)) {
                 // Note: Our implementation combines "compactSymbol" and "compactName" into one field, "compactIdentifier".
 
+                auto identifier_index = part.substring_view("compactIdentifier:"sv.length()).to_uint();
+                VERIFY(identifier_index.has_value());
+
                 // 1. Let compactSymbol be an ILD string representing exponent in short form, which may depend on x in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a "{compactSymbol}" placeholder.
-                auto compact_identifier = number_format.compact_format().identifier;
+                auto compact_identifier = number_format.compact_format().identifiers[*identifier_index];
 
                 // 2. Append a new Record { [[Type]]: "compact", [[Value]]: compactSymbol } as the last element of result.
                 result.append({ "compact"sv, compact_identifier });

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -966,7 +966,7 @@ Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_for
                 // Note: Our implementation combines "compactSymbol" and "compactName" into one field, "compactIdentifier".
 
                 // 1. Let compactSymbol be an ILD string representing exponent in short form, which may depend on x in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a "{compactSymbol}" placeholder.
-                auto compact_identifier = number_format.compact_format().compact_identifier;
+                auto compact_identifier = number_format.compact_format().identifier;
 
                 // 2. Append a new Record { [[Type]]: "compact", [[Value]]: compactSymbol } as the last element of result.
                 result.append({ "compact"sv, compact_identifier });

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -211,7 +211,7 @@ Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number
 RawFormatResult to_raw_precision(double number, int min_precision, int max_precision);
 RawFormatResult to_raw_fixed(double number, int min_fraction, int max_fraction);
 ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_object, NumberFormat& intl_object, Object const& options);
-Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& number_format, double number);
+Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& number_format, double number, Unicode::NumberFormat& found_pattern);
 Optional<StringView> get_notation_sub_pattern(NumberFormat& number_format, int exponent);
 int compute_exponent(NumberFormat& number_format, double number);
 int compute_exponent_for_magniude(NumberFormat& number_format, int magnitude);

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -889,3 +889,119 @@ describe("style=currency", () => {
         expect(ar2.format(-1)).toBe("\u061c-\u0661\u066b\u0660\u0660\u00a0US$");
     });
 });
+
+describe("style=unit", () => {
+    test("unitDisplay=long", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "gigabit",
+            unitDisplay: "long",
+        });
+        expect(en1.format(1)).toBe("1 gigabit");
+        expect(en1.format(1.2)).toBe("1.2 gigabits");
+        expect(en1.format(123)).toBe("123 gigabits");
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "long",
+        });
+        expect(en2.format(1)).toBe("1 kilometer per hour");
+        expect(en2.format(1.2)).toBe("1.2 kilometers per hour");
+        expect(en2.format(123)).toBe("123 kilometers per hour");
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "unit",
+            unit: "foot",
+            unitDisplay: "long",
+        });
+        expect(ar.format(1)).toBe("قدم");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662 قدم");
+        expect(ar.format(123)).toBe("\u0661\u0662\u0663 قدم");
+
+        const ja = new Intl.NumberFormat("ja", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "long",
+        });
+        expect(ja.format(1)).toBe("時速 1 キロメートル");
+        expect(ja.format(1.2)).toBe("時速 1.2 キロメートル");
+        expect(ja.format(123)).toBe("時速 123 キロメートル");
+    });
+
+    test("unitDisplay=short", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "gigabit",
+            unitDisplay: "short",
+        });
+        expect(en1.format(1)).toBe("1 Gb");
+        expect(en1.format(1.2)).toBe("1.2 Gb");
+        expect(en1.format(123)).toBe("123 Gb");
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "short",
+        });
+        expect(en2.format(1)).toBe("1 km/h");
+        expect(en2.format(1.2)).toBe("1.2 km/h");
+        expect(en2.format(123)).toBe("123 km/h");
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "unit",
+            unit: "foot",
+            unitDisplay: "short",
+        });
+        expect(ar.format(1)).toBe("قدم");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662 قدم");
+        expect(ar.format(123)).toBe("\u0661\u0662\u0663 قدم");
+
+        const ja = new Intl.NumberFormat("ja", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "short",
+        });
+        expect(ja.format(1)).toBe("1 km/h");
+        expect(ja.format(1.2)).toBe("1.2 km/h");
+        expect(ja.format(123)).toBe("123 km/h");
+    });
+
+    test("unitDisplay=narrow", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "gigabit",
+            unitDisplay: "narrow",
+        });
+        expect(en1.format(1)).toBe("1Gb");
+        expect(en1.format(1.2)).toBe("1.2Gb");
+        expect(en1.format(123)).toBe("123Gb");
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "narrow",
+        });
+        expect(en2.format(1)).toBe("1km/h");
+        expect(en2.format(1.2)).toBe("1.2km/h");
+        expect(en2.format(123)).toBe("123km/h");
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "unit",
+            unit: "foot",
+            unitDisplay: "narrow",
+        });
+        expect(ar.format(1)).toBe("قدم");
+        expect(ar.format(1.2)).toBe("\u0661\u066b\u0662 قدم");
+        expect(ar.format(123)).toBe("\u0661\u0662\u0663 قدمًا");
+
+        const ja = new Intl.NumberFormat("ja", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "narrow",
+        });
+        expect(ja.format(1)).toBe("1km/h");
+        expect(ja.format(1.2)).toBe("1.2km/h");
+        expect(ja.format(123)).toBe("123km/h");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
@@ -1100,3 +1100,213 @@ describe("style=currency", () => {
         ]);
     });
 });
+
+describe("style=unit", () => {
+    test("unitDisplay=long", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "gigabit",
+            unitDisplay: "long",
+        });
+        expect(en1.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "gigabit" },
+        ]);
+        expect(en1.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "gigabits" },
+        ]);
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "long",
+        });
+        expect(en2.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "kilometer per hour" },
+        ]);
+        expect(en2.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "kilometers per hour" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "unit",
+            unit: "foot",
+            unitDisplay: "long",
+        });
+        expect(ar.formatToParts(1)).toEqual([{ type: "unit", value: "قدم" }]);
+        expect(ar.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "قدم" },
+        ]);
+
+        const ja = new Intl.NumberFormat("ja", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "long",
+        });
+        expect(ja.formatToParts(1)).toEqual([
+            { type: "unit", value: "時速" },
+            { type: "literal", value: " " },
+            { type: "integer", value: "1" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "キロメートル" },
+        ]);
+        expect(ja.formatToParts(1.2)).toEqual([
+            { type: "unit", value: "時速" },
+            { type: "literal", value: " " },
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "キロメートル" },
+        ]);
+    });
+
+    test("unitDisplay=short", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "gigabit",
+            unitDisplay: "short",
+        });
+        expect(en1.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "Gb" },
+        ]);
+        expect(en1.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "Gb" },
+        ]);
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "short",
+        });
+        expect(en2.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "km/h" },
+        ]);
+        expect(en2.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "km/h" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "unit",
+            unit: "foot",
+            unitDisplay: "short",
+        });
+        expect(ar.formatToParts(1)).toEqual([{ type: "unit", value: "قدم" }]);
+        expect(ar.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "قدم" },
+        ]);
+
+        const ja = new Intl.NumberFormat("ja", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "short",
+        });
+        expect(ja.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "km/h" },
+        ]);
+        expect(ja.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "km/h" },
+        ]);
+    });
+
+    test("unitDisplay=narrow", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "gigabit",
+            unitDisplay: "narrow",
+        });
+        expect(en1.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "unit", value: "Gb" },
+        ]);
+        expect(en1.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "unit", value: "Gb" },
+        ]);
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "narrow",
+        });
+        expect(en2.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "unit", value: "km/h" },
+        ]);
+        expect(en2.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "unit", value: "km/h" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            style: "unit",
+            unit: "foot",
+            unitDisplay: "narrow",
+        });
+        expect(ar.formatToParts(1)).toEqual([{ type: "unit", value: "قدم" }]);
+        expect(ar.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "decimal", value: "\u066b" },
+            { type: "fraction", value: "\u0662" },
+            { type: "literal", value: " " },
+            { type: "unit", value: "قدم" },
+        ]);
+
+        const ja = new Intl.NumberFormat("ja", {
+            style: "unit",
+            unit: "kilometer-per-hour",
+            unitDisplay: "narrow",
+        });
+        expect(ja.formatToParts(1)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "unit", value: "km/h" },
+        ]);
+        expect(ja.formatToParts(1.2)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "decimal", value: "." },
+            { type: "fraction", value: "2" },
+            { type: "unit", value: "km/h" },
+        ]);
+    });
+});

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -20,6 +20,7 @@ enum class Locale : u16;
 enum class Property : u8;
 enum class Script : u8;
 enum class StandardNumberFormatType : u8;
+enum class Style : u8;
 enum class Territory : u8;
 enum class WordBreakProperty : u8;
 

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -995,7 +995,7 @@ Optional<NumberFormat> select_pattern_with_plurality(Vector<NumberFormat> const&
     } else if (number == 2) {
         if (auto patterns = find_plurality(NumberFormat::Plurality::Two); patterns.has_value())
             return patterns;
-    } else {
+    } else if (number > 2) {
         if (auto patterns = find_plurality(NumberFormat::Plurality::Many); patterns.has_value())
             return patterns;
     }

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -975,13 +975,11 @@ String resolve_most_likely_territory([[maybe_unused]] LanguageID const& language
     return aliases[0].to_string();
 }
 
-Optional<NumberFormat> select_currency_unit_pattern(StringView locale, StringView system, double number)
+Optional<NumberFormat> select_pattern_with_plurality(Vector<NumberFormat> const& formats, double number)
 {
     // FIXME: This is a rather naive and locale-unaware implementation Unicode's TR-35 pluralization
     //        rules: https://www.unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
     //        Once those rules are implemented for LibJS, we better use them instead.
-    auto formats = get_compact_number_system_formats(locale, system, CompactNumberFormatType::CurrencyUnit);
-
     auto find_plurality = [&](auto plurality) -> Optional<NumberFormat> {
         if (auto it = formats.find_if([&](auto& patterns) { return patterns.plurality == plurality; }); it != formats.end())
             return *it;

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -851,6 +851,15 @@ Optional<NumberFormat> get_standard_number_system_format([[maybe_unused]] String
 #endif
 }
 
+Vector<NumberFormat> get_unit_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView unit, [[maybe_unused]] Style style)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_unit_formats(locale, unit, style);
+#else
+    return {};
+#endif
+}
+
 Optional<ListPatterns> get_locale_list_patterns([[maybe_unused]] StringView locale, [[maybe_unused]] StringView type, [[maybe_unused]] StringView style)
 {
 #if ENABLE_UNICODE_DATA

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -203,7 +203,7 @@ Optional<LanguageID> add_likely_subtags(LanguageID const& language_id);
 Optional<LanguageID> remove_likely_subtags(LanguageID const& language_id);
 String resolve_most_likely_territory(LanguageID const& language_id, StringView territory_alias);
 
-Optional<NumberFormat> select_currency_unit_pattern(StringView locale, StringView system, double number);
+Optional<NumberFormat> select_pattern_with_plurality(Vector<NumberFormat> const& formats, double number);
 Optional<String> augment_currency_format_pattern(StringView currency_display, StringView base_pattern);
 
 }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -122,7 +122,7 @@ struct NumberFormat {
     StringView zero_format {};
     StringView positive_format {};
     StringView negative_format {};
-    StringView identifier {};
+    Vector<StringView> identifiers {};
 };
 
 struct ListPatterns {

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -191,6 +191,7 @@ Optional<StringView> get_number_system_symbol(StringView locale, StringView syst
 Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system);
 Optional<NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);
 Vector<NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type);
+Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style);
 Optional<ListPatterns> get_locale_list_patterns(StringView locale, StringView type, StringView style);
 
 Optional<StringView> resolve_language_alias(StringView language);

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -122,7 +122,7 @@ struct NumberFormat {
     StringView zero_format {};
     StringView positive_format {};
     StringView negative_format {};
-    StringView compact_identifier {};
+    StringView identifier {};
 };
 
 struct ListPatterns {


### PR DESCRIPTION
```js
> Intl.NumberFormat('en', {style:'unit', unit:'gigabit', unitDisplay:'narrow'}).format(1)
"1Gb"
> Intl.NumberFormat('en', {style:'unit', unit:'gigabit', unitDisplay:'long'}).format(1)
"1 gigabit"
> Intl.NumberFormat('en', {style:'unit', unit:'gigabit', unitDisplay:'long'}).format(2)
"2 gigabits"

> Intl.NumberFormat('ja', {style:'unit', unit:'kilometer-per-hour', unitDisplay:'long'}).formatToParts(2)
[ { "type": "unit", "value": "時速" }, { "type": "literal", "value": " " }, { "type": "integer", "value": "2" }, { "type": "literal", "value": " " }, { "type": "unit", "value": "キロメートル" } ]
```

This should just about do it for `Intl.NumberFormat` :partying_face:. Well, until we go and implement [NumberFormat V3](https://github.com/tc39/proposal-intl-numberformat-v3). Remaining test262 failures are:
* Mostly V3 tests
* A couple tests rely on BCP-47 data which we can't generate yet (see #10854 and [CLDR-15158](https://unicode-org.atlassian.net/browse/CLDR-15158)).
* We don't recognize `zh-TW` locale as really being `zh-Hant`...not sure why yet.
* This bug in our `strtod` implementation:
```js
> 123.445
123.444999999999993
```