### PR TITLE
CrashReporter: Add "Inspect in HackStudio" button

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -461,13 +461,13 @@ struct SC_stat_params {
 struct SC_ptrace_params {
     int request;
     pid_t tid;
-    u8* addr;
-    int data;
+    void* addr;
+    FlatPtr data;
 };
 
 struct SC_ptrace_peek_params {
-    const u32* address;
-    u32* out_data;
+    const void* address;
+    FlatPtr* out_data;
 };
 
 struct SC_set_coredump_metadata_params {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -480,8 +480,8 @@ public:
         m_wait_for_tracer_at_next_execve = val;
     }
 
-    ErrorOr<u32> peek_user_data(Userspace<const u32*> address);
-    ErrorOr<void> poke_user_data(Userspace<u32*> address, u32 data);
+    ErrorOr<FlatPtr> peek_user_data(Userspace<const FlatPtr*> address);
+    ErrorOr<void> poke_user_data(Userspace<FlatPtr*> address, FlatPtr data);
 
     void disowned_by_waiter(Process& process);
     void unblock_waiters(Thread::WaitBlocker::UnblockFlags, u8 signal = 0);

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1011,8 +1011,8 @@ public:
     u32 signal_mask() const;
     void clear_signals();
 
-    ErrorOr<u32> peek_debug_register(u32 register_index);
-    ErrorOr<void> poke_debug_register(u32 register_index, u32 data);
+    ErrorOr<FlatPtr> peek_debug_register(u32 register_index);
+    ErrorOr<void> poke_debug_register(u32 register_index, FlatPtr data);
 
     void set_dump_backtrace_on_finalization() { m_dump_backtrace_on_finalization = true; }
 

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -82,6 +82,13 @@
 
         layout: @GUI::HorizontalBoxLayout
 
+        @GUI::Button {
+            name: "inspect_button"
+            text: "Inspect in Hack Studio"
+            fixed_width: 150
+            fixed_height: 22
+        }
+
         // HACK: We need something like Layout::add_spacer() in GML! :^)
         @GUI::Widget
 

--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -50,5 +50,5 @@ set(SOURCES
 )
 
 serenity_app(HackStudio ICON app-hack-studio)
-target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibCpp LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell LibSymbolication LibRegex LibSQL)
+target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibCpp LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell LibSymbolication LibRegex LibSQL LibCoredump)
 add_dependencies(HackStudio CppLanguageServer)

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.cpp
@@ -36,21 +36,30 @@ Vector<BacktraceModel::FrameInfo> BacktraceModel::create_backtrace(Debug::Proces
     FlatPtr current_ebp = regs.bp();
     FlatPtr current_instruction = regs.ip();
     Vector<BacktraceModel::FrameInfo> frames;
+    size_t frame_index = 0;
     do {
-        auto lib = inspector.library_at(regs.ip());
+        auto lib = inspector.library_at(current_instruction);
         if (!lib)
             continue;
-        String name = lib->debug_info->name_of_containing_function(current_instruction - lib->base_address);
+
+        // After the first frame, current_instruction holds the return address from the function call.
+        // We need to go back to the 'call' instruction to get accurate source position information.
+        if (frame_index > 0)
+            --current_instruction;
+        String name = lib->debug_info->elf().symbolicate(current_instruction - lib->base_address);
         if (name.is_null()) {
-            dbgln("BacktraceModel: couldn't find containing function for address: {:p}", current_instruction);
+            dbgln("BacktraceModel: couldn't find containing function for address: {:p} (library={})", current_instruction, lib->name);
             name = "<missing>";
         }
 
-        frames.append({ name, current_instruction, current_ebp });
+        auto source_position = lib->debug_info->get_source_position(current_instruction - lib->base_address);
+
+        frames.append({ name, current_instruction, current_ebp, source_position });
         auto frame_info = Debug::StackFrameUtils::get_info(inspector, current_ebp);
         VERIFY(frame_info.has_value());
         current_instruction = frame_info.value().return_address;
         current_ebp = frame_info.value().next_ebp;
+        ++frame_index;
     } while (current_ebp && current_instruction);
     return frames;
 }

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
@@ -38,8 +38,9 @@ public:
 
     struct FrameInfo {
         String function_name;
-        FlatPtr instruction_address;
-        FlatPtr frame_base;
+        FlatPtr instruction_address { 0 };
+        FlatPtr frame_base { 0 };
+        Optional<Debug::DebugInfo::SourcePosition> m_source_position;
     };
 
     const Vector<FrameInfo>& frames() const { return m_frames; }

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibDebug/ProcessInspector.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/Model.h>
 #include <sys/arch/i386/regs.h>
