### PR TITLE
Kernel+strace: Remove unused dbgputch syscall, add some strace support (dbgputstr, get_process_name, gettid)

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -62,7 +62,6 @@ enum class NeedsBigProcessLock {
     S(connect, NeedsBigProcessLock::Yes)                    \
     S(create_inode_watcher, NeedsBigProcessLock::Yes)       \
     S(create_thread, NeedsBigProcessLock::Yes)              \
-    S(dbgputch, NeedsBigProcessLock::No)                    \
     S(dbgputstr, NeedsBigProcessLock::No)                   \
     S(detach_thread, NeedsBigProcessLock::Yes)              \
     S(disown, NeedsBigProcessLock::Yes)                     \

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -273,7 +273,6 @@ public:
     ErrorOr<FlatPtr> sys$create_inode_watcher(u32 flags);
     ErrorOr<FlatPtr> sys$inode_watcher_add_watch(Userspace<const Syscall::SC_inode_watcher_add_watch_params*> user_params);
     ErrorOr<FlatPtr> sys$inode_watcher_remove_watch(int fd, int wd);
-    ErrorOr<FlatPtr> sys$dbgputch(u8);
     ErrorOr<FlatPtr> sys$dbgputstr(Userspace<const char*>, size_t);
     ErrorOr<FlatPtr> sys$dump_backtrace();
     ErrorOr<FlatPtr> sys$gettid();

--- a/Kernel/Syscalls/debug.cpp
+++ b/Kernel/Syscalls/debug.cpp
@@ -18,13 +18,6 @@ ErrorOr<FlatPtr> Process::sys$dump_backtrace()
     return 0;
 }
 
-ErrorOr<FlatPtr> Process::sys$dbgputch(u8 ch)
-{
-    VERIFY_NO_PROCESS_BIG_LOCK(this);
-    dbgputch(ch);
-    return 0;
-}
-
 ErrorOr<FlatPtr> Process::sys$dbgputstr(Userspace<const char*> characters, size_t size)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -152,12 +152,6 @@ static inline void internal_dbgputch(char ch)
     IO::out8(IO::BOCHS_DEBUG_PORT, ch);
 }
 
-extern "C" void dbgputch(char ch)
-{
-    SpinlockLocker lock(s_log_lock);
-    internal_dbgputch(ch);
-}
-
 extern "C" void dbgputstr(const char* characters, size_t length)
 {
     if (!characters)

--- a/Kernel/kstdio.h
+++ b/Kernel/kstdio.h
@@ -10,7 +10,6 @@
 #include <AK/Types.h>
 
 extern "C" {
-void dbgputch(char);
 void dbgputstr(const char*, size_t);
 void kernelputstr(const char*, size_t);
 void kernelcriticalputstr(const char*, size_t);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -180,7 +180,6 @@ private:
     int virt$clock_gettime(int, FlatPtr);
     int virt$clock_nanosleep(FlatPtr);
     int virt$dbgputstr(FlatPtr characters, int length);
-    int virt$dbgputch(char);
     int virt$chmod(FlatPtr, size_t, mode_t);
     int virt$fchmod(int, mode_t);
     int virt$chown(FlatPtr);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -169,8 +169,6 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$set_process_name(arg1, arg2);
     case SC_dbgputstr:
         return virt$dbgputstr(arg1, arg2);
-    case SC_dbgputch:
-        return virt$dbgputch(arg1);
     case SC_chmod:
         return virt$chmod(arg1, arg2, arg3);
     case SC_fchmod:
@@ -536,12 +534,6 @@ int Emulator::virt$connect(int sockfd, FlatPtr address, socklen_t address_size)
 int Emulator::virt$shutdown(int sockfd, int how)
 {
     return syscall(SC_shutdown, sockfd, how);
-}
-
-int Emulator::virt$dbgputch(char ch)
-{
-    dbgputch(ch);
-    return 0;
 }
 
 int Emulator::virt$listen(int fd, int backlog)

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1149,11 +1149,6 @@ int rename(const char* oldpath, const char* newpath)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-void dbgputch(char ch)
-{
-    syscall(SC_dbgputch, ch);
-}
-
 void dbgputstr(const char* characters, size_t length)
 {
     syscall(SC_dbgputstr, characters, length);

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -75,7 +75,6 @@ int vsprintf(char* buffer, const char* fmt, va_list) __attribute__((format(print
 int vsnprintf(char* buffer, size_t, const char* fmt, va_list) __attribute__((format(printf, 3, 0)));
 int fprintf(FILE*, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void dbgputch(char);
 void dbgputstr(const char*, size_t);
 int sprintf(char* buffer, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 int asprintf(char** strp, const char* fmt, ...) __attribute__((format(printf, 2, 3)));

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -667,6 +667,11 @@ static void format_dbgputstr(FormattedSyscallBuilder& builder, char* characters,
     builder.add_string_argument({ characters, size }, "\0\n"sv);
 }
 
+static void format_get_process_name(FormattedSyscallBuilder& builder, char* buffer, size_t buffer_size)
+{
+    builder.add_string_argument({ buffer, buffer_size });
+}
+
 static void format_syscall(FormattedSyscallBuilder& builder, Syscall::Function syscall_function, syscall_arg_t arg1, syscall_arg_t arg2, syscall_arg_t arg3, syscall_arg_t res)
 {
     enum ResultType {
@@ -747,12 +752,16 @@ static void format_syscall(FormattedSyscallBuilder& builder, Syscall::Function s
     case SC_dbgputstr:
         format_dbgputstr(builder, (char*)arg1, (size_t)arg2);
         break;
+    case SC_get_process_name:
+        format_get_process_name(builder, (char*)arg1, (size_t)arg2);
+        break;
     case SC_getuid:
     case SC_geteuid:
     case SC_getgid:
     case SC_getegid:
     case SC_getpid:
     case SC_getppid:
+    case SC_gettid:
         break;
     default:
         builder.add_arguments((void*)arg1, (void*)arg2, (void*)arg3);


### PR DESCRIPTION
The goal of this PR is to make debugging strace and debugging a program with strace much nicer:

Before:
![Bildschirmfoto_2021-11-24_19-45-38](https://user-images.githubusercontent.com/2690845/143313891-a20ecb62-debe-46a3-a396-4a3ea7844aa5.png)

After:
![Bildschirmfoto_2021-11-24_22-01-58](https://user-images.githubusercontent.com/2690845/143313909-1d993c06-f7f3-4e1c-9d26-e0f5d6b2a34d.png)