### PR TITLE
Starfield: Implement warp speed

### DIFF
--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -47,6 +47,7 @@ private:
 
     Vector<Coordinate> m_stars;
     int m_sweep_plane = 2000;
+    unsigned m_speed = 1;
 };
 
 Starfield::Starfield(int interval)
@@ -102,18 +103,26 @@ void Starfield::timer_event(Core::TimerEvent&)
     auto half_x = width() / 2;
     auto half_y = height() / 2;
 
+    GUI::Painter painter(*m_bitmap);
+
     for (auto star : m_stars) {
         auto z = ((star.z + m_sweep_plane) % 2000) * 0.0005;
         computed_point.set_x(half_x + star.x / z);
         computed_point.set_y(half_y + star.y / z);
 
+        auto computed_end_point = Gfx::IntPoint();
+
+        auto z_end = ((star.z + m_sweep_plane - m_speed) % 2000) * 0.0005;
+        computed_end_point.set_x(half_x + star.x / z_end);
+        computed_end_point.set_y(half_y + star.y / z_end);
+
         if (computed_point.x() < 0 || computed_point.x() >= width() || computed_point.y() < 0 || computed_point.y() >= height())
             continue;
 
         u8 falloff = (1 - z * z) * 255;
-        m_bitmap->set_pixel(computed_point, Color(falloff, falloff, falloff));
+        painter.draw_line(computed_point, computed_end_point, Color(falloff, falloff, falloff));
     }
-    m_sweep_plane -= 1;
+    m_sweep_plane -= m_speed;
     if (m_sweep_plane < 0)
         m_sweep_plane = 2000;
     update();

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -34,6 +34,8 @@ public:
     virtual ~Starfield() override;
     void create_stars(int, int, int);
 
+    void set_speed(unsigned speed) { m_speed = speed; }
+
 private:
     Starfield(int);
     RefPtr<Gfx::Bitmap> m_bitmap;
@@ -142,20 +144,16 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    int star_count = 0;
-    int refresh_rate = 0;
+    unsigned star_count = 1000;
+    unsigned refresh_rate = 16;
+    unsigned speed = 1;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The classic starfield screensaver.");
     args_parser.add_option(star_count, "Number of stars to draw (default = 1000)", "stars", 'c', "number");
     args_parser.add_option(refresh_rate, "Refresh rate (default = 16)", "rate", 'r', "milliseconds");
+    args_parser.add_option(speed, "Speed (default = 1)", "speed", 's', "number");
     args_parser.parse(argc, argv);
-
-    if (star_count == 0)
-        star_count = 1000;
-
-    if (refresh_rate == 0)
-        refresh_rate = 16;
 
     auto app = GUI::Application::construct(argc, argv);
 
@@ -182,6 +180,7 @@ int main(int argc, char** argv)
     window->show();
 
     starfield_window.create_stars(window->width(), window->height(), star_count);
+    starfield_window.set_speed(speed);
     starfield_window.update();
 
     window->move_to_front();

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -85,9 +85,19 @@ void Starfield::mousedown_event(GUI::MouseEvent&)
     GUI::Application::the()->quit();
 }
 
-void Starfield::keydown_event(GUI::KeyEvent&)
+void Starfield::keydown_event(GUI::KeyEvent& event)
 {
-    GUI::Application::the()->quit();
+    switch (event.key()) {
+    case Key_Plus:
+        m_speed++;
+        break;
+    case Key_Minus:
+        if (--m_speed < 1)
+            m_speed = 1;
+        break;
+    default:
+        GUI::Application::the()->quit();
+    }
 }
 
 void Starfield::paint_event(GUI::PaintEvent& event)


### PR DESCRIPTION
These changes allow us to modify the speed in which the Starfield is navigated.
Increasing the speed also increases the length of each star trail.
The speed can be changed the by passing a command-line argument `-s` or `--speed`, or by pressing the `Plus` or `Minus` keys on your keyboard for extra interactability. :^)

Link for demo video: https://streamable.com/hgnquh