### PR TITLE
Kernel: Wrap format timespec assignment in a check for !AARCH64

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -873,8 +873,11 @@ void vdmesgln(StringView fmtstr, TypeErasedFormatParams& params)
 
 #    ifdef __serenity__
     struct timespec ts = {};
+
+#        if !ARCH(AARCH64)
     if (TimeManagement::is_initialized())
         ts = TimeManagement::the().monotonic_time(TimePrecision::Coarse).to_timespec();
+#        endif
 
     if (Kernel::Processor::is_initialized() && Kernel::Thread::current()) {
         auto& thread = *Kernel::Thread::current();


### PR DESCRIPTION
Currently TimeManagement wont compile on AARCH64, so it is not included.
This creates a link error since format.cpp now relies on functionality
in TimeManagement.cpp to add timestamps to log lines.

This PR disables that functionality for AARCH64 builds until
TimeManagement will compile.