### PR TITLE
FontEditor: Support flipping and rotating, fix pasting, and other cosmetic errors

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -113,6 +113,9 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
     auto& toolbar = *find_descendant_of_type_named<GUI::Toolbar>("toolbar");
     auto& glyph_map_container = *find_descendant_of_type_named<GUI::Widget>("glyph_map_container");
     auto& move_glyph_button = *find_descendant_of_type_named<GUI::Button>("move_glyph_button");
+    auto& rotate_90_button = *find_descendant_of_type_named<GUI::Button>("rotate_90");
+    auto& flip_vertical_button = *find_descendant_of_type_named<GUI::Button>("flip_vertical");
+    auto& flip_horizontal_button = *find_descendant_of_type_named<GUI::Button>("flip_horizontal");
     m_statusbar = *find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     m_glyph_editor_container = *find_descendant_of_type_named<GUI::Widget>("glyph_editor_container");
     m_left_column_container = *find_descendant_of_type_named<GUI::Widget>("left_column_container");
@@ -328,6 +331,21 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
             m_glyph_editor_widget->set_mode(GlyphEditorWidget::Paint);
     };
     move_glyph_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/selection-move.png").release_value_but_fixme_should_propagate_errors());
+
+    rotate_90_button.on_click = [&](auto) {
+        m_glyph_editor_widget->rotate_90();
+    };
+    rotate_90_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-cw.png").release_value_but_fixme_should_propagate_errors());
+
+    flip_vertical_button.on_click = [&](auto) {
+        m_glyph_editor_widget->flip_vertically();
+    };
+    flip_vertical_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-flip-vertical.png").release_value_but_fixme_should_propagate_errors());
+
+    flip_horizontal_button.on_click = [&](auto) {
+        m_glyph_editor_widget->flip_horizontally();
+    };
+    flip_horizontal_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-flip-horizontal.png").release_value_but_fixme_should_propagate_errors());
 
     GUI::Clipboard::the().on_change = [&](const String& data_type) {
         m_paste_action->set_enabled(data_type == "glyph/x-fonteditor");

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -116,6 +116,7 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
     auto& rotate_90_button = *find_descendant_of_type_named<GUI::Button>("rotate_90");
     auto& flip_vertical_button = *find_descendant_of_type_named<GUI::Button>("flip_vertical");
     auto& flip_horizontal_button = *find_descendant_of_type_named<GUI::Button>("flip_horizontal");
+    auto& copy_code_point_button = *find_descendant_of_type_named<GUI::Button>("copy_code_point");
     m_statusbar = *find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     m_glyph_editor_container = *find_descendant_of_type_named<GUI::Widget>("glyph_editor_container");
     m_left_column_container = *find_descendant_of_type_named<GUI::Widget>("left_column_container");
@@ -346,6 +347,13 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
         m_glyph_editor_widget->flip_horizontally();
     };
     flip_horizontal_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-flip-horizontal.png").release_value_but_fixme_should_propagate_errors());
+
+    copy_code_point_button.on_click = [&](auto) {
+        StringBuilder glyph_builder;
+        glyph_builder.append_code_point(m_glyph_editor_widget->glyph());
+        GUI::Clipboard::the().set_plain_text(glyph_builder.build());
+    };
+    copy_code_point_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-copy.png").release_value_but_fixme_should_propagate_errors());
 
     GUI::Clipboard::the().on_change = [&](const String& data_type) {
         m_paste_action->set_enabled(data_type == "glyph/x-fonteditor");

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -327,7 +327,6 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
         else
             m_glyph_editor_widget->set_mode(GlyphEditorWidget::Paint);
     };
-    move_glyph_button.set_checkable(true);
     move_glyph_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/selection-move.png").release_value_but_fixme_should_propagate_errors());
 
     GUI::Clipboard::the().on_change = [&](const String& data_type) {

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -80,11 +80,29 @@
                         button_style: "Coolbar"
                         focus_policy: "TabFocus"
                     }
