### PR TITLE
PixelPaint: Paste improvements

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -116,6 +116,24 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             }
         });
 
+    m_new_image_from_clipboard_action = GUI::Action::create(
+        "&New Image from Clipboard", { Mod_Ctrl | Mod_Shift, Key_V }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+            auto bitmap = GUI::Clipboard::the().fetch_data_and_type().as_bitmap();
+            if (!bitmap) {
+                GUI::MessageBox::show(&window, "There is no image in a clipboard to paste.", "PixelPaint", GUI::MessageBox::Type::Warning);
+                return;
+            }
+
+            auto image = PixelPaint::Image::try_create_with_size(bitmap->size()).release_value_but_fixme_should_propagate_errors();
+            auto layer = PixelPaint::Layer::try_create_with_bitmap(image, *bitmap, "Pasted layer").release_value_but_fixme_should_propagate_errors();
+            image->add_layer(*layer);
+            image->set_title("Untitled");
+
+            create_new_editor(*image);
+            m_layer_list_widget->set_image(image);
+            m_layer_list_widget->set_selected_layer(layer);
+        });
+
     m_open_image_action = GUI::CommonActions::make_open_action([&](auto&) {
         auto result = FileSystemAccessClient::Client::the().open_file(window.window_id());
         if (result.error != 0)
@@ -140,6 +158,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     });
 
     file_menu.add_action(*m_new_image_action);
+    file_menu.add_action(*m_new_image_from_clipboard_action);
     file_menu.add_action(*m_open_image_action);
     file_menu.add_action(*m_save_image_as_action);
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -118,20 +118,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     m_new_image_from_clipboard_action = GUI::Action::create(
         "&New Image from Clipboard", { Mod_Ctrl | Mod_Shift, Key_V }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
-            auto bitmap = GUI::Clipboard::the().fetch_data_and_type().as_bitmap();
-            if (!bitmap) {
-                GUI::MessageBox::show(&window, "There is no image in a clipboard to paste.", "PixelPaint", GUI::MessageBox::Type::Warning);
-                return;
-            }
-
-            auto image = PixelPaint::Image::try_create_with_size(bitmap->size()).release_value_but_fixme_should_propagate_errors();
-            auto layer = PixelPaint::Layer::try_create_with_bitmap(image, *bitmap, "Pasted layer").release_value_but_fixme_should_propagate_errors();
-            image->add_layer(*layer);
-            image->set_title("Untitled");
-
-            create_new_editor(*image);
-            m_layer_list_widget->set_image(image);
-            m_layer_list_widget->set_selected_layer(layer);
+            create_image_from_clipboard();
         });
 
     m_open_image_action = GUI::CommonActions::make_open_action([&](auto&) {
@@ -240,8 +227,11 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     m_paste_action = GUI::CommonActions::make_paste_action([&](auto&) {
         auto* editor = current_image_editor();
-        if (!editor)
+        if (!editor) {
+            create_image_from_clipboard();
             return;
+        }
+
         auto bitmap = GUI::Clipboard::the().fetch_data_and_type().as_bitmap();
         if (!bitmap)
             return;
@@ -823,6 +813,24 @@ void MainWidget::create_default_image()
 
     auto& editor = create_new_editor(*image);
     editor.set_active_layer(bg_layer);
+}
+
+void MainWidget::create_image_from_clipboard()
+{
+    auto bitmap = GUI::Clipboard::the().fetch_data_and_type().as_bitmap();
+    if (!bitmap) {
+        GUI::MessageBox::show(window(), "There is no image in a clipboard to paste.", "PixelPaint", GUI::MessageBox::Type::Warning);
+        return;
+    }
+
+    auto image = PixelPaint::Image::try_create_with_size(bitmap->size()).release_value_but_fixme_should_propagate_errors();
+    auto layer = PixelPaint::Layer::try_create_with_bitmap(image, *bitmap, "Pasted layer").release_value_but_fixme_should_propagate_errors();
+    image->add_layer(*layer);
+    image->set_title("Untitled");
+
+    create_new_editor(*image);
+    m_layer_list_widget->set_image(image);
+    m_layer_list_widget->set_selected_layer(layer);
 }
 
 bool MainWidget::request_close()

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -43,6 +43,7 @@ private:
 
     ImageEditor* current_image_editor();
     ImageEditor& create_new_editor(NonnullRefPtr<Image>);
+    void create_image_from_clipboard();
 
     virtual void drop_event(GUI::DropEvent&) override;
 

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -58,6 +58,7 @@ private:
     RefPtr<GUI::ComboBox> m_zoom_combobox;
 
     RefPtr<GUI::Action> m_new_image_action;
+    RefPtr<GUI::Action> m_new_image_from_clipboard_action;
     RefPtr<GUI::Action> m_open_image_action;
     RefPtr<GUI::Action> m_save_image_as_action;
 


### PR DESCRIPTION
**PixelPaint: Add a way to quickly create an image from clipboard**

Ctrl+Shift+V, like in GIMP.

**PixelPaint: Make paste action create new image if no editor is opened**

This matches GIMP behaviour.