### PR TITLE
LibJS: Throw InternalErrors instead of Errors on CallStackSizeExceeded

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1517,7 +1517,7 @@ static ThrowCompletionOr<size_t> flatten_into_array(GlobalObject& global_object,
 
         if (depth > 0 && TRY(value.is_array(global_object))) {
             if (vm.did_reach_stack_space_limit())
-                return vm.throw_completion<Error>(global_object, ErrorType::CallStackSizeExceeded);
+                return vm.throw_completion<InternalError>(global_object, ErrorType::CallStackSizeExceeded);
 
             auto length = TRY(length_of_array_like(global_object, value.as_object()));
             target_index = TRY(flatten_into_array(global_object, new_array, value.as_object(), length, target_index, depth - 1));

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -487,7 +487,7 @@ ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_n
     //
     // In JS code: `h = {}; p = new Proxy({}, h); h.__proto__ = p; p.foo // or h.foo`
     if (vm.did_reach_stack_space_limit())
-        return vm.throw_completion<Error>(global_object, ErrorType::CallStackSizeExceeded);
+        return vm.throw_completion<InternalError>(global_object, ErrorType::CallStackSizeExceeded);
 
     // 6. Let trap be ? GetMethod(handler, "get").
     auto trap = TRY(Value(&m_handler).get_method(global_object, vm.names.get));

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -103,7 +103,7 @@ public:
         VERIFY(!exception());
         // Ensure we got some stack space left, so the next function call doesn't kill us.
         if (did_reach_stack_space_limit())
-            return throw_completion<Error>(global_object, ErrorType::CallStackSizeExceeded);
+            return throw_completion<InternalError>(global_object, ErrorType::CallStackSizeExceeded);
         m_execution_context_stack.append(&context);
         return {};
     }

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flat.js
@@ -8,7 +8,7 @@ describe("error", () => {
         a[0] = a;
         expect(() => {
             a.flat(3893232121);
-        }).toThrowWithMessage(Error, "Call stack size limit exceeded");
+        }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
     });
 });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
@@ -114,5 +114,5 @@ test("Proxy handler that has the Proxy itself as its prototype", () => {
     handler.__proto__ = proxy;
     expect(() => {
         proxy.foo;
-    }).toThrowWithMessage(Error, "Call stack size limit exceeded");
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
 });

--- a/Userland/Libraries/LibJS/Tests/runtime-error-call-stack-size.js
+++ b/Userland/Libraries/LibJS/Tests/runtime-error-call-stack-size.js
@@ -6,16 +6,16 @@ test("infinite recursion", () => {
     try {
         infiniteRecursion();
     } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect(e.name).toBe("Error");
+        expect(e).toBeInstanceOf(InternalError);
+        expect(e.name).toBe("InternalError");
         expect(e.message).toBe("Call stack size limit exceeded");
     }
 
     expect(() => {
         JSON.stringify({}, () => ({ foo: "bar" }));
-    }).toThrowWithMessage(Error, "Call stack size limit exceeded");
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
 
     expect(() => {
         new Proxy({}, { get: (_, __, p) => p.foo }).foo;
-    }).toThrowWithMessage(Error, "Call stack size limit exceeded");
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
 });


### PR DESCRIPTION
These seem more appropriate. (Just making sure this is fine before merging)