### PR TITLE
WindowServer+DisplaySettings: Minor fixes when setting wallpaper (feat. clearing wallpaper works again)

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -20,6 +20,7 @@
 #include <LibGUI/FileSystemModel.h>
 #include <LibGUI/IconView.h>
 #include <LibGUI/ItemListModel.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
@@ -139,11 +140,12 @@ void BackgroundSettingsWidget::load_current_settings()
 
 void BackgroundSettingsWidget::apply_settings()
 {
-    Config::write_string("WindowManager", "Background", "Wallpaper", m_monitor_widget->wallpaper());
+    if (GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper()))
+        Config::write_string("WindowManager", "Background", "Wallpaper", m_monitor_widget->wallpaper());
+    else
+        GUI::MessageBox::show_error(window(), String::formatted("Unable to load file {} as wallpaper", m_monitor_widget->wallpaper()));
 
-    GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper());
     GUI::Desktop::the().set_background_color(m_color_input->text());
-
     GUI::Desktop::the().set_wallpaper_mode(m_monitor_widget->wallpaper_mode());
 }
 

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -141,12 +141,8 @@ void BackgroundSettingsWidget::apply_settings()
 {
     Config::write_string("WindowManager", "Background", "Wallpaper", m_monitor_widget->wallpaper());
 
-    if (!m_monitor_widget->wallpaper().is_empty()) {
-        GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper());
-    } else {
-        GUI::Desktop::the().set_wallpaper("");
-        GUI::Desktop::the().set_background_color(m_color_input->text());
-    }
+    GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper());
+    GUI::Desktop::the().set_background_color(m_color_input->text());
 
     GUI::Desktop::the().set_wallpaper_mode(m_monitor_widget->wallpaper_mode());
 }

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -813,12 +813,15 @@ bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callba
         },
 
         [this, path, callback = move(callback)](ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap) {
-            if (bitmap.is_error()) {
+            if (bitmap.is_error() && !path.is_empty()) {
                 callback(false);
                 return;
             }
             m_wallpaper_path = path;
-            m_wallpaper = bitmap.release_value();
+            if (bitmap.is_error())
+                m_wallpaper = nullptr;
+            else
+                m_wallpaper = bitmap.release_value();
             invalidate_screen();
             callback(true);
         });


### PR DESCRIPTION
- **WindowServer: Clear wallpaper if the requested path is empty**

  https://github.com/SerenityOS/serenity/commit/235f39e449ebffed26114c7166b0b632a3f2232e secretly added an if check that ignores all the files that couldn’t be loaded into bitmaps.  Unfortunately, we send an empty path as a way to unset the wallpaper, which meant that we couldn’t go back
to the default background color anymore.

- **DisplaySettings: Always save the background color to the config**

  Previously, you could notice that the background color isn’t being updated when you picked a small bitmap image with the ‘center’ mode.

- **DisplaySettings: Update wallpaper config path only on success**

  The Window Server is ignoring incorrect files since https://github.com/SerenityOS/serenity/commit/235f39e449ebffed26114c7166b0b632a3f2232e, so let’s not update the config when that happens and an error message instead!