@@ -21,7 +22,7 @@ namespace HackStudio {
 
 class BacktraceModel final : public GUI::Model {
 public:
-    static NonnullRefPtr<BacktraceModel> create(const Debug::DebugSession&, const PtraceRegisters& regs);
+    static NonnullRefPtr<BacktraceModel> create(Debug::ProcessInspector const&, PtraceRegisters const& regs);
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_frames.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
@@ -49,7 +50,7 @@ private:
     {
     }
 
-    static Vector<FrameInfo> create_backtrace(const Debug::DebugSession&, const PtraceRegisters&);
+    static Vector<FrameInfo> create_backtrace(Debug::ProcessInspector const&, PtraceRegisters const&);
 
     Vector<FrameInfo> m_frames;
 };

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
@@ -13,7 +13,6 @@
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/InputBox.h>
-#include <LibGUI/Layout.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Model.h>
@@ -150,10 +149,10 @@ NonnullRefPtr<GUI::Widget> DebugInfoWidget::build_registers_tab()
     return registers_widget;
 }
 
-void DebugInfoWidget::update_state(const Debug::DebugSession& debug_session, const PtraceRegisters& regs)
+void DebugInfoWidget::update_state(const Debug::ProcessInspector& inspector, const PtraceRegisters& regs)
 {
     m_variables_view->set_model(VariablesModel::create(regs));
-    m_backtrace_view->set_model(BacktraceModel::create(debug_session, regs));
+    m_backtrace_view->set_model(BacktraceModel::create(inspector, regs));
     if (m_registers_view->model()) {
         auto& previous_registers = static_cast<RegistersModel*>(m_registers_view->model())->raw_registers();
         m_registers_view->set_model(RegistersModel::create(regs, previous_registers));

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.h
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.h
@@ -26,9 +26,11 @@ class DebugInfoWidget final : public GUI::Widget {
 public:
     virtual ~DebugInfoWidget() override { }
 
-    void update_state(Debug::ProcessInspector const&, PtraceRegisters const&);
+    void update_state(Debug::ProcessInspector&, PtraceRegisters const&);
     void program_stopped();
     void set_debug_actions_enabled(bool enabled);
+
+    Function<void(Debug::DebugInfo::SourcePosition const&)> on_backtrace_frame_selection;
 
 private:
     explicit DebugInfoWidget();

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.h
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.h
@@ -26,7 +26,7 @@ class DebugInfoWidget final : public GUI::Widget {
 public:
     virtual ~DebugInfoWidget() override { }
 
-    void update_state(const Debug::DebugSession&, const PtraceRegisters&);
+    void update_state(Debug::ProcessInspector const&, PtraceRegisters const&);
     void program_stopped();
     void set_debug_actions_enabled(bool enabled);
 

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.h
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.h
@@ -16,7 +16,7 @@ namespace HackStudio {
 
 class VariablesModel final : public GUI::Model {
 public:
-    static RefPtr<VariablesModel> create(const PtraceRegisters& regs);
+    static RefPtr<VariablesModel> create(Debug::ProcessInspector&, PtraceRegisters const& regs);
 
     void set_variable_value(const GUI::ModelIndex&, StringView, GUI::Window*);
 
@@ -25,11 +25,13 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
     virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    Debug::ProcessInspector& inspector() { return m_inspector; }
 
 private:
-    explicit VariablesModel(NonnullOwnPtrVector<Debug::DebugInfo::VariableInfo>&& variables, const PtraceRegisters& regs)
+    explicit VariablesModel(Debug::ProcessInspector& inspector, NonnullOwnPtrVector<Debug::DebugInfo::VariableInfo>&& variables, const PtraceRegisters& regs)
         : m_variables(move(variables))
         , m_regs(regs)
+        , m_inspector(inspector)
     {
         m_variable_icon.set_bitmap_for_size(16, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspector-object.png").release_value_but_fixme_should_propagate_errors());
     }
@@ -37,6 +39,7 @@ private:
     PtraceRegisters m_regs;
 
     GUI::Icon m_variable_icon;
+    Debug::ProcessInspector& m_inspector;
 };
 
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -21,6 +21,7 @@
 #include "ProjectFile.h"
 #include "TerminalWrapper.h"
 #include "ToDoEntriesWidget.h"
+#include <LibCoredump/Inspector.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGUI/Splitter.h>
@@ -62,11 +63,19 @@ public:
     };
     ContinueDecision warn_unsaved_changes(const String& prompt);
 
+    enum class Mode {
+        Code,
+        Coredump
+    };
+
+    void open_coredump(String const& coredump_path);
+
 private:
     static String get_full_path_of_serenity_source(const String& file);
+    String get_absolute_path(String const&) const;
     Vector<String> selected_file_paths() const;
 
-    HackStudioWidget(const String& path_to_project);
+    HackStudioWidget(String path_to_project);
     void open_project(const String& root_path);
 
     enum class EditMode {
@@ -215,5 +224,8 @@ private:
     RefPtr<GUI::Action> m_no_wrapping_action;
     RefPtr<GUI::Action> m_wrap_anywhere_action;
     RefPtr<GUI::Action> m_wrap_at_words_action;
+
+    Mode m_mode { Mode::Code };
+    OwnPtr<Coredump::Inspector> m_coredump_inspector;
 };
 }

--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -51,7 +51,7 @@ NonnullRefPtr<ProjectFile> Project::create_file(const String& path) const
     return ProjectFile::construct_with_name(full_path);
 }
 
-String Project::to_absolute_path(const String& path) const
+String Project::to_absolute_path(String const& path) const
 {
     if (LexicalPath { path }.is_absolute()) {
         return path;

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -29,11 +29,10 @@ public:
     NonnullRefPtr<ProjectFile> create_file(const String& path) const;
 
     void for_each_text_file(Function<void(const ProjectFile&)>) const;
+    String to_absolute_path(String const&) const;
 
 private:
     explicit Project(const String& root_path);
-
-    String to_absolute_path(const String&) const;
 
     RefPtr<GUI::FileSystemModel> m_model;
 

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -52,14 +52,16 @@ int main(int argc, char** argv)
     }
 
     const char* path_argument = nullptr;
+    bool mode_coredump = false;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path_argument, "Path to a workspace or a file", "path", Core::ArgsParser::Required::No);
+    args_parser.add_option(mode_coredump, "Inspect a coredump in HackStudio", "coredump", 'c');
     args_parser.parse(argc, argv);
 
     auto argument_absolute_path = Core::File::real_path_for(path_argument);
 
     auto project_path = argument_absolute_path;
-    if (argument_absolute_path.is_null())
+    if (argument_absolute_path.is_null() || mode_coredump)
         project_path = Core::File::real_path_for(".");
 
     s_hack_studio_widget = window->set_main_widget<HackStudioWidget>(project_path);
@@ -76,8 +78,10 @@ int main(int argc, char** argv)
     };
 
     window->show();
-
     s_hack_studio_widget->update_actions();
+
+    if (mode_coredump)
+        s_hack_studio_widget->open_coredump(argument_absolute_path);
 
     return app->exec();
 }

--- a/Userland/Libraries/LibC/sys/ptrace.h
+++ b/Userland/Libraries/LibC/sys/ptrace.h
@@ -13,6 +13,6 @@ __BEGIN_DECLS
 // FIXME: PID/TID ISSUE
 // Affects the entirety of LibDebug and Userland/strace.cpp.
 // See also Kernel/Ptrace.cpp
-int ptrace(int request, pid_t tid, void* addr, int data);
+long ptrace(int request, pid_t tid, void* addr, void* data);
 
 __END_DECLS

--- a/Userland/Libraries/LibCoredump/CMakeLists.txt
+++ b/Userland/Libraries/LibCoredump/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Backtrace.cpp
+    Inspector.cpp
     Reader.cpp
 )
 

