### PR TITLE
Settings: Fix launch of settings dialog

### DIFF
--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -104,8 +104,7 @@ int main(int argc, char** argv)
     icon_view.set_model(*model);
 
     icon_view.on_activation = [&](GUI::ModelIndex const& index) {
-        auto& app = *(Desktop::AppFile*)index.internal_data();
-        auto executable = app.executable();
+        auto executable = model->data(index, GUI::ModelRole::Custom).as_string();
 
         auto launch_origin_rect = icon_view.to_widget_rect(icon_view.content_rect(index)).translated(icon_view.screen_relative_rect().location());
         setenv("__libgui_launch_origin_rect", String::formatted("{},{},{},{}", launch_origin_rect.x(), launch_origin_rect.y(), launch_origin_rect.width(), launch_origin_rect.height()).characters(), 1);


### PR DESCRIPTION
There was a bug report on discord where someone mentioned that
launching the keyboard settings always crashed. When looking
at the backtrace it became clear we were calling down the
`AppFile::executable()` path on uninitialized memory.

We can fix this by using the "official" API for obtaining data
from the GUI ModelIndex, instead of casting random memory to
the object type we expect it to be. :^)

Validated this fixes the issue for me locally.