### PR TITLE
PixelPaint: Display zoom level, add box to change it, arrange for initial zoom level to be 100%

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -72,8 +72,8 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     width_spinbox.set_range(1, 16384);
     height_spinbox.set_range(1, 16384);
 
-    width_spinbox.set_value(480);
-    height_spinbox.set_value(360);
+    width_spinbox.set_value(510);
+    height_spinbox.set_value(356);
 }
 
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -610,7 +610,7 @@ void ImageEditor::set_pan_origin(Gfx::FloatPoint const& pan_origin)
     relayout();
 }
 
-void ImageEditor::fit_image_to_view()
+void ImageEditor::fit_image_to_view(FitType type)
 {
     auto viewport_rect = rect();
     m_pan_origin = Gfx::FloatPoint(0, 0);
@@ -628,7 +628,17 @@ void ImageEditor::fit_image_to_view()
     auto image_size = image().size();
     auto height_ratio = floorf(border_ratio * viewport_rect.height()) / (float)image_size.height();
     auto width_ratio = floorf(border_ratio * viewport_rect.width()) / (float)image_size.width();
-    set_absolute_scale(min(height_ratio, width_ratio), false);
+    switch (type) {
+    case FitType::Width:
+        set_absolute_scale(width_ratio, false);
+        break;
+    case FitType::Height:
+        set_absolute_scale(height_ratio, false);
+        break;
+    case FitType::Image:
+        set_absolute_scale(min(height_ratio, width_ratio), false);
+        break;
+    }
 
     float offset = m_show_rulers ? -m_ruler_thickness / (m_scale * 2.0f) : 0.0f;
     m_pan_origin = Gfx::FloatPoint(offset, offset);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -616,9 +616,9 @@ void ImageEditor::fit_image_to_view()
 
     const float border_ratio = 0.95f;
     auto image_size = image().size();
-    auto height_ratio = viewport_rect.height() / (float)image_size.height();
-    auto width_ratio = viewport_rect.width() / (float)image_size.width();
-    m_scale = border_ratio * min(height_ratio, width_ratio);
+    auto height_ratio = floorf(border_ratio * viewport_rect.height()) / (float)image_size.height();
+    auto width_ratio = floorf(border_ratio * viewport_rect.width()) / (float)image_size.width();
+    m_scale = min(height_ratio, width_ratio);
 
     float offset = m_show_rulers ? -m_ruler_thickness / (m_scale * 2.0f) : 0.0f;
     m_pan_origin = Gfx::FloatPoint(offset, offset);

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -59,6 +59,8 @@ public:
     void fit_image_to_view();
     void reset_scale_and_position();
     void scale_by(float);
+    void set_absolute_scale(float, bool do_relayout = true);
+    Function<void(float)> on_scale_changed;
 
     void set_pan_origin(Gfx::FloatPoint const&);
     Gfx::FloatPoint pan_origin() const { return m_pan_origin; }
@@ -134,7 +136,7 @@ private:
     GUI::MouseEvent event_adjusted_for_layer(GUI::MouseEvent const&, Layer const&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
 
-    void clamped_scale(float);
+    void clamped_scale_by(float, bool do_relayout);
     void relayout();
 
     int calculate_ruler_step_size() const;

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -54,9 +54,15 @@ public:
 
     Layer* layer_at_editor_position(Gfx::IntPoint const&);
 
+    enum class FitType {
+        Width,
+        Height,
+        Image
+    };
+
     float scale() const { return m_scale; }
     void scale_centered_on_position(Gfx::IntPoint const&, float);
-    void fit_image_to_view();
+    void fit_image_to_view(FitType type = FitType::Image);
     void reset_scale_and_position();
     void scale_by(float);
     void set_absolute_scale(float, bool do_relayout = true);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -794,7 +794,7 @@ void MainWidget::open_image_fd(int fd, String const& path)
 
 void MainWidget::create_default_image()
 {
-    auto image = Image::try_create_with_size({ 480, 360 }).release_value_but_fixme_should_propagate_errors();
+    auto image = Image::try_create_with_size({ 510, 356 }).release_value_but_fixme_should_propagate_errors();
 
     auto bg_layer = Layer::try_create_with_size(*image, image->size(), "Background").release_value_but_fixme_should_propagate_errors();
     image->add_layer(*bg_layer);

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -18,6 +18,7 @@
 #include "ToolboxWidget.h"
 #include "Tools/Tool.h"
 #include <LibGUI/Action.h>
+#include <LibGUI/ComboBox.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TabWidget.h>
@@ -54,6 +55,7 @@ private:
     RefPtr<ToolPropertiesWidget> m_tool_properties_widget;
     RefPtr<GUI::TabWidget> m_tab_widget;
     RefPtr<GUI::Statusbar> m_statusbar;
+    RefPtr<GUI::ComboBox> m_zoom_combobox;
 
     RefPtr<GUI::Action> m_new_image_action;
     RefPtr<GUI::Action> m_open_image_action;


### PR DESCRIPTION
This PR:
- Adds a ComboBox in the toolbar that displays the zoom level, e.g. 100% or 836%.
- Provides a nice way to select "fit to width" and "fit to height" and "fit entire image", in addition to a selection of reasonable zoom levels like 100%, 800%, etc.
- Tweaks the default image sizes such that the initial zoom level always ends up at 100%, which means that by default there will be no scale-induced image artifacts, which might trip up first-time users (#10975).

![Bildschirmfoto_2021-11-22_01-10-19](https://user-images.githubusercontent.com/2690845/142784688-4953a671-f35f-4fdd-9378-09c3b5c868ea.png)