### PR TITLE
LibWeb: Properly support <general-enclosed>

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/GeneralEnclosed.h
+++ b/Userland/Libraries/LibWeb/CSS/GeneralEnclosed.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Web::CSS {
+
+// Corresponds to Kleene 3-valued logic.
+// https://www.w3.org/TR/mediaqueries-4/#evaluating
+enum class MatchResult {
+    False,
+    True,
+    Unknown,
+};
+
+inline MatchResult as_match_result(bool value)
+{
+    return value ? MatchResult::True : MatchResult::False;
+}
+
+inline MatchResult negate(MatchResult value)
+{
+    switch (value) {
+    case MatchResult::False:
+        return MatchResult::True;
+    case MatchResult::True:
+        return MatchResult::False;
+    case MatchResult::Unknown:
+        return MatchResult::Unknown;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+template<typename Collection, typename Evaluate>
+inline MatchResult evaluate_and(Collection& collection, Evaluate evaluate)
+{
+    size_t true_results = 0;
+    for (auto& item : collection) {
+        auto item_match = evaluate(item);
+        if (item_match == MatchResult::False)
+            return MatchResult::False;
+        if (item_match == MatchResult::True)
+            true_results++;
+    }
+    if (true_results == collection.size())
+        return MatchResult::True;
+    return MatchResult::Unknown;
+}
+
+template<typename Collection, typename Evaluate>
+inline MatchResult evaluate_or(Collection& collection, Evaluate evaluate)
+{
+    size_t false_results = 0;
+    for (auto& item : collection) {
+        auto item_match = evaluate(item);
+        if (item_match == MatchResult::True)
+            return MatchResult::True;
+        if (item_match == MatchResult::False)
+            false_results++;
+    }
+    if (false_results == collection.size())
+        return MatchResult::False;
+    return MatchResult::Unknown;
+}
+
+// https://www.w3.org/TR/mediaqueries-4/#typedef-general-enclosed
+class GeneralEnclosed {
+public:
+    GeneralEnclosed(String serialized_contents)
+        : m_serialized_contents(move(serialized_contents))
+    {
+    }
+
+    MatchResult evaluate() const { return MatchResult::Unknown; }
+    StringView to_string() const { return m_serialized_contents.view(); }
+
+private:
+    String m_serialized_contents;
+};
+}

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -106,6 +106,9 @@ String MediaQuery::MediaCondition::to_string() const
     case Type::Or:
         builder.join(" or ", conditions);
         break;
+    case Type::GeneralEnclosed:
+        builder.append(general_enclosed->to_string());
+        break;
     }
     builder.append(')');
     return builder.to_string();
@@ -122,6 +125,8 @@ MatchResult MediaQuery::MediaCondition::evaluate(DOM::Window const& window) cons
         return evaluate_and(conditions, [&](auto& child) { return child.evaluate(window); });
     case Type::Or:
         return evaluate_or(conditions, [&](auto& child) { return child.evaluate(window); });
+    case Type::GeneralEnclosed:
+        return general_enclosed->evaluate();
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -65,11 +65,13 @@ public:
             And,
             Or,
             Not,
+            GeneralEnclosed,
         };
 
         Type type;
         MediaFeature feature;
         NonnullOwnPtrVector<MediaCondition> conditions;
