### PR TITLE
Taskbar: Add dropping of AppFiles to QuickLaunch

### DIFF
--- a/Userland/Services/Taskbar/CMakeLists.txt
+++ b/Userland/Services/Taskbar/CMakeLists.txt
@@ -7,6 +7,7 @@ serenity_component(
 set(SOURCES
     main.cpp
     ClockWidget.cpp
+    QuickLaunchWidget.cpp
     ShutdownDialog.cpp
     TaskbarButton.cpp
     TaskbarWindow.cpp

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021, Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "QuickLaunchWidget.h"
+#include <LibConfig/Client.h>
+#include <LibCore/MimeData.h>
+#include <LibGUI/BoxLayout.h>
+#include <serenity.h>
+
+namespace Taskbar {
+
+constexpr auto quick_launch = "QuickLaunch"sv;
+constexpr int quick_launch_button_size = 24;
+
+QuickLaunchWidget::QuickLaunchWidget()
+{
+    set_shrink_to_fit(true);
+    set_layout<GUI::HorizontalBoxLayout>();
+    layout()->set_spacing(0);
+    set_frame_thickness(0);
+    set_fixed_height(24);
+
+    auto keys = Config::list_keys("Taskbar", quick_launch);
+    for (auto& name : keys) {
+        auto af_name = Config::read_string("Taskbar", quick_launch, name);
+        auto af_path = String::formatted("{}/{}", Desktop::AppFile::APP_FILES_DIRECTORY, af_name);
+        auto af = Desktop::AppFile::open(af_path);
+        add_or_adjust_button(name, af);
+    }
+}
+
+QuickLaunchWidget::~QuickLaunchWidget()
+{
+}
+
+void QuickLaunchWidget::add_or_adjust_button(String const& button_name, NonnullRefPtr<Desktop::AppFile> app_file)
+{
+    if (!app_file->is_valid())
+        return;
+    auto button = find_child_of_type_named<GUI::Button>(button_name);
+    if (!button) {
+        button = &add<GUI::Button>();
+    }
+    auto app_executable = app_file->executable();
+    auto app_run_in_terminal = app_file->run_in_terminal();
+    button->set_fixed_size(quick_launch_button_size, quick_launch_button_size);
+    button->set_button_style(Gfx::ButtonStyle::Coolbar);
+    button->set_icon(app_file->icon().bitmap_for_size(16));
+    button->set_tooltip(app_file->name());
+    button->set_name(button_name);
+    button->on_click = [app_executable, app_run_in_terminal](auto) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+        } else if (pid == 0) {
+            if (chdir(Core::StandardPaths::home_directory().characters()) < 0) {
+                perror("chdir");
+                exit(1);
+            }
+            if (app_run_in_terminal)
+                execl("/bin/Terminal", "Terminal", "-e", app_executable.characters(), nullptr);
+            else
+                execl(app_executable.characters(), app_executable.characters(), nullptr);
+            perror("execl");
+            VERIFY_NOT_REACHED();
+        } else {
+            if (disown(pid) < 0)
+                perror("disown");
+        }
+    };
+}
+
+void QuickLaunchWidget::config_key_was_removed(String const& domain, String const& group, String const& key)
+{
+    if (domain == "Taskbar" && group == quick_launch) {
+        auto button = find_child_of_type_named<GUI::Button>(key);
+        if (button)
+            remove_child(*button);
+    }
+}
+
+void QuickLaunchWidget::config_string_did_change(String const& domain, String const& group, String const& key, String const& value)
+{
+    if (domain == "Taskbar" && group == quick_launch) {
+        auto af_path = String::formatted("{}/{}", Desktop::AppFile::APP_FILES_DIRECTORY, value);
+        auto af = Desktop::AppFile::open(af_path);
+        add_or_adjust_button(key, af);
+    }
+}
+
+void QuickLaunchWidget::drop_event(GUI::DropEvent& event)
+{
+    event.accept();
+
+    if (event.mime_data().has_urls()) {
+        auto urls = event.mime_data().urls();
+        for (auto& url : urls) {
+            auto af = Desktop::AppFile::open(url.path());
+            if (af->is_valid()) {
+                auto item_name = af->name().replace(" ", "", true);
+                add_or_adjust_button(item_name, af);
+                Config::write_string("Taskbar", quick_launch, item_name, url.basename());
+            }
+        }
+    }
+}
+
+}

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibConfig/Listener.h>
+#include <LibDesktop/AppFile.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Frame.h>
+
+namespace Taskbar {
+
+class QuickLaunchWidget : public GUI::Frame
+    , public Config::Listener {
+    C_OBJECT(QuickLaunchWidget);
+
+public:
+    virtual ~QuickLaunchWidget() override;
+
+    virtual void config_key_was_removed(String const&, String const&, String const&) override;
+    virtual void config_string_did_change(String const&, String const&, String const&, String const&) override;
+
+    virtual void drop_event(GUI::DropEvent&);
+
+private:
+    QuickLaunchWidget();
+    void add_or_adjust_button(String const&, NonnullRefPtr<Desktop::AppFile>);
+};
+
+}

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -23,11 +23,14 @@ public:
     virtual void config_key_was_removed(String const&, String const&, String const&) override;
     virtual void config_string_did_change(String const&, String const&, String const&, String const&) override;
 
-    virtual void drop_event(GUI::DropEvent&);
+    virtual void drop_event(GUI::DropEvent&) override;
 
 private:
     QuickLaunchWidget();
     void add_or_adjust_button(String const&, NonnullRefPtr<Desktop::AppFile>);
+    RefPtr<GUI::Menu> m_context_menu;
+    RefPtr<GUI::Action> m_context_menu_default_action;
+    String m_context_menu_app_name;
 };
 
 }

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -14,8 +14,7 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <WindowServer/ScreenLayout.h>
 
-class TaskbarWindow final : public GUI::Window
-    , public Config::Listener {
+class TaskbarWindow final : public GUI::Window {
     C_OBJECT(TaskbarWindow);
 
 public:
@@ -24,13 +23,9 @@ public:
     static int taskbar_height() { return 27; }
     static int taskbar_icon_size() { return 16; }
 
-    virtual void config_key_was_removed(String const&, String const&, String const&) override;
-    virtual void config_string_did_change(String const&, String const&, String const&, String const&) override;
-
 private:
     explicit TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu);
     static void show_desktop_button_clicked(unsigned);
-    void create_quick_launch_bar();
     void set_quick_launch_button_data(GUI::Button&, String const&, NonnullRefPtr<Desktop::AppFile>);
     void on_screen_rects_change(const Vector<Gfx::IntRect, 4>&, size_t);
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
@@ -53,7 +48,6 @@ private:
     NonnullRefPtr<GUI::Menu> m_start_menu;
     RefPtr<GUI::Widget> m_task_button_container;
     RefPtr<Gfx::Bitmap> m_default_icon;
-    RefPtr<GUI::Frame> m_quick_launch_bar;
 
     Gfx::IntSize m_applet_area_size;
     RefPtr<GUI::Frame> m_applet_area_container;


### PR DESCRIPTION
This change adds the capability to drop AppFiles to the quick launch section of the Taskbar. All logic was moved to a new QuickLaunchWidget.

![drop_quicklaunch](https://user-images.githubusercontent.com/5813055/142478480-2354770e-4aa2-449e-a189-d5bc79ab2267.gif)


