### PR TITLE
UserspaceEmulator: Fix after add_positional_argument API change :^)

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -41,7 +41,7 @@ Emulator& Emulator::the()
     return *s_the;
 }
 
-Emulator::Emulator(String const& executable_path, Vector<String> const& arguments, Vector<String> const& environment)
+Emulator::Emulator(String const& executable_path, Vector<StringView> const& arguments, Vector<String> const& environment)
     : m_executable_path(executable_path)
     , m_arguments(arguments)
     , m_environment(environment)
@@ -103,7 +103,7 @@ void Emulator::setup_stack(Vector<ELF::AuxiliaryValue> aux_vector)
     Vector<u32> argv_entries;
 
     for (auto& argument : m_arguments) {
-        m_cpu.push_string(argument.characters());
+        m_cpu.push_string(argument);
         argv_entries.append(m_cpu.esp().value());
     }
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -31,7 +31,7 @@ class Emulator {
 public:
     static Emulator& the();
 
-    Emulator(String const& executable_path, Vector<String> const& arguments, Vector<String> const& environment);
+    Emulator(String const& executable_path, Vector<StringView> const& arguments, Vector<String> const& environment);
 
     void set_profiling_details(bool should_dump_profile, size_t instruction_interval, OutputFileStream* profile_stream, NonnullOwnPtrVector<String>* profiler_strings, Vector<int>* profiler_string_id_map)
     {
@@ -113,7 +113,7 @@ public:
 
 private:
     const String m_executable_path;
-    const Vector<String> m_arguments;
+    const Vector<StringView> m_arguments;
     const Vector<String> m_environment;
 
     SoftMMU m_mmu;

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -21,7 +21,7 @@ bool g_report_to_debug = false;
 
 int main(int argc, char** argv, char** env)
 {
-    Vector<String> arguments;
+    Vector<StringView> arguments;
     bool pause_on_startup { false };
     String profile_dump_path;
     FILE* profile_output_file { nullptr };


### PR DESCRIPTION
Get UE compiling again after the `Vector<String>` API was changed to
`Vector<StringView>`.