+        Optional<GeneralEnclosed> general_enclosed;
 
         MatchResult evaluate(DOM::Window const&) const;
         String to_string() const;

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -12,6 +12,7 @@
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
+#include <LibWeb/CSS/GeneralEnclosed.h>
 #include <LibWeb/CSS/StyleValue.h>
 
 namespace Web::CSS {
@@ -70,7 +71,7 @@ public:
         MediaFeature feature;
         NonnullOwnPtrVector<MediaCondition> conditions;
 
-        bool evaluate(DOM::Window const&) const;
+        MatchResult evaluate(DOM::Window const&) const;
         String to_string() const;
     };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1083,7 +1083,7 @@ Optional<Supports::InParens> Parser::parse_supports_in_parens(TokenStream<StyleC
     // `<general-enclosed>`
     if (auto general_enclosed = parse_general_enclosed(tokens); general_enclosed.has_value()) {
         return Supports::InParens {
-            .value = Supports::GeneralEnclosed {}
+            .value = general_enclosed.release_value()
         };
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1113,7 +1113,7 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<StyleComp
         TokenStream block_tokens { first_token.block().values() };
         if (auto declaration = consume_a_declaration(block_tokens); declaration.has_value()) {
             return Supports::Feature {
-                .declaration = declaration.release_value()
+                .declaration = declaration->to_string()
             };
         }
     }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1111,10 +1111,26 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<StyleComp
     return {};
 }
 
-template<typename T>
-Optional<Parser::GeneralEnclosed> Parser::parse_general_enclosed(TokenStream<T>&)
+// https://www.w3.org/TR/mediaqueries-4/#typedef-general-enclosed
+Optional<GeneralEnclosed> Parser::parse_general_enclosed(TokenStream<StyleComponentValueRule>& tokens)
 {
-    // FIXME: Actually parse this! https://www.w3.org/TR/mediaqueries-5/#typedef-general-enclosed
+    tokens.skip_whitespace();
+    auto start_position = tokens.position();
+
+    auto& first_token = tokens.next_token();
+
+    // `[ <function-token> <any-value> ) ]`
+    if (first_token.is_function())
+        return GeneralEnclosed { first_token.to_string() };
+
+    // `( <ident> <any-value> )`
+    if (first_token.is_block() && first_token.block().is_paren()) {
+        auto& block = first_token.block();
+        if (!block.values().is_empty() && block.values().first().is(Token::Type::Ident))
+            return GeneralEnclosed { first_token.to_string() };
+    }
+
+    tokens.rewind_to_position(start_position);
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -113,9 +113,6 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
-    // FIXME: This is a hack, while CSS::Supports is using a StyleDeclarationRule
-    [[nodiscard]] Optional<StyleProperty> convert_to_style_property(StyleDeclarationRule const&);
-
 private:
     enum class ParsingResult {
         Done,
@@ -175,6 +172,7 @@ private:
 
     [[nodiscard]] RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
     [[nodiscard]] RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_declaration(NonnullRefPtr<StyleBlockRule>);
+    [[nodiscard]] Optional<StyleProperty> convert_to_style_property(StyleDeclarationRule const&);
 
     Optional<Color> parse_color(StyleComponentValueRule const&);
     Optional<Length> parse_length(StyleComponentValueRule const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -13,6 +13,7 @@
 #include <AK/Result.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
+#include <LibWeb/CSS/GeneralEnclosed.h>
 #include <LibWeb/CSS/MediaQuery.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
@@ -170,10 +171,7 @@ private:
     template<typename T>
     [[nodiscard]] NonnullRefPtr<StyleFunctionRule> consume_a_function(TokenStream<T>&);
 
-    struct GeneralEnclosed {
-    };
-    template<typename T>
-    [[nodiscard]] Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<T>&);
+    [[nodiscard]] Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<StyleComponentValueRule>&);
 
     [[nodiscard]] RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
     [[nodiscard]] RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_declaration(NonnullRefPtr<StyleBlockRule>);

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleComponentValueRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleComponentValueRule.h
@@ -52,6 +52,7 @@ public:
     Token const& token() const { return m_token; }
     operator Token() const { return m_token; }
 
+    String to_string() const;
     String to_debug_string() const;
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -133,6 +133,25 @@ String StyleBlockRule::to_string() const
     return builder.to_string();
 }
 
