### PR TITLE
Kernel: Make sys$msync more posix compliant and reduce its IO heaviness

### DIFF
--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -35,11 +35,13 @@ SharedInodeVMObject::SharedInodeVMObject(SharedInodeVMObject const& other)
 {
 }
 
-ErrorOr<void> SharedInodeVMObject::sync()
+ErrorOr<void> SharedInodeVMObject::sync(off_t offset_in_pages, size_t pages)
 {
     SpinlockLocker locker(m_lock);
 
-    for (size_t page_index = 0; page_index < page_count(); ++page_index) {
+    size_t highest_page_to_flush = min(page_count(), offset_in_pages + pages);
+
+    for (size_t page_index = offset_in_pages; page_index < highest_page_to_flush; ++page_index) {
         auto& physical_page = m_physical_pages[page_index];
         if (!physical_page)
             continue;

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -18,7 +18,7 @@ public:
     static ErrorOr<NonnullRefPtr<SharedInodeVMObject>> try_create_with_inode(Inode&);
     virtual ErrorOr<NonnullRefPtr<VMObject>> try_clone() override;
 
-    ErrorOr<void> sync();
+    ErrorOr<void> sync(off_t offset_in_pages = 0, size_t pages = -1);
 
 private:
     virtual bool is_shared_inode() const override { return true; }

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -616,8 +616,12 @@ ErrorOr<FlatPtr> Process::sys$msync(Userspace<void*> address, size_t size, int f
     if (!vmobject.is_shared_inode())
         return 0;
 
+    off_t offset = region->offset_in_vmobject() + address.ptr() - region->range().base().get();
+
     auto& inode_vmobject = static_cast<Memory::SharedInodeVMObject&>(vmobject);
-    TRY(inode_vmobject.sync());
+    // FIXME: Handle MS_ASYNC
+    TRY(inode_vmobject.sync(offset / PAGE_SIZE, size / PAGE_SIZE));
+    // FIXME: Handle MS_INVALIDATE
     // FIXME: If msync() causes any write to a file, the file's st_ctime and st_mtime fields shall be marked for update.
     return 0;
 }

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -607,7 +607,7 @@ ErrorOr<FlatPtr> Process::sys$msync(Userspace<void*> address, size_t size, int f
     size = Memory::page_round_up(size);
 
     // FIXME: We probably want to sync all mappings in the address+size range.
-    auto* region = address_space().find_region_from_range(Memory::VirtualRange { address.vaddr(), size });
+    auto* region = address_space().find_region_containing(Memory::VirtualRange { address.vaddr(), size });
     // All regions from address upto address+size shall be mapped
     if (!region)
         return ENOMEM;


### PR DESCRIPTION
This also adds some more FIXME's.
Note: These are sadly not directly tested, due to us not having any tests for msync.



#### Kernel: Handle more error cases in sys$msync

#### Kernel: Allow flushing of partial regions in sys$msync

#### Kernel: Don't rewrite the whole file on sys$msync 