### PR TITLE
LibJS + js: Rethrow exception on the vm after bytecode interpreter run

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -769,7 +769,11 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
             return throw_completion(exception->value());
 
         VERIFY(result_and_frame.frame != nullptr);
-        auto result = TRY(result_and_frame.value);
+        if (result_and_frame.value.is_error()) {
+            vm.throw_exception(bytecode_interpreter->global_object(), result_and_frame.value.release_error().value());
+            return throw_completion(vm.exception()->value());
+        }
+        auto result = result_and_frame.value.release_value();
 
         // NOTE: Running the bytecode should eventually return a completion.
         // Until it does, we assume "return" and include the undefined fallback from the call site.

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -837,7 +837,10 @@ static bool parse_and_run(JS::Interpreter& interpreter, StringView source, Strin
 
             if (s_run_bytecode) {
                 JS::Bytecode::Interpreter bytecode_interpreter(interpreter.global_object(), interpreter.realm());
-                TRY_OR_DISCARD(bytecode_interpreter.run(executable));
+                auto result = bytecode_interpreter.run(executable);
+                // Since all the error handling code uses vm.exception() we just rethrow any exception we got here.
+                if (result.is_error())
+                    vm->throw_exception(interpreter.global_object(), result.throw_completion().value());
             } else {
                 return true;
             }


### PR DESCRIPTION
I just checked and this does not cover all the cases of `Bytecode::Interpreter::run()`
However there are a lot of implicit assumptions going on here between `vm.exception()` and completions so testing all of this is kind of tricky.

I'm currently running the test262 bytecode tests but that takes a long time and I won't be sure what errors are real...
Also see the test262 PR: https://github.com/linusg/libjs-test262/pull/45