### PR TITLE
WindowServer: Don't crash when closing an AutocompleteBox

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -898,6 +898,9 @@ void Window::window_menu_activate_default()
 
 void Window::request_close()
 {
+    if (is_destroyed())
+        return;
+
     Event close_request(Event::WindowCloseRequest);
     event(close_request);
 }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -146,7 +146,7 @@ void Window::set_rect(const Gfx::IntRect& rect)
     m_rect = rect;
     if (rect.is_empty()) {
         m_backing_store = nullptr;
-    } else if (!m_client && (!m_backing_store || old_rect.size() != rect.size())) {
+    } else if (is_internal() && (!m_backing_store || old_rect.size() != rect.size())) {
         auto format = has_alpha_channel() ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
         m_backing_store = Gfx::Bitmap::try_create(format, m_rect.size()).release_value_but_fixme_should_propagate_errors();
     }
@@ -525,7 +525,7 @@ void Window::set_resizable(bool resizable)
 
 void Window::event(Core::Event& event)
 {
-    if (!m_client) {
+    if (is_internal()) {
         VERIFY(parent());
         event.ignore();
         return;


### PR DESCRIPTION
This fixes #10982

If a `GUI::WindowType::ToolWindow` Window is open when the AutocompleteBox closes, then WindowServer crashes on a VERIFY().. In `Window::event()`, the WindowCloseRequest event was being sent to the AutocompleteBox while it had no client and no parent attached, even though it had a parent when it was created. This patch fixes the crash by avoiding the VERIFY, since I believe that the WindowCloseRequest does not make sense to bubble up to a parent anyway.

I still don't understand why the situation was happening, but this does stop the crashing. I could not find any other windows which would cause the crash when they are closed. Maybe someone who understands WindowServer will have a better idea.