### PR TITLE
LibUnicode: Support code point names that apply to ranges of code points

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -95,7 +95,6 @@ struct UnicodeData {
     Vector<String> conditions;
 
     Vector<CodePointData> code_point_data;
-    Vector<CodePointRange> code_point_ranges;
 
     PropList general_categories;
     Vector<Alias> general_category_aliases;
@@ -454,7 +453,6 @@ static void parse_unicode_data(Core::File& file, UnicodeData& unicode_data)
             VERIFY(code_point_range_start.has_value());
 
             CodePointRange code_point_range { *code_point_range_start, data.code_point };
-            unicode_data.code_point_ranges.append(code_point_range);
             assigned_code_points.append(code_point_range);
 
             data.name = data.name.substring(1, data.name.length() - 8);

--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -629,3 +629,34 @@ TEST_CASE(script_extension)
     EXPECT(Unicode::code_point_has_script(0x101fd, script_inherited));
     EXPECT(Unicode::code_point_has_script_extension(0x101fd, script_inherited));
 }
+
+TEST_CASE(code_point_display_name)
+{
+    auto code_point_display_name = [](u32 code_point) {
+        auto name = Unicode::code_point_display_name(code_point);
+        VERIFY(name.has_value());
+        return name.release_value();
+    };
+
+    // Control code points.
+    EXPECT_EQ(code_point_display_name(0), "NULL"sv);
+    EXPECT_EQ(code_point_display_name(1), "START OF HEADING"sv);
+    EXPECT_EQ(code_point_display_name(0xa), "LINE FEED"sv);
+
+    // Ideographic code points (which already appeared in a range in UnicodeData.txt).
+    EXPECT_EQ(code_point_display_name(0x3400), "CJK UNIFIED IDEOGRAPH-3400"sv);
+    EXPECT_EQ(code_point_display_name(0x3401), "CJK UNIFIED IDEOGRAPH-3401"sv);
+    EXPECT_EQ(code_point_display_name(0x3402), "CJK UNIFIED IDEOGRAPH-3402"sv);
+    EXPECT_EQ(code_point_display_name(0x4dbf), "CJK UNIFIED IDEOGRAPH-4DBF"sv);
+
+    EXPECT_EQ(code_point_display_name(0x20000), "CJK UNIFIED IDEOGRAPH-20000"sv);
+    EXPECT_EQ(code_point_display_name(0x20001), "CJK UNIFIED IDEOGRAPH-20001"sv);
+    EXPECT_EQ(code_point_display_name(0x20002), "CJK UNIFIED IDEOGRAPH-20002"sv);
+    EXPECT(!Unicode::code_point_display_name(0x2a6df).has_value());
+
+    // Ideographic code points (which appeared individually in UnicodeData.txt and were coalesced into a range).
+    EXPECT_EQ(code_point_display_name(0x2f800), "CJK COMPATIBILITY IDEOGRAPH-2F800"sv);
+    EXPECT_EQ(code_point_display_name(0x2f801), "CJK COMPATIBILITY IDEOGRAPH-2F801"sv);
+    EXPECT_EQ(code_point_display_name(0x2f802), "CJK COMPATIBILITY IDEOGRAPH-2F802"sv);
+    EXPECT_EQ(code_point_display_name(0x2fa1d), "CJK COMPATIBILITY IDEOGRAPH-2FA1D"sv);
+}

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -222,13 +222,10 @@ u32 to_unicode_uppercase(u32 code_point)
 #endif
 }
 
-Optional<StringView> code_point_display_name([[maybe_unused]] u32 code_point)
+Optional<String> code_point_display_name([[maybe_unused]] u32 code_point)
 {
 #if ENABLE_UNICODE_DATA
-    auto name = Detail::code_point_display_name(code_point);
-    if (name.is_null())
-        return {};
-    return name;
+    return Detail::code_point_display_name(code_point);
 #else
     return {};
 #endif

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -19,7 +19,7 @@ namespace Unicode {
 u32 to_unicode_lowercase(u32 code_point);
 u32 to_unicode_uppercase(u32 code_point);
 
-Optional<StringView> code_point_display_name(u32 code_point);
+Optional<String> code_point_display_name(u32 code_point);
 
 String to_unicode_lowercase_full(StringView, Optional<StringView> locale = {});
 String to_unicode_uppercase_full(StringView, Optional<StringView> locale = {});


### PR DESCRIPTION
Noticed while playing around with FontEditor that we were missing names for code points that fall into ranges listed in UnicodeData.txt.