### PR TITLE
PixelPaint: Improve Image size handling

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
     PaletteWidget.cpp
     PixelPaintWindowGML.h
     ProjectLoader.cpp
+    ResizeImageDialog.cpp
     Selection.cpp
     ToolPropertiesWidget.cpp
     ToolboxWidget.cpp

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -481,6 +481,12 @@ void Image::set_path(String path)
     set_title(LexicalPath::basename(m_path));
 }
 
+void Image::resize(Gfx::IntSize const& size)
+{
+    m_size = size;
+    did_change_rect();
+}
+
 void Image::flip(Gfx::Orientation orientation)
 {
     for (auto& layer : m_layers) {

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -99,6 +99,7 @@ public:
     String const& title() const { return m_title; }
     void set_title(String);
 
+    void resize(Gfx::IntSize const& size);
     void flip(Gfx::Orientation orientation);
     void rotate(Gfx::RotationDirection direction);
     void crop(Gfx::IntRect const& rect);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -11,6 +11,7 @@
 #include "CreateNewLayerDialog.h"
 #include "EditGuideDialog.h"
 #include "FilterParams.h"
+#include "ResizeImageDialog.h"
 #include <Applications/PixelPaint/PixelPaintWindowGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/File.h>
@@ -418,6 +419,16 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     });
 
     auto& image_menu = window.add_menu("&Image");
+    image_menu.add_action(GUI::Action::create(
+        "&Resize", [&](auto&) {
+            auto* editor = current_image_editor();
+            if (!editor)
+                return;
+            auto dialog = PixelPaint::ResizeImageDialog::construct(editor->image().size(), &window);
+            if (dialog->exec() == GUI::Dialog::ExecOK)
+                editor->image().resize(dialog->image_size());
+        }));
+    image_menu.add_separator();
     image_menu.add_action(GUI::Action::create(
         "Flip &Vertically", [&](auto&) {
             auto* editor = current_image_editor();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -227,6 +227,17 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         if (!bitmap)
             return;
 
+        auto& image = editor->image();
+        const auto& bitmap_size = bitmap->size();
+        const auto& image_size = image.size();
+        if (bitmap_size.width() > image_size.width() || bitmap_size.height() > image_size.height()) {
+            auto expand_canvas = GUI::MessageBox::show(&window, "Do you want to expand the editor image?", "Expand image?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNoCancel);
+            if (expand_canvas == GUI::MessageBox::ExecYes)
+                image.resize(bitmap_size);
+            else if (expand_canvas == GUI::MessageBox::ExecCancel)
+                return;
+        }
+
         auto layer = PixelPaint::Layer::try_create_with_bitmap(editor->image(), *bitmap, "Pasted layer").release_value_but_fixme_should_propagate_errors();
         editor->image().add_layer(*layer);
         editor->set_active_layer(layer);

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Kamil Chojnowski <contact@diath.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ResizeImageDialog.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/SpinBox.h>
+#include <LibGUI/TextBox.h>
+
+namespace PixelPaint {
+
+ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& current_size, GUI::Window* parent_window)
+    : Dialog(parent_window)
+{
+    set_title("Resize image");
+    set_icon(parent_window->icon());
+    resize(200, 160);
+
+    auto& main_widget = set_main_widget<GUI::Widget>();
+    main_widget.set_fill_with_background_color(true);
+
+    auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
+    layout.set_margins(4);
+
+    auto& width_label = main_widget.add<GUI::Label>("Width:");
+    width_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+
+    auto& width_spinbox = main_widget.add<GUI::SpinBox>();
+
+    auto& height_label = main_widget.add<GUI::Label>("Height:");
+    height_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+
+    auto& height_spinbox = main_widget.add<GUI::SpinBox>();
+
+    auto& button_container = main_widget.add<GUI::Widget>();
+    button_container.set_layout<GUI::HorizontalBoxLayout>();
+
+    auto& ok_button = button_container.add<GUI::Button>("OK");
+    ok_button.on_click = [this](auto) {
+        done(ExecOK);
+    };
+
+    auto& cancel_button = button_container.add<GUI::Button>("Cancel");
+    cancel_button.on_click = [this](auto) {
+        done(ExecCancel);
+    };
+
+    width_spinbox.on_change = [this](int value) {
+        m_image_size.set_width(value);
+    };
+
+    height_spinbox.on_change = [this](int value) {
+        m_image_size.set_height(value);
+    };
+
+    width_spinbox.set_range(1, 16384);
+    height_spinbox.set_range(1, 16384);
+
+    width_spinbox.set_value(current_size.width());
+    height_spinbox.set_value(current_size.height());
+}
+
+}

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.h
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, Kamil Chojnowski <contact@diath.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Dialog.h>
+
+namespace PixelPaint {
+
+class ResizeImageDialog final : public GUI::Dialog {
+    C_OBJECT(ResizeImageDialog)
+
+public:
+    Gfx::IntSize const& image_size() const { return m_image_size; }
+
+private:
+    ResizeImageDialog(Gfx::IntSize const& current_size, GUI::Window* parent_window);
+
+    Gfx::IntSize m_image_size;
+};
+
+}


### PR DESCRIPTION
This PR adds the following changes to PixelPaint:
* Added `Image::resize(Gfx::IntSize const&)` method, this method updates the internal `m_size` member and calls `did_change_rect()` callback in one go.
* Added "expand image" question prompt when pasting a new bitmap from the clipboard whose dimensions are larger than the size of the image of the current editor.
* Added `Image` -> `Resize` menu action that opens new `ResizeImageDialog` that allows resizing of the currently open image.