### PR TITLE
tar: Implement usage of prefixes when extracting

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -164,6 +164,11 @@ LexicalPath LexicalPath::append(StringView value) const
     return LexicalPath::join(m_string, value);
 }
 
+LexicalPath LexicalPath::prepend(StringView value) const
+{
+    return LexicalPath::join(value, m_string);
+}
+
 LexicalPath LexicalPath::parent() const
 {
     return append("..");

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -30,6 +30,7 @@ public:
     bool has_extension(StringView) const;
 
     [[nodiscard]] LexicalPath append(StringView) const;
+    [[nodiscard]] LexicalPath prepend(StringView) const;
     [[nodiscard]] LexicalPath parent() const;
 
     [[nodiscard]] static String canonicalized_path(String);

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -76,7 +76,13 @@ int main(int argc, char** argv)
                 Archive::TarFileStream file_stream = tar_stream.file_contents();
 
                 const Archive::TarFileHeader& header = tar_stream.header();
-                String absolute_path = Core::File::absolute_path(header.filename());
+
+                LexicalPath path = LexicalPath(header.filename());
+                if (!header.prefix().is_empty())
+                    path = path.prepend(header.prefix());
+
+                String absolute_path = Core::File::absolute_path(path.string());
+
                 switch (header.type_flag()) {
                 case Archive::TarFileType::NormalFile:
                 case Archive::TarFileType::AlternateNormalFile: {


### PR DESCRIPTION
The prefix feature is used a lot by tarballs that have been generated by GitHub.