### PR TITLE
SoundPlayer+LibDSP: Move the FFT implementation to LibDSP

### DIFF
--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "BarsVisualizationWidget.h"
-#include "AudioAlgorithms.h"
 #include <AK/Math.h>
+#include <LibDSP/FFT.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
@@ -25,7 +25,7 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     if (m_sample_buffer.is_empty())
         return;
 
-    fft(m_sample_buffer, false);
+    LibDSP::fft(m_sample_buffer, false);
     double max = AK::sqrt(m_sample_count * 2.);
 
     double freq_bin = m_samplerate / (double)m_sample_count;

--- a/Userland/Applications/SoundPlayer/CMakeLists.txt
+++ b/Userland/Applications/SoundPlayer/CMakeLists.txt
@@ -13,11 +13,10 @@ set(SOURCES
     SampleWidget.cpp
     SoundPlayerWidgetAdvancedView.cpp
     BarsVisualizationWidget.cpp
-    AudioAlgorithms.cpp
     NoVisualizationWidget.cpp
     M3UParser.cpp
     PlaylistWidget.cpp
 )
 
 serenity_app(SoundPlayer ICON app-sound-player)
-target_link_libraries(SoundPlayer LibAudio LibGUI)
+target_link_libraries(SoundPlayer LibAudio LibDSP LibGUI)

--- a/Userland/Libraries/LibDSP/CMakeLists.txt
+++ b/Userland/Libraries/LibDSP/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     Track.cpp
     Effects.cpp
     Synthesizers.cpp
+    FFT.cpp
 )
 
 serenity_lib(LibDSP dsp)

--- a/Userland/Libraries/LibDSP/FFT.cpp
+++ b/Userland/Libraries/LibDSP/FFT.cpp
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "AudioAlgorithms.h"
+#include "FFT.h"
 #include <AK/Complex.h>
 #include <AK/Math.h>
+
+namespace LibDSP {
 
 // This function uses the input vector as output too. therefore, if you wish to
 // leave it intact, pass a copy to this function
@@ -55,4 +57,6 @@ void fft(Vector<Complex<double>>& sample_data, bool invert)
         for (int i = 0; i < n; i++)
             data[i] /= n;
     }
+}
+
 }

--- a/Userland/Libraries/LibDSP/FFT.h
+++ b/Userland/Libraries/LibDSP/FFT.h
@@ -9,4 +9,8 @@
 #include <AK/Complex.h>
 #include <AK/Vector.h>
 
-void fft(Vector<Complex<double>>& sample_data, bool invert);
+namespace LibDSP {
+
+void fft(Vector<Complex<double>>& sample_data, bool invert = false);
+
+}


### PR DESCRIPTION
LibDSP can greatly benefit from this nice FFT implementation, so let's move it into the fitting library :^)

Note that this now requires linking SoundPlayer against LibDSP. That's not an issue (LibDSP is rather small currently anyways), as we can probably make great use of it in the future anyways.