### PR TITLE
Clipboard: Fix some data races, add missing format checks

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -77,7 +77,7 @@ GUI::Variant ClipboardHistoryModel::data(const GUI::ModelIndex& index, GUI::Mode
             builder.append('x');
             builder.append(data_and_type.metadata.get("height").value_or("?"));
             builder.append('x');
-            builder.append(bpp_for_format_resilient(data_and_type.metadata.get("height").value_or("0")));
+            builder.append(bpp_for_format_resilient(data_and_type.metadata.get("format").value_or("0")));
             builder.append(" bitmap");
             builder.append("]");
             return builder.to_string();

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -44,7 +44,7 @@ private:
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     // ^GUI::Clipboard::ClipboardClient
-    virtual void clipboard_content_did_change(const String&) override { add_item(GUI::Clipboard::the().data_and_type()); }
+    virtual void clipboard_content_did_change(const String&) override { add_item(GUI::Clipboard::the().fetch_data_and_type()); }
 
     Vector<GUI::Clipboard::DataAndType> m_history_items;
     size_t m_history_limit;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -136,7 +136,7 @@ Tab::Tab(BrowserWindow& window)
     };
 
     m_location_box->add_custom_context_menu_action(GUI::Action::create("Paste && Go", [this](auto&) {
-        auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+        auto [data, mime_type, _] = GUI::Clipboard::the().fetch_data_and_type();
         if (!mime_type.starts_with("text/"))
             return;
         auto const& paste_text = data;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -136,9 +136,10 @@ Tab::Tab(BrowserWindow& window)
     };
 
     m_location_box->add_custom_context_menu_action(GUI::Action::create("Paste && Go", [this](auto&) {
-        if (!GUI::Clipboard::the().mime_type().starts_with("text/"))
+        auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+        if (!mime_type.starts_with("text/"))
             return;
-        auto const& paste_text = GUI::Clipboard::the().data();
+        auto const& paste_text = data;
         if (paste_text.is_empty())
             return;
         m_location_box->set_text(paste_text);

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
         GUI::Clipboard::the().set_plain_text(widget.get_entry());
     }));
     edit_menu.add_action(GUI::CommonActions::make_paste_action([&](auto&) {
-        auto clipboard = GUI::Clipboard::the().data_and_type();
+        auto clipboard = GUI::Clipboard::the().fetch_data_and_type();
         if (clipboard.mime_type == "text/plain") {
             if (!clipboard.data.is_empty()) {
                 auto data = atof(StringView(clipboard.data).to_string().characters());

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -151,7 +151,7 @@ void do_copy(Vector<String> const& selected_file_paths, FileOperation file_opera
 
 void do_paste(String const& target_directory, GUI::Window* window)
 {
-    auto data_and_type = GUI::Clipboard::the().data_and_type();
+    auto data_and_type = GUI::Clipboard::the().fetch_data_and_type();
     if (data_and_type.mime_type != "text/uri-list") {
         dbgln("Cannot paste clipboard type {}", data_and_type.mime_type);
         return;
@@ -345,7 +345,7 @@ int run_in_desktop_mode()
             do_paste(directory_view.path(), directory_view.window());
         },
         window);
-    paste_action->set_enabled(GUI::Clipboard::the().mime_type() == "text/uri-list" && access(directory_view.path().characters(), W_OK) == 0);
+    paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "text/uri-list" && access(directory_view.path().characters(), W_OK) == 0);
 
     GUI::Clipboard::the().on_change = [&](String const& data_type) {
         paste_action->set_enabled(data_type == "text/uri-list" && access(directory_view.path().characters(), W_OK) == 0);
@@ -1007,7 +1007,7 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
 
         mkdir_action->set_enabled(can_write_in_path);
         touch_action->set_enabled(can_write_in_path);
-        paste_action->set_enabled(can_write_in_path && GUI::Clipboard::the().mime_type() == "text/uri-list");
+        paste_action->set_enabled(can_write_in_path && GUI::Clipboard::the().fetch_mime_type() == "text/uri-list");
         go_forward_action->set_enabled(directory_view.path_history_position() < directory_view.path_history_size() - 1);
         go_back_action->set_enabled(directory_view.path_history_position() > 0);
         open_parent_directory_action->set_enabled(new_path != "/");
@@ -1089,7 +1089,7 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
             auto& node = directory_view.node(index);
 
             if (node.is_directory()) {
-                auto should_get_enabled = access(node.full_path().characters(), W_OK) == 0 && GUI::Clipboard::the().mime_type() == "text/uri-list";
+                auto should_get_enabled = access(node.full_path().characters(), W_OK) == 0 && GUI::Clipboard::the().fetch_mime_type() == "text/uri-list";
                 folder_specific_paste_action->set_enabled(should_get_enabled);
                 directory_context_menu->popup(event.screen_position(), directory_open_action);
             } else {
@@ -1207,7 +1207,7 @@ int run_in_windowed_mode(String initial_location, String entry_focused_on_init)
     directory_view.open(initial_location);
     directory_view.set_focus(true);
 
-    paste_action->set_enabled(GUI::Clipboard::the().mime_type() == "text/uri-list" && access(initial_location.characters(), W_OK) == 0);
+    paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "text/uri-list" && access(initial_location.characters(), W_OK) == 0);
 
     window->set_rect({ left, top, width, height });
     if (was_maximized)

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -202,7 +202,7 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::BitmapFont>&&
         m_glyph_editor_widget->paste_glyph();
         m_glyph_map_widget->update_glyph(m_glyph_map_widget->selected_glyph());
     });
-    m_paste_action->set_enabled(GUI::Clipboard::the().mime_type() == "glyph/x-fonteditor");
+    m_paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "glyph/x-fonteditor");
     m_delete_action = GUI::CommonActions::make_delete_action([this](auto&) {
         if (m_glyph_editor_widget->is_glyph_empty() && m_edited_font->raw_glyph_width(m_glyph_map_widget->selected_glyph()) == 0)
             return;

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -84,7 +84,7 @@ void GlyphEditorWidget::copy_glyph()
 
 void GlyphEditorWidget::paste_glyph()
 {
-    auto [data, mime_type, metadata] = GUI::Clipboard::the().data_and_type();
+    auto [data, mime_type, metadata] = GUI::Clipboard::the().fetch_data_and_type();
     if (!mime_type.starts_with("glyph/"))
         return;
 

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -84,16 +84,16 @@ void GlyphEditorWidget::copy_glyph()
 
 void GlyphEditorWidget::paste_glyph()
 {
-    auto mime_type = GUI::Clipboard::the().mime_type();
+    auto [data, mime_type, metadata] = GUI::Clipboard::the().data_and_type();
     if (!mime_type.starts_with("glyph/"))
         return;
 
     if (on_undo_event)
         on_undo_event();
 
-    auto byte_buffer = GUI::Clipboard::the().data();
-    auto buffer_height = GUI::Clipboard::the().data_and_type().metadata.get("height").value().to_int();
-    auto buffer_width = GUI::Clipboard::the().data_and_type().metadata.get("width").value().to_int();
+    auto byte_buffer = data.data();
+    auto buffer_height = metadata.get("height").value().to_int();
+    auto buffer_width = metadata.get("width").value().to_int();
 
     u8 bits[buffer_width.value()][buffer_height.value()];
     int i = 0;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -214,7 +214,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         auto* editor = current_image_editor();
         if (!editor)
             return;
-        auto bitmap = GUI::Clipboard::the().bitmap();
+        auto bitmap = GUI::Clipboard::the().data_and_type().as_bitmap();
         if (!bitmap)
             return;
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -214,7 +214,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         auto* editor = current_image_editor();
         if (!editor)
             return;
-        auto bitmap = GUI::Clipboard::the().data_and_type().as_bitmap();
+        auto bitmap = GUI::Clipboard::the().fetch_data_and_type().as_bitmap();
         if (!bitmap)
             return;
 
@@ -226,7 +226,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     GUI::Clipboard::the().on_change = [&](auto& mime_type) {
         m_paste_action->set_enabled(mime_type == "image/x-serenityos");
     };
-    m_paste_action->set_enabled(GUI::Clipboard::the().mime_type() == "image/x-serenityos");
+    m_paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "image/x-serenityos");
 
     m_undo_action = GUI::CommonActions::make_undo_action([&](auto&) {
         if (auto* editor = current_image_editor())

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -170,7 +170,7 @@ SpreadsheetWidget::SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets, bool s
         auto& sheet = *worksheet_ptr;
         auto& cells = sheet.selected_cells();
         VERIFY(!cells.is_empty());
-        const auto& data = GUI::Clipboard::the().data_and_type();
+        const auto& data = GUI::Clipboard::the().fetch_data_and_type();
         if (auto spreadsheet_data = data.metadata.get("text/x-spreadsheet-data"); spreadsheet_data.has_value()) {
             Vector<Spreadsheet::Position> source_positions, target_positions;
             auto lines = spreadsheet_data.value().split_view('\n');

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -64,34 +64,34 @@ Clipboard::DataAndType Clipboard::data_and_type() const
     return { data.release_value(), type, metadata };
 }
 
-RefPtr<Gfx::Bitmap> Clipboard::bitmap() const
+RefPtr<Gfx::Bitmap> Clipboard::DataAndType::as_bitmap() const
 {
-    auto clipping = data_and_type();
-
-    if (clipping.mime_type != "image/x-serenityos")
+    if (mime_type != "image/x-serenityos")
         return nullptr;
 
-    auto width = clipping.metadata.get("width").value_or("0").to_uint();
+    auto width = metadata.get("width").value_or("0").to_uint();
     if (!width.has_value() || width.value() == 0)
         return nullptr;
 
-    auto height = clipping.metadata.get("height").value_or("0").to_uint();
+    auto height = metadata.get("height").value_or("0").to_uint();
     if (!height.has_value() || height.value() == 0)
         return nullptr;
 
-    auto scale = clipping.metadata.get("scale").value_or("0").to_uint();
+    auto scale = metadata.get("scale").value_or("0").to_uint();
     if (!scale.has_value() || scale.value() == 0)
         return nullptr;
 
-    auto pitch = clipping.metadata.get("pitch").value_or("0").to_uint();
+    auto pitch = metadata.get("pitch").value_or("0").to_uint();
     if (!pitch.has_value() || pitch.value() == 0)
         return nullptr;
 
-    auto format = clipping.metadata.get("format").value_or("0").to_uint();
+    auto format = metadata.get("format").value_or("0").to_uint();
     if (!format.has_value() || format.value() == 0)
         return nullptr;
 
-    auto clipping_bitmap_or_error = Gfx::Bitmap::try_create_wrapper((Gfx::BitmapFormat)format.value(), { (int)width.value(), (int)height.value() }, scale.value(), pitch.value(), clipping.data.data());
+    // We won't actually write to the clipping_bitmap, so casting away the const is okay.
+    auto clipping_data = const_cast<u8*>(data.data());
+    auto clipping_bitmap_or_error = Gfx::Bitmap::try_create_wrapper((Gfx::BitmapFormat)format.value(), { (int)width.value(), (int)height.value() }, scale.value(), pitch.value(), clipping_data);
     if (clipping_bitmap_or_error.is_error())
         return nullptr;
     auto clipping_bitmap = clipping_bitmap_or_error.release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -50,7 +50,7 @@ Clipboard& Clipboard::the()
     return *s_the;
 }
 
-Clipboard::DataAndType Clipboard::data_and_type() const
+Clipboard::DataAndType Clipboard::fetch_data_and_type() const
 {
     auto response = connection().get_clipboard_data();
     if (!response.data().is_valid())

--- a/Userland/Libraries/LibGUI/Clipboard.h
+++ b/Userland/Libraries/LibGUI/Clipboard.h
@@ -39,9 +39,8 @@ public:
     static void initialize(Badge<Application>);
     static Clipboard& the();
 
-    DataAndType data_and_type() const;
-    ByteBuffer data() const { return data_and_type().data; }
-    String mime_type() const { return data_and_type().mime_type; }
+    DataAndType fetch_data_and_type() const;
+    String fetch_mime_type() const { return fetch_data_and_type().mime_type; }
 
     void set_data(ReadonlyBytes data, String const& mime_type = "text/plain", HashMap<String, String> const& metadata = {});
     void set_plain_text(String const& text) { set_data(text.bytes()); }

--- a/Userland/Libraries/LibGUI/Clipboard.h
+++ b/Userland/Libraries/LibGUI/Clipboard.h
@@ -32,6 +32,8 @@ public:
         ByteBuffer data;
         String mime_type;
         HashMap<String, String> metadata;
+
+        RefPtr<Gfx::Bitmap> as_bitmap() const;
     };
 
     static void initialize(Badge<Application>);
@@ -40,7 +42,6 @@ public:
     DataAndType data_and_type() const;
     ByteBuffer data() const { return data_and_type().data; }
     String mime_type() const { return data_and_type().mime_type; }
-    RefPtr<Gfx::Bitmap> bitmap() const;
 
     void set_data(ReadonlyBytes data, String const& mime_type = "text/plain", HashMap<String, String> const& metadata = {});
     void set_plain_text(String const& text) { set_data(text.bytes()); }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -83,7 +83,7 @@ void TextEditor::create_actions()
     m_cut_action->set_enabled(false);
     m_copy_action->set_enabled(false);
     m_paste_action = CommonActions::make_paste_action([&](auto&) { paste(); }, this);
-    m_paste_action->set_enabled(is_editable() && Clipboard::the().mime_type().starts_with("text/"));
+    m_paste_action->set_enabled(is_editable() && Clipboard::the().fetch_mime_type().starts_with("text/"));
     if (is_multi_line()) {
         m_go_to_line_action = Action::create(
             "Go to line...", { Mod_Ctrl, Key_L }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
@@ -1453,7 +1453,7 @@ void TextEditor::paste()
     if (!is_editable())
         return;
 
-    auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+    auto [data, mime_type, _] = GUI::Clipboard::the().fetch_data_and_type();
     if (!mime_type.starts_with("text/"))
         return;
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -83,7 +83,7 @@ void TextEditor::create_actions()
     m_cut_action->set_enabled(false);
     m_copy_action->set_enabled(false);
     m_paste_action = CommonActions::make_paste_action([&](auto&) { paste(); }, this);
-    m_paste_action->set_enabled(is_editable() && Clipboard::the().mime_type().starts_with("text/") && !Clipboard::the().data().is_empty());
+    m_paste_action->set_enabled(is_editable() && Clipboard::the().mime_type().starts_with("text/"));
     if (is_multi_line()) {
         m_go_to_line_action = Action::create(
             "Go to line...", { Mod_Ctrl, Key_L }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
@@ -1882,7 +1882,7 @@ void TextEditor::cursor_did_change()
 
 void TextEditor::clipboard_content_did_change(String const& mime_type)
 {
-    m_paste_action->set_enabled(is_editable() && mime_type.starts_with("text/") && !Clipboard::the().data().is_empty());
+    m_paste_action->set_enabled(is_editable() && mime_type.starts_with("text/"));
 }
 
 void TextEditor::set_document(TextDocument& document)

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1453,18 +1453,17 @@ void TextEditor::paste()
     if (!is_editable())
         return;
 
-    if (!Clipboard::the().mime_type().starts_with("text/"))
+    auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+    if (!mime_type.starts_with("text/"))
         return;
 
-    auto paste_text = Clipboard::the().data();
-
-    if (paste_text.is_empty())
+    if (data.is_empty())
         return;
 
-    dbgln_if(TEXTEDITOR_DEBUG, "Paste: \"{}\"", String::copy(paste_text));
+    dbgln_if(TEXTEDITOR_DEBUG, "Paste: \"{}\"", String::copy(data));
 
     TemporaryChange change(m_automatic_indentation_enabled, false);
-    insert_at_cursor_or_replace_selection(paste_text);
+    insert_at_cursor_or_replace_selection(data);
 }
 
 void TextEditor::defer_reflow()

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -752,13 +752,12 @@ void TerminalWidget::paste()
     if (m_ptm_fd == -1)
         return;
 
-    auto mime_type = GUI::Clipboard::the().mime_type();
+    auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
     if (!mime_type.starts_with("text/"))
         return;
-    auto text = GUI::Clipboard::the().data();
-    if (text.is_empty())
+    if (data.is_empty())
         return;
-    send_non_user_input(text);
+    send_non_user_input(data);
 }
 
 void TerminalWidget::copy()
@@ -1167,7 +1166,8 @@ void TerminalWidget::update_copy_action()
 
 void TerminalWidget::update_paste_action()
 {
-    m_paste_action->set_enabled(GUI::Clipboard::the().mime_type().starts_with("text/") && !GUI::Clipboard::the().data().is_empty());
+    auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+    m_paste_action->set_enabled(mime_type.starts_with("text/") && !data.is_empty());
 }
 
 void TerminalWidget::set_color_scheme(StringView name)

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -752,7 +752,7 @@ void TerminalWidget::paste()
     if (m_ptm_fd == -1)
         return;
 
-    auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+    auto [data, mime_type, _] = GUI::Clipboard::the().fetch_data_and_type();
     if (!mime_type.starts_with("text/"))
         return;
     if (data.is_empty())
@@ -1166,7 +1166,7 @@ void TerminalWidget::update_copy_action()
 
 void TerminalWidget::update_paste_action()
 {
-    auto [data, mime_type, _] = GUI::Clipboard::the().data_and_type();
+    auto [data, mime_type, _] = GUI::Clipboard::the().fetch_data_and_type();
     m_paste_action->set_enabled(mime_type.starts_with("text/") && !data.is_empty());
 }
 

--- a/Userland/Utilities/paste.cpp
+++ b/Userland/Utilities/paste.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
 
         clipboard.on_change = [&](const String&) {
             // Technically there's a race here...
-            auto data_and_type = clipboard.data_and_type();
+            auto data_and_type = clipboard.fetch_data_and_type();
             if (data_and_type.mime_type.is_null()) {
                 spawn_command(watch_command, {}, "clear");
             } else {
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
         return app->exec();
     }
 
-    auto data_and_type = clipboard.data_and_type();
+    auto data_and_type = clipboard.fetch_data_and_type();
 
     if (data_and_type.mime_type.is_null()) {
         warnln("Nothing copied");


### PR DESCRIPTION
In several places, parsing was done in multiple requests to ClipboardServer. Not only is this wasteful, it also means that the state can change between requests, which could cause data corruption or even crashes. To avoid issues like this in the future, I renamed the Clipboard methods to `fetch_data_and_type` and `fetch_mimetype`.

Furthermore, I found missing checks (Gfx::BitmapFormat for bitmaps, and bitmap size for glyphs) and even a typo (ClipboardHistory, which is [my fault](https://github.com/SerenityOS/serenity/commit/6c2ea4c4e9627fef0415a9e7fc50837a26e433fa)), and fixed those.