### PR TITLE
LibWeb: Background all the things!

### DIFF
--- a/Base/res/html/misc/backgrounds.html
+++ b/Base/res/html/misc/backgrounds.html
@@ -102,16 +102,17 @@
 
     <h3>Images should fill the content-box, with padding on each side. (5px, 10px, 15px, 20px) and aligned so their top-left corner will be at the top-left of the box. This produces clipping.</h3>
     <div class="example">
-        <code>background: url('background-repeat.png') padding-box content-box</code>
-        <div class="box" style="background: url('background-repeat.png') padding-box content-box"></div>
+        <code>background: url('background-repeat.png') yellow padding-box content-box</code>
+        <div class="box" style="background: url('background-repeat.png') yellow padding-box content-box"></div>
     </div>
     <div class="example">
         <code>
             background-image: url('background-repeat.png');<br/>
+            background-color: yellow;<br/>
             background-origin: padding-box;<br/>
             background-clip: content-box;
         </code>
-        <div class="box" style="background-image: url('background-repeat.png'); background-origin: padding-box; background-clip: content-box"></div>
+        <div class="box" style="background-image: url('background-repeat.png'); background-color: yellow; background-origin: padding-box; background-clip: content-box"></div>
     </div>
 
     <h2>Size</h2>
@@ -183,6 +184,19 @@
             background-repeat: round;
         </code>
         <div class="box" style="background-image: url('background-repeat.png'); background-repeat: round"></div>
+    </div>
+
+    <h3>Images should all be whole, and be shrunk and spaced to fill the box</h3>
+    <div class="example">
+        <code>background: url('background-repeat.png') space round</code>
+        <div class="box" style="background: url('background-repeat.png') space round"></div>
+    </div>
+    <div class="example">
+        <code>
+            background-image: url('background-repeat.png');<br/>
+            background-repeat: space round;
+        </code>
+        <div class="box" style="background-image: url('background-repeat.png'); background-repeat: space round"></div>
     </div>
 
     <h2>Multiple backgrounds</h2>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -25,7 +25,6 @@ public:
     static CSS::Display display() { return CSS::Display { CSS::Display::Outside::Inline, CSS::Display::Inside::Flow }; }
     static Color color() { return Color::Black; }
     static Color background_color() { return Color::Transparent; }
-    static CSS::Repeat background_repeat() { return CSS::Repeat::Repeat; }
     static CSS::ListStyleType list_style_type() { return CSS::ListStyleType::Disc; }
     static CSS::FlexDirection flex_direction() { return CSS::FlexDirection::Row; }
     static CSS::FlexWrap flex_wrap() { return CSS::FlexWrap::Nowrap; }
@@ -126,7 +125,6 @@ public:
     Color color() const { return m_inherited.color; }
     Color background_color() const { return m_noninherited.background_color; }
     Vector<BackgroundLayerData> const& background_layers() const { return m_noninherited.background_layers; }
-    BackgroundRepeatData background_repeat() const { return m_noninherited.background_repeat; }
 
     CSS::ListStyleType list_style_type() const { return m_inherited.list_style_type; }
 
@@ -184,7 +182,6 @@ protected:
         Length border_top_right_radius;
         Color background_color { InitialValues::background_color() };
         Vector<BackgroundLayerData> background_layers;
-        BackgroundRepeatData background_repeat { InitialValues::background_repeat(), InitialValues::background_repeat() };
         CSS::FlexDirection flex_direction { InitialValues::flex_direction() };
         CSS::FlexWrap flex_wrap { InitialValues::flex_wrap() };
         CSS::FlexBasisData flex_basis {};
@@ -210,7 +207,6 @@ public:
     void set_cursor(CSS::Cursor cursor) { m_inherited.cursor = cursor; }
     void set_pointer_events(CSS::PointerEvents value) { m_inherited.pointer_events = value; }
     void set_background_color(const Color& color) { m_noninherited.background_color = color; }
-    void set_background_repeat(BackgroundRepeatData repeat) { m_noninherited.background_repeat = repeat; }
     void set_background_layers(Vector<BackgroundLayerData>&& layers) { m_noninherited.background_layers = move(layers); }
     void set_float(CSS::Float value) { m_noninherited.float_ = value; }
     void set_clear(CSS::Clear value) { m_noninherited.clear = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -39,6 +39,12 @@ public:
     static float opacity() { return 1.0f; }
 };
 
