### PR TITLE
Kernel: Fix asm constraint in switch_context

### DIFF
--- a/Kernel/Arch/x86/i386/Processor.cpp
+++ b/Kernel/Arch/x86/i386/Processor.cpp
@@ -264,7 +264,7 @@ UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_th
         "call enter_trap_no_irq \n"
         "addl $4, %%esp \n"
         "lret \n"
-        :: [new_esp] "g" (regs.esp),
+        :: [new_esp] "r" (regs.esp),
            [new_eip] "a" (regs.eip),
            [from_to_thread] "b" (&initial_thread),
            [cpu] "c" (Processor::current_id())

--- a/Kernel/Arch/x86/i386/Processor.cpp
+++ b/Kernel/Arch/x86/i386/Processor.cpp
@@ -222,8 +222,8 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
           [tss_esp0] "=m" (m_tss.esp0),
           "=d" (from_thread), // needed so that from_thread retains the correct value
           "=a" (to_thread) // needed so that to_thread retains the correct value
-        : [to_esp] "g" (to_thread->regs().esp),
-          [to_esp0] "g" (to_thread->regs().esp0),
+        : [to_esp] "r" (to_thread->regs().esp),
+          [to_esp0] "r" (to_thread->regs().esp0),
           [to_eip] "c" (to_thread->regs().eip),
           [from_thread] "d" (from_thread),
           [to_thread] "a" (to_thread)

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -230,8 +230,8 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
         [tss_rsp0h] "=m" (m_tss.rsp0h),
         "=d" (from_thread), // needed so that from_thread retains the correct value
         "=a" (to_thread) // needed so that to_thread retains the correct value
-        : [to_rsp] "g" (to_thread->regs().rsp),
-        [to_rsp0] "g" (to_thread->regs().rsp0),
+        : [to_rsp] "r" (to_thread->regs().rsp),
+        [to_rsp0] "r" (to_thread->regs().rsp0),
         [to_rip] "c" (to_thread->regs().rip),
         [from_thread] "d" (from_thread),
         [to_thread] "a" (to_thread)

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -268,7 +268,7 @@ UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_th
         "movq 24(%%rsp), %%rdi \n" // move pointer to TrapFrame into place
         "call enter_trap_no_irq \n"
         "retq \n"
-        :: [new_rsp] "g" (regs.rsp),
+        :: [new_rsp] "r" (regs.rsp),
         [new_rip] "a" (regs.rip),
         [from_to_thread] "b" (&initial_thread),
         [cpu] "c" ((u64)id())


### PR DESCRIPTION
The `"g"` constraint means that the compiler may use memory to store `to_esp` and `to_esp0`. However, when we attempt to access `to_esp`/`to_esp0` in the inline assembly, we've moved `%esp` by pushing things onto the stack, causing us to access the wrong stack offset for `to_esp`/`to_esp0`. Using the `"r"` constraint fixes this since it forces `to_esp`/`to_esp0` to be stored in a register.