### PR TITLE
PixelPaint: Fix LineTool&RectangleTool previews when the active layer is moved

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -108,8 +108,8 @@ void LineTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    auto preview_start = editor_stroke_position(m_line_start_position, m_thickness);
-    auto preview_end = editor_stroke_position(m_line_end_position, m_thickness);
+    auto preview_start = editor_stroke_position(layer, m_line_start_position, m_thickness);
+    auto preview_end = editor_stroke_position(layer, m_line_end_position, m_thickness);
     painter.draw_line(preview_start, preview_end, m_editor->color_for(m_drawing_button), AK::max(m_thickness * m_editor->scale(), 1));
 }
 

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -113,9 +113,9 @@ void RectangleTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    auto start_position = editor_stroke_position(m_rectangle_start_position, m_thickness);
-    auto end_position = editor_stroke_position(m_rectangle_end_position, m_thickness);
-    draw_using(painter, start_position, end_position, AK::max(m_thickness * m_editor->scale(), 1));
+    auto preview_start = editor_stroke_position(layer, m_rectangle_start_position, m_thickness);
+    auto preview_end = editor_stroke_position(layer, m_rectangle_end_position, m_thickness);
+    draw_using(painter, preview_start, preview_end, AK::max(m_thickness * m_editor->scale(), 1));
 }
 
 void RectangleTool::on_keydown(GUI::KeyEvent& event)

--- a/Userland/Applications/PixelPaint/Tools/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/Tool.cpp
@@ -53,9 +53,9 @@ void Tool::on_keydown(GUI::KeyEvent& event)
     }
 }
 
-Gfx::IntPoint Tool::editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const
+Gfx::IntPoint Tool::editor_stroke_position(Layer const* layer, Gfx::IntPoint const& pixel_coords, int stroke_thickness) const
 {
-    auto position = m_editor->image_position_to_editor_position(pixel_coords);
+    auto position = m_editor->layer_position_to_editor_position(*layer, pixel_coords);
     auto offset = (stroke_thickness % 2 == 0) ? 0 : m_editor->scale() / 2;
     position = position.translated(offset, offset);
     return position.to_type<int>();

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -77,7 +77,7 @@ protected:
     WeakPtr<ImageEditor> m_editor;
     RefPtr<GUI::Action> m_action;
 
-    virtual Gfx::IntPoint editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const;
+    virtual Gfx::IntPoint editor_stroke_position(Layer const* layer, Gfx::IntPoint const& pixel_coords, int stroke_thickness) const;
 
     void set_primary_slider(GUI::ValueSlider* primary) { m_primary_slider = primary; }
     void set_secondary_slider(GUI::ValueSlider* secondary) { m_secondary_slider = secondary; }


### PR DESCRIPTION
In PixelPaint, if you move the active layer and use the Line tool, the preview is not drawn in the correct location.