### PR TITLE
Spreadsheet: Make ranges more laaaaaazy

### DIFF
--- a/Userland/Applications/Spreadsheet/Cell.cpp
+++ b/Userland/Applications/Spreadsheet/Cell.cpp
@@ -74,12 +74,12 @@ const CellType& Cell::type() const
     return *CellType::get_by_name("Identity");
 }
 
-String Cell::typed_display() const
+JS::ThrowCompletionOr<String> Cell::typed_display() const
 {
     return type().display(const_cast<Cell&>(*this), m_type_metadata);
 }
 
-JS::Value Cell::typed_js_data() const
+JS::ThrowCompletionOr<JS::Value> Cell::typed_js_data() const
 {
     return type().js_value(const_cast<Cell&>(*this), m_type_metadata);
 }

--- a/Userland/Applications/Spreadsheet/Cell.h
+++ b/Userland/Applications/Spreadsheet/Cell.h
@@ -79,8 +79,8 @@ struct Cell : public Weakable<Cell> {
         m_conditional_formats = move(fmts);
     }
 
-    String typed_display() const;
-    JS::Value typed_js_data() const;
+    JS::ThrowCompletionOr<String> typed_display() const;
+    JS::ThrowCompletionOr<JS::Value> typed_js_data() const;
 
     const CellType& type() const;
     const CellTypeMetadata& type_metadata() const { return m_type_metadata; }

--- a/Userland/Applications/Spreadsheet/CellType/Date.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Date.cpp
@@ -21,7 +21,7 @@ DateCell::~DateCell()
 {
 }
 
-String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
+JS::ThrowCompletionOr<String> DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 {
     ScopeGuard propagate_exception { [&cell] {
         if (auto exc = cell.sheet().interpreter().exception()) {
@@ -29,8 +29,8 @@ String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
             cell.set_exception(exc);
         }
     } };
-    auto timestamp = js_value(cell, metadata);
-    auto string = Core::DateTime::from_timestamp(TRY_OR_DISCARD(timestamp.to_i32(cell.sheet().global_object()))).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S" : metadata.format.characters());
+    auto timestamp = TRY(js_value(cell, metadata));
+    auto string = Core::DateTime::from_timestamp(TRY(timestamp.to_i32(cell.sheet().global_object()))).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S" : metadata.format.characters());
 
     if (metadata.length >= 0)
         return string.substring(0, metadata.length);
@@ -38,10 +38,10 @@ String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
     return string;
 }
 
-JS::Value DateCell::js_value(Cell& cell, const CellTypeMetadata&) const
+JS::ThrowCompletionOr<JS::Value> DateCell::js_value(Cell& cell, const CellTypeMetadata&) const
 {
     auto js_data = cell.js_data();
-    auto value = TRY_OR_DISCARD(js_data.to_double(cell.sheet().global_object()));
+    auto value = TRY(js_data.to_double(cell.sheet().global_object()));
     return JS::Value(value / 1000); // Turn it to seconds
 }
 

--- a/Userland/Applications/Spreadsheet/CellType/Date.h
+++ b/Userland/Applications/Spreadsheet/CellType/Date.h
@@ -15,8 +15,8 @@ class DateCell : public CellType {
 public:
     DateCell();
     virtual ~DateCell() override;
-    virtual String display(Cell&, const CellTypeMetadata&) const override;
-    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, const CellTypeMetadata&) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Identity.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.cpp
@@ -19,12 +19,12 @@ IdentityCell::~IdentityCell()
 {
 }
 
-String IdentityCell::display(Cell& cell, const CellTypeMetadata&) const
+JS::ThrowCompletionOr<String> IdentityCell::display(Cell& cell, const CellTypeMetadata&) const
 {
-    return cell.js_data().to_string_without_side_effects();
+    return cell.js_data().to_string(cell.sheet().global_object());
 }
 
-JS::Value IdentityCell::js_value(Cell& cell, const CellTypeMetadata&) const
+JS::ThrowCompletionOr<JS::Value> IdentityCell::js_value(Cell& cell, const CellTypeMetadata&) const
 {
     return cell.js_data();
 }

--- a/Userland/Applications/Spreadsheet/CellType/Identity.h
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.h
@@ -15,8 +15,8 @@ class IdentityCell : public CellType {
 public:
     IdentityCell();
     virtual ~IdentityCell() override;
-    virtual String display(Cell&, const CellTypeMetadata&) const override;
-    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, const CellTypeMetadata&) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Numeric.h
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.h
@@ -15,8 +15,8 @@ class NumericCell : public CellType {
 public:
     NumericCell();
     virtual ~NumericCell() override;
-    virtual String display(Cell&, const CellTypeMetadata&) const override;
-    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, const CellTypeMetadata&) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/String.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/String.cpp
@@ -19,18 +19,18 @@ StringCell::~StringCell()
 {
 }
 
-String StringCell::display(Cell& cell, const CellTypeMetadata& metadata) const
+JS::ThrowCompletionOr<String> StringCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 {
-    auto string = cell.js_data().to_string_without_side_effects();
+    auto string = TRY(cell.js_data().to_string(cell.sheet().global_object()));
     if (metadata.length >= 0)
         return string.substring(0, metadata.length);
 
     return string;
 }
 
-JS::Value StringCell::js_value(Cell& cell, const CellTypeMetadata& metadata) const
+JS::ThrowCompletionOr<JS::Value> StringCell::js_value(Cell& cell, const CellTypeMetadata& metadata) const
 {
-    auto string = display(cell, metadata);
+    auto string = TRY(display(cell, metadata));
     return JS::js_string(cell.sheet().interpreter().heap(), string);
 }
 

