### PR TITLE
Toolchain: Update Dockerfile

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -30,7 +30,7 @@ QEMU version 5 is available in Ubuntu 20.10, but it is recommended to build Qemu
 Note that you might need additional dev packages:
 
 ```console
-sudo apt install libgtk-3-dev libpixman-1-dev libspice-server-dev
+sudo apt install libgtk-3-dev libpixman-1-dev libsdl2-dev libspice-server-dev
 ```
 
 ### Windows

--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:21.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,6 +8,8 @@ RUN apt-get update -y \
         ccache \
         cmake \
         curl \
+        g++-10 \
+        gcc-10 \
         genext2fs \
         gettext \
         git \
@@ -22,9 +24,9 @@ RUN apt-get update -y \
         sudo \
         tzdata \
         unzip \
-        wget
-RUN apt install gcc-10 g++-10; \
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+        wget \
+    && rm -rf /var/lib/apt/lists/ \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
 RUN git clone --depth 1 https://github.com/SerenityOS/serenity.git /serenity/serenity-git
 RUN cd /serenity/serenity-git/Toolchain; \

--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update -y \
         sudo \
         tzdata \
         unzip \
-        wget \
     && rm -rf /var/lib/apt/lists/ \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 

--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -10,14 +10,18 @@ RUN apt-get update -y \
         curl \
         g++-10 \
         gcc-10 \
+        e2fsprogs \
         genext2fs \
         gettext \
         git \
         imagemagick \
-        libmpfr-dev \
-        libmpc-dev \
         libgmp-dev \
-        e2fsprogs \
+        libgtk-3-dev \
+        libmpc-dev \
+        libmpfr-dev \
+        libpixman-1-dev \
+        libsdl2-dev \
+        libspice-server-dev \
         ninja-build \
         qemu-utils \
         rsync \

--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -29,10 +29,3 @@ RUN apt-get update -y \
         unzip \
     && rm -rf /var/lib/apt/lists/ \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-
-RUN git clone --depth 1 https://github.com/SerenityOS/serenity.git /serenity/serenity-git
-RUN cd /serenity/serenity-git/Toolchain; \
-        ./BuildIt.sh
-
-WORKDIR /serenity
-VOLUME /serenity/out

--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -y \
         gcc-10 \
         e2fsprogs \
         genext2fs \
-        gettext \
         git \
         imagemagick \
         libgmp-dev \


### PR DESCRIPTION
* Update to Ubuntu 21.10
* Make it possible to build Qemu inside of the container
* Remove the now unused `gettext` and `wget` packages
* Remove the `git clone` action (commit message contains rationale) - see #9310