### PR TITLE
Kernel: Make `futex()` actually return error codes

### DIFF
--- a/Kernel/Syscalls/futex.cpp
+++ b/Kernel/Syscalls/futex.cpp
@@ -99,7 +99,7 @@ ErrorOr<FlatPtr> Process::sys$futex(Userspace<const Syscall::SC_futex_params*> u
     auto user_address = FlatPtr(params.userspace_address);
     auto user_address2 = FlatPtr(params.userspace_address2);
 
-    auto do_wait = [&](u32 bitset) -> int {
+    auto do_wait = [&](u32 bitset) -> ErrorOr<FlatPtr> {
         bool did_create;
         RefPtr<FutexQueue> futex_queue;
         do {
@@ -136,7 +136,7 @@ ErrorOr<FlatPtr> Process::sys$futex(Userspace<const Syscall::SC_futex_params*> u
         return 0;
     };
 
-    auto do_requeue = [&](Optional<u32> val3) -> int {
+    auto do_requeue = [&](Optional<u32> val3) -> ErrorOr<FlatPtr> {
         auto user_value = user_atomic_load_relaxed(params.userspace_address);
         if (!user_value.has_value())
             return EFAULT;
@@ -204,7 +204,7 @@ ErrorOr<FlatPtr> Process::sys$futex(Userspace<const Syscall::SC_futex_params*> u
         if (!oldval.has_value())
             return EFAULT;
         atomic_thread_fence(AK::MemoryOrder::memory_order_acquire);
-        int result = do_wake(user_address, params.val, {});
+        auto result = do_wake(user_address, params.val, {});
         if (params.val2 > 0) {
             bool compare_result;
             switch (_FUTEX_CMP(params.val3)) {

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -40,8 +40,6 @@ int futex(uint32_t* userspace_address, int futex_op, uint32_t value, const struc
 {
     int rc;
     switch (futex_op & FUTEX_CMD_MASK) {
-    //case FUTEX_CMP_REQUEUE:
-    // FUTEX_CMP_REQUEUE_PI:
     case FUTEX_WAKE_OP: {
         // These interpret timeout as a u32 value for val2
         Syscall::SC_futex_params params {

--- a/Userland/Libraries/LibPthread/pthread_cond.cpp
+++ b/Userland/Libraries/LibPthread/pthread_cond.cpp
@@ -48,7 +48,7 @@ int pthread_cond_init(pthread_cond_t* cond, const pthread_condattr_t* attr)
 {
     cond->mutex = nullptr;
     cond->value = 0;
-    cond->clockid = attr ? attr->clockid : CLOCK_MONOTONIC_COARSE;
+    cond->clockid = attr ? attr->clockid : CLOCK_REALTIME_COARSE;
     return 0;
 }
 


### PR DESCRIPTION
* Fixes `futex()` not returning proper error codes
* Fixes `pthread_cond_init`'s default clock type

As a result, Grim Fandango now successfully plays its intro movie and the audio in-game is no longer broken!

![image](https://user-images.githubusercontent.com/3210731/143290443-b476417f-6708-4256-97b4-281cb3a6c752.png)