--- a/Userland/Libraries/LibCoredump/Inspector.cpp
+++ b/Userland/Libraries/LibCoredump/Inspector.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Inspector.h"
+
+namespace Coredump {
+
+OwnPtr<Inspector> Inspector::create(String const& coredump_path, Function<void(float)> on_progress)
+{
+    auto reader = Reader::create(coredump_path);
+    if (!reader)
+        return {};
+    return AK::adopt_own_if_nonnull(new (nothrow) Inspector(reader.release_nonnull(), move(on_progress)));
+}
+
+Inspector::Inspector(NonnullOwnPtr<Reader>&& reader, Function<void(float)> on_progress)
+    : m_reader(move(reader))
+{
+    parse_loaded_libraries(move(on_progress));
+}
+
+size_t Inspector::number_of_libraries_in_coredump() const
+{
+    size_t count = 0;
+    m_reader->for_each_library([&count](Coredump::Reader::LibraryInfo) {
+        ++count;
+    });
+    return count;
+}
+
+void Inspector::parse_loaded_libraries(Function<void(float)> on_progress)
+{
+    size_t number_of_libraries = number_of_libraries_in_coredump();
+    size_t library_index = 0;
+
+    m_reader->for_each_library([this, number_of_libraries, &library_index, &on_progress](Coredump::Reader::LibraryInfo library) {
+        ++library_index;
+        if (on_progress)
+            on_progress(library_index / (float)number_of_libraries);
+
+        auto file_or_error = MappedFile::map(library.path);
+        if (file_or_error.is_error())
+            return;
+
+        auto image = make<ELF::Image>(file_or_error.value()->bytes());
+        auto debug_info = make<Debug::DebugInfo>(*image, String {}, library.base_address);
+        m_loaded_libraries.append(make<Debug::LoadedLibrary>(library.name, file_or_error.value(), move(image), move(debug_info), library.base_address));
+    });
+}
+
+bool Inspector::poke(void*, FlatPtr) { return false; }
+
+Optional<FlatPtr> Inspector::peek(void* address) const
+{
+    return m_reader->peek_memory((FlatPtr)address);
+}
+
+PtraceRegisters Inspector::get_registers() const
+{
+    PtraceRegisters registers {};
+    m_reader->for_each_thread_info([&](ELF::Core::ThreadInfo const& thread_info) {
+        registers = thread_info.regs;
+        return IterationDecision::Break;
+    });
+    return registers;
+}
+
+void Inspector::set_registers(PtraceRegisters const&) {};
+
+void Inspector::for_each_loaded_library(Function<IterationDecision(Debug::LoadedLibrary const&)> func) const
+{
+    for (auto& library : m_loaded_libraries) {
+        if (func(library) == IterationDecision::Break)
+            break;
+    }
+}
+
+}