+                }
+
+                @GUI::Widget {
+                    shrink_to_fit: true
+
+                    layout: @GUI::HorizontalBoxLayout {
+                    }
 
                     @GUI::Button {
                         name: "rotate_90"
                         fixed_width: 22
                         tooltip: "Rotate 90° clockwise"
+                        button_style: "Coolbar"
+                        focus_policy: "TabFocus"
+                    }
+
+                    @GUI::Widget {
+                    }
+
+                    @GUI::Button {
+                        name: "copy_code_point"
+                        fixed_width: 22
+                        tooltip: "Copy this codepoint (not glyph)"
                         button_style: "Coolbar"
                         focus_policy: "TabFocus"
                     }

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -47,6 +47,7 @@
                     @GUI::CheckBox {
                         name: "glyph_editor_present_checkbox"
                         text: "Present"
+                        focus_policy: "TabFocus"
                     }
 
                     @GUI::Button {

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -46,7 +46,7 @@
 
                     @GUI::CheckBox {
                         name: "glyph_editor_present_checkbox"
-                        text: "Show"
+                        text: "Present"
                     }
 
                     @GUI::Button {
@@ -54,6 +54,7 @@
                         fixed_width: 22
                         tooltip: "Move Glyph"
                         button_style: "Coolbar"
+                        checkable: true
                     }
                 }
             }

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -58,9 +58,37 @@
                         checkable: true
                     }
                 }
-            }
 
