### PR TITLE
LibGUI: Add on_return_pressed event callback to Dialog

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -55,14 +55,13 @@ private:
         m_title_textbox->set_text(title);
         m_title_textbox->set_focus(true);
         m_title_textbox->select_all();
-        m_title_textbox->on_return_pressed = [this] {
-            done(Dialog::ExecOK);
-        };
 
         m_url_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("url_textbox");
         m_url_textbox->set_text(url);
-        m_url_textbox->on_return_pressed = [this] {
+
+        on_return_pressed = [this] {
             done(Dialog::ExecOK);
+            return true;
         };
 
         auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -132,11 +132,12 @@ FindDialog::FindDialog()
     };
 
     m_find_button->on_click = [this](auto) {
-        auto text = m_text_editor->text();
-        if (!text.is_empty()) {
-            m_text_value = text;
-            done(ExecResult::ExecOK);
-        }
+        on_find();
+    };
+
+    on_return_pressed = [this] {
+        on_find();
+        return true;
     };
 
     m_find_all_button->on_click = [this](auto) {
@@ -151,4 +152,13 @@ FindDialog::FindDialog()
 
 FindDialog::~FindDialog()
 {
+}
+
+void FindDialog::on_find()
+{
+    auto text = m_text_editor->text();
+    if (!text.is_empty()) {
+        m_text_value = text;
+        done(ExecResult::ExecOK);
+    }
 }

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -32,6 +32,8 @@ private:
     FindDialog();
     virtual ~FindDialog() override;
 
+    void on_find();
+
     RefPtr<GUI::TextEditor> m_text_editor;
     RefPtr<GUI::Button> m_find_button;
     RefPtr<GUI::Button> m_find_all_button;

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
@@ -124,7 +124,7 @@ GoToOffsetDialog::GoToOffsetDialog()
     };
 
     m_go_button->on_click = [this](auto) {
-        done(ExecResult::ExecOK);
+        done(Dialog::ExecOK);
     };
 
     m_text_editor->on_change = [this]() {
@@ -142,6 +142,11 @@ GoToOffsetDialog::GoToOffsetDialog()
 
     m_offset_from_box->on_change = [this](auto&, auto&) {
         update_statusbar();
+    };
+
+    on_return_pressed = [this] {
+        done(Dialog::ExecOK);
+        return true;
     };
 
     update_statusbar();

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -65,8 +65,9 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
         m_image_size.set_height(value);
     };
 
-    m_name_textbox->on_return_pressed = [this] {
-        done(ExecOK);
+    on_return_pressed = [this] {
+        done(ExecResult::ExecOK);
+        return true;
     };
 
     width_spinbox.set_range(1, 16384);

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -67,8 +67,9 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize const& suggested_size, G
         m_layer_size.set_height(value);
     };
 
-    m_name_textbox->on_return_pressed = [this] {
-        done(ExecOK);
+    on_return_pressed = [this] {
+        done(ExecResult::ExecOK);
+        return true;
     };
 
     width_spinbox.set_range(1, 16384);

--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -110,6 +110,11 @@ void Dialog::event(Core::Event& event)
             done(ExecCancel);
             event.accept();
             return;
+        } else if (key_event.key() == KeyCode::Key_Return) {
+            if (on_return_pressed && on_return_pressed()) {
+                event.accept();
+                return;
+            }
         }
     }
 

--- a/Userland/Libraries/LibGUI/Dialog.h
+++ b/Userland/Libraries/LibGUI/Dialog.h
@@ -47,6 +47,8 @@ public:
 
     virtual void close() override;
 
+    Function<bool()> on_return_pressed;
+
 protected:
     explicit Dialog(Window* parent_window, ScreenPosition screen_position = CenterWithinParent);
 


### PR DESCRIPTION
Rationale: While working on a feature for `PixelPaint`, I noticed that I could only submit the `New Image` dialog by pressing the return key when the name `TextEditor` widget is focused, but not when the width and height `SpinBox` widgets are focused. As it turns out, the dialog was being manually `done(ExecOK)`'d in a custom `on_return_pressed` callback in the `TextEditor`, I propose an own `on_return_pressed` handler for `Dialog` class that allows for submitting the `Dialog` regardless of which child widget is focused, improving keyboard based navigation. Additionally, the `on_return_pressed` callback returns a boolean value, returning `false` value from the callback will then propagate the event to the child widgets (as needed).