--- a/Userland/Applications/Spreadsheet/CellType/String.h
+++ b/Userland/Applications/Spreadsheet/CellType/String.h
@@ -15,8 +15,8 @@ class StringCell : public CellType {
 public:
     StringCell();
     virtual ~StringCell() override;
-    virtual String display(Cell&, const CellTypeMetadata&) const override;
-    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, const CellTypeMetadata&) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Type.h
+++ b/Userland/Applications/Spreadsheet/CellType/Type.h
@@ -28,8 +28,8 @@ public:
     static const CellType* get_by_name(StringView);
     static Vector<StringView> names();
 
-    virtual String display(Cell&, const CellTypeMetadata&) const = 0;
-    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const = 0;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, const CellTypeMetadata&) const = 0;
+    virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, const CellTypeMetadata&) const = 0;
     virtual ~CellType() { }
 
     const String& name() const { return m_name; }

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -356,7 +356,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::get_column_bound)
 }
 
 WorkbookObject::WorkbookObject(Workbook& workbook)
-    : JS::Object(*JS::Object::create(workbook.global_object(), workbook.global_object().object_prototype()))
+    : JS::Object(*JS::Object::create(workbook.vm().interpreter().global_object(), workbook.vm().interpreter().global_object().object_prototype()))
     , m_workbook(workbook)
 {
 }

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -38,6 +38,7 @@ public:
     JS_DECLARE_NATIVE_FUNCTION(current_cell_position);
     JS_DECLARE_NATIVE_FUNCTION(column_index);
     JS_DECLARE_NATIVE_FUNCTION(column_arithmetic);
+    JS_DECLARE_NATIVE_FUNCTION(get_column_bound);
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -598,8 +598,11 @@ Vector<Vector<String>> Sheet::to_xsv() const
         row.resize(column_count);
         for (size_t j = 0; j < column_count; ++j) {
             auto cell = at({ j, i });
-            if (cell)
-                row[j] = cell->typed_display();
+            if (cell) {
+                auto result = cell->typed_display();
+                if (result.has_value())
+                    row[j] = result.value();
+            }
         }
 
         data.append(move(row));

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -468,11 +468,13 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
     return sheet;
 }
 
-Position Sheet::written_data_bounds() const
+Position Sheet::written_data_bounds(Optional<size_t> column_index) const
 {
     Position bound;
-    for (auto& entry : m_cells) {
+    for (auto const& entry : m_cells) {
         if (entry.value->data().is_empty())
+            continue;
+        if (column_index.has_value() && entry.key.column != *column_index)
             continue;
         if (entry.key.row >= bound.row)
             bound.row = entry.key.row;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -166,9 +166,6 @@ Sheet::ValueAndException Sheet::evaluate(StringView source, Cell* on_behalf_of)
     if (parser.has_errors() || interpreter().exception())
         return { JS::js_undefined(), interpreter().exception() };
 
-    // FIXME: This creates a GlobalEnvironment for every evaluate call which we might be able to circumvent with multiple realms.
-    interpreter().realm().set_global_object(global_object(), &global_object());
-
     interpreter().run(global_object(), program);
     if (interpreter().exception()) {
         auto exc = interpreter().exception();

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -147,6 +147,8 @@ private:
     Workbook& m_workbook;
     mutable SheetGlobalObject* m_global_object;
 
+    NonnullOwnPtr<JS::Interpreter> m_interpreter;
+
     Cell* m_current_cell_being_evaluated { nullptr };
 
     HashTable<Cell*> m_visited_cells_in_update;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -127,8 +127,8 @@ public:
 
     void copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to = {}, CopyOperation copy_operation = CopyOperation::Copy);
 
-    /// Gives the bottom-right corner of the smallest bounding box containing all the written data.
-    Position written_data_bounds() const;
+    /// Gives the bottom-right corner of the smallest bounding box containing all the written data, optionally limited to the given column.
+    Position written_data_bounds(Optional<size_t> column_index = {}) const;
 
     bool columns_are_standard() const;
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -42,7 +42,7 @@ SpreadsheetWidget::SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets, bool s
     auto& current_cell_label = top_bar.add<GUI::Label>("");
     current_cell_label.set_fixed_width(50);
 
-    auto& help_button = top_bar.add<GUI::Button>("🛈");
+    auto& help_button = top_bar.add<GUI::Button>("i");
     help_button.set_fixed_size(20, 20);
     help_button.on_click = [&](auto) {
         if (!m_selected_view) {

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -37,19 +37,17 @@ public:
         return *sheet;
     }
 
-    JS::Interpreter& interpreter() { return *m_interpreter; }
-    const JS::Interpreter& interpreter() const { return *m_interpreter; }
-
-    JS::GlobalObject& global_object() { return m_interpreter->global_object(); }
-    const JS::GlobalObject& global_object() const { return m_interpreter->global_object(); }
-
     WorkbookObject* workbook_object() { return m_workbook_object; }
+    JS::VM& vm() { return *m_vm; }
+    JS::VM const& vm() const { return *m_vm; }
 
 private:
     NonnullRefPtrVector<Sheet> m_sheets;
+    NonnullRefPtr<JS::VM> m_vm;
     NonnullOwnPtr<JS::Interpreter> m_interpreter;
     JS::VM::InterpreterExecutionScope m_interpreter_scope;
     WorkbookObject* m_workbook_object { nullptr };
+    JS::ExecutionContext m_main_execution_context;
 
     String m_current_filename;
     bool m_dirty { false };


### PR DESCRIPTION
This makes ranges a bit nicer and a bit faster by not generating all the cell names eagerly, and allows ranges to be added together for extra added fun.
So now this is possible:
```js
// average all the values in column C starting at C2 and every other value in column B starting at B1
=average(R`C2:C`.union(R`B1:B:1:2`))
```

Also replaces the eyesore `\ufffd` text on the Functions Help button :P