### PR TITLE
SystemServer+kcov-example: Make /dev/kcov0 available again, improve error message if missing

### DIFF
--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -150,6 +150,10 @@ static void populate_devfs_block_devices()
             create_devfs_block_device(String::formatted("/dev/fb{}", minor_number), 0666, 29, minor_number);
             break;
         }
+        case 30: {
+            create_devfs_block_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
+            break;
+        }
         case 3: {
             create_devfs_block_device(String::formatted("/dev/hd{}", offset_character_with_number('a', minor_number)), 0600, 3, minor_number);
             break;

--- a/Userland/Utilities/kcov-example.cpp
+++ b/Userland/Utilities/kcov-example.cpp
@@ -21,6 +21,7 @@ int main(void)
     int fd = open("/dev/kcov0", O_RDWR);
     if (fd == -1) {
         perror("open");
+        fprintf(stderr, "Could not open /dev/kcov0 - is ENABLE_KERNEL_COVERAGE_COLLECTION enabled?\n");
         return 1;
     }
     if (ioctl(fd, KCOV_SETBUFSIZE, num_entries) == -1) {

--- a/Userland/Utilities/kcov-example.cpp
+++ b/Userland/Utilities/kcov-example.cpp
@@ -18,7 +18,7 @@ int main(void)
 {
     constexpr size_t num_entries = 1024 * 100;
 
-    int fd = open("/dev/kcov", O_RDWR);
+    int fd = open("/dev/kcov0", O_RDWR);
     if (fd == -1) {
         perror("open");
         return 1;


### PR DESCRIPTION
`open: No such file or directory`

That's not a very descriptive error. This PR improves the error message and points out the most likely solution (that the user should recompile the kernel with `ENABLE_KERNEL_COVERAGE_COLLECTION=ON`), as well as fixes SystemServer support for this special device.