### PR TITLE
Kernel: Implement variable rate audio support for AC97 devices

### DIFF
--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -54,6 +54,7 @@ private:
     };
 
     enum ExtendedAudioStatusControlFlag : u16 {
+        VariableRateAudio = 1 << 0,
         DoubleRateAudio = 1 << 1,
     };
 
@@ -170,7 +171,8 @@ private:
     u8 m_output_buffer_page_count = 4;
     u8 m_output_buffer_page_index = 0;
     AC97Channel m_pcm_out_channel;
-    u32 m_sample_rate = 44100;
+    u32 m_sample_rate = 0;
+    bool m_variable_rate_pcm_supported = false;
 };
 
 }


### PR DESCRIPTION
Previously we `VERIFY()`ed that the device supports variable-rate audio (VRA). Now, we query the VRA bit and if VRA is not supported, we do not enable double-rate audio and disallow setting any sample rate except the fixed 48kHz rate as defined by the AC'97 specification. This should allow the driver to function on a wider array of hardware.

Note that in the AC'97 specification, DRA without VRA is allowed when supported: this effectively doubles the sample rate to 96kHZ. For now, we ignore that possibility and let it default to 48kHZ.