+String StyleComponentValueRule::to_string() const
+{
+    StringBuilder builder;
+
+    switch (m_type) {
+    case StyleComponentValueRule::ComponentType::Token:
+        builder.append(m_token.to_string());
+        break;
+    case StyleComponentValueRule::ComponentType::Function:
+        builder.append(m_function->to_string());
+        break;
+    case StyleComponentValueRule::ComponentType::Block:
+        builder.append(m_block->to_string());
+        break;
+    }
+
+    return builder.to_string();
+}
+
 String StyleComponentValueRule::to_debug_string() const
 {
     StringBuilder builder;

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
 #include <LibWeb/CSS/Parser/StyleFunctionRule.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
+#include <LibWeb/CSS/Serialize.h>
 
 namespace Web::CSS {
 
@@ -70,20 +71,7 @@ void append_with_to_string(StringBuilder& builder, SeparatorType& separator, Col
             first = false;
         else
             builder.append(separator);
-        builder.append(item.to_debug_string());
-    }
-}
-
-template<class SeparatorType, class CollectionType>
-void append_raw(StringBuilder& builder, SeparatorType& separator, CollectionType& collection)
-{
-    bool first = true;
-    for (auto& item : collection) {
-        if (first)
-            first = false;
-        else
-            builder.append(separator);
-        builder.append(item);
+        builder.append(item.to_string());
     }
 }
 
@@ -109,7 +97,7 @@ String StyleRule::to_string() const
 
     if (m_type == Type::At) {
         builder.append("@");
-        builder.append(m_name);
+        serialize_an_identifier(builder, m_name);
     }
 
     append_with_to_string(builder, " ", m_prelude);
@@ -127,7 +115,7 @@ String StyleBlockRule::to_string() const
     StringBuilder builder;
 
     builder.append(m_token.bracket_string());
-    append_with_to_string(builder, ", ", m_values);
+    append_with_to_string(builder, " ", m_values);
     builder.append(m_token.bracket_mirror_string());
 
     return builder.to_string();
@@ -135,21 +123,16 @@ String StyleBlockRule::to_string() const
 
 String StyleComponentValueRule::to_string() const
 {
-    StringBuilder builder;
-
     switch (m_type) {
     case StyleComponentValueRule::ComponentType::Token:
-        builder.append(m_token.to_string());
-        break;
+        return m_token.to_string();
     case StyleComponentValueRule::ComponentType::Function:
-        builder.append(m_function->to_string());
-        break;
+        return m_function->to_string();
     case StyleComponentValueRule::ComponentType::Block:
-        builder.append(m_block->to_string());
-        break;
+        return m_block->to_string();
+    default:
+        VERIFY_NOT_REACHED();
     }
-
-    return builder.to_string();
 }
 
 String StyleComponentValueRule::to_debug_string() const
@@ -178,7 +161,7 @@ String StyleDeclarationRule::to_string() const
 {
     StringBuilder builder;
 
-    builder.append(m_name);
+    serialize_an_identifier(builder, m_name);
     builder.append(": ");
     append_with_to_string(builder, " ", m_values);
 
@@ -192,9 +175,9 @@ String StyleFunctionRule::to_string() const
 {
     StringBuilder builder;
 
-    builder.append(m_name);
+    serialize_an_identifier(builder, m_name);
     builder.append("(");
-    append_with_to_string(builder, ", ", m_values);
+    append_with_to_string(builder, " ", m_values);
     builder.append(")");
 
     return builder.to_string();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
@@ -6,8 +6,70 @@
 
 #include <AK/String.h>
 #include <LibWeb/CSS/Parser/Token.h>
+#include <LibWeb/CSS/Serialize.h>
 
 namespace Web::CSS {
+
+String Token::to_string() const
+{
+    StringBuilder builder;
+
+    switch (m_type) {
+    case Type::EndOfFile:
+        return "";
+    case Type::Ident:
+        return serialize_an_identifier(ident());
+    case Type::Function:
+        return String::formatted("{}(", serialize_an_identifier(function()));
+    case Type::AtKeyword:
+        return String::formatted("@{}", serialize_an_identifier(at_keyword()));
+    case Type::Hash:
+        return String::formatted("#{}", serialize_an_identifier(hash_value()));
+    case Type::String:
+        return serialize_a_string(string());
+    case Type::BadString:
+        return "";
+    case Type::Url:
+        return serialize_a_url(url());
+    case Type::BadUrl:
+        return "url()";
+    case Type::Delim:
+        return m_value;
+    case Type::Number:
+        return String::number(m_number_value);
+    case Type::Percentage:
+        return String::formatted("{}%", m_number_value);
+    case Type::Dimension:
+        return String::formatted("{}{}", m_number_value, m_unit);
+    case Type::Whitespace:
+        return " ";
+    case Type::CDO:
+        return "<!--";
+    case Type::CDC:
+        return "-->";
+    case Type::Colon:
+        return ":";
+    case Type::Semicolon:
+        return ";";
+    case Type::Comma:
+        return ",";
+    case Type::OpenSquare:
+        return "[";
+    case Type::CloseSquare:
+        return "]";
+    case Type::OpenParen:
+        return "(";
+    case Type::CloseParen:
+        return ")";
+    case Type::OpenCurly:
+        return "{";
+    case Type::CloseCurly:
+        return "}";
+    case Type::Invalid:
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
 
 String Token::to_debug_string() const
 {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -157,6 +157,7 @@ public:
     String bracket_string() const;
     String bracket_mirror_string() const;
 
+    String to_string() const;
     String to_debug_string() const;
 
     Position const& start_position() const { return m_start_position; }

--- a/Userland/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Supports.cpp
@@ -48,7 +48,7 @@ MatchResult Supports::InParens::evaluate() const
 
 MatchResult Supports::Feature::evaluate() const
 {
-    auto style_property = Parser({}, "").convert_to_style_property(declaration);
+    auto style_property = Parser({}, declaration).parse_as_declaration();
     if (style_property.has_value())
         return MatchResult::True;
     return MatchResult::False;

--- a/Userland/Libraries/LibWeb/CSS/Supports.h
+++ b/Userland/Libraries/LibWeb/CSS/Supports.h
@@ -21,8 +21,7 @@ class Supports final : public RefCounted<Supports> {
 
 public:
     struct Feature {
-        // FIXME: Using this internal parser class is a bit of a hack.
-        StyleDeclarationRule declaration;
+        String declaration;
         MatchResult evaluate() const;
     };
 

--- a/Userland/Libraries/LibWeb/CSS/Supports.h
+++ b/Userland/Libraries/LibWeb/CSS/Supports.h
@@ -11,6 +11,7 @@
 #include <AK/String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/GeneralEnclosed.h>
 #include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
 
 namespace Web::CSS {
@@ -18,30 +19,7 @@ namespace Web::CSS {
 class Supports final : public RefCounted<Supports> {
     friend class Parser;
 
-private:
-    enum class MatchResult {
-        False,
-        True,
-        Unknown,
-    };
-
-    static MatchResult negate(MatchResult value)
-    {
-        switch (value) {
-        case MatchResult::False:
-            return MatchResult::True;
-        case MatchResult::True:
-            return MatchResult::False;
-        case MatchResult::Unknown:
-            return MatchResult::Unknown;
-        }
-        VERIFY_NOT_REACHED();
-    }
-
 public:
-    struct GeneralEnclosed {
-    };
-
     struct Feature {
         // FIXME: Using this internal parser class is a bit of a hack.
         StyleDeclarationRule declaration;


### PR DESCRIPTION
A `<general-enclosed>` value represents a section of a `@media` or `@supports` rule that exists in some future standard that we don't understand yet, but don't want to make the entire rule invalid. Rather than evaluate to `true` or `false`, it returns `unknown`, which when combined with other values can still result in `true`/`false`.

For the sake of being able to serialize rules that include a `<general-enclosed>`, it holds a string representation of its source. This meant giving Token a proper `to_string()` method, and making sure other methods also return valid CSS.

Serialization for CSS is not clearly defined in the spec. [This section](https://www.w3.org/TR/css-syntax-3/#serialization) notes that some combinations of tokens require a comment be preserved or inserted, which we don't do yet, but that's outside the scope of this PR.