### PR TITLE
Kernel: Allow higher audio sample rates than 65kHZ (`u16`)

### DIFF
--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -43,12 +43,18 @@ private:
         SetMasterOutputVolume = 0x02,
         SetPCMOutputVolume = 0x18,
         ExtendedAudioID = 0x28,
+        ExtendedAudioStatusControl = 0x2a,
         PCMFrontDACRate = 0x2c,
     };
 
     enum ExtendedAudioMask : u16 {
         VariableRatePCMAudio = 1 << 0,
+        DoubleRatePCMAudio = 1 << 1,
         Revision = 3 << 10,
+    };
+
+    enum ExtendedAudioStatusControlFlag : u16 {
+        DoubleRateAudio = 1 << 1,
     };
 
     enum AC97Revision : u8 {
@@ -150,12 +156,13 @@ private:
     void initialize();
     void reset_pcm_out();
     void set_master_output_volume(u8, u8, Muted);
-    void set_pcm_output_sample_rate(u16);
+    ErrorOr<void> set_pcm_output_sample_rate(u32);
     void set_pcm_output_volume(u8, u8, Muted);
     ErrorOr<void> write_single_buffer(UserOrKernelBuffer const&, size_t, size_t);
 
     OwnPtr<Memory::Region> m_buffer_descriptor_list;
     u8 m_buffer_descriptor_list_index = 0;
+    bool m_double_rate_pcm_enabled = false;
     IOAddress m_io_mixer_base;
     IOAddress m_io_bus_base;
     WaitQueue m_irq_queue;
@@ -163,7 +170,7 @@ private:
     u8 m_output_buffer_page_count = 4;
     u8 m_output_buffer_page_index = 0;
     AC97Channel m_pcm_out_channel;
-    u16 m_sample_rate = 44100;
+    u32 m_sample_rate = 44100;
 };
 
 }

--- a/Kernel/Devices/Audio/SB16.cpp
+++ b/Kernel/Devices/Audio/SB16.cpp
@@ -123,9 +123,10 @@ ErrorOr<void> SB16::ioctl(OpenFileDescription&, unsigned request, Userspace<void
         return copy_to_user(output, &m_sample_rate);
     }
     case SOUNDCARD_IOCTL_SET_SAMPLE_RATE: {
-        auto sample_rate_value = static_cast<u16>(arg.ptr());
-        if (sample_rate_value == 0)
-            return EINVAL;
+        auto sample_rate_input = static_cast<u32>(arg.ptr());
+        if (sample_rate_input == 0 || sample_rate_input > 44100)
+            return ENOTSUP;
+        auto sample_rate_value = static_cast<u16>(sample_rate_input);
         if (m_sample_rate != sample_rate_value)
             set_sample_rate(sample_rate_value);
         return {};

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -11,8 +11,8 @@ endpoint AudioServer
     set_self_volume(double volume) => ()
 
     // Audio device
-    set_sample_rate(u16 sample_rate) => ()
-    get_sample_rate() => (u16 sample_rate)
+    set_sample_rate(u32 sample_rate) => ()
+    get_sample_rate() => (u32 sample_rate)
 
     // Buffer playback
     enqueue_buffer(Core::AnonymousBuffer buffer, i32 buffer_id, int sample_count) => (bool success)

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -73,7 +73,7 @@ Messages::AudioServer::GetSampleRateResponse ClientConnection::get_sample_rate()
     return { m_mixer.audiodevice_get_sample_rate() };
 }
 
-void ClientConnection::set_sample_rate(u16 sample_rate)
+void ClientConnection::set_sample_rate(u32 sample_rate)
 {
     m_mixer.audiodevice_set_sample_rate(sample_rate);
 }

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -49,7 +49,7 @@ private:
     virtual Messages::AudioServer::GetPlayingBufferResponse get_playing_buffer() override;
     virtual Messages::AudioServer::GetMutedResponse get_muted() override;
     virtual void set_muted(bool) override;
-    virtual void set_sample_rate(u16 sample_rate) override;
+    virtual void set_sample_rate(u32 sample_rate) override;
     virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
 
     Mixer& m_mixer;

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -165,7 +165,7 @@ void Mixer::set_muted(bool muted)
     });
 }
 
-int Mixer::audiodevice_set_sample_rate(u16 sample_rate)
+int Mixer::audiodevice_set_sample_rate(u32 sample_rate)
 {
     int code = ioctl(m_device->fd(), SOUNDCARD_IOCTL_SET_SAMPLE_RATE, sample_rate);
     if (code != 0)
@@ -173,9 +173,9 @@ int Mixer::audiodevice_set_sample_rate(u16 sample_rate)
     return code;
 }
 
-u16 Mixer::audiodevice_get_sample_rate() const
+u32 Mixer::audiodevice_get_sample_rate() const
 {
-    u16 sample_rate = 0;
+    u32 sample_rate = 0;
     int code = ioctl(m_device->fd(), SOUNDCARD_IOCTL_GET_SAMPLE_RATE, &sample_rate);
     if (code != 0)
         dbgln("Error while getting sample rate: ioctl error: {}", strerror(errno));

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -119,8 +119,8 @@ public:
     bool is_muted() const { return m_muted; }
     void set_muted(bool);
 
-    int audiodevice_set_sample_rate(u16 sample_rate);
-    u16 audiodevice_get_sample_rate() const;
+    int audiodevice_set_sample_rate(u32 sample_rate);
+    u32 audiodevice_get_sample_rate() const;
 
 private:
     Mixer(NonnullRefPtr<Core::ConfigFile> config);

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
                 break;
             }
             case AudioVariable::SampleRate: {
-                u16 sample_rate = audio_client->get_sample_rate();
+                u32 sample_rate = audio_client->get_sample_rate();
                 if (human_mode)
                     outln("Sample rate: {:5d} Hz", sample_rate);
                 else


### PR DESCRIPTION
Executing `asctl set r 96000` no longer results in weird sample rates being set on the audio devices. SB16 checks for a sample rate between 1 and 44100 Hz, while AC97 implements double-rate support which allows sample rates between 8kHz and 96kHZ.

Note: Qemu does not support double-rate AC97, so setting 96kHz should result in `ENOTSUP`.