### PR TITLE
CrashReporter: Don't visualize whitespace in memory regions text editor

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -358,6 +358,7 @@ int main(int argc, char** argv)
     memory_regions_text_editor.set_text(String::join("\n", memory_regions));
     memory_regions_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
     memory_regions_text_editor.set_should_hide_unnecessary_scrollbars(true);
+    memory_regions_text_editor.set_visualize_trailing_whitespace(false);
 
     auto& close_button = *widget.find_descendant_of_type_named<GUI::Button>("close_button");
     close_button.on_click = [&](auto) {


### PR DESCRIPTION
This was visible for memory regions with empty name.