-            @GUI::Widget {
+                @GUI::Widget {
+                    shrink_to_fit: true
+
+                    layout: @GUI::HorizontalBoxLayout {
+                    }
+
+                    @GUI::Button {
+                        name: "flip_vertical"
+                        fixed_width: 22
+                        tooltip: "Flip vertically (top to bottom)"
+                        button_style: "Coolbar"
+                        focus_policy: "TabFocus"
+                    }
+
+                    @GUI::Button {
+                        name: "flip_horizontal"
+                        fixed_width: 22
+                        tooltip: "Flip horizontally (left to right)"
+                        button_style: "Coolbar"
+                        focus_policy: "TabFocus"
+                    }
+
+                    @GUI::Button {
+                        name: "rotate_90"
+                        fixed_width: 22
+                        tooltip: "Rotate 90° clockwise"
+                        button_style: "Coolbar"
+                        focus_policy: "TabFocus"
+                    }
+                }
             }
         }
 

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -1,5 +1,6 @@
 @GUI::Widget {
     fill_with_background_color: true
+
     layout: @GUI::VerticalBoxLayout {
         spacing: 2
     }
@@ -18,21 +19,24 @@
 
         @GUI::Widget {
             name: "left_column_container"
+
             layout: @GUI::VerticalBoxLayout {
             }
 
             @GUI::Widget {
                 name: "glyph_editor_container"
+
                 layout: @GUI::VerticalBoxLayout {
                 }
             }
 
             @GUI::Widget {
-                fixed_height: 22
                 layout: @GUI::VerticalBoxLayout {
                 }
 
                 @GUI::Widget {
+                    shrink_to_fit: true
+
                     layout: @GUI::HorizontalBoxLayout {
                     }
 
@@ -60,12 +64,14 @@
 
         @GUI::Widget {
             name: "right_column_container"
+
             layout: @GUI::VerticalBoxLayout {
                 spacing: 6
             }
 
             @GUI::Widget {
                 name: "glyph_map_container"
+
                 layout: @GUI::VerticalBoxLayout {
                 }
             }
@@ -74,6 +80,7 @@
                 name: "font_metadata_groupbox"
                 title: "Metadata"
                 fixed_height: 220
+
                 layout: @GUI::VerticalBoxLayout {
                     margins: [6, 6, 6, 6]
                 }
@@ -198,6 +205,7 @@
 
                 @GUI::Widget {
                     fixed_height: 22
+
                     layout: @GUI::HorizontalBoxLayout {
                     }
 

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -250,6 +250,92 @@ void GlyphEditorWidget::move_at_mouse(const GUI::MouseEvent& event)
     update();
 }
 
+static Vector<Vector<u8>> glyph_as_matrix(Gfx::GlyphBitmap const& bitmap)
+{
+    Vector<Vector<u8>> result;
+    result.ensure_capacity(bitmap.height());
+
+    for (int y = 0; y < bitmap.height(); y++) {
+        result.empend();
+        auto& row = result.last();
+        row.ensure_capacity(bitmap.width());
+        for (int x = 0; x < bitmap.width(); x++) {
+            row.append(bitmap.bit_at(x, y));
+        }
+    }
+
+    return result;
+}
+
+void GlyphEditorWidget::rotate_90()
+{
+    if (on_undo_event)
+        on_undo_event();
+
+    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto matrix = glyph_as_matrix(bitmap);
+
+    for (int y = 0; y < bitmap.height(); y++) {
+        for (int x = 0; x < bitmap.width(); x++) {
+            int source_x = y;
+            int source_y = bitmap.width() - 1 - x;
+            bool value = false;
+            if (source_x < bitmap.width() && source_y < bitmap.height()) {
+                value = matrix[source_y][source_x];
+            }
+            bitmap.set_bit_at(x, y, value);
+        }
+    }
+
+    if (on_glyph_altered)
+        on_glyph_altered(m_glyph);
+    update();
+}
+
+void GlyphEditorWidget::flip_vertically()
+{
+    if (on_undo_event)
+        on_undo_event();
+
+    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto matrix = glyph_as_matrix(bitmap);
+
+    for (int y = 0; y < bitmap.height(); y++) {
+        for (int x = 0; x < bitmap.width(); x++) {
+            int source_x = x;
+            int source_y = bitmap.height() - 1 - y;
+            bool value = matrix[source_y][source_x];
+            bitmap.set_bit_at(x, y, value);
+        }
+    }
+
+    if (on_glyph_altered)
+        on_glyph_altered(m_glyph);
+    update();
+}
+
+void GlyphEditorWidget::flip_horizontally()
+{
+    if (on_undo_event)
+        on_undo_event();
+
+    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto matrix = glyph_as_matrix(bitmap);
+
+    for (int y = 0; y < bitmap.height(); y++) {
+        for (int x = 0; x < bitmap.width(); x++) {
+            int source_x = bitmap.width() - 1 - x;
+            int source_y = y;
+            bool value = matrix[source_y][source_x];
+            bitmap.set_bit_at(x, y, value);
+        }
+    }
+
+    if (on_glyph_altered)
+        on_glyph_altered(m_glyph);
+    update();
+}
+
 int GlyphEditorWidget::preferred_width() const
 {
     return frame_thickness() * 2 + font().max_glyph_width() * m_scale - 1;

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -107,8 +107,7 @@ void GlyphEditorWidget::paste_glyph()
     auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
     for (int x = 0; x < min(bitmap.width(), buffer_width.value()); x++) {
         for (int y = 0; y < min(bitmap.height(), buffer_height.value()); y++) {
-            if (bits[x][y])
-                bitmap.set_bit_at(x, y, bits[x][y]);
+            bitmap.set_bit_at(x, y, bits[x][y]);
         }
     }
 

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.h
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.h
@@ -34,6 +34,10 @@ public:
     void delete_glyph();
     bool is_glyph_empty();
 
+    void rotate_90();
+    void flip_vertically();
+    void flip_horizontally();
+
     int preferred_width() const;
     int preferred_height() const;
 

--- a/Userland/Applications/FontEditor/UndoGlyph.h
+++ b/Userland/Applications/FontEditor/UndoGlyph.h
@@ -17,7 +17,7 @@ public:
         , m_font(font)
     {
     }
-    RefPtr<UndoGlyph> save_state() const
+    NonnullRefPtr<UndoGlyph> save_state() const
     {
         auto state = adopt_ref(*new UndoGlyph(m_code_point, *m_font));
         auto glyph = font().glyph(m_code_point).glyph_bitmap();
@@ -70,7 +70,7 @@ public:
     }
 
 private:
-    RefPtr<UndoGlyph> m_undo_state;
+    NonnullRefPtr<UndoGlyph> m_undo_state;
     RefPtr<UndoGlyph> m_redo_state;
     UndoGlyph& m_undo_glyph;
 };


### PR DESCRIPTION
Follow-up to #10964

![Bildschirmfoto_2021-11-20_03-11-16](https://user-images.githubusercontent.com/2690845/142710853-53d9025d-292f-47a5-a24c-08b36275ab46.png)