### PR TITLE
Piano: Support running without audio device

### DIFF
--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -31,7 +31,11 @@ AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_writ
         (void)buffer_id;
         enqueue_audio();
     };
-    m_resampler = Audio::ResampleHelper<double>(Music::sample_rate, m_audio_client->get_sample_rate());
+
+    auto target_sample_rate = m_audio_client->get_sample_rate();
+    if (target_sample_rate == 0)
+        target_sample_rate = Music::sample_rate;
+    m_resampler = Audio::ResampleHelper<double>(Music::sample_rate, target_sample_rate);
 }
 
 void AudioPlayerLoop::enqueue_audio()

--- a/Userland/Libraries/LibAudio/Buffer.cpp
+++ b/Userland/Libraries/LibAudio/Buffer.cpp
@@ -166,6 +166,8 @@ ResampleHelper<SampleType>::ResampleHelper(u32 source, u32 target)
     : m_source(source)
     , m_target(target)
 {
+    VERIFY(source > 0);
+    VERIFY(target > 0);
 }
 template ResampleHelper<i32>::ResampleHelper(u32, u32);
 template ResampleHelper<double>::ResampleHelper(u32, u32);

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -169,7 +169,7 @@ int Mixer::audiodevice_set_sample_rate(u16 sample_rate)
 {
     int code = ioctl(m_device->fd(), SOUNDCARD_IOCTL_SET_SAMPLE_RATE, sample_rate);
     if (code != 0)
-        dbgln("Error while setting sample rate to {}: ioctl returned with {}", sample_rate, strerror(code));
+        dbgln("Error while setting sample rate to {}: ioctl error: {}", sample_rate, strerror(errno));
     return code;
 }
 
@@ -178,7 +178,7 @@ u16 Mixer::audiodevice_get_sample_rate() const
     u16 sample_rate = 0;
     int code = ioctl(m_device->fd(), SOUNDCARD_IOCTL_GET_SAMPLE_RATE, &sample_rate);
     if (code != 0)
-        dbgln("Error while getting sample rate: ioctl returned with {}", strerror(code));
+        dbgln("Error while getting sample rate: ioctl error: {}", strerror(errno));
     return sample_rate;
 }
 


### PR DESCRIPTION
Before, when running SerenityOS without an audio device present, Piano would crash on application start. After this change, it starts but does not perform any audio processing.