### PR TITLE
LibGUI: Reverse FilteringProxyModel update propagation flow

### DIFF
--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -46,7 +46,6 @@ Variant FilteringProxyModel::data(ModelIndex const& index, ModelRole role) const
 
 void FilteringProxyModel::invalidate()
 {
-    m_model.invalidate();
     filter();
     did_update();
 }

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -14,14 +14,18 @@
 
 namespace GUI {
 
-class FilteringProxyModel final : public Model {
+class FilteringProxyModel final : public Model
+    , public ModelClient {
 public:
     static NonnullRefPtr<FilteringProxyModel> construct(Model& model)
     {
         return adopt_ref(*new FilteringProxyModel(model));
     }
 
-    virtual ~FilteringProxyModel() override {};
+    virtual ~FilteringProxyModel() override
+    {
+        m_model.unregister_client(*this);
+    };
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
@@ -35,11 +39,15 @@ public:
 
     ModelIndex map(ModelIndex const&) const;
 
+protected:
+    virtual void model_did_update([[maybe_unused]] unsigned flags) override { invalidate(); }
+
 private:
     void filter();
     explicit FilteringProxyModel(Model& model)
         : m_model(model)
     {
+        m_model.register_client(*this);
     }
 
     Model& m_model;


### PR DESCRIPTION
FilteringProxyModel is a narrowing projection of its parent model with
a filter applied. That means that updates of FilteringProxyModel should
not propagate to its parent model, but the opposite - updates happening
in the parent model should "trickle down" and trigger an update of the
filtering model.

Fixes #10127
