### PR TITLE
LibGL: Implement `glScissor()`

### DIFF
--- a/Userland/Libraries/LibGL/DepthBuffer.cpp
+++ b/Userland/Libraries/LibGL/DepthBuffer.cpp
@@ -33,4 +33,12 @@ void DepthBuffer::clear(float depth)
     }
 }
 
+void DepthBuffer::clear(Gfx::IntRect bounds, float depth)
+{
+    bounds.intersect({ 0, 0, m_size.width(), m_size.height() });
+    for (int y = bounds.top(); y <= bounds.bottom(); ++y)
+        for (int x = bounds.left(); x <= bounds.right(); ++x)
+            m_data[y * m_size.width() + x] = depth;
+}
+
 }

--- a/Userland/Libraries/LibGL/DepthBuffer.h
+++ b/Userland/Libraries/LibGL/DepthBuffer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
 
 namespace GL {
@@ -18,6 +19,7 @@ public:
     float* scanline(int y);
 
     void clear(float depth);
+    void clear(Gfx::IntRect bounds, float depth);
 
 private:
     Gfx::IntSize m_size;

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -290,6 +290,10 @@ extern "C" {
 #define GL_FOG_COLOR 0x0B66
 #define GL_FOG_DENSITY 0x0B62
 
+// Scissor enums
+#define GL_SCISSOR_BOX 0x0C10
+#define GL_SCISSOR_TEST 0x0C11
+
 // OpenGL State & GLGet
 #define GL_MODELVIEW_MATRIX 0x0BA6
 
@@ -416,6 +420,7 @@ GLAPI void glFogfv(GLenum mode, GLfloat* params);
 GLAPI void glFogf(GLenum pname, GLfloat param);
 GLAPI void glFogi(GLenum pname, GLint param);
 GLAPI void glPixelStorei(GLenum pname, GLint param);
+GLAPI void glScissor(GLint x, GLint y, GLsizei width, GLsizei height);
 
 #ifdef __cplusplus
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -86,6 +86,7 @@ public:
     virtual void gl_fogf(GLenum pname, GLfloat params) = 0;
     virtual void gl_fogi(GLenum pname, GLint param) = 0;
     virtual void gl_pixel_store(GLenum pname, GLfloat param) = 0;
+    virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -154,3 +154,8 @@ void glPixelStorei(GLenum pname, GLint param)
 {
     g_gl_context->gl_pixel_store(pname, param);
 }
+
+void glScissor(GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    g_gl_context->gl_scissor(x, y, width, height);
+}

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -20,6 +20,7 @@
 #include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Matrix4x4.h>
+#include <LibGfx/Rect.h>
 #include <LibGfx/Vector3.h>
 
 namespace GL {
@@ -96,6 +97,7 @@ public:
     virtual void gl_fogf(GLenum pname, GLfloat param) override;
     virtual void gl_fogi(GLenum pname, GLint param) override;
     virtual void gl_pixel_store(GLenum pname, GLfloat param) override;
+    virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height);
     virtual void present() override;
 
 private:
@@ -231,7 +233,8 @@ private:
             decltype(&SoftwareGLContext::gl_draw_arrays),
             decltype(&SoftwareGLContext::gl_draw_elements),
             decltype(&SoftwareGLContext::gl_depth_range),
-            decltype(&SoftwareGLContext::gl_polygon_offset)>;
+            decltype(&SoftwareGLContext::gl_polygon_offset),
+            decltype(&SoftwareGLContext::gl_scissor)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -14,6 +14,7 @@
 #include <AK/Array.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Rect.h>
 #include <LibGfx/Vector4.h>
 
 namespace GL {
@@ -44,6 +45,8 @@ struct RasterizerOptions {
     GLboolean fog_enabled { false };
     GLfloat fog_start { 0.0f };
     GLfloat fog_end { 1.0f };
+    bool scissor_enabled { false };
+    Gfx::IntRect scissor_box {};
     GLenum draw_buffer { GL_BACK };
     GLfloat depth_offset_factor { 0 };
     GLfloat depth_offset_constant { 0 };


### PR DESCRIPTION
This PR introduces support for scissor boxes in LibGL:
* Implements `glScissor(x, y, width, height)`
* Implements `glEnable` / `glDisable` / `glIsEnabled` with `GL_SCISSOR_TEST`
* Implements `glGetIntegerV` with `GL_SCISSOR_BOX`

Example:
![image](https://user-images.githubusercontent.com/3210731/143700659-2a2e312b-3657-4a6b-b443-88568d98ac24.png)

CC @sunverwerth 