### PR TITLE
HackStudio: Disable the Rename action on insufficient permissions (+small cleanup)

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -983,7 +983,7 @@ void HackStudioWidget::configure_project_tree_view()
             return access(m_project->model().full_path(selected_file.parent()).characters(), W_OK) == 0;
         });
         bool has_permissions = it != selections.end();
-        m_delete_action->set_enabled(!m_project_tree_view->selection().is_empty() && has_permissions);
+        m_delete_action->set_enabled(has_permissions);
     };
 
     m_project_tree_view->on_activation = [this](auto& index) {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -983,6 +983,7 @@ void HackStudioWidget::configure_project_tree_view()
             return access(m_project->model().full_path(selected_file.parent()).characters(), W_OK) == 0;
         });
         bool has_permissions = it != selections.end();
+        m_tree_view_rename_action->set_enabled(has_permissions);
         m_delete_action->set_enabled(has_permissions);
     };
 


### PR DESCRIPTION
- **HackStudio: Remove noop when deciding whether to disable delete action**

  The iterator in `has_permissions` will just be equal to `sections.end()` when there are no selected files.

- **HackStudio: Disable the Rename action on insufficient permissions**

  This patch will disable the Rename action in the project Tree View if a user does not have write access to the selected file directory.