### PR TITLE
LibGL: Implement `GL_(UN)PACK_ALIGNMENT`, fix scissor box coordinates and other changes

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -35,8 +35,8 @@ struct Array {
     [[nodiscard]] constexpr T const& front() const { return at(0); }
     [[nodiscard]] constexpr T& front() { return at(0); }
 
-    [[nodiscard]] constexpr T const& back() const { return at(max(1, size()) - 1); }
-    [[nodiscard]] constexpr T& back() { return at(max(1, size()) - 1); }
+    [[nodiscard]] constexpr T const& back() const requires(Size > 0) { return at(Size - 1); }
+    [[nodiscard]] constexpr T& back() requires(Size > 0) { return at(Size - 1); }
 
     [[nodiscard]] constexpr bool is_empty() const { return size() == 0; }
 

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -129,8 +129,10 @@ extern "C" {
 #define GL_GENERATE_MIPMAP_HINT 0x8192
 #define GL_TEXTURE_COMPRESSION_HINT 0x84EF
 
-// Read pixels
+// Reading pixels & unpacking texture patterns
 #define GL_UNPACK_ROW_LENGTH 0x0CF2
+#define GL_UNPACK_ALIGNMENT 0x0CF5
+#define GL_PACK_ALIGNMENT 0x0D05
 
 // Listing enums
 #define GL_COMPILE 0x1300

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -32,11 +32,11 @@ extern "C" {
 #define GL_PROJECTION 0x1701
 
 // glBegin/glEnd primitive types
-#define GL_TRIANGLES 0x0100
-#define GL_QUADS 0x0101
-#define GL_TRIANGLE_FAN 0x0102
-#define GL_TRIANGLE_STRIP 0x0103
-#define GL_POLYGON 0x0104
+#define GL_TRIANGLES 0x0004
+#define GL_TRIANGLE_STRIP 0x0005
+#define GL_TRIANGLE_FAN 0x0006
+#define GL_QUADS 0x0007
+#define GL_POLYGON 0x0009
 
 // Depth buffer and alpha test compare functions
 #define GL_NEVER 0x0200
@@ -49,8 +49,8 @@ extern "C" {
 #define GL_ALWAYS 0x0207
 
 // Buffer bits
-#define GL_COLOR_BUFFER_BIT 0x0200
-#define GL_DEPTH_BUFFER_BIT 0x0400
+#define GL_DEPTH_BUFFER_BIT 0x00100
+#define GL_COLOR_BUFFER_BIT 0x04000
 
 // Enable capabilities
 #define GL_CULL_FACE 0x0B44

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -85,7 +85,7 @@ public:
     virtual void gl_fogfv(GLenum pname, GLfloat* params) = 0;
     virtual void gl_fogf(GLenum pname, GLfloat params) = 0;
     virtual void gl_fogi(GLenum pname, GLint param) = 0;
-    virtual void gl_pixel_store(GLenum pname, GLfloat param) = 0;
+    virtual void gl_pixel_storei(GLenum pname, GLint param) = 0;
     virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) = 0;
 
     virtual void present() = 0;

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -152,7 +152,7 @@ void glPolygonOffset(GLfloat factor, GLfloat units)
 
 void glPixelStorei(GLenum pname, GLint param)
 {
-    g_gl_context->gl_pixel_store(pname, param);
+    g_gl_context->gl_pixel_storei(pname, param);
 }
 
 void glScissor(GLint x, GLint y, GLsizei width, GLsizei height)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1421,7 +1421,6 @@ void SoftwareGLContext::gl_bind_texture(GLenum target, GLuint texture)
             break;
         default:
             VERIFY_NOT_REACHED();
-            break;
         }
 
         m_allocated_textures.set(texture, texture_object);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -673,10 +673,12 @@ void SoftwareGLContext::gl_delete_textures(GLsizei n, const GLuint* textures)
     RETURN_WITH_ERROR_IF(n < 0, GL_INVALID_VALUE);
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    m_name_allocator.free(n, textures);
-
     for (auto i = 0; i < n; i++) {
         GLuint name = textures[i];
+        if (name == 0)
+            continue;
+
+        m_name_allocator.free(name);
 
         auto texture_object = m_allocated_textures.find(name);
         if (texture_object == m_allocated_textures.end() || texture_object->value.is_null())

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1532,10 +1532,10 @@ void SoftwareGLContext::gl_get_integerv(GLenum pname, GLint* data)
         break;
     case GL_SCISSOR_BOX: {
         auto scissor_box = m_rasterizer.options().scissor_box;
-        *(data + 0) = scissor_box.x();
-        *(data + 1) = scissor_box.y();
-        *(data + 2) = scissor_box.width();
-        *(data + 3) = scissor_box.height();
+        data[0] = scissor_box.x();
+        data[1] = scissor_box.y();
+        data[2] = scissor_box.width();
+        data[3] = scissor_box.height();
         break;
     }
     case GL_UNPACK_ALIGNMENT:

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -96,7 +96,7 @@ public:
     virtual void gl_fogfv(GLenum pname, GLfloat* params) override;
     virtual void gl_fogf(GLenum pname, GLfloat param) override;
     virtual void gl_fogi(GLenum pname, GLint param) override;
-    virtual void gl_pixel_store(GLenum pname, GLfloat param) override;
+    virtual void gl_pixel_storei(GLenum pname, GLint param) override;
     virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) override;
     virtual void present() override;
 
@@ -265,7 +265,9 @@ private:
     VertexAttribPointer m_client_color_pointer;
     VertexAttribPointer m_client_tex_coord_pointer;
 
-    size_t m_unpack_row_length { 0 };
+    u8 m_pack_alignment { 4 };
+    GLsizei m_unpack_row_length { 0 };
+    u8 m_unpack_alignment { 4 };
 };
 
 }

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -34,7 +34,7 @@ constexpr static T mix(const T& x, const T& y, float interp)
     return x * (1 - interp) + y * interp;
 }
 
