### PR TITLE
LibMain: Rename .arguments to .strings

### DIFF
--- a/Userland/Libraries/LibMain/Main.cpp
+++ b/Userland/Libraries/LibMain/Main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
     auto result = serenity_main({
         .argc = argc,
         .argv = argv,
-        .arguments = arguments.span(),
+        .strings = arguments.span(),
     });
     if (result.is_error()) {
         auto error = result.release_error();

--- a/Userland/Libraries/LibMain/Main.h
+++ b/Userland/Libraries/LibMain/Main.h
@@ -13,7 +13,7 @@ namespace Main {
 struct Arguments {
     int argc {};
     char** argv {};
-    Span<StringView> arguments;
+    Span<StringView> strings;
 };
 
 }


### PR DESCRIPTION
Before this change, we would need to write `arguments.arguments` to access the `Span<>`, which doesn't feel too pretty.