+struct BackgroundLayerData {
+    RefPtr<CSS::ImageStyleValue> image;
+    CSS::Repeat repeat_x;
+    CSS::Repeat repeat_y;
+};
+
 struct BorderData {
 public:
     Color color { Color::Transparent };
@@ -119,6 +125,7 @@ public:
 
     Color color() const { return m_inherited.color; }
     Color background_color() const { return m_noninherited.background_color; }
+    Vector<BackgroundLayerData> const& background_layers() const { return m_noninherited.background_layers; }
     BackgroundRepeatData background_repeat() const { return m_noninherited.background_repeat; }
 
     CSS::ListStyleType list_style_type() const { return m_inherited.list_style_type; }
@@ -176,6 +183,7 @@ protected:
         Length border_top_left_radius;
         Length border_top_right_radius;
         Color background_color { InitialValues::background_color() };
+        Vector<BackgroundLayerData> background_layers;
         BackgroundRepeatData background_repeat { InitialValues::background_repeat(), InitialValues::background_repeat() };
         CSS::FlexDirection flex_direction { InitialValues::flex_direction() };
         CSS::FlexWrap flex_wrap { InitialValues::flex_wrap() };
@@ -203,6 +211,7 @@ public:
     void set_pointer_events(CSS::PointerEvents value) { m_inherited.pointer_events = value; }
     void set_background_color(const Color& color) { m_noninherited.background_color = color; }
     void set_background_repeat(BackgroundRepeatData repeat) { m_noninherited.background_repeat = repeat; }
+    void set_background_layers(Vector<BackgroundLayerData>&& layers) { m_noninherited.background_layers = move(layers); }
     void set_float(CSS::Float value) { m_noninherited.float_ = value; }
     void set_clear(CSS::Clear value) { m_noninherited.clear = value; }
     void set_z_index(Optional<int> value) { m_noninherited.z_index = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -39,9 +39,19 @@ public:
 };
 
 struct BackgroundLayerData {
-    RefPtr<CSS::ImageStyleValue> image;
-    CSS::Repeat repeat_x;
-    CSS::Repeat repeat_y;
+    RefPtr<CSS::ImageStyleValue> image { nullptr };
+    CSS::BackgroundAttachment attachment { CSS::BackgroundAttachment::Scroll };
+    CSS::BackgroundBox origin { CSS::BackgroundBox::PaddingBox };
+    CSS::BackgroundBox clip { CSS::BackgroundBox::BorderBox };
+    CSS::PositionEdge position_edge_x { CSS::PositionEdge::Left };
+    CSS::Length position_offset_x { CSS::Length::make_px(0) };
+    CSS::PositionEdge position_edge_y { CSS::PositionEdge::Top };
+    CSS::Length position_offset_y { CSS::Length::make_px(0) };
+    CSS::BackgroundSize size_type { CSS::BackgroundSize::LengthPercentage };
+    CSS::Length size_x { CSS::Length::make_auto() };
+    CSS::Length size_y { CSS::Length::make_auto() };
+    CSS::Repeat repeat_x { CSS::Repeat::Repeat };
+    CSS::Repeat repeat_y { CSS::Repeat::Repeat };
 };
 
 struct BorderData {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1111,21 +1111,11 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<StyleComp
     return {};
 }
 
-Optional<Parser::GeneralEnclosed> Parser::parse_general_enclosed()
-{
-    return parse_general_enclosed(m_token_stream);
-}
-
 template<typename T>
 Optional<Parser::GeneralEnclosed> Parser::parse_general_enclosed(TokenStream<T>&)
 {
     // FIXME: Actually parse this! https://www.w3.org/TR/mediaqueries-5/#typedef-general-enclosed
     return {};
-}
-
-NonnullRefPtrVector<StyleRule> Parser::consume_a_list_of_rules(bool top_level)
-{
-    return consume_a_list_of_rules(m_token_stream, top_level);
 }
 
 template<typename T>
@@ -1174,11 +1164,6 @@ NonnullRefPtrVector<StyleRule> Parser::consume_a_list_of_rules(TokenStream<T>& t
     return rules;
 }
 
-NonnullRefPtr<StyleRule> Parser::consume_an_at_rule()
-{
-    return consume_an_at_rule(m_token_stream);
-}
-
 template<typename T>
 NonnullRefPtr<StyleRule> Parser::consume_an_at_rule(TokenStream<T>& tokens)
 {
@@ -1216,11 +1201,6 @@ NonnullRefPtr<StyleRule> Parser::consume_an_at_rule(TokenStream<T>& tokens)
         auto value = consume_a_component_value(tokens);
         rule->m_prelude.append(value);
     }
-}
-
-RefPtr<StyleRule> Parser::consume_a_qualified_rule()
-{
-    return consume_a_qualified_rule(m_token_stream);
 }
 
 template<typename T>
@@ -1277,16 +1257,6 @@ StyleComponentValueRule Parser::consume_a_component_value(TokenStream<T>& tokens
     return StyleComponentValueRule(token);
 }
 
-StyleComponentValueRule Parser::consume_a_component_value()
-{
-    return consume_a_component_value(m_token_stream);
-}
-
-NonnullRefPtr<StyleBlockRule> Parser::consume_a_simple_block()
-{
-    return consume_a_simple_block(m_token_stream);
-}
-
 template<typename T>
 NonnullRefPtr<StyleBlockRule> Parser::consume_a_simple_block(TokenStream<T>& tokens)
 {
@@ -1313,11 +1283,6 @@ NonnullRefPtr<StyleBlockRule> Parser::consume_a_simple_block(TokenStream<T>& tok
     }
 }
 
-NonnullRefPtr<StyleFunctionRule> Parser::consume_a_function()
-{
-    return consume_a_function(m_token_stream);
-}
-
 template<typename T>
 NonnullRefPtr<StyleFunctionRule> Parser::consume_a_function(TokenStream<T>& tokens)
 {
@@ -1342,11 +1307,6 @@ NonnullRefPtr<StyleFunctionRule> Parser::consume_a_function(TokenStream<T>& toke
     }
 
     return function;
-}
-
-Optional<StyleDeclarationRule> Parser::consume_a_declaration()
-{
-    return consume_a_declaration(m_token_stream);
 }
 
 // https://www.w3.org/TR/css-syntax-3/#consume-declaration
@@ -1452,11 +1412,6 @@ Optional<StyleDeclarationRule> Parser::consume_a_declaration(TokenStream<T>& tok
     return declaration;
 }
 
-Vector<DeclarationOrAtRule> Parser::consume_a_list_of_declarations()
-{
-    return consume_a_list_of_declarations(m_token_stream);
-}
-
 template<typename T>
 Vector<DeclarationOrAtRule> Parser::consume_a_list_of_declarations(TokenStream<T>& tokens)
 {
@@ -1530,7 +1485,7 @@ RefPtr<CSSRule> Parser::parse_a_rule(TokenStream<T>& tokens)
     if (token.is(Token::Type::EndOfFile)) {
         return {};
     } else if (token.is(Token::Type::AtKeyword)) {
-        auto at_rule = consume_an_at_rule();
+        auto at_rule = consume_an_at_rule(m_token_stream);
         rule = convert_to_rule(at_rule);
     } else {
         auto qualified_rule = consume_a_qualified_rule(tokens);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2647,7 +2647,7 @@ RefPtr<StyleValue> Parser::parse_single_background_position_value(TokenStream<St
         if (seen_items == 2)
             break;
 
-        auto& token = tokens.next_token();
+        auto& token = tokens.peek_token();
         auto maybe_value = parse_css_value(token);
         if (!maybe_value || !property_accepts_value(PropertyID::BackgroundPosition, *maybe_value))
             break;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -151,41 +151,25 @@ private:
 
     Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>&);
 
-    [[nodiscard]] NonnullRefPtrVector<StyleRule> consume_a_list_of_rules(bool top_level);
     template<typename T>
     [[nodiscard]] NonnullRefPtrVector<StyleRule> consume_a_list_of_rules(TokenStream<T>&, bool top_level);
-
-    [[nodiscard]] NonnullRefPtr<StyleRule> consume_an_at_rule();
     template<typename T>
     [[nodiscard]] NonnullRefPtr<StyleRule> consume_an_at_rule(TokenStream<T>&);
-
-    [[nodiscard]] RefPtr<StyleRule> consume_a_qualified_rule();
     template<typename T>
     [[nodiscard]] RefPtr<StyleRule> consume_a_qualified_rule(TokenStream<T>&);
-
-    [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_list_of_declarations();
     template<typename T>
     [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_list_of_declarations(TokenStream<T>&);
-
-    [[nodiscard]] Optional<StyleDeclarationRule> consume_a_declaration();
     template<typename T>
     [[nodiscard]] Optional<StyleDeclarationRule> consume_a_declaration(TokenStream<T>&);
-
-    [[nodiscard]] StyleComponentValueRule consume_a_component_value();
     template<typename T>
     [[nodiscard]] StyleComponentValueRule consume_a_component_value(TokenStream<T>&);
-
-    [[nodiscard]] NonnullRefPtr<StyleBlockRule> consume_a_simple_block();
     template<typename T>
     [[nodiscard]] NonnullRefPtr<StyleBlockRule> consume_a_simple_block(TokenStream<T>&);
-
-    [[nodiscard]] NonnullRefPtr<StyleFunctionRule> consume_a_function();
     template<typename T>
     [[nodiscard]] NonnullRefPtr<StyleFunctionRule> consume_a_function(TokenStream<T>&);
 
     struct GeneralEnclosed {
     };
-    [[nodiscard]] Optional<GeneralEnclosed> parse_general_enclosed();
     template<typename T>
     [[nodiscard]] Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<T>&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -57,6 +57,8 @@ public:
     explicit TokenStream(Vector<T> const&);
     ~TokenStream();
 
+    TokenStream(TokenStream<T> const&) = delete;
+
     bool has_next_token();
     T const& next_token();
     T const& peek_token(int offset = 0);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -198,14 +198,14 @@ private:
     RefPtr<StyleValue> parse_color_value(StyleComponentValueRule const&);
     RefPtr<StyleValue> parse_string_value(StyleComponentValueRule const&);
     RefPtr<StyleValue> parse_image_value(StyleComponentValueRule const&);
+    template<typename ParseFunction>
+    RefPtr<StyleValue> parse_comma_separated_value_list(Vector<StyleComponentValueRule> const&, ParseFunction);
+    RefPtr<StyleValue> parse_simple_comma_separated_value_list(Vector<StyleComponentValueRule> const&);
+
     RefPtr<StyleValue> parse_background_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_background_image_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_single_background_position_value(TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_background_position_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_background_repeat_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_single_background_size_value(TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_background_size_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_border_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_border_radius_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -193,58 +193,58 @@ private:
     [[nodiscard]] RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_declaration(NonnullRefPtr<StyleBlockRule>);
 
     Optional<float> try_parse_float(StringView string);
-    Optional<Color> parse_color(ParsingContext const&, StyleComponentValueRule const&);
-    Optional<Length> parse_length(ParsingContext const&, StyleComponentValueRule const&);
+    Optional<Color> parse_color(StyleComponentValueRule const&);
+    Optional<Length> parse_length(StyleComponentValueRule const&);
 
     enum class AllowedDataUrlType {
         None,
         Image,
     };
-    Optional<AK::URL> parse_url_function(ParsingContext const&, StyleComponentValueRule const&, AllowedDataUrlType = AllowedDataUrlType::None);
+    Optional<AK::URL> parse_url_function(StyleComponentValueRule const&, AllowedDataUrlType = AllowedDataUrlType::None);
 
     Result<NonnullRefPtr<StyleValue>, ParsingResult> parse_css_value(PropertyID, TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_css_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_builtin_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_dynamic_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_length_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_numeric_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_identifier_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_color_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_string_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_image_value(ParsingContext const&, StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_background_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_background_image_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_single_background_position_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_background_position_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_single_background_repeat_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_single_background_size_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_background_size_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_border_radius_shorthand_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_box_shadow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_flex_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_flex_flow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_font_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_font_family_value(ParsingContext const&, Vector<StyleComponentValueRule> const&, size_t start_index = 0);
-    RefPtr<StyleValue> parse_list_style_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_overflow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_text_decoration_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_transform_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_css_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_builtin_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_dynamic_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_length_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_numeric_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_identifier_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_color_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_string_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_image_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_background_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_background_image_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_background_position_value(TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_background_position_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_background_repeat_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_background_size_value(TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_background_size_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_border_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_border_radius_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_box_shadow_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_flex_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_flex_flow_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_font_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_font_family_value(Vector<StyleComponentValueRule> const&, size_t start_index = 0);
+    RefPtr<StyleValue> parse_list_style_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_overflow_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_text_decoration_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_transform_value(Vector<StyleComponentValueRule> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
-    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    Optional<CalculatedStyleValue::CalcValue> parse_calc_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>& tokens);
-    OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(TokenStream<StyleComponentValueRule>&);
+    Optional<CalculatedStyleValue::CalcValue> parse_calc_value(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(TokenStream<StyleComponentValueRule>&);
+    Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(TokenStream<StyleComponentValueRule>& tokens);
+    OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(Vector<StyleComponentValueRule> const&);
 
     Result<NonnullRefPtr<Selector>, ParsingResult> parse_complex_selector(TokenStream<StyleComponentValueRule>&, bool allow_starting_combinator);
     Result<Selector::CompoundSelector, ParsingResult> parse_compound_selector(TokenStream<StyleComponentValueRule>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -192,59 +192,59 @@ private:
     [[nodiscard]] RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
     [[nodiscard]] RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_declaration(NonnullRefPtr<StyleBlockRule>);
 
-    static Optional<float> try_parse_float(StringView string);
-    static Optional<Color> parse_color(ParsingContext const&, StyleComponentValueRule const&);
-    static Optional<Length> parse_length(ParsingContext const&, StyleComponentValueRule const&);
+    Optional<float> try_parse_float(StringView string);
+    Optional<Color> parse_color(ParsingContext const&, StyleComponentValueRule const&);
+    Optional<Length> parse_length(ParsingContext const&, StyleComponentValueRule const&);
 
     enum class AllowedDataUrlType {
         None,
         Image,
     };
-    static Optional<AK::URL> parse_url_function(ParsingContext const&, StyleComponentValueRule const&, AllowedDataUrlType = AllowedDataUrlType::None);
+    Optional<AK::URL> parse_url_function(ParsingContext const&, StyleComponentValueRule const&, AllowedDataUrlType = AllowedDataUrlType::None);
 
     Result<NonnullRefPtr<StyleValue>, ParsingResult> parse_css_value(PropertyID, TokenStream<StyleComponentValueRule>&);
-    static RefPtr<StyleValue> parse_css_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_builtin_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_dynamic_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_length_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_numeric_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_identifier_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_color_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_string_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_image_value(ParsingContext const&, StyleComponentValueRule const&);
-    static RefPtr<StyleValue> parse_background_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_background_image_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_single_background_position_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static RefPtr<StyleValue> parse_background_position_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_single_background_repeat_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_single_background_size_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static RefPtr<StyleValue> parse_background_size_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_border_radius_shorthand_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_box_shadow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_flex_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_flex_flow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_font_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_font_family_value(ParsingContext const&, Vector<StyleComponentValueRule> const&, size_t start_index = 0);
-    static RefPtr<StyleValue> parse_list_style_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_overflow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_text_decoration_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
-    static RefPtr<StyleValue> parse_transform_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_css_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_builtin_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_dynamic_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_length_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_numeric_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_identifier_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_color_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_string_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_image_value(ParsingContext const&, StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_background_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_background_image_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_background_position_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_background_position_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_background_repeat_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_background_repeat_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_background_size_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_background_size_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_border_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_border_radius_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_border_radius_shorthand_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_box_shadow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_flex_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_flex_flow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_font_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_font_family_value(ParsingContext const&, Vector<StyleComponentValueRule> const&, size_t start_index = 0);
+    RefPtr<StyleValue> parse_list_style_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_overflow_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_text_decoration_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_transform_value(ParsingContext const&, Vector<StyleComponentValueRule> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
-    static OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static Optional<CalculatedStyleValue::CalcValue> parse_calc_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>& tokens);
-    static OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
-    static OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(ParsingContext const&, Vector<StyleComponentValueRule> const&);
+    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    Optional<CalculatedStyleValue::CalcValue> parse_calc_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>& tokens);
+    OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(ParsingContext const&, TokenStream<StyleComponentValueRule>&);
+    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(ParsingContext const&, Vector<StyleComponentValueRule> const&);
 
     Result<NonnullRefPtr<Selector>, ParsingResult> parse_complex_selector(TokenStream<StyleComponentValueRule>&, bool allow_starting_combinator);
     Result<Selector::CompoundSelector, ParsingResult> parse_compound_selector(TokenStream<StyleComponentValueRule>&);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -645,10 +645,6 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return ColorStyleValue::create(layout_node.computed_values().color());
     case PropertyID::BackgroundColor:
         return ColorStyleValue::create(layout_node.computed_values().background_color());
-    case CSS::PropertyID::BackgroundRepeat:
-        return BackgroundRepeatStyleValue::create(
-            layout_node.computed_values().background_repeat().repeat_x,
-            layout_node.computed_values().background_repeat().repeat_y);
     case CSS::PropertyID::Background: {
         auto maybe_background_color = property(CSS::PropertyID::BackgroundColor);
         auto maybe_background_image = property(CSS::PropertyID::BackgroundImage);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -293,7 +293,8 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
     }
 
     if (property_id == CSS::PropertyID::Background) {
-        auto set_single_background = [&](CSS::BackgroundStyleValue const& background) {
+        if (value.is_background()) {
+            auto& background = value.as_background();
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundColor, background.color(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundImage, background.image(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundPosition, background.position(), document);
@@ -302,21 +303,6 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, background.attachment(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, background.origin(), document);
             set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, background.clip(), document);
-        };
-
-        if (value.is_background()) {
-            auto& background = value.as_background();
-            set_single_background(background);
-            return;
-        }
-        if (value.is_value_list()) {
-            auto& background_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_list.is_empty()) {
-                auto& background = background_list.first();
-                if (background.is_background())
-                    set_single_background(background.as_background());
-            }
             return;
         }
 
@@ -328,110 +314,6 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundAttachment, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundOrigin, value, document);
         set_property_expanding_shorthands(style, CSS::PropertyID::BackgroundClip, value, document);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundAttachment) {
-        if (value.is_value_list()) {
-            auto& background_attachment_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_attachment_list.is_empty()) {
-                auto& background_attachment = background_attachment_list.first();
-                style.set_property(CSS::PropertyID::BackgroundAttachment, background_attachment);
-            }
-            return;
-        }
-
-        style.set_property(CSS::PropertyID::BackgroundAttachment, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundClip) {
-        if (value.is_value_list()) {
-            auto& background_clip_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_clip_list.is_empty()) {
-                auto& background_clip = background_clip_list.first();
-                style.set_property(CSS::PropertyID::BackgroundClip, background_clip);
-            }
-            return;
-        }
-
-        style.set_property(CSS::PropertyID::BackgroundClip, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundImage) {
-        if (value.is_value_list()) {
-            auto& background_image_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_image_list.is_empty()) {
-                auto& background_image = background_image_list.first();
-                style.set_property(CSS::PropertyID::BackgroundImage, background_image);
-            }
-            return;
-        }
-
-        style.set_property(CSS::PropertyID::BackgroundImage, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundOrigin) {
-        if (value.is_value_list()) {
-            auto& background_origin_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_origin_list.is_empty()) {
-                auto& background_origin = background_origin_list.first();
-                style.set_property(CSS::PropertyID::BackgroundOrigin, background_origin);
-            }
-            return;
-        }
-
-        style.set_property(CSS::PropertyID::BackgroundOrigin, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundPosition) {
-        if (value.is_value_list()) {
-            auto& background_position_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_position_list.is_empty()) {
-                auto& background_position = background_position_list.first();
-                style.set_property(CSS::PropertyID::BackgroundPosition, background_position);
-            }
-            return;
-        }
-
-        style.set_property(CSS::PropertyID::BackgroundPosition, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundRepeat) {
-        if (value.is_value_list()) {
-            auto& background_repeat_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_repeat_list.is_empty()) {
-                auto& background_repeat = background_repeat_list.first();
-                style.set_property(CSS::PropertyID::BackgroundRepeat, background_repeat);
-            }
-            return;
-        }
-        style.set_property(CSS::PropertyID::BackgroundRepeat, value);
-        return;
-    }
-
-    if (property_id == CSS::PropertyID::BackgroundSize) {
-        if (value.is_value_list()) {
-            auto& background_size_list = value.as_value_list().values();
-            // FIXME: Handle multiple backgrounds.
-            if (!background_size_list.is_empty()) {
-                auto& background_size = background_size_list.first();
-                style.set_property(CSS::PropertyID::BackgroundSize, background_size);
-            }
-            return;
-        }
-
-        style.set_property(CSS::PropertyID::BackgroundSize, value);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -408,6 +408,8 @@ public:
     }
     virtual ~BackgroundStyleValue() override { }
 
+    size_t layer_count() const { return m_layer_count; }
+
     NonnullRefPtr<StyleValue> attachment() const { return m_attachment; }
     NonnullRefPtr<StyleValue> clip() const { return m_clip; }
     NonnullRefPtr<StyleValue> color() const { return m_color; }
@@ -417,10 +419,7 @@ public:
     NonnullRefPtr<StyleValue> repeat() const { return m_repeat; }
     NonnullRefPtr<StyleValue> size() const { return m_size; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("{} {} {} {} {} {} {} {}", m_color->to_string(), m_image->to_string(), m_position->to_string(), m_size->to_string(), m_repeat->to_string(), m_attachment->to_string(), m_origin->to_string(), m_clip->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     BackgroundStyleValue(
@@ -431,18 +430,8 @@ private:
         NonnullRefPtr<StyleValue> repeat,
         NonnullRefPtr<StyleValue> attachment,
         NonnullRefPtr<StyleValue> origin,
-        NonnullRefPtr<StyleValue> clip)
-        : StyleValue(Type::Background)
-        , m_color(color)
-        , m_image(image)
-        , m_position(position)
-        , m_size(size)
-        , m_repeat(repeat)
-        , m_attachment(attachment)
-        , m_origin(origin)
-        , m_clip(clip)
-    {
-    }
+        NonnullRefPtr<StyleValue> clip);
+
     NonnullRefPtr<StyleValue> m_color;
     NonnullRefPtr<StyleValue> m_image;
     NonnullRefPtr<StyleValue> m_position;
@@ -451,6 +440,8 @@ private:
     NonnullRefPtr<StyleValue> m_attachment;
     NonnullRefPtr<StyleValue> m_origin;
     NonnullRefPtr<StyleValue> m_clip;
+
+    size_t m_layer_count;
 };
 
 class PositionStyleValue final : public StyleValue {
@@ -1321,7 +1312,14 @@ class StyleValueList final : public StyleValue {
 public:
     static NonnullRefPtr<StyleValueList> create(NonnullRefPtrVector<StyleValue>&& values) { return adopt_ref(*new StyleValueList(move(values))); }
 
+    size_t size() const { return m_values.size(); }
     NonnullRefPtrVector<StyleValue> const& values() const { return m_values; }
+    NonnullRefPtr<StyleValue> value_at(size_t i, bool allow_loop) const
+    {
+        if (allow_loop)
+            return m_values[i % size()];
+        return m_values[i];
+    }
 
     virtual String to_string() const
     {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -39,6 +39,24 @@ enum class AlignItems {
     Stretch,
 };
 
+enum class BackgroundAttachment {
+    Fixed,
+    Local,
+    Scroll,
+};
+
+enum class BackgroundBox {
+    BorderBox,
+    ContentBox,
+    PaddingBox,
+};
+
+enum class BackgroundSize {
+    Contain,
+    Cover,
+    LengthPercentage,
+};
+
 enum class BoxSizing {
     BorderBox,
     ContentBox,

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -353,6 +353,19 @@ Color Document::background_color(const Palette& palette) const
     return color;
 }
 
+Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
+{
+    auto* body_element = body();
+    if (!body_element)
+        return {};
+
+    auto* body_layout_node = body_element->layout_node();
+    if (!body_layout_node)
+        return {};
+
+    return &body_layout_node->background_layers();
+}
+
 RefPtr<Gfx::Bitmap> Document::background_image() const
 {
     auto* body_element = body();

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -366,48 +366,6 @@ Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
     return &body_layout_node->background_layers();
 }
 
-RefPtr<Gfx::Bitmap> Document::background_image() const
-{
-    auto* body_element = body();
-    if (!body_element)
-        return {};
-
-    auto* body_layout_node = body_element->layout_node();
-    if (!body_layout_node)
-        return {};
-
-    auto background_image = body_layout_node->background_image();
-    if (!background_image)
-        return {};
-    return background_image->bitmap();
-}
-
-CSS::Repeat Document::background_repeat_x() const
-{
-    auto* body_element = body();
-    if (!body_element)
-        return CSS::Repeat::Repeat;
-
-    auto* body_layout_node = body_element->layout_node();
-    if (!body_layout_node)
-        return CSS::Repeat::Repeat;
-
-    return body_layout_node->computed_values().background_repeat().repeat_x;
-}
-
-CSS::Repeat Document::background_repeat_y() const
-{
-    auto* body_element = body();
-    if (!body_element)
-        return CSS::Repeat::Repeat;
-
-    auto* body_layout_node = body_element->layout_node();
-    if (!body_layout_node)
-        return CSS::Repeat::Repeat;
-
-    return body_layout_node->computed_values().background_repeat().repeat_y;
-}
-
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
 AK::URL Document::parse_url(String const& url) const
 {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -130,6 +130,7 @@ public:
     const Page* page() const;
 
     Color background_color(const Gfx::Palette&) const;
+    Vector<CSS::BackgroundLayerData> const* background_layers() const;
     RefPtr<Gfx::Bitmap> background_image() const;
     CSS::Repeat background_repeat_x() const;
     CSS::Repeat background_repeat_y() const;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -131,9 +131,6 @@ public:
 
     Color background_color(const Gfx::Palette&) const;
     Vector<CSS::BackgroundLayerData> const* background_layers() const;
-    RefPtr<Gfx::Bitmap> background_image() const;
-    CSS::Repeat background_repeat_x() const;
-    CSS::Repeat background_repeat_y() const;
 
     Color link_color() const;
     void set_link_color(Color);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -254,6 +254,7 @@ class LineBox;
 class LineBoxFragment;
 class Node;
 class NodeWithStyle;
+class NodeWithStyleAndBoxModelMetrics;
 class RadioButton;
 class ReplacedBox;
 class TextNode;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -20,9 +20,14 @@ HTMLHtmlElement::~HTMLHtmlElement()
 bool HTMLHtmlElement::should_use_body_background_properties() const
 {
     auto background_color = layout_node()->computed_values().background_color();
-    const auto* background_image = layout_node()->background_image();
+    auto const& background_layers = layout_node()->background_layers();
 
-    return (background_color == Color::Transparent) && !background_image;
+    for (auto& layer : background_layers) {
+        if (layer.image)
+            return false;
+    }
+
+    return (background_color == Color::Transparent);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -93,7 +93,7 @@ void Box::paint_background(PaintContext& context)
     if (computed_values().border_top().width || computed_values().border_right().width || computed_values().border_bottom().width || computed_values().border_left().width)
         background_rect = enclosing_int_rect(bordered_rect());
 
-    Painting::paint_background(context, background_rect, background_color, background_layers, normalized_border_radius_data());
+    Painting::paint_background(context, *this, background_rect, background_color, background_layers, normalized_border_radius_data());
 }
 
 void Box::paint_box_shadow(PaintContext& context)

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -73,8 +73,6 @@ void Box::paint_background(PaintContext& context)
     Gfx::IntRect background_rect;
     Color background_color = computed_values().background_color();
     auto* background_layers = &computed_values().background_layers();
-    const Gfx::Bitmap* background_image = this->background_image() ? this->background_image()->bitmap() : nullptr;
-    CSS::BackgroundRepeatData background_repeat = computed_values().background_repeat();
 
     if (is_root_element()) {
         // CSS 2.1 Appendix E.2: If the element is a root element, paint the background over the entire canvas.
@@ -85,8 +83,6 @@ void Box::paint_background(PaintContext& context)
         if (document().html_element()->should_use_body_background_properties()) {
             background_layers = document().background_layers();
             background_color = document().background_color(context.palette());
-            background_image = document().background_image();
-            background_repeat = { document().background_repeat_x(), document().background_repeat_y() };
         }
     } else {
         background_rect = enclosing_int_rect(padded_rect());
@@ -97,13 +93,7 @@ void Box::paint_background(PaintContext& context)
     if (computed_values().border_top().width || computed_values().border_right().width || computed_values().border_bottom().width || computed_values().border_left().width)
         background_rect = enclosing_int_rect(bordered_rect());
 
-    auto background_data = Painting::BackgroundData {
-        .color = background_color,
-        .image = background_image,
-        .repeat_x = background_repeat.repeat_x,
-        .repeat_y = background_repeat.repeat_y
-    };
-    Painting::paint_background(context, background_rect, background_data, normalized_border_radius_data());
+    Painting::paint_background(context, background_rect, background_color, background_layers, normalized_border_radius_data());
 }
 
 void Box::paint_box_shadow(PaintContext& context)

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -72,6 +72,7 @@ void Box::paint_background(PaintContext& context)
 
     Gfx::IntRect background_rect;
     Color background_color = computed_values().background_color();
+    auto* background_layers = &computed_values().background_layers();
     const Gfx::Bitmap* background_image = this->background_image() ? this->background_image()->bitmap() : nullptr;
     CSS::BackgroundRepeatData background_repeat = computed_values().background_repeat();
 
@@ -82,6 +83,7 @@ void Box::paint_background(PaintContext& context)
         // Section 2.11.2: If the computed value of background-image on the root element is none and its background-color is transparent,
         // user agents must instead propagate the computed values of the background properties from that element’s first HTML BODY child element.
         if (document().html_element()->should_use_body_background_properties()) {
+            background_layers = document().background_layers();
             background_color = document().background_color(context.palette());
             background_image = document().background_image();
             background_repeat = { document().background_repeat_x(), document().background_repeat_y() };

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -49,13 +49,6 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
     auto& painter = context.painter();
 
     if (phase == PaintPhase::Background) {
-        auto background_data = Painting::BackgroundData {
-            .color = computed_values().background_color(),
-            .image = background_image() ? background_image()->bitmap() : nullptr,
-            .repeat_x = computed_values().background_repeat().repeat_x,
-            .repeat_y = computed_values().background_repeat().repeat_y
-        };
-
         auto top_left_border_radius = computed_values().border_top_left_radius();
         auto top_right_border_radius = computed_values().border_top_right_radius();
         auto bottom_right_border_radius = computed_values().border_bottom_right_radius();
@@ -65,7 +58,7 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
             // FIXME: This recalculates our (InlineNode's) absolute_rect() for every single fragment!
             auto rect = fragment.absolute_rect();
             auto border_radius_data = Painting::normalized_border_radius_data(*this, rect, top_left_border_radius, top_right_border_radius, bottom_right_border_radius, bottom_left_border_radius);
-            Painting::paint_background(context, enclosing_int_rect(rect), background_data, border_radius_data);
+            Painting::paint_background(context, enclosing_int_rect(rect), computed_values().background_color(), &computed_values().background_layers(), border_radius_data);
 
             if (auto computed_box_shadow = computed_values().box_shadow(); computed_box_shadow.has_value()) {
                 auto box_shadow_data = Painting::BoxShadowData {

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -58,7 +58,7 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
             // FIXME: This recalculates our (InlineNode's) absolute_rect() for every single fragment!
             auto rect = fragment.absolute_rect();
             auto border_radius_data = Painting::normalized_border_radius_data(*this, rect, top_left_border_radius, top_right_border_radius, bottom_right_border_radius, bottom_left_border_radius);
-            Painting::paint_background(context, enclosing_int_rect(rect), computed_values().background_color(), &computed_values().background_layers(), border_radius_data);
+            Painting::paint_background(context, *this, enclosing_int_rect(rect), computed_values().background_color(), &computed_values().background_layers(), border_radius_data);
 
             if (auto computed_box_shadow = computed_values().box_shadow(); computed_box_shadow.has_value()) {
                 auto box_shadow_data = Painting::BoxShadowData {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -300,10 +300,6 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     if (border_top_right_radius.has_value())
         computed_values.set_border_top_right_radius(border_top_right_radius.value()->to_length());
 
-    auto background_repeat = specified_style.background_repeat();
-    if (background_repeat.has_value())
-        computed_values.set_background_repeat(background_repeat.value());
-
     computed_values.set_display(specified_style.display());
 
     auto flex_direction = specified_style.flex_direction();

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -274,13 +274,6 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     }
     computed_values.set_background_color(specified_style.color_or_fallback(CSS::PropertyID::BackgroundColor, *this, CSS::InitialValues::background_color()));
 
-    // FIXME: Remove this
-    auto bgimage = specified_style.property(CSS::PropertyID::BackgroundImage);
-    if (bgimage.has_value() && bgimage.value()->is_image()) {
-        m_background_image = bgimage.value()->as_image();
-        m_background_image->load_bitmap(document());
-    }
-
     computed_values.set_box_sizing(specified_style.box_sizing());
 
     // FIXME: BorderXRadius properties are now BorderRadiusStyleValues, so make use of that.
@@ -485,7 +478,6 @@ NonnullRefPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const
     wrapper->m_font = m_font;
     wrapper->m_font_size = m_font_size;
     wrapper->m_line_height = m_line_height;
-    wrapper->m_background_image = m_background_image;
     return wrapper;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -206,6 +206,7 @@ public:
     float line_height() const { return m_line_height; }
     float font_size() const { return m_font_size; }
     const CSS::ImageStyleValue* background_image() const { return m_background_image; }
+    Vector<CSS::BackgroundLayerData> const& background_layers() const { return computed_values().background_layers(); }
     const CSS::ImageStyleValue* list_style_image() const { return m_list_style_image; }
 
     NonnullRefPtr<NodeWithStyle> create_anonymous_wrapper() const;

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -205,7 +205,6 @@ public:
     const Gfx::Font& font() const { return *m_font; }
     float line_height() const { return m_line_height; }
     float font_size() const { return m_font_size; }
-    const CSS::ImageStyleValue* background_image() const { return m_background_image; }
     Vector<CSS::BackgroundLayerData> const& background_layers() const { return computed_values().background_layers(); }
     const CSS::ImageStyleValue* list_style_image() const { return m_list_style_image; }
 
@@ -223,7 +222,6 @@ private:
     RefPtr<Gfx::Font> m_font;
     float m_line_height { 0 };
     float m_font_size { 0 };
-    RefPtr<CSS::ImageStyleValue> m_background_image;
     RefPtr<CSS::ImageStyleValue> m_list_style_image;
 
     bool m_has_definite_height { false };

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -60,8 +60,25 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         // FIXME: Size
         Gfx::IntRect image_rect { border_rect.x(), border_rect.y(), image.width(), image.height() };
 
-        // FIXME: Origin
-        // FIXME: Position
+        // Origin
+        auto background_positioning_area = get_box(layer.origin);
+        int space_x = background_positioning_area.width() - image_rect.width();
+        int space_y = background_positioning_area.height() - image_rect.height();
+
+        // Position
+        int offset_x = layer.position_offset_x.resolved_or_zero(layout_node, space_x).to_px(layout_node);
+        if (layer.position_edge_x == CSS::PositionEdge::Right) {
+            image_rect.set_right_without_resize(background_positioning_area.right() - offset_x);
+        } else {
+            image_rect.set_left(background_positioning_area.left() + offset_x);
+        }
+
+        int offset_y = layer.position_offset_y.resolved_or_zero(layout_node, space_y).to_px(layout_node);
+        if (layer.position_edge_y == CSS::PositionEdge::Bottom) {
+            image_rect.set_bottom_without_resize(background_positioning_area.bottom() - offset_y);
+        } else {
+            image_rect.set_top(background_positioning_area.top() + offset_y);
+        }
 
         // Repetition
         bool repeat_x = false;

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -27,7 +27,7 @@ void paint_background(PaintContext& context, Gfx::IntRect const& background_rect
             // The background rect is already sized to align with 'repeat'.
             break;
         case CSS::Repeat::NoRepeat:
-            image_rect.set_width(background_data.image->width());
+            image_rect.set_width(min(image_rect.width(), background_data.image->width()));
             break;
         }
 
@@ -39,7 +39,7 @@ void paint_background(PaintContext& context, Gfx::IntRect const& background_rect
             // The background rect is already sized to align with 'repeat'.
             break;
         case CSS::Repeat::NoRepeat:
-            image_rect.set_height(background_data.image->height());
+            image_rect.set_height(min(image_rect.height(), background_data.image->height()));
             break;
         }
 

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -127,8 +127,19 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         switch (layer.repeat_x) {
         case CSS::Repeat::Round:
-        case CSS::Repeat::Space:
-            // FIXME: Support 'round' and 'space'. Fall through to 'repeat' since that most closely resembles these.
+            break;
+        case CSS::Repeat::Space: {
+            int whole_images = background_positioning_area.width() / image_rect.width();
+            if (whole_images <= 1) {
+                x_step = image_rect.width();
+                repeat_x = false;
+            } else {
+                int space = background_positioning_area.width() % image_rect.width();
+                x_step = image_rect.width() + ((float)space / (float)(whole_images - 1));
+                repeat_x = true;
+            }
+            break;
+        }
         case CSS::Repeat::Repeat:
             x_step = image_rect.width();
             repeat_x = true;
@@ -145,8 +156,19 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         switch (layer.repeat_y) {
         case CSS::Repeat::Round:
-        case CSS::Repeat::Space:
-            // FIXME: Support 'round' and 'space'. Fall through to 'repeat' since that most closely resembles these.
+            break;
+        case CSS::Repeat::Space: {
+            int whole_images = background_positioning_area.height() / image_rect.height();
+            if (whole_images <= 1) {
+                y_step = image_rect.height();
+                repeat_y = false;
+            } else {
+                int space = background_positioning_area.height() % image_rect.height();
+                y_step = image_rect.height() + ((float)space / (float)(whole_images - 1));
+                repeat_y = true;
+            }
+            break;
+        }
         case CSS::Repeat::Repeat:
             y_step = image_rect.height();
             repeat_y = true;

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
@@ -8,11 +8,12 @@
 
 #include <LibGfx/Forward.h>
 #include <LibWeb/CSS/StyleValue.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/PaintContext.h>
 
 namespace Web::Painting {
 
-void paint_background(PaintContext&, Gfx::IntRect const&, Color background_color, Vector<CSS::BackgroundLayerData> const*, BorderRadiusData const&);
+void paint_background(PaintContext&, Layout::NodeWithStyleAndBoxModelMetrics const&, Gfx::IntRect const&, Color background_color, Vector<CSS::BackgroundLayerData> const*, BorderRadiusData const&);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
@@ -13,13 +13,6 @@
 
 namespace Web::Painting {
 
-struct BackgroundData {
-    Color color;
-    Gfx::Bitmap const* image;
-    CSS::Repeat repeat_x;
-    CSS::Repeat repeat_y;
-};
-
-void paint_background(PaintContext&, Gfx::IntRect const&, BackgroundData const&, BorderRadiusData const&);
+void paint_background(PaintContext&, Gfx::IntRect const&, Color background_color, Vector<CSS::BackgroundLayerData> const*, BorderRadiusData const&);
 
 }


### PR DESCRIPTION
*Screenshots taken from https://github.com/SerenityOS/serenity/blob/master/Base/res/html/misc/backgrounds.html*

![image](https://user-images.githubusercontent.com/222642/142211336-f016788e-7cc1-4705-b7cb-8426aca19ca1.png)
![image](https://user-images.githubusercontent.com/222642/142211395-3449de9c-7d35-494b-9f8c-89aa0c31ad68.png)
![image](https://user-images.githubusercontent.com/222642/142211439-3ca3882b-fc86-4777-8f43-880fe61a3bad.png)
![image](https://user-images.githubusercontent.com/222642/142211219-cd509107-216e-49ba-820d-cea60d125421.png)


It's finally done! This is chonkier than I had hoped, but since the background properties are so interconnected it made sense to me to put them all together.

Now, we parse background properties as comma-separated lists, which define "background layers". (Except `background-color` which is only valid for the bottom layer.) Layers are painted from back to front, and allow some fancy effects without creating lots of `<div>`s.

When painting these layers, we now support all the background-properties (except `background-attachment`, see below):
- size, including the `cover` and `contain` special values. Lets your resize the images.
- origin and position, which let you move the images around.
- clip, which lets you decide which of the box-model boxes the background is visible in.
- repeat, which we supported before but now also handles the `round` and `space` special values.

I haven't implemented `background-attachment` yet since we don't support overflow scrolling, making it hard to test. Also I wasn't sure how to pass the required information in, and this is a big enough PR already. :^)

There's also a little bit of refactoring of the CSS Parser in here, but hopefully that is clear enough.