-static Gfx::RGBA32 to_rgba32(const FloatVector4& v)
+ALWAYS_INLINE constexpr static Gfx::RGBA32 to_rgba32(const FloatVector4& v)
 {
     auto clamped = v.clamped(0, 1);
     u8 r = clamped.x() * 255;

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -46,7 +46,7 @@ struct RasterizerOptions {
     GLfloat fog_start { 0.0f };
     GLfloat fog_end { 1.0f };
     bool scissor_enabled { false };
-    Gfx::IntRect scissor_box {};
+    Gfx::IntRect scissor_box;
     GLenum draw_buffer { GL_BACK };
     GLfloat depth_offset_factor { 0 };
     GLfloat depth_offset_constant { 0 };

--- a/Userland/Libraries/LibGL/Tex/NameAllocator.cpp
+++ b/Userland/Libraries/LibGL/Tex/NameAllocator.cpp
@@ -22,12 +22,9 @@ void TextureNameAllocator::allocate(GLsizei count, GLuint* textures)
     }
 }
 
-void TextureNameAllocator::free(GLsizei count, const GLuint* textures)
+void TextureNameAllocator::free(GLuint texture)
 {
-    size_t tex_array_index = 0;
-
-    while (count-- > 0)
-        m_free_texture_names.push(textures[tex_array_index++]);
+    m_free_texture_names.push(texture);
 }
 
 }

--- a/Userland/Libraries/LibGL/Tex/NameAllocator.h
+++ b/Userland/Libraries/LibGL/Tex/NameAllocator.h
@@ -16,7 +16,7 @@ public:
     TextureNameAllocator() = default;
 
     void allocate(GLsizei count, GLuint* textures);
-    void free(GLsizei count, const GLuint* textures);
+    void free(GLuint texture);
 
 private:
     Stack<GLuint, 512> m_free_texture_names;

