### PR TITLE
Kernel/Audio: Implement 2 correctness fixes in AC97

### DIFF
--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -44,7 +44,7 @@ UNMAP_AFTER_INIT void AC97::detect()
     });
 }
 
-UNMAP_AFTER_INIT AC97::AC97(PCI::DeviceIdentifier pci_device_identifier)
+UNMAP_AFTER_INIT AC97::AC97(PCI::DeviceIdentifier const& pci_device_identifier)
     : PCI::Device(pci_device_identifier.address())
     , IRQHandler(pci_device_identifier.interrupt_line().value())
     , CharacterDevice(42, 42)

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -145,7 +145,7 @@ private:
         StringView m_name;
     };
 
-    AC97(PCI::DeviceIdentifier);
+    explicit AC97(PCI::DeviceIdentifier const&);
 
     // ^IRQHandler
     virtual bool handle_irq(const RegisterState&) override;


### PR DESCRIPTION
The fixes are:
1. Don't copy PCI::DeviceIdentifier during construction. This is a heavy
structure to copy so we definitely don't want to do that. Instead, use
a const reference to it like what happens in other parts in the Kernel.
2. Declare the constructor as explicit to avoid construction errors.

A note on this pull request: This is the start of a work I planned to do a long time ago, and the purpose is to make the Kernel to be able to drive multiple instances of Audio controllers at once, so there's more to be expected :)