### PR TITLE
Kernel: Crash fix and channel support for AC97

### DIFF
--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -152,6 +152,7 @@ private:
     void set_master_output_volume(u8, u8, Muted);
     void set_pcm_output_sample_rate(u16);
     void set_pcm_output_volume(u8, u8, Muted);
+    ErrorOr<void> write_single_buffer(UserOrKernelBuffer const&, size_t, size_t);
 
     OwnPtr<Memory::Region> m_buffer_descriptor_list;
     u8 m_buffer_descriptor_list_index = 0;


### PR DESCRIPTION
* Implement "theoretical support" (no user-facing functionality) for all AC97 channels: PCM out, PCM in, PCM in 2, microphone in, microphone in 2 and S/PDIF
* Allow for larger writes than `PAGE_SIZE` to the AC97 character device - you can now `cat /dev/random > /dev/audio` as much as you want