--- a/Userland/Libraries/LibCoredump/Inspector.h
+++ b/Userland/Libraries/LibCoredump/Inspector.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Reader.h"
+#include <AK/Noncopyable.h>
+#include <LibDebug/ProcessInspector.h>
+
+namespace Coredump {
+
+class Inspector : public Debug::ProcessInspector {
+    AK_MAKE_NONCOPYABLE(Inspector);
+    AK_MAKE_NONMOVABLE(Inspector);
+
+public:
+    static OwnPtr<Inspector> create(String const& coredump_path, Function<void(float)> on_progress = {});
+    virtual ~Inspector() override = default;
+
+    // ^Debug::ProcessInspector
+    virtual bool poke(void* address, FlatPtr data) override;
+    virtual Optional<FlatPtr> peek(void* address) const override;
+    virtual PtraceRegisters get_registers() const override;
+    virtual void set_registers(PtraceRegisters const&) override;
+    virtual void for_each_loaded_library(Function<IterationDecision(Debug::LoadedLibrary const&)>) const override;
+
+private:
+    Inspector(NonnullOwnPtr<Reader>&&, Function<void(float)> on_progress);
+
+    void parse_loaded_libraries(Function<void(float)> on_progress);
+    size_t number_of_libraries_in_coredump() const;
+
+    NonnullOwnPtr<Reader> m_reader;
+
+    NonnullOwnPtrVector<Debug::LoadedLibrary> m_loaded_libraries;
+};
+
+}

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -15,7 +15,7 @@
 
 namespace Coredump {
 
-OwnPtr<Reader> Reader::create(const String& path)
+OwnPtr<Reader> Reader::create(StringView path)
 {
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -26,6 +26,14 @@ public:
     template<typename Func>
     void for_each_memory_region_info(Func func) const;
 
+    struct LibraryInfo {
+        String name;
+        String path;
+        FlatPtr base_address { 0 };
+    };
+
+    void for_each_library(Function<void(LibraryInfo)> func) const;
+
     template<typename Func>
     void for_each_thread_info(Func func) const;
 

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -20,7 +20,7 @@ class Reader {
     AK_MAKE_NONMOVABLE(Reader);
 
 public:
-    static OwnPtr<Reader> create(const String&);
+    static OwnPtr<Reader> create(StringView);
     ~Reader();
 
     template<typename Func>

--- a/Userland/Libraries/LibDebug/CMakeLists.txt
+++ b/Userland/Libraries/LibDebug/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     Dwarf/DwarfInfo.cpp
     Dwarf/Expression.cpp
     Dwarf/LineProgram.cpp
+    ProcessInspector.cpp
     StackFrameUtils.cpp
 )
 

--- a/Userland/Libraries/LibDebug/LoadedLibrary.h
+++ b/Userland/Libraries/LibDebug/LoadedLibrary.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "DebugInfo.h"
+#include <AK/MappedFile.h>
+#include <AK/Types.h>
+#include <LibELF/Image.h>
+
+namespace Debug {
+struct LoadedLibrary {
+    String name;
+    NonnullRefPtr<MappedFile> file;
+    NonnullOwnPtr<ELF::Image> image;
+    NonnullOwnPtr<DebugInfo> debug_info;
+    FlatPtr base_address {};
+
+    LoadedLibrary(String const& name, NonnullRefPtr<MappedFile> file, NonnullOwnPtr<ELF::Image> image, NonnullOwnPtr<DebugInfo>&& debug_info, FlatPtr base_address)
+        : name(name)
+        , file(move(file))
+        , image(move(image))
+        , debug_info(move(debug_info))
+        , base_address(base_address)
+    {
+    }
+};
+
+}

--- a/Userland/Libraries/LibDebug/ProcessInspector.cpp
+++ b/Userland/Libraries/LibDebug/ProcessInspector.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ProcessInspector.h"
+#include "DebugInfo.h"
+
+namespace Debug {
+
+const LoadedLibrary* ProcessInspector::library_at(FlatPtr address) const
+{
+    const LoadedLibrary* result = nullptr;
+    for_each_loaded_library([&result, address](const auto& lib) {
+        if (address >= lib.base_address && address < lib.base_address + lib.debug_info->elf().size()) {
+            result = &lib;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+    return result;
+}
+
+Optional<ProcessInspector::SymbolicationResult> ProcessInspector::symbolicate(FlatPtr address) const
+{
+    auto* lib = library_at(address);
+    if (!lib)
+        return {};
+    // FIXME: ELF::Image symlicate() API should return String::empty() if symbol is not found (It currently returns ??)
+    auto symbol = lib->debug_info->elf().symbolicate(address - lib->base_address);
+    return { { lib->name, symbol } };
+}
+
+Optional<DebugInfo::SourcePositionAndAddress> ProcessInspector::get_address_from_source_position(String const& file, size_t line) const
+{
+    Optional<DebugInfo::SourcePositionAndAddress> result;
+    for_each_loaded_library([file, line, &result](auto& lib) {
+        // The loader contains its own definitions for LibC symbols, so we don't want to include it in the search.
+        if (lib.name == "Loader.so")
+            return IterationDecision::Continue;
+
+        auto source_position_and_address = lib.debug_info->get_address_from_source_position(file, line);
+        if (!source_position_and_address.has_value())
+            return IterationDecision::Continue;
+
+        result = source_position_and_address;
+        result.value().address += lib.base_address;
+        return IterationDecision::Break;
+    });
+    return result;
+}
+
+Optional<DebugInfo::SourcePosition> ProcessInspector::get_source_position(FlatPtr address) const
+{
+    auto* lib = library_at(address);
+    if (!lib)
+        return {};
+    return lib->debug_info->get_source_position(address - lib->base_address);
+}
+
+}

--- a/Userland/Libraries/LibDebug/ProcessInspector.h
+++ b/Userland/Libraries/LibDebug/ProcessInspector.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "LoadedLibrary.h"
+#include <AK/Types.h>
+#include <LibC/sys/arch/i386/regs.h>
+
+namespace Debug {
+
+class ProcessInspector {
+public:
+    virtual ~ProcessInspector() { }
+    virtual bool poke(void* address, FlatPtr data) = 0;
+    virtual Optional<FlatPtr> peek(void* address) const = 0;
+    virtual PtraceRegisters get_registers() const = 0;
+    virtual void set_registers(PtraceRegisters const&) = 0;
+    virtual void for_each_loaded_library(Function<IterationDecision(LoadedLibrary const&)>) const = 0;
+
+    const LoadedLibrary* library_at(FlatPtr address) const;
+    struct SymbolicationResult {
+        String library_name;
+        String symbol;
+    };
+    Optional<SymbolicationResult> symbolicate(FlatPtr address) const;
+    Optional<DebugInfo::SourcePositionAndAddress> get_address_from_source_position(String const& file, size_t line) const;
+    Optional<DebugInfo::SourcePosition> get_source_position(FlatPtr address) const;
+
+protected:
+    ProcessInspector() = default;
+};
+
+};

--- a/Userland/Libraries/LibDebug/StackFrameUtils.cpp
+++ b/Userland/Libraries/LibDebug/StackFrameUtils.cpp
@@ -8,10 +8,10 @@
 
 namespace Debug::StackFrameUtils {
 
-Optional<StackFrameInfo> get_info(DebugSession const& session, FlatPtr current_ebp)
+Optional<StackFrameInfo> get_info(ProcessInspector const& inspector, FlatPtr current_ebp)
 {
-    auto return_address = session.peek(reinterpret_cast<u32*>(current_ebp + sizeof(FlatPtr)));
-    auto next_ebp = session.peek(reinterpret_cast<u32*>(current_ebp));
+    auto return_address = inspector.peek(reinterpret_cast<u32*>(current_ebp + sizeof(FlatPtr)));
+    auto next_ebp = inspector.peek(reinterpret_cast<u32*>(current_ebp));
     if (!return_address.has_value() || !next_ebp.has_value())
         return {};
 

--- a/Userland/Libraries/LibDebug/StackFrameUtils.h
+++ b/Userland/Libraries/LibDebug/StackFrameUtils.h
@@ -18,6 +18,6 @@ struct StackFrameInfo {
     FlatPtr next_ebp;
 };
 
-Optional<StackFrameInfo> get_info(DebugSession const&, FlatPtr current_ebp);
+Optional<StackFrameInfo> get_info(ProcessInspector const&, FlatPtr current_ebp);
 
 }

--- a/Userland/Services/CrashDaemon/main.cpp
+++ b/Userland/Services/CrashDaemon/main.cpp
@@ -29,11 +29,11 @@ static void wait_until_coredump_is_ready(const String& coredump_path)
     }
 }
 
-static void launch_crash_reporter(const String& coredump_path, bool unlink_after_use)
+static void launch_crash_reporter(const String& coredump_path, bool unlink_on_exit)
 {
     pid_t child;
     const char* argv[4] = { "CrashReporter" };
-    if (unlink_after_use) {
+    if (unlink_on_exit) {
         argv[1] = "--unlink";
         argv[2] = coredump_path.characters();
         argv[3] = nullptr;

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -70,7 +70,7 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
 static NonnullOwnPtr<HashMap<void*, X86::Instruction>> instrument_code()
 {
     auto instrumented = make<HashMap<void*, X86::Instruction>>();
-    g_debug_session->for_each_loaded_library([&](const Debug::DebugSession::LoadedLibrary& lib) {
+    g_debug_session->for_each_loaded_library([&](const Debug::LoadedLibrary& lib) {
         lib.debug_info->elf().for_each_section_of_type(SHT_PROGBITS, [&](const ELF::Image::Section& section) {
             if (section.name() != ".text")
                 return IterationDecision::Continue;


### PR DESCRIPTION
Clicking the "Inspect in HackStudio" button opens HackStudio and allows the user to inspect the coredump in the Debug tab.

To support inspecting coredumps in the Debug tab, HackStudio's `DebugInfoWidget` now uses an abstract base class called `ProcessInspector` to display the backtrace instead of interacting directly with the `Debugger` object.
Both `DebugSession` and `Coredump::Inspector` are now derived from `ProcessInspector`.

Screenshots:
![crashreporter-coredump](https://user-images.githubusercontent.com/9247514/142722293-ca699217-f7e6-4cee-8e43-3c5fc9cf310f.png)

Inspecting the coredump in HackStudio:
![hs-coredump](https://user-images.githubusercontent.com/9247514/142722654-2c63513c-44ba-4d70-9212-f8c8cc8e8486.png)


