### PR TITLE
Meta: Increase PulseAudio timer period to 2ms

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -146,7 +146,7 @@ elif [ "$NATIVE_WINDOWS_QEMU" -eq "1" ]; then
 elif "$SERENITY_QEMU_BIN" -audio-help 2>&1 | grep -- "-audiodev id=sdl" >/dev/null; then
     SERENITY_AUDIO_BACKEND="-audiodev sdl,id=snd0"
 else
-    SERENITY_AUDIO_BACKEND="-audiodev pa,timer-period=1000,id=snd0"
+    SERENITY_AUDIO_BACKEND="-audiodev pa,timer-period=2000,id=snd0"
 fi
 
 if [ "$installed_major_version" -eq 5 ] && [ "$installed_minor_version" -eq 0 ]; then


### PR DESCRIPTION
This seems to prevent crackling audio when starting up Qemu whenever there is audio already playing.

CC @awesomekling 