### PR TITLE
LibWeb+WebContent: Enable iframe contents inspection

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -84,6 +84,7 @@ public:
 
     virtual bool is_html_html_element() const { return false; }
     virtual bool is_html_template_element() const { return false; }
+    virtual bool is_browsing_context_container() const { return false; }
 
     ExceptionOr<NonnullRefPtr<Node>> pre_insert(NonnullRefPtr<Node>, RefPtr<Node>);
     ExceptionOr<NonnullRefPtr<Node>> pre_remove(NonnullRefPtr<Node>);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -116,6 +116,7 @@ class DOMRectReadOnly;
 
 namespace Web::HTML {
 class BrowsingContext;
+class BrowsingContextContainer;
 class CanvasRenderingContext2D;
 class CloseEvent;
 class DOMParser;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.h
@@ -29,6 +29,14 @@ public:
 
 protected:
     RefPtr<BrowsingContext> m_nested_browsing_context;
+
+private:
+    virtual bool is_browsing_context_container() const override { return true; }
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::BrowsingContextContainer>() const { return is_browsing_context_container(); }
 }


### PR DESCRIPTION
This change allows for nested browser contexts to be embedded in the
serialized JSON of their container element (like `iframe`) and enables
their inspection in the DOM Inspector. When user selects a node from 
a nested browsing context in the Inspector (e.g. a node inside an `iframe` 
document) it is highlighted on the page.

Closes #8934

![Screenshot from 2021-11-24 20-00-12](https://user-images.githubusercontent.com/1694616/143283722-571dbb24-7bc3-4610-ba61-8510abb368bf.png)