### PR TITLE
Hexdump: Add coalescing and verbose feature

### DIFF
--- a/Userland/Utilities/hexdump.cpp
+++ b/Userland/Utilities/hexdump.cpp
@@ -22,7 +22,9 @@ int main(int argc, char** argv)
 {
     Core::ArgsParser args_parser;
     const char* path = nullptr;
+    bool verbose = false;
     args_parser.add_positional_argument(path, "Input", "input", Core::ArgsParser::Required::No);
+    args_parser.add_option(verbose, "Display all input data", "verbose", 'v');
 
     args_parser.parse(argc, argv);
 
@@ -79,6 +81,11 @@ int main(int argc, char** argv)
 
         size_t offset;
         for (offset = 0; offset + LINE_LENGTH_BYTES - 1 < contents_size; offset += LINE_LENGTH_BYTES) {
+            if (verbose) {
+                print_line(&contents[offset], LINE_LENGTH_BYTES);
+                continue;
+            }
+
             auto current_line = contents.span().slice(offset, LINE_LENGTH_BYTES);
             bool is_same_contents = (current_line == previous_line);
             if (!is_same_contents)


### PR DESCRIPTION
@awesomekling mentioned about not having coalesce feature in hexdump in one of his recent streams. 

Added a feature to coalesce identical lines and an extra verbose option to dump everything (the default behavior before). 
Sample output:
![image](https://user-images.githubusercontent.com/33182938/142466917-09f92548-a688-4d55-b0ee-bc172cd2d49a.png)
