### PR TITLE
CI: Prevent false errors if a commit message contains CRLF

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -20,7 +20,7 @@ jobs:
                 error: "Commit message contains CRLF line breaks (only unix-style LF linebreaks are allowed)",
               },
               {
-                pattern: /^.{0,72}(?:\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$/,
+                pattern: /^.{0,72}(?:\r?\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$/,
                 error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs)",
               },
               {
@@ -32,7 +32,7 @@ jobs:
                 error: "First word of commit after the subsystem is not capitalized",
               },
               {
-                pattern: /^.+[^.\n](\n.*)*$/,
+                pattern: /^.+[^.\n](\r?\n.*)*$/,
                 error: "Commit title ends in a period",
               },
               {


### PR DESCRIPTION
Previously if a commit message contained any carriage returns it would correctly fail the 'contains CRLF line breaks' test, but it would also report 'Commit message lines are too long' and 'Commit title ends in a period', even if neither is true.

This was discovered in [this run](https://github.com/thislooksfun/serenity/runs/4248060425?check_suite_focus=true) from #10934.