--- a/Userland/Libraries/LibGL/Tex/Texture2D.cpp
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.cpp
@@ -36,7 +36,6 @@ void Texture2D::replace_sub_texture_data(GLuint lod, GLint xoffset, GLint yoffse
 
     // FIXME: We currently only support GL_UNSIGNED_BYTE pixel data
     VERIFY(type == GL_UNSIGNED_BYTE);
-    VERIFY(lod < m_mipmaps.size());
     VERIFY(xoffset >= 0 && yoffset >= 0 && xoffset + width <= mip.width() && yoffset + height <= mip.height());
     VERIFY(pixels_per_row == 0 || pixels_per_row >= xoffset + width);
 
@@ -109,14 +108,6 @@ void Texture2D::replace_sub_texture_data(GLuint lod, GLint xoffset, GLint yoffse
     } else {
         VERIFY_NOT_REACHED();
     }
-}
-
-MipMap const& Texture2D::mipmap(unsigned lod) const
-{
-    if (lod >= m_mipmaps.size())
-        return m_mipmaps.back();
-
-    return m_mipmaps.at(lod);
 }
 
 }

--- a/Userland/Libraries/LibGL/Tex/Texture2D.cpp
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.cpp
@@ -116,7 +116,7 @@ void Texture2D::replace_sub_texture_data(GLuint lod, GLint xoffset, GLint yoffse
 MipMap const& Texture2D::mipmap(unsigned lod) const
 {
     if (lod >= m_mipmaps.size())
-        return m_mipmaps.at(m_mipmaps.size() - 1);
+        return m_mipmaps.back();
 
     return m_mipmaps.at(lod);
 }

--- a/Userland/Libraries/LibGL/Tex/Texture2D.h
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.h
@@ -38,7 +38,13 @@ public:
     void upload_texture_data(GLuint lod, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* pixels, GLsizei pixels_per_row, u8 byte_alignment);
     void replace_sub_texture_data(GLuint lod, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* pixels, GLsizei pixels_per_row, u8 byte_alignment);
 
-    MipMap const& mipmap(unsigned lod) const;
+    MipMap const& mipmap(unsigned lod) const
+    {
+        if (lod >= m_mipmaps.size())
+            return m_mipmaps.back();
+
+        return m_mipmaps.at(lod);
+    }
 
     GLenum internal_format() const { return m_internal_format; }
     Sampler2D const& sampler() const { return m_sampler; }

--- a/Userland/Libraries/LibGL/Tex/Texture2D.h
+++ b/Userland/Libraries/LibGL/Tex/Texture2D.h
@@ -35,8 +35,8 @@ public:
 
     virtual bool is_texture_2d() const override { return true; }
 
-    void upload_texture_data(GLuint lod, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* pixels, size_t pixels_per_row);
-    void replace_sub_texture_data(GLuint lod, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* pixels, size_t pixels_per_row);
+    void upload_texture_data(GLuint lod, GLint internal_format, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* pixels, GLsizei pixels_per_row, u8 byte_alignment);
+    void replace_sub_texture_data(GLuint lod, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* pixels, GLsizei pixels_per_row, u8 byte_alignment);
 
     MipMap const& mipmap(unsigned lod) const;
 


### PR DESCRIPTION
* Implement `glPixelStorei`, `glTex(Sub)Image2d` and `glReadPixels` support for `GL_PACK_ALIGNMENT` and `GL_UNPACK_ALIGNMENT`
* Reimplement `GL_UNPACK_ROW_LENGTH` support in `glTex(Sub)Image2d`
* Change `glScissor` coordinates from a top-left to a bottom-left window coordinate system
* Fix texture deletion when texture name is `0`
* Change some enum values to match their values as defined by the Khronos Group
* Fix `AK::Array::back()`
* Mark `to_rgba32` as `constexpr`
* Inline mipmap lookups

These changes are tested against glquake, which shows no obvious regressions - and our ScummVM port now shows its main menu in OpenGL mode!

![image](https://user-images.githubusercontent.com/3210731/143788448-3242fdb7-4864-4e9c-baf9-9030ba7f5621.png)

(It crashes immediately after that though)