### PR TITLE
Everywhere: Update APIs to accept Main::Arguments directly

### DIFF
--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -196,7 +196,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Core::ArgsParser args_parser;
     args_parser.add_option(cpu, "Create CPU graph", "cpu", 'C', "cpu");
     args_parser.add_option(memory, "Create memory graph", "memory", 'M', "memory");
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     if (!cpu && !memory) {
         printf("At least one of --cpu or --memory must be used");

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -187,7 +187,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio recvfd sendfd proc exec rpath unix", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TRY(System::pledge("stdio recvfd sendfd proc exec rpath", nullptr));
 

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -284,7 +284,7 @@ bool GLContextWidget::load_file(Core::File& file, String const& filename)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TRY(System::pledge("stdio thread recvfd sendfd rpath unix", nullptr));
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(specified_url, "URL to open", "url", Core::ArgsParser::Required::No);
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     auto app = GUI::Application::construct(arguments.argc, arguments.argv);
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -47,7 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(specified_url, "URL to open", "url", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     Config::pledge_domains("Browser");
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -78,7 +78,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(is_selection_mode, "Show entry in parent folder", "select", 's');
     args_parser.add_option(ignore_path_resolution, "Use raw path, do not resolve real path", "raw", 'r');
     args_parser.add_positional_argument(initial_location, "Path to open", "path", Core::ArgsParser::Required::No);
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     auto app = GUI::Application::construct(arguments.argc, arguments.argv);
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -80,7 +80,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(initial_location, "Path to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TRY(System::pledge("stdio thread recvfd sendfd cpath rpath wpath fattr proc exec unix", nullptr));
 

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio recvfd sendfd rpath unix inet", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     Config::pledge_domains("Mail");
 

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -17,7 +17,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
     auto app_icon = GUI::Icon::default_icon("app-pdf-viewer");
 
     auto window = GUI::Window::construct();

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio thread rpath cpath wpath recvfd sendfd unix", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TrackManager track_manager;
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     const char* image_file = nullptr;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(image_file, "Image file to open", "path", Core::ArgsParser::Required::No);
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     TRY(System::unveil("/res", "r"));
     TRY(System::unveil("/tmp/portal/clipboard", "rw"));

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
     Config::pledge_domains("PixelPaint");
 
     const char* image_file = nullptr;

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -261,7 +261,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(System::sigaction(SIGCHLD, &act, nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TRY(System::pledge("stdio tty rpath cpath wpath recvfd sendfd proc exec unix", nullptr));
 

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -274,7 +274,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(command_to_execute, "Execute this command inside the terminal", nullptr, 'e', "command");
     args_parser.add_option(keep_open, "Keep the terminal open after the command has finished executing", nullptr, 'k');
 
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     if (keep_open && !command_to_execute) {
         warnln("Option -k can only be used in combination with -e.");

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -162,7 +162,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(speed, "Speed (default = 1)", "speed", 's', "number");
     args_parser.parse(arguments);
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TRY(System::pledge("stdio recvfd sendfd rpath", nullptr));
 

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -160,7 +160,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(star_count, "Number of stars to draw (default = 1000)", "stars", 'c', "number");
     args_parser.add_option(refresh_rate, "Refresh rate (default = 16)", "rate", 'r', "milliseconds");
     args_parser.add_option(speed, "Speed (default = 1)", "speed", 's', "number");
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     auto app = GUI::Application::construct(arguments.argc, arguments.argv);
 

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     srand(time(nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
     auto app_icon = GUI::Icon::default_icon("app-2048");
 
     auto window = GUI::Window::construct();

--- a/Userland/Games/Breakout/main.cpp
+++ b/Userland/Games/Breakout/main.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio recvfd sendfd rpath unix", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     TRY(System::pledge("stdio recvfd sendfd rpath", nullptr));
 

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio rpath wpath cpath recvfd sendfd thread proc exec unix", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     Config::pledge_domains("Chess");
 

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(System::pledge("stdio rpath recvfd sendfd unix", nullptr));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = GUI::Application::construct(arguments);
 
     Config::pledge_domains("Minesweeper");
 

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -9,6 +9,7 @@
 #include <AK/Function.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibMain/Main.h>
 #include <stdio.h>
 
 namespace Core {
@@ -54,6 +55,11 @@ public:
     };
 
     bool parse(int argc, char* const* argv, FailureBehavior failure_behavior = FailureBehavior::PrintUsageAndExit);
+    bool parse(Main::Arguments const& arguments, FailureBehavior failure_behavior = FailureBehavior::PrintUsageAndExit)
+    {
+        return parse(arguments.argc, arguments.argv, failure_behavior);
+    }
+
     // *Without* trailing newline!
     void set_general_help(const char* help_string) { m_general_help = help_string; };
     void set_stop_on_first_non_option(bool stop_on_first_non_option) { m_stop_on_first_non_option = stop_on_first_non_option; }

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -16,6 +16,7 @@
 #include <LibGUI/Shortcut.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Point.h>
+#include <LibMain/Main.h>
 
 namespace GUI {
 
@@ -85,6 +86,10 @@ public:
 
 private:
     Application(int argc, char** argv, Core::EventLoop::MakeInspectable = Core::EventLoop::MakeInspectable::No);
+    Application(Main::Arguments const& arguments, Core::EventLoop::MakeInspectable inspectable = Core::EventLoop::MakeInspectable::No)
+        : Application(arguments.argc, arguments.argv, inspectable)
+    {
+    }
 
     virtual void event(Core::Event&) override;
 

--- a/Userland/Utilities/id.cpp
+++ b/Userland/Utilities/id.cpp
@@ -36,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_print_gid_all, "Print all GIDs", nullptr, 'G');
     args_parser.add_option(flag_print_name, "Print name", nullptr, 'n');
     args_parser.add_positional_argument(user_str, "User name/UID to query", "USER", Core::ArgsParser::Required::No);
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     if (flag_print_name && !(flag_print_uid || flag_print_gid || flag_print_gid_all)) {
         warnln("cannot print only names or real IDs in default format");

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1129,7 +1129,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #endif
     args_parser.add_option(disable_syntax_highlight, "Disable live syntax highlighting", "no-syntax-highlight", 's');
     args_parser.add_positional_argument(script_paths, "Path to script files", "scripts", Core::ArgsParser::Required::No);
-    args_parser.parse(arguments.argc, arguments.argv);
+    args_parser.parse(arguments);
 
     bool syntax_highlight = !disable_syntax_highlight;
 


### PR DESCRIPTION
Previously `GUI::Application::Construct()` and `ArgsParser::parse()` both accepted `argc` and `argv` separately, but with the new `Main::Arguments`, we can have a functions that accepts the arguments object instead of us manually having to pull out `arguments.argc` and `arguments